### PR TITLE
fix(jq): has(key) catches a non-string key before its match, find gets #1677 (#2288)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -290,20 +290,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - **`has(key)`/`contains()` on objects didn't raise on a non-string sibling key
-  (`{"a":1,123:2}`), and `JsonFields::find` (unlike its `find_cursor` sibling) had no #1677
-  `,`/`:` delimiter check at all** (#2288, found reviewing #1995/PR #2287): `has(key)`'s
-  `DocumentFields::contains_checked` (already checking `,`/`:` delimiters and #2261's own
-  trailing-comma gap) now also checks `key_is_malformed` on every key it visits during its
-  existing early-exit walk — free, riding the same walk, but only for keys visited *before*
-  a match (the identical #2261-established "early exit legitimately misses a later fault"
-  trade, since there's no O(1) shortcut to "is there a malformed key anywhere else in this
-  object" the way there is for the trailing gap's single fixed position); see
+  (`{"a":1,123:2}`), and `JsonFields::find` (unlike its `find_cursor` sibling) had neither
+  the #1677 `,`/`:` delimiter check nor the #2261 trailing-comma check at all** (#2288,
+  found reviewing #1995/PR #2287): `has(key)`'s `DocumentFields::contains_checked` (already
+  checking `,`/`:` delimiters and #2261's own trailing-comma gap) now also derives "is this
+  key malformed" from the same `key_display_string_kind` call it already makes for the match
+  check (code review caught a first draft paying for a second, redundant decode pass via a
+  separate `key_is_malformed` call) — free, riding the same walk, but only for keys visited
+  *before* a match (the identical #2261-established "early exit legitimately misses a later
+  fault" trade, since there's no O(1) shortcut to "is there a malformed key anywhere else in
+  this object" the way there is for the trailing gap's single fixed position); see
   `docs/compliance/jq/limitations.md` for the full accounting, including this issue's own
   headline repro (`{"a":1,123:2} | has("a")`) remaining a documented, accepted gap. `find`
-  gained the same deferred-to-the-winner `,`/`:` check `find_cursor` already had, reusing it
-  rather than re-deriving it — confirmed not reachable from either shipped CLI today (same
-  "library-API-only" shape as #2293's `eval.rs` gaps), fixed anyway since it's narrow,
-  mechanical, and reuses an existing, already-proven check within the same file.
+  gained the same deferred-to-the-winner `,`/`:` check and the same unconditional
+  trailing-comma check `find_cursor` already had (a second code-review round caught that a
+  first draft ported only the delimiter check and missed the trailing-comma one), reusing
+  both rather than re-deriving them — confirmed not reachable from either shipped CLI today
+  (same "library-API-only" shape as #2293's `eval.rs` gaps, which also covers `eval.rs`'s own
+  `has_one_key` sharing this same non-string-key gap), fixed anyway since the change is
+  narrow, mechanical, and reuses existing, already-proven checks within the same file.
 - **`succinctly jq`'s most common query idioms -- `.[]`, `keys`/`keys_unsorted`, bare `.a`
   field access, `length`, `.[0]` -- silently accepted a trailing stray `,` after a real last
   array/object child** (#2261): `echo '[1,]' | succinctly jq -c '.[]'` printed `1` at exit 0,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -289,6 +289,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`has(key)`/`contains()` on objects didn't raise on a non-string sibling key
+  (`{"a":1,123:2}`), and `JsonFields::find` (unlike its `find_cursor` sibling) had no #1677
+  `,`/`:` delimiter check at all** (#2288, found reviewing #1995/PR #2287): `has(key)`'s
+  `DocumentFields::contains_checked` (already checking `,`/`:` delimiters and #2261's own
+  trailing-comma gap) now also checks `key_is_malformed` on every key it visits during its
+  existing early-exit walk — free, riding the same walk, but only for keys visited *before*
+  a match (the identical #2261-established "early exit legitimately misses a later fault"
+  trade, since there's no O(1) shortcut to "is there a malformed key anywhere else in this
+  object" the way there is for the trailing gap's single fixed position); see
+  `docs/compliance/jq/limitations.md` for the full accounting, including this issue's own
+  headline repro (`{"a":1,123:2} | has("a")`) remaining a documented, accepted gap. `find`
+  gained the same deferred-to-the-winner `,`/`:` check `find_cursor` already had, reusing it
+  rather than re-deriving it — confirmed not reachable from either shipped CLI today (same
+  "library-API-only" shape as #2293's `eval.rs` gaps), fixed anyway since it's narrow,
+  mechanical, and reuses an existing, already-proven check within the same file.
 - **`succinctly jq`'s most common query idioms -- `.[]`, `keys`/`keys_unsorted`, bare `.a`
   field access, `length`, `.[0]` -- silently accepted a trailing stray `,` after a real last
   array/object child** (#2261): `echo '[1,]' | succinctly jq -c '.[]'` printed `1` at exit 0,

--- a/docs/compliance/jq/limitations.md
+++ b/docs/compliance/jq/limitations.md
@@ -1744,6 +1744,67 @@ against each (`{"a":[1,2,3,]} | if .a then ... end`;
 something upstream of either function already validates for the shapes
 tried. Not chased further given no live reproduction.
 
+## `has(key)`/`contains()` and `find()` get two more pre-existing gaps closed (#2288)
+
+Code review of #1995/PR #2287 found two further, unrelated gaps, both predating that PR:
+
+**1. `has(key)`/`contains()` didn't raise on a non-string sibling key at all** (not the
+trailing-comma shape #2261 above fixes -- a genuinely different malformed-JSON class,
+#1194/#1995's own `key_is_malformed`):
+
+```
+$ echo '{"a":1,123:2}' | jq  -c 'has("a")'   # parse error, exit 5
+$ echo '{"a":1,123:2}' | sjq -c 'has("a")'   # true, exit 0 -- was WRONG before this fix
+```
+
+Fixed the same way #2261's own `has(key)` fix was shaped: `contains_checked`'s existing
+per-key walk (already checking `,`/`:` delimiters for #1677) now also checks
+`key_is_malformed` on every key it visits -- free, since it's the identical walk, not an
+added pass. That "visits" qualifier matters: **a malformed key strictly *after* the match
+is the same class of accepted early-exit gap #2261 already established for the trailing
+comma**, and for the identical reason -- there is no O(1) shortcut from the matched key's
+own cursor to "is there a malformed key anywhere else in this object," unlike the trailing
+gap (a single, fixed, cheaply-reachable position). Closing it in general would mean
+walking to the object's true end on every `has()` call, the exact ~4x regression #2261's
+own `has(key)` fix (documented above) already measured and rejected.
+
+```
+$ echo '{123:1,"a":2}' | jq  -c 'has("a")'   # parse error, exit 5
+$ echo '{123:1,"a":2}' | sjq -c 'has("a")'   # parse error, exit 5 -- fixed: bad key visited before the match
+$ echo '{"a":1,123:2}' | jq  -c 'has("a")'   # parse error, exit 5
+$ echo '{"a":1,123:2}' | sjq -c 'has("a")'   # true, exit 0 -- still a known gap: bad key visited after the match
+$ echo '{"z":1,123:2}' | sjq -c 'has("a")'   # parse error, exit 5 -- no match, so the walk reaches 123 regardless
+```
+
+So this issue's own headline repro (`{"a":1,123:2} | has("a")`) is **not** fully closed --
+only the general class (a non-string key existing at all) is now caught in every case
+except "the match itself happens to come first." Recorded here rather than left as an
+unstated side effect of the fix, matching how #2261's own `has(key)` fix above documents
+its identical trade-off.
+
+**2. `JsonFields::find` (unlike its `find_cursor` sibling) had no #1677 delimiter check at
+all** -- a missing `:` before the winning occurrence's value used to slip through
+silently (`find("a")` on `{"a" 1}` returned `Ok(Some(1))` with no error, where
+`find_cursor("a")` on the identical document already correctly raised). Fixed by deferring
+the same `preceding_gap_ok` check `find_cursor` already runs to the actual winning
+occurrence (last-duplicate-key-wins), reusing the exact check rather than re-deriving it
+(#106).
+
+**Confirmed not reachable from either shipped CLI**, the identical "library-API-only, inert
+for genuine JSON input via either CLI" shape #2293 already established for `eval.rs`'s
+whole parallel evaluator: `find`'s only production caller is `eval.rs`'s `find_field`/
+`index_object_by_name` (`.field` navigation in that evaluator), and `eval.rs` itself is
+only ever reached, from either CLI, via `succinctly yq`'s `evaluate_input`/
+`eval_owned_with_file_index` -- both of which hand it a cursor re-serialized from an
+already-materialized `OwnedValue`, which can never contain a missing `:` regardless of
+query (confirmed live: `succinctly yq --input-format json --slurp/--eval-all` on
+`{"a" 1}` already raises during the initial parse, before `find` is ever reached). Real
+only for a library consumer building their own cursor directly from raw, unvalidated
+document bytes. Fixed anyway (unlike #2293's own eval.rs gaps, left as a follow-up) because
+the change is narrow, mechanical, and reuses an existing, already-proven check within the
+same file -- not the broader, riskier `eval.rs`-wide sweep #2293 recommends as its own
+issue.
+
 ## Refusing an allocation jq does not survive
 
 `setpath` takes its array index from the document, so the array it pads is sized by the

--- a/docs/compliance/jq/limitations.md
+++ b/docs/compliance/jq/limitations.md
@@ -1782,13 +1782,27 @@ except "the match itself happens to come first." Recorded here rather than left 
 unstated side effect of the fix, matching how #2261's own `has(key)` fix above documents
 its identical trade-off.
 
-**2. `JsonFields::find` (unlike its `find_cursor` sibling) had no #1677 delimiter check at
-all** -- a missing `:` before the winning occurrence's value used to slip through
-silently (`find("a")` on `{"a" 1}` returned `Ok(Some(1))` with no error, where
-`find_cursor("a")` on the identical document already correctly raised). Fixed by deferring
-the same `preceding_gap_ok` check `find_cursor` already runs to the actual winning
-occurrence (last-duplicate-key-wins), reusing the exact check rather than re-deriving it
-(#106).
+Code review on this fix also caught that the naive shape (a separate `key_is_malformed`
+call alongside the pre-existing `key_display_string` call) paid for **two** independent
+key decodes per key -- `key_is_malformed(k) == key_display_string_kind(k).is_none()` by
+construction, so the fix calls `key_display_string_kind` once and derives both "is this key
+malformed" and "does it match `name`" from that single result, rather than adding a second
+decode pass on top of the one `contains`/`contains_checked` already paid.
+
+**2. `JsonFields::find` (unlike its `find_cursor` sibling) had neither the #1677 delimiter
+check nor the #2261 trailing-comma check at all** -- a missing `:` before the winning
+occurrence's value, or a trailing stray comma after the object's real last field, both used
+to slip through silently (`find("a")` on `{"a" 1}` returned `Ok(Some(1))` with no error,
+and `find("a")` on `{"a":1,}` also returned `Ok(Some(1))`, where `find_cursor` on the
+identical documents already correctly raised for both). Fixed by threading the same
+`preceding_gap_ok`/`trailing_element_gap_ok` checks `find_cursor` already runs -- the
+`,`/`:` check deferred to the actual winning occurrence (last-duplicate-key-wins), the
+trailing-comma check unconditional on whether `name` matched anything, exactly mirroring
+`find_cursor`'s own two checks and reusing them rather than re-deriving either (#106). A
+first draft of this PR ported only the `,`/`:` check and missed the trailing-comma one
+entirely -- a second code-review round on this same PR caught the residual asymmetry
+between two functions this file's own doc comments describe as sharing "the same
+last-duplicate-key-wins semantics."
 
 **Confirmed not reachable from either shipped CLI**, the identical "library-API-only, inert
 for genuine JSON input via either CLI" shape #2293 already established for `eval.rs`'s
@@ -1796,14 +1810,22 @@ whole parallel evaluator: `find`'s only production caller is `eval.rs`'s `find_f
 `index_object_by_name` (`.field` navigation in that evaluator), and `eval.rs` itself is
 only ever reached, from either CLI, via `succinctly yq`'s `evaluate_input`/
 `eval_owned_with_file_index` -- both of which hand it a cursor re-serialized from an
-already-materialized `OwnedValue`, which can never contain a missing `:` regardless of
-query (confirmed live: `succinctly yq --input-format json --slurp/--eval-all` on
-`{"a" 1}` already raises during the initial parse, before `find` is ever reached). Real
-only for a library consumer building their own cursor directly from raw, unvalidated
-document bytes. Fixed anyway (unlike #2293's own eval.rs gaps, left as a follow-up) because
-the change is narrow, mechanical, and reuses an existing, already-proven check within the
-same file -- not the broader, riskier `eval.rs`-wide sweep #2293 recommends as its own
-issue.
+already-materialized `OwnedValue`, which can never contain a missing `:` or a stray
+trailing `,` regardless of query (confirmed live: `succinctly yq --input-format json
+--slurp/--eval-all` on both `{"a" 1}` and `{"a":1,}` already raise during the initial
+parse, before `find` is ever reached). Real only for a library consumer building their own
+cursor directly from raw, unvalidated document bytes. Fixed anyway (unlike #2293's own
+`eval.rs` gaps, left as a follow-up) because the change is narrow, mechanical, and reuses
+existing, already-proven checks within the same file -- not the broader, riskier
+`eval.rs`-wide sweep #2293 recommends as its own issue.
+
+**3. `eval.rs`'s own `has_one_key` (its object arm, a raw `.any()` with zero gap checks)
+shares this same #2288 non-string-key gap** -- already tracked as part of #2293's own
+"`eval.rs`'s parallel evaluator" umbrella finding (filed alongside `builtin_length`/
+`builtin_keys`'s identical shape during #2261's own round-2 review), not a new discovery
+here. Same reachability analysis applies: `succinctly yq`'s one call site into `eval.rs`
+only ever sees an already-materialized, pre-validated `OwnedValue`, so this is inert for
+both CLIs today. Not re-filed as a separate issue; see #2293 for the tracking.
 
 ## Refusing an allocation jq does not survive
 

--- a/src/jq/document.rs
+++ b/src/jq/document.rs
@@ -1015,21 +1015,29 @@ pub trait DocumentFields: Sized + Clone {
         while let Some((key, key_cursor, rest)) = fields.uncons_key() {
             // #1677/#2288: cheap per-key checks, riding the walk `contains`
             // already makes regardless of early exit -- no extra cost,
-            // early-exit or not. `key_is_malformed` (#1194/#1995) catches a
-            // key the format's grammar never allowed at all (a non-string
+            // early-exit or not. `display` being `None` (#1194/#1995) means
+            // a key the format's grammar never allowed at all (a non-string
             // JSON key); the delimiter checks catch a missing/doubled
             // `,`/`:` around a key that *is* well-shaped. Both only cover
             // keys actually visited before a match -- see this method's own
             // doc comment for why a malformed key strictly *after* the
             // match is a documented, accepted gap, not something this walk
             // closes.
-            if key_is_malformed(&key)
+            //
+            // `key_display_string_kind` once, not `key_is_malformed` (#1194
+            // check) plus a separate `key_display_string` (match check) --
+            // `key_is_malformed(k) == key_display_string_kind(k).is_none()`
+            // by construction (code review on this fix caught the
+            // redundant second decode pass a naive two-call version would
+            // pay for every key, every `has()` call).
+            let display = key_display_string_kind(&key);
+            if display.is_none()
                 || !key_delimiter_ok::<Self>(&key, &key_cursor, is_first)
                 || !key_only_value_delimiter_ok::<Self>(&key, &key_cursor)
             {
                 return Err(self.malformed_member_error());
             }
-            if key_display_string(&key).is_some_and(|k| k.as_ref() == name) {
+            if display.is_some_and(|(k, _is_fallback)| k.as_ref() == name) {
                 // #2261: free exactly when the match is also the last
                 // field -- see this method's own doc comment for why a
                 // match elsewhere accepts the documented early-exit trade

--- a/src/jq/document.rs
+++ b/src/jq/document.rs
@@ -988,6 +988,22 @@ pub trait DocumentFields: Sized + Clone {
     /// gaps `contains` never checked at all, not the separate, already-
     /// accepted "isn't full behavioral parity with `keys`" divergence
     /// `contains`'s own doc comment describes.
+    ///
+    /// **#2288: a non-string sibling key (`{"a":1,123:2}`, #1194/#1995's own
+    /// `key_is_malformed`) is caught only when visited *before* the match**
+    /// -- exactly the same early-exit trade as the trailing-comma case
+    /// above, and for the identical reason: detecting a non-string key
+    /// *anywhere* in the object (not just at a fixed, cheaply-reachable
+    /// position like "the object's real last field") has no O(1) shortcut
+    /// from the matched key's own cursor, so catching one strictly *after*
+    /// the match would mean walking past the match regardless -- the exact
+    /// cost #1739 exists to avoid. `{"a":1,123:2} | has("a")` (this issue's
+    /// own headline repro) therefore still answers `true` rather than
+    /// raising, since "a" is visited *before* 123 ever is; `{123:1,"a":2} |
+    /// has("a")` does now correctly raise, since 123 is visited first. A
+    /// non-match still walks to the object's true end regardless (the
+    /// existing shape `contains` itself already has), so every sibling key
+    /// is checked there, match-position dependence and all.
     fn contains_checked(&self, name: &str) -> Result<bool, EvalError> {
         let mut fields = self.clone();
         let mut is_first = true;
@@ -997,10 +1013,18 @@ pub trait DocumentFields: Sized + Clone {
         // check is free, unlike the early-exit match path above.
         let mut last_key_cursor: Option<Self::Cursor> = None;
         while let Some((key, key_cursor, rest)) = fields.uncons_key() {
-            // #1677: cheap per-key checks, riding the walk `contains`
+            // #1677/#2288: cheap per-key checks, riding the walk `contains`
             // already makes regardless of early exit -- no extra cost,
-            // early-exit or not.
-            if !key_delimiter_ok::<Self>(&key, &key_cursor, is_first)
+            // early-exit or not. `key_is_malformed` (#1194/#1995) catches a
+            // key the format's grammar never allowed at all (a non-string
+            // JSON key); the delimiter checks catch a missing/doubled
+            // `,`/`:` around a key that *is* well-shaped. Both only cover
+            // keys actually visited before a match -- see this method's own
+            // doc comment for why a malformed key strictly *after* the
+            // match is a documented, accepted gap, not something this walk
+            // closes.
+            if key_is_malformed(&key)
+                || !key_delimiter_ok::<Self>(&key, &key_cursor, is_first)
                 || !key_only_value_delimiter_ok::<Self>(&key, &key_cursor)
             {
                 return Err(self.malformed_member_error());

--- a/src/json/light.rs
+++ b/src/json/light.rs
@@ -1101,12 +1101,30 @@ impl<'a, W: AsRef<[u64]>> JsonFields<'a, W> {
     /// walks already use for this exact question, rather than a second,
     /// hand-rolled `match` on `StandardJson::String` -- one definition of
     /// "malformed key", not two that could silently diverge (#106).
+    ///
+    /// `Err` too when the *winning* occurrence's own `,`/`:` delimiters are
+    /// malformed (#1677/#2288) -- unlike the non-string-key check just
+    /// above, deferred to the end rather than checked as each candidate is
+    /// found: only the field that actually wins (the *last* matching
+    /// occurrence) should be validated this way, since an earlier
+    /// same-named field's own delimiter gap is moot once a later one
+    /// supersedes it. Exactly [`find_cursor`](Self::find_cursor)'s own
+    /// check, reused rather than re-derived (#106) -- `find` predates
+    /// `find_cursor` and was missing it entirely until #2288 found the gap
+    /// via `find_cursor`'s own inherent walk-through duplicate-key
+    /// resolution, which `find`'s simpler last-write-wins loop doesn't
+    /// share, so the check has to be threaded through separately here
+    /// rather than shared by construction.
     pub fn find(&self, name: &str) -> Result<Option<StandardJson<'a, W>>, EvalError>
     where
         W: Clone,
     {
         let mut fields = *self;
-        let mut result = None;
+        // (key's own text start, winning field, is this field the object's
+        // first) -- same bookkeeping `find_cursor` keeps, needed so the
+        // deferred `,`/`:` check below validates only the actual winner.
+        let mut winner: Option<(usize, JsonField<'a, W>, bool)> = None;
+        let mut index = 0usize;
         while let Some((field, rest)) = fields.uncons() {
             let key = field.key();
             if key_is_malformed(&key) {
@@ -1123,14 +1141,27 @@ impl<'a, W: AsRef<[u64]>> JsonFields<'a, W> {
             // own doc comment for why this case, unlike #1995's, is
             // deliberately *not* what it answers `true` for); this only
             // stops one bad key destroying valid results.
-            if let StandardJson::String(key) = key {
-                if key.as_str().is_ok_and(|k| k == name) {
-                    result = Some(field.value());
+            if let StandardJson::String(key_str) = key {
+                if key_str.as_str().is_ok_and(|k| k == name) {
+                    winner = Some((key_str.start(), field, index == 0));
                 }
             }
             fields = rest;
+            index += 1;
         }
-        Ok(result)
+        if let Some((key_start, field, is_first)) = winner {
+            let value_cursor = field.value_cursor();
+            let comma_expected = if is_first { None } else { Some(b',') };
+            if !preceding_gap_ok(value_cursor.text(), key_start, comma_expected) {
+                return Err(EvalError::malformed_json_text(value_cursor.text()));
+            }
+            if let Some(value_start) = value_cursor.text_position() {
+                if !preceding_gap_ok(value_cursor.text(), value_start, Some(b':')) {
+                    return Err(EvalError::malformed_json_text(value_cursor.text()));
+                }
+            }
+        }
+        Ok(winner.map(|(_, field, _)| field.value()))
     }
 
     /// Find a field by name and return a cursor to its value.
@@ -4304,6 +4335,71 @@ mod tests {
                 .find_cursor("a")
                 .unwrap_or_else(|e| panic!("{json:?}: {e:?}"));
             assert!(cursor.is_some(), "{json:?}: expected to find `a`");
+        }
+    }
+
+    /// #2288: `find` (unlike `find_cursor`, already fixed for this shape)
+    /// had no #1677 delimiter check at all -- a missing `:` before the
+    /// winning occurrence's value used to slip through silently.
+    #[test]
+    fn test_find_rejects_missing_colon_before_winning_value_2288() {
+        let json = br#"{"a" 1}"#;
+        let index = JsonIndex::build(json);
+        let root = index.root(json);
+        let StandardJson::Object(fields) = root.value() else {
+            panic!("expected object");
+        };
+        let err = fields
+            .find("a")
+            .expect_err("missing colon before value should raise");
+        assert!(
+            err.message.contains("Invalid JSON text"),
+            "message: {}",
+            err.message
+        );
+    }
+
+    /// #2288: same shape, but the winning occurrence is a *later* duplicate
+    /// -- `find`'s last-duplicate-key-wins resolution must still validate
+    /// only the actual winner's own delimiters, not an earlier, superseded
+    /// occurrence's (which may be perfectly well-formed).
+    #[test]
+    fn test_find_rejects_missing_colon_on_winning_duplicate_2288() {
+        let json = br#"{"a":1,"a" 2}"#;
+        let index = JsonIndex::build(json);
+        let root = index.root(json);
+        let StandardJson::Object(fields) = root.value() else {
+            panic!("expected object");
+        };
+        let err = fields
+            .find("a")
+            .expect_err("missing colon on the winning duplicate should raise");
+        assert!(
+            err.message.contains("Invalid JSON text"),
+            "message: {}",
+            err.message
+        );
+    }
+
+    /// #2288: well-formed objects (including a duplicate key, exercising
+    /// the same winning-occurrence resolution as the tests above) are
+    /// unaffected by the new delimiter check.
+    #[test]
+    fn test_find_wellformed_unaffected_by_delimiter_check_2288() {
+        for json in [
+            br#"{"a":1}"#.as_slice(),
+            br#"{"a":1,"b":2}"#.as_slice(),
+            br#"{"a":1,"b":2,"a":3}"#.as_slice(),
+        ] {
+            let index = JsonIndex::build(json);
+            let root = index.root(json);
+            let StandardJson::Object(fields) = root.value() else {
+                panic!("{json:?}: expected object");
+            };
+            let value = fields
+                .find("a")
+                .unwrap_or_else(|e| panic!("{json:?}: {e:?}"));
+            assert!(value.is_some(), "{json:?}: expected to find `a`");
         }
     }
 

--- a/src/json/light.rs
+++ b/src/json/light.rs
@@ -4376,6 +4376,27 @@ mod tests {
         );
     }
 
+    /// #2288: the sibling gap on the *other* side of the winning
+    /// occurrence's key -- a missing `,` before a non-first key (as
+    /// opposed to the missing `:` after it, tested above).
+    #[test]
+    fn test_find_rejects_missing_comma_before_winning_key_2288() {
+        let json = br#"{"a":1"b":2}"#;
+        let index = JsonIndex::build(json);
+        let root = index.root(json);
+        let StandardJson::Object(fields) = root.value() else {
+            panic!("expected object");
+        };
+        let err = fields
+            .find("b")
+            .expect_err("missing comma before a non-first key should raise");
+        assert!(
+            err.message.contains("Invalid JSON text"),
+            "message: {}",
+            err.message
+        );
+    }
+
     /// #2288: same shape, but the winning occurrence is a *later* duplicate
     /// -- `find`'s last-duplicate-key-wins resolution must still validate
     /// only the actual winner's own delimiters, not an earlier, superseded

--- a/src/json/light.rs
+++ b/src/json/light.rs
@@ -1103,17 +1103,20 @@ impl<'a, W: AsRef<[u64]>> JsonFields<'a, W> {
     /// "malformed key", not two that could silently diverge (#106).
     ///
     /// `Err` too when the *winning* occurrence's own `,`/`:` delimiters are
-    /// malformed (#1677/#2288) -- unlike the non-string-key check just
-    /// above, deferred to the end rather than checked as each candidate is
-    /// found: only the field that actually wins (the *last* matching
-    /// occurrence) should be validated this way, since an earlier
-    /// same-named field's own delimiter gap is moot once a later one
-    /// supersedes it. Exactly [`find_cursor`](Self::find_cursor)'s own
-    /// check, reused rather than re-derived (#106) -- `find` predates
-    /// `find_cursor` and was missing it entirely until #2288 found the gap
-    /// via `find_cursor`'s own inherent walk-through duplicate-key
+    /// malformed (#1677/#2288), or when there's a trailing stray comma
+    /// after the object's real last field (`{"a":1,}`, #2261/#2288) --
+    /// unlike the non-string-key check just above, both deferred to the
+    /// end rather than checked as each candidate is found: only the field
+    /// that actually wins (the *last* matching occurrence) needs its own
+    /// `,`/`:` validated, since an earlier same-named field's own delimiter
+    /// gap is moot once a later one supersedes it; the trailing-comma check
+    /// is unconditional on whether `name` matched anything, same as every
+    /// other #2261 fix. Exactly [`find_cursor`](Self::find_cursor)'s own
+    /// checks, reused rather than re-derived (#106) -- `find` predates
+    /// `find_cursor` and was missing both entirely until #2288 found the
+    /// gap via `find_cursor`'s own inherent walk-through duplicate-key
     /// resolution, which `find`'s simpler last-write-wins loop doesn't
-    /// share, so the check has to be threaded through separately here
+    /// share, so the checks have to be threaded through separately here
     /// rather than shared by construction.
     pub fn find(&self, name: &str) -> Result<Option<StandardJson<'a, W>>, EvalError>
     where
@@ -1124,6 +1127,11 @@ impl<'a, W: AsRef<[u64]>> JsonFields<'a, W> {
         // first) -- same bookkeeping `find_cursor` keeps, needed so the
         // deferred `,`/`:` check below validates only the actual winner.
         let mut winner: Option<(usize, JsonField<'a, W>, bool)> = None;
+        // #2261/#2288: the textually last field's own value cursor, in raw
+        // document order -- independent of `winner`, which a later
+        // non-matching field must not disturb. Same bookkeeping
+        // `find_cursor` keeps.
+        let mut last_value_cursor: Option<JsonCursor<'a, W>> = None;
         let mut index = 0usize;
         while let Some((field, rest)) = fields.uncons() {
             let key = field.key();
@@ -1146,6 +1154,7 @@ impl<'a, W: AsRef<[u64]>> JsonFields<'a, W> {
                     winner = Some((key_str.start(), field, index == 0));
                 }
             }
+            last_value_cursor = Some(field.value_cursor());
             fields = rest;
             index += 1;
         }
@@ -1159,6 +1168,14 @@ impl<'a, W: AsRef<[u64]>> JsonFields<'a, W> {
                 if !preceding_gap_ok(value_cursor.text(), value_start, Some(b':')) {
                     return Err(EvalError::malformed_json_text(value_cursor.text()));
                 }
+            }
+        }
+        // #2261/#2288: trailing stray comma after the object's real last
+        // field, checked regardless of whether `name` matched anything --
+        // see this function's own doc comment above.
+        if let Some(last) = last_value_cursor {
+            if !trailing_element_gap_ok(&last, b'}') {
+                return Err(EvalError::malformed_json_text(last.text()));
             }
         }
         Ok(winner.map(|(_, field, _)| field.value()))
@@ -4381,9 +4398,56 @@ mod tests {
         );
     }
 
+    /// #2288: the mirror image of the two tests above -- an *earlier*,
+    /// non-winning duplicate's own missing colon must be ignored once a
+    /// later, well-formed occurrence supersedes it. Pins the doc comment's
+    /// own key claim ("an earlier same-named field's own delimiter gap is
+    /// moot once a later one supersedes it") in the direction the other
+    /// two tests don't cover.
+    #[test]
+    fn test_find_ignores_missing_colon_on_superseded_earlier_duplicate_2288() {
+        let json = br#"{"a" 1,"a":2}"#;
+        let index = JsonIndex::build(json);
+        let root = index.root(json);
+        let StandardJson::Object(fields) = root.value() else {
+            panic!("expected object");
+        };
+        let value = fields
+            .find("a")
+            .unwrap_or_else(|e| panic!("superseded duplicate's own gap should be ignored: {e:?}"));
+        match value {
+            Some(StandardJson::Number(n)) => assert_eq!(n.as_i64().unwrap(), 2),
+            other => panic!("expected the winning duplicate's value 2, got {other:?}"),
+        }
+    }
+
+    /// #2288: `find` (unlike `find_cursor`, already fixed for this shape by
+    /// #2261) had no trailing-stray-comma check either -- a trailing `,`
+    /// after the object's real last field used to slip through silently,
+    /// whether or not `name` matched anything.
+    #[test]
+    fn test_find_rejects_trailing_comma_after_real_last_field_2288() {
+        let json = br#"{"a":1,}"#;
+        let index = JsonIndex::build(json);
+        let root = index.root(json);
+        let StandardJson::Object(fields) = root.value() else {
+            panic!("expected object");
+        };
+        for name in ["a", "nonexistent"] {
+            let err = fields
+                .find(name)
+                .expect_err(&format!("{name}: trailing comma should raise"));
+            assert!(
+                err.message.contains("Invalid JSON text"),
+                "{name}: message: {}",
+                err.message
+            );
+        }
+    }
+
     /// #2288: well-formed objects (including a duplicate key, exercising
     /// the same winning-occurrence resolution as the tests above) are
-    /// unaffected by the new delimiter check.
+    /// unaffected by the new delimiter and trailing-comma checks.
     #[test]
     fn test_find_wellformed_unaffected_by_delimiter_check_2288() {
         for json in [

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -22568,6 +22568,40 @@ fn test_jq_len_checked_and_collect_cursors_checked_siblings_wellformed_unaffecte
     Ok(())
 }
 
+/// #2288: `has(key)` on objects now also raises on a non-string sibling key
+/// (#1194/#1995's `key_is_malformed`), but -- like the #2261 trailing-comma
+/// check above -- only when that key is visited *before* the match, riding
+/// `contains_checked`'s existing per-key walk for free rather than paying
+/// for a full scan on every call (see `contains_checked`'s own doc comment
+/// for the ~4x-regression measurement that rules out an unconditional full
+/// scan). A malformed key strictly *after* the match is the same class of
+/// documented, accepted early-exit gap #2261 already established for the
+/// trailing comma -- pinned here rather than left as an unstated limitation
+/// of the fix.
+#[test]
+fn test_jq_has_object_rejects_nonstring_key_before_match_2288() -> Result<()> {
+    // Malformed key visited *before* the match -- caught, free.
+    let (out, stderr, code) = run_jq_full(&["-c", "has(\"a\")"], Some(r#"{123:1,"a":2}"#))?;
+    assert_eq!(code, 5, "out: {out:?}, stderr: {stderr:?}");
+    assert!(out.trim().is_empty(), "unexpected output {out:?}");
+    assert!(stderr.contains("Invalid JSON text"), "stderr: {stderr:?}");
+
+    // Malformed key visited *after* the match -- documented, accepted gap:
+    // real jq raises here too (it can't parse the document at all), but
+    // catching it would mean walking past every early match, every time.
+    let (out, stderr, code) = run_jq_full(&["-c", "has(\"a\")"], Some(r#"{"a":1,123:2}"#))?;
+    assert_eq!(code, 0, "known gap: out: {out:?}, stderr: {stderr:?}");
+    assert_eq!(out.trim(), "true", "known gap: unexpected output");
+
+    // No match at all -- the walk already reaches the malformed key
+    // regardless of where it sits, so this always raises.
+    let (out, stderr, code) = run_jq_full(&["-c", "has(\"z\")"], Some(r#"{"a":1,123:2}"#))?;
+    assert_eq!(code, 5, "out: {out:?}, stderr: {stderr:?}");
+    assert!(stderr.contains("Invalid JSON text"), "stderr: {stderr:?}");
+
+    Ok(())
+}
+
 /// #2261: `len_checked`/`Expr::Index`'s own #1677 *leading*-gap check (a
 /// malformed comma *between* two real elements, `[1,,3]`) is the sibling
 /// case to this issue's own trailing-comma repro, and shares the same new


### PR DESCRIPTION
## Summary

Fixes #2288: two pre-existing gaps found reviewing #1995/PR #2287, both unrelated to that
PR's own non-string-key fix (which only touched `find`/`find_cursor`'s malformed-key
check, not `has`/`contains`, and not `find`'s own missing #1677/#2261 checks).

### 1. `has(key)`/`contains()` on objects didn't raise on a non-string sibling key

A different malformed-JSON class than #2261's trailing comma (#1194/#1995's own
`key_is_malformed`):

```console
$ echo '{"a":1,123:2}' | jq  -c 'has("a")'
jq: parse error: Object keys must be strings at line 1, column 11
$ echo '{"a":1,123:2}' | succinctly jq -c 'has("a")'
true                                          # WRONG -- before this fix
```

### 2. `JsonFields::find` was missing both of `find_cursor`'s checks

Unlike its `find_cursor` sibling, `find` had neither the #1677 `,`/`:` delimiter check nor
the #2261 trailing-comma check:

```console
$ succinctly's JsonFields::find("a") on {"a" 1}    # Ok(Some(1)) -- WRONG, no colon check
$ succinctly's JsonFields::find("a") on {"a":1,}   # Ok(Some(1)) -- WRONG, no trailing-comma check
$ succinctly's JsonFields::find_cursor(...) on both  # Err(...) -- correct, already had both
```

## Fix (round 1)

- **`has(key)`/`contains()`**: `DocumentFields::contains_checked` (already checking
  `,`/`:` delimiters and #2261's own trailing-comma gap) now also checks for a
  non-string key on every key it visits during its existing early-exit walk — free,
  riding the same walk, **but only for keys visited before a match**. A malformed key
  strictly *after* the match remains a documented, accepted gap — the identical shape
  #2261's own `has(key)` fix already established for the trailing comma: there's no O(1)
  shortcut to "is there a malformed key anywhere else in this object," so closing it
  fully would mean walking to the object's true end on *every* `has()` call — the same
  ~4x regression #2261 already measured and rejected.

  **This means the issue's own headline repro (`{"a":1,123:2} | has("a")`) is still
  open** — the match ("a") precedes the bad key (123). `{123:1,"a":2} | has("a")` is
  now fixed, since the bad key is visited first. A non-match still walks to the true end
  regardless, so it always catches it.

- **`find`**: gained the same `,`/`:` delimiter check `find_cursor` already had.
  Confirmed **not reachable from either shipped CLI today** — the identical
  "library-API-only" shape #2293 already established for `eval.rs`'s whole parallel
  evaluator (`find`'s only production caller is `eval.rs`'s `find_field`/
  `index_object_by_name`, and `eval.rs` is only ever reached, from either CLI, via
  `succinctly yq`'s reindex bridge, which hands it a cursor built from an
  already-materialized, pre-validated value). Fixed anyway since it's narrow and
  mechanical.

## Fix (round 2 — code-review follow-up)

A second `/code-review` pass on this PR found and confirmed live:

- **`find` was still missing the #2261 trailing-comma check** `find_cursor` has — round 1
  only ported the `,`/`:` delimiter check. Fixed by threading the same
  `trailing_element_gap_ok` check through, unconditional on whether `name` matched
  anything, exactly mirroring `find_cursor`. Added a test for this shape, plus a
  previously-missing test for the mirror-image "an earlier, non-winning duplicate's own
  gap is correctly ignored once superseded" case.
- **A redundant decode pass**: `contains_checked`'s round-1 fix called `key_is_malformed`
  *and* `key_display_string` separately per key — two independent decodes where one
  suffices (`key_is_malformed(k) == key_display_string_kind(k).is_none()` by
  construction). Switched to a single `key_display_string_kind` call deriving both
  signals. A/B: `has("k0")` over a 1,000,000-key object went from ~0.04s (round 1) to
  ~0.03s (round 2, matching/beating the pre-fix baseline).
- **Cross-referenced** (not re-filed): `eval.rs`'s own `has_one_key` shares this same
  non-string-key gap — already tracked under #2293's own `eval.rs` sweep.

## Verification

- Live-verified against `/usr/bin/jq` 1.7.1: all repro shapes match or are documented as
  an accepted, precedented divergence (see `docs/compliance/jq/limitations.md`).
- New unit tests: 6 in `src/json/light.rs` (`find`'s delimiter check, trailing-comma
  check, superseded-duplicate case, well-formed sanity) + 1 CLI test in
  `tests/jq_cli_tests.rs` (`has(key)`'s before/after/no-match matrix).
- Full test suite: 57/57 test binaries, 0 failures (re-run after round 2).
- `cargo clippy --all-targets --all-features -- -D warnings`, `cargo fmt --check`,
  `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features`: all clean (re-run
  after round 2).
- Patch coverage: pending (background run in progress, will report before merge).

Fixes #2288
