### PR TITLE
fix(jq): catch_error_under_optional lacks the uncatchable-error carve-out (#2302)

### DIFF
--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -30619,6 +30619,21 @@ fn accumulate_path_context_step<'a, W: Clone + AsRef<[u64]>>(
 /// hand, makes that gap structurally impossible to reintroduce at a future
 /// call site.
 ///
+/// **#2302: an uncatchable-at-value-position error (#2254) is never
+/// swallowed by `optional`, in either the bare-`Error` or `Partial` shape**
+/// -- checked before the table below runs, by recursing once with
+/// `optional` forced to `false` (still respecting `atomic`'s own
+/// discard-prefix-or-keep-it distinction). PR #2300's review found this
+/// function had no such carve-out at all, unlike every other
+/// `optional`-consulting site since #2270/#2289/#2292 -- inert today for
+/// the same reason the paragraph below explains (`optional` is currently
+/// always `false` here), but two of this function's five call sites
+/// (`Expr::Iterate`, `Builtin::Map`) are live on every `.[]`/`map(f)` call,
+/// not merely inert-until-`optional`-changes -- so a future path-context
+/// arm that legitimately reaches this machinery with `optional: true`
+/// would otherwise silently collapse a decode failure or yq negative-index
+/// error into `None`/a dropped tag instead of propagating it.
+///
 /// **`optional` is currently always `false` at every call site reachable from
 /// the path-context evaluator (#2212).** #2073 removed `Expr::Optional`'s
 /// combined-with-`rest` fallback -- the only route that ever forced a `true`
@@ -30653,6 +30668,31 @@ fn catch_error_under_optional<W>(
     optional: bool,
     atomic: bool,
 ) -> QueryResult<'_, W> {
+    // #2302: an uncatchable-at-value-position error (#2254's decode
+    // failure / yq negative-index raise) must never be silently dropped
+    // by `optional`'s swallow, matching every other optional-consulting
+    // site since #2270/#2289/#2292 -- `eval_try`'s own `is_uncatchable_
+    // at_value_position()` arms (above) are the model this follows: treat
+    // the error as though `optional` were `false`, which still respects
+    // `atomic`'s own discard-prefix-or-keep-it distinction (an atomic
+    // array construction still discards its prefix on an uncatchable
+    // error, exactly as it already does for `(true, false)`'s ordinary
+    // case; a non-atomic generator still keeps and propagates it, exactly
+    // as `(false, false)` already does) by recursing once with `optional`
+    // forced. Single choke point for all five call sites this function
+    // has (`continue_rest_with_context`/`_with_paths`/`_with_fresh_root`'s
+    // own `Partial` arms, `Expr::Iterate`, `Builtin::Map`) rather than
+    // hand-copying the guard into each one.
+    if optional {
+        let uncatchable = match &stopped {
+            QueryResult::Error(e) => e.is_uncatchable_at_value_position(),
+            QueryResult::Partial(_, Control::Error(e)) => e.is_uncatchable_at_value_position(),
+            _ => false,
+        };
+        if uncatchable {
+            return catch_error_under_optional(stopped, false, atomic);
+        }
+    }
     match stopped {
         // `atomic` only has a prefix to discard-or-keep once one was
         // actually accumulated (the `Partial` arm below); a bare `Error`
@@ -45009,6 +45049,55 @@ mod tests {
                 (vec![], "break:out".to_string())
             );
         }
+
+        // #2302: an uncatchable-at-value-position error (#2254) under
+        // `optional: true` must behave exactly as though `optional` were
+        // `false` -- still respecting `atomic`'s own discard-prefix-or-
+        // keep-it distinction -- rather than being swallowed to `None`
+        // (bare `Error`) or having its prefix silently kept with the
+        // error dropped (`Partial`, the `(false, true)` cell above). Only
+        // `optional: true` is worth asserting here: `optional: false`
+        // already takes the unmodified match below regardless of
+        // catchability, covered by the ordinary cases above.
+        let uncatchable = || EvalError::decode_failure("boom");
+        assert_eq!(
+            normalize(catch_error_under_optional::<W>(
+                QueryResult::Error(uncatchable()),
+                true,
+                true
+            )),
+            (vec![], "error:boom".to_string()),
+            "uncatchable bare Error survives optional=true regardless of atomic"
+        );
+        assert_eq!(
+            normalize(catch_error_under_optional::<W>(
+                QueryResult::Error(uncatchable()),
+                true,
+                false
+            )),
+            (vec![], "error:boom".to_string()),
+            "uncatchable bare Error survives optional=true regardless of atomic"
+        );
+        assert_eq!(
+            normalize(catch_error_under_optional::<W>(
+                QueryResult::Partial(prefix(), Control::Error(uncatchable())),
+                true,
+                true
+            )),
+            (vec![], "error:boom".to_string()),
+            "atomic + optional=true: uncatchable still discards prefix and raises, \
+             matching (atomic=true, optional=false)"
+        );
+        assert_eq!(
+            normalize(catch_error_under_optional::<W>(
+                QueryResult::Partial(prefix(), Control::Error(uncatchable())),
+                true,
+                false
+            )),
+            (prefix(), "error:boom".to_string()),
+            "non-atomic + optional=true: uncatchable still keeps prefix and raises, \
+             matching (atomic=false, optional=false)"
+        );
     }
 
     /// **The invariant the whole #820 design rests on**: with a sink that

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -30621,11 +30621,13 @@ fn accumulate_path_context_step<'a, W: Clone + AsRef<[u64]>>(
 ///
 /// **#2302: an uncatchable-at-value-position error (#2254) is never
 /// swallowed by `optional`, in either the bare-`Error` or `Partial` shape**
-/// -- checked before the table below runs, by recursing once with
-/// `optional` forced to `false` (still respecting `atomic`'s own
-/// discard-prefix-or-keep-it distinction). PR #2300's review found this
-/// function had no such carve-out at all, unlike every other
-/// `optional`-consulting site since #2270/#2289/#2292 -- inert today for
+/// -- each arm gates on `optional && !e.is_uncatchable_at_value_position()`
+/// instead of bare `optional` (still respecting `atomic`'s own
+/// discard-prefix-or-keep-it distinction), matching this file's own
+/// identical guard elsewhere and `eval_try`'s own uncatchable arms above.
+/// PR #2300's review found this function had no such carve-out at all,
+/// unlike every other `optional`-consulting site since #2270/#2289/#2292 --
+/// inert today for
 /// the same reason the paragraph below explains (`optional` is currently
 /// always `false` here), but two of this function's five call sites
 /// (`Expr::Iterate`, `Builtin::Map`) are live on every `.[]`/`map(f)` call,
@@ -30668,38 +30670,25 @@ fn catch_error_under_optional<W>(
     optional: bool,
     atomic: bool,
 ) -> QueryResult<'_, W> {
-    // #2302: an uncatchable-at-value-position error (#2254's decode
-    // failure / yq negative-index raise) must never be silently dropped
-    // by `optional`'s swallow, matching every other optional-consulting
-    // site since #2270/#2289/#2292 -- `eval_try`'s own `is_uncatchable_
-    // at_value_position()` arms (above) are the model this follows: treat
-    // the error as though `optional` were `false`, which still respects
-    // `atomic`'s own discard-prefix-or-keep-it distinction (an atomic
-    // array construction still discards its prefix on an uncatchable
-    // error, exactly as it already does for `(true, false)`'s ordinary
-    // case; a non-atomic generator still keeps and propagates it, exactly
-    // as `(false, false)` already does) by recursing once with `optional`
-    // forced. Single choke point for all five call sites this function
-    // has (`continue_rest_with_context`/`_with_paths`/`_with_fresh_root`'s
-    // own `Partial` arms, `Expr::Iterate`, `Builtin::Map`) rather than
-    // hand-copying the guard into each one.
-    if optional {
-        let uncatchable = match &stopped {
-            QueryResult::Error(e) => e.is_uncatchable_at_value_position(),
-            QueryResult::Partial(_, Control::Error(e)) => e.is_uncatchable_at_value_position(),
-            _ => false,
-        };
-        if uncatchable {
-            return catch_error_under_optional(stopped, false, atomic);
-        }
-    }
     match stopped {
         // `atomic` only has a prefix to discard-or-keep once one was
         // actually accumulated (the `Partial` arm below); a bare `Error`
         // (`partial()`'s own empty-prefix collapse, #400/#494) has nothing
         // for `atomic` to affect either way.
+        //
+        // #2302: `optional && !e.is_uncatchable_at_value_position()`, not
+        // bare `optional` -- an uncatchable-at-value-position error
+        // (#2254's decode failure / yq negative-index raise) must never be
+        // silently dropped by `optional`'s swallow here, matching every
+        // other optional-consulting site since #2270/#2289/#2292 and the
+        // identical guard already used at this file's own `Err(e) if
+        // optional && !e.is_uncatchable_at_value_position()` site. Single
+        // choke point for all five call sites this function has
+        // (`continue_rest_with_context`/`_with_paths`/`_with_fresh_root`'s
+        // own `Partial` arms, `Expr::Iterate`, `Builtin::Map`) rather than
+        // hand-copying the guard into each one.
         QueryResult::Error(e) => {
-            if optional {
+            if optional && !e.is_uncatchable_at_value_position() {
                 QueryResult::None
             } else {
                 QueryResult::Error(e)
@@ -30709,12 +30698,23 @@ fn catch_error_under_optional<W>(
         // rather than nested conditionals so each is visible at a glance:
         // `atomic` decides whether `prefix` survives at all; `optional`
         // decides whether the survival (or lack of one) also raises.
-        QueryResult::Partial(prefix, Control::Error(e)) => match (atomic, optional) {
-            (true, true) => QueryResult::None,
-            (true, false) => QueryResult::Error(e),
-            (false, true) => owned_vec_to_result(prefix),
-            (false, false) => QueryResult::Partial(prefix, Control::Error(e)),
-        },
+        //
+        // #2302: `optional` is shadowed by the same uncatchable carve-out
+        // as the bare-`Error` arm above before it ever reaches the table,
+        // so an uncatchable error always lands in the `(atomic, false)`
+        // column -- discarding its prefix for an atomic array
+        // construction exactly as an ordinary non-optional error already
+        // does, keeping and propagating it for a non-atomic generator
+        // exactly as an ordinary non-optional error already does.
+        QueryResult::Partial(prefix, Control::Error(e)) => {
+            let optional = optional && !e.is_uncatchable_at_value_position();
+            match (atomic, optional) {
+                (true, true) => QueryResult::None,
+                (true, false) => QueryResult::Error(e),
+                (false, true) => owned_vec_to_result(prefix),
+                (false, false) => QueryResult::Partial(prefix, Control::Error(e)),
+            }
+        }
         QueryResult::Partial(_, Control::Break(label)) if atomic => QueryResult::Break(label),
         QueryResult::Partial(_, Control::Halt(code)) if atomic => QueryResult::Halt(code),
         other => other,


### PR DESCRIPTION
## Summary

- `catch_error_under_optional` (`src/jq/eval.rs`) — the shared helper behind `continue_rest_with_context`/`_with_paths`/`_with_fresh_root`'s own `Partial` arms, `Expr::Iterate`, and `Builtin::Map` — had no carve-out for an uncatchable-at-value-position error (#2254's decode failure / yq negative-index raise), unlike every other `optional`-consulting site since #2270/#2289/#2292.
- Under `optional: true`, a decode failure or yq negative-index error surfacing mid-`map(f)`, mid-`.[]`, or mid-`rest` continuation after a comma/if/try would have silently collapsed to `QueryResult::None` (bare `Error`) or had its error tag dropped while keeping the prefix (`Partial`), instead of propagating.
- Confirmed inert today, for the same reason #2270/#2289/#2292's own sites were: `optional` is provably always `false` at every call site reachable from the path-context evaluator (this function's own doc comment, #2212). But `Iterate`/`Map` are live on every `.[]`/`map(f)` call, not merely inert-until-`optional`-changes the way the #2292 series' `Array`/`StringInterpolation` sites are — so a future path-context arm that legitimately reaches `optional: true` here would otherwise silently drop the error.
- Fixed via a single choke point (the issue's own suggested approach): checked before the existing match, recursing once with `optional` forced to `false` when the error is uncatchable — mirrors `eval_try`'s own `is_uncatchable_at_value_position()` arms, and still respects `atomic`'s own discard-prefix-or-keep-it distinction rather than a blanket rule.

Fixes #2302

## Test plan

- [x] Extended `test_catch_error_under_optional_full_truth_table_1888` with the new uncatchable cases (bare `Error` and `Partial`, both `atomic` values, under `optional: true`)
- [x] Fail-without-fix / pass-with-fix verified manually before committing
- [x] Full local test suite (`cargo test --features cli,simd,regex,serde`), both `cargo clippy` legs, `cargo fmt --check`, `cargo test --no-default-features`, and `cargo doc --no-deps --all-features` (`RUSTDOCFLAGS=-D warnings`) all pass