### PR TITLE
fix(jq): reject trailing comma after a real last child in lazy path

### DIFF
--- a/docs/compliance/jq/limitations.md
+++ b/docs/compliance/jq/limitations.md
@@ -1223,6 +1223,74 @@ check against the actual binary proves that, and is worth doing for any future b
 (or might grow) its own native `eval_generic.rs` implementation rather than falling through to
 this file via the bridge.
 
+## A trailing comma after a genuine last child, scoped to one materializer (#2243)
+
+`[1,]`/`{"a":1,}` -- a stray trailing `,` after the container's own *last real
+member*, with every member present otherwise well-formed -- is a distinct
+malformed-delimiter shape from #1677's missing/doubled `,`/`:` between two
+members above, and from #2211's `[,]`/`{,}` (a stray `,` with **no** real
+member at all). #2243 closed it for `eval_generic::to_owned_cursor_at_depth`
+(the materializer behind the `evaluate_bytes_lazy`/non-cursor-transparent
+path -- `if`/arithmetic/function calls, anything `expr_is_cursor_transparent`
+answers `false` for, same gate #2211 used) by adding
+`DocumentCursor::trailing_element_gap_ok`/`DocumentValue::scalar_text_end` to
+the shared trait system ([src/jq/document.rs](../../../src/jq/document.rs)),
+implemented for JSON by reusing the CLI printer's own existing
+`trailing_gap_ok`/`scalar_end_pos` primitives (#1676/#1576) rather than a
+third hand-copied pair:
+
+```
+$ echo '[1,]'      | jq  -c 'if true then . else . end'   # parse error, exit 5
+$ echo '[1,]'      | sjq -c 'if true then . else . end'   # exit 5 now (was: [1], exit 0)
+$ echo '{"a":1,}'  | jq  -c 'if true then . else . end'   # parse error, exit 5
+$ echo '{"a":1,}'  | sjq -c 'if true then . else . end'   # exit 5 now (was: {"a":1}, exit 0)
+```
+
+**Residual gap: a *container-typed* last child still passes through.**
+`scalar_text_end` only knows how to answer a scalar's own end position from
+its start (`start + raw_bytes().len()`, or a fixed literal length for
+`Bool`/`Null`) -- a container's own end position is not derivable from its
+start alone without a further cursor walk, so it answers `None` there by
+design, and `trailing_element_gap_ok` treats that the same as "can't
+determine, skip" (the same convention every other gap check in this family
+already follows):
+
+```
+$ echo '[1,[2,3],]'          | jq  -c '.'   # parse error, exit 5
+$ echo '[1,[2,3],]'          | sjq -c '.'   # [1,[2,3]], exit 0 -- still open
+$ echo '{"a":1,"b":[1,2],}'  | jq  -c '.'   # parse error, exit 5
+$ echo '{"a":1,"b":[1,2],}'  | sjq -c '.'   # {"a":1,"b":[1,2]}, exit 0 -- still open
+```
+
+This is not new: the cursor-transparent `.` path (`stream_json_pretty`'s own
+`scalar_end_pos`, #1676) already has the identical gap for the identical
+reason, confirmed live against `main` prior to #2243. Pinned by
+`test_jq_lazy_path_trailing_comma_after_container_last_child_still_a_known_gap_2243`
+in [tests/jq_cli_tests.rs](../../../tests/jq_cli_tests.rs) rather than left
+untested.
+
+**Much narrower reach than #1677/#2211's own checks, tracked as three
+follow-ups rather than folded in here** (same "one materializer at a time"
+practice #2243's own issue text cites for not folding into #2211):
+
+- **#2261**: every *cursor-transparent* fast path -- `.[]`, `keys`/
+  `keys_unsorted`/`to_entries`, bare `.a`/`.[0]`/`.["a"]` field/index access,
+  `length` -- takes a route through `eval_generic.rs` that never reaches
+  `to_owned_cursor_at_depth` at all, so this fix does not reach jq's most
+  common query idioms; only the non-cursor-transparent shape #2243's own
+  repro uses (`if`/arithmetic/function calls) is covered.
+- **#2262**: three sibling materializers -- `eval.rs`'s own `to_owned_at_depth`
+  (behind this crate's documented public `eval()` API), `eval_generic.rs`'s
+  own cursor-less `to_owned_at_depth`, and `yq_runner.rs`'s
+  `to_owned_canonicalizing_numbers_at_depth` (behind `succinctly yq --slurp`/
+  `--eval-all`/`--inplace --input-format json`, live and CLI-reachable) --
+  still lack #2211's and #2243's checks the same way #1975 found they lacked
+  #1677's.
+- **#2263**: `jq_runner.rs` still carries its own independent, hand-copied
+  `trailing_gap_ok`/`scalar_end_pos` pair rather than the new trait methods --
+  a cleanup, not a behavior gap, but the same "duplicated predicates diverge
+  silently" shape (#106) this fix was written to reduce, not add to.
+
 ## Refusing an allocation jq does not survive
 
 `setpath` takes its array index from the document, so the array it pads is sized by the

--- a/src/jq/document.rs
+++ b/src/jq/document.rs
@@ -262,6 +262,38 @@ pub trait DocumentCursor: Sized + Copy + Clone {
         true
     }
 
+    /// Whether nothing but whitespace separates `gap_start` (a container's
+    /// *last real child's* own already-resolved span end, via
+    /// [`DocumentValue::scalar_text_end`]) from `close_char` (`]`/`}`) --
+    /// #2243, the sibling of [`container_gap_ok`](Self::container_gap_ok)
+    /// for a container whose child walk produced at least one real child.
+    ///
+    /// `container_gap_ok` only ever fires when the walk produced **zero**
+    /// children (`[,]`, `{,}`) -- it has nothing to compare a *trailing*
+    /// stray comma after a genuine last child (`[1,]`, `{"a":1,}`) against,
+    /// since it derives the gap from its own `text_position()` (the
+    /// container's *opening* delimiter), not the last child's end. This
+    /// closes that gap the same way `crate::json::light`'s own
+    /// `trailing_gap_ok` already does for the CLI's cursor-native writers
+    /// (#1676) -- one gap-scanning primitive, this one more entry point
+    /// shaped for what `eval_generic::to_owned_cursor_at_depth` already has
+    /// in hand (a resolved last-child cursor and its own decoded value).
+    ///
+    /// Called on the *last child's* cursor, not the container's -- unlike
+    /// `container_gap_ok`, the gap start here is a value the caller already
+    /// resolved (never re-derivable from `self` alone the way an empty
+    /// container's own opening position is), so `self` only needs to expose
+    /// whatever the underlying format needs to scan forward from it (JSON:
+    /// the shared source buffer).
+    ///
+    /// The default answers `true` unconditionally, same reasoning as
+    /// [`container_gap_ok`](Self::container_gap_ok): every format but JSON
+    /// validates this while parsing.
+    fn trailing_element_gap_ok(&self, gap_start: usize, close_char: u8) -> bool {
+        let _ = (gap_start, close_char);
+        true
+    }
+
     /// Whether the value immediately following this key (at `key_end`, the
     /// key's own already-known span end) is preceded by exactly one `:`
     /// (#1677) -- the forward-scan twin of
@@ -718,6 +750,34 @@ pub trait DocumentValue: Sized + Clone {
     /// this is used for -- a key is never a `Number` on a well-formed
     /// document, and #1194's own check already refuses one that is.
     fn text_end(&self) -> Option<usize> {
+        None
+    }
+
+    /// The byte position immediately past this value's own text span, given
+    /// `start` (this value's own already-resolved opening position, e.g.
+    /// [`DocumentCursor::text_position`]) -- #2243, the trait-level
+    /// generalization of `crate::json::light`'s own free-function
+    /// `scalar_end_pos`, which this and that function's remaining callers
+    /// (`stream_json_pretty`) both now share one definition for.
+    ///
+    /// Unlike [`text_end`](Self::text_end), this takes `start` explicitly
+    /// rather than assuming the value carries its own position: `Bool`/
+    /// `Null` need one to answer at all (JSON's own `StandardJson::Bool`/
+    /// `::Null` variants carry no position, only their two/four/five-byte
+    /// spelling once a start is known), and `String`/`Number` -- which do
+    /// carry their own position -- still accept `start` for a uniform
+    /// signature rather than a third arm just for them.
+    ///
+    /// `None` for a container (`Array`/`Object`) is deliberate, not a gap:
+    /// a container's own last child may have arbitrary trailing whitespace
+    /// before its closing bracket, so its end position is only knowable via
+    /// a real cursor lookup at that depth, not derivable from `start` alone
+    /// -- callers checking a trailing gap treat `None` here as "can't
+    /// determine, skip" (matching `scalar_end_pos`'s own original doc
+    /// comment). Defaults to `None`; JSON overrides it for every scalar
+    /// variant.
+    fn scalar_text_end(&self, start: usize) -> Option<usize> {
+        let _ = start;
         None
     }
 

--- a/src/jq/document.rs
+++ b/src/jq/document.rs
@@ -288,7 +288,16 @@ pub trait DocumentCursor: Sized + Copy + Clone {
     ///
     /// The default answers `true` unconditionally, same reasoning as
     /// [`container_gap_ok`](Self::container_gap_ok): every format but JSON
-    /// validates this while parsing.
+    /// validates this while parsing. Provably unreachable for every format
+    /// shipped today, not just trivially correct for them: this method's one
+    /// caller only reaches it once `scalar_text_end` has already answered
+    /// `Some`, and JSON is the only format whose `scalar_text_end` ever does
+    /// -- and JSON overrides this method too, so its own default body never
+    /// runs either. Kept so this default exists to keep a future non-JSON,
+    /// non-parse-validating format honest rather than to be exercised by
+    /// anything shipped today (same reasoning as
+    /// [`malformed_delimiter_error`](Self::malformed_delimiter_error)'s own
+    /// default).
     fn trailing_element_gap_ok(&self, gap_start: usize, close_char: u8) -> bool {
         let _ = (gap_start, close_char);
         true

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -351,6 +351,31 @@ pub fn to_owned_all_cursors<'a, C: DocumentCursor + 'a>(
     cursors.into_iter().map(to_owned_cursor).collect()
 }
 
+/// #2243: whether a trailing stray `,` (`[1,]`, `{"a":1,}`) sits between a
+/// container's *last real child* (`last_cursor`/`last_value`) and
+/// `close_char` -- shared by [`to_owned_cursor_at_depth`]'s object and
+/// array arms, one definition instead of two hand-copied ones (this
+/// crate's own "duplicated predicates diverge silently" lesson).
+///
+/// `None` from either half of the lookup -- no resolvable start position,
+/// or a container-typed child whose own end isn't derivable from its start
+/// alone (see [`DocumentValue::scalar_text_end`]'s own doc comment) --
+/// answers `true` (nothing to flag), the same "can't determine, skip"
+/// convention every sibling gap check in this file already follows.
+fn trailing_element_gap_ok<C: DocumentCursor>(
+    last_cursor: &C,
+    last_value: &C::Value,
+    close_char: u8,
+) -> bool {
+    match last_cursor.text_position() {
+        Some(start) => match last_value.scalar_text_end(start) {
+            Some(end) => last_cursor.trailing_element_gap_ok(end, close_char),
+            None => true,
+        },
+        None => true,
+    }
+}
+
 fn to_owned_cursor_at_depth<C: DocumentCursor>(
     cursor: &C,
     depth: usize,
@@ -362,6 +387,12 @@ fn to_owned_cursor_at_depth<C: DocumentCursor>(
         let mut guard = DisplayKeyGuard::default();
         let mut f = fields;
         let mut is_first = true;
+        // #2243: the last real field's own value+cursor, retained past the
+        // loop so the trailing-gap check below (a stray `,` *after* a real
+        // last field, `{"a":1,}`) has something to check from -- distinct
+        // from #2211's `map.is_empty()` check just below, which only ever
+        // catches a stray `,` with no real field at all (`{,}`).
+        let mut last_field: Option<(C::Value, C)> = None;
         while let Some((field, rest)) = f.uncons() {
             // Same key handling as `to_owned_at_depth` above, same reasons --
             // these two conversions are copies of each other and a fix that
@@ -385,6 +416,7 @@ fn to_owned_cursor_at_depth<C: DocumentCursor>(
                 key,
                 to_owned_cursor_at_depth(&field.value_cursor, depth + 1)?,
             );
+            last_field = Some((field.value.clone(), field.value_cursor));
             f = rest;
             is_first = false;
         }
@@ -397,14 +429,24 @@ fn to_owned_cursor_at_depth<C: DocumentCursor>(
         // it. `map.is_empty()` after the walk is exactly that case (a
         // genuine `{}` also reaches here, and `container_gap_ok` answers
         // `true` for it -- see that method's own doc comment).
-        if map.is_empty() && !cursor.container_gap_ok(b'}') {
-            return Err(cursor.malformed_delimiter_error());
+        if map.is_empty() {
+            if !cursor.container_gap_ok(b'}') {
+                return Err(cursor.malformed_delimiter_error());
+            }
+        } else {
+            let (value, value_cursor) =
+                last_field.expect("map non-empty implies a real field was inserted");
+            if !trailing_element_gap_ok(&value_cursor, &value, b'}') {
+                return Err(cursor.malformed_delimiter_error());
+            }
         }
         Ok(OwnedValue::Object(map))
     } else if let Some(elements) = value.as_array() {
         let mut items = Vec::new();
         let mut elems = elements;
         let mut is_first = true;
+        // #2243: same reasoning as the object arm's own `last_field` above.
+        let mut last_elem: Option<C> = None;
         while let Some((elem_cursor, rest)) = elems.uncons_cursor() {
             // #1677: same gap check as `to_owned_at_depth`'s array loop.
             if let Some(pos) = elem_cursor.text_position() {
@@ -414,13 +456,22 @@ fn to_owned_cursor_at_depth<C: DocumentCursor>(
                 }
             }
             items.push(to_owned_cursor_at_depth(&elem_cursor, depth + 1)?);
+            last_elem = Some(elem_cursor);
             elems = rest;
             is_first = false;
         }
         // #2211: same reasoning as the object arm's own check just above,
         // for a stray `,` with no real element (`[,]`).
-        if items.is_empty() && !cursor.container_gap_ok(b']') {
-            return Err(cursor.malformed_delimiter_error());
+        if items.is_empty() {
+            if !cursor.container_gap_ok(b']') {
+                return Err(cursor.malformed_delimiter_error());
+            }
+        } else {
+            let last = last_elem.expect("items non-empty implies a real element was pushed");
+            let last_value = last.value();
+            if !trailing_element_gap_ok(&last, &last_value, b']') {
+                return Err(cursor.malformed_delimiter_error());
+            }
         }
         Ok(OwnedValue::Array(items))
     } else {

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -352,23 +352,28 @@ pub fn to_owned_all_cursors<'a, C: DocumentCursor + 'a>(
 }
 
 /// #2243: whether a trailing stray `,` (`[1,]`, `{"a":1,}`) sits between a
-/// container's *last real child* (`last_cursor`/`last_value`) and
-/// `close_char` -- shared by [`to_owned_cursor_at_depth`]'s object and
-/// array arms, one definition instead of two hand-copied ones (this
-/// crate's own "duplicated predicates diverge silently" lesson).
+/// container's *last real child* (`last_cursor`) and `close_char` -- shared
+/// by [`to_owned_cursor_at_depth`]'s object and array arms, one definition
+/// instead of two hand-copied ones (this crate's own "duplicated predicates
+/// diverge silently" lesson).
 ///
-/// `None` from either half of the lookup -- no resolvable start position,
-/// or a container-typed child whose own end isn't derivable from its start
-/// alone (see [`DocumentValue::scalar_text_end`]'s own doc comment) --
-/// answers `true` (nothing to flag), the same "can't determine, skip"
-/// convention every sibling gap check in this file already follows.
-fn trailing_element_gap_ok<C: DocumentCursor>(
-    last_cursor: &C,
-    last_value: &C::Value,
-    close_char: u8,
-) -> bool {
+/// Takes only the cursor, not an already-resolved value: [`DocumentValue::
+/// scalar_text_end`] unconditionally answers `None` for a container-typed
+/// child (see its own doc comment), so resolving one here first -- via
+/// `is_container()`, cheap and already required by every [`DocumentCursor`]
+/// impl -- skips a `.value()` call this check could never use anyway,
+/// rather than decoding it and immediately discarding the result.
+///
+/// `None` from either remaining half of the lookup -- no resolvable start
+/// position, or (for a scalar child) no derivable end position -- answers
+/// `true` (nothing to flag), the same "can't determine, skip" convention
+/// every sibling gap check in this file already follows.
+fn trailing_element_gap_ok<C: DocumentCursor>(last_cursor: &C, close_char: u8) -> bool {
+    if last_cursor.is_container() {
+        return true;
+    }
     match last_cursor.text_position() {
-        Some(start) => match last_value.scalar_text_end(start) {
+        Some(start) => match last_cursor.value().scalar_text_end(start) {
             Some(end) => last_cursor.trailing_element_gap_ok(end, close_char),
             None => true,
         },
@@ -387,12 +392,15 @@ fn to_owned_cursor_at_depth<C: DocumentCursor>(
         let mut guard = DisplayKeyGuard::default();
         let mut f = fields;
         let mut is_first = true;
-        // #2243: the last real field's own value+cursor, retained past the
-        // loop so the trailing-gap check below (a stray `,` *after* a real
-        // last field, `{"a":1,}`) has something to check from -- distinct
-        // from #2211's `map.is_empty()` check just below, which only ever
-        // catches a stray `,` with no real field at all (`{,}`).
-        let mut last_field: Option<(C::Value, C)> = None;
+        // #2243: the last real field's own cursor, retained past the loop so
+        // the trailing-gap check below (a stray `,` *after* a real last
+        // field, `{"a":1,}`) has something to check from -- distinct from
+        // #2211's `map.is_empty()` check just below, which only ever catches
+        // a stray `,` with no real field at all (`{,}`). Mirrors the array
+        // arm's own `last_elem`: only the cursor is kept, and
+        // `trailing_element_gap_ok` resolves a value from it (if it even
+        // needs to) once, after the loop, not per field.
+        let mut last_field: Option<C> = None;
         while let Some((field, rest)) = f.uncons() {
             // Same key handling as `to_owned_at_depth` above, same reasons --
             // these two conversions are copies of each other and a fix that
@@ -416,7 +424,7 @@ fn to_owned_cursor_at_depth<C: DocumentCursor>(
                 key,
                 to_owned_cursor_at_depth(&field.value_cursor, depth + 1)?,
             );
-            last_field = Some((field.value.clone(), field.value_cursor));
+            last_field = Some(field.value_cursor);
             f = rest;
             is_first = false;
         }
@@ -434,9 +442,8 @@ fn to_owned_cursor_at_depth<C: DocumentCursor>(
                 return Err(cursor.malformed_delimiter_error());
             }
         } else {
-            let (value, value_cursor) =
-                last_field.expect("map non-empty implies a real field was inserted");
-            if !trailing_element_gap_ok(&value_cursor, &value, b'}') {
+            let value_cursor = last_field.expect("map non-empty implies a real field was inserted");
+            if !trailing_element_gap_ok(&value_cursor, b'}') {
                 return Err(cursor.malformed_delimiter_error());
             }
         }
@@ -468,8 +475,7 @@ fn to_owned_cursor_at_depth<C: DocumentCursor>(
             }
         } else {
             let last = last_elem.expect("items non-empty implies a real element was pushed");
-            let last_value = last.value();
-            if !trailing_element_gap_ok(&last, &last_value, b']') {
+            if !trailing_element_gap_ok(&last, b']') {
                 return Err(cursor.malformed_delimiter_error());
             }
         }

--- a/src/json/light.rs
+++ b/src/json/light.rs
@@ -2149,6 +2149,17 @@ impl<'a, W: AsRef<[u64]> + Clone> DocumentCursor for JsonCursor<'a, W> {
         }
     }
 
+    /// #2243: reuses the same `trailing_gap_ok` primitive
+    /// [`container_gap_ok`](Self::container_gap_ok) does, just against a
+    /// caller-supplied `gap_start` (a real last child's own end) instead of
+    /// `self`'s own opening position + 1 -- `self` is only used for its
+    /// shared `text` buffer, so any cursor from the same document answers
+    /// identically regardless of which node it happens to point at.
+    #[inline]
+    fn trailing_element_gap_ok(&self, gap_start: usize, close_char: u8) -> bool {
+        trailing_gap_ok(self.text, gap_start, close_char)
+    }
+
     #[inline]
     fn line(&self) -> usize {
         JsonCursor::line(self)
@@ -2483,6 +2494,18 @@ impl<'a, W: AsRef<[u64]> + Clone> DocumentValue for StandardJson<'a, W> {
             StandardJson::String(s) => Some(s.end()),
             _ => None,
         }
+    }
+
+    /// #2243: delegates to this module's own (now-shared) `scalar_end_pos`
+    /// free function -- every variant answers `start + its own byte length`
+    /// (`s`/`n`'s own `raw_bytes().len()` for `String`/`Number`, a fixed
+    /// 4/5/4 for `Bool(true)`/`Bool(false)`/`Null`), trusting the caller's
+    /// `start` rather than re-deriving it from `s`/`n`'s own `start()`
+    /// (which would be redundant work when `start` is already this same
+    /// value's own resolved position, the only way callers ever have one
+    /// to pass).
+    fn scalar_text_end(&self, start: usize) -> Option<usize> {
+        scalar_end_pos(start, self)
     }
 
     fn as_object(&self) -> Option<Self::Fields> {

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -21807,21 +21807,49 @@ fn test_jq_lazy_path_wellformed_empty_containers_unaffected_2211() -> Result<()>
     Ok(())
 }
 
-/// #2211 follow-up (filed as #2243), pinned here as a known, still-open gap
-/// rather than left silently uncovered: a trailing comma after a *real*
-/// scalar last child (`[1,]`, `{"a":1,}`) is a related but distinct shape
-/// from the apparently-empty-container case this issue fixed -- catching it
-/// needs the last real child's own text-end position, which
-/// `to_owned_cursor_at_depth`'s array/object loops don't track at all (the
+/// #2211 follow-up (#2243): a trailing comma after a *real* scalar last
+/// child (`[1,]`, `{"a":1,}`) is a related but distinct shape from the
+/// apparently-empty-container case #2211 fixed -- catching it needs the
+/// last real child's own text-end position, which
+/// `to_owned_cursor_at_depth`'s array/object loops didn't track at all (the
 /// #2211 fix only needed the container's own opening-delimiter position,
-/// correct for the empty case but not this one). The cursor-transparent `.`
-/// path already gets this right via `print_json`'s `scalar_end_pos`/
-/// `trailing_gap_ok` pair (#1676); the lazy path does not yet share it. A
-/// future fix for #2243 should update this test rather than leave it
-/// silently passing on the wrong behavior.
+/// correct for the empty case but not this one). Now shares the same
+/// `scalar_end_pos`/`trailing_gap_ok` pair the cursor-transparent `.` path
+/// already used via `print_json` (#1676), generalized onto
+/// `DocumentValue::scalar_text_end`/`DocumentCursor::trailing_element_gap_ok`
+/// so both paths call one definition. Verified against jq 1.7.1: both
+/// shapes are a parse error (exit 5), matching the cursor-transparent
+/// path's own (already-correct) behavior for the same input.
 #[test]
-fn test_jq_lazy_path_trailing_comma_after_scalar_last_child_still_a_known_gap_2243() -> Result<()> {
-    for (input, expected) in [(r"[1,]", "[1]"), (r#"{"a":1,}"#, r#"{"a":1}"#)] {
+fn test_jq_lazy_path_trailing_comma_after_scalar_last_child_2243() -> Result<()> {
+    for input in [r"[1,]", r#"{"a":1,}"#] {
+        let (out, stderr, code) = run_jq_full(&["-c", "if true then . else . end"], Some(input))?;
+        assert_eq!(code, 5, "{input}: out: {out:?}, stderr: {stderr:?}");
+        assert!(out.trim().is_empty(), "{input}: unexpected output {out:?}");
+        assert!(
+            stderr.contains("Invalid JSON text"),
+            "{input}: stderr: {stderr:?}"
+        );
+    }
+
+    Ok(())
+}
+
+/// #2243: a trailing comma after a *container-typed* last child (`[1,[2,3],]`)
+/// is a deliberately deferred residual gap, not something this fix closes --
+/// a container's own end position isn't derivable from its start alone (it
+/// may have arbitrary trailing whitespace before its own closing bracket),
+/// matching `scalar_text_end`'s own documented `None`-for-container
+/// contract. Confirmed this is not a regression: the cursor-transparent `.`
+/// path (`print_json`'s own `scalar_end_pos`, #1676) has the identical gap
+/// for the same input, verified live against this exact build.
+#[test]
+fn test_jq_lazy_path_trailing_comma_after_container_last_child_still_a_known_gap_2243() -> Result<()>
+{
+    for (input, expected) in [
+        (r"[1,[2,3],]", "[1,[2,3]]"),
+        (r#"{"a":1,"b":[1,2],}"#, r#"{"a":1,"b":[1,2]}"#),
+    ] {
         let (out, stderr, code) = run_jq_full(&["-c", "if true then . else . end"], Some(input))?;
         assert_eq!(code, 0, "{input}: stderr: {stderr:?}");
         assert_eq!(out.trim(), expected, "{input}");


### PR DESCRIPTION
## Summary

`to_owned_cursor_at_depth`'s object/array arms in `src/jq/eval_generic.rs` only
checked for a stray trailing comma on the *empty*-container case (`container_gap_ok`).
A trailing `,` after a genuine last child — `[1,]`, `{"a":1,}` — was silently accepted
by the lazy-materialization path instead of rejected, diverging from the CLI's own
pretty-printer path (#1676/#1576), which already catches this.

- Adds `trailing_element_gap_ok`/`scalar_text_end` to the shared `DocumentCursor`/
  `DocumentValue` traits (`src/jq/document.rs`), with safe `true`/`None` defaults for
  formats (YAML) that don't yet implement them.
- JSON's implementation (`src/json/light.rs`) reuses the existing `trailing_gap_ok`/
  `scalar_end_pos` primitives already used by the CLI printer, rather than a third
  independent copy — this crate's own "duplicated predicates diverge silently" lesson.
- `to_owned_cursor_at_depth`'s object/array arms now track the last real
  field/element and run the new check against it when the container isn't empty.
- A trailing comma after a *nested-container* last child (`[1,[2,3],]`) remains a
  known, separately-pinned gap — out of scope here, matching the same limitation
  already present in the reference cursor-transparent path.

Fixes #2243

## Test plan

- [x] `cargo build --features cli`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --all-features --no-deps`
- [x] `cargo test --features cli --test jq_cli_tests` (1338 passed)
- [x] Full CLI integration suite (yq_cli_tests, yq_golden_tests, yq_path_consistency_tests, jq_golden_tests, yaml_bench_suite_coverage, dsv_cli_tests, text_cli_tests, json_validate_tests, yaml_validate_tests, cli_golden_tests, cli_characterization_tests, deep_nesting_valid_tests) — all passed
- [x] `cargo test --verbose` (default features)
- [x] `cargo test --verbose --features simd`
- [x] `cargo test --verbose --features portable-popcount`
- [x] `cargo test --no-default-features --verbose` (no_std)
- [x] Updated existing test (previously pinned the buggy accept-behavior as a "known gap") to assert correct rejection; added a new test pinning the still-open nested-container residual gap