### PR TITLE
fix(jq): validate empty-container stray commas in evaluate_bytes_lazy (#2211)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -314,16 +314,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   conversion) *both* validated nothing at all for their own `Array` arms — not even the older
   #1677 missing/doubled-comma-*between two real children* check, which
   `cursor_to_owned_at_depth`'s own `Object` arm neighbor already had (#1956) and
-  `standard_json_to_jq_value`'s `Object` arm never did either. Neither gap was previously
-  reachable as a live differential against real jq: whatever either function converts is still
-  printed via `write_output_jq_value`/`print_json` immediately afterward regardless of what
-  `-e`'s own materialize() call found, and `print_json`'s independent, pre-existing #1643/#1676
-  checks re-validate the same document on the way out — confirmed live against the pre-fix
-  binary (`git stash`) that every CLI-reachable repro tried still correctly rejected malformed
-  input purely through that redundant check. Both are fixed now regardless, each reusing the
-  same per-child `preceding_delimiter_ok`/`preceding_gap_ok` check the array/object arms that
-  already had it use — a future refactor that ever removes the masking check in `print_json`
-  would otherwise have silently reintroduced this bug with nothing here to catch it.
+  `standard_json_to_jq_value`'s `Object` arm never did either. Neither gap was reachable as a
+  live differential *through the `succinctly` CLI binary against real jq*: whatever either
+  function converts is still printed via `write_output_jq_value`/`print_json` immediately
+  afterward regardless of what `-e`'s own materialize() call found, and `print_json`'s
+  independent, pre-existing #1643/#1676 checks re-validate the same document on the way out —
+  confirmed live against the pre-fix binary (`git stash`) that every CLI-reachable repro tried
+  still correctly rejected malformed input purely through that redundant check.
+
+  That masking is CLI-specific, though, and does not extend to this crate used as a library:
+  `JqValue` is public API (`pub use lazy::JqValue` in `src/jq/mod.rs`), and
+  `JqValue::from_cursor(...).materialize()`/`.into_owned()` are directly callable with no
+  `print_json` redispatch anywhere in that call chain — code review confirmed empirically
+  (reconstructing the pre-fix function in isolation) that a library embedder calling
+  `materialize()`/`into_owned()` directly on a cursor built over `[1 2, 3]` or `[,]` got a
+  silently wrong `OwnedValue` back, not an error. So this was a live, silently-wrong-output bug
+  for any consumer of the public `JqValue` API, not merely a latent defense-in-depth
+  improvement — the CLI's own redundant `print_json` check happened to mask it for the one
+  entry point (`succinctly jq`) this issue's own repro used. Both are fixed now regardless,
+  each reusing the same per-child `preceding_delimiter_ok`/`preceding_gap_ok` check the
+  array/object arms that already had it use — a future refactor that ever removes the masking
+  check in `print_json` would otherwise have silently reintroduced this bug for the CLI too,
+  with nothing here left to catch it.
   `cursor_to_owned_at_depth`'s `Array`/`Object` arms also gained `container_gap_ok`, the same
   empty-container check as `to_owned_cursor_at_depth` above (it has its own container cursor to
   check against); `standard_json_to_jq_value`'s arms do not gain an equivalent empty-container

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -289,6 +289,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`evaluate_bytes_lazy` (the default CLI path for a non-cursor-transparent jq filter --
+  `if`/arithmetic/function calls/anything `expr_is_cursor_transparent` answers `false` for)
+  silently accepted a stray `,` inside an apparently-empty array/object, anywhere in the
+  document** (#2211): `{"a": [,]}" | if true then . else . end` printed `{"a":[]}` at exit 0,
+  where real jq and every other reading path in this codebase (the M2 fast path, the general
+  streaming path, and the `-S`/`--slurp`/`-C` fully-materializing path) already reject it —
+  confirmed against `/usr/bin/jq` 1.7.1. Root cause: `eval_generic::to_owned_cursor_at_depth`'s
+  array/object loops (the materializing conversion `eval_single`'s fallback arm uses for every
+  expression it doesn't natively match) only ever validate the delimiter *preceding a real
+  child* (#1677's `key_delimiter_ok`/`value_delimiter_ok`/`preceding_delimiter_ok` family) —
+  when the walk produces zero real children at all, none of those checks ever run, so the
+  container's own opening-to-closing gap was never inspected. Fixed with a new
+  `DocumentCursor::container_gap_ok` method (default `true` for every format but JSON, same
+  convention as `preceding_delimiter_ok`), whose JSON override reuses the exact same
+  `trailing_gap_ok` primitive `src/json/light.rs`'s `stream_json`/`stream_json_pretty` and
+  `src/bin/succinctly/jq_runner.rs`'s `print_json` already use for their own #1676 fix — one
+  gap-scanning definition, now three call sites instead of two. Verified no behavior change on
+  well-formed input (full existing suite plus a 100 KB generated-JSON differential sweep against
+  `/usr/bin/jq` 1.7.1, byte-identical) and that the fix reaches every nesting depth, not just the
+  top level (`to_owned_cursor_at_depth` recurses via cursor at every container level). A related
+  but distinct shape — a trailing comma after a *real* scalar last child (`[1,]`, `{"a":1,}`),
+  needing the last child's own text-end position rather than the container's opening position —
+  is a known, still-open gap on this same path, filed as #2243 and pinned by
+  `test_jq_lazy_path_trailing_comma_after_scalar_last_child_still_a_known_gap_2243` rather than
+  left silently uncovered.
+
 - **`|=`/`+=`/other compound assignment operators, and `del()`, could crash the process on a
   sufficiently long chained path** (`.k0.k1.k2...` or `del(.k0.k1.k2...)`, #2115) — a
   sufficiently long chain put one native stack frame on every path component, `SIGKILL` at

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -293,25 +293,56 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `if`/arithmetic/function calls/anything `expr_is_cursor_transparent` answers `false` for)
   silently accepted a stray `,` inside an apparently-empty array/object, anywhere in the
   document** (#2211): `{"a": [,]}" | if true then . else . end` printed `{"a":[]}` at exit 0,
-  where real jq and every other reading path in this codebase (the M2 fast path, the general
-  streaming path, and the `-S`/`--slurp`/`-C` fully-materializing path) already reject it —
-  confirmed against `/usr/bin/jq` 1.7.1. Root cause: `eval_generic::to_owned_cursor_at_depth`'s
-  array/object loops (the materializing conversion `eval_single`'s fallback arm uses for every
-  expression it doesn't natively match) only ever validate the delimiter *preceding a real
-  child* (#1677's `key_delimiter_ok`/`value_delimiter_ok`/`preceding_delimiter_ok` family) —
-  when the walk produces zero real children at all, none of those checks ever run, so the
-  container's own opening-to-closing gap was never inspected. Fixed with a new
-  `DocumentCursor::container_gap_ok` method (default `true` for every format but JSON, same
-  convention as `preceding_delimiter_ok`), whose JSON override reuses the exact same
-  `trailing_gap_ok` primitive `src/json/light.rs`'s `stream_json`/`stream_json_pretty` and
-  `src/bin/succinctly/jq_runner.rs`'s `print_json` already use for their own #1676 fix — one
-  gap-scanning definition, now three call sites instead of two. Verified no behavior change on
-  well-formed input (full existing suite plus a 100 KB generated-JSON differential sweep against
-  `/usr/bin/jq` 1.7.1, byte-identical) and that the fix reaches every nesting depth, not just the
-  top level (`to_owned_cursor_at_depth` recurses via cursor at every container level). A related
-  but distinct shape — a trailing comma after a *real* scalar last child (`[1,]`, `{"a":1,}`),
+  where real jq already rejects it — confirmed against `/usr/bin/jq` 1.7.1. Root cause:
+  `eval_generic::to_owned_cursor_at_depth`'s array/object loops (the materializing conversion
+  `eval_single`'s fallback arm uses for every expression it doesn't natively match) only ever
+  validate the delimiter *preceding a real child* (#1677's `key_delimiter_ok`/
+  `value_delimiter_ok`/`preceding_delimiter_ok` family) — when the walk produces zero real
+  children at all, none of those checks ever run, so the container's own opening-to-closing gap
+  was never inspected. Fixed with a new `DocumentCursor::container_gap_ok` method (default
+  `true` for every format but JSON, same convention as `preceding_delimiter_ok`), whose JSON
+  override reuses the exact same `trailing_gap_ok` primitive `src/json/light.rs`'s
+  `stream_json`/`stream_json_pretty` and `src/bin/succinctly/jq_runner.rs`'s `print_json`
+  already use for their own #1676 fix.
+
+  Code review on the resulting PR (#2246) found two more independent materializers with the
+  identical gap, the same "one fix, one sibling missed" shape this codebase has hit before
+  (`cursor_to_owned_at_depth`'s own doc comment already references #998/#1021 for exactly this
+  pattern): `jq::lazy::cursor_to_owned_at_depth` (backing `JqValue::materialize`/`into_owned`,
+  reached whenever `-e`/`--exit-status` forces materialization) and
+  `jq_runner::standard_json_to_jq_value` (backing the top-level `GenericResult::One`/`Many`
+  conversion) *both* validated nothing at all for their own `Array` arms — not even the older
+  #1677 missing/doubled-comma-*between two real children* check, which
+  `cursor_to_owned_at_depth`'s own `Object` arm neighbor already had (#1956) and
+  `standard_json_to_jq_value`'s `Object` arm never did either. Neither gap was previously
+  reachable as a live differential against real jq: whatever either function converts is still
+  printed via `write_output_jq_value`/`print_json` immediately afterward regardless of what
+  `-e`'s own materialize() call found, and `print_json`'s independent, pre-existing #1643/#1676
+  checks re-validate the same document on the way out — confirmed live against the pre-fix
+  binary (`git stash`) that every CLI-reachable repro tried still correctly rejected malformed
+  input purely through that redundant check. Both are fixed now regardless, each reusing the
+  same per-child `preceding_delimiter_ok`/`preceding_gap_ok` check the array/object arms that
+  already had it use — a future refactor that ever removes the masking check in `print_json`
+  would otherwise have silently reintroduced this bug with nothing here to catch it.
+  `cursor_to_owned_at_depth`'s `Array`/`Object` arms also gained `container_gap_ok`, the same
+  empty-container check as `to_owned_cursor_at_depth` above (it has its own container cursor to
+  check against); `standard_json_to_jq_value`'s arms do not gain an equivalent empty-container
+  check — by construction, `GenericResult::One`/`Many` are only ever produced when *this specific
+  node's* own cursor position is not being tracked (see `Expr::Identity`'s own doc comment in
+  `eval_generic.rs`), so there is no container-level position here to check safely; each real
+  child's own cursor is unaffected by that and still gets its own check. Both additions are
+  covered by direct unit tests calling these functions in isolation (bypassing `print_json`'s
+  masking entirely) rather than CLI-level tests, which cannot distinguish the fix from the
+  pre-existing redundant check — confirmed each new test fails against the pre-fix function body
+  and passes against the fixed one.
+
+  Verified no behavior change on well-formed input (full existing suite, unit tests for all
+  three fixed functions, plus a 100 KB generated-JSON differential sweep against `/usr/bin/jq`
+  1.7.1, byte-identical) and that the primary fix reaches every nesting depth, not just the top
+  level (`to_owned_cursor_at_depth` recurses via cursor at every container level). A related but
+  distinct shape — a trailing comma after a *real* scalar last child (`[1,]`, `{"a":1,}`),
   needing the last child's own text-end position rather than the container's opening position —
-  is a known, still-open gap on this same path, filed as #2243 and pinned by
+  is a known, still-open gap on all three of these paths, filed as #2243 and pinned by
   `test_jq_lazy_path_trailing_comma_after_scalar_last_child_still_a_known_gap_2243` rather than
   left silently uncovered.
 

--- a/src/bin/succinctly/jq_runner.rs
+++ b/src/bin/succinctly/jq_runner.rs
@@ -5093,13 +5093,41 @@ fn standard_json_to_jq_value<'a, W: Clone + AsRef<[u64]>>(
         }
         StandardJson::Array(elements) => {
             // LAZY: Store cursor references instead of materializing children
-            let items: Vec<JqValue<'a, W>> = elements.cursor_iter().map(JqValue::Cursor).collect();
+            //
+            // #2211 code review: this walk used to validate *nothing* about
+            // the delimiter preceding each element -- not even the older
+            // #1677 missing/doubled-comma-between-two-real-elements check
+            // `print_json`'s own array arm (`check_preceding_delimiter`) and
+            // `eval_generic::to_owned_cursor_at_depth`'s array loop already
+            // perform. Only the top level (`GenericResult::One`/`Many`)
+            // reaches this function at all, and its own container position
+            // is not available here by construction (`GenericResult::One`
+            // is only ever produced when no cursor is being tracked for
+            // *this* node -- see `Expr::Identity`'s own doc comment in
+            // `eval_generic.rs`), so unlike its `to_owned_cursor_at_depth`/
+            // `cursor_to_owned_at_depth` siblings this cannot also check an
+            // apparently-*empty* container's own opening-to-closing gap
+            // (`[,]`) -- there is no cursor for `[,]` itself to check that
+            // against, only for its (zero) children. Each child's *own*
+            // cursor is still valid and positioned regardless, so the
+            // between-real-elements check below is fully safe.
+            let mut items: Vec<JqValue<'a, W>> = Vec::new();
+            for (i, child_cursor) in elements.cursor_iter().enumerate() {
+                if let Some(pos) = child_cursor.text_position() {
+                    let expected = if i == 0 { None } else { Some(b',') };
+                    if !preceding_gap_ok(child_cursor.text(), pos, expected) {
+                        return Err(EvalError::malformed_json_text(child_cursor.text()));
+                    }
+                }
+                items.push(JqValue::Cursor(child_cursor));
+            }
             JqValue::Array(items)
         }
         StandardJson::Object(fields) => {
             // LAZY: Store cursor references instead of materializing values
             let mut map: IndexMap<String, JqValue<'a, W>> = IndexMap::new();
             let mut remaining = fields;
+            let mut is_first = true;
             while let Some((f, rest)) = remaining.uncons() {
                 // A key that isn't `StandardJson::String` at all is a
                 // structurally malformed key, not a decode failure. This used
@@ -5114,9 +5142,29 @@ fn standard_json_to_jq_value<'a, W: Clone + AsRef<[u64]>>(
                     },
                     _ => return Err(EvalError::malformed_json_text(parent_cursor.text())),
                 };
+                // #2211 code review: same missing #1677 check as the array
+                // arm above -- neither the key's own preceding `,` nor the
+                // value's own preceding `:` was ever validated here. Same
+                // "no container-level cursor available" limitation as the
+                // array arm for the apparently-*empty* case (`{,}`); each
+                // real field's own key/value cursor is unaffected by that.
+                let key_cursor = f.key_cursor();
+                let value_cursor = f.value_cursor();
+                if let Some(key_pos) = key_cursor.text_position() {
+                    let expected = if is_first { None } else { Some(b',') };
+                    if !preceding_gap_ok(key_cursor.text(), key_pos, expected) {
+                        return Err(EvalError::malformed_json_text(key_cursor.text()));
+                    }
+                }
+                if let Some(value_pos) = value_cursor.text_position() {
+                    if !preceding_gap_ok(value_cursor.text(), value_pos, Some(b':')) {
+                        return Err(EvalError::malformed_json_text(value_cursor.text()));
+                    }
+                }
                 // Use cursor for value instead of materializing
-                map.insert(key, JqValue::Cursor(f.value_cursor()));
+                map.insert(key, JqValue::Cursor(value_cursor));
                 remaining = rest;
+                is_first = false;
             }
             // A child with no sibling to pair as a value: the object is
             // malformed and `uncons` would drop it silently (#1194).
@@ -7377,6 +7425,74 @@ mod tests {
         let err =
             standard_json_to_jq_value(value, &cursor).expect_err("a bareword is not a JSON value");
         assert!(!err.message.is_empty(), "{err:?}");
+    }
+
+    /// #2211 code review: this function's `Array`/`Object` arms never
+    /// validated *any* delimiter at all -- not even the older #1677
+    /// missing/doubled-comma-between-two-real-children check `print_json`'s
+    /// own array/object arms and `eval_generic::to_owned_cursor_at_depth`
+    /// already perform. `[1 2, 3]` is missing the comma between its first
+    /// two elements (three real elements: `1`, `2`, `3`); `{"a" 1, "b": 2}`
+    /// is missing the colon after its first key.
+    ///
+    /// No CLI-level regression test accompanies either half of this, same
+    /// reasoning as this function's other unit-tested-only fixes above
+    /// (see e.g. `test_standard_json_to_jq_value_raises_on_malformed_top_
+    /// level_value_1194`'s own doc comment): whenever this function's
+    /// output is actually printed, `print_json`'s own independent,
+    /// pre-existing #1643/#1676 checks re-validate the same document
+    /// (confirmed live against the pre-fix binary via `git stash`) and mask
+    /// this function's own gap end-to-end -- calling this function
+    /// directly is the only way to exercise its own validation in
+    /// isolation.
+    #[test]
+    fn test_standard_json_to_jq_value_raises_on_missing_delimiter_between_array_elements_2211() {
+        let json: &[u8] = b"[1 2, 3]";
+        let index = JsonIndex::build(json);
+        let cursor = index.root(json);
+        let value = cursor.value();
+        let err = standard_json_to_jq_value(value, &cursor)
+            .expect_err("a missing comma between two real elements is not JSON");
+        assert!(
+            err.message.contains("Invalid JSON text"),
+            "message: {}",
+            err.message
+        );
+    }
+
+    #[test]
+    fn test_standard_json_to_jq_value_raises_on_missing_delimiter_in_object_2211() {
+        let json: &[u8] = b"{\"a\" 1, \"b\": 2}";
+        let index = JsonIndex::build(json);
+        let cursor = index.root(json);
+        let value = cursor.value();
+        let err = standard_json_to_jq_value(value, &cursor)
+            .expect_err("a missing colon after a real key is not JSON");
+        assert!(
+            err.message.contains("Invalid JSON text"),
+            "message: {}",
+            err.message
+        );
+    }
+
+    /// #2211: well-formed multi-element arrays/objects are unaffected by
+    /// the new between-elements delimiter check above --
+    /// `test_standard_json_to_jq_value_succeeds_on_valid_input_1192`'s own
+    /// object case only has two well-formed fields; this exercises a
+    /// three-element well-formed array too, so the `is_first`/subsequent-
+    /// element branches of the new check both get a `true` answer pinned.
+    #[test]
+    fn test_standard_json_to_jq_value_wellformed_array_unaffected_2211() {
+        let json: &[u8] = b"[1, 2, 3]";
+        let index = JsonIndex::build(json);
+        let cursor = index.root(json);
+        let value = cursor.value();
+        let jq_value =
+            standard_json_to_jq_value(value, &cursor).expect("a well-formed array must not raise");
+        let JqValue::Array(items) = jq_value else {
+            panic!("expected an array");
+        };
+        assert_eq!(items.len(), 3);
     }
 
     /// #1194: `MalformedJsonError` exists to be `downcast_ref`'d out of an

--- a/src/bin/succinctly/jq_runner.rs
+++ b/src/bin/succinctly/jq_runner.rs
@@ -7475,6 +7475,25 @@ mod tests {
         );
     }
 
+    /// #2211: the sibling half of the object check above -- a missing comma
+    /// between two real *fields* (rather than a missing colon after one
+    /// key) is caught by the second field's own `key_cursor()` delimiter
+    /// check, not the first field's `value_cursor()` one.
+    #[test]
+    fn test_standard_json_to_jq_value_raises_on_missing_comma_between_object_fields_2211() {
+        let json: &[u8] = b"{\"a\":1 \"b\":2}";
+        let index = JsonIndex::build(json);
+        let cursor = index.root(json);
+        let value = cursor.value();
+        let err = standard_json_to_jq_value(value, &cursor)
+            .expect_err("a missing comma between two real fields is not JSON");
+        assert!(
+            err.message.contains("Invalid JSON text"),
+            "message: {}",
+            err.message
+        );
+    }
+
     /// #2211: well-formed multi-element arrays/objects are unaffected by
     /// the new between-elements delimiter check above --
     /// `test_standard_json_to_jq_value_succeeds_on_valid_input_1192`'s own

--- a/src/jq/document.rs
+++ b/src/jq/document.rs
@@ -240,7 +240,8 @@ pub trait DocumentCursor: Sized + Copy + Clone {
     /// walk yields no children at all, which is exactly the gap
     /// `crate::json::light`'s own `empty_container_gap_ok`/`trailing_gap_ok`
     /// pair closed for the CLI's cursor-native writers (#1676) and this
-    /// closes for [`crate::jq::eval_generic::to_owned_cursor_at_depth`] (and
+    /// closes for `crate::jq::eval_generic::to_owned_cursor_at_depth` (a
+    /// private function, not linkable here) -- and
     /// therefore every `evaluate_bytes_lazy`-reachable filter that isn't one
     /// of that evaluator's natively-matched shapes, e.g. `if`/arithmetic/
     /// function calls) -- the one materializing conversion that still

--- a/src/jq/document.rs
+++ b/src/jq/document.rs
@@ -231,6 +231,36 @@ pub trait DocumentCursor: Sized + Copy + Clone {
         EvalError::new("Invalid document text: malformed delimiter")
     }
 
+    /// Whether an array/object cursor whose child walk produced **zero**
+    /// real children is genuinely empty (`[]`, `{}`) rather than a stray
+    /// `,` with no real child at all (`[,]`, `{,}`) -- #2211.
+    ///
+    /// [`preceding_delimiter_ok`](Self::preceding_delimiter_ok) (#1677) only
+    /// ever runs *against a real child* -- it has nothing to check when the
+    /// walk yields no children at all, which is exactly the gap
+    /// `crate::json::light`'s own `empty_container_gap_ok`/`trailing_gap_ok`
+    /// pair closed for the CLI's cursor-native writers (#1676) and this
+    /// closes for [`crate::jq::eval_generic::to_owned_cursor_at_depth`] (and
+    /// therefore every `evaluate_bytes_lazy`-reachable filter that isn't one
+    /// of that evaluator's natively-matched shapes, e.g. `if`/arithmetic/
+    /// function calls) -- the one materializing conversion that still
+    /// silently accepted `[,]` as `[]` because it held a per-child cursor at
+    /// every point except the empty case, where there is no child cursor to
+    /// hold.
+    ///
+    /// `close_char` is the container's own closing delimiter (`]` for an
+    /// array, `}` for an object); the caller already knows which arm it is
+    /// in, so unlike `empty_container_gap_ok` (whose callers don't) there is
+    /// no need to derive it from the container's own raw span here.
+    ///
+    /// The default answers `true` unconditionally, same reasoning as
+    /// [`preceding_delimiter_ok`](Self::preceding_delimiter_ok): every format
+    /// but JSON validates this while parsing.
+    fn container_gap_ok(&self, close_char: u8) -> bool {
+        let _ = close_char;
+        true
+    }
+
     /// Whether the value immediately following this key (at `key_end`, the
     /// key's own already-known span end) is preceded by exactly one `:`
     /// (#1677) -- the forward-scan twin of

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -391,6 +391,15 @@ fn to_owned_cursor_at_depth<C: DocumentCursor>(
         if f.ends_unpaired() {
             return Err(f.malformed_member_error());
         }
+        // #2211: `key_delimiter_ok`/`value_delimiter_ok` above only ever run
+        // against a real field -- a stray `,` with no real field at all
+        // (`{,}`) leaves the loop never having run, so nothing above catches
+        // it. `map.is_empty()` after the walk is exactly that case (a
+        // genuine `{}` also reaches here, and `container_gap_ok` answers
+        // `true` for it -- see that method's own doc comment).
+        if map.is_empty() && !cursor.container_gap_ok(b'}') {
+            return Err(cursor.malformed_delimiter_error());
+        }
         Ok(OwnedValue::Object(map))
     } else if let Some(elements) = value.as_array() {
         let mut items = Vec::new();
@@ -407,6 +416,11 @@ fn to_owned_cursor_at_depth<C: DocumentCursor>(
             items.push(to_owned_cursor_at_depth(&elem_cursor, depth + 1)?);
             elems = rest;
             is_first = false;
+        }
+        // #2211: same reasoning as the object arm's own check just above,
+        // for a stray `,` with no real element (`[,]`).
+        if items.is_empty() && !cursor.container_gap_ok(b']') {
+            return Err(cursor.malformed_delimiter_error());
         }
         Ok(OwnedValue::Array(items))
     } else {

--- a/src/jq/lazy.rs
+++ b/src/jq/lazy.rs
@@ -29,7 +29,8 @@ use crate::json::light::{JsonCursor, StandardJson};
 
 use super::document::{
     effective_len, effective_len_checked, key_delimiter_ok, key_display_string,
-    resolve_display_key, value_delimiter_ok, DisplayKeyGuard, DistinctKeyCursors, DocumentFields,
+    resolve_display_key, value_delimiter_ok, DisplayKeyGuard, DistinctKeyCursors, DocumentCursor,
+    DocumentFields,
 };
 use super::error::EvalError;
 use super::escape::write_json_body_jq;
@@ -847,10 +848,34 @@ fn cursor_to_owned_at_depth<W: Clone + AsRef<[u64]>>(
         ),
         StandardJson::Array(_) => {
             // Use cursor navigation to iterate children
-            let items: Vec<OwnedValue> = cursor
-                .children()
-                .map(|child| cursor_to_owned_at_depth(&child, depth + 1))
-                .collect::<Result<_, _>>()?;
+            let mut items = Vec::new();
+            let mut is_first = true;
+            for child in cursor.children() {
+                // #2211 code review: this walk (unlike its
+                // `eval_generic::to_owned_cursor_at_depth` sibling it
+                // otherwise mirrors) never called `preceding_delimiter_ok`
+                // at all -- not even the missing/doubled-comma-between-two-
+                // real-elements check (#1677), which the `Object` arm below
+                // already had. `{"a" 1, "b": 2} | -e` used to silently
+                // succeed for the array shape (`[1 2, 3]`) the same way this
+                // object shape used to before #1956.
+                if let Some(pos) = child.text_position() {
+                    let expected = if is_first { None } else { Some(b',') };
+                    if !child.preceding_delimiter_ok(pos, expected) {
+                        return Err(child.malformed_delimiter_error());
+                    }
+                }
+                items.push(cursor_to_owned_at_depth(&child, depth + 1)?);
+                is_first = false;
+            }
+            // #2211: a stray `,` with no real element at all (`[,]`) left
+            // the loop above with nothing to check a delimiter against --
+            // `items.is_empty()` after the walk is exactly that case (a
+            // genuine `[]` also reaches here, and `container_gap_ok`
+            // answers `true` for it).
+            if items.is_empty() && !cursor.container_gap_ok(b']') {
+                return Err(cursor.malformed_delimiter_error());
+            }
             OwnedValue::Array(items)
         }
         StandardJson::Object(fields) => {
@@ -893,6 +918,14 @@ fn cursor_to_owned_at_depth<W: Clone + AsRef<[u64]>>(
             }
             if f.ends_unpaired() {
                 return Err(f.malformed_member_error());
+            }
+            // #2211: same reasoning as the array arm's own check just
+            // above, for a stray `,` with no real field at all (`{,}`) --
+            // `key_delimiter_ok`/`value_delimiter_ok` above only ever run
+            // against a real field, so the walk producing zero fields at
+            // all leaves nothing to check.
+            if map.is_empty() && !cursor.container_gap_ok(b'}') {
+                return Err(cursor.malformed_delimiter_error());
             }
             OwnedValue::Object(map)
         }
@@ -1101,6 +1134,107 @@ mod tests {
         // `into_owned` is a separate walk of the same tree; it must agree.
         let val: JqValue<'_, Vec<u64>> = JqValue::from_cursor(index.root(json));
         assert!(val.into_owned().is_err());
+    }
+
+    /// #2211 code review: `cursor_to_owned_at_depth`'s `Array` arm never
+    /// validated *any* element delimiter at all -- unlike its `Object` arm
+    /// neighbor, which already had the #1956/#1677 `key_delimiter_ok`/
+    /// `value_delimiter_ok` check. `[1 2, 3]` is missing the comma between
+    /// its first two (real) elements.
+    ///
+    /// No CLI-level test accompanies this: `-e`/`--exit-status` (the flag
+    /// that forces `.materialize()` at all) still always prints its result
+    /// through `write_output_jq_value`/`print_json` afterward regardless of
+    /// what `.materialize()` found, and `print_json`'s own independent
+    /// #1643/#1676 checks catch this document too -- confirmed live against
+    /// the pre-fix binary (`git stash`) that `succinctly jq -e -c '...'`
+    /// already rejected every one of this test's inputs before this fix,
+    /// via that unrelated, redundant check rather than this function's own
+    /// validation. Calling `materialize`/`into_owned` directly is the only
+    /// way to exercise this function's own gap in isolation.
+    #[test]
+    fn materialize_raises_on_missing_delimiter_between_array_elements_2211() {
+        use crate::json::JsonIndex;
+
+        let json: &[u8] = b"[1 2, 3]";
+        let index = JsonIndex::build(json);
+        let cursor = index.root(json);
+        let val = JqValue::from_cursor(cursor);
+        let err = val
+            .materialize()
+            .expect_err("a missing comma between two real elements is not JSON");
+        assert!(
+            err.message.contains("Invalid JSON text"),
+            "message: {}",
+            err.message
+        );
+
+        let val: JqValue<'_, Vec<u64>> = JqValue::from_cursor(index.root(json));
+        assert!(val.into_owned().is_err(), "into_owned must agree");
+    }
+
+    /// #2211: a stray `,` with no real child at all (`[,]`, `{,}`) left
+    /// both the array loop (which now validates a *real* element's own
+    /// preceding delimiter, added by this same fix) and the pre-existing
+    /// object loop (which validates a real field's own key/value
+    /// delimiters) with nothing to check a delimiter against, since neither
+    /// loop body ever ran -- the same "no real child to check against" gap
+    /// #2211's `eval_generic::to_owned_cursor_at_depth` fix closed via
+    /// `DocumentCursor::container_gap_ok`, needed again here for this
+    /// independent materializer.
+    #[test]
+    fn materialize_raises_on_stray_comma_in_empty_containers_2211() {
+        use crate::json::JsonIndex;
+
+        for json in [b"[,]".as_slice(), b"{,}".as_slice()] {
+            let index = JsonIndex::build(json);
+            let cursor = index.root(json);
+            let val = JqValue::from_cursor(cursor);
+            let err = val
+                .materialize()
+                .expect_err("a stray comma in an apparently-empty container is not JSON");
+            assert!(
+                err.message.contains("Invalid JSON text"),
+                "{json:?}: message: {}",
+                err.message
+            );
+
+            let val: JqValue<'_, Vec<u64>> = JqValue::from_cursor(index.root(json));
+            assert!(val.into_owned().is_err(), "{json:?}: into_owned must agree");
+        }
+    }
+
+    /// #2211: well-formed arrays/objects (including genuinely empty ones,
+    /// which must still materialize as `[]`/`{}` rather than being caught
+    /// by either new check above) are unaffected.
+    #[test]
+    fn materialize_wellformed_containers_unaffected_2211() {
+        use crate::json::JsonIndex;
+
+        for (json, expected) in [
+            (b"[]".as_slice(), OwnedValue::Array(vec![])),
+            (b"{}".as_slice(), OwnedValue::Object(IndexMap::new())),
+            (
+                b"[1,2,3]".as_slice(),
+                OwnedValue::Array(vec![
+                    OwnedValue::from_number_literal("1"),
+                    OwnedValue::from_number_literal("2"),
+                    OwnedValue::from_number_literal("3"),
+                ]),
+            ),
+        ] {
+            let index = JsonIndex::build(json);
+            let cursor = index.root(json);
+            let val = JqValue::from_cursor(cursor);
+            assert_eq!(
+                val.materialize().unwrap(),
+                expected,
+                "{json:?}: materialize"
+            );
+
+            let val: JqValue<'_, Vec<u64>> = JqValue::from_cursor(index.root(json));
+            assert_eq!(val.into_owned().unwrap(), expected, "{json:?}: into_owned");
+        }
     }
 
     /// #1247 used to raise here; #1642 preserves instead, matching

--- a/src/json/light.rs
+++ b/src/json/light.rs
@@ -2134,6 +2134,21 @@ impl<'a, W: AsRef<[u64]> + Clone> DocumentCursor for JsonCursor<'a, W> {
         following_gap_ok(self.text, key_end)
     }
 
+    /// #2211: reuses the same `trailing_gap_ok` primitive this module's own
+    /// `empty_container_gap_ok` free function already runs for
+    /// `stream_json`/`stream_json_pretty`, and `jq_runner.rs`'s copy already
+    /// runs for `print_json` -- one gap-scanning definition, three entry
+    /// points shaped for what each caller already has in hand (this one:
+    /// only the container's own cursor and which bracket closes it, no
+    /// resolved value or raw span required).
+    #[inline]
+    fn container_gap_ok(&self, close_char: u8) -> bool {
+        match self.text_position() {
+            Some(pos) => trailing_gap_ok(self.text, pos + 1, close_char),
+            None => true,
+        }
+    }
+
     #[inline]
     fn line(&self) -> usize {
         JsonCursor::line(self)

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -20824,6 +20824,119 @@ fn test_jq_trailing_comma_after_container_last_child_still_a_known_gap_1676() ->
     Ok(())
 }
 
+/// #2211: `evaluate_bytes_lazy` (the `JqValue`-iterator-based default path
+/// used for a non-cursor-transparent filter -- `if`/arithmetic/function
+/// calls/anything `expr_is_cursor_transparent` answers `false` for) never
+/// checked a container's own "apparently empty" delimiter gap at all, unlike
+/// `print_json`'s identical check (#1676) that the cursor-transparent `.`
+/// path above already exercises. `eval_generic::to_owned_cursor_at_depth`'s
+/// array/object loops only ever validate the delimiter *preceding a real
+/// child* (#1677's `preceding_delimiter_ok`/`key_delimiter_ok`/
+/// `value_delimiter_ok` family) -- when the walk produces zero real
+/// children at all, nothing ran that check, so `[,]`/`{,}` (bare, or nested
+/// inside an otherwise well-formed document) silently "healed" into
+/// `[]`/`{}` at exit 0. `if true then . else . end` forces the lazy path
+/// (see `test_lazyseq_map_halt_propagates_through_default_lazy_path`'s own
+/// comment for why plain `.` doesn't); this is the issue's own repro
+/// (`{"a": [,]}`) plus every sibling shape from that shape's own family.
+/// Verified against `/usr/bin/jq` 1.7.1, which rejects every one of these
+/// at exit 5, matching the cursor-transparent path's own #1676 fix.
+#[test]
+fn test_jq_lazy_path_rejects_stray_comma_in_empty_container_2211() -> Result<()> {
+    for input in [
+        // The issue's own exact repro: a nested empty array.
+        r#"{"a": [,]}"#,
+        // Bare, top-level empty containers with a stray comma.
+        "[,]",
+        "{,}",
+        "{  ,  }",
+        "[  ,  ]",
+        // Nested empty object, and nested one level deeper than the
+        // issue's own repro.
+        r#"{"a": {,}}"#,
+        r#"{"a": {"b": [,]}}"#,
+        "[[,]]",
+        "[{,}]",
+    ] {
+        let (out, stderr, code) = run_jq_full(&["-c", "if true then . else . end"], Some(input))?;
+        assert_eq!(code, 5, "{input}: out: {out:?}, stderr: {stderr:?}");
+        assert!(out.trim().is_empty(), "{input}: unexpected output {out:?}");
+        assert!(
+            stderr.contains("Invalid JSON text"),
+            "{input}: stderr: {stderr:?}"
+        );
+    }
+
+    Ok(())
+}
+
+/// #2211: a non-empty container with a genuinely malformed comma (a stray
+/// comma *between* two real children, or a leading comma before the first
+/// real key/element) was already correctly rejected on the lazy path before
+/// this fix -- only the *apparently empty* case above was the gap. Pins
+/// that this fix didn't change (or need to change) this already-correct
+/// behavior.
+#[test]
+fn test_jq_lazy_path_already_rejected_nonempty_stray_comma_2211() -> Result<()> {
+    for input in [r#"{"a":[1,,2]}"#, r#"{,"a":1}"#] {
+        let (out, stderr, code) = run_jq_full(&["-c", "if true then . else . end"], Some(input))?;
+        assert_eq!(code, 5, "{input}: out: {out:?}, stderr: {stderr:?}");
+        assert!(out.trim().is_empty(), "{input}: unexpected output {out:?}");
+        assert!(
+            stderr.contains("Invalid JSON text"),
+            "{input}: stderr: {stderr:?}"
+        );
+    }
+
+    Ok(())
+}
+
+/// #2211: well-formed documents -- including genuinely empty containers,
+/// which must still print as `[]`/`{}` rather than being caught by the new
+/// check -- are unaffected on the lazy path, matching the cursor-transparent
+/// path's own equivalent (`test_jq_wellformed_documents_unaffected_by_1677`)
+/// and real jq.
+#[test]
+fn test_jq_lazy_path_wellformed_empty_containers_unaffected_2211() -> Result<()> {
+    for (input, expected) in [
+        ("{}", "{}"),
+        ("[]", "[]"),
+        (r#"{"a":[]}"#, r#"{"a":[]}"#),
+        (r#"{"a":{}}"#, r#"{"a":{}}"#),
+        ("[[],{},[1,2],{\"x\":1}]", "[[],{},[1,2],{\"x\":1}]"),
+        (r#"{"a":1,"b":[1,2,3]}"#, r#"{"a":1,"b":[1,2,3]}"#),
+    ] {
+        let (out, stderr, code) = run_jq_full(&["-c", "if true then . else . end"], Some(input))?;
+        assert_eq!(code, 0, "{input}: stderr: {stderr:?}");
+        assert_eq!(out.trim(), expected, "{input}");
+    }
+
+    Ok(())
+}
+
+/// #2211 follow-up (filed as #2243), pinned here as a known, still-open gap
+/// rather than left silently uncovered: a trailing comma after a *real*
+/// scalar last child (`[1,]`, `{"a":1,}`) is a related but distinct shape
+/// from the apparently-empty-container case this issue fixed -- catching it
+/// needs the last real child's own text-end position, which
+/// `to_owned_cursor_at_depth`'s array/object loops don't track at all (the
+/// #2211 fix only needed the container's own opening-delimiter position,
+/// correct for the empty case but not this one). The cursor-transparent `.`
+/// path already gets this right via `print_json`'s `scalar_end_pos`/
+/// `trailing_gap_ok` pair (#1676); the lazy path does not yet share it. A
+/// future fix for #2243 should update this test rather than leave it
+/// silently passing on the wrong behavior.
+#[test]
+fn test_jq_lazy_path_trailing_comma_after_scalar_last_child_still_a_known_gap_2243() -> Result<()> {
+    for (input, expected) in [(r"[1,]", "[1]"), (r#"{"a":1,}"#, r#"{"a":1}"#)] {
+        let (out, stderr, code) = run_jq_full(&["-c", "if true then . else . end"], Some(input))?;
+        assert_eq!(code, 0, "{input}: stderr: {stderr:?}");
+        assert_eq!(out.trim(), expected, "{input}");
+    }
+
+    Ok(())
+}
+
 /// #1643 follow-up: `-S`/`-C`/`--slurp` bypass `print_json` entirely --
 /// they materialize via `parse_json_stream`'s fallback (which backs the
 /// "original" input path `-S`/`-C`/`--slurp` force), reaching


### PR DESCRIPTION
## Summary

Fixes #2211: `evaluate_bytes_lazy` (the `JqValue`-iterator-based path used for a
non-cursor-transparent expression) did not detect a stray comma in a nested empty
container at all, where every other reading path in this CLI correctly rejects it:

```console
$ printf '{"a": [,]}' > /tmp/t.json
$ succinctly jq -c 'if true then . else . end' /tmp/t.json    # pre-fix
{"a":[]}
$ echo $?
0
```

## Root cause and fix

`eval_single`'s fallback `_` arm (`src/jq/eval_generic.rs`) materializes via
`to_owned_cursor_at_depth`. Its array/object loops only validate the delimiter
*preceding a real child*; when the walk yields zero real children (a stray comma with
nothing behind it), none of those checks ever ran. Fixed by a new
`DocumentCursor::container_gap_ok(&self, close_char: u8) -> bool` trait method
(`src/jq/document.rs`, default `true`), a JSON-specific override in `src/json/light.rs`
reusing the existing private `trailing_gap_ok` primitive (already shared by
`stream_json`/`stream_json_pretty` and `jq_runner.rs`'s `print_json`), and a call site in
`to_owned_cursor_at_depth`'s array/object arms.

## Two sibling materializer gaps found and fixed in the same pass (code review)

Code review found the identical bug class in two more places:

- **`cursor_to_owned_at_depth`** (`src/jq/lazy.rs`, backs `JqValue::materialize()`/
  `.into_owned()`, reached via `-e`/`--exit-status`): its `Array` arm had **zero**
  delimiter validation at all — not even the older #1677 check its own `Object` arm
  already had. Fixed with the same per-element `preceding_delimiter_ok` check plus
  `container_gap_ok` for the empty-container case, on both arms.
- **`standard_json_to_jq_value`** (`src/bin/succinctly/jq_runner.rs`): both `Array` and
  `Object` arms validated nothing. Fixed with a per-child delimiter check (reusing the
  same `preceding_gap_ok`/`check_preceding_delimiter` this file already uses elsewhere).
  Deliberately **not** given a container-level empty check: this function's only caller
  (`GenericResult::One`/`Many`) doesn't reliably have this specific node's own cursor
  position available (see in-code doc comment) — adding one against the wrong reference
  cursor would risk false positives on well-formed input, so this is a documented,
  safety-driven scope limit rather than an oversight.

Neither of these two gaps was reachable as a live CLI differential today — both are
masked end-to-end because whatever either function converts is always re-printed via
`write_output_jq_value`/`print_json` immediately afterward, and `print_json`'s own
independent #1643/#1676 checks re-validate the same document on the way out. Confirmed by
reverting each fix in isolation: every CLI-level repro still exited 5 correctly (via the
masking layer), but the corresponding new *unit* test (calling `materialize()`/
`standard_json_to_jq_value` directly, bypassing `print_json`) failed — proving each test
exercises the function's own validation, not the masking. Fixed anyway as a defense
against a future `print_json` refactor silently reintroducing the bug with nothing left
to catch it, and because a reader shouldn't have to know about this masking to trust that
`-e` genuinely validates its own input.

## Verification (independently re-run twice, not just taken on the implementer's word)

- Fully clean rebuild (`cargo clean` + from-scratch `cargo build --release --features
  cli`) before every round of testing, given a prior round in this session left a stale,
  debug-instrumented binary that a clean `git diff` didn't catch.
- Re-confirmed the original bug and the `-e`/`--exit-status` path live, on the fresh
  build: both now error cleanly, matching `/usr/bin/jq` 1.7.1 (exit 5).
- Spot-checked sibling malformed shapes (bare top-level `[,]`, `{,"a":1}`, doubly-nested,
  missing-comma-between-real-elements) — all now correctly rejected, matching the oracle.
- Full test suite: 57/57 test binaries, 0 failures.
- `cargo clippy --all-targets --all-features -- -D warnings` and `cargo fmt --check`: clean.
- Patch coverage: 95.86% (139/145 new lines) — remaining uncovered lines are defensive
  `None`-branch fallbacks matching this trait family's own accepted convention
  (`container_gap_ok`'s own `None => true` arm), spot-checked directly.
- yq mode unaffected (YAML's default `container_gap_ok` is a no-op) — confirmed via the
  full yq test suite passing unchanged.

**A distinct, related gap found and filed separately, not fixed here**: a trailing comma
after a *real* scalar last child (`[1,]`, `{"a":1,}`) is still silently accepted on
`evaluate_bytes_lazy` — needs the last child's own text-end position rather than the
container's opening position, a different mechanism than this fix. Filed as #2243.

Fixes #2211
