### PR TITLE
docs(jq): cross-reference path()/key-path-parent's duplicate-key policy split

### DIFF
--- a/docs/compliance/yq/limitations.md
+++ b/docs/compliance/yq/limitations.md
@@ -646,6 +646,29 @@ would still not close the gap (the irregular per-level part is unmodeled by both
 every non-default `-I` width, not just `-I0`), so this remains open rather than folded into
 #1575's fix.
 
+**One more deliberate divergence, this time between two `succinctly`-internal walks rather
+than against real yq**: `path(f)`
+([`path_walk_generic`](../../../src/jq/eval_generic.rs), #2075) and `key`/`path`/`parent`
+([`path_context_step_generic`](../../../src/jq/eval_generic.rs), #2061) both delegate to the
+same shared `path_step_generic`, but pass it different duplicate-key collapse flags —
+[#2147](https://github.com/rust-works/succinctly/issues/2147) recorded why, since the two
+call sites sit ~500 lines apart and the mismatch reads as an oversight without this:
+
+```bash
+$ printf '{"a":1,"a":2}' | succinctly yq -o=json -I=0 '[path(.[])]'   # [["a"],["a"]]
+$ printf '{"a":1,"a":2}' | succinctly yq -o=json -I=0 '[.[] | key]'   # ["a"]
+```
+
+`key`/`path`/`parent` pass `true` unconditionally because they replace a bridge that used to
+materialize into an `IndexMap` (which collapses structurally in both modes) — real yq agrees
+(`["a"]` in v4.53.3). `path(f)` passes `S::COLLAPSE_DUPLICATE_KEYS` (the mode's own rule)
+instead, because it isn't replacing a materialization and has **no yq oracle at all**: real
+yq's `path` is the no-argument form only, so `path(f)` is a jq builtin succinctly exposes as
+an extension in yq mode, exempt from ADR-0018's divergence rule. In jq mode both walks agree
+with real jq 1.7.1 (`[["a"]]`). So the two flags are a recorded choice, not a bug — this
+entry (plus the cross-referencing doc comments on both functions) is what keeps a future
+reader from "fixing" the mismatch into a real divergence.
+
 ### Stacked compact block-sequence items — one narrow, pre-existing width anomaly
 
 [#1485](https://github.com/rust-works/succinctly/issues/1485) fixed the general rule for a

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -9015,6 +9015,19 @@ fn path_node_type_name<V: DocumentValue>(node: &PathNode<V>) -> &'static str {
 /// Error texts are taken from the same constructors the materializing path
 /// uses, so the two agree exactly -- verified live against every shape in
 /// `test_path_cursor_native_matches_the_materializing_path_2061`.
+///
+/// #2147: this walk passes `S::COLLAPSE_DUPLICATE_KEYS` (the mode's own
+/// rule) to the shared `path_step_generic`, where
+/// [`path_context_step_generic`]'s own `key`/`path`/`parent` walk below
+/// passes `true` unconditionally -- a deliberate divergence, not an
+/// oversight. `path(f)` has no yq oracle at all (real yq rejects it as a
+/// parse error; `path(f)` is a jq builtin succinctly exposes as an
+/// extension there, so ADR-0018's divergence rule doesn't apply), where
+/// `[.[] | key]` does (`{"a":1,"a":2} | [.[] | key]` is `["a"]` in real yq
+/// v4.53.3, matching `path_context_step_generic`'s `true`). See that
+/// function's own doc comment for the full reasoning, and
+/// [docs/compliance/yq/limitations.md](../../docs/compliance/yq/limitations.md)'s
+/// "Duplicate mapping keys" section for the oracle evidence.
 fn path_walk_generic<S: EvalSemantics, V: DocumentValue>(
     expr: &Expr,
     node: &PathNode<V>,
@@ -9534,8 +9547,13 @@ fn path_context_step_generic<S: EvalSemantics, V: DocumentValue>(
             // `OwnedValue::Object(IndexMap<String, _>)`, which collapses a
             // repeated key structurally in *both* modes, and real yq agrees
             // (`{"a":1,"a":2} | [.[] | key]` is `["a"]` in v4.53.3).
-            // `path()`'s own walk keeps the mode's flag, because it is not
-            // replacing a materialization.
+            // `path()`'s own walk ([`path_walk_generic`], #2147) keeps the
+            // mode's flag instead, because it is not replacing a
+            // materialization and has no yq oracle to match in the first
+            // place (`path(f)` is a jq-only extension there) -- a
+            // deliberate divergence between the two walks, not an
+            // oversight; see that function's doc comment for the full
+            // cross-reference.
             let stepped = path_step_generic::<S, V>(
                 expr,
                 &PathNode::At(pos.node),

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -9547,13 +9547,12 @@ fn path_context_step_generic<S: EvalSemantics, V: DocumentValue>(
             // `OwnedValue::Object(IndexMap<String, _>)`, which collapses a
             // repeated key structurally in *both* modes, and real yq agrees
             // (`{"a":1,"a":2} | [.[] | key]` is `["a"]` in v4.53.3).
-            // `path()`'s own walk ([`path_walk_generic`], #2147) keeps the
-            // mode's flag instead, because it is not replacing a
-            // materialization and has no yq oracle to match in the first
-            // place (`path(f)` is a jq-only extension there) -- a
-            // deliberate divergence between the two walks, not an
-            // oversight; see that function's doc comment for the full
-            // cross-reference.
+            // `path()`'s own walk ([`path_walk_generic`]) keeps the mode's
+            // flag instead, because it is not replacing a materialization
+            // and has no yq oracle to match in the first place (`path(f)`
+            // is a jq-only extension there) -- a deliberate divergence
+            // between the two walks, recorded as #2147, not an oversight;
+            // see that function's doc comment for the full cross-reference.
             let stepped = path_step_generic::<S, V>(
                 expr,
                 &PathNode::At(pos.node),


### PR DESCRIPTION
## Summary
- `path_walk_generic` (`path(f)`, #2075) and `path_context_step_generic` (`key`/`path`/`parent`, #2061) pass different duplicate-key collapse flags to the same shared `path_step_generic` helper — the two call sites sit ~500 lines apart in `eval_generic.rs` and the mismatch reads as an oversight without documentation.
- Confirmed live against both oracles (already gathered in the issue) that this is a **justified divergence, not a bug**: `key`/`path`/`parent` match real yq v4.53.3 (`[.[] | key]` is `["a"]` on `{"a":1,"a":2}`), while `path(f)` has no yq oracle at all (real yq's `path` is no-arg only; `path(f)` is a jq builtin succinctly exposes as an extension there, exempt from ADR-0018's divergence rule). Both walks agree with real jq 1.7.1.
- Cross-references both functions' doc comments and adds a paragraph to `docs/compliance/yq/limitations.md`'s "Duplicate mapping keys" section recording the choice.

## Test plan
- No behavior change — docs-only.
- [x] `cargo build --features cli,simd,regex,serde`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo clippy` second leg (`std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests`)
- [x] `cargo test --no-fail-fast --features cli,simd,regex,serde` (0 failed)
- [x] `cargo test --no-default-features --verbose` (no_std)
- [x] `cargo doc --no-deps --all-features` with `RUSTDOCFLAGS=-D warnings` (confirms the new intra-doc `[path_context_step_generic]` link resolves)

Fixes #2147