### PR TITLE
fix(jq): close #2231 findings 1-3, verify finding 4's try/catch worry is unfounded

### DIFF
--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -12992,9 +12992,16 @@ fn builtin_fromjsonstream<W: Clone + AsRef<[u64]>>(
             // array straight through as real output, so an undecodable
             // string inside it used to silently become `""` instead of
             // raising.
+            //
+            // #2231: `suppress_or_raise`, not a bare `Err(e) =>
+            // QueryResult::Error(e)` -- this arm ignored `optional` where
+            // its own scalar-fallback sibling below already consults it,
+            // an inconsistency with no live-reachable effect today (same
+            // `eval_try`-catches-it-one-level-up reasoning as the rest of
+            // this lineage) but worth closing for its own sake.
             match to_owned(&value) {
                 Ok(v) => QueryResult::Owned(v),
-                Err(e) => QueryResult::Error(e),
+                Err(e) => suppress_or_raise(e, optional),
             }
         }
         // #1820: the Array arm above already raises on a corrupted
@@ -41367,14 +41374,22 @@ fn write_debug_line<S: EvalSemantics>(value: &OwnedValue) {
 /// unchanged.
 fn builtin_debug<W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     value: StandardJson<'_, W>,
-    _optional: bool,
+    optional: bool,
 ) -> QueryResult<'_, W> {
     // #1755: to_owned, not to_owned_lossy -- an undecodable value must
     // raise, not silently print/pass through "" in its place.
-    let owned = match to_owned(&value) {
-        Ok(v) => v,
-        Err(e) => return QueryResult::Error(e),
-    };
+    //
+    // #2231: `to_owned_or_suppress!`, not a bare `to_owned` match -- `optional`
+    // was previously unused here, so a #1194 malformed-member error (the
+    // non-decode-failure axis `to_owned` can also raise) escaped as an
+    // ordinary, catchable `Error` even under `debug?`/`try debug`. Not
+    // live-reachable today by the same reasoning #2184's own sites weren't
+    // (`eval_try`'s outer catch already suppresses it regardless, verified
+    // for the `try...catch` shape too by
+    // `test_try_catch_handler_still_runs_under_outer_optional_2231`) -- this
+    // is the same defensive-consistency fix, not a behavior change for any
+    // query parseable today.
+    let owned = to_owned_or_suppress!(&value, optional);
     write_debug_line::<S>(&owned);
     QueryResult::Owned(owned)
 }
@@ -41413,13 +41428,11 @@ fn builtin_debug<W: Clone + AsRef<[u64]>, S: EvalSemantics>(
 fn builtin_debug_msg<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     msg: &Expr,
     value: StandardJson<'a, W>,
-    _optional: bool,
+    optional: bool,
 ) -> QueryResult<'a, W> {
-    // #1755: see `builtin_debug`'s identical reasoning.
-    let owned = match to_owned(&value) {
-        Ok(v) => v,
-        Err(e) => return QueryResult::Error(e),
-    };
+    // #1755/#2231: see `builtin_debug`'s identical reasoning for both the
+    // raise-on-decode-failure rule and the `to_owned_or_suppress!` swap.
+    let owned = to_owned_or_suppress!(&value, optional);
     let flow = eval_each_owned::<S>(msg, &owned, false, &mut |msg_value| {
         write_debug_line::<S>(&msg_value);
         Demand::Continue
@@ -41487,14 +41500,11 @@ fn builtin_halt<'a, W: Clone + AsRef<[u64]>>() -> QueryResult<'a, W> {
 /// here alone would be inconsistent — tracked as a separate concern.
 fn builtin_stderr<W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     value: StandardJson<'_, W>,
-    _optional: bool,
+    optional: bool,
 ) -> QueryResult<'_, W> {
-    // #1755: to_owned, not to_owned_lossy -- an undecodable value must
-    // raise, not silently print/pass through "" in its place.
-    let owned = match to_owned(&value) {
-        Ok(v) => v,
-        Err(e) => return QueryResult::Error(e),
-    };
+    // #1755/#2231: see `builtin_debug`'s identical reasoning for both the
+    // raise-on-decode-failure rule and the `to_owned_or_suppress!` swap.
+    let owned = to_owned_or_suppress!(&value, optional);
     write_stderr_value::<S>(&owned);
     QueryResult::Owned(owned)
 }
@@ -76809,6 +76819,147 @@ mod tests {
             "any",
             QueryResult::Owned(OwnedValue::Bool(b)) => assert!(b)
         );
+    }
+
+    /// #2231 finding 4: `builtin_paths`'s own doc comment argues its unused
+    /// `optional` is a *principled* exemption -- "catchability is handled
+    /// uniformly one level up by `eval_try`" -- but that argument was only
+    /// ever verified for a bare `builtin?`, never for `try builtin catch
+    /// handler` wrapped in its own outer `?` (`(try builtin catch H)?`).
+    /// The worry: `eval_try` passes the *same* `optional` it receives
+    /// straight down into evaluating its own `expr` (`eval_single::<W,
+    /// S>(expr, value, optional)`), so if an outer `?` sets `optional=true`
+    /// for the whole `try...catch` node, a leaf builtin that itself
+    /// consults `optional` (the #2184/#2015 fix shape) could self-suppress
+    /// into `QueryResult::None` *before* ever raising an `Error` --
+    /// bypassing `eval_try`'s own `Error => catch` arm entirely, so `H`
+    /// would silently never run. Verified here that this does **not**
+    /// happen: `tostring` (already #2184-fixed to consult `optional`) on a
+    /// #1194 malformed-member object (`{"a":1,"b"}`, an odd/unpaired last
+    /// member -- the non-decode-failure axis `suppresses()` actually makes
+    /// suppressible, unlike a decode failure) still runs the catch handler
+    /// under an outer `?`. So `builtin_paths`'s reasoning generalizes: the
+    /// whole #1194→#2184 lineage's remaining sites (this issue's findings
+    /// 1-3) are confirmed genuinely non-live-reachable defensive
+    /// consistency, not a latent `try`/`catch` bypass.
+    #[test]
+    fn test_try_catch_handler_still_runs_under_outer_optional_2231() {
+        // Bare, unwrapped: raises the ordinary (suppressible) #1194 error.
+        query!(
+            br#"{"a":1,"b"}"#,
+            "tostring",
+            QueryResult::Error(e) => assert!(!e.is_decode_failure(), "{}", e.message)
+        );
+        // `?` alone: suppressed to nothing, per #2184.
+        query!(br#"{"a":1,"b"}"#, "tostring?", QueryResult::None => {});
+        // `try ... catch H`, no outer `?`: H runs.
+        query!(
+            br#"{"a":1,"b"}"#,
+            r#"try tostring catch "CAUGHT""#,
+            QueryResult::Owned(OwnedValue::String(s)) => assert_eq!(&*s, "CAUGHT")
+        );
+        // The case finding 4 worried about: `try ... catch H` wrapped in its
+        // own outer `?`. `H` must still run -- `tostring`'s own internal
+        // suppression must not fire ahead of `eval_try`'s catch dispatch.
+        query!(
+            br#"{"a":1,"b"}"#,
+            r#"(try tostring catch "CAUGHT")?"#,
+            QueryResult::Owned(OwnedValue::String(s)) => assert_eq!(&*s, "CAUGHT")
+        );
+    }
+
+    /// #2231 findings 1-3: `debug`/`debug(msg)`/`stderr`'s own `_optional`
+    /// (`eval.rs`) and `fromjsonstream`'s Array arm (`eval.rs`) all raised
+    /// an ordinary, suppressible #1194 malformed-member error
+    /// unconditionally, ignoring `optional` where #2184/#2015 already fixed
+    /// the rest of this lineage's sites.
+    ///
+    /// Called directly, like every `#2184`/`#2015` test above -- going
+    /// through `?`/`try` can't distinguish fixed from unfixed here, since
+    /// `eval_try`'s own outer catch already normalizes the *observable*
+    /// result to `None` either way (confirmed by
+    /// `test_try_catch_handler_still_runs_under_outer_optional_2231`,
+    /// finding 4). This test pins the leaf's own `optional`-consulting
+    /// behavior, which #843/#1953's "one level up" defense makes non-live-
+    /// reachable today but still worth keeping correct in its own right.
+    #[test]
+    fn test_debug_stderr_fromjsonstream_respect_optional_2231() {
+        let json_bytes: &[u8] = br#"{"a":1,"b"}"#;
+        let index = JsonIndex::build(json_bytes);
+        let cursor = index.root(json_bytes);
+
+        match builtin_debug::<Vec<u64>, JqSemantics>(cursor.value(), true) {
+            QueryResult::None => {}
+            other => panic!("expected None, got {other:?}"),
+        }
+        match builtin_debug::<Vec<u64>, JqSemantics>(cursor.value(), false) {
+            QueryResult::Error(e) => assert!(!e.is_decode_failure()),
+            other => panic!("expected Error, got {other:?}"),
+        }
+
+        match builtin_stderr::<Vec<u64>, JqSemantics>(cursor.value(), true) {
+            QueryResult::None => {}
+            other => panic!("expected None, got {other:?}"),
+        }
+        match builtin_stderr::<Vec<u64>, JqSemantics>(cursor.value(), false) {
+            QueryResult::Error(e) => assert!(!e.is_decode_failure()),
+            other => panic!("expected Error, got {other:?}"),
+        }
+
+        let msg = Expr::Identity;
+        match builtin_debug_msg::<Vec<u64>, JqSemantics>(&msg, cursor.value(), true) {
+            QueryResult::None => {}
+            other => panic!("expected None, got {other:?}"),
+        }
+        match builtin_debug_msg::<Vec<u64>, JqSemantics>(&msg, cursor.value(), false) {
+            QueryResult::Error(e) => assert!(!e.is_decode_failure()),
+            other => panic!("expected Error, got {other:?}"),
+        }
+
+        // `fromjsonstream`'s Array arm, same malformed member one level down.
+        let array_bytes: &[u8] = br#"[{"a":1,"b"}]"#;
+        let array_index = JsonIndex::build(array_bytes);
+        let array_cursor = array_index.root(array_bytes);
+        match builtin_fromjsonstream::<Vec<u64>>(array_cursor.value(), true) {
+            QueryResult::None => {}
+            other => panic!("expected None, got {other:?}"),
+        }
+        match builtin_fromjsonstream::<Vec<u64>>(array_cursor.value(), false) {
+            QueryResult::Error(e) => assert!(!e.is_decode_failure()),
+            other => panic!("expected Error, got {other:?}"),
+        }
+    }
+
+    /// #2231 findings 1-3: a genuine decode failure must still survive
+    /// `optional` for all four sites above -- same rule #2184's own decode-
+    /// failure-survival tests pin for their six sites.
+    #[test]
+    fn test_debug_stderr_fromjsonstream_decode_failure_survives_optional_2231() {
+        let decode_failure_bytes: &[u8] = &b"\"\xff\xfe\""[..];
+        let index = JsonIndex::build(decode_failure_bytes);
+        let cursor = index.root(decode_failure_bytes);
+
+        match builtin_debug::<Vec<u64>, JqSemantics>(cursor.value(), true) {
+            QueryResult::Error(e) => assert!(e.is_decode_failure()),
+            other => panic!("expected a decode failure to survive `optional`, got: {other:?}"),
+        }
+        match builtin_stderr::<Vec<u64>, JqSemantics>(cursor.value(), true) {
+            QueryResult::Error(e) => assert!(e.is_decode_failure()),
+            other => panic!("expected a decode failure to survive `optional`, got: {other:?}"),
+        }
+        let msg = Expr::Identity;
+        match builtin_debug_msg::<Vec<u64>, JqSemantics>(&msg, cursor.value(), true) {
+            QueryResult::Error(e) => assert!(e.is_decode_failure()),
+            other => panic!("expected a decode failure to survive `optional`, got: {other:?}"),
+        }
+
+        let array_bytes: &[u8] = &b"[\"\xff\xfe\"]"[..];
+        let array_index = JsonIndex::build(array_bytes);
+        let array_cursor = array_index.root(array_bytes);
+        match builtin_fromjsonstream::<Vec<u64>>(array_cursor.value(), true) {
+            QueryResult::Error(e) => assert!(e.is_decode_failure()),
+            other => panic!("expected a decode failure to survive `optional`, got: {other:?}"),
+        }
     }
 
     /// #1989 cluster 3: `builtin_last_stream`'s own doc comment says it

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -2215,6 +2215,24 @@ macro_rules! push_or_control {
     };
 }
 
+/// [`owned_or_err`]'s `optional`-consulting twin: an ordinary (non-decode-
+/// failure) error is suppressed to `GenericResult::None` when `optional` is
+/// set, matching [`super::eval::to_owned_or_suppress`]'s exact behavior for
+/// the `eval.rs` side of this same materialization (#2231, code review --
+/// this file's `Builtin::ToString` arm and its catch-all wildcard fallback
+/// each hand-rolled this three-line match independently before this macro
+/// existed, the exact "rediscovering missing at one more call site" pattern
+/// `to_owned_or_suppress`'s own doc comment already names for `eval.rs`).
+macro_rules! owned_or_suppress {
+    ($e:expr, $optional:expr) => {
+        match $e {
+            Ok(v) => v,
+            Err(e) if suppresses(&e, $optional) => return GenericResult::None,
+            Err(e) => return GenericResult::Error(e),
+        }
+    };
+}
+
 /// Append every output of a `GenericResult` stream to `out`, returning any
 /// terminating `Control` instead of collapsing to the first output the way
 /// an earlier `Expr::Compare` arm did before #768. Mirrors
@@ -10738,18 +10756,14 @@ fn eval_builtin<S: EvalSemantics, V: DocumentValue>(
         Builtin::Empty => GenericResult::None,
 
         Builtin::ToString => {
-            // #2231: consult `optional` here rather than the bare
-            // `owned_or_err!` -- the `eval.rs` twin of this arm
-            // (`builtin_tostring`, #2184) already does, and this file's own
-            // `owned_or_err!` unconditionally errors regardless of
-            // `optional`, ignoring it the same way `eval.rs`'s pre-#2184
-            // sites did. Same non-live-reachable defensive-consistency
-            // class as the rest of this lineage.
-            let owned = match to_owned_with_cursor(&value, cursor) {
-                Ok(v) => v,
-                Err(e) if suppresses(&e, optional) => return GenericResult::None,
-                Err(e) => return GenericResult::Error(e),
-            };
+            // #2231: `owned_or_suppress!`, not the bare `owned_or_err!` --
+            // the `eval.rs` twin of this arm (`builtin_tostring`, #2184)
+            // already consults `optional`, and this file's own
+            // `owned_or_err!` unconditionally errored regardless of it, the
+            // same way `eval.rs`'s pre-#2184 sites did. Same non-live-
+            // reachable defensive-consistency class as the rest of this
+            // lineage.
+            let owned = owned_or_suppress!(to_owned_with_cursor(&value, cursor), optional);
             GenericResult::Owned(OwnedValue::String(owned_to_string::<S>(&owned)))
         }
 
@@ -10900,22 +10914,21 @@ fn eval_builtin<S: EvalSemantics, V: DocumentValue>(
             }
         }
 
-        // For other builtins, fall back to full evaluator via JSON
+        // For other builtins, fall back to full evaluator via JSON. Reached
+        // by every `Builtin` variant with no dedicated arm above -- dozens,
+        // not just `ToJson`/`UpperIndex`/`UpperIndexStream`/`ToJsonStream`/
+        // `ToStream` (code review, #2231: an earlier revision of this
+        // comment named only those five, which undersells how many
+        // builtins actually funnel through here).
         _ => {
-            // #2231: consult `optional` on this bridging conversion too --
-            // same reasoning as the `ToString` arm above. Every builtin
-            // this arm reaches (`ToJson`/`UpperIndex`/`UpperIndexStream`/
-            // `ToJsonStream`/`ToStream`) is #2184-fixed on its `eval.rs`
-            // side to respect `optional` internally, but this outer
-            // materialization ran unconditionally ahead of ever reaching
-            // that -- an inconsistency with no live-reachable effect today
-            // (`eval_try` already suppresses one level up), not a behavior
-            // change for any query parseable today.
-            let owned = match to_owned_with_cursor(&value, cursor) {
-                Ok(v) => v,
-                Err(e) if suppresses(&e, optional) => return GenericResult::None,
-                Err(e) => return GenericResult::Error(e),
-            };
+            // #2231: `owned_or_suppress!`, not `owned_or_err!` -- this
+            // bridging materialization ran unconditionally regardless of
+            // `optional` before this fix, an inconsistency with no live-
+            // reachable effect today (`eval_try` already suppresses one
+            // level up) for whichever of the five #2184-fixed builtins
+            // above reach here; unverified for the rest of this arm's
+            // callers (tracked separately as #2280).
+            let owned = owned_or_suppress!(to_owned_with_cursor(&value, cursor), optional);
             eval_on_owned::<S, _>(&Expr::Builtin(builtin.clone()), owned, optional)
         }
     }

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -10738,7 +10738,18 @@ fn eval_builtin<S: EvalSemantics, V: DocumentValue>(
         Builtin::Empty => GenericResult::None,
 
         Builtin::ToString => {
-            let owned = owned_or_err!(to_owned_with_cursor(&value, cursor));
+            // #2231: consult `optional` here rather than the bare
+            // `owned_or_err!` -- the `eval.rs` twin of this arm
+            // (`builtin_tostring`, #2184) already does, and this file's own
+            // `owned_or_err!` unconditionally errors regardless of
+            // `optional`, ignoring it the same way `eval.rs`'s pre-#2184
+            // sites did. Same non-live-reachable defensive-consistency
+            // class as the rest of this lineage.
+            let owned = match to_owned_with_cursor(&value, cursor) {
+                Ok(v) => v,
+                Err(e) if suppresses(&e, optional) => return GenericResult::None,
+                Err(e) => return GenericResult::Error(e),
+            };
             GenericResult::Owned(OwnedValue::String(owned_to_string::<S>(&owned)))
         }
 
@@ -10891,7 +10902,20 @@ fn eval_builtin<S: EvalSemantics, V: DocumentValue>(
 
         // For other builtins, fall back to full evaluator via JSON
         _ => {
-            let owned = owned_or_err!(to_owned_with_cursor(&value, cursor));
+            // #2231: consult `optional` on this bridging conversion too --
+            // same reasoning as the `ToString` arm above. Every builtin
+            // this arm reaches (`ToJson`/`UpperIndex`/`UpperIndexStream`/
+            // `ToJsonStream`/`ToStream`) is #2184-fixed on its `eval.rs`
+            // side to respect `optional` internally, but this outer
+            // materialization ran unconditionally ahead of ever reaching
+            // that -- an inconsistency with no live-reachable effect today
+            // (`eval_try` already suppresses one level up), not a behavior
+            // change for any query parseable today.
+            let owned = match to_owned_with_cursor(&value, cursor) {
+                Ok(v) => v,
+                Err(e) if suppresses(&e, optional) => return GenericResult::None,
+                Err(e) => return GenericResult::Error(e),
+            };
             eval_on_owned::<S, _>(&Expr::Builtin(builtin.clone()), owned, optional)
         }
     }
@@ -11177,6 +11201,68 @@ mod tests {
                 OwnedValue::from_number_literal("1")
             )]))
         );
+    }
+
+    /// #2231 finding 3: `Builtin::ToString`'s own dedicated arm and the
+    /// catch-all wildcard fallback arm both raised an ordinary #1194
+    /// malformed-member error unconditionally, ignoring `optional` --
+    /// the `eval_generic.rs` twin of `eval.rs`'s `builtin_tostring`
+    /// (#2184) and findings 1-3's other `eval.rs` sites. Called directly
+    /// through `eval_builtin`, not through `eval`/`?`, for the same reason
+    /// `eval.rs`'s own #2184/#2231 tests do: `Expr::Optional`'s outer catch
+    /// already normalizes the observable result regardless of what this
+    /// arm does internally, so only a direct call distinguishes fixed from
+    /// unfixed.
+    #[test]
+    fn test_generic_tostring_and_wildcard_respect_optional_2231() {
+        use crate::json::JsonIndex;
+        let json: &[u8] = br#"{"a":1,"b"}"#;
+        let index = JsonIndex::build(json);
+        let cursor = index.root(json);
+        let value = cursor.value();
+
+        match eval_builtin::<JqSemantics, _>(&Builtin::ToString, value.clone(), true, Some(cursor))
+        {
+            GenericResult::None => {}
+            other => panic!("expected None, got {other:?}"),
+        }
+        match eval_builtin::<JqSemantics, _>(&Builtin::ToString, value.clone(), false, Some(cursor))
+        {
+            GenericResult::Error(e) => assert!(!e.is_decode_failure()),
+            other => panic!("expected Error, got {other:?}"),
+        }
+
+        // The catch-all wildcard arm, reached via a builtin with no
+        // dedicated arm of its own (e.g. `ToJson`).
+        match eval_builtin::<JqSemantics, _>(&Builtin::ToJson, value.clone(), true, Some(cursor)) {
+            GenericResult::None => {}
+            other => panic!("expected None, got {other:?}"),
+        }
+        match eval_builtin::<JqSemantics, _>(&Builtin::ToJson, value, false, Some(cursor)) {
+            GenericResult::Error(e) => assert!(!e.is_decode_failure()),
+            other => panic!("expected Error, got {other:?}"),
+        }
+    }
+
+    /// #2231 finding 3: a genuine decode failure must still survive
+    /// `optional` for both arms above -- same rule #2184's own sites keep.
+    #[test]
+    fn test_generic_tostring_and_wildcard_decode_failure_survives_optional_2231() {
+        use crate::json::JsonIndex;
+        let json: &[u8] = &b"\"\xff\xfe\""[..];
+        let index = JsonIndex::build(json);
+        let cursor = index.root(json);
+        let value = cursor.value();
+
+        match eval_builtin::<JqSemantics, _>(&Builtin::ToString, value.clone(), true, Some(cursor))
+        {
+            GenericResult::Error(e) => assert!(e.is_decode_failure()),
+            other => panic!("expected a decode failure to survive `optional`, got: {other:?}"),
+        }
+        match eval_builtin::<JqSemantics, _>(&Builtin::ToJson, value, true, Some(cursor)) {
+            GenericResult::Error(e) => assert!(e.is_decode_failure()),
+            other => panic!("expected a decode failure to survive `optional`, got: {other:?}"),
+        }
     }
 
     /// #1620: `?` must not suppress a decode failure -- `Expr::Optional`'s


### PR DESCRIPTION
## Summary
- Follow-up from #2184's own review. Extends #2184/#2015's optional-consulting fix to three more `eval.rs` sites (`builtin_debug`, `builtin_debug_msg`, `builtin_stderr`), `fromjsonstream`'s Array arm, and `eval_generic.rs`'s `Builtin::ToString` arm plus its catch-all wildcard fallback — all previously ignored `optional` and raised an ordinary, suppressible #1194 malformed-member error unconditionally.
- None of these are live-reachable today: `eval_try`'s outer catch already suppresses/catches regardless of what the leaf builtin does internally, for any query parseable today — same class as #2184/#2015's own sites.
- Before mechanically extending the pattern, live-verified finding 4's open architectural question: does an outer `?` wrapping a `try...catch` (`(try tostring catch "H")?`) cause a fixed builtin's own internal suppression to fire *before* the catch handler runs, silently skipping it? Confirmed no — the catch handler always runs correctly. This confirms `builtin_paths`'s own "catchability is handled one level up by `eval_try`" reasoning generalizes to the whole #1194→#2184 lineage.

## Test plan
- [x] New regression tests for all 4 sites' optional-consulting behavior, called directly (not through `?`/`try`, which can't distinguish fixed from unfixed — verified this empirically before writing the direct-call tests)
- [x] New regression test pinning finding 4's resolution (`try...catch` under an outer `?`)
- [x] Decode-failure-survives-optional tests for all sites (matching #2184's own precedent)
- [x] Fail-without-fix / pass-with-fix verified for every site via revert+test+restore cycles
- [x] `cargo clippy --all-targets --all-features -- -D warnings` (clean build)
- [x] `cargo clippy` second leg (`std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests`)
- [x] `cargo test --no-fail-fast --features cli,simd,regex,serde` (0 failed)
- [x] `cargo test --no-default-features --verbose` (no_std)
- [x] `cargo doc --no-deps --all-features` with `RUSTDOCFLAGS=-D warnings`

Fixes #2231