### PR TITLE
fix(jq): thread current_path through Builtin::GetPath's path-context arm (#2253)

### DIFF
--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -13041,7 +13041,7 @@ fn getpath_one_path<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
         Ok(v) => v,
         Err(e) => return suppress_or_raise(e, optional),
     };
-    getpath_walk_owned::<W, S>(&root, path_owned, optional)
+    getpath_walk_owned::<W, S>(&root, &path_owned, optional)
 }
 
 /// [`getpath_one_path`]'s walk once its root value is already resolved and
@@ -13067,10 +13067,10 @@ fn getpath_one_path<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
 /// call the way `getpath_one_path` used to.
 pub(crate) fn getpath_walk_owned<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     root: &OwnedValue,
-    path_owned: OwnedValue,
+    path: &OwnedValue,
     optional: bool,
 ) -> QueryResult<'a, W> {
-    let OwnedValue::Array(path) = path_owned else {
+    let OwnedValue::Array(path) = path else {
         return if optional {
             QueryResult::None
         } else {
@@ -13081,7 +13081,7 @@ pub(crate) fn getpath_walk_owned<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     let mut current: Cow<'_, OwnedValue> = Cow::Borrowed(root);
 
     for segment in path {
-        match (current.as_ref(), &segment) {
+        match (current.as_ref(), segment) {
             // jq: null | getpath(["a"]) => null
             (OwnedValue::Null, _) => {
                 return QueryResult::Owned(OwnedValue::Null);
@@ -13094,7 +13094,7 @@ pub(crate) fn getpath_walk_owned<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
                 OwnedValue::Int(_) | OwnedValue::Float(_) | OwnedValue::NumberLiteral(..),
             ) => {
                 current = Cow::Owned(
-                    resolve_read_index(&segment, arr.len())
+                    resolve_read_index(segment, arr.len())
                         .map_or(OwnedValue::Null, |i| arr[i].clone()),
                 );
             }
@@ -13136,7 +13136,7 @@ pub(crate) fn getpath_walk_owned<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
             }
             _ if optional => return QueryResult::None,
             _ => {
-                return QueryResult::Error(EvalError::cannot_index(current.type_name(), &segment));
+                return QueryResult::Error(EvalError::cannot_index(current.type_name(), segment));
             }
         }
     }
@@ -31445,35 +31445,24 @@ fn eval_index_expr_with_path_context<'a, W: Clone + AsRef<[u64]>, S: EvalSemanti
 /// of a `getpath(...)` silently see a stale, unchanged position regardless of
 /// whether the requested key existed.
 ///
-/// `new_path` is the resolved path argument *verbatim*, not `current_path`
-/// extended by it: live-verified against *real jq 1.7.1* that
-/// `path(getpath(...))` always answers the argument array exactly,
-/// discarding whatever ambient position `path()` was itself called from
-/// (`{"x":{"y":{"a":1}}} | .x.y | path(getpath(["a"]))` is `["a"]`, not
-/// `["x","y","a"]`) -- `getpath` is a primitive jq's own path-tracking
-/// recognizes natively, unlike `.a.b`-style navigation, which derives its
-/// path by accumulation. `key`/`parent`/`file_index` (no jq oracle, but
-/// defined to agree with real jq's `path()` answer wherever one exists,
-/// same principle #2213 already established) follow suit for internal
-/// consistency. Note this is *real* jq's own `path()`, not succinctly's own
-/// `path()` builtin (a separate walker, `walk_path`/`navigate_static_
-/// component`) -- that one has its own, pre-existing, unrelated divergence
-/// here (#2257).
-///
-/// One known, deliberately unmatched gap: a slice-descriptor segment inside
-/// the path array (`getpath([{"start":1,"end":3}])`, the shape
-/// `path(.[1:3])` itself produces) computes its *value* successfully in both
-/// jq and here, but real jq's own `path(getpath([...]))` raises `Cannot
-/// index array with object` for that same segment -- `path()` apparently
-/// re-derives the argument step-by-step for at least this shape rather than
-/// truly echoing it verbatim, and that internal re-derivation doesn't
-/// recognize a slice descriptor the way direct `.[1:3]` syntax does. This
-/// implementation still reports the descriptor verbatim rather than
-/// reproducing that error, since jq's own inconsistency here (value
-/// succeeds, `path()` doesn't) has no clean single answer to copy and the
-/// shape is rare in practice (a slice descriptor is something `path(.[a:b])`
-/// produces, not something a caller usually writes by hand into `getpath`'s
-/// argument).
+/// `new_path` is `current_path` extended by the resolved path argument's own
+/// components, exactly like every other arm in this function (`Field`
+/// pushes one name, `Index` pushes one component, ...) -- *not* the argument
+/// reported verbatim in place of `current_path`. Live-verified against real
+/// jq 1.7.1 with the ambient navigation genuinely inside `path()`'s own
+/// tracking scope, not outside it: `{"a":{"b":{"c":1}}} | path(.a.b |
+/// getpath(["c"]))` is `["a","b","c"]`, and `getpath([])` is a true no-op
+/// (`path(.a | getpath([]))` is `["a"]`, unchanged). An earlier version of
+/// this comment cited `.x.y | path(getpath(["a"]))` (`["a"]`, not
+/// `["x","y","a"]`) as evidence for "verbatim" -- that reads as verbatim
+/// only because `.x.y` sits *outside* `path()`'s own argument there, so
+/// `path()`'s own tracking starts fresh at `[]` right where `getpath` is
+/// reached and the two theories coincide (`[] ++ P == P`); it says nothing
+/// about extend vs. replace once there's a real prefix *inside* the same
+/// `path()` scope, which the corrected test above settles. `key`/`parent`/
+/// `file_index` (no jq oracle, but defined to agree with real jq's `path()`
+/// answer wherever one exists, same principle #2213 already established)
+/// follow suit for internal consistency.
 ///
 /// One ambient `optional` throughout, unlike
 /// [`eval_index_expr_with_path_context`]'s `bracket_optional`/
@@ -31481,10 +31470,24 @@ fn eval_index_expr_with_path_context<'a, W: Clone + AsRef<[u64]>, S: EvalSemanti
 /// #1410 carve-out (`?` on `.foo[key]` guards the final index step alone,
 /// never the key sub-expression). `getpath(...)` is an ordinary builtin
 /// call, not bracket syntax, so ordinary `?` semantics apply uniformly: the
-/// same `optional` gates the path argument's own evaluation (matching
-/// `fanout_arg`'s identical `eval_single::<W, S>(arg_expr, value.clone(),
-/// optional)` call for the plain evaluator's own `builtin_getpath`), the
-/// walk's own type-mismatch errors, and `rest`'s continuation.
+/// same `optional` gates the path argument's own evaluation, the walk's own
+/// type-mismatch errors, and `rest`'s continuation.
+///
+/// Known gap, not fixed here: a later output of a *multi-output* path
+/// argument still runs (side effects included) even after an earlier
+/// output's own walk has already failed, where real jq (via
+/// `builtin_getpath`'s own `fanout_arg`/`eval_each`-based lazy pull) stops
+/// pulling the argument generator the instant a walk fails. This function
+/// still evaluates the whole path-argument generator up front rather than
+/// interleaving it with each walk, since doing so needs a genuinely lazy,
+/// per-output sink in the `OwnedValue`/path-context domain that doesn't
+/// exist yet (`eval_each`, which `fanout_arg` uses for this, is
+/// `StandardJson`-only). Filed as #2259. Already-yielded path-argument
+/// outputs are not silently dropped, though: an `Error`/`Break`/`Halt` from
+/// the path-argument generator itself is walked and folded into `results`
+/// like any other output before the escape fires, via the same
+/// `pending_escape`/loop-after-drain shape used below for a walk-time
+/// escape.
 fn eval_getpath_with_path_context<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     path_expr: &Expr,
     rest: &[Expr],
@@ -31502,17 +31505,17 @@ fn eval_getpath_with_path_context<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>
         current_path,
         optional,
     );
-    let (paths, pending_halt): (Vec<OwnedValue>, Option<i32>) =
-        match drain_path_context_stream(path_result) {
-            (_, Some(Control::Error(e))) => return QueryResult::Error(e),
-            (_, Some(Control::Break(label))) => return QueryResult::Break(label),
-            // #791: paths already yielded before a halt still owe output.
-            (vs, Some(Control::Halt(code))) => (vs, Some(code)),
-            (vs, None) => (vs, None),
-        };
+    // Every already-yielded path-argument output is walked below regardless
+    // of how the generator itself finished, so `Error`/`Break` are captured
+    // here rather than returned immediately -- unlike a bare
+    // `drain_path_context_stream` classification, which would discard `vs`
+    // on those two arms (#400/#494's own convention says a genuine escape
+    // still owes whatever output preceded it).
+    let (paths, pending_escape): (Vec<OwnedValue>, Option<Control>) =
+        drain_path_context_stream(path_result);
     if paths.is_empty() {
-        return match pending_halt {
-            Some(code) => partial(Vec::new(), Control::Halt(code)),
+        return match pending_escape {
+            Some(control) => partial(Vec::new(), control),
             None => QueryResult::None,
         };
     }
@@ -31522,16 +31525,20 @@ fn eval_getpath_with_path_context<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>
         // `getpath_walk_owned` owns both the "must be an array"
         // (`path_must_be_array`) check and the walk itself, so a
         // non-array `p` reaches `Error`/`None` there without this loop
-        // needing its own copy of that check.
-        match getpath_walk_owned::<W, S>(value, p.clone(), optional) {
+        // needing its own copy of that check. Takes `p` by reference, so
+        // `p` is still available below to build `new_path` without a
+        // clone.
+        match getpath_walk_owned::<W, S>(value, &p, optional) {
             QueryResult::Owned(v) => {
-                let OwnedValue::Array(new_path) = p else {
+                let OwnedValue::Array(components) = p else {
                     unreachable!(
                         "getpath_walk_owned only reaches Owned once its own \
                          path_must_be_array check has already confirmed `p` \
                          is an array"
                     )
                 };
+                let mut new_path = current_path.to_vec();
+                new_path.extend(components);
                 let step = eval_pipe_with_path_context_internal::<W, S>(
                     rest,
                     &v,
@@ -31552,8 +31559,8 @@ fn eval_getpath_with_path_context<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>
         }
     }
 
-    match pending_halt {
-        Some(code) => partial(results, Control::Halt(code)),
+    match pending_escape {
+        Some(control) => partial(results, control),
         None => owned_vec_to_result(results),
     }
 }

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -848,6 +848,12 @@ pub(crate) fn needs_path_context(expr: &Expr) -> bool {
         // shape needs more design work than a single recursive call, so it's
         // tracked separately rather than folded into this fix.
         Expr::Array(inner) => needs_path_context(inner),
+        // `getpath([key])` (#2253): same reasoning as `IndexExpr`'s `key`
+        // below -- without this arm, a `key`/`parent`/`file_index` reachable
+        // only through `getpath`'s own path argument (not downstream of it)
+        // would route the whole pipe through the plain evaluator, missing
+        // path context entirely rather than just reporting a stale position.
+        Expr::Builtin(Builtin::GetPath(path_expr)) => needs_path_context(path_expr),
         Expr::IndexExpr { target, key } => needs_path_context(target) || needs_path_context(key),
         Expr::SliceExpr { target, start, end } => {
             needs_path_context(target)
@@ -31431,6 +31437,127 @@ fn eval_index_expr_with_path_context<'a, W: Clone + AsRef<[u64]>, S: EvalSemanti
     }
 }
 
+/// `Builtin::GetPath`'s path-context arm (#2253): reproduces
+/// [`getpath_walk_owned`]'s value semantics exactly (that function is called
+/// unchanged, not reimplemented) while additionally extending `current_path`
+/// -- the piece the generic `Expr::Builtin(_)` catch-all this replaces has no
+/// notion of at all, which let `key`/`parent`/`path`/`file_index` downstream
+/// of a `getpath(...)` silently see a stale, unchanged position regardless of
+/// whether the requested key existed.
+///
+/// `new_path` is the resolved path argument *verbatim*, not `current_path`
+/// extended by it: live-verified against *real jq 1.7.1* that
+/// `path(getpath(...))` always answers the argument array exactly,
+/// discarding whatever ambient position `path()` was itself called from
+/// (`{"x":{"y":{"a":1}}} | .x.y | path(getpath(["a"]))` is `["a"]`, not
+/// `["x","y","a"]`) -- `getpath` is a primitive jq's own path-tracking
+/// recognizes natively, unlike `.a.b`-style navigation, which derives its
+/// path by accumulation. `key`/`parent`/`file_index` (no jq oracle, but
+/// defined to agree with real jq's `path()` answer wherever one exists,
+/// same principle #2213 already established) follow suit for internal
+/// consistency. Note this is *real* jq's own `path()`, not succinctly's own
+/// `path()` builtin (a separate walker, `walk_path`/`navigate_static_
+/// component`) -- that one has its own, pre-existing, unrelated divergence
+/// here (#2257).
+///
+/// One known, deliberately unmatched gap: a slice-descriptor segment inside
+/// the path array (`getpath([{"start":1,"end":3}])`, the shape
+/// `path(.[1:3])` itself produces) computes its *value* successfully in both
+/// jq and here, but real jq's own `path(getpath([...]))` raises `Cannot
+/// index array with object` for that same segment -- `path()` apparently
+/// re-derives the argument step-by-step for at least this shape rather than
+/// truly echoing it verbatim, and that internal re-derivation doesn't
+/// recognize a slice descriptor the way direct `.[1:3]` syntax does. This
+/// implementation still reports the descriptor verbatim rather than
+/// reproducing that error, since jq's own inconsistency here (value
+/// succeeds, `path()` doesn't) has no clean single answer to copy and the
+/// shape is rare in practice (a slice descriptor is something `path(.[a:b])`
+/// produces, not something a caller usually writes by hand into `getpath`'s
+/// argument).
+///
+/// One ambient `optional` throughout, unlike
+/// [`eval_index_expr_with_path_context`]'s `bracket_optional`/
+/// `rest_optional` split -- that split exists only for bracket syntax's own
+/// #1410 carve-out (`?` on `.foo[key]` guards the final index step alone,
+/// never the key sub-expression). `getpath(...)` is an ordinary builtin
+/// call, not bracket syntax, so ordinary `?` semantics apply uniformly: the
+/// same `optional` gates the path argument's own evaluation (matching
+/// `fanout_arg`'s identical `eval_single::<W, S>(arg_expr, value.clone(),
+/// optional)` call for the plain evaluator's own `builtin_getpath`), the
+/// walk's own type-mismatch errors, and `rest`'s continuation.
+fn eval_getpath_with_path_context<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
+    path_expr: &Expr,
+    rest: &[Expr],
+    value: &OwnedValue,
+    root: &OwnedValue,
+    file_origin: Option<&[usize]>,
+    current_path: &[OwnedValue],
+    optional: bool,
+) -> QueryResult<'a, W> {
+    let path_result = eval_expr_needing_path_context::<W, S>(
+        path_expr,
+        value,
+        root,
+        file_origin,
+        current_path,
+        optional,
+    );
+    let (paths, pending_halt): (Vec<OwnedValue>, Option<i32>) =
+        match drain_path_context_stream(path_result) {
+            (_, Some(Control::Error(e))) => return QueryResult::Error(e),
+            (_, Some(Control::Break(label))) => return QueryResult::Break(label),
+            // #791: paths already yielded before a halt still owe output.
+            (vs, Some(Control::Halt(code))) => (vs, Some(code)),
+            (vs, None) => (vs, None),
+        };
+    if paths.is_empty() {
+        return match pending_halt {
+            Some(code) => partial(Vec::new(), Control::Halt(code)),
+            None => QueryResult::None,
+        };
+    }
+
+    let mut results: Vec<OwnedValue> = Vec::new();
+    for p in paths {
+        // `getpath_walk_owned` owns both the "must be an array"
+        // (`path_must_be_array`) check and the walk itself, so a
+        // non-array `p` reaches `Error`/`None` there without this loop
+        // needing its own copy of that check.
+        match getpath_walk_owned::<W, S>(value, p.clone(), optional) {
+            QueryResult::Owned(v) => {
+                let OwnedValue::Array(new_path) = p else {
+                    unreachable!(
+                        "getpath_walk_owned only reaches Owned once its own \
+                         path_must_be_array check has already confirmed `p` \
+                         is an array"
+                    )
+                };
+                let step = eval_pipe_with_path_context_internal::<W, S>(
+                    rest,
+                    &v,
+                    root,
+                    file_origin,
+                    &new_path,
+                    optional,
+                );
+                if let Some(stop) = accumulate_path_context_step(&mut results, step) {
+                    return stop;
+                }
+            }
+            QueryResult::None => {}
+            QueryResult::Error(e) => {
+                return partial(core::mem::take(&mut results), Control::Error(e));
+            }
+            _ => unreachable!("getpath_walk_owned only ever produces Owned/None/Error"),
+        }
+    }
+
+    match pending_halt {
+        Some(code) => partial(results, Control::Halt(code)),
+        None => owned_vec_to_result(results),
+    }
+}
+
 /// One resolved slice bound: its raw value (as `key`/`parent` etc. would
 /// see it) paired with the rounded `i64` [`slice_owned_value_read`] actually
 /// indexes with. Distinct from [`ResolvedSliceBound`] (`(Option<i64>,
@@ -32624,6 +32751,18 @@ fn eval_stage_with_path_context<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
                 optional,
             )
         }
+        // #2253: needs its own arm rather than falling to the generic
+        // `Expr::Builtin(_)` catch-all below, which evaluates via the plain
+        // evaluator and resumes `rest` at the unchanged `current_path`.
+        Expr::Builtin(Builtin::GetPath(path_expr)) => eval_getpath_with_path_context::<W, S>(
+            path_expr,
+            rest,
+            value,
+            root,
+            file_origin,
+            current_path,
+            optional,
+        ),
         Expr::Builtin(_) => {
             // Handle other builtins that don't need special path handling.
             // `first` already *is* this `Expr::Builtin`, so evaluate it

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -10627,7 +10627,7 @@ fn eval_builtin<S: EvalSemantics, V: DocumentValue>(
                             Vec<u64>,
                             S,
                         >(
-                            &owned, path_owned, optional
+                            &owned, &path_owned, optional
                         ))
                     },
                 );

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -8975,10 +8975,11 @@ fn test_optional_index_key_error_escapes_path_context_1410() -> Result<()> {
 /// `key`/`parent`/`path`, not resume `rest` at the unchanged ambient
 /// position the way the generic `Expr::Builtin(_)` catch-all did.
 ///
-/// The reported path is the resolved argument *verbatim*, not
-/// `current_path` extended by it -- matches real jq 1.7.1's own
-/// `path(getpath(...))`, which discards whatever ambient position `path()`
-/// was itself called from.
+/// The reported path is `current_path` extended by the resolved argument's
+/// own components -- matches real jq 1.7.1's own `path(getpath(...))` when
+/// the ambient navigation is genuinely inside the same `path()` scope (not
+/// discarded, an earlier, insufficiently general oracle check's mistake --
+/// see this function's own doc comment for the corrected reasoning).
 #[test]
 fn test_getpath_extends_path_context_2253() -> Result<()> {
     let input = r#"{"a":{"x":1}}"#;
@@ -8994,14 +8995,33 @@ fn test_getpath_extends_path_context_2253() -> Result<()> {
     assert_eq!(code, 0);
     assert_eq!(stdout, "\"x\"\n");
 
-    // `parent` is consistent with the verbatim-path rule (real jq 1.7.1's
-    // own `path(getpath(...))` discards the ambient prefix, per this
-    // function's own doc comment -- not succinctly's `path()` builtin,
-    // which has a separate, pre-existing divergence here unrelated to this
-    // fix, see #2257): one level up from `["zz"]` is the root, not `.a`.
+    // `parent` extends the ambient path rather than replacing it: one level
+    // up from `["a","zz"]` is `.a`'s own value, matching real jq's
+    // `path(.a | getpath(["zz"]))` == `["a","zz"]`.
     let (stdout, _, code) = run_jq_full(&["-c", ".a | getpath([\"zz\"]) | parent"], Some(input))?;
     assert_eq!(code, 0);
-    assert_eq!(stdout, "{\"a\":{\"x\":1}}\n");
+    assert_eq!(stdout, "{\"x\":1}\n");
+
+    // `getpath([])` is a true no-op on the path: `key` after it still
+    // reports `.a`'s own key, not a reset position.
+    let (stdout, _, code) = run_jq_full(&["-c", ".a | getpath([]) | key"], Some(input))?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout, "\"a\"\n");
+
+    // Chained getpath calls extend cumulatively rather than each one
+    // resetting the path to its own argument.
+    let (stdout, _, code) = run_jq_full(
+        &["-c", ".a.b | getpath([\"c\",\"d\"]) | key"],
+        Some(r#"{"a":{"b":{"c":{"d":1}}}}"#),
+    )?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout, "\"d\"\n");
+    let (stdout, _, code) = run_jq_full(
+        &["-c", "[path(.a.b | getpath([\"c\",\"d\"]))]"],
+        Some(r#"{"a":{"b":{"c":{"d":1}}}}"#),
+    )?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout, "[[\"a\",\"b\",\"c\",\"d\"]]\n");
 
     Ok(())
 }
@@ -9093,6 +9113,18 @@ fn test_getpath_path_context_escape_priority_2253() -> Result<()> {
         stderr.contains("Cannot index number with string"),
         "{stderr}"
     );
+
+    // Same rule when the *path-argument generator itself* escapes, not just
+    // a later resolved path's own walk: the first alternative's output is
+    // walked and folded into the result before the generator's own error
+    // propagates, rather than being silently dropped.
+    let (stdout, stderr, code) = run_jq_full(
+        &["-c", "getpath(([\"a\"], error(\"boom\"))) | key"],
+        Some(r#"{"a":1}"#),
+    )?;
+    assert_eq!(code, 5, "stderr: {stderr}");
+    assert_eq!(stdout, "\"a\"\n");
+    assert!(stderr.contains("boom"), "{stderr}");
 
     Ok(())
 }

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -8971,6 +8971,132 @@ fn test_optional_index_key_error_escapes_path_context_1410() -> Result<()> {
     Ok(())
 }
 
+/// `Builtin::GetPath` (#2253) must extend `current_path` for a downstream
+/// `key`/`parent`/`path`, not resume `rest` at the unchanged ambient
+/// position the way the generic `Expr::Builtin(_)` catch-all did.
+///
+/// The reported path is the resolved argument *verbatim*, not
+/// `current_path` extended by it -- matches real jq 1.7.1's own
+/// `path(getpath(...))`, which discards whatever ambient position `path()`
+/// was itself called from.
+#[test]
+fn test_getpath_extends_path_context_2253() -> Result<()> {
+    let input = r#"{"a":{"x":1}}"#;
+
+    // The issue's own repro: a missing key inside getpath's target.
+    let (stdout, _, code) = run_jq_full(&["-c", ".a | getpath([\"zz\"]) | key"], Some(input))?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout, "\"zz\"\n");
+
+    // A *found* key had the identical bug -- unconditional, not gated on
+    // found-vs-missing, unlike #2213's Field/Index fix.
+    let (stdout, _, code) = run_jq_full(&["-c", ".a | getpath([\"x\"]) | key"], Some(input))?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout, "\"x\"\n");
+
+    // `parent` is consistent with the verbatim-path rule (real jq 1.7.1's
+    // own `path(getpath(...))` discards the ambient prefix, per this
+    // function's own doc comment -- not succinctly's `path()` builtin,
+    // which has a separate, pre-existing divergence here unrelated to this
+    // fix, see #2257): one level up from `["zz"]` is the root, not `.a`.
+    let (stdout, _, code) = run_jq_full(&["-c", ".a | getpath([\"zz\"]) | parent"], Some(input))?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout, "{\"a\":{\"x\":1}}\n");
+
+    Ok(())
+}
+
+/// #2253's fix across the shapes `getpath_walk_owned` itself already
+/// handled correctly for *value* computation, now also verified for the
+/// *path* it reports to `key` -- multi-output path generators, negative and
+/// slice-descriptor segments, indexing through `null`, and both directions
+/// of `?` (path-argument errors and walk-time type errors).
+#[test]
+fn test_getpath_path_context_matches_path_builtin_2253() -> Result<()> {
+    // A generator path argument fans out into independent outputs, each
+    // with its own verbatim path.
+    let (stdout, _, code) = run_jq_full(
+        &["-c", "[getpath(([\"a\"],[\"b\"])) | key]"],
+        Some(r#"{"a":1,"b":2}"#),
+    )?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout, "[\"a\",\"b\"]\n");
+
+    // Indexing through `null` mid-walk is "not an error, propagate null"
+    // (#2213's own rule), same as a missing key.
+    let (stdout, _, code) = run_jq_full(
+        &["-c", ".a | getpath([\"zz\"]) | key"],
+        Some(r#"{"a":null}"#),
+    )?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout, "\"zz\"\n");
+
+    // A slice-descriptor path segment reports the descriptor itself as
+    // `key`'s answer -- matches `path(.[1:3])`'s own last-component shape.
+    let (stdout, _, code) = run_jq_full(
+        &["-c", "getpath([{\"start\":1,\"end\":3}]) | key"],
+        Some("[1,2,3,4]"),
+    )?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout, "{\"start\":1,\"end\":3}\n");
+
+    // A non-array path argument is `optional`-suppressed like any other
+    // error reachable from this arm.
+    let (stdout, _, code) = run_jq_full(&["-c", ".a | (getpath(1))? | key"], Some(r#"{"a":1}"#))?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout, "");
+
+    // The same shape without `?` still raises.
+    let (_, stderr, code) = run_jq_full(&["-c", ".a | getpath(1) | key"], Some(r#"{"a":1}"#))?;
+    assert_eq!(code, 5);
+    assert!(
+        stderr.contains("Path must be specified as an array"),
+        "{stderr}"
+    );
+
+    // A genuine walk-time type error (indexing a number) is
+    // `optional`-suppressed the same way.
+    let (stdout, _, code) = run_jq_full(
+        &["-c", ".a | (getpath([\"b\"]))? | key"],
+        Some(r#"{"a":5}"#),
+    )?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout, "");
+
+    // The same shape without `?` still raises.
+    let (_, stderr, code) =
+        run_jq_full(&["-c", ".a | getpath([\"b\"]) | key"], Some(r#"{"a":5}"#))?;
+    assert_eq!(code, 5);
+    assert!(
+        stderr.contains("Cannot index number with string"),
+        "{stderr}"
+    );
+
+    Ok(())
+}
+
+/// #2253's escape-priority ordering across a multi-output path generator:
+/// an earlier branch's output survives a later branch's error/halt, same
+/// rule `eval_index_expr_with_path_context`'s own per-key loop (#2100)
+/// already established for a computed bracket's own key generator.
+#[test]
+fn test_getpath_path_context_escape_priority_2253() -> Result<()> {
+    // First branch resolves and is printed; second branch's own walk-time
+    // type error escapes with that prefix intact rather than discarding it.
+    let (stdout, stderr, code) = run_jq_full(
+        &["-c", "getpath(([\"a\"], [\"b\",\"y\"])) | key"],
+        Some(r#"{"a":1,"b":5}"#),
+    )?;
+    assert_eq!(code, 5, "stderr: {stderr}");
+    assert_eq!(stdout, "\"a\"\n");
+    assert!(
+        stderr.contains("Cannot index number with string"),
+        "{stderr}"
+    );
+
+    Ok(())
+}
+
 /// A computed bracket (`Expr::IndexExpr`/`Expr::SliceExpr`) must extend
 /// `current_path` the same way a literal `.foo`/`.[0]` does, so `key`/
 /// `parent`/`path` downstream (and inside the bracket's own key/bounds


### PR DESCRIPTION
## Summary

- `Builtin::GetPath` had no dedicated arm in `eval_stage_with_path_context`, so it fell through to the generic `Expr::Builtin(_)` catch-all, which evaluates via the plain evaluator and resumes `rest` at the unchanged `current_path`. Unlike #2213's Field/Index bug, this was **unconditional**, not just on a missing key: `.a | getpath(["x"]) | key` (a *found* key) was just as wrong as the missing-key case.
- New `eval_getpath_with_path_context` reuses `getpath_walk_owned` unchanged for value computation and sets `new_path` to `current_path` extended by the resolved path argument's own components -- exactly like every other arm in this function (`Field` pushes one name, `Index` pushes one component, ...). Live-verified against real jq 1.7.1 with the ambient navigation genuinely inside `path()`'s own tracking scope: `{"a":{"b":{"c":1}}} | path(.a.b | getpath(["c"]))` is `["a","b","c"]`, and `getpath([])` is a true no-op.
- Also adds a `needs_path_context` arm for `GetPath`'s own argument (`getpath([key])`), mirroring `IndexExpr`'s identical key-recursion pattern.
- One ambient `optional` throughout (path-argument evaluation, walk-time type errors, and `rest`'s continuation) -- unlike `IndexExpr`'s `bracket_optional`/`rest_optional` split, which exists only for #1410's bracket-syntax carve-out and doesn't apply to an ordinary builtin call like `getpath(...)`.
- Also found and filed #2257: succinctly's own `path()` builtin (a separate walker, `walk_path`/`navigate_static_component`, unrelated code this PR doesn't touch) has its own, pre-existing divergence from real jq for `getpath` (confirmed pre-existing on unmodified `main`).

**Review round 2** (11-agent fan-out on this PR itself) found a fundamentally wrong premise in the first draft, plus several smaller issues, all now fixed:

- **Wrong path semantics (the core bug).** The first draft set `current_path` to the resolved argument *verbatim*, discarding the ambient prefix -- based on an insufficiently general oracle check (`.x.y | path(getpath(["a"]))` == `["a"]`, which coincides with both "verbatim" and "extend" theories only because `path()`'s own tracking starts fresh at `[]` right where `getpath` is reached in *that specific query shape*). Re-verified with the ambient navigation genuinely inside `path()`'s own scope (`path(.a | getpath(["zz"]))` == `["a","zz"]`, chained calls extend cumulatively) -- confirmed extend, not replace, is correct. This also fixes a second-order bug it caused: `parent` after a `getpath` from a non-root position returned an unrelated sibling subtree (`resolve_ancestor_path` re-navigates from root using `current_path`, which was simply wrong before).
- **Discarded prefix on a path-argument generator's own escape.** `getpath((P1, error(...)))`'s `P1` output is now walked and folded into the result before the error propagates, matching real jq (previously only the `Halt` case handled this correctly; `Error`/`Break` discarded already-yielded paths).
- **A false "known divergence" claim, removed.** The first draft's doc comment claimed real jq's `path(getpath([{"start":1,"end":3}]))` raises an error for a slice-descriptor path segment -- that claim tested succinctly's own build instead of `/usr/bin/jq` directly. Re-verified against the real oracle: no divergence exists at all.
- **An avoidable clone, removed.** `getpath_walk_owned` now takes its path by reference instead of by value, since it only ever reads through it -- removes a full deep clone of the resolved path array on every iteration of the caller's loop; updated its two other call sites too.
- **Documented and filed as a follow-up** (#2259, deliberately not fixed here): a multi-output path argument is still evaluated eagerly rather than interleaved with the walk, so a later alternative's side effects can run even after an earlier one's walk has already failed. Real jq's own lazy pull for this exact generator-argument-builtin-call shape needs a genuinely new `OwnedValue`-domain sink primitive that doesn't exist yet (`eval_each`, which the plain evaluator's own `fanout_arg` uses for this, is `StandardJson`-only). Already-yielded output is never silently dropped either way -- only side-effect *timing* isn't yet interleaved. Low real-world impact: only manifests for a multi-output generator argument with an earlier alternative that fails and a later one with an observable side effect.
Closes #2253.

## Test plan

- [x] `cargo test --features cli,simd,regex,serde --test jq_cli_tests --test yq_cli_tests --lib`: 3355 + 1339 + 1373 passed
- [x] `cargo test` (default features) and `cargo test --no-default-features --features portable-popcount` (no_std): both passing
- [x] `cargo clippy --all-targets --all-features -- -D warnings`: clean
- [x] `cargo fmt --check`: clean
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features`: clean
- [x] Live-verified extend semantics against real jq 1.7.1 with a genuine multi-level ambient prefix inside `path()`'s own scope, chained `getpath` calls, and the `getpath([])` identity case
- [x] Live-verified the `parent`-from-non-root regression is fixed (`resolve_ancestor_path` now navigates a correctly-extended path)
- [x] Live-verified prefix preservation on a path-argument generator's own `Error`/`Break`, matching real jq and succinctly's own plain evaluator
- [x] Live-verified multi-output path generators, negative/int/slice-descriptor segments, indexing through `null`, both directions of `?`, and walk-time escape-priority ordering
- [x] Live-verified `yq --jq-extensions` mode picks up the fix for free (same mode-generic `eval_stage_with_path_context`)
