### PR TITLE
fix(jq): resolve_index_expr/resolve_slice_expr keep prefix past an untrackable branch

### DIFF
--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -24947,6 +24947,35 @@ fn is_passthrough_target(target: &Expr) -> bool {
     components.is_empty()
 }
 
+/// The shared "#843 (the caller's own trackability context) OR #986 (this
+/// specific branch's own untrackability)" check both [`resolve_index_expr`]
+/// and [`resolve_slice_expr`] run against each of `target`'s resolved
+/// branches, immediately before that branch is navigated further (indexed
+/// or sliced) -- #2248. One shared definition, not two hand-copied call
+/// sites, so the two can't drift apart (this file's own "duplicated
+/// predicates diverge silently" lesson, #106).
+///
+/// Checked per branch, not as an upfront whole-list scan: a branch that
+/// already resolved and indexed/sliced cleanly before an untrackable one
+/// later in the list must still contribute to the escape's own `out`
+/// prefix, matching real jq's per-branch generator semantics rather than
+/// discarding the whole list wholesale. `near` is the value naming the
+/// navigation attempt in jq's error wording (the key for `resolve_index_expr`,
+/// the slice bounds for `resolve_slice_expr`); `target_value` is this
+/// branch's own value, jq's "container" in that same wording.
+fn untrackable_branch_escape(
+    trackable: bool,
+    branch_trackable: bool,
+    near: &OwnedValue,
+    target_value: &OwnedValue,
+) -> Option<EvalEscape> {
+    if trackable && branch_trackable {
+        None
+    } else {
+        Some(EvalError::invalid_path_expression_near_access(near, target_value).into())
+    }
+}
+
 /// Resolve `E[K]` in path context, with or without a trailing `?`.
 ///
 /// The two spellings differ in one thing only: what happens when the resolved
@@ -25081,27 +25110,6 @@ fn resolve_index_expr<'a, S: EvalSemantics>(
         // value, not a fixed `keys[0]` — jq's own error names whichever
         // key was actually being navigated when the untracked branch was
         // reached.
-        if !trackable {
-            if let Some(PathBranch {
-                value: first_value, ..
-            }) = branches.first()
-            {
-                escape!(EvalError::invalid_path_expression_near_access(k, first_value).into());
-            }
-        }
-        // #986: the same check, for a `target` that resolved fine but is
-        // itself untracked — `(1 | .) [K]`, where the pipe's own literal
-        // deferred here rather than raising. `trackable` above is the
-        // *caller's* context; this is the target's own. Both produce jq's
-        // "near attempt" wording, naming this key as the navigation that
-        // failed.
-        if let Some(PathBranch {
-            value: first_value, ..
-        }) = branches.iter().find(|b| !b.trackable)
-        {
-            escape!(EvalError::invalid_path_expression_near_access(k, first_value).into());
-        }
-
         // Reserved once per key, ahead of that key's own indexing loop,
         // rather than once for the whole `keys x target` product up front
         // -- `target`'s own length can vary per key now (#2139, mirroring
@@ -25120,11 +25128,28 @@ fn resolve_index_expr<'a, S: EvalSemantics>(
         for PathBranch {
             path: components,
             value: target_value,
-            // Every untracked target branch was already rejected by the
-            // check above, so anything reaching here is tracked.
+            trackable: branch_trackable,
             ..
         } in &branches
         {
+            // #843/#986 (#2248 review): checked per branch, right before
+            // that branch is indexed, not as an upfront `branches.first()`/
+            // `.find()` scan before this loop starts. An upfront scan
+            // escaped on *any* untrackable branch anywhere in the list,
+            // discarding every trackable branch that came before it in
+            // `out` -- confirmed live as a real output-loss bug: `path((.,5)
+            // [(0,error("mid"))])` on jq 1.7.1 prints `[0]` (the `.`
+            // branch's own successful index) before raising `mid`; the
+            // upfront scan here produced no stdout at all, since the `5`
+            // branch's untrackability was noticed before `.`'s own
+            // already-successful indexing was ever pushed to `out`. See
+            // `untrackable_branch_escape`'s own doc comment for why the two
+            // conditions stay merged.
+            if let Some(control) =
+                untrackable_branch_escape(trackable, *branch_trackable, k, target_value)
+            {
+                escape!(control);
+            }
             // A NaN key names no element for a write to land on, so `?` does not
             // save it — but only where a number addresses an element at all. On
             // an object the failure is the ordinary `Cannot index object with
@@ -25386,41 +25411,6 @@ fn resolve_slice_expr<'a, S: EvalSemantics>(
                 )
                 .into());
             }
-            // #843: `resolve_index_expr`'s sibling `getpath`-laundering
-            // check — `target` can also resolve successfully with
-            // `trackable: false` through `Builtin::GetPath`'s deliberate
-            // exemption, which doesn't certify what comes after it as
-            // trackable. Without this, `catch (getpath(["other"])[0:2]) =
-            // [...]` silently wrote into the real document instead of
-            // raising — found in review.
-            // #986: `!b.trackable` is the same question asked of the
-            // target's own branches rather than the caller's context —
-            // `(1 | .)[0:2]`, where the pipe's literal deferred here
-            // instead of raising. Kept as one condition with `!trackable`
-            // so the two can't drift: this file's own "duplicated
-            // predicates diverge silently" lesson (#106).
-            //
-            // Re-checked on *every* pair's own freshly-resolved
-            // `branches`, not just the first (#2249, mirroring #2139's
-            // own review finding for `resolve_index_expr`): `target`'s
-            // trackability can differ per pair once `target` is genuinely
-            // re-evaluated per pair, if its own AST has a runtime branch
-            // (`if`/`select`/`try`-`catch`) whose taken arm a stateful
-            // condition (`input`, ...) steers differently across pairs.
-            // Latching a single verdict from the first pair would let a
-            // later pair's genuinely untracked branch through unchecked
-            // -- confirmed as a real data-corruption bug for
-            // `resolve_index_expr`'s own first draft of #2139.
-            if let Some(PathBranch {
-                value: first_value, ..
-            }) = branches.iter().find(|b| !trackable || !b.trackable)
-            {
-                escape!(EvalError::invalid_path_expression_near_access(
-                    &slice_component_value(*s, s_key.as_ref(), *e, e_key.as_ref()),
-                    first_value,
-                )
-                .into());
-            }
             // Keeps `target`'s own partial prefix, not just discarding it
             // via `?`, the same fix #896's review applied to
             // `resolve_index_expr`'s sibling target-resolution step (found
@@ -25451,11 +25441,36 @@ fn resolve_slice_expr<'a, S: EvalSemantics>(
             for PathBranch {
                 path: components,
                 value: target_value,
-                // As in `resolve_index_expr`: the check above already
-                // rejected every untracked target branch.
+                trackable: branch_trackable,
                 ..
             } in &branches
             {
+                // #843/#986 (#2248 review): checked per branch, right
+                // before that branch is sliced, not as an upfront
+                // `.find()` scan before this loop starts. An upfront scan
+                // escaped on *any* untrackable branch anywhere in the
+                // list, discarding every trackable branch that came
+                // before it in `out` -- confirmed live as a real
+                // output-loss bug, mirroring `resolve_index_expr`'s
+                // identical one: `path((.,5)[(0,1):(2,error("mid"))])` on
+                // jq 1.7.1 prints `[{"start":0,"end":2}]` (the `.`
+                // branch's own successful slice) before raising `mid`;
+                // the upfront scan here produced no stdout at all.
+                // Re-checked on *every* pair's own freshly-resolved
+                // `branches` (#2249: `target` is no longer cached across
+                // pairs at all, so there is nothing to skip re-checking --
+                // unlike this same review's finding for #2245-era cached
+                // `target_branches`, which #2249 has since replaced with
+                // per-pair re-resolution). See `untrackable_branch_escape`'s
+                // own doc comment for why the two conditions stay merged.
+                if let Some(control) = untrackable_branch_escape(
+                    trackable,
+                    *branch_trackable,
+                    &slice_component_value(*s, s_key.as_ref(), *e, e_key.as_ref()),
+                    target_value,
+                ) {
+                    escape!(control);
+                }
                 // `false`, not `optional`: the failure has to arrive as an
                 // error for the two spellings to be told apart here, same
                 // as `resolve_index_expr`'s `index_one_owned` call.

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -13659,6 +13659,29 @@ fn test_resolve_index_expr_checks_trackability_every_key_2139() -> Result<()> {
     Ok(())
 }
 
+/// #2248 (found during #2245's own live-oracle verification): the #843/#986
+/// "is target trackable" check used to scan `target`'s whole branch list
+/// *before* any of them were indexed, so hitting an untrackable branch
+/// anywhere in that list discarded every trackable branch that came before
+/// it -- even ones already known to resolve cleanly. Fixed by checking each
+/// branch's trackability right before indexing it, so branches ahead of the
+/// untrackable one still contribute to the output prefix. Verified against
+/// jq 1.7.1: `path((.,5)[(0,error("mid"))])` on `null` prints `[0]` (the `.`
+/// branch's own successful index) before raising "Invalid path expression".
+#[test]
+fn test_resolve_index_expr_untrackable_branch_keeps_earlier_prefix_2248() -> Result<()> {
+    let (stdout, stderr, code) =
+        run_jq_full(&["-c", r#"path((.,5)[(0,error("mid"))])"#], Some("null"))?;
+    assert_eq!(code, 5, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert_eq!(stdout, "[0]\n");
+    assert!(
+        stderr.contains("Invalid path expression"),
+        "stderr: {stderr:?}"
+    );
+
+    Ok(())
+}
+
 /// #972 Guard A: the exact shape that got PR #985 reverted for silent data
 /// corruption on the write side. Before the Stage 1 precursor fix above,
 /// `resolve_index_expr`'s untruncated `Err` prefix for
@@ -14508,6 +14531,27 @@ fn test_resolve_slice_expr_target_not_evaluated_when_end_always_empty_2245() -> 
     assert!(
         stderr.is_empty(),
         "target's stderr side effect should never fire: stderr: {stderr:?}"
+    );
+
+    Ok(())
+}
+
+/// #2248, `resolve_slice_expr`'s identical sibling to
+/// `resolve_index_expr`'s own fix above. Verified against jq 1.7.1:
+/// `path((.,5)[(0,1):(2,error("mid"))])` on `null` prints
+/// `[{"start":0,"end":2}]` (the `.` branch's own successful slice) before
+/// raising "Invalid path expression".
+#[test]
+fn test_resolve_slice_expr_untrackable_branch_keeps_earlier_prefix_2248() -> Result<()> {
+    let (stdout, stderr, code) = run_jq_full(
+        &["-c", r#"path((.,5)[(0,1):(2,error("mid"))])"#],
+        Some("null"),
+    )?;
+    assert_eq!(code, 5, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert_eq!(stdout, "[{\"start\":0,\"end\":2}]\n");
+    assert!(
+        stderr.contains("Invalid path expression"),
+        "stderr: {stderr:?}"
     );
 
     Ok(())


### PR DESCRIPTION
## Summary

`resolve_index_expr` (`E[K]`) and `resolve_slice_expr` (`E[S:T]`) — the
`path()`/`=`/`del()` write-path resolvers for indexing and slicing — both
resolve `target` (`E`) into a list of branches, then check whether *any*
branch is untrackable using an upfront `.find()`/`.first()` scan **before**
any branch is actually indexed/sliced. When the untrackable branch isn't
first in the list, this discarded every trackable branch that came before
it — even ones already known to resolve cleanly — instead of raising once
it actually reached the untrackable one, the way real jq's own per-branch
generator does.

Fixes #2248 by moving the trackability check into each function's
per-branch loop, checked immediately before that branch is
indexed/sliced, so branches ahead of the untrackable one still contribute
to the escape's `out` prefix — the same "an escape's already-produced
prefix must survive" pattern already established by #1517/#2143/#2225.

```console
$ echo null | jq -c 'path((.,5)[(0,error("mid"))])'
[0]
jq: error (at <stdin>:1): Invalid path expression near attempt to access element 0 of 5

$ echo null | succinctly jq -c 'path((.,5)[(0,error("mid"))])'   # before this fix
jq: error (at <stdin>:1): Invalid path expression near attempt to access element 0 of 5
# (no stdout at all -- the `.` branch's own [0] output was silently dropped)
```

Both `resolve_index_expr` and `resolve_slice_expr` had the identical shape;
both are fixed here.

## Test plan

- [x] `cargo build --features cli`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --all-features --no-deps`
- [x] `cargo test --features cli --test jq_cli_tests` (1343 passed, incl. 2 new regression tests)
- [x] Full CLI integration suite (yq_cli_tests, yq_golden_tests, yq_path_consistency_tests, jq_golden_tests, yaml_bench_suite_coverage, dsv_cli_tests, text_cli_tests, json_validate_tests, yaml_validate_tests, cli_golden_tests, cli_characterization_tests, deep_nesting_valid_tests, jq_computed_key_tests) — all passed
- [x] `cargo test --verbose` (default), `--features simd`, `--features portable-popcount`, `--no-default-features` (no_std)
- [x] Live-verified against `/usr/bin/jq` 1.7.1 across multi-key/multi-pair cases, untrackable-branch-first vs. untrackable-branch-last, `getpath` laundering (#843), `?`-optional (does not suppress the error), and ordinary writes — all match