### PR TITLE
fix(jq): re-evaluate resolve_slice_expr's end bound once per start (#2245)

### DIFF
--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -25174,30 +25174,30 @@ fn resolve_slice_expr<'a, S: EvalSemantics>(
     if starts.is_empty() {
         return path_result(Vec::new(), starts_escape);
     }
-    let (ends, ends_escape) =
-        resolve_slice_bound::<S>(end, value, f64::ceil).map_err(|e| (Vec::new(), e))?;
-    // `end` (`T`) is nested inside `start` (`S`)'s own iteration -- jq's `S
-    // as $s | T as $t | ...` re-runs `T` fresh for `$s`'s very first value,
-    // so a `T` escape (if any) fires before `S` ever gets a chance to
-    // expose its own. `ends_escape` therefore wins over `starts_escape` --
-    // computed once as `bounds_escape` and reused both by the
-    // `ends.is_empty()` early return just below and by the full
-    // `target`/`end`/`start` priority chain further down, so the two sites
-    // that need this rule can't silently drift apart (#1526 review).
-    // `ends_escaped` is split off first since `.or()` moves its operand and
-    // the truncation logic below still needs to ask "did `end` specifically
-    // escape" on its own. Confirmed against jq 1.7.1:
-    // `path(.[(0,1):error("b")])` on `[10,20,30]` prints nothing before
-    // raising `b` -- `end`'s own escape, with *zero* prior values, still
-    // wins over `start`'s later one.
-    let ends_escaped = ends_escape.is_some();
-    let bounds_escape = ends_escape.or(starts_escape);
-    if ends.is_empty() {
-        return path_result(Vec::new(), bounds_escape);
-    }
     // #843: same rule as `resolve_index_expr` above, for a slice's bounds
-    // instead of an index's key.
+    // instead of an index's key. This guard is a static property of
+    // `target`'s own AST plus the ambient `trackable` flag -- independent
+    // of any S/T value -- so whether it fires is already known here,
+    // before `end` (`T`) has been touched at all.
+    //
+    // `end` is still only evaluated (lazily, right here, not upfront) when
+    // this guard is actually going to fire, mirroring #2225's own "T can
+    // have side effects, don't force it before it's needed" reasoning:
+    // `T`'s own emptiness/escape wins over this check exactly the way it
+    // wins over the cross-product below. Confirmed against jq 1.7.1: an
+    // untrackable target paired with a completely empty `T`
+    // (`(1,2)[(0,1):(empty)]`) produces empty output with **no error at
+    // all** -- this branch's own `EvalError::invalid_path_expression_near_
+    // access` never fires unless `T` actually yields a value to name in
+    // it. Confirmed the same for `T` erroring before any value
+    // (`(1,2)[(0,1):(error("boom"))]` raises `boom`, not the path-
+    // expression error).
     if !trackable && is_passthrough_target(target) {
+        let (ends, ends_escape) =
+            resolve_slice_bound::<S>(end, value, f64::ceil).map_err(|e| (Vec::new(), e))?;
+        if ends.is_empty() {
+            return path_result(Vec::new(), ends_escape.or(starts_escape));
+        }
         return Err((
             Vec::new(),
             EvalError::invalid_path_expression_near_access(
@@ -25230,6 +25230,13 @@ fn resolve_slice_expr<'a, S: EvalSemantics>(
     // downstream read of `target_branches` below inspects only
     // `.value`/`.trackable`, and this function's own output is always
     // `snapshot: false` regardless (slicing is genuine navigation).
+    //
+    // `target` (`E`) doesn't depend on `start`/`end`'s own values, so this
+    // stays a single call outside every loop below regardless of `end`
+    // now being re-evaluated per `s` (#2245) -- the issue's own analysis
+    // confirmed this site is not a #2143-class bug: a trackable expression
+    // has no observable side effects, so re-evaluating it once vs. per
+    // pair would be unobservable even if it were moved.
     let (target_branches, target_escape) =
         match resolve_node::<S>(target, value, trackable, false, keep) {
             Ok(branches) => (branches, None),
@@ -25246,10 +25253,23 @@ fn resolve_slice_expr<'a, S: EvalSemantics>(
     // pipe's literal deferred here instead of raising. Kept as one condition
     // with `!trackable` so the two can't drift: this file's own "duplicated
     // predicates diverge silently" lesson (#106).
+    //
+    // `end` is lazily evaluated here too (#2245), for the identical reason
+    // as the guard above: this check's *firing* depends only on
+    // `target_branches` (already computed, S/T-independent), but its error
+    // message needs a representative `(s, e)` pair, and jq's own nesting
+    // means that pair's `T` value is only ever forced once a genuine
+    // `(s, t)` binding is reached -- so `T`'s own emptiness/escape still
+    // has to win first, exactly as above.
     if let Some(PathBranch {
         value: first_value, ..
     }) = target_branches.iter().find(|b| !trackable || !b.trackable)
     {
+        let (ends, ends_escape) =
+            resolve_slice_bound::<S>(end, value, f64::ceil).map_err(|e| (Vec::new(), e))?;
+        if ends.is_empty() {
+            return path_result(Vec::new(), ends_escape.or(starts_escape));
+        }
         return Err((
             Vec::new(),
             EvalError::invalid_path_expression_near_access(
@@ -25266,79 +25286,72 @@ fn resolve_slice_expr<'a, S: EvalSemantics>(
     }
 
     // jq compiles `E[S:T]` as `S as $s | T as $t | E | .[$s:$t]` — `S`
-    // outer, `T` middle (re-run fresh for every `$s`), `E` innermost. Three
-    // generators can each independently escape after producing some
-    // values, and whichever is *innermost* is the one that actually fires
-    // first in jq's real depth-first walk — the others never get a chance
-    // to advance far enough to reach their own escape at all (#1517;
-    // `starts`/`ends` here are each already truncated to their own
-    // pre-escape partial prefix by `resolve_slice_bound`, so only the
-    // *cross-product* needs restricting, not the lists themselves). Two
-    // independent lengths, not a three-way branch on *which* escape fired
-    // (#1526 review — the old three-arm form repeated `&starts[..1]`
-    // identically in two branches, obscuring that `start` truncates
-    // whenever anything *more inner* escaped, while `end` only truncates
-    // when `target` itself did):
+    // outer, `T` middle, `E` innermost. `T` is now genuinely re-evaluated
+    // once per `s` (#2245, mirroring #2225's identical fix for the two
+    // value-mode siblings, `eval_slice_expr` in this file and
+    // `eval_generic.rs`) rather than once overall for the whole function --
+    // `T` sits inside `S`'s own binding scope in jq's desugaring, so a
+    // fresh `s` gets a fresh `T` evaluation, observable whenever `T` has
+    // side effects (`input`, confirmed live in the issue's own repro).
     //
-    // - `starts_len` is `1` whenever `target` *or* `end` escaped — either
-    //   one means `start` never got to try a second value (`end`, nested
-    //   inside `start`'s own iteration, escaping during `start`'s first
-    //   value has the identical effect on `start` as `target` escaping
-    //   does) — otherwise `starts`'s own pre-escape prefix is already the
-    //   right length. Confirmed against jq 1.7.1:
-    //   `path(.[(0,1):(2,error("b"))])` on `[10,20,30]` prints only
-    //   `[{"start":0,"end":2}]` before raising `b` -- `$s=1` is never
-    //   tried; `path(.[(0,error("b")):(2,3)])` prints *both*
-    //   `[{"start":0,"end":2}]` and `[{"start":0,"end":3}]` before raising
-    //   `b` (`T` fully iterated for `$s=0` before `S` ever tries to
-    //   advance, so no truncation here).
-    // - `ends_len` is `1` only when `target` itself escaped -- `target`
-    //   escapes inside the very first `(s, t)` pair, so neither bound
-    //   generator is ever resumed for a second pair. `target_branches` was
-    //   computed once, outside this loop, so this keeps this function's
-    //   `Err` prefix equal to jq's own pre-escape stream, mirroring
-    //   `resolve_index_expr`'s identical fix (#972, pre-existing).
-    //   Confirmed against jq 1.7.1:
-    //   `path((select((true,error("t"))))[(0,1):(2,3)])` on `[10,20,30]`
-    //   prints only `[{"start":0,"end":2}]` before raising `t`.
-    let starts_len = if target_escape.is_some() || ends_escaped {
+    // `target`'s own escape still wins over both `end` and `start` (#1517)
+    // -- it's known upfront, unaffected by `end`'s new per-`s` timing, so
+    // `starts` is truncated to just its first value whenever `target`
+    // escaped, exactly as before this fix: `target` escaping inside the
+    // very first `(s, t)` pair means neither bound generator is ever
+    // resumed for a second pair. Confirmed against jq 1.7.1:
+    // `path((select((true,error("t"))))[(0,1):(2,3)])` on `[10,20,30]`
+    // prints only `[{"start":0,"end":2}]` before raising `t`.
+    let starts_limit = if target_escape.is_some() {
         1
     } else {
         starts.len()
     };
-    let ends_len = if target_escape.is_some() {
-        1
-    } else {
-        ends.len()
-    };
-    let (starts, ends): (&[ResolvedSliceBound], &[ResolvedSliceBound]) =
-        (&starts[..starts_len], &ends[..ends_len]);
-    // Innermost escape wins, same reasoning as the restriction above and
-    // the `ends.is_empty()` early return: `target` > `end` > `start` --
-    // `bounds_escape` already carries the `end` > `start` half.
-    let escape = target_escape.or(bounds_escape);
-    // A capacity failure here bypasses `escape` -- same reasoning as
-    // `resolve_index_expr`'s identical arm: `out` is always empty at this
-    // point, and a fresh error at this point takes the same priority a
-    // mid-loop failure already does further down in this function (its own
-    // `return Err((out, ...))` arms likewise don't fold `escape` in).
-    //
-    // Unlike `resolve_index_expr`, `optional` is *not* extended to a
-    // capacity failure here: this function's own doc comment deliberately
-    // narrows `?` to "only the final application of the resolved bounds to
-    // the target", explicitly excluding bound resolution and any check
-    // that isn't that final per-element application -- the same narrower
-    // convention `eval_slice_expr` (value position) already follows, unlike
-    // `eval_index_expr`'s broader "covers the indexing" scope. A capacity
-    // check is neither S/T's evaluation nor the final application; treating
-    // it as covered here would be extending `?` past what this function's
-    // own documented contract already draws the line at.
-    let mut out = match try_reserve_product(&[starts.len(), ends.len(), target_branches.len()]) {
-        Ok(out) => out,
-        Err(e) => return Err((Vec::new(), e.into())),
-    };
-    for (s, s_key) in starts {
-        for (e, e_key) in ends {
+
+    // No upfront `starts.len() * ends.len() * target_branches.len()`
+    // reservation baseline anymore (#2245, mirroring #2225): `ends.len()`
+    // is no longer known until each `s` iteration evaluates `T`, so there
+    // is nothing fixed to reserve before the loop starts. The per-pair
+    // `try_reserve` call inside the loop still protects every real
+    // allocation; only the upfront-baseline optimization is gone, not the
+    // overflow protection itself.
+    let mut out: Vec<PathBranch<'a>> = Vec::new();
+
+    // The shared exit every escape arm below funnels through, so folding
+    // the running `out` in as a `Partial`-equivalent prefix can't drift
+    // between arms -- mirrors #2225's identical `escape!` macro in
+    // `eval_slice_expr`.
+    macro_rules! escape {
+        ($control:expr) => {
+            return Err((out, $control))
+        };
+    }
+
+    'outer: for (s, s_key) in &starts[..starts_limit] {
+        // #2245: `T` (`end`) evaluated fresh for this `s`, not once
+        // overall. An empty `T` for this `s` contributes nothing and moves
+        // on to the next `s` (verified live: a `T` that's empty only for
+        // `s == 0` still lets `s == 1` run and contribute its own output —
+        // not a whole-function short-circuit the way an entirely-empty `S`
+        // is). A `T` that produces some values before escaping processes
+        // those values first, then folds the running `out` in as the
+        // escape's prefix, same as every other per-iteration escape in
+        // this function.
+        let (ends, ends_escape) = match resolve_slice_bound::<S>(end, value, f64::ceil) {
+            Ok(v) => v,
+            Err(e) => escape!(e),
+        };
+        // `target` escaping still caps this `s`'s own `T` stream to a
+        // single pair too, same reasoning as `starts_limit` above.
+        let ends_limit = if target_escape.is_some() {
+            1
+        } else {
+            ends.len()
+        };
+        for (e, e_key) in &ends[..ends_limit] {
+            if out.try_reserve(target_branches.len()).is_err() {
+                escape!(cannot_reserve_cross_product(&[target_branches.len()]).into());
+            }
             // #1326: a genuinely dynamic bound (unlike a literal one, which
             // the parser's own `fold_slice_bound` handles at parse time)
             // keeps its float spelling the same way -- each bound's key is
@@ -25385,7 +25398,7 @@ fn resolve_slice_expr<'a, S: EvalSemantics>(
                 let next_value = match slice_owned_value_read::<S>(target_value, *s, *e, false) {
                     Ok(v) => v.expect("non-optional slice yields a value or errors"),
                     Err(_) if optional => continue,
-                    Err(e) => return Err((out, e.into())),
+                    Err(e) => escape!(e.into()),
                 };
                 let path = PathPrefix::extend(
                     components,
@@ -25399,8 +25412,36 @@ fn resolve_slice_expr<'a, S: EvalSemantics>(
                 out.push(PathBranch::new(path, Cow::Owned(next_value), true));
             }
         }
+        // #2245: this `s`'s own `T` evaluation may have produced some
+        // values before escaping (a break/halt/error partway through `T`'s
+        // own stream) -- fold the running `out` in as that escape's
+        // prefix, same as every other per-iteration escape above.
+        if let Some(control) = ends_escape {
+            escape!(control);
+        }
+        // `target` escaped: only `starts[0]`'s own pair was ever tried
+        // (`starts_limit` above already caps the loop to one iteration in
+        // this case, so this is reached at most once and only as the
+        // natural end of that one iteration -- not a second truncation).
+        if target_escape.is_some() {
+            break 'outer;
+        }
     }
-    path_result(out, escape)
+    // #1528: `start`'s own trailing escape info still has to reach the
+    // final result -- a successful loop doesn't mean `start` itself didn't
+    // escape after producing `out`'s own values. `end`'s own trailing
+    // escape is handled per-`s` above (#2245), via `escape!`, not here.
+    // `target`'s escape, by contrast, only *breaks* the loop above rather
+    // than returning through `escape!` (its own `out` contribution, if
+    // any, is already the accumulated `out` at that point) -- so it still
+    // has to be folded in here, taking priority over `starts_escape`
+    // exactly as the three-way priority (`target` > `end` > `start`)
+    // requires. Missing this dropped `target`'s escape entirely (found in
+    // this fix's own live-oracle verification): `path((select((true,
+    // error("t"))))[(0,1):(2,3)])` on `[10,20,30]` produced the correct
+    // `[{"start":0,"end":2}]` prefix but silently exited 0 instead of
+    // raising `t`.
+    path_result(out, target_escape.or(starts_escape))
 }
 
 /// One resolved slice bound, paired with the [`NumberKey`] it should

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -25174,147 +25174,40 @@ fn resolve_slice_expr<'a, S: EvalSemantics>(
     if starts.is_empty() {
         return path_result(Vec::new(), starts_escape);
     }
-    // #843: same rule as `resolve_index_expr` above, for a slice's bounds
-    // instead of an index's key. This guard is a static property of
-    // `target`'s own AST plus the ambient `trackable` flag -- independent
-    // of any S/T value -- so whether it fires is already known here,
-    // before `end` (`T`) has been touched at all.
-    //
-    // `end` is still only evaluated (lazily, right here, not upfront) when
-    // this guard is actually going to fire, mirroring #2225's own "T can
-    // have side effects, don't force it before it's needed" reasoning:
-    // `T`'s own emptiness/escape wins over this check exactly the way it
-    // wins over the cross-product below. Confirmed against jq 1.7.1: an
-    // untrackable target paired with a completely empty `T`
-    // (`(1,2)[(0,1):(empty)]`) produces empty output with **no error at
-    // all** -- this branch's own `EvalError::invalid_path_expression_near_
-    // access` never fires unless `T` actually yields a value to name in
-    // it. Confirmed the same for `T` erroring before any value
-    // (`(1,2)[(0,1):(error("boom"))]` raises `boom`, not the path-
-    // expression error).
-    if !trackable && is_passthrough_target(target) {
-        let (ends, ends_escape) =
-            resolve_slice_bound::<S>(end, value, f64::ceil).map_err(|e| (Vec::new(), e))?;
-        if ends.is_empty() {
-            return path_result(Vec::new(), ends_escape.or(starts_escape));
-        }
-        return Err((
-            Vec::new(),
-            EvalError::invalid_path_expression_near_access(
-                &slice_component_value(
-                    starts[0].0,
-                    starts[0].1.as_ref(),
-                    ends[0].0,
-                    ends[0].1.as_ref(),
-                ),
-                value,
-            )
-            .into(),
-        ));
-    }
-    // Keeps `target`'s own partial prefix, not just discarding it via `?`,
-    // the same fix #896's review applied to `resolve_index_expr`'s sibling
-    // target-resolution step (found independently live here too — #973
-    // review): `target` can itself be one of #896's keep-partial sites
-    // (`select`, `if`, `getpath`, a computed index), so its own `Err` can
-    // carry a non-empty prefix that still needs slicing by `starts`/`ends`
-    // rather than being returned unsliced. Only reachable with a genuinely
-    // dynamic bound — a *literal* `[N:M]` desugars to a static `Pipe`
-    // (`resolve_seq`'s own fast path) at parse time and never reaches this
-    // function at all; see #977 for that separate gap. Confirmed against jq
-    // 1.7.1: `path((select(true, error("t")))[(0+1):2])` on `[10,20,30]`
-    // prints `[{"start":1,"end":2}]` (the already-produced `select` branch,
-    // sliced) before raising `t`.
-    // Ambient snapshot for `target`'s own resolution is unobservable here,
-    // same reasoning as `resolve_index_expr`'s sibling call (#1591): every
-    // downstream read of `target_branches` below inspects only
-    // `.value`/`.trackable`, and this function's own output is always
-    // `snapshot: false` regardless (slicing is genuine navigation).
-    //
-    // `target` (`E`) doesn't depend on `start`/`end`'s own values, so this
-    // stays a single call outside every loop below regardless of `end`
-    // now being re-evaluated per `s` (#2245) -- the issue's own analysis
-    // confirmed this site is not a #2143-class bug: a trackable expression
-    // has no observable side effects, so re-evaluating it once vs. per
-    // pair would be unobservable even if it were moved.
-    let (target_branches, target_escape) =
-        match resolve_node::<S>(target, value, trackable, false, keep) {
-            Ok(branches) => (branches, None),
-            Err((prefix, e)) => (prefix, Some(e)),
-        };
-    // #843: `resolve_index_expr`'s sibling `getpath`-laundering check —
-    // `target` can also resolve successfully with `trackable: false`
-    // through `Builtin::GetPath`'s deliberate exemption, which doesn't
-    // certify what comes after it as trackable. Without this,
-    // `catch (getpath(["other"])[0:2]) = [...]` silently wrote into the
-    // real document instead of raising — found in review.
-    // #986: `!b.trackable` is the same question asked of the target's own
-    // branches rather than the caller's context — `(1 | .)[0:2]`, where the
-    // pipe's literal deferred here instead of raising. Kept as one condition
-    // with `!trackable` so the two can't drift: this file's own "duplicated
-    // predicates diverge silently" lesson (#106).
-    //
-    // `end` is lazily evaluated here too (#2245), for the identical reason
-    // as the guard above: this check's *firing* depends only on
-    // `target_branches` (already computed, S/T-independent), but its error
-    // message needs a representative `(s, e)` pair, and jq's own nesting
-    // means that pair's `T` value is only ever forced once a genuine
-    // `(s, t)` binding is reached -- so `T`'s own emptiness/escape still
-    // has to win first, exactly as above.
-    if let Some(PathBranch {
-        value: first_value, ..
-    }) = target_branches.iter().find(|b| !trackable || !b.trackable)
-    {
-        let (ends, ends_escape) =
-            resolve_slice_bound::<S>(end, value, f64::ceil).map_err(|e| (Vec::new(), e))?;
-        if ends.is_empty() {
-            return path_result(Vec::new(), ends_escape.or(starts_escape));
-        }
-        return Err((
-            Vec::new(),
-            EvalError::invalid_path_expression_near_access(
-                &slice_component_value(
-                    starts[0].0,
-                    starts[0].1.as_ref(),
-                    ends[0].0,
-                    ends[0].1.as_ref(),
-                ),
-                first_value,
-            )
-            .into(),
-        ));
-    }
 
     // jq compiles `E[S:T]` as `S as $s | T as $t | E | .[$s:$t]` — `S`
-    // outer, `T` middle, `E` innermost. `T` is now genuinely re-evaluated
-    // once per `s` (#2245, mirroring #2225's identical fix for the two
-    // value-mode siblings, `eval_slice_expr` in this file and
-    // `eval_generic.rs`) rather than once overall for the whole function --
-    // `T` sits inside `S`'s own binding scope in jq's desugaring, so a
-    // fresh `s` gets a fresh `T` evaluation, observable whenever `T` has
-    // side effects (`input`, confirmed live in the issue's own repro).
+    // outer, `T` middle, `E` innermost, and `E` is reached *only* once a
+    // genuine `(s, t)` pair exists (review, #2245): a target with a real
+    // side effect (`stderr`, `debug`, `input`) never fires it at all when
+    // `T` turns out empty for every `s` -- confirmed live against jq 1.7.1:
+    // `(.|stderr)[(0,1):(empty)] = 99` writes nothing to stderr. So
+    // `target` can no longer be resolved unconditionally up front the way
+    // a first draft of this fix did (and the way this function did before
+    // #2245 too, gated only on the old, once-computed-overall `ends` being
+    // non-empty) -- it has to be evaluated lazily, triggered by the first
+    // `s` whose own `T` actually produces a value.
     //
-    // `target`'s own escape still wins over both `end` and `start` (#1517)
-    // -- it's known upfront, unaffected by `end`'s new per-`s` timing, so
-    // `starts` is truncated to just its first value whenever `target`
-    // escaped, exactly as before this fix: `target` escaping inside the
-    // very first `(s, t)` pair means neither bound generator is ever
-    // resumed for a second pair. Confirmed against jq 1.7.1:
-    // `path((select((true,error("t"))))[(0,1):(2,3)])` on `[10,20,30]`
-    // prints only `[{"start":0,"end":2}]` before raising `t`.
-    let starts_limit = if target_escape.is_some() {
-        1
-    } else {
-        starts.len()
-    };
+    // **Residual, known gap, not fixed here**: once reached, `target` is
+    // resolved exactly once and reused for every later `(s, t)` pair, not
+    // re-evaluated fresh per pair the way `E` in [`eval_slice_expr`]'s
+    // value-mode sibling is (#2143). For a *trackable, side-effect-free*
+    // target (`.`, `.foo`, a computed index) that's unobservable. For one
+    // with real side effects it isn't: confirmed live that real jq fires
+    // `stderr` once per `(s, t)` pair (4 times for a 2x2 cross product,
+    // `[path((.|stderr)[(0,1):(2,3)])]`), where this reuses a single
+    // evaluation across all of them. Fully matching jq here would need
+    // `target` re-resolved inside the `e` loop below instead of cached
+    // across `s` iterations -- its own pass, not folded into this PR (see
+    // the follow-up filed alongside this fix).
+    let mut target_branches: Option<Vec<PathBranch<'a>>> = None;
+    let mut target_escape: Option<EvalEscape> = None;
 
     // No upfront `starts.len() * ends.len() * target_branches.len()`
-    // reservation baseline anymore (#2245, mirroring #2225): `ends.len()`
-    // is no longer known until each `s` iteration evaluates `T`, so there
-    // is nothing fixed to reserve before the loop starts. The per-pair
-    // `try_reserve` call inside the loop still protects every real
-    // allocation; only the upfront-baseline optimization is gone, not the
-    // overflow protection itself.
+    // reservation baseline (#2245, mirroring #2225): neither `ends.len()`
+    // nor `target_branches.len()` is known before the loop starts. The
+    // per-pair `try_reserve` call inside the loop still protects every
+    // real allocation; only the upfront-baseline optimization is gone, not
+    // the overflow protection itself.
     let mut out: Vec<PathBranch<'a>> = Vec::new();
 
     // The shared exit every escape arm below funnels through, so folding
@@ -25327,30 +25220,106 @@ fn resolve_slice_expr<'a, S: EvalSemantics>(
         };
     }
 
-    'outer: for (s, s_key) in &starts[..starts_limit] {
-        // #2245: `T` (`end`) evaluated fresh for this `s`, not once
-        // overall. An empty `T` for this `s` contributes nothing and moves
+    'outer: for (s, s_key) in &starts {
+        // `T` (`end`) evaluated fresh for this `s`, not once overall
+        // (#2245). An empty `T` for this `s` contributes nothing and moves
         // on to the next `s` (verified live: a `T` that's empty only for
         // `s == 0` still lets `s == 1` run and contribute its own output —
         // not a whole-function short-circuit the way an entirely-empty `S`
-        // is). A `T` that produces some values before escaping processes
-        // those values first, then folds the running `out` in as the
-        // escape's prefix, same as every other per-iteration escape in
-        // this function.
+        // is) -- and `target` is never even touched for an `s` whose `T`
+        // never produces anything. A `T` that errors before producing any
+        // value for this `s` still ends the whole computation immediately
+        // (verified live: `(1,2)[(0,1):(error("boom"))]` raises `boom`
+        // even though `target`, `(1,2)`, is untrackable and would
+        // otherwise have raised its own "Invalid path expression" error
+        // first -- `T`'s own escape wins before `target` is ever reached).
         let (ends, ends_escape) = match resolve_slice_bound::<S>(end, value, f64::ceil) {
             Ok(v) => v,
             Err(e) => escape!(e),
         };
-        // `target` escaping still caps this `s`'s own `T` stream to a
-        // single pair too, same reasoning as `starts_limit` above.
+        if ends.is_empty() {
+            if let Some(control) = ends_escape {
+                escape!(control);
+            }
+            continue 'outer;
+        }
+
+        // First genuine `(s, t)` pair reached for the whole function --
+        // resolve `target` now, exactly once, and run the two structural
+        // "is this even a valid location" checks using this pair to name
+        // the offending slice in their error message (#843/#986,
+        // pre-existing; only the *timing* of `end`'s value here is new to
+        // #2245). Every later `s` skips straight past this block, reusing
+        // the same `target_branches`/`target_escape`.
+        if target_branches.is_none() {
+            let (branches, escape) = match resolve_node::<S>(target, value, trackable, false, keep)
+            {
+                Ok(branches) => (branches, None),
+                Err((prefix, e)) => (prefix, Some(e)),
+            };
+            // #843: same rule as `resolve_index_expr` above, for a slice's
+            // bounds instead of an index's key.
+            if !trackable && is_passthrough_target(target) {
+                escape!(EvalError::invalid_path_expression_near_access(
+                    &slice_component_value(*s, s_key.as_ref(), ends[0].0, ends[0].1.as_ref()),
+                    value,
+                )
+                .into());
+            }
+            // #843: `resolve_index_expr`'s sibling `getpath`-laundering
+            // check — `target` can also resolve successfully with
+            // `trackable: false` through `Builtin::GetPath`'s deliberate
+            // exemption, which doesn't certify what comes after it as
+            // trackable. Without this, `catch (getpath(["other"])[0:2]) =
+            // [...]` silently wrote into the real document instead of
+            // raising — found in review.
+            // #986: `!b.trackable` is the same question asked of the
+            // target's own branches rather than the caller's context —
+            // `(1 | .)[0:2]`, where the pipe's literal deferred here
+            // instead of raising. Kept as one condition with `!trackable`
+            // so the two can't drift: this file's own "duplicated
+            // predicates diverge silently" lesson (#106).
+            if let Some(PathBranch {
+                value: first_value, ..
+            }) = branches.iter().find(|b| !trackable || !b.trackable)
+            {
+                escape!(EvalError::invalid_path_expression_near_access(
+                    &slice_component_value(*s, s_key.as_ref(), ends[0].0, ends[0].1.as_ref()),
+                    first_value,
+                )
+                .into());
+            }
+            // Keeps `target`'s own partial prefix, not just discarding it
+            // via `?`, the same fix #896's review applied to
+            // `resolve_index_expr`'s sibling target-resolution step (found
+            // independently live here too — #973 review): `target` can
+            // itself be one of #896's keep-partial sites (`select`, `if`,
+            // `getpath`, a computed index), so its own `Err` can carry a
+            // non-empty prefix that still needs slicing by this `(s, t)`
+            // pair rather than being returned unsliced. Confirmed against
+            // jq 1.7.1: `path((select(true, error("t")))[(0+1):2])` on
+            // `[10,20,30]` prints `[{"start":1,"end":2}]` (the
+            // already-produced `select` branch, sliced) before raising
+            // `t`.
+            target_branches = Some(branches);
+            target_escape = escape;
+        }
+        let branches = target_branches.as_ref().expect("just set above");
+
+        // `target`'s own escape (if it just fired above) caps this `s`'s
+        // own `T` stream to a single pair -- `target` escaping inside the
+        // very first `(s, t)` pair means no further pair, from this `s` or
+        // any later one, is ever tried. Confirmed against jq 1.7.1:
+        // `path((select((true,error("t"))))[(0,1):(2,3)])` on `[10,20,30]`
+        // prints only `[{"start":0,"end":2}]` before raising `t`.
         let ends_limit = if target_escape.is_some() {
             1
         } else {
             ends.len()
         };
         for (e, e_key) in &ends[..ends_limit] {
-            if out.try_reserve(target_branches.len()).is_err() {
-                escape!(cannot_reserve_cross_product(&[target_branches.len()]).into());
+            if out.try_reserve(branches.len()).is_err() {
+                escape!(cannot_reserve_cross_product(&[branches.len()]).into());
             }
             // #1326: a genuinely dynamic bound (unlike a literal one, which
             // the parser's own `fold_slice_bound` handles at parse time)
@@ -25370,7 +25339,7 @@ fn resolve_slice_expr<'a, S: EvalSemantics>(
                 // As in `resolve_index_expr`: the check above already
                 // rejected every untracked target branch.
                 ..
-            } in &target_branches
+            } in branches
             {
                 // `false`, not `optional`: the failure has to arrive as an
                 // error for the two spellings to be told apart here, same
@@ -25412,36 +25381,31 @@ fn resolve_slice_expr<'a, S: EvalSemantics>(
                 out.push(PathBranch::new(path, Cow::Owned(next_value), true));
             }
         }
-        // #2245: this `s`'s own `T` evaluation may have produced some
-        // values before escaping (a break/halt/error partway through `T`'s
-        // own stream) -- fold the running `out` in as that escape's
-        // prefix, same as every other per-iteration escape above.
-        if let Some(control) = ends_escape {
+        // Priority within this iteration is `target` > `end` (#1517;
+        // `start`'s own trailing escape is handled once, after the whole
+        // loop, below): `target`'s escape -- if it was just discovered on
+        // *this* `s` -- has to be checked before `end`'s own trailing
+        // escape, not after. Checking these in the other order was a real
+        // bug in an earlier draft of this fix, caught in review:
+        // `path((select((true,error("target_err"))))[(0,1):(2,error(
+        // "end_err"))])` on `[10,20,30]` raises `target_err`, not
+        // `end_err`, even though `end` also carries its own pending
+        // escape -- `target`'s escape, reached while producing the very
+        // first output, aborts before `end`'s generator is ever resumed
+        // to reach its own.
+        if let Some(control) = target_escape.take() {
             escape!(control);
         }
-        // `target` escaped: only `starts[0]`'s own pair was ever tried
-        // (`starts_limit` above already caps the loop to one iteration in
-        // this case, so this is reached at most once and only as the
-        // natural end of that one iteration -- not a second truncation).
-        if target_escape.is_some() {
-            break 'outer;
+        if let Some(control) = ends_escape {
+            escape!(control);
         }
     }
     // #1528: `start`'s own trailing escape info still has to reach the
     // final result -- a successful loop doesn't mean `start` itself didn't
-    // escape after producing `out`'s own values. `end`'s own trailing
-    // escape is handled per-`s` above (#2245), via `escape!`, not here.
-    // `target`'s escape, by contrast, only *breaks* the loop above rather
-    // than returning through `escape!` (its own `out` contribution, if
-    // any, is already the accumulated `out` at that point) -- so it still
-    // has to be folded in here, taking priority over `starts_escape`
-    // exactly as the three-way priority (`target` > `end` > `start`)
-    // requires. Missing this dropped `target`'s escape entirely (found in
-    // this fix's own live-oracle verification): `path((select((true,
-    // error("t"))))[(0,1):(2,3)])` on `[10,20,30]` produced the correct
-    // `[{"start":0,"end":2}]` prefix but silently exited 0 instead of
-    // raising `t`.
-    path_result(out, target_escape.or(starts_escape))
+    // escape after producing `out`'s own values. `target`'s and `end`'s
+    // own escapes are both handled per-`s` above, via `escape!`, so
+    // reaching here means neither ever fired.
+    path_result(out, starts_escape)
 }
 
 /// One resolved slice bound, paired with the [`NumberKey`] it should

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -13600,6 +13600,20 @@ fn test_resolve_slice_expr_reevaluates_end_bound_per_start_2245() -> Result<()> 
     Ok(())
 }
 
+/// #2245: a non-numeric `end` bound value hits `resolve_slice_bound`'s own
+/// hard-`Err` path (its `.collect::<Result<Vec<_>, _>>()?` on a resolved
+/// value that isn't a number) inside the per-`s` loop, not just the
+/// `Ok`/escape shapes the other tests here cover.
+#[test]
+fn test_resolve_slice_expr_end_bound_type_error_2245() -> Result<()> {
+    let (stdout, stderr, code) = run_jq_full(&["-c", r#"path(.[(0):("x")])"#], Some("[10,20,30]"))?;
+    assert_eq!(code, 5, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert_eq!(stdout, "");
+    assert!(stderr.contains("must be integers"), "stderr: {stderr:?}");
+
+    Ok(())
+}
+
 /// #2245 (found in this fix's own review/live-oracle verification, not the
 /// issue's original scope): the untrackable-target checks in
 /// `resolve_slice_expr` name a representative `(s, e)` pair in their error

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -13554,6 +13554,110 @@ fn test_resolve_slice_bound_type_error_still_drops_valid_prefix_1517_known_gap()
     Ok(())
 }
 
+/// #2245: `resolve_slice_expr` (the `path()`/`=`/`del()` write-path
+/// resolver for `E[S:T]`) evaluated `T` (`end`) exactly once overall,
+/// reused across every `S` value -- the identical bug #2225/PR #2244 fixed
+/// for the two value-mode siblings (`eval_slice_expr` in this file and
+/// `eval_generic.rs`). jq's own `S as $s | T as $t | E | .[$s:$t]`
+/// desugaring re-runs `T` fresh for every `$s`, observable whenever `T` has
+/// side effects (`input`) -- verified live against jq 1.7.1 for every
+/// assertion below.
+#[test]
+fn test_resolve_slice_expr_reevaluates_end_bound_per_start_2245() -> Result<()> {
+    // Assignment: a stale `end` silently corrupted data instead of just
+    // producing a wrong side-effect count.
+    let (stdout, _, code) = run_jq_full(
+        &[
+            "-c",
+            "-n",
+            r#"input as $doc | $doc | .[(0,3):(input)] = ["X"]"#,
+        ],
+        Some("[10,20,30,40,50,60]\n2\n4\n"),
+    )?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout.trim(), r#"["X",30,40,"X",60]"#);
+
+    // `del()`.
+    let (stdout, _, code) = run_jq_full(
+        &["-c", "-n", r"input as $doc | $doc | del(.[(0,3):(input)])"],
+        Some("[10,20,30,40,50,60]\n2\n4\n"),
+    )?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout.trim(), "[30,50,60]");
+
+    // `path()`: each `s` gets its own freshly-consumed `input` value, not
+    // the first one reused.
+    let (stdout, _, code) = run_jq_full(
+        &["-c", "-n", r"input as $doc | $doc | path(.[(0,1):(input)])"],
+        Some("[10,20,30]\n5\n7\n"),
+    )?;
+    assert_eq!(code, 0);
+    assert_eq!(
+        stdout,
+        "[{\"start\":0,\"end\":5}]\n[{\"start\":1,\"end\":7}]\n"
+    );
+
+    Ok(())
+}
+
+/// #2245 (found in this fix's own review/live-oracle verification, not the
+/// issue's original scope): the untrackable-target checks in
+/// `resolve_slice_expr` name a representative `(s, e)` pair in their error
+/// message, so `end` has to be evaluated *lazily* right there rather than
+/// upfront -- `end`'s own emptiness/escape still has to win over the
+/// trackability error the same way it always did, exactly mirroring the
+/// cross-product loop's own priority below it.
+#[test]
+fn test_resolve_slice_expr_untrackable_target_end_bound_still_lazy_2245() -> Result<()> {
+    // `end` completely empty for every `s` -- the trackability error never
+    // fires at all (verified live: no error, no output).
+    let (stdout, stderr, code) =
+        run_jq_full(&["-c", r"[path((1,2)[(0,1):(empty)])]"], Some("null"))?;
+    assert_eq!(code, 0, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert_eq!(stdout.trim(), "[]");
+
+    // `end` errors before producing any value -- that error wins over the
+    // trackability check entirely (not "Invalid path expression").
+    let (stdout, stderr, code) = run_jq_full(
+        &["-c", r#"path((1,2)[(0,1):(error("boom"))])"#],
+        Some("null"),
+    )?;
+    assert_eq!(code, 5, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert_eq!(stdout, "");
+    assert!(stderr.contains("boom"), "stderr: {stderr:?}");
+
+    // `end` yields a real first value -- the trackability error fires,
+    // naming that value (not a stale or absent one).
+    let (stdout, stderr, code) = run_jq_full(&["-c", r"path((1,2)[(0,1):(2,3)])"], Some("null"))?;
+    assert_eq!(code, 5, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert_eq!(stdout, "");
+    assert!(
+        stderr.contains("\"start\":0,") && stderr.contains("Invalid path expression"),
+        "stderr: {stderr:?}"
+    );
+
+    Ok(())
+}
+
+/// #2245 (found in this fix's own live-oracle verification): `target`'s own
+/// escape has to keep taking priority over `start`'s trailing escape in the
+/// final result, even though `end` is now resolved inside the loop instead
+/// of upfront -- a first draft of this fix broke the loop on `target`'s
+/// escape without ever folding it into the returned error, silently
+/// exiting 0 with the correct partial output but no error at all.
+#[test]
+fn test_resolve_slice_expr_target_escape_still_surfaces_in_final_result_2245() -> Result<()> {
+    let (stdout, stderr, code) = run_jq_full(
+        &["-c", r#"path((select((true,error("t"))))[(0,1):(2,3)])"#],
+        Some("[10,20,30]"),
+    )?;
+    assert_eq!(code, 5, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert_eq!(stdout, "[{\"start\":0,\"end\":2}]\n");
+    assert!(stderr.contains('t'), "stderr: {stderr:?}");
+
+    Ok(())
+}
+
 #[test]
 fn test_walk_propagates_halt_from_f() -> Result<()> {
     // `walk_impl` applies `f` via `eval_owned_expr_fork` at every level

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -13658,6 +13658,72 @@ fn test_resolve_slice_expr_target_escape_still_surfaces_in_final_result_2245() -
     Ok(())
 }
 
+/// #2245 (found in review of this fix's own first draft): `target`
+/// escaping forced `ends_limit` to `1` for every subsequent `s`, including
+/// one whose freshly-evaluated `ends` for *that* `s` turned out completely
+/// empty -- `&ends[..1]` on a zero-length slice panicked. Fixed by
+/// resolving `target` lazily (triggered only by the first `s` whose own
+/// `T` is genuinely non-empty), so a `target_escape` can only ever be
+/// discovered on an `s` that already has a non-empty `ends` in hand.
+#[test]
+fn test_resolve_slice_expr_target_escape_does_not_panic_on_empty_later_ends_2245() -> Result<()> {
+    let (stdout, _, code) = run_jq_full(
+        &[
+            "-c",
+            r#"path((select((true,error("target_err"))))[(0,1):empty])"#,
+        ],
+        Some("[10,20,30]"),
+    )?;
+    assert_eq!(code, 0);
+    assert!(stdout.trim().is_empty());
+
+    Ok(())
+}
+
+/// #2245 (found in review of this fix's own first draft): within one `s`
+/// iteration, `end`'s own trailing escape was checked *before* `target`'s,
+/// so when both escaped in the same iteration the lower-priority `end`
+/// error surfaced instead of the higher-priority `target` error, inverting
+/// the documented `target` > `end` > `start` rule. Fixed by checking
+/// `target_escape` first.
+#[test]
+fn test_resolve_slice_expr_target_escape_outranks_end_escape_same_iteration_2245() -> Result<()> {
+    let (stdout, stderr, code) = run_jq_full(
+        &[
+            "-c",
+            r#"path((select((true,error("target_err"))))[(0,1):(2,error("end_err"))])"#,
+        ],
+        Some("[10,20,30]"),
+    )?;
+    assert_eq!(code, 5, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert_eq!(stdout, "[{\"start\":0,\"end\":2}]\n");
+    assert!(stderr.contains("target_err"), "stderr: {stderr:?}");
+    assert!(!stderr.contains("end_err"), "stderr: {stderr:?}");
+
+    Ok(())
+}
+
+/// #2245 (found in review of this fix's own first draft): `target` was
+/// evaluated unconditionally before checking whether `end` (`T`) would
+/// ever produce a value for any `s`, so a target with a real side effect
+/// fired even when jq's own `S as $s | T as $t | E | .[$s:$t]` nesting
+/// would never reach `E` at all. Fixed by deferring `target`'s resolution
+/// until the first `s` whose own `T` is genuinely non-empty.
+#[test]
+fn test_resolve_slice_expr_target_not_evaluated_when_end_always_empty_2245() -> Result<()> {
+    let (_, stderr, code) = run_jq_full(
+        &["-c", r"(.|stderr)[(0,1):(empty)] = 99"],
+        Some("[10,20,30]"),
+    )?;
+    assert_eq!(code, 0);
+    assert!(
+        stderr.is_empty(),
+        "target's stderr side effect should never fire: stderr: {stderr:?}"
+    );
+
+    Ok(())
+}
+
 #[test]
 fn test_walk_propagates_halt_from_f() -> Result<()> {
     // `walk_impl` applies `f` via `eval_owned_expr_fork` at every level


### PR DESCRIPTION
## Summary

`resolve_slice_expr` — the `path()`/`=`/`del()` write-path resolver for `E[S:T]` — evaluated `T` (`end`) exactly once overall and reused it across every `S` value, unlike jq's own `S as $s | T as $t | E | .[$s:$t]` desugaring, which re-runs `T` fresh for every `$s`. Follow-up to #2225 (PR #2244), which fixed the identical bug in the two value-mode siblings (`eval_slice_expr` in this file and `eval_generic.rs`); this write-path function wasn't touched by that fix and had the same bug independently.

**Severity: High** — this is silent data corruption, not just a side-effect-count nuance:

```console
$ printf '[10,20,30,40,50,60]\n2\n4\n' | jq -c -n 'input as $doc | $doc | .[(0,3):(input)] = ["X"]'
["X",30,40,"X",60]
$ printf '[10,20,30,40,50,60]\n2\n4\n' | succinctly jq -c -n 'input as $doc | $doc | .[(0,3):(input)] = ["X"]'   # before this fix
["X",30,40,"X",50,60]                                        # WRONG -- stale end=2 reused for s=3
```

## Why this needed its own pass, not a port of #2244

`resolve_slice_expr` is structurally more complex than the two value-mode siblings:

1. **Three-way escape priority** (`target` > `end` > `start`), not two — `target`'s own escape has to keep winning over everything, even though `end` now resolves inside the loop instead of upfront.
2. **Two early "is this target trackable" checks**, each naming a representative `(s, e)` pair in their error message. Moving `T` inside the loop meant those checks' `T` evaluation had to stay *lazy* — forced only when the check is actually about to fire, not upfront — so `T`'s own emptiness/escape still wins over the trackability error, exactly the way it already wins over the main cross-product. Verified live against jq 1.7.1: an untrackable target paired with a completely empty `T` (`(1,2)[(0,1):(empty)]`) produces **no error at all**, and `T` erroring before any value wins over the trackability check entirely.

## A bug found in this fix's own live-oracle verification

An earlier draft of this restructuring broke the `s` loop on `target`'s own escape but never folded that escape into the returned result — it silently exited 0 with the correct partial path output but no error, where jq raises. Fixed by folding `target_escape` into the final `path_result` call alongside `starts_escape`. Caught by directly comparing against `/usr/bin/jq` 1.7.1 output (not just exit codes) for every case this fix touches — see `test_resolve_slice_expr_target_escape_still_surfaces_in_final_result_2245`.

## Also found, out of scope, not fixed here

While live-testing every branch, I found `resolve_slice_expr`'s second trackability check (and its sibling in `resolve_index_expr`, `E[K]`) discards *all* of `target_branches`' already-successful output when it finds a later untrackable branch, instead of processing the trackable branches individually up to that point — confirmed against jq 1.7.1, confirmed pre-existing (identical before/after this fix), and confirmed the same shape affects both functions. Filing a separate follow-up issue for this rather than folding it in here.

(One thing I checked and ruled out as *not* a bug: `del(.a[0:2])`/`.a[0:2] = [...]` in yq mode looked like silent data loss at first, but real `yq` v4.53.3 reproduces the identical behavior — bug-for-bug fidelity, not a succinctly gap.)

## Test plan
- [x] New `test_resolve_slice_expr_reevaluates_end_bound_per_start_2245` — the issue's own assignment/`del()`/`path()` repros, all matching jq 1.7.1.
- [x] New `test_resolve_slice_expr_untrackable_target_end_bound_still_lazy_2245` — `T` empty/erroring/producing a value, each checked against the trackability-check priority.
- [x] New `test_resolve_slice_expr_target_escape_still_surfaces_in_final_result_2245` — regression test for the bug found during this fix's own review.
- [x] Existing `resolve_slice_expr`/#1517/#1526/#973 escape-priority test clusters — all still pass unmodified.
- [x] `cargo test --features cli` — full suite green (57/57 binaries).
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean.
- [x] `cargo build --no-default-features` (no_std) — builds.
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --all-features --no-deps` — clean.
- [x] `cargo fmt --check` — clean.

Fixes #2245