### PR TITLE
fix(jq): swap json_bytes_to_owned_value's remaining call sites to checked (#2295)

### DIFF
--- a/src/bin/succinctly/jq_runner.rs
+++ b/src/bin/succinctly/jq_runner.rs
@@ -2987,8 +2987,8 @@ fn find_literal_end(bytes: &[u8], pos: usize) -> Option<usize> {
 /// `serde::de::IgnoredAny`: `IgnoredAny` doesn't range-check numbers at
 /// all, so a magnitude-overflowing literal (`1e400`) that `Value`
 /// correctly rejects ("number out of range") would instead silently reach
-/// `json_bytes_to_owned_value` and materialize as `null` -- trading a
-/// clear error for silent data loss (#1095 review). `parse_json_stream`
+/// [`json_bytes_to_owned_value_checked`] and materialize as `null` --
+/// trading a clear error for silent data loss (#1095 review). `parse_json_stream`
 /// below doesn't call this: it validates a whole multi-value stream via
 /// `serde_json::Deserializer` instead of one value via `from_str`, a
 /// structurally different mechanism this helper can't drive.
@@ -2997,14 +2997,27 @@ fn validate_json_str(s: &str) -> serde_json::Result<()> {
 }
 
 /// Validate `s` via `validate_json_str`, then materialize the real
-/// `OwnedValue` from those same bytes via `json_bytes_to_owned_value` --
-/// the full "validate, then reparse the same span" pattern #1163 asked to
+/// `OwnedValue` from those same bytes via [`json_bytes_to_owned_value_checked`]
+/// -- the full "validate, then reparse the same span" pattern #1163 asked to
 /// share, for the call sites where the validated string and the
 /// materialized string are the same one. `parse_json_value`'s own
 /// leading-zero/low-surrogate retry (#1094/#2012) can't use this for its
 /// retry branch (it validates a *normalized* copy but must still
 /// materialize the *original* text, see its own comment), so that branch
 /// calls `validate_json_str` directly instead.
+///
+/// #2295: [`json_bytes_to_owned_value_checked`], not the bare, panicking
+/// materializer this used to call directly -- `s` is genuinely external
+/// text (`--argjson`/`--jsonargs`), and
+/// `serde_json::from_str`'s own default recursion limit (128) only
+/// *incidentally* protects the panicking `generic_to_owned` call the bare
+/// version reaches past `MAX_NESTING_DEPTH` (256); it was never a designed
+/// guard for this call site and would silently stop protecting it if
+/// `validate_json_str` were ever skipped, relaxed, or `serde_json`'s own
+/// default changed. `validate_json_delimiters`'s own `check_nesting_depth`
+/// call converts that panic into a catchable `EvalError` instead, matching
+/// the shape #2282 already fixed for `succinctly yq --eval-all`'s
+/// analogous gap.
 fn validate_and_materialize_json(
     s: &str,
 ) -> serde_json::Result<core::result::Result<OwnedValue, EvalError>> {
@@ -3013,7 +3026,7 @@ fn validate_and_materialize_json(
     // it may trigger the caller's leading-zero retry. A decode failure
     // (#1247) is not a validation failure serde could disagree about, so it
     // must not be mistaken for one -- retrying would just fail again.
-    Ok(crate::output::json_bytes_to_owned_value(s.as_bytes()))
+    Ok(json_bytes_to_owned_value_checked(s.as_bytes()))
 }
 
 /// Parse a JSON value from a string (`--argjson`/`--jsonargs`), preserving
@@ -3061,7 +3074,16 @@ fn parse_json_value(s: &str) -> Result<OwnedValue> {
             // silently rewrite the value's source spelling.
             let normalized = normalize_json_leniently(s);
             if normalized != s && validate_json_str(&normalized).is_ok() {
-                return crate::output::json_bytes_to_owned_value(s.as_bytes())
+                // #2295: checked, not the bare materializer -- same
+                // reasoning as `validate_and_materialize_json`'s own call
+                // site above (`s` is external text; `normalize_json_leniently`
+                // only rewrites number/escape spelling, never container
+                // structure, so `s`'s own nesting depth is identical to
+                // `normalized`'s already-validated one -- but relying on
+                // that equivalence to skip a real depth guard here would be
+                // exactly the "incidental, fragile" protection #2295 warns
+                // against).
+                return json_bytes_to_owned_value_checked(s.as_bytes())
                     .map_err(|e| anyhow::anyhow!("Invalid JSON: {s}: {e}"));
             }
 
@@ -3397,8 +3419,8 @@ fn normalize_leading_zero_numbers(s: &str) -> String {
 /// Preserves number-literal source fidelity the same way `parse_json_value`
 /// does for `--argjson` (#1058, extended here to `--slurpfile`, #1093):
 /// `serde_json::Deserializer::byte_offset()` delimits each value's own
-/// span within the stream, and `json_bytes_to_owned_value` materializes
-/// the real result from that span.
+/// span within the stream, and [`json_bytes_to_owned_value_checked`]
+/// materializes the real result from that span.
 ///
 /// Doesn't *primarily* share span-finding with `find_json_values` (above,
 /// #1163 follow-up question), despite both walking a byte string to
@@ -3490,7 +3512,15 @@ fn parse_json_stream_strict(s: &str) -> Result<Vec<OwnedValue>> {
             // it apart from an I/O failure and report it in jq's own channel
             // at exit 5. Flattening lost that, and the run exited 1 with an
             // `Error:` prefix jq never prints (#1194).
-            crate::output::json_bytes_to_owned_value(&bytes[start..end])
+            //
+            // #2295: checked, not the bare materializer -- `serde_json`'s
+            // own `Deserializer` above already rejected anything past its
+            // default 128-deep recursion limit before this line runs, but
+            // that's the same incidental (not designed-for-this-purpose)
+            // protection #2295 found fragile elsewhere in this file --
+            // this is the primary `--slurp`/`--slurpfile` document-input
+            // path, worth the same defense-in-depth swap.
+            json_bytes_to_owned_value_checked(&bytes[start..end])
                 .map_err(|e| anyhow::Error::from(MalformedJsonError(e)))?,
         );
         prev_end = end;
@@ -3823,8 +3853,15 @@ fn parse_json_seq_with_ends(s: &str) -> Vec<(OwnedValue, usize)> {
         // this record yields -- empty for one it dropped, so there is no
         // separate "does this parse" gate here.
         for &(vs, ve) in &ranges {
-            let Ok(v) = crate::output::json_bytes_to_owned_value(&raw_segment.as_bytes()[vs..ve])
-            else {
+            // #2295: checked, not the bare materializer -- `seq_value_is_valid`
+            // (above, via `seq_record_scan`) already filters most malformed
+            // values via its own designed `validate::validate` depth guard,
+            // but reaching for the checked materializer here too costs
+            // nothing (a delimiter/depth `Err` folds into the same
+            // `else { continue }` a decode failure already takes below) and
+            // removes the reliance on that upstream guard's specific limit
+            // never drifting independently of this one.
+            let Ok(v) = json_bytes_to_owned_value_checked(&raw_segment.as_bytes()[vs..ve]) else {
                 // Parses but will not decode (#1247): dropped, exactly as
                 // the pre-#1723 path dropped it.
                 continue;
@@ -4018,8 +4055,8 @@ fn seq_pending_token_is_terminated(
 /// #2012 fixed for `--argjson` reappearing one function over).
 ///
 /// Normalization is needed *here* and only here: the value-building side
-/// (`json_bytes_to_owned_value`, reached once a record is judged valid)
-/// already reads `0007` as `7` and substitutes U+FFFD for a lone low
+/// ([`json_bytes_to_owned_value_checked`], reached once a record is judged
+/// valid) already reads `0007` as `7` and substitutes U+FFFD for a lone low
 /// surrogate on its own -- so it needs no fallback of its own for either
 /// leniency.
 fn seq_value_is_valid(value_text: &str) -> bool {
@@ -5646,13 +5683,13 @@ fn check_preceding_delimiter<W: AsRef<[u64]>>(
 /// check `print_json`'s object/array arms perform, needed again here for a
 /// caller that doesn't go through `print_json` at all.
 ///
-/// [`crate::output::json_bytes_to_owned_value`]'s own doc comment says
-/// plainly that it "performs no validation of its own" and expects the
-/// caller to have done so first; [`parse_json_stream`]'s fallback below
-/// (which backs `-S`, `-C`, and `--slurp` -- none of which route through
-/// `print_json`) was calling it directly on unvalidated bytes, so `{"a"
-/// 1}` would silently materialize as `{"a":1}` under those flags even
-/// though the default `sjq -c .` path already rejects it since #1643.
+/// The evaluator's own materializer performs no validation of its own; it
+/// expects the caller to have done so first -- [`parse_json_stream`]'s
+/// fallback below (which backs `-S`, `-C`, and `--slurp` -- none of which
+/// route through `print_json`) used to call it directly on unvalidated
+/// bytes, so `{"a" 1}` would silently materialize as `{"a":1}` under those
+/// flags even though the default `sjq -c .` path already rejects it since
+/// #1643.
 ///
 /// `depth` guards against a stack overflow on adversarially deep input the
 /// same way [`generic_to_owned`]'s own recursion does, but as a catchable
@@ -5765,13 +5802,28 @@ fn validate_json_delimiters<W: AsRef<[u64]>>(
     Ok(())
 }
 
-/// [`crate::output::json_bytes_to_owned_value`], preceded by the #1643
-/// delimiter check that function's own doc comment says its caller must
-/// supply. Used only by [`parse_json_stream`]'s fallback -- every other
-/// caller of the unchecked version re-serializes an already-validated span
-/// (`--argjson`'s retry re-validates its normalized copy against
-/// `serde_json` before ever reaching it; the primary lazy input path
-/// validates via `print_json` instead).
+/// Materializes a complete JSON document into an `OwnedValue` via the
+/// evaluator's own `generic_to_owned`, preceded by the #1643 delimiter
+/// check `bytes` must already satisfy -- `validate_json_delimiters`'s own
+/// `check_nesting_depth` call also converts `generic_to_owned`'s panicking
+/// `MAX_NESTING_DEPTH` guard into a catchable `EvalError` (#2295), so every
+/// caller here is protected against adversarially deep input by a real,
+/// designed guard rather than an unrelated library's incidental default.
+///
+/// #2295: used by every call site in this file that parses genuinely
+/// external text -- `validate_and_materialize_json` and `parse_json_value`'s
+/// leading-zero/low-surrogate retry (`--argjson`/`--jsonargs`),
+/// `parse_json_stream_strict` (the primary `--slurp`/`--slurpfile`
+/// document-input path), and the `--seq` per-record materializer. Before
+/// #2295 only `parse_json_stream`'s `find_json_values` fallback used this;
+/// every other caller reached a since-removed bare, panicking version
+/// directly (`crate::output::json_bytes_to_owned_value`, now dead code with
+/// no remaining callers -- deleted rather than left unused),
+/// protected only incidentally by whichever upstream validator happened to
+/// run first (`serde_json`'s own default 128-deep recursion limit, or
+/// `validate::validate`'s own designed guard for `--seq`) -- fragile if
+/// that upstream step were ever skipped, relaxed, or its own limit changed
+/// independently of this one.
 fn json_bytes_to_owned_value_checked(bytes: &[u8]) -> core::result::Result<OwnedValue, EvalError> {
     let index = JsonIndex::build(bytes);
     let cursor = index.root(bytes);

--- a/src/bin/succinctly/output.rs
+++ b/src/bin/succinctly/output.rs
@@ -12,50 +12,12 @@ use succinctly::jq::escape::{
     escape_json_body as run_escaper, write_json_body_jq, write_json_body_jq_ascii,
     write_json_body_yq, write_json_body_yq_ascii,
 };
-use succinctly::jq::eval_generic::to_owned as generic_to_owned;
 use succinctly::jq::{
     assert_value_tree_depth, format_number_jq_compat, nonfinite_display_string, EvalError,
     JqSemantics, NumberRepr, OwnedValue, StreamError,
 };
-use succinctly::json::JsonIndex;
 use succinctly::yaml::format_float_with_fraction;
 pub use succinctly::yaml::format_float_yq;
-
-/// Materialize a complete JSON document into an `OwnedValue`, preserving
-/// each number's exact source spelling (`1.500` stays `1.500`, `1e100`
-/// stays exponent notation) the way a document read from the program's
-/// primary input already does -- unlike routing through
-/// `serde_json::Value`, whose `Number` variant round-trips only through
-/// Rust's own `f64`/`i64` `Display` and loses that spelling (#1058).
-///
-/// `bytes` must already be known-valid JSON with no trailing content --
-/// this crate's own semi-indexer is deliberately lenient (`42 garbage`
-/// parses as `42` with the rest silently ignored, #284) and performs no
-/// validation of its own. Callers that accept raw external text (a CLI
-/// argument, a file) need their own strict pre-validation pass first; see
-/// `jq_runner::parse_json_value`'s doc comment for why that pass can't
-/// simply reuse the `serde_json::Value` it produces.
-///
-/// Shared by `jq_runner::parse_json_value` (`--argjson`/`--jsonargs`) and
-/// `yq_runner::parse_input`'s `InputFormat::Json` arm (the primary input
-/// path) -- previously two independent copies of the same three-line
-/// `JsonIndex::build`/`.root()`/`generic_to_owned` sequence (#1095 review).
-/// `yq_runner::parse_input` immediately discards the preserved spelling
-/// this function keeps (`canonicalize_json_numbers`, #978/#999) -- kept
-/// local to `yq_runner.rs` rather than a second variant here, since it's a
-/// yq-CLI-specific oracle quirk this shared helper has no business knowing
-/// about.
-///
-/// Fallible since #1247: a string that fails to decode raises instead of
-/// materializing as `null`. Every caller here re-serializes an *already
-/// decoded* `OwnedValue`, so in practice this cannot fail on those paths --
-/// but the signature says so rather than a comment promising it, and the
-/// `--argjson`/`--jsonargs` paths take genuinely external text.
-pub fn json_bytes_to_owned_value(bytes: &[u8]) -> Result<OwnedValue, EvalError> {
-    let index = JsonIndex::build(bytes);
-    let cursor = index.root(bytes);
-    generic_to_owned(&cursor.value())
-}
 
 /// Which terminator follows a written value: NUL (`-0`/`--nul-output`),
 /// a bare newline (the default), or nothing (`-j`/`--join-output`). `nul`

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -29966,9 +29966,10 @@ fn test_fromjson_lone_high_surrogate_key_no_longer_silently_collapses_2013() {
 /// `src/bin/succinctly/jq_runner.rs`) is a *third*, independent surrogate
 /// decoder from the two #2008 already fixed above -- it validates via
 /// `serde_json` first, which rejects a lone low surrogate outright, before
-/// this crate's own leniency (`json_bytes_to_owned_value`) ever gets a
-/// chance to run. Confirmed live against the pinned oracle before the fix
-/// (succinctly errored, real jq substituted U+FFFD, exit 0 either way).
+/// this crate's own leniency (`json_bytes_to_owned_value_checked`, #2295)
+/// ever gets a chance to run. Confirmed live against the pinned oracle
+/// before the fix (succinctly errored, real jq substituted U+FFFD, exit 0
+/// either way).
 #[test]
 fn test_argjson_low_surrogate_substitutes_replacement_character_2012() {
     let (stdout, stderr, code) =
@@ -35074,6 +35075,13 @@ fn test_stderr_in_update_assignment_target_2234() -> Result<()> {
 /// path), `parse_json_value`'s retry branch, `parse_json_stream_strict`
 /// (the primary `--slurp`/`--slurpfile` document-input path), and the
 /// `--seq` per-record materializer.
+///
+/// The leniency assertions here overlap
+/// `test_argjson_tolerates_leading_zero_number_1094`/
+/// `test_argjson_low_surrogate_substitutes_replacement_character_2012`
+/// deliberately -- this test's own point is pinning all four sites'
+/// behavior together as one #2295-scoped regression suite, not replacing
+/// those issue-scoped ones.
 #[test]
 fn test_argjson_wellformed_and_leniency_unaffected_by_checked_swap_2295() -> Result<()> {
     // Happy path (`validate_and_materialize_json`).

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -35065,3 +35065,58 @@ fn test_stderr_in_update_assignment_target_2234() -> Result<()> {
     assert_eq!(stderr, "1");
     Ok(())
 }
+
+/// #2295: every `json_bytes_to_owned_value` call site left unchecked now
+/// routes through `json_bytes_to_owned_value_checked` instead -- pins that
+/// the swap doesn't regress well-formed input or either leniency
+/// (`--argjson`'s own leading-zero/low-surrogate retry) at any of the four
+/// fixed call sites: `validate_and_materialize_json` (`--argjson`'s happy
+/// path), `parse_json_value`'s retry branch, `parse_json_stream_strict`
+/// (the primary `--slurp`/`--slurpfile` document-input path), and the
+/// `--seq` per-record materializer.
+#[test]
+fn test_argjson_wellformed_and_leniency_unaffected_by_checked_swap_2295() -> Result<()> {
+    // Happy path (`validate_and_materialize_json`).
+    let (out, code) = run_jq_null("$x", &["-c", "--argjson", "x", r#"{"a":1,"b":[1,2,3]}"#])?;
+    assert_eq!(code, 0, "out: {out:?}");
+    assert_eq!(out.trim(), r#"{"a":1,"b":[1,2,3]}"#);
+
+    // Leading-zero leniency retry (`parse_json_value`'s own branch).
+    let (out, code) = run_jq_null("$x", &["-c", "--argjson", "x", "007"])?;
+    assert_eq!(code, 0, "out: {out:?}");
+    assert_eq!(out.trim(), "7");
+
+    // Lone low-surrogate leniency, the retry's other half (#2012).
+    let (out, code) = run_jq_null("$x", &["-c", "--argjson", "x", r#""\udc00""#])?;
+    assert_eq!(code, 0, "out: {out:?}");
+    assert_eq!(out.trim(), "\"\u{fffd}\"");
+    Ok(())
+}
+
+/// #2295: `parse_json_stream_strict` (`--slurp`/`--slurpfile`'s primary
+/// document-input path) unaffected by the checked swap.
+#[test]
+fn test_slurp_wellformed_unaffected_by_checked_swap_2295() -> Result<()> {
+    let (stdout, stderr, code) = run_jq_full(&["--slurp", "-c", "."], Some(r#"{"a":1} {"b":2}"#))?;
+    assert_eq!(code, 0, "stderr: {stderr:?}");
+    assert_eq!(stdout.trim(), r#"[{"a":1},{"b":2}]"#);
+    Ok(())
+}
+
+/// #2295: `--seq`'s own per-record materializer (both delimiter checks and
+/// leniency) unaffected by the checked swap. `--seq` prefixes *output*
+/// records with an RS byte too (RFC 7464), same as real jq -- confirmed
+/// against `/usr/bin/jq` 1.7.1 -- so the expected values below carry it.
+#[test]
+fn test_seq_wellformed_and_leniency_unaffected_by_checked_swap_2295() -> Result<()> {
+    let (stdout, stderr, code) = run_jq_full(&["--seq", "-c", "."], Some("\x1e[1,2,3]\n"))?;
+    assert_eq!(code, 0, "stderr: {stderr:?}");
+    assert_eq!(stdout.trim(), "\x1e[1,2,3]");
+
+    // Leading-zero leniency (#1243), the same normalization `--argjson`
+    // shares via `normalize_json_leniently`.
+    let (stdout, stderr, code) = run_jq_full(&["--seq", "-c", "."], Some("\x1e007\n"))?;
+    assert_eq!(code, 0, "stderr: {stderr:?}");
+    assert_eq!(stdout.trim(), "\x1e7");
+    Ok(())
+}


### PR DESCRIPTION
## Summary

Fixes #2295: `json_bytes_to_owned_value` (`output.rs`) called the panicking
`eval_generic::to_owned` directly, with no depth pre-check of its own, at
four call sites parsing genuinely external text -- `--argjson`/`--jsonargs`,
`--slurp`/`--slurpfile`'s primary document-input path, and `--seq`'s
per-record materializer.

Each was protected only *incidentally* by whichever upstream validator
happened to run first (`serde_json`'s own default recursion limit for the
first three, `validate::validate`'s own designed guard for `--seq`) --
confirmed live **not currently exploitable**, but fragile if that upstream
step were ever skipped, relaxed, or its own limit changed independently,
per this project's own #1098 precedent that a CLI-reachable panic is worth
closing even when not currently live.

## Fix

Switched all four call sites to `json_bytes_to_owned_value_checked` (already
existed -- used only by `parse_json_stream`'s `find_json_values` fallback
before this PR), which threads `validate_json_delimiters`'s own
`check_nesting_depth` call ahead of the materializer, converting the panic
into a catchable `EvalError` -- the same shape #2282 already fixed for
`succinctly yq --eval-all`'s analogous gap.

`json_bytes_to_owned_value` itself is now dead code with no remaining
callers anywhere (confirmed via grep across `src/`/`tests/`) -- **deleted**
rather than left unused, along with its now-unused `generic_to_owned`/
`JsonIndex` imports in `output.rs`. Fixed six stale doc-comment references
to the deleted function across `jq_runner.rs`.

## Verification

- Live-verified against `/usr/bin/jq` 1.7.1: well-formed input and both
  `--argjson` leniencies (leading zero #1094, lone low surrogate #2012)
  unaffected at every fixed call site.
- New CLI regression tests (`tests/jq_cli_tests.rs`): well-formed +
  leniency sanity for `--argjson` (both leniencies), `--slurp`, and `--seq`
  (including its own RS-byte output framing, confirmed against
  `/usr/bin/jq` too).
- Full test suite: 57/57 test binaries, 0 failures.
- `cargo clippy --all-targets --all-features -- -D warnings`, `cargo fmt
  --check`, `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features`:
  all clean.
- Deep-nesting boundary investigated at length (see below) -- the fix is
  correct and matches the issue's own scope, but is provably a no-observable-
  difference defense-in-depth improvement for this exact repro shape at
  every one of the four sites, since each site's own upstream validator
  already rejects deep input before reaching the materializer either way.
  Kept anyway per the issue's own stated rationale (removing reliance on an
  *incidental* protection, not a designed one).

## A distinct, more severe bug found along the way -- filed separately as #2299

Investigating the exact depth boundary here surfaced that `succinctly jq
--slurp '.'` on ordinary deeply-nested JSON **panics live**, through a
completely different function (`materialize_stream_item`'s own unguarded
`generic_to_owned` calls in `jq_runner.rs`, converting the *filter's output*
back to `OwnedValue` for printing) -- no exotic flags needed, just ordinary
`--slurp` usage. Unlike every #2295 site, this one is not incidentally
protected by anything. Filed as #2299 rather than folded in here: it's a
different mechanism (evaluator output re-materialization, not input
parsing), and a real depth-counting discrepancy between
`json_bytes_to_owned_value_checked`'s own guard and `to_owned_at_depth`'s
actual panic point needs resolving first, not just adding a same-shaped
guard.

Fixes #2295
