### PR TITLE
fix(ci): refresh the ARM64-Linux perf-guard baseline

### DIFF
--- a/tests/data/perf-guard-baseline.json
+++ b/tests/data/perf-guard-baseline.json
@@ -1,11 +1,11 @@
 {
   "ARM64-Linux": {
-    "arrays_identity": 1486074505,
-    "users_identity": 337129160,
-    "users_keys_unsorted": 43388740,
-    "users_yq_keys_unsorted": 72762888,
-    "wide_identity": 668045547,
-    "wide_keys_unsorted": 289871551
+    "arrays_identity": 1054844086,
+    "users_identity": 343420725,
+    "users_keys_unsorted": 44469171,
+    "users_yq_keys_unsorted": 72214718,
+    "wide_identity": 622777831,
+    "wide_keys_unsorted": 321864371
   },
   "x86_64": {
     "arrays_identity": 1602058719,


### PR DESCRIPTION
## Summary

Fixes #2116. The `ARM64-Linux` half of `tests/data/perf-guard-baseline.json` was 789 commits stale (last measured at `bed5f7d2f`, 2026-08-24) and unfixable locally per #2059's own note: `valgrind` has no Apple Silicon support, and no Linux/ARM64 + valgrind machine was available.

Measured instead inside a native `linux/arm64` Docker container (no emulation — the host, `johns-mac-mini`, is Apple Silicon) on `ubuntu:24.04`, matching the `ubuntu-24.04-arm` image `ci.yml`'s `perf-guard` `ARM64-Linux` leg itself runs on: `apt-get install valgrind`, `cargo build --release --features cli`, then `scripts/perf-guard.py --update-baseline`.

Drift ranged from -29.0% (`arrays_identity`) to +11.0% (`wide_keys_unsorted`) — larger than #2059's x86_64 refresh (+2.8% to +6.3% over 644 commits), consistent with this window also containing #1576 (stream map/sort/navigation output from cursors instead of an `OwnedValue` DOM, landed 2026-09-02), which would disproportionately help an identity query over a large flat array. Re-verified with `--check` immediately after: 0.0% drift on all six queries.

**Note:** #1576 landed one day after the x86_64 baseline's own refresh (`d8a73c944`, 2026-09-01), so that half is stale again too (confirmed both `Perf Regression Guard (x86_64)` and `(ARM64-Linux)` are currently failing on `main`'s own push-triggered CI runs). That's a separate fix needing `terminus` (the pinned x86_64 box) — filing as a follow-up issue rather than bundling it here.

## Test plan

- [x] `--update-baseline` run inside the container, `git diff` limited to the `ARM64-Linux` section only
- [x] Immediate `--check` re-run against the new baseline: 0.0% drift on all six queries
- [ ] CI green (`Perf Regression Guard (ARM64-Linux)` job)