### PR TITLE
fix(jq): bring eval.rs's has/length/keys in line with eval_generic.rs

### DIFF
--- a/docs/compliance/jq/limitations.md
+++ b/docs/compliance/jq/limitations.md
@@ -1708,7 +1708,7 @@ and differently-shaped problem than this section's own fixes):
 - **`src/jq/eval.rs`'s parallel evaluator** -- a second, independently-tested
   evaluator behind the crate's public `jq::eval`/`jq::eval_lenient`/
   `jq::eval_owned_with_file_index` entry points (see
-  `tests/jq_evaluator_parity_tests.rs`), not `eval_generic.rs`, backs `has(key)`
+  `tests/jq_evaluator_parity_tests.rs`), not `eval_generic.rs`, backed `has(key)`
   (object arm, a raw `.any()` with zero gap checks), `length` (array arm
   `.count()`, object arm bare `effective_len`), and `keys`/`keys_unsorted`
   (array arm `.count()`) -- the identical unchecked shape this whole issue
@@ -1729,9 +1729,30 @@ and differently-shaped problem than this section's own fixes):
   already established for `to_owned_with_comments_at_depth` above -- a caller
   of the public library API who builds their own cursor directly from raw,
   unvalidated document bytes (bypassing both CLIs' own materialization step)
-  would still observe the gap. Recommended as its own follow-up issue
-  (tracking `eval.rs`/`eval_generic.rs` parity for the whole #2261 family), not
-  folded in here.
+  would still observe the gap.
+
+  **Fixed by #2293**: `has_one_key`'s object arm now uses `contains_checked`
+  (also closing the #2288 non-string-key gap item 3 below used to track
+  separately -- `contains_checked` already checks for that as part of its
+  own walk), its array arm and `builtin_length`/`builtin_keys`'s array arms
+  now use `len_checked`, and `builtin_length`'s object arm now uses
+  `effective_len_checked`. Parity pinned in
+  `tests/jq_evaluator_parity_tests.rs`'s
+  `test_parity_eval_rs_trailing_comma_sibling_gaps_2293`. Still inert for
+  both CLIs today, same reachability analysis as above -- real only for a
+  library consumer building a cursor directly from raw bytes. The broader
+  "systematic sweep of the rest of `eval.rs`" #2293's own issue also
+  suggested (dozens of further `StandardJson::Array`/`StandardJson::Object`
+  match sites in that file, most already covered by other routes) remains
+  unaddressed and would need its own follow-up issue if pursued.
+
+  Writing that parity test also surfaced a further, unrelated, **live and
+  CLI-reachable** bug shared by *both* evaluators: `{"a":1,} | length` in jq
+  mode (`collapse: true`) silently returns `1` instead of raising --
+  `effective_len_checked`'s `census` path never calls `trailing_gap_ok` at
+  all, unlike every sibling helper in this file. Filed as #2307; not fixed
+  by #2293, which only brings `eval.rs` in line with `eval_generic.rs`'s
+  *existing* behavior, not fixes a bug both evaluators already shared.
 
 Two further leads from the same sweep were investigated and **not**
 reproduced live (so not reported as confirmed bugs, only as ruled out):
@@ -1820,12 +1841,14 @@ existing, already-proven checks within the same file -- not the broader, riskier
 `eval.rs`-wide sweep #2293 recommends as its own issue.
 
 **3. `eval.rs`'s own `has_one_key` (its object arm, a raw `.any()` with zero gap checks)
-shares this same #2288 non-string-key gap** -- already tracked as part of #2293's own
+shared this same #2288 non-string-key gap** -- tracked as part of #2293's own
 "`eval.rs`'s parallel evaluator" umbrella finding (filed alongside `builtin_length`/
 `builtin_keys`'s identical shape during #2261's own round-2 review), not a new discovery
-here. Same reachability analysis applies: `succinctly yq`'s one call site into `eval.rs`
-only ever sees an already-materialized, pre-validated `OwnedValue`, so this is inert for
-both CLIs today. Not re-filed as a separate issue; see #2293 for the tracking.
+here. **Fixed by #2293**: the object arm now uses `contains_checked`, which already
+performs this exact check as part of its own walk, so no separate fix was needed here
+beyond switching helpers. Same reachability analysis applies: `succinctly yq`'s one call
+site into `eval.rs` only ever sees an already-materialized, pre-validated `OwnedValue`, so
+this remains inert for both CLIs today, same as the rest of #2293's fix.
 
 ## Refusing an allocation jq does not survive
 

--- a/docs/compliance/jq/limitations.md
+++ b/docs/compliance/jq/limitations.md
@@ -1746,6 +1746,23 @@ and differently-shaped problem than this section's own fixes):
   match sites in that file, most already covered by other routes) remains
   unaddressed and would need its own follow-up issue if pursued.
 
+  Round-2 code review on #2311 found two more real gaps, neither folded into
+  that PR: `has_one_key`'s array arm called `numeric_key_to_array_index`
+  *before* `len_checked`, short-circuiting to `Bool(false)` on `None` (a NaN
+  key in jq mode, any Float key in yq mode) without ever running the gap
+  check -- fixed in #2311 itself by reordering to match `eval_generic.rs`'s
+  own unconditional-`len_checked`-first shape exactly. Two further siblings
+  sharing the identical unchecked-`.count()` shape were found but
+  deliberately left unfixed: `count_elements` (backs
+  `get_element_at_index`'s negative-index resolution, `.foo[-1]`) needs a
+  genuine new error-type design (its `Result<_, usize>` return already
+  carries a distinct, meaningful "negative still negative" signal, #2254 --
+  not a drop-in swap like the others), filed as #2312; and `builtin_keys`
+  never collapses duplicate keys in *either* mode (it has no
+  `S: EvalSemantics` parameter to derive `S::COLLAPSE_DUPLICATE_KEYS` from,
+  unlike `eval_generic.rs`'s own `Keys`/`KeysUnsorted` arms), filed as
+  #2313.
+
   Writing that parity test also surfaced a further, unrelated, **live and
   CLI-reachable** bug shared by *both* evaluators: `{"a":1,} | length` in jq
   mode (`collapse: true`) silently returns `1` instead of raising --

--- a/src/jq/document.rs
+++ b/src/jq/document.rs
@@ -2494,9 +2494,11 @@ pub fn effective_len<F: DocumentFields>(fields: &F, collapse: bool) -> usize {
 /// covered only the first spelling, leaving `{invalid} | length` erroring
 /// while `{invalid} | keys | length` answered `0`.
 ///
-/// [`effective_len`] itself stays infallible for the two `eval.rs`-side
-/// callers, which reach `length` through the other evaluator and answer for
-/// an already-materialized value.
+/// [`effective_len`] itself stays infallible for its one remaining caller,
+/// `lazy.rs`'s `JqValue::length` (`LazyKeysArray` arm) -- `eval.rs`'s own
+/// `builtin_length` used to be a second infallible caller, but #2293
+/// switched it to this checked sibling, closing the same #2261
+/// trailing-comma gap `eval_generic.rs`'s own `length` arm already had.
 pub fn effective_len_checked<F: DocumentFields>(
     fields: &F,
     collapse: bool,

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -7267,24 +7267,28 @@ fn has_one_key<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
             StandardJson::Array(elements),
             OwnedValue::Int(_) | OwnedValue::Float(_) | OwnedValue::NumberLiteral(..),
         ) => {
+            // #2293 review round 2: `len_checked` runs unconditionally
+            // *before* the `None`/`Some` dispatch below, not only inside
+            // the `Some` arm -- matching `eval_generic.rs`'s own
+            // `eval_has_one_key` array arm exactly (#2291). The #909-era
+            // comment this replaced short-circuited on `None` (a NaN key
+            // in jq mode, any Float key in yq mode) *before* ever calling
+            // `len_checked`, which silently skipped the #1677/#2261 gap
+            // check for exactly that shape -- confirmed live: `has(nan)`
+            // on `[1,2,3,]` answered `false` here while `eval_generic.rs`
+            // correctly raised. `elements` is a lazy O(n) cursor walk
+            // either way, so paying for it even when the key is later
+            // discarded is the same "ride the already-mandatory walk"
+            // trade #2261 uses everywhere else, not a new cost class.
+            let len = match (*elements).len_checked() {
+                Ok(len) => len as i64,
+                Err(e) => return QueryResult::Error(e),
+            };
             let in_bounds = match numeric_key_to_array_index::<S>(&key_owned) {
                 // NaN: a number, so the container check above still
-                // applies, but no element -- never in bounds. `elements`
-                // is a lazy O(n) cursor walk (`StandardJson::Array`, #909
-                // review), so this short-circuits before paying for it,
-                // matching the `Some` arm's own `len` computation being
-                // needed at all.
+                // applies, but no element -- never in bounds.
                 None => false,
-                // #2293: `len_checked`, not the bare `count()` -- same
-                // #1677/#2261 gap `eval_generic.rs`'s own
-                // `eval_has_one_key` array arm already closed (#2291).
-                Some(idx) => {
-                    let len = match (*elements).len_checked() {
-                        Ok(len) => len as i64,
-                        Err(e) => return QueryResult::Error(e),
-                    };
-                    index_in_array_bounds::<S>(idx, len)
-                }
+                Some(idx) => index_in_array_bounds::<S>(idx, len),
             };
             QueryResult::Owned(OwnedValue::Bool(in_bounds))
         }

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -39,9 +39,10 @@ use std::rc::Rc;
 use indexmap::IndexMap;
 
 use super::document::{
-    effective_fields, effective_fields_checked, effective_keys, effective_len, key_delimiter_ok,
-    key_display_string, key_display_string_kind, resolve_display_key, trailing_element_gap_ok,
-    value_delimiter_ok, DisplayKeyGuard, DocumentCursor, DocumentElements, DocumentFields,
+    effective_fields, effective_fields_checked, effective_keys, effective_len_checked,
+    key_delimiter_ok, key_display_string, key_display_string_kind, resolve_display_key,
+    trailing_element_gap_ok, value_delimiter_ok, DisplayKeyGuard, DocumentCursor, DocumentElements,
+    DocumentFields,
 };
 use super::slice::{self, SliceBounds};
 use super::walk::{any_subexpr, map_builtin_subexprs, map_subexprs};
@@ -7074,14 +7075,25 @@ fn builtin_length<W: Clone + AsRef<[u64]>, S: EvalSemantics>(
             Ok(cow) => QueryResult::Owned(OwnedValue::Int(cow.chars().count() as i64)),
             Err(e) => QueryResult::Error(EvalError::decode_failure(e.message())),
         },
-        StandardJson::Array(elements) => {
-            QueryResult::Owned(OwnedValue::Int((*elements).count() as i64))
-        }
+        // #2293: `len_checked`, not the bare `count()` -- the same
+        // #1677/#2261 gap checks `eval_generic.rs`'s own `Length` arm
+        // closed for this exact shape (#2291). Currently unreachable from
+        // either shipped CLI (see this fix's issue for why), but a real
+        // gap for a library consumer of `jq::eval*` navigating raw,
+        // unvalidated document bytes directly.
+        StandardJson::Array(elements) => match (*elements).len_checked() {
+            Ok(len) => QueryResult::Owned(OwnedValue::Int(len as i64)),
+            Err(e) => QueryResult::Error(e),
+        },
         // Distinct keys in jq mode (#1385); every occurrence in yq mode.
-        StandardJson::Object(fields) => QueryResult::Owned(OwnedValue::Int(effective_len(
-            fields,
-            S::COLLAPSE_DUPLICATE_KEYS,
-        ) as i64)),
+        // #2293: `effective_len_checked`, not the bare `effective_len` --
+        // same reasoning as the array arm above.
+        StandardJson::Object(fields) => {
+            match effective_len_checked(fields, S::COLLAPSE_DUPLICATE_KEYS) {
+                Ok(len) => QueryResult::Owned(OwnedValue::Int(len as i64)),
+                Err(e) => QueryResult::Error(e),
+            }
+        }
         StandardJson::Number(n) => {
             // Length of a number is its absolute value.
             // checked_abs: i64::MIN has no i64 absolute value; use f64
@@ -7175,7 +7187,13 @@ fn builtin_keys<W: Clone + AsRef<[u64]>>(
         }
         StandardJson::Array(elements) => {
             // For arrays, keys returns indices [0, 1, 2, ...]
-            let len = elements.count();
+            // #2293: `len_checked`, not the bare `count()` -- same
+            // #1677/#2261 gap `eval_generic.rs`'s own `Keys` array arm
+            // already closed (#2291).
+            let len = match elements.len_checked() {
+                Ok(len) => len,
+                Err(e) => return QueryResult::Error(e),
+            };
             let arr: Vec<OwnedValue> = (0..len).map(|i| OwnedValue::Int(i as i64)).collect();
             QueryResult::Owned(OwnedValue::Array(arr))
         }
@@ -7225,16 +7243,16 @@ fn has_one_key<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
         // jq: null | has("key") => false
         (StandardJson::Null, _) => QueryResult::Owned(OwnedValue::Bool(false)),
         // Object has string key
+        // #2293: `contains_checked`, not a raw `.any()` walk -- the same
+        // #1194/#1677/#2261 gap checks `eval_generic.rs`'s own
+        // `eval_has_one_key` object arm already closed (#2291). See
+        // `contains_checked`'s own doc comment (`document.rs`) for the
+        // early-exit-on-match trade this inherits.
         (StandardJson::Object(fields), OwnedValue::String(key)) => {
-            let found = (*fields).clone().any(|f| {
-                if let StandardJson::String(k) = f.key() {
-                    if let Ok(cow) = k.as_str() {
-                        return cow.as_ref() == key;
-                    }
-                }
-                false
-            });
-            QueryResult::Owned(OwnedValue::Bool(found))
+            match fields.contains_checked(key) {
+                Ok(found) => QueryResult::Owned(OwnedValue::Bool(found)),
+                Err(e) => QueryResult::Error(e),
+            }
         }
         // Array has index - jq returns false for negative, yq returns true if
         // in range. Any numeric key type is accepted here, not just Int --
@@ -7257,8 +7275,14 @@ fn has_one_key<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
                 // matching the `Some` arm's own `len` computation being
                 // needed at all.
                 None => false,
+                // #2293: `len_checked`, not the bare `count()` -- same
+                // #1677/#2261 gap `eval_generic.rs`'s own
+                // `eval_has_one_key` array arm already closed (#2291).
                 Some(idx) => {
-                    let len = (*elements).count() as i64;
+                    let len = match (*elements).len_checked() {
+                        Ok(len) => len as i64,
+                        Err(e) => return QueryResult::Error(e),
+                    };
                     index_in_array_bounds::<S>(idx, len)
                 }
             };

--- a/tests/jq_evaluator_parity_tests.rs
+++ b/tests/jq_evaluator_parity_tests.rs
@@ -1197,6 +1197,13 @@ fn test_parity_has_native_arm_1739() {
 /// the shared `document.rs` helper both evaluators call, not an eval.rs/
 /// eval_generic.rs parity drift -- out of this fix's scope; filed as
 /// #2307.
+///
+/// `has(nan)` pins round-2 review's own finding: the array arm's first
+/// draft called `numeric_key_to_array_index` *before* `len_checked`,
+/// short-circuiting to `Bool(false)` on `None` (a NaN key in jq mode)
+/// without ever running the gap check -- `eval_generic.rs`'s own
+/// `eval_has_one_key` calls `len_checked` unconditionally first. Fixed to
+/// match that order exactly.
 #[test]
 fn test_parity_eval_rs_trailing_comma_sibling_gaps_2293() {
     for (json, filter) in [
@@ -1205,6 +1212,7 @@ fn test_parity_eval_rs_trailing_comma_sibling_gaps_2293() {
         (br"[1,2,3,]", "keys"),
         (br"[1,2,3,]", "keys_unsorted"),
         (br"[1,2,3,]", "has(0)"),
+        (br"[1,2,3,]", "has(nan)"),
         (br#"{"a":1,}"#, r#"has("a")"#),
     ] {
         assert_error_parity(json, filter);

--- a/tests/jq_evaluator_parity_tests.rs
+++ b/tests/jq_evaluator_parity_tests.rs
@@ -1174,6 +1174,43 @@ fn test_parity_has_native_arm_1739() {
     assert_parity(br#"{"a":1,"b":2}"#, r#"[has(("a","z"))]"#);
 }
 
+/// #2293: `eval.rs`'s `has_one_key`/`builtin_length`/`builtin_keys` had the
+/// same missing #1677/#2261 trailing-comma/malformed-member gap checks that
+/// `eval_generic.rs`'s own siblings already closed (#2291) -- unreachable
+/// from either shipped CLI today (both route through `eval_generic.rs`
+/// exclusively, and `succinctly yq`'s `eval.rs` call site only ever
+/// re-serializes an already-validated `OwnedValue`), but a real gap for a
+/// library consumer of `jq::eval*` building a cursor directly from raw,
+/// unvalidated bytes -- exactly what `full_outputs`/`assert_error_parity`
+/// do here, bypassing the CLI's own upfront checks entirely. Every input
+/// mirrors an existing `eval_generic.rs`-side CLI repro (`jq_cli_tests.rs`'s
+/// `test_jq_cursor_transparent_fast_paths_reject_trailing_comma_2261`/
+/// `test_jq_len_checked_sibling_paths_reject_trailing_comma_2261`), so both
+/// evaluators must now raise with the same message.
+///
+/// Deliberately excludes `{"a":1,} | length` (jq mode, `collapse: true`):
+/// found live while writing this test that `effective_len_checked`'s
+/// `census` path never calls `trailing_gap_ok` at all, so *both*
+/// evaluators already agree today -- on the wrong answer (`1`, not a
+/// raise; confirmed against `/usr/bin/jq` 1.7.1, which raises `Expected
+/// another key-value pair`). That's a real, live, CLI-reachable bug in
+/// the shared `document.rs` helper both evaluators call, not an eval.rs/
+/// eval_generic.rs parity drift -- out of this fix's scope; filed as
+/// #2307.
+#[test]
+fn test_parity_eval_rs_trailing_comma_sibling_gaps_2293() {
+    for (json, filter) in [
+        (br"[1,]".as_slice(), "length"),
+        (br"[1,2,3,]", "length"),
+        (br"[1,2,3,]", "keys"),
+        (br"[1,2,3,]", "keys_unsorted"),
+        (br"[1,2,3,]", "has(0)"),
+        (br#"{"a":1,}"#, r#"has("a")"#),
+    ] {
+        assert_error_parity(json, filter);
+    }
+}
+
 /// `assert_parity` compares only *successful* outputs: `collect_owned`'s
 /// `Error(_) => vec![]` arm swallows the error, so two evaluators that raise
 /// different messages -- or one that raises where the other doesn't -- both


### PR DESCRIPTION
## Summary
- `eval.rs`'s parallel evaluator (behind the public `jq::eval`/`jq::eval_lenient`/`jq::eval_owned_with_file_index` entry points) had the same missing #1677/#2261/#2288 trailing-comma and malformed-member gap checks that `eval_generic.rs`'s own siblings already closed (#2291):
  - `has_one_key`'s object arm: raw `.any()` walk → `contains_checked` (also closes the #2288 non-string-key gap for free, since `contains_checked` already checks for that as part of its own walk).
  - `has_one_key`'s array arm, `builtin_length`'s array arm, `builtin_keys`'s array arm: raw `.count()` → `len_checked`.
  - `builtin_length`'s object arm: bare `effective_len` → `effective_len_checked`.
- Confirmed not reachable from either shipped CLI today (`succinctly jq` never calls into `eval.rs`; `succinctly yq`'s one call site always hands it an already-materialized, re-serialized `OwnedValue` that can't contain a stray trailing comma) — a real gap only for a library consumer of `jq::eval*` building a cursor directly from raw, unvalidated document bytes.
- Parity pinned in a new `tests/jq_evaluator_parity_tests.rs` test (`test_parity_eval_rs_trailing_comma_sibling_gaps_2293`), calling both evaluators directly against raw malformed bytes (bypassing the CLI's own upfront checks) to actually exercise the fixed arms.
- `docs/compliance/jq/limitations.md`'s existing "parallel evaluator" entry (and its related #2288 item 3) updated to record the fix.
- Out of scope, left as suggested by the issue: a full sweep of the other ~65 `StandardJson::Array`/`StandardJson::Object` match sites in `eval.rs` (most already covered by other routes) — only the three functions this issue named, plus sibling gaps found by direct comparison with `eval_generic.rs`'s own already-fixed arms.

## Round-2 review fix

Review found `has_one_key`'s array arm called `numeric_key_to_array_index` **before** `len_checked`, so a key resolving to `None` (a NaN key in jq mode, any Float key in yq mode) short-circuited to `Bool(false)` without ever running the gap check — unlike `eval_generic.rs`'s own `eval_has_one_key`, which calls `len_checked` unconditionally first. Reordered to match exactly; added a `has(nan)` regression case to the parity test. Also fixed a `document.rs` doc comment this PR's own fix left stale ("two `eval.rs`-side callers" → one, now that `builtin_length` is checked).

Review also found two further sibling gaps, deliberately **not** folded into this PR:
- `count_elements` (backs `get_element_at_index`'s negative-index resolution, `.foo[-1]`) needs a genuine new error-type design — its `Result<_, usize>` return already carries a distinct, meaningful "negative still negative" signal (#2254), not a drop-in swap like the others. Filed as #2312.
- `builtin_keys` never collapses duplicate keys in *either* mode — it has no `S: EvalSemantics` parameter to derive `S::COLLAPSE_DUPLICATE_KEYS` from, an unrelated pre-existing divergence from `eval_generic.rs`'s own `Keys`/`KeysUnsorted` arms. Filed as #2313.

## A bug found along the way (filed separately, not fixed here)

Writing the parity test surfaced that `{"a":1,} | length` in jq mode (`collapse: true`) silently returns `1` on **both** evaluators today — `effective_len_checked`'s `census` path never calls `trailing_gap_ok` at all, unlike every sibling helper in `document.rs`. Confirmed against `/usr/bin/jq` 1.7.1, which raises `Expected another key-value pair`. This is a live, CLI-reachable bug shared by both evaluators (not an `eval.rs`/`eval_generic.rs` parity drift this issue is about), so it's filed as #2307 rather than folded into this PR.

Closes #2293.

## Test plan
- [x] `cargo test --lib jq::` — 1983 passed
- [x] `cargo test --test yq_cli_tests --features cli` — 1389 passed
- [x] `cargo test --test jq_cli_tests --features cli` — 1374 passed
- [x] `cargo test --test jq_evaluator_parity_tests --features cli` — 42 passed (new test, incl. `has(nan)` round-2 regression case)
- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings`
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features`
- [x] `cargo test --no-default-features --verbose` (no_std)
