### PR TITLE
fix(jq): guard Array/StringInterpolation/delpaths_one uncatchable errors

### DIFF
--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -33433,6 +33433,21 @@ fn eval_stage_with_path_context<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
                 &mut out,
             ) {
                 Ok(()) => owned_vec_to_result(out),
+                // #2292 review round 2: an uncatchable error must survive
+                // unconditionally, and can't safely take the
+                // prefix-preserving `partial(out, ...)` path below this
+                // match -- `intermediate` would then flow into
+                // `continue_rest_with_fresh_root`'s own `Partial` arm,
+                // which re-wraps it through `catch_error_under_optional`;
+                // that helper has no uncatchable-error awareness at all and
+                // would silently drop `e` under a future `optional == true`
+                // regardless. A hard return here (discarding `out`) is the
+                // only way this arm can actually guarantee what the other
+                // three #2292 sites guarantee, matching the `Array` arm's
+                // own atomic treatment above.
+                Err(Control::Error(e)) if e.is_uncatchable_at_value_position() => {
+                    return QueryResult::Error(e);
+                }
                 // `?` swallows only a genuine error, and -- unlike the
                 // `Array` arm's atomic catch above -- string
                 // interpolation's own already-produced output survives the
@@ -33441,14 +33456,6 @@ fn eval_stage_with_path_context<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
                 // `{"a":1}`, not `[1,error("x")]?`'s empty result.
                 // `Break`/`Halt` are never caught by `?`, matching every
                 // other `?` site in this file.
-                // #2292 review: an uncatchable error must survive this
-                // arm's own `optional` swallow unconditionally too, same as
-                // every other site this issue and #2270/#2289 touch --
-                // falls through to `Err(control) => partial(...)` below,
-                // preserving whatever prefix `out` already holds.
-                Err(Control::Error(e)) if e.is_uncatchable_at_value_position() => {
-                    partial(out, Control::Error(e))
-                }
                 // #2212/#2227: currently unreachable with `optional ==
                 // true` in *this* (path-context) evaluator (see this
                 // function's own doc comment) -- the jq 1.7.1-verified

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -33264,12 +33264,26 @@ fn eval_stage_with_path_context<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
                 QueryResult::Owned(v) => vec![v],
                 QueryResult::ManyOwned(vs) => vs,
                 QueryResult::None => vec![],
+                // #2292 review: an uncatchable error (a decode failure or a
+                // yq negative-index raise -- see
+                // `EvalError::is_uncatchable_at_value_position`'s own doc
+                // comment) must survive this arm's own `optional` swallow
+                // unconditionally, the same way `Expr::Optional`/
+                // `Expr::Try`'s arms above already do (#2270/#2289).
+                // Currently inert either way -- `optional` is proven always
+                // `false` at this function's own entry (see this function's
+                // own doc comment) -- but kept as the same defensive parity
+                // #2270/#2289 established for the sibling arms, against a
+                // future change reintroducing a `true`-producer.
+                QueryResult::Error(e) if e.is_uncatchable_at_value_position() => {
+                    return QueryResult::Error(e);
+                }
                 // #2212/#2227: currently unreachable with `optional ==
                 // true` (see this function's own doc comment) --
                 // `inner_result`'s own ambient `false` a few lines up
                 // doesn't affect what this arm reads, `optional` here is
                 // still the function's own top-level parameter.
-                QueryResult::Error(_) | QueryResult::Partial(_, Control::Error(_)) if optional => {
+                QueryResult::Error(_) if optional => {
                     return QueryResult::None;
                 }
                 QueryResult::Error(e) => return QueryResult::Error(e),
@@ -33279,6 +33293,14 @@ fn eval_stage_with_path_context<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
                 // identical reasoning): a control signal after some output
                 // still abandons the whole array rather than keeping a
                 // partial one.
+                QueryResult::Partial(_, Control::Error(e))
+                    if e.is_uncatchable_at_value_position() =>
+                {
+                    return QueryResult::Error(e);
+                }
+                QueryResult::Partial(_, Control::Error(_)) if optional => {
+                    return QueryResult::None;
+                }
                 QueryResult::Partial(_, Control::Error(e)) => return QueryResult::Error(e),
                 QueryResult::Partial(_, Control::Break(label)) => return QueryResult::Break(label),
                 QueryResult::Partial(_, Control::Halt(code)) => return QueryResult::Halt(code),
@@ -33344,16 +33366,34 @@ fn eval_stage_with_path_context<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
                             vs.first().map(owned_to_string::<S>).unwrap_or_default()
                         }
                         QueryResult::None => String::new(),
+                        // #2292 review: an uncatchable error (a decode
+                        // failure or a yq negative-index raise) must
+                        // survive this arm's own `optional` swallow
+                        // unconditionally, the same way `Expr::Optional`/
+                        // `Expr::Try`'s arms and the `Array` arm above
+                        // already do (#2270/#2289/#2292). Currently inert
+                        // either way -- `optional` is proven always `false`
+                        // at this function's own entry -- kept for the same
+                        // defensive parity.
+                        QueryResult::Error(e) if e.is_uncatchable_at_value_position() => {
+                            return QueryResult::Error(e);
+                        }
                         // #2212/#2227: currently unreachable with `optional
                         // == true` (see this function's own doc comment).
-                        QueryResult::Error(_) | QueryResult::Partial(_, Control::Error(_))
-                            if optional =>
-                        {
+                        QueryResult::Error(_) if optional => {
                             return QueryResult::None;
                         }
                         QueryResult::Error(e) => return QueryResult::Error(e),
                         QueryResult::Break(label) => return QueryResult::Break(label),
                         QueryResult::Halt(code) => return QueryResult::Halt(code),
+                        QueryResult::Partial(_, Control::Error(e))
+                            if e.is_uncatchable_at_value_position() =>
+                        {
+                            return QueryResult::Error(e);
+                        }
+                        QueryResult::Partial(_, Control::Error(_)) if optional => {
+                            return QueryResult::None;
+                        }
                         QueryResult::Partial(_, Control::Error(e)) => {
                             return QueryResult::Error(e);
                         }
@@ -33401,6 +33441,14 @@ fn eval_stage_with_path_context<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
                 // `{"a":1}`, not `[1,error("x")]?`'s empty result.
                 // `Break`/`Halt` are never caught by `?`, matching every
                 // other `?` site in this file.
+                // #2292 review: an uncatchable error must survive this
+                // arm's own `optional` swallow unconditionally too, same as
+                // every other site this issue and #2270/#2289 touch --
+                // falls through to `Err(control) => partial(...)` below,
+                // preserving whatever prefix `out` already holds.
+                Err(Control::Error(e)) if e.is_uncatchable_at_value_position() => {
+                    partial(out, Control::Error(e))
+                }
                 // #2212/#2227: currently unreachable with `optional ==
                 // true` in *this* (path-context) evaluator (see this
                 // function's own doc comment) -- the jq 1.7.1-verified
@@ -40989,8 +41037,14 @@ fn delpaths_one<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
         // (`eval_assign`/`eval_update`/`builtin_path`/`builtin_setpath`/
         // `builtin_del` all `return QueryResult::Error(e)` unconditionally
         // for it) -- `delete_paths_sorted`'s own ordinary errors are
-        // unaffected, since `is_uncatchable()` is `false` for those.
-        Err(e) if optional && !e.is_uncatchable() => QueryResult::None,
+        // unaffected, since `is_uncatchable_at_value_position()` is `false`
+        // for those. This is a value-position `?` dispatch point (unlike
+        // `resolve_node`'s own path-tracking one), so it uses the same
+        // narrower predicate `eval_try`/`each_try`/`try_single_generic`/
+        // `each_try_generic` do (review, #2292) -- behavior-identical to
+        // the broader `is_uncatchable()` this used before, since
+        // `is_invalid_path_expression()` is never actually raised here.
+        Err(e) if optional && !e.is_uncatchable_at_value_position() => QueryResult::None,
         Err(e) => e.into(),
     }
 }


### PR DESCRIPTION
## Summary
- `eval_stage_with_path_context`'s `Expr::Array` and `Expr::StringInterpolation` arms, and `delpaths_one`'s optional-swallow, had the same missing uncatchable-error guard that #2270/#2289 fixed for the `Try`/`Optional` pair: an `optional` swallow (`if optional => None`) could in principle absorb a decode failure or yq negative-index raise that must always propagate, per `EvalError::is_uncatchable_at_value_position`.
- Adds the same positive-first guard (`QueryResult::Error(e) if e.is_uncatchable_at_value_position() => return QueryResult::Error(e)`, mirrored for the `Partial(_, Control::Error(e))` variant) ahead of each `if optional` arm, matching the structure `eval_try` already uses and that #2270's round-2 review settled on.
- The jq-mode `build_string_parts_with_context` fallback **hard-returns** (`return QueryResult::Error(e)`) rather than routing through `partial(out, ...)` — round-2 review found the prefix-preserving path doesn't actually guarantee survival: `continue_rest_with_fresh_root`'s `Partial` arm re-wraps it through `catch_error_under_optional`, which has no uncatchable-error awareness and would silently drop it under a future `optional == true` anyway. Hard-returning matches the `Array` arm's own atomic treatment and is the only way this site can actually deliver the guarantee it claims.
- `delpaths_one`'s guard changed from `!e.is_uncatchable()` to `!e.is_uncatchable_at_value_position()`, since this is a value-position dispatch point (not `resolve_node`'s own path-tracking resolver), and `is_invalid_path_expression()` is not itself uncatchable at value position (see #2270).
- All sites are currently inert: `optional` is proven always `false` at `eval_stage_with_path_context`'s entry today (per that function's own doc comment), and `delete_paths_sorted` never actually raises `is_invalid_path_expression()`. This is defensive parity against a future change reintroducing a `true`-producer or a raise, matching the precedent #2270/#2289 already established — no new test or limitations.md entry, since there's no live, observable behavior change today.
- Round-1 review (10 independent finder angles) also surfaced that the *same* carve-out is missing from `catch_error_under_optional` itself and its other callers (`Iterate`, `Map`, `continue_rest_with_context`, `continue_rest_with_paths`) — two of which are live/reachable, not inert. That's a materially larger change (a shared choke point touching frequently-exercised code paths) and is out of scope here; filed as #2302.

Closes #2292.

## Test plan
- [x] `cargo test --lib jq::` — 1974 passed
- [x] `cargo test --test yq_cli_tests --features cli` — 1389 passed
- [x] `cargo test --test jq_cli_tests --features cli` — 1366 passed
- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings`
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features`
