### PR TITLE
docs(jq): document catch_error_under_optional's dead optional==true cells (#2212)

### DIFF
--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -5034,6 +5034,23 @@ fn binary_fanout_each<'a, W: Clone + AsRef<[u64]>>(
                     // pairing, the outputs already pushed stand either way,
                     // and `optional` decides whether the failure itself
                     // survives.
+                    //
+                    // #2212: this `optional` can currently only be `true` via
+                    // a path-context `?` that used to leak into an operand's
+                    // own evaluation through #2073's now-removed
+                    // combined-with-`rest` fallback (`.a | (.[])? | (key,
+                    // (1 + "x"))` -- needs an arithmetic op to reach this
+                    // `combine`-failure arm at all; `==`'s own `combine`
+                    // (`apply_compare_op`) is infallible, so an error from a
+                    // `==`-wrapped operand like `error("x")` never lands
+                    // here, it propagates through a different path entirely)
+                    // -- the plain (non-path-context) evaluator's own
+                    // `Expr::Optional` forwards the *ambient* `optional`
+                    // rather than forcing `true` (#693), so nothing else
+                    // ever delivers one here. Currently dead by the same
+                    // evidence as `catch_error_under_optional`'s own doc
+                    // comment, despite living outside the path-context
+                    // evaluator itself.
                     abort = Some(if optional {
                         Flow::Exhausted
                     } else {
@@ -30107,6 +30124,29 @@ fn accumulate_path_context_step<'a, W: Clone + AsRef<[u64]>>(
 /// time a caller's loop breaks, its own `results` binding is already empty
 /// -- reusing it here instead of the pattern's own `prefix` would silently
 /// keep nothing.
+/// #2212: every caller of this function lives inside the path-context
+/// evaluator's own call graph, and `optional` reaches every one of them
+/// through a chain that bottoms out at `eval_stage_with_path_context`'s own
+/// `optional` parameter. #2073 removed `Expr::Optional`'s combined-with-
+/// `rest` fallback there -- the only route that ever forced a `true` into
+/// that parameter -- so `optional` is `false` at every one of this
+/// function's call sites today, making the `optional == true` cells below
+/// (`(true, true)` and `(false, true)`, plus the bare `Error(e)` arm above)
+/// currently unreachable. Confirmed two independent ways (#2212): an
+/// `assert!(!optional, ...)` probe at `eval_stage_with_path_context`'s own
+/// entry point fires zero times across the full suite (it fires 5 times on
+/// pre-#2073 `main`), and `llvm-cov`'s patch-coverage diff on the #2073 PR
+/// itself reported these lines losing coverage on otherwise-unchanged code.
+/// Left in place rather than removed -- deleting `optional` from this
+/// function's signature (and from every caller's own signature in turn)
+/// would ripple well beyond this one function, and a future path-context
+/// arm could legitimately reintroduce a real producer of `true` the same
+/// way #2073's fallback used to be one. `test_catch_error_under_optional_full_truth_table_1888`
+/// is the sole test exercising these cells now that #1826/#1869/#1964's own
+/// end-to-end tests reach the `optional == false` branch either through
+/// #2073's new hard-error behavior or through `Expr::Optional`'s own
+/// structural catch instead -- treat it as this function's spec for the
+/// `optional == true` column, not just a regression pin.
 fn catch_error_under_optional<W>(
     stopped: QueryResult<'_, W>,
     optional: bool,
@@ -31321,7 +31361,8 @@ fn eval_stage_with_path_context<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
             Ok(Some(ref v)) => match classify_parent_n::<S>(v, current_path.len()) {
                 Ok(n) => n,
                 // `?` swallows only a genuine error; a halt always escapes
-                // (#791).
+                // (#791). #2212: currently unreachable with `optional ==
+                // true` -- see `catch_error_under_optional`'s doc comment.
                 Err(_) if optional => return QueryResult::None,
                 Err(e) => return QueryResult::Error(e),
             },
@@ -31584,6 +31625,10 @@ fn eval_stage_with_path_context<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
                         }
                     }
                 }
+                // #2212: `optional` is this arm's own ambient parameter, not
+                // `iterate_element_step`'s per-element `false` above --
+                // currently unreachable with `optional == true`, same
+                // evidence as `catch_error_under_optional`'s doc comment.
                 _ if optional => return QueryResult::None,
                 _ => return QueryResult::Error(EvalError::cannot_iterate_with(S::TAG, value)),
             }
@@ -31595,7 +31640,8 @@ fn eval_stage_with_path_context<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
                 // means a caught `Error` keeps the already-produced prefix
                 // rather than discarding it, and `Break`/`Halt` are left
                 // completely untouched (`catch_error_under_optional`,
-                // #1888).
+                // #1888; #2212: the `optional == true` half of that dispatch
+                // is currently unreachable here too).
                 Some(stop) => catch_error_under_optional::<W>(stop, optional, false),
             }
         }
@@ -32047,6 +32093,8 @@ fn eval_stage_with_path_context<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
                         }
                     }
                 }
+                // #2212: currently unreachable with `optional == true`, same
+                // evidence as `catch_error_under_optional`'s doc comment.
                 _ if optional => return QueryResult::None,
                 _ => return QueryResult::Error(EvalError::cannot_iterate_with(S::TAG, value)),
             }
@@ -32057,7 +32105,9 @@ fn eval_stage_with_path_context<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
                 // far rather than letting them leak out as this arm's
                 // result (#791), which is what `atomic: true` means to
                 // `catch_error_under_optional` (#1888) -- only `Error` is
-                // gated on this arm's own ambient `optional`.
+                // gated on this arm's own ambient `optional`. #2212: the
+                // `optional == true` half of that dispatch is currently
+                // unreachable here too.
                 Some(stop) => catch_error_under_optional::<W>(stop, optional, true),
                 None => QueryResult::Owned(OwnedValue::Array(results)),
             };
@@ -43211,15 +43261,11 @@ mod tests {
     /// Every `(atomic, optional)` cell of [`catch_error_under_optional`],
     /// plus the bare-`Error` and `Break`/`Halt` shapes around them.
     ///
-    /// Since #2073 this is the *only* test that reaches the helper's
-    /// `optional == true` cells at all: that fix removed
-    /// `Expr::Optional`'s combined-with-`rest` fallback, and with it the
-    /// last producer of an ambient `optional == true` anywhere inside the
-    /// path-context evaluator, so #1826's and #1869's own end-to-end tests
-    /// now exercise the `false` column instead (#2212 tracks whether the
-    /// parameter should survive at all). Deleting or weakening a row here
-    /// therefore removes the last check on that behaviour rather than a
-    /// duplicate of an integration test's.
+    /// #2212: the sole test exercising `catch_error_under_optional`'s
+    /// `optional == true` cells now that every production call site's own
+    /// `optional` is provably always `false` (see the function's own doc
+    /// comment) -- treat this as the spec for that column, not just a
+    /// regression pin against a shape no live query can trigger today.
     #[test]
     fn test_catch_error_under_optional_full_truth_table_1888() {
         type W = Vec<u64>;

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -30108,14 +30108,25 @@ fn accumulate_path_context_step<'a, W: Clone + AsRef<[u64]>>(
 ///
 /// **`optional` is currently always `false` at every call site reachable from
 /// the path-context evaluator (#2212).** #2073 removed `Expr::Optional`'s
-/// combined-with-`rest` fallback, which was the last thing that produced an
-/// `optional == true` in there, so the three cells below that consult it are
-/// live only through this function's own unit test
-/// (`test_catch_error_under_optional_full_truth_table_1888`) -- which is
-/// therefore the sole load-bearing test for the truth table, not a
-/// belt-and-braces duplicate of an end-to-end one. Whether to delete the
-/// parameter or keep it as defence in depth is #2212's call; until then, do
-/// not cite these cells as evidence of live behaviour.
+/// combined-with-`rest` fallback -- the only route that ever forced a `true`
+/// into `eval_stage_with_path_context`'s own `optional` parameter -- so the
+/// three cells below that consult it (`(true, true)` and `(false, true)`,
+/// plus the bare `Error(e)` arm above) are live only through this function's
+/// own unit test (`test_catch_error_under_optional_full_truth_table_1888`);
+/// #1826's and #1869's own end-to-end tests now reach the `optional ==
+/// false` branch instead, either through #2073's new hard-error behaviour or
+/// through `Expr::Optional`'s own structural catch. Treat the unit test as
+/// this function's spec for the `optional == true` column, not just a
+/// regression pin against a shape no live query can trigger today. Confirmed
+/// two independent ways: an `assert!(!optional, ...)` probe at
+/// `eval_stage_with_path_context`'s own entry point fires zero times across
+/// the full suite (5 times on pre-#2073 `main`), and `llvm-cov`'s
+/// patch-coverage diff on the #2073 PR itself reported these lines losing
+/// coverage on otherwise-unchanged code. #2212 chose to leave `optional` in
+/// place rather than remove it -- deleting it from this function's signature
+/// (and every caller's in turn) would ripple well beyond this one function,
+/// and a future path-context arm could legitimately reintroduce a real
+/// producer of `true` the same way #2073's fallback used to be one.
 ///
 /// The prefix lives *inside* the matched `Partial` pattern, not in a
 /// separately-passed accumulator: `accumulate_path_context_step` already
@@ -30124,29 +30135,6 @@ fn accumulate_path_context_step<'a, W: Clone + AsRef<[u64]>>(
 /// time a caller's loop breaks, its own `results` binding is already empty
 /// -- reusing it here instead of the pattern's own `prefix` would silently
 /// keep nothing.
-/// #2212: every caller of this function lives inside the path-context
-/// evaluator's own call graph, and `optional` reaches every one of them
-/// through a chain that bottoms out at `eval_stage_with_path_context`'s own
-/// `optional` parameter. #2073 removed `Expr::Optional`'s combined-with-
-/// `rest` fallback there -- the only route that ever forced a `true` into
-/// that parameter -- so `optional` is `false` at every one of this
-/// function's call sites today, making the `optional == true` cells below
-/// (`(true, true)` and `(false, true)`, plus the bare `Error(e)` arm above)
-/// currently unreachable. Confirmed two independent ways (#2212): an
-/// `assert!(!optional, ...)` probe at `eval_stage_with_path_context`'s own
-/// entry point fires zero times across the full suite (it fires 5 times on
-/// pre-#2073 `main`), and `llvm-cov`'s patch-coverage diff on the #2073 PR
-/// itself reported these lines losing coverage on otherwise-unchanged code.
-/// Left in place rather than removed -- deleting `optional` from this
-/// function's signature (and from every caller's own signature in turn)
-/// would ripple well beyond this one function, and a future path-context
-/// arm could legitimately reintroduce a real producer of `true` the same
-/// way #2073's fallback used to be one. `test_catch_error_under_optional_full_truth_table_1888`
-/// is the sole test exercising these cells now that #1826/#1869/#1964's own
-/// end-to-end tests reach the `optional == false` branch either through
-/// #2073's new hard-error behavior or through `Expr::Optional`'s own
-/// structural catch instead -- treat it as this function's spec for the
-/// `optional == true` column, not just a regression pin.
 fn catch_error_under_optional<W>(
     stopped: QueryResult<'_, W>,
     optional: bool,
@@ -31366,6 +31354,9 @@ fn eval_stage_with_path_context<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
                 Err(_) if optional => return QueryResult::None,
                 Err(e) => return QueryResult::Error(e),
             },
+            // Same `optional`, same evidence, same #2212 conclusion as the
+            // arm just above -- currently unreachable with `optional ==
+            // true`, see `catch_error_under_optional`'s doc comment.
             Err(EvalEscape::Error(_)) if optional => return QueryResult::None,
             Err(escape) => return escape.into(),
         };


### PR DESCRIPTION
## Summary

- #2073 removed `Expr::Optional`'s combined-with-`rest` fallback in `eval_stage_with_path_context` — the only route that ever forced `optional = true` into the path-context evaluator. #2212 confirmed (via an `assert!(!optional, ...)` probe across the full suite, and independently via an `llvm-cov` patch-coverage diff on #2073's own PR) that this makes `catch_error_under_optional`'s `optional == true` cells, plus several call sites that feed it, currently unreachable.
- #2212's own text lays out two remedies (remove `optional` from the whole call chain, or keep it and document the dead cells) with no clear default. Chose the lower-risk option: document, don't remove. Central doc comment on `catch_error_under_optional` itself, plus annotations at `binary_fanout_each`, both `Builtin::ParentN` arms, `Expr::Iterate`'s two-site arm, and `Builtin::Map`'s two-site arm — 8 call sites in total, all independently re-verified, not just re-asserted from the issue text.
- This is a resurrection of #2228 (closed without merging): that PR's premise didn't hold because it was cut from `main` before #2217 (the actual #2073 fix) had merged. Now that #2217 is on `main`, rebased the original work onto it and re-verified from scratch — the `assert!(!optional, ...)` probe still fires zero times across 6044 tests post-rebase.
- Also fixes a genuine defect #2228's own code review caught in the copied repro: `binary_fanout_each`'s comment used `.a | (.[])? | (key, (1 == error("x")))`, but `==`'s own `combine` (`apply_compare_op`) is infallible — it can never reach this arm's failure branch regardless of #2073's status. `error("x")` errors through a different path entirely (the operand's own evaluation), not through `combine`. Corrected to `(1 + "x")`, live-verified: `1 + "x"` genuinely fails at `combine` ("number (1) and string (\"x\") cannot be added"), unlike the old repro.
- Strengthened `test_catch_error_under_optional_full_truth_table_1888`'s doc comment to point at the central doc comment as the single source of truth, per #2212's own suggestion.
- **Review round 2** (2-agent fan-out on this PR itself): found the central doc comment duplicated ~80% of a paragraph already on `main` (added by #2073/#2217's own landing) instead of merging into it, and that a second `Builtin::ParentN` arm (`eval_owned_expr_opt`'s error path, one line below the annotated one) was dead by identical evidence but left un-annotated. Both fixed in the follow-up commit — independently re-verified the reachability trace end to end (full call-graph walk plus an empirical `eprintln!` probe across the entire suite), confirming no REFUTED claims.

Filed #2227 (already on the board) for the remaining `if optional` sites this pass found but did not individually verify.

Closes #2212.

## Test plan

- [x] `cargo test --features cli,simd,regex,serde --test jq_cli_tests --test yq_cli_tests --lib`: 3352 + 1319 + 1373 passed
- [x] Reachability re-verified post-rebase: temporary `assert!(!optional, ...)` probe at `eval_stage_with_path_context`'s entry point fires 0 times across the full suite (6044 tests), matching the original pre-#2228 investigation
- [x] `cargo test` (default features) and `cargo test --no-default-features --features portable-popcount` (no_std): both passing
- [x] `cargo clippy --all-targets --all-features -- -D warnings`: clean
- [x] `cargo fmt --check`: clean
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features`: clean
- [x] Live-verified the corrected `binary_fanout_each` repro: `echo '{"a":[1,2,3]}' | succinctly jq -c '.a | (.[])? | (key, (1 + "x"))'` hits the `combine`-failure arm as claimed
- [x] Full call-graph trace (not just eyeballing) confirmed every `optional`-passing call site across the path-context family and `binary_fanout_each` forwards the ambient value or a literal `false`, never a derived `true`