### PR TITLE
fix(yq): catch --eval-all's deep-nesting panic before it fires

### DIFF
--- a/docs/compliance/yq/limitations.md
+++ b/docs/compliance/yq/limitations.md
@@ -514,10 +514,30 @@ plain nesting when `YamlIndex` itself accepts it — its own `nesting_depth` cou
 also means `--slurp`/`--inplace` no longer reach `assert_nesting_depth`'s 256-deep panic at all
 (previously reachable, and — for the few minutes the buggy fix stood — silently *more*
 reachable, through this same fallback); `--eval-all`'s own, unrelated, pre-existing instance of
-that exact panic is unaffected by any of this and is now tracked as
+that exact panic was unaffected by any of this and was tracked separately as
 [#2282](https://github.com/rust-works/succinctly/issues/2282), per this project's own #1098
 precedent that a CLI-reachable panic on untrusted input is a real robustness concern worth a
-tracking issue even when not newly introduced.
+tracking issue even when not newly introduced. Closed at the panic's own source:
+`to_owned_canonicalizing_numbers_at_depth` (`yq_runner.rs`) now calls `check_nesting_depth`
+(`eval_generic.rs`, #1818's existing catchable sibling of `assert_nesting_depth`) instead of
+the panicking guard directly — the same panic-to-`Result` conversion `jq_runner.rs`'s
+`json_bytes_to_owned_value_checked` already made for jq mode's own analogous pre-filter parse
+path (#1818), for the identical reason: this call sits ahead of any user filter evaluation,
+parsing raw external JSON text for `--slurp`/`--eval-all`/`--inplace`, not inside the
+evaluator's own hot recursion where a panic is deliberately kept uncatchable. An earlier
+revision of this fix instead added a second, parallel pre-check walk ahead of `--eval-all`'s
+own call site (mirroring `parse_input_m2_parity`'s shape) — reworked during review in favor of
+fixing the guard directly: the parallel-walk approach needed its own, different
+depth-counting convention to match `assert_nesting_depth`'s real per-node semantics (which
+checks *every* visited value, leaf included, unlike `parse_input_m2_parity`'s container-only
+count), got that convention wrong on the first attempt (silently under-rejecting a
+leaf-terminated subtree by one level — 256 levels of `[...]` wrapped around a scalar leaf still
+panicked even after a naive generalization of the M2-parity walk was in place), duplicated
+~130 lines of tree-walking logic that fixing the guard's own call site avoids entirely, and
+risked a fidelity mismatch of its own on structurally malformed input (a non-string object key
+containing deep nesting would have been walked by the pre-check but never reached by the real
+evaluator, which rejects a non-string key immediately without descending into it) — all
+avoided by converting the panic at its source instead of predicting it from a second walk.
 
 **Known cost: `--inplace`/`--slurp` with well-formed, duplicate-keyed JSON input still
 collapses those duplicates** (`{"a":1,"a":2}` → `{"a":2}`) — `any_input_is_json` is a blanket,

--- a/src/bin/succinctly/yq_runner.rs
+++ b/src/bin/succinctly/yq_runner.rs
@@ -17,7 +17,7 @@ use succinctly::jq::document::{
 use succinctly::jq::escape::AsciiEscapeWriter;
 use succinctly::jq::eval_generic::{
     assert_nesting_depth, eval_with_cursor_using, to_owned as generic_to_owned,
-    to_owned_with_comments, AnchorMark, CommentTree, GenericResult, NodeMeta,
+    to_owned_with_comments, AnchorMark, CommentTree, GenericResult, NodeMeta, MAX_NESTING_DEPTH,
 };
 use succinctly::jq::stream::StreamFailure;
 use succinctly::jq::{
@@ -1248,58 +1248,75 @@ fn to_owned_canonicalizing_numbers_at_depth<V: DocumentValue>(
 /// rejected, not a shared source of truth the parser itself depends on.
 const M2_PARSE_TIME_DEPTH_LIMIT: usize = 128;
 
-/// #2276: whether `cursor`'s subtree nests to `M2_PARSE_TIME_DEPTH_LIMIT`
-/// levels or deeper -- a pure BP-navigation walk (`first_child`/
-/// `next_sibling`/`is_container`, never `.value()`) so it costs nothing
-/// beyond pointer-chasing, no scalar decoding, for well-formed input.
+/// #2276: whether `cursor`'s subtree nests to `limit` levels or deeper --
+/// a pure BP-navigation walk (`first_child`/`next_sibling`/`is_container`,
+/// never `.value()`) so it costs nothing beyond pointer-chasing, no scalar
+/// decoding, for well-formed input. `limit` also bounds this function's
+/// own recursion depth (an early `true` return the moment the check
+/// fires, before ever recursing further), so a large `limit` argument is
+/// still safe -- the walk simply hasn't rejected yet by that point, it
+/// never recurses *past* it.
 ///
-/// `--slurp`'s and `--inplace`'s own DOM fallback (`parse_input`, reached
-/// exactly when their M2 fast path declines JSON-sourced input, #2276)
-/// must reject nesting at least as strictly as the M2 fast path it
-/// replaces did -- `YamlIndex::build`'s own parser enforced
-/// `M2_PARSE_TIME_DEPTH_LIMIT` at *parse* time, before this fallback
-/// existed for JSON input at all. `to_owned_canonicalizing_numbers_at_depth`'s
-/// own guard (`assert_nesting_depth`, 256, a panic) is a *different*,
-/// looser ceiling for a *different* reason -- stack-overflow safety for
-/// the conversion step itself, not fidelity with what the fast path used
-/// to reject -- so without this check, depth 129-255 would silently go
-/// from "rejected at parse time" (the fast path) to "silently accepted"
-/// (this fallback) purely because the fast path was declined for a
-/// malformed-comma reason unrelated to depth. Confirmed live before this
-/// fix: 150 levels of `[...]` via `--slurp --input-format json` printed
-/// the full nested structure at exit 0, where the pre-#2276 binary
-/// (still unconditionally on the M2/`YamlIndex` path) correctly rejected
-/// it at exit 1.
+/// `count_leaves` selects between two genuinely different counting
+/// conventions (#2282 review: NOT interchangeable, discovered while
+/// reusing this walk for a second caller with a different ceiling --
+/// picking the wrong one silently under-rejects by exactly one level for
+/// a leaf-terminated subtree, see below):
 ///
-/// Deliberately a *separate* check, not folded into `parse_input`/
-/// `to_owned_canonicalizing_numbers_at_depth` themselves: `--eval-all`
-/// shares that same function but has no M2 fast path of its own to have
-/// declined, so it never had this 128-deep guarantee to begin with --
-/// tightening it there would be an unrelated, unasked-for behavior change
-/// to an already-established (if unfortunate) precedent, not a fix for
-/// anything `--eval-all` regressed. See
-/// [`parse_input_m2_parity`](self::parse_input_m2_parity), this check's
-/// only caller, for where it's actually wired in.
-///
-/// `depth` counts *containers only* (`[`/`{`), matching `YamlIndex`'s own
-/// `enter_nested`, which is called once per opened `[`/`{` and never for a
-/// leaf scalar -- a leaf never itself constitutes a nesting level. Getting
-/// this off by one either way changes the accepted/rejected boundary: 128
-/// levels of plain `[...]` nesting is accepted by `YamlIndex` (`nesting_
-/// depth` reaches 127 on the innermost `[`, checked before incrementing),
-/// only 129+ is rejected -- confirmed against the pre-#2276 binary
-/// (still unconditionally on `YamlIndex` for this input) directly, not
-/// assumed from the constant's name alone.
-fn json_nested_past_m2_limit<W: AsRef<[u64]>>(cursor: JsonCursor<'_, W>, depth: usize) -> bool {
-    if !cursor.is_container() {
-        return false;
-    }
-    if depth >= M2_PARSE_TIME_DEPTH_LIMIT {
+/// - `count_leaves = false`: `depth` counts *containers only* (`[`/`{`),
+///   checked only when `cursor.is_container()` -- matching `YamlIndex`'s
+///   own `enter_nested`, called once per opened `[`/`{` and never for a
+///   leaf scalar. Used by
+///   [`parse_input_m2_parity`] at
+///   `limit = M2_PARSE_TIME_DEPTH_LIMIT`, for parity with `YamlIndex`'s
+///   own parse-time rejection boundary (#2276): `--slurp`'s and
+///   `--inplace`'s own DOM fallback (`parse_input`, reached exactly when
+///   their M2 fast path declines JSON-sourced input) must reject nesting
+///   at least as strictly as the M2 fast path it replaces did --
+///   `YamlIndex::build`'s own parser enforced `M2_PARSE_TIME_DEPTH_LIMIT`
+///   at *parse* time, before this fallback existed for JSON input at all.
+///   Confirmed live: 128 levels of plain `[...]` nesting is accepted,
+///   129+ rejected -- true for both a scalar leaf and an empty innermost
+///   container, the one boundary where the two conventions below happen
+///   to agree.
+/// - `count_leaves = true`: `depth` is checked on *every* visited node,
+///   container or leaf, before any container check -- matching
+///   `to_owned_canonicalizing_numbers_at_depth`'s own unconditional
+///   `assert_nesting_depth(depth)` call, made on every value regardless
+///   of its type. Used by
+///   [`parse_input_eval_all`] at
+///   `limit = MAX_NESTING_DEPTH`, for parity with *that* function's own
+///   panic boundary -- see its own doc comment for why `--eval-all` needs
+///   a different ceiling than the M2-parity one above, not just a
+///   different counting convention. A leaf-terminated subtree recurses
+///   one level deeper into `to_owned_canonicalizing_numbers_at_depth` than
+///   a container-only count would predict, so `count_leaves = false`
+///   here would under-reject by exactly one level whenever the deepest
+///   nesting bottoms out at a scalar rather than an empty container:
+///   confirmed live, 256 levels of `[...]` (and, separately, of nested
+///   `{"k":...}`) wrapped around a scalar leaf panics
+///   `to_owned_canonicalizing_numbers_at_depth` (`assert_nesting_depth`'s
+///   own check on the leaf's `depth = 256` call fires first), where
+///   `count_leaves = false` at the same `limit` would still call it
+///   accepted -- its own boundary (256 accepted / 257 rejected) only
+///   matches the real one for an empty-innermost-container subtree, not a
+///   leaf-terminated one, confirmed live for that case too.
+fn json_nested_past_depth_limit<W: AsRef<[u64]>>(
+    cursor: JsonCursor<'_, W>,
+    depth: usize,
+    limit: usize,
+    count_leaves: bool,
+) -> bool {
+    let is_container = cursor.is_container();
+    if depth >= limit && (count_leaves || is_container) {
         return true;
+    }
+    if !is_container {
+        return false;
     }
     let mut child = cursor.first_child();
     while let Some(c) = child {
-        if json_nested_past_m2_limit(c, depth + 1) {
+        if json_nested_past_depth_limit(c, depth + 1, limit, count_leaves) {
             return true;
         }
         child = c.next_sibling();
@@ -1307,16 +1324,52 @@ fn json_nested_past_m2_limit<W: AsRef<[u64]>>(cursor: JsonCursor<'_, W>, depth: 
     false
 }
 
-/// [`parse_input`], preceded by [`json_nested_past_m2_limit`]'s depth check
-/// for JSON-sourced input -- see that function's own doc comment for why.
-/// Used by `--slurp`'s and `--inplace`'s own DOM-fallback call sites only;
-/// `--eval-all`'s call site uses plain `parse_input` (see the same doc
-/// comment for why it's deliberately excluded).
+/// [`parse_input`], preceded by [`json_nested_past_depth_limit`]'s depth
+/// check (`count_leaves = false`, at `M2_PARSE_TIME_DEPTH_LIMIT`) for
+/// JSON-sourced input -- see that function's own doc comment for why.
+/// Used by `--slurp`'s and `--inplace`'s own DOM-fallback call sites
+/// only; `--eval-all`'s call site uses [`parse_input_eval_all`] instead
+/// (see its own doc comment for why both a different ceiling *and* a
+/// different counting convention are needed there).
 fn parse_input_m2_parity(bytes: &[u8], format: InputFormat) -> Result<Vec<OwnedValue>> {
     if format == InputFormat::Json {
         let index = JsonIndex::build(bytes);
-        if json_nested_past_m2_limit(index.root(bytes), 0) {
+        if json_nested_past_depth_limit(index.root(bytes), 0, M2_PARSE_TIME_DEPTH_LIMIT, false) {
             anyhow::bail!(nesting_depth_exceeded_message(M2_PARSE_TIME_DEPTH_LIMIT));
+        }
+    }
+    parse_input(bytes, format)
+}
+
+/// [`parse_input`], preceded by [`json_nested_past_depth_limit`]'s depth
+/// check (`count_leaves = true`, at [`MAX_NESTING_DEPTH`]) for
+/// JSON-sourced input, rather than [`parse_input_m2_parity`]'s own
+/// `M2_PARSE_TIME_DEPTH_LIMIT`/`count_leaves = false` pairing (#2282).
+///
+/// `--eval-all` has no M2 fast path of its own to have declined (unlike
+/// `--slurp`/`--inplace`, [`parse_input_m2_parity`]'s own two callers), so
+/// tightening it to the *M2-parity* ceiling would be the same
+/// unrelated, unasked-for behavior change that function's own doc comment
+/// already rules out for this exact call site. What `--eval-all` *does*
+/// need is protection from `to_owned_canonicalizing_numbers_at_depth`'s
+/// own panicking `assert_nesting_depth` guard, reachable from raw CLI
+/// input: confirmed live, `succinctly yq --eval-all --input-format json`
+/// on 300 levels of `[...]` nesting panicked (exit 101, "nesting depth
+/// exceeds limit of 256") instead of reporting a clean, catchable error.
+/// `count_leaves = true` is required alongside `MAX_NESTING_DEPTH`, not
+/// optional -- `count_leaves = false` at this same ceiling silently lets
+/// a leaf-terminated 256-deep subtree back through to the panic (see
+/// `json_nested_past_depth_limit`'s own doc comment for the confirmed
+/// live repro). With the right pairing, this pre-check rejects precisely
+/// the inputs the panicking guard would otherwise have crashed on, and no
+/// others -- `--eval-all` keeps tolerating everything up to that same
+/// real ceiling, same as before this fix, just without the panic at the
+/// boundary.
+fn parse_input_eval_all(bytes: &[u8], format: InputFormat) -> Result<Vec<OwnedValue>> {
+    if format == InputFormat::Json {
+        let index = JsonIndex::build(bytes);
+        if json_nested_past_depth_limit(index.root(bytes), 0, MAX_NESTING_DEPTH, true) {
+            anyhow::bail!(nesting_depth_exceeded_message(MAX_NESTING_DEPTH));
         }
     }
     parse_input(bytes, format)
@@ -5079,7 +5132,12 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
         let mut file_origin: Vec<usize> = Vec::new();
         let mut global_doc_index: usize = 0;
         for (file_idx, (bytes, format, _)) in input_sources.iter().enumerate() {
-            let inputs = parse_input(bytes, *format)?;
+            // #2282: `parse_input_eval_all`, not plain `parse_input` -- see
+            // that function's own doc comment for why `--eval-all` needs
+            // its own, wider-ceiling catchable pre-check rather than
+            // reaching `to_owned_canonicalizing_numbers_at_depth`'s
+            // panicking guard directly.
+            let inputs = parse_input_eval_all(bytes, *format)?;
             for input in inputs {
                 let should_include = args
                     .document

--- a/src/bin/succinctly/yq_runner.rs
+++ b/src/bin/succinctly/yq_runner.rs
@@ -16,8 +16,8 @@ use succinctly::jq::document::{
 };
 use succinctly::jq::escape::AsciiEscapeWriter;
 use succinctly::jq::eval_generic::{
-    assert_nesting_depth, eval_with_cursor_using, to_owned as generic_to_owned,
-    to_owned_with_comments, AnchorMark, CommentTree, GenericResult, NodeMeta, MAX_NESTING_DEPTH,
+    check_nesting_depth, eval_with_cursor_using, to_owned as generic_to_owned,
+    to_owned_with_comments, AnchorMark, CommentTree, GenericResult, NodeMeta,
 };
 use succinctly::jq::stream::StreamFailure;
 use succinctly::jq::{
@@ -1071,7 +1071,7 @@ fn to_owned_canonicalizing_numbers_at_depth<V: DocumentValue>(
     value: &V,
     depth: usize,
 ) -> Result<OwnedValue, EvalError> {
-    // `assert_nesting_depth` (256, matching `eval_generic::to_owned_at_depth`
+    // `check_nesting_depth` (256, matching `eval_generic::to_owned_at_depth`
     // exactly), not `assert_value_tree_depth` (384) -- this walks a
     // `DocumentCursor`-backed `V` directly, the same recursion shape
     // `to_owned_at_depth` guards with the tighter limit, not the looser
@@ -1081,7 +1081,26 @@ fn to_owned_canonicalizing_numbers_at_depth<V: DocumentValue>(
     // `--input-format json` documents from 256 to 384, since this is now
     // the only pass -- there's no first, 256-guarded `to_owned` call ahead
     // of it anymore to bind the real ceiling).
-    assert_nesting_depth(depth);
+    //
+    // #2282: `check_nesting_depth`, the catchable sibling of
+    // `assert_nesting_depth` (#1818), not the panicking guard itself --
+    // this function's only two callers (`to_owned_canonicalizing_numbers`,
+    // reached from `parse_input`'s JSON arm) sit ahead of any user filter
+    // evaluation, parsing raw external JSON text for `--slurp`/
+    // `--eval-all`/`--inplace`. That's CLI-level input parsing, not the
+    // evaluator's own hot recursion over an already-parsed value -- the
+    // same distinction `jq_runner.rs`'s `json_bytes_to_owned_value_checked`
+    // (#1818) already draws for jq mode's own analogous pre-filter parse
+    // path, converting an identical panic into a catchable error there for
+    // the identical reason. `--slurp`/`--inplace` never reach this call at
+    // all (their own M2-fallback `parse_input_m2_parity` pre-check, #2276,
+    // rejects nesting past 128 first); `--eval-all` has no such pre-check
+    // and was, before this fix, the one remaining path where 257+ levels
+    // of JSON nesting reached this line and panicked (exit 101) instead of
+    // reporting a clean, catchable error (exit 1) -- confirmed live,
+    // `succinctly yq --eval-all --input-format json` on 300 levels of
+    // `[...]` nesting used to panic here.
+    check_nesting_depth(depth)?;
     Ok(if let Some(fields) = value.as_object() {
         let mut map = IndexMap::new();
         let mut guard = DisplayKeyGuard::default();
@@ -1251,72 +1270,48 @@ const M2_PARSE_TIME_DEPTH_LIMIT: usize = 128;
 /// #2276: whether `cursor`'s subtree nests to `limit` levels or deeper --
 /// a pure BP-navigation walk (`first_child`/`next_sibling`/`is_container`,
 /// never `.value()`) so it costs nothing beyond pointer-chasing, no scalar
-/// decoding, for well-formed input. `limit` also bounds this function's
-/// own recursion depth (an early `true` return the moment the check
-/// fires, before ever recursing further), so a large `limit` argument is
-/// still safe -- the walk simply hasn't rejected yet by that point, it
-/// never recurses *past* it.
+/// decoding, for well-formed input. `depth` counts *containers only*
+/// (`[`/`{`), matching `YamlIndex`'s own `enter_nested`, which is called
+/// once per opened `[`/`{` and never for a leaf scalar -- a leaf never
+/// itself constitutes a nesting level. `limit` also bounds this function's
+/// own recursion depth (an early `true` return the moment
+/// `depth >= limit`, before ever recursing further), so a large `limit`
+/// argument is still safe -- the walk simply hasn't rejected yet by that
+/// point, it never recurses *past* it.
 ///
-/// `count_leaves` selects between two genuinely different counting
-/// conventions (#2282 review: NOT interchangeable, discovered while
-/// reusing this walk for a second caller with a different ceiling --
-/// picking the wrong one silently under-rejects by exactly one level for
-/// a leaf-terminated subtree, see below):
+/// Used by [`parse_input_m2_parity`] at `limit =
+/// M2_PARSE_TIME_DEPTH_LIMIT`, for parity with `YamlIndex`'s own
+/// parse-time rejection boundary (#2276): `--slurp`'s and `--inplace`'s
+/// own DOM fallback (`parse_input`, reached exactly when their M2 fast
+/// path declines JSON-sourced input) must reject nesting at least as
+/// strictly as the M2 fast path it replaces did -- `YamlIndex::build`'s
+/// own parser enforced `M2_PARSE_TIME_DEPTH_LIMIT` at *parse* time,
+/// before this fallback existed for JSON input at all. Confirmed live:
+/// 128 levels of plain `[...]` nesting is accepted (`nesting_depth`
+/// reaches 127 on the innermost bracket, checked before incrementing),
+/// only 129+ is rejected -- confirmed against the pre-#2276 binary
+/// directly, not assumed from the constant's name alone.
 ///
-/// - `count_leaves = false`: `depth` counts *containers only* (`[`/`{`),
-///   checked only when `cursor.is_container()` -- matching `YamlIndex`'s
-///   own `enter_nested`, called once per opened `[`/`{` and never for a
-///   leaf scalar. Used by
-///   [`parse_input_m2_parity`] at
-///   `limit = M2_PARSE_TIME_DEPTH_LIMIT`, for parity with `YamlIndex`'s
-///   own parse-time rejection boundary (#2276): `--slurp`'s and
-///   `--inplace`'s own DOM fallback (`parse_input`, reached exactly when
-///   their M2 fast path declines JSON-sourced input) must reject nesting
-///   at least as strictly as the M2 fast path it replaces did --
-///   `YamlIndex::build`'s own parser enforced `M2_PARSE_TIME_DEPTH_LIMIT`
-///   at *parse* time, before this fallback existed for JSON input at all.
-///   Confirmed live: 128 levels of plain `[...]` nesting is accepted,
-///   129+ rejected -- true for both a scalar leaf and an empty innermost
-///   container, the one boundary where the two conventions below happen
-///   to agree.
-/// - `count_leaves = true`: `depth` is checked on *every* visited node,
-///   container or leaf, before any container check -- matching
-///   `to_owned_canonicalizing_numbers_at_depth`'s own unconditional
-///   `assert_nesting_depth(depth)` call, made on every value regardless
-///   of its type. Used by
-///   [`parse_input_eval_all`] at
-///   `limit = MAX_NESTING_DEPTH`, for parity with *that* function's own
-///   panic boundary -- see its own doc comment for why `--eval-all` needs
-///   a different ceiling than the M2-parity one above, not just a
-///   different counting convention. A leaf-terminated subtree recurses
-///   one level deeper into `to_owned_canonicalizing_numbers_at_depth` than
-///   a container-only count would predict, so `count_leaves = false`
-///   here would under-reject by exactly one level whenever the deepest
-///   nesting bottoms out at a scalar rather than an empty container:
-///   confirmed live, 256 levels of `[...]` (and, separately, of nested
-///   `{"k":...}`) wrapped around a scalar leaf panics
-///   `to_owned_canonicalizing_numbers_at_depth` (`assert_nesting_depth`'s
-///   own check on the leaf's `depth = 256` call fires first), where
-///   `count_leaves = false` at the same `limit` would still call it
-///   accepted -- its own boundary (256 accepted / 257 rejected) only
-///   matches the real one for an empty-innermost-container subtree, not a
-///   leaf-terminated one, confirmed live for that case too.
+/// `--eval-all` needs no equivalent pre-check: unlike `--slurp`/
+/// `--inplace`, it never had an M2 fast path of its own to fall back
+/// from, so there is no M2-parity boundary for it to match. Its own,
+/// unrelated exposure to `to_owned_canonicalizing_numbers_at_depth`'s
+/// nesting-depth guard is fixed at the guard itself (#2282) -- see
+/// `check_nesting_depth`'s call site in that function's own doc comment.
 fn json_nested_past_depth_limit<W: AsRef<[u64]>>(
     cursor: JsonCursor<'_, W>,
     depth: usize,
     limit: usize,
-    count_leaves: bool,
 ) -> bool {
-    let is_container = cursor.is_container();
-    if depth >= limit && (count_leaves || is_container) {
-        return true;
-    }
-    if !is_container {
+    if !cursor.is_container() {
         return false;
+    }
+    if depth >= limit {
+        return true;
     }
     let mut child = cursor.first_child();
     while let Some(c) = child {
-        if json_nested_past_depth_limit(c, depth + 1, limit, count_leaves) {
+        if json_nested_past_depth_limit(c, depth + 1, limit) {
             return true;
         }
         child = c.next_sibling();
@@ -1325,51 +1320,16 @@ fn json_nested_past_depth_limit<W: AsRef<[u64]>>(
 }
 
 /// [`parse_input`], preceded by [`json_nested_past_depth_limit`]'s depth
-/// check (`count_leaves = false`, at `M2_PARSE_TIME_DEPTH_LIMIT`) for
-/// JSON-sourced input -- see that function's own doc comment for why.
-/// Used by `--slurp`'s and `--inplace`'s own DOM-fallback call sites
-/// only; `--eval-all`'s call site uses [`parse_input_eval_all`] instead
-/// (see its own doc comment for why both a different ceiling *and* a
-/// different counting convention are needed there).
+/// check (at `M2_PARSE_TIME_DEPTH_LIMIT`) for JSON-sourced input -- see
+/// that function's own doc comment for why. Used by `--slurp`'s and
+/// `--inplace`'s own DOM-fallback call sites only -- `--eval-all` calls
+/// plain [`parse_input`] directly (#2282: no M2-parity pre-check applies
+/// to it).
 fn parse_input_m2_parity(bytes: &[u8], format: InputFormat) -> Result<Vec<OwnedValue>> {
     if format == InputFormat::Json {
         let index = JsonIndex::build(bytes);
-        if json_nested_past_depth_limit(index.root(bytes), 0, M2_PARSE_TIME_DEPTH_LIMIT, false) {
+        if json_nested_past_depth_limit(index.root(bytes), 0, M2_PARSE_TIME_DEPTH_LIMIT) {
             anyhow::bail!(nesting_depth_exceeded_message(M2_PARSE_TIME_DEPTH_LIMIT));
-        }
-    }
-    parse_input(bytes, format)
-}
-
-/// [`parse_input`], preceded by [`json_nested_past_depth_limit`]'s depth
-/// check (`count_leaves = true`, at [`MAX_NESTING_DEPTH`]) for
-/// JSON-sourced input, rather than [`parse_input_m2_parity`]'s own
-/// `M2_PARSE_TIME_DEPTH_LIMIT`/`count_leaves = false` pairing (#2282).
-///
-/// `--eval-all` has no M2 fast path of its own to have declined (unlike
-/// `--slurp`/`--inplace`, [`parse_input_m2_parity`]'s own two callers), so
-/// tightening it to the *M2-parity* ceiling would be the same
-/// unrelated, unasked-for behavior change that function's own doc comment
-/// already rules out for this exact call site. What `--eval-all` *does*
-/// need is protection from `to_owned_canonicalizing_numbers_at_depth`'s
-/// own panicking `assert_nesting_depth` guard, reachable from raw CLI
-/// input: confirmed live, `succinctly yq --eval-all --input-format json`
-/// on 300 levels of `[...]` nesting panicked (exit 101, "nesting depth
-/// exceeds limit of 256") instead of reporting a clean, catchable error.
-/// `count_leaves = true` is required alongside `MAX_NESTING_DEPTH`, not
-/// optional -- `count_leaves = false` at this same ceiling silently lets
-/// a leaf-terminated 256-deep subtree back through to the panic (see
-/// `json_nested_past_depth_limit`'s own doc comment for the confirmed
-/// live repro). With the right pairing, this pre-check rejects precisely
-/// the inputs the panicking guard would otherwise have crashed on, and no
-/// others -- `--eval-all` keeps tolerating everything up to that same
-/// real ceiling, same as before this fix, just without the panic at the
-/// boundary.
-fn parse_input_eval_all(bytes: &[u8], format: InputFormat) -> Result<Vec<OwnedValue>> {
-    if format == InputFormat::Json {
-        let index = JsonIndex::build(bytes);
-        if json_nested_past_depth_limit(index.root(bytes), 0, MAX_NESTING_DEPTH, true) {
-            anyhow::bail!(nesting_depth_exceeded_message(MAX_NESTING_DEPTH));
         }
     }
     parse_input(bytes, format)
@@ -5132,12 +5092,11 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
         let mut file_origin: Vec<usize> = Vec::new();
         let mut global_doc_index: usize = 0;
         for (file_idx, (bytes, format, _)) in input_sources.iter().enumerate() {
-            // #2282: `parse_input_eval_all`, not plain `parse_input` -- see
-            // that function's own doc comment for why `--eval-all` needs
-            // its own, wider-ceiling catchable pre-check rather than
-            // reaching `to_owned_canonicalizing_numbers_at_depth`'s
-            // panicking guard directly.
-            let inputs = parse_input_eval_all(bytes, *format)?;
+            // #2282: `to_owned_canonicalizing_numbers_at_depth` (reached via
+            // plain `parse_input` for JSON-sourced input) now reports its
+            // own nesting-depth violations as a catchable error rather than
+            // panicking -- see that function's own doc comment for why.
+            let inputs = parse_input(bytes, *format)?;
             for input in inputs {
                 let should_include = args
                     .document
@@ -6935,14 +6894,19 @@ mod tests {
     /// #999: `to_owned_canonicalizing_numbers` is a genuinely separate
     /// recursion from `to_owned` (kept local to this file rather than
     /// added to the shared library, #999 review), so its own
-    /// `assert_nesting_depth` call needed its own pinning test. 255/256,
+    /// `check_nesting_depth` call needed its own pinning test. 255/256,
     /// not `MAX_VALUE_TREE_DEPTH`'s 384: this walks a `DocumentCursor`
     /// directly, the same recursion shape `to_owned_at_depth` guards with
     /// the tighter `MAX_NESTING_DEPTH`, not the looser guard the old
     /// two-pass code's *second* pass (over an already-materialized
     /// `OwnedValue` tree) used.
+    ///
+    /// Updated for #2282: this guard now returns a catchable `EvalError`
+    /// rather than panicking (`check_nesting_depth`, not
+    /// `assert_nesting_depth`) -- see that call site's own doc comment for
+    /// why. `catch_unwind` is no longer needed or correct here.
     #[test]
-    fn to_owned_canonicalizing_numbers_panics_past_nesting_depth_limit_999() {
+    fn to_owned_canonicalizing_numbers_raises_past_nesting_depth_limit_999() {
         let json = linear_json_nest(255);
         let index = JsonIndex::build(json.as_bytes());
         let cursor = index.root(json.as_bytes());
@@ -6952,13 +6916,10 @@ mod tests {
         let json = linear_json_nest(256);
         let index = JsonIndex::build(json.as_bytes());
         let cursor = index.root(json.as_bytes());
-        let value = cursor.value();
-        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-            to_owned_canonicalizing_numbers(&value)
-        }));
+        let result = to_owned_canonicalizing_numbers(&cursor.value());
         assert!(
             result.is_err(),
-            "to_owned_canonicalizing_numbers should panic at depth 256"
+            "to_owned_canonicalizing_numbers should raise a catchable error at depth 256"
         );
     }
 

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -16995,20 +16995,17 @@ fn test_json_input_rejects_adversarial_nesting_via_eval_all_998() -> Result<()> 
     Ok(())
 }
 
-/// #2282 review: pins the exact off-by-one this fix's own review caught --
-/// `parse_input_eval_all`'s pre-check must reject nesting at exactly the
-/// same boundary `to_owned_canonicalizing_numbers_at_depth`'s
-/// `assert_nesting_depth` panic would, not one level looser. A
-/// container-only depth count (`json_nested_past_depth_limit`'s
-/// `count_leaves = false` convention, correct for the *M2-parity* 128
-/// guard elsewhere in this file) under-counts a leaf-terminated subtree by
-/// one level relative to that panic: 256 levels of `[...]` wrapped around
-/// a scalar leaf reaches `assert_nesting_depth(256)` (256 `>=` 256, panics)
-/// but a container-only count of the same input only reaches 256 at the
-/// outermost container, one short of its own would-be 257 rejection
-/// threshold. Confirmed live before the `count_leaves` fix: this exact
-/// input panicked (exit 101) even after `parse_input_eval_all`'s
-/// container-only pre-check had already run and declined to reject it.
+/// #2282: pins the exact boundary `check_nesting_depth` now enforces
+/// (catchably) at `to_owned_canonicalizing_numbers_at_depth`'s own call
+/// site -- 256 levels of `[...]` wrapped around a scalar leaf reaches
+/// `check_nesting_depth(256)` (256 `>=` `MAX_NESTING_DEPTH`, errors). An
+/// earlier revision of this fix used a separate, container-only-counting
+/// pre-check walk instead of fixing the guard itself, and that walk
+/// under-counted a leaf-terminated subtree by one level relative to the
+/// real guard's own per-node counting -- confirmed live at the time: this
+/// exact input still panicked (exit 101) even with that pre-check already
+/// run and declined to reject it. Kept as a regression test for the
+/// boundary itself, independent of which mechanism enforces it.
 #[test]
 fn test_json_eval_all_rejects_scalar_terminated_nesting_at_exact_boundary_2282() -> Result<()> {
     let depth = 256;

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -16969,17 +16969,71 @@ fn test_json_input_rejects_adversarial_nesting_via_m2_path_996() -> Result<()> {
 /// routed through `parse_input`'s `JsonIndex`-based path (#1343 tracks
 /// unifying those too), so `--eval-all` is what still reaches this
 /// conversion-time guard.
+///
+/// Updated for #2282: the conversion-time 256 guard is still what
+/// ultimately bounds this input, but `--eval-all` no longer reaches it
+/// live -- `parse_input_eval_all`'s own pre-check
+/// (`json_nested_past_depth_limit` at `MAX_NESTING_DEPTH`,
+/// `count_leaves = true`) now catches nesting at or past that same
+/// ceiling first and reports a clean, catchable `anyhow` error (exit 1),
+/// not a panic (exit 101) -- confirmed live before this fix, 300+ levels
+/// via `--eval-all --input-format json` panicked with exit 101 instead of
+/// reporting cleanly. The message text is unchanged
+/// (`nesting_depth_exceeded_message`, shared by both the panicking guard
+/// and this pre-check), only the delivery mechanism and exit code differ.
 #[test]
 fn test_json_input_rejects_adversarial_nesting_via_eval_all_998() -> Result<()> {
     let depth = 500;
     let input = format!("{}1{}", "[".repeat(depth), "]".repeat(depth));
     let (_stdout, stderr, code) =
         run_yq_stdin_with_stderr(".", &input, &["--input-format", "json", "--eval-all"])?;
-    assert_eq!(code, 101, "stderr: {stderr:?}");
+    assert_eq!(code, 1, "stderr: {stderr:?}");
     assert!(
         stderr.contains("nesting depth exceeds limit of 256"),
         "stderr: {stderr:?}"
     );
+    Ok(())
+}
+
+/// #2282 review: pins the exact off-by-one this fix's own review caught --
+/// `parse_input_eval_all`'s pre-check must reject nesting at exactly the
+/// same boundary `to_owned_canonicalizing_numbers_at_depth`'s
+/// `assert_nesting_depth` panic would, not one level looser. A
+/// container-only depth count (`json_nested_past_depth_limit`'s
+/// `count_leaves = false` convention, correct for the *M2-parity* 128
+/// guard elsewhere in this file) under-counts a leaf-terminated subtree by
+/// one level relative to that panic: 256 levels of `[...]` wrapped around
+/// a scalar leaf reaches `assert_nesting_depth(256)` (256 `>=` 256, panics)
+/// but a container-only count of the same input only reaches 256 at the
+/// outermost container, one short of its own would-be 257 rejection
+/// threshold. Confirmed live before the `count_leaves` fix: this exact
+/// input panicked (exit 101) even after `parse_input_eval_all`'s
+/// container-only pre-check had already run and declined to reject it.
+#[test]
+fn test_json_eval_all_rejects_scalar_terminated_nesting_at_exact_boundary_2282() -> Result<()> {
+    let depth = 256;
+    let input = format!("{}1{}", "[".repeat(depth), "]".repeat(depth));
+    let (_stdout, stderr, code) =
+        run_yq_stdin_with_stderr(".", &input, &["--input-format", "json", "--eval-all"])?;
+    assert_eq!(code, 1, "stderr: {stderr:?}");
+    assert!(
+        stderr.contains("nesting depth exceeds limit of 256"),
+        "stderr: {stderr:?}"
+    );
+    Ok(())
+}
+
+/// Companion to the above: one level shallower (255) must still be
+/// accepted -- confirms the fix didn't over-tighten the boundary while
+/// closing the off-by-one.
+#[test]
+fn test_json_eval_all_accepts_scalar_terminated_nesting_one_below_boundary_2282() -> Result<()> {
+    let depth = 255;
+    let input = format!("{}1{}", "[".repeat(depth), "]".repeat(depth));
+    let (stdout, stderr, code) =
+        run_yq_stdin_with_stderr(".", &input, &["--input-format", "json", "--eval-all"])?;
+    assert_eq!(code, 0, "stderr: {stderr:?}");
+    assert!(stdout.contains('1'), "stdout: {stdout:?}");
     Ok(())
 }
 


### PR DESCRIPTION
## Summary

Fixes #2282: `succinctly yq --eval-all --input-format json` on adversarially
deep JSON nesting (>256 levels) raised an uncaught panic (exit 101) instead of
a clean, catchable error (exit 1).

**Root cause and fix**: `to_owned_canonicalizing_numbers_at_depth`
(`src/bin/succinctly/yq_runner.rs`) already returns `Result<OwnedValue,
EvalError>` and already propagates every other error via `?` -- the panicking
`assert_nesting_depth` call was the one outlier. This swaps it for
`check_nesting_depth` (`eval_generic.rs`, #1818's existing catchable sibling
of that exact guard), mirroring `jq_runner.rs`'s own
`json_bytes_to_owned_value_checked` (#1818), which made the identical
panic-to-`Result` conversion for jq mode's analogous pre-filter parse path:
this call sits ahead of any user filter evaluation (parsing raw external JSON
text for `--slurp`/`--eval-all`/`--inplace`), not inside the evaluator's own
hot recursion where a panic is deliberately kept uncatchable.

An earlier revision of this PR instead added a second, parallel pre-check
walk ahead of `--eval-all`'s own call site (mirroring `parse_input_m2_parity`'s
shape from #2276). Code review found the direct fix above instead -- the
parallel-walk approach needed its own depth-counting convention to
approximate `assert_nesting_depth`'s real per-node semantics, got that
convention wrong on the first attempt (silently under-rejecting a
leaf-terminated subtree by one level), duplicated ~130 lines the direct fix
avoids entirely, and risked a fidelity mismatch of its own on structurally
malformed input. That approach has been reverted in favor of fixing the
guard at its source.

## Test plan

- [x] `cargo build --features cli`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings`
- [x] `cargo fmt --check`
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features`
- [x] `cargo test --features cli,simd,regex,serde --no-fail-fast` (all green, including a renamed/updated unit test that no longer needs `catch_unwind` since the guard is catchable now)
- [x] `cargo test --no-fail-fast` (default features)
- [x] `cargo test --no-default-features --verbose` (no_std)
- [x] Live-verified against the full boundary matrix (255/256/257 levels, both scalar-leaf and empty-container termination, arrays and objects) -- matches `check_nesting_depth`'s real boundary exactly, and the M2-parity path (`--slurp`, 128/129 boundary) is unaffected
