### PR TITLE
fix(jq): navigation_element unwraps Expr::Optional components (#2272)

### DIFF
--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -22729,6 +22729,24 @@ fn resolve_iterate_bounded<S: EvalSemantics>(
 /// hand-rolled here). `None` for `Identity` and anything else — `Identity`
 /// performs no navigation at all, so both call sites deliberately route it
 /// to the ordinary `#530` "with result" check instead.
+///
+/// #2272: `Expr::Optional` unwraps to its inner shape rather than falling
+/// into the `_ => None` catch-all -- a component here can carry a `?` from
+/// its own source spelling (`E[K]?`'s `resolve_index_expr` call still
+/// builds `Expr::Optional(Field(...))`/`Expr::Optional(Index{...})`/
+/// `Expr::Optional(Slice{...})` components even though *this* function's
+/// own caller, `resolve_static_tail`, is asking the #530-vs-#843 question
+/// one level below where `?` gets stripped for the write path (#498) --
+/// this read-path check runs before that stripping ever happens). Without
+/// this arm, any optional index/slice/field access into an untracked value
+/// fell back to the generic "with result" wording instead of #843's own
+/// more specific "near attempt to access element K of V", losing exactly
+/// the key/index/slice being attempted. Confirmed live against jq 1.7.1:
+/// `path((.,5)[("a")]?)` raises "near attempt to access element \"a\" of
+/// 5", not jq's generic wording -- `?` here only covers the *indexing*
+/// failure (#530 is documented never to be one), so this is purely a
+/// missing-shape gap in the message construction, not an optional-
+/// suppression question.
 fn navigation_element(component: &Expr) -> Option<OwnedValue> {
     match component {
         Expr::Field(name) => Some(OwnedValue::String(name.clone())),
@@ -22744,6 +22762,7 @@ fn navigation_element(component: &Expr) -> Option<OwnedValue> {
             *end,
             end_key.as_ref(),
         )),
+        Expr::Optional(inner) => navigation_element(inner),
         _ => None,
     }
 }

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -18293,6 +18293,49 @@ fn test_resolve_node_alternative_falsy_literal_interacts_correctly_with_untracke
     Ok(())
 }
 
+/// #2272: `navigation_element` fell into its own `_ => None` catch-all for
+/// an `Expr::Optional`-wrapped component (`E[K]?`'s own `resolve_index_expr`
+/// call site still builds `Expr::Optional(Field(...))`/`Expr::Optional(
+/// Index{..})`/`Expr::Optional(Slice{..})` components, since `?`'s wrapper
+/// isn't stripped until later, write-side (#498)) -- so `resolve_static_tail`
+/// fell back to the generic `#530` "with result" wording instead of #843's
+/// "near attempt to access element K of V" whenever a trailing `?` was
+/// involved. Verified live against jq 1.7.1 for every assertion below.
+#[test]
+fn test_navigation_element_unwraps_optional_component_2272() -> Result<()> {
+    // Field access through a computed-key index expression.
+    let (stdout, stderr, code) = run_jq_full(&["-c", r#"path((.,5)[("a")]?)"#], Some("null"))?;
+    assert_eq!(code, 5, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert_eq!(stdout, "[\"a\"]\n");
+    assert!(
+        stderr.contains(r#"near attempt to access element "a" of 5"#),
+        "stderr: {stderr:?}"
+    );
+
+    // Slice access, same shape.
+    let (stdout, stderr, code) = run_jq_full(&["-c", "path((.,5)[(0):(2)]?)"], Some("null"))?;
+    assert_eq!(code, 5, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert_eq!(stdout, "[{\"start\":0,\"end\":2}]\n");
+    assert!(
+        stderr.contains(r#"near attempt to access element {"start":0,... of 5"#),
+        "stderr: {stderr:?}"
+    );
+
+    // The bare postfix `?` cases (`.field?`) already correctly hit
+    // `is_untracked_navigation_error`'s own carve-out before this fix and
+    // must stay unaffected -- pinned here so a future change to
+    // `navigation_element` can't quietly re-break this sibling shape.
+    let (stdout, stderr, code) =
+        run_jq_full(&["-c", "path(try (.a, error(5)) catch .b?)"], Some("null"))?;
+    assert_eq!(code, 5, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert!(
+        stderr.contains(r#"near attempt to access element "b" of 5"#),
+        "stderr: {stderr:?}"
+    );
+
+    Ok(())
+}
+
 // ============================================================================
 // #1023: resolve_node's Select/If arms both hand-rolled the identical
 // "evaluate cond via eval_owned_multi_keep_partial, fork per output's

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -18321,6 +18321,35 @@ fn test_navigation_element_unwraps_optional_component_2272() -> Result<()> {
         "stderr: {stderr:?}"
     );
 
+    // Integer/negative index and an open-ended slice bound (review): the
+    // same `Expr::Optional(Index{..})`/`Expr::Optional(Slice{..})` shapes
+    // as above, but exercising `index_component_value`'s negative-index
+    // path and `slice_component_value`'s `None` end bound specifically,
+    // not just the string-key/two-sided-bound cases already covered.
+    let (stdout, stderr, code) = run_jq_full(&["-c", "path((.,5)[(0)]?)"], Some("null"))?;
+    assert_eq!(code, 5, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert_eq!(stdout, "[0]\n");
+    assert!(
+        stderr.contains("near attempt to access element 0 of 5"),
+        "stderr: {stderr:?}"
+    );
+
+    let (stdout, stderr, code) = run_jq_full(&["-c", "path((.,5)[(-1)]?)"], Some("null"))?;
+    assert_eq!(code, 5, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert_eq!(stdout, "[-1]\n");
+    assert!(
+        stderr.contains("near attempt to access element -1 of 5"),
+        "stderr: {stderr:?}"
+    );
+
+    let (stdout, stderr, code) = run_jq_full(&["-c", "path((.,5)[(1):]?)"], Some("null"))?;
+    assert_eq!(code, 5, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert_eq!(stdout, "[{\"start\":1,\"end\":null}]\n");
+    assert!(
+        stderr.contains(r#"near attempt to access element {"start":1,... of 5"#),
+        "stderr: {stderr:?}"
+    );
+
     // The bare postfix `?` cases (`.field?`) already correctly hit
     // `is_untracked_navigation_error`'s own carve-out before this fix and
     // must stay unaffected -- pinned here so a future change to


### PR DESCRIPTION
## Summary
- An optional index/slice into an untracked value (`E[K]?`, `E[S:T]?`) reported the generic `Invalid path expression with result V` instead of jq's specific `Invalid path expression near attempt to access element K of V` — verified live against jq 1.7.1: `path((.,5)[("a")]?)` prints `["a"]` then raises the specific wording on real jq, but the generic one on unmodified `main`.
- **Root cause, found via direct tracing** (added and removed temporary `eprintln!` instrumentation at each candidate call site, since hand-tracing the ~15 interacting functions in this area proved unreliable): `resolve_static_tail` calls `navigation_element(components.first())` to decide which wording to use — but the component it examines carries an `Expr::Optional` wrapper (from `resolve_index_expr`/`resolve_slice_expr`'s own `?`-handling call sites, which build `Expr::Optional(Field(...))`/`Expr::Optional(Index{..})`/`Expr::Optional(Slice{..})` — `?`'s wrapper isn't stripped until later, on the write path, per #498). `navigation_element`'s `match` had no arm for `Expr::Optional`, so it fell into the same catch-all `None` that correctly applies to bare `Expr::Identity`, losing the specific wording whenever a trailing `?` was involved.
- Fix: add `Expr::Optional(inner) => navigation_element(inner)`, recursing through the wrapper to the `Field`/`Index`/`Slice` shape underneath.
- Live-verified the sibling bare-postfix-`?` carve-out (`is_untracked_navigation_error`, a separate mechanism) is unaffected, and the already-correct unwrapped (`E[K]`, no `?`) case stays unaffected.

## Test plan
- [x] New test `test_navigation_element_unwraps_optional_component_2272`, covering the field case, the slice case (with correctly-truncated element wording), and the sibling bare-`?` case as a regression pin
- [x] Fail-without-fix / pass-with-fix confirmed: reverted the one-line fix, test failed with the generic wording; restored, test passes
- [x] Broad live differential testing against pinned jq 1.7.1 (12 scenarios: original repro, slice variant, bare `?`, no trailing `?`, `getpath` via `catch`, `?`-free slice, optional slice on untracked target, nested-optional parse, iterate variant, field access, assignment, `del()`) — all match
- [x] yq mode: `path()` itself isn't valid yq syntax without `--jq-extensions` (confirmed live against pinned yq v4.53.3 — no oracle to compare against for this specific repro), so scope is effectively jq-mode; confirmed no regression to ordinary yq-mode `path()` usage through `--jq-extensions`-gated call sites
- [x] `cargo clippy --all-targets --all-features -- -D warnings` (clean build)
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings`
- [x] `cargo test --no-fail-fast --features cli,simd,regex,serde` (0 failed)
- [x] `cargo test --no-default-features --verbose` (no_std, 0 failed)
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features`

Fixes #2272