### PR TITLE
fix(jq): close #2211/#2243's trailing-comma gap in 3 sibling materializers (#2262)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -318,6 +318,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   re-serializes an already-materialized `OwnedValue` first) — both are library-API-only
   completeness fixes, pinned by direct unit tests calling the function itself.
 
+  **Code review on this same fix (#2276) found the CLI fix above was reachable only through a
+  filter that forces the DOM path (`.[0]`), not `--slurp`'s/`--inplace`'s own M2 streaming fast
+  path for a plain identity/M2-streamable filter** — which parses via `YamlIndex`/
+  `mark_json_sourced` instead (JSON is a syntactic subset of YAML's flow grammar), bypassing
+  `to_owned_canonicalizing_numbers_at_depth` and its new checks entirely, since that grammar
+  legitimately allows a trailing `,`. For `--inplace` this was silent data loss, not just wrong
+  output: `printf '[1,]' > f.json && succinctly yq -i --input-format json '.' f.json` rewrote
+  the file to `- 1` at exit 0, where real yq refuses and leaves it byte-for-byte untouched.
+  Fixed conservatively (declining M2 for JSON-sourced input, matching the exact run-wide
+  `any_input_is_json` gate #978 originally introduced and #996 later removed for a different
+  reason) rather than by extending `YamlCursor`'s own comma-validation, which would need much
+  broader new test coverage to be confident is airtight — both `--slurp`'s and `--inplace`'s
+  own `else` arm already correctly reject the same input via this same fixed materializer, so
+  no further changes were needed there. Known cost: `--slurp`/`--inplace` with well-formed,
+  *duplicate-keyed* JSON input collapses those duplicates again (the exact #996 regression this
+  same gate caused before #996 fixed it at the source for the plain stdout M2 path, left
+  untouched here) — accepted deliberately, and already tracked as a known DOM-path limitation
+  (#1343). The plain stdout M2 path (no `--slurp`/`--inplace`) has the identical underlying
+  validation gap but was left alone: its own fallback (`evaluate_yaml_direct_filtered`) shares
+  the same gap, so declining that fast path would cost performance with no correctness gain —
+  a real, broader, non-destructive sibling issue, tracked separately rather than folded in here.
+
 - **`del(EXPR | .)` -- a `del()` path whose *last* component is a bare `.` reached after
   navigating through a real `Field`/`Index`/`Iterate` step -- nulled the targeted slot in place
   instead of removing it from its parent container** (#2256), diverging from both real jq and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -326,19 +326,55 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   legitimately allows a trailing `,`. For `--inplace` this was silent data loss, not just wrong
   output: `printf '[1,]' > f.json && succinctly yq -i --input-format json '.' f.json` rewrote
   the file to `- 1` at exit 0, where real yq refuses and leaves it byte-for-byte untouched.
-  Fixed conservatively (declining M2 for JSON-sourced input, matching the exact run-wide
-  `any_input_is_json` gate #978 originally introduced and #996 later removed for a different
-  reason) rather than by extending `YamlCursor`'s own comma-validation, which would need much
-  broader new test coverage to be confident is airtight — both `--slurp`'s and `--inplace`'s
-  own `else` arm already correctly reject the same input via this same fixed materializer, so
-  no further changes were needed there. Known cost: `--slurp`/`--inplace` with well-formed,
-  *duplicate-keyed* JSON input collapses those duplicates again (the exact #996 regression this
-  same gate caused before #996 fixed it at the source for the plain stdout M2 path, left
-  untouched here) — accepted deliberately, and already tracked as a known DOM-path limitation
-  (#1343). The plain stdout M2 path (no `--slurp`/`--inplace`) has the identical underlying
-  validation gap but was left alone: its own fallback (`evaluate_yaml_direct_filtered`) shares
-  the same gap, so declining that fast path would cost performance with no correctness gain —
-  a real, broader, non-destructive sibling issue, tracked separately rather than folded in here.
+
+  Two approaches were tried. Extending `YamlCursor`'s own `DocumentCursor` overrides
+  (`container_gap_ok`/`trailing_element_gap_ok`/`preceding_delimiter_ok`) to validate commas in
+  place when JSON-sourced — keeping the same parser and its same parse-time depth guard, so no
+  depth regression could occur — was built and confirmed live *not* to work: `--slurp`'s and
+  `--inplace`'s M2 fast path streams cursor results directly
+  (`stream_json_sequence`/`stream_yaml_sequence`, `YamlCursor::stream_json`/`stream_yaml`)
+  without ever materializing through `to_owned_cursor_at_depth`, the only place those trait
+  methods are consulted — the whole point of M2 streaming is to avoid exactly that step, so the
+  overrides were simply never reached by the code path that needed fixing. Reverted in favor of
+  declining the fast path for JSON-sourced input (reusing the exact run-wide `any_input_is_json`
+  gate #978 originally introduced and #996 later removed for a different reason), which both
+  `--slurp`'s and `--inplace`'s own `else` arm already correctly rejected the same input via —
+  this fix's own materializer — with no further changes needed to either fallback.
+
+  **That in turn silently loosened a different guard**: `YamlIndex`'s own parser enforces a
+  128-deep parse-time nesting limit, while `to_owned_canonicalizing_numbers_at_depth`'s own
+  guard is a looser, panicking 256-deep one (a different ceiling for a different reason — stack-
+  overflow safety for the conversion step, not fidelity with what the fast path used to reject).
+  Declining the fast path therefore silently *accepted* JSON nested 129–255 levels deep that the
+  fast path used to reject at parse time, confirmed live before this correction (150 levels via
+  `--slurp` printed the full structure at exit 0). Closed by `parse_input_m2_parity`
+  (`yq_runner.rs`), a depth-128 pre-check specific to `--slurp`'s and `--inplace`'s own DOM
+  fallback (not `--eval-all`'s, which never had this 128-deep guarantee to begin with, so
+  tightening it there would be an unrelated behavior change) — verified to match the pre-#2276
+  binary exactly at every boundary value (127/128/129/255/256/257), including the off-by-one an
+  earlier revision of this same check got wrong (128 levels of plain nesting is accepted, not
+  rejected — `YamlIndex`'s own `nesting_depth` counter is checked before incrementing and never
+  counts a leaf scalar as its own nesting level). This incidentally also means `--slurp`/
+  `--inplace` no longer reach the 256-deep guard's panic at all (previously reachable — and,
+  briefly, *more* reachable — through this same fallback); `--eval-all`'s own, unrelated,
+  pre-existing instance of that exact panic is unaffected and is now tracked as its own issue,
+  [#2282](https://github.com/rust-works/succinctly/issues/2282).
+
+  Known cost, factored into one `fast_path_json_comma_safe` term (#2276 review: `&&
+  !any_input_is_json` had been copy-pasted into three separate gate definitions) rather than
+  left duplicated: `--slurp`/`--inplace` with well-formed, *duplicate-keyed* JSON input
+  collapses those duplicates again (the exact #996 regression this same gate caused before #996
+  fixed it at the source for the plain stdout M2 path, left untouched here) — accepted
+  deliberately, and already tracked as a known DOM-path limitation (#1343). Also spelled out
+  explicitly rather than left implicit in "conservative for mixed-format": a well-formed YAML
+  file's own duplicate keys collapse too if it shares an `--inplace`/`--slurp` invocation with
+  even one JSON-sourced file, since `any_input_is_json` is one run-wide boolean with no per-file
+  M2-vs-DOM switch — pinned by
+  `test_yq_inplace_mixed_yaml_json_files_collapses_yaml_duplicate_keys_too_2276`. The plain
+  stdout M2 path (no `--slurp`/`--inplace`) has the identical underlying validation gap but was
+  left alone: its own fallback (`evaluate_yaml_direct_filtered`) shares the same gap, so
+  declining that fast path would cost performance with no correctness gain — a real, broader,
+  non-destructive sibling issue, tracked separately rather than folded in here.
 
 - **`del(EXPR | .)` -- a `del()` path whose *last* component is a bare `.` reached after
   navigating through a real `Field`/`Index`/`Iterate` step -- nulled the targeted slot in place

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -289,6 +289,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`succinctly yq --slurp`/`--eval-all`/`--inplace --input-format json` silently accepted a
+  trailing stray `,` after a real last array/object child** (#2262): `echo '[1,]' | succinctly
+  yq --slurp --input-format json -o json '.[0]'` printed `1` at exit 0, where real yq (v4.53.3)
+  rejects the document outright. This was one of (at least) four independent materializers
+  that each walk a JSON object/array and build an `OwnedValue`, checking for malformed comma
+  placement as they go — `eval_generic::to_owned_cursor_at_depth` got both #2211's
+  `container_gap_ok` (a stray `,` with *zero* real children, `[,]`/`{,}`) and #2243's
+  `trailing_element_gap_ok` (a stray `,` *after* a real last child, `[1,]`/`{"a":1,}`); the
+  other three — `eval.rs`'s own `to_owned_at_depth` (the materializer behind this crate's
+  documented public library API), `eval_generic.rs`'s cursor-less `to_owned_at_depth` sibling
+  (distinct from the cursor-carrying one above, reached from `GenericResult::One`/`Many`
+  whenever a value materializes without a live cursor), and `yq_runner.rs`'s
+  `to_owned_canonicalizing_numbers_at_depth` (the CLI-reachable one, above) — never received
+  either fix. Fixed all three by reusing the same `DocumentCursor::trailing_element_gap_ok`
+  primitive (moved from a private copy in `eval_generic.rs` into `document.rs` as `pub`, so
+  all three plus the already-fixed original share one definition instead of drifting into
+  four hand-copied ones) — each arm now retains its last real child's own cursor (already
+  available via `uncons`/`uncons_cursor`) and checks it after the loop. `container_gap_ok`
+  (`[,]`/`{,}`) remains a known, deliberately unclosed gap in all three: unlike
+  `to_owned_cursor_at_depth`, none of them is ever given a cursor for the *container itself*
+  (only a bare `value: &V`), so once a container's child walk is exhausted there is no cursor
+  left to find its opening bracket from — the same limitation #2211 already documented for
+  `jq_runner::standard_json_to_jq_value`'s identical value-only shape. `eval.rs`'s
+  `to_owned_at_depth` also gained #1677's malformed-`,`/`:` delimiter check, which it had none
+  of at all. Neither `eval.rs`'s nor `eval_generic.rs`'s cursor-less fix is independently
+  reachable through the shipped CLI with raw untrusted text (every production caller
+  re-serializes an already-materialized `OwnedValue` first) — both are library-API-only
+  completeness fixes, pinned by direct unit tests calling the function itself.
+
 - **`del(EXPR | .)` -- a `del()` path whose *last* component is a bare `.` reached after
   navigating through a real `Field`/`Index`/`Iterate` step -- nulled the targeted slot in place
   instead of removing it from its parent container** (#2256), diverging from both real jq and

--- a/docs/compliance/jq/limitations.md
+++ b/docs/compliance/jq/limitations.md
@@ -1304,7 +1304,18 @@ practice #2243's own issue text cites for not folding into #2211):
   `[1,]` rewrote the file instead of refusing), closed by declining those
   two fast paths entirely for JSON-sourced input (`any_input_is_json` in
   `yq_runner.rs`), since their own `else` arm already routes back through
-  this now-fixed materializer. The *plain* stdout fast path
+  this now-fixed materializer. Declining the fast path this way surfaced
+  a second, independent gap in review: it silently traded `YamlIndex`'s
+  128-deep parse-time nesting guard for `to_owned_canonicalizing_numbers_
+  at_depth`'s own looser, panicking 256-deep one, so JSON nested 129-255
+  levels deep went from "rejected at parse time" to "silently accepted" --
+  closed by `parse_input_m2_parity`'s own depth-128 pre-check, verified
+  against a pre-fix build at every boundary value (127/128/129/255/256/
+  257). See [docs/compliance/yq/limitations.md](../yq/limitations.md)'s
+  own `#1975`/`#2262` section for the full account, including a
+  `YamlCursor`-trait-override approach that was tried first and found not
+  to work (M2 streams cursors directly without ever materializing through
+  the trait methods it would have added). The *plain* stdout fast path
   (`can_json_fast_path`/`can_yaml_fast_path`) has the identical underlying
   gap but was left alone: its own `else` arm is `evaluate_yaml_direct_filtered`
   (#1398's cursor-native evaluator, used for *every* ordinary

--- a/docs/compliance/jq/limitations.md
+++ b/docs/compliance/jq/limitations.md
@@ -1279,13 +1279,39 @@ practice #2243's own issue text cites for not folding into #2211):
   `to_owned_cursor_at_depth` at all, so this fix does not reach jq's most
   common query idioms; only the non-cursor-transparent shape #2243's own
   repro uses (`if`/arithmetic/function calls) is covered.
-- **#2262**: three sibling materializers -- `eval.rs`'s own `to_owned_at_depth`
-  (behind this crate's documented public `eval()` API), `eval_generic.rs`'s
-  own cursor-less `to_owned_at_depth`, and `yq_runner.rs`'s
-  `to_owned_canonicalizing_numbers_at_depth` (behind `succinctly yq --slurp`/
-  `--eval-all`/`--inplace --input-format json`, live and CLI-reachable) --
-  still lack #2211's and #2243's checks the same way #1975 found they lacked
-  #1677's.
+- **#2262 (fixed)**: the three sibling materializers named above --
+  `eval.rs`'s own `to_owned_at_depth` (behind this crate's documented public
+  `eval()` API), `eval_generic.rs`'s own cursor-less `to_owned_at_depth`, and
+  `yq_runner.rs`'s `to_owned_canonicalizing_numbers_at_depth` (behind
+  `succinctly yq --slurp`/`--eval-all`/`--inplace --input-format json`) --
+  now all share #2243's `DocumentCursor::trailing_element_gap_ok` (moved to
+  `document.rs` as `pub` for this) via the same "retain the last real
+  child's own cursor, check it after the loop" shape #2211/#2243 already
+  established, closing the trailing-comma case (`[1,]`, `{"a":1,}`) for all
+  three. #2211's `container_gap_ok` (`[,]`, `{,}`) remains open in all
+  three, and is expected to stay that way: unlike `to_owned_cursor_at_depth`,
+  none of the three is ever given a cursor for the *container itself* --
+  only a bare `value`, so once a container's child walk is exhausted there
+  is nothing left to find its opening bracket from. `eval.rs`'s and
+  `eval_generic.rs`'s cursor-less `to_owned_at_depth` are both library-API-
+  only (not reachable through the shipped CLI with raw untrusted text);
+  `yq_runner.rs`'s was live and CLI-reachable, and review of its own fix
+  (filed as #2276) found the *fast-path* routes `--slurp`/`--inplace` each
+  have for a plain identity/M2-streamable filter bypass this materializer
+  entirely (they parse via `YamlIndex`/`mark_json_sourced` instead, whose
+  flow-sequence grammar legitimately allows a trailing `,`) -- confirmed
+  live as a real, `--inplace`-destructive gap (`succinctly yq -i '.'` on
+  `[1,]` rewrote the file instead of refusing), closed by declining those
+  two fast paths entirely for JSON-sourced input (`any_input_is_json` in
+  `yq_runner.rs`), since their own `else` arm already routes back through
+  this now-fixed materializer. The *plain* stdout fast path
+  (`can_json_fast_path`/`can_yaml_fast_path`) has the identical underlying
+  gap but was left alone: its own `else` arm is `evaluate_yaml_direct_filtered`
+  (#1398's cursor-native evaluator, used for *every* ordinary
+  `--input-format json` filter, not just fast-path-eligible ones), which
+  shares the same validation hole, so declining the fast path there would
+  cost M2's performance with no correctness gain -- tracked as a further,
+  broader follow-up rather than folded into #2276.
 - **#2263**: `jq_runner.rs` still carries its own independent, hand-copied
   `trailing_gap_ok`/`scalar_end_pos` pair rather than the new trait methods --
   a cleanup, not a behavior gap, but the same "duplicated predicates diverge

--- a/docs/compliance/yq/limitations.md
+++ b/docs/compliance/yq/limitations.md
@@ -424,6 +424,40 @@ the same way:
   `to_owned_at_depth`'s own `string_decode_error()`/`is_error()` arms (#1247) were missing
   from this function entirely.
 
+[#2262](https://github.com/rust-works/succinctly/issues/2262) extended this same bridge with
+the two remaining checks `eval_generic::to_owned_at_depth` — the function this bridge's own
+doc comment has always claimed to "mirror ... exactly" — had gained since #1975 landed:
+[#2211](https://github.com/rust-works/succinctly/issues/2211)'s `container_gap_ok` (a stray
+`,` with *zero* real children, `[,]`/`{,}`) and
+[#2243](https://github.com/rust-works/succinctly/issues/2243)'s `trailing_element_gap_ok` (a
+stray `,` *after* a real last child, `[1,]`/`{"a":1,}`). Only the second is addable here:
+`container_gap_ok` needs a cursor to the container itself, and this function (like
+`eval_generic::to_owned_at_depth`) is only ever given a bare `value: &V` — once a container's
+child walk is exhausted there is no cursor left to find its opening bracket from. `[,]`/`{,}`
+therefore remain silently accepted; `[1,]`/`{"a":1,}` now correctly raise, confirmed live and
+CLI-reachable:
+
+```console
+$ echo '[1,]' | succinctly yq --slurp --input-format json -o json '.[0]'
+Error: Invalid JSON text: expected JSON value, found ']'                    # correct (was: 1, exit 0)
+$ echo '[1,]' | yq -p json '.[0]'
+json: null unexpected end of JSON input                                    # real yq agrees
+```
+
+**A pre-existing divergence this widens by one case, not a new one.** Real yq's own
+`-p json`/`eval-all -p json --input-format json` path (confirmed live against v4.53.3) is far
+more lenient about a comma or colon inside a JSON *object* than #1975's own delimiter checks
+already were — it accepts a trailing comma (`{"a":1,}`), a leading one (`{,"a":1}`), a doubled
+one (`{"a":1,,}`), and even a missing colon (`{"a" 1}` → `{"a": 1}`) — apparently because its
+JSON input is routed through a YAML flow-mapping parser rather than a strict JSON one; a JSON
+*array* gets none of that leniency (`[1,]`/`[1 2, 3]` both error). #1975 already rejected the
+missing-colon and missing-comma object cases before #2262 touched anything (confirmed: that
+divergence predates this issue, was never gated behind `--jq-extensions` or otherwise
+softened, and was accepted implicitly by #1975's own goal of mirroring
+`eval_generic::to_owned_at_depth`'s *strict* JSON grammar rather than real yq's specific
+JSON-via-YAML-flow routing). #2262's `{"a":1,}` addition is the same design choice applied to
+one more comma shape, not a new departure from it.
+
 Pulling the other way: [#442](https://github.com/rust-works/succinctly/issues/442),
 [#478](https://github.com/rust-works/succinctly/issues/478),
 [#868](https://github.com/rust-works/succinctly/issues/868) and

--- a/docs/compliance/yq/limitations.md
+++ b/docs/compliance/yq/limitations.md
@@ -466,29 +466,90 @@ Error: bad file 'f2.json': json: null unexpected end of JSON input
 [1,]                                                         # real yq refuses, file untouched
 ```
 
-Fixed conservatively rather than by extending `YamlCursor`'s own `DocumentCursor` trait
-methods to validate commas when JSON-sourced (a more surgical fix that would keep M2's
-performance for this case too, but needs new test coverage across a much larger, shared
-surface — every `YamlCursor` consumer, not just these two gates — to be confident it is
-airtight): `any_input_is_json` (reusing #978's own original run-wide boolean, briefly removed
-by #996 once #996 fixed *its* own reason for needing it) now gates
-`can_inplace_json_fast_path`/`can_inplace_yaml_fast_path` and `can_slurp_fast_path`
-specifically, declining the fast path for JSON-sourced input so both routes fall back to
-their own `else` arm — `parse_input`, i.e. this now-fixed materializer — rather than silently
-accepting a malformed document. Confirmed live that both `else` arms already rejected the
-same input correctly before this fix (reached via a non-M2-streamable filter, `. + []`/
-`.[0]`), so declining the fast path needed no further changes to either fallback.
+**Two approaches were tried.** Extending `YamlCursor`'s own `DocumentCursor` trait methods
+(`container_gap_ok`/`trailing_element_gap_ok`/`preceding_delimiter_ok`) to validate commas in
+place when JSON-sourced (via the already-exposed `canonicalize_numbers()` flag) was actually
+*built* — it would have kept the same parser and its same parse-time depth guard, so no depth
+regression (below) could ever have arisen — and then confirmed live *not to work*: `--slurp`'s
+and `--inplace`'s M2 fast path streams cursor results directly
+(`stream_json_sequence`/`stream_yaml_sequence`, `YamlCursor::stream_json`/`stream_yaml`)
+without ever materializing through `to_owned_cursor_at_depth`, the only place those trait
+methods are consulted. The whole point of M2 streaming is to avoid exactly that materialization
+step, so the overrides were simply never reached by the code path that needed fixing — `echo
+'[1,]' | succinctly yq --slurp --input-format json -o json '.'` still printed `[[1]]` at exit 0
+with those overrides in place, confirmed live before reverting them.
 
-**Known cost: `--inplace`/`--slurp` with well-formed, duplicate-keyed JSON input now
-collapses those duplicates again** (`{"a":1,"a":2}` → `{"a":2}`), the exact #996 regression
-this same gate caused before #996 fixed it at the source for the *other* three JSON M2 gates
-(`can_json_fast_path`/`can_yaml_fast_path`, the plain stdout path, both left untouched by this
-fix — see below). Accepted deliberately: `--inplace` mutating a file on a false accept is a
-correctness/data-safety concern; a collapsed duplicate key on *well-formed* input is a
-narrower, already-tracked one ([#1343](https://github.com/rust-works/succinctly/issues/1343),
-"the DOM fallback for `--slurp`/`--eval-all`/`--inplace` still collapses duplicate keys for
-both formats" — already true before this fix for any filter forcing that fallback; this fix
-just widens which filters do).
+Reverted in favor of declining the fast path instead: `any_input_is_json` (reusing #978's own
+original run-wide boolean, briefly removed by #996 once #996 fixed *its* own reason for needing
+it) now gates `can_inplace_json_fast_path`/`can_inplace_yaml_fast_path` and
+`can_slurp_fast_path` specifically (factored into one `fast_path_json_comma_safe` term rather
+than `&& !any_input_is_json` copy-pasted into each gate separately, #2276 review), declining
+the fast path for JSON-sourced input so both routes fall back to their own `else` arm —
+`parse_input`, i.e. this now-fixed materializer — rather than silently accepting a malformed
+document. Confirmed live that both `else` arms already rejected the same input correctly before
+this fix (reached via a non-M2-streamable filter, `. + []`/`.[0]`), so declining the fast path
+needed no further changes to either fallback for the *comma* class of gap. Correctness over
+performance given `--inplace`'s destructive potential on a false accept: reverting to the
+smaller, already-proven-correct surface rather than risk a second subtle miss in the larger
+one under time pressure.
+
+**Declining the fast path this way silently loosened a *different* guard, though**: `YamlIndex`'s
+own parser enforces a 128-deep parse-time nesting limit, while
+`to_owned_canonicalizing_numbers_at_depth`'s own guard (`assert_nesting_depth`) is a looser,
+*panicking* 256-deep one — a different ceiling for a different reason (stack-overflow safety
+for the conversion step itself, not fidelity with what the fast path used to reject). Declining
+the fast path therefore silently *accepted* JSON nested 129–255 levels deep that the fast path
+used to reject at parse time — confirmed live before this correction: 150 levels of `[...]` via
+`--slurp` printed the full nested structure at exit 0, where the pre-fix binary (still
+unconditionally on `YamlIndex`) correctly rejected it at exit 1. Closed by
+`parse_input_m2_parity` (`yq_runner.rs`), a depth-128 pre-check specific to `--slurp`'s and
+`--inplace`'s own DOM fallback — deliberately *not* `--eval-all`'s, which never had this
+128-deep guarantee to begin with (no M2 fast path of its own to have declined), so tightening
+it there would be an unrelated, unasked-for behavior change. Verified to match a pre-fix build
+exactly at every boundary value (127/128/129/255/256/257), including an off-by-one an earlier
+revision of this same check got wrong in the *stricter* direction (rejecting 128 levels of
+plain nesting when `YamlIndex` itself accepts it — its own `nesting_depth` counter is checked
+*before* incrementing and never counts a leaf scalar as its own nesting level, so 128 levels of
+`[...]` peaks at `nesting_depth == 127` on the innermost bracket, not 128). This incidentally
+also means `--slurp`/`--inplace` no longer reach `assert_nesting_depth`'s 256-deep panic at all
+(previously reachable, and — for the few minutes the buggy fix stood — silently *more*
+reachable, through this same fallback); `--eval-all`'s own, unrelated, pre-existing instance of
+that exact panic is unaffected by any of this and is now tracked as
+[#2282](https://github.com/rust-works/succinctly/issues/2282), per this project's own #1098
+precedent that a CLI-reachable panic on untrusted input is a real robustness concern worth a
+tracking issue even when not newly introduced.
+
+**Known cost: `--inplace`/`--slurp` with well-formed, duplicate-keyed JSON input still
+collapses those duplicates** (`{"a":1,"a":2}` → `{"a":2}`) — `any_input_is_json` is a blanket,
+content-independent gate (computed from `--input-format`/file extension alone, never from
+whether the document is actually malformed), so it declines the fast path for *every* JSON-
+sourced `--slurp`/`--inplace` invocation, not just the malformed ones this fix exists for. This
+is the exact #996 regression that gate caused before #996 fixed it at the source for the
+*other* two JSON M2 gates (`can_json_fast_path`/`can_yaml_fast_path`, the plain stdout path,
+both left untouched by this fix — see below). Accepted deliberately: `--inplace` mutating a
+file on a false accept is a correctness/data-safety concern; a collapsed duplicate key on
+*well-formed* input is a narrower, already-tracked one
+([#1343](https://github.com/rust-works/succinctly/issues/1343), "the DOM fallback for
+`--slurp`/`--eval-all`/`--inplace` still collapses duplicate keys for both formats" — already
+true before this fix for any filter forcing that fallback; this fix just widens which filters
+do). This same collapsing is also what the CLI test suite uses to *prove* the fast path
+actually declined for well-formed JSON input, not merely that ordinary output happened to match
+either way (`test_yq_slurp_fast_path_rejects_trailing_comma_2276`/
+`test_yq_inplace_fast_path_rejects_trailing_comma_leaves_file_untouched_2276`'s own duplicate-
+key assertions) — a `[1,2,3]`-shaped well-formed check alone can't distinguish "the fast path
+ran" from "silently fell back and produced the same bytes."
+
+**A further collateral cost, spelled out explicitly rather than left implicit in "conservative
+for mixed-format"**: `any_input_is_json` is one run-wide boolean with no per-file M2-vs-DOM
+switch (a per-file version was not attempted — each of `can_inplace_fast_path`'s two branches
+is its own, separately-parsed loop, decided once before either starts, so routing within one
+file at a time would mean restructuring both loops into one, a materially larger change for a
+cost real yq has no equivalent to weigh against). `succinctly yq -i '.' a.yaml b.json`, where
+`a.yaml` alone (genuinely YAML, well-formed) would be safe on the M2 fast path and `b.json` is
+what forces the whole run onto the DOM fallback, now collapses `a.yaml`'s own duplicate mapping
+keys too — the exact #442/#1343 loss the M2 fast path exists to avoid, even though `a.yaml` in
+isolation would not lose them. Pinned by
+`test_yq_inplace_mixed_yaml_json_files_collapses_yaml_duplicate_keys_too_2276`.
 
 **The plain stdout fast path (`can_json_fast_path`/`can_yaml_fast_path`, no `--slurp`/
 `--inplace`) has the identical underlying gap and was deliberately left alone**, confirmed

--- a/docs/compliance/yq/limitations.md
+++ b/docs/compliance/yq/limitations.md
@@ -444,6 +444,63 @@ $ echo '[1,]' | yq -p json '.[0]'
 json: null unexpected end of JSON input                                    # real yq agrees
 ```
 
+**Code review on #2262's own PR found the fix above was reachable only for a filter
+that forces the DOM path — `.[0]` above, matching this issue's own test suite, not the far
+more common plain identity (`.`)** — filed and fixed as
+[#2276](https://github.com/rust-works/succinctly/issues/2276). `--slurp` and `--inplace` each
+have their own M2 streaming fast path for a plain identity (`--slurp`) or M2-streamable
+(`--inplace`) filter that bypasses `to_owned_canonicalizing_numbers_at_depth` entirely,
+parsing via `YamlIndex::build`/`mark_json_sourced` instead (JSON is a syntactic subset of
+YAML's flow grammar, and #996 already routes JSON through it for M2 streaming's own
+duplicate-key/number-formatting reasons) — whose flow-sequence grammar *legitimately* allows
+a trailing `,`, so none of #2262's new checks were ever reached on that route. For
+`--inplace` this is not just wrong output — it is silent, incorrect data loss:
+
+```console
+$ printf '[1,]' > f.json && succinctly yq -i --input-format json '.' f.json; echo $?; cat f.json
+0
+- 1                                                          # WRONG -- file rewritten with a "healed" value
+$ printf '[1,]' > f2.json && yq -i -p json '.' f2.json; echo $?; cat f2.json
+Error: bad file 'f2.json': json: null unexpected end of JSON input
+1
+[1,]                                                         # real yq refuses, file untouched
+```
+
+Fixed conservatively rather than by extending `YamlCursor`'s own `DocumentCursor` trait
+methods to validate commas when JSON-sourced (a more surgical fix that would keep M2's
+performance for this case too, but needs new test coverage across a much larger, shared
+surface — every `YamlCursor` consumer, not just these two gates — to be confident it is
+airtight): `any_input_is_json` (reusing #978's own original run-wide boolean, briefly removed
+by #996 once #996 fixed *its* own reason for needing it) now gates
+`can_inplace_json_fast_path`/`can_inplace_yaml_fast_path` and `can_slurp_fast_path`
+specifically, declining the fast path for JSON-sourced input so both routes fall back to
+their own `else` arm — `parse_input`, i.e. this now-fixed materializer — rather than silently
+accepting a malformed document. Confirmed live that both `else` arms already rejected the
+same input correctly before this fix (reached via a non-M2-streamable filter, `. + []`/
+`.[0]`), so declining the fast path needed no further changes to either fallback.
+
+**Known cost: `--inplace`/`--slurp` with well-formed, duplicate-keyed JSON input now
+collapses those duplicates again** (`{"a":1,"a":2}` → `{"a":2}`), the exact #996 regression
+this same gate caused before #996 fixed it at the source for the *other* three JSON M2 gates
+(`can_json_fast_path`/`can_yaml_fast_path`, the plain stdout path, both left untouched by this
+fix — see below). Accepted deliberately: `--inplace` mutating a file on a false accept is a
+correctness/data-safety concern; a collapsed duplicate key on *well-formed* input is a
+narrower, already-tracked one ([#1343](https://github.com/rust-works/succinctly/issues/1343),
+"the DOM fallback for `--slurp`/`--eval-all`/`--inplace` still collapses duplicate keys for
+both formats" — already true before this fix for any filter forcing that fallback; this fix
+just widens which filters do).
+
+**The plain stdout fast path (`can_json_fast_path`/`can_yaml_fast_path`, no `--slurp`/
+`--inplace`) has the identical underlying gap and was deliberately left alone**, confirmed
+live: `succinctly yq --input-format json -o json '.[0]'` on `[1,]` also wrongly returns `1` at
+exit 0, with neither flag involved. Its own `else` arm is not this materializer at all, but
+`evaluate_yaml_direct_filtered` (#1398's cursor-native evaluator, used for *every* ordinary
+`--input-format json` filter regardless of M2 eligibility) — which routes through the same
+`YamlIndex`/`mark_json_sourced` flow-grammar path and shares the identical gap, so declining
+the fast path here would cost M2's performance for JSON input with no correctness gain. This
+is a real, broader, non-destructive sibling gap — tracked as a further follow-up rather than
+folded into #2276.
+
 **A pre-existing divergence this widens by one case, not a new one.** Real yq's own
 `-p json`/`eval-all -p json --input-format json` path (confirmed live against v4.53.3) is far
 more lenient about a comma or colon inside a JSON *object* than #1975's own delimiter checks

--- a/src/bin/succinctly/yq_runner.rs
+++ b/src/bin/succinctly/yq_runner.rs
@@ -21,9 +21,10 @@ use succinctly::jq::eval_generic::{
 };
 use succinctly::jq::stream::StreamFailure;
 use succinctly::jq::{
-    self, assert_value_tree_depth, nonfinite_display_string, sync_aliased_paths, Builtin,
-    EvalError, Expr, NumberRepr, OwnedValue, QueryResult, YqSemantics,
+    self, assert_value_tree_depth, nesting_depth_exceeded_message, nonfinite_display_string,
+    sync_aliased_paths, Builtin, EvalError, Expr, NumberRepr, OwnedValue, QueryResult, YqSemantics,
 };
+use succinctly::json::light::JsonCursor;
 use succinctly::json::JsonIndex;
 use succinctly::yaml::{
     format_float_yq_yaml, format_float_yq_yaml_nested, resolve_plain, resolve_tagged,
@@ -1238,6 +1239,87 @@ fn to_owned_canonicalizing_numbers_at_depth<V: DocumentValue>(
         // by number canonicalization.
         OwnedValue::Null
     })
+}
+
+/// The parse-time nesting-depth ceiling `YamlIndex`'s own parser enforces
+/// (`src/yaml/parser.rs`'s `MAX_NESTING_DEPTH`) -- kept here as a
+/// same-named literal rather than importing that private constant, since
+/// this check's only job is parity with what the M2 fast path *would have*
+/// rejected, not a shared source of truth the parser itself depends on.
+const M2_PARSE_TIME_DEPTH_LIMIT: usize = 128;
+
+/// #2276: whether `cursor`'s subtree nests to `M2_PARSE_TIME_DEPTH_LIMIT`
+/// levels or deeper -- a pure BP-navigation walk (`first_child`/
+/// `next_sibling`/`is_container`, never `.value()`) so it costs nothing
+/// beyond pointer-chasing, no scalar decoding, for well-formed input.
+///
+/// `--slurp`'s and `--inplace`'s own DOM fallback (`parse_input`, reached
+/// exactly when their M2 fast path declines JSON-sourced input, #2276)
+/// must reject nesting at least as strictly as the M2 fast path it
+/// replaces did -- `YamlIndex::build`'s own parser enforced
+/// `M2_PARSE_TIME_DEPTH_LIMIT` at *parse* time, before this fallback
+/// existed for JSON input at all. `to_owned_canonicalizing_numbers_at_depth`'s
+/// own guard (`assert_nesting_depth`, 256, a panic) is a *different*,
+/// looser ceiling for a *different* reason -- stack-overflow safety for
+/// the conversion step itself, not fidelity with what the fast path used
+/// to reject -- so without this check, depth 129-255 would silently go
+/// from "rejected at parse time" (the fast path) to "silently accepted"
+/// (this fallback) purely because the fast path was declined for a
+/// malformed-comma reason unrelated to depth. Confirmed live before this
+/// fix: 150 levels of `[...]` via `--slurp --input-format json` printed
+/// the full nested structure at exit 0, where the pre-#2276 binary
+/// (still unconditionally on the M2/`YamlIndex` path) correctly rejected
+/// it at exit 1.
+///
+/// Deliberately a *separate* check, not folded into `parse_input`/
+/// `to_owned_canonicalizing_numbers_at_depth` themselves: `--eval-all`
+/// shares that same function but has no M2 fast path of its own to have
+/// declined, so it never had this 128-deep guarantee to begin with --
+/// tightening it there would be an unrelated, unasked-for behavior change
+/// to an already-established (if unfortunate) precedent, not a fix for
+/// anything `--eval-all` regressed. See
+/// [`parse_input_m2_parity`](self::parse_input_m2_parity), this check's
+/// only caller, for where it's actually wired in.
+///
+/// `depth` counts *containers only* (`[`/`{`), matching `YamlIndex`'s own
+/// `enter_nested`, which is called once per opened `[`/`{` and never for a
+/// leaf scalar -- a leaf never itself constitutes a nesting level. Getting
+/// this off by one either way changes the accepted/rejected boundary: 128
+/// levels of plain `[...]` nesting is accepted by `YamlIndex` (`nesting_
+/// depth` reaches 127 on the innermost `[`, checked before incrementing),
+/// only 129+ is rejected -- confirmed against the pre-#2276 binary
+/// (still unconditionally on `YamlIndex` for this input) directly, not
+/// assumed from the constant's name alone.
+fn json_nested_past_m2_limit<W: AsRef<[u64]>>(cursor: JsonCursor<'_, W>, depth: usize) -> bool {
+    if !cursor.is_container() {
+        return false;
+    }
+    if depth >= M2_PARSE_TIME_DEPTH_LIMIT {
+        return true;
+    }
+    let mut child = cursor.first_child();
+    while let Some(c) = child {
+        if json_nested_past_m2_limit(c, depth + 1) {
+            return true;
+        }
+        child = c.next_sibling();
+    }
+    false
+}
+
+/// [`parse_input`], preceded by [`json_nested_past_m2_limit`]'s depth check
+/// for JSON-sourced input -- see that function's own doc comment for why.
+/// Used by `--slurp`'s and `--inplace`'s own DOM-fallback call sites only;
+/// `--eval-all`'s call site uses plain `parse_input` (see the same doc
+/// comment for why it's deliberately excluded).
+fn parse_input_m2_parity(bytes: &[u8], format: InputFormat) -> Result<Vec<OwnedValue>> {
+    if format == InputFormat::Json {
+        let index = JsonIndex::build(bytes);
+        if json_nested_past_m2_limit(index.root(bytes), 0) {
+            anyhow::bail!(nesting_depth_exceeded_message(M2_PARSE_TIME_DEPTH_LIMIT));
+        }
+    }
+    parse_input(bytes, format)
 }
 
 /// Parse input bytes according to the specified format.
@@ -4142,7 +4224,28 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
     // disables the relevant fast path for *every* source in the run, not
     // just the JSON one(s), since `can_inplace_fast_path`/
     // `can_slurp_fast_path` are single, run-wide booleans with no
-    // per-file M2-vs-DOM switch to hook into instead.
+    // per-file M2-vs-DOM switch to hook into instead. A per-file switch
+    // was not attempted (#2276 review): each of `can_inplace_fast_path`'s/
+    // `can_slurp_fast_path`'s two branches is its own, separately-parsed
+    // loop over `input_files`/`input_sources` (M2 branch vs. DOM branch),
+    // decided once before either loop starts -- routing *within* one file
+    // at a time, rather than picking one branch for the whole run, would
+    // mean restructuring both loops into one that decides per file, a
+    // materially larger change than this fix's own scope for a collateral
+    // cost real yq itself has no equivalent to weigh against (it has no
+    // M2-style fast path to decline in the first place).
+    //
+    // **The concrete cost, spelled out rather than left implicit**:
+    // `succinctly yq -i '.' a.yaml b.json`, where `a.yaml` alone
+    // (genuinely YAML, well-formed) is safe on the M2 fast path and
+    // `b.json` is what forces this whole run onto the DOM fallback --
+    // `a.yaml`'s own duplicate mapping keys (`a: 1` / `a: 2`, both
+    // present) now silently collapse to the last value (`a: 2`) too, the
+    // exact #442/#1343 loss the M2 fast path exists to avoid, even though
+    // `a.yaml` in isolation (`succinctly yq -i '.' a.yaml`, no JSON file
+    // in the same invocation) would not lose them. Confirmed live and
+    // pinned by
+    // `test_yq_inplace_mixed_yaml_json_files_collapses_yaml_duplicate_keys_too_2276`.
     let any_input_is_json = if input_files.is_empty() {
         resolve_input_format(args.input_format, None) == InputFormat::Json
     } else {
@@ -4150,6 +4253,20 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
             resolve_input_format(args.input_format, Some(Path::new(f))) == InputFormat::Json
         })
     };
+    // #2276 review: one shared term for the three JSON-declining gates
+    // below (`can_inplace_json_fast_path`/`can_inplace_yaml_fast_path`/
+    // `can_slurp_fast_path`) to `&&` in, rather than `&& !any_input_is_json`
+    // copy-pasted into each one separately -- this crate's own "duplicated
+    // predicates diverge silently" lesson (#106: three copies of one
+    // predicate, one of them quadratic) applies just as much to a boolean
+    // gate as to an algorithm: a future change to what "safe for this fast
+    // path" means only needs one edit here instead of three kept in sync
+    // by hand. Positively named (unlike `any_input_is_json` itself, which
+    // reads naturally as `!any_input_is_json` at its own two other call
+    // sites -- `is_m2_streamable`'s doc comment and `mark_json_sourced`'s
+    // conditionals -- but awkwardly as a double negative at every gate
+    // below).
+    let fast_path_json_comma_safe = !any_input_is_json;
     // pretty_print isn't implemented by the cursor streamers, so it still
     // falls back to the DOM path, unchanged, rather than silently ignoring
     // the flag the way compact mode already does today. `sort_keys` and
@@ -4255,13 +4372,14 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
     // DOM path either.
     // Shares `can_json_fast_path`'s `can_stream_json_output_style` above.
     //
-    // `!any_input_is_json` (#2276, see its own doc comment above): unlike
-    // `can_json_fast_path`/`can_yaml_fast_path`, this gate's `else` arm is
-    // `parse_input` -- the DOM bridge #2262 fixed -- so declining it for
+    // `fast_path_json_comma_safe` (#2276, see its own doc comment above):
+    // unlike `can_json_fast_path`/`can_yaml_fast_path`, this gate's `else`
+    // arm is `parse_input_m2_parity` -- the DOM bridge #2262 fixed, now
+    // depth-checked to match too (#2276 review) -- so declining it for
     // JSON-sourced input actually closes the comma-gap validation hole
     // rather than just moving it to an equally-unvalidated fallback.
     let can_inplace_json_fast_path = is_m2_streamable
-        && !any_input_is_json
+        && fast_path_json_comma_safe
         && can_stream_json_output_style
         && output_config.output_format == OutputFormat::Json
         && !args.null_input
@@ -4270,7 +4388,7 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
         && args.front_matter.is_none()
         && context.named.is_empty();
     let can_inplace_yaml_fast_path = is_m2_streamable
-        && !any_input_is_json
+        && fast_path_json_comma_safe
         && (output_config.compact || can_stream_pretty_or_colored)
         && output_config.output_format == OutputFormat::Yaml
         && !args.null_input
@@ -4297,12 +4415,12 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
     // once the escaping moved to the sink. This route's own `json_ascii!`
     // wrap is on its `stream_json_sequence` call below.
     //
-    // `!any_input_is_json` (#2276, see `any_input_is_json`'s own doc comment
-    // above): same reasoning as `can_inplace_fast_path`'s identical addition
-    // -- this gate's `else` arm is `parse_input` too, so declining here for
-    // JSON-sourced input actually closes the comma-gap hole.
+    // `fast_path_json_comma_safe` (#2276, see its own doc comment above):
+    // same reasoning as `can_inplace_fast_path`'s identical addition --
+    // this gate's `else` arm is `parse_input_m2_parity` too, so declining
+    // here for JSON-sourced input actually closes the comma-gap hole.
     let can_slurp_fast_path = is_identity
-        && !any_input_is_json
+        && fast_path_json_comma_safe
         && match output_config.output_format {
             OutputFormat::Json => can_stream_json_output_style,
             OutputFormat::Yaml => can_stream_pretty_or_colored,
@@ -5406,7 +5524,10 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
             // Parse all inputs and collect documents
             let mut global_doc_index: usize = 0;
             for (bytes, format, _) in &input_sources {
-                let inputs = parse_input(bytes, *format)?;
+                // #2276: `parse_input_m2_parity`, not plain `parse_input` --
+                // this is `--slurp`'s own DOM fallback, reached exactly
+                // when its M2 fast path declines JSON-sourced input.
+                let inputs = parse_input_m2_parity(bytes, *format)?;
                 for input in inputs {
                     // Apply --doc filter if specified
                     if let Some(target_doc) = args.document {
@@ -5641,7 +5762,10 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
                 // already reflects whether any real output happened.
                 !output_buffer.is_empty()
             } else {
-                let inputs = parse_input(&input_bytes, format)?;
+                // #2276: `parse_input_m2_parity`, not plain `parse_input` --
+                // this is `--inplace`'s own DOM fallback, reached exactly
+                // when its M2 fast path declines JSON-sourced input.
+                let inputs = parse_input_m2_parity(&input_bytes, format)?;
 
                 let mut buf_writer = BufWriter::new(&mut output_buffer);
                 // Count matching docs for multi-doc separator logic

--- a/src/bin/succinctly/yq_runner.rs
+++ b/src/bin/succinctly/yq_runner.rs
@@ -10,8 +10,9 @@ use std::io::{BufWriter, IsTerminal, Read, Write};
 use std::path::Path;
 
 use succinctly::jq::document::{
-    effective_keys, key_delimiter_ok, resolve_display_key, value_delimiter_ok, DisplayKeyGuard,
-    DocumentCursor, DocumentElements, DocumentFields, DocumentValue, IndentSpec, JsonConvention,
+    effective_keys, key_delimiter_ok, resolve_display_key, trailing_element_gap_ok,
+    value_delimiter_ok, DisplayKeyGuard, DocumentCursor, DocumentElements, DocumentFields,
+    DocumentValue, IndentSpec, JsonConvention,
 };
 use succinctly::jq::escape::AsciiEscapeWriter;
 use succinctly::jq::eval_generic::{
@@ -1047,6 +1048,20 @@ fn gather_input_sources(
 /// or a value token the semi-index couldn't classify) -- #1975 found this
 /// function missing every one of `to_owned_at_depth`'s checks for these,
 /// despite this doc comment's own "mirrors ... exactly" claim above.
+///
+/// Also raises on a trailing stray `,` after a real last child (`[1,]`,
+/// `{"a":1,}`, #2243) -- #2262 found this function still missing that
+/// check (and #2211's sibling `container_gap_ok` check for a stray `,`
+/// with *zero* real children, `[,]`/`{,}`) after #1975 gave it #1677's
+/// delimiter check but predates #2211/#2243 landing. Confirmed live and
+/// CLI-reachable through `--slurp`/`--eval-all`/`--inplace
+/// --input-format json` (this function's only callers):
+/// `echo '[1,]' | succinctly yq --slurp --input-format json -o json '.[0]'`
+/// used to exit 0 with `1`, where real yq rejects it. `[,]`/`{,}` remain
+/// unchecked here, same as `eval_generic::to_owned_at_depth`'s identical
+/// cursor-less shape: this function is never given a cursor for the
+/// *container itself*, only `value: &V`, so once a container's child walk
+/// is exhausted there is no cursor left to find its opening bracket from.
 fn to_owned_canonicalizing_numbers<V: DocumentValue>(value: &V) -> Result<OwnedValue, EvalError> {
     to_owned_canonicalizing_numbers_at_depth(value, 0)
 }
@@ -1071,6 +1086,12 @@ fn to_owned_canonicalizing_numbers_at_depth<V: DocumentValue>(
         let mut guard = DisplayKeyGuard::default();
         let mut f = fields;
         let mut is_first = true;
+        // #2262: the last real field's own cursor, retained past the loop
+        // so the trailing-gap check below (a stray `,` *after* a real last
+        // field, `{"a":1,}`) has something to check from -- mirrors
+        // `eval_generic::to_owned_cursor_at_depth`'s own `last_field`
+        // (#2243).
+        let mut last_field: Option<V::Cursor> = None;
         while let Some((field, rest)) = f.uncons() {
             // `resolve_display_key`, not `field.key_str()`: a key that will
             // not *decode* (#1247/#1385) is preserved via its raw source
@@ -1106,6 +1127,7 @@ fn to_owned_canonicalizing_numbers_at_depth<V: DocumentValue>(
                 key,
                 to_owned_canonicalizing_numbers_at_depth(&field.value, depth + 1)?,
             );
+            last_field = Some(field.value_cursor);
             f = rest;
             is_first = false;
         }
@@ -1116,11 +1138,27 @@ fn to_owned_canonicalizing_numbers_at_depth<V: DocumentValue>(
         if f.ends_unpaired() {
             return Err(f.malformed_member_error());
         }
+        // #2262: #2211's `container_gap_ok` (a stray `,` with zero real
+        // fields, `{,}`) needs the *container's own* cursor to find its
+        // opening `{` -- this function only ever receives a bare
+        // `value: &V` (never a cursor for the container itself), and once
+        // `f` is exhausted there is no way to reconstruct one. Same
+        // limitation `eval_generic::to_owned_at_depth`'s identical
+        // value-only shape has -- `{,}` remains unchecked here for that
+        // reason. #2243's `trailing_element_gap_ok` *is* checkable, though:
+        // it only needs the last real field's own cursor, retained above.
+        if let Some(last) = &last_field {
+            if !trailing_element_gap_ok(last, b'}') {
+                return Err(last.malformed_delimiter_error());
+            }
+        }
         OwnedValue::Object(map)
     } else if let Some(elements) = value.as_array() {
         let mut items = Vec::new();
         let mut elems = elements;
         let mut is_first = true;
+        // #2262: same reasoning as the object arm's own `last_field` above.
+        let mut last_elem: Option<V::Cursor> = None;
         while let Some((elem_cursor, rest)) = elems.uncons_cursor() {
             // #1975: matches `eval_generic::to_owned_at_depth`'s array arm --
             // a missing/doubled `,` between elements was silently accepted
@@ -1135,8 +1173,19 @@ fn to_owned_canonicalizing_numbers_at_depth<V: DocumentValue>(
                 &elem_cursor.value(),
                 depth + 1,
             )?);
+            last_elem = Some(elem_cursor);
             elems = rest;
             is_first = false;
+        }
+        // #2262: same reasoning as the object arm's own check above --
+        // `[,]` remains unchecked here (no container cursor available),
+        // but `[1,]` is, via the last real element's own cursor. This is
+        // the live, CLI-reachable fix: `echo '[1,]' | succinctly yq --slurp
+        // --input-format json -o json '.[0]'` used to exit 0 with `1`.
+        if let Some(last) = &last_elem {
+            if !trailing_element_gap_ok(last, b']') {
+                return Err(last.malformed_delimiter_error());
+            }
         }
         OwnedValue::Array(items)
     } else if value.is_null() {
@@ -6817,6 +6866,70 @@ mod tests {
         let cursor = index.root(json);
         to_owned_canonicalizing_numbers(&cursor.value())
             .expect_err("an unclassifiable value token is not well-formed JSON");
+    }
+
+    /// #2262: `to_owned_canonicalizing_numbers` gained #1975's #1677/#1194
+    /// checks, but never #2211's `container_gap_ok` or #2243's
+    /// `trailing_element_gap_ok` -- unlike its `eval_generic::
+    /// to_owned_cursor_at_depth` counterpart, which has both. This is the
+    /// live, CLI-reachable half of #2262: confirmed before this fix,
+    /// `echo '[1,]' | succinctly yq --slurp --input-format json -o json
+    /// '.[0]'` printed `1` at exit 0, where real yq (v4.53.3, `yq eval-all
+    /// -p json -o json '.[0]' -`) rejects the document outright.
+    #[test]
+    fn to_owned_canonicalizing_numbers_raises_on_trailing_comma_2262() {
+        for json in [&br"[1,]"[..], &br#"{"a":1,}"#[..]] {
+            let index = JsonIndex::build(json);
+            let cursor = index.root(json);
+            to_owned_canonicalizing_numbers(&cursor.value()).expect_err(&format!(
+                "{json:?}: a trailing comma after a real last child is not JSON"
+            ));
+        }
+
+        // Well-formed data is unaffected.
+        let json = br#"{"a":1,"b":2}"#;
+        let index = JsonIndex::build(json);
+        let cursor = index.root(json);
+        let owned = to_owned_canonicalizing_numbers(&cursor.value()).unwrap();
+        assert_eq!(
+            owned,
+            OwnedValue::Object(IndexMap::from([
+                ("a".to_string(), OwnedValue::Int(1)),
+                ("b".to_string(), OwnedValue::Int(2)),
+            ]))
+        );
+        let json = br"[1,2,3]";
+        let index = JsonIndex::build(json);
+        let cursor = index.root(json);
+        assert_eq!(
+            to_owned_canonicalizing_numbers(&cursor.value()).unwrap(),
+            OwnedValue::Array(vec![
+                OwnedValue::Int(1),
+                OwnedValue::Int(2),
+                OwnedValue::Int(3),
+            ])
+        );
+    }
+
+    /// #2262: unlike the trailing-comma case above, a stray `,` with *zero*
+    /// real children (`[,]`, `{,}`) remains a known, deliberately unclosed
+    /// gap here -- #2211's `container_gap_ok` needs a cursor to the
+    /// *container itself* to find its opening bracket, and this function is
+    /// only ever given a bare `value: &V` (never a cursor for the container,
+    /// unlike `eval_generic::to_owned_cursor_at_depth`'s own `cursor`
+    /// parameter). Once the child walk is exhausted there is nothing left
+    /// to check against -- the same limitation
+    /// `eval_generic::to_owned_at_depth`'s identical value-only shape has.
+    /// Pinned rather than left silently uncovered.
+    #[test]
+    fn to_owned_canonicalizing_numbers_stray_comma_in_empty_container_remains_a_known_gap_2262() {
+        for json in [&br"[,]"[..], &br"{,}"[..]] {
+            let index = JsonIndex::build(json);
+            let cursor = index.root(json);
+            if let Err(e) = to_owned_canonicalizing_numbers(&cursor.value()) {
+                panic!("{json:?}: known gap -- silently accepted, got error {e:?}");
+            }
+        }
     }
 
     /// `depth` levels of single-child `CommentTree::Array` nesting, mirroring

--- a/src/bin/succinctly/yq_runner.rs
+++ b/src/bin/succinctly/yq_runner.rs
@@ -4083,6 +4083,73 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
     // input at all: it now gets *both* correct numbers and duplicate-key
     // preservation, matching real yq on both counts.
     let is_m2_streamable = can_use_m2_streaming(&program.expr);
+    // #2276 code review (found live against this exact binary, on top of
+    // #2262): `any_input_is_json` -- the same run-wide boolean #978
+    // introduced and #996 later removed from `is_m2_streamable` above --
+    // is reintroduced here, narrower this time: it gates only
+    // `can_inplace_json_fast_path`/`can_inplace_yaml_fast_path` and
+    // `can_slurp_fast_path` below, not `is_m2_streamable` itself (so the
+    // plain stdout M2 path, `can_json_fast_path`/`can_yaml_fast_path`, is
+    // untouched -- see why below).
+    //
+    // Neither M2 fast-path streamer (nor `YamlIndex`'s underlying
+    // flow-sequence/flow-mapping grammar, which legitimately allows a
+    // trailing `,` -- unlike JSON's) validates for a malformed stray/
+    // trailing `,` the way `#2262`'s now-fixed
+    // `to_owned_canonicalizing_numbers_at_depth` (the `--slurp`/
+    // `--eval-all`/`--inplace` DOM bridge) does. Confirmed live before
+    // this fix, both destructive and non-destructive:
+    // ```console
+    // $ printf '[1,]' > f.json && succinctly yq -i --input-format json '.' f.json; cat f.json
+    // - 1                                              # WRONG -- file rewritten with a "healed" value
+    // $ echo '[1,]' | succinctly yq --slurp --input-format json -o json '.'
+    // [[1]]                                             # WRONG -- exit 0, no error
+    // ```
+    // real yq (`-i`) refuses and leaves the file byte-for-byte untouched;
+    // `eval-all -p json` similarly rejects the array case outright.
+    //
+    // `#2262`'s own fix reaches only the *DOM* bridge
+    // (`to_owned_canonicalizing_numbers_at_depth`) -- reached by
+    // `--slurp`/`--inplace` only when `can_slurp_fast_path`/
+    // `can_inplace_fast_path` is `false`, confirmed live: declining the
+    // fast path for `--inplace` already routes through `parse_input`
+    // (this same function) via the `else` arm a few hundred lines below,
+    // and `--slurp`'s own `else` arm does too -- both correctly reject a
+    // malformed document today when forced onto that arm by a
+    // non-M2-streamable filter (`. + []`, `.[0]`). Declining the *fast*
+    // path specifically for JSON-sourced input therefore closes this gap
+    // completely for both, with no further changes needed to either
+    // `else` arm.
+    //
+    // The plain stdout path (`can_json_fast_path`/`can_yaml_fast_path`)
+    // is deliberately NOT gated by this: its own `else` arm is
+    // `evaluate_yaml_direct_filtered` (`#1398`'s cursor-native evaluator,
+    // used for every ordinary `succinctly yq --input-format json` filter
+    // regardless of M2 eligibility, not just non-m2-streamable ones) --
+    // which routes JSON through the identical `YamlIndex`/
+    // `mark_json_sourced` flow-grammar path and has the *same* gap
+    // (confirmed live: `succinctly yq --input-format json -o json '.[0]'`
+    // on `[1,]` also wrongly returns `1` at exit 0, with no `--slurp`/
+    // `--inplace` involved at all). Declining `can_json_fast_path`/
+    // `can_yaml_fast_path` here would cost M2's performance for JSON
+    // input with zero correctness gain, since the fallback shares the
+    // identical validation gap -- a real, pre-existing issue, broader
+    // than and independent of `#2276`'s `--slurp`/`--inplace` finding,
+    // filed separately rather than folded in here.
+    //
+    // Conservative for a mixed-format multi-file `--inplace`/`--slurp`
+    // invocation, same trade-off #978's original version accepted: this
+    // disables the relevant fast path for *every* source in the run, not
+    // just the JSON one(s), since `can_inplace_fast_path`/
+    // `can_slurp_fast_path` are single, run-wide booleans with no
+    // per-file M2-vs-DOM switch to hook into instead.
+    let any_input_is_json = if input_files.is_empty() {
+        resolve_input_format(args.input_format, None) == InputFormat::Json
+    } else {
+        input_files.iter().any(|f| {
+            resolve_input_format(args.input_format, Some(Path::new(f))) == InputFormat::Json
+        })
+    };
     // pretty_print isn't implemented by the cursor streamers, so it still
     // falls back to the DOM path, unchanged, rather than silently ignoring
     // the flag the way compact mode already does today. `sort_keys` and
@@ -4187,7 +4254,14 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
     // disk, but no longer forces a fallback to the duplicate-key-collapsing
     // DOM path either.
     // Shares `can_json_fast_path`'s `can_stream_json_output_style` above.
+    //
+    // `!any_input_is_json` (#2276, see its own doc comment above): unlike
+    // `can_json_fast_path`/`can_yaml_fast_path`, this gate's `else` arm is
+    // `parse_input` -- the DOM bridge #2262 fixed -- so declining it for
+    // JSON-sourced input actually closes the comma-gap validation hole
+    // rather than just moving it to an equally-unvalidated fallback.
     let can_inplace_json_fast_path = is_m2_streamable
+        && !any_input_is_json
         && can_stream_json_output_style
         && output_config.output_format == OutputFormat::Json
         && !args.null_input
@@ -4196,6 +4270,7 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
         && args.front_matter.is_none()
         && context.named.is_empty();
     let can_inplace_yaml_fast_path = is_m2_streamable
+        && !any_input_is_json
         && (output_config.compact || can_stream_pretty_or_colored)
         && output_config.output_format == OutputFormat::Yaml
         && !args.null_input
@@ -4221,7 +4296,13 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
     // existed, and #1700 then removed the flag from the predicate entirely
     // once the escaping moved to the sink. This route's own `json_ascii!`
     // wrap is on its `stream_json_sequence` call below.
+    //
+    // `!any_input_is_json` (#2276, see `any_input_is_json`'s own doc comment
+    // above): same reasoning as `can_inplace_fast_path`'s identical addition
+    // -- this gate's `else` arm is `parse_input` too, so declining here for
+    // JSON-sourced input actually closes the comma-gap hole.
     let can_slurp_fast_path = is_identity
+        && !any_input_is_json
         && match output_config.output_format {
             OutputFormat::Json => can_stream_json_output_style,
             OutputFormat::Yaml => can_stream_pretty_or_colored,
@@ -5193,12 +5274,15 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
             // `Vec` unless their backing bytes/index all outlive that `Vec`.
             let mut parsed_sources: Vec<(Vec<u8>, YamlIndex<Vec<u64>>)> =
                 Vec::with_capacity(input_sources.len());
-            for (bytes, format, _) in input_sources {
-                let mut index = YamlIndex::build(&bytes)
+            for (bytes, _format, _) in input_sources {
+                // #2276: no `mark_json_sourced()` call here anymore --
+                // `can_slurp_fast_path` now requires `!any_input_is_json`
+                // (see its own doc comment), so every source reaching this
+                // branch is genuine YAML; `_format` is unused here for that
+                // reason (still threaded through so the loop's tuple shape
+                // matches `input_sources`'s own type unchanged).
+                let index = YamlIndex::build(&bytes)
                     .map_err(|e| anyhow::anyhow!("YAML parse error: {e}"))?;
-                if format == InputFormat::Json {
-                    index.mark_json_sourced();
-                }
                 parsed_sources.push((bytes, index));
             }
 
@@ -5427,11 +5511,13 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
                 // directly into this file's buffer, skipping the OwnedValue
                 // DOM (and its IndexMap, which cannot represent duplicate
                 // mapping keys) the same way the stdout M2 path above does.
-                let mut index = YamlIndex::build(&input_bytes)
+                //
+                // #2276: no `mark_json_sourced()` call here anymore --
+                // `can_inplace_fast_path` now requires `!any_input_is_json`
+                // (see its own doc comment), so `format` is never `Json`
+                // for any file reaching this branch.
+                let index = YamlIndex::build(&input_bytes)
                     .map_err(|e| anyhow::anyhow!("YAML parse error in {file_path}: {e}"))?;
-                if format == InputFormat::Json {
-                    index.mark_json_sourced();
-                }
                 let root = index.root(&input_bytes);
 
                 {

--- a/src/jq/document.rs
+++ b/src/jq/document.rs
@@ -1379,6 +1379,42 @@ pub fn value_delimiter_ok<F: DocumentFields>(
     }
 }
 
+/// Whether a trailing stray `,` (`[1,]`, `{"a":1,}`) sits between a
+/// container's *last real child* (`last_cursor`) and `close_char` -- #2243.
+///
+/// Moved here from a private copy in `eval_generic.rs` (#2262) so
+/// `eval::to_owned_at_depth`, `eval_generic`'s own cursor-carrying and
+/// cursor-less `to_owned_at_depth` pair, and `src/bin/succinctly`'s
+/// `yq_runner::to_owned_canonicalizing_numbers_at_depth` (a separate crate,
+/// hence `pub` rather than `pub(crate)`, matching [`key_delimiter_ok`]'s own
+/// reasoning) all share one definition instead of drifting into four
+/// hand-copied ones.
+///
+/// Takes only the cursor, not an already-resolved value:
+/// [`DocumentValue::scalar_text_end`] unconditionally answers `None` for a
+/// container-typed child (see its own doc comment), so resolving one here
+/// first -- via `is_container()`, cheap and already required by every
+/// [`DocumentCursor`] impl -- skips a `.value()` call this check could
+/// never use anyway, rather than decoding it and immediately discarding the
+/// result.
+///
+/// `None` from either remaining half of the lookup -- no resolvable start
+/// position, or (for a scalar child) no derivable end position -- answers
+/// `true` (nothing to flag), the same "can't determine, skip" convention
+/// every sibling gap check in this module already follows.
+pub fn trailing_element_gap_ok<C: DocumentCursor>(last_cursor: &C, close_char: u8) -> bool {
+    if last_cursor.is_container() {
+        return true;
+    }
+    match last_cursor.text_position() {
+        Some(start) => match last_cursor.value().scalar_text_end(start) {
+            Some(end) => last_cursor.trailing_element_gap_ok(end, close_char),
+            None => true,
+        },
+        None => true,
+    }
+}
+
 /// [`value_delimiter_ok`], for a key-only walk (`census`, `checked_len`,
 /// [`DistinctKeyCursors`]) that has not resolved a value cursor at all.
 ///

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -39,9 +39,9 @@ use std::rc::Rc;
 use indexmap::IndexMap;
 
 use super::document::{
-    effective_fields, effective_fields_checked, effective_keys, effective_len, key_display_string,
-    key_display_string_kind, resolve_display_key, DisplayKeyGuard, DocumentElements,
-    DocumentFields,
+    effective_fields, effective_fields_checked, effective_keys, effective_len, key_delimiter_ok,
+    key_display_string, key_display_string_kind, resolve_display_key, trailing_element_gap_ok,
+    value_delimiter_ok, DisplayKeyGuard, DocumentCursor, DocumentElements, DocumentFields,
 };
 use super::slice::{self, SliceBounds};
 use super::walk::{any_subexpr, map_builtin_subexprs, map_subexprs};
@@ -613,8 +613,21 @@ fn to_owned_lossy_at_depth<W: Clone + AsRef<[u64]>>(
 /// soundness rule.
 ///
 /// Mirrors `eval_generic::to_owned_at_depth`'s already-fixed shape
-/// (#1247/#1620/#1660), which this private, `StandardJson`-specific copy
-/// originally never received.
+/// (#1247/#1620/#1660/#1677/#2243), which this private, `StandardJson`-
+/// specific copy originally never received in full -- #2262 found this
+/// function still missing #1677's malformed-`,`/`:` delimiter check and
+/// #2243's trailing-comma-after-a-real-last-child check entirely (not
+/// independently reachable through the shipped CLI with raw untrusted
+/// text -- every production caller re-serializes an already-materialized
+/// `OwnedValue` before this function ever runs on it -- but a real gap for
+/// a direct library caller of the public `succinctly::jq::eval` entry
+/// point). #2211's `container_gap_ok` (a stray `,` with *zero* real
+/// children, `[,]`/`{,}`) is not addable here: unlike
+/// `to_owned_cursor_at_depth`, this function is never given a cursor for
+/// the *container itself* (only `value: &StandardJson<'_, W>`), so once a
+/// container's child walk is exhausted there is no cursor left to find its
+/// opening bracket from -- the same limitation #2211 already documented for
+/// `jq_runner::standard_json_to_jq_value`'s identical value-only shape.
 ///
 /// A decode failure raised here is never suppressed by `?` — see
 /// [`suppresses`], and [`to_owned_or_suppress`] for the call-site idiom
@@ -650,9 +663,36 @@ fn to_owned_at_depth<W: Clone + AsRef<[u64]>>(
             Err(e) => return Err(EvalError::decode_failure(e.message())),
         },
         StandardJson::Array(elements) => {
-            let items: Vec<OwnedValue> = (*elements)
-                .map(|e| to_owned_at_depth(&e, depth + 1))
-                .collect::<Result<_, _>>()?;
+            let mut items = Vec::new();
+            let mut elems = *elements;
+            let mut is_first = true;
+            // #2262: last real element's own cursor, retained past the loop
+            // so the trailing-gap check below (`[1,]`) has something to
+            // check from -- mirrors `eval_generic::to_owned_cursor_at_depth`'s
+            // own `last_elem` (#2243).
+            let mut last_elem: Option<JsonCursor<'_, W>> = None;
+            while let Some((elem_cursor, rest)) = elems.uncons_cursor() {
+                // #1677/#2262: same gap check as
+                // `eval_generic::to_owned_at_depth`'s array loop -- this
+                // function had none of it before #2262.
+                if !elem_cursor.element_gap_ok(is_first) {
+                    return Err(elem_cursor.malformed_delimiter_error());
+                }
+                items.push(to_owned_at_depth(&elem_cursor.value(), depth + 1)?);
+                last_elem = Some(elem_cursor);
+                elems = rest;
+                is_first = false;
+            }
+            // #2262: see this function's own doc comment above -- `[,]`
+            // (#2211's `container_gap_ok`) can't be checked here, no
+            // container cursor is ever in hand. `[1,]` (#2243) can: it
+            // only needs the last real element's own cursor, retained
+            // above.
+            if let Some(last) = &last_elem {
+                if !trailing_element_gap_ok(last, b']') {
+                    return Err(last.malformed_delimiter_error());
+                }
+            }
             OwnedValue::Array(items)
         }
         StandardJson::Object(fields) => {
@@ -668,6 +708,10 @@ fn to_owned_at_depth<W: Clone + AsRef<[u64]>>(
             // from). Mirrors `eval_generic::to_owned_at_depth`'s own walk
             // shape for exactly this reason.
             let mut f = *fields;
+            let mut is_first = true;
+            // #2262: same reasoning as the array arm's own `last_elem`
+            // above.
+            let mut last_field: Option<JsonCursor<'_, W>> = None;
             while let Some((field, rest)) = f.uncons() {
                 let key_val = field.key();
                 // `resolve_display_key` covers both key axes in one call
@@ -683,11 +727,30 @@ fn to_owned_at_depth<W: Clone + AsRef<[u64]>>(
                 let Some(key) = resolve_display_key(&key_val, &map, &mut guard)? else {
                     return Err(f.malformed_member_error());
                 };
+                // #1677/#2262: same delimiter checks as
+                // `eval_generic::to_owned_at_depth`'s object loop -- this
+                // function had none of it before #2262.
+                if !key_delimiter_ok::<JsonFields<'_, W>>(&key_val, &field.key_cursor(), is_first)
+                    || !value_delimiter_ok::<JsonFields<'_, W>>(
+                        Some(&field.value()),
+                        &field.value_cursor(),
+                    )
+                {
+                    return Err(f.malformed_member_error());
+                }
                 map.insert(key, to_owned_at_depth(&field.value(), depth + 1)?);
+                last_field = Some(field.value_cursor());
                 f = rest;
+                is_first = false;
             }
             if f.ends_unpaired() {
                 return Err(f.malformed_member_error());
+            }
+            // #2262: same reasoning as the array arm's own check above.
+            if let Some(last) = &last_field {
+                if !trailing_element_gap_ok(last, b'}') {
+                    return Err(last.malformed_delimiter_error());
+                }
             }
             OwnedValue::Object(map)
         }
@@ -54187,6 +54250,116 @@ mod tests {
         query!(doc, "keys",
             QueryResult::Error(_) => {}
         );
+    }
+
+    /// #2262: this crate's own `to_owned_at_depth` -- the materializer
+    /// behind the documented public library API (`succinctly::jq::eval`) --
+    /// had none of #1677's malformed-`,`/`:` delimiter check at all before
+    /// this fix, unlike `eval_generic::to_owned_at_depth`'s already-fixed
+    /// sibling it otherwise mirrors. Not independently reachable through
+    /// the shipped CLI (every production caller re-serializes an
+    /// already-materialized `OwnedValue` first), so this is a direct unit
+    /// test of the function itself, the only way to exercise the gap in
+    /// isolation -- same reasoning as
+    /// `test_nonreserializing_builtins_raise_on_missing_delimiter_1677`
+    /// (`eval_generic.rs`) and #2211's own `materialize_raises_on_...`
+    /// tests for their identical library-API-only findings.
+    #[test]
+    fn test_to_owned_raises_on_missing_delimiter_2262() {
+        for json in [b"[1 2, 3]".as_slice(), br#"{"a" 1, "b": 2}"#.as_slice()] {
+            let index = JsonIndex::build(json);
+            let cursor = index.root(json);
+            let err = match to_owned(&cursor.value()) {
+                Err(e) => e,
+                Ok(v) => panic!("{json:?}: a malformed delimiter is not JSON, got {v:?}"),
+            };
+            assert!(
+                err.message.contains("Invalid JSON text"),
+                "{json:?}: message: {}",
+                err.message
+            );
+        }
+    }
+
+    /// #2262: same function, #2243's trailing-stray-`,`-after-a-real-last-
+    /// child check (`[1,]`, `{"a":1,}`) -- also entirely missing before
+    /// this fix. Confirmed live before the fix (matching the issue's own
+    /// repro): `to_owned(&cursor.value())` on `[1,]` returned
+    /// `Ok(Array([Int(1)]))` at no error, where real jq 1.7.1 rejects the
+    /// document outright.
+    #[test]
+    fn test_to_owned_raises_on_trailing_comma_after_real_last_child_2262() {
+        for json in [b"[1,]".as_slice(), br#"{"a":1,}"#.as_slice()] {
+            let index = JsonIndex::build(json);
+            let cursor = index.root(json);
+            let err = match to_owned(&cursor.value()) {
+                Err(e) => e,
+                Ok(v) => panic!(
+                    "{json:?}: a trailing comma after a real last child is not JSON, got {v:?}"
+                ),
+            };
+            assert!(
+                err.message.contains("Invalid JSON text"),
+                "{json:?}: message: {}",
+                err.message
+            );
+        }
+    }
+
+    /// #2262: unlike the trailing-comma case above, a stray `,` with *zero*
+    /// real children (`[,]`, `{,}`) remains a known, deliberately unclosed
+    /// gap -- #2211's `container_gap_ok` needs a cursor to the *container
+    /// itself* to find its opening bracket, and this function is only ever
+    /// given a bare `value: &StandardJson<'_, W>`, never a cursor for the
+    /// container (unlike `eval_generic::to_owned_cursor_at_depth`'s own
+    /// `cursor` parameter). Once the child walk is exhausted there is no
+    /// cursor left to check against -- the same limitation #2211 already
+    /// documented for `jq_runner::standard_json_to_jq_value`'s identical
+    /// value-only shape. This pins the disagreement rather than leaving it
+    /// silently uncovered.
+    #[test]
+    fn test_to_owned_stray_comma_in_empty_container_remains_a_known_gap_2262() {
+        for json in [b"[,]".as_slice(), b"{,}".as_slice()] {
+            let index = JsonIndex::build(json);
+            let cursor = index.root(json);
+            if let Err(e) = to_owned(&cursor.value()) {
+                panic!("{json:?}: known gap -- silently accepted, got error {e:?}");
+            }
+        }
+    }
+
+    /// #2262: well-formed arrays/objects (including a multi-element array
+    /// and a multi-field object) are unaffected by the two new checks
+    /// above.
+    #[test]
+    fn test_to_owned_wellformed_containers_unaffected_2262() {
+        for (json, expected) in [
+            (b"[]".as_slice(), OwnedValue::Array(vec![])),
+            (b"{}".as_slice(), OwnedValue::Object(IndexMap::new())),
+            (
+                b"[1,2,3]".as_slice(),
+                OwnedValue::Array(vec![
+                    OwnedValue::from_number_literal("1"),
+                    OwnedValue::from_number_literal("2"),
+                    OwnedValue::from_number_literal("3"),
+                ]),
+            ),
+            (
+                br#"{"a":1,"b":2}"#.as_slice(),
+                OwnedValue::Object(IndexMap::from([
+                    ("a".to_string(), OwnedValue::from_number_literal("1")),
+                    ("b".to_string(), OwnedValue::from_number_literal("2")),
+                ])),
+            ),
+        ] {
+            let index = JsonIndex::build(json);
+            let cursor = index.root(json);
+            assert_eq!(
+                to_owned(&cursor.value()).unwrap(),
+                expected,
+                "{json:?}: to_owned"
+            );
+        }
     }
 
     /// Code review, #1829/#1835: the object arm's new error paths (#1194,

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -29,9 +29,9 @@ use indexmap::IndexMap;
 use super::document::{
     collapsed_fields, collapsed_fields_if, effective_fields, effective_fields_checked,
     effective_keys, effective_len_checked, key_delimiter_ok, key_display_string,
-    key_display_string_kind, key_is_malformed, resolve_display_key, value_delimiter_ok,
-    DisplayKeyGuard, DistinctKeyCursors, DocumentCursor, DocumentElements, DocumentFields,
-    DocumentValue, IndentSpec, JsonConvention,
+    key_display_string_kind, key_is_malformed, resolve_display_key, trailing_element_gap_ok,
+    value_delimiter_ok, DisplayKeyGuard, DistinctKeyCursors, DocumentCursor, DocumentElements,
+    DocumentFields, DocumentValue, IndentSpec, JsonConvention,
 };
 use super::eval::{
     apply_compare_op, arith_combine, as_var_refs, bind_def, bind_def_call,
@@ -217,6 +217,11 @@ fn to_owned_at_depth<V: DocumentValue>(value: &V, depth: usize) -> Result<OwnedV
         let mut guard = DisplayKeyGuard::default();
         let mut f = fields;
         let mut is_first = true;
+        // #2262: the last real field's own cursor, retained past the loop
+        // so the trailing-gap check below (a stray `,` *after* a real last
+        // field, `{"a":1,}`) has something to check from -- mirrors
+        // `to_owned_cursor_at_depth`'s own `last_field` (#2243).
+        let mut last_field: Option<V::Cursor> = None;
         while let Some((field, rest)) = f.uncons() {
             // A key that will not *decode* (#1247/#1385) is preserved via
             // its raw source span rather than raised on (#1642), matching
@@ -238,6 +243,7 @@ fn to_owned_at_depth<V: DocumentValue>(value: &V, depth: usize) -> Result<OwnedV
                 return Err(f.malformed_member_error());
             }
             map.insert(key, to_owned_at_depth(&field.value, depth + 1)?);
+            last_field = Some(field.value_cursor);
             f = rest;
             is_first = false;
         }
@@ -248,11 +254,29 @@ fn to_owned_at_depth<V: DocumentValue>(value: &V, depth: usize) -> Result<OwnedV
         if f.ends_unpaired() {
             return Err(f.malformed_member_error());
         }
+        // #2262: #2211's `container_gap_ok` (a stray `,` with zero real
+        // fields, `{,}`) needs the *container's own* cursor to find its
+        // opening `{` -- this function only ever receives a bare `value: &V`
+        // (never a cursor for the container itself, unlike
+        // `to_owned_cursor_at_depth`'s `cursor` parameter), and once `f` is
+        // exhausted there is no way to reconstruct one. Same limitation
+        // #2211 already documented for `jq_runner::standard_json_to_jq_value`'s
+        // identical "value only, no container position" shape -- `{,}`
+        // remains unchecked here for that reason. #2243's
+        // `trailing_element_gap_ok` *is* checkable, though: it only needs
+        // the last real field's own cursor, retained above.
+        if let Some(last) = &last_field {
+            if !trailing_element_gap_ok(last, b'}') {
+                return Err(last.malformed_delimiter_error());
+            }
+        }
         Ok(OwnedValue::Object(map))
     } else if let Some(elements) = value.as_array() {
         let mut items = Vec::new();
         let mut elems = elements;
         let mut is_first = true;
+        // #2262: same reasoning as the object arm's own `last_field` above.
+        let mut last_elem: Option<V::Cursor> = None;
         while let Some((elem_cursor, rest)) = elems.uncons_cursor() {
             // #1677: no bare-value walk over `DocumentElements` carries a
             // position, so this switches to the cursor-yielding sibling of
@@ -265,8 +289,17 @@ fn to_owned_at_depth<V: DocumentValue>(value: &V, depth: usize) -> Result<OwnedV
                 }
             }
             items.push(to_owned_at_depth(&elem_cursor.value(), depth + 1)?);
+            last_elem = Some(elem_cursor);
             elems = rest;
             is_first = false;
+        }
+        // #2262: same reasoning as the object arm's own check above --
+        // `[,]` remains unchecked here (no container cursor available),
+        // but `[1,]` is, via the last real element's own cursor.
+        if let Some(last) = &last_elem {
+            if !trailing_element_gap_ok(last, b']') {
+                return Err(last.malformed_delimiter_error());
+            }
         }
         Ok(OwnedValue::Array(items))
     // Then check scalars in order of specificity
@@ -349,36 +382,6 @@ pub fn to_owned_all_cursors<'a, C: DocumentCursor + 'a>(
     cursors: impl IntoIterator<Item = &'a C>,
 ) -> Result<Vec<OwnedValue>, EvalError> {
     cursors.into_iter().map(to_owned_cursor).collect()
-}
-
-/// #2243: whether a trailing stray `,` (`[1,]`, `{"a":1,}`) sits between a
-/// container's *last real child* (`last_cursor`) and `close_char` -- shared
-/// by [`to_owned_cursor_at_depth`]'s object and array arms, one definition
-/// instead of two hand-copied ones (this crate's own "duplicated predicates
-/// diverge silently" lesson).
-///
-/// Takes only the cursor, not an already-resolved value: [`DocumentValue::
-/// scalar_text_end`] unconditionally answers `None` for a container-typed
-/// child (see its own doc comment), so resolving one here first -- via
-/// `is_container()`, cheap and already required by every [`DocumentCursor`]
-/// impl -- skips a `.value()` call this check could never use anyway,
-/// rather than decoding it and immediately discarding the result.
-///
-/// `None` from either remaining half of the lookup -- no resolvable start
-/// position, or (for a scalar child) no derivable end position -- answers
-/// `true` (nothing to flag), the same "can't determine, skip" convention
-/// every sibling gap check in this file already follows.
-fn trailing_element_gap_ok<C: DocumentCursor>(last_cursor: &C, close_char: u8) -> bool {
-    if last_cursor.is_container() {
-        return true;
-    }
-    match last_cursor.text_position() {
-        Some(start) => match last_cursor.value().scalar_text_end(start) {
-            Some(end) => last_cursor.trailing_element_gap_ok(end, close_char),
-            None => true,
-        },
-        None => true,
-    }
 }
 
 fn to_owned_cursor_at_depth<C: DocumentCursor>(
@@ -18712,6 +18715,112 @@ mod tests {
             );
         }
         assert_eq!(value_err.message, cursor_err.message);
+    }
+
+    /// #2262: `to_owned_at_depth` (the cursor-less sibling `GenericResult::
+    /// One`/`Many` reach whenever a value materializes without a live
+    /// cursor) never checked for a trailing stray `,` after a real last
+    /// child at all, unlike `to_owned_cursor_at_depth` (#2243). Both
+    /// conversions now agree, mirroring
+    /// `test_both_owned_conversions_raise_on_missing_delimiter_1677`'s same
+    /// same-document, same-cause pattern for this delimiter class instead.
+    #[test]
+    fn test_both_owned_conversions_raise_on_trailing_comma_2262() {
+        for json in [b"[1,]".as_slice(), br#"{"a":1,}"#.as_slice()] {
+            let index = JsonIndex::build(json);
+            let cursor = index.root(json);
+
+            let value_err = match to_owned(&cursor.value()) {
+                Err(e) => e,
+                Ok(v) => panic!(
+                    "{json:?}: a trailing comma after a real last child is not JSON, got {v:?}"
+                ),
+            };
+            let cursor_err = match to_owned_cursor(&cursor) {
+                Err(e) => e,
+                Ok(v) => panic!("{json:?}: the cursor domain must agree, got {v:?}"),
+            };
+
+            for err in [&value_err, &cursor_err] {
+                assert!(
+                    err.message.contains("Invalid JSON text"),
+                    "{json:?}: message: {}",
+                    err.message
+                );
+            }
+            assert_eq!(
+                value_err.message, cursor_err.message,
+                "{json:?}: one document, one cause"
+            );
+        }
+    }
+
+    /// #2262: unlike the trailing-comma case above, a stray `,` with *zero*
+    /// real children (`[,]`, `{,}`) is a known, deliberately unclosed gap
+    /// for `to_owned`/`to_owned_at_depth` specifically -- #2211's
+    /// `container_gap_ok` needs a cursor to the *container itself* to find
+    /// its opening bracket, and this cursor-less conversion is only ever
+    /// given a bare `value: &V`, never a cursor for the container (only
+    /// per-child cursors, once a child actually exists to hold one). Once
+    /// the child walk is exhausted there is nothing left to check against.
+    /// `to_owned_cursor` -- which *is* given the container's own cursor --
+    /// already closed this via #2211 and continues to reject both shapes,
+    /// so the two conversions deliberately disagree here. This pins that
+    /// disagreement as the documented, still-open half of #2262 rather
+    /// than leaving it silently uncovered.
+    #[test]
+    fn test_to_owned_stray_comma_in_empty_container_remains_a_known_gap_2262() {
+        for json in [b"[,]".as_slice(), b"{,}".as_slice()] {
+            let index = JsonIndex::build(json);
+            let cursor = index.root(json);
+
+            if let Err(e) = to_owned(&cursor.value()) {
+                panic!("{json:?}: known gap -- silently accepted, got error {e:?}");
+            }
+            if let Ok(v) = to_owned_cursor(&cursor) {
+                panic!("{json:?}: the cursor domain already rejects this, got {v:?}");
+            }
+        }
+    }
+
+    /// #2262: well-formed arrays/objects (including a multi-element array
+    /// and a multi-field object, so both the "at least one real child, no
+    /// trailing gap" branch and the untouched empty-container branch are
+    /// each pinned) are unaffected by the new trailing-comma check above.
+    #[test]
+    fn test_to_owned_wellformed_containers_unaffected_by_trailing_comma_check_2262() {
+        for (json, expected) in [
+            (b"[]".as_slice(), OwnedValue::Array(vec![])),
+            (b"{}".as_slice(), OwnedValue::Object(IndexMap::new())),
+            (
+                b"[1,2,3]".as_slice(),
+                OwnedValue::Array(vec![
+                    OwnedValue::from_number_literal("1"),
+                    OwnedValue::from_number_literal("2"),
+                    OwnedValue::from_number_literal("3"),
+                ]),
+            ),
+            (
+                br#"{"a":1,"b":2}"#.as_slice(),
+                OwnedValue::Object(IndexMap::from([
+                    ("a".to_string(), OwnedValue::from_number_literal("1")),
+                    ("b".to_string(), OwnedValue::from_number_literal("2")),
+                ])),
+            ),
+        ] {
+            let index = JsonIndex::build(json);
+            let cursor = index.root(json);
+            assert_eq!(
+                to_owned(&cursor.value()).unwrap(),
+                expected,
+                "{json:?}: to_owned"
+            );
+            assert_eq!(
+                to_owned_cursor(&cursor).unwrap(),
+                expected,
+                "{json:?}: to_owned_cursor must agree"
+            );
+        }
     }
 
     /// #1687: the sort family's array-valued results (`sort`, `sort_by`,

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -1823,7 +1823,7 @@ fn test_yq_slurp_fast_path_rejects_trailing_comma_2276() -> Result<()> {
         "expected an 'Invalid JSON text' error, got: {stderr}"
     );
 
-    // Well-formed data still takes the fast path and is unaffected.
+    // Ordinary well-formed data still round-trips correctly.
     let (output, code) = run_yq_stdin(
         ".",
         "[1,2,3]",
@@ -1831,6 +1831,35 @@ fn test_yq_slurp_fast_path_rejects_trailing_comma_2276() -> Result<()> {
     )?;
     assert_eq!(code, 0);
     assert_eq!(output.trim(), "[[1,2,3]]");
+
+    // #2276 review: "still round-trips correctly" above can't tell "the M2
+    // fast path ran" apart from "silently fell back to the DOM path and it
+    // happened to produce the same bytes" -- `[1,2,3]` alone is identical
+    // either way. A *duplicate* mapping key can distinguish them: only the
+    // M2 fast path preserves one (the DOM fallback's `OwnedValue::Object`
+    // is `IndexMap`-backed and collapses it to the last value, #442/#1343).
+    // `any_input_is_json` (`yq_runner.rs`) is a blanket, content-independent
+    // gate -- it declines the fast path for *every* `--input-format json`
+    // `--slurp` invocation, well-formed or not, not just the malformed ones
+    // this test's first half exercises -- so this must observe the
+    // duplicate *collapsing*, proving the DOM fallback is what actually
+    // ran, not the other way around. This is the documented, accepted
+    // "known cost" of the conservative fix (CHANGELOG.md, #1343): pinned
+    // here as a regression guard against the fast path being silently
+    // (and incorrectly) reintroduced for JSON input without re-closing
+    // the comma-gap/depth holes it would reopen.
+    let (output, code) = run_yq_stdin(
+        ".",
+        r#"{"a":1,"a":2}"#,
+        &["--slurp", "--input-format", "json", "-o", "json", "-I=0"],
+    )?;
+    assert_eq!(code, 0);
+    assert_eq!(
+        output.trim(),
+        r#"[{"a":2}]"#,
+        "the duplicate key collapsing proves the DOM fallback ran, not \
+         the M2 fast path -- matching this fix's documented, accepted cost"
+    );
 
     Ok(())
 }
@@ -1869,8 +1898,8 @@ fn test_yq_inplace_fast_path_rejects_trailing_comma_leaves_file_untouched_2276()
         "a raised --inplace write must leave the file byte-for-byte untouched"
     );
 
-    // Well-formed data still takes the fast path, is unaffected, and the
-    // file really is rewritten (unlike the raised case above).
+    // Well-formed data still works correctly, and the file really is
+    // rewritten (unlike the raised case above).
     let mut ok_file = NamedTempFile::new()?;
     write!(ok_file, "[1,2,3]")?;
     let output = Command::new(env!("CARGO_BIN_EXE_succinctly"))
@@ -1884,6 +1913,94 @@ fn test_yq_inplace_fast_path_rejects_trailing_comma_leaves_file_untouched_2276()
     assert!(output.status.success());
     let file_contents = std::fs::read_to_string(ok_file.path())?;
     assert_eq!(file_contents.trim(), "[1,2,3]");
+
+    // #2276 review: same reasoning as
+    // `test_yq_slurp_fast_path_rejects_trailing_comma_2276`'s identical
+    // check -- `[1,2,3]` above can't distinguish "the M2 fast path ran"
+    // from "silently fell back to the DOM path and it happened to produce
+    // the same bytes." A duplicate mapping key can: `any_input_is_json` is
+    // a blanket, content-independent gate, so it declines the fast path
+    // for *every* `--input-format json` `--inplace` invocation, well-formed
+    // or not -- this must observe the duplicate *collapsing*, proving the
+    // DOM fallback ran. Documented, accepted cost (CHANGELOG.md, #1343);
+    // pinned as a regression guard against the fast path being silently
+    // reintroduced without re-closing the comma-gap/depth holes above.
+    let mut dup_file = NamedTempFile::new()?;
+    write!(dup_file, r#"{{"a":1,"a":2}}"#)?;
+    let output = Command::new(env!("CARGO_BIN_EXE_succinctly"))
+        .arg("yq")
+        .arg("-i")
+        .args(["--input-format", "json", "-o", "json", "-I=0"])
+        .arg(".")
+        .arg(dup_file.path())
+        .stdin(Stdio::null())
+        .output()?;
+    assert!(output.status.success());
+    let file_contents = std::fs::read_to_string(dup_file.path())?;
+    assert_eq!(
+        file_contents.trim(),
+        r#"{"a":2}"#,
+        "the duplicate key collapsing proves the DOM fallback ran, not \
+         the M2 fast path -- matching this fix's documented, accepted cost"
+    );
+
+    Ok(())
+}
+
+/// #2276 review: `any_input_is_json` is one run-wide boolean, not a
+/// per-file switch (see its own doc comment in `yq_runner.rs` for why a
+/// per-file version wasn't attempted here) -- so a single JSON-sourced
+/// file anywhere in a multi-file `--inplace` invocation declines the M2
+/// fast path for *every* file in that run, including a genuinely YAML
+/// file that would have been perfectly safe on its own. Pinned as a known,
+/// deliberately-accepted collateral cost rather than left to be discovered
+/// by a future regression report: `a.yaml`'s own duplicate mapping key
+/// (`a: 1`/`a: 2`) survives `succinctly yq -i '.' a.yaml` in isolation
+/// (M2 fast path, #442/#1343's own guarantee), but collapses to the last
+/// value once `b.json` is added to the same invocation and forces the
+/// whole run onto the DOM fallback.
+#[test]
+fn test_yq_inplace_mixed_yaml_json_files_collapses_yaml_duplicate_keys_too_2276() -> Result<()> {
+    let dir = TempDir::new()?;
+    let yaml_file = dir.path().join("a.yaml");
+    let json_file = dir.path().join("b.json");
+    std::fs::write(&yaml_file, "a: 1\na: 2\n")?;
+    std::fs::write(&json_file, "{\"b\":1,\"b\":2}")?;
+
+    // Baseline: `a.yaml` alone keeps both duplicate values via the M2 fast
+    // path -- confirms the "collateral" framing (it really was safe alone).
+    let solo_yaml = dir.path().join("solo.yaml");
+    std::fs::write(&solo_yaml, "a: 1\na: 2\n")?;
+    let output = Command::new(env!("CARGO_BIN_EXE_succinctly"))
+        .arg("yq")
+        .arg("-i")
+        .arg(".")
+        .arg(&solo_yaml)
+        .stdin(Stdio::null())
+        .output()?;
+    assert!(output.status.success());
+    assert_eq!(
+        std::fs::read_to_string(&solo_yaml)?,
+        "a: 1\na: 2\n",
+        "a.yaml alone must keep both duplicate values (M2 fast path)"
+    );
+
+    // Together with a JSON source, the same YAML file's duplicates collapse.
+    let output = Command::new(env!("CARGO_BIN_EXE_succinctly"))
+        .arg("yq")
+        .arg("-i")
+        .arg(".")
+        .arg(&yaml_file)
+        .arg(&json_file)
+        .stdin(Stdio::null())
+        .output()?;
+    assert!(output.status.success());
+    assert_eq!(
+        std::fs::read_to_string(&yaml_file)?,
+        "a: 2\n",
+        "a known, accepted collateral cost -- update this alongside \
+         yq_runner.rs's own doc comment if a per-file switch closes it later"
+    );
 
     Ok(())
 }
@@ -16891,27 +17008,111 @@ fn test_json_input_rejects_adversarial_nesting_via_pretty_print_1398() -> Result
 /// gate: `--slurp`'s M2 fast path never validated JSON input for a
 /// malformed stray/trailing `,` at all (`YamlIndex`'s flow-sequence
 /// grammar legitimately allows one), which for `--inplace` was a real,
-/// silent-data-loss bug (a false accept rewrites the file). `--slurp` with
-/// JSON-sourced input now falls back to `parse_input`'s `JsonIndex`-based
-/// DOM path unconditionally, same as `--eval-all` always has (see
-/// `test_json_input_rejects_adversarial_nesting_via_eval_all_998` just
-/// above, which this test now matches exactly instead of the M2 path's own
-/// depth-128 guard): a raw panic (exit 101, conversion-time 256 guard)
-/// rather than a clean parse-time error (exit 1, 128) -- a real, accepted
-/// trade-off, not an oversight: `--eval-all` already panics on this exact
-/// input today, so `--slurp` reaching the identical, already-shipped
-/// behavior is not a new class of risk, just a wider door to it.
+/// silent-data-loss bug (a false accept rewrites the file).
+///
+/// `--slurp` with JSON-sourced input now falls back to `parse_input`'s
+/// `JsonIndex`-based DOM path unconditionally -- which on its own would
+/// have *silently loosened* depth validation from the M2 path's 128-deep
+/// parse-time guard to `to_owned_canonicalizing_numbers_at_depth`'s own
+/// looser, panicking 256-deep one (confirmed live in an earlier, since-
+/// corrected revision of this fix: depth 500 exited 101 with "nesting
+/// depth exceeds limit of 256", *silently accepting* depth 129-255 that
+/// used to be rejected outright). `parse_input_m2_parity`'s own depth-128
+/// pre-check (added specifically for `--slurp`'s and `--inplace`'s DOM
+/// fallback, not `--eval-all`'s -- see that function's own doc comment)
+/// closes this ahead of the DOM path ever running, so this test now
+/// matches the *original*, pre-#2276 `--slurp` behavior exactly: a clean
+/// parse-time-equivalent error (exit 1, "128"), not `--eval-all`'s own
+/// panic (exit 101, "256") -- see
+/// `test_yq_slurp_inplace_json_depth_matches_m2_parse_time_limit_2276` for
+/// the full boundary sweep this pins one more value of.
 #[test]
 fn test_json_input_rejects_adversarial_nesting_via_slurp_996() -> Result<()> {
     let depth = 500;
     let input = format!("{}1{}", "[".repeat(depth), "]".repeat(depth));
     let (_stdout, stderr, code) =
         run_yq_stdin_with_stderr(".", &input, &["--input-format", "json", "--slurp"])?;
-    assert_eq!(code, 101, "stderr: {stderr:?}");
+    assert_eq!(code, 1, "stderr: {stderr:?}");
     assert!(
-        stderr.contains("nesting depth exceeds limit of 256"),
+        stderr.contains("nesting depth exceeds limit of 128"),
         "stderr: {stderr:?}"
     );
+    Ok(())
+}
+
+/// #2276 code review, critical finding: verifies the exact
+/// accept/reject boundary `parse_input_m2_parity`'s depth pre-check
+/// (`yq_runner.rs`) must land on for `--slurp`'s and `--inplace`'s own DOM
+/// fallback -- 128 levels of plain `[...]` nesting accepted, 129 rejected,
+/// matching `YamlIndex`'s own parse-time guard (`src/yaml/parser.rs`)
+/// exactly, confirmed directly against a pre-#2276 build rather than
+/// assumed from the guard's own name: `nesting_depth` there is checked
+/// *before* incrementing, so it reaches 127 (not 128) on the innermost of
+/// 128 nested `[`s, and only the 129th `[` sees `nesting_depth == 128` and
+/// fails. An earlier revision of this same depth-check got exactly this
+/// off by one (checking every node, including the leaf scalar, against the
+/// limit -- rejecting 128 when it should have accepted it) -- caught by
+/// diffing against a pre-#2276 build at every boundary value rather than
+/// trusting the fix's own self-consistency, which is what this test now
+/// pins permanently. Both directions (127/128 accept, 129 reject) and both
+/// flags (`--slurp`, `--inplace`) are checked, since either flag alone or
+/// either direction alone would have missed this exact bug when it was
+/// live.
+#[test]
+fn test_yq_slurp_inplace_json_depth_matches_m2_parse_time_limit_2276() -> Result<()> {
+    let nested = |depth: usize| format!("{}1{}", "[".repeat(depth), "]".repeat(depth));
+
+    for (depth, should_reject) in [(127, false), (128, false), (129, true)] {
+        let input = nested(depth);
+
+        let (_stdout, stderr, code) = run_yq_stdin_with_stderr(
+            ".",
+            &input,
+            &["--slurp", "--input-format", "json", "-o", "json"],
+        )?;
+        if should_reject {
+            assert_eq!(code, 1, "--slurp depth={depth}: stderr: {stderr}");
+            assert!(
+                stderr.contains("nesting depth exceeds limit of 128"),
+                "--slurp depth={depth}: stderr: {stderr}"
+            );
+        } else {
+            assert_eq!(code, 0, "--slurp depth={depth}: stderr: {stderr}");
+        }
+
+        let mut file = NamedTempFile::new()?;
+        write!(file, "{input}")?;
+        let output = Command::new(env!("CARGO_BIN_EXE_succinctly"))
+            .arg("yq")
+            .arg("-i")
+            .args(["--input-format", "json"])
+            .arg(".")
+            .arg(file.path())
+            .stdin(Stdio::null())
+            .output()?;
+        let stderr = String::from_utf8(output.stderr)?;
+        if should_reject {
+            assert!(
+                !output.status.success(),
+                "--inplace depth={depth}: stderr: {stderr}"
+            );
+            assert!(
+                stderr.contains("nesting depth exceeds limit of 128"),
+                "--inplace depth={depth}: stderr: {stderr}"
+            );
+            let file_contents = std::fs::read_to_string(file.path())?;
+            assert_eq!(
+                file_contents, input,
+                "--inplace depth={depth}: a raised write must leave the file untouched"
+            );
+        } else {
+            assert!(
+                output.status.success(),
+                "--inplace depth={depth}: stderr: {stderr}"
+            );
+        }
+    }
+
     Ok(())
 }
 

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -1798,6 +1798,96 @@ fn test_input_format_json_bridge_raises_on_malformed_delimiter_1975() -> Result<
     Ok(())
 }
 
+/// #2276 code review on #2262's own PR: `--slurp`'s and `--inplace`'s own M2
+/// streaming fast paths (`can_slurp_fast_path`/`can_inplace_fast_path` in
+/// `yq_runner.rs`) parse a plain identity (`--slurp`) or M2-streamable
+/// (`--inplace`) filter's JSON-sourced input via `YamlIndex`/
+/// `mark_json_sourced` instead of `parse_input`'s `to_owned_canonicalizing_
+/// numbers_at_depth` bridge (#2262's own fix) -- and `YamlIndex`'s
+/// flow-sequence grammar legitimately allows a trailing `,`, so none of
+/// #2262's new checks were ever reached on that route. Confirmed live
+/// before this fix: `--slurp --input-format json -o json '.'` on `[1,]`
+/// returned `[[1]]` at exit 0 (`.[0]`, which #2262's own tests used, forces
+/// the DOM path instead and was already correct -- this is specifically the
+/// plain-identity gap those tests didn't cover).
+#[test]
+fn test_yq_slurp_fast_path_rejects_trailing_comma_2276() -> Result<()> {
+    let (_output, stderr, code) = run_yq_stdin_with_stderr(
+        ".",
+        "[1,]",
+        &["--slurp", "--input-format", "json", "-o", "json"],
+    )?;
+    assert_eq!(code, 1, "stderr: {stderr}");
+    assert!(
+        stderr.contains("Invalid JSON text"),
+        "expected an 'Invalid JSON text' error, got: {stderr}"
+    );
+
+    // Well-formed data still takes the fast path and is unaffected.
+    let (output, code) = run_yq_stdin(
+        ".",
+        "[1,2,3]",
+        &["--slurp", "--input-format", "json", "-o", "json", "-I=0"],
+    )?;
+    assert_eq!(code, 0);
+    assert_eq!(output.trim(), "[[1,2,3]]");
+
+    Ok(())
+}
+
+/// #2276: `--inplace`'s own sibling of the fast-path gap above -- and the
+/// higher-stakes one, since a false accept here rewrites the user's file
+/// with a "healed" interpretation of a document real yq refuses to touch
+/// at all. Confirmed live before this fix: `succinctly yq -i '.'
+/// --input-format json` on `[1,]` exited 0 and rewrote the file to `- 1`
+/// (YAML output, `-o` defaults to `auto`) instead of leaving it untouched.
+#[test]
+fn test_yq_inplace_fast_path_rejects_trailing_comma_leaves_file_untouched_2276() -> Result<()> {
+    let json = "[1,]";
+    let mut input_file = NamedTempFile::new()?;
+    write!(input_file, "{json}")?;
+    let output = Command::new(env!("CARGO_BIN_EXE_succinctly"))
+        .arg("yq")
+        .arg("-i")
+        .args(["--input-format", "json"])
+        .arg(".")
+        .arg(input_file.path())
+        .stdin(Stdio::null())
+        .output()?;
+    let stderr = String::from_utf8(output.stderr)?;
+    assert!(
+        !output.status.success(),
+        "--inplace should raise, stderr: {stderr}"
+    );
+    assert!(
+        stderr.contains("Invalid JSON text"),
+        "expected an 'Invalid JSON text' error, got: {stderr}"
+    );
+    let file_contents = std::fs::read_to_string(input_file.path())?;
+    assert_eq!(
+        file_contents, json,
+        "a raised --inplace write must leave the file byte-for-byte untouched"
+    );
+
+    // Well-formed data still takes the fast path, is unaffected, and the
+    // file really is rewritten (unlike the raised case above).
+    let mut ok_file = NamedTempFile::new()?;
+    write!(ok_file, "[1,2,3]")?;
+    let output = Command::new(env!("CARGO_BIN_EXE_succinctly"))
+        .arg("yq")
+        .arg("-i")
+        .args(["--input-format", "json", "-o", "json", "-I=0"])
+        .arg(".")
+        .arg(ok_file.path())
+        .stdin(Stdio::null())
+        .output()?;
+    assert!(output.status.success());
+    let file_contents = std::fs::read_to_string(ok_file.path())?;
+    assert_eq!(file_contents.trim(), "[1,2,3]");
+
+    Ok(())
+}
+
 /// #1749 sibling: `DisplayKeyGuard::check`'s own contract is "a fallback
 /// spelling on *either side* of the collision is refused" (`document.rs`'s
 /// own doc comment) -- not just fallback-vs-fallback. Pins both orders: a
@@ -16794,22 +16884,32 @@ fn test_json_input_rejects_adversarial_nesting_via_pretty_print_1398() -> Result
     Ok(())
 }
 
-/// #996's `can_slurp_fast_path` also dropped its own `!any_input_is_json`
-/// gate, so `--slurp`'s default (YAML) output now routes adversarially
-/// deep JSON input through `YamlIndex::build`'s parse-time depth-128
-/// guard too, same as identity above -- pinned separately since
-/// `can_slurp_fast_path`/`is_m2_streamable` are independent gates with
-/// their own call sites, not a shared code path that the identity test
-/// above would also exercise.
+/// #996's `can_slurp_fast_path` dropped its own `!any_input_is_json` gate,
+/// routing `--slurp`'s default (YAML) output through `YamlIndex::build`'s
+/// parse-time depth-128 guard for adversarially deep JSON input, same as
+/// identity above -- but #2276 (found reviewing #2262) reinstated that
+/// gate: `--slurp`'s M2 fast path never validated JSON input for a
+/// malformed stray/trailing `,` at all (`YamlIndex`'s flow-sequence
+/// grammar legitimately allows one), which for `--inplace` was a real,
+/// silent-data-loss bug (a false accept rewrites the file). `--slurp` with
+/// JSON-sourced input now falls back to `parse_input`'s `JsonIndex`-based
+/// DOM path unconditionally, same as `--eval-all` always has (see
+/// `test_json_input_rejects_adversarial_nesting_via_eval_all_998` just
+/// above, which this test now matches exactly instead of the M2 path's own
+/// depth-128 guard): a raw panic (exit 101, conversion-time 256 guard)
+/// rather than a clean parse-time error (exit 1, 128) -- a real, accepted
+/// trade-off, not an oversight: `--eval-all` already panics on this exact
+/// input today, so `--slurp` reaching the identical, already-shipped
+/// behavior is not a new class of risk, just a wider door to it.
 #[test]
 fn test_json_input_rejects_adversarial_nesting_via_slurp_996() -> Result<()> {
     let depth = 500;
     let input = format!("{}1{}", "[".repeat(depth), "]".repeat(depth));
     let (_stdout, stderr, code) =
         run_yq_stdin_with_stderr(".", &input, &["--input-format", "json", "--slurp"])?;
-    assert_eq!(code, 1, "stderr: {stderr:?}");
+    assert_eq!(code, 101, "stderr: {stderr:?}");
     assert!(
-        stderr.contains("nesting depth exceeds limit of 128"),
+        stderr.contains("nesting depth exceeds limit of 256"),
         "stderr: {stderr:?}"
     );
     Ok(())


### PR DESCRIPTION
## Summary

Fixes #2262: `eval_generic::to_owned_cursor_at_depth` (fixed by #2211/#2243) is one of at
least four independent materializer functions in this codebase that each walk a JSON
object/array and build an `OwnedValue`, checking for malformed comma placement as they go.
Three others never received #2211's/#2243's checks — this PR fixes all three, plus two
additional gaps found during code review.

## Part 1: the three sibling materializers

1. **`src/jq/eval.rs`'s own `to_owned_at_depth`** — backs this crate's documented public
   library API. Had zero gap-checking of any kind.
2. **`eval_generic.rs`'s own cursor-less sibling, also named `to_owned_at_depth`** — had
   #1677's checks but neither #2211's nor #2243's.
3. **`src/bin/succinctly/yq_runner.rs`'s `to_owned_canonicalizing_numbers_at_depth`** — backs
   `succinctly yq --slurp`/`--eval-all`/`--inplace --input-format json`. Live and
   CLI-reachable: `echo '[1,]' | succinctly yq --slurp --input-format json -o json '.[0]'`
   printed `1` at exit 0 where real yq (v4.53.3) rejects it.

Fix: moved `trailing_element_gap_ok` (previously private to `eval_generic.rs`) into
`document.rs` as `pub`, and wired it into all three functions by retaining each arm's last
real child's own cursor and checking it after the loop — no duplicated logic.
`container_gap_ok` (`[,]`/`{,}`) is deliberately left unfixed in all three: none of them
receive a container-level cursor, only a bare value reference, matching #2211's own
established precedent for the identical shape.

## Part 2: code review found a bypass — the DOM fix above was unreachable for the common case

`--slurp`'s and `--inplace`'s own M2 streaming fast paths never called the newly-fixed
materializer for a plain identity filter (`.`) — they parse JSON-sourced input via
`YamlIndex::build` instead (JSON is a syntactic subset of YAML's flow grammar), bypassing
`to_owned_canonicalizing_numbers_at_depth` entirely. For `--inplace` this was silent data
loss, not just wrong output:

```console
$ printf '[1,]' > f.json && succinctly yq -i --input-format json '.' f.json && cat f.json
- 1                    # WRONG -- file rewritten with a "healed" value; real yq refuses
                        # and leaves the file byte-for-byte untouched
```

Fixed by gating `can_inplace_json_fast_path`/`can_inplace_yaml_fast_path` and
`can_slurp_fast_path` on a (factored-once) `fast_path_json_comma_safe` term, declining the
fast path for JSON-sourced input so both routes fall back to `parse_input`, the now-fixed
materializer.

## Part 3: that fix itself reopened a different gap — closed here too

Declining the M2 fast path routes JSON through `parse_input`'s `MAX_NESTING_DEPTH = 256`
guard instead of `YamlIndex`'s own, *lower* 128-deep parse-time guard — silently accepting
JSON nested 129–255 levels deep that used to be correctly rejected (the identical
silent-`--inplace`-data-loss class, now via depth instead of a comma). Fixed with
`parse_input_m2_parity`/`json_nested_past_m2_limit`: a pure BP-navigation depth pre-check
(no scalar decoding — costs nothing beyond pointer-chasing for well-formed input),
specific to `--slurp`'s/`--inplace`'s own DOM-fallback call sites. Boundary verified
against a pre-fix reference binary at every value spanning both limits (127/128/129/
255/256/257) for both flags — this caught a real off-by-one in an earlier attempt.
`--eval-all` (which never had this 128-deep guarantee, having no M2 fast path of its own
to decline) is deliberately unaffected; its own pre-existing exit-101 panic on adversarially
deep input is unrelated to this fix and tracked separately as #2282.

## Other findings addressed

- Duplicated `!any_input_is_json` predicate (copy-pasted into 3 gates) factored into one
  `fast_path_json_comma_safe` term.
- Mixed-format multi-file collateral regression (a co-processed JSON file forcing a
  well-formed YAML file's own duplicate keys to collapse too) — documented explicitly with
  a concrete example, plus a dedicated regression test.
- Corrected an earlier, wrong claim in this PR's own tests ("well-formed data still takes
  the fast path") — `fast_path_json_comma_safe` is a blanket, content-independent gate, so
  the fast path is never taken for any `--input-format json` `--slurp`/`--inplace`
  invocation; tests now correctly assert the documented #996/#1343 duplicate-key-collapse
  cost instead, which only happens on the DOM path.
- `docs/compliance/jq/limitations.md`'s stale #2262 bullet updated to match what's fixed.

## Verification (independently re-run three times across three review rounds)

- Rebuilt genuinely fresh each round (`cargo clean`-equivalent, confirmed non-trivial
  ~20s recompiles, never a stale binary).
- Full depth-boundary sweep (127/128/129/150/255/256/257) for both `--slurp` and
  `--inplace`, confirmed matching the pre-fix reference binary's own boundary exactly.
- `--inplace` on all rejected inputs (comma-gap and depth-window): file confirmed
  byte-for-byte untouched.
- Original comma-gap fix (`[1,]` etc.) still correctly rejected on the final build.
- Full test suite: 57/57 test binaries, 0 failures.
- `cargo clippy --all-targets --all-features -- -D warnings`, `cargo fmt --check`,
  `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features`,
  `cargo build --no-default-features`: all clean.
- Patch coverage: 96.41% (242/251 new lines) — remaining uncovered lines are inert
  assertion-failure branches in tests or documented-unreachable defensive fallbacks.

Follow-up issues filed: #2279 (the plain-stdout M2 path shares the original comma gap,
non-destructive, needs its own investigation), #2282 (`--eval-all`'s separate, pre-existing
exit-101 panic on deep nesting).

Fixes #2262
