### PR TITLE
fix(yq): del()/delpaths() raise on a negative out-of-range index (#2268)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -289,6 +289,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`del()`/`delpaths()` silently no-op on a negative out-of-range array index instead of
+  raising** (#2268): #2254 already fixed every ordinary *read* (`.a[-N]`) to raise real yq's
+  own "index [N] out of range" error, but `del()`/`delpaths()` shared the identical gap with a
+  more severe symptom — not a differently-worded error, but no error at all (exit 0, document
+  unchanged), where real yq aborts the write. Three independent array arms shared it
+  (`delete_at_path`'s `del()` dispatch, `delete_paths_under`'s `delpaths()` mid-path
+  navigation, `delete_keys`'s `delpaths()` terminal batch), fixed via a new `bool`-based
+  sibling of #2254's own `yq_negative_index_check`/`yq_negative_index_error` helpers (these
+  three take a plain `yq_mode: bool`, not `S: EvalSemantics`). Unlike the read-side fix, not
+  suppressible by an earlier `?` in the path chain — confirmed live, real yq's own
+  `del(.a?[-5])` still raises. One residual divergence documented, not chased: when grouped
+  with an earlier same-array deletion in one `delpaths()` call, real yq's own error reports
+  the array's *already-shrunk* size (sequential resolution), where this crate's own
+  `delete_keys` deliberately resolves every key against the array's length on entry (the
+  invariant that makes an overlapping range union rather than compound) — still correctly
+  raises either way, only the reported number can differ, and only in that one
+  multi-key-same-array shape. Also surfaced, and filed separately as #2305 (out of this
+  issue's negative-index scope): real yq's `del()` on a *positive* out-of-range index extends
+  the array with nulls instead of no-op, which succinctly (matching jq) doesn't reproduce.
 - **`has(key)`/`contains()` on objects didn't raise on a non-string sibling key
   (`{"a":1,123:2}`), and `JsonFields::find` (unlike its `find_cursor` sibling) had neither
   the #1677 `,`/`:` delimiter check nor the #2261 trailing-comma check at all** (#2288,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -293,11 +293,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   raising** (#2268): #2254 already fixed every ordinary *read* (`.a[-N]`) to raise real yq's
   own "index [N] out of range" error, but `del()`/`delpaths()` shared the identical gap with a
   more severe symptom — not a differently-worded error, but no error at all (exit 0, document
-  unchanged), where real yq aborts the write. Three independent array arms shared it
-  (`delete_at_path`'s `del()` dispatch, `delete_paths_under`'s `delpaths()` mid-path
-  navigation, `delete_keys`'s `delpaths()` terminal batch), fixed via a new `bool`-based
-  sibling of #2254's own `yq_negative_index_check`/`yq_negative_index_error` helpers (these
-  three take a plain `yq_mode: bool`, not `S: EvalSemantics`). Unlike the read-side fix, not
+  unchanged), where real yq aborts the write. Five independent array arms shared it
+  (`delete_at_path`'s single-step `del()` dispatch, `delete_path_steps`'s mid-chain `del()`
+  equivalent for a pipe-chained path like `del(.a[-5].x)`, `delete_trie_array`'s equivalent for
+  a comma-grouped path like `del(.a[-5].x, .c)` — code review found the latter two, missed in
+  the first pass — plus `delpaths()`'s own `delete_paths_under` mid-path navigation and
+  `delete_keys` terminal batch), fixed via a new `bool`-based sibling of #2254's own
+  `yq_negative_index_check`/`yq_negative_index_error` helpers (all five take a plain
+  `yq_mode: bool`, not `S: EvalSemantics`). Unlike the read-side fix, not
   suppressible by an earlier `?` in the path chain — confirmed live, real yq's own
   `del(.a?[-5])` still raises. One residual divergence documented, not chased: when grouped
   with an earlier same-array deletion in one `delpaths()` call, real yq's own error reports

--- a/docs/compliance/yq/limitations.md
+++ b/docs/compliance/yq/limitations.md
@@ -1739,11 +1739,15 @@ $ echo '{"a":[1,2]}' | yq -o=json 'del(.a[-5])'          # Error: index [-5] out
 $ echo '{"a":[1,2]}' | succinctly yq 'del(.a[-5])' -o json  # {"a":[1,2]} -- WRONG, before this fix
 ```
 
-Three independent array arms shared the gap, none `EvalSemantics`-aware (all three take a
+Five independent array arms shared the gap, none `EvalSemantics`-aware (all five take a
 plain `yq_mode: bool`, not generic `S`, so the fix reuses a new `bool`-based sibling of
 `yq_negative_index_check`/`yq_negative_index_error` rather than threading `S` through the
 whole delete-path recursion): `delete_at_path`'s own `Expr::Index` array arm (`del()`'s
-literal-index dispatch), `delete_paths_under`'s array arm (`delpaths()`'s mid-path
+single-step literal-index dispatch), `delete_path_steps`'s own mid-chain `Expr::Index` arm
+(a pipe-chained `del()` path, e.g. `del(.a[-5].x)` -- missed in the first pass, found by code
+review), `delete_trie_array`'s own `ArrayStep::Index` arm (a comma-grouped `del()` path, e.g.
+`del(.a[-5].x, .c)`, which real yq aborts *entirely* on -- `.c` is not deleted either -- also
+missed in the first pass), `delete_paths_under`'s array arm (`delpaths()`'s mid-path
 navigation, e.g. `delpaths([["a",-5]])`), and `delete_keys`'s array arm (`delpaths()`'s
 terminal per-container batch, e.g. `delpaths([[-5]])`). Unlike the read-side fix, this one is
 **not** suppressible by an earlier `?` in the path chain -- confirmed live, `del(.a?[-5])`
@@ -1764,9 +1768,9 @@ this one multi-key-same-array shape.
 
 **A separate, unrelated divergence found investigating this one, not fixed here**: real yq's
 `del()` on a *positive* out-of-range index doesn't no-op the way jq does -- it extends the
-array with `null`s up to that position (`del(.[5])` on `[1,2]` yields a 6-element array with 4
-trailing nulls in real yq, confirmed live), where succinctly (matching jq) leaves the array
-unchanged. Filed separately as
+array with `null`s up to (not including) that position (`del(.[5])` on `[1,2]` yields a
+5-element array, `[1,2,null,null,null]`, in real yq, confirmed live), where succinctly
+(matching jq) leaves the array unchanged. Filed separately as
 [#2305](https://github.com/rust-works/succinctly/issues/2305), since it's about a positive
 index and has nothing to do with #2268's own negative-index scope.
 

--- a/docs/compliance/yq/limitations.md
+++ b/docs/compliance/yq/limitations.md
@@ -1727,6 +1727,49 @@ consolidating what `eval_try`/`each_try`/`try_single_generic`/`each_try_generic`
 `eval_generic.rs`) already hand-copied inline at six sites onto one shared definition,
 matching this function's own two new call sites too.
 
+### `del()`/`delpaths()` on a negative out-of-range index now raise too (#2268)
+
+[#2268](https://github.com/rust-works/succinctly/issues/2268). #2254 above fixed every
+*ordinary read* (`.a[-N]`); `del()`/`delpaths()` had the identical gap but a more severe
+symptom -- not a differently-worded error, but silently no-op (exit 0, document unchanged)
+where real yq aborts the whole operation:
+
+```bash
+$ echo '{"a":[1,2]}' | yq -o=json 'del(.a[-5])'          # Error: index [-5] out of range, array size is 2
+$ echo '{"a":[1,2]}' | succinctly yq 'del(.a[-5])' -o json  # {"a":[1,2]} -- WRONG, before this fix
+```
+
+Three independent array arms shared the gap, none `EvalSemantics`-aware (all three take a
+plain `yq_mode: bool`, not generic `S`, so the fix reuses a new `bool`-based sibling of
+`yq_negative_index_check`/`yq_negative_index_error` rather than threading `S` through the
+whole delete-path recursion): `delete_at_path`'s own `Expr::Index` array arm (`del()`'s
+literal-index dispatch), `delete_paths_under`'s array arm (`delpaths()`'s mid-path
+navigation, e.g. `delpaths([["a",-5]])`), and `delete_keys`'s array arm (`delpaths()`'s
+terminal per-container batch, e.g. `delpaths([[-5]])`). Unlike the read-side fix, this one is
+**not** suppressible by an earlier `?` in the path chain -- confirmed live, `del(.a?[-5])`
+still raises the identical error in real yq, matching `del()`'s own `optional` parameter's
+established scope (a `?`/type-mismatch suppression, never extended to this new check).
+
+**One residual divergence, not chased here**: when a negative-out-of-range index is grouped
+in the *same* `delpaths()` call as an earlier deletion on the same array, real yq's own error
+reports the array's size *after* that earlier deletion already happened -- confirmed live,
+`delpaths([[0],[-5]])` on a 2-element array reports "array size is 1", not 2, meaning real
+yq's own `delpaths` resolves indices *sequentially*, not against the array's length on entry.
+`delete_keys`'s own batch invariant is the opposite by design (every key resolves against the
+length the array had on entry, which is what makes an overlapping range union rather than
+compound, per its own doc comment) -- matching real yq's sequential resolution here would mean
+abandoning that invariant, a materially larger change than this fix's own scope. Still
+correctly *raises* either way; only the reported array-size number can differ, and only in
+this one multi-key-same-array shape.
+
+**A separate, unrelated divergence found investigating this one, not fixed here**: real yq's
+`del()` on a *positive* out-of-range index doesn't no-op the way jq does -- it extends the
+array with `null`s up to that position (`del(.[5])` on `[1,2]` yields a 6-element array with 4
+trailing nulls in real yq, confirmed live), where succinctly (matching jq) leaves the array
+unchanged. Filed separately as
+[#2305](https://github.com/rust-works/succinctly/issues/2305), since it's about a positive
+index and has nothing to do with #2268's own negative-index scope.
+
 ### Other categories
 
 Float and number formatting ([#1071](https://github.com/rust-works/succinctly/issues/1071),

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -36892,7 +36892,16 @@ fn delete_trie_array(
                 .expect("index_groups holds live indices indices");
             match step {
                 ArrayStep::Index(idx) => {
-                    match resolve_read_index(&OwnedValue::Int(*idx), arr.len()) {
+                    let key = OwnedValue::Int(*idx);
+                    // #2268: real yq raises here too -- confirmed live,
+                    // `del(.a[-5].x, .c)` on `{"a":[1,2],"c":3}` raises the
+                    // same "index [-5] out of range" a single-path
+                    // `del(.a[-5])` does, and aborts the *whole* comma-
+                    // grouped call (`.c` is not deleted either).
+                    if let Some(err) = yq_negative_index_error_for_len(yq_mode, &key, arr.len()) {
+                        return Err(err);
+                    }
+                    match resolve_read_index(&key, arr.len()) {
                         Some(actual) => {
                             let target = &mut arr[actual];
                             let old = core::mem::replace(target, OwnedValue::Null);
@@ -36921,11 +36930,12 @@ fn delete_trie_array(
         }
     }
 
-    // Terminal indices go through `delete_keys`, which already silently drops
-    // an index that names nothing — including an out-of-range one, `?` or not
-    // (#415/#477) — and resolves every negative index against the length the
-    // array had on entry, in one batch, so overlapping ranges union rather
-    // than compound (#424).
+    // Terminal indices go through `delete_keys`, which silently drops an
+    // index that names nothing in jq mode (or a positive-out-of-range one in
+    // any mode), `?` or not (#415/#477) — but raises on a negative
+    // out-of-range one in yq mode instead (#2268) — and resolves every
+    // negative index against the length the array had on entry, in one
+    // batch, so overlapping ranges union rather than compound (#424).
     let doomed: Vec<OwnedValue> = node
         .indices
         .iter()
@@ -37596,7 +37606,16 @@ fn delete_path_steps(
             },
             Expr::Index { idx, .. } => match root {
                 OwnedValue::Array(arr) => {
-                    match resolve_read_index(&OwnedValue::Int(*idx), arr.len()) {
+                    let key = OwnedValue::Int(*idx);
+                    // #2268: real yq raises here too, mid-chain -- confirmed
+                    // live, `del(.a[-5].x)` on `{"a":[1,2]}` raises the same
+                    // "index [-5] out of range" a terminal `del(.a[-5])`
+                    // does, not just `delete_at_path`'s own single-step
+                    // equivalent (fixed alongside this).
+                    if let Some(err) = yq_negative_index_error_for_len(yq_mode, &key, arr.len()) {
+                        return Err(err);
+                    }
+                    match resolve_read_index(&key, arr.len()) {
                         Some(actual_idx) => {
                             root = &mut arr[actual_idx];
                             steps = rest;

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -16150,26 +16150,69 @@ fn index_one<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     }
 }
 
-/// yq mode only (#2254): `Some(error)` iff `resolved` is still negative --
-/// real yq raises here (`index_array_by_position`'s own doc comment has the
-/// full rationale). `idx`/`len` are only for the error's own message, which
-/// reports the argument as written, not the arithmetic.
+/// Core of [`yq_negative_index_check`]: `Some(error)` iff `yq_mode` and
+/// `resolved` is still negative -- real yq raises here
+/// (`index_array_by_position`'s own doc comment has the full rationale).
+/// `idx`/`len` are only for the error's own message, which reports the
+/// argument as written, not the arithmetic.
 ///
-/// The `i64`/`usize`-only signature (not `OwnedValue`) is deliberate: both
-/// this function's own `OwnedValue`-domain callers ([`yq_negative_index_error`]
+/// Takes a plain `bool` rather than `S: EvalSemantics`, unlike every other
+/// caller of this rule: `delete_at_path`/`delete_paths_under`/`delete_keys`
+/// (#2268's own fix) resolve yq-mode-ness as a plain `yq_mode: bool` already
+/// threaded through the whole delete-path machinery, not `S` -- see
+/// [`yq_negative_index_error_for_len`] below, the shared entry point both
+/// that `bool`-based machinery and this function's own `S`-generic callers
+/// route through, so the boundary condition and error text live in exactly
+/// one place either way.
+fn yq_negative_index_check_core(
+    yq_mode: bool,
+    idx: i64,
+    resolved: i64,
+    len: usize,
+) -> Option<EvalError> {
+    if !yq_mode {
+        return None;
+    }
+    (resolved < 0).then(|| EvalError::yq_negative_index_out_of_range(idx, len))
+}
+
+/// [`yq_negative_index_check_core`], `S: EvalSemantics`-generic -- the
+/// `i64`/`usize`-only signature (not `OwnedValue`) is deliberate: both this
+/// function's own `OwnedValue`-domain callers ([`yq_negative_index_error`]
 /// below) and `eval_generic.rs`'s two independent numeric-index arms (which
 /// already reduce to plain integers before their own indexing decision)
-/// reach the identical rule through it, so the boundary condition and error
-/// text live in exactly one place.
+/// reach the identical rule through it.
 pub(crate) fn yq_negative_index_check<S: EvalSemantics>(
     idx: i64,
     resolved: i64,
     len: usize,
 ) -> Option<EvalError> {
-    if S::TAG != EvalTag::Yq {
-        return None;
-    }
-    (resolved < 0).then(|| EvalError::yq_negative_index_out_of_range(idx, len))
+    yq_negative_index_check_core(S::TAG == EvalTag::Yq, idx, resolved, len)
+}
+
+/// [`yq_negative_index_check_core`] for the common shape: an array of length
+/// `len`, indexed by a key that might be a negative numeric index. `None`
+/// covers every case that isn't this one (jq mode, a non-numeric key, an
+/// in-bounds or positive-direction index) uniformly, so a caller checks this
+/// once and falls through to its own ordinary null/error handling otherwise.
+///
+/// #2268: shared by `delete_at_path`/`delete_paths_under`/`delete_keys`,
+/// which resolve `yq_mode` as a plain `bool` rather than carrying `S`
+/// through the whole delete-path recursion -- deliberately taking `len`
+/// rather than a whole `target: &OwnedValue` the way
+/// [`yq_negative_index_error`] does, since every one of those three call
+/// sites has already matched its target down to `OwnedValue::Array` (and in
+/// two cases, already borrowed it mutably) by the time this runs, so
+/// re-deriving "is this an array" from a fresh `&OwnedValue` would be
+/// redundant, not simpler.
+fn yq_negative_index_error_for_len(
+    yq_mode: bool,
+    key: &OwnedValue,
+    len: usize,
+) -> Option<EvalError> {
+    let idx = numeric_key_to_index(key)?;
+    let resolved = if idx < 0 { len as i64 + idx } else { idx };
+    yq_negative_index_check_core(yq_mode, idx, resolved, len)
 }
 
 /// [`yq_negative_index_check`] for the common `OwnedValue`-domain shape: a
@@ -16180,11 +16223,12 @@ pub(crate) fn yq_negative_index_check<S: EvalSemantics>(
 /// own ordinary null/error handling otherwise -- deliberately *not*
 /// threaded into [`index_one_owned`] itself, since that function's own
 /// callers include write-path resolvers (`resolve_node`/`resolve_index_expr`,
-/// `write_index`) that currently have their own gaps here too (`del()`/
-/// `delpaths()` silently no-op instead of raising, tracked separately as
-/// #2268; assignment raises jq's own differently-worded message instead of
-/// yq's, noted in that same issue) -- real, separate bugs, not yet fixed,
-/// rather than folded into this read-only helper's contract.
+/// `write_index`) that currently have their own gaps here too (assignment
+/// raises jq's own differently-worded message instead of yq's, noted in
+/// #2268) -- a real, separate bug, not yet fixed, rather than folded into
+/// this read-only helper's contract. `del()`/`delpaths()`'s own gap #2268
+/// also found is fixed via [`yq_negative_index_error_for_len`] above, not
+/// this function -- see that one's own doc comment for why.
 fn yq_negative_index_error<S: EvalSemantics>(
     target: &OwnedValue,
     key: &OwnedValue,
@@ -16192,13 +16236,7 @@ fn yq_negative_index_error<S: EvalSemantics>(
     let OwnedValue::Array(items) = target else {
         return None;
     };
-    let idx = numeric_key_to_index(key)?;
-    let resolved = if idx < 0 {
-        items.len() as i64 + idx
-    } else {
-        idx
-    };
-    yq_negative_index_check::<S>(idx, resolved, items.len())
+    yq_negative_index_error_for_len(S::TAG == EvalTag::Yq, key, items.len())
 }
 
 /// [`index_one`] for a target that is already an owned value, as when the
@@ -35937,6 +35975,14 @@ fn delete_paths_under(
                 Ok(OwnedValue::Array(arr))
             }
             OwnedValue::Int(_) | OwnedValue::Float(_) | OwnedValue::NumberLiteral(..) => {
+                // #2268: real yq raises here too -- confirmed live,
+                // `delpaths([["a",-5]])` on `{"a":[1,2]}` raises the same
+                // "index [-5] out of range" a terminal `delpaths([[-5]])`
+                // does, not just `del()`'s own equivalent (`delete_at_path`,
+                // fixed alongside this).
+                if let Some(err) = yq_negative_index_error_for_len(yq_mode, key, arr.len()) {
+                    return Err(err);
+                }
                 if let Some(index) = resolve_read_index(key, arr.len()) {
                     let old = core::mem::replace(&mut arr[index], OwnedValue::Null);
                     arr[index] = delete_paths_sorted(old, paths, start, yq_mode)?;
@@ -36020,6 +36066,28 @@ fn delete_keys(
                         indices.extend(SliceBounds::from_descriptor(desc)?.resolve(arr.len()));
                     }
                     OwnedValue::Int(_) | OwnedValue::Float(_) | OwnedValue::NumberLiteral(..) => {
+                        // #2268: real yq raises on a negative out-of-range
+                        // index here too. Resolved against `arr.len()` (the
+                        // length on entry, this function's own established
+                        // batch invariant -- see its own doc comment) rather
+                        // than a shrinking length as each key is processed:
+                        // confirmed live that real yq's own error message
+                        // reports the *already-shrunk* size when grouped
+                        // with an earlier same-array deletion
+                        // (`delpaths([[0],[-5]])` on a 2-element array
+                        // reports "array size is 1", not 2) -- a real,
+                        // narrower divergence this fix does not chase, since
+                        // matching it would mean abandoning the batch
+                        // invariant this function's every other property
+                        // (overlapping-range union, not compound) already
+                        // depends on. Still correctly *raises* either way,
+                        // which is this issue's own actual scope; only the
+                        // reported array-size number can differ in this one
+                        // multi-key-same-array shape.
+                        if let Some(err) = yq_negative_index_error_for_len(yq_mode, key, arr.len())
+                        {
+                            return Err(err);
+                        }
                         if let Some(idx) = resolve_read_index(key, arr.len()) {
                             indices.push(idx);
                         }
@@ -37243,7 +37311,16 @@ fn delete_at_path(
         },
         Expr::Index { idx, .. } => match root {
             OwnedValue::Array(arr) => {
-                if let Some(actual_idx) = resolve_read_index(&OwnedValue::Int(*idx), arr.len()) {
+                let key = OwnedValue::Int(*idx);
+                // #2268: real yq raises on a negative index whose magnitude
+                // still exceeds the array length after resolving against it
+                // -- checked before the silent-skip fallback below, which
+                // still applies to jq mode and to yq's own ordinary
+                // positive-out-of-range case (#477).
+                if let Some(err) = yq_negative_index_error_for_len(yq_mode, &key, arr.len()) {
+                    return Err(err);
+                }
+                if let Some(actual_idx) = resolve_read_index(&key, arr.len()) {
                     arr.remove(actual_idx);
                 }
                 // An out-of-range index names nothing to delete — jq's

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -28922,3 +28922,108 @@ fn test_negative_index_out_of_range_unaffected_in_jq_mode_2254() -> Result<()> {
 
     Ok(())
 }
+
+/// #2268: `del()` on a negative out-of-range array index used to silently
+/// no-op (returning the document unchanged, exit 0) instead of raising the
+/// same "index [N] out of range" error #2254 already gave ordinary reads.
+/// Confirmed live against yq v4.53.3.
+#[test]
+fn test_del_negative_index_out_of_range_raises_2268() -> Result<()> {
+    let (out, stderr, code) =
+        run_yq_stdin_with_stderr("del(.a[-5])", "a: [1, 2]\n", &["-o", "json"])?;
+    assert_eq!(code, 1, "out: {out:?}");
+    assert_eq!(
+        stderr.trim(),
+        "Error: index [-5] out of range, array size is 2"
+    );
+
+    // Real yq still raises even with a `?` earlier in the path chain --
+    // confirmed live, `del(.a?[-5])` raises the identical error.
+    let (out, stderr, code) =
+        run_yq_stdin_with_stderr("del(.a?[-5])", "a: [1, 2]\n", &["-o", "json"])?;
+    assert_eq!(code, 1, "out: {out:?}");
+    assert_eq!(
+        stderr.trim(),
+        "Error: index [-5] out of range, array size is 2"
+    );
+
+    // In-bounds negative wraparound is unaffected.
+    let (out, code) = run_yq_stdin("del(.a[-1])", "a: [1, 2]\n", &["-o=json", "-I=0"])?;
+    assert_eq!(code, 0);
+    assert_eq!(out.trim(), "{\"a\":[1]}");
+
+    Ok(())
+}
+
+/// #2268: `delpaths()`'s own array arms (`delete_paths_under`'s mid-path
+/// navigation, `delete_keys`'s terminal batch) share the identical gap --
+/// both confirmed live to silently no-op before this fix.
+#[test]
+fn test_delpaths_negative_index_out_of_range_raises_2268() -> Result<()> {
+    // Terminal component (`delete_keys`).
+    let (out, stderr, code) =
+        run_yq_stdin_with_stderr("delpaths([[-5]])", "- 1\n- 2\n", &["-o", "json"])?;
+    assert_eq!(code, 1, "out: {out:?}");
+    assert_eq!(
+        stderr.trim(),
+        "Error: index [-5] out of range, array size is 2"
+    );
+
+    // Mid-path component (`delete_paths_under`).
+    let (out, stderr, code) =
+        run_yq_stdin_with_stderr("delpaths([[\"a\",-5]])", "a: [1, 2]\n", &["-o", "json"])?;
+    assert_eq!(code, 1, "out: {out:?}");
+    assert_eq!(
+        stderr.trim(),
+        "Error: index [-5] out of range, array size is 2"
+    );
+
+    // In-bounds, well-formed deletion is unaffected.
+    let (out, code) = run_yq_stdin("delpaths([[0]])", "- 1\n- 2\n- 3\n", &["-o=json", "-I=0"])?;
+    assert_eq!(code, 0);
+    assert_eq!(out.trim(), "[2,3]");
+
+    Ok(())
+}
+
+/// #2268: a documented, accepted residual divergence -- when a
+/// negative-out-of-range index is grouped in the *same* `delpaths()` call
+/// as an earlier deletion on the same array, real yq's own error reports
+/// the array's size *after* that earlier deletion already happened
+/// (confirmed live, v4.53.3: `delpaths([[0],[-5]])` on a 2-element array
+/// reports "array size is 1", not 2). `delete_keys`'s own batch invariant
+/// -- every key resolves against the length the array had on *entry*, not
+/// a shrinking length as each is processed, which is what makes an
+/// overlapping range union rather than compound -- means this crate always
+/// reports the *entry* length instead. Still correctly raises, which is
+/// this issue's own actual scope; only the reported number can differ in
+/// this one multi-key-same-array shape, not pinned against real yq itself.
+#[test]
+fn test_delpaths_grouped_negative_index_reports_entry_length_2268() -> Result<()> {
+    let (out, stderr, code) =
+        run_yq_stdin_with_stderr("delpaths([[0],[-5]])", "- 1\n- 2\n", &["-o", "json"])?;
+    assert_eq!(code, 1, "out: {out:?}");
+    assert_eq!(
+        stderr.trim(),
+        "Error: index [-5] out of range, array size is 2"
+    );
+
+    Ok(())
+}
+
+/// #2268's jq-mode control: jq has no such rule -- both `del()` and
+/// `delpaths()` stay a silent no-op on a negative out-of-range index in jq
+/// mode, matching #477's own established precedent.
+#[test]
+fn test_del_and_delpaths_negative_index_unaffected_in_jq_mode_2268() -> Result<()> {
+    let (out, stderr, code) = run_jq_stdin_with_stderr("del(.a[-5])", "{\"a\":[1,2]}", &["-c"])?;
+    assert_eq!(code, 0, "stderr: {stderr}");
+    assert_eq!(out.trim(), "{\"a\":[1,2]}");
+
+    let (out, stderr, code) =
+        run_jq_stdin_with_stderr("delpaths([[\"a\",-5]])", "{\"a\":[1,2]}", &["-c"])?;
+    assert_eq!(code, 0, "stderr: {stderr}");
+    assert_eq!(out.trim(), "{\"a\":[1,2]}");
+
+    Ok(())
+}

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -28955,6 +28955,55 @@ fn test_del_negative_index_out_of_range_raises_2268() -> Result<()> {
     Ok(())
 }
 
+/// #2268 (round 2, code review): `delete_path_steps`'s own mid-chain
+/// `Expr::Index` arm -- used for a pipe-chained `del()` path like
+/// `del(.a[-5].x)`, distinct from `delete_at_path`'s single-step dispatch
+/// above -- shared the identical gap. Confirmed live before this fix.
+#[test]
+fn test_del_negative_index_out_of_range_raises_mid_chain_2268() -> Result<()> {
+    let (out, stderr, code) =
+        run_yq_stdin_with_stderr("del(.a[-5].x)", "a: [1, 2]\nb: 3\n", &["-o", "json"])?;
+    assert_eq!(code, 1, "out: {out:?}");
+    assert_eq!(
+        stderr.trim(),
+        "Error: index [-5] out of range, array size is 2"
+    );
+
+    // Well-formed mid-chain deletion is unaffected.
+    let (out, code) = run_yq_stdin(
+        "del(.a[0].x)",
+        "a:\n  - x: 1\n    y: 2\n",
+        &["-o=json", "-I=0"],
+    )?;
+    assert_eq!(code, 0);
+    assert_eq!(out.trim(), "{\"a\":[{\"y\":2}]}");
+
+    Ok(())
+}
+
+/// #2268 (round 2, code review): `delete_trie_array`'s own `ArrayStep::Index`
+/// mid-navigation arm -- comma-grouped `del()` paths like
+/// `del(.a[-5].x, .c)` -- shared the identical gap, and real yq aborts the
+/// *whole* comma-grouped call on it (`.c` is not deleted either). Confirmed
+/// live before this fix.
+#[test]
+fn test_del_negative_index_out_of_range_raises_comma_grouped_2268() -> Result<()> {
+    let (out, stderr, code) =
+        run_yq_stdin_with_stderr("del(.a[-5].x, .c)", "a: [1, 2]\nc: 3\n", &["-o", "json"])?;
+    assert_eq!(code, 1, "out: {out:?}");
+    assert_eq!(
+        stderr.trim(),
+        "Error: index [-5] out of range, array size is 2"
+    );
+
+    // Well-formed comma-grouped deletion is unaffected.
+    let (out, code) = run_yq_stdin("del(.a[0], .c)", "a: [1, 2]\nc: 3\n", &["-o=json", "-I=0"])?;
+    assert_eq!(code, 0);
+    assert_eq!(out.trim(), "{\"a\":[2]}");
+
+    Ok(())
+}
+
 /// #2268: `delpaths()`'s own array arms (`delete_paths_under`'s mid-path
 /// navigation, `delete_keys`'s terminal batch) share the identical gap --
 /// both confirmed live to silently no-op before this fix.


### PR DESCRIPTION
## Summary

Fixes #2268: #2254 fixed every ordinary *read* (`.a[-N]`) to raise real yq's
own "index [N] out of range" error, but `del()`/`delpaths()` shared the
identical gap with a more severe symptom — not a differently-worded error,
but no error at all (exit 0, document unchanged), where real yq aborts the
whole write:

```console
$ echo '{"a":[1,2]}' | yq -o=json 'del(.a[-5])'
Error: index [-5] out of range, array size is 2
$ echo '{"a":[1,2]}' | succinctly yq 'del(.a[-5])' -o json
{"a":[1,2]}                                          # WRONG -- before this fix
```

## Fix (round 1)

Three independent array arms shared the gap, none `EvalSemantics`-aware
(all take a plain `yq_mode: bool`, not generic `S`):

- `delete_at_path`'s `Expr::Index` array arm (`del()`'s single-step dispatch)
- `delete_paths_under`'s array arm (`delpaths()`'s mid-path navigation)
- `delete_keys`'s array arm (`delpaths()`'s terminal per-container batch)

Fixed via a new `bool`-based sibling of #2254's own `yq_negative_index_check`/
`yq_negative_index_error` (`yq_negative_index_check_core`/
`yq_negative_index_error_for_len`), reused by every call site rather than
re-deriving the arithmetic again.

Confirmed live against yq v4.53.3: **not suppressible by an earlier `?` in
the path chain** — `del(.a?[-5])` still raises in real yq, matching this fix.

## Fix (round 2 — code-review follow-up)

Code review found and confirmed live two more sibling array arms sharing the
identical gap, both missed in round 1:

- `delete_path_steps`'s own mid-chain `Expr::Index` arm — a pipe-chained
  `del()` path like `del(.a[-5].x)` still silently no-opped.
- `delete_trie_array`'s own `ArrayStep::Index` arm — a comma-grouped `del()`
  path like `del(.a[-5].x, .c)` also silently no-opped, and worse: it let
  `.c` get deleted anyway, where real yq aborts the whole call on the
  earlier error.

Both already threaded `yq_mode: bool`, so both reuse the exact same
`yq_negative_index_error_for_len` helper round 1 introduced.

Also fixed a documentation inaccuracy code review caught: an earlier note
about a *separate*, unrelated divergence (real yq's `del()` on a *positive*
out-of-range index extends the array with nulls, filed as #2305) claimed
`del(.[5])` on `[1,2]` yields a 6-element array with 4 trailing nulls;
live-verified it's actually a 5-element array with 3 trailing nulls
(extended to length `== idx`, not `idx+1`) — corrected in both the doc and
the follow-up issue's own description was already close enough to leave.

## One residual divergence, documented, not chased

When a negative-out-of-range index is grouped in the *same* `delpaths()`
call as an earlier deletion on the same array, real yq's own error reports
the array's size *after* that earlier deletion already happened — confirmed
live, `delpaths([[0],[-5]])` on a 2-element array reports "array size is 1",
not 2 (real yq resolves indices *sequentially*). `delete_keys`'s own batch
invariant is the opposite by design (every key resolves against the array's
length on entry — what makes an overlapping range union rather than
compound) — matching real yq's sequential resolution would mean abandoning
that invariant, out of scope here. Still correctly *raises* either way;
only the reported number can differ, and only in this one
multi-key-same-array shape.

## Verification

- Live-verified against yq v4.53.3 for all five call sites, well-formed
  input, jq-mode control (unaffected, matches #477's established
  silent-skip precedent), and the `?`-chain non-suppression case.
- New CLI regression tests (`tests/yq_cli_tests.rs`): `del()` (negative OOB,
  `?`-chain, mid-chain, comma-grouped, in-bounds unaffected), `delpaths()`
  (mid-path + terminal negative OOB, well-formed unaffected), the grouped
  array-size residual divergence (pinned against succinctly's own answer),
  and jq-mode control.
- Full test suite: 57/57 test binaries, 0 failures.
- `cargo clippy --all-targets --all-features -- -D warnings`, `cargo fmt
  --check`, `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features`:
  all clean.
- Patch coverage: pending re-check for the final (7-fix) state.

Fixes #2268
