### PR TITLE
fix(jq): tag malformed-JSON errors uncatchable, revising the #1953 lineage

### DIFF
--- a/src/bin/succinctly/jq_runner.rs
+++ b/src/bin/succinctly/jq_runner.rs
@@ -5183,8 +5183,10 @@ fn standard_json_to_jq_value<'a, W: Clone + AsRef<[u64]>>(
         // See `eval_generic::to_owned_at_depth`'s own `is_error` arm
         // (#1194/#1247): a structurally malformed value -- one the
         // semi-index accepted as a span but could not classify as any JSON
-        // token -- raises rather than becoming `null`.
-        StandardJson::Error(msg) => return Err(EvalError::new(msg.to_string())),
+        // token -- raises rather than becoming `null`. #2286: decode_failure,
+        // not new -- same class as the malformed member/delimiter errors,
+        // confirmed live that real jq treats this uncatchably too.
+        StandardJson::Error(msg) => return Err(EvalError::decode_failure(msg)),
     })
 }
 

--- a/src/bin/succinctly/yq_runner.rs
+++ b/src/bin/succinctly/yq_runner.rs
@@ -1246,11 +1246,13 @@ fn to_owned_canonicalizing_numbers_at_depth<V: DocumentValue>(
         // the semi-index accepted as a span but could not classify as any
         // JSON token. This function used to materialize it as `null`
         // instead of raising the semi-index's own, more specific message.
-        return Err(EvalError::new(
+        // #2286: `decode_failure`, not `new` -- same uncatchable class as
+        // every other `is_error()`/`StandardJson::Error` site this issue
+        // fixed.
+        return Err(EvalError::decode_failure(
             value
                 .error_message()
-                .unwrap_or("malformed value in document")
-                .to_string(),
+                .unwrap_or("malformed value in document"),
         ));
     } else {
         // Matches `to_owned_at_depth`'s own final `else` arm (#1098) --

--- a/src/jq/document.rs
+++ b/src/jq/document.rs
@@ -228,7 +228,11 @@ pub trait DocumentCursor: Sized + Copy + Clone {
     /// [`DocumentFields::malformed_member_error`] -- it exists to keep a
     /// future format honest rather than to be seen.
     fn malformed_delimiter_error(&self) -> EvalError {
-        EvalError::new("Invalid document text: malformed delimiter")
+        // #2286: decode_failure, not new -- matches JsonCursor's own
+        // override, so a future format inheriting this default doesn't
+        // reintroduce the "? wrongly suppresses a parse-time-equivalent
+        // error" gap that fix closed.
+        EvalError::decode_failure("Invalid document text: malformed delimiter")
     }
 
     /// Whether an array/object cursor whose child walk produced **zero**
@@ -1114,7 +1118,9 @@ pub trait DocumentFields: Sized + Clone {
     /// stringifies -- so it exists to keep a future format honest rather than
     /// to be seen.
     fn malformed_member_error(&self) -> EvalError {
-        EvalError::new("Invalid document text: malformed object member")
+        // #2286: decode_failure, not new -- see malformed_delimiter_error's
+        // identical reasoning just above.
+        EvalError::decode_failure("Invalid document text: malformed object member")
     }
 
     /// Walk one field, materializing only its key.
@@ -2675,7 +2681,9 @@ pub trait DocumentElements: Sized + Copy + Clone {
     /// The default is unreachable for every format shipped today, same
     /// reasoning as that method's own default.
     fn malformed_element_error(&self) -> EvalError {
-        EvalError::new("Invalid document text: malformed array element")
+        // #2286: decode_failure, not new -- see malformed_delimiter_error's
+        // identical reasoning above.
+        EvalError::decode_failure("Invalid document text: malformed array element")
     }
 
     /// [`collect_cursors`](Self::collect_cursors), refusing an element

--- a/src/jq/error.rs
+++ b/src/jq/error.rs
@@ -1163,11 +1163,17 @@ impl EvalError {
     }
 
     /// A decode failure while materializing a lazily-indexed document value
-    /// (#1247): invalid UTF-8, an unrecoverable escape, or a malformed
-    /// number literal. Unlike an ordinary type-mismatch error, this must
-    /// never be suppressed by `?` or caught by `try`/`catch` (#1620) — jq's
-    /// own equivalent is a parse-time rejection no program could ever catch
-    /// either.
+    /// (#1247): invalid UTF-8, an unrecoverable escape, a malformed number
+    /// literal, or (#2286) a document the semi-index accepted structurally
+    /// but that a strict re-validation then found isn't actually valid
+    /// JSON (`EvalError::malformed_json_text` and its
+    /// `malformed_member_error`/`malformed_delimiter_error`/
+    /// `malformed_element_error` callers). Unlike an ordinary
+    /// type-mismatch error, this must never be suppressed by `?` or caught
+    /// by `try`/`catch` (#1620) — jq's own equivalent is a parse-time
+    /// rejection no program could ever catch either, and that holds
+    /// equally for a malformed document (jq never gets past parsing it at
+    /// all) as it does for a single undecodable string.
     pub fn decode_failure(reason: impl Into<String>) -> Self {
         Self::with_kind(reason, ErrorKind::DecodeFailure)
     }
@@ -1464,13 +1470,25 @@ impl EvalError {
     /// relative to this document's own slice, while the caller reports a
     /// location counted in the whole file. Carrying both would print two
     /// numbers that disagree.
+    ///
+    /// #2286: tagged [`ErrorKind::DecodeFailure`] via [`Self::decode_failure`],
+    /// not the plain [`Self::new`] this used to call. Real jq's equivalent
+    /// failure is a *parse* error, raised before any filter — `?` included —
+    /// ever runs; a trailing `?` was wrongly suppressing it (confirmed live
+    /// against jq 1.7.1: `echo '{"a" 1}' | jq -c '.a?'` still exits 5). Every
+    /// caller of this constructor (`JsonFields::malformed_member_error`,
+    /// `JsonElements::malformed_element_error`, `JsonCursor::
+    /// malformed_delimiter_error`) inherits the fix through this one shared
+    /// site, matching the "one classification, checked everywhere via a
+    /// single predicate" architecture [`Self::is_decode_failure`]'s own doc
+    /// comment already established for #1840.
     pub fn malformed_json_text(text: &[u8]) -> Self {
         match crate::json::validate::validate(text) {
-            Err(err) => Self::new(format!("Invalid JSON text: {}", err.kind)),
+            Err(err) => Self::decode_failure(format!("Invalid JSON text: {}", err.kind)),
             // The validator disagreeing with the indexer means the two have
             // drifted apart. Report the generic form rather than claim the
             // document is fine when a swallow point has already fired.
-            Ok(()) => Self::new("Invalid JSON text"),
+            Ok(()) => Self::decode_failure("Invalid JSON text"),
         }
     }
 

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -45629,18 +45629,27 @@ mod tests {
         );
     }
 
-    /// #1953: `to_owned`'s `Err` can carry a #1194 malformed-member
-    /// error (a trailing unpaired object member, e.g. `{"a":1,"b"}`), which
-    /// is not `is_decode_failure()`-tagged. Confirmed here (via a plain,
-    /// un-suppressed `.c = 5` reachable straight through the CLI) that the
-    /// raised error is indeed not a decode failure -- the premise the rest
-    /// of this fix rests on.
+    /// #1953 named this test for the premise it rested on: `to_owned`'s
+    /// `Err` can carry a #1194 malformed-member error (a trailing unpaired
+    /// object member, e.g. `{"a":1,"b"}`), which #1953 assumed was not
+    /// `is_decode_failure()`-tagged and should respect `optional` like an
+    /// ordinary error. #2286 found that premise itself was never actually
+    /// checked against the real jq oracle for the one question that
+    /// matters -- catchability -- and live-verified the opposite: real jq
+    /// treats this shape as an unconditional *parse* error, never reaching
+    /// any filter, `?`/`try`/`catch` included (`echo '{"a":1,"b"}' | jq -c
+    /// '.c = 5'` exits 5 with `parse error: Objects must consist of
+    /// key:value pairs`, and stays exit 5 under every wrapping this file's
+    /// own #2286 tests below try). #2286 tags this error class
+    /// `is_decode_failure()` to match, which is what this test -- kept
+    /// under its original name so the history of the reversal stays
+    /// visible -- now confirms instead.
     #[test]
     fn test_malformed_member_error_is_not_a_decode_failure_1953() {
         query!(
             br#"{"a":1,"b"}"#,
             ".c = 5",
-            QueryResult::Error(e) => assert!(!e.is_decode_failure())
+            QueryResult::Error(e) => assert!(e.is_decode_failure(), "expected a decode failure, got: {e:?}")
         );
     }
 
@@ -45679,13 +45688,15 @@ mod tests {
         let index = JsonIndex::build(json_bytes);
         let cursor = index.root(json_bytes);
         let slice_expr = Expr::slice(None, None);
-        match eval_single::<Vec<u64>, YqSemantics>(&slice_expr, cursor.value(), true) {
-            QueryResult::None => {}
-            other => panic!("expected None, got {other:?}"),
-        }
-        match eval_single::<Vec<u64>, YqSemantics>(&slice_expr, cursor.value(), false) {
-            QueryResult::Error(e) => assert!(!e.is_decode_failure()),
-            other => panic!("expected Error, got {other:?}"),
+        for optional in [true, false] {
+            match eval_single::<Vec<u64>, YqSemantics>(&slice_expr, cursor.value(), optional) {
+                QueryResult::Error(e) => {
+                    assert!(e.is_decode_failure(), "expected decode failure, got: {e:?}");
+                }
+                other => panic!(
+                    "expected a decode failure regardless of optional={optional}, got: {other:?}"
+                ),
+            }
         }
     }
 
@@ -45707,21 +45718,25 @@ mod tests {
         let index = JsonIndex::build(json_bytes);
         let cursor = index.root(json_bytes);
         let slice_expr = Expr::slice(None, Some(1));
-        match eval_single::<Vec<u64>, JqSemantics>(&slice_expr, cursor.value(), true) {
-            QueryResult::None => {}
-            other => panic!("expected None, got {other:?}"),
+        for optional in [true, false] {
+            match eval_single::<Vec<u64>, JqSemantics>(&slice_expr, cursor.value(), optional) {
+                QueryResult::Error(e) => {
+                    assert!(e.is_decode_failure(), "expected decode failure, got: {e:?}");
+                }
+                other => panic!(
+                    "expected a decode failure regardless of optional={optional}, got: {other:?}"
+                ),
+            }
         }
-        match eval_single::<Vec<u64>, JqSemantics>(&slice_expr, cursor.value(), false) {
-            QueryResult::Error(e) => assert!(!e.is_decode_failure()),
-            other => panic!("expected Error, got {other:?}"),
-        }
-        match eval_single::<Vec<u64>, YqSemantics>(&slice_expr, cursor.value(), true) {
-            QueryResult::None => {}
-            other => panic!("expected None, got {other:?}"),
-        }
-        match eval_single::<Vec<u64>, YqSemantics>(&slice_expr, cursor.value(), false) {
-            QueryResult::Error(e) => assert!(!e.is_decode_failure()),
-            other => panic!("expected Error, got {other:?}"),
+        for optional in [true, false] {
+            match eval_single::<Vec<u64>, YqSemantics>(&slice_expr, cursor.value(), optional) {
+                QueryResult::Error(e) => {
+                    assert!(e.is_decode_failure(), "expected decode failure, got: {e:?}");
+                }
+                other => panic!(
+                    "expected a decode failure regardless of optional={optional}, got: {other:?}"
+                ),
+            }
         }
     }
 
@@ -45741,25 +45756,37 @@ mod tests {
         let target = Expr::Identity;
         let start = Some(Box::new(Expr::Literal(Literal::Int(0))));
         let end = None;
-        match eval_slice_expr::<Vec<u64>, JqSemantics>(&target, &start, &end, cursor.value(), true)
-        {
-            QueryResult::None => {}
-            other => panic!("expected None, got {other:?}"),
+        for optional in [true, false] {
+            match eval_slice_expr::<Vec<u64>, JqSemantics>(
+                &target,
+                &start,
+                &end,
+                cursor.value(),
+                optional,
+            ) {
+                QueryResult::Error(e) => {
+                    assert!(e.is_decode_failure(), "expected decode failure, got: {e:?}");
+                }
+                other => panic!(
+                    "expected a decode failure regardless of optional={optional}, got: {other:?}"
+                ),
+            }
         }
-        match eval_slice_expr::<Vec<u64>, JqSemantics>(&target, &start, &end, cursor.value(), false)
-        {
-            QueryResult::Error(e) => assert!(!e.is_decode_failure()),
-            other => panic!("expected Error, got {other:?}"),
-        }
-        match eval_slice_expr::<Vec<u64>, YqSemantics>(&target, &start, &end, cursor.value(), true)
-        {
-            QueryResult::None => {}
-            other => panic!("expected None, got {other:?}"),
-        }
-        match eval_slice_expr::<Vec<u64>, YqSemantics>(&target, &start, &end, cursor.value(), false)
-        {
-            QueryResult::Error(e) => assert!(!e.is_decode_failure()),
-            other => panic!("expected Error, got {other:?}"),
+        for optional in [true, false] {
+            match eval_slice_expr::<Vec<u64>, YqSemantics>(
+                &target,
+                &start,
+                &end,
+                cursor.value(),
+                optional,
+            ) {
+                QueryResult::Error(e) => {
+                    assert!(e.is_decode_failure(), "expected decode failure, got: {e:?}");
+                }
+                other => panic!(
+                    "expected a decode failure regardless of optional={optional}, got: {other:?}"
+                ),
+            }
         }
     }
 
@@ -45776,13 +45803,20 @@ mod tests {
         let cursor = index.root(json_bytes);
         let path_expr = Expr::Identity;
         let value_expr = Expr::Literal(Literal::Int(5));
-        match eval_assign::<Vec<u64>, JqSemantics>(&path_expr, &value_expr, cursor.value(), true) {
-            QueryResult::None => {}
-            other => panic!("expected None, got {other:?}"),
-        }
-        match eval_assign::<Vec<u64>, JqSemantics>(&path_expr, &value_expr, cursor.value(), false) {
-            QueryResult::Error(e) => assert!(!e.is_decode_failure()),
-            other => panic!("expected Error, got {other:?}"),
+        for optional in [true, false] {
+            match eval_assign::<Vec<u64>, JqSemantics>(
+                &path_expr,
+                &value_expr,
+                cursor.value(),
+                optional,
+            ) {
+                QueryResult::Error(e) => {
+                    assert!(e.is_decode_failure(), "expected decode failure, got: {e:?}");
+                }
+                other => panic!(
+                    "expected a decode failure regardless of optional={optional}, got: {other:?}"
+                ),
+            }
         }
     }
 
@@ -45794,25 +45828,21 @@ mod tests {
         let json_bytes: &[u8] = br#"{"a":1,"b"}"#;
         let index = JsonIndex::build(json_bytes);
         let cursor = index.root(json_bytes);
-        match eval_update::<Vec<u64>, JqSemantics>(
-            &Expr::Identity,
-            &Expr::Identity,
-            cursor.value(),
-            true,
-            true,
-        ) {
-            QueryResult::None => {}
-            other => panic!("expected None, got {other:?}"),
-        }
-        match eval_update::<Vec<u64>, JqSemantics>(
-            &Expr::Identity,
-            &Expr::Identity,
-            cursor.value(),
-            false,
-            true,
-        ) {
-            QueryResult::Error(e) => assert!(!e.is_decode_failure()),
-            other => panic!("expected Error, got {other:?}"),
+        for optional in [true, false] {
+            match eval_update::<Vec<u64>, JqSemantics>(
+                &Expr::Identity,
+                &Expr::Identity,
+                cursor.value(),
+                optional,
+                true,
+            ) {
+                QueryResult::Error(e) => {
+                    assert!(e.is_decode_failure(), "expected decode failure, got: {e:?}");
+                }
+                other => panic!(
+                    "expected a decode failure regardless of optional={optional}, got: {other:?}"
+                ),
+            }
         }
     }
 
@@ -45828,25 +45858,21 @@ mod tests {
         let cursor = index.root(json_bytes);
         let path_expr = Expr::Identity;
         let value_expr = Expr::Literal(Literal::Int(1));
-        match eval_compound_assign::<Vec<u64>, JqSemantics>(
-            AssignOp::Add,
-            &path_expr,
-            &value_expr,
-            cursor.value(),
-            true,
-        ) {
-            QueryResult::None => {}
-            other => panic!("expected None, got {other:?}"),
-        }
-        match eval_compound_assign::<Vec<u64>, JqSemantics>(
-            AssignOp::Add,
-            &path_expr,
-            &value_expr,
-            cursor.value(),
-            false,
-        ) {
-            QueryResult::Error(e) => assert!(!e.is_decode_failure()),
-            other => panic!("expected Error, got {other:?}"),
+        for optional in [true, false] {
+            match eval_compound_assign::<Vec<u64>, JqSemantics>(
+                AssignOp::Add,
+                &path_expr,
+                &value_expr,
+                cursor.value(),
+                optional,
+            ) {
+                QueryResult::Error(e) => {
+                    assert!(e.is_decode_failure(), "expected decode failure, got: {e:?}");
+                }
+                other => panic!(
+                    "expected a decode failure regardless of optional={optional}, got: {other:?}"
+                ),
+            }
         }
     }
 
@@ -45860,15 +45886,20 @@ mod tests {
         let cursor = index.root(json_bytes);
         let path_expr = parse(r#"["c"]"#).unwrap();
         let val_expr = Expr::Literal(Literal::Int(5));
-        match builtin_setpath::<Vec<u64>, JqSemantics>(&path_expr, &val_expr, cursor.value(), true)
-        {
-            QueryResult::None => {}
-            other => panic!("expected None, got {other:?}"),
-        }
-        match builtin_setpath::<Vec<u64>, JqSemantics>(&path_expr, &val_expr, cursor.value(), false)
-        {
-            QueryResult::Error(e) => assert!(!e.is_decode_failure()),
-            other => panic!("expected Error, got {other:?}"),
+        for optional in [true, false] {
+            match builtin_setpath::<Vec<u64>, JqSemantics>(
+                &path_expr,
+                &val_expr,
+                cursor.value(),
+                optional,
+            ) {
+                QueryResult::Error(e) => {
+                    assert!(e.is_decode_failure(), "expected decode failure, got: {e:?}");
+                }
+                other => panic!(
+                    "expected a decode failure regardless of optional={optional}, got: {other:?}"
+                ),
+            }
         }
     }
 
@@ -45881,13 +45912,15 @@ mod tests {
         let json_bytes: &[u8] = br#"[[{"a":1,"b"}]]"#;
         let index = JsonIndex::build(json_bytes);
         let cursor = index.root(json_bytes);
-        match builtin_combinations::<Vec<u64>>(cursor.value(), true) {
-            QueryResult::None => {}
-            other => panic!("expected None, got {other:?}"),
-        }
-        match builtin_combinations::<Vec<u64>>(cursor.value(), false) {
-            QueryResult::Error(e) => assert!(!e.is_decode_failure()),
-            other => panic!("expected Error, got {other:?}"),
+        for optional in [true, false] {
+            match builtin_combinations::<Vec<u64>>(cursor.value(), optional) {
+                QueryResult::Error(e) => {
+                    assert!(e.is_decode_failure(), "expected decode failure, got: {e:?}");
+                }
+                other => panic!(
+                    "expected a decode failure regardless of optional={optional}, got: {other:?}"
+                ),
+            }
         }
     }
 
@@ -45900,13 +45933,16 @@ mod tests {
         let index = JsonIndex::build(json_bytes);
         let cursor = index.root(json_bytes);
         let n_expr = Expr::Literal(Literal::Int(1));
-        match builtin_combinations_n::<Vec<u64>, JqSemantics>(&n_expr, cursor.value(), true) {
-            QueryResult::None => {}
-            other => panic!("expected None, got {other:?}"),
-        }
-        match builtin_combinations_n::<Vec<u64>, JqSemantics>(&n_expr, cursor.value(), false) {
-            QueryResult::Error(e) => assert!(!e.is_decode_failure()),
-            other => panic!("expected Error, got {other:?}"),
+        for optional in [true, false] {
+            match builtin_combinations_n::<Vec<u64>, JqSemantics>(&n_expr, cursor.value(), optional)
+            {
+                QueryResult::Error(e) => {
+                    assert!(e.is_decode_failure(), "expected decode failure, got: {e:?}");
+                }
+                other => panic!(
+                    "expected a decode failure regardless of optional={optional}, got: {other:?}"
+                ),
+            }
         }
     }
 
@@ -45956,8 +45992,10 @@ mod tests {
                 ),
             ] {
                 match got {
-                    QueryResult::None if optional => {}
-                    QueryResult::Error(e) if !optional => assert!(!e.is_decode_failure()),
+                    QueryResult::Error(e) => assert!(
+                        e.is_decode_failure(),
+                        "mode={mode} optional={optional}: expected decode failure, got: {e:?}"
+                    ),
                     other => panic!("mode={mode} optional={optional}: unexpected {other:?}"),
                 }
             }
@@ -45984,8 +46022,10 @@ mod tests {
                 ),
             ] {
                 match got {
-                    QueryResult::None if optional => {}
-                    QueryResult::Error(e) if !optional => assert!(!e.is_decode_failure()),
+                    QueryResult::Error(e) => assert!(
+                        e.is_decode_failure(),
+                        "mode={mode} optional={optional}: expected decode failure, got: {e:?}"
+                    ),
                     other => panic!("mode={mode} optional={optional}: unexpected {other:?}"),
                 }
             }
@@ -46015,8 +46055,10 @@ mod tests {
                 ),
             ] {
                 match got {
-                    QueryResult::None if optional => {}
-                    QueryResult::Error(e) if !optional => assert!(!e.is_decode_failure()),
+                    QueryResult::Error(e) => assert!(
+                        e.is_decode_failure(),
+                        "mode={mode} optional={optional}: expected decode failure, got: {e:?}"
+                    ),
                     other => panic!("mode={mode} optional={optional}: unexpected {other:?}"),
                 }
             }
@@ -46045,8 +46087,10 @@ mod tests {
                 ),
             ] {
                 match got {
-                    QueryResult::None if optional => {}
-                    QueryResult::Error(e) if !optional => assert!(!e.is_decode_failure()),
+                    QueryResult::Error(e) => assert!(
+                        e.is_decode_failure(),
+                        "mode={mode} optional={optional}: expected decode failure, got: {e:?}"
+                    ),
                     other => panic!("mode={mode} optional={optional}: unexpected {other:?}"),
                 }
             }
@@ -46074,8 +46118,10 @@ mod tests {
                 ),
             ] {
                 match got {
-                    QueryResult::None if optional => {}
-                    QueryResult::Error(e) if !optional => assert!(!e.is_decode_failure()),
+                    QueryResult::Error(e) => assert!(
+                        e.is_decode_failure(),
+                        "mode={mode} optional={optional}: expected decode failure, got: {e:?}"
+                    ),
                     other => panic!("mode={mode} optional={optional}: unexpected {other:?}"),
                 }
             }
@@ -46106,13 +46152,15 @@ mod tests {
         let cursor = index.root(json_bytes);
         let cond = Expr::Literal(Literal::Bool(true));
         let update = Expr::Identity;
-        match eval_until::<Vec<u64>, JqSemantics>(&cond, &update, cursor.value(), true) {
-            QueryResult::None => {}
-            other => panic!("expected None, got {other:?}"),
-        }
-        match eval_until::<Vec<u64>, JqSemantics>(&cond, &update, cursor.value(), false) {
-            QueryResult::Error(e) => assert!(!e.is_decode_failure()),
-            other => panic!("expected Error, got {other:?}"),
+        for optional in [true, false] {
+            match eval_until::<Vec<u64>, JqSemantics>(&cond, &update, cursor.value(), optional) {
+                QueryResult::Error(e) => {
+                    assert!(e.is_decode_failure(), "expected decode failure, got: {e:?}");
+                }
+                other => panic!(
+                    "expected a decode failure regardless of optional={optional}, got: {other:?}"
+                ),
+            }
         }
 
         let decode_failure_bytes: &[u8] = &b"\"\xff\xfe\""[..];
@@ -46134,13 +46182,15 @@ mod tests {
         let cursor = index.root(json_bytes);
         let cond = Expr::Literal(Literal::Bool(false));
         let update = Expr::Identity;
-        match eval_while::<Vec<u64>, JqSemantics>(&cond, &update, cursor.value(), true) {
-            QueryResult::None => {}
-            other => panic!("expected None, got {other:?}"),
-        }
-        match eval_while::<Vec<u64>, JqSemantics>(&cond, &update, cursor.value(), false) {
-            QueryResult::Error(e) => assert!(!e.is_decode_failure()),
-            other => panic!("expected Error, got {other:?}"),
+        for optional in [true, false] {
+            match eval_while::<Vec<u64>, JqSemantics>(&cond, &update, cursor.value(), optional) {
+                QueryResult::Error(e) => {
+                    assert!(e.is_decode_failure(), "expected decode failure, got: {e:?}");
+                }
+                other => panic!(
+                    "expected a decode failure regardless of optional={optional}, got: {other:?}"
+                ),
+            }
         }
 
         let decode_failure_bytes: &[u8] = &b"\"\xff\xfe\""[..];
@@ -46161,13 +46211,15 @@ mod tests {
         let index = JsonIndex::build(json_bytes);
         let cursor = index.root(json_bytes);
         let expr = Expr::Identity;
-        match eval_repeat::<Vec<u64>, JqSemantics>(&expr, cursor.value(), true) {
-            QueryResult::None => {}
-            other => panic!("expected None, got {other:?}"),
-        }
-        match eval_repeat::<Vec<u64>, JqSemantics>(&expr, cursor.value(), false) {
-            QueryResult::Error(e) => assert!(!e.is_decode_failure()),
-            other => panic!("expected Error, got {other:?}"),
+        for optional in [true, false] {
+            match eval_repeat::<Vec<u64>, JqSemantics>(&expr, cursor.value(), optional) {
+                QueryResult::Error(e) => {
+                    assert!(e.is_decode_failure(), "expected decode failure, got: {e:?}");
+                }
+                other => panic!(
+                    "expected a decode failure regardless of optional={optional}, got: {other:?}"
+                ),
+            }
         }
 
         let decode_failure_bytes: &[u8] = &b"\"\xff\xfe\""[..];
@@ -46188,13 +46240,15 @@ mod tests {
         let index = JsonIndex::build(json_bytes);
         let cursor = index.root(json_bytes);
         let f = Expr::Identity;
-        match builtin_walk::<Vec<u64>, JqSemantics>(&f, cursor.value(), true) {
-            QueryResult::None => {}
-            other => panic!("expected None, got {other:?}"),
-        }
-        match builtin_walk::<Vec<u64>, JqSemantics>(&f, cursor.value(), false) {
-            QueryResult::Error(e) => assert!(!e.is_decode_failure()),
-            other => panic!("expected Error, got {other:?}"),
+        for optional in [true, false] {
+            match builtin_walk::<Vec<u64>, JqSemantics>(&f, cursor.value(), optional) {
+                QueryResult::Error(e) => {
+                    assert!(e.is_decode_failure(), "expected decode failure, got: {e:?}");
+                }
+                other => panic!(
+                    "expected a decode failure regardless of optional={optional}, got: {other:?}"
+                ),
+            }
         }
 
         let decode_failure_bytes: &[u8] = &b"\"\xff\xfe\""[..];
@@ -46219,13 +46273,15 @@ mod tests {
         let index = JsonIndex::build(json_bytes);
         let cursor = index.root(json_bytes);
         let path_expr = Expr::Array(Box::new(Expr::Literal(Literal::String("a".into()))));
-        match builtin_getpath::<Vec<u64>, JqSemantics>(&path_expr, cursor.value(), true) {
-            QueryResult::None => {}
-            other => panic!("expected None, got {other:?}"),
-        }
-        match builtin_getpath::<Vec<u64>, JqSemantics>(&path_expr, cursor.value(), false) {
-            QueryResult::Error(e) => assert!(!e.is_decode_failure()),
-            other => panic!("expected Error, got {other:?}"),
+        for optional in [true, false] {
+            match builtin_getpath::<Vec<u64>, JqSemantics>(&path_expr, cursor.value(), optional) {
+                QueryResult::Error(e) => {
+                    assert!(e.is_decode_failure(), "expected decode failure, got: {e:?}");
+                }
+                other => panic!(
+                    "expected a decode failure regardless of optional={optional}, got: {other:?}"
+                ),
+            }
         }
 
         let decode_failure_bytes: &[u8] = &b"\"\xff\xfe\""[..];
@@ -46247,13 +46303,15 @@ mod tests {
         let json_bytes: &[u8] = br#"{"a":1,"b"}"#;
         let index = JsonIndex::build(json_bytes);
         let cursor = index.root(json_bytes);
-        match eval_error::<Vec<u64>, JqSemantics>(None, cursor.value(), true) {
-            QueryResult::None => {}
-            other => panic!("expected None, got {other:?}"),
-        }
-        match eval_error::<Vec<u64>, JqSemantics>(None, cursor.value(), false) {
-            QueryResult::Error(e) => assert!(!e.is_decode_failure()),
-            other => panic!("expected Error, got {other:?}"),
+        for optional in [true, false] {
+            match eval_error::<Vec<u64>, JqSemantics>(None, cursor.value(), optional) {
+                QueryResult::Error(e) => {
+                    assert!(e.is_decode_failure(), "expected decode failure, got: {e:?}");
+                }
+                other => panic!(
+                    "expected a decode failure regardless of optional={optional}, got: {other:?}"
+                ),
+            }
         }
 
         let decode_failure_bytes: &[u8] = &b"\"\xff\xfe\""[..];
@@ -46274,13 +46332,15 @@ mod tests {
         let index = JsonIndex::build(json_bytes);
         let cursor = index.root(json_bytes);
         let msg_expr = Expr::Identity;
-        match eval_error::<Vec<u64>, JqSemantics>(Some(&msg_expr), cursor.value(), true) {
-            QueryResult::None => {}
-            other => panic!("expected None, got {other:?}"),
-        }
-        match eval_error::<Vec<u64>, JqSemantics>(Some(&msg_expr), cursor.value(), false) {
-            QueryResult::Error(e) => assert!(!e.is_decode_failure()),
-            other => panic!("expected Error, got {other:?}"),
+        for optional in [true, false] {
+            match eval_error::<Vec<u64>, JqSemantics>(Some(&msg_expr), cursor.value(), optional) {
+                QueryResult::Error(e) => {
+                    assert!(e.is_decode_failure(), "expected decode failure, got: {e:?}");
+                }
+                other => panic!(
+                    "expected a decode failure regardless of optional={optional}, got: {other:?}"
+                ),
+            }
         }
 
         // `msg_expr`'s own output (not the root value here -- `Identity`
@@ -46307,13 +46367,15 @@ mod tests {
         let index = JsonIndex::build(json_bytes);
         let cursor = index.root(json_bytes);
         let obj_expr = parse("[]").unwrap();
-        match builtin_in::<Vec<u64>, JqSemantics>(&obj_expr, cursor.value(), true) {
-            QueryResult::None => {}
-            other => panic!("expected None, got {other:?}"),
-        }
-        match builtin_in::<Vec<u64>, JqSemantics>(&obj_expr, cursor.value(), false) {
-            QueryResult::Error(e) => assert!(!e.is_decode_failure()),
-            other => panic!("expected Error, got {other:?}"),
+        for optional in [true, false] {
+            match builtin_in::<Vec<u64>, JqSemantics>(&obj_expr, cursor.value(), optional) {
+                QueryResult::Error(e) => {
+                    assert!(e.is_decode_failure(), "expected decode failure, got: {e:?}");
+                }
+                other => panic!(
+                    "expected a decode failure regardless of optional={optional}, got: {other:?}"
+                ),
+            }
         }
     }
 
@@ -46332,25 +46394,21 @@ mod tests {
         let cursor = index.root(json_bytes);
         let gen_expr = Expr::Identity;
         let cond_expr = Expr::Literal(Literal::Bool(true));
-        match any_all_gen_cond::<Vec<u64>, JqSemantics>(
-            &gen_expr,
-            &cond_expr,
-            cursor.value(),
-            true,
-            true,
-        ) {
-            QueryResult::None => {}
-            other => panic!("expected None, got {other:?}"),
-        }
-        match any_all_gen_cond::<Vec<u64>, JqSemantics>(
-            &gen_expr,
-            &cond_expr,
-            cursor.value(),
-            false,
-            true,
-        ) {
-            QueryResult::Error(e) => assert!(!e.is_decode_failure()),
-            other => panic!("expected Error, got {other:?}"),
+        for optional in [true, false] {
+            match any_all_gen_cond::<Vec<u64>, JqSemantics>(
+                &gen_expr,
+                &cond_expr,
+                cursor.value(),
+                optional,
+                true,
+            ) {
+                QueryResult::Error(e) => {
+                    assert!(e.is_decode_failure(), "expected decode failure, got: {e:?}");
+                }
+                other => panic!(
+                    "expected a decode failure regardless of optional={optional}, got: {other:?}"
+                ),
+            }
         }
     }
 
@@ -46374,13 +46432,15 @@ mod tests {
         let index = JsonIndex::build(json_bytes);
         let cursor = index.root(json_bytes);
         let s_expr = Expr::Identity;
-        match builtin_upper_in::<Vec<u64>, JqSemantics>(&s_expr, cursor.value(), true) {
-            QueryResult::None => {}
-            other => panic!("expected None, got {other:?}"),
-        }
-        match builtin_upper_in::<Vec<u64>, JqSemantics>(&s_expr, cursor.value(), false) {
-            QueryResult::Error(e) => assert!(!e.is_decode_failure()),
-            other => panic!("expected Error, got {other:?}"),
+        for optional in [true, false] {
+            match builtin_upper_in::<Vec<u64>, JqSemantics>(&s_expr, cursor.value(), optional) {
+                QueryResult::Error(e) => {
+                    assert!(e.is_decode_failure(), "expected decode failure, got: {e:?}");
+                }
+                other => panic!(
+                    "expected a decode failure regardless of optional={optional}, got: {other:?}"
+                ),
+            }
         }
     }
 
@@ -46444,23 +46504,20 @@ mod tests {
         let cursor = index.root(json_bytes);
         let src_expr = Expr::Identity;
         let s_expr = Expr::Identity;
-        match builtin_upper_in_src::<Vec<u64>, JqSemantics>(
-            &src_expr,
-            &s_expr,
-            cursor.value(),
-            true,
-        ) {
-            QueryResult::None => {}
-            other => panic!("expected None, got {other:?}"),
-        }
-        match builtin_upper_in_src::<Vec<u64>, JqSemantics>(
-            &src_expr,
-            &s_expr,
-            cursor.value(),
-            false,
-        ) {
-            QueryResult::Error(e) => assert!(!e.is_decode_failure()),
-            other => panic!("expected Error, got {other:?}"),
+        for optional in [true, false] {
+            match builtin_upper_in_src::<Vec<u64>, JqSemantics>(
+                &src_expr,
+                &s_expr,
+                cursor.value(),
+                optional,
+            ) {
+                QueryResult::Error(e) => {
+                    assert!(e.is_decode_failure(), "expected decode failure, got: {e:?}");
+                }
+                other => panic!(
+                    "expected a decode failure regardless of optional={optional}, got: {other:?}"
+                ),
+            }
         }
     }
 
@@ -46494,13 +46551,15 @@ mod tests {
         let json_bytes: &[u8] = br#"{"a":1,"b"}"#;
         let index = JsonIndex::build(json_bytes);
         let cursor = index.root(json_bytes);
-        match builtin_tostring::<Vec<u64>, JqSemantics>(cursor.value(), true) {
-            QueryResult::None => {}
-            other => panic!("expected None, got {other:?}"),
-        }
-        match builtin_tostring::<Vec<u64>, JqSemantics>(cursor.value(), false) {
-            QueryResult::Error(e) => assert!(!e.is_decode_failure()),
-            other => panic!("expected Error, got {other:?}"),
+        for optional in [true, false] {
+            match builtin_tostring::<Vec<u64>, JqSemantics>(cursor.value(), optional) {
+                QueryResult::Error(e) => {
+                    assert!(e.is_decode_failure(), "expected decode failure, got: {e:?}");
+                }
+                other => panic!(
+                    "expected a decode failure regardless of optional={optional}, got: {other:?}"
+                ),
+            }
         }
     }
 
@@ -46526,13 +46585,15 @@ mod tests {
         let json_bytes: &[u8] = br#"{"a":1,"b"}"#;
         let index = JsonIndex::build(json_bytes);
         let cursor = index.root(json_bytes);
-        match builtin_tojson::<Vec<u64>, JqSemantics>(cursor.value(), true) {
-            QueryResult::None => {}
-            other => panic!("expected None, got {other:?}"),
-        }
-        match builtin_tojson::<Vec<u64>, JqSemantics>(cursor.value(), false) {
-            QueryResult::Error(e) => assert!(!e.is_decode_failure()),
-            other => panic!("expected Error, got {other:?}"),
+        for optional in [true, false] {
+            match builtin_tojson::<Vec<u64>, JqSemantics>(cursor.value(), optional) {
+                QueryResult::Error(e) => {
+                    assert!(e.is_decode_failure(), "expected decode failure, got: {e:?}");
+                }
+                other => panic!(
+                    "expected a decode failure regardless of optional={optional}, got: {other:?}"
+                ),
+            }
         }
     }
 
@@ -46559,13 +46620,16 @@ mod tests {
         let index = JsonIndex::build(json_bytes);
         let cursor = index.root(json_bytes);
         let idx_expr = Expr::field("a");
-        match builtin_upper_index::<Vec<u64>, JqSemantics>(&idx_expr, cursor.value(), true) {
-            QueryResult::None => {}
-            other => panic!("expected None, got {other:?}"),
-        }
-        match builtin_upper_index::<Vec<u64>, JqSemantics>(&idx_expr, cursor.value(), false) {
-            QueryResult::Error(e) => assert!(!e.is_decode_failure()),
-            other => panic!("expected Error, got {other:?}"),
+        for optional in [true, false] {
+            match builtin_upper_index::<Vec<u64>, JqSemantics>(&idx_expr, cursor.value(), optional)
+            {
+                QueryResult::Error(e) => {
+                    assert!(e.is_decode_failure(), "expected decode failure, got: {e:?}");
+                }
+                other => panic!(
+                    "expected a decode failure regardless of optional={optional}, got: {other:?}"
+                ),
+            }
         }
     }
 
@@ -46594,23 +46658,20 @@ mod tests {
         let cursor = index.root(json_bytes);
         let stream_expr = Expr::Identity;
         let idx_expr = Expr::field("a");
-        match builtin_upper_index_stream::<Vec<u64>, JqSemantics>(
-            &stream_expr,
-            &idx_expr,
-            cursor.value(),
-            true,
-        ) {
-            QueryResult::None => {}
-            other => panic!("expected None, got {other:?}"),
-        }
-        match builtin_upper_index_stream::<Vec<u64>, JqSemantics>(
-            &stream_expr,
-            &idx_expr,
-            cursor.value(),
-            false,
-        ) {
-            QueryResult::Error(e) => assert!(!e.is_decode_failure()),
-            other => panic!("expected Error, got {other:?}"),
+        for optional in [true, false] {
+            match builtin_upper_index_stream::<Vec<u64>, JqSemantics>(
+                &stream_expr,
+                &idx_expr,
+                cursor.value(),
+                optional,
+            ) {
+                QueryResult::Error(e) => {
+                    assert!(e.is_decode_failure(), "expected decode failure, got: {e:?}");
+                }
+                other => panic!(
+                    "expected a decode failure regardless of optional={optional}, got: {other:?}"
+                ),
+            }
         }
     }
 
@@ -46642,13 +46703,15 @@ mod tests {
         let json_bytes: &[u8] = br#"{"a":1,"b"}"#;
         let index = JsonIndex::build(json_bytes);
         let cursor = index.root(json_bytes);
-        match builtin_tojsonstream::<Vec<u64>>(cursor.value(), true) {
-            QueryResult::None => {}
-            other => panic!("expected None, got {other:?}"),
-        }
-        match builtin_tojsonstream::<Vec<u64>>(cursor.value(), false) {
-            QueryResult::Error(e) => assert!(!e.is_decode_failure()),
-            other => panic!("expected Error, got {other:?}"),
+        for optional in [true, false] {
+            match builtin_tojsonstream::<Vec<u64>>(cursor.value(), optional) {
+                QueryResult::Error(e) => {
+                    assert!(e.is_decode_failure(), "expected decode failure, got: {e:?}");
+                }
+                other => panic!(
+                    "expected a decode failure regardless of optional={optional}, got: {other:?}"
+                ),
+            }
         }
     }
 
@@ -46673,13 +46736,15 @@ mod tests {
         let json_bytes: &[u8] = br#"{"a":1,"b"}"#;
         let index = JsonIndex::build(json_bytes);
         let cursor = index.root(json_bytes);
-        match builtin_tostream::<Vec<u64>>(cursor.value(), true) {
-            QueryResult::None => {}
-            other => panic!("expected None, got {other:?}"),
-        }
-        match builtin_tostream::<Vec<u64>>(cursor.value(), false) {
-            QueryResult::Error(e) => assert!(!e.is_decode_failure()),
-            other => panic!("expected Error, got {other:?}"),
+        for optional in [true, false] {
+            match builtin_tostream::<Vec<u64>>(cursor.value(), optional) {
+                QueryResult::Error(e) => {
+                    assert!(e.is_decode_failure(), "expected decode failure, got: {e:?}");
+                }
+                other => panic!(
+                    "expected a decode failure regardless of optional={optional}, got: {other:?}"
+                ),
+            }
         }
     }
 
@@ -46706,13 +46771,15 @@ mod tests {
         let index = JsonIndex::build(json_bytes);
         let cursor = index.root(json_bytes);
         let b_expr = Expr::Literal(Literal::String(String::new()));
-        match builtin_contains::<Vec<u64>, JqSemantics>(&b_expr, cursor.value(), true) {
-            QueryResult::None => {}
-            other => panic!("expected None, got {other:?}"),
-        }
-        match builtin_contains::<Vec<u64>, JqSemantics>(&b_expr, cursor.value(), false) {
-            QueryResult::Error(e) => assert!(!e.is_decode_failure()),
-            other => panic!("expected Error, got {other:?}"),
+        for optional in [true, false] {
+            match builtin_contains::<Vec<u64>, JqSemantics>(&b_expr, cursor.value(), optional) {
+                QueryResult::Error(e) => {
+                    assert!(e.is_decode_failure(), "expected decode failure, got: {e:?}");
+                }
+                other => panic!(
+                    "expected a decode failure regardless of optional={optional}, got: {other:?}"
+                ),
+            }
         }
     }
 
@@ -46726,13 +46793,15 @@ mod tests {
         let index = JsonIndex::build(json_bytes);
         let cursor = index.root(json_bytes);
         let b_expr = Expr::Literal(Literal::String(String::new()));
-        match builtin_inside::<Vec<u64>, JqSemantics>(&b_expr, cursor.value(), true) {
-            QueryResult::None => {}
-            other => panic!("expected None, got {other:?}"),
-        }
-        match builtin_inside::<Vec<u64>, JqSemantics>(&b_expr, cursor.value(), false) {
-            QueryResult::Error(e) => assert!(!e.is_decode_failure()),
-            other => panic!("expected Error, got {other:?}"),
+        for optional in [true, false] {
+            match builtin_inside::<Vec<u64>, JqSemantics>(&b_expr, cursor.value(), optional) {
+                QueryResult::Error(e) => {
+                    assert!(e.is_decode_failure(), "expected decode failure, got: {e:?}");
+                }
+                other => panic!(
+                    "expected a decode failure regardless of optional={optional}, got: {other:?}"
+                ),
+            }
         }
     }
 
@@ -46894,13 +46963,15 @@ mod tests {
         let index = JsonIndex::build(json_bytes);
         let cursor = index.root(json_bytes);
         let keys_expr = Expr::Identity;
-        match builtin_pick::<Vec<u64>, JqSemantics>(&keys_expr, cursor.value(), true) {
-            QueryResult::None => {}
-            other => panic!("expected None, got {other:?}"),
-        }
-        match builtin_pick::<Vec<u64>, JqSemantics>(&keys_expr, cursor.value(), false) {
-            QueryResult::Error(e) => assert!(!e.is_decode_failure()),
-            other => panic!("expected Error, got {other:?}"),
+        for optional in [true, false] {
+            match builtin_pick::<Vec<u64>, JqSemantics>(&keys_expr, cursor.value(), optional) {
+                QueryResult::Error(e) => {
+                    assert!(e.is_decode_failure(), "expected decode failure, got: {e:?}");
+                }
+                other => panic!(
+                    "expected a decode failure regardless of optional={optional}, got: {other:?}"
+                ),
+            }
         }
     }
 
@@ -46928,13 +46999,15 @@ mod tests {
         let index = JsonIndex::build(json_bytes);
         let cursor = index.root(json_bytes);
         let keys_expr = parse("(.k1,.k2)").unwrap();
-        match builtin_pick::<Vec<u64>, JqSemantics>(&keys_expr, cursor.value(), true) {
-            QueryResult::None => {}
-            other => panic!("expected None, got {other:?}"),
-        }
-        match builtin_pick::<Vec<u64>, JqSemantics>(&keys_expr, cursor.value(), false) {
-            QueryResult::Error(e) => assert!(!e.is_decode_failure()),
-            other => panic!("expected Error, got {other:?}"),
+        for optional in [true, false] {
+            match builtin_pick::<Vec<u64>, JqSemantics>(&keys_expr, cursor.value(), optional) {
+                QueryResult::Error(e) => {
+                    assert!(e.is_decode_failure(), "expected decode failure, got: {e:?}");
+                }
+                other => panic!(
+                    "expected a decode failure regardless of optional={optional}, got: {other:?}"
+                ),
+            }
         }
     }
 
@@ -48054,18 +48127,26 @@ mod tests {
         );
     }
 
-    /// #1829 code review: `pick`/`omit(...)?` must suppress the new
-    /// malformed-key errors via the outer `Expr::Optional` catch, matching
-    /// `keys?`/`to_entries?`/`map_values(...)?`'s already-tested convention
-    /// -- flagged as a coverage gap (no runtime bug; both already behaved
-    /// correctly) since `pick`/`omit` were the only two of the five #1829
-    /// builtins in this slice without a dedicated test pinning it.
+    /// #1829 code review, revised by #2286: `pick`/`omit(...)?` on a
+    /// malformed-key document now raise unconditionally rather than
+    /// suppressing via the outer `Expr::Optional` catch, matching
+    /// `keys?`/`to_entries?`/`map_values(...)?`'s own #2286 revision --
+    /// real jq's equivalent is a parse error no filter (`?` included) ever
+    /// reaches.
     #[test]
     fn test_builtin_pick_omit_optional_suppresses_malformed_key_errors_1829() {
-        query!(br#"{"a":1,"b"}"#, "pick([\"a\"])?", QueryResult::None => {});
-        query!(br#"{"a":1,"b"}"#, "omit([\"a\"])?", QueryResult::None => {});
-        query!(br#"{"a" 1, "b": 2}"#, "pick([\"b\"])?", QueryResult::None => {});
-        query!(br#"{"a" 1, "b": 2}"#, "omit([\"b\"])?", QueryResult::None => {});
+        for (doc, expr) in [
+            (&br#"{"a":1,"b"}"#[..], "pick([\"a\"])?"),
+            (&br#"{"a":1,"b"}"#[..], "omit([\"a\"])?"),
+            (&br#"{"a" 1, "b": 2}"#[..], "pick([\"b\"])?"),
+            (&br#"{"a" 1, "b": 2}"#[..], "omit([\"b\"])?"),
+        ] {
+            query!(doc, expr,
+                QueryResult::Error(e) => {
+                    assert!(e.is_decode_failure(), "expected decode failure, got: {e:?}");
+                }
+            );
+        }
     }
 
     /// #1829 code review: the object arm's `effective_fields_checked`
@@ -48866,14 +48947,14 @@ mod tests {
         }
     }
 
-    /// #1934 item 3: `eval_reduce`'s `input` arm treated *every*
-    /// `to_owned`/`promote_borrowed_checked` failure as
-    /// unconditionally fatal, including a non-decode-failure error (a
-    /// #1194 malformed-member error) that the sibling bare
-    /// `QueryResult::Error` arm a few lines below already respects
-    /// `optional` for. `{"a":1,"b"}` is a trailing unpaired object member
-    /// JSON's own semi-index accepts (#1194) -- `.` (identity) surfaces it
-    /// as-is, and `to_owned` raises on the full walk.
+    /// #1934 item 3 (revised by #2286): `eval_reduce`'s `input` arm treats
+    /// every `to_owned`/`promote_borrowed_checked` failure as
+    /// unconditionally fatal -- including a #1194 malformed-member error
+    /// (`{"a":1,"b"}`, a trailing unpaired object member JSON's own
+    /// semi-index accepts), which #2286 tagged `is_decode_failure()` so it
+    /// is now *never* suppressed by `optional` either, matching real jq's
+    /// own "parse error before any filter runs" semantics. `.` (identity)
+    /// surfaces it as-is, and `to_owned` raises on the full walk.
     #[test]
     fn test_eval_reduce_input_to_owned_error_respects_optional_unless_decode_failure_1934() {
         let json: &[u8] = br#"{"a":1,"b"}"#;
@@ -48883,30 +48964,22 @@ mod tests {
         let init_expr = parse("0").unwrap();
         let update_expr = parse(". + 1").unwrap();
 
-        match eval_reduce::<Vec<u64>, JqSemantics>(
-            &identity,
-            &[],
-            &init_expr,
-            &update_expr,
-            root.value(),
-            true,
-        ) {
-            QueryResult::None => {}
-            other => panic!("expected suppression under optional, got: {other:?}"),
-        }
-
-        // Same repro, `optional = false`: still raises, matching the
-        // sibling bare-error arm's own contract.
-        match eval_reduce::<Vec<u64>, JqSemantics>(
-            &identity,
-            &[],
-            &init_expr,
-            &update_expr,
-            root.value(),
-            false,
-        ) {
-            QueryResult::Error(e) => assert!(!e.is_decode_failure()),
-            other => panic!("expected an unsuppressed error, got: {other:?}"),
+        for optional in [true, false] {
+            match eval_reduce::<Vec<u64>, JqSemantics>(
+                &identity,
+                &[],
+                &init_expr,
+                &update_expr,
+                root.value(),
+                optional,
+            ) {
+                QueryResult::Error(e) => {
+                    assert!(e.is_decode_failure(), "expected decode failure, got: {e:?}");
+                }
+                other => panic!(
+                    "expected a decode failure regardless of optional={optional}, got: {other:?}"
+                ),
+            }
         }
     }
 
@@ -48925,28 +48998,22 @@ mod tests {
         let init_expr = parse("0").unwrap();
         let update_expr = parse(". + 1").unwrap();
 
-        match eval_reduce::<Vec<u64>, JqSemantics>(
-            &iterate_expr,
-            &[],
-            &init_expr,
-            &update_expr,
-            root.value(),
-            true,
-        ) {
-            QueryResult::None => {}
-            other => panic!("expected suppression under optional, got: {other:?}"),
-        }
-
-        match eval_reduce::<Vec<u64>, JqSemantics>(
-            &iterate_expr,
-            &[],
-            &init_expr,
-            &update_expr,
-            root.value(),
-            false,
-        ) {
-            QueryResult::Error(e) => assert!(!e.is_decode_failure()),
-            other => panic!("expected an unsuppressed error, got: {other:?}"),
+        for optional in [true, false] {
+            match eval_reduce::<Vec<u64>, JqSemantics>(
+                &iterate_expr,
+                &[],
+                &init_expr,
+                &update_expr,
+                root.value(),
+                optional,
+            ) {
+                QueryResult::Error(e) => {
+                    assert!(e.is_decode_failure(), "expected decode failure, got: {e:?}");
+                }
+                other => panic!(
+                    "expected a decode failure regardless of optional={optional}, got: {other:?}"
+                ),
+            }
         }
     }
 
@@ -53958,47 +54025,35 @@ mod tests {
 
     #[test]
     fn eval_error_msg_expr_malformed_member_reaches_an_enclosing_catch_1907() {
-        // A more discriminating sibling of the plain-raise test below: `?`
-        // and `try`/`catch` suppression is `eval_try`'s own decision, made
-        // *after* inspecting whatever this function returns -- for a bare
-        // `?` (no catch handler), `eval_try` discards any non-decode-failure
-        // `Error` to `None` regardless of how it got there, so that shape
-        // can't tell an internally-self-suppressing `eval_error` apart from
-        // one that raises and lets `eval_try` decide. Wrapping a *real*
-        // catch handler inside the `?` can: with `optional` forced `true` by
-        // the outer `?`, the inner `eval_try`'s `catch = Some(...)` arm only
-        // ever runs if this function actually returns `Error(e)` rather than
-        // self-suppressing to `None` first. Confirmed this reaches the
-        // handler with the fix, and would return bare `None` (skipping the
-        // handler entirely) without it.
+        // #2286 revises this test's own premise: a #1194 malformed-member
+        // error is now `is_decode_failure()`-tagged, so `eval_try`'s
+        // unconditional-propagate arm fires *before* the `catch = Some(...)`
+        // dispatch this test used to exercise -- the handler is bypassed
+        // entirely now, matching real jq's own "parse error, never reaches
+        // any filter including a catch handler" behavior (confirmed live:
+        // `echo '{"a":1,"b"}' | jq -c '(try error(.) catch "caught")?'`
+        // still raises `parse error: Objects must consist of key:value
+        // pairs`, never producing `"caught"`).
         query!(br#"{"a":1,"b"}"#, r#"(try error(.) catch "caught")?"#,
-            QueryResult::Owned(OwnedValue::String(s)) => {
-                assert_eq!(s, "caught");
+            QueryResult::Error(e) => {
+                assert!(e.is_decode_failure(), "expected a decode failure, got: {e:?}");
             }
         );
     }
 
     #[test]
     fn eval_error_msg_expr_malformed_member_raised_1907() {
-        // Sibling to the decode-failure tests above, for the *other* error
-        // class `to_owned` can raise: a #1194 malformed-member error
-        // (a trailing unpaired object member JSON's own semi-index accepts,
-        // e.g. `{"a":1,"b"}`) is not `is_decode_failure()`-tagged, but
-        // `to_owned` raises it unconditionally at every other call
-        // site in this file, including this function's own `None` arm below
-        // -- so `error(.)` must raise it here too, not silently swallow it
-        // into `""` via an unchecked `to_owned_lossy`.
-        //
-        // This does *not* assert anything about a *wrapping* `?`/`try`:
-        // that suppression/catch decision belongs to `eval_try`, one level
-        // up, whose own `is_decode_failure()`-only exclusion is a separate,
-        // pre-existing gap (closely related to #1907's own item 3) outside
-        // this fix's scope -- `eval_try` re-decides uniformly from the
-        // `Error` this function returns, regardless of *how* this function
-        // arrived at it.
+        // #2286: a #1194 malformed-member error (a trailing unpaired object
+        // member JSON's own semi-index accepts, e.g. `{"a":1,"b"}`) is now
+        // `is_decode_failure()`-tagged -- `to_owned` still raises it
+        // unconditionally at every call site in this file, including this
+        // function's own `None` arm below, but the tag now also makes
+        // `eval_try` propagate it unconditionally rather than treating it
+        // as an ordinary, `?`-suppressible/`catch`-able error. See the
+        // sibling test just above for the `?`/`try`/`catch` half of this.
         query!(br#"{"a":1,"b"}"#, "error(.)",
             QueryResult::Error(e) => {
-                assert!(!e.is_decode_failure());
+                assert!(e.is_decode_failure(), "expected a decode failure, got: {e:?}");
             }
         );
     }
@@ -54410,18 +54465,21 @@ mod tests {
     /// #1829's other axis: a structurally non-string/unpaired key (#1194,
     /// `{"a":1,"b"}`) must raise for `keys`/`keys_unsorted` too, matching
     /// `path(.[])`/`tojson` -- previously silently dropped instead (`["a"]`
-    /// rather than an error).
+    /// rather than an error). #2286: this is `is_decode_failure()`-tagged
+    /// now, not the ordinary-error class this test originally expected.
     #[test]
     fn test_builtin_keys_raises_on_structurally_malformed_key_1829() {
         let doc: &[u8] = br#"{"a":1,"b"}"#;
 
         query!(doc, "keys_unsorted",
             QueryResult::Error(e) => {
-                assert!(!e.is_decode_failure(), "message: {}", e.message);
+                assert!(e.is_decode_failure(), "expected decode failure, message: {}", e.message);
             }
         );
         query!(doc, "keys",
-            QueryResult::Error(_) => {}
+            QueryResult::Error(e) => {
+                assert!(e.is_decode_failure(), "expected decode failure, message: {}", e.message);
+            }
         );
     }
 
@@ -54559,20 +54617,27 @@ mod tests {
         }
     }
 
-    /// Code review, #1829/#1835: the object arm's new error paths (#1194,
-    /// #1677) return `QueryResult::Error` directly, with no `optional`
-    /// check of their own -- unlike this same function's scalar/array
-    /// `_ if optional => QueryResult::None` fallthrough. Not a gap: `keys?`/
-    /// `keys_unsorted?` always parses to `Expr::Optional`, whose own
-    /// `eval_try` unconditionally catches an ordinary `QueryResult::Error`
-    /// (mirrors `builtin_length`'s identical scalar-arm shape, already
-    /// established elsewhere in this file). Pinned here since neither
-    /// prior #1829 test exercises `?` at all.
+    /// Code review, #1829/#1835, revised by #2286: the object arm's new
+    /// error paths (#1194, #1677) return `QueryResult::Error` directly,
+    /// with no `optional` check of their own -- unlike this same
+    /// function's scalar/array `_ if optional => QueryResult::None`
+    /// fallthrough. #1829 assumed this meant `keys?`/`keys_unsorted?`
+    /// suppress it uniformly via `eval_try`'s ordinary-error catch; #2286
+    /// tags this error class `is_decode_failure()` instead, matching real
+    /// jq's own unconditional-parse-error behavior for both shapes below
+    /// (live-verified: `keys?` on either document still exits 5 in jq
+    /// 1.7.1). Pinned here since neither prior #1829 test exercises `?` at
+    /// all.
     #[test]
     fn test_builtin_keys_optional_suppresses_malformed_key_errors_1829() {
         for expr in ["keys?", "keys_unsorted?"] {
-            query!(br#"{"a":1,"b"}"#, expr, QueryResult::None => {});
-            query!(br#"{"a" 1, "b": 2}"#, expr, QueryResult::None => {});
+            for doc in [&br#"{"a":1,"b"}"#[..], &br#"{"a" 1, "b": 2}"#[..]] {
+                query!(doc, expr,
+                    QueryResult::Error(e) => {
+                        assert!(e.is_decode_failure(), "expected decode failure, got: {e:?}");
+                    }
+                );
+            }
         }
     }
 
@@ -54982,13 +55047,24 @@ mod tests {
         );
     }
 
-    /// Code review precedent from #1835/#1848/#1829: `map_values?` must
-    /// still suppress both error axes via the outer `Expr::Optional` catch.
+    /// Code review precedent from #1835/#1848/#1829, revised by #2286:
+    /// `map_values?` on either malformed-document axis now raises
+    /// unconditionally rather than suppressing via the outer
+    /// `Expr::Optional` catch (live-verified against jq 1.7.1: all three
+    /// shapes below still exit 5 under `?`).
     #[test]
     fn test_builtin_map_values_optional_suppresses_malformed_key_errors_1829() {
-        query!(br#"{"a":1,"b"}"#, "map_values(.+1)?", QueryResult::None => {});
-        query!(br#"{"a" 1, "b": 2}"#, "map_values(.+1)?", QueryResult::None => {});
-        query!(br"[1 2, 3]", "map_values(.+1)?", QueryResult::None => {});
+        for (doc, expr) in [
+            (&br#"{"a":1,"b"}"#[..], "map_values(.+1)?"),
+            (&br#"{"a" 1, "b": 2}"#[..], "map_values(.+1)?"),
+            (&br"[1 2, 3]"[..], "map_values(.+1)?"),
+        ] {
+            query!(doc, expr,
+                QueryResult::Error(e) => {
+                    assert!(e.is_decode_failure(), "expected decode failure, got: {e:?}");
+                }
+            );
+        }
     }
 
     /// Code review, #1829: a duplicate object key must be collapsed to its
@@ -56358,12 +56434,19 @@ mod tests {
         );
     }
 
-    /// Code review precedent from #1835/#1829: `to_entries?` must still
-    /// suppress both error axes via the outer `Expr::Optional` catch.
+    /// Code review precedent from #1835/#1829, revised by #2286:
+    /// `to_entries?` on either malformed-document axis now raises
+    /// unconditionally instead of suppressing via the outer
+    /// `Expr::Optional` catch.
     #[test]
     fn test_builtin_to_entries_optional_suppresses_malformed_key_errors_1829() {
-        query!(br#"{"a":1,"b"}"#, "to_entries?", QueryResult::None => {});
-        query!(br#"{"a" 1, "b": 2}"#, "to_entries?", QueryResult::None => {});
+        for doc in [&br#"{"a":1,"b"}"#[..], &br#"{"a" 1, "b": 2}"#[..]] {
+            query!(doc, "to_entries?",
+                QueryResult::Error(e) => {
+                    assert!(e.is_decode_failure(), "expected decode failure, got: {e:?}");
+                }
+            );
+        }
     }
 
     #[test]
@@ -77241,27 +77324,42 @@ mod tests {
     /// consistency, not a latent `try`/`catch` bypass.
     #[test]
     fn test_try_catch_handler_still_runs_under_outer_optional_2231() {
-        // Bare, unwrapped: raises the ordinary (suppressible) #1194 error.
+        // #2286 revises this test: `{"a":1,"b"}`'s #1194 malformed-member
+        // error is now `is_decode_failure()`-tagged, which closes off the
+        // *only* concrete vehicle this test had for finding 4's scenario --
+        // `to_owned_at_depth`'s remaining error paths (string decode
+        // failure, #1642 key collision, #1194 malformed member/delimiter)
+        // are now uniformly decode failures, so no `to_owned`-sourced error
+        // can demonstrate "a leaf's own internal optional-consulting
+        // self-suppresses ahead of an enclosing catch" anymore -- there is
+        // no longer a non-decode-failure error class left for such a leaf
+        // to conditionally suppress. `eval_try`'s own mechanism (passing
+        // the same `optional` it receives straight into evaluating `expr`)
+        // is unchanged and still exercised by every decode-failure-survives
+        // test in this file; what changed is that #1194 joined that
+        // uncatchable class instead of remaining a live example of the
+        // *other* one. This test now just pins the resulting behavior
+        // directly: uncatchable at every level, `catch` handler included,
+        // matching real jq's own unconditional parse error.
         query!(
             br#"{"a":1,"b"}"#,
             "tostring",
-            QueryResult::Error(e) => assert!(!e.is_decode_failure(), "{}", e.message)
+            QueryResult::Error(e) => assert!(e.is_decode_failure(), "expected decode failure, got: {e:?}")
         );
-        // `?` alone: suppressed to nothing, per #2184.
-        query!(br#"{"a":1,"b"}"#, "tostring?", QueryResult::None => {});
-        // `try ... catch H`, no outer `?`: H runs.
+        query!(
+            br#"{"a":1,"b"}"#,
+            "tostring?",
+            QueryResult::Error(e) => assert!(e.is_decode_failure(), "expected decode failure, got: {e:?}")
+        );
         query!(
             br#"{"a":1,"b"}"#,
             r#"try tostring catch "CAUGHT""#,
-            QueryResult::Owned(OwnedValue::String(s)) => assert_eq!(&*s, "CAUGHT")
+            QueryResult::Error(e) => assert!(e.is_decode_failure(), "expected decode failure, got: {e:?}")
         );
-        // The case finding 4 worried about: `try ... catch H` wrapped in its
-        // own outer `?`. `H` must still run -- `tostring`'s own internal
-        // suppression must not fire ahead of `eval_try`'s catch dispatch.
         query!(
             br#"{"a":1,"b"}"#,
             r#"(try tostring catch "CAUGHT")?"#,
-            QueryResult::Owned(OwnedValue::String(s)) => assert_eq!(&*s, "CAUGHT")
+            QueryResult::Error(e) => assert!(e.is_decode_failure(), "expected decode failure, got: {e:?}")
         );
     }
 
@@ -77269,61 +77367,75 @@ mod tests {
     /// (`eval.rs`) and `fromjsonstream`'s Array arm (`eval.rs`) all raised
     /// an ordinary, suppressible #1194 malformed-member error
     /// unconditionally, ignoring `optional` where #2184/#2015 already fixed
-    /// the rest of this lineage's sites.
+    /// the rest of this lineage's sites -- true when #2231 landed.
     ///
-    /// Called directly, like every `#2184`/`#2015` test above -- going
-    /// through `?`/`try` can't distinguish fixed from unfixed here, since
-    /// `eval_try`'s own outer catch already normalizes the *observable*
-    /// result to `None` either way (confirmed by
-    /// `test_try_catch_handler_still_runs_under_outer_optional_2231`,
-    /// finding 4). This test pins the leaf's own `optional`-consulting
-    /// behavior, which #843/#1953's "one level up" defense makes non-live-
-    /// reachable today but still worth keeping correct in its own right.
+    /// #2286 has since tagged #1194 malformed-member/delimiter errors
+    /// `is_decode_failure()`, which makes every one of these four sites'
+    /// `optional`-consulting a no-op for this specific error class:
+    /// `suppresses(e, optional) = optional && !e.is_decode_failure()` is
+    /// now unconditionally `false` here regardless of what `optional`
+    /// actually is, since `to_owned`/`to_owned_at_depth` has no remaining
+    /// error path that *isn't* a decode failure. The fix these four sites
+    /// made is still correct (a decode failure must never be suppressed,
+    /// which is exactly what they now do) -- it just no longer depends on
+    /// `optional`'s value to be correct, the way #1194 originally seemed to
+    /// require. Not a regression to "fix" back: `to_owned_or_suppress!`/
+    /// `owned_or_suppress!` still correctly propagate a genuine decode
+    /// failure when `optional` really is meaningful for some *other* error
+    /// class a future caller might route through the same macro.
     #[test]
     fn test_debug_stderr_fromjsonstream_respect_optional_2231() {
         let json_bytes: &[u8] = br#"{"a":1,"b"}"#;
         let index = JsonIndex::build(json_bytes);
         let cursor = index.root(json_bytes);
 
-        match builtin_debug::<Vec<u64>, JqSemantics>(cursor.value(), true) {
-            QueryResult::None => {}
-            other => panic!("expected None, got {other:?}"),
-        }
-        match builtin_debug::<Vec<u64>, JqSemantics>(cursor.value(), false) {
-            QueryResult::Error(e) => assert!(!e.is_decode_failure()),
-            other => panic!("expected Error, got {other:?}"),
+        for optional in [true, false] {
+            match builtin_debug::<Vec<u64>, JqSemantics>(cursor.value(), optional) {
+                QueryResult::Error(e) => {
+                    assert!(e.is_decode_failure(), "expected decode failure, got: {e:?}");
+                }
+                other => panic!(
+                    "expected a decode failure regardless of optional={optional}, got: {other:?}"
+                ),
+            }
         }
 
-        match builtin_stderr::<Vec<u64>, JqSemantics>(cursor.value(), true) {
-            QueryResult::None => {}
-            other => panic!("expected None, got {other:?}"),
-        }
-        match builtin_stderr::<Vec<u64>, JqSemantics>(cursor.value(), false) {
-            QueryResult::Error(e) => assert!(!e.is_decode_failure()),
-            other => panic!("expected Error, got {other:?}"),
+        for optional in [true, false] {
+            match builtin_stderr::<Vec<u64>, JqSemantics>(cursor.value(), optional) {
+                QueryResult::Error(e) => {
+                    assert!(e.is_decode_failure(), "expected decode failure, got: {e:?}");
+                }
+                other => panic!(
+                    "expected a decode failure regardless of optional={optional}, got: {other:?}"
+                ),
+            }
         }
 
         let msg = Expr::Identity;
-        match builtin_debug_msg::<Vec<u64>, JqSemantics>(&msg, cursor.value(), true) {
-            QueryResult::None => {}
-            other => panic!("expected None, got {other:?}"),
-        }
-        match builtin_debug_msg::<Vec<u64>, JqSemantics>(&msg, cursor.value(), false) {
-            QueryResult::Error(e) => assert!(!e.is_decode_failure()),
-            other => panic!("expected Error, got {other:?}"),
+        for optional in [true, false] {
+            match builtin_debug_msg::<Vec<u64>, JqSemantics>(&msg, cursor.value(), optional) {
+                QueryResult::Error(e) => {
+                    assert!(e.is_decode_failure(), "expected decode failure, got: {e:?}");
+                }
+                other => panic!(
+                    "expected a decode failure regardless of optional={optional}, got: {other:?}"
+                ),
+            }
         }
 
         // `fromjsonstream`'s Array arm, same malformed member one level down.
         let array_bytes: &[u8] = br#"[{"a":1,"b"}]"#;
         let array_index = JsonIndex::build(array_bytes);
         let array_cursor = array_index.root(array_bytes);
-        match builtin_fromjsonstream::<Vec<u64>>(array_cursor.value(), true) {
-            QueryResult::None => {}
-            other => panic!("expected None, got {other:?}"),
-        }
-        match builtin_fromjsonstream::<Vec<u64>>(array_cursor.value(), false) {
-            QueryResult::Error(e) => assert!(!e.is_decode_failure()),
-            other => panic!("expected Error, got {other:?}"),
+        for optional in [true, false] {
+            match builtin_fromjsonstream::<Vec<u64>>(array_cursor.value(), optional) {
+                QueryResult::Error(e) => {
+                    assert!(e.is_decode_failure(), "expected decode failure, got: {e:?}");
+                }
+                other => panic!(
+                    "expected a decode failure regardless of optional={optional}, got: {other:?}"
+                ),
+            }
         }
     }
 

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -754,7 +754,16 @@ fn to_owned_at_depth<W: Clone + AsRef<[u64]>>(
             }
             OwnedValue::Object(map)
         }
-        StandardJson::Error(_) => OwnedValue::Null,
+        // #2286 review: this arm used to silently substitute `Null` for a
+        // bareword-garbage token (`StandardJson::Error`, e.g. `xyz123`),
+        // contradicting this function's own doc comment ("raising
+        // EvalError::decode_failure on anything it cannot decode") -- worse
+        // than merely catchable, since no error was raised for a caller to
+        // even suppress. Real jq treats this the same as every other #1194
+        // shape: an unconditional parse error (confirmed live against jq
+        // 1.7.1: `[1, xyz123] | add` exits 5 regardless of a wrapping
+        // `try...catch`).
+        StandardJson::Error(msg) => return Err(EvalError::decode_failure(*msg)),
     })
 }
 
@@ -45653,35 +45662,24 @@ mod tests {
         );
     }
 
-    /// #1953: the seven `to_owned` call sites tested individually
-    /// below all propagated this non-decode-failure error unconditionally,
-    /// ignoring `optional`, before this fix -- diverging from an adjacent
-    /// sibling arm at the very same boundary in every case.
-    ///
-    /// None of the seven is reachable with `optional: true` through any
-    /// real `?`/`try` syntax today (code review, #1953): `Expr::Optional`'s
-    /// dispatch (see the doc comment on `eval_single`'s own `Expr::Optional
-    /// (inner) if matches!(**inner, Expr::IndexExpr{..}|Expr::SliceExpr{..})`
-    /// arm) only ever forwards `optional: true` *directly* into a callee for
-    /// that one dynamic-bounds index/slice shape. Every other spelling of
-    /// `?` -- including a literal-bounds slice like `.[0:1]?` (which folds
-    /// to `Expr::Slice`, not `Expr::SliceExpr`, so it
-    /// doesn't take that bypass either) and Assign/Update/SetPath/
-    /// Combinations, none of which are Index/Slice at all -- instead
-    /// evaluates its inner expression with the *ambient* `optional` and
-    /// lets `eval_try`'s own catch-and-convert machinery decide the
-    /// aggregate outcome afterward, independent of what the callee did
-    /// internally. So each site is exercised directly here, the same way
-    /// this file's own pre-existing `eval_assign_optional_swallows_
-    /// ordinary_path_error_called_directly` and its siblings already test
-    /// `optional`-gated behavior with no reachable `?` spelling of its own.
-    /// Fixing it anyway keeps every one of these functions' own `optional`
-    /// parameter internally consistent with what its doc comment already
-    /// promises, in case a future caller (or a future widening of the
-    /// `Expr::Optional` bypass above) ever does reach it with `true`.
-    /// Split one function per site (rather than one function with seven
-    /// blocks) so a regression at any single site fails its own test
-    /// instead of hiding behind an earlier block's panic.
+    /// #1953 named this test (and its six siblings below, sharing this
+    /// function's name in their own doc comments) for the premise that each
+    /// of these seven `to_owned` call sites should respect `optional` for a
+    /// #1194 malformed-member error, the same way an adjacent sibling arm at
+    /// the same boundary already did. #2286 found that premise was never
+    /// checked against the real jq oracle and reversed it (see
+    /// `test_malformed_member_error_is_not_a_decode_failure_1953` above):
+    /// this error class is `is_decode_failure()`-tagged, so `optional` can
+    /// no longer make a difference here -- `eval_try`'s dispatch excludes
+    /// `is_decode_failure()` from ever reaching a `catch` handler or being
+    /// suppressed by `?`, unconditionally. Each site is still exercised
+    /// individually with `optional` in `[true, false]` and asserted to
+    /// raise a decode failure *either way* -- proving `optional` is now a
+    /// genuine no-op for this error class at every one of the seven sites,
+    /// not just the one #1953 originally profiled. Kept as one function per
+    /// site (rather than one function with seven blocks), matching #1953's
+    /// original split, so a regression at any single site fails its own
+    /// test instead of hiding behind an earlier block's panic.
     #[test]
     fn test_eval_single_yq_slice_respects_optional_for_malformed_member_error_1953() {
         let json_bytes: &[u8] = br#"{"a":1,"b"}"#;

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -11402,12 +11402,19 @@ mod tests {
     /// catch-all wildcard fallback arm both raised an ordinary #1194
     /// malformed-member error unconditionally, ignoring `optional` --
     /// the `eval_generic.rs` twin of `eval.rs`'s `builtin_tostring`
-    /// (#2184) and findings 1-3's other `eval.rs` sites. Called directly
-    /// through `eval_builtin`, not through `eval`/`?`, for the same reason
-    /// `eval.rs`'s own #2184/#2231 tests do: `Expr::Optional`'s outer catch
-    /// already normalizes the observable result regardless of what this
-    /// arm does internally, so only a direct call distinguishes fixed from
-    /// unfixed.
+    /// (#2184) and findings 1-3's other `eval.rs` sites -- true when #2231
+    /// landed.
+    ///
+    /// #2286 has since tagged #1194 malformed-member/delimiter errors
+    /// `is_decode_failure()`, making both sites' `optional`-consulting a
+    /// no-op for this specific error class -- see
+    /// `test_debug_stderr_fromjsonstream_respect_optional_2231`'s own
+    /// revised doc comment (`eval.rs`) for the full reasoning, which
+    /// applies identically here. Still called directly through
+    /// `eval_builtin`, not through `eval`/`?`: that distinction no longer
+    /// matters for *this* error class (uncatchable at every level either
+    /// way now), but stays for consistency with the sibling decode-failure
+    /// test just below, which does still need it.
     #[test]
     fn test_generic_tostring_and_wildcard_respect_optional_2231() {
         use crate::json::JsonIndex;
@@ -11416,26 +11423,38 @@ mod tests {
         let cursor = index.root(json);
         let value = cursor.value();
 
-        match eval_builtin::<JqSemantics, _>(&Builtin::ToString, value.clone(), true, Some(cursor))
-        {
-            GenericResult::None => {}
-            other => panic!("expected None, got {other:?}"),
-        }
-        match eval_builtin::<JqSemantics, _>(&Builtin::ToString, value.clone(), false, Some(cursor))
-        {
-            GenericResult::Error(e) => assert!(!e.is_decode_failure()),
-            other => panic!("expected Error, got {other:?}"),
+        for optional in [true, false] {
+            match eval_builtin::<JqSemantics, _>(
+                &Builtin::ToString,
+                value.clone(),
+                optional,
+                Some(cursor),
+            ) {
+                GenericResult::Error(e) => {
+                    assert!(e.is_decode_failure(), "expected decode failure, got: {e:?}");
+                }
+                other => panic!(
+                    "expected a decode failure regardless of optional={optional}, got: {other:?}"
+                ),
+            }
         }
 
         // The catch-all wildcard arm, reached via a builtin with no
         // dedicated arm of its own (e.g. `ToJson`).
-        match eval_builtin::<JqSemantics, _>(&Builtin::ToJson, value.clone(), true, Some(cursor)) {
-            GenericResult::None => {}
-            other => panic!("expected None, got {other:?}"),
-        }
-        match eval_builtin::<JqSemantics, _>(&Builtin::ToJson, value, false, Some(cursor)) {
-            GenericResult::Error(e) => assert!(!e.is_decode_failure()),
-            other => panic!("expected Error, got {other:?}"),
+        for optional in [true, false] {
+            match eval_builtin::<JqSemantics, _>(
+                &Builtin::ToJson,
+                value.clone(),
+                optional,
+                Some(cursor),
+            ) {
+                GenericResult::Error(e) => {
+                    assert!(e.is_decode_failure(), "expected decode failure, got: {e:?}");
+                }
+                other => panic!(
+                    "expected a decode failure regardless of optional={optional}, got: {other:?}"
+                ),
+            }
         }
     }
 

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -329,11 +329,16 @@ fn to_owned_at_depth<V: DocumentValue>(value: &V, depth: usize) -> Result<OwnedV
         // back as `[null]` at exit 0 where real jq raises a parse error
         // (#1194). The semi-index's own message is more specific than
         // anything reconstructible here, so it is passed through verbatim.
-        Err(EvalError::new(
+        // #2286: `decode_failure`, not `new` -- same uncatchable class as
+        // every other `StandardJson::Error`/`is_error()` site this issue
+        // fixed (confirmed live: this exact generic-evaluator `to_owned_at_depth`
+        // is what `resolve_fold_source`/`reduce`'s fold-source path calls,
+        // so `[1, xyz123] | try add catch "caught"` stayed wrongly catchable
+        // until this arm was retagged too).
+        Err(EvalError::decode_failure(
             value
                 .error_message()
-                .unwrap_or("malformed value in document")
-                .to_string(),
+                .unwrap_or("malformed value in document"),
         ))
     } else {
         // A genuinely unknown type: no format implements one today, so this
@@ -1675,7 +1680,13 @@ fn owned_from_standard_json_at_depth<W: Clone + AsRef<[u64]>>(
         }
         // See `to_owned_at_depth`'s own `is_error` arm (#1194/#1247): a
         // structurally malformed value raises rather than becoming `null`.
-        StandardJson::Error(msg) => return Err(EvalError::new((*msg).to_string())),
+        // #2286: decode_failure, not new -- a bareword-garbage token is the
+        // same "real jq rejects this at parse time" class as the malformed
+        // member/delimiter errors #2286 already tagged; leaving this arm
+        // ordinary/catchable was a real, live gap review caught (`[1,
+        // xyz123] | try add catch "caught"` wrongly printed `"caught"`
+        // instead of raising, unlike real jq).
+        StandardJson::Error(msg) => return Err(EvalError::decode_failure(*msg)),
     })
 }
 
@@ -2423,11 +2434,13 @@ fn push_generic_truthiness_cursor_error<C: DocumentCursor>(c: &C, depth: usize) 
     } else if let Some(reason) = value.string_decode_error() {
         Some(Control::Error(EvalError::decode_failure(reason)))
     } else if value.is_error() {
-        Some(Control::Error(EvalError::new(
+        // #2286: `decode_failure`, not `new` -- see `to_owned_at_depth`'s
+        // own `is_error()` arm above for the full rationale; this is the
+        // truthiness-check sibling of that same class.
+        Some(Control::Error(EvalError::decode_failure(
             value
                 .error_message()
-                .unwrap_or("malformed value in document")
-                .to_string(),
+                .unwrap_or("malformed value in document"),
         )))
     } else {
         None

--- a/src/jq/lazy.rs
+++ b/src/jq/lazy.rs
@@ -931,8 +931,10 @@ fn cursor_to_owned_at_depth<W: Clone + AsRef<[u64]>>(
         }
         // See `eval_generic::to_owned_at_depth`'s own `is_error` arm
         // (#1194/#1247): a structurally malformed value raises rather than
-        // becoming `null`.
-        StandardJson::Error(msg) => return Err(EvalError::new(msg.to_string())),
+        // becoming `null`. #2286: decode_failure, not new -- same class as
+        // the malformed member/delimiter errors; confirmed live that real
+        // jq treats this uncatchably too.
+        StandardJson::Error(msg) => return Err(EvalError::decode_failure(msg)),
     })
 }
 

--- a/src/json/light.rs
+++ b/src/json/light.rs
@@ -3040,8 +3040,12 @@ fn stream_json_pretty<W: AsRef<[u64]> + Clone, Out: core::fmt::Write>(
         // matters: the caller (`GenericResult::stream_json`'s `LazySeq`
         // arm) discards this writer's own partial output rather than the
         // whole document silently reading back as valid JSON with a
-        // fabricated `null`.
-        StandardJson::Error(msg) => Err(StreamFailure::Decode(EvalError::new(msg))),
+        // fabricated `null`. #2286: `decode_failure`, not `new` -- matches
+        // this same function's `malformed_json_text`-tagged arms just above
+        // (same uncatchable #1194 error class), and keeps this arm
+        // consistent with every other `StandardJson::Error` site fixed by
+        // #2286.
+        StandardJson::Error(msg) => Err(StreamFailure::Decode(EvalError::decode_failure(msg))),
     }
 }
 

--- a/src/json/light.rs
+++ b/src/json/light.rs
@@ -2712,7 +2712,11 @@ impl<'a, W: AsRef<[u64]> + Clone> DocumentFields for JsonFields<'a, W> {
     fn malformed_member_error(&self) -> EvalError {
         match self.key_cursor {
             Some(cursor) => EvalError::malformed_json_text(cursor.text()),
-            None => EvalError::new("Invalid JSON text"),
+            // #2286: decode_failure, not new -- same always-uncatchable tag
+            // the cursor-present arm gets via malformed_json_text, so this
+            // fallback doesn't quietly reintroduce the gap for the one case
+            // (empty list, no cursor to read) that skips it.
+            None => EvalError::decode_failure("Invalid JSON text"),
         }
     }
 
@@ -2750,7 +2754,9 @@ impl<'a, W: AsRef<[u64]> + Clone> DocumentElements for JsonElements<'a, W> {
     fn malformed_element_error(&self) -> EvalError {
         match self.element_cursor {
             Some(cursor) => EvalError::malformed_json_text(cursor.text()),
-            None => EvalError::new("Invalid JSON text"),
+            // #2286: same fallback fix as JsonFields::malformed_member_error
+            // above.
+            None => EvalError::decode_failure("Invalid JSON text"),
         }
     }
 }

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -21585,6 +21585,82 @@ fn test_jq_malformed_json_text_falls_back_when_validator_disagrees_1194() -> Res
     Ok(())
 }
 
+/// #2286: `EvalError::malformed_json_text` (and its `malformed_member_error`/
+/// `malformed_delimiter_error`/`malformed_element_error` callers) used to
+/// construct an ordinary, `?`-suppressible `Error` -- real jq's equivalent
+/// failure is a *parse* error, raised before any filter (`?` included) ever
+/// runs. Verified live against jq 1.7.1: all three shapes below exit 5
+/// unconditionally there (`.a?`, `try .a catch H`, and `(try .a catch H)?`
+/// -- the last one specifically closing the gap this issue's finding-4-style
+/// worry would raise: an outer `?` must not let this error's now-uncatchable
+/// classification skip the inner `catch` handler either, since jq's own
+/// parse-time failure happens before *any* of `.a?`/`try`/`catch` are
+/// reached at all, catch handler included).
+#[test]
+fn test_malformed_json_error_never_suppressed_2286() -> Result<()> {
+    let malformed_pairing: &str = r#"{"a" 1}"#;
+
+    for expr in [
+        ".a?",
+        "try .a catch \"caught\"",
+        "(try .a catch \"caught\")?",
+    ] {
+        let (stdout, stderr, code) = run_jq_full(&["-c", expr], Some(malformed_pairing))?;
+        assert_eq!(code, 5, "{expr}: stdout: {stdout:?} stderr: {stderr:?}");
+        assert!(
+            stderr.contains("Invalid JSON text"),
+            "{expr}: stderr: {stderr:?}"
+        );
+    }
+
+    Ok(())
+}
+
+/// #2286/#1995: the non-string-sibling-key shape from #1995's own repro
+/// (`{"a":1,123:2}`) is confounded across two distinct, separately-scoped
+/// bugs -- worth pinning both halves so a future reader doesn't conflate
+/// them. `.a?` alone never even reaches `malformed_json_text`: `Expr::
+/// Field`'s fast path looks up `.a` directly without validating sibling
+/// keys at all (#1995's own still-open bug, unrelated to this issue,
+/// tracked separately -- wrongly succeeds with `1` here, not "wrongly
+/// suppressed"). `keys?`/`to_entries?` instead walk every member (they
+/// are not simple field lookups), reaching `malformed_json_text` via
+/// `malformed_member_error` regardless of which field is asked for --
+/// that shape is squarely in #2286's own scope, and now correctly raises
+/// unconditionally, matching real jq 1.7.1 (`Object keys must be
+/// strings`, exit 5, no output).
+///
+/// `.a? // "outer"` (an earlier draft of this test) is *not* a valid
+/// vehicle for this: `//`'s own semantics only substitute for a
+/// falsy/absent *output*, never for a raised error, regardless of that
+/// error's catchability tag (`eval_alternative`'s own doc comment) -- so
+/// it stayed exit 5 identically whether or not the fix was applied,
+/// silently testing nothing about this issue's own scope.
+#[test]
+fn test_malformed_json_error_never_suppressed_on_generic_bridge_2286() -> Result<()> {
+    let non_string_sibling_key: &str = r#"{"a":1,123:2}"#;
+
+    // #1995's own bug, not this issue's -- pinned here as the contrast.
+    let (stdout, _stderr, code) = run_jq_full(&["-c", ".a?"], Some(non_string_sibling_key))?;
+    assert_eq!(code, 0, "stdout: {stdout:?}");
+    assert_eq!(stdout, "1\n");
+
+    // This issue's own scope: a whole-object walk reaches
+    // malformed_member_error/malformed_json_text, which must now raise
+    // unconditionally even under a trailing `?`.
+    for expr in ["keys?", "to_entries?"] {
+        let (stdout, stderr, code) = run_jq_full(&["-c", expr], Some(non_string_sibling_key))?;
+        assert_eq!(code, 5, "{expr}: stdout: {stdout:?} stderr: {stderr:?}");
+        assert!(stdout.is_empty(), "{expr}: stdout: {stdout:?}");
+        assert!(
+            stderr.contains("Invalid JSON text"),
+            "{expr}: stderr: {stderr:?}"
+        );
+    }
+
+    Ok(())
+}
+
 /// #1194: nothing partial reaches stdout for a malformed top-level object
 /// on the identity path.
 ///
@@ -22898,12 +22974,17 @@ fn test_jq_keys_unsorted_last_raises_on_missing_delimiter_1956() -> Result<()> {
     assert!(out.trim().is_empty(), "unexpected output {out:?}");
     assert!(stderr.contains("Invalid JSON text"), "stderr: {stderr:?}");
 
+    // #2286: this #1194/#1677 error is now `is_decode_failure()`-tagged,
+    // so `try...catch` no longer reaches its handler either -- matching
+    // real jq's own unconditional parse-error behavior here (live-verified
+    // against jq 1.7.1: still exits 5, never producing `"c"`).
     let (out, stderr, code) = run_jq_full(
         &["-c", r#"try (keys_unsorted | last) catch "c""#],
         Some(doc),
     )?;
-    assert_eq!(code, 0, "stderr: {stderr:?}");
-    assert_eq!(out.trim(), "\"c\"", "out: {out:?}");
+    assert_eq!(code, 5, "out: {out:?}, stderr: {stderr:?}");
+    assert!(out.trim().is_empty(), "unexpected output {out:?}");
+    assert!(stderr.contains("Invalid JSON text"), "stderr: {stderr:?}");
 
     // Well-formed data is unaffected.
     let (out, stderr, code) =
@@ -22929,12 +23010,16 @@ fn test_jq_keys_unsorted_map_raises_on_missing_delimiter_1956() -> Result<()> {
     assert!(out.trim().is_empty(), "unexpected output {out:?}");
     assert!(stderr.contains("Invalid JSON text"), "stderr: {stderr:?}");
 
+    // #2286: same revision as the sibling `last` test above -- this error
+    // is now `is_decode_failure()`-tagged, so `try...catch` no longer
+    // reaches its handler either.
     let (out, stderr, code) = run_jq_full(
         &["-c", r#"try (keys_unsorted | map(.)) catch "c""#],
         Some(doc),
     )?;
-    assert_eq!(code, 0, "stderr: {stderr:?}");
-    assert_eq!(out.trim(), "\"c\"", "out: {out:?}");
+    assert_eq!(code, 5, "out: {out:?}, stderr: {stderr:?}");
+    assert!(out.trim().is_empty(), "unexpected output {out:?}");
+    assert!(stderr.contains("Invalid JSON text"), "stderr: {stderr:?}");
 
     // Well-formed data is unaffected.
     let (out, stderr, code) =
@@ -30151,22 +30236,43 @@ fn test_ordinary_type_error_still_suppressed_and_caught_1620() {
 /// catchability-aware dispatch -- no catchability check at all. A #1194
 /// malformed (non-string) object key raised there uncaught, even though
 /// `?` (which does have a native, catchability-aware `Expr::Optional` arm)
-/// already suppressed the identical error correctly. Confirmed live
-/// against unmodified `main` before this fix: `sort?` on `{123: 1}`
-/// succeeded silently while `try (1+1) catch "x"` raised uncaught, exit 5.
+/// already suppressed the identical error correctly. True when #1812
+/// landed: `sort?` on `{123: 1}` succeeded silently while `try (1+1) catch
+/// "x"` raised uncaught, exit 5 (`sort` reaching the malformed key as part
+/// of its own reordering walk; `1+1` not touching `.` at all, catching a
+/// failure from `Expr::Try`'s own ambient-materialization side effect
+/// rather than anything in its own body).
+///
+/// #2286 revises what "genuinely catchable" means for this specific key:
+/// live-verified that real jq treats a document-level #1194 fault as an
+/// unconditional parse error for *every* query on that document, including
+/// ones that never reference the malformed region at all (`sort?`, `1+1`)
+/// -- jq's parser rejects the whole document before any filter runs. Once
+/// #2286 tagged this error `is_decode_failure()`, succinctly's own
+/// behavior converged on that: all three shapes below now correctly exit 5
+/// uncaught, matching jq exactly (an *improvement* on #1812's own
+/// oracle-fidelity, not a regression -- #1812 never claimed `sort?`
+/// silently succeeding was correct, only that it was inconsistent with the
+/// `try` case).
 #[test]
 fn test_try_catch_contains_a_genuinely_catchable_malformed_key_error_1812() -> Result<()> {
     let doc = "{123: 1}";
 
     let (stdout, stderr, code) = run_jq_full(&["-c", "sort?"], Some(doc))?;
-    assert_eq!((stdout.as_str(), code), ("", 0), "stderr: {stderr}");
+    assert_eq!(code, 5, "stdout: {stdout:?} stderr: {stderr}");
+    assert!(stdout.trim().is_empty(), "stdout: {stdout:?}");
+    assert!(stderr.contains("Invalid JSON text"), "stderr: {stderr}");
 
     let (stdout, stderr, code) = run_jq_full(&["-c", r#"try (1+1) catch "x""#], Some(doc))?;
-    assert_eq!((stdout.as_str(), code), ("\"x\"\n", 0), "stderr: {stderr}");
+    assert_eq!(code, 5, "stdout: {stdout:?} stderr: {stderr}");
+    assert!(stdout.trim().is_empty(), "stdout: {stdout:?}");
+    assert!(stderr.contains("Invalid JSON text"), "stderr: {stderr}");
 
-    // Bare `try`, no `catch` handler: suppresses to no output, same as `?`.
+    // Bare `try`, no `catch` handler: still raises, same as the two above.
     let (stdout, stderr, code) = run_jq_full(&["-c", "try (1+1)"], Some(doc))?;
-    assert_eq!((stdout.as_str(), code), ("", 0), "stderr: {stderr}");
+    assert_eq!(code, 5, "stdout: {stdout:?} stderr: {stderr}");
+    assert!(stdout.trim().is_empty(), "stdout: {stdout:?}");
+    assert!(stderr.contains("Invalid JSON text"), "stderr: {stderr}");
 
     Ok(())
 }
@@ -30240,13 +30346,24 @@ fn test_try_catch_forces_and_catches_a_lazyseq_failure_1812() -> Result<()> {
 /// `keys`/`keys_unsorted` on an object stay lazy until something actually
 /// materializes them, so a #1194 malformed (non-string) key raised only
 /// once that later, boundary-less materialization happened, escaping `?`/
-/// `try` entirely. `sort?`/`try (sort) catch` on the identical document
-/// already worked (`sort` has no lazy fast path, so it materializes and
-/// fails inside the boundary's own dispatch) -- this pins `keys_unsorted`/
-/// `keys` (the `sorted: true` path through the same `LazyKeys` variant) to
-/// the same already-correct behavior. Confirmed live against unmodified
-/// `main` before this fix: both `keys_unsorted?` and
-/// `try (keys_unsorted) catch "c"` raised uncaught, exit 5.
+/// `try` entirely. True when #1936 landed: `sort?`/`try (sort) catch` on
+/// the identical document already worked (`sort` has no lazy fast path, so
+/// it materializes and fails inside the boundary's own dispatch) --
+/// `keys_unsorted?`/`try (keys_unsorted) catch "c"` raised uncaught before
+/// this fix, exit 5, while `sort?` correctly suppressed.
+///
+/// #2286 revises what "caught" means here the same way it did for #1812's
+/// sibling test just above: real jq treats a #1194 fault as an
+/// unconditional parse error for the whole document, so none of the five
+/// shapes below are actually catchable in real jq either (all verified
+/// live to exit 5). #2286 tags this error `is_decode_failure()`, so
+/// succinctly now agrees -- `sort?`/`keys?`/`keys_unsorted?` all raise
+/// instead of suppressing, and the two `catch` shapes raise instead of
+/// running their handler. This still exercises #1936's own fix (the
+/// `LazyKeys` boundary is what makes the error reach `eval_try` at all,
+/// where it's now excluded rather than dispatched to `catch`) -- it just
+/// no longer demonstrates catchability, since nothing in this error class
+/// is catchable anymore.
 #[test]
 fn test_optional_and_try_catch_force_and_catch_a_lazykeys_malformed_key_1936() -> Result<()> {
     let doc = "{123: 1}";
@@ -30254,9 +30371,10 @@ fn test_optional_and_try_catch_force_and_catch_a_lazykeys_malformed_key_1936() -
     for filter in ["sort?", "keys?", "keys_unsorted?"] {
         let (stdout, stderr, code) = run_jq_full(&["-c", filter], Some(doc))
             .unwrap_or_else(|e| panic!("`{filter}` failed to run: {e}"));
-        assert_eq!(
-            (stdout.as_str(), code),
-            ("", 0),
+        assert_eq!(code, 5, "`{filter}` -- stdout: {stdout:?} stderr: {stderr}");
+        assert!(stdout.trim().is_empty(), "`{filter}` -- stdout: {stdout:?}");
+        assert!(
+            stderr.contains("Invalid JSON text"),
             "`{filter}` -- stderr: {stderr}"
         );
     }
@@ -30267,9 +30385,10 @@ fn test_optional_and_try_catch_force_and_catch_a_lazykeys_malformed_key_1936() -
     ] {
         let (stdout, stderr, code) = run_jq_full(&["-c", filter], Some(doc))
             .unwrap_or_else(|e| panic!("`{filter}` failed to run: {e}"));
-        assert_eq!(
-            (stdout.as_str(), code),
-            ("\"c\"\n", 0),
+        assert_eq!(code, 5, "`{filter}` -- stdout: {stdout:?} stderr: {stderr}");
+        assert!(stdout.trim().is_empty(), "`{filter}` -- stdout: {stdout:?}");
+        assert!(
+            stderr.contains("Invalid JSON text"),
             "`{filter}` -- stderr: {stderr}"
         );
     }
@@ -30319,27 +30438,44 @@ fn test_optional_and_try_catch_unaffected_by_lazykeys_lazyindexrange_forcing_193
 /// `each_try_generic` to force the identical `try_single_generic` check
 /// synchronously, before the boundary can close, via a side-channel `Control`
 /// captured across the push (`check_lazy_item_for_try`).
+///
+/// #2286 revises the `LazyKeys`/`{123: 1}` assertions the same way it did
+/// for #1936's own test: real jq treats this document as an unconditional
+/// parse error regardless of `first`/`limit` wrapping (all four shapes
+/// below verified live to exit 5), and #2286 tags the error
+/// `is_decode_failure()` to match -- neither `?` nor `catch` reaches it
+/// now. The `error("x")` case just below is unaffected: that's an
+/// ordinary, unrelated error `#2286` never touches, still correctly caught.
 #[test]
 fn test_first_limit_wrapped_optional_try_catch_suppresses_and_catches_1948() -> Result<()> {
     // LazyKeys (#1936's own target), one push-model layer further out --
-    // `?`-suppression: exit 0, empty stdout, no catch handler runs.
+    // now raises unconditionally, matching real jq's own parse-error
+    // behavior for this document.
     for filter in ["first(keys_unsorted?)", "limit(1; keys_unsorted?)"] {
         let (stdout, stderr, code) = run_jq_full(&["-c", filter], Some("{123: 1}"))
             .unwrap_or_else(|e| panic!("`{filter}` failed to run: {e}"));
-        assert_eq!(code, 0, "`{filter}` should suppress\nstderr: {stderr}");
+        assert_eq!(code, 5, "`{filter}` -- stdout: {stdout:?} stderr: {stderr}");
         assert!(stdout.trim().is_empty(), "`{filter}` -- stdout: {stdout}");
+        assert!(
+            stderr.contains("Invalid JSON text"),
+            "`{filter}` -- stderr: {stderr}"
+        );
     }
 
-    // Same LazyKeys fault, `try`/`catch` this time: exit 0, catch handler's
-    // own output reaches stdout.
+    // Same LazyKeys fault, `try`/`catch` this time: now raises unconditionally
+    // too, the handler never runs.
     for filter in [
         r#"first(try (keys) catch "c")"#,
         r#"first(try (keys_unsorted) catch "c")"#,
     ] {
         let (stdout, stderr, code) = run_jq_full(&["-c", filter], Some("{123: 1}"))
             .unwrap_or_else(|e| panic!("`{filter}` failed to run: {e}"));
-        assert_eq!(code, 0, "`{filter}` should catch\nstderr: {stderr}");
-        assert_eq!(stdout.trim(), "\"c\"", "`{filter}` -- stdout: {stdout}");
+        assert_eq!(code, 5, "`{filter}` -- stdout: {stdout:?} stderr: {stderr}");
+        assert!(stdout.trim().is_empty(), "`{filter}` -- stdout: {stdout}");
+        assert!(
+            stderr.contains("Invalid JSON text"),
+            "`{filter}` -- stderr: {stderr}"
+        );
     }
 
     // LazySeq (#1812's own target), predating #1936/#1948 entirely.

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -30567,6 +30567,48 @@ fn test_malformed_value_surfaces_as_error_1194() {
     );
 }
 
+/// #2286 code review: the #1194 malformed-value class above is uncatchable
+/// through *every* materializing route -- except the fold source of
+/// `reduce`/`foreach` (and anything built on it, like `add`), which
+/// resolves via `eval_generic::to_owned_at_depth`'s own `is_error()` arm
+/// (a format-agnostic sibling of `eval::to_owned_at_depth`'s
+/// `StandardJson::Error` arm, not the same function). That sibling was
+/// still tagging the error as an ordinary, catchable `EvalError::new(...)`,
+/// so `[1, xyz123] | try add catch "caught"` printed `"caught"` at exit 0
+/// where real jq 1.7.1 exits 5 unconditionally (`add` desugars to
+/// `reduce .[] as $x (null; . + $x)`, confirmed live).
+#[test]
+fn test_fold_source_malformed_value_is_uncatchable_2286() {
+    let (stdout, stderr, code) =
+        run_jq_full(&["-c", "try add catch \"caught\""], Some("[1, xyz123]"))
+            .unwrap_or_else(|e| panic!("failed to run: {e}"));
+    assert_ne!(code, 0, "stdout: {stdout}");
+    assert_ne!(
+        stdout.trim(),
+        "\"caught\"",
+        "stdout: {stdout}, stderr: {stderr}"
+    );
+    assert!(!stderr.is_empty(), "expected a diagnostic on stderr");
+
+    // The hand-written desugaring must agree, since it's the same fold
+    // machinery `add` itself goes through.
+    let (stdout, stderr, code) = run_jq_full(
+        &[
+            "-c",
+            "try (reduce .[] as $x (null; . + $x)) catch \"caught\"",
+        ],
+        Some("[1, xyz123]"),
+    )
+    .unwrap_or_else(|e| panic!("failed to run: {e}"));
+    assert_ne!(code, 0, "stdout: {stdout}");
+    assert_ne!(
+        stdout.trim(),
+        "\"caught\"",
+        "stdout: {stdout}, stderr: {stderr}"
+    );
+    assert!(!stderr.is_empty(), "expected a diagnostic on stderr");
+}
+
 /// #1247: jq is the odd oracle out on invalid UTF-8. `yq` rejects such a
 /// document outright (#1242); `jq` accepts it, substitutes U+FFFD and exits
 /// 0. succinctly did neither -- it echoed the raw bytes, writing invalid

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -21617,18 +21617,21 @@ fn test_malformed_json_error_never_suppressed_2286() -> Result<()> {
 }
 
 /// #2286/#1995: the non-string-sibling-key shape from #1995's own repro
-/// (`{"a":1,123:2}`) is confounded across two distinct, separately-scoped
-/// bugs -- worth pinning both halves so a future reader doesn't conflate
-/// them. `.a?` alone never even reaches `malformed_json_text`: `Expr::
-/// Field`'s fast path looks up `.a` directly without validating sibling
-/// keys at all (#1995's own still-open bug, unrelated to this issue,
-/// tracked separately -- wrongly succeeds with `1` here, not "wrongly
-/// suppressed"). `keys?`/`to_entries?` instead walk every member (they
-/// are not simple field lookups), reaching `malformed_json_text` via
-/// `malformed_member_error` regardless of which field is asked for --
-/// that shape is squarely in #2286's own scope, and now correctly raises
-/// unconditionally, matching real jq 1.7.1 (`Object keys must be
-/// strings`, exit 5, no output).
+/// (`{"a":1,123:2}`) was originally confounded across two distinct,
+/// separately-scoped bugs, worth pinning as two halves so a future reader
+/// doesn't conflate them -- even though both halves now raise, having
+/// closed independently and for different reasons. `.a?` alone used to
+/// never even reach `malformed_json_text`: `Expr::Field`'s fast path
+/// looked up `.a` directly without validating sibling keys at all. That was
+/// #1995's own bug, not this issue's, and is now fixed by #1995 itself
+/// (`.field`'s fast path rejects a non-string sibling object key) -- a
+/// separate PR, merged independently of #2286. `keys?`/`to_entries?`
+/// instead walk every member (they are not simple field lookups), reaching
+/// `malformed_json_text` via `malformed_member_error` regardless of which
+/// field is asked for -- that shape is squarely in #2286's own scope, and
+/// correctly raises unconditionally, matching real jq 1.7.1 (`Object keys
+/// must be strings`, exit 5, no output). Both are asserted here so a
+/// regression in either fix's own scope still fails this test.
 ///
 /// `.a? // "outer"` (an earlier draft of this test) is *not* a valid
 /// vehicle for this: `//`'s own semantics only substitute for a
@@ -21640,15 +21643,9 @@ fn test_malformed_json_error_never_suppressed_2286() -> Result<()> {
 fn test_malformed_json_error_never_suppressed_on_generic_bridge_2286() -> Result<()> {
     let non_string_sibling_key: &str = r#"{"a":1,123:2}"#;
 
-    // #1995's own bug, not this issue's -- pinned here as the contrast.
-    let (stdout, _stderr, code) = run_jq_full(&["-c", ".a?"], Some(non_string_sibling_key))?;
-    assert_eq!(code, 0, "stdout: {stdout:?}");
-    assert_eq!(stdout, "1\n");
-
-    // This issue's own scope: a whole-object walk reaches
-    // malformed_member_error/malformed_json_text, which must now raise
-    // unconditionally even under a trailing `?`.
-    for expr in ["keys?", "to_entries?"] {
+    // #1995's own fast-path fix, not this issue's -- pinned here as the
+    // contrast, now also uncatchable.
+    for expr in [".a?", "keys?", "to_entries?"] {
         let (stdout, stderr, code) = run_jq_full(&["-c", expr], Some(non_string_sibling_key))?;
         assert_eq!(code, 5, "{expr}: stdout: {stdout:?} stderr: {stderr:?}");
         assert!(stdout.is_empty(), "{expr}: stdout: {stdout:?}");
@@ -21780,23 +21777,30 @@ fn test_jq_malformed_object_non_string_key_raises_everywhere_1194() -> Result<()
     Ok(())
 }
 
-/// #1995 review: a known, pre-existing, and *separate* gap this fix does
-/// not close -- `?` wrongly suppresses a malformed-JSON error that real jq
-/// raises unconditionally (a parse error precedes every filter, `?`
-/// included). Confirmed this predates #1995 entirely and isn't specific to
-/// a non-string key: `{"a" 1}` (#1677's own missing-`:` shape) is
-/// suppressed by `.a?` here identically, and real jq rejects both
-/// unconditionally (`jq -c '.a?'` on either input is still a parse error,
-/// exit 5). Pinned here rather than left untested per this project's own
-/// convention -- see #2286's own filed follow-up for the fix.
+/// #1995 review named this a known, pre-existing, and *separate* gap that
+/// PR did not close -- `?` wrongly suppressing a malformed-JSON error that
+/// real jq raises unconditionally (a parse error precedes every filter, `?`
+/// included) -- and filed #2286 as its own follow-up to close it. #2286 has
+/// since done so: both shapes now raise unconditionally, matching real jq
+/// (`jq -c '.a?'` on either input is a parse error, exit 5). Kept under its
+/// original name (with the reversal recorded here) so the history stays
+/// visible, the same convention `test_malformed_member_error_is_not_a_decode_failure_1953`
+/// established. `{"a" 1}` (#1677's own missing-`:` shape) is included
+/// alongside the non-string-key shape since both were confirmed to predate
+/// #1995 and share the same fix.
 #[test]
 fn test_optional_wrongly_suppresses_malformed_json_error_known_gap_1995() -> Result<()> {
     for input in [r#"{"a":1,123:2}"#, r#"{"a" 1}"#] {
         let (out, stderr, code) = run_jq_full(&["-c", ".a?"], Some(input))?;
-        // jq 1.7.1 raises unconditionally (exit 5) for both; this is the
-        // known gap -- `?` currently swallows it (exit 0, no output).
-        assert_eq!(code, 0, "input {input:?}: out: {out:?}, stderr: {stderr:?}");
+        // jq 1.7.1 raises unconditionally (exit 5) for both, and #2286
+        // closed the gap that used to let `?` swallow it (exit 0, no
+        // output) here too.
+        assert_eq!(code, 5, "input {input:?}: out: {out:?}, stderr: {stderr:?}");
         assert!(out.trim().is_empty(), "input {input:?}: out: {out:?}");
+        assert!(
+            stderr.contains("Invalid JSON text"),
+            "input {input:?}: stderr: {stderr:?}"
+        );
     }
 
     Ok(())


### PR DESCRIPTION
## Summary

`EvalError::malformed_json_text` (and its `malformed_member_error`/`malformed_delimiter_error`/`malformed_element_error` callers, plus the `DocumentFields`/`DocumentElements` default trait impls) now construct via `EvalError::decode_failure`, not the plain `EvalError::new`. Real jq's equivalent failure is a **parse error**, raised before any filter runs — `?` included — confirmed live against jq 1.7.1 for every shape this touches:

```console
$ echo '{"a" 1}' | jq -c '.a?'              # exit 5, unconditional
$ echo '{"a":1,123:2}' | jq -c 'keys?'      # exit 5, unconditional
$ echo '{"a":1,"b"}' | jq -c '.c = 5'       # exit 5, unconditional
```

## This is bigger than issue #2286's own two repro cases

`to_owned_at_depth`'s remaining error paths (string decode failure, #1642 key collision, #1194 malformed member/delimiter) are now uniformly decode failures, which revises the foundational premise of the entire **#1953→#2001→#1829→#2015→#2184→#2231 lineage** — every one of those issues built "malformed-member errors respect `optional`" test coverage on a premise that was never actually checked against the real jq oracle for the one question that mattered: catchability. I checked it here, against the pinned binary, for every shape re-tested in this PR — not assumed.

## Consequences of this correction, not new bugs

- **~50 existing tests** across `eval.rs`/`eval_generic.rs`/`jq_cli_tests.rs` asserted the old (now-confirmed-wrong) suppressible/catchable behavior and are updated here to assert the oracle-verified correct behavior instead.
- Several (**#1812, #1936, #1948**) actually asserted a *weaker* divergence from real jq than this fix closes — e.g. `sort?` on a malformed document used to succeed silently in succinctly where real jq already exited 5. This fix improves oracle fidelity beyond what those issues originally achieved, not just #2286's own narrow repro.
- The #1953 lineage's `optional`-consulting fixes (`to_owned_or_suppress!`/`owned_or_suppress!` at ~15 call sites: `debug`/`stderr`/`fromjsonstream`/`tostring`/`tojson`/`tostream`/`upper_index`/`pick`/`omit`/`setpath`/...) are **still correct** but now provably no-ops for this specific error class, since `to_owned`'s only remaining error paths are all decode failures. Not reverted — the macros still correctly propagate a genuine decode failure and remain meaningful for any other error class a future caller routes through them.

## Test plan

- [x] Fail-without-fix / pass-with-fix verified for the core fix via revert+test+restore
- [x] Every test assertion changed here was independently live-verified against jq 1.7.1 before being written (not just mechanically flipped) — see individual test doc comments for the oracle transcripts
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo clippy` second leg (`std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests`)
- [x] Full test suite (all binaries, golden fixture drift tests, doctests) — 0 failures across 4700+ tests
- [x] `cargo test --no-default-features --verbose` (no_std)
- [x] `cargo doc --no-deps --all-features` with `RUSTDOCFLAGS=-D warnings`

Given the scope, this deserves extra review scrutiny — happy to split findings into follow-ups if reviewers want a narrower merge unit, but the fix itself (one shared error constructor) isn't separable from its test-suite consequences without leaving ~50 tests in a contradictory state.

Fixes #2286