### PR TITLE
fix(jq): close cursor-transparent fast-path trailing-comma gaps (#2261)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -324,6 +324,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   surfaces — not a new divergence, the same one already pinned for a truncating `.[]`
   consumer.
 
+- **Eleven more `succinctly jq` sibling paths shared #2261's own trailing-stray-comma gap**
+  (#2261 code review, PR #2291): `has(idx)` on arrays, `has(key)` on objects,
+  `keys`/`keys_unsorted` on *arrays* (the object arm had already been fixed above), computed/
+  dynamic index access (`E[K]`, e.g. `.[0,1]`/`.[$i]`), and `last`/`.[-1]` all shared the exact
+  "already walks `.len()`/every field, so the check rides free" shape used throughout the
+  #2261 fix above but had been missed in the first pass — e.g. `printf '[1,2,3,]' | succinctly
+  jq 'last'` printed `3` at exit 0 where real jq (1.7.1) raises. A follow-up systematic sweep of
+  every remaining unchecked `DocumentElements::collect_cursors`/`.len()` call site in
+  `eval_generic.rs`/`document.rs` then turned up six more of the identical shape: `path(.[])`
+  (whose array arm had drifted onto the unchecked `collect_cursors` even though its own
+  object-arm sibling already used the checked helper) and
+  `reverse`/`sort`/`sort_by`/`unique`/`unique_by`/`min`/`min_by`/`max`/`max_by` (all resolved
+  every element via the unchecked `collect_cursors` despite the already-checked
+  `collect_cursors_checked` — fixed for `.[]` itself — existing the whole time); `shuffle`/
+  `pivot` share the identical code but have no jq oracle, fixed for internal consistency only.
+  `has(key)` on objects is the one fix in this batch that is not free: `DocumentFields::contains`
+  deliberately early-exits on a match (#1739), so answering the trailing-gap question too
+  needs its own design — the shipped fix resolves it from the matched key's own cursor via two
+  O(1) `next_sibling()` hops rather than walking further, after a first draft that dropped the
+  early exit measured a real ~4x regression on `has()` for a key near the front of a
+  1,000,000-key object. A match that is not the object's own true last field still takes the
+  same #1629/#1770-established "early exit misses a later fault" trade every other truncating
+  consumer in this codebase already accepts. Two further leads from the same sweep
+  (`to_owned_with_comments_at_depth`, a fourth copy of the #2262 materializer family backing
+  yq's write path; and `LazySource::advance`'s lazy pull behind `map(f)`, confirmed live and
+  reproducible but not fixed here given the size/risk of touching that hot path) are documented
+  in `docs/compliance/jq/limitations.md` as recommended follow-ups rather than folded in.
+
 - **`succinctly yq --slurp`/`--eval-all`/`--inplace --input-format json` silently accepted a
   trailing stray `,` after a real last array/object child** (#2262): `echo '[1,]' | succinctly
   yq --slurp --input-format json -o json '.[0]'` printed `1` at exit 0, where real yq (v4.53.3)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -289,6 +289,41 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`succinctly jq`'s most common query idioms -- `.[]`, `keys`/`keys_unsorted`, bare `.a`
+  field access, `length`, `.[0]` -- silently accepted a trailing stray `,` after a real last
+  array/object child** (#2261): `echo '[1,]' | succinctly jq -c '.[]'` printed `1` at exit 0,
+  where real jq (1.7.1) rejects the document outright with a parse error (exit 5). #2243 had
+  already closed this exact shape for `to_owned_cursor_at_depth`, but that materializer only
+  backs the *non-cursor-transparent* route (`if`/arithmetic/function calls) — every idiom
+  above takes its own native, cursor-carrying arm in `eval_generic.rs` that never calls it.
+  Closed for `.[]` (`each_lazy_array_iterate_sink`/`DocumentElements::collect_cursors_checked`,
+  which already walked every element's cursor for #1677's leading-gap check and now retain the
+  last one to check the trailing gap too), `length`/`.[0]` on arrays (a new
+  `DocumentElements::len_checked`, since resolving *any* array index — not just a negative one
+  — already calls `.len()` to normalize/bounds-check it, so the check rides along for free on
+  every index, reversing this issue's own assumption that `.[0]` had to stay an O(1)-lookup
+  exception), `keys`/`keys_unsorted` in every shape (bare, `keys[]`, `keys_unsorted[]`,
+  `keys_unsorted | last`, a negative `keys_unsorted[n]` — all via a new
+  `DistinctKeyCursors::trailing_gap_ok`, which needed care to track the object's *textually*
+  last field across a confirmed duplicate-key collapse rather than whichever key the
+  collapsed/sorted output lists last), bare `.a`/`.nonexistent` field access
+  (`JsonFields::find_cursor`, which — contrary to this issue's own "genuine O(1) lookup"
+  description — already walks every field regardless of `name` to honor last-duplicate-
+  key-wins, so the check is free there too), and `to_entries` on both arrays and objects (a
+  new `effective_fields_with_raw_last`, since `to_entries`'s own collapsed field list can list
+  a different field last than the raw walk once a duplicate key collapses). Left open, and
+  documented in `docs/compliance/jq/limitations.md`: `keys_unsorted[0]` (a genuine O(1)
+  positional lookup into an object's key list, matching #1629's own established
+  "would cost strictly more than the answer" precedent), `length` on objects (`{"a":1,}|
+  length`, not one of this issue's own repros — its walk deliberately never resolves any
+  field's value, by design, since #1514), and #2211's own sibling shape (`[,]`/`{,}`, a stray
+  `,` with *zero* real children) through every path above, none of which is ever handed a
+  cursor to the container itself. `.[]` and a bare `keys_unsorted` are the two genuinely
+  streaming writers among these fixes and can (like the pre-existing, already-documented
+  `limit(3;.[])` case) still write a confirmed-good prefix to stdout before the trailing fault
+  surfaces — not a new divergence, the same one already pinned for a truncating `.[]`
+  consumer.
+
 - **`succinctly yq --slurp`/`--eval-all`/`--inplace --input-format json` silently accepted a
   trailing stray `,` after a real last array/object child** (#2262): `echo '[1,]' | succinctly
   yq --slurp --input-format json -o json '.[0]'` printed `1` at exit 0, where real yq (v4.53.3)

--- a/docs/compliance/jq/limitations.md
+++ b/docs/compliance/jq/limitations.md
@@ -1705,6 +1705,34 @@ and differently-shaped problem than this section's own fixes):
   required, but for a colder, more central path. Recommended as its own,
   separate follow-up issue.
 
+- **`src/jq/eval.rs`'s parallel evaluator** -- a second, independently-tested
+  evaluator behind the crate's public `jq::eval`/`jq::eval_lenient`/
+  `jq::eval_owned_with_file_index` entry points (see
+  `tests/jq_evaluator_parity_tests.rs`), not `eval_generic.rs`, backs `has(key)`
+  (object arm, a raw `.any()` with zero gap checks), `length` (array arm
+  `.count()`, object arm bare `effective_len`), and `keys`/`keys_unsorted`
+  (array arm `.count()`) -- the identical unchecked shape this whole issue
+  chain fixes elsewhere, confirmed by code review on this PR (round 2).
+  **Confirmed not reachable from either shipped CLI**: `succinctly jq`'s
+  `jq_runner.rs` never calls into `eval.rs` at all (only `eval_generic.rs`);
+  `succinctly yq`'s one call site (`yq_runner.rs`'s `evaluate_input`, and
+  `eval_owned_with_file_index` for `--eval-all`) always hands `eval.rs` a
+  cursor built by re-serializing an *already-materialized* `OwnedValue`
+  (`to_json_for_reindex`) into a fresh index -- a value that reached that
+  point only by surviving the CLI's own (already-fixed) parse/materialize
+  step, so the re-serialized text this function actually navigates can never
+  contain a stray trailing comma regardless of query. Verified live: `succinctly
+  yq --input-format json --slurp/--eval-all` on both a top-level and a nested
+  `[1,2,3,] | has(0)`/`length`/`keys` already raises correctly, before
+  `eval.rs`'s own unchecked arms are ever reached. The identical
+  "library-API-only, inert for genuine JSON input via either CLI" shape
+  already established for `to_owned_with_comments_at_depth` above -- a caller
+  of the public library API who builds their own cursor directly from raw,
+  unvalidated document bytes (bypassing both CLIs' own materialization step)
+  would still observe the gap. Recommended as its own follow-up issue
+  (tracking `eval.rs`/`eval_generic.rs` parity for the whole #2261 family), not
+  folded in here.
+
 Two further leads from the same sweep were investigated and **not**
 reproduced live (so not reported as confirmed bugs, only as ruled out):
 `push_generic_truthiness_cursor_error` (`if COND then ... end` on a

--- a/docs/compliance/jq/limitations.md
+++ b/docs/compliance/jq/limitations.md
@@ -1572,6 +1572,150 @@ Every other path this section fixed (`length`, `to_entries`, `keys`, `.a`,
 fully-collected `Vec` before printing anything, so a mid-walk failure there
 never leaks a partial value.
 
+### PR #2291 code review: eleven more sibling paths, found by a systematic sweep
+
+Code review on the PR carrying the section above found and live-confirmed
+five more sibling paths sharing the exact "already walks `.len()`/every
+field, so the check rides free" shape used throughout this section, missed
+in the first pass: `has(idx)` on arrays, `has(key)` on objects,
+`keys`/`keys_unsorted` on *arrays* (the object arm above was fixed; this
+array arm two branches below it, returning `GenericResult::LazyIndexRange`,
+was not), computed/dynamic index access (`E[K]`, e.g. `.[0,1]`/`.[$i]` --
+`index_one_generic`, distinct from the literal-index `Expr::Index` arm
+fixed above), and `last`/`.[-1]` (`Builtin::Last`; unlike `first`, which is
+genuine O(1) via `get_cursor(0)` and stays the documented exception per
+#1629's own precedent this section already established).
+
+A follow-up systematic sweep -- every `DocumentElements`/`DocumentFields`
+binding in `eval_generic.rs`, checked for an unchecked `.len()` or an
+unchecked `collect_cursors()` sitting alongside an already-checked sibling
+-- turned up **six more real, live, jq-oracle-backed bugs** of the second
+shape: `path(.[])`'s array arm (`path_step_generic`) had drifted onto the
+unchecked `collect_cursors()` even though its own object-arm sibling three
+lines above already used the checked `effective_fields_checked`; and
+`reverse`/`sort`/`sort_by`/`unique`/`unique_by`/`min`/`min_by`/`max`/`max_by`
+all resolved every element via the unchecked `collect_cursors()` before
+this fix, despite `collect_cursors_checked` (fixed for `.[]` itself) having
+existed the whole time. `shuffle`/`pivot` share the identical code
+(`collect_cursors()` feeding `to_owned_all_cursors`) but have no jq oracle
+(`pivot/0 is not defined`/`shuffle/0 is not defined` in real jq 1.7.1) --
+fixed anyway for internal consistency with every other builtin in this
+list, not for jq parity.
+
+```
+$ printf '[1,2,3,]' | jq          'has(0)'        # parse error, exit 5
+$ printf '[1,2,3,]' | sjq         'has(0)'        # exit 5 now (was: true, exit 0)
+$ printf '{"a":1,}' | jq          'has("a")'      # parse error, exit 5
+$ printf '{"a":1,}' | sjq         'has("a")'      # exit 5 now (was: true, exit 0)
+$ printf '[1,2,3,]' | jq       -c 'keys'          # parse error, exit 5
+$ printf '[1,2,3,]' | sjq      -c 'keys'          # exit 5 now (was: [0,1,2], exit 0)
+$ printf '[1,2,3,]' | jq       -c '.[0,1]'        # parse error, exit 5
+$ printf '[1,2,3,]' | sjq      -c '.[0,1]'        # exit 5 now (was: 1\n2, exit 0)
+$ printf '[1,2,3,]' | jq          'last'          # parse error, exit 5
+$ printf '[1,2,3,]' | sjq         'last'          # exit 5 now (was: 3, exit 0)
+$ printf '[1,2,3,]' | jq       -c '[path(.[])]'   # parse error, exit 5
+$ printf '[1,2,3,]' | sjq      -c '[path(.[])]'   # exit 5 now (was: [[0],[1],[2]], exit 0)
+$ printf '[1,2,3,]' | jq          'reverse'       # parse error, exit 5
+$ printf '[1,2,3,]' | sjq         'reverse'       # exit 5 now (was: [3,2,1], exit 0)
+```
+
+(`sort`/`unique`/`min`/`max`/`sort_by`/`unique_by`/`min_by`/`max_by` all show
+the identical shape as `reverse`.)
+
+**`has(key)` on objects is the one fix in this whole issue that is not
+free**, and needed two drafts to get right. `DocumentFields::contains`
+early-exits the instant it finds a match -- a documented, deliberate
+design (#1739) this fix does not get to ignore: `has(key)`'s existence
+question and the trailing-gap question are two different questions that
+can only both be answered by walking to the object's true end, and a match
+can sit anywhere. A first draft dropped the early exit entirely (walk
+fully regardless, matching `keys`'s own shape) and measured a real **~4x**
+regression on `has("k0")` (the object's very first key) over a
+1,000,000-key well-formed object: ~0.03s → ~0.12s, interleaved A/B, release
+build, three reps. The shipped fix instead resolves the trailing gap from
+the *matched* key's own cursor alone -- `key_cursor.next_sibling()` is the
+matched field's value (an O(1) BP hop, no walk), and *that* cursor's own
+`next_sibling()` answers "is there another field after this one" for free.
+Only when the match *is* the object's real last field (`{"a":1,} |
+has("a")`, this issue's own repro) does checking cost anything at all, and
+even then it costs one more O(1) hop, not a walk. A match that is **not**
+the last field takes the exact #1629/#1770-established "early exit
+legitimately misses a later fault" trade every other truncating consumer
+in this file already takes:
+
+```
+$ printf '{"a":1,"b":2,}' | jq  'has("a")'   # parse error, exit 5
+$ printf '{"a":1,"b":2,}' | sjq 'has("a")'   # true, exit 0 -- known gap, matches "a" before "b"'s own comma is ever reached
+$ printf '{"a":1,"b":2,}' | sjq 'has("z")'   # parse error, exit 5 -- a non-match still walks to the true end, so it still catches it
+```
+
+A first-draft version of `has(key)`'s CLI test also wrongly attributed a
+result to `stream_lazy_keys_json` a second time (`pivot` on
+`[{},{},]`) -- this one for a different reason than the earlier
+`stream_lazy_keys_json` misattribution above: `pivot` only accepts an
+array of arrays/objects, so its own last element is always container-typed,
+which the #2243 "container-typed last child still passes through" residual
+gap (documented earlier in this file) already leaves open regardless of
+this fix. Corrected to use a *leading*-gap malformed input instead
+(`[{"a":1},,{"a":2}]`), which the identical `collect_cursors`-to-`_checked`
+fix also closes and which the residual container gap does not affect.
+
+Every fix above except `has(key)` on objects was confirmed to show **no
+measurable difference** in an interleaved A/B (a build from immediately
+before this round vs. after, three reps each, release profile) at 2M
+array elements / 1M object keys -- consistent with each one already
+walking the whole container for an unrelated reason before this fix, the
+same "free" pattern established throughout this file.
+
+**Confirmed still open, and out of scope for this round**, from the same
+sweep, for reasons unrelated to `.len()`/`collect_cursors()` (each is
+missing *every* gap check, not specifically the trailing one, a broader
+and differently-shaped problem than this section's own fixes):
+
+- **`to_owned_with_comments_at_depth`** (`eval_generic.rs`) -- a *fourth*
+  copy of the `to_owned_at_depth`/`to_owned_cursor_at_depth` materializer
+  family #2262 already found three of, backing the write path's
+  comment/anchor-preserving conversion (`succinctly yq`'s own `=`/`|=`/
+  `del()` machinery). Has no gap checks of any kind. Confirmed **not**
+  reachable from either shipped CLI with a genuinely JSON-sourced cursor
+  today: `succinctly jq`'s own write path uses the already-fixed
+  `to_owned_at_depth`/`to_owned_cursor_at_depth` instead (confirmed live:
+  `[1,2,3,] | .[0] = 99` already correctly raises), and `succinctly yq
+  --input-format json` parses through `YamlIndex` rather than `JsonIndex`
+  (per #1975/#2262's own account), so its own trailing-gap check would be
+  a permanent no-op there regardless. The identical "library-API-only,
+  inert for genuine JSON input via either CLI" shape already established
+  for `stream_lazy_keys_json` above. Recommended as a `#2262`-scoped
+  follow-up (a fourth materializer copy), not folded in here.
+- **`LazySource::advance`'s `Self::Elements`/`Self::Values` arms**
+  (`eval_generic.rs`), the lazy pull behind `map(f)`/`select(f)`/etc:
+  genuinely live and CLI-reachable, confirmed both for this issue's own
+  trailing-comma shape and for the older, broader #1677 leading-gap shape
+  that predates #2261 entirely:
+  ```
+  $ printf '[1,,3]'   | jq  -c 'map(.+1)'   # parse error, exit 5 (#1677, predates this issue)
+  $ printf '[1,,3]'   | sjq -c 'map(.+1)'   # [2,4], exit 0 -- pre-existing, not new
+  $ printf '[1,2,3,]' | jq  -c 'map(.+1)'   # parse error, exit 5
+  $ printf '[1,2,3,]' | sjq -c 'map(.+1)'   # [2,3,4], exit 0
+  ```
+  Not attempted here: this is `map(f)`'s own performance-tuned hot pull
+  loop (#1565/#1599), and adding gap-checking to it is a materially larger,
+  riskier change than swapping an already-checked sibling in for an
+  unchecked one -- the same "no free ride" caution `has(key)` above
+  required, but for a colder, more central path. Recommended as its own,
+  separate follow-up issue.
+
+Two further leads from the same sweep were investigated and **not**
+reproduced live (so not reported as confirmed bugs, only as ruled out):
+`push_generic_truthiness_cursor_error` (`if COND then ... end` on a
+container condition) and `owned_from_standard_json_at_depth` (the
+`input`/`inputs`-with-cursor-metadata-builtins bridge, #1504) both lack
+their own internal gap checks by inspection, but every constructed repro
+against each (`{"a":[1,2,3,]} | if .a then ... end`;
+`[1,2,3,] | [inputs, line]` with `-n`) already raised correctly, meaning
+something upstream of either function already validates for the shapes
+tried. Not chased further given no live reproduction.
+
 ## Refusing an allocation jq does not survive
 
 `setpath` takes its array index from the document, so the array it pads is sized by the

--- a/docs/compliance/jq/limitations.md
+++ b/docs/compliance/jq/limitations.md
@@ -1421,17 +1421,47 @@ duplicate-key rows in [tests/jq_cli_tests.rs](../../../tests/jq_cli_tests.rs).
 
 The bare-`keys`/`keys_unsorted` materializer (`document.rs::effective_keys`,
 which already walks `DistinctKeyCursors` for an unrelated reason -- decoding
-every key's display spelling) and three CLI-level writers each needed their
-own one-line addition once `DistinctKeyCursors::trailing_gap_ok` existed:
-`stream_lazy_keys_json` (`src/jq/stream.rs`, the M2 streaming writer for
-`keys_unsorted[]`-shaped queries with a further pipe stage `stream_json`
-can inline), `bail_if_keys_malformed` (`jq_runner.rs`, the CLI's own
-`JqValue::LazyKeysArray` writer behind a *bare* `keys_unsorted`), and
-`eval_generic.rs`'s own `walk_distinct_keys_checked`/`Expr::Builtin(Builtin::Last)`
-arm (covering `keys_unsorted[]`/`keys_unsorted[-1]` and `keys_unsorted |
-last` respectively, reached through `eval_single`'s eager path since
-`keys_unsorted` alone is not one of `jq_runner.rs`'s own
-`expr_is_cursor_transparent` shapes).
+every key's display spelling) and several call sites each needed their own
+one-line addition once `DistinctKeyCursors::trailing_gap_ok` existed:
+`bail_if_keys_malformed` (`jq_runner.rs`, the CLI's own `JqValue::LazyKeysArray`
+writer behind a *bare* `keys_unsorted`), `eval_generic.rs`'s own
+`walk_distinct_keys_checked`/`Expr::Builtin(Builtin::Last)` arm (covering
+`keys_unsorted[]`/`keys_unsorted[-1]` and `keys_unsorted | last` respectively,
+reached through `eval_single`'s eager path since `keys_unsorted` alone is not
+one of `jq_runner.rs`'s own `expr_is_cursor_transparent` shapes), and
+`each_lazy_keys_iterate_sink`'s own `!sorted` branch (the demand-aware sink,
+reached once a pipe's *first* stage already descends off the root --
+`.x | keys_unsorted[]`, where `.x`'s own `Expr::Field` shape is one of
+`expr_descends`'s matched cases, so `expr_is_cursor_transparent` admits
+everything after it unconditionally, taking the M2/`eval_each_with_cursor`
+route instead of the eager one).
+
+`stream_lazy_keys_json` (`src/jq/stream.rs`) also received the same
+one-line addition, but **turns out not to be reachable from either shipped
+CLI today, the identical shape `test_stream_lazy_keys_honors_collapse_1514`'s
+own review already established for this exact function**: `succinctly jq`
+excludes bare `Builtin::KeysUnsorted` from its own M2 *output* gate
+unconditionally (`m2_json_fallback_safe`, `jq_runner.rs` -- a *different*
+gate from `expr_is_cursor_transparent` above, which only controls eager-vs-
+demand-aware *evaluation*, not which writer prints the result), regardless of
+AST shape, so this function is never invoked from `succinctly jq` at all.
+`succinctly yq --input-format json` has no such exclusion and does reach
+this function, but only with YAML-sourced `fields` (JSON parses through
+`YamlIndex` there, per #1975/#2262's own account), whose `trailing_gap_ok`
+always answers `true` by design (YAML's flow-mapping grammar legitimately
+allows a trailing `,`) -- so a genuinely JSON-sourced `fields` never reaches
+this function from either CLI as things stand today. A first draft of this
+fix's own test suite wrongly attributed a CLI-level test
+(`.x | keys_unsorted[]`) to this function; code review, disabling each
+candidate check in turn and re-running the exact query, found it actually
+exercises `each_lazy_keys_iterate_sink` above instead -- retitled as
+`test_jq_descended_pipe_prefix_reaches_demand_aware_keys_sink_2261` in
+[tests/jq_cli_tests.rs](../../../tests/jq_cli_tests.rs), and
+`stream_lazy_keys_json`'s own fix is pinned instead by two direct unit tests
+in `src/jq/stream.rs` itself (`test_stream_lazy_keys_raises_on_trailing_comma_2261`/
+`test_stream_lazy_keys_wellformed_unaffected_by_trailing_comma_check_2261`),
+calling the function the same way `test_stream_lazy_keys_honors_collapse_1514`
+already does.
 
 **Bare `.a`/`.nonexistent` field access (`JsonFields::find_cursor`,
 `src/json/light.rs`).** This issue's own text characterized this as a

--- a/docs/compliance/jq/limitations.md
+++ b/docs/compliance/jq/limitations.md
@@ -1273,12 +1273,16 @@ untested.
 follow-ups rather than folded in here** (same "one materializer at a time"
 practice #2243's own issue text cites for not folding into #2211):
 
-- **#2261**: every *cursor-transparent* fast path -- `.[]`, `keys`/
-  `keys_unsorted`/`to_entries`, bare `.a`/`.[0]`/`.["a"]` field/index access,
-  `length` -- takes a route through `eval_generic.rs` that never reaches
-  `to_owned_cursor_at_depth` at all, so this fix does not reach jq's most
+- **#2261 (fixed, mostly)**: every *cursor-transparent* fast path -- `.[]`,
+  `keys`/`keys_unsorted`/`to_entries`, bare `.a`/`.[0]` field/index access,
+  `length` -- took a route through `eval_generic.rs` that never reached
+  `to_owned_cursor_at_depth` at all, so this fix did not reach jq's most
   common query idioms; only the non-cursor-transparent shape #2243's own
-  repro uses (`if`/arithmetic/function calls) is covered.
+  repro uses (`if`/arithmetic/function calls) was covered. #2261 closed
+  this for every one of those idioms except a genuinely O(1) object-key
+  lookup (`keys_unsorted[0]`) -- see its own section below for the full
+  accounting, including a case (`.[0]`/`Expr::Index` on an array) this
+  issue's own repro assumed would stay open but turned out to be free.
 - **#2262 (fixed)**: the three sibling materializers named above --
   `eval.rs`'s own `to_owned_at_depth` (behind this crate's documented public
   `eval()` API), `eval_generic.rs`'s own cursor-less `to_owned_at_depth`, and
@@ -1327,6 +1331,216 @@ practice #2243's own issue text cites for not folding into #2211):
   `trailing_gap_ok`/`scalar_end_pos` pair rather than the new trait methods --
   a cleanup, not a behavior gap, but the same "duplicated predicates diverge
   silently" shape (#106) this fix was written to reduce, not add to.
+
+## The trailing-comma check reaches jq's own most common idioms (#2261)
+
+#2243 closed the trailing-stray-comma-after-a-real-last-child shape (`[1,]`,
+`{"a":1,}`) for `to_owned_cursor_at_depth` -- but that materializer backs
+only the *non-cursor-transparent* route (`if`/arithmetic/function calls).
+The far more common idioms -- `.[]`, `keys`/`keys_unsorted`/`to_entries`,
+bare `.a`, `length`, `.[0]` -- each take their own native, cursor-carrying
+arm in `eval_generic.rs` and never call it at all:
+
+```
+$ echo '[1,]'     | jq  -c '.[]'          # parse error, exit 5
+$ echo '[1,]'     | sjq -c '.[]'          # exit 5 now (was: 1, exit 0)
+$ echo '[1,]'     | jq  -c 'length'       # parse error, exit 5
+$ echo '[1,]'     | sjq -c 'length'       # exit 5 now (was: 1, exit 0)
+$ echo '[1,]'     | jq  -c '.[0]'         # parse error, exit 5
+$ echo '[1,]'     | sjq -c '.[0]'         # exit 5 now (was: 1, exit 0)
+$ echo '{"a":1,}' | jq  -c 'keys'         # parse error, exit 5
+$ echo '{"a":1,}' | sjq -c 'keys'         # exit 5 now (was: ["a"], exit 0)
+$ echo '{"a":1,}' | jq  -c '.a'           # parse error, exit 5
+$ echo '{"a":1,}' | sjq -c '.a'           # exit 5 now (was: 1, exit 0)
+```
+
+**Every one of these turned out to be free or near-free**, riding a walk the
+arm already had to perform for an unrelated reason -- with exactly one
+deliberate exception. The full per-path accounting:
+
+**`.[]` (arrays).** Both the demand-aware `each_lazy_array_iterate_sink`
+(`eval_generic.rs`, #1597) and the eager `DocumentElements::collect_cursors_checked`
+(`document.rs`, #1677) already walk every element's own cursor to check its
+*leading* `,` -- retaining the last cursor seen and checking
+`trailing_element_gap_ok` once after the loop exhausts costs nothing new.
+`each_lazy_array_iterate_sink`'s own pre-existing early-exit divergence
+(#1629-shaped: a truncating consumer like `first(.[])` never walks past its
+own stopping point) still applies unchanged -- the new check runs only on
+`Flow::Exhausted`, the same gate `is_malformed`-style checks elsewhere in
+this file already use.
+
+**`length` (arrays) and `.[0]`/`Expr::Index` (arrays).** A new
+`DocumentElements::len_checked` (the array counterpart of the object side's
+long-standing `effective_len_checked`) walks with `uncons_cursor` instead of
+`len`'s plain `uncons`, checking the same #1677 leading-gap plus the new
+trailing one, and `Builtin::Length`'s array arm now calls it. `.[0]`
+(`Expr::Index` in `eval_generic.rs`) turned out to need the identical fix,
+for a reason this issue's own description did not anticipate: resolving
+*any* array index -- positive or negative -- already calls `.len()` first
+(to normalize a negative index against the array's length, and to raise
+yq's own out-of-range error), so switching that call to `len_checked` closes
+the gap on every index, not just negative ones. **This reverses the
+plan the rest of this section still follows for the object-key
+counterpart below** (`keys_unsorted[0]`, which really is O(1) and stays
+open) -- the array case looked like the same shape from the issue text
+alone, and only reading `Expr::Index`'s own body (not the issue's
+characterization of it) surfaced that `len()` was already unconditional.
+
+**`keys`/`keys_unsorted` (objects, both bare and piped: `keys[]`,
+`keys_unsorted[]`, `keys_unsorted | last`, a negative `keys_unsorted[n]`).**
+Every one of these walks `DistinctKeyCursors` (`document.rs`), which now
+tracks `last_key_cursor` -- the textually last field's own *key* cursor, in
+raw document order -- alongside its existing `ended_unpaired`/
+`delimiter_fault` bookkeeping, and exposes it via a new
+`DistinctKeyCursors::trailing_gap_ok(close_char)`. The check itself needs
+the last field's *value* cursor, not its key cursor, to compare against
+`}` -- resolved via `key_cursor.next_sibling()`, an O(1) BP hop mirroring
+how `JsonFields::uncons` itself derives a value cursor from a key cursor
+(`let value_cursor = key_cursor.next_sibling()?;`), run once here rather
+than during the walk.
+
+This needed real care around a duplicate key under jq's default collapse
+rule ("first position, last value"). `DistinctKeyCursors`' own *yielded*
+order is first-occurrence order, which for `{"a":1,"b":2,"a":3}` is `a`
+(now carrying the *second* `a`'s cursor, once collapse detects and
+resolves the repeat), then `b` -- so naively tracking "the last cursor this
+loop yielded" would land on `b`'s value (`2`), and checking the gap after
+it against `}` would see the perfectly ordinary `,"a":3}` that follows and
+wrongly reject this well-formed document. The actual fix: `next()`'s
+non-collapsed branch updates `last_key_cursor` on every raw field it
+examines, in document order; the moment a repeat is confirmed,
+`collapse_confirmed_repeat`'s own from-scratch re-walk (which already
+covers the whole object, needed anyway to build the exact collapsed list)
+hands back its own `last_key_cursor` too, and `next()` overwrites with
+that authoritative answer rather than whatever the raw walk had reached so
+far. An earlier version of this fix (caught reviewing this same issue,
+before it shipped) used the naive "last yielded" cursor and would have
+regressed exactly this case -- pinned by
+`test_jq_cursor_transparent_fast_paths_wellformed_unaffected_2261`'s own
+duplicate-key rows in [tests/jq_cli_tests.rs](../../../tests/jq_cli_tests.rs).
+
+The bare-`keys`/`keys_unsorted` materializer (`document.rs::effective_keys`,
+which already walks `DistinctKeyCursors` for an unrelated reason -- decoding
+every key's display spelling) and three CLI-level writers each needed their
+own one-line addition once `DistinctKeyCursors::trailing_gap_ok` existed:
+`stream_lazy_keys_json` (`src/jq/stream.rs`, the M2 streaming writer for
+`keys_unsorted[]`-shaped queries with a further pipe stage `stream_json`
+can inline), `bail_if_keys_malformed` (`jq_runner.rs`, the CLI's own
+`JqValue::LazyKeysArray` writer behind a *bare* `keys_unsorted`), and
+`eval_generic.rs`'s own `walk_distinct_keys_checked`/`Expr::Builtin(Builtin::Last)`
+arm (covering `keys_unsorted[]`/`keys_unsorted[-1]` and `keys_unsorted |
+last` respectively, reached through `eval_single`'s eager path since
+`keys_unsorted` alone is not one of `jq_runner.rs`'s own
+`expr_is_cursor_transparent` shapes).
+
+**Bare `.a`/`.nonexistent` field access (`JsonFields::find_cursor`,
+`src/json/light.rs`).** This issue's own text characterized this as a
+genuine O(1) lookup, the same shape #1629 already established should stay
+unchecked for cost reasons -- **verifying that assumption rather than
+trusting it found it was wrong**. `find_cursor` must resolve
+last-duplicate-key-wins semantics (#1251), so its `while` loop always walks
+every field in the object regardless of `name` or where a match sits --
+never returning early on a match, because a later same-named field could
+still supersede it. That means it is already paying the O(n) cost this
+issue assumed only `.[]`/`keys`/`length` paid, and the trailing-gap check
+rides along for free: track the last field's value cursor (regardless of
+match), check it once after the loop, and raise for `.a` *and*
+`.nonexistent` alike on `{"a":1,}` -- matching real jq, which can't parse
+the document at all, so every field access into it raises, not just the
+ones that happen to touch a real key.
+
+**`to_entries` (both arrays and objects).** The array arm already used
+`collect_cursors_checked` and so was fixed for free by that function's own
+change above. The object arm needed one more piece: it already resolves
+every field's value cursor (`to_owned_cursor` is called on each one
+regardless), so retaining the last one costs nothing -- but it iterates the
+*already-collapsed* list `effective_fields` returns, which (per the
+`keys`/`keys_unsorted` account above) can list a different, earlier field
+last once a duplicate key collapses. A new `effective_fields_with_raw_last`
+(`document.rs`) hands back the *raw, pre-collapse* walk's own last field's
+cursor alongside the (possibly reordered) collapsed list `to_entries`
+still iterates to build its output -- free, since `all_fields()`'s `Vec`
+already exists in raw document order before any collapsing runs, so
+reading its last element costs nothing beyond the call already made.
+
+### What stayed open, and why (the genuine O(1) exception)
+
+**`keys_unsorted[0]`** (a *positive* index into an object's key list,
+`fold_lazy_keys_stage`'s `Expr::Index { idx: 0, .. }` arm) is the one case
+in this issue that really does match #1629's own "would cost strictly more
+than the answer" reasoning: it reads only `fields.uncons_key()`'s first
+field and returns, never touching the rest of the object -- the same
+positional-access shape #1629 itself already left unchecked for
+`Builtin::First`/a positive `Expr::Index` on `LazyKeys`, for the identical
+reason (checking would mean walking the whole object purely to validate
+it, undoing the point of the O(1) lookup). Confirmed still open, and
+pinned rather than silently left uncovered, by
+`test_jq_keys_unsorted_positive_index_trailing_comma_remains_a_known_gap_2261`
+in [tests/jq_cli_tests.rs](../../../tests/jq_cli_tests.rs).
+
+**#2211's own sibling shape (`[,]`, `{,}` -- a stray comma with *zero* real
+elements/fields) remains open through every path this section fixed**, for
+the same reason it remains open through `to_owned_at_depth`'s cursor-less
+callers (#2262's own account above): `container_gap_ok` needs a cursor to
+the *container itself* to find its opening bracket, and none of
+`each_lazy_array_iterate_sink`/`collect_cursors_checked`/`len_checked`
+(elements only), `effective_fields_checked`/`effective_keys`/
+`DistinctKeyCursors`/`find_cursor` (fields only) ever receive one -- only
+per-child cursors, once a child exists to hold one. One path in this set
+*does* have a container cursor sitting unused at its call site:
+`eval_each_generic`'s `Expr::Iterate` arm already threads `cursor:
+Option<V::Cursor>` through to `each_lazy_array_iterate_sink`'s call site
+but doesn't pass it in. Deliberately not wired up here -- doing so would
+mean widening a hot-path function's signature and its one call site for a
+case outside this issue's own five repros, a scoped follow-up rather than
+opportunistic scope creep. Pinned as still open by
+`test_jq_cursor_transparent_fast_paths_empty_container_stray_comma_remains_a_known_gap_2261`.
+
+**`length` (objects).** Not one of this issue's own five repros, but
+checked for consistency: `{"a":1,}| length` also stays open. `length`'s
+object arm (`effective_len_checked` → `census`, `document.rs`) walks with
+`uncons_key` specifically to avoid resolving any field's *value* at all
+(#1514: "a key-only walk pays for one `key()` and no `value()`" --
+`census`/`checked_len` never call `field.value_cursor()`, unlike every
+fixed path above). Retrofitting the trailing-value check here would need
+the last field's value cursor, which this walk deliberately never
+resolves -- adding it would either (a) always resolve one extra value
+cursor from a field that might not even be the last one until the walk
+finishes (a real, if small, per-call cost the #1514 design specifically
+avoids paying), or (b) require a broader trait-level change to expose a
+"free" value cursor per key-only step, which is a larger architectural
+change than a single-issue scope justifies. Left open, matching this
+same "would cost more than length's own answer" reasoning `#1629`
+established for the object's own positional-index case above.
+
+### Partial output before the error, on the two genuinely streaming writers
+
+Two of the newly-checked paths can write real, already-confirmed-good
+output to stdout before the trailing-comma fault surfaces -- not a new
+divergence, but the same one already pinned for `limit(3;.[])` on
+`[1,2,,4]` (see "A truncating consumer of a plain array `.[]` skips a
+malformed comma it never needed", above): a streaming writer emits each
+element/key as it confirms it, and only learns about a trailing fault once
+the walk exhausts.
+
+```
+$ echo '[1,]'     | jq  -c '.[]'            # (parses nothing) exit 5
+$ echo '[1,]'     | sjq -c '.[]'            # 1, then error, exit 5
+$ echo '{"a":1,}' | jq  -c 'keys_unsorted'   # (parses nothing) exit 5
+$ echo '{"a":1,}' | sjq -c 'keys_unsorted'   # ["a" (no closing bracket), then error, exit 5
+```
+
+Real jq's parser is atomic (whole-document parse before any evaluation, so
+a malformed document produces no output at all); succinctly's semi-index
+validates incrementally as each element/writer step confirms itself good.
+Pinned by
+`test_jq_lazy_array_iterate_trailing_comma_streams_confirmed_prefix_first_2261`
+and
+`test_jq_lazy_keys_array_trailing_comma_leaves_truncated_bracket_2261`.
+Every other path this section fixed (`length`, `to_entries`, `keys`, `.a`,
+`keys_unsorted[]`/`| last`/`[-1]`) resolves to a single owned result or a
+fully-collected `Vec` before printing anything, so a mid-walk failure there
+never leaks a partial value.
 
 ## Refusing an allocation jq does not survive
 

--- a/src/bin/succinctly/jq_runner.rs
+++ b/src/bin/succinctly/jq_runner.rs
@@ -852,11 +852,18 @@ fn identity_exit_status_value(json_bytes: &[u8]) -> OwnedValue {
 /// so either fault surfaces only here, potentially behind an
 /// already-written partial `[`/array -- see `JqValue::LazyKeysArray`'s own
 /// doc comment for why that trade is accepted.
+///
+/// #2261: also checks [`DistinctKeyCursors::trailing_gap_ok`] -- a trailing
+/// stray `,` after the object's own real last key (`{"a":1,}`), same "ask
+/// only once the walk is done" contract, same O(1) `next_sibling()` cost.
 fn bail_if_keys_malformed<F: succinctly::jq::document::DocumentFields>(
     keys: &DistinctKeyCursors<F>,
     doc_text: Option<&[u8]>,
 ) -> Result<()> {
-    match (keys.is_malformed(), doc_text) {
+    match (
+        (keys.is_malformed() || !keys.trailing_gap_ok(b'}')),
+        doc_text,
+    ) {
         (true, Some(text)) => Err(MalformedJsonError(EvalError::malformed_json_text(text)).into()),
         _ => Ok(()),
     }

--- a/src/jq/document.rs
+++ b/src/jq/document.rs
@@ -1814,14 +1814,46 @@ pub fn effective_fields<F: DocumentFields>(
     fields: &F,
     collapse: bool,
 ) -> Vec<DocumentField<F::Value, F::Cursor>> {
-    if !collapse {
-        return fields.all_fields();
-    }
+    effective_fields_with_raw_last(fields, collapse).0
+}
+
+/// [`effective_fields`], additionally handing back the raw last field's cursor (#2261).
+///
+/// The extra value is the *raw, pre-collapse* walk's own textually last
+/// field's value cursor -- for a caller that (like `Builtin::ToEntries`'s
+/// object arm) wants to check a trailing stray comma (`{"a":1,}`) against
+/// the object's real last field.
+///
+/// **Not** `effective_fields(...).last()`: collapsing is "first position,
+/// last value" (see `collapse_repeated`'s own doc comment) -- the
+/// returned `Vec`'s own *order* still reflects first-occurrence position,
+/// so its last element is whichever key's first occurrence happens to
+/// sort last among survivors, not whichever field sits last in the source
+/// text. `{"a":1,"b":2,"a":3}` collapses to `[("a", value 3), ("b", value
+/// 2)]` in that order -- "b" last, even though "a"'s second occurrence is
+/// the real last field before `}`. Checking the collapsed list's own last
+/// entry there would scan the gap after `2`, see the perfectly ordinary
+/// `,"a":3}` that follows it, and wrongly refuse a well-formed document
+/// (the same mistake `DistinctKeyCursors::last_key_cursor`'s own doc
+/// comment already describes and fixes for `keys`/`keys_unsorted`).
+///
+/// Free: `all_fields()`'s own `Vec` already exists in raw document order
+/// before any collapsing runs, so reading its last element costs nothing
+/// beyond the call this function already makes.
+#[allow(clippy::type_complexity)] // STYLE-0004: mirrors effective_fields_checked's own Vec<DocumentField<..>>, plus the raw-last cursor; a named alias would add indirection for one extra wrapper.
+pub fn effective_fields_with_raw_last<F: DocumentFields>(
+    fields: &F,
+    collapse: bool,
+) -> (Vec<DocumentField<F::Value, F::Cursor>>, Option<F::Cursor>) {
     let all = fields.all_fields();
+    let raw_last = all.last().map(|f| f.value_cursor);
+    if !collapse {
+        return (all, raw_last);
+    }
     if keys_repeat(&all) {
-        collapse_repeated(all)
+        (collapse_repeated(all), raw_last)
     } else {
-        all
+        (all, raw_last)
     }
 }
 
@@ -1845,6 +1877,13 @@ pub fn effective_fields_checked<F: DocumentFields>(
     let mut out = Vec::new();
     let mut walk = fields.clone();
     let mut is_first = true;
+    // #2261: the raw walk's own textually-last field, retained regardless of
+    // any later collapse -- collapsing a repeated key onto its first
+    // occurrence changes which *entries* `out` keeps, never where the
+    // object's own closing `}` sits in the source text, so the trailing-gap
+    // check below must run against the walk's real last field, not
+    // whatever `out` holds once collapsing (if any) has run.
+    let mut last_value_cursor: Option<F::Cursor> = None;
     while let Some((field, rest)) = walk.uncons() {
         if key_is_malformed(&field.key) {
             return Err(walk.malformed_member_error());
@@ -1856,12 +1895,24 @@ pub fn effective_fields_checked<F: DocumentFields>(
         {
             return Err(walk.malformed_member_error());
         }
+        last_value_cursor = Some(field.value_cursor);
         out.push(field);
         walk = rest;
         is_first = false;
     }
     if walk.ends_unpaired() {
         return Err(walk.malformed_member_error());
+    }
+    // #2261: trailing stray comma after a real last field (`{"a":1,}`) --
+    // free here too, same reasoning as the #1677 checks above: this walk
+    // already resolved every field's value cursor, `last_value_cursor`
+    // included. No container cursor is available here to also check the
+    // zero-field stray-comma shape (`{,}`, #2211) -- same documented
+    // limitation as `to_owned_at_depth`'s own value-only callers.
+    if let Some(last) = last_value_cursor {
+        if !trailing_element_gap_ok(&last, b'}') {
+            return Err(walk.malformed_member_error());
+        }
     }
     if collapse && keys_repeat(&out) {
         out = collapse_repeated(out);
@@ -1978,6 +2029,22 @@ pub struct DistinctKeyCursors<F: DocumentFields> {
     /// [`ended_unpaired`](Self::ended_unpaired), and for the same reason:
     /// answering up front would cost a second walk.
     delimiter_fault: bool,
+    /// The textually **last** field's own key cursor, in raw document
+    /// order -- independent of which key this walk actually *yielded*
+    /// last, which under a confirmed collapse (#1385) is whichever key's
+    /// first occurrence happens to sort last among survivors, not
+    /// whichever field sits last in the source text (#2261).
+    ///
+    /// Updated on every field the raw `self.rest`-based walk examines
+    /// (before this walk has proved a repeat exists), and overwritten
+    /// wholesale from [`ConfirmedRepeat::last_key_cursor`] the moment a
+    /// repeat *is* confirmed -- that re-walk covers the whole object from
+    /// its own start, so its answer is already final and needs no further
+    /// updates from the collapsed-list branch afterwards (which never
+    /// touches `self.rest` again). A hash collision with no real repeat
+    /// leaves `self.rest` in charge again, and this field simply keeps
+    /// updating as normal until the true end.
+    last_key_cursor: Option<F::Cursor>,
 }
 
 impl<F: DocumentFields> DistinctKeyCursors<F> {
@@ -1993,6 +2060,7 @@ impl<F: DocumentFields> DistinctKeyCursors<F> {
             ended_unpaired: false,
             walked: 0,
             delimiter_fault: false,
+            last_key_cursor: None,
         }
     }
 
@@ -2039,6 +2107,32 @@ impl<F: DocumentFields> DistinctKeyCursors<F> {
     pub fn malformed_member_error(&self) -> EvalError {
         self.all.malformed_member_error()
     }
+
+    /// Whether a trailing stray `,` (`{"a":1,}`) sits between the object's
+    /// textually last field's own value and `close_char` (`}`) -- #2261.
+    ///
+    /// **Only meaningful once the iterator is exhausted and
+    /// [`is_malformed`](Self::is_malformed) has already answered `false`**,
+    /// the same contract [`ended_unpaired`](Self::ended_unpaired)/
+    /// [`delimiter_fault`](Self::delimiter_fault) share -- an object this
+    /// walk never actually finished walking (an early-stopped consumer, or
+    /// one this same walk already flagged malformed for an unrelated
+    /// reason) has no reliable "last field" answer to check yet.
+    ///
+    /// `last_key_cursor` (this struct's own private field) tracks the key; the value
+    /// this check needs sits at that key's own `next_sibling()` -- an O(1)
+    /// BP hop mirroring how every [`DocumentFields::uncons`] impl derives a
+    /// field's value cursor from its key cursor in the first place (see
+    /// `JsonFields::uncons`), run once here rather than during the walk.
+    /// `None` (an empty object, or a format whose cursor carries no
+    /// position) answers `true` -- nothing to flag, same "can't determine,
+    /// skip" convention every sibling gap check in this module follows.
+    pub fn trailing_gap_ok(&self, close_char: u8) -> bool {
+        match self.last_key_cursor.and_then(|c| c.next_sibling()) {
+            Some(value_cursor) => trailing_element_gap_ok(&value_cursor, close_char),
+            None => true,
+        }
+    }
 }
 
 impl<F: DocumentFields> Iterator for DistinctKeyCursors<F> {
@@ -2062,6 +2156,12 @@ impl<F: DocumentFields> Iterator for DistinctKeyCursors<F> {
             return None;
         };
         self.rest = tail;
+        // #2261: recorded for every field this raw walk examines, in
+        // document order -- overwritten wholesale below the moment a
+        // repeat is confirmed, from a re-walk that already knows the true
+        // answer regardless of where in the object *this* walk currently
+        // stands.
+        self.last_key_cursor = Some(key_cursor);
         // #1677: checked for every field examined, in raw document order,
         // before any collapse decision -- a comma/colon fault must surface
         // even for a field a later duplicate ends up collapsing away.
@@ -2078,6 +2178,16 @@ impl<F: DocumentFields> Iterator for DistinctKeyCursors<F> {
             .is_some_and(|seen| key_hash_of(&key).is_some_and(|hash| seen.insert(hash)));
         if repeat {
             let confirmed = collapse_confirmed_repeat(&self.all);
+            // #2261: `confirmed`'s own walk starts from `self.all` (the
+            // object's very beginning) and runs to its true end regardless
+            // of collapsing, so its answer is authoritative -- unlike
+            // `self.rest`'s own remaining walk, which (on a genuine
+            // collapse, just below) stops advancing once this arm switches
+            // to serving the pre-resolved `collapsed` list instead, and so
+            // would otherwise leave `last_key_cursor` stuck on whichever
+            // field happened to trigger this detection rather than the
+            // object's real last one.
+            self.last_key_cursor = confirmed.last_key_cursor;
             // Recorded here as well as at exhaustion above: on the
             // collapsing branch below `rest` stops mid-object and never
             // reaches the `None` arm, so that arm would never see the
@@ -2126,10 +2236,18 @@ fn collapse_confirmed_repeat<F: DocumentFields>(fields: &F) -> ConfirmedRepeat<F
     let mut out: Vec<(F::Value, F::Cursor)> = Vec::new();
     let mut total = 0usize;
     let mut delimiter_fault = false;
+    let mut last_key_cursor: Option<F::Cursor> = None;
     let mut walk = fields.clone();
     let mut is_first = true;
     while let Some((key, key_cursor, rest)) = walk.uncons_key() {
         total += 1;
+        // #2261: recorded in raw document order regardless of which slot
+        // this key ends up collapsing into -- the caller needs the
+        // object's real last field, not whichever key this walk last
+        // *inserted or updated* in `out` (order that already differs from
+        // document order once collapsing runs, see `DistinctKeyCursors`'s
+        // own `last_key_cursor` doc comment).
+        last_key_cursor = Some(key_cursor);
         // #1677: re-walks the whole object from the start, so this repeats
         // a check `DistinctKeyCursors::next` already ran on fields before
         // the repeat was confirmed -- negligible next to this function's
@@ -2162,6 +2280,7 @@ fn collapse_confirmed_repeat<F: DocumentFields>(fields: &F) -> ConfirmedRepeat<F
         delimiter_fault,
         keys: out,
         total,
+        last_key_cursor,
     }
 }
 
@@ -2181,6 +2300,11 @@ struct ConfirmedRepeat<F: DocumentFields> {
     ends_unpaired: bool,
     /// Whether any field had a malformed `,`/`:` delimiter (#1677).
     delimiter_fault: bool,
+    /// The textually last field's own key cursor (#2261) -- see
+    /// [`DistinctKeyCursors::last_key_cursor`]'s own doc comment for why
+    /// this must come from this whole-object re-walk rather than from
+    /// whichever key `keys`/`out` above last inserted or updated.
+    last_key_cursor: Option<F::Cursor>,
 }
 
 /// Collapse fields known to contain at least one repeated key.
@@ -2315,6 +2439,13 @@ pub fn effective_keys<F: DocumentFields>(
     if cursors.is_malformed() {
         return Err(fields.malformed_member_error());
     }
+    // #2261: trailing stray comma after a real last key (`{"a":1,}`) --
+    // `DistinctKeyCursors::trailing_gap_ok` resolves it from the key cursor
+    // this walk already retained, an O(1) `next_sibling()` hop rather than
+    // a further walk.
+    if !cursors.trailing_gap_ok(b'}') {
+        return Err(fields.malformed_member_error());
+    }
     Ok(keys)
 }
 
@@ -2442,7 +2573,52 @@ pub trait DocumentElements: Sized + Copy + Clone {
             elems = rest;
             is_first = false;
         }
+        // #2261: trailing stray comma after a real last element (`[1,]`) --
+        // free here since this walk already resolved every element's own
+        // cursor; mirrors `to_owned_cursor_at_depth`'s own `last_elem` check
+        // (#2243) rather than duplicating its logic. `collect_cursors_checked`
+        // has no container cursor to check the *zero-element* stray-comma
+        // shape (`[,]`, #2211) against -- same documented limitation as
+        // `to_owned_at_depth`'s own value-only callers.
+        if let Some(last) = cursors.last() {
+            if !trailing_element_gap_ok(last, b']') {
+                return Err(self.malformed_element_error());
+            }
+        }
         Ok(cursors)
+    }
+
+    /// [`DocumentElements::len`], refusing a trailing stray `,` after a real
+    /// last element (`[1,]`, #2261) as it walks -- the array counterpart of
+    /// [`effective_len_checked`]'s object case.
+    ///
+    /// Walks with `uncons_cursor` rather than `len`'s own `uncons`: the
+    /// check needs each element's own position, which only the cursor
+    /// carries (`len`'s plain `Value` does not). Keeps no `Vec` unlike
+    /// [`collect_cursors_checked`](Self::collect_cursors_checked) -- `length`
+    /// only ever wanted the count, and collecting one would be a pure
+    /// O(n)-space cost for an O(1)-space answer, the same reasoning
+    /// `Builtin::Last`'s own inline walk already applies (#1629).
+    fn len_checked(&self) -> Result<usize, EvalError> {
+        let mut count = 0usize;
+        let mut elems = *self;
+        let mut is_first = true;
+        let mut last: Option<Self::Cursor> = None;
+        while let Some((cursor, rest)) = elems.uncons_cursor() {
+            if !cursor.element_gap_ok(is_first) {
+                return Err(self.malformed_element_error());
+            }
+            count += 1;
+            last = Some(cursor);
+            elems = rest;
+            is_first = false;
+        }
+        if let Some(last) = last {
+            if !trailing_element_gap_ok(&last, b']') {
+                return Err(self.malformed_element_error());
+            }
+        }
+        Ok(count)
     }
 }
 

--- a/src/jq/document.rs
+++ b/src/jq/document.rs
@@ -946,6 +946,101 @@ pub trait DocumentFields: Sized + Clone {
         false
     }
 
+    /// [`contains`](Self::contains), refusing an object whose members the
+    /// format's grammar never allowed (#1194's unpaired tail, #1677's
+    /// missing/doubled `,`/`:`, #2261's trailing stray comma after a real
+    /// last field) -- `has(key)`'s own check for objects.
+    ///
+    /// **Preserves `contains`'s own early exit on a match** -- unlike every
+    /// other #2261 fix, which rides an already-mandatory full walk for
+    /// free, checking the trailing gap here would mean walking *past* a
+    /// match purely to look for a fault that might not even exist, on a
+    /// method whose whole point (like `keys_unsorted[0]`/`first`, #1629's
+    /// own precedent) is answering without walking the rest of the object.
+    /// Measured: on a 1,000,000-key well-formed object, `has("k0")` (the
+    /// very first key) went from ~0.03s to ~0.12s under a first-draft
+    /// version of this fix that dropped the early exit entirely -- a real
+    /// ~4x regression for exactly the case #1629 exists to keep cheap.
+    ///
+    /// So a match's own trailing-gap answer rides the *cheapest* available
+    /// signal instead: `key_cursor.next_sibling()` is the matched field's
+    /// own value (the same O(1) BP hop [`DistinctKeyCursors::trailing_gap_ok`]
+    /// uses), and *that* cursor's own `next_sibling()` answers "is there
+    /// another field after this one" for free, no walk required. Only when
+    /// the match turns out to *be* the object's real last field --
+    /// `{"a":1,} | has("a")`, this issue's own repro -- does checking cost
+    /// anything at all, and even then it's one more O(1) hop, not a walk.
+    /// A match that is *not* the last field takes the exact
+    /// #1629/#1770-established trade every other early-exit consumer in
+    /// this codebase already takes: `{"a":1,"b":2,} | has("a")` matches
+    /// "a" and returns before ever reaching "b"'s own trailing comma --
+    /// a documented, narrower gap, not silently wrong the way the
+    /// unpatched method was on its own headline repro.
+    ///
+    /// A *non-match* still has to walk to the true end regardless (the
+    /// existing shape `contains` itself already has), so that path's own
+    /// #1194/#1677/#2261 checks stay free, exactly like every other #2261
+    /// fix.
+    ///
+    /// An undecodable/unstringifiable key (`key_display_string` -> `None`)
+    /// still just fails to match, exactly as `contains` already documents
+    /// for itself -- this method closes the #1194/#1677/#2261 *structural*
+    /// gaps `contains` never checked at all, not the separate, already-
+    /// accepted "isn't full behavioral parity with `keys`" divergence
+    /// `contains`'s own doc comment describes.
+    fn contains_checked(&self, name: &str) -> Result<bool, EvalError> {
+        let mut fields = self.clone();
+        let mut is_first = true;
+        // The last key cursor seen, for the *non-match* exhaustion path
+        // below -- that walk always reaches the true end regardless (the
+        // same shape `contains` itself already has), so its own trailing
+        // check is free, unlike the early-exit match path above.
+        let mut last_key_cursor: Option<Self::Cursor> = None;
+        while let Some((key, key_cursor, rest)) = fields.uncons_key() {
+            // #1677: cheap per-key checks, riding the walk `contains`
+            // already makes regardless of early exit -- no extra cost,
+            // early-exit or not.
+            if !key_delimiter_ok::<Self>(&key, &key_cursor, is_first)
+                || !key_only_value_delimiter_ok::<Self>(&key, &key_cursor)
+            {
+                return Err(self.malformed_member_error());
+            }
+            if key_display_string(&key).is_some_and(|k| k.as_ref() == name) {
+                // #2261: free exactly when the match is also the last
+                // field -- see this method's own doc comment for why a
+                // match elsewhere accepts the documented early-exit trade
+                // instead of paying for a walk to confirm one way or
+                // the other.
+                if let Some(value_cursor) = key_cursor.next_sibling() {
+                    if value_cursor.next_sibling().is_none()
+                        && !trailing_element_gap_ok(&value_cursor, b'}')
+                    {
+                        return Err(self.malformed_member_error());
+                    }
+                }
+                return Ok(true);
+            }
+            last_key_cursor = Some(key_cursor);
+            fields = rest;
+            is_first = false;
+        }
+        if fields.ends_unpaired() {
+            return Err(self.malformed_member_error());
+        }
+        // #2261: no match found anywhere, so this walk already reached the
+        // object's true end -- the trailing-gap check is free here, same
+        // as every other #2261 fix, via the same `next_sibling()` hop
+        // `DistinctKeyCursors::trailing_gap_ok` uses.
+        if let Some(key_cursor) = last_key_cursor {
+            if let Some(value_cursor) = key_cursor.next_sibling() {
+                if !trailing_element_gap_ok(&value_cursor, b'}') {
+                    return Err(self.malformed_member_error());
+                }
+            }
+        }
+        Ok(false)
+    }
+
     /// Check if there are no fields.
     fn is_empty(&self) -> bool;
 

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -7871,7 +7871,17 @@ fn index_one_generic<S: EvalSemantics, V: DocumentValue>(
             // and NaN has no index at all — also null.
             let idx = numeric_key_to_index(key);
             if let Some(elements) = target.as_array() {
-                let len = elements.len();
+                // #2261: `len_checked`, not the bare `len()` -- this
+                // resolves *any* index (`E[K]`, e.g. `.[0,1]`, `.[$i]`),
+                // not just a negative one, so the length walk (needed to
+                // normalize a negative index and to raise yq's own
+                // out-of-range error below) already happens unconditionally
+                // on every call, same reasoning as the literal-index
+                // sibling arm in `eval_single`'s own `Expr::Index`.
+                let len = match elements.len_checked() {
+                    Ok(len) => len,
+                    Err(err) => return GenericResult::Error(err),
+                };
                 let resolved = idx.map(|idx| if idx < 0 { len as i64 + idx } else { idx });
                 // yq mode only (#2254): same rule as `eval_single`'s
                 // `Expr::Index` arm above -- a negative index still
@@ -8815,17 +8825,34 @@ fn eval_has_one_key<S: EvalSemantics, V: DocumentValue>(
         return GenericResult::Owned(OwnedValue::Bool(false));
     }
     match (&key_owned, value.as_object(), value.as_array()) {
-        (OwnedValue::String(key), Some(fields), _) => {
-            GenericResult::Owned(OwnedValue::Bool(fields.contains(key)))
-        }
+        // #2261: `contains_checked`, not the bare `contains` -- catches a
+        // trailing stray comma (`{"a":1,} | has("a")`), a #1194 unpaired
+        // tail, and a #1677 delimiter fault, none of which `contains`
+        // itself ever checked. See `contains_checked`'s own doc comment
+        // for why this walks to completion (a real cost increase for the
+        // "key found early" case) rather than riding an already-mandatory
+        // walk for free like every other #2261 fix.
+        (OwnedValue::String(key), Some(fields), _) => match fields.contains_checked(key) {
+            Ok(found) => GenericResult::Owned(OwnedValue::Bool(found)),
+            Err(err) => GenericResult::Error(err),
+        },
         (
             OwnedValue::Int(_) | OwnedValue::Float(_) | OwnedValue::NumberLiteral(..),
             _,
             Some(elements),
         ) => {
+            // #2261: `len_checked`, not the bare `len()` -- `elements.len()`
+            // already needed the whole array's cursor walk (`in_bounds`
+            // reads only the count, never a value), so the #1677/#2261 gap
+            // checks ride along for free, same reasoning as
+            // `Expr::Index`'s own array arm in `eval_single`.
+            let len = match elements.len_checked() {
+                Ok(len) => len,
+                Err(err) => return GenericResult::Error(err),
+            };
             let in_bounds = match numeric_key_to_array_index::<S>(&key_owned) {
                 None => false,
-                Some(idx) => index_in_array_bounds::<S>(idx, elements.len() as i64),
+                Some(idx) => index_in_array_bounds::<S>(idx, len as i64),
             };
             GenericResult::Owned(OwnedValue::Bool(in_bounds))
         }
@@ -9307,7 +9334,15 @@ fn path_step_generic<S: EvalSemantics, V: DocumentValue>(
                     }
                     Ok(())
                 } else if let Some(elements) = v.as_array() {
-                    for (i, ec) in elements.collect_cursors().into_iter().enumerate() {
+                    // #2261 (systematic sweep): `collect_cursors_checked`,
+                    // not the unchecked `collect_cursors` this arm used --
+                    // the object arm just above already routes through the
+                    // checked `effective_fields_checked`; this array
+                    // sibling had drifted onto the wrong one, so
+                    // `[path(.[])]` on `[1,2,3,]` silently answered
+                    // `[[0],[1],[2]]` instead of raising like every other
+                    // `.[]` consumer already does.
+                    for (i, ec) in elements.collect_cursors_checked()?.into_iter().enumerate() {
                         out.push((
                             PathTrail::extend(path, OwnedValue::Int(i as i64)),
                             PathNode::At(ec),
@@ -10072,8 +10107,13 @@ fn eval_builtin<S: EvalSemantics, V: DocumentValue>(
                 use rand_chacha::ChaCha8Rng;
 
                 if let Some(elements) = value.as_array() {
-                    let mut values: Vec<OwnedValue> =
-                        owned_or_err!(to_owned_all_cursors(&elements.collect_cursors()));
+                    // #2261 (systematic sweep): `collect_cursors_checked`,
+                    // not the unchecked `collect_cursors` this arm used --
+                    // this walk already materializes every element via
+                    // `to_owned_all_cursors` regardless, so the #1677/#2261
+                    // gap checks ride along for free.
+                    let cursors = owned_or_err!(elements.collect_cursors_checked());
+                    let mut values: Vec<OwnedValue> = owned_or_err!(to_owned_all_cursors(&cursors));
                     let mut rng = ChaCha8Rng::from_rng(&mut rand::rng());
                     values.shuffle(&mut rng);
                     GenericResult::Owned(OwnedValue::Array(values))
@@ -10094,8 +10134,11 @@ fn eval_builtin<S: EvalSemantics, V: DocumentValue>(
 
         Builtin::Pivot => {
             if let Some(elements) = value.as_array() {
-                let items: Vec<OwnedValue> =
-                    owned_or_err!(to_owned_all_cursors(&elements.collect_cursors()));
+                // #2261 (systematic sweep): same `collect_cursors_checked`
+                // fix as `Shuffle` just above -- free here too, for the
+                // same reason.
+                let cursors = owned_or_err!(elements.collect_cursors_checked());
+                let items: Vec<OwnedValue> = owned_or_err!(to_owned_all_cursors(&cursors));
                 if items.is_empty() {
                     return GenericResult::Owned(OwnedValue::Array(vec![]));
                 }
@@ -10261,7 +10304,17 @@ fn eval_builtin<S: EvalSemantics, V: DocumentValue>(
                 // lazy (#684) — don't materialize a `Vec<OwnedValue::Int>`
                 // yet; `length`, `.[]`, `.[n]`, `first`, and `last` can all
                 // answer directly from `len` (see the `Pipe` dispatch below).
-                GenericResult::LazyIndexRange(elements.len())
+                //
+                // #2261: `len_checked`, not the bare `len()` -- this call
+                // already walks the whole array to answer `len` (same as
+                // `Builtin::Length`'s own array arm), so the #1677/#2261
+                // gap checks ride along for free, and `[1,2,3,] | keys`
+                // now agrees with real jq (parse error) instead of
+                // silently returning `[0,1,2]`.
+                match elements.len_checked() {
+                    Ok(len) => GenericResult::LazyIndexRange(len),
+                    Err(err) => GenericResult::Error(err),
+                }
             } else {
                 decode_failure_or(&value, optional, || {
                     GenericResult::Error(EvalError::has_no_keys(&to_owned_for_diagnostic(
@@ -10284,8 +10337,13 @@ fn eval_builtin<S: EvalSemantics, V: DocumentValue>(
                     collapse: S::COLLAPSE_DUPLICATE_KEYS,
                 }
             } else if let Some(elements) = value.as_array() {
-                // Same laziness as the array branch of `Keys` above (#684).
-                GenericResult::LazyIndexRange(elements.len())
+                // Same laziness as the array branch of `Keys` above (#684),
+                // and the same #2261 fix: `len_checked` rides the same
+                // already-mandatory walk.
+                match elements.len_checked() {
+                    Ok(len) => GenericResult::LazyIndexRange(len),
+                    Err(err) => GenericResult::Error(err),
+                }
             } else {
                 decode_failure_or(&value, optional, || {
                     GenericResult::Error(EvalError::has_no_keys(&to_owned_for_diagnostic(
@@ -10523,7 +10581,16 @@ fn eval_builtin<S: EvalSemantics, V: DocumentValue>(
         Builtin::Last => {
             // jq: last == .[-1], so [] and null both yield null
             if let Some(elements) = value.as_array() {
-                let len = elements.len();
+                // #2261: `len_checked`, not the bare `len()` -- unlike
+                // `Builtin::First` just above (genuinely O(1) via
+                // `get_cursor(0)`, left unchecked per #1629's precedent),
+                // `last` already has to walk the whole array to find its
+                // own length, so the #1677/#2261 gap checks ride along for
+                // free on that same mandatory walk.
+                let len = match elements.len_checked() {
+                    Ok(len) => len,
+                    Err(err) => return GenericResult::Error(err),
+                };
                 match len.checked_sub(1).and_then(|i| elements.get_cursor(i)) {
                     Some(c) => GenericResult::OneCursor(c),
                     None => GenericResult::Owned(OwnedValue::Null),
@@ -10591,7 +10658,11 @@ fn eval_builtin<S: EvalSemantics, V: DocumentValue>(
                 );
             }
             if let Some(elements) = value.as_array() {
-                let mut cursors = elements.collect_cursors();
+                // #2261 (systematic sweep): `collect_cursors_checked`, not
+                // the unchecked `collect_cursors` this arm used -- this
+                // walk already resolves every element's cursor to reverse
+                // them, so the #1677/#2261 gap checks ride along for free.
+                let mut cursors = owned_or_err!(elements.collect_cursors_checked());
                 cursors.reverse();
                 GenericResult::LazySeq(Box::new(LazySeq::from_cursors(cursors)))
             } else if optional {
@@ -10636,24 +10707,25 @@ fn eval_builtin<S: EvalSemantics, V: DocumentValue>(
                 _ => None,
             };
             let dedup = matches!(builtin, Builtin::Unique | Builtin::UniqueBy(_));
-            sort_family_array_generic::<S, _>(
-                elements.collect_cursors(),
-                key,
-                optional,
-                |mut keyed| {
-                    sort_keyed_elements::<V>(&mut keyed);
-                    if dedup {
-                        // `owned_value_eq::<S>`, not `compare_values(..) ==
-                        // Equal`: the sort above stays widening, but two
-                        // elements only count as duplicates under `==`'s own
-                        // yq-mode strict Int/Float distinction (#950). Same
-                        // choice `eval::builtin_unique` makes, reused rather
-                        // than re-derived.
-                        keyed.dedup_by(|(a, _), (b, _)| owned_value_eq::<S>(a, b));
-                    }
-                    keyed.into_iter().map(|(_, cursor)| cursor).collect()
-                },
-            )
+            // #2261 (systematic sweep): `collect_cursors_checked`, not the
+            // unchecked `collect_cursors` this arm used -- every one of
+            // these builtins already resolves each element's cursor to
+            // sort/dedup them, so the #1677/#2261 gap checks ride along
+            // for free.
+            let cursors = owned_or_err!(elements.collect_cursors_checked());
+            sort_family_array_generic::<S, _>(cursors, key, optional, |mut keyed| {
+                sort_keyed_elements::<V>(&mut keyed);
+                if dedup {
+                    // `owned_value_eq::<S>`, not `compare_values(..) ==
+                    // Equal`: the sort above stays widening, but two
+                    // elements only count as duplicates under `==`'s own
+                    // yq-mode strict Int/Float distinction (#950). Same
+                    // choice `eval::builtin_unique` makes, reused rather
+                    // than re-derived.
+                    keyed.dedup_by(|(a, _), (b, _)| owned_value_eq::<S>(a, b));
+                }
+                keyed.into_iter().map(|(_, cursor)| cursor).collect()
+            })
         }
 
         // The single-element half of the same family. `min`/`max` answer one
@@ -10672,7 +10744,12 @@ fn eval_builtin<S: EvalSemantics, V: DocumentValue>(
                     optional,
                 );
             };
-            let cursors = elements.collect_cursors();
+            // #2261 (systematic sweep): `collect_cursors_checked`, not the
+            // unchecked `collect_cursors` this arm used -- every one of
+            // these builtins already resolves each element's cursor to
+            // compare them, so the #1677/#2261 gap checks ride along for
+            // free.
+            let cursors = owned_or_err!(elements.collect_cursors_checked());
             // jq answers `null` for an empty array, for all four spellings.
             if cursors.is_empty() {
                 return GenericResult::Owned(OwnedValue::Null);

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -19299,4 +19299,52 @@ mod tests {
         assert!(control.is_none(), "control: {control:?}");
         assert_eq!(count, 3);
     }
+
+    /// #2261: a trailing stray comma after a real last key (`{"a":1,}`) is
+    /// the same "only checked on exhaustion" shape #1653 already pins above
+    /// for `ended_unpaired`/`delimiter_fault`, extended to
+    /// `DistinctKeyCursors::trailing_gap_ok`. Every real key still reaches
+    /// the sink first (the same "prefix before the fault" contract).
+    #[test]
+    fn each_lazy_keys_iterate_sink_raises_on_trailing_comma_at_exhaustion_2261() {
+        let (count, control) = drive_each(br#"{"a":1,}"#, "keys_unsorted[]");
+        match control {
+            Some(Control::Error(err)) => assert!(
+                err.message.contains("Invalid JSON text"),
+                "message: {}",
+                err.message
+            ),
+            other => panic!("expected Control::Error, got {other:?}"),
+        }
+        assert_eq!(count, 1, "the one real key before the fault");
+    }
+
+    /// #2261: the identical shape, but with a duplicate key ahead of the
+    /// trailing comma (`{"a":1,"b":2,"a":3,}`) -- pins that
+    /// `last_key_cursor` survives a confirmed collapse and still points at
+    /// the object's *textually* last field, not whichever key the
+    /// collapsed walk happened to yield last.
+    #[test]
+    fn each_lazy_keys_iterate_sink_raises_on_trailing_comma_with_duplicate_key_2261() {
+        let (count, control) = drive_each(br#"{"a":1,"b":2,"a":3,}"#, "keys_unsorted[]");
+        match control {
+            Some(Control::Error(err)) => assert!(
+                err.message.contains("Invalid JSON text"),
+                "message: {}",
+                err.message
+            ),
+            other => panic!("expected Control::Error, got {other:?}"),
+        }
+        assert_eq!(count, 2, "both distinct keys before the fault");
+    }
+
+    /// #2261's own early-exit exemption, mirroring #1770's above: a
+    /// truncating consumer never reaches the tail, so it never sees the
+    /// trailing comma either.
+    #[test]
+    fn each_lazy_keys_iterate_sink_early_exit_still_skips_the_trailing_comma_2261() {
+        let (count, control) = drive_each(br#"{"a":1,}"#, "first(keys_unsorted[])");
+        assert!(control.is_none(), "control: {control:?}");
+        assert_eq!(count, 1);
+    }
 }

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -27,11 +27,11 @@ use std::rc::Rc;
 use indexmap::IndexMap;
 
 use super::document::{
-    collapsed_fields, collapsed_fields_if, effective_fields, effective_fields_checked,
-    effective_keys, effective_len_checked, key_delimiter_ok, key_display_string,
-    key_display_string_kind, key_is_malformed, resolve_display_key, trailing_element_gap_ok,
-    value_delimiter_ok, DisplayKeyGuard, DistinctKeyCursors, DocumentCursor, DocumentElements,
-    DocumentFields, DocumentValue, IndentSpec, JsonConvention,
+    collapsed_fields, collapsed_fields_if, effective_fields_checked,
+    effective_fields_with_raw_last, effective_keys, effective_len_checked, key_delimiter_ok,
+    key_display_string, key_display_string_kind, key_is_malformed, resolve_display_key,
+    trailing_element_gap_ok, value_delimiter_ok, DisplayKeyGuard, DistinctKeyCursors,
+    DocumentCursor, DocumentElements, DocumentFields, DocumentValue, IndentSpec, JsonConvention,
 };
 use super::eval::{
     apply_compare_op, arith_combine, as_var_refs, bind_def, bind_def_call,
@@ -1092,6 +1092,15 @@ fn walk_distinct_keys_checked<V: DocumentValue>(
         on_cursor(cursor);
     }
     if cursors.is_malformed() {
+        return Err(fields.malformed_member_error());
+    }
+    // #2261: trailing stray comma after a real last key (`{"a":1,}`) --
+    // `cursors` already retained the last key cursor this walk saw, so this
+    // is one more O(1) `next_sibling()` hop, not a further walk. Covers
+    // both callers: `distinct_key_cursors_checked` (`keys_unsorted[]`, a
+    // negative `keys_unsorted[n]`) and `keys_are_well_formed`
+    // (`try_single_generic`'s `LazyKeys` probe).
+    if !cursors.trailing_gap_ok(b'}') {
         return Err(fields.malformed_member_error());
     }
     Ok(())
@@ -4104,6 +4113,14 @@ fn fold_lazy_keys_stage<S: EvalSemantics, V: DocumentValue>(
             if cursors.is_malformed() {
                 return GenericResult::Error(fields.malformed_member_error());
             }
+            // #2261: same trailing-comma check those two siblings now run
+            // too -- this arm already walks the whole object regardless
+            // (there is no way to find "the last key" without reaching the
+            // end), so it rides along for free, same reasoning as the rest
+            // of this arm's own #1956 fix.
+            if !cursors.trailing_gap_ok(b'}') {
+                return GenericResult::Error(fields.malformed_member_error());
+            }
             match last_cursor {
                 Some(c) => GenericResult::OneCursor(c),
                 None => GenericResult::Owned(OwnedValue::Null),
@@ -4513,11 +4530,25 @@ fn each_lazy_keys_iterate_sink<S: EvalSemantics, V: DocumentValue>(
         // the tail, and charging it for one would restore exactly the whole-
         // object probe such a consumer exists to avoid (#1514/#1599) --
         // which is the divergence #1770 accepted, scoped to early exit.
-        if matches!(flow, Flow::Exhausted) && cursors.is_malformed() {
-            return drain_result_generic(
-                GenericResult::Error(cursors.malformed_member_error()),
-                sink,
-            );
+        if matches!(flow, Flow::Exhausted) {
+            if cursors.is_malformed() {
+                return drain_result_generic(
+                    GenericResult::Error(cursors.malformed_member_error()),
+                    sink,
+                );
+            }
+            // #2261: trailing stray comma after a real last key
+            // (`{"a":1,}`) -- `cursors` already retained the last key
+            // cursor this walk saw (`DistinctKeyCursors::last_key_cursor`),
+            // so this is one more O(1) `next_sibling()` hop, not a further
+            // walk. Same early-exit exemption as the `is_malformed()` check
+            // just above.
+            if !cursors.trailing_gap_ok(b'}') {
+                return drain_result_generic(
+                    GenericResult::Error(cursors.malformed_member_error()),
+                    sink,
+                );
+            }
         }
         return flow;
     }
@@ -4611,16 +4642,25 @@ fn each_lazy_seq_iterate_sink<S: EvalSemantics, V: DocumentValue>(
 /// that would find it never runs past what was asked for. `first(.[])` on
 /// `[1,,3]` still raises correctly (the fault is on the very first element
 /// examined); `first(.[])` on a well-formed `1` followed by a *later*
-/// malformed gap does not see it. Every eager caller of
+/// malformed gap does not see it -- including the #2261 trailing-comma
+/// shape below (`[1,]`), which by definition only shows up once the walk
+/// reaches the container's real last element. Every eager caller of
 /// `collect_cursors_checked` (`.[]` reached through the rest of the
-/// evaluator, `to_entries`) is unaffected -- only this demand-aware path
-/// takes the trade. Recorded in `docs/compliance/jq/limitations.md`.
+/// evaluator, `to_entries`) does see it (#2261 closed that gap in
+/// `collect_cursors_checked` itself) -- only this demand-aware path takes
+/// the early-exit trade. Recorded in `docs/compliance/jq/limitations.md`.
 fn each_lazy_array_iterate_sink<V: DocumentValue>(
     elements: V::Elements,
     sink: &mut dyn FnMut(GenericItem<V>) -> Demand,
 ) -> Flow {
     let mut elems = elements;
     let mut is_first = true;
+    // #2261: the last real element's own cursor, retained past the loop so
+    // the trailing-gap check below (a stray `,` *after* a real last
+    // element, `[1,]`) has something to check from once the walk exhausts
+    // -- mirrors `to_owned_cursor_at_depth`'s own `last_elem` (#2243) and
+    // `collect_cursors_checked`'s identical addition (#2261).
+    let mut last_cursor: Option<V::Cursor> = None;
     while let Some((cursor, next)) = elems.uncons_cursor() {
         if !cursor.element_gap_ok(is_first) {
             // `elements.malformed_element_error()`, not `elems` (the
@@ -4635,8 +4675,16 @@ fn each_lazy_array_iterate_sink<V: DocumentValue>(
         }
         is_first = false;
         elems = next;
+        last_cursor = Some(cursor);
         if sink(GenericItem::OneCursor(cursor)) == Demand::Stop {
             return Flow::Stopped { pending: None };
+        }
+    }
+    // #2261: only on exhaustion -- see this function's own doc comment
+    // above for why an early-stopped consumer never reaches this check.
+    if let Some(last) = last_cursor {
+        if !trailing_element_gap_ok(&last, b']') {
+            return Flow::Escaped(Control::Error(elements.malformed_element_error()));
         }
     }
     Flow::Exhausted
@@ -4985,7 +5033,20 @@ fn eval_single<S: EvalSemantics, V: DocumentValue>(
 
         Expr::Index { idx, .. } => {
             if let Some(elements) = value.as_array() {
-                let len = elements.len();
+                // #2261: `_checked`, not the bare `len()` this used to call
+                // -- free here, unlike a *positive*-only lookup elsewhere
+                // in this evaluator (`Expr::Iterate`'s sorted-key positive-
+                // index arm, #1629's own precedent for "would cost strictly
+                // more than the answer"): resolving *any* index here,
+                // negative or positive, already walks the whole array via
+                // `len()` first (to normalize a negative index and to raise
+                // yq's own out-of-range error), so the trailing/leading gap
+                // checks ride along for free on every call, not just the
+                // negative-index ones.
+                let len = match elements.len_checked() {
+                    Ok(len) => len,
+                    Err(err) => return GenericResult::Error(err),
+                };
                 let resolved = if *idx < 0 { len as i64 + idx } else { *idx };
                 // yq mode only (#2254): a negative index still negative
                 // after resolving against the length raises in real yq --
@@ -10135,7 +10196,17 @@ fn eval_builtin<S: EvalSemantics, V: DocumentValue>(
             } else if let Some(s) = value.as_str() {
                 GenericResult::Owned(OwnedValue::Int(s.chars().count() as i64))
             } else if let Some(elements) = value.as_array() {
-                GenericResult::Owned(OwnedValue::Int(elements.len() as i64))
+                // #2261: `_checked` refuses a trailing stray comma after a
+                // real last element (`[1,]`) -- the array counterpart of
+                // `effective_len_checked` just below, walking with
+                // `uncons_cursor` (needed for the check's own position,
+                // `len`'s plain `uncons` doesn't carry one) but keeping no
+                // `Vec`, same reasoning as `collect_cursors_checked`'s own
+                // O(1)-space sibling `len_checked`.
+                match elements.len_checked() {
+                    Ok(len) => GenericResult::Owned(OwnedValue::Int(len as i64)),
+                    Err(err) => GenericResult::Error(err),
+                }
             } else if let Some(fields) = value.as_object() {
                 // #1194: `effective_len` counts a member whose key never
                 // stringifies (`census`'s `unkeyed`), so `length` answered 1
@@ -10281,7 +10352,16 @@ fn eval_builtin<S: EvalSemantics, V: DocumentValue>(
                 }
                 // A loop for the same reason as the array arm above.
                 let mut entries: Vec<OwnedValue> = Vec::new();
-                for field in effective_fields(&fields, S::COLLAPSE_DUPLICATE_KEYS) {
+                // #2261: the *raw, pre-collapse* walk's own textually last
+                // field's value cursor -- not derivable from the collapsed
+                // list this loop iterates below, whose own last element can
+                // be a different, earlier-in-source field once a repeated
+                // key collapses (see `effective_fields_with_raw_last`'s own
+                // doc comment for why, and the well-formed case this would
+                // otherwise wrongly reject).
+                let (effective, last_value_cursor) =
+                    effective_fields_with_raw_last(&fields, S::COLLAPSE_DUPLICATE_KEYS);
+                for field in effective {
                     // A key that will not *decode* is preserved via its raw
                     // source span rather than raised on (#1247/#1642),
                     // matching `length`/`keys_unsorted`/`.`. `continue` here
@@ -10313,6 +10393,13 @@ fn eval_builtin<S: EvalSemantics, V: DocumentValue>(
                         owned_or_err!(to_owned_cursor(&field.value_cursor)),
                     );
                     entries.push(OwnedValue::Object(entry));
+                }
+                // #2261: trailing stray comma after a real last field
+                // (`{"a":1,}`).
+                if let Some(last) = last_value_cursor {
+                    if !trailing_element_gap_ok(&last, b'}') {
+                        return GenericResult::Error(fields.malformed_member_error());
+                    }
                 }
                 GenericResult::Owned(OwnedValue::Array(entries))
             } else {
@@ -11762,11 +11849,12 @@ mod tests {
     fn test_lazyseq_size_is_pinned_1973() {
         assert_eq!(
             core::mem::size_of::<LazySeq<crate::yaml::YamlValue<'_, Vec<u64>>>>(),
-            184,
+            216,
             "LazySeq<YamlValue>'s size changed -- if it grew, a new unboxed-wide field \
              snuck onto LazySeq/LazySource/DistinctKeyCursors (investigate before \
              accepting); if it shrank, DistinctKeyCursors shrank further -- update this \
-             pinned value to match"
+             pinned value to match. 184 -> 216 (#2261) is accounted for: \
+             `DistinctKeyCursors::last_key_cursor` below grew by one cursor's worth."
         );
     }
 
@@ -11784,6 +11872,14 @@ mod tests {
     /// in code review before this landed). `rest`/`all`'s own two full
     /// field-cursor copies remain unboxed and out of scope here too
     /// (#1973's own "why deferred" section).
+    ///
+    /// 152 -> 184 (#2261): `last_key_cursor: Option<F::Cursor>` is a new
+    /// field, deliberately unboxed and updated on *every* non-collapsed
+    /// iteration (the #2261 trailing-comma-after-real-last-key check needs
+    /// it once the walk exhausts) -- the same "common path, not rare path"
+    /// reasoning `seen` above already established, not the mistake this
+    /// test exists to catch. Reviewed and accepted, not merely updated to
+    /// match.
     #[test]
     #[cfg(target_pointer_width = "64")]
     fn test_distinct_key_cursors_size_is_pinned_1973() {
@@ -11791,7 +11887,7 @@ mod tests {
             core::mem::size_of::<
                 crate::jq::document::DistinctKeyCursors<crate::yaml::YamlFields<'_, Vec<u64>>>,
             >(),
-            152,
+            184,
             "DistinctKeyCursors<YamlFields>'s size changed -- if it grew, a new field \
              landed unboxed on the rare-path (seen/collapsed) or copied cursor (rest/all) \
              members (investigate before accepting); if it shrank, update this pinned \

--- a/src/jq/stream.rs
+++ b/src/jq/stream.rs
@@ -705,6 +705,12 @@ pub fn stream_lazy_keys_json<W: core::fmt::Write, F: DocumentFields>(
     if error.is_none() && cursors.is_malformed() {
         *error = Some(fields.malformed_member_error());
     }
+    // #2261: trailing stray comma after a real last key (`{"a":1,}`) --
+    // `cursors` already retained the last key cursor this walk saw, so this
+    // is one more O(1) `next_sibling()` hop, not a further walk.
+    if error.is_none() && !cursors.trailing_gap_ok(b'}') {
+        *error = Some(fields.malformed_member_error());
+    }
     if indent.width > 0 {
         out.write_char('\n')?;
     }

--- a/src/jq/stream.rs
+++ b/src/jq/stream.rs
@@ -1428,6 +1428,78 @@ mod tests {
         assert_eq!(yaml_block, "- b");
     }
 
+    /// #2261: a trailing stray comma after a real last key (`{"a":1,}`) --
+    /// caught by `trailing_gap_ok` rather than `is_malformed()`, the same
+    /// "ask only once the walk is done" contract as the #1679 tests above.
+    ///
+    /// **Not reachable from either shipped CLI today**, the same "library-
+    /// API-only completeness fix" shape `test_stream_lazy_keys_honors_
+    /// collapse_1514` already documents for this function: `succinctly jq`
+    /// excludes bare `Builtin::KeysUnsorted` from its own M2 fast-path gate
+    /// unconditionally (`m2_json_fallback_safe`, `jq_runner.rs`, since
+    /// #1679 -- this writer's own malformed-key detection wasn't
+    /// established when that gate was written), so this function is never
+    /// invoked from `succinctly jq` regardless of AST shape; `succinctly
+    /// yq --input-format json` has no such exclusion and does reach this
+    /// function, but only with YAML-sourced `fields` (JSON parses through
+    /// `YamlIndex` there, per #1975/#2262), whose own `trailing_gap_ok`
+    /// always answers `true` by design (YAML's flow-mapping grammar
+    /// legitimately allows a trailing `,`) -- so a genuinely JSON-sourced
+    /// `fields` never reaches this function from either CLI as things
+    /// stand today. Pinned directly here, calling the function itself,
+    /// exactly as #1514's own review already established the precedent for
+    /// doing when a fix to this function outruns what any CLI path
+    /// currently exercises.
+    #[test]
+    fn test_stream_lazy_keys_raises_on_trailing_comma_2261() {
+        use crate::json::light::{JsonIndex, StandardJson};
+
+        let json = br#"{"a":1,}"#;
+        let index = JsonIndex::build(json);
+        let StandardJson::Object(fields) = index.root(json).value() else {
+            panic!("expected object");
+        };
+
+        let mut json_out = String::new();
+        let mut err = None;
+        stream_lazy_keys_json(&fields, true, &mut json_out, IndentSpec::COMPACT, &mut err).unwrap();
+        let e = err.expect("a trailing stray comma is not JSON");
+        assert!(e.message.contains("Invalid JSON text"), "{e:?}");
+        assert_eq!(
+            json_out, r#"["a"]"#,
+            "the one real key written before the fault stays written, closing bracket \
+             included -- unlike jq_runner.rs's own `JqValue::LazyKeysArray` writer, this \
+             function always finishes the bracket and lets `error` (not a truncated `[`) \
+             signal the fault to its caller, matching test_stream_lazy_keys_raises_on_non_\
+             string_key_1679's identical convention"
+        );
+    }
+
+    /// #2261: the well-formed sibling of the test above -- a genuine `{}`
+    /// and an ordinary multi-key object are both unaffected by the new
+    /// check.
+    #[test]
+    fn test_stream_lazy_keys_wellformed_unaffected_by_trailing_comma_check_2261() {
+        use crate::json::light::{JsonIndex, StandardJson};
+
+        for (json, expected) in [
+            (&b"{}"[..], "[]"),
+            (&b"{\"a\":1}"[..], r#"["a"]"#),
+            (&b"{\"a\":1,\"b\":2}"[..], r#"["a","b"]"#),
+        ] {
+            let index = JsonIndex::build(json);
+            let StandardJson::Object(fields) = index.root(json).value() else {
+                panic!("{json:?}: expected object");
+            };
+            let mut json_out = String::new();
+            let mut err = None;
+            stream_lazy_keys_json(&fields, true, &mut json_out, IndentSpec::COMPACT, &mut err)
+                .unwrap();
+            assert!(err.is_none(), "{json:?}: {err:?}");
+            assert_eq!(json_out, expected, "{json:?}");
+        }
+    }
+
     /// #1679: the unpaired-tail sibling of the test above -- an object whose
     /// last child has no value to pair with. Only
     /// [`DistinctKeyCursors::ended_unpaired`] (meaningful once the walk is

--- a/src/json/light.rs
+++ b/src/json/light.rs
@@ -1140,19 +1140,32 @@ impl<'a, W: AsRef<[u64]>> JsonFields<'a, W> {
     /// (needed for `line`/`column`) doesn't require re-navigating.
     ///
     /// `Err` when the *winning* occurrence's own `,`/`:` delimiters are
-    /// malformed (#1677), or when *any* sibling's key isn't even
-    /// string-shaped at all (#1995) -- a targeted lookup like `.a` never
-    /// walks every sibling the way `.[]`/`length`/`keys` do, so it needs
-    /// its own check for both. A non-string key (`{"a":1,123:2}`) is real
-    /// jq's own parse-time rejection ("Object keys must be strings"),
-    /// unconditional on the document as a whole -- unlike the `,`/`:` gap
-    /// check below, checked as each candidate is found (not deferred to
-    /// the winner alone): the document is malformed the moment *any*
-    /// member's key isn't a string, whether or not that member is the one
-    /// this lookup would otherwise have returned. Same shared
-    /// `key_is_malformed`/[`DocumentFields::malformed_member_error`]
-    /// pair as [`find`](Self::find) uses for this, not a second copy of
-    /// the check (#106).
+    /// malformed (#1677), when *any* sibling's key isn't even string-shaped
+    /// at all (#1995), or when there's a trailing stray comma after the
+    /// object's real last field (`{"a":1,}`, #2261) -- a targeted lookup
+    /// like `.a` never walks every sibling the way `.[]`/`length`/`keys` do,
+    /// so it needs its own checks for all three. A non-string key
+    /// (`{"a":1,123:2}`) is real jq's own parse-time rejection ("Object keys
+    /// must be strings"), unconditional on the document as a whole -- unlike
+    /// the `,`/`:` gap check for the winner, checked as each candidate is
+    /// found (not deferred to the winner alone): the document is malformed
+    /// the moment *any* member's key isn't a string, whether or not that
+    /// member is the one this lookup would otherwise have returned. Same
+    /// shared `key_is_malformed`/[`DocumentFields::malformed_member_error`]
+    /// pair as [`find`](Self::find) uses for this, not a second copy of the
+    /// check (#106).
+    ///
+    /// **Not actually O(1)**, despite being a targeted single-field lookup:
+    /// last-duplicate-key-wins means every candidate could still be
+    /// superseded by a later one, so the `while` loop below always walks
+    /// every field regardless of `name` or where a match sits (#2261 code
+    /// review, verifying the O(1) assumption this function's doc comment
+    /// never actually claimed but a caller could reasonably have inferred
+    /// from "targeted lookup"). That means checking a trailing stray comma
+    /// after the object's real last field here is free -- this walk already
+    /// reaches it, for `.a` and `.nonexistent` alike (real jq can't even
+    /// parse `{"a":1,}` to begin with, so it rejects *every* field access
+    /// into it, matching field or not).
     pub fn find_cursor(&self, name: &str) -> Result<Option<JsonCursor<'a, W>>, EvalError>
     where
         W: Clone,
@@ -1161,6 +1174,10 @@ impl<'a, W: AsRef<[u64]>> JsonFields<'a, W> {
         // (key's own text start, value cursor, is this field the object's
         // first) for the winning candidate seen so far.
         let mut winner: Option<(usize, JsonCursor<'a, W>, bool)> = None;
+        // #2261: the textually last field's own value cursor, in raw
+        // document order -- independent of `winner`, which a later
+        // non-matching field must not disturb.
+        let mut last_value_cursor: Option<JsonCursor<'a, W>> = None;
         let mut index = 0usize;
         while let Some((field, rest)) = fields.uncons() {
             let key = field.key();
@@ -1173,22 +1190,30 @@ impl<'a, W: AsRef<[u64]>> JsonFields<'a, W> {
                     winner = Some((key.start(), field.value_cursor(), index == 0));
                 }
             }
+            last_value_cursor = Some(field.value_cursor());
             fields = rest;
             index += 1;
         }
-        let Some((key_start, value_cursor, is_first)) = winner else {
-            return Ok(None);
-        };
-        let comma_expected = if is_first { None } else { Some(b',') };
-        if !preceding_gap_ok(value_cursor.text(), key_start, comma_expected) {
-            return Err(EvalError::malformed_json_text(value_cursor.text()));
-        }
-        if let Some(value_start) = value_cursor.text_position() {
-            if !preceding_gap_ok(value_cursor.text(), value_start, Some(b':')) {
+        if let Some((key_start, value_cursor, is_first)) = winner {
+            let comma_expected = if is_first { None } else { Some(b',') };
+            if !preceding_gap_ok(value_cursor.text(), key_start, comma_expected) {
                 return Err(EvalError::malformed_json_text(value_cursor.text()));
             }
+            if let Some(value_start) = value_cursor.text_position() {
+                if !preceding_gap_ok(value_cursor.text(), value_start, Some(b':')) {
+                    return Err(EvalError::malformed_json_text(value_cursor.text()));
+                }
+            }
         }
-        Ok(Some(value_cursor))
+        // #2261: trailing stray comma after the object's real last field
+        // (`{"a":1,}`), checked regardless of whether `name` matched
+        // anything -- see this function's own doc comment above.
+        if let Some(last) = last_value_cursor {
+            if !trailing_element_gap_ok(&last, b'}') {
+                return Err(EvalError::malformed_json_text(last.text()));
+            }
+        }
+        Ok(winner.map(|(_, value_cursor, _)| value_cursor))
     }
 }
 
@@ -1945,8 +1970,8 @@ pub type BorrowedJsonCursor<'a> = JsonCursor<'a, &'a [u64]>;
 // ============================================================================
 
 use crate::jq::document::{
-    effective_fields_checked, key_is_malformed, DocumentCursor, DocumentElements, DocumentField,
-    DocumentFields, DocumentValue, IndentSpec, JsonConvention,
+    effective_fields_checked, key_is_malformed, trailing_element_gap_ok, DocumentCursor,
+    DocumentElements, DocumentField, DocumentFields, DocumentValue, IndentSpec, JsonConvention,
 };
 use crate::jq::escape::{write_json_body_jq, write_json_body_yq};
 use crate::jq::stream::{StreamFailure, StreamResult};
@@ -4205,6 +4230,81 @@ mod tests {
             err.to_string().contains("expected string key"),
             "unexpected error: {err}"
         );
+    }
+
+    /// #2261: `find_cursor` walks every field regardless of `name` (it must,
+    /// to honour last-duplicate-key-wins), so a trailing stray comma after
+    /// the object's real last field (`{"a":1,}`) is caught here too --
+    /// whether or not `name` matches anything, matching real jq's own
+    /// behavior (a malformed document can't be parsed at all, so *every*
+    /// field access into it raises).
+    #[test]
+    fn test_find_cursor_rejects_trailing_comma_after_real_last_field_2261() {
+        let json = br#"{"a":1,}"#;
+        let index = JsonIndex::build(json);
+        let root = index.root(json);
+        let StandardJson::Object(fields) = root.value() else {
+            panic!("expected object");
+        };
+        for name in ["a", "nonexistent"] {
+            let err = fields
+                .find_cursor(name)
+                .expect_err(&format!("{name}: trailing comma should raise"));
+            assert!(
+                err.message.contains("Invalid JSON text"),
+                "{name}: message: {}",
+                err.message
+            );
+        }
+    }
+
+    /// #2261: unlike the single-real-field case above, a duplicate key
+    /// followed by a trailing stray comma (`{"a":1,"b":2,"a":3,}`) must
+    /// still raise -- `find_cursor`'s own winning-occurrence resolution
+    /// (last-duplicate-key-wins) and the #2261 trailing-gap check are two
+    /// independent questions the walk answers from the same pass, and a
+    /// non-matching key's own gap must not stop the walk before it reaches
+    /// the object's real last field.
+    #[test]
+    fn test_find_cursor_rejects_trailing_comma_with_duplicate_key_2261() {
+        let json = br#"{"a":1,"b":2,"a":3,}"#;
+        let index = JsonIndex::build(json);
+        let root = index.root(json);
+        let StandardJson::Object(fields) = root.value() else {
+            panic!("expected object");
+        };
+        for name in ["a", "b"] {
+            let err = fields
+                .find_cursor(name)
+                .expect_err(&format!("{name}: trailing comma should raise"));
+            assert!(
+                err.message.contains("Invalid JSON text"),
+                "{name}: message: {}",
+                err.message
+            );
+        }
+    }
+
+    /// #2261: well-formed objects (including a duplicate key, so the
+    /// winning-occurrence resolution above is exercised alongside the new
+    /// trailing-gap check) are unaffected.
+    #[test]
+    fn test_find_cursor_wellformed_unaffected_by_trailing_comma_check_2261() {
+        for json in [
+            br#"{"a":1}"#.as_slice(),
+            br#"{"a":1,"b":2}"#.as_slice(),
+            br#"{"a":1,"b":2,"a":3}"#.as_slice(),
+        ] {
+            let index = JsonIndex::build(json);
+            let root = index.root(json);
+            let StandardJson::Object(fields) = root.value() else {
+                panic!("{json:?}: expected object");
+            };
+            let cursor = fields
+                .find_cursor("a")
+                .unwrap_or_else(|e| panic!("{json:?}: {e:?}"));
+            assert!(cursor.is_some(), "{json:?}: expected to find `a`");
+        }
     }
 
     #[test]

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -22401,6 +22401,49 @@ fn test_jq_cursor_transparent_fast_paths_wellformed_unaffected_2261() -> Result<
     Ok(())
 }
 
+/// #2261: `len_checked`/`Expr::Index`'s own #1677 *leading*-gap check (a
+/// malformed comma *between* two real elements, `[1,,3]`) is the sibling
+/// case to this issue's own trailing-comma repro, and shares the same new
+/// code path (`length`/`.[0]` no longer call the bare, unchecked `len()`).
+/// Pins that the leading-gap arm still raises through both builtins now
+/// that they route through `len_checked`.
+#[test]
+fn test_jq_length_and_index_leading_comma_gap_still_raises_2261() -> Result<()> {
+    for query in ["length", ".[0]"] {
+        let (out, stderr, code) = run_jq_full(&["-c", query], Some(r"[1,,3]"))?;
+        assert_eq!(code, 5, "query={query}: out: {out:?}, stderr: {stderr:?}");
+        assert!(
+            out.trim().is_empty(),
+            "query={query}: unexpected output {out:?}"
+        );
+        assert!(
+            stderr.contains("Invalid JSON text"),
+            "query={query}: stderr: {stderr:?}"
+        );
+    }
+    Ok(())
+}
+
+/// #2261: `stream_lazy_keys_json` (`src/jq/stream.rs`) is a *different*
+/// writer from the bare-`keys_unsorted` one pinned above
+/// (`test_jq_lazy_keys_array_trailing_comma_leaves_truncated_bracket_2261`)
+/// -- it backs `keys_unsorted[]` reached through the M2 streaming path
+/// (`jq_runner.rs`'s `expr_is_cursor_transparent`, which admits
+/// `.x | keys_unsorted[]`: the pipe's first stage `.x` already descends off
+/// the root, so nothing after it needs to be root-safe). Confirmed this is
+/// really a different code path -- not just the same check reached twice --
+/// by grepping the touched-line coverage report for this exact line before
+/// adding the test.
+#[test]
+fn test_jq_m2_streaming_keys_unsorted_after_descend_rejects_trailing_comma_2261() -> Result<()> {
+    let (out, stderr, code) =
+        run_jq_full(&["-c", ".x | keys_unsorted[]"], Some(r#"{"x":{"a":1,}}"#))?;
+    assert_eq!(code, 5, "out: {out:?}, stderr: {stderr:?}");
+    assert_eq!(out.trim(), "\"a\"", "the one real key should still stream");
+    assert!(stderr.contains("Invalid JSON text"), "stderr: {stderr:?}");
+    Ok(())
+}
+
 /// #1643 follow-up: `-S`/`-C`/`--slurp` bypass `print_json` entirely --
 /// they materialize via `parse_json_stream`'s fallback (which backs the
 /// "original" input path `-S`/`-C`/`--slurp` force), reaching

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -22401,6 +22401,173 @@ fn test_jq_cursor_transparent_fast_paths_wellformed_unaffected_2261() -> Result<
     Ok(())
 }
 
+/// #2261 follow-up: code review on PR #2291 found and live-confirmed five
+/// more sibling paths sharing the exact "already walks `.len()`/every
+/// field, so the check rides free" shape the original fix used elsewhere,
+/// missed in the first pass: `has(idx)` on arrays, `has(key)` on objects,
+/// `keys`/`keys_unsorted` on *arrays* (the object arm was fixed; this array
+/// arm two branches below it was not), computed/dynamic index access
+/// (`E[K]`, e.g. `.[0,1]`/`.[$i]` -- the literal-index sibling was already
+/// fixed), and `last`/`.[-1]` (unlike `first`, which is genuine O(1) via
+/// `get_cursor(0)` and stays a documented exception per #1629's own
+/// precedent). All five verified against `/usr/bin/jq` 1.7.1.
+#[test]
+fn test_jq_len_checked_sibling_paths_reject_trailing_comma_2261() -> Result<()> {
+    for (input, query) in [
+        (r"[1,2,3,]", "has(0)"),
+        (r#"{"a":1,}"#, "has(\"a\")"),
+        (r"[1,2,3,]", "keys"),
+        (r"[1,2,3,]", ".[0,1]"),
+        (r"[1,2,3,]", "last"),
+    ] {
+        let (out, stderr, code) = run_jq_full(&["-c", query], Some(input))?;
+        assert_eq!(
+            code, 5,
+            "input={input} query={query}: out: {out:?}, stderr: {stderr:?}"
+        );
+        assert!(
+            out.trim().is_empty(),
+            "input={input} query={query}: unexpected output {out:?}"
+        );
+        assert!(
+            stderr.contains("Invalid JSON text"),
+            "input={input} query={query}: stderr: {stderr:?}"
+        );
+    }
+
+    Ok(())
+}
+
+/// #2261 follow-up: a systematic sweep for every other unchecked
+/// `DocumentElements::collect_cursors`/`.len()` call site in
+/// `eval_generic.rs`/`document.rs` (prompted by the five paths above)
+/// turned up six more real, live, jq-oracle-backed sibling bugs sharing the
+/// identical shape: each already fully resolves every element's cursor
+/// (`collect_cursors`, an already-mandatory walk with an already-checked
+/// `collect_cursors_checked` sibling used elsewhere), so switching to the
+/// checked variant is free. `path(.[])`'s array arm had drifted onto the
+/// unchecked helper even though its own object-arm sibling three lines
+/// above already used the checked `effective_fields_checked`. `pivot` has
+/// no jq oracle (`pivot/0 is not defined` in real jq) but is fixed for
+/// internal consistency with every other builtin here. All others verified
+/// against `/usr/bin/jq` 1.7.1.
+#[test]
+fn test_jq_collect_cursors_checked_sibling_paths_reject_trailing_comma_2261() -> Result<()> {
+    for query in [
+        "[path(.[])]",
+        "reverse",
+        "sort",
+        "unique",
+        "min",
+        "max",
+        "sort_by(.)",
+        "unique_by(.)",
+        "min_by(.)",
+        "max_by(.)",
+    ] {
+        let (out, stderr, code) = run_jq_full(&["-c", query], Some(r"[1,2,3,]"))?;
+        assert_eq!(code, 5, "query={query}: out: {out:?}, stderr: {stderr:?}");
+        assert!(
+            out.trim().is_empty(),
+            "query={query}: unexpected output {out:?}"
+        );
+        assert!(
+            stderr.contains("Invalid JSON text"),
+            "query={query}: stderr: {stderr:?}"
+        );
+    }
+
+    // `pivot`/`shuffle`: succinctly-only extensions, no jq oracle -- fixed
+    // for internal consistency (every other builtin above now rejects this
+    // shape) rather than jq parity. `shuffle`'s own output is
+    // non-deterministic, so only its error behavior is checked here.
+    //
+    // `pivot` only accepts an array of arrays/objects, so its own trailing
+    // element is always container-typed -- the #2243 "container-typed last
+    // child still passes through" residual gap (`scalar_text_end` can't
+    // determine a container's own end position, so `trailing_element_gap_ok`
+    // defaults to "can't determine, skip" for it) means a *trailing* comma
+    // can never demonstrate this fix for `pivot` specifically. A *leading*
+    // stray comma between two elements is unaffected by that residual gap
+    // and demonstrates the identical `collect_cursors`-to-`_checked` fix.
+    let (out, stderr, code) = run_jq_full(&["-c", "pivot"], Some(r#"[{"a":1},,{"a":2}]"#))?;
+    assert_eq!(code, 5, "pivot: out: {out:?}, stderr: {stderr:?}");
+    assert!(stderr.contains("Invalid JSON text"), "pivot: {stderr:?}");
+
+    let (out, stderr, code) = run_jq_full(&["-c", "shuffle"], Some(r"[1,2,3,]"))?;
+    assert_eq!(code, 5, "shuffle: out: {out:?}, stderr: {stderr:?}");
+    assert!(stderr.contains("Invalid JSON text"), "shuffle: {stderr:?}");
+
+    Ok(())
+}
+
+/// #2261 follow-up: `has(key)` on objects (`DocumentFields::contains_checked`)
+/// deliberately preserves `contains`'s own early exit on a match -- unlike
+/// every other #2261 fix, checking the trailing gap here is not free, and a
+/// first-draft version that dropped the early exit measured a real ~4x
+/// regression on `has("k0")` over a 1,000,000-key object (see
+/// `contains_checked`'s own doc comment). The tradeoff: a match that is
+/// *not* the object's true last field takes the same #1629/#1770-established
+/// "early exit legitimately misses a later fault" divergence every other
+/// truncating consumer in this codebase already accepts. Pinned here rather
+/// than left as an unstated side effect of the perf fix.
+#[test]
+fn test_jq_has_object_early_exit_still_skips_a_later_trailing_comma_2261() -> Result<()> {
+    // The match *is* the object's real last field -- #2261's own repro,
+    // and the one case `has(key)` must catch without walking further.
+    let (out, stderr, code) = run_jq_full(&["-c", "has(\"a\")"], Some(r#"{"a":1,}"#))?;
+    assert_eq!(code, 5, "out: {out:?}, stderr: {stderr:?}");
+    assert!(out.trim().is_empty(), "unexpected output {out:?}");
+    assert!(stderr.contains("Invalid JSON text"), "stderr: {stderr:?}");
+
+    // The match is *not* the last field -- a later trailing comma exists
+    // but this early-exit consumer never reaches it, a documented,
+    // deliberately accepted divergence from real jq (which would still
+    // raise, since it can't parse the document at all).
+    let (out, stderr, code) = run_jq_full(&["-c", "has(\"a\")"], Some(r#"{"a":1,"b":2,}"#))?;
+    assert_eq!(code, 0, "known gap: out: {out:?}, stderr: {stderr:?}");
+    assert_eq!(out.trim(), "true", "known gap: unexpected output");
+
+    // A non-match still walks to the true end regardless (the shape
+    // `contains` itself already has), so it catches the same fault the
+    // match-not-last case above misses.
+    let (out, stderr, code) = run_jq_full(&["-c", "has(\"z\")"], Some(r#"{"a":1,"b":2,}"#))?;
+    assert_eq!(code, 5, "out: {out:?}, stderr: {stderr:?}");
+    assert!(stderr.contains("Invalid JSON text"), "stderr: {stderr:?}");
+
+    Ok(())
+}
+
+/// #2261 follow-up: well-formed documents (including a duplicate key and
+/// an object where `has`'s match is *not* the last field) are unaffected
+/// by every new check above.
+#[test]
+fn test_jq_len_checked_and_collect_cursors_checked_siblings_wellformed_unaffected_2261(
+) -> Result<()> {
+    for (input, query, expected) in [
+        ("[1,2,3]", "has(0)", "true"),
+        ("[1,2,3]", "has(5)", "false"),
+        (r#"{"a":1,"b":2}"#, "has(\"a\")", "true"),
+        (r#"{"a":1,"b":2}"#, "has(\"z\")", "false"),
+        ("[1,2,3]", "keys", "[0,1,2]"),
+        ("[1,2,3]", ".[0,1]", "1\n2"),
+        ("[1,2,3]", "last", "3"),
+        ("[1,2,3]", "reverse", "[3,2,1]"),
+        ("[3,1,2]", "sort", "[1,2,3]"),
+        ("[1,1,2]", "unique", "[1,2]"),
+        ("[3,1,2]", "min", "1"),
+        ("[3,1,2]", "max", "3"),
+        (r#"[{"a":1},{"a":2}]"#, "pivot", r#"{"a":[1,2]}"#),
+        (r#"{"a":1,"b":2,"a":3}"#, "has(\"a\")", "true"),
+    ] {
+        let (out, stderr, code) = run_jq_full(&["-c", query], Some(input))?;
+        assert_eq!(code, 0, "input={input} query={query}: stderr: {stderr:?}");
+        assert_eq!(out.trim(), expected, "input={input} query={query}");
+    }
+
+    Ok(())
+}
+
 /// #2261: `len_checked`/`Expr::Index`'s own #1677 *leading*-gap check (a
 /// malformed comma *between* two real elements, `[1,,3]`) is the sibling
 /// case to this issue's own trailing-comma repro, and shares the same new

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -22424,18 +22424,26 @@ fn test_jq_length_and_index_leading_comma_gap_still_raises_2261() -> Result<()> 
     Ok(())
 }
 
-/// #2261: `stream_lazy_keys_json` (`src/jq/stream.rs`) is a *different*
-/// writer from the bare-`keys_unsorted` one pinned above
-/// (`test_jq_lazy_keys_array_trailing_comma_leaves_truncated_bracket_2261`)
-/// -- it backs `keys_unsorted[]` reached through the M2 streaming path
-/// (`jq_runner.rs`'s `expr_is_cursor_transparent`, which admits
-/// `.x | keys_unsorted[]`: the pipe's first stage `.x` already descends off
-/// the root, so nothing after it needs to be root-safe). Confirmed this is
-/// really a different code path -- not just the same check reached twice --
-/// by grepping the touched-line coverage report for this exact line before
-/// adding the test.
+/// #2261: `.x | keys_unsorted[]` is a *different* code path from bare
+/// `keys_unsorted[]` (pinned as part of
+/// `test_jq_cursor_transparent_fast_paths_reject_trailing_comma_2261`
+/// above): a bare `keys_unsorted[]` isn't cursor-transparent
+/// (`Builtin::KeysUnsorted` alone isn't root-safe) and takes the eager
+/// route (`fold_lazy_keys_stage`/`distinct_key_cursors_checked`), but once
+/// a pipe's first stage already descends off the root (`.x`, `Expr::Field`,
+/// one of `expr_descends`'s own matched shapes), `jq_runner.rs`'s
+/// `expr_is_cursor_transparent` admits everything after it unconditionally
+/// -- so this reaches the *demand-aware* sink
+/// (`each_lazy_keys_iterate_sink`, driven through `eval_each_with_cursor`)
+/// instead. Confirmed this is a genuinely different route (a code-review
+/// correction on this fix's first draft, which had wrongly attributed this
+/// test to `stream_lazy_keys_json` in `src/jq/stream.rs` -- that writer
+/// turns out to be excluded from `succinctly jq`'s own M2 output gate
+/// entirely, `m2_json_fallback_safe`, and is pinned separately, by direct
+/// unit test, in `src/jq/stream.rs` itself) by disabling each candidate
+/// check in turn and re-running this exact query.
 #[test]
-fn test_jq_m2_streaming_keys_unsorted_after_descend_rejects_trailing_comma_2261() -> Result<()> {
+fn test_jq_descended_pipe_prefix_reaches_demand_aware_keys_sink_2261() -> Result<()> {
     let (out, stderr, code) =
         run_jq_full(&["-c", ".x | keys_unsorted[]"], Some(r#"{"x":{"a":1,}}"#))?;
     assert_eq!(code, 5, "out: {out:?}, stderr: {stderr:?}");

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -22181,6 +22181,226 @@ fn test_jq_lazy_path_trailing_comma_after_container_last_child_still_a_known_gap
     Ok(())
 }
 
+/// #2261: the *cursor-transparent* fast paths never reached #2243's fix at
+/// all -- they route through `eval_generic.rs`'s own native arms
+/// (`each_lazy_array_iterate_sink`/`collect_cursors_checked` for `.[]`,
+/// `DistinctKeyCursors`-based walks for `keys`/`keys_unsorted`/`keys_unsorted[]`/
+/// `keys_unsorted | last`/`keys_unsorted[-1]`, `JsonFields::find_cursor` for
+/// bare `.a`, `DocumentElements::len_checked` for `length`/`.[0]`), never
+/// through `to_owned_cursor_at_depth`. Confirmed live against `/usr/bin/jq`
+/// 1.7.1: every one of these is a parse error (exit 5) on a trailing stray
+/// comma after a real last element/field, for both the array (`[1,]`) and
+/// object (`{"a":1,}`) shapes.
+///
+/// Every query here writes *nothing* to stdout before the error --
+/// `length`/`to_entries`/`keys`/`.a`/`keys_unsorted | last`/
+/// `keys_unsorted[-1]`/`keys_unsorted[]` all resolve to a single owned
+/// result or a fully-collected `Vec` before anything is printed, so a
+/// mid-walk failure never leaks a partial value. `.[]` and bare
+/// `keys_unsorted` are exercised separately below -- both are genuinely
+/// *streaming* writers that can (and, on this exact input, do) emit a
+/// real prefix before discovering the terminal fault, the same
+/// established "partial output before an error surfaces" shape already
+/// pinned for `limit(3;.[])` on `[1,2,,4]`
+/// (`docs/compliance/jq/limitations.md`'s "truncating consumer of a plain
+/// array `.[]`" section) -- not a new divergence this fix introduces.
+#[test]
+fn test_jq_cursor_transparent_fast_paths_reject_trailing_comma_2261() -> Result<()> {
+    for (input, query) in [
+        (r"[1,]", "length"),
+        (r"[1,]", "to_entries"),
+        (r#"{"a":1,}"#, "keys"),
+        (r#"{"a":1,}"#, "keys_unsorted[]"),
+        (r#"{"a":1,}"#, "keys_unsorted | last"),
+        (r#"{"a":1,}"#, "keys_unsorted[-1]"),
+        (r#"{"a":1,}"#, "to_entries"),
+        (r#"{"a":1,}"#, ".a"),
+        (r#"{"a":1,}"#, ".nonexistent"),
+    ] {
+        let (out, stderr, code) = run_jq_full(&["-c", query], Some(input))?;
+        assert_eq!(
+            code, 5,
+            "input={input} query={query}: out: {out:?}, stderr: {stderr:?}"
+        );
+        assert!(
+            out.trim().is_empty(),
+            "input={input} query={query}: unexpected output {out:?}"
+        );
+        assert!(
+            stderr.contains("Invalid JSON text"),
+            "input={input} query={query}: stderr: {stderr:?}"
+        );
+    }
+
+    Ok(())
+}
+
+/// #2261: `.[]` over `[1,]` -- the demand-aware `each_lazy_array_iterate_sink`
+/// (and the eager `collect_cursors_checked` it shares its check with)
+/// writes the one real element it already confirmed good (`1`) as it
+/// streams, then discovers the trailing stray comma only once the walk
+/// exhausts and errors -- so, unlike every query in the test above, real
+/// output reaches stdout ahead of the exit-5 diagnostic. Real jq, whose
+/// parser is atomic, never gets this far and prints nothing at all. This
+/// is the identical, already-documented divergence
+/// `limit(3;.[])` on `[1,2,,4]` pins (prints `1`, `2`, *then* errors) --
+/// not new here, just landing on the container's real last element instead
+/// of a bound the consumer stopped short of.
+#[test]
+fn test_jq_lazy_array_iterate_trailing_comma_streams_confirmed_prefix_first_2261() -> Result<()> {
+    let (out, stderr, code) = run_jq_full(&["-c", ".[]"], Some(r"[1,]"))?;
+    assert_eq!(code, 5, "out: {out:?}, stderr: {stderr:?}");
+    assert_eq!(out.trim(), "1", "the one real element should still stream");
+    assert!(stderr.contains("Invalid JSON text"), "stderr: {stderr:?}");
+    Ok(())
+}
+
+/// #2261: bare `keys_unsorted` over `{"a":1,}` -- the CLI's own
+/// `JqValue::LazyKeysArray` writer (`jq_runner.rs`) streams straight to
+/// stdout with no `Vec<String>`/rewind buffer (#685), and the same
+/// `bail_if_keys_malformed` check this fix extended only runs once that
+/// walk exhausts -- so it can leave a truncated `[` behind, exactly as its
+/// own doc comment already documents for the #1194/#1677 faults it caught
+/// before this fix (a non-string key, a missing/doubled `,`/`:`). This is
+/// that same, pre-existing trade extended to the new trailing-comma fault,
+/// not a new one.
+#[test]
+fn test_jq_lazy_keys_array_trailing_comma_leaves_truncated_bracket_2261() -> Result<()> {
+    let (out, stderr, code) = run_jq_full(&["-c", "keys_unsorted"], Some(r#"{"a":1,}"#))?;
+    assert_eq!(code, 5, "out: {out:?}, stderr: {stderr:?}");
+    assert_eq!(
+        out, r#"["a""#,
+        "truncated bracket should still reach stdout"
+    );
+    assert!(stderr.contains("Invalid JSON text"), "stderr: {stderr:?}");
+    Ok(())
+}
+
+/// #2261: unlike the array-index case, `keys_unsorted[0]`/`.[0]`-on-an-
+/// object's own #1629 precedent, positive *array* index access (`.[0]`,
+/// `Expr::Index` in `eval_generic.rs`) turns out **not** to be the O(1)
+/// lookup that precedent -- and this issue's own description -- assumed:
+/// resolving *any* array index, positive or negative, already calls
+/// `len()` first (to normalize a negative index, and to raise yq's own
+/// out-of-range error), so switching that call to `len_checked` closes
+/// this gap for free rather than leaving it open. Verified live against
+/// jq 1.7.1's own exit 5 on this exact input -- code review of this
+/// fix's first draft wrongly assumed this one had to stay a documented
+/// limitation like `keys_unsorted[0]` below; re-reading `Expr::Index`'s
+/// own body before accepting that assumption is what caught it.
+#[test]
+fn test_jq_array_positive_index_trailing_comma_fixed_2261() -> Result<()> {
+    let (out, stderr, code) = run_jq_full(&["-c", ".[0]"], Some(r"[1,]"))?;
+    assert_eq!(code, 5, "out: {out:?}, stderr: {stderr:?}");
+    assert!(out.trim().is_empty(), "unexpected output {out:?}");
+    assert!(stderr.contains("Invalid JSON text"), "stderr: {stderr:?}");
+    Ok(())
+}
+
+/// #2261: `keys_unsorted[0]` (a positive index into an object's *key*
+/// list) is a deliberately left-open gap, matching #1629's own established
+/// "would cost strictly more than the answer" reasoning for the identical
+/// shape (`fold_lazy_keys_stage`'s `Expr::Index { idx: 0, .. }` arm reads
+/// only `fields.uncons_key()`'s first field, never walking the rest of the
+/// object) -- the one case in this issue where the object counterpart of
+/// an array fast path genuinely differs from its array twin above, rather
+/// than merely mirroring it. See `docs/compliance/jq/limitations.md`'s own
+/// `#2261` section for the full accounting.
+#[test]
+fn test_jq_keys_unsorted_positive_index_trailing_comma_remains_a_known_gap_2261() -> Result<()> {
+    let (out, stderr, code) = run_jq_full(&["-c", "keys_unsorted[0]"], Some(r#"{"a":1,}"#))?;
+    assert_eq!(code, 0, "known gap: out: {out:?}, stderr: {stderr:?}");
+    assert_eq!(out.trim(), "\"a\"", "known gap: unexpected output");
+    Ok(())
+}
+
+/// #2261: the #2211 sibling shape -- a stray `,` with *zero* real
+/// elements/fields (`[,]`, `{,}`) -- remains unreachable through the same
+/// fast paths above, for the same reason #2211's own `container_gap_ok`
+/// stays unreachable through `to_owned_at_depth`'s cursor-less callers
+/// (#2262's own documented residual): none of these paths ever receive a
+/// cursor to the *container itself*, only to its children -- and an
+/// apparently-empty container has none. `.a`/`.[0]` are excluded here: both
+/// still raise, but for an unrelated reason (indexing an array with a
+/// string key / an object with a number), not the delimiter check this
+/// test is about.
+#[test]
+fn test_jq_cursor_transparent_fast_paths_empty_container_stray_comma_remains_a_known_gap_2261(
+) -> Result<()> {
+    for (input, query, expected) in [
+        ("[,]", ".[]", ""),
+        ("[,]", "length", "0"),
+        ("{,}", "keys", "[]"),
+        ("{,}", "keys_unsorted", "[]"),
+        ("{,}", "to_entries", "[]"),
+        ("{,}", ".a", "null"),
+    ] {
+        let (out, stderr, code) = run_jq_full(&["-c", query], Some(input))?;
+        assert_eq!(
+            code, 0,
+            "input={input} query={query}: known gap, expected exit 0: stderr: {stderr:?}"
+        );
+        assert_eq!(
+            out.trim(),
+            expected,
+            "input={input} query={query}: known gap"
+        );
+    }
+
+    Ok(())
+}
+
+/// #2261: well-formed documents (including empty containers, a duplicate
+/// key under jq's default collapse rule, and a multi-element/multi-field
+/// container) are unaffected by every new check above -- the same
+/// "verify no behavioral change" pairing #2211/#2243/#2262 each carry
+/// alongside their own positive repro.
+#[test]
+fn test_jq_cursor_transparent_fast_paths_wellformed_unaffected_2261() -> Result<()> {
+    for (input, query, expected) in [
+        ("[1,2,3]", ".[]", "1\n2\n3"),
+        ("[1,2,3]", "length", "3"),
+        ("[1,2,3]", ".[0]", "1"),
+        ("[1,2,3]", ".[-1]", "3"),
+        ("[]", "length", "0"),
+        ("[]", ".[]", ""),
+        (r#"{"a":1,"b":2}"#, "keys", r#"["a","b"]"#),
+        (r#"{"a":1,"b":2}"#, "keys_unsorted", r#"["a","b"]"#),
+        (r#"{"a":1,"b":2}"#, "keys_unsorted[]", "\"a\"\n\"b\""),
+        (r#"{"a":1,"b":2}"#, "keys_unsorted | last", "\"b\""),
+        (r#"{"a":1,"b":2}"#, "keys_unsorted[-1]", "\"b\""),
+        (r#"{"a":1,"b":2}"#, "keys_unsorted[0]", "\"a\""),
+        (
+            r#"{"a":1,"b":2}"#,
+            "to_entries",
+            r#"[{"key":"a","value":1},{"key":"b","value":2}]"#,
+        ),
+        (r#"{"a":1,"b":2}"#, ".a", "1"),
+        ("{}", "keys", "[]"),
+        // A duplicate key, jq's default collapse rule ("first position,
+        // last value") -- the #2261 fix must retain the object's real
+        // *textual* last field for the trailing-gap check, not whichever
+        // key the collapsed/sorted output happens to list last (#2261 code
+        // review: an earlier version of this fix checked the gap after the
+        // wrong field here and would have wrongly rejected this well-formed
+        // input).
+        (r#"{"a":1,"b":2,"a":3}"#, "keys", r#"["a","b"]"#),
+        (r#"{"a":1,"b":2,"a":3}"#, "keys_unsorted", r#"["a","b"]"#),
+        (
+            r#"{"a":1,"b":2,"a":3}"#,
+            "to_entries",
+            r#"[{"key":"a","value":3},{"key":"b","value":2}]"#,
+        ),
+        (r#"{"a":1,"b":2,"a":3}"#, ".a", "3"),
+    ] {
+        let (out, stderr, code) = run_jq_full(&["-c", query], Some(input))?;
+        assert_eq!(code, 0, "input={input} query={query}: stderr: {stderr:?}");
+        assert_eq!(out.trim(), expected, "input={input} query={query}");
+    }
+
+    Ok(())
+}
+
 /// #1643 follow-up: `-S`/`-C`/`--slurp` bypass `print_json` entirely --
 /// they materialize via `parse_json_stream`'s fallback (which backs the
 /// "original" input path `-S`/`-C`/`--slurp` force), reaching


### PR DESCRIPTION
## Summary

Fixes #2261: a trailing stray comma after a real last element/field
(`[1,]`, `{"a":1,}`) silently passed through jq's most common query idioms
— `.[]`, `keys`/`keys_unsorted`/`to_entries`, bare `.a`, `.[0]`, `length` —
all of which take "cursor-transparent" fast paths that never reach any of
#2211's/#2243's/#2262's materializer fixes.

```console
$ echo '[1,]' | jq -c '.[]'          # real jq: parse error, exit 5
$ echo '[1,]' | succinctly jq -c '.[]'         # pre-fix: 1, exit 0 -- wrong
$ echo '[1,]' | jq -c 'length'       # real jq: parse error, exit 5
$ echo '[1,]' | succinctly jq -c 'length'      # pre-fix: 1, exit 0 -- wrong
```

## Fix (round 1)

- **`.[]`**: `each_lazy_array_iterate_sink`/`collect_cursors_checked` already walk every
  element's cursor for #1677's leading-gap check — retain the last cursor, check the
  trailing gap once on exhaustion.
- **`length`/`.[0]` on arrays**: new `DocumentElements::len_checked`. Any array index
  (not just negative) already calls `.len()` to normalize/bounds-check, so the check
  rides free on every index.
- **`keys`/`keys_unsorted`/`to_entries`** in every shape: new `DistinctKeyCursors::
  trailing_gap_ok`, resolving the last key's value via an O(1) `next_sibling()` hop —
  needed real care around jq's duplicate-key collapse rule (caught and fixed pre-ship:
  a naive "last yielded" cursor breaks under `{"a":1,"b":2,"a":3}`-shaped input).
- **Bare `.a`**: `JsonFields::find_cursor`'s loop always walks every field for
  last-duplicate-key-wins, so the check is free regardless of match.

## Fix (round 2 — code-review follow-up)

A first code-review round confirmed five more sibling paths sharing the exact same
"already walks `.len()`/every field, so the check rides free" shape, missed in round 1:

- **`has(idx)` on arrays** and **computed/dynamic index** (`E[K]`, e.g. `.[0,1]`/`.[$i]`):
  same `len_checked()` swap as `length`/`.[0]`.
- **`keys`/`keys_unsorted`'s array arm** (`[1,2,3,] | keys`): same `len_checked()` swap
  as the object arm, which round 1 had already fixed.
- **`last`/`.[-1]`**: same `len_checked()` swap (`first` stays unchecked — genuine O(1)
  via `get_cursor(0)`, #1629's own precedent).
- **`has(key)` on objects**: the one fix in this round that isn't free.
  `DocumentFields::contains`'s early exit on a match is a documented design (#1739) this
  fix must not silently drop — a first draft that walked to completion regardless
  measured a real ~4x regression on `has()` for a key near the front of a
  1,000,000-key object (~0.03s → ~0.12s). Redesigned (`contains_checked`) to resolve the
  trailing gap from the matched key's own cursor via two O(1) `next_sibling()` hops
  instead, so a match that genuinely is the object's last field pays for the check, while
  a match elsewhere takes the same #1629/#1770-established "early exit misses a later
  fault" trade every other truncating consumer here already accepts.

A follow-up systematic sweep of every remaining unchecked `.len()`/`collect_cursors()`
call site in `eval_generic.rs`/`document.rs` found six more of the same shape
(`path(.[])`'s array arm, `reverse`, `sort`/`sort_by`, `unique`/`unique_by`,
`min`/`min_by`, `max`/`max_by`, plus `shuffle`/`pivot` for internal consistency — no jq
oracle for the latter two), all switched to `collect_cursors_checked()`.

Two further leads confirmed live but deliberately **not** fixed here (documented in
`docs/compliance/jq/limitations.md` as follow-ups instead): a 4th copy of the #2262
materializer family (`to_owned_with_comments_at_depth`, library-API-only, not CLI
reachable), and `map(f)`'s lazy pull (`LazySource::advance`) — real and CLI-reachable,
but touches a performance-tuned hot path (#1565/#1599) too large/risky to fold in here.

## What's deliberately left unfixed (documented, with cost/benefit reasoning)

- **`keys_unsorted[0]`**: genuine O(1) — `fold_lazy_keys_stage`'s positive-index arm
  reads only the first field, matching #1629's own established precedent exactly.
- **`length` on objects**: `census`/`checked_len` deliberately never resolve a value
  cursor (#1514 design); retrofitting would need a broader trait change.
- **#2211's `[,]`/`{,}` empty-container shape**: no path touched here ever holds a
  container-level cursor, the same limitation #2211/#2262 already established elsewhere.

## A known, pre-existing streaming trade-off, not new here

`.[]` on `[1,]` streams the confirmed-good first element (`1`) to stdout *before*
discovering the trailing comma and erroring — real jq's atomic parser never gets that
far and prints nothing. This is the identical, already-documented divergence
`limit(3;.[])` on `[1,2,,4]` pins elsewhere in this codebase (prints partial output,
then errors) — not a new class of issue, just landing on the container's real last
element instead of a bound the consumer stopped short of. Pinned by a dedicated test.
`keys_unsorted` has an analogous pre-existing "leaves a truncated `[`" trade for the
same reason.

## Verification (independently re-run, not just taken on the implementer's word)

- Rebased onto latest `main` (which had picked up an independent, overlapping
  `find_cursor` change, #1995's non-string-sibling-key check) — resolved by hand,
  keeping both checks and both test sets; re-verified everything below post-rebase.
- Rebuilt genuinely fresh at every step (confirmed non-trivial ~20-25s recompiles,
  not stale cache hits).
- Re-confirmed all 10 repros (5 original + 5 round-2) match `/usr/bin/jq` 1.7.1 exactly
  (all exit 5): `has(0)`/`has("a")`/`keys`/`.[0,1]`/`last` on `[1,2,3,]`/`{"a":1,}`, plus
  the original `.[]`/`length`/`.[0]`/`keys`/`.a` on `[1,]`/`{"a":1,}`.
- Well-formed input sanity sweep across all touched builtins (including `has(key)` at
  match-not-last, match-is-last, and no-match) matches jq exactly.
- Real interleaved A/B benchmarks: `length`/`.[0]` on a 2,000,000-element array showed no
  measurable difference (0.09-0.10s either way). `has(key)` on a 1,000,000-key object
  confirmed the documented early-exit trade directly: ~0.04s for a match near the front,
  ~0.12-0.13s for a match at the end or a miss — matching the fix's own accounting.
- Full test suite: 57/57 test binaries, 0 failures (re-run after the rebase).
- `cargo clippy --all-targets --all-features -- -D warnings`, `cargo fmt --check`,
  `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features`: all clean
  (re-run after the rebase).
- Patch coverage: re-checking for the current (post-rebase, 7-commit) state.

Fixes #2261
