### PR TITLE
fix(jq): .field's fast path rejects a non-string sibling object key

### DIFF
--- a/src/jq/document.rs
+++ b/src/jq/document.rs
@@ -863,7 +863,15 @@ pub trait DocumentFields: Sized + Clone {
     fn uncons(&self) -> Option<(DocumentField<Self::Value, Self::Cursor>, Self)>;
 
     /// Find a field by name.
-    fn find(&self, name: &str) -> Option<Self::Value>;
+    ///
+    /// `Err` on the same terms [`find_cursor`](Self::find_cursor) already
+    /// documents for its own `Result` (#1995 review): widened to match, so
+    /// a caller reached through this trait method rather than a format's
+    /// own inherent `find` can't silently miss a malformed-key error a
+    /// format's implementation raises -- structurally, not just by
+    /// convention. YAML's own implementation always answers `Ok` (its
+    /// grammar has no equivalent "keys must be strings" rule to enforce).
+    fn find(&self, name: &str) -> Result<Option<Self::Value>, EvalError>;
 
     /// Find a field by name and return a cursor to its value.
     ///
@@ -885,6 +893,13 @@ pub trait DocumentFields: Sized + Clone {
     /// overrides this to check after resolving which occurrence wins, not
     /// during the search); every other format's default answers `Ok` via
     /// [`DocumentCursor::preceding_delimiter_ok`]'s own no-op default.
+    ///
+    /// Also `Err` when *any* sibling's key isn't string-shaped at all
+    /// (#1995, JSON only -- unlike the `,`/`:` check above, this one is
+    /// checked as each candidate is found during the search, not deferred
+    /// to the winner alone, since the document is malformed the moment any
+    /// member's key isn't a string, whether or not that member is the one
+    /// this lookup would otherwise have returned).
     fn find_cursor(&self, name: &str) -> Result<Option<Self::Cursor>, EvalError>;
 
     /// Whether any field has this key -- existence only, no particular

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -15962,9 +15962,14 @@ fn index_object_by_name<'a, W: Clone + AsRef<[u64]>>(
 ) -> QueryResult<'a, W> {
     match value {
         // #1995: a non-string sibling key (`fields.find`'s own `Err`) is a
-        // hard parse-time error in real jq, never suppressed by `optional`
-        // -- same precedence as every other malformed-JSON `Err` this file
-        // surfaces unconditionally.
+        // hard parse-time error in real jq, never suppressed by this
+        // function's own `optional` parameter -- same precedence as every
+        // other malformed-JSON `Err` this file surfaces unconditionally.
+        // Not the same guarantee as jq's postfix `?` (`Expr::Try`), a
+        // separate suppression mechanism one level up that currently *does*
+        // wrongly swallow this error class -- a distinct, pre-existing,
+        // separately-tracked gap (#2286), not something this arm's own
+        // unconditional `Err` propagation controls.
         StandardJson::Object(fields) => match find_field::<W>(fields, name) {
             Ok(Some(v)) => QueryResult::One(v),
             // jq returns null for missing fields on objects (not an error)

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -15944,7 +15944,7 @@ fn eval_owned_pipe<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
 fn find_field<'a, W: Clone + AsRef<[u64]>>(
     fields: JsonFields<'a, W>,
     name: &str,
-) -> Option<StandardJson<'a, W>> {
+) -> Result<Option<StandardJson<'a, W>>, EvalError> {
     fields.find(name)
 }
 
@@ -15961,10 +15961,15 @@ fn index_object_by_name<'a, W: Clone + AsRef<[u64]>>(
     optional: bool,
 ) -> QueryResult<'a, W> {
     match value {
+        // #1995: a non-string sibling key (`fields.find`'s own `Err`) is a
+        // hard parse-time error in real jq, never suppressed by `optional`
+        // -- same precedence as every other malformed-JSON `Err` this file
+        // surfaces unconditionally.
         StandardJson::Object(fields) => match find_field::<W>(fields, name) {
-            Some(v) => QueryResult::One(v),
+            Ok(Some(v)) => QueryResult::One(v),
             // jq returns null for missing fields on objects (not an error)
-            None => QueryResult::One(StandardJson::Null),
+            Ok(None) => QueryResult::One(StandardJson::Null),
+            Err(e) => QueryResult::Error(e),
         },
         // jq returns null for field access on null
         StandardJson::Null => QueryResult::One(StandardJson::Null),

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -4964,8 +4964,10 @@ fn eval_single<S: EvalSemantics, V: DocumentValue>(
                     Ok(Some(c)) => GenericResult::OneCursor(c),
                     // jq returns null for missing fields on objects (not an error)
                     Ok(None) => GenericResult::Owned(OwnedValue::Null),
-                    // #1677: the field this lookup resolved to has a
-                    // malformed `,`/`:` delimiter.
+                    // Either #1677 (the field this lookup resolved to has a
+                    // malformed `,`/`:` delimiter) or #1995 (some sibling's
+                    // key isn't string-shaped at all) -- see
+                    // `find_cursor`'s own doc comment.
                     Err(err) => GenericResult::Error(err),
                 }
             } else if value.is_null() {
@@ -7791,7 +7793,7 @@ fn index_one_generic<S: EvalSemantics, V: DocumentValue>(
                 match fields.find_cursor(s) {
                     Ok(Some(c)) => GenericResult::OneCursor(c),
                     Ok(None) => GenericResult::Owned(OwnedValue::Null),
-                    // #1677: same malformed-delimiter check as `Expr::Field`.
+                    // #1677/#1995: same checks as `Expr::Field`'s own arm.
                     Err(err) => GenericResult::Error(err),
                 }
             } else if target.is_null() {

--- a/src/json/light.rs
+++ b/src/json/light.rs
@@ -1096,27 +1096,37 @@ impl<'a, W: AsRef<[u64]>> JsonFields<'a, W> {
     /// comment) -- real jq rejects a non-string object key at parse time,
     /// unconditional on the document as a whole, so this checks every
     /// candidate as it's found rather than deferring to whichever one (if
-    /// any) would otherwise have won.
-    pub fn find(&self, name: &str) -> Result<Option<StandardJson<'a, W>>, EvalError> {
+    /// any) would otherwise have won. Uses the same `key_is_malformed`/
+    /// [`DocumentFields::malformed_member_error`] pair `#1194`'s own shared
+    /// walks already use for this exact question, rather than a second,
+    /// hand-rolled `match` on `StandardJson::String` -- one definition of
+    /// "malformed key", not two that could silently diverge (#106).
+    pub fn find(&self, name: &str) -> Result<Option<StandardJson<'a, W>>, EvalError>
+    where
+        W: Clone,
+    {
         let mut fields = *self;
         let mut result = None;
         while let Some((field, rest)) = fields.uncons() {
-            match field.key() {
-                StandardJson::String(key) => {
-                    // An undecodable key (invalid UTF-8, an invalid escape, an
-                    // invalid `\u` codepoint) is *skipped*, not treated as the
-                    // end of the search. This `?` used to return from `find`
-                    // itself, so a single such key hid every field after it from
-                    // lookup -- `.b` answered `null` on `{"\ud800":1,"b":2}` --
-                    // while `keys`/`length`, which don't decode, still reported
-                    // them (#1247). Surfacing the decode failure as a real
-                    // `EvalError` is tracked separately; this only stops one bad
-                    // key destroying valid results.
-                    if key.as_str().is_ok_and(|k| k == name) {
-                        result = Some(field.value());
-                    }
+            let key = field.key();
+            if key_is_malformed(&key) {
+                return Err(fields.malformed_member_error());
+            }
+            // An undecodable key (invalid UTF-8, an invalid escape, an
+            // invalid `\u` codepoint) is *skipped*, not treated as the
+            // end of the search. This `?` used to return from `find`
+            // itself, so a single such key hid every field after it from
+            // lookup -- `.b` answered `null` on `{"\ud800":1,"b":2}` --
+            // while `keys`/`length`, which don't decode, still reported
+            // them (#1247). Surfacing the decode failure as a real
+            // `EvalError` is tracked separately (see `key_is_malformed`'s
+            // own doc comment for why this case, unlike #1995's, is
+            // deliberately *not* what it answers `true` for); this only
+            // stops one bad key destroying valid results.
+            if let StandardJson::String(key) = key {
+                if key.as_str().is_ok_and(|k| k == name) {
+                    result = Some(field.value());
                 }
-                _ => return Err(EvalError::malformed_json_text(field.key_cursor().text())),
             }
             fields = rest;
         }
@@ -1139,22 +1149,29 @@ impl<'a, W: AsRef<[u64]>> JsonFields<'a, W> {
     /// check below, checked as each candidate is found (not deferred to
     /// the winner alone): the document is malformed the moment *any*
     /// member's key isn't a string, whether or not that member is the one
-    /// this lookup would otherwise have returned.
-    pub fn find_cursor(&self, name: &str) -> Result<Option<JsonCursor<'a, W>>, EvalError> {
+    /// this lookup would otherwise have returned. Same shared
+    /// `key_is_malformed`/[`DocumentFields::malformed_member_error`]
+    /// pair as [`find`](Self::find) uses for this, not a second copy of
+    /// the check (#106).
+    pub fn find_cursor(&self, name: &str) -> Result<Option<JsonCursor<'a, W>>, EvalError>
+    where
+        W: Clone,
+    {
         let mut fields = *self;
         // (key's own text start, value cursor, is this field the object's
         // first) for the winning candidate seen so far.
         let mut winner: Option<(usize, JsonCursor<'a, W>, bool)> = None;
         let mut index = 0usize;
         while let Some((field, rest)) = fields.uncons() {
-            match field.key() {
-                StandardJson::String(key) => {
-                    // Same undecodable-key skip as `find` above (#1247).
-                    if key.as_str().is_ok_and(|k| k == name) {
-                        winner = Some((key.start(), field.value_cursor(), index == 0));
-                    }
+            let key = field.key();
+            if key_is_malformed(&key) {
+                return Err(fields.malformed_member_error());
+            }
+            // Same undecodable-key skip as `find` above (#1247).
+            if let StandardJson::String(key) = key {
+                if key.as_str().is_ok_and(|k| k == name) {
+                    winner = Some((key.start(), field.value_cursor(), index == 0));
                 }
-                _ => return Err(EvalError::malformed_json_text(field.key_cursor().text())),
             }
             fields = rest;
             index += 1;
@@ -1928,8 +1945,8 @@ pub type BorrowedJsonCursor<'a> = JsonCursor<'a, &'a [u64]>;
 // ============================================================================
 
 use crate::jq::document::{
-    effective_fields_checked, DocumentCursor, DocumentElements, DocumentField, DocumentFields,
-    DocumentValue, IndentSpec, JsonConvention,
+    effective_fields_checked, key_is_malformed, DocumentCursor, DocumentElements, DocumentField,
+    DocumentFields, DocumentValue, IndentSpec, JsonConvention,
 };
 use crate::jq::escape::{write_json_body_jq, write_json_body_yq};
 use crate::jq::stream::{StreamFailure, StreamResult};
@@ -2595,19 +2612,8 @@ impl<'a, W: AsRef<[u64]> + Clone> DocumentFields for JsonFields<'a, W> {
         Some((field.key(), field.key_cursor(), rest))
     }
 
-    // #1995: `DocumentFields::find` (unlike its own `find_cursor` sibling,
-    // just below) has no `Result` in its trait signature to report a
-    // non-string sibling key through -- not something this one impl block
-    // can widen, since it's a trait-wide contract every format's own
-    // implementation shares. Not a live gap in practice: this trait
-    // method's only real (non-test, non-doctest) caller anywhere in the
-    // crate is `JsonFields::find` itself, one line below -- every actual
-    // production call site (`eval.rs`'s own `find_field`) reaches the
-    // *inherent* `JsonFields::find` (already `Result`-returning, per its
-    // own #1995 fix) directly, never through this trait dispatch, so
-    // folding an error into `None` here costs nothing observable today.
-    fn find(&self, name: &str) -> Option<Self::Value> {
-        JsonFields::find(self, name).ok().flatten()
+    fn find(&self, name: &str) -> Result<Option<Self::Value>, EvalError> {
+        JsonFields::find(self, name)
     }
 
     fn find_cursor(&self, name: &str) -> Result<Option<Self::Cursor>, EvalError> {

--- a/src/json/light.rs
+++ b/src/json/light.rs
@@ -4184,6 +4184,29 @@ mod tests {
         }
     }
 
+    /// #1995: `JsonFields::find` (not just its `find_cursor` sibling,
+    /// already covered end-to-end via the CLI's `.b` dispatch) raises on a
+    /// non-string sibling key too -- exercised directly here since `find`'s
+    /// only production caller (`eval.rs`'s own separate evaluator) isn't
+    /// reachable from the CLI test suite with raw document text.
+    #[test]
+    fn test_object_find_raises_on_non_string_sibling_key_1995() {
+        let json = br#"{"a":1,123:2}"#;
+        let index = JsonIndex::build(json);
+        let root = index.root(json);
+
+        let StandardJson::Object(fields) = root.value() else {
+            panic!("expected object");
+        };
+        let err = fields
+            .find("a")
+            .expect_err("non-string sibling key must raise");
+        assert!(
+            err.to_string().contains("expected string key"),
+            "unexpected error: {err}"
+        );
+    }
+
     #[test]
     fn test_array_single_element() {
         let json = br"[42]";

--- a/src/json/light.rs
+++ b/src/json/light.rs
@@ -31,7 +31,7 @@
 //! let root = index.root(json);
 //!
 //! if let StandardJson::Object(fields) = root.value() {
-//!     if let Some(name) = fields.find("name") {
+//!     if let Some(name) = fields.find("name").unwrap() {
 //!         if let StandardJson::String(s) = name {
 //!             assert_eq!(&*s.as_str().unwrap(), "Alice");
 //!         }
@@ -1090,27 +1090,37 @@ impl<'a, W: AsRef<[u64]>> JsonFields<'a, W> {
     /// `YamlFields::find` already applies for YAML's own last-duplicate-
     /// key-wins semantics (#174), just the opposite of YAML's genuine-
     /// duplicates preservation elsewhere (`to_entries`, #443).
-    pub fn find(&self, name: &str) -> Option<StandardJson<'a, W>> {
+    ///
+    /// `Err` when *any* sibling's key isn't string-shaped at all (#1995,
+    /// same reasoning as [`find_cursor`](Self::find_cursor)'s own doc
+    /// comment) -- real jq rejects a non-string object key at parse time,
+    /// unconditional on the document as a whole, so this checks every
+    /// candidate as it's found rather than deferring to whichever one (if
+    /// any) would otherwise have won.
+    pub fn find(&self, name: &str) -> Result<Option<StandardJson<'a, W>>, EvalError> {
         let mut fields = *self;
         let mut result = None;
         while let Some((field, rest)) = fields.uncons() {
-            if let StandardJson::String(key) = field.key() {
-                // An undecodable key (invalid UTF-8, an invalid escape, an
-                // invalid `\u` codepoint) is *skipped*, not treated as the
-                // end of the search. This `?` used to return from `find`
-                // itself, so a single such key hid every field after it from
-                // lookup -- `.b` answered `null` on `{"\ud800":1,"b":2}` --
-                // while `keys`/`length`, which don't decode, still reported
-                // them (#1247). Surfacing the decode failure as a real
-                // `EvalError` is tracked separately; this only stops one bad
-                // key destroying valid results.
-                if key.as_str().is_ok_and(|k| k == name) {
-                    result = Some(field.value());
+            match field.key() {
+                StandardJson::String(key) => {
+                    // An undecodable key (invalid UTF-8, an invalid escape, an
+                    // invalid `\u` codepoint) is *skipped*, not treated as the
+                    // end of the search. This `?` used to return from `find`
+                    // itself, so a single such key hid every field after it from
+                    // lookup -- `.b` answered `null` on `{"\ud800":1,"b":2}` --
+                    // while `keys`/`length`, which don't decode, still reported
+                    // them (#1247). Surfacing the decode failure as a real
+                    // `EvalError` is tracked separately; this only stops one bad
+                    // key destroying valid results.
+                    if key.as_str().is_ok_and(|k| k == name) {
+                        result = Some(field.value());
+                    }
                 }
+                _ => return Err(EvalError::malformed_json_text(field.key_cursor().text())),
             }
             fields = rest;
         }
-        result
+        Ok(result)
     }
 
     /// Find a field by name and return a cursor to its value.
@@ -1120,12 +1130,16 @@ impl<'a, W: AsRef<[u64]>> JsonFields<'a, W> {
     /// (needed for `line`/`column`) doesn't require re-navigating.
     ///
     /// `Err` when the *winning* occurrence's own `,`/`:` delimiters are
-    /// malformed (#1677) -- a targeted lookup like `.a` never walks every
-    /// sibling the way `.[]`/`length`/`keys` do, so it needs its own check.
-    /// Deferred to the end rather than checked as each candidate is found:
-    /// only the field that actually wins (the *last* matching occurrence)
-    /// should be validated, since an earlier same-named field's own gap is
-    /// moot once a later one supersedes it.
+    /// malformed (#1677), or when *any* sibling's key isn't even
+    /// string-shaped at all (#1995) -- a targeted lookup like `.a` never
+    /// walks every sibling the way `.[]`/`length`/`keys` do, so it needs
+    /// its own check for both. A non-string key (`{"a":1,123:2}`) is real
+    /// jq's own parse-time rejection ("Object keys must be strings"),
+    /// unconditional on the document as a whole -- unlike the `,`/`:` gap
+    /// check below, checked as each candidate is found (not deferred to
+    /// the winner alone): the document is malformed the moment *any*
+    /// member's key isn't a string, whether or not that member is the one
+    /// this lookup would otherwise have returned.
     pub fn find_cursor(&self, name: &str) -> Result<Option<JsonCursor<'a, W>>, EvalError> {
         let mut fields = *self;
         // (key's own text start, value cursor, is this field the object's
@@ -1133,11 +1147,14 @@ impl<'a, W: AsRef<[u64]>> JsonFields<'a, W> {
         let mut winner: Option<(usize, JsonCursor<'a, W>, bool)> = None;
         let mut index = 0usize;
         while let Some((field, rest)) = fields.uncons() {
-            if let StandardJson::String(key) = field.key() {
-                // Same undecodable-key skip as `find` above (#1247).
-                if key.as_str().is_ok_and(|k| k == name) {
-                    winner = Some((key.start(), field.value_cursor(), index == 0));
+            match field.key() {
+                StandardJson::String(key) => {
+                    // Same undecodable-key skip as `find` above (#1247).
+                    if key.as_str().is_ok_and(|k| k == name) {
+                        winner = Some((key.start(), field.value_cursor(), index == 0));
+                    }
                 }
+                _ => return Err(EvalError::malformed_json_text(field.key_cursor().text())),
             }
             fields = rest;
             index += 1;
@@ -1189,7 +1206,13 @@ impl<W> Clone for JsonField<'_, W> {
 impl<W> Copy for JsonField<'_, W> {}
 
 impl<'a, W: AsRef<[u64]>> JsonField<'a, W> {
-    /// Get the field key (always a string).
+    /// Get the field key.
+    ///
+    /// A well-formed JSON object's key is always a string, but this
+    /// method doesn't itself enforce that (#1995) -- a lazily-indexed
+    /// document can present a non-string key (`{"a":1,123:2}`), which
+    /// real jq rejects at parse time. Callers that need this distinction
+    /// (`find`/`find_cursor`, both in this file) check for it explicitly.
     #[inline]
     pub fn key(&self) -> StandardJson<'a, W> {
         self.key_cursor.value()
@@ -2572,8 +2595,19 @@ impl<'a, W: AsRef<[u64]> + Clone> DocumentFields for JsonFields<'a, W> {
         Some((field.key(), field.key_cursor(), rest))
     }
 
+    // #1995: `DocumentFields::find` (unlike its own `find_cursor` sibling,
+    // just below) has no `Result` in its trait signature to report a
+    // non-string sibling key through -- not something this one impl block
+    // can widen, since it's a trait-wide contract every format's own
+    // implementation shares. Not a live gap in practice: this trait
+    // method's only real (non-test, non-doctest) caller anywhere in the
+    // crate is `JsonFields::find` itself, one line below -- every actual
+    // production call site (`eval.rs`'s own `find_field`) reaches the
+    // *inherent* `JsonFields::find` (already `Result`-returning, per its
+    // own #1995 fix) directly, never through this trait dispatch, so
+    // folding an error into `None` here costs nothing observable today.
     fn find(&self, name: &str) -> Option<Self::Value> {
-        JsonFields::find(self, name)
+        JsonFields::find(self, name).ok().flatten()
     }
 
     fn find_cursor(&self, name: &str) -> Result<Option<Self::Cursor>, EvalError> {
@@ -4058,25 +4092,25 @@ mod tests {
         match root.value() {
             StandardJson::Object(fields) => {
                 // Find existing field
-                match fields.find("age") {
+                match fields.find("age").unwrap() {
                     Some(StandardJson::Number(n)) => assert_eq!(n.as_i64().unwrap(), 25),
                     _ => panic!("expected number"),
                 }
 
                 // Find first field
-                match fields.find("name") {
+                match fields.find("name").unwrap() {
                     Some(StandardJson::String(s)) => assert_eq!(s.as_str().unwrap(), "Charlie"),
                     _ => panic!("expected string"),
                 }
 
                 // Find last field
-                match fields.find("city") {
+                match fields.find("city").unwrap() {
                     Some(StandardJson::String(s)) => assert_eq!(s.as_str().unwrap(), "NYC"),
                     _ => panic!("expected string"),
                 }
 
                 // Non-existent field
-                assert!(fields.find("missing").is_none());
+                assert!(fields.find("missing").unwrap().is_none());
             }
             _ => panic!("expected object"),
         }
@@ -4094,7 +4128,7 @@ mod tests {
 
         match root.value() {
             StandardJson::Object(fields) => {
-                match fields.find("a") {
+                match fields.find("a").unwrap() {
                     Some(StandardJson::Number(n)) => assert_eq!(n.as_i64().unwrap(), 3),
                     other => panic!("expected number 3, got {other:?}"),
                 }
@@ -4129,7 +4163,7 @@ mod tests {
             let StandardJson::Object(fields) = root.value() else {
                 panic!("expected object");
             };
-            match fields.find("b") {
+            match fields.find("b").unwrap() {
                 Some(StandardJson::Number(n)) => assert_eq!(n.as_i64().unwrap(), 2),
                 other => panic!("expected number 2, got {other:?}"),
             }
@@ -4230,13 +4264,15 @@ mod tests {
         let root = index.root(json);
 
         match root.value() {
-            StandardJson::Object(fields) => match fields.find("person") {
-                Some(StandardJson::Object(inner_fields)) => match inner_fields.find("name") {
-                    Some(StandardJson::String(s)) => {
-                        assert_eq!(s.as_str().unwrap(), "Dave");
+            StandardJson::Object(fields) => match fields.find("person").unwrap() {
+                Some(StandardJson::Object(inner_fields)) => {
+                    match inner_fields.find("name").unwrap() {
+                        Some(StandardJson::String(s)) => {
+                            assert_eq!(s.as_str().unwrap(), "Dave");
+                        }
+                        _ => panic!("expected string"),
                     }
-                    _ => panic!("expected string"),
-                },
+                }
                 _ => panic!("expected nested object"),
             },
             _ => panic!("expected object"),
@@ -4253,7 +4289,7 @@ mod tests {
             StandardJson::Array(elements) => {
                 // First object
                 match elements.get(0) {
-                    Some(StandardJson::Object(fields)) => match fields.find("a") {
+                    Some(StandardJson::Object(fields)) => match fields.find("a").unwrap() {
                         Some(StandardJson::Number(n)) => assert_eq!(n.as_i64().unwrap(), 1),
                         _ => panic!("expected number"),
                     },
@@ -4262,7 +4298,7 @@ mod tests {
 
                 // Second object
                 match elements.get(1) {
-                    Some(StandardJson::Object(fields)) => match fields.find("b") {
+                    Some(StandardJson::Object(fields)) => match fields.find("b").unwrap() {
                         Some(StandardJson::Number(n)) => assert_eq!(n.as_i64().unwrap(), 2),
                         _ => panic!("expected number"),
                     },

--- a/src/yaml/light.rs
+++ b/src/yaml/light.rs
@@ -6697,8 +6697,12 @@ impl<'a, W: AsRef<[u64]> + Clone> DocumentFields for YamlFields<'a, W> {
         Some((field.key(), field.key_cursor(), rest))
     }
 
-    fn find(&self, name: &str) -> Option<Self::Value> {
-        YamlFields::find(self, name)
+    // #1995: `Ok` unconditionally -- YAML's grammar has no equivalent
+    // "keys must be strings" rule to enforce (unlike JSON's own
+    // `DocumentFields::find` impl, `src/json/light.rs`), so there is
+    // nothing for this format's own `find` to ever raise.
+    fn find(&self, name: &str) -> Result<Option<Self::Value>, EvalError> {
+        Ok(YamlFields::find(self, name))
     }
 
     fn find_cursor(&self, name: &str) -> Result<Option<Self::Cursor>, EvalError> {

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -21678,6 +21678,14 @@ fn test_jq_malformed_object_non_string_key_raises_everywhere_1194() -> Result<()
         &["-c", "-S", "."][..], // --sort-keys: ditto
         &["-c", "-a", "."][..], // --ascii-output: ditto
         &["-c", "., ."][..],    // loses its cursor to `Many`
+        // #1995: `.b`, the targeted field-lookup fast path
+        // (`JsonFields::find_cursor`) -- the one route this list left
+        // uncovered when this test was first written. Confirmed live
+        // against jq 1.7.1 that this exact gap existed: `succinctly jq -c
+        // '.b'` on this input silently answered `2` instead of raising,
+        // even though every filter above already raised on the same
+        // document.
+        &["-c", ".b"][..],
     ] {
         let (out, stderr, code) = run_jq_full(args, Some(input))?;
         assert_eq!(code, 5, "{args:?}: out: {out:?}, stderr: {stderr:?}");
@@ -21691,6 +21699,28 @@ fn test_jq_malformed_object_non_string_key_raises_everywhere_1194() -> Result<()
             stderr.contains("expected string key"),
             "{args:?}: stderr: {stderr:?}"
         );
+    }
+
+    Ok(())
+}
+
+/// #1995 review: a known, pre-existing, and *separate* gap this fix does
+/// not close -- `?` wrongly suppresses a malformed-JSON error that real jq
+/// raises unconditionally (a parse error precedes every filter, `?`
+/// included). Confirmed this predates #1995 entirely and isn't specific to
+/// a non-string key: `{"a" 1}` (#1677's own missing-`:` shape) is
+/// suppressed by `.a?` here identically, and real jq rejects both
+/// unconditionally (`jq -c '.a?'` on either input is still a parse error,
+/// exit 5). Pinned here rather than left untested per this project's own
+/// convention -- see #2286's own filed follow-up for the fix.
+#[test]
+fn test_optional_wrongly_suppresses_malformed_json_error_known_gap_1995() -> Result<()> {
+    for input in [r#"{"a":1,123:2}"#, r#"{"a" 1}"#] {
+        let (out, stderr, code) = run_jq_full(&["-c", ".a?"], Some(input))?;
+        // jq 1.7.1 raises unconditionally (exit 5) for both; this is the
+        // known gap -- `?` currently swallows it (exit 0, no output).
+        assert_eq!(code, 0, "input {input:?}: out: {out:?}, stderr: {stderr:?}");
+        assert!(out.trim().is_empty(), "input {input:?}: out: {out:?}");
     }
 
     Ok(())


### PR DESCRIPTION
## Summary

`JsonFields::find`/`find_cursor`'s search loop only ever matched a field
whose key was already `StandardJson::String` — a key of any other type
(number, bool, null, array, object) was silently skipped past rather than
treated as malformed, so a targeted lookup like `.a` walked right by a
document real jq rejects at parse time.

```console
$ echo '{"a":1,123:2}' | jq -c '.a'
jq: parse error: Object keys must be strings at line 1, column 11

$ echo '{"a":1,123:2}' | succinctly jq -c '.a'   # before this fix
1
```

Fixes #1995.

## Fix

Both `find` and `find_cursor` now raise `EvalError::malformed_json_text`
as soon as they walk past *any* non-string key, not just the ones
matching the target name — the whole document is malformed the moment any
member's key isn't a string, whether or not that member is the one the
lookup would otherwise have returned (confirmed against jq 1.7.1: a
non-string key *after* the target field still raises).

`find`'s own signature widens to `Result` to carry this; its one
production caller (`eval.rs`'s `find_field`/`index_object_by_name`)
propagates the error. The `DocumentFields` trait's own `find` (no
`Result` in its contract, and with no real caller anywhere in the crate
besides this exact delegation — confirmed via a full-crate grep) folds
the new `Err` into `None`, preserving its existing contract at zero cost
to any actual caller.

Also extends the existing `test_jq_malformed_object_non_string_key_raises_everywhere_1194`
test to cover the fast path (`.b`) — the one route its own coverage list
had missed, which is exactly how #1995 stayed uncaught.

## Found along the way, filed separately (#2286)

While verifying, found that `?` currently suppresses this same class of
malformed-JSON error unconditionally — confirmed both pre-existing (the
identical gap exists for #1677's own missing-`:` shape too, unrelated to
this PR) and wrong (real jq's equivalent is a parse error, which `?`
cannot suppress since parsing precedes every filter). Out of scope here
(affects a broader set of malformed-JSON call sites, not just this fix's
own `find`/`find_cursor`), pinned as a known gap in this PR's own test
suite, and filed as #2286 with a suggested fix direction.

## Test plan

- [x] `cargo build --features cli`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --all-features --no-deps`
- [x] `cargo test --features cli --test jq_cli_tests` (1352 passed)
- [x] `cargo test --features cli --lib` (3368 passed, incl. all `json::light` unit tests and the module doctest, both updated for `find`'s new signature)
- [x] Full CLI integration suite (yq_cli_tests, yq_golden_tests, yq_path_consistency_tests, jq_golden_tests, yaml_bench_suite_coverage, dsv_cli_tests, text_cli_tests, json_validate_tests, yaml_validate_tests, cli_golden_tests, cli_characterization_tests, deep_nesting_valid_tests, jq_computed_key_tests) — all passed
- [x] `cargo test --verbose` (default), `--features simd`, `--features portable-popcount`, `--no-default-features` (no_std)
- [x] Live-verified against `/usr/bin/jq` 1.7.1: original repro, non-string key before/after the target field, missing field with a non-string sibling present, bool/null/array-typed keys, nested objects, duplicate valid keys (unaffected), and the already-correct wildcard-bridge path (`.a? // "outer"`, now agreeing with the fast path)