### PR TITLE
docs(jq): pin evaluate_bytes_streaming's own prefix-leak as the established trade-off (#2210)

### DIFF
--- a/docs/compliance/jq/limitations.md
+++ b/docs/compliance/jq/limitations.md
@@ -2819,16 +2819,23 @@ Pinned by `test_unbuffered_interleaves_stdout_and_stderr_1653`,
 `test_jq_missing_delimiter_raises_through_nonreserializing_filters_1677`
 ([tests/jq_cli_tests.rs](../../../tests/jq_cli_tests.rs)).
 
-The identical trade-off covers a *stray-comma* fault the same way it covers a *missing*
-delimiter above — `{"a": [,]}` under bare `.` writes `{"a":` before the walk reaches the
-empty array's stray comma and raises (#2210). `-S` forces the fully materializing path,
-which validates the whole document before printing anything, so it emits nothing on the
-same input — the exit code still agrees, only the prefix differs, same as every other case
-in this section. This shape was unreachable through the general (non-`-S`) path before
-#1576's own M2 fast-path fix started correctly declining a nested empty container's stray
-comma instead of silently accepting it as `[]`; only once M2 declines and falls back here
-does this path's own pre-existing, already-accepted non-atomicity apply to it for the first
-time. Pinned by
+The same trade-off also covers a fault found *partway through writing a single result's
+own value*, not just one discovered by a later top-level result's generator advance —
+`print_json`/`write_output_jq_value` stream byte-by-byte with no rewind, so `{"a": [,]}`
+under bare `.` writes `{"a":` before its own recursive walk reaches the stray comma nested
+inside the empty array and raises (#2210), the identical shape `test_jq_identity_on_
+malformed_array_element_errors_1641` above already pins for `[xyz123]`/`[tru]`/
+`[1,zzz,3]`/`{"a": xyz123}` — a bareword-garbage token instead of a stray comma, reaching
+the fault through the same writer the same way. A first pass at this fix buffered
+`write_output_jq_value`'s per-call output and only committed it to real stdout once known
+good (mirroring `evaluate_m2_fast_path`'s own identical contract for its own single-result
+case) — reverted once the existing #1641 test above caught it as a real regression against
+an already-established, deliberately tested contract for this exact writer, not a
+previously-undocumented gap. It would also have needed carving out `--unbuffered`, whose
+own flush (`write_terminator`) is embedded inside this same call tree keyed on whatever
+writer it's given — buffering would make that flush a silent no-op on a temporary buffer
+instead of the real, immediate per-value flush `--unbuffered` promises, breaking its
+interleaving guarantee with side effects from later results. Pinned by
 `test_jq_general_streaming_path_leaks_prefix_before_nested_comma_fault_2210`
 ([tests/jq_cli_tests.rs](../../../tests/jq_cli_tests.rs)).
 

--- a/docs/compliance/jq/limitations.md
+++ b/docs/compliance/jq/limitations.md
@@ -2819,6 +2819,19 @@ Pinned by `test_unbuffered_interleaves_stdout_and_stderr_1653`,
 `test_jq_missing_delimiter_raises_through_nonreserializing_filters_1677`
 ([tests/jq_cli_tests.rs](../../../tests/jq_cli_tests.rs)).
 
+The identical trade-off covers a *stray-comma* fault the same way it covers a *missing*
+delimiter above — `{"a": [,]}` under bare `.` writes `{"a":` before the walk reaches the
+empty array's stray comma and raises (#2210). `-S` forces the fully materializing path,
+which validates the whole document before printing anything, so it emits nothing on the
+same input — the exit code still agrees, only the prefix differs, same as every other case
+in this section. This shape was unreachable through the general (non-`-S`) path before
+#1576's own M2 fast-path fix started correctly declining a nested empty container's stray
+comma instead of silently accepting it as `[]`; only once M2 declines and falls back here
+does this path's own pre-existing, already-accepted non-atomicity apply to it for the first
+time. Pinned by
+`test_jq_general_streaming_path_leaks_prefix_before_nested_comma_fault_2210`
+([tests/jq_cli_tests.rs](../../../tests/jq_cli_tests.rs)).
+
 ## Deliberate divergences (ADR-0018 rule 4)
 
 ### A structurally malformed value doesn't abort the rest of a multi-value stream — no carve-out; this one is out of policy

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -22957,22 +22957,25 @@ fn test_jq_missing_delimiter_raises_through_nonreserializing_filters_1677() -> R
     Ok(())
 }
 
-/// #2210: `evaluate_bytes_streaming`'s general path (the non-M2,
-/// non-`-S` route, reached once M2's own fast path declines a malformed
-/// document -- `{"a": [,]}`'s stray comma inside a nested empty container is
-/// exactly the shape M2 now correctly declines rather than silently
-/// accepting) walks into `.a`'s value and writes `{"a":` before discovering
-/// the fault, leaking that prefix to stdout ahead of the error. Confirmed
-/// this is the *same* documented, deliberate trade-off
+/// #2210: `{"a": [,]}` under bare `.` is the identical shape
+/// `test_jq_identity_on_malformed_array_element_errors_1641` above already
+/// pins (a fault found partway through `write_output_jq_value`'s own
+/// byte-by-byte, no-rewind write of a *single* top-level result) -- a
+/// stray comma nested inside an empty array instead of a bareword-garbage
+/// token, reaching the fault through the same writer the same way. This
+/// was unreachable through this exact shape before #1576's own M2
+/// nested-empty-container fix started correctly declining it (M2 used to
+/// silently accept `{"a": [,]}` as `{"a":[]}`, exit 0, never falling back
+/// to the general path at all). Investigated whether this specific
+/// single-result shape could be fixed by buffering the write (mirroring
+/// `evaluate_m2_fast_path`'s own identical contract for its own
+/// single-result case) rather than merely pinned as more of the same
+/// trade-off -- reverted once `test_jq_identity_on_malformed_array_
+/// element_errors_1641`'s own pre-existing assertions caught it as a
+/// regression against that already-established, deliberately tested
+/// contract, not a previously-undocumented gap. See
 /// `docs/compliance/jq/limitations.md`'s "A fault found by walking to it
-/// leaves the prefix on stdout" section already pins for `[1,,3] | .[]`
-/// (`test_jq_missing_delimiter_raises_through_nonreserializing_filters_1677`
-/// above), not a new inconsistency needing its own fix -- both paths reach
-/// the fault only by walking to it, which is the cost semi-indexing exists
-/// to avoid paying up front. This was unreachable through this exact input
-/// shape before #1576's own M2 nested-empty-container fix started correctly
-/// declining it (M2 used to silently accept `{"a": [,]}` as `{"a":[]}`,
-/// exit 0, never falling back here at all).
+/// leaves the prefix on stdout" for the full writeup.
 #[test]
 fn test_jq_general_streaming_path_leaks_prefix_before_nested_comma_fault_2210() -> Result<()> {
     let (out, stderr, code) = run_jq_full(&["-c", "."], Some(r#"{"a": [,]}"#))?;

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -22957,6 +22957,41 @@ fn test_jq_missing_delimiter_raises_through_nonreserializing_filters_1677() -> R
     Ok(())
 }
 
+/// #2210: `evaluate_bytes_streaming`'s general path (the non-M2,
+/// non-`-S` route, reached once M2's own fast path declines a malformed
+/// document -- `{"a": [,]}`'s stray comma inside a nested empty container is
+/// exactly the shape M2 now correctly declines rather than silently
+/// accepting) walks into `.a`'s value and writes `{"a":` before discovering
+/// the fault, leaking that prefix to stdout ahead of the error. Confirmed
+/// this is the *same* documented, deliberate trade-off
+/// `docs/compliance/jq/limitations.md`'s "A fault found by walking to it
+/// leaves the prefix on stdout" section already pins for `[1,,3] | .[]`
+/// (`test_jq_missing_delimiter_raises_through_nonreserializing_filters_1677`
+/// above), not a new inconsistency needing its own fix -- both paths reach
+/// the fault only by walking to it, which is the cost semi-indexing exists
+/// to avoid paying up front. This was unreachable through this exact input
+/// shape before #1576's own M2 nested-empty-container fix started correctly
+/// declining it (M2 used to silently accept `{"a": [,]}` as `{"a":[]}`,
+/// exit 0, never falling back here at all).
+#[test]
+fn test_jq_general_streaming_path_leaks_prefix_before_nested_comma_fault_2210() -> Result<()> {
+    let (out, stderr, code) = run_jq_full(&["-c", "."], Some(r#"{"a": [,]}"#))?;
+    assert_eq!(code, 5, "out: {out:?}, stderr: {stderr:?}");
+    assert_eq!(out, "{\"a\":", "unexpected output {out:?}");
+    assert!(stderr.contains("Invalid JSON text"), "stderr: {stderr:?}");
+
+    // `-S` forces the fully materializing path, which validates before
+    // printing anything -- confirms the two paths' outputs genuinely
+    // differ only in the accepted prefix, not in whether the fault is
+    // caught at all.
+    let (out, stderr, code) = run_jq_full(&["-c", "-S", "."], Some(r#"{"a": [,]}"#))?;
+    assert_eq!(code, 5, "out: {out:?}, stderr: {stderr:?}");
+    assert!(out.is_empty(), "unexpected output {out:?}");
+    assert!(stderr.contains("Invalid JSON text"), "stderr: {stderr:?}");
+
+    Ok(())
+}
+
 /// #1677: a plain field access that doesn't need to reach a leaf's own
 /// container -- `.a` where `.a` is itself a scalar with a malformed
 /// delimiter -- raises too. Unlike the nested case


### PR DESCRIPTION
## Summary

- `evaluate_bytes_streaming` (the general, non-M2, non-`-S` path, reached once M2's own fast path declines a malformed document) leaks a container's already-written prefix to stdout before its walk reaches a nested fault — `{"a": [,]}` under bare `.` writes `{"a":` before raising on the stray comma inside the empty array. This surfaced for the first time only because #1576's own M2 fix now correctly declines this shape (it used to silently accept it as `{"a":[]}`, exit 0, never falling back to this path at all).
- Investigated both options the issue named: rearchitecting `evaluate_bytes_streaming` to buffer-then-commit, or documenting the existing behavior as an accepted trade-off. Chose the latter — `docs/compliance/jq/limitations.md` already pins the *identical* shape for a missing delimiter (`[1,,3] | .[]`, `test_jq_missing_delimiter_raises_through_nonreserializing_filters_1677`), for the same reason: "suppressing it would mean validating the whole document up front, which is the cost semi-indexing exists to avoid." Buffering this one path specifically would create an inconsistency with that already-established, deliberate architectural convention rather than fix a real one.
- Extends that doc section with this new confirmed instance and adds a regression test pinning the exact repro (live-verified against both the general path and `-S`, which validates upfront and so writes nothing on the same input).

Fixes #2210

## Test plan

- [x] New regression test `test_jq_general_streaming_path_leaks_prefix_before_nested_comma_fault_2210` pins both the general path's prefix-then-error behavior and `-S`'s clean-error behavior on the same input
- [x] Live-verified the exact repro from the issue against the built binary before and after
- [x] Full local test suite (`cargo test --features cli,simd,regex,serde`), both `cargo clippy` legs, `cargo fmt --check`, `cargo test --no-default-features`, and `cargo doc --no-deps --all-features` (`RUSTDOCFLAGS=-D warnings`) all pass