### PR TITLE
fix(yq): del()/delpaths() extend array with null on positive OOB index

### DIFF
--- a/docs/compliance/yq/limitations.md
+++ b/docs/compliance/yq/limitations.md
@@ -1766,13 +1766,58 @@ abandoning that invariant, a materially larger change than this fix's own scope.
 correctly *raises* either way; only the reported array-size number can differ, and only in
 this one multi-key-same-array shape.
 
-**A separate, unrelated divergence found investigating this one, not fixed here**: real yq's
-`del()` on a *positive* out-of-range index doesn't no-op the way jq does -- it extends the
-array with `null`s up to (not including) that position (`del(.[5])` on `[1,2]` yields a
-5-element array, `[1,2,null,null,null]`, in real yq, confirmed live), where succinctly
-(matching jq) leaves the array unchanged. Filed separately as
-[#2305](https://github.com/rust-works/succinctly/issues/2305), since it's about a positive
-index and has nothing to do with #2268's own negative-index scope.
+**A separate, unrelated divergence found investigating this one**: real yq's `del()` on a
+*positive* out-of-range index doesn't no-op the way jq does -- it extends the array with
+`null`s up to (not including) that position (`del(.[5])` on `[1,2]` yields a 5-element array,
+`[1,2,null,null,null]`, in real yq, confirmed live), where succinctly (matching jq) used to
+leave the array unchanged. Was its own issue, [#2305](https://github.com/rust-works/succinctly/issues/2305),
+since it's about a positive index and has nothing to do with #2268's own negative-index
+scope -- closed by the next section below.
+
+### `del()`/`delpaths()` on a positive out-of-range array index extends with `null` instead of no-opping
+
+[#2305](https://github.com/rust-works/succinctly/issues/2305). Real yq's own asymmetry between
+positive and negative out-of-range indices (the section above covers the negative half) has a
+second half specific to `del()`/`delpaths()`: a **positive** out-of-range index -- where a plain
+*read* answers `null` in both jq and yq -- makes yq's own `del()` *grow* the array with `null`
+up to the requested length, where jq (and, before this fix, succinctly) leaves it unchanged:
+
+```bash
+$ echo '[1,2]' | yq -o=json 'del(.[5])'      # [1, 2, null, null, null] -- length 5, not a no-op
+$ echo '[1,2]' | jq -c 'del(.[5])'           # [1,2]                    -- jq: genuine no-op
+```
+
+The extension target is the *requested* index itself, not `index + 1` -- there is nothing to
+place *at* the deleted position, only a gap to fill *before* it, so `del(.[2])` on a
+length-2 array (index == current length exactly, no gap) is a true no-op in both tools, and
+only `index > length` triggers the growth. Closed by `extend_array_with_nulls_for_delete`
+(`src/jq/eval.rs`), a fallible-reserve-then-resize sibling of `pad_with_nulls` (`setpath`'s own
+array-growth helper, #1670) shared by `delete_at_path`'s `Expr::Index` arm (`del(.[N])`) and
+`delete_keys`'s own single-key case (`delpaths([[N]])`, confirmed live to share the identical
+extension behavior) -- gated on `yq_mode`, since jq has no such rule at all.
+
+**Deliberately not extended to a `delpaths()` batch of two or more keys.** Confirmed live that
+mixing an in-range delete with an out-of-range one in the same `delpaths()` call is
+**order-dependent** in real yq -- the same *set* of keys, given in a different literal order,
+produces a *different*-length result:
+
+```bash
+$ echo '[1,2,3]' | yq -o=json 'delpaths([[0],[5]])'   # [2,3,null,null,null] -- length 5
+$ echo '[1,2,3]' | yq -o=json 'delpaths([[5],[0]])'   # [2,3,null,null]      -- length 4
+```
+
+`delete_keys`'s array arm resolves every key against the array's length *on entry* and applies
+them all in one batched `retain` pass -- deliberately order-independent, which is what keeps its
+existing (already-correct) in-range-only semantics matching real jq's own order-independent
+`delpaths` union rule. Replicating the order-dependent out-of-range case would need the array
+arm restructured to apply keys sequentially instead, a materially larger change than this fix
+attempts -- tracked separately as
+[#2306](https://github.com/rust-works/succinctly/issues/2306), including whether `del()`'s own
+comma-separated multi-target form (`del(.[0], .[5])`, a different call path than `delpaths()`'s
+path-array form) shares the same order-dependence.
+
+A negative out-of-range index is untouched by this fix either way -- it raises instead
+(#2268, the section above, landed separately and already covers it).
 
 ### Other categories
 

--- a/docs/compliance/yq/limitations.md
+++ b/docs/compliance/yq/limitations.md
@@ -1819,6 +1819,14 @@ path-array form) shares the same order-dependence.
 A negative out-of-range index is untouched by this fix either way -- it raises instead
 (#2268, the section above, landed separately and already covers it).
 
+Also scoped to a *terminal* index only -- a positive out-of-range index with more path
+after it (`del(.[5].a)`, `del(.[5][])`) extends too in real yq, to `index + 1` rather than
+`index` (there *is* something at the out-of-range position once the rest of the path needs
+to navigate into it), and `del(.[5][])` specifically auto-vivifies `[]` there rather than
+`null` -- a different shape from this fix's own terminal-only rule, confirmed live but not
+implemented; tracked separately as
+[#2314](https://github.com/rust-works/succinctly/issues/2314).
+
 ### Other categories
 
 Float and number formatting ([#1071](https://github.com/rust-works/succinctly/issues/1071),

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -13096,6 +13096,51 @@ fn resolve_read_index(key: &OwnedValue, len: usize) -> Option<usize> {
     usize::try_from(resolved).ok().filter(|i| *i < len)
 }
 
+/// The three outcomes an array index can resolve to for a *delete*
+/// (`del()`/`delpaths()`), distinct from [`resolve_read_index`]'s simpler
+/// "in range or not" contract -- yq mode treats a positive out-of-range
+/// index differently from a negative one, so callers that need to tell
+/// them apart use this instead (#2305).
+enum DeleteIndexResolution {
+    /// `key` names a real element -- delete it normally.
+    InRange(usize),
+    /// `key` resolved non-negative but still `>= len` -- real yq (v4.53.3,
+    /// confirmed live) extends the array with `null` up to this length
+    /// rather than treating the deletion as a no-op:
+    /// `[1,2] | del(.[5])` is `[1,2,null,null,null]`, length 5 (the
+    /// requested index itself, not `index + 1` -- there is nothing *at*
+    /// the deleted position once it exists, only a gap filled up to it).
+    /// jq has no such rule (`del(.[5])` on the same input is a no-op), so
+    /// this variant is only ever acted on in yq mode.
+    PositiveOutOfRange(usize),
+    /// `key` is NaN, or resolved negative even after adjusting for `len`
+    /// (magnitude too large) -- a no-op in both modes today, matching
+    /// `resolve_read_index`'s existing contract for reads. Real yq
+    /// actually *raises* on the negative case (confirmed live:
+    /// `[1,2] | del(.[-10])` errors "index [-10] out of range, array size
+    /// is 2") -- #2268 tracks that separately; this variant intentionally
+    /// does not distinguish NaN from negative-OOB, since #2305's own scope
+    /// is the positive case only.
+    Skip,
+}
+
+/// [`resolve_read_index`]'s delete-specific sibling -- same truncation and
+/// negative-index resolution, but keeps the positive-out-of-range case
+/// distinguishable from everything else that would otherwise collapse into
+/// "no such element" (see [`DeleteIndexResolution`]'s own doc comment for
+/// why that distinction matters).
+fn resolve_delete_index(key: &OwnedValue, len: usize) -> DeleteIndexResolution {
+    let Some(index) = numeric_key_to_index(key) else {
+        return DeleteIndexResolution::Skip;
+    };
+    let resolved = if index < 0 { len as i64 + index } else { index };
+    match usize::try_from(resolved) {
+        Ok(i) if i < len => DeleteIndexResolution::InRange(i),
+        Ok(i) => DeleteIndexResolution::PositiveOutOfRange(i),
+        Err(_) => DeleteIndexResolution::Skip,
+    }
+}
+
 /// Builtin: getpath(path) - get value at path
 fn builtin_getpath<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     path_expr: &Expr,
@@ -35640,6 +35685,35 @@ fn pad_with_nulls(arr: &mut Vec<OwnedValue>, index: usize) -> Result<(), EvalErr
     Ok(())
 }
 
+/// [`pad_with_nulls`]'s delete-side counterpart (#2305) -- extends `arr`
+/// with `null` up to `target_len` exactly, not `target_len + 1`: a
+/// positive out-of-range *delete* index needs the gap *before* it filled,
+/// never the index itself (there is nothing to put there once it's being
+/// deleted), where `setpath`'s own `pad_with_nulls` grows to make the
+/// target index itself valid for the write that follows. Shared by
+/// `delete_at_path`'s `Expr::Index` arm and `delete_keys`'s own
+/// single-key case rather than duplicating the fallible-reserve-then-
+/// resize dance (#1670) twice. `target_len <= arr.len()` is a safe no-op
+/// (matches `Vec::resize`'s own contract, and is exactly what real yq
+/// does when the requested index lands right at the current length) --
+/// callers never need to check first.
+fn extend_array_with_nulls_for_delete(
+    arr: &mut Vec<OwnedValue>,
+    target_len: usize,
+) -> Result<(), EvalError> {
+    if target_len <= arr.len() {
+        return Ok(());
+    }
+    arr.try_reserve(target_len - arr.len())
+        .map_err(|_| cannot_grow_array(target_len as u64))?;
+    // #1670: already guarded -- `try_reserve` above already proved the
+    // capacity is reservable, so this can't panic the way an unguarded
+    // `resize` (#1017's own panic site) can.
+    #[allow(clippy::disallowed_methods)]
+    arr.resize(target_len, OwnedValue::Null);
+    Ok(())
+}
+
 /// Helper to set a value at a path
 ///
 /// Follows jq: `null` is the only value auto-vivified into whatever container
@@ -36059,7 +36133,21 @@ fn delete_keys(
             // .[1:3])` is `[4]`, and a slice naming the same element as a bare
             // index deletes it once — `delpaths([[1],[{"start":1,"end":2}]])`
             // is `[1,3,4]`.
+            //
+            // #2305: a *single*-key batch's own positive-out-of-range index
+            // gets the same null-extension `delete_at_path`'s `Expr::Index`
+            // arm does (`delpaths([[5]])` on `[1,2]` matches `del(.[5])`
+            // exactly, confirmed live) -- gated on `keys.len() == 1`
+            // deliberately, not extended to a multi-key batch: confirmed
+            // live that mixing an in-range delete with an out-of-range one
+            // is order-*dependent* in real yq (`delpaths([[0],[5]])` vs
+            // `delpaths([[5],[0]])` on the same `[1,2,3]` give *different*
+            // results, 5 vs 4 elements) -- this batch/single-`retain`-pass
+            // model has no way to replicate that without processing keys
+            // sequentially, a materially larger change; tracked separately
+            // as #2306 rather than guessed at here.
             let mut indices: Vec<usize> = vec_with_capacity(keys.len());
+            let mut single_key_oob_target: Option<usize> = None;
             for key in keys {
                 match key {
                     OwnedValue::Object(desc) => {
@@ -36088,8 +36176,22 @@ fn delete_keys(
                         {
                             return Err(err);
                         }
-                        if let Some(idx) = resolve_read_index(key, arr.len()) {
-                            indices.push(idx);
+                        // #2305: a positive out-of-range index needs its own,
+                        // different treatment (extend, not raise) -- see
+                        // `resolve_delete_index`'s own doc comment. Reached
+                        // only when the negative-raise check above didn't
+                        // already return, so `Skip` here only ever means
+                        // NaN or (in jq mode) a negative-OOB index that
+                        // stays a no-op.
+                        match resolve_delete_index(key, arr.len()) {
+                            DeleteIndexResolution::InRange(idx) => indices.push(idx),
+                            DeleteIndexResolution::PositiveOutOfRange(target_len)
+                                if yq_mode && keys.len() == 1 =>
+                            {
+                                single_key_oob_target = Some(target_len);
+                            }
+                            DeleteIndexResolution::PositiveOutOfRange(_)
+                            | DeleteIndexResolution::Skip => {}
                         }
                     }
                     other => {
@@ -36109,6 +36211,9 @@ fn delete_keys(
                 index += 1;
                 !doomed
             });
+            if let Some(target_len) = single_key_oob_target {
+                extend_array_with_nulls_for_delete(&mut arr, target_len)?;
+            }
             Ok(OwnedValue::Array(arr))
         }
         // `null` has no fields to begin with, so deleting one is a no-op —
@@ -37324,17 +37429,31 @@ fn delete_at_path(
                 let key = OwnedValue::Int(*idx);
                 // #2268: real yq raises on a negative index whose magnitude
                 // still exceeds the array length after resolving against it
-                // -- checked before the silent-skip fallback below, which
+                // -- checked before the resolution match below, which
                 // still applies to jq mode and to yq's own ordinary
                 // positive-out-of-range case (#477).
                 if let Some(err) = yq_negative_index_error_for_len(yq_mode, &key, arr.len()) {
                     return Err(err);
                 }
-                if let Some(actual_idx) = resolve_read_index(&key, arr.len()) {
-                    arr.remove(actual_idx);
+                // #2305: a positive out-of-range index needs its own,
+                // different treatment (extend, not raise) -- see
+                // `DeleteIndexResolution`'s own doc comment for the
+                // confirmed live boundary. jq has no such rule, so the
+                // extension is yq-mode only; jq mode falls through to the
+                // existing no-op below (`Skip` here only ever means NaN,
+                // since a real negative-OOB index already raised above,
+                // when it was going to).
+                match resolve_delete_index(&key, arr.len()) {
+                    DeleteIndexResolution::InRange(actual_idx) => {
+                        arr.remove(actual_idx);
+                    }
+                    DeleteIndexResolution::PositiveOutOfRange(target_len) if yq_mode => {
+                        extend_array_with_nulls_for_delete(arr, target_len)?;
+                    }
+                    // An out-of-range index names nothing to delete — jq's
+                    // delpaths silently skips it, `?` or not (#477).
+                    DeleteIndexResolution::PositiveOutOfRange(_) | DeleteIndexResolution::Skip => {}
                 }
-                // An out-of-range index names nothing to delete — jq's
-                // delpaths silently skips it, `?` or not (#477).
                 Ok(())
             }
             // `null` has no elements at any index, so this is always a
@@ -68498,6 +68617,101 @@ mod tests {
         // covered here only to pin that this fix didn't disturb it.
         yq_query!(br#"{"a":1}"#, r"del(.)",
             QueryResult::None => {}
+        );
+    }
+
+    #[test]
+    fn test_del_positive_out_of_range_index_extends_with_null_yq_mode_2305() {
+        // #2305: real yq (v4.53.3, confirmed live) extends the array with
+        // `null` up to the requested out-of-range length rather than
+        // no-opping the way jq does -- `[1,2] | del(.[5])` is
+        // `[1,2,null,null,null]`, length 5 (the requested index itself,
+        // not `index + 1`).
+        yq_query!(br"[1,2]", r"del(.[5])",
+            QueryResult::Owned(OwnedValue::Array(arr)) => {
+                assert_eq!(
+                    arr,
+                    vec![
+                        OwnedValue::Int(1), OwnedValue::Int(2),
+                        OwnedValue::Null, OwnedValue::Null, OwnedValue::Null,
+                    ]
+                );
+            }
+        );
+        // From an empty array -- extends purely with `null`.
+        yq_query!(br"[]", r"del(.[3])",
+            QueryResult::Owned(OwnedValue::Array(arr)) => {
+                assert_eq!(arr, vec![OwnedValue::Null; 3]);
+            }
+        );
+        // The boundary case: index == length exactly names the very next
+        // append position, with no gap to fill -- a genuine no-op, same as
+        // jq (and unaffected by this fix, since `resolve_delete_index`
+        // still resolves this as `InRange`... no -- `PositiveOutOfRange`
+        // with target_len == current len, `arr.resize` to the same length
+        // is itself a no-op). Confirmed live against real yq.
+        yq_query!(br"[1,2]", r"del(.[2])",
+            QueryResult::Owned(OwnedValue::Array(arr)) => {
+                assert_eq!(arr, vec![OwnedValue::Int(1), OwnedValue::Int(2)]);
+            }
+        );
+        // A negative out-of-range index is untouched by this fix -- #2268
+        // (landed separately) makes it raise instead of no-opping, matching
+        // real yq; this fix's own `resolve_delete_index`/`Skip` path is
+        // never reached for this case since #2268's own check runs first.
+        yq_query!(br"[1,2]", r"del(.[-10])",
+            QueryResult::Error(e) => {
+                assert!(e.message.contains("out of range"), "message: {}", e.message);
+            }
+        );
+    }
+
+    #[test]
+    fn test_del_positive_out_of_range_index_jq_mode_stays_noop_2305() {
+        // jq has no such extension rule -- `del(.[5])` on `[1,2]` is a
+        // plain no-op in real jq 1.7.1, confirmed live. This fix is
+        // yq-mode only.
+        query!(br"[1,2]", r"del(.[5])",
+            QueryResult::Owned(OwnedValue::Array(arr)) => {
+                assert_eq!(arr, vec![OwnedValue::Int(1), OwnedValue::Int(2)]);
+            }
+        );
+    }
+
+    #[test]
+    fn test_delpaths_single_key_positive_out_of_range_extends_with_null_yq_mode_2305() {
+        // #2305: `delpaths([[N]])` (a single-element outer path list, the
+        // same terminal shape `del(.[N])` reduces to) shares the identical
+        // null-extension behavior -- confirmed live, byte-for-byte the
+        // same result as `del(.[5])` above.
+        yq_query!(br"[1,2]", r"delpaths([[5]])",
+            QueryResult::Owned(OwnedValue::Array(arr)) => {
+                assert_eq!(
+                    arr,
+                    vec![
+                        OwnedValue::Int(1), OwnedValue::Int(2),
+                        OwnedValue::Null, OwnedValue::Null, OwnedValue::Null,
+                    ]
+                );
+            }
+        );
+    }
+
+    #[test]
+    fn test_delpaths_multi_key_out_of_range_stays_noop_known_gap_2305() {
+        // #2306 (deferred from #2305, not this issue's scope): a
+        // multi-key `delpaths()` batch mixing an in-range delete with an
+        // out-of-range one is order-*dependent* in real yq (confirmed
+        // live in #2306's own filing) -- the batch/single-`retain`-pass
+        // model this function uses has no way to replicate that, so a
+        // 2+-key batch's own out-of-range members stay a no-op exactly
+        // like before this fix. Pinned here as a known gap, not a
+        // regression: only the in-range key (index 0) is actually
+        // deleted.
+        yq_query!(br"[1,2,3]", r"delpaths([[0],[5]])",
+            QueryResult::Owned(OwnedValue::Array(arr)) => {
+                assert_eq!(arr, vec![OwnedValue::Int(2), OwnedValue::Int(3)]);
+            }
         );
     }
 

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -35690,13 +35690,19 @@ fn pad_with_nulls(arr: &mut Vec<OwnedValue>, index: usize) -> Result<(), EvalErr
 /// positive out-of-range *delete* index needs the gap *before* it filled,
 /// never the index itself (there is nothing to put there once it's being
 /// deleted), where `setpath`'s own `pad_with_nulls` grows to make the
-/// target index itself valid for the write that follows. Shared by
+/// target index itself valid for the write that follows. A thin
+/// `target_len - 1` adapter over `pad_with_nulls` rather than a second
+/// copy of its fallible-reserve-then-resize dance (#1670's own guard,
+/// reused rather than duplicated -- #2305 review) -- shared by
 /// `delete_at_path`'s `Expr::Index` arm and `delete_keys`'s own
-/// single-key case rather than duplicating the fallible-reserve-then-
-/// resize dance (#1670) twice. `target_len <= arr.len()` is a safe no-op
-/// (matches `Vec::resize`'s own contract, and is exactly what real yq
-/// does when the requested index lands right at the current length) --
-/// callers never need to check first.
+/// single-key case. `target_len <= arr.len()` is a safe no-op (matches
+/// `Vec::resize`'s own contract, and is exactly what real yq does when
+/// the requested index lands right at the current length) -- callers
+/// never need to check first, and this guard is also what keeps
+/// `target_len - 1` (below) from underflowing: `pad_with_nulls` itself
+/// has no such guard on its own `index`, relying on every existing
+/// caller already establishing `index + 1 > arr.len()` first, same as
+/// this one now does.
 fn extend_array_with_nulls_for_delete(
     arr: &mut Vec<OwnedValue>,
     target_len: usize,
@@ -35704,14 +35710,7 @@ fn extend_array_with_nulls_for_delete(
     if target_len <= arr.len() {
         return Ok(());
     }
-    arr.try_reserve(target_len - arr.len())
-        .map_err(|_| cannot_grow_array(target_len as u64))?;
-    // #1670: already guarded -- `try_reserve` above already proved the
-    // capacity is reservable, so this can't panic the way an unguarded
-    // `resize` (#1017's own panic site) can.
-    #[allow(clippy::disallowed_methods)]
-    arr.resize(target_len, OwnedValue::Null);
-    Ok(())
+    pad_with_nulls(arr, target_len - 1)
 }
 
 /// Helper to set a value at a path
@@ -37036,11 +37035,19 @@ fn delete_trie_array(
     }
 
     // Terminal indices go through `delete_keys`, which silently drops an
-    // index that names nothing in jq mode (or a positive-out-of-range one in
-    // any mode), `?` or not (#415/#477) — but raises on a negative
-    // out-of-range one in yq mode instead (#2268) — and resolves every
+    // index that names nothing in jq mode (or a positive-out-of-range one
+    // in any mode), `?` or not (#415/#477) — but raises on a negative
+    // out-of-range one in yq mode instead (#2268), and resolves every
     // negative index against the length the array had on entry, in one
-    // batch, so overlapping ranges union rather than compound (#424).
+    // batch, so overlapping ranges union rather than compound (#424). A
+    // *positive* out-of-range index is a different story since #2305: in
+    // yq mode, when `doomed` names exactly one terminal index and it
+    // resolves out of range, `delete_keys` extends the array with `null`
+    // instead of dropping it — see that function's own doc comment for
+    // why this is gated on a single-key batch specifically (a
+    // `del(.[5], .[7])` comma-form reaching two or more terminal indices
+    // here shares that same gate, and stays at the pre-#2305 no-op
+    // behavior).
     let doomed: Vec<OwnedValue> = node
         .indices
         .iter()


### PR DESCRIPTION
## Summary

Fixes #2305: real yq's own `del()`/`delpaths()` grows an array with `null`
up to a positive out-of-range index rather than treating the deletion as a
no-op the way jq does -- `[1,2] | del(.[5])` is `[1,2,null,null,null]` in
real yq (length 5, the requested index itself), a plain no-op in jq (and,
before this fix, in succinctly's own yq mode).

- Adds `resolve_delete_index`/`DeleteIndexResolution` -- a delete-specific
  sibling of `resolve_read_index` that keeps the positive-out-of-range case
  distinguishable from negative-OOB/NaN (which stay a no-op today; #2268
  tracks making the negative case raise instead, matching real yq -- out of
  scope here).
- Adds `extend_array_with_nulls_for_delete` -- a fallible-reserve-then-resize
  sibling of `setpath`'s own `pad_with_nulls` (#1670), so an absurd index
  (`del(.[100000000000000])`) refuses cleanly instead of risking a `resize`
  panic.
- Wired into both `delete_at_path`'s `Expr::Index` arm (`del(.[N])`) and
  `delete_keys`'s single-key case (`delpaths([[N]])`, confirmed live to
  share the identical extension behavior) -- yq mode only, jq unaffected.

**Deliberately scoped to the single-key case.** Confirmed live that a
`delpaths()` batch mixing an in-range delete with an out-of-range one is
**order-dependent** in real yq -- the same *set* of keys, given in a
different literal order, produces a *different*-length result
(`delpaths([[0],[5]])` vs `delpaths([[5],[0]])` on the same `[1,2,3]` give
length 5 vs length 4). The existing order-independent batch/`retain` model
can't replicate that without a materially larger restructure -- filed
separately as #2306 rather than guessed at here; that multi-key case stays
at its pre-existing (no-op-on-OOB) behavior, not a regression.

Documented in `docs/compliance/yq/limitations.md`.

## Test plan

- [x] `cargo build --features cli`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings`
- [x] `cargo fmt --check`
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features`
- [x] `cargo test --features cli,simd,regex,serde --no-fail-fast` (all green, 4 new tests)
- [x] `cargo test --no-fail-fast` (default features)
- [x] `cargo test --no-default-features --verbose` (no_std)
- [x] Live-verified against the pinned yq v4.53.3 oracle: positive-OOB single-index `del()`/`delpaths()`, the exact-length-boundary no-op case, negative-OOB stays untouched, jq mode stays untouched, and an absurdly large index refuses cleanly (`Error: Cannot grow array to N elements`) rather than panicking
