### PR TITLE
fix(jq): thread rest and new_path through missing-key/OOB-index navigation (#2213)

### DIFF
--- a/docs/compliance/jq/limitations.md
+++ b/docs/compliance/jq/limitations.md
@@ -443,7 +443,13 @@ way `set_value_at_path` already did for `setpath()`) and
 bounds check now survives `?`, since padding is what makes the positive case succeed rather
 than needing `?` to swallow a failure). No write operator produces `index N out of bounds
 (length M)` any more; a numeric index past the end is not an error jq raises, so there is no
-longer a positive case for succinctly's own wording to cover.
+longer a positive case for succinctly's own wording to cover. The one remaining read-side
+producer -- `eval_stage_with_path_context`'s `Expr::Index` arm, reached only when a
+path-context builtin (`key`/`parent`/`path`/`file_index`) sits downstream of an out-of-bounds
+`.[N]` -- was closed the same way by
+[#2213](https://github.com/rust-works/succinctly/issues/2213): the arm now continues with
+`null` at the extended path instead of raising, matching plain `.a[5]`. `EvalError::
+index_out_of_bounds` (the constructor for this exact wording) is now unused and was removed.
 
 `del()` used to sit here too — `del(.[5])` and `del(.[-5])` on `[1,2]`, plus a missing
 intermediate key or an out-of-range index — but every one of those is a silent no-op now,

--- a/docs/compliance/yq/limitations.md
+++ b/docs/compliance/yq/limitations.md
@@ -1437,6 +1437,55 @@ disagree). Fully aligning yq-mode `fromjson` with real yq's stricter, non-pairin
 [#2018](https://github.com/rust-works/succinctly/issues/2018), since it needs its own
 yq-mode branch checked ahead of all of jq's pairing logic, not an arm-by-arm patch.
 
+### `parent` doesn't auto-vivify the missing node it navigated through
+
+[#2146](https://github.com/rust-works/succinctly/issues/2146) (defect 3, still open --
+defects 1 and 2 there were fixed by
+[#2213](https://github.com/rust-works/succinctly/issues/2213)). `key`/`parent`/`path`/
+`file_index` are real yq builtins with no jq counterpart, so real yq v4.53.3 is the only
+oracle for them. Navigating through a missing object key or an out-of-bounds array index is
+"not an error, propagate `null`" in both tools -- but real yq's `parent` goes one step
+further and auto-vivifies the missing node *into the object it returns*, as if the write had
+already happened:
+
+```bash
+$ echo '{}' | yq            -o=json -I=0 '.a | parent'
+{"a":null}
+$ echo '{}' | succinctly yq -o=json -I=0 '.a | parent'
+{}
+```
+
+succinctly has no vivification machinery anywhere in the codebase -- `parent`'s return value
+is always a real node already present in the document, walked to via the accumulated path.
+Post-#2213, that's the *un-vivified* ancestor (`{}`, the actual root) rather than the
+pre-#2213 stub (`null`, `key`/`path`/`parent`'s shared fallback for any path-tracking
+failure) -- a real improvement, since `{}` is at least a genuine document node consistent
+with what `path()`/`key` now report for the same navigation, but still short of yq's
+synthetic `{"a":null}`. Implementing this needs `parent`/`parent(n)` to be able to construct
+a value that isn't a snapshot of anything in the document -- a different kind of change than
+#2213's path-threading fix, which only ever continues with a value already known to be
+correct (`Null`, jq's own answer for what the missing/OOB read itself evaluates to).
+
+### A negative out-of-range array index (`.a[-N]`) silently returns `null` instead of raising
+
+[#2254](https://github.com/rust-works/succinctly/issues/2254), pre-existing and unrelated to
+#2213 -- found while verifying that fix's own reach. Real yq disagrees with real jq on a
+negative index whose magnitude exceeds the array length: jq treats it the same as a positive
+out-of-range index (`null`, not an error); yq raises. A positive out-of-range index is `null`
+in both tools -- the asymmetry is specific to the negative-magnitude case:
+
+```bash
+$ echo '{"a":[1,2]}' | yq -o=json '.a[-1]'   # 2   (in-bounds negative wraparound: fine)
+$ echo '{"a":[1,2]}' | yq -o=json '.a[-2]'   # 1   (in-bounds: fine)
+$ echo '{"a":[1,2]}' | yq -o=json '.a[-3]'   # Error: index [-3] out of range, array size is 2
+```
+
+`resolve_read_index`/`index_one`/`index_one_owned` (`src/jq/eval.rs`) treat "index doesn't
+resolve" as one outcome with no `EvalSemantics`-based dispatch on sign, so `succinctly yq`
+currently gives `null` for the negative-out-of-range case rather than raising -- reachable
+via the plain evaluator alone (`.a[-5]`, no path-context builtin involved), predating #2213
+entirely.
+
 ### Other categories
 
 Float and number formatting ([#1071](https://github.com/rust-works/succinctly/issues/1071),

--- a/src/jq/error.rs
+++ b/src/jq/error.rs
@@ -595,11 +595,6 @@ impl EvalError {
         Self::new(format!("expected {expected}, got {got}"))
     }
 
-    /// Create an index out of bounds error.
-    pub fn index_out_of_bounds(index: i64, len: usize) -> Self {
-        Self::new(format!("index {index} out of bounds (length {len})"))
-    }
-
     // ===== jq message shapes ============================================
     //
     // Grouped by sentence shape rather than by call site, because jq reuses

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -31870,6 +31870,11 @@ fn eval_stage_with_path_context<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
                 // regardless of `optional`, rather than routing it through
                 // the error-suppression path below, which both swallowed
                 // `rest` entirely under `?` and wrongly raised without one.
+                // `resolve_read_index` doesn't distinguish sign here, but
+                // real yq does (#2254, pre-existing, unrelated to this fix):
+                // it raises on a negative index whose magnitude exceeds the
+                // array length, where jq (and yq's own positive-OOB case)
+                // both agree on `null`.
                 return continue_rest_with_borrowed_value::<W, S>(
                     &OwnedValue::Null,
                     rest,

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -31809,12 +31809,31 @@ fn eval_stage_with_path_context<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
                         optional,
                     );
                 }
-                // jq returns null for missing fields on objects (not an error)
-                return QueryResult::Owned(OwnedValue::Null);
+                // jq returns null for missing fields on objects (not an
+                // error) -- continue `rest` from that `Null` at `new_path`
+                // rather than returning early (#2213): an early return here
+                // skipped `rest` entirely and left `key`/`parent` seeing the
+                // stale pre-navigation path.
+                return continue_rest_with_borrowed_value::<W, S>(
+                    &OwnedValue::Null,
+                    rest,
+                    root,
+                    file_origin,
+                    &new_path,
+                    optional,
+                );
             }
-            // jq returns null for field access on null
+            // jq returns null for field access on null, same #2213 fix as
+            // the missing-field case just above.
             if matches!(value, OwnedValue::Null) {
-                return QueryResult::Owned(OwnedValue::Null);
+                return continue_rest_with_borrowed_value::<W, S>(
+                    &OwnedValue::Null,
+                    rest,
+                    root,
+                    file_origin,
+                    &new_path,
+                    optional,
+                );
             }
             // Non-object/null: error (or None if optional)
             if optional {
@@ -31845,13 +31864,37 @@ fn eval_stage_with_path_context<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
                         optional,
                     );
                 }
+                // jq treats an out-of-bounds array index as `null`, never an
+                // error (#2213, same fix as `Expr::Field`'s missing-key arm
+                // above) -- continue `rest` from that `Null` at `new_path`
+                // regardless of `optional`, rather than routing it through
+                // the error-suppression path below, which both swallowed
+                // `rest` entirely under `?` and wrongly raised without one.
+                return continue_rest_with_borrowed_value::<W, S>(
+                    &OwnedValue::Null,
+                    rest,
+                    root,
+                    file_origin,
+                    &new_path,
+                    optional,
+                );
+            }
+            // jq treats indexing `null` with an integer the same way
+            // (#2213): always `null`, never an error.
+            if matches!(value, OwnedValue::Null) {
+                return continue_rest_with_borrowed_value::<W, S>(
+                    &OwnedValue::Null,
+                    rest,
+                    root,
+                    file_origin,
+                    &new_path,
+                    optional,
+                );
             }
             if optional {
                 QueryResult::None
-            } else if let OwnedValue::Array(arr) = value {
-                QueryResult::Error(EvalError::index_out_of_bounds(*idx, arr.len()))
             } else {
-                // Indexing a non-array is not an out-of-bounds access; jq
+                // Indexing a non-array/non-null is a genuine type error; jq
                 // reports it as an indexing type error like `.[0]` does.
                 QueryResult::Error(EvalError::cannot_index_with_type(
                     owned_type_name(value),

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -9428,19 +9428,19 @@ fn path_context_step_generic<S: EvalSemantics, V: DocumentValue>(
                 // `Vec<OwnedValue>` (see `PathTrail::from_slice`'s own doc
                 // comment for why), so it flattens back out here.
                 let path = path.to_vec();
-                // An absent node is where the bridge and this walk genuinely
-                // disagree, so it is handed back rather than answered.
-                //
-                // The bridge *loses* path context through a missing field --
-                // `{} | .a | key` is `null` there -- and *raises* on an
-                // out-of-bounds index, where plain `.[0]` on `[]` does not.
-                // Real yq does neither: it answers `"a"`, and it
-                // auto-vivifies the missing node (`{} | .a | parent` is
-                // `{"a":null}`, `[] | .[0] | key` is `0`), all confirmed
-                // against v4.53.3. Continuing the walk here would silently
-                // change all three into a fourth answer inside a performance
-                // change, so absent positions stay on the bridge and keep
-                // today's behaviour exactly. Filed separately.
+                // An absent node still bails to the bridge, even though
+                // #2213 fixed the bridge's own `key`/`path` answers to match
+                // real yq (`{} | .a | key` is `"a"`, `[] | .[0] | key` is
+                // `0`, both confirmed against v4.53.3) rather than the
+                // stale `null`/raise this comment used to describe. `parent`
+                // is why the walk still can't continue on its own: real yq
+                // auto-vivifies the missing node into `parent`'s return
+                // value (`{} | .a | parent` is `{"a":null}`), and this
+                // walk's `PathContextPos::node` has nowhere to hold a
+                // synthesized value -- only real document nodes. #2146
+                // (defect 3, still open) is the design question that would
+                // let this stop bailing for the cases that don't touch
+                // `parent`.
                 let PathNode::At(node) = node else {
                     return Err(PathContextAbort::Unsupported);
                 };

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -8705,45 +8705,35 @@ fn test_optional_ambient_no_longer_suppresses_rest_error_2073() -> Result<()> {
     Ok(())
 }
 
-/// #2073 side effect, characterized rather than fixed: isolating `inner`
-/// unconditionally changes what a path-context `rest` sees after a
-/// *missing* field -- a shape with no error in it anywhere, so nothing about
-/// `?`'s own suppression applies.
+/// #2213 fix: `Expr::Field`'s missing-key arm (and its sibling
+/// field-access-on-`null` arm) now fall through to the normal continuation
+/// -- `continue_rest_with_borrowed_value` with `Null` at the freshly-built
+/// `new_path` -- instead of returning `QueryResult::Owned(Null)` early.
 ///
-/// `Expr::Field`'s missing-key arm returns `QueryResult::Owned(Null)`
-/// without running `rest` and without threading the `new_path` it just
-/// built. Under the old combined-with-`rest` route that early return
-/// swallowed the whole downstream pipe, so `| key` never ran and `.zz`'s own
-/// `null` leaked out as the final output. Under isolation the probe never
-/// runs either, so `split_probe_pair` takes its fallback branch and `rest`
-/// continues from the *stale*, pre-`inner` path -- reporting the parent's
-/// key.
-///
-/// Both answers are wrong: `path(.b.zz)` is `["b","zz"]` in succinctly and
-/// in real jq 1.7.1 alike, so `"zz"` is what all of these should say. The
-/// value pinned below is the one that makes `?` agree with the five sibling
-/// isolating constructs, which have reported the stale key since #1409 and
-/// are unaffected by #2073 -- checked here alongside it so a future fix for
-/// #2213 moves all six together or fails loudly.
+/// Before the fix, the early return both skipped `rest` entirely (the plain
+/// pipe spelling) and, once isolation made `rest` run via
+/// `split_probe_pair`'s fallback branch, left it continuing from the
+/// *stale*, pre-navigation path (the six isolating-construct spellings,
+/// `?` included since #2073 joined them). All seven spellings now agree
+/// with each other and with `path(.b.zz)`.
 #[test]
-fn test_optional_missing_field_reports_stale_path_like_its_siblings_2213() -> Result<()> {
+fn test_missing_field_reports_correct_path_across_all_spellings_2213() -> Result<()> {
     let input = r#"{"b":{"x":1}}"#;
 
-    // The `?` case #2073 moved: `null` (rest skipped) before, the stale
-    // parent key now.
+    // `?`: `null` (rest skipped) pre-#2073, the stale parent key `"b"`
+    // post-#2073/pre-#2213, now the correct `"zz"`.
     let (stdout, _, code) = run_jq_full(&["-c", ".b | (.zz)? | key"], Some(input))?;
     assert_eq!(code, 0);
-    assert_eq!(stdout, "\"b\"\n");
+    assert_eq!(stdout, "\"zz\"\n");
 
-    // `rest` genuinely runs now, where the old route dropped it entirely --
-    // the second output is what proves it, not just the changed first one.
+    // `rest` genuinely runs and sees the right path for every output, not
+    // just the first.
     let (stdout, _, code) = run_jq_full(&["-c", ".b | (.zz)? | (key, 1)"], Some(input))?;
     assert_eq!(code, 0);
-    assert_eq!(stdout, "\"b\"\n1\n");
+    assert_eq!(stdout, "\"zz\"\n1\n");
 
-    // The five sibling isolating constructs, unchanged by #2073 and already
-    // reporting the same stale key on `main`. A fix for #2213 should move
-    // every one of these to `"zz"` at once.
+    // The five sibling isolating constructs, which reported the same stale
+    // key as `?` since #1409 -- all move to `"zz"` together.
     for query in [
         ".b | (try .zz) | key",
         ".b | (try .zz catch \"c\") | key",
@@ -8753,21 +8743,115 @@ fn test_optional_missing_field_reports_stale_path_like_its_siblings_2213() -> Re
     ] {
         let (stdout, _, code) = run_jq_full(&["-c", query], Some(input))?;
         assert_eq!(code, 0, "query: {query}");
-        assert_eq!(stdout, "\"b\"\n", "query: {query}");
+        assert_eq!(stdout, "\"zz\"\n", "query: {query}");
     }
 
-    // The plain pipe keeps the *other* wrong answer -- `.zz`'s own `null`,
-    // with `| key` never having run. Pinned so #2213's fix has to address
-    // this spelling too, not just the isolating ones.
+    // The plain pipe used to skip `rest` entirely (`.zz`'s own `null`
+    // leaking out as `key`'s result) -- now runs `rest` and reports `"zz"`
+    // like every other spelling.
     let (stdout, _, code) = run_jq_full(&["-c", ".b | .zz | key"], Some(input))?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout, "\"zz\"\n");
+
+    // The value itself is still `null` -- the fix only corrects the path
+    // `rest` sees, not what `.zz` evaluates to.
+    let (stdout, _, code) = run_jq_full(&["-c", ".b | .zz"], Some(input))?;
     assert_eq!(code, 0);
     assert_eq!(stdout, "null\n");
 
-    // What all seven should agree on, and the reason `"zz"` is the target:
-    // the path itself is right, and matches real jq 1.7.1.
+    // What all seven now agree on, and the reason `"zz"` is the target: the
+    // path itself, matching real jq 1.7.1.
     let (stdout, _, code) = run_jq_full(&["-c", "[path(.b.zz)]"], Some(input))?;
     assert_eq!(code, 0);
     assert_eq!(stdout, "[[\"b\",\"zz\"]]\n");
+
+    Ok(())
+}
+
+/// #2213's sibling case: `Expr::Field` on a `null` value (as opposed to a
+/// missing key on an object) gets the identical fix, since jq treats both
+/// as "not an error, propagate null" the same way.
+#[test]
+fn test_field_access_on_null_reports_correct_path_2213() -> Result<()> {
+    let input = r#"{"a":null}"#;
+
+    let (stdout, _, code) = run_jq_full(&["-c", ".a | (.zz)? | key"], Some(input))?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout, "\"zz\"\n");
+
+    let (stdout, _, code) = run_jq_full(&["-c", "[path(.a.zz)]"], Some(input))?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout, "[[\"a\",\"zz\"]]\n");
+
+    Ok(())
+}
+
+/// #2213's `Expr::Index` fix, and its overlap with #2146: a genuine
+/// out-of-bounds array index and an index into `null` are both "not an
+/// error, propagate null" in jq (`[1,2] | .[5]` and `null | .[5]` are both
+/// `null`, never an error) -- exactly like a missing object field. The
+/// path-context arm previously routed *both* through the error-suppression
+/// branch (`QueryResult::None` under `?`, a genuine `Error` without one),
+/// which both swallowed `rest` under `?` and wrongly raised without one.
+///
+/// This table reproduces #2146's own repro rows for the non-`parent` cases
+/// (defects 1 and 2 there) and confirms they now match real yq v4.53.3's
+/// values, captured in that issue -- `parent`'s auto-vivification (#2146's
+/// defect 3) is a separate, harder problem (succinctly has no vivification
+/// machinery anywhere) and is intentionally left unfixed here.
+#[test]
+fn test_out_of_bounds_index_and_null_index_report_correct_path_2213() -> Result<()> {
+    // True out-of-bounds: array exists, index doesn't resolve.
+    let (stdout, _, code) = run_jq_full(&["-c", ".a | (.[5])? | key"], Some(r#"{"a":[1,2]}"#))?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout, "5\n");
+
+    // Same shape, no `?` -- used to raise (index N out of bounds); now
+    // agrees with the optional spelling, matching the plain evaluator's own
+    // `.a[5]` (`null`, no error).
+    let (stdout, _, code) = run_jq_full(&["-c", ".a[5] | key"], Some(r#"{"a":[1,2]}"#))?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout, "5\n");
+
+    // Negative out-of-bounds.
+    let (stdout, _, code) = run_jq_full(&["-c", ".a | (.[-5])? | key"], Some(r#"{"a":[1,2]}"#))?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout, "-5\n");
+
+    // Indexing `null` with an integer: also not an error.
+    let (stdout, _, code) = run_jq_full(&["-c", ".a | (.[5])? | key"], Some(r#"{"a":null}"#))?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout, "5\n");
+
+    // #2146's own table, the non-`parent` rows: matches real yq v4.53.3.
+    let (stdout, _, code) = run_jq_full(&["-c", ".[0] | key"], Some("[]"))?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout, "0\n");
+
+    let (stdout, _, code) = run_jq_full(&["-c", ".a[5] | key"], Some(r#"{"a":[1]}"#))?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout, "5\n");
+
+    // Genuine type errors are unaffected: indexing a string/number with an
+    // integer, or a scalar/object with a field name, still raises.
+    let (_, stderr, code) = run_jq_full(&["-c", ".zz"], Some(r#""hi""#))?;
+    assert_eq!(code, 5);
+    assert!(
+        stderr.contains("Cannot index string with string"),
+        "{stderr}"
+    );
+
+    let (_, stderr, code) = run_jq_full(&["-c", ".[0]"], Some("5"))?;
+    assert_eq!(code, 5);
+    assert!(
+        stderr.contains("Cannot index number with number"),
+        "{stderr}"
+    );
+
+    // `?` suppresses those genuine type errors, same as before.
+    let (stdout, _, code) = run_jq_full(&["-c", "(.zz)?"], Some(r#""hi""#))?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout, "");
 
     Ok(())
 }

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -27682,15 +27682,21 @@ fn test_path_context_cursor_walk_composite_stages_2061() -> Result<()> {
 #[test]
 fn test_path_context_cursor_walk_falls_back_2061() -> Result<()> {
     for (filter, input, want) in [
-        // An absent node. The bridge *loses* path context through a missing
-        // field (`null`, not `"a"`) and *raises* on an out-of-bounds index
-        // where plain `.[0]` does not. Real yq v4.53.3 does neither -- it
-        // answers `"a"` and auto-vivifies -- so all three disagree, and the
-        // walk declines to invent a fourth answer inside a perf change.
-        (".a | key", "{}", "null"),
-        (".a.b | key", "{}", "null"),
-        (".missing | path", r#"{"a":1}"#, "null"),
-        (".a | parent", "{}", "null"),
+        // An absent node. The walk still bails here -- unaffected by #2213,
+        // which fixed only what the bridge itself answers, not whether the
+        // walk hands off to it. #2213 fixed the bridge's `key`/`path`
+        // answers to match real yq v4.53.3 (`"a"`, not the old stale
+        // `null`) by threading the path through a missing field/
+        // out-of-bounds index instead of returning early. `parent` is the
+        // one case #2213 deliberately left alone (#2146's remaining defect
+        // 3): real yq auto-vivifies the missing node into the returned
+        // parent (`{"a":null}`), which needs vivification machinery
+        // succinctly doesn't have yet, so the bridge now answers with the
+        // real, un-vivified root (`{}`) rather than the old stub `null`.
+        (".a | key", "{}", r#""a""#),
+        (".a.b | key", "{}", r#""b""#),
+        (".missing | path", r#"{"a":1}"#, r#"["missing"]"#),
+        (".a | parent", "{}", "{}"),
         // `parent` back at the root would materialize the whole document --
         // exactly what the bridge already does, and the walk would pay its
         // validity gate on top for a net loss.
@@ -27728,10 +27734,11 @@ fn test_path_context_cursor_walk_falls_back_2061() -> Result<()> {
         assert_eq!(out.trim(), want, "`{filter}` on `{input}`");
     }
 
-    // An out-of-bounds index still raises, as it does on the bridge.
+    // An out-of-bounds index used to raise on the bridge (#2213 fixed this
+    // too, matching real yq v4.53.3's `0` -- #2146's own table row).
     let (out, code) = run_yq_stdin(".[0] | key", "[]", &["-o", "json", "-I0"])?;
-    assert_eq!(code, 1, "out: {out:?}");
-    assert_eq!(out.trim(), "");
+    assert_eq!(code, 0, "out: {out:?}");
+    assert_eq!(out.trim(), "0");
 
     Ok(())
 }


### PR DESCRIPTION
## Summary

- `Expr::Field`'s missing-key arm and `Expr::Index`'s out-of-bounds/optional arm in `eval_stage_with_path_context` returned `QueryResult::Owned(Null)` (or, for `Index`, routed through the `optional` error-suppression branch) without running `rest` or threading the `new_path` they'd just built. jq treats a missing object field, an out-of-bounds array index, and indexing `null` as "not an error, propagate null" — never an error — so this made `key`/`parent`/`path`/`file_index` downstream of one of these report a stale pre-navigation path (or, for the plain-pipe spelling, skip `rest` entirely), and made a bare (non-optional) out-of-bounds index wrongly raise where plain `.a[5]` does not.
- Both arms now fall through to `continue_rest_with_borrowed_value` with `Null` at the freshly-built `new_path`, exactly like the issue's own suggested approach. Live-verified all six isolating-construct spellings (`?`, `try`, `label`, `if`, `first`) plus the plain pipe now agree with each other and with `path()`, matching real jq 1.7.1.
- Verified the blast radius the issue called out: `path()`/`del()`/`|=` for missing keys and out-of-bounds indices are unaffected (they go through a separate write-path resolver, untouched here) — before/after output identical.
- **Bonus overlap with #2146**: found while checking this fix's reach that it also resolves #2146's defects 1 and 2 (path context dropped through an absent node; out-of-bounds index raises) — same function, same root cause. Verified against #2146's own repro table, matching real yq v4.53.3 for every non-`parent` row. #2146's defect 3 (`parent` auto-vivifying the missing node into its return value) is deliberately **not** fixed here — succinctly has no vivification machinery anywhere, and that's a separate, harder problem per #2146's own text. Commented on #2146 narrowing its remaining scope to defect 3, and documented the gap in `docs/compliance/yq/limitations.md`.
- Updated `test_path_context_cursor_walk_falls_back_2061` (#2061), whose pinned values characterized this exact bug in the "bridge" it deliberately falls back to for absent nodes — its own doc comment described the bug in detail, now updated to describe the fix.

**Review round 2** (9-agent fan-out on this PR itself) found and fixed:
- `EvalError::index_out_of_bounds` (`src/jq/error.rs`) had zero remaining call sites after this fix removed its only caller — deleted, and `docs/compliance/jq/limitations.md`'s existing note updated to record that the last read-side producer of this message is now gone too.
- `eval_generic.rs`'s `path_context_step_generic` had a stale comment describing "the bridge" as losing path context and raising on OOB — both now fixed by this PR. Updated to describe what's actually still unfixed (`parent`'s auto-vivification, #2146 defect 3) instead.
- **Real, independently-confirmed pre-existing divergence, exposed but not created by this fix's reach**: real yq raises on a negative out-of-range array index (`.a[-5]`) where jq (and yq's own positive-OOB case) return `null` — reachable via the plain evaluator alone (`.a[-5]`, no path-context builtin involved) before this PR touched anything. Documented in `docs/compliance/yq/limitations.md` and filed as #2254 (not fixed here — it's a deep, mode-generic `resolve_read_index`/`index_one` gap unrelated to this PR's own missing-key/OOB-index-thread-path scope).
- **Related but out-of-scope finding**: `Builtin::GetPath` (`getpath([...])`) has a similar but strictly worse (unconditional, not found-vs-missing) stale-path bug in its own path-context handling — filed as #2253, not fixed here (needs its own path-context arm, not a small patch to the arm this PR touched).

Closes #2213.

## Test plan

- [x] `cargo test --features cli,simd,regex,serde --test jq_cli_tests --test yq_cli_tests --lib`: 3355 + 1334 + 1373 passed
- [x] `cargo test` (default features) and `cargo test --no-default-features --features portable-popcount` (no_std): both passing
- [x] `cargo clippy --all-targets --all-features -- -D warnings`: clean
- [x] `cargo fmt --check`: clean
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features`: clean
- [x] Live-verified the issue's own six-spelling repro table, all now `"zz"`, matching `path(.b.zz)` = `["b","zz"]`
- [x] Live-verified #2146's own repro table (jq and yq mode) for the non-`parent` rows, matching real yq v4.53.3
- [x] Live-verified genuine type errors (indexing a string/number/object with the wrong shape) still raise, and `?` still suppresses them
- [x] Live-verified `path()`/`del()`/`|=` for missing keys and out-of-bounds indices are byte-identical before/after
- [x] Live-verified the negative-OOB divergence against both pinned oracles (jq 1.7.1: `null`; yq v4.53.3: raises) before filing #2254
