### PR TITLE
fix(ci): refresh the x86_64 perf-guard baseline (#2059)

### DIFF
--- a/tests/data/perf-guard-baseline.json
+++ b/tests/data/perf-guard-baseline.json
@@ -8,11 +8,11 @@
     "wide_keys_unsorted": 321864371
   },
   "x86_64": {
-    "arrays_identity": 1602058719,
-    "users_identity": 397455066,
-    "users_keys_unsorted": 69246555,
-    "users_yq_keys_unsorted": 82479427,
-    "wide_identity": 775571299,
-    "wide_keys_unsorted": 373599725
+    "arrays_identity": 1149137279,
+    "users_identity": 403081537,
+    "users_keys_unsorted": 69322632,
+    "users_yq_keys_unsorted": 82609293,
+    "wide_identity": 729461833,
+    "wide_keys_unsorted": 376704931
   }
 }


### PR DESCRIPTION
## Summary
- Fixes #2059 — `Perf Regression Guard (x86_64)` is failing on `main`'s own commits again, ~2 days after #2118's own refresh. `ARM64-Linux` is confirmed green (via #2116).
- Confirmed drift is stable across several recent `main` commits: `wide_identity` -5.9%, `arrays_identity` -28.3% — both improvements (fewer instructions), not regressions.
- **Attributed to #1576** (stream map/sort/navigation output from cursors instead of an OwnedValue DOM), which landed 2026-09-02 — one day after #2118's own x86_64 refresh. The very next baseline refresh in this file's own history, commit `e97caf94d` (#2116, ARM64-Linux), hit an almost identical -29.0% `arrays_identity` drop on the same query and named #1576 explicitly, predicting x86_64 would need this same refresh. Code review caught that my own first pass missed this already-established attribution (I'd only searched `perf(jq):`-tagged commits; #1576 is tagged `feat(jq):`) and fell back to a weaker "indirect side effect, not attributed" framing — corrected in the commit message.
- `terminus` (the usual pinned x86_64 box) needed interactive Tailscale re-authentication this session and was unreachable, so this uses `main`'s own CI run's numbers directly (GitHub-hosted x86_64 runner, same `cachegrind`-based instruction counting `scripts/perf-guard.py` always uses — host-independent by design, so equivalent to running `--update-baseline` locally).

## Test plan
- [x] JSON validated (`python3 -m json.tool`) and format-diffed against what `json.dump(data, f, indent=2, sort_keys=True)` (the script's own writer) would produce — byte-identical.
- [x] `cargo fmt --check`
- [x] All 6 new x86_64 values programmatically cross-checked character-for-character against the CI log's own "current binary" measurement table — exact match, no transcription risk.
- [x] Values cross-checked against two independent `main`-tip CI runs (several commits apart) — identical numbers both times.

Note: this PR's own CI runs in `pull_request` mode, which compares against a freshly-built merge-base binary (`--baseline-binary`) rather than reading this checked-in file — so it cannot itself validate these numbers against a `push`-event run. The verification above is the substitute for that gap.