### PR TITLE
fix(jq): eval_stage_with_path_context's Expr::Try arm lets uncatchable errors survive

### DIFF
--- a/docs/compliance/yq/limitations.md
+++ b/docs/compliance/yq/limitations.md
@@ -1695,12 +1695,17 @@ resolver) was itself too broad for this specific function: `is_uncatchable()` al
 `is_invalid_path_expression()`, correct for `resolve_node` but not for
 `eval_stage_with_path_context`, which runs whenever *any* sibling in the same pipe needs path
 context, not only when the branch actually being evaluated is itself a path expression --
-confirmed live that `.a | (try path(1) catch "x"), key` wrongly let the error escape uncaught
-purely because of the unrelated `key` sibling, where real jq (and `try path(1) catch "x"`
-alone, without that sibling) always catches it. Fixed with a narrower, function-local
-predicate (`path_context_stage_uncatchable`, `src/jq/eval.rs`) matching the same
-`is_decode_failure() || is_yq_negative_index_error()` exclusion `eval_try`/`each_try`/
-`try_single_generic`/`each_try_generic` already apply at pure value position.
+confirmed that `.a | (try path(1) catch "x"), key` wrongly let the error escape uncaught
+purely because of the unrelated `key` sibling. `key` is a succinctly-only path-context
+extension real jq's own lexer rejects outright, so only the isolated `try path(1) catch "x"`
+half of that claim has a real-jq oracle to check against -- confirmed live it always catches
+there; the combined query is an internal-consistency claim against succinctly's own build
+instead (the unrelated `key` sibling must not change what `try path(1) catch "x"` alone
+already does). Fixed with `EvalError::is_uncatchable_at_value_position` (`src/jq/error.rs`),
+a narrower sibling of `is_uncatchable()` that excludes `is_invalid_path_expression()` --
+consolidating what `eval_try`/`each_try`/`try_single_generic`/`each_try_generic` (`eval.rs`/
+`eval_generic.rs`) already hand-copied inline at six sites onto one shared definition,
+matching this function's own two new call sites too.
 
 ### Other categories
 

--- a/docs/compliance/yq/limitations.md
+++ b/docs/compliance/yq/limitations.md
@@ -1686,11 +1686,21 @@ handling, and `getpath`'s own path-array walk (jq-only syntax, so this only matt
 `--jq-extensions`) -- filed as [#2264](https://github.com/rust-works/succinctly/issues/2264).
 `del()`/`delpaths()` silently no-op on this shape instead of raising at all (more severe than
 a suppression gap -- a missing error, not a differently-worded one) -- filed separately as
-[#2268](https://github.com/rust-works/succinctly/issues/2268). And
-`eval_stage_with_path_context`'s own `Expr::Try`/`Expr::Optional` arms (`--eval-all` combined
-with a path-context-triggering builtin like `file_index`) have no uncatchable-error guard at
-all, for any error class, not just this one -- filed as
-[#2270](https://github.com/rust-works/succinctly/issues/2270).
+[#2268](https://github.com/rust-works/succinctly/issues/2268). `eval_stage_with_path_context`'s
+own `Expr::Optional`/`Expr::Try` arms (`--eval-all` combined with a path-context-triggering
+builtin like `file_index`) had no uncatchable-error guard at all -- filed and fixed as
+[#2270](https://github.com/rust-works/succinctly/issues/2270), whose own review found the
+first attempt (`EvalError::is_uncatchable()`, matching `resolve_node`'s own path-tracking
+resolver) was itself too broad for this specific function: `is_uncatchable()` also covers
+`is_invalid_path_expression()`, correct for `resolve_node` but not for
+`eval_stage_with_path_context`, which runs whenever *any* sibling in the same pipe needs path
+context, not only when the branch actually being evaluated is itself a path expression --
+confirmed live that `.a | (try path(1) catch "x"), key` wrongly let the error escape uncaught
+purely because of the unrelated `key` sibling, where real jq (and `try path(1) catch "x"`
+alone, without that sibling) always catches it. Fixed with a narrower, function-local
+predicate (`path_context_stage_uncatchable`, `src/jq/eval.rs`) matching the same
+`is_decode_failure() || is_yq_negative_index_error()` exclusion `eval_try`/`each_try`/
+`try_single_generic`/`each_try_generic` already apply at pure value position.
 
 ### Other categories
 

--- a/src/jq/error.rs
+++ b/src/jq/error.rs
@@ -1261,18 +1261,43 @@ impl EvalError {
     /// check next.
     ///
     /// The value-position dispatch points (`eval_try`/`each_try`/
-    /// `try_single_generic`/`each_try_generic`) deliberately do *not* switch
-    /// to this predicate: they need `is_decode_failure() ||
-    /// is_yq_negative_index_error()` specifically, without
-    /// `is_invalid_path_expression()`, which is meaningful only in path
-    /// context (`path()`/`getpath`) and was never verified against value
-    /// position -- widening those four to this broader predicate as a side
-    /// effect of #2254 would be an untested behavior change, not this fix's
-    /// job.
+    /// `try_single_generic`/`each_try_generic`), and `eval_stage_with_path_context`'s
+    /// own `Expr::Optional`/`Expr::Try` arms (#2270/#2289), deliberately do
+    /// *not* switch to this predicate -- see
+    /// [`Self::is_uncatchable_at_value_position`], which they all call
+    /// instead, for why `is_invalid_path_expression()` doesn't belong there.
     pub fn is_uncatchable(&self) -> bool {
         self.is_invalid_path_expression()
             || self.is_decode_failure()
             || self.is_yq_negative_index_error()
+    }
+
+    /// [`Self::is_uncatchable`], narrowed to the subset that also applies at
+    /// *value* position -- a decode failure or a yq negative-index raise,
+    /// but not [`Self::is_invalid_path_expression`]. That third condition is
+    /// meaningful only in path context (`path()`/`getpath`'s own walker,
+    /// `resolve_node`) and was never verified against value position, so
+    /// widening a value-position dispatch point to the full
+    /// `is_uncatchable()` would be an untested behavior change (#2254).
+    /// Confirmed live against jq 1.7.1 that widening it is a *real* bug, not
+    /// just an untested one: `eval_stage_with_path_context`'s `Expr::Try`/
+    /// `Expr::Optional` arms briefly used the broader `is_uncatchable()`
+    /// (matching `resolve_node`'s own path-tracking-position precedent) and
+    /// it wrongly made an ordinary `path(1)` call uncatchable merely because
+    /// an unrelated sibling (`key`/`file_index`) elsewhere in the same pipe
+    /// forced this function's own dispatch to run at all --
+    /// `eval_stage_with_path_context` is itself a value-position dispatcher
+    /// for any branch that isn't actually a path expression, even though it
+    /// happens to run inside path-context plumbing (#2270 review, #2289).
+    ///
+    /// Shared by six call sites across two files, kept in agreement here
+    /// rather than each hand-copying `is_decode_failure() ||
+    /// is_yq_negative_index_error()`: `eval_try`/`each_try` (`eval.rs`),
+    /// `try_single_generic`/`each_try_generic` (`eval_generic.rs`), and
+    /// `eval_stage_with_path_context`'s own `Expr::Optional`/`Expr::Try`
+    /// arms (`eval.rs`).
+    pub fn is_uncatchable_at_value_position(&self) -> bool {
+        self.is_decode_failure() || self.is_yq_negative_index_error()
     }
 
     /// `Cannot check whether <container> has a <key type> key`.

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -3816,9 +3816,7 @@ fn each_try<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
         // identical arm too -- reached from e.g. `any(.a[-5]?; .)`, whose
         // generator argument runs through this function via `eval_each`'s
         // own `Expr::Optional` dispatch.
-        Flow::Escaped(Control::Error(e))
-            if e.is_decode_failure() || e.is_yq_negative_index_error() =>
-        {
+        Flow::Escaped(Control::Error(e)) if e.is_uncatchable_at_value_position() => {
             Flow::Escaped(Control::Error(e))
         }
         Flow::Escaped(Control::Error(e)) => match catch {
@@ -6420,9 +6418,7 @@ fn eval_try<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
         // there too keeps one consistent "never caught" rule rather than
         // one that depends on whether a catch handler happens to be
         // present.
-        QueryResult::Error(e) if e.is_decode_failure() || e.is_yq_negative_index_error() => {
-            QueryResult::Error(e)
-        }
+        QueryResult::Error(e) if e.is_uncatchable_at_value_position() => QueryResult::Error(e),
         // If error, use catch handler or return nothing. jq runs the handler
         // with the *raised value* as its input, not the original input, so
         // `try error("boom") catch .` yields "boom".
@@ -6442,9 +6438,7 @@ fn eval_try<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
         // Same #1620 decode-failure exclusion as the bare `Error` arm above
         // -- a `Partial` ending in a decode failure must still propagate
         // uncaught, not run the catch handler.
-        QueryResult::Partial(prefix, Control::Error(e))
-            if e.is_decode_failure() || e.is_yq_negative_index_error() =>
-        {
+        QueryResult::Partial(prefix, Control::Error(e)) if e.is_uncatchable_at_value_position() => {
             QueryResult::Partial(prefix, Control::Error(e))
         }
         // The body produced some outputs before erroring (#400): emit them
@@ -32117,30 +32111,6 @@ fn eval_pipe_with_path_context_internal<'a, W: Clone + AsRef<[u64]>, S: EvalSema
     )
 }
 
-/// Which errors survive `eval_stage_with_path_context`'s own
-/// `Expr::Optional`/`Expr::Try` dispatch unconditionally -- deliberately
-/// narrower than [`EvalError::is_uncatchable`], which also includes
-/// `is_invalid_path_expression()`. That inclusion is correct for
-/// `resolve_node`'s own path-tracking resolver (`path()`/`getpath`'s own
-/// walker), but wrong here: `eval_stage_with_path_context` runs whenever
-/// *any* sibling elsewhere in the same pipe needs path context
-/// (`key`/`parent`/`file_index`/`path`), not only when the branch actually
-/// being dispatched is itself a path expression -- so an ordinary
-/// `path(1)` call reached through here (because an unrelated `key` sits
-/// elsewhere in the pipe) must stay catchable the same way it is at
-/// top-level/value position. Confirmed live against jq 1.7.1: `.a | (try
-/// path(1) catch "x"), key` gives `"x"` then `null` in real jq;
-/// `is_uncatchable()`'s own broader check made this arm's `try`/`catch`
-/// wrongly escape uncaught instead (found by code review on #2289, after
-/// #2227 had already introduced the same over-broadening one arm up, in
-/// `Expr::Optional`). Matches the same exclusion
-/// `eval_try`/`each_try`/`try_single_generic`/`each_try_generic` already
-/// apply at pure value position -- see [`EvalError::is_uncatchable`]'s own
-/// doc comment for why those four stay narrower too.
-fn path_context_stage_uncatchable(e: &EvalError) -> bool {
-    e.is_decode_failure() || e.is_yq_negative_index_error()
-}
-
 /// One pipe stage, plus the stages that follow it, threaded by borrow.
 ///
 /// Split out of `eval_pipe_with_path_context_internal` (#1510) so the arms
@@ -32783,25 +32753,34 @@ fn eval_stage_with_path_context<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
             let caught = match inner_result {
                 // #2254/#2289 review: an uncatchable error (a yq
                 // negative-index raise or a decode failure --
-                // `path_context_stage_uncatchable`'s own doc comment has
-                // the full rationale for why this is narrower than
-                // `is_uncatchable()`) must survive this bare `?` the same
-                // way `resolve_node`'s own `Expr::Optional` arm already
+                // `EvalError::is_uncatchable_at_value_position`'s own doc
+                // comment has the full rationale for why this is narrower
+                // than `is_uncatchable()`) must survive this bare `?` the
+                // same way `resolve_node`'s own `Expr::Optional` arm already
                 // guarantees for path-tracking evaluation -- confirmed live
                 // that `.a[-5]? | key` wrongly swallowed the error and
-                // exited 0 with no output before this guard existed. The
-                // uncatchable case falls through to `other => other` below,
-                // unchanged. `Break` has no error payload to check and
-                // stays unconditionally caught here, matching
-                // `eval_try`/`each_try`'s own bare-`?` semantics (#562).
-                QueryResult::Error(e) if !path_context_stage_uncatchable(&e) => QueryResult::None,
-                QueryResult::Break(_) => QueryResult::None,
+                // exited 0 with no output before this guard existed.
+                // Structured to mirror `eval_try`'s own identical arm
+                // (`is_decode_failure()`-only there, #1620) rather than
+                // `resolve_node`'s negated-guard-plus-catch-all shape: this
+                // arm and `Expr::Try`'s below share the same `QueryResult`
+                // representation `eval_try` does, `resolve_node`'s own
+                // `Result<_, (prefix, EvalEscape)>` doesn't. `Break` has no
+                // error payload to check and stays unconditionally caught
+                // here, matching `eval_try`/`each_try`'s own bare-`?`
+                // semantics (#562).
+                QueryResult::Error(e) if e.is_uncatchable_at_value_position() => {
+                    QueryResult::Error(e)
+                }
+                QueryResult::Error(_) | QueryResult::Break(_) => QueryResult::None,
                 QueryResult::Partial(prefix, Control::Error(e))
-                    if !path_context_stage_uncatchable(&e) =>
+                    if e.is_uncatchable_at_value_position() =>
                 {
+                    QueryResult::Partial(prefix, Control::Error(e))
+                }
+                QueryResult::Partial(prefix, Control::Error(_) | Control::Break(_)) => {
                     owned_vec_to_result(prefix)
                 }
-                QueryResult::Partial(prefix, Control::Break(_)) => owned_vec_to_result(prefix),
                 other => other,
             };
             if rest.is_empty() {
@@ -34256,9 +34235,11 @@ fn eval_stage_with_path_context<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
             // Each output continues `rest` from its own path, not this
             // arm's ambient one -- see `path_probe_stage` (#1409).
             let paired = !rest.is_empty() && rest.iter().any(needs_path_context);
-            // One probe for the whole arm, shared by the body and by
-            // whichever catch handler runs -- the closure this replaces
-            // deep-cloned its argument on each of up to five calls (#1510).
+            // Probe for the try body only -- each catch-handler call below
+            // builds its own single-expression slice from `catch_expr`
+            // directly instead, so this isn't shared the way an earlier
+            // version of this comment claimed (review, #2289). Avoids
+            // deep-cloning the body on each of up to five calls (#1510).
             let probe = probe_stages(paired);
             // Evaluate the try body (and catch handler) through the
             // path-context evaluator too, so `try select(file_index == 1)
@@ -34288,33 +34269,35 @@ fn eval_stage_with_path_context<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
             let try_result = match result {
                 // #2270/#2289 review: an uncatchable error (a decode
                 // failure or a yq negative-index raise --
-                // `path_context_stage_uncatchable`'s own doc comment has
-                // the full rationale for why this is narrower than
-                // `is_uncatchable()`) must survive `try`/`catch` here the
-                // same way `resolve_node`'s own `Expr::Try` arm already
-                // guarantees for path-tracking evaluation, and the same
-                // way this function's own `Expr::Optional` arm does
-                // (#2227) -- confirmed live that
-                // `(try .[0].a[-5] catch "c"), file_index` under
-                // `--eval-all` wrongly ran the catch handler before this
-                // guard existed. The uncatchable case falls through to
-                // `other => other` below, unchanged.
-                QueryResult::Error(e) if !path_context_stage_uncatchable(&e) => {
-                    match catch.as_deref() {
-                        Some(catch_expr) => pair_outputs_with_path::<W>(
-                            eval_pipe_with_path_context_internal::<W, S>(
-                                core::slice::from_ref(catch_expr),
-                                &e.payload(),
-                                root,
-                                file_origin,
-                                current_path,
-                                optional,
-                            ),
-                            paired.then_some(current_path),
-                        ),
-                        None => QueryResult::None,
-                    }
+                // `EvalError::is_uncatchable_at_value_position`'s own doc
+                // comment has the full rationale for why this is narrower
+                // than `is_uncatchable()`) must survive `try`/`catch` here
+                // the same way `resolve_node`'s own `Expr::Try` arm already
+                // guarantees for path-tracking evaluation, and the same way
+                // this function's own `Expr::Optional` arm does (#2227) --
+                // confirmed live that `(try .[0].a[-5] catch "c"),
+                // file_index` under `--eval-all` wrongly ran the catch
+                // handler before this guard existed. Structured to mirror
+                // `eval_try`'s own identical arm (positive guard, explicit
+                // early return) rather than a negated-guard-plus-catch-all
+                // shape, matching `Expr::Optional`'s own arm just above.
+                QueryResult::Error(e) if e.is_uncatchable_at_value_position() => {
+                    QueryResult::Error(e)
                 }
+                QueryResult::Error(e) => match catch.as_deref() {
+                    Some(catch_expr) => pair_outputs_with_path::<W>(
+                        eval_pipe_with_path_context_internal::<W, S>(
+                            core::slice::from_ref(catch_expr),
+                            &e.payload(),
+                            root,
+                            file_origin,
+                            current_path,
+                            optional,
+                        ),
+                        paired.then_some(current_path),
+                    ),
+                    None => QueryResult::None,
+                },
                 QueryResult::Break(_) => match catch.as_deref() {
                     Some(catch_expr) => pair_outputs_with_path::<W>(
                         eval_pipe_with_path_context_internal::<W, S>(
@@ -34330,8 +34313,11 @@ fn eval_stage_with_path_context<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
                     None => QueryResult::None,
                 },
                 QueryResult::Partial(prefix, Control::Error(e))
-                    if !path_context_stage_uncatchable(&e) =>
+                    if e.is_uncatchable_at_value_position() =>
                 {
+                    QueryResult::Partial(prefix, Control::Error(e))
+                }
+                QueryResult::Partial(prefix, Control::Error(e)) => {
                     let handled = match catch.as_deref() {
                         Some(catch_expr) => pair_outputs_with_path::<W>(
                             eval_pipe_with_path_context_internal::<W, S>(

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -34250,6 +34250,17 @@ fn eval_stage_with_path_context<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
                 optional,
             );
             let try_result = match result {
+                // #2270: an uncatchable error (a decode failure, an
+                // invalid-path-expression complaint, or a yq
+                // negative-index raise) must survive `try`/`catch` here
+                // the same way `resolve_node`'s own `Expr::Try` arm
+                // already guarantees for path-tracking evaluation, and
+                // the same way this function's own `Expr::Optional` arm
+                // now does (#2227) -- confirmed live that
+                // `(try .[0].a[-5] catch "c"), file_index` under
+                // `--eval-all` wrongly ran the catch handler before this
+                // guard existed.
+                QueryResult::Error(e) if e.is_uncatchable() => QueryResult::Error(e),
                 QueryResult::Error(e) => match catch.as_deref() {
                     Some(catch_expr) => pair_outputs_with_path::<W>(
                         eval_pipe_with_path_context_internal::<W, S>(
@@ -34278,6 +34289,9 @@ fn eval_stage_with_path_context<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
                     ),
                     None => QueryResult::None,
                 },
+                QueryResult::Partial(prefix, Control::Error(e)) if e.is_uncatchable() => {
+                    QueryResult::Partial(prefix, Control::Error(e))
+                }
                 QueryResult::Partial(prefix, Control::Error(e)) => {
                     let handled = match catch.as_deref() {
                         Some(catch_expr) => pair_outputs_with_path::<W>(

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -32117,6 +32117,30 @@ fn eval_pipe_with_path_context_internal<'a, W: Clone + AsRef<[u64]>, S: EvalSema
     )
 }
 
+/// Which errors survive `eval_stage_with_path_context`'s own
+/// `Expr::Optional`/`Expr::Try` dispatch unconditionally -- deliberately
+/// narrower than [`EvalError::is_uncatchable`], which also includes
+/// `is_invalid_path_expression()`. That inclusion is correct for
+/// `resolve_node`'s own path-tracking resolver (`path()`/`getpath`'s own
+/// walker), but wrong here: `eval_stage_with_path_context` runs whenever
+/// *any* sibling elsewhere in the same pipe needs path context
+/// (`key`/`parent`/`file_index`/`path`), not only when the branch actually
+/// being dispatched is itself a path expression -- so an ordinary
+/// `path(1)` call reached through here (because an unrelated `key` sits
+/// elsewhere in the pipe) must stay catchable the same way it is at
+/// top-level/value position. Confirmed live against jq 1.7.1: `.a | (try
+/// path(1) catch "x"), key` gives `"x"` then `null` in real jq;
+/// `is_uncatchable()`'s own broader check made this arm's `try`/`catch`
+/// wrongly escape uncaught instead (found by code review on #2289, after
+/// #2227 had already introduced the same over-broadening one arm up, in
+/// `Expr::Optional`). Matches the same exclusion
+/// `eval_try`/`each_try`/`try_single_generic`/`each_try_generic` already
+/// apply at pure value position -- see [`EvalError::is_uncatchable`]'s own
+/// doc comment for why those four stay narrower too.
+fn path_context_stage_uncatchable(e: &EvalError) -> bool {
+    e.is_decode_failure() || e.is_yq_negative_index_error()
+}
+
 /// One pipe stage, plus the stages that follow it, threaded by borrow.
 ///
 /// Split out of `eval_pipe_with_path_context_internal` (#1510) so the arms
@@ -32757,24 +32781,27 @@ fn eval_stage_with_path_context<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
                 false,
             );
             let caught = match inner_result {
-                // #2254 review: an uncatchable error (a yq negative-index
-                // raise, a decode failure, an invalid-path-expression
-                // complaint) must survive this bare `?` the same way
-                // `resolve_node`'s own `Expr::Optional` arm already
+                // #2254/#2289 review: an uncatchable error (a yq
+                // negative-index raise or a decode failure --
+                // `path_context_stage_uncatchable`'s own doc comment has
+                // the full rationale for why this is narrower than
+                // `is_uncatchable()`) must survive this bare `?` the same
+                // way `resolve_node`'s own `Expr::Optional` arm already
                 // guarantees for path-tracking evaluation -- confirmed live
                 // that `.a[-5]? | key` wrongly swallowed the error and
-                // exited 0 with no output before this guard existed. `Break`
-                // has no error payload to check and stays unconditionally
-                // caught here, matching `eval_try`/`each_try`'s own bare-`?`
-                // semantics (#562).
-                QueryResult::Error(e) if e.is_uncatchable() => QueryResult::Error(e),
-                QueryResult::Error(_) | QueryResult::Break(_) => QueryResult::None,
-                QueryResult::Partial(prefix, Control::Error(e)) if e.is_uncatchable() => {
-                    QueryResult::Partial(prefix, Control::Error(e))
-                }
-                QueryResult::Partial(prefix, Control::Error(_) | Control::Break(_)) => {
+                // exited 0 with no output before this guard existed. The
+                // uncatchable case falls through to `other => other` below,
+                // unchanged. `Break` has no error payload to check and
+                // stays unconditionally caught here, matching
+                // `eval_try`/`each_try`'s own bare-`?` semantics (#562).
+                QueryResult::Error(e) if !path_context_stage_uncatchable(&e) => QueryResult::None,
+                QueryResult::Break(_) => QueryResult::None,
+                QueryResult::Partial(prefix, Control::Error(e))
+                    if !path_context_stage_uncatchable(&e) =>
+                {
                     owned_vec_to_result(prefix)
                 }
+                QueryResult::Partial(prefix, Control::Break(_)) => owned_vec_to_result(prefix),
                 other => other,
             };
             if rest.is_empty() {
@@ -34239,7 +34266,16 @@ fn eval_stage_with_path_context<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
             // correctly instead of falling back to the stub (#715
             // follow-up). Mirrors `eval_try`'s Error/Break/Partial handling
             // above, just routed through path context instead of
-            // `eval_single`.
+            // `eval_single`. `optional` forced to `false`, not
+            // ambient-forwarded -- same defense the sibling `Expr::Optional`
+            // arm's own recursive call already applies (#1302's technique):
+            // a leaf deep inside `try_expr`'s own subtree must not
+            // self-swallow its own error before this arm's own catch/guard
+            // below ever gets to see it. Currently inert either way --
+            // `optional` is proven always `false` at this function's own
+            // entry (see this function's own doc comment) -- but unlike
+            // `Expr::Optional`, this arm had no local defense against a
+            // future change reintroducing a `true`-producer (review, #2289).
             let result = eval_stage_with_path_context::<W, S>(
                 try_expr,
                 &probe,
@@ -34247,34 +34283,38 @@ fn eval_stage_with_path_context<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
                 root,
                 file_origin,
                 current_path,
-                optional,
+                false,
             );
             let try_result = match result {
-                // #2270: an uncatchable error (a decode failure, an
-                // invalid-path-expression complaint, or a yq
-                // negative-index raise) must survive `try`/`catch` here
-                // the same way `resolve_node`'s own `Expr::Try` arm
-                // already guarantees for path-tracking evaluation, and
-                // the same way this function's own `Expr::Optional` arm
-                // now does (#2227) -- confirmed live that
+                // #2270/#2289 review: an uncatchable error (a decode
+                // failure or a yq negative-index raise --
+                // `path_context_stage_uncatchable`'s own doc comment has
+                // the full rationale for why this is narrower than
+                // `is_uncatchable()`) must survive `try`/`catch` here the
+                // same way `resolve_node`'s own `Expr::Try` arm already
+                // guarantees for path-tracking evaluation, and the same
+                // way this function's own `Expr::Optional` arm does
+                // (#2227) -- confirmed live that
                 // `(try .[0].a[-5] catch "c"), file_index` under
                 // `--eval-all` wrongly ran the catch handler before this
-                // guard existed.
-                QueryResult::Error(e) if e.is_uncatchable() => QueryResult::Error(e),
-                QueryResult::Error(e) => match catch.as_deref() {
-                    Some(catch_expr) => pair_outputs_with_path::<W>(
-                        eval_pipe_with_path_context_internal::<W, S>(
-                            core::slice::from_ref(catch_expr),
-                            &e.payload(),
-                            root,
-                            file_origin,
-                            current_path,
-                            optional,
+                // guard existed. The uncatchable case falls through to
+                // `other => other` below, unchanged.
+                QueryResult::Error(e) if !path_context_stage_uncatchable(&e) => {
+                    match catch.as_deref() {
+                        Some(catch_expr) => pair_outputs_with_path::<W>(
+                            eval_pipe_with_path_context_internal::<W, S>(
+                                core::slice::from_ref(catch_expr),
+                                &e.payload(),
+                                root,
+                                file_origin,
+                                current_path,
+                                optional,
+                            ),
+                            paired.then_some(current_path),
                         ),
-                        paired.then_some(current_path),
-                    ),
-                    None => QueryResult::None,
-                },
+                        None => QueryResult::None,
+                    }
+                }
                 QueryResult::Break(_) => match catch.as_deref() {
                     Some(catch_expr) => pair_outputs_with_path::<W>(
                         eval_pipe_with_path_context_internal::<W, S>(
@@ -34289,10 +34329,9 @@ fn eval_stage_with_path_context<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
                     ),
                     None => QueryResult::None,
                 },
-                QueryResult::Partial(prefix, Control::Error(e)) if e.is_uncatchable() => {
-                    QueryResult::Partial(prefix, Control::Error(e))
-                }
-                QueryResult::Partial(prefix, Control::Error(e)) => {
+                QueryResult::Partial(prefix, Control::Error(e))
+                    if !path_context_stage_uncatchable(&e) =>
+                {
                     let handled = match catch.as_deref() {
                         Some(catch_expr) => pair_outputs_with_path::<W>(
                             eval_pipe_with_path_context_internal::<W, S>(

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -4897,13 +4897,11 @@ fn try_single_generic<S: EvalSemantics, V: DocumentValue>(
         // surface in yq mode; excluding it from `catch` there too keeps one
         // consistent "never caught" rule rather than one that depends on
         // whether a catch handler happens to be present.
-        GenericResult::Error(e) if e.is_decode_failure() || e.is_yq_negative_index_error() => {
-            GenericResult::Error(e)
-        }
+        GenericResult::Error(e) if e.is_uncatchable_at_value_position() => GenericResult::Error(e),
         GenericResult::Error(e) => run_catch(&e.payload()),
         GenericResult::Break(_) => run_catch(&OwnedValue::Null),
         GenericResult::Partial(prefix, Control::Error(e))
-            if e.is_decode_failure() || e.is_yq_negative_index_error() =>
+            if e.is_uncatchable_at_value_position() =>
         {
             GenericResult::Partial(prefix, Control::Error(e))
         }
@@ -4915,7 +4913,7 @@ fn try_single_generic<S: EvalSemantics, V: DocumentValue>(
         }
         GenericResult::LazySeq(seq) => match seq.materialize_atomic() {
             Ok(owned) => GenericResult::Owned(owned),
-            Err(Control::Error(e)) if e.is_decode_failure() || e.is_yq_negative_index_error() => {
+            Err(Control::Error(e)) if e.is_uncatchable_at_value_position() => {
                 GenericResult::Error(e)
             }
             Err(Control::Error(e)) => run_catch(&e.payload()),
@@ -6226,9 +6224,7 @@ fn each_try_generic<S: EvalSemantics, V: DocumentValue>(
         // `each_try`/`try_single_generic` (`src/jq/eval.rs`/this file) --
         // reached from the same `any(.a[-5]?; .)` shape those cover, via
         // this file's own generic dispatch.
-        Flow::Escaped(Control::Error(e))
-            if e.is_decode_failure() || e.is_yq_negative_index_error() =>
-        {
+        Flow::Escaped(Control::Error(e)) if e.is_uncatchable_at_value_position() => {
             Flow::Escaped(Control::Error(e))
         }
         Flow::Escaped(Control::Error(e)) => match catch {

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -28797,6 +28797,59 @@ fn test_negative_index_out_of_range_survives_try_catch_under_eval_all_2270() -> 
     Ok(())
 }
 
+/// #2270 review: the `Partial(prefix, Control::Error(e))` arm this fix
+/// touches (not just the bare `Error(e)` one the test above exercises) --
+/// a `try` body that produces some output *before* raising the
+/// negative-index error must keep that output on stdout while the error
+/// still survives to stderr uncaught, matching `Partial`'s own #400/#494
+/// prefix-preservation contract everywhere else in this codebase.
+#[test]
+fn test_negative_index_out_of_range_survives_try_catch_partial_prefix_2270() -> Result<()> {
+    let multi_doc = "a: [1, 2]\n---\na: [3, 4]\n";
+
+    let (out, stderr, code) = run_yq_stdin_with_stderr(
+        ".[0].a | (try (1, .[-5]) catch \"c\") | key",
+        multi_doc,
+        &["-o", "json", "--eval-all"],
+    )?;
+    assert_eq!(code, 1, "out: {out:?}");
+    assert_eq!(out.trim(), "null");
+    assert_eq!(
+        stderr.trim(),
+        "Error: index [-5] out of range, array size is 2"
+    );
+
+    Ok(())
+}
+
+/// #2289 review: `eval_stage_with_path_context`'s `Expr::Optional`/
+/// `Expr::Try` arms must NOT treat `EvalError::is_invalid_path_expression()`
+/// as uncatchable the way `resolve_node`'s own path-tracking resolver
+/// correctly does -- this function runs whenever *any* sibling elsewhere in
+/// the same pipe needs path context, not only when the branch actually
+/// being dispatched is itself a path expression, so an ordinary
+/// `path(<non-path-expr>)` call reached through here (because an unrelated
+/// `key`/`file_index` sits elsewhere in the pipe) must stay catchable the
+/// same way it is at top-level/value position. Confirmed live against jq
+/// 1.7.1: `.a | (try path(1) catch "x"), key` gives `"x"` then `"a"` there;
+/// `is_uncatchable()`'s own broader check (which includes
+/// `is_invalid_path_expression()`) made both this arm and its `Expr::Optional`
+/// sibling wrongly let the error escape uncaught instead, before this fix.
+#[test]
+fn test_invalid_path_expression_stays_catchable_under_path_context_dispatch_2289() -> Result<()> {
+    let (out, stderr, code) =
+        run_jq_stdin_with_stderr(".a | (try path(1) catch \"x\"), key", "{\"a\":1}", &["-c"])?;
+    assert_eq!(code, 0, "stderr: {stderr}");
+    assert_eq!(out.trim(), "\"x\"\n\"a\"");
+
+    let (out, stderr, code) =
+        run_jq_stdin_with_stderr(".a | (path(1)?), key", "{\"a\":1}", &["-c"])?;
+    assert_eq!(code, 0, "stderr: {stderr}");
+    assert_eq!(out.trim(), "\"a\"");
+
+    Ok(())
+}
+
 /// #2254's jq-mode control: jq has no equivalent of this yq-only rule, so
 /// jq mode must be entirely unaffected by the fix -- every case above
 /// answers `null`, never raises.

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -28760,6 +28760,43 @@ fn test_negative_index_out_of_range_survives_owned_target_computed_index_2254() 
     Ok(())
 }
 
+/// #2270: `eval_stage_with_path_context`'s `Expr::Try` arm had no
+/// uncatchable-error guard at all (unlike its `Expr::Optional` sibling,
+/// fixed by #2227) -- `try`/`catch` under `--eval-all`, combined with a
+/// path-context-triggering builtin elsewhere in the same pipeline
+/// (`file_index` here), wrongly ran the catch handler on a yq
+/// negative-index error instead of letting it survive. Each case pairs the
+/// `try`/`catch` query with an equivalent bare-`?` one to confirm both
+/// dispatch paths through this function now agree.
+#[test]
+fn test_negative_index_out_of_range_survives_try_catch_under_eval_all_2270() -> Result<()> {
+    let multi_doc = "a: [1, 2]\n---\na: [3, 4]\n";
+
+    let (out, stderr, code) = run_yq_stdin_with_stderr(
+        "(try .[0].a[-5] catch \"c\"), file_index",
+        multi_doc,
+        &["-o", "json", "--eval-all"],
+    )?;
+    assert_eq!(code, 1, "out: {out:?}");
+    assert_eq!(
+        stderr.trim(),
+        "Error: index [-5] out of range, array size is 2"
+    );
+
+    let (out, stderr, code) = run_yq_stdin_with_stderr(
+        "(.[0].a[-5]?, file_index)",
+        multi_doc,
+        &["-o", "json", "--eval-all"],
+    )?;
+    assert_eq!(code, 1, "out: {out:?}");
+    assert_eq!(
+        stderr.trim(),
+        "Error: index [-5] out of range, array size is 2"
+    );
+
+    Ok(())
+}
+
 /// #2254's jq-mode control: jq has no equivalent of this yq-only rule, so
 /// jq mode must be entirely unaffected by the fix -- every case above
 /// answers `null`, never raises.

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -28831,10 +28831,16 @@ fn test_negative_index_out_of_range_survives_try_catch_partial_prefix_2270() -> 
 /// `path(<non-path-expr>)` call reached through here (because an unrelated
 /// `key`/`file_index` sits elsewhere in the pipe) must stay catchable the
 /// same way it is at top-level/value position. Confirmed live against jq
-/// 1.7.1: `.a | (try path(1) catch "x"), key` gives `"x"` then `"a"` there;
-/// `is_uncatchable()`'s own broader check (which includes
+/// 1.7.1 that bare `.a | try path(1) catch "x"` (no `key` sibling) gives
+/// `"x"` there -- `key` is a succinctly-only path-context extension real
+/// jq's own lexer rejects outright (`key/0 is not defined`), so the query
+/// this test actually runs has no real-jq equivalent to check against; it
+/// pins succinctly's own internal consistency instead (the unrelated `key`
+/// sibling must not change what `try path(1) catch "x"` alone already
+/// does). `is_uncatchable()`'s own broader check (which includes
 /// `is_invalid_path_expression()`) made both this arm and its `Expr::Optional`
-/// sibling wrongly let the error escape uncaught instead, before this fix.
+/// sibling wrongly let the error escape uncaught once `key` forced
+/// path-context dispatch, before this fix.
 #[test]
 fn test_invalid_path_expression_stays_catchable_under_path_context_dispatch_2289() -> Result<()> {
     let (out, stderr, code) =


### PR DESCRIPTION
## Summary
- Fixes #2270 — `eval_stage_with_path_context`'s `Expr::Try` arm had no uncatchable-error guard at all, unlike its `Expr::Optional` sibling (already fixed by #2227) and unlike `resolve_node`'s own `Expr::Try`/`Expr::Optional` pair, the established precedent for this exact path-tracking-position pattern.
- Only reachable via a fairly specific combination: `try`/`catch` (or bare `?`) combined with a path-context-triggering builtin elsewhere in the same pipeline (`file_index`/`key`/`parent`/`path`), most commonly under `--eval-all`. An ordinary query without one of those builtins already takes a different, correctly-guarded path even under `--eval-all`.
- Confirmed live: `(try .[0].a[-5] catch "c"), file_index` under `--eval-all` wrongly ran the catch handler on a yq negative-index error instead of letting it survive.

## Test plan
- [x] `cargo build --release --features cli`
- [x] Both repros from #2270's own issue body confirmed fixed
- [x] `cargo test --release --features cli,simd,regex,serde --test yq_cli_tests --test jq_cli_tests` (1351 + 1385 passed)
- [x] `cargo test --features cli,simd,regex,serde --lib` (3369 passed, debug mode)
- [x] `cargo test` (default features, 44 passed)
- [x] `cargo test --no-default-features --features portable-popcount` (no_std, 44 passed)
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings`
- [x] `cargo fmt --check`
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features`