### PR TITLE
perf(jq): extend #2086's reduce fast path to array/object accumulators

### DIFF
--- a/docs/compliance/jq/limitations.md
+++ b/docs/compliance/jq/limitations.md
@@ -3155,13 +3155,45 @@ since `eval_owned_fast_path` is shared by 3 call sites (`eval_each_owned`,
 the fallback branch, not just the one new arm; tracked as
 [#2157](https://github.com/rust-works/succinctly/issues/2157).
 
-Array/object-accumulating shapes (`reduce ... as $x ([]; . + [$x])`) are
-**not** covered by #2086's fix at all -- after
-substitution the right-hand side is an `Expr::Array`/`Expr::Object`
-construction wrapping a `Literal`, not a bare `Literal` itself, so it still
-falls through to the same slow path, and measures *worse* than the string
-case ever did (~36s at just 25,000 elements); tracked separately as
-[#2152](https://github.com/rust-works/succinctly/issues/2152). A precomputed fanout-product bound
+Array/object-accumulating shapes (`reduce ... as $x ([]; . + [$x])`) were
+**not** covered by #2086's fix at all -- after substitution the right-hand
+side is an `Expr::Array`/`Expr::Object` construction wrapping a `Literal`,
+not a bare `Literal` itself, so it fell through to the same slow path, and
+measured *worse* than the string case ever did (~36s at just 25,000
+elements). Closed by [#2152](https://github.com/rust-works/succinctly/issues/2152)'s
+`literal_shaped_expr_to_owned` (`eval.rs`), which extends the same
+`eval_owned_fast_path` arm to recognize an `Expr::Array`/`Expr::Object`
+right-hand side whose every leaf is itself a `Literal` (or, for a dynamic
+object key, resolves to one), converting it to an `OwnedValue` directly the
+same way `literal_to_owned` already does for the scalar case, then reusing
+`arith_combine` exactly as #2086's own arm does -- no new arithmetic
+semantics, only a new way to build the operand. Same "constant factor, not
+asymptotic" caveat as #2086's own fix above applies here too (still calls
+`input.clone()` per step, #2157's own residual is unchanged) -- measured
+directly: 25,000-element array accumulation dropped from ~38.8s to ~6.0-6.6s
+(~6x), and the analogous object-accumulator idiom
+(`reduce ... as $x ({}; . + {($x): v})`) went from *not completing inside
+60s* to ~6.3s at the same N. Interleaved A/B at two sizes confirms the same
+quadratic shape survives at a smaller constant, matching #2157's own
+finding for the string case (5,000: ~1.36s -> ~0.25s, 10,000: ~5.77s ->
+~0.91s -- before roughly quadruples per doubling of N, after roughly
+triples).
+
+**One correction to the AST shape this issue's own text guessed, confirmed
+live via a debug probe against the real repro rather than assumed**: a
+*single*-element array literal like `[$x]` does **not** wrap its substituted
+element in `Expr::Comma` -- `parse_array_construction` only introduces a
+`Comma` node when an actual `,` token is present inside `[...]`, so `[$x]`
+parses as `Expr::Array(Box::new(Expr::Var("x")))`, and after `substitute_var`
+folds `$x` into a `Literal` the shape is
+`Expr::Array(Box::new(Expr::Literal(...)))` -- a *bare* `Literal` directly
+inside `Array`, not `Expr::Array(Box::new(Expr::Comma(vec![Expr::Literal(...)])))`
+as this issue's own "Suggested fix direction" section stated. `literal_shaped_expr_to_owned`
+handles both shapes (a bare non-`Comma` inner expression, and an actual
+multi-element `Comma`), confirmed by a dedicated unit test
+(`test_2152_literal_shaped_expr_to_owned_single_element_array_has_no_comma_wrapper`)
+rather than relying on the single repro's own AST happening to exercise the
+right arm. A precomputed fanout-product bound
 (INIT-fork count x element count, both known before either loop starts)
 would not avoid this either way -- for the single-INIT-fork case #2079
 reports, fork count is 1, so the product collapses to the element count and

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -60875,6 +60875,15 @@ mod tests {
             outputs(b"null", r"reduce (1,2) as $x ({}; . + {count: $x})"),
             [r#"{"count":2}"#]
         );
+        // Coverage: the `Expr::Builtin(Builtin::Empty)` arm (an empty
+        // array literal, `[]`, `owned_to_expr`'s own empty-array shape and
+        // also directly parseable) is only reached via a genuinely empty
+        // `[...]` on the right of `+` -- every other case above has at
+        // least one element.
+        assert_eq!(
+            outputs(b"null", r"reduce (1,2) as $x ([1]; . + [])"),
+            ["[1]"]
+        );
     }
 
     #[test]
@@ -60938,6 +60947,16 @@ mod tests {
                 ]))),
                 0
             ),
+            None
+        );
+        // Same rejection, but through the *bare* (non-`Comma`) single-child
+        // array arm rather than the `Comma`-items loop above -- `[.foo]`
+        // parses as `Expr::Array(Box::new(Expr::Field("foo")))`, with no
+        // `Comma` wrapper (same shape a single substituted element takes,
+        // see the sibling AST-shape test), so this exercises that arm's
+        // own `?` failure path independently of the multi-element one.
+        assert_eq!(
+            literal_shaped_expr_to_owned(&Expr::Array(Box::new(Expr::Field("foo".to_string()))), 0),
             None
         );
         assert_eq!(

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -28008,6 +28008,69 @@ pub(crate) fn eval_reduce_with_values<'a, W: Clone + AsRef<[u64]>, S: EvalSemant
 /// comment (`eval_generic.rs`) for the exact limitation (only the
 /// immediately-next bare `tostring` is covered) and #1134, which tracks
 /// the general fix neither sibling attempts.
+/// Converts `expr` to an `OwnedValue` directly, without the general
+/// evaluator, succeeding only when every leaf `expr` reaches is already an
+/// `Expr::Literal` -- the exact shape `substitute_var`'s `Expr::Var` arm
+/// (via `owned_to_expr_at_depth`) leaves behind when a `reduce`/`foreach`
+/// UPDATE body's bound variable sits inside an array/object accumulator
+/// literal (`. + [$x]`, `. + {($x): true}`, #2152). Returns `None` for
+/// anything else, so [`eval_owned_fast_path`]'s own caller falls back to
+/// the general evaluator unchanged -- this never has to recognize every
+/// possible shape, only the ones substitution can actually produce.
+///
+/// Confirmed live (not assumed from #2152's own text, which guessed a
+/// different, incorrect AST shape): `[$x]` parses as
+/// `Expr::Array(Box::new(Expr::Var("x")))` -- `parse_array_construction`
+/// only wraps its inner expression in `Expr::Comma` when an actual `,`
+/// token is present, so a *single*-element array's inner expression is
+/// substituted directly, with no `Comma` wrapper at all
+/// (`Expr::Array(Box::new(Expr::Literal(...)))` post-substitution, not
+/// `Expr::Array(Box::new(Expr::Comma(vec![Expr::Literal(...)])))`) --
+/// handled here via the recursive call on `inner` directly for any shape
+/// other than `Comma`, rather than assuming every array has one.
+///
+/// Object keys: a static key (`ObjectKey::Literal`) needs no conversion; a
+/// dynamic key (`ObjectKey::Expr`, `{($x): ...}`) is handled the same
+/// recursive way and must itself resolve to `OwnedValue::String` (jq's own
+/// rule for what a computed object key may be) or this returns `None`.
+/// Duplicate keys are collected in entry order and folded via
+/// `IndexMap`'s own `FromIterator`, matching `eval_object_construction`'s
+/// identical `acc.into_iter().collect::<IndexMap<_, _>>()` -- same
+/// later-value-wins, first-position-kept semantics, not reimplemented.
+fn literal_shaped_expr_to_owned(expr: &Expr) -> Option<OwnedValue> {
+    match expr {
+        Expr::Literal(lit) => Some(literal_to_owned(lit)),
+        Expr::Array(inner) => match inner.as_ref() {
+            Expr::Builtin(Builtin::Empty) => Some(OwnedValue::Array(Vec::new())),
+            Expr::Comma(items) => {
+                let mut out = vec_with_capacity(items.len());
+                for item in items {
+                    out.push(literal_shaped_expr_to_owned(item)?);
+                }
+                Some(OwnedValue::Array(out))
+            }
+            single => Some(OwnedValue::Array(vec![literal_shaped_expr_to_owned(
+                single,
+            )?])),
+        },
+        Expr::Object(entries) => {
+            let mut out = vec_with_capacity(entries.len());
+            for entry in entries {
+                let key = match &entry.key {
+                    ObjectKey::Literal(s) => s.clone(),
+                    ObjectKey::Expr(e) => match literal_shaped_expr_to_owned(e)? {
+                        OwnedValue::String(s) => s,
+                        _ => return None,
+                    },
+                };
+                out.push((key, literal_shaped_expr_to_owned(&entry.value)?));
+            }
+            Some(OwnedValue::Object(out.into_iter().collect()))
+        }
+        _ => None,
+    }
+}
+
 fn eval_owned_fast_path<S: EvalSemantics>(
     expr: &Expr,
     input: &OwnedValue,
@@ -28038,11 +28101,14 @@ fn eval_owned_fast_path<S: EvalSemantics>(
         // it only shrinks the constant factor -- the fold remains O(n^2)
         // over a growing accumulator; see #2157 and
         // docs/compliance/jq/limitations.md.
+        //
+        // #2152: extended from a bare `Expr::Literal` `right` to any shape
+        // [`literal_shaped_expr_to_owned`] recognizes -- the array/object
+        // accumulator idioms (`. + [$x]`, `. + {($x): true}`) that #2086's
+        // own body flagged as unmeasured and out of scope at the time.
         Expr::Arithmetic { op, left, right } if matches!(left.as_ref(), Expr::Identity) => {
-            let Expr::Literal(lit) = right.as_ref() else {
-                return None;
-            };
-            match arith_combine::<S>(*op, input.clone(), literal_to_owned(lit)) {
+            let rhs = literal_shaped_expr_to_owned(right.as_ref())?;
+            match arith_combine::<S>(*op, input.clone(), rhs) {
                 Ok(v) => Some(Ok(Some(v))),
                 // Mirrors the `Field`/`Index` arms' own `_ if optional`
                 // convention below, so a caller that ever does reach this
@@ -60761,6 +60827,117 @@ mod tests {
         assert_eq!(
             outputs(b"null", r#"(reduce range(3) as $x (1; . + "a"))?"#),
             Vec::<&str>::new()
+        );
+    }
+
+    #[test]
+    fn test_2152_array_object_accumulator_fast_path_matches_general_evaluator() {
+        // #2152: extends #2086's fast-path arm from a bare `Expr::Literal`
+        // `right` to any shape `literal_shaped_expr_to_owned` recognizes --
+        // the array/object accumulator idioms (`. + [$x]`, `. + {($x):
+        // v}`) #2086's own body flagged as unmeasured. Every case here is
+        // confirmed live against jq 1.7.1 to still agree byte-for-byte with
+        // the general evaluator's answer.
+        assert_eq!(
+            outputs(b"null", r"reduce (1,2,3) as $x ([]; . + [$x])"),
+            ["[1,2,3]"]
+        );
+        assert_eq!(
+            outputs(b"null", r#"reduce ("a","b") as $x ([9]; . + [$x, "sep"])"#),
+            [r#"[9,"a","sep","b","sep"]"#]
+        );
+        assert_eq!(
+            outputs(b"null", r"reduce (1,2) as $x ([]; . + [[$x]])"),
+            ["[[1],[2]]"]
+        );
+        assert_eq!(
+            outputs(
+                b"null",
+                r#"reduce ("a","b","a") as $x ({}; . + {($x): true})"#
+            ),
+            [r#"{"a":true,"b":true}"#]
+        );
+        assert_eq!(
+            outputs(b"null", r"reduce (1,2) as $x ({}; . + {count: $x})"),
+            [r#"{"count":2}"#]
+        );
+    }
+
+    #[test]
+    fn test_2152_array_object_accumulator_fast_path_type_error_respects_optional() {
+        // #2152: same convention as #2086's own sibling test above, now
+        // exercised for the array/object RHS shapes this issue adds.
+        // Confirmed live against jq 1.7.1: unsuppressed errors, suppressed
+        // emits nothing.
+        query!(b"\"str\"", r"reduce (1,2) as $x (.; . + [$x])",
+            QueryResult::Error(e) => {
+                assert!(e.message.contains("cannot be added"));
+            }
+        );
+        assert_eq!(
+            outputs(b"\"str\"", r"(reduce (1,2) as $x (.; . + [$x]))?"),
+            Vec::<&str>::new()
+        );
+    }
+
+    #[test]
+    fn test_2152_literal_shaped_expr_to_owned_single_element_array_has_no_comma_wrapper() {
+        // #2152 review: pins the exact AST shape confirmed live (a debug
+        // probe against the real repro), correcting this issue's own
+        // stated hypothesis (`Expr::Array(Expr::Comma([Literal(...)]))`) --
+        // `parse_array_construction` only wraps its inner expression in
+        // `Expr::Comma` when an actual `,` token is present, so a single
+        // substituted element leaves a *bare* `Expr::Literal` directly
+        // inside `Expr::Array`, with no `Comma` in between. Both shapes
+        // are exercised so a future change to either the parser's or
+        // `literal_shaped_expr_to_owned`'s own assumption is caught here
+        // rather than only showing up as a silent fast-path miss.
+        let bare = Expr::Array(Box::new(Expr::Literal(Literal::Int(1))));
+        assert_eq!(
+            literal_shaped_expr_to_owned(&bare),
+            Some(OwnedValue::Array(vec![OwnedValue::Int(1)]))
+        );
+        let comma = Expr::Array(Box::new(Expr::Comma(vec![
+            Expr::Literal(Literal::Int(1)),
+            Expr::Literal(Literal::Int(2)),
+        ])));
+        assert_eq!(
+            literal_shaped_expr_to_owned(&comma),
+            Some(OwnedValue::Array(vec![
+                OwnedValue::Int(1),
+                OwnedValue::Int(2)
+            ]))
+        );
+    }
+
+    #[test]
+    fn test_2152_literal_shaped_expr_to_owned_falls_back_on_non_literal_leaf() {
+        // A shape this function doesn't recognize (a field access mixed
+        // into an otherwise-literal array/object) must return `None`, not
+        // a wrong/partial value -- the caller's whole point in checking
+        // for `None` is to fall back to the general evaluator safely.
+        assert_eq!(
+            literal_shaped_expr_to_owned(&Expr::Array(Box::new(Expr::Comma(vec![
+                Expr::Literal(Literal::Int(1)),
+                Expr::Field("foo".to_string()),
+            ])))),
+            None
+        );
+        assert_eq!(
+            literal_shaped_expr_to_owned(&Expr::Object(vec![ObjectEntry {
+                key: ObjectKey::Literal("a".to_string()),
+                value: Expr::Field("foo".to_string()),
+            }])),
+            None
+        );
+        // A dynamic key that doesn't resolve to a string is also rejected,
+        // matching jq's own "object keys must be strings" rule.
+        assert_eq!(
+            literal_shaped_expr_to_owned(&Expr::Object(vec![ObjectEntry {
+                key: ObjectKey::Expr(Box::new(Expr::Literal(Literal::Int(1)))),
+                value: Expr::Literal(Literal::Bool(true)),
+            }])),
+            None
         );
     }
 

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -28010,13 +28010,16 @@ pub(crate) fn eval_reduce_with_values<'a, W: Clone + AsRef<[u64]>, S: EvalSemant
 /// the general fix neither sibling attempts.
 /// Converts `expr` to an `OwnedValue` directly, without the general
 /// evaluator, succeeding only when every leaf `expr` reaches is already an
-/// `Expr::Literal` -- the exact shape `substitute_var`'s `Expr::Var` arm
-/// (via `owned_to_expr_at_depth`) leaves behind when a `reduce`/`foreach`
-/// UPDATE body's bound variable sits inside an array/object accumulator
-/// literal (`. + [$x]`, `. + {($x): true}`, #2152). Returns `None` for
-/// anything else, so [`eval_owned_fast_path`]'s own caller falls back to
-/// the general evaluator unchanged -- this never has to recognize every
-/// possible shape, only the ones substitution can actually produce.
+/// `Expr::Literal` -- the shape `substitute_var`'s `Expr::Var` arm (via
+/// `owned_to_expr_at_depth`) leaves behind when a `reduce`/`foreach`
+/// UPDATE body's bound variable sits *directly* inside an array/object
+/// accumulator literal (`. + [$x]`, `. + {($x): true}`, #2152). Returns
+/// `None` for anything else -- notably, a leaf that is itself computed
+/// rather than merely placed (`. + [$x + 1]`, `Expr::Arithmetic`, not
+/// `Expr::Literal`) is not recognized and falls back to the general
+/// evaluator unchanged, same as [`eval_owned_fast_path`]'s own caller does
+/// for any other unrecognized shape -- this function's job is narrow
+/// (literal-tree conversion only), not "every way `$x` might appear".
 ///
 /// Confirmed live (not assumed from #2152's own text, which guessed a
 /// different, incorrect AST shape): `[$x]` parses as
@@ -28037,7 +28040,17 @@ pub(crate) fn eval_reduce_with_values<'a, W: Clone + AsRef<[u64]>, S: EvalSemant
 /// `IndexMap`'s own `FromIterator`, matching `eval_object_construction`'s
 /// identical `acc.into_iter().collect::<IndexMap<_, _>>()` -- same
 /// later-value-wins, first-position-kept semantics, not reimplemented.
-fn literal_shaped_expr_to_owned(expr: &Expr) -> Option<OwnedValue> {
+///
+/// `depth`/`assert_value_tree_depth` (#2152 review): this walks exactly
+/// the `Expr::Array`/`Expr::Object` shapes `owned_to_expr_at_depth` builds
+/// (#1025's own guard against unbounded recursion when splicing a value
+/// back into the AST) -- not currently reachable past that ceiling, since
+/// every input either comes from that same guarded splice or from
+/// `MAX_EXPR_DEPTH`-bounded parsed source, but guarded explicitly anyway
+/// to match every other recursive `Expr`/`OwnedValue`-tree walker in this
+/// file rather than relying on an upstream bound staying in place.
+fn literal_shaped_expr_to_owned(expr: &Expr, depth: usize) -> Option<OwnedValue> {
+    assert_value_tree_depth(depth);
     match expr {
         Expr::Literal(lit) => Some(literal_to_owned(lit)),
         Expr::Array(inner) => match inner.as_ref() {
@@ -28045,12 +28058,13 @@ fn literal_shaped_expr_to_owned(expr: &Expr) -> Option<OwnedValue> {
             Expr::Comma(items) => {
                 let mut out = vec_with_capacity(items.len());
                 for item in items {
-                    out.push(literal_shaped_expr_to_owned(item)?);
+                    out.push(literal_shaped_expr_to_owned(item, depth + 1)?);
                 }
                 Some(OwnedValue::Array(out))
             }
             single => Some(OwnedValue::Array(vec![literal_shaped_expr_to_owned(
                 single,
+                depth + 1,
             )?])),
         },
         Expr::Object(entries) => {
@@ -28058,12 +28072,12 @@ fn literal_shaped_expr_to_owned(expr: &Expr) -> Option<OwnedValue> {
             for entry in entries {
                 let key = match &entry.key {
                     ObjectKey::Literal(s) => s.clone(),
-                    ObjectKey::Expr(e) => match literal_shaped_expr_to_owned(e)? {
+                    ObjectKey::Expr(e) => match literal_shaped_expr_to_owned(e, depth + 1)? {
                         OwnedValue::String(s) => s,
                         _ => return None,
                     },
                 };
-                out.push((key, literal_shaped_expr_to_owned(&entry.value)?));
+                out.push((key, literal_shaped_expr_to_owned(&entry.value, depth + 1)?));
             }
             Some(OwnedValue::Object(out.into_iter().collect()))
         }
@@ -28107,7 +28121,7 @@ fn eval_owned_fast_path<S: EvalSemantics>(
         // accumulator idioms (`. + [$x]`, `. + {($x): true}`) that #2086's
         // own body flagged as unmeasured and out of scope at the time.
         Expr::Arithmetic { op, left, right } if matches!(left.as_ref(), Expr::Identity) => {
-            let rhs = literal_shaped_expr_to_owned(right.as_ref())?;
+            let rhs = literal_shaped_expr_to_owned(right.as_ref(), 0)?;
             match arith_combine::<S>(*op, input.clone(), rhs) {
                 Ok(v) => Some(Ok(Some(v))),
                 // Mirrors the `Field`/`Index` arms' own `_ if optional`
@@ -60894,7 +60908,7 @@ mod tests {
         // rather than only showing up as a silent fast-path miss.
         let bare = Expr::Array(Box::new(Expr::Literal(Literal::Int(1))));
         assert_eq!(
-            literal_shaped_expr_to_owned(&bare),
+            literal_shaped_expr_to_owned(&bare, 0),
             Some(OwnedValue::Array(vec![OwnedValue::Int(1)]))
         );
         let comma = Expr::Array(Box::new(Expr::Comma(vec![
@@ -60902,7 +60916,7 @@ mod tests {
             Expr::Literal(Literal::Int(2)),
         ])));
         assert_eq!(
-            literal_shaped_expr_to_owned(&comma),
+            literal_shaped_expr_to_owned(&comma, 0),
             Some(OwnedValue::Array(vec![
                 OwnedValue::Int(1),
                 OwnedValue::Int(2)
@@ -60917,27 +60931,74 @@ mod tests {
         // a wrong/partial value -- the caller's whole point in checking
         // for `None` is to fall back to the general evaluator safely.
         assert_eq!(
-            literal_shaped_expr_to_owned(&Expr::Array(Box::new(Expr::Comma(vec![
-                Expr::Literal(Literal::Int(1)),
-                Expr::Field("foo".to_string()),
-            ])))),
+            literal_shaped_expr_to_owned(
+                &Expr::Array(Box::new(Expr::Comma(vec![
+                    Expr::Literal(Literal::Int(1)),
+                    Expr::Field("foo".to_string()),
+                ]))),
+                0
+            ),
             None
         );
         assert_eq!(
-            literal_shaped_expr_to_owned(&Expr::Object(vec![ObjectEntry {
-                key: ObjectKey::Literal("a".to_string()),
-                value: Expr::Field("foo".to_string()),
-            }])),
+            literal_shaped_expr_to_owned(
+                &Expr::Object(vec![ObjectEntry {
+                    key: ObjectKey::Literal("a".to_string()),
+                    value: Expr::Field("foo".to_string()),
+                }]),
+                0
+            ),
             None
         );
         // A dynamic key that doesn't resolve to a string is also rejected,
         // matching jq's own "object keys must be strings" rule.
         assert_eq!(
-            literal_shaped_expr_to_owned(&Expr::Object(vec![ObjectEntry {
-                key: ObjectKey::Expr(Box::new(Expr::Literal(Literal::Int(1)))),
-                value: Expr::Literal(Literal::Bool(true)),
-            }])),
+            literal_shaped_expr_to_owned(
+                &Expr::Object(vec![ObjectEntry {
+                    key: ObjectKey::Expr(Box::new(Expr::Literal(Literal::Int(1)))),
+                    value: Expr::Literal(Literal::Bool(true)),
+                }]),
+                0
+            ),
             None
+        );
+    }
+
+    /// `Expr::Array`-nesting analog of `linear_array_nest` (`OwnedValue`),
+    /// one level per `Expr::Array` wrapping a bare `Expr::Literal(Int(0))`
+    /// innermost.
+    fn linear_expr_array_nest(depth: usize) -> Expr {
+        let mut e = Expr::Literal(Literal::Int(0));
+        for _ in 0..depth {
+            e = Expr::Array(Box::new(e));
+        }
+        e
+    }
+
+    #[test]
+    fn test_2152_literal_shaped_expr_to_owned_panics_past_nesting_depth_limit() {
+        // #2152 review: `literal_shaped_expr_to_owned` walks exactly the
+        // `Expr::Array`/`Expr::Object` shapes `owned_to_expr_at_depth`
+        // builds (#1025's own guarded splice), but had no depth guard of
+        // its own -- unlike every other recursive `Expr`/`OwnedValue`-tree
+        // walker in this file. Not reachable past `MAX_VALUE_TREE_DEPTH`
+        // in practice (bounded transitively by `MAX_EXPR_DEPTH`/
+        // `owned_to_expr_at_depth`'s own guard), but pinned directly here
+        // anyway so a future call site that feeds this function an
+        // unbounded tree fails loudly instead of risking an uncatchable
+        // stack overflow.
+        use crate::jq::value::MAX_VALUE_TREE_DEPTH;
+
+        let under = linear_expr_array_nest(MAX_VALUE_TREE_DEPTH - 1);
+        assert!(literal_shaped_expr_to_owned(&under, 0).is_some());
+
+        let over = linear_expr_array_nest(MAX_VALUE_TREE_DEPTH);
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+            literal_shaped_expr_to_owned(&over, 0)
+        }));
+        assert!(
+            result.is_err(),
+            "literal_shaped_expr_to_owned should panic at MAX_VALUE_TREE_DEPTH"
         );
     }
 


### PR DESCRIPTION
## Summary

Fixes #2152: `reduce`/`foreach`'s array/object-accumulating UPDATE body
(`. + [$x]`, `. + {($x): v}`) fell through to the general evaluator's JSON
round-trip -- the same shape #2086 fixed for the string/number case, but
measurably worse (~36-38s at 25,000 elements for array accumulation; object
accumulation didn't complete inside 60s at the same N).

- Adds `literal_shaped_expr_to_owned` (`src/jq/eval.rs`), which converts an
  `Expr::Array`/`Expr::Object` right-hand side whose every leaf is already an
  `Expr::Literal` directly to an `OwnedValue`, then reuses `arith_combine`
  exactly as #2086's own arm does -- no new arithmetic semantics, only a new
  way to build the operand. Falls back to the general evaluator (`None`) for
  anything else, so this can never mishandle a shape it doesn't recognize.
- Corrects an AST-shape claim from #2152's own issue text, confirmed live via
  a debug probe against the real repro rather than assumed: a single-element
  array literal like `[$x]` does **not** wrap its substituted element in
  `Expr::Comma` -- `parse_array_construction` only introduces one when an
  actual `,` token is present, so the real shape is a bare `Expr::Literal`
  directly inside `Expr::Array`. Both shapes are handled, pinned by a
  dedicated unit test rather than relying on the one repro's own AST
  happening to exercise the right arm.
- Still O(n²) after this fix, same residual #2157 already tracks for the
  string/number case (still clones the accumulator per step) -- a
  constant-factor win only, not asymptotic. Documented in
  `docs/compliance/jq/limitations.md` alongside the AST-shape correction.

## Measurements

Interleaved A/B against the pre-fix binary (same methodology as #2086's own
measurement):

| N | array accum, before | array accum, after |
|---|---|---|
| 5,000 | ~1.36s | ~0.25s (5.5x) |
| 10,000 | ~5.77s | ~0.91s (6.3x) |
| 25,000 | ~38.8s | ~6.0-6.6s (~6x) |

Object accumulation (`reduce ... as $x ({}; . + {($x): v})`) at N=25,000:
did not complete inside 60s before this fix, ~6.3s after.

## Test plan

- [x] `cargo build --features cli`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings`
- [x] `cargo fmt --check`
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features`
- [x] `cargo test --features cli,simd,regex,serde --no-fail-fast` (all green, including 4 new tests and the pre-existing #2086 regression tests)
- [x] `cargo test --no-fail-fast` (default features)
- [x] `cargo test --no-default-features --verbose` (no_std)
- [x] Differential-verified 15+ cases against the pinned jq 1.7.1 oracle (array/object accumulation, mixed literals, nested arrays, duplicate keys, type errors, `?`/`try`-catch suppression, `foreach`/`until` variants) -- all byte-for-byte identical
