### PR TITLE
fix(jq): mid-chain bare Identity no longer discards the rest of a write path (#2241)

### DIFF
--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -20215,6 +20215,23 @@ fn update_path_steps<S: EvalSemantics>(
                     |sub| update_path_steps::<S>(sub, rest, filter_expr, optional, scalar_noop),
                 );
             }
+            // #2241: a *mid-chain* bare `.` (`.a | . | .b`) is a transparent
+            // pass-through, same as everywhere else in this file that walks
+            // a path component list (`push_path_components`'s own `Expr::
+            // Identity => {}`, dropping it entirely rather than treating it
+            // as a component). Falling to the catch-all below sent it
+            // through `update_path`'s own *terminal* `Expr::Identity` arm
+            // instead -- correct only when Identity is genuinely the last
+            // step (the `[] => ...`/`[last] => ...` arms above already
+            // cover that shape) -- which applies `filter_expr` right there
+            // and returns, silently discarding `rest` (`.b`) rather than
+            // continuing the walk through it. Confirmed against jq 1.7.1:
+            // `{"a":{"b":1}} | (.a | . | .b) |= 99` is `{"a":{"b":99}}`,
+            // not `{"a":99}`.
+            Expr::Identity => {
+                steps = rest;
+                continue;
+            }
             _ => return update_path::<S>(root, first, filter_expr, here, scalar_noop),
         }
     }
@@ -36894,6 +36911,19 @@ fn delete_path_steps(
                     |sub| always_wrote(delete_path_steps(sub, rest, optional, yq_mode)),
                 )
                 .map(|_| ());
+            }
+            // #2241: same fix as `update_path_steps`'s identical arm -- a
+            // mid-chain bare `.` (`del(.a | . | .b)`) is a transparent
+            // pass-through, not a delete target in its own right. Falling
+            // to the catch-all below sent it through `delete_at_path`'s own
+            // *terminal* `Expr::Identity` arm instead, which replaces the
+            // whole current position with `null` and returns -- silently
+            // discarding `rest` (`.b`). Confirmed against jq 1.7.1:
+            // `{"a":{"b":1}} | del(.a | . | .b)` is `{"a":{}}`, not
+            // `{"a":null}`.
+            Expr::Identity => {
+                steps = rest;
+                continue;
             }
             _ => return delete_at_path(root, first, here, yq_mode),
         }

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -30642,6 +30642,49 @@ fn test_slice_update_with_identity_tail_still_raises_1428() -> Result<()> {
     Ok(())
 }
 
+/// #2241: a *mid-chain* bare `.` in a write path (`|=`/`del()`) is a
+/// transparent pass-through, not a delete/update target in its own right --
+/// `update_path_steps`/`delete_path_steps` both fell to a catch-all that
+/// routed it into `update_path`/`delete_at_path`'s own *terminal*
+/// `Expr::Identity` arm instead, silently discarding everything after it in
+/// the chain. Verified against jq 1.7.1 for every assertion below.
+#[test]
+fn test_mid_chain_identity_does_not_discard_rest_of_write_path_2241() -> Result<()> {
+    // `|=`: the issue's own repro.
+    let (stdout, _, code) = run_jq_full(&["-c", "(.a | . | .b) |= 99"], Some(r#"{"a":{"b":1}}"#))?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout.trim(), r#"{"a":{"b":99}}"#);
+
+    // `del()`: the same shape.
+    let (stdout, _, code) = run_jq_full(&["-c", "del(.a | . | .b)"], Some(r#"{"a":{"b":1}}"#))?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout.trim(), r#"{"a":{}}"#);
+
+    // A compound operator (`+=`) routes through the identical `update_path`
+    // machinery as `|=`.
+    let (stdout, _, code) = run_jq_full(&["-c", "(.a | . | .b) += 10"], Some(r#"{"a":{"b":1}}"#))?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout.trim(), r#"{"a":{"b":11}}"#);
+
+    // Two identities in a row, and an identity immediately followed by
+    // `.[]` -- each exercises a different next-step shape after the
+    // pass-through.
+    let (stdout, _, code) =
+        run_jq_full(&["-c", "(.a | . | . | .b) |= 99"], Some(r#"{"a":{"b":1}}"#))?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout.trim(), r#"{"a":{"b":99}}"#);
+
+    let (stdout, _, code) = run_jq_full(&["-c", "(.a | . | .[]) |= 99"], Some(r#"{"a":[1,2,3]}"#))?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout.trim(), r#"{"a":[99,99,99]}"#);
+
+    let (stdout, _, code) = run_jq_full(&["-c", "del(.a | . | .[1])"], Some(r#"{"a":[1,2,3]}"#))?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout.trim(), r#"{"a":[1,3]}"#);
+
+    Ok(())
+}
+
 /// #1876/#1883: `through_slice`'s `OwnedValue::String` *terminal-write* arm
 /// used to refuse with the generic `Cannot update string slices` message
 /// immediately, without ever running the update filter -- unlike its

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -12202,6 +12202,28 @@ fn test_literal_slice_parent_ancestor_resolves_yq_2215() -> Result<()> {
 }
 
 /// yq-mode counterpart to `jq_cli_tests.rs`'s
+/// `test_mid_chain_identity_does_not_discard_rest_of_write_path_2241` --
+/// `update_path_steps`/`delete_path_steps` are shared, mode-blind evaluator
+/// code, so this confirms the fix reaches yq's own `|=`/`del()` dispatch
+/// too, not just jq's. Verified against real yq v4.53.3.
+#[test]
+fn test_mid_chain_identity_does_not_discard_rest_of_write_path_yq_2241() -> Result<()> {
+    let (output, code) = run_yq_stdin(
+        "(.a | . | .b) |= 99",
+        "a:\n  b: 1\n",
+        &["-o", "json", "-I0"],
+    )?;
+    assert_eq!(code, 0);
+    assert_eq!(output.trim(), r#"{"a":{"b":99}}"#);
+
+    let (output, code) = run_yq_stdin("del(.a | . | .b)", "a:\n  b: 1\n", &["-o", "json", "-I0"])?;
+    assert_eq!(code, 0);
+    assert_eq!(output.trim(), r#"{"a":{}}"#);
+
+    Ok(())
+}
+
+/// yq-mode counterpart to `jq_cli_tests.rs`'s
 /// `test_string_interpolation_path_context_builtins_1334`/
 /// `test_func_def_path_context_builtins_1306` -- both new
 /// `needs_path_context`/`eval_pipe_with_path_context_internal` arms


### PR DESCRIPTION
## Summary

`update_path_steps` and `delete_path_steps` (the flat-chain walkers backing `|=`/compound-assignment and `del()`) both walk a run of path components (`Field`/`Index`/`Iterate`/`Slice`, an occasional spliced `Pipe`), falling to a catch-all for anything else that delegates the *whole remaining walk* to `update_path`/`delete_at_path` on that one component. A mid-chain bare `Expr::Identity` (`.a | . | .b`) fell into that catch-all too, landing on `update_path`'s/`delete_at_path`'s own **terminal** `Identity` arm — which applies the filter (or nulls the value) right there and returns, silently discarding every step after it in the chain.

```console
$ echo '{"a":{"b":1}}' | jq -c '(.a | . | .b) |= 99'
{"a":{"b":99}}
$ echo '{"a":{"b":1}}' | succinctly jq -c '(.a | . | .b) |= 99'   # before this fix
{"a":99}                          # .b silently discarded

$ echo '{"a":{"b":1}}' | jq -c 'del(.a | . | .b)'
{"a":{}}
$ echo '{"a":{"b":1}}' | succinctly jq -c 'del(.a | . | .b)'   # before this fix
{"a":null}                        # whole .a nulled instead of just .b removed
```

Pre-existing, independent of #2115 — confirmed via direct checkout of pre-#2115 `eval.rs`, which reproduces identically. Found incidentally while verifying that fix (see #2241's own issue body).

## Fix

Gives both `update_path_steps` and `delete_path_steps` an explicit `Expr::Identity` arm that advances to the next step (`steps = rest; continue;`) instead of falling to the catch-all — matching how every other path-component walker in this file already treats a bare `.`: a transparent pass-through, never a navigation or write target of its own (e.g. `push_path_components`'s own `Expr::Identity => {}`, which drops it during flattening).

Plain assignment (`=`) was already unaffected — it resolves through a different route (`flatten_path_components`) that already drops `Identity` during flattening, so this divergence never had a value-mode counterpart.

## Test plan
- [x] New `test_mid_chain_identity_does_not_discard_rest_of_write_path_2241` (jq mode): the issue's own `|=`/`del()` repros, plus `+=` (compound assignment routes through the same `update_path` machinery), double-identity, identity-then-iterate, and `del()` through an identity-then-index — all matching jq 1.7.1.
- [x] New `test_mid_chain_identity_does_not_discard_rest_of_write_path_yq_2241` (yq mode): `update_path_steps`/`delete_path_steps` are shared, mode-blind evaluator code — confirmed the fix reaches yq's own dispatch too, matching real yq v4.53.3.
- [x] Existing identity-related tests (`test_slice_update_with_identity_tail_still_raises_1428`, `test_del_with_comma_mixing_identity_and_other_paths`, 13 others) — all still pass unmodified.
- [x] Live-verified additional edge cases: `.? ` on the identity, identity at the start/end of a chain — all match jq 1.7.1.
- [x] `cargo test --features cli` — full suite green (57/57 binaries).
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean.
- [x] `cargo build --no-default-features` (no_std) — builds.
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --all-features --no-deps` — clean.
- [x] `cargo fmt --check` — clean.

Fixes #2241