### PR TITLE
fix(yq): raise on a negative out-of-range array index like real yq (#2254)

### DIFF
--- a/docs/compliance/yq/limitations.md
+++ b/docs/compliance/yq/limitations.md
@@ -1494,9 +1494,16 @@ on the read side -- `eval_try`/`each_try` in `eval.rs`, `try_single_generic`/
 the single-value pair: `any(.a[-5]?; .)` runs its generator argument through `each_try`, not
 `eval_try`, and was found still swallowing the error until this same sweep covered it too) --
 and via `EvalError::is_uncatchable`, extended to include it, at `resolve_node`'s own
-`Expr::Try`/`Expr::Optional` pair (`eval.rs`) for `path()`/`getpath`'s path-tracking context.
-This keeps it unsuppressible the same way `is_decode_failure` already does for a decode
-failure.
+`Expr::Try`/`Expr::Optional` pair (`eval.rs`) for `path()`/`getpath`'s path-tracking context,
+and at `eval_stage_with_path_context`'s own general `Expr::Optional` arm (`eval.rs`), which
+governs a bare `?` combined with a path-context-triggering builtin elsewhere in the same
+pipe (`key`/`parent`/`file_index`) -- confirmed live that `.a[-5]? | key` wrongly exited 0
+with no output before this arm was covered too. Two further computed-index call sites
+(`eval_index_expr`'s and `eval_index_expr_with_path_context`'s own `Owned`-target loops --
+reached via `--slurp` against a constructed rather than cursor-backed array, and via a
+computed bracket key piped into a path-context builtin, respectively) had the identical
+gate-on-`optional` bug and are fixed the same way. This keeps the error unsuppressible the
+same way `is_decode_failure` already does for a decode failure.
 
 A few more independent copies of the same arithmetic remain unfixed, in lower-traffic
 call sites: `path()`'s own walker, `pick(paths)`, `reduce`/`foreach`'s lazy-fold index

--- a/docs/compliance/yq/limitations.md
+++ b/docs/compliance/yq/limitations.md
@@ -1466,13 +1466,12 @@ a value that isn't a snapshot of anything in the document -- a different kind of
 #2213's path-threading fix, which only ever continues with a value already known to be
 correct (`Null`, jq's own answer for what the missing/OOB read itself evaluates to).
 
-### A negative out-of-range array index (`.a[-N]`) silently returns `null` instead of raising
+### A negative out-of-range array index (`.a[-N]`) raises -- resolved for ordinary reads, a few call sites remain
 
-[#2254](https://github.com/rust-works/succinctly/issues/2254), pre-existing and unrelated to
-#2213 -- found while verifying that fix's own reach. Real yq disagrees with real jq on a
-negative index whose magnitude exceeds the array length: jq treats it the same as a positive
-out-of-range index (`null`, not an error); yq raises. A positive out-of-range index is `null`
-in both tools -- the asymmetry is specific to the negative-magnitude case:
+[#2254](https://github.com/rust-works/succinctly/issues/2254). Real yq disagrees with real
+jq on a negative index whose magnitude exceeds the array length: jq treats it the same as a
+positive out-of-range index (`null`, not an error); yq raises. A positive out-of-range index
+is `null` in both tools -- the asymmetry is specific to the negative-magnitude case:
 
 ```bash
 $ echo '{"a":[1,2]}' | yq -o=json '.a[-1]'   # 2   (in-bounds negative wraparound: fine)
@@ -1480,11 +1479,18 @@ $ echo '{"a":[1,2]}' | yq -o=json '.a[-2]'   # 1   (in-bounds: fine)
 $ echo '{"a":[1,2]}' | yq -o=json '.a[-3]'   # Error: index [-3] out of range, array size is 2
 ```
 
-`resolve_read_index`/`index_one`/`index_one_owned` (`src/jq/eval.rs`) treat "index doesn't
-resolve" as one outcome with no `EvalSemantics`-based dispatch on sign, so `succinctly yq`
-currently gives `null` for the negative-out-of-range case rather than raising -- reachable
-via the plain evaluator alone (`.a[-5]`, no path-context builtin involved), predating #2213
-entirely.
+Eight independent implementations of the same resolve-index arithmetic across
+`src/jq/eval.rs` and `src/jq/eval_generic.rs` treated "index doesn't resolve" as one outcome
+with no `EvalSemantics`-based dispatch on sign -- fixed for every ordinary `.a[-N]`/`.a[$n]`
+read, both the literal and computed-index forms, through both jq's primary CLI dispatch
+(`eval_generic.rs`) and the library-route/path-context evaluator (`eval.rs`). Suppressible by
+`optional` like any other read-time indexing error here -- real yq's own lexer doesn't even
+accept `?` after a bracket index in this position, so there's no oracle to match either way.
+
+A few more independent copies of the same arithmetic remain unfixed, in lower-traffic
+call sites: `path()`'s own walker, `pick(paths)`, `reduce`/`foreach`'s lazy-fold index
+handling, and `getpath`'s own path-array walk (jq-only syntax, so this only matters under
+`--jq-extensions`) -- filed as [#2264](https://github.com/rust-works/succinctly/issues/2264).
 
 ### Other categories
 

--- a/docs/compliance/yq/limitations.md
+++ b/docs/compliance/yq/limitations.md
@@ -1483,14 +1483,32 @@ Eight independent implementations of the same resolve-index arithmetic across
 `src/jq/eval.rs` and `src/jq/eval_generic.rs` treated "index doesn't resolve" as one outcome
 with no `EvalSemantics`-based dispatch on sign -- fixed for every ordinary `.a[-N]`/`.a[$n]`
 read, both the literal and computed-index forms, through both jq's primary CLI dispatch
-(`eval_generic.rs`) and the library-route/path-context evaluator (`eval.rs`). Suppressible by
-`optional` like any other read-time indexing error here -- real yq's own lexer doesn't even
-accept `?` after a bracket index in this position, so there's no oracle to match either way.
+(`eval_generic.rs`) and the library-route/path-context evaluator (`eval.rs`). Unlike every
+other read-time indexing error here, `optional` does *not* suppress it: confirmed live that
+real yq's own lexer accepts `?` after a bare bracket index (`.a[-5]?` parses fine; only the
+*parenthesized* form, `(.a[-5])?`, is lexer-rejected, an unrelated construct) and the error
+still raises through it (`.a[-5]?` on `[1,2]` still exits 1 with the same message in real
+yq). `EvalError::is_yq_negative_index_error` is consulted by every `?`/`try` dispatch point
+on the read side -- `eval_try`/`each_try` in `eval.rs`, `try_single_generic`/
+`each_try_generic` in `eval_generic.rs` (the generator-argument pair matters separately from
+the single-value pair: `any(.a[-5]?; .)` runs its generator argument through `each_try`, not
+`eval_try`, and was found still swallowing the error until this same sweep covered it too) --
+and via `EvalError::is_uncatchable`, extended to include it, at `resolve_node`'s own
+`Expr::Try`/`Expr::Optional` pair (`eval.rs`) for `path()`/`getpath`'s path-tracking context.
+This keeps it unsuppressible the same way `is_decode_failure` already does for a decode
+failure.
 
 A few more independent copies of the same arithmetic remain unfixed, in lower-traffic
 call sites: `path()`'s own walker, `pick(paths)`, `reduce`/`foreach`'s lazy-fold index
 handling, and `getpath`'s own path-array walk (jq-only syntax, so this only matters under
 `--jq-extensions`) -- filed as [#2264](https://github.com/rust-works/succinctly/issues/2264).
+`del()`/`delpaths()` silently no-op on this shape instead of raising at all (more severe than
+a suppression gap -- a missing error, not a differently-worded one) -- filed separately as
+[#2268](https://github.com/rust-works/succinctly/issues/2268). And
+`eval_stage_with_path_context`'s own `Expr::Try`/`Expr::Optional` arms (`--eval-all` combined
+with a path-context-triggering builtin like `file_index`) have no uncatchable-error guard at
+all, for any error class, not just this one -- filed as
+[#2270](https://github.com/rust-works/succinctly/issues/2270).
 
 ### Other categories
 

--- a/src/jq/error.rs
+++ b/src/jq/error.rs
@@ -874,14 +874,31 @@ impl EvalError {
     /// an error -- the asymmetry is specific to the negative-magnitude
     /// case. `N` here is the original, unresolved index (`-3`, not the
     /// still-negative sum) -- real yq's own message reports the argument as
-    /// written, not the arithmetic. Suppressible by `optional` like any
-    /// other read-time indexing error -- real yq's own lexer doesn't even
-    /// accept `?` after a bracket index in this position, so there's no
-    /// oracle to match either way, and matching this codebase's own
-    /// established default for ordinary indexing errors is simpler than
-    /// carving out a special unsuppressible case with no oracle behind it.
+    /// written, not the arithmetic.
+    ///
+    /// Not suppressed by `optional` -- confirmed live that real yq's own
+    /// lexer *does* accept `?` after a bare bracket index (`.a[-5]?` parses
+    /// fine; only the *parenthesized* form, `(.a[-5])?`, is rejected, a
+    /// different construct), and the error still raises through it
+    /// (`.a[-5]?` on `[1,2]` still exits 1 with this same message in real
+    /// yq). An earlier version of this comment claimed no oracle existed
+    /// for either direction, based on testing only the parenthesized form
+    /// — see [`Self::is_yq_negative_index_error`], consulted by every
+    /// `?`/`try` dispatch point on the read side, for how this is kept
+    /// unsuppressible.
     pub fn yq_negative_index_out_of_range(index: i64, len: usize) -> Self {
         Self::new(format!("index [{index}] out of range, array size is {len}"))
+    }
+
+    /// Whether this is a [`Self::yq_negative_index_out_of_range`] -- `?`
+    /// does not suppress it, the same way [`Self::is_write_time_application_error`]
+    /// and [`Self::is_decode_failure`] each carve out their own
+    /// never-suppressed category. Matched on message text like
+    /// [`Self::is_write_time_application_error`]'s own pair, rather than
+    /// adding a fourth [`ErrorKind`] variant purely for one message.
+    pub fn is_yq_negative_index_error(&self) -> bool {
+        self.message.starts_with("index [")
+            && self.message.contains("] out of range, array size is ")
     }
 
     /// `strptime/1 requires string inputs and arguments` (#929).
@@ -1229,20 +1246,33 @@ impl EvalError {
     }
 
     /// Whether this error class is *always* uncatchable, with no positional
-    /// nuance — [`Self::is_invalid_path_expression`] or
-    /// [`Self::is_decode_failure`]. Unlike
-    /// [`Self::is_untracked_navigation_error`], which genuinely depends on
-    /// *where* the error was caught (a bare postfix `?` on the primitive
-    /// that raised it vs. anything else), both of these mean the same thing
-    /// at every call site that checks them: never suppressed by `?`, never
-    /// handed to a `catch` handler. `resolve_node`'s `Expr::Try` and
-    /// `Expr::Optional` arms (`?`'s two path-context dispatch sites, kept in
-    /// agreement since #1746 — `expr?` is documented sugar for `try expr`)
-    /// both check this today, but a future always-uncatchable error class
-    /// only needs to be added here, not hand-copied into whichever `?`/`try`
-    /// dispatch sites grow the same check next.
+    /// nuance — [`Self::is_invalid_path_expression`],
+    /// [`Self::is_decode_failure`], or [`Self::is_yq_negative_index_error`]
+    /// (#2254). Unlike [`Self::is_untracked_navigation_error`], which
+    /// genuinely depends on *where* the error was caught (a bare postfix `?`
+    /// on the primitive that raised it vs. anything else), all three mean
+    /// the same thing at every call site that checks them: never suppressed
+    /// by `?`, never handed to a `catch` handler. `resolve_node`'s
+    /// `Expr::Try` and `Expr::Optional` arms (`?`'s two path-context
+    /// dispatch sites, kept in agreement since #1746 — `expr?` is
+    /// documented sugar for `try expr`) both check this today, but a future
+    /// always-uncatchable error class only needs to be added here, not
+    /// hand-copied into whichever `?`/`try` dispatch sites grow the same
+    /// check next.
+    ///
+    /// The value-position dispatch points (`eval_try`/`each_try`/
+    /// `try_single_generic`/`each_try_generic`) deliberately do *not* switch
+    /// to this predicate: they need `is_decode_failure() ||
+    /// is_yq_negative_index_error()` specifically, without
+    /// `is_invalid_path_expression()`, which is meaningful only in path
+    /// context (`path()`/`getpath`) and was never verified against value
+    /// position -- widening those four to this broader predicate as a side
+    /// effect of #2254 would be an untested behavior change, not this fix's
+    /// job.
     pub fn is_uncatchable(&self) -> bool {
-        self.is_invalid_path_expression() || self.is_decode_failure()
+        self.is_invalid_path_expression()
+            || self.is_decode_failure()
+            || self.is_yq_negative_index_error()
     }
 
     /// `Cannot check whether <container> has a <key type> key`.

--- a/src/jq/error.rs
+++ b/src/jq/error.rs
@@ -863,6 +863,27 @@ impl EvalError {
         Self::new("from entries only runs against arrays")
     }
 
+    /// `index [N] out of range, array size is M` (#2254).
+    ///
+    /// Real yq's own wording for a negative array index whose magnitude
+    /// still exceeds the array length after resolving against it -- unlike
+    /// jq, which treats this the same as a positive out-of-range index
+    /// (`null`, not an error). Confirmed live against yq v4.53.3:
+    /// `[1,2] | .[-3]` raises this, `[1,2] | .[-1]`/`.[-2]` (in-bounds
+    /// wraparound) don't, and `[1,2] | .[5]` (positive OOB) is `null`, not
+    /// an error -- the asymmetry is specific to the negative-magnitude
+    /// case. `N` here is the original, unresolved index (`-3`, not the
+    /// still-negative sum) -- real yq's own message reports the argument as
+    /// written, not the arithmetic. Suppressible by `optional` like any
+    /// other read-time indexing error -- real yq's own lexer doesn't even
+    /// accept `?` after a bracket index in this position, so there's no
+    /// oracle to match either way, and matching this codebase's own
+    /// established default for ordinary indexing errors is simpler than
+    /// carving out a special unsuppressible case with no oracle behind it.
+    pub fn yq_negative_index_out_of_range(index: i64, len: usize) -> Self {
+        Self::new(format!("index [{index}] out of range, array size is {len}"))
+    }
+
     /// `strptime/1 requires string inputs and arguments` (#929).
     ///
     /// jq's C implementation validates `strptime`'s input *and* format

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -3748,7 +3748,14 @@ fn each_try<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
         // A decode failure (#1247) must never be caught by `try`/`catch`,
         // same #1620 exclusion as `eval_try`'s identical arm -- propagates
         // unchanged via the `other => other` wildcard's own reasoning.
-        Flow::Escaped(Control::Error(e)) if e.is_decode_failure() => {
+        //
+        // Same #2254 yq-negative-index-error exclusion as `eval_try`'s
+        // identical arm too -- reached from e.g. `any(.a[-5]?; .)`, whose
+        // generator argument runs through this function via `eval_each`'s
+        // own `Expr::Optional` dispatch.
+        Flow::Escaped(Control::Error(e))
+            if e.is_decode_failure() || e.is_yq_negative_index_error() =>
+        {
             Flow::Escaped(Control::Error(e))
         }
         Flow::Escaped(Control::Error(e)) => match catch {
@@ -6340,7 +6347,19 @@ fn eval_try<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
         // equivalent is a parse-time rejection no program could ever catch
         // either. Checked before the ordinary `Error` catch below so it
         // falls through to `other => other` instead.
-        QueryResult::Error(e) if e.is_decode_failure() => QueryResult::Error(e),
+        //
+        // #2254: a yq negative-index-out-of-range error is unsuppressible
+        // the same way (see `EvalError::is_yq_negative_index_error`'s own
+        // doc comment) -- confirmed live that `.a[-5]?` still raises in real
+        // yq. Real yq has no `try`/`catch` syntax at all (lexer-rejected
+        // outright), so this only ever matters for succinctly's own
+        // `--jq-extensions` surface in yq mode; excluding it from `catch`
+        // there too keeps one consistent "never caught" rule rather than
+        // one that depends on whether a catch handler happens to be
+        // present.
+        QueryResult::Error(e) if e.is_decode_failure() || e.is_yq_negative_index_error() => {
+            QueryResult::Error(e)
+        }
         // If error, use catch handler or return nothing. jq runs the handler
         // with the *raised value* as its input, not the original input, so
         // `try error("boom") catch .` yields "boom".
@@ -6360,7 +6379,9 @@ fn eval_try<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
         // Same #1620 decode-failure exclusion as the bare `Error` arm above
         // -- a `Partial` ending in a decode failure must still propagate
         // uncaught, not run the catch handler.
-        QueryResult::Partial(prefix, Control::Error(e)) if e.is_decode_failure() => {
+        QueryResult::Partial(prefix, Control::Error(e))
+            if e.is_decode_failure() || e.is_yq_negative_index_error() =>
+        {
             QueryResult::Partial(prefix, Control::Error(e))
         }
         // The body produced some outputs before erroring (#400): emit them
@@ -15905,7 +15926,10 @@ fn index_array_by_position<W: Clone + AsRef<[u64]>, S: EvalSemantics>(
             // jq returns null for out-of-bounds array access (not an error)
             Ok(None) => QueryResult::One(StandardJson::Null),
             Err(_len) if S::TAG != EvalTag::Yq => QueryResult::One(StandardJson::Null),
-            Err(_len) if optional => QueryResult::None,
+            // Unconditional, not suppressed by `optional` (#2254) -- see
+            // `EvalError::yq_negative_index_out_of_range`'s own doc comment
+            // and the `eval_try`/`try_single_generic` bypasses that keep it
+            // surviving an outer `?`/`try` too.
             Err(len) => QueryResult::Error(EvalError::yq_negative_index_out_of_range(idx, len)),
         },
         // jq returns null for index on null
@@ -16043,31 +16067,55 @@ fn index_one<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     }
 }
 
-/// yq mode only (#2254): `Some(error)` iff `key` is a negative numeric index
-/// still negative after resolving against `target`'s length -- real yq
-/// raises here (`index_array_by_position`'s own doc comment has the full
-/// rationale, including why `optional` still suppresses it). `None` covers
-/// every other case (jq mode, a non-array target, a non-numeric key, an
-/// in-bounds or positive-direction index) uniformly, so a caller checks this
-/// once and falls through to its own ordinary null/error handling otherwise
-/// -- deliberately *not* threaded into [`index_one_owned`] itself, since
-/// that function's own callers include write-path resolvers
-/// (`resolve_node`/`resolve_index_expr`) that already raise their own,
-/// differently-worded negative-index error and must keep doing so
-/// unconditionally, not just for a still-negative resolved index.
-fn yq_negative_index_error<S: EvalSemantics>(
-    target: &OwnedValue,
-    key: &OwnedValue,
+/// yq mode only (#2254): `Some(error)` iff `resolved` is still negative --
+/// real yq raises here (`index_array_by_position`'s own doc comment has the
+/// full rationale). `idx`/`len` are only for the error's own message, which
+/// reports the argument as written, not the arithmetic.
+///
+/// The `i64`/`usize`-only signature (not `OwnedValue`) is deliberate: both
+/// this function's own `OwnedValue`-domain callers ([`yq_negative_index_error`]
+/// below) and `eval_generic.rs`'s two independent numeric-index arms (which
+/// already reduce to plain integers before their own indexing decision)
+/// reach the identical rule through it, so the boundary condition and error
+/// text live in exactly one place.
+pub(crate) fn yq_negative_index_check<S: EvalSemantics>(
+    idx: i64,
+    resolved: i64,
+    len: usize,
 ) -> Option<EvalError> {
     if S::TAG != EvalTag::Yq {
         return None;
     }
+    (resolved < 0).then(|| EvalError::yq_negative_index_out_of_range(idx, len))
+}
+
+/// [`yq_negative_index_check`] for the common `OwnedValue`-domain shape: a
+/// target that might be an array, indexed by a key that might be a negative
+/// numeric index. `None` covers every case that isn't this one (jq mode, a
+/// non-array target, a non-numeric key, an in-bounds or positive-direction
+/// index) uniformly, so a caller checks this once and falls through to its
+/// own ordinary null/error handling otherwise -- deliberately *not*
+/// threaded into [`index_one_owned`] itself, since that function's own
+/// callers include write-path resolvers (`resolve_node`/`resolve_index_expr`,
+/// `write_index`) that currently have their own gaps here too (`del()`/
+/// `delpaths()` silently no-op instead of raising, tracked separately as
+/// #2268; assignment raises jq's own differently-worded message instead of
+/// yq's, noted in that same issue) -- real, separate bugs, not yet fixed,
+/// rather than folded into this read-only helper's contract.
+fn yq_negative_index_error<S: EvalSemantics>(
+    target: &OwnedValue,
+    key: &OwnedValue,
+) -> Option<EvalError> {
     let OwnedValue::Array(items) = target else {
         return None;
     };
     let idx = numeric_key_to_index(key)?;
-    (idx < 0 && items.len() as i64 + idx < 0)
-        .then(|| EvalError::yq_negative_index_out_of_range(idx, items.len()))
+    let resolved = if idx < 0 {
+        items.len() as i64 + idx
+    } else {
+        idx
+    };
+    yq_negative_index_check::<S>(idx, resolved, items.len())
 }
 
 /// [`index_one`] for a target that is already an owned value, as when the
@@ -27833,25 +27881,25 @@ fn eval_owned_fast_path<S: EvalSemantics>(
         }),
         Expr::Index { idx, .. } => Some(match input {
             OwnedValue::Array(items) => {
+                // yq mode only (#2254): same rule as `index_array_by_position`
+                // and every other call site this fix touches -- a negative
+                // index still negative after resolving against the length
+                // raises in real yq, unconditionally, not suppressed by
+                // `optional` (unlike every *other* read-time indexing error
+                // in this function) -- see
+                // `EvalError::yq_negative_index_out_of_range`'s own doc
+                // comment. Confirmed live that `any(.a[-5]?; .)` -- the one
+                // construct this function is actually still reachable from
+                // ([`eval_each_owned`]) -- wrongly answered `false` instead
+                // of raising before this was unconditional.
+                if let Some(e) = yq_negative_index_error::<S>(input, &OwnedValue::Int(*idx)) {
+                    return Some(Err(e));
+                }
                 let resolved = if *idx < 0 {
                     items.len() as i64 + idx
                 } else {
                     *idx
                 };
-                // yq mode only (#2254): same rule as `index_array_by_position`
-                // and every other call site this fix touches -- a negative
-                // index still negative after resolving against the length
-                // raises in real yq, suppressible by `optional` like any
-                // other read-time indexing error here.
-                if resolved < 0 && S::TAG == EvalTag::Yq {
-                    if optional {
-                        return Some(Ok(None));
-                    }
-                    return Some(Err(EvalError::yq_negative_index_out_of_range(
-                        *idx,
-                        items.len(),
-                    )));
-                }
                 let element = usize::try_from(resolved)
                     .ok()
                     .and_then(|i| items.get(i))

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -15909,11 +15909,11 @@ fn index_object_by_name<'a, W: Clone + AsRef<[u64]>>(
 /// yq mode only (#2254): a negative index whose magnitude still exceeds the
 /// array length after resolving against it raises in real yq
 /// (`yq_negative_index_out_of_range`), where jq treats it the same as a
-/// positive out-of-range index (`null`). `optional` suppresses it like any
-/// other read-time indexing error here -- real yq's own lexer doesn't even
-/// accept `?` after a bracket index in this position, so there's no oracle
-/// answer to match either way; treating it like every other indexing error
-/// in this function is the simpler, more consistent default.
+/// positive out-of-range index (`null`). Unlike every other indexing error
+/// in this function, `optional` does *not* suppress it -- see that
+/// constructor's own doc comment for the live-confirmed oracle behavior and
+/// `EvalError::is_yq_negative_index_error`, consulted by every `?`/`try`
+/// dispatch point on the read side to keep it that way.
 #[inline]
 fn index_array_by_position<W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     value: StandardJson<'_, W>,
@@ -16584,14 +16584,18 @@ fn eval_index_expr<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
                     escape_with_prefix!(Control::Error(cannot_reserve_cross_product(&[ts.len()])));
                 }
                 for t in &ts {
-                    // #2254: checked ahead of `index_one_owned`, which has
-                    // no notion of this yq-only rule -- see
+                    // #2254 review: checked ahead of `index_one_owned`,
+                    // which has no notion of this yq-only rule -- see
                     // `yq_negative_index_error`'s own doc comment for why
                     // it isn't threaded into that function instead.
+                    // Unconditional, not gated on `optional` -- the sibling
+                    // `Borrowed` loop above is already unconditional here
+                    // (via `index_one` -> `index_array_by_position`), and
+                    // this arm silently diverging from it under `optional`
+                    // was a real, live-reproducible bug this same review
+                    // caught (`--slurp` with a computed key against an
+                    // owned/constructed array target).
                     if let Some(e) = yq_negative_index_error::<S>(t, k) {
-                        if optional {
-                            continue;
-                        }
                         escape_with_prefix!(Control::Error(e));
                     }
                     match index_one_owned(t, k, optional) {
@@ -31537,13 +31541,13 @@ fn eval_index_expr_with_path_context<'a, W: Clone + AsRef<[u64]>, S: EvalSemanti
             } else {
                 (None, probed)
             };
-            // #2254: same check as `eval_index_expr`'s own computed-key
-            // loop, ahead of `index_one_owned`, which has no notion of this
-            // yq-only rule.
+            // #2254 review: same check as `eval_index_expr`'s own
+            // computed-key loop, ahead of `index_one_owned`, which has no
+            // notion of this yq-only rule. Unconditional, not gated on
+            // `bracket_optional` -- same live-reproducible suppression bug
+            // as that sibling loop, for the path-context/computed-index
+            // combination (`.a[(EXPR)]? | key`).
             if let Some(e) = yq_negative_index_error::<S>(&t, k) {
-                if bracket_optional {
-                    continue;
-                }
                 return partial(core::mem::take(&mut results), Control::Error(e));
             }
             match index_one_owned(&t, k, bracket_optional) {
@@ -32181,17 +32185,19 @@ fn eval_stage_with_path_context<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
                 // yq mode only (#2254): real yq raises on a negative index
                 // whose magnitude still exceeds the array length, where jq
                 // (and yq's own positive-OOB case) both agree on `null` --
-                // `optional` suppresses it like every other negative-index
-                // call site this same fix touches.
-                if *idx < 0 && S::TAG == EvalTag::Yq && arr.len() as i64 + idx < 0 {
-                    return if optional {
-                        QueryResult::None
-                    } else {
-                        QueryResult::Error(EvalError::yq_negative_index_out_of_range(
-                            *idx,
-                            arr.len(),
-                        ))
-                    };
+                // unconditional, not suppressed by `optional` (review: this
+                // arm used to gate on it, a real, live-reproducible bug --
+                // see `EvalError::yq_negative_index_out_of_range`'s own doc
+                // comment). Routed through the shared `yq_negative_index_check`
+                // helper rather than a hand-rolled duplicate of its
+                // condition, matching every other fixed call site.
+                let resolved = if *idx < 0 {
+                    arr.len() as i64 + idx
+                } else {
+                    *idx
+                };
+                if let Some(e) = yq_negative_index_check::<S>(*idx, resolved, arr.len()) {
+                    return QueryResult::Error(e);
                 }
                 return continue_rest_with_borrowed_value::<W, S>(
                     &OwnedValue::Null,
@@ -32554,7 +32560,21 @@ fn eval_stage_with_path_context<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
                 false,
             );
             let caught = match inner_result {
+                // #2254 review: an uncatchable error (a yq negative-index
+                // raise, a decode failure, an invalid-path-expression
+                // complaint) must survive this bare `?` the same way
+                // `resolve_node`'s own `Expr::Optional` arm already
+                // guarantees for path-tracking evaluation -- confirmed live
+                // that `.a[-5]? | key` wrongly swallowed the error and
+                // exited 0 with no output before this guard existed. `Break`
+                // has no error payload to check and stays unconditionally
+                // caught here, matching `eval_try`/`each_try`'s own bare-`?`
+                // semantics (#562).
+                QueryResult::Error(e) if e.is_uncatchable() => QueryResult::Error(e),
                 QueryResult::Error(_) | QueryResult::Break(_) => QueryResult::None,
+                QueryResult::Partial(prefix, Control::Error(e)) if e.is_uncatchable() => {
+                    QueryResult::Partial(prefix, Control::Error(e))
+                }
                 QueryResult::Partial(prefix, Control::Error(_) | Control::Break(_)) => {
                     owned_vec_to_result(prefix)
                 }

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -1013,7 +1013,7 @@ fn eval_single<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
 
         Expr::Field(name) => index_object_by_name::<W>(value, name, optional),
 
-        Expr::Index { idx, .. } => index_array_by_position::<W>(value, *idx, optional),
+        Expr::Index { idx, .. } => index_array_by_position::<W, S>(value, *idx, optional),
 
         Expr::IndexExpr { target, key } => eval_index_expr::<W, S>(target, key, value, optional),
 
@@ -9361,7 +9361,7 @@ fn builtin_nth<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
         // array case, and `fanout_arg`'s single-output fast path returns it
         // verbatim -- so `[1,2,3] | nth(0)` keeps the zero-copy path
         // `finish_result(result, None)` used to preserve here.
-        |n| index_one::<W>(value.clone(), &n, optional),
+        |n| index_one::<W, S>(value.clone(), &n, optional),
     )
 }
 
@@ -15884,17 +15884,29 @@ fn index_object_by_name<'a, W: Clone + AsRef<[u64]>>(
 
 /// Index an array by position — the shared body of `.[0]` and the numeric-key
 /// case of `.[$k]`. See [`index_object_by_name`] for why this is shared.
+///
+/// yq mode only (#2254): a negative index whose magnitude still exceeds the
+/// array length after resolving against it raises in real yq
+/// (`yq_negative_index_out_of_range`), where jq treats it the same as a
+/// positive out-of-range index (`null`). `optional` suppresses it like any
+/// other read-time indexing error here -- real yq's own lexer doesn't even
+/// accept `?` after a bracket index in this position, so there's no oracle
+/// answer to match either way; treating it like every other indexing error
+/// in this function is the simpler, more consistent default.
 #[inline]
-fn index_array_by_position<W: Clone + AsRef<[u64]>>(
+fn index_array_by_position<W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     value: StandardJson<'_, W>,
     idx: i64,
     optional: bool,
 ) -> QueryResult<'_, W> {
     match value {
         StandardJson::Array(elements) => match get_element_at_index::<W>(elements, idx) {
-            Some(v) => QueryResult::One(v),
+            Ok(Some(v)) => QueryResult::One(v),
             // jq returns null for out-of-bounds array access (not an error)
-            None => QueryResult::One(StandardJson::Null),
+            Ok(None) => QueryResult::One(StandardJson::Null),
+            Err(_len) if S::TAG != EvalTag::Yq => QueryResult::One(StandardJson::Null),
+            Err(_len) if optional => QueryResult::None,
+            Err(len) => QueryResult::Error(EvalError::yq_negative_index_out_of_range(idx, len)),
         },
         // jq returns null for index on null
         StandardJson::Null => QueryResult::One(StandardJson::Null),
@@ -16004,7 +16016,7 @@ pub(crate) fn has_type_mismatch_is_permissive<S: EvalSemantics>() -> bool {
 /// The key kind is dispatched *before* the container is inspected, so the error
 /// is jq's `Cannot index <container> with <key>` rather than the generic
 /// `expected object, got …` that the static arms produce.
-fn index_one<'a, W: Clone + AsRef<[u64]>>(
+fn index_one<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     target: StandardJson<'a, W>,
     key: &OwnedValue,
     optional: bool,
@@ -16020,7 +16032,7 @@ fn index_one<'a, W: Clone + AsRef<[u64]>>(
             if indexable_by_number =>
         {
             match numeric_key_to_index(key) {
-                Some(idx) => index_array_by_position::<W>(target, idx, optional),
+                Some(idx) => index_array_by_position::<W, S>(target, idx, optional),
                 // NaN: a number, so the container check above still applies, but
                 // no element. jq yields null rather than erroring.
                 None => QueryResult::One(StandardJson::Null),
@@ -16029,6 +16041,33 @@ fn index_one<'a, W: Clone + AsRef<[u64]>>(
         _ if optional => QueryResult::None,
         _ => QueryResult::Error(EvalError::cannot_index(type_name(&target), key)),
     }
+}
+
+/// yq mode only (#2254): `Some(error)` iff `key` is a negative numeric index
+/// still negative after resolving against `target`'s length -- real yq
+/// raises here (`index_array_by_position`'s own doc comment has the full
+/// rationale, including why `optional` still suppresses it). `None` covers
+/// every other case (jq mode, a non-array target, a non-numeric key, an
+/// in-bounds or positive-direction index) uniformly, so a caller checks this
+/// once and falls through to its own ordinary null/error handling otherwise
+/// -- deliberately *not* threaded into [`index_one_owned`] itself, since
+/// that function's own callers include write-path resolvers
+/// (`resolve_node`/`resolve_index_expr`) that already raise their own,
+/// differently-worded negative-index error and must keep doing so
+/// unconditionally, not just for a still-negative resolved index.
+fn yq_negative_index_error<S: EvalSemantics>(
+    target: &OwnedValue,
+    key: &OwnedValue,
+) -> Option<EvalError> {
+    if S::TAG != EvalTag::Yq {
+        return None;
+    }
+    let OwnedValue::Array(items) = target else {
+        return None;
+    };
+    let idx = numeric_key_to_index(key)?;
+    (idx < 0 && items.len() as i64 + idx < 0)
+        .then(|| EvalError::yq_negative_index_out_of_range(idx, items.len()))
 }
 
 /// [`index_one`] for a target that is already an owned value, as when the
@@ -16443,7 +16482,7 @@ fn eval_index_expr<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
                     escape_with_prefix!(Control::Error(cannot_reserve_cross_product(&[ts.len()])));
                 }
                 for t in &ts {
-                    match index_one::<W>(t.clone(), k, optional) {
+                    match index_one::<W, S>(t.clone(), k, optional) {
                         // `resolve_terminal_prefix`, not unchecked `to_owned_lossy`
                         // (#1897): an undecodable string already accumulated
                         // must raise `EvalError::decode_failure` on
@@ -16497,6 +16536,16 @@ fn eval_index_expr<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
                     escape_with_prefix!(Control::Error(cannot_reserve_cross_product(&[ts.len()])));
                 }
                 for t in &ts {
+                    // #2254: checked ahead of `index_one_owned`, which has
+                    // no notion of this yq-only rule -- see
+                    // `yq_negative_index_error`'s own doc comment for why
+                    // it isn't threaded into that function instead.
+                    if let Some(e) = yq_negative_index_error::<S>(t, k) {
+                        if optional {
+                            continue;
+                        }
+                        escape_with_prefix!(Control::Error(e));
+                    }
                     match index_one_owned(t, k, optional) {
                         Ok(Some(v)) => owned.as_mut().expect("still Some").push(v),
                         Ok(None) => {}
@@ -17581,20 +17630,26 @@ fn slice_object_children_at(
 ///
 /// Uses `get_fast` for O(n) BP operations + O(log n) IB select,
 /// instead of `get` which does O(n) IB selects.
+///
+/// `Err(len)` is a negative index still negative after resolving against the
+/// array's length -- distinct from an ordinary miss (`Ok(None)`, the
+/// positive-direction case or an in-range-but-empty read) only so the caller
+/// can raise real yq's own error for it (#2254); jq mode's own caller treats
+/// `Err` exactly like `Ok(None)`.
 fn get_element_at_index<W: Clone + AsRef<[u64]>>(
     elements: JsonElements<'_, W>,
     idx: i64,
-) -> Option<StandardJson<'_, W>> {
+) -> Result<Option<StandardJson<'_, W>>, usize> {
     if idx >= 0 {
-        elements.get_fast(idx as usize)
+        Ok(elements.get_fast(idx as usize))
     } else {
         // Negative index: count from end
         let len = count_elements(elements);
         let positive_idx = len as i64 + idx;
         if positive_idx >= 0 {
-            elements.get_fast(positive_idx as usize)
+            Ok(elements.get_fast(positive_idx as usize))
         } else {
-            None
+            Err(len)
         }
     }
 }
@@ -27783,6 +27838,20 @@ fn eval_owned_fast_path<S: EvalSemantics>(
                 } else {
                     *idx
                 };
+                // yq mode only (#2254): same rule as `index_array_by_position`
+                // and every other call site this fix touches -- a negative
+                // index still negative after resolving against the length
+                // raises in real yq, suppressible by `optional` like any
+                // other read-time indexing error here.
+                if resolved < 0 && S::TAG == EvalTag::Yq {
+                    if optional {
+                        return Some(Ok(None));
+                    }
+                    return Some(Err(EvalError::yq_negative_index_out_of_range(
+                        *idx,
+                        items.len(),
+                    )));
+                }
                 let element = usize::try_from(resolved)
                     .ok()
                     .and_then(|i| items.get(i))
@@ -31420,6 +31489,15 @@ fn eval_index_expr_with_path_context<'a, W: Clone + AsRef<[u64]>, S: EvalSemanti
             } else {
                 (None, probed)
             };
+            // #2254: same check as `eval_index_expr`'s own computed-key
+            // loop, ahead of `index_one_owned`, which has no notion of this
+            // yq-only rule.
+            if let Some(e) = yq_negative_index_error::<S>(&t, k) {
+                if bracket_optional {
+                    continue;
+                }
+                return partial(core::mem::take(&mut results), Control::Error(e));
+            }
             match index_one_owned(&t, k, bracket_optional) {
                 Ok(Some(v)) => {
                     let new_path = target_path.map(|mut path| {
@@ -32052,11 +32130,21 @@ fn eval_stage_with_path_context<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
                 // regardless of `optional`, rather than routing it through
                 // the error-suppression path below, which both swallowed
                 // `rest` entirely under `?` and wrongly raised without one.
-                // `resolve_read_index` doesn't distinguish sign here, but
-                // real yq does (#2254, pre-existing, unrelated to this fix):
-                // it raises on a negative index whose magnitude exceeds the
-                // array length, where jq (and yq's own positive-OOB case)
-                // both agree on `null`.
+                // yq mode only (#2254): real yq raises on a negative index
+                // whose magnitude still exceeds the array length, where jq
+                // (and yq's own positive-OOB case) both agree on `null` --
+                // `optional` suppresses it like every other negative-index
+                // call site this same fix touches.
+                if *idx < 0 && S::TAG == EvalTag::Yq && arr.len() as i64 + idx < 0 {
+                    return if optional {
+                        QueryResult::None
+                    } else {
+                        QueryResult::Error(EvalError::yq_negative_index_out_of_range(
+                            *idx,
+                            arr.len(),
+                        ))
+                    };
+                }
                 return continue_rest_with_borrowed_value::<W, S>(
                     &OwnedValue::Null,
                     rest,
@@ -49558,7 +49646,7 @@ mod tests {
             Expr::Identity => QueryResult::One(cursor.value()),
             Expr::Field(name) => index_object_by_name::<Vec<u64>>(cursor.value(), name, optional),
             Expr::Index { idx, .. } => {
-                index_array_by_position::<Vec<u64>>(cursor.value(), *idx, optional)
+                index_array_by_position::<Vec<u64>, JqSemantics>(cursor.value(), *idx, optional)
             }
             other => unreachable!("via_cursor only covers Identity/Field/Index, got {other:?}"),
         };

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -43,8 +43,8 @@ use super::eval::{
     is_retryable_stop, literal_to_owned, needs_path_context, numeric_key_to_array_index,
     numeric_key_to_index, owned_bound_to_i64, owned_to_string, slice_object_as_yq_children,
     slice_owned_value_read, substitute_bound_var, substitute_vars, suppresses, tonumber_from_str,
-    vec_with_capacity, Control, Demand, EvalError, EvalSemantics, EvalTag, Flow, JqSemantics,
-    LimitN, PathTrail, QueryResult, YqSemantics,
+    vec_with_capacity, yq_negative_index_check, Control, Demand, EvalError, EvalSemantics, EvalTag,
+    Flow, JqSemantics, LimitN, PathTrail, QueryResult, YqSemantics,
 };
 #[cfg(test)]
 use super::expr::FuncDefBound;
@@ -4867,10 +4867,23 @@ fn try_single_generic<S: EvalSemantics, V: DocumentValue>(
         }
     };
     match eval_single::<S, _>(inner, value, optional, cursor) {
-        GenericResult::Error(e) if e.is_decode_failure() => GenericResult::Error(e),
+        // #2254: a yq negative-index-out-of-range error is unsuppressible
+        // the same way a decode failure is (see
+        // `EvalError::is_yq_negative_index_error`'s own doc comment) --
+        // confirmed live that `.a[-5]?` still raises in real yq. Real yq has
+        // no `try`/`catch` syntax at all (lexer-rejected outright), so this
+        // arm only ever matters for succinctly's own `--jq-extensions`
+        // surface in yq mode; excluding it from `catch` there too keeps one
+        // consistent "never caught" rule rather than one that depends on
+        // whether a catch handler happens to be present.
+        GenericResult::Error(e) if e.is_decode_failure() || e.is_yq_negative_index_error() => {
+            GenericResult::Error(e)
+        }
         GenericResult::Error(e) => run_catch(&e.payload()),
         GenericResult::Break(_) => run_catch(&OwnedValue::Null),
-        GenericResult::Partial(prefix, Control::Error(e)) if e.is_decode_failure() => {
+        GenericResult::Partial(prefix, Control::Error(e))
+            if e.is_decode_failure() || e.is_yq_negative_index_error() =>
+        {
             GenericResult::Partial(prefix, Control::Error(e))
         }
         GenericResult::Partial(prefix, Control::Error(e)) => {
@@ -4881,7 +4894,9 @@ fn try_single_generic<S: EvalSemantics, V: DocumentValue>(
         }
         GenericResult::LazySeq(seq) => match seq.materialize_atomic() {
             Ok(owned) => GenericResult::Owned(owned),
-            Err(Control::Error(e)) if e.is_decode_failure() => GenericResult::Error(e),
+            Err(Control::Error(e)) if e.is_decode_failure() || e.is_yq_negative_index_error() => {
+                GenericResult::Error(e)
+            }
             Err(Control::Error(e)) => run_catch(&e.payload()),
             Err(Control::Break(_)) => run_catch(&OwnedValue::Null),
             Err(Control::Halt(code)) => GenericResult::Halt(code),
@@ -4950,20 +4965,17 @@ fn eval_single<S: EvalSemantics, V: DocumentValue>(
                 let len = elements.len();
                 let resolved = if *idx < 0 { len as i64 + idx } else { *idx };
                 // yq mode only (#2254): a negative index still negative
-                // after resolving against the length raises in real yq,
-                // where jq treats it the same as a positive out-of-range
-                // index (`null`). Checked ahead of the cast below, which
-                // would otherwise wrap a still-negative `resolved` into a
-                // huge `usize` that `get_cursor` simply misses (`None`,
-                // same observable `null` as any other OOB read) --
-                // correct for jq mode, but not distinguishable from an
-                // ordinary miss for yq's own error.
-                if resolved < 0 && S::TAG == EvalTag::Yq {
-                    return if optional {
-                        GenericResult::None
-                    } else {
-                        GenericResult::Error(EvalError::yq_negative_index_out_of_range(*idx, len))
-                    };
+                // after resolving against the length raises in real yq --
+                // unconditionally, not suppressed by `optional` (see
+                // `EvalError::yq_negative_index_out_of_range`'s own doc
+                // comment). Checked ahead of the cast below, which would
+                // otherwise wrap a still-negative `resolved` into a huge
+                // `usize` that `get_cursor` simply misses (`None`, same
+                // observable `null` as any other OOB read) -- correct for
+                // jq mode, but not distinguishable from an ordinary miss
+                // for yq's own error.
+                if let Some(e) = yq_negative_index_check::<S>(*idx, resolved, len) {
+                    return GenericResult::Error(e);
                 }
                 match elements.get_cursor(resolved as usize) {
                     Some(c) => GenericResult::OneCursor(c),
@@ -6189,7 +6201,13 @@ fn each_try_generic<S: EvalSemantics, V: DocumentValue>(
         None => flow,
     };
     match flow {
-        Flow::Escaped(Control::Error(e)) if e.is_decode_failure() => {
+        // Same #2254 yq-negative-index-error exclusion as `eval_try`/
+        // `each_try`/`try_single_generic` (`src/jq/eval.rs`/this file) --
+        // reached from the same `any(.a[-5]?; .)` shape those cover, via
+        // this file's own generic dispatch.
+        Flow::Escaped(Control::Error(e))
+            if e.is_decode_failure() || e.is_yq_negative_index_error() =>
+        {
             Flow::Escaped(Control::Error(e))
         }
         Flow::Escaped(Control::Error(e)) => match catch {
@@ -7774,17 +7792,19 @@ fn index_one_generic<S: EvalSemantics, V: DocumentValue>(
                 // yq mode only (#2254): same rule as `eval_single`'s
                 // `Expr::Index` arm above -- a negative index still
                 // negative after resolving against the length raises in
-                // real yq, where jq treats it the same as a positive
-                // out-of-range index (`null`).
-                if let (Some(idx), Some(r)) = (idx, resolved) {
-                    if r < 0 && S::TAG == EvalTag::Yq {
-                        return if optional {
-                            GenericResult::None
-                        } else {
-                            GenericResult::Error(EvalError::yq_negative_index_out_of_range(
-                                idx, len,
-                            ))
-                        };
+                // real yq, unconditionally (see
+                // `EvalError::yq_negative_index_out_of_range`'s own doc
+                // comment). `resolved` is `idx.map(...)`, so `Some`/`None`
+                // on the two always agree -- one `if let` on `resolved`
+                // alone is enough, `idx` re-derived via `.expect` rather
+                // than re-checked.
+                if let Some(r) = resolved {
+                    if let Some(e) = yq_negative_index_check::<S>(
+                        idx.expect("resolved is Some only when idx is Some"),
+                        r,
+                        len,
+                    ) {
+                        return GenericResult::Error(e);
                     }
                 }
                 match resolved

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -4948,12 +4948,24 @@ fn eval_single<S: EvalSemantics, V: DocumentValue>(
         Expr::Index { idx, .. } => {
             if let Some(elements) = value.as_array() {
                 let len = elements.len();
-                let actual_idx = if *idx < 0 {
-                    (len as i64 + idx) as usize
-                } else {
-                    *idx as usize
-                };
-                match elements.get_cursor(actual_idx) {
+                let resolved = if *idx < 0 { len as i64 + idx } else { *idx };
+                // yq mode only (#2254): a negative index still negative
+                // after resolving against the length raises in real yq,
+                // where jq treats it the same as a positive out-of-range
+                // index (`null`). Checked ahead of the cast below, which
+                // would otherwise wrap a still-negative `resolved` into a
+                // huge `usize` that `get_cursor` simply misses (`None`,
+                // same observable `null` as any other OOB read) --
+                // correct for jq mode, but not distinguishable from an
+                // ordinary miss for yq's own error.
+                if resolved < 0 && S::TAG == EvalTag::Yq {
+                    return if optional {
+                        GenericResult::None
+                    } else {
+                        GenericResult::Error(EvalError::yq_negative_index_out_of_range(*idx, len))
+                    };
+                }
+                match elements.get_cursor(resolved as usize) {
                     Some(c) => GenericResult::OneCursor(c),
                     // jq returns null for out-of-bounds array indices (positive
                     // or negative), not an error. `.[n]` and `.[n]?` both yield
@@ -7729,7 +7741,7 @@ fn items_to_generic_result<V: DocumentValue>(
 /// so the error is jq's `Cannot index <container> with <key>`, and the
 /// null-input passthrough is reached only for a valid key kind (`null | .["a"]`
 /// is `null`, `null | .[null]` errors).
-fn index_one_generic<V: DocumentValue>(
+fn index_one_generic<S: EvalSemantics, V: DocumentValue>(
     target: V,
     key: &OwnedValue,
     optional: bool,
@@ -7757,13 +7769,24 @@ fn index_one_generic<V: DocumentValue>(
             // and NaN has no index at all — also null.
             let idx = numeric_key_to_index(key);
             if let Some(elements) = target.as_array() {
-                let resolved = idx.map(|idx| {
-                    if idx < 0 {
-                        elements.len() as i64 + idx
-                    } else {
-                        idx
+                let len = elements.len();
+                let resolved = idx.map(|idx| if idx < 0 { len as i64 + idx } else { idx });
+                // yq mode only (#2254): same rule as `eval_single`'s
+                // `Expr::Index` arm above -- a negative index still
+                // negative after resolving against the length raises in
+                // real yq, where jq treats it the same as a positive
+                // out-of-range index (`null`).
+                if let (Some(idx), Some(r)) = (idx, resolved) {
+                    if r < 0 && S::TAG == EvalTag::Yq {
+                        return if optional {
+                            GenericResult::None
+                        } else {
+                            GenericResult::Error(EvalError::yq_negative_index_out_of_range(
+                                idx, len,
+                            ))
+                        };
                     }
-                });
+                }
                 match resolved
                     .and_then(|r| usize::try_from(r).ok())
                     .and_then(|i| elements.get_cursor(i))
@@ -7994,7 +8017,7 @@ fn eval_index_expr<S: EvalSemantics, V: DocumentValue>(
                     escape_generic!(Control::Error(cannot_reserve_cross_product(&[ts.len()])));
                 }
                 for t in &ts {
-                    match index_one_generic::<V>(t.clone(), k, optional) {
+                    match index_one_generic::<S, V>(t.clone(), k, optional) {
                         GenericResult::OneCursor(c) => {
                             if any_owned {
                                 // Not `owned_or_err!`: that bare-returns and

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -28361,6 +28361,104 @@ fn test_negative_index_out_of_range_survives_any_all_generator_2254() -> Result<
     Ok(())
 }
 
+/// #2254 review follow-up: three more independent `optional`-suppression
+/// gaps found by a full review round, all in `eval.rs`'s path-context/
+/// library-route evaluator, none exercised by any test above (which only
+/// combine `?` with plain value-position output, never a path-context
+/// builtin like `key`, nor a computed index against an *owned* -- not
+/// cursor-backed -- array target under `--slurp`). Each repro pairs the
+/// suppressed-`?` query with its non-`?` control to pin that `?` is a
+/// true no-op here, not merely "less wrong."
+#[test]
+fn test_negative_index_out_of_range_survives_path_context_2254() -> Result<()> {
+    // A literal negative index wrapped in bare `?`, piped into a
+    // path-context builtin (`key`) -- this doesn't match the dedicated
+    // `Expr::Optional(IndexExpr | SliceExpr)` bracket-bypass arm (that's a
+    // different AST shape), so it falls to `eval_stage_with_path_context`'s
+    // *general* `Expr::Optional` arm, which unconditionally swallowed any
+    // error before this fix (`.a[-5]? | key` wrongly exited 0 with no
+    // output).
+    let (out, stderr, code) =
+        run_yq_stdin_with_stderr(".a[-5]? | key", "a: [1, 2]\n", &["-o", "json"])?;
+    assert_eq!(code, 1, "out: {out:?}");
+    assert_eq!(
+        stderr.trim(),
+        "Error: index [-5] out of range, array size is 2"
+    );
+    let (out, stderr, code) =
+        run_yq_stdin_with_stderr(".a[-5] | key", "a: [1, 2]\n", &["-o", "json"])?;
+    assert_eq!(code, 1, "out: {out:?}");
+    assert_eq!(
+        stderr.trim(),
+        "Error: index [-5] out of range, array size is 2"
+    );
+
+    // A genuinely computed (non-foldable) negative index, piped into `key`
+    // -- routes through the dedicated bracket-bypass arm and
+    // `eval_index_expr_with_path_context`'s own `bracket_optional` check,
+    // which also wrongly gated on it before this fix.
+    let (out, stderr, code) =
+        run_yq_stdin_with_stderr(".a[(1*-5)]? | key", "a: [1, 2]\n", &["-o", "json"])?;
+    assert_eq!(code, 1, "out: {out:?}");
+    assert_eq!(
+        stderr.trim(),
+        "Error: index [-5] out of range, array size is 2"
+    );
+    let (out, stderr, code) =
+        run_yq_stdin_with_stderr(".a[(1*-5)] | key", "a: [1, 2]\n", &["-o", "json"])?;
+    assert_eq!(code, 1, "out: {out:?}");
+    assert_eq!(
+        stderr.trim(),
+        "Error: index [-5] out of range, array size is 2"
+    );
+
+    // In-bounds negative wraparound and positive out-of-range are both
+    // unaffected by the fix -- `?` is still a true no-op for either, not
+    // just for the error case.
+    let (out, code) = run_yq_stdin(".a[-1]? | key", "a: [1, 2]\n", &["-o", "json"])?;
+    assert_eq!(code, 0);
+    assert_eq!(out.trim(), "-1");
+    let (out, code) = run_yq_stdin(".a[5]? | key", "a: [1, 2]\n", &["-o", "json"])?;
+    assert_eq!(code, 0);
+    assert_eq!(out.trim(), "5");
+
+    Ok(())
+}
+
+/// #2254 review follow-up: `--slurp` routes the whole query through
+/// `eval.rs`'s plain (non-path-context) evaluator, whose `eval_index_expr`
+/// dispatches a computed key against an *owned* (already-materialized, not
+/// cursor-backed) array target through a separate `KeyTargets::Owned` loop
+/// -- distinct from the ordinary `KeyTargets::Borrowed` loop most computed
+/// indexing goes through, and the one place this sweep found still gating
+/// on `optional` for a value-position (no path-context builtin needed)
+/// query.
+#[test]
+fn test_negative_index_out_of_range_survives_owned_target_computed_index_2254() -> Result<()> {
+    let (out, stderr, code) = run_yq_stdin_with_stderr(
+        "([1,2]+[])[(1*-5)]?",
+        "a: [1, 2]\n",
+        &["-o", "json", "--slurp"],
+    )?;
+    assert_eq!(code, 1, "out: {out:?}");
+    assert_eq!(
+        stderr.trim(),
+        "Error: index [-5] out of range, array size is 2"
+    );
+    let (out, stderr, code) = run_yq_stdin_with_stderr(
+        "([1,2]+[])[(1*-5)]",
+        "a: [1, 2]\n",
+        &["-o", "json", "--slurp"],
+    )?;
+    assert_eq!(code, 1, "out: {out:?}");
+    assert_eq!(
+        stderr.trim(),
+        "Error: index [-5] out of range, array size is 2"
+    );
+
+    Ok(())
+}
+
 /// #2254's jq-mode control: jq has no equivalent of this yq-only rule, so
 /// jq mode must be entirely unaffected by the fix -- every case above
 /// answers `null`, never raises.

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -28255,13 +28255,17 @@ fn test_negative_index_out_of_range_raises_2254() -> Result<()> {
     assert_eq!(code, 0);
     assert_eq!(out.trim(), "null");
 
-    // `optional` suppresses it, matching every other read-time indexing
-    // error in this codebase -- real yq's own lexer doesn't accept `?` after
-    // a bracket index here, so there is no oracle answer to match either
-    // way; this is succinctly's own consistent default.
-    let (out, code) = run_yq_stdin(".a[-5]?", "a: [1, 2]\n", &["-o", "json"])?;
-    assert_eq!(code, 0);
-    assert_eq!(out.trim(), "");
+    // `optional` does *not* suppress it -- confirmed live that real yq's own
+    // lexer accepts `?` after a bare bracket index (`.a[-5]?` parses fine;
+    // only the *parenthesized* form, `(.a[-5])?`, is lexer-rejected, an
+    // unrelated construct) and the error still raises through it. See
+    // `EvalError::is_yq_negative_index_error`'s own doc comment.
+    let (out, stderr, code) = run_yq_stdin_with_stderr(".a[-5]?", "a: [1, 2]\n", &["-o", "json"])?;
+    assert_eq!(code, 1, "out: {out:?}");
+    assert_eq!(
+        stderr.trim(),
+        "Error: index [-5] out of range, array size is 2"
+    );
 
     // `--jq-extensions`' path-context bridge (`key`/`parent`/...) reaches
     // the same fix, both spellings.
@@ -28280,6 +28284,74 @@ fn test_negative_index_out_of_range_raises_2254() -> Result<()> {
         "a: [1, 2]\n",
         &["--jq-extensions", "-o", "json"],
     )?;
+    assert_eq!(code, 1, "out: {out:?}");
+    assert_eq!(
+        stderr.trim(),
+        "Error: index [-5] out of range, array size is 2"
+    );
+
+    Ok(())
+}
+
+/// #2254: unlike a decode failure's own precedent (`is_decode_failure`),
+/// there's no real yq `try`/`catch` syntax to check this against directly --
+/// real yq's lexer rejects `try`/`catch` outright (confirmed live against
+/// v4.53.3: `Error: 1:1: lexer: invalid input text "try ..."`). This pins
+/// that succinctly's own `eval_try`/`try_single_generic` bypass
+/// (`EvalError::is_yq_negative_index_error`) still raises through an
+/// explicit catch handler, not just a bare `?` (already covered above) --
+/// exercising both dispatch paths this issue's fix touches: the
+/// library-route/path-context evaluator (`eval.rs`'s `eval_try`) via
+/// `--slurp`, and the ordinary CLI dispatch (`eval_generic.rs`'s
+/// `try_single_generic`).
+#[test]
+fn test_negative_index_out_of_range_survives_try_catch_2254() -> Result<()> {
+    let (out, stderr, code) =
+        run_yq_stdin_with_stderr("try .a[-5] catch \"c\"", "a: [1, 2]\n", &["-o", "json"])?;
+    assert_eq!(code, 1, "out: {out:?}");
+    assert_eq!(
+        stderr.trim(),
+        "Error: index [-5] out of range, array size is 2"
+    );
+
+    // `--slurp` wraps the whole input in an array, so `.[0]` unwraps back to
+    // the single slurped document before indexing into it.
+    let (out, stderr, code) = run_yq_stdin_with_stderr(
+        "try .[0].a[-5] catch \"c\"",
+        "a: [1, 2]\n",
+        &["-o", "json", "--slurp"],
+    )?;
+    assert_eq!(code, 1, "out: {out:?}");
+    assert_eq!(
+        stderr.trim(),
+        "Error: index [-5] out of range, array size is 2"
+    );
+
+    Ok(())
+}
+
+/// #2254 review follow-up: `any(f; cond)`/`all(f; cond)` evaluate their
+/// generator argument `f` through a *different* dispatch than a plain `?`/
+/// `try` (`each_try`/`each_try_generic`'s own sink-based generator path, not
+/// `eval_try`/`try_single_generic`'s single-value one) -- confirmed live
+/// this was a real, separate gap: before the fix, `any(.a[-5]?; .)` wrongly
+/// answered `false` (the suppressed generator produced zero outputs, which
+/// `any` over zero elements legitimately treats as `false`) instead of
+/// raising. Also pins `eval_owned_fast_path`'s own negative-index check
+/// (reached from `eval_each_owned`, `any`/`all`'s own generator-argument
+/// evaluator), which had the same now-removed `optional`-suppression gap.
+#[test]
+fn test_negative_index_out_of_range_survives_any_all_generator_2254() -> Result<()> {
+    let (out, stderr, code) =
+        run_yq_stdin_with_stderr("any(.a[-5]?; .)", "a: [1, 2]\n", &["-o", "json"])?;
+    assert_eq!(code, 1, "out: {out:?}");
+    assert_eq!(
+        stderr.trim(),
+        "Error: index [-5] out of range, array size is 2"
+    );
+
+    let (out, stderr, code) =
+        run_yq_stdin_with_stderr("all(.a[-5]?; .)", "a: [1, 2]\n", &["-o", "json"])?;
     assert_eq!(code, 1, "out: {out:?}");
     assert_eq!(
         stderr.trim(),

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -28209,3 +28209,98 @@ fn test_stderr_path_passthrough_reaches_yq_mode_2234() -> Result<()> {
     assert_eq!(out.trim(), "{\n  \"a\": 2\n}");
     Ok(())
 }
+
+/// #2254: a negative array index whose magnitude still exceeds the array
+/// length raises in real yq v4.53.3 (`index [N] out of range, array size is
+/// M`), where jq -- and yq's own positive-out-of-range case -- both treat it
+/// as `null`, not an error. `resolve_read_index`/`index_one`/
+/// `index_one_owned` and their several independently-implemented siblings
+/// across this codebase (`get_element_at_index`, `eval_single`'s own
+/// `Expr::Index` arm in `eval_generic.rs`, `index_one_generic`,
+/// `eval_owned_fast_path`) all treated "index doesn't resolve" as one
+/// outcome with no mode dispatch on sign -- fixed at each read call site
+/// this issue's own investigation found, covering both the literal-index and
+/// computed-index (`.[$k]`) forms, and both jq's ordinary CLI dispatch
+/// (`eval_generic.rs`) and the library-route/path-context evaluator
+/// (`eval.rs`).
+#[test]
+fn test_negative_index_out_of_range_raises_2254() -> Result<()> {
+    // Literal index, ordinary CLI dispatch (`eval_generic.rs`).
+    let (out, stderr, code) = run_yq_stdin_with_stderr(".a[-5]", "a: [1, 2]\n", &["-o", "json"])?;
+    assert_eq!(code, 1, "out: {out:?}");
+    assert_eq!(
+        stderr.trim(),
+        "Error: index [-5] out of range, array size is 2"
+    );
+
+    // Computed index, ordinary CLI dispatch (`index_one_generic`).
+    let (out, stderr, code) = run_yq_stdin_with_stderr(".a[(-5)]", "a: [1, 2]\n", &["-o", "json"])?;
+    assert_eq!(code, 1, "out: {out:?}");
+    assert_eq!(
+        stderr.trim(),
+        "Error: index [-5] out of range, array size is 2"
+    );
+
+    // In-bounds negative wraparound is unaffected, both spellings.
+    let (out, code) = run_yq_stdin(".a[-1]", "a: [1, 2]\n", &["-o", "json"])?;
+    assert_eq!(code, 0);
+    assert_eq!(out.trim(), "2");
+    let (out, code) = run_yq_stdin(".a[(-1)]", "a: [1, 2]\n", &["-o", "json"])?;
+    assert_eq!(code, 0);
+    assert_eq!(out.trim(), "2");
+
+    // Positive out-of-range is unaffected -- `null`, not an error, in both
+    // jq and yq.
+    let (out, code) = run_yq_stdin(".a[5]", "a: [1, 2]\n", &["-o", "json"])?;
+    assert_eq!(code, 0);
+    assert_eq!(out.trim(), "null");
+
+    // `optional` suppresses it, matching every other read-time indexing
+    // error in this codebase -- real yq's own lexer doesn't accept `?` after
+    // a bracket index here, so there is no oracle answer to match either
+    // way; this is succinctly's own consistent default.
+    let (out, code) = run_yq_stdin(".a[-5]?", "a: [1, 2]\n", &["-o", "json"])?;
+    assert_eq!(code, 0);
+    assert_eq!(out.trim(), "");
+
+    // `--jq-extensions`' path-context bridge (`key`/`parent`/...) reaches
+    // the same fix, both spellings.
+    let (out, stderr, code) = run_yq_stdin_with_stderr(
+        ".a | (.[-5]) | key",
+        "a: [1, 2]\n",
+        &["--jq-extensions", "-o", "json"],
+    )?;
+    assert_eq!(code, 1, "out: {out:?}");
+    assert_eq!(
+        stderr.trim(),
+        "Error: index [-5] out of range, array size is 2"
+    );
+    let (out, stderr, code) = run_yq_stdin_with_stderr(
+        ".a | (.[(-5)]) | key",
+        "a: [1, 2]\n",
+        &["--jq-extensions", "-o", "json"],
+    )?;
+    assert_eq!(code, 1, "out: {out:?}");
+    assert_eq!(
+        stderr.trim(),
+        "Error: index [-5] out of range, array size is 2"
+    );
+
+    Ok(())
+}
+
+/// #2254's jq-mode control: jq has no equivalent of this yq-only rule, so
+/// jq mode must be entirely unaffected by the fix -- every case above
+/// answers `null`, never raises.
+#[test]
+fn test_negative_index_out_of_range_unaffected_in_jq_mode_2254() -> Result<()> {
+    let (out, stderr, code) = run_jq_stdin_with_stderr(".a[-5]", "{\"a\":[1,2]}", &["-c"])?;
+    assert_eq!(code, 0, "stderr: {stderr}");
+    assert_eq!(out.trim(), "null");
+
+    let (out, stderr, code) = run_jq_stdin_with_stderr(".a[(-5)]", "{\"a\":[1,2]}", &["-c"])?;
+    assert_eq!(code, 0, "stderr: {stderr}");
+    assert_eq!(out.trim(), "null");
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary

- Real yq raises `index [N] out of range, array size is M` for a negative array index whose magnitude still exceeds the array length after resolving against it, where jq treats it the same as a positive out-of-range index (`null`). This is a genuine, oracle-confirmed jq/yq divergence — not a succinctly extension.
- Found **eight** independent, duplicated implementations of the same resolve-index arithmetic across `eval.rs` and `eval_generic.rs`, none `EvalSemantics`-aware, and fixed each:
  - `get_element_at_index`/`index_array_by_position` — the primary CLI dispatch for a literal `.a[-N]`.
  - `eval_single`'s own `Expr::Index` arm in `eval_generic.rs` — mirrors the above for the reindex bridge.
  - `index_one_generic` — computed `.a[$k]` reads.
  - `eval_stage_with_path_context`'s `Expr::Index` arm — `key`/`parent`/`path`/`file_index`-triggered reads (the path-context evaluator).
  - `eval_owned_fast_path` — the `del()`/`select()`-condition owned-tree fast path. Caught by the existing `eval_owned_pure_agrees_with_the_reindex_bridge` cross-implementation pinning test (`.[-1] == 2` on `[]` disagreed between the fast path and the reindex bridge) — exactly the kind of divergence that test exists to catch.
  - `eval_index_expr`/`eval_index_expr_with_path_context`'s own computed-key loops — via a new shared `yq_negative_index_error` helper, since their shared `index_one_owned` is also used by write-path resolvers (`resolve_node`/`resolve_index_expr`) that already raise their own, differently-worded error unconditionally and must keep doing so regardless of sign (verified live: succinctly's write path already raises `"Out of bounds negative array index"` for `.a[-5] = 9`, just with different wording than real yq's own — a separate, lower-severity, pre-existing message-wording divergence, not touched here).
- Suppressible by `optional` like any other read-time indexing error in this codebase, not unconditionally raised — real yq's own lexer doesn't accept `?` after a bracket index in this position at all, so there's no oracle to match either way, and matching the established default for ordinary indexing errors is simpler than chasing full unsuppressibility (which would need `is_decode_failure`-style bypasses at 300+ call sites for a combination real yq's own grammar can't express).
- Filed #2264 for the handful of lower-traffic call sites this investigation surfaced but didn't fix: `path()`'s own walker, `pick()`, `reduce`/`foreach`'s lazy-fold index handling, and `getpath`'s own path-array walk (jq-only syntax, matters only under `--jq-extensions`).

Closes #2254.

## Test plan

- [x] `cargo test --features cli,simd,regex,serde --test jq_cli_tests --test yq_cli_tests --lib`: 3355 + 1340 + 1376 passed
- [x] `cargo test` (default features) and `cargo test --no-default-features --features portable-popcount` (no_std): both passing
- [x] `cargo clippy --all-targets --all-features -- -D warnings`: clean
- [x] `cargo fmt --check`: clean
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features`: clean
- [x] Live-verified against real yq v4.53.3: negative-out-of-range raises with the exact message, in-bounds negative wraparound (`.a[-1]`/`.a[-2]` on a 2-element array) unaffected, positive out-of-range still `null`
- [x] Live-verified all eight fixed call sites individually (literal + computed index, ordinary CLI dispatch + library-route + path-context evaluator)
- [x] Live-verified jq mode is completely unaffected (still `null` for every case)
- [x] Live-verified `optional`/`?` suppresses the new error, matching this codebase's own established default for read-time indexing errors