### PR TITLE
fix(jq): length on an object now checks #2261's trailing-comma gap

### DIFF
--- a/docs/compliance/jq/limitations.md
+++ b/docs/compliance/jq/limitations.md
@@ -1526,22 +1526,33 @@ case outside this issue's own five repros, a scoped follow-up rather than
 opportunistic scope creep. Pinned as still open by
 `test_jq_cursor_transparent_fast_paths_empty_container_stray_comma_remains_a_known_gap_2261`.
 
-**`length` (objects).** Not one of this issue's own five repros, but
-checked for consistency: `{"a":1,}| length` also stays open. `length`'s
-object arm (`effective_len_checked` → `census`, `document.rs`) walks with
-`uncons_key` specifically to avoid resolving any field's *value* at all
-(#1514: "a key-only walk pays for one `key()` and no `value()`" --
-`census`/`checked_len` never call `field.value_cursor()`, unlike every
-fixed path above). Retrofitting the trailing-value check here would need
-the last field's value cursor, which this walk deliberately never
-resolves -- adding it would either (a) always resolve one extra value
-cursor from a field that might not even be the last one until the walk
-finishes (a real, if small, per-call cost the #1514 design specifically
-avoids paying), or (b) require a broader trait-level change to expose a
-"free" value cursor per key-only step, which is a larger architectural
-change than a single-issue scope justifies. Left open, matching this
-same "would cost more than length's own answer" reasoning `#1629`
-established for the object's own positional-index case above.
+**`length` (objects) -- fixed by #2307/#2311.** Not one of this issue's own
+five repros, originally left open here with reasoning that turned out to be
+wrong: this entry used to claim closing the gap would need either paying to
+resolve an extra value cursor per call, or a "larger architectural change."
+Neither was true. `census`/`checked_len` (`document.rs`) already retain the
+last-visited key's *cursor* at zero extra cost (same as
+`DistinctKeyCursors`/`contains_checked`); once the walk finishes naturally
+that cursor's own `next_sibling()` is an O(1) BP hop to its value -- the
+exact same "free" derivation `DocumentFields::uncons` already performs to
+turn a key cursor into a value cursor in the first place, not a fresh
+resolve. `{"a":1,} | length` now raises in both modes (`census`'s
+`collapse: true` path and `checked_len`'s `collapse: false` one),
+consolidated into a shared `last_field_trailing_gap_ok` helper alongside
+`DistinctKeyCursors::trailing_gap_ok`/`contains_checked`'s own identical
+hop (code review on #2311, found by mistake while writing #2293's own
+parity test -- neither PR's original scope named this).
+
+**Residual gap, inherited from `trailing_element_gap_ok` itself, not new
+here:** a trailing comma is only caught when the object's real last
+field's *value* is a scalar. When it's a container (array/object, empty or
+not), `trailing_element_gap_ok`'s own unconditional `is_container()` early
+return means no text position is ever resolved to check against -- the
+same #2243 residual every other #2261-family fix in this file already has
+(`array` `length`/`len_checked`, `has(key)`, `keys`, ...), now shared by
+object `length` too. `{"a":{"x":1},} | length` still answers `1` instead
+of raising. Pinned as still open by
+`test_jq_length_object_trailing_comma_container_last_value_still_a_known_gap_2307`.
 
 ### Partial output before the error, on the two genuinely streaming writers
 
@@ -1765,11 +1776,13 @@ and differently-shaped problem than this section's own fixes):
 
   Writing that parity test also surfaced a further, unrelated, **live and
   CLI-reachable** bug shared by *both* evaluators: `{"a":1,} | length` in jq
-  mode (`collapse: true`) silently returns `1` instead of raising --
-  `effective_len_checked`'s `census` path never calls `trailing_gap_ok` at
-  all, unlike every sibling helper in this file. Filed as #2307; not fixed
-  by #2293, which only brings `eval.rs` in line with `eval_generic.rs`'s
-  *existing* behavior, not fixes a bug both evaluators already shared.
+  mode (`collapse: true`) silently returned `1` instead of raising --
+  `effective_len_checked`'s `census` path never called `trailing_gap_ok` at
+  all, unlike every sibling helper in this file. Not fixed by #2293, which
+  only brought `eval.rs` in line with `eval_generic.rs`'s *existing*
+  behavior, not a bug both evaluators already shared -- filed and fixed
+  separately as #2307/#2316; see this doc's own "`length` (objects)"
+  entry above for the fix and its residual gap.
 
 Two further leads from the same sweep were investigated and **not**
 reproduced live (so not reported as confirmed bugs, only as ruled out):

--- a/docs/compliance/yq/limitations.md
+++ b/docs/compliance/yq/limitations.md
@@ -596,6 +596,44 @@ softened, and was accepted implicitly by #1975's own goal of mirroring
 JSON-via-YAML-flow routing). #2262's `{"a":1,}` addition is the same design choice applied to
 one more comma shape, not a new departure from it.
 
+**`length` on an object had the identical missing-check shape, in yq mode too, but this one
+is *not* a real-yq divergence fix** — found and fixed as
+[#2307](https://github.com/rust-works/succinctly/issues/2307)/
+[#2316](https://github.com/rust-works/succinctly/pull/2316), the yq-mode half of a fix
+`jq`'s own limitations.md documents in full (its "`length` (objects)" entry). `document.rs`'s
+`checked_len` (this mode's `collapse: false` field-count walk, shared with `census`'s jq-mode
+`collapse: true` one) never checked for a trailing stray comma after the object's real last
+field at all. The same `census`/`checked_len` code is reached from *both* routes -- the
+plain-stdout cursor-native path (`evaluate_yaml_direct_filtered`) evaluates through the same
+`eval_generic.rs` `Length` arm as `--slurp`/`--eval-all`/`--inplace`'s own DOM materialization
+bridge (`to_owned_canonicalizing_numbers_at_depth`) -- but the *cursor type* differs: the
+plain path's `YamlCursor` never overrides `trailing_element_gap_ok`/`scalar_text_end`, so this
+fix is a genuine no-op there (verified live, unchanged before/after); the DOM bridge's
+`JsonCursor` does override them, so the fix's only observable effect is on that one route --
+the same deliberately *stricter-than-real-yq* JSON grammar #1975/#2262 already established
+above:
+
+```console
+$ printf '{"a":1,}' | succinctly yq --input-format json --slurp '.[0] | length'
+1                                                            # WRONG on this bridge's own strict-JSON policy (was: silently accepted)
+$ printf '{"a":1,}' | succinctly yq --input-format json 'length'
+1                                                            # unaffected, correct -- checked_len runs but the check is a no-op on a YamlCursor
+$ printf '{"a":1,}' | yq -p json 'length'
+1                                                            # real yq is lenient here too (no --slurp equivalent exists to compare against)
+```
+
+Real yq has no oracle to check the `--slurp` bridge's own behavior against at all (it has no
+`--slurp` flag, and its one JSON-input route, `-p json`, is the same lenient one #1975 already
+chose not to mirror for other comma shapes) -- this fix is internal consistency with the DOM
+bridge's own established strictness policy, not a new real-yq-parity claim, exactly like every
+other #1975/#2262 comma check on this bridge. Only reachable via `--input-format json`: native
+YAML flow-maps *legitimately* allow a trailing comma on every route, confirmed live against
+the pinned v4.53.3 (`{a: 1,} | length` answers `1` at exit 0 there too), so this fix leaves
+YAML's own leniency untouched everywhere. Same residual gap as the jq-mode fix: a trailing
+comma before a *container*-typed last value (`{"a":[1,2],}`) still slips through on this
+bridge, inherited from `trailing_element_gap_ok`'s own unconditional container skip (#2243) --
+pinned by `test_yq_length_object_trailing_comma_container_last_value_still_a_known_gap_2307`.
+
 Pulling the other way: [#442](https://github.com/rust-works/succinctly/issues/442),
 [#478](https://github.com/rust-works/succinctly/issues/478),
 [#868](https://github.com/rust-works/succinctly/issues/868) and

--- a/src/jq/document.rs
+++ b/src/jq/document.rs
@@ -1836,6 +1836,7 @@ fn census<F: DocumentFields>(fields: &F) -> KeyCensus {
     let mut malformed = false;
     let mut walk = fields.clone();
     let mut is_first = true;
+    let mut last_key_cursor: Option<F::Cursor> = None;
     while let Some((key, cursor, rest)) = walk.uncons_key() {
         // #1677: both checks are free here -- comma-before-key reuses
         // `key`'s own decode, and colon-before-value scans forward from
@@ -1856,12 +1857,29 @@ fn census<F: DocumentFields>(fields: &F) -> KeyCensus {
                 malformed |= key_is_malformed(&key);
             }
         }
+        last_key_cursor = Some(cursor);
         walk = rest;
         is_first = false;
     }
     // `walk` is the list this loop *finished* on, the only list
     // `ends_unpaired` answers for (#1194), and asking it is O(1).
     malformed |= walk.ends_unpaired();
+    // #2307: trailing stray comma after a real last field (`{"a":1,}`) --
+    // `census` never checked this at all, unlike every sibling walk in this
+    // file (`effective_keys`'s `DistinctKeyCursors::trailing_gap_ok`,
+    // `DocumentElements::len_checked`'s own array counterpart). `walk`
+    // finished naturally, so `last_key_cursor` is genuinely the object's
+    // last field -- its value's own `next_sibling()` hop is the same O(1)
+    // move `contains_checked` already uses, mirroring `len_checked`'s
+    // unconditional post-loop check (no "is this really last" guard
+    // needed there either, for the identical reason).
+    if let Some(last) = &last_key_cursor {
+        if let Some(value_cursor) = last.next_sibling() {
+            if !trailing_element_gap_ok(&value_cursor, b'}') {
+                malformed = true;
+            }
+        }
+    }
     hashes.sort_unstable();
     let (shared, distinct_hashes) = shared_hashes(&hashes);
     if shared.is_empty() {
@@ -2523,6 +2541,7 @@ fn checked_len<F: DocumentFields>(fields: &F) -> Result<usize, EvalError> {
     let mut count = 0usize;
     let mut walk = fields.clone();
     let mut is_first = true;
+    let mut last_key_cursor: Option<F::Cursor> = None;
     while let Some((key, cursor, rest)) = walk.uncons_key() {
         if key_is_malformed(&key) {
             return Err(walk.malformed_member_error());
@@ -2534,11 +2553,21 @@ fn checked_len<F: DocumentFields>(fields: &F) -> Result<usize, EvalError> {
             return Err(walk.malformed_member_error());
         }
         count += 1;
+        last_key_cursor = Some(cursor);
         walk = rest;
         is_first = false;
     }
     if walk.ends_unpaired() {
         return Err(walk.malformed_member_error());
+    }
+    // #2307: trailing stray comma after a real last field (`{"a":1,}`) --
+    // same gap, same fix as `census` above.
+    if let Some(last) = &last_key_cursor {
+        if let Some(value_cursor) = last.next_sibling() {
+            if !trailing_element_gap_ok(&value_cursor, b'}') {
+                return Err(fields.malformed_member_error());
+            }
+        }
     }
     Ok(count)
 }

--- a/src/jq/document.rs
+++ b/src/jq/document.rs
@@ -1065,14 +1065,11 @@ pub trait DocumentFields: Sized + Clone {
         }
         // #2261: no match found anywhere, so this walk already reached the
         // object's true end -- the trailing-gap check is free here, same
-        // as every other #2261 fix, via the same `next_sibling()` hop
-        // `DistinctKeyCursors::trailing_gap_ok` uses.
-        if let Some(key_cursor) = last_key_cursor {
-            if let Some(value_cursor) = key_cursor.next_sibling() {
-                if !trailing_element_gap_ok(&value_cursor, b'}') {
-                    return Err(self.malformed_member_error());
-                }
-            }
+        // as every other #2261 fix, via `last_field_trailing_gap_ok`
+        // (#2307), consolidating what used to be a fourth inline copy of
+        // this same hop-then-check shape.
+        if !last_field_trailing_gap_ok(last_key_cursor, b'}') {
+            return Err(self.malformed_member_error());
         }
         Ok(false)
     }
@@ -1563,6 +1560,34 @@ pub fn trailing_element_gap_ok<C: DocumentCursor>(last_cursor: &C, close_char: u
     }
 }
 
+/// [`trailing_element_gap_ok`], for a key-only object walk that has
+/// tracked only the last field's *key* cursor (`census`, `checked_len`,
+/// `contains_checked`'s exhaustion path, [`DistinctKeyCursors`]'s own
+/// field of the same name) rather than its value.
+///
+/// `last_key_cursor` is `None` for an empty object or a walk that never
+/// reached a true last key; either way this answers `true` -- nothing to
+/// flag, the same "can't determine, skip" convention every sibling gap
+/// check in this module follows. Otherwise hops to the key's value via
+/// `next_sibling()` -- an O(1) BP hop mirroring how every
+/// [`DocumentFields::uncons`] impl already derives a field's value cursor
+/// from its key cursor -- and defers to [`trailing_element_gap_ok`],
+/// inheriting its own container-typed-last-child residual gap (#2243).
+///
+/// Four call sites duplicated this exact hop-then-check inline before
+/// consolidating here (code review, #2307): [`DistinctKeyCursors`]'s own
+/// `trailing_gap_ok`, `contains_checked`'s exhaustion path, and `census`/
+/// `checked_len`'s post-loop checks below.
+pub(crate) fn last_field_trailing_gap_ok<C: DocumentCursor>(
+    last_key_cursor: Option<C>,
+    close_char: u8,
+) -> bool {
+    match last_key_cursor.and_then(|c| c.next_sibling()) {
+        Some(value_cursor) => trailing_element_gap_ok(&value_cursor, close_char),
+        None => true,
+    }
+}
+
 /// [`value_delimiter_ok`], for a key-only walk (`census`, `checked_len`,
 /// [`DistinctKeyCursors`]) that has not resolved a value cursor at all.
 ///
@@ -1866,20 +1891,11 @@ fn census<F: DocumentFields>(fields: &F) -> KeyCensus {
     malformed |= walk.ends_unpaired();
     // #2307: trailing stray comma after a real last field (`{"a":1,}`) --
     // `census` never checked this at all, unlike every sibling walk in this
-    // file (`effective_keys`'s `DistinctKeyCursors::trailing_gap_ok`,
-    // `DocumentElements::len_checked`'s own array counterpart). `walk`
-    // finished naturally, so `last_key_cursor` is genuinely the object's
-    // last field -- its value's own `next_sibling()` hop is the same O(1)
-    // move `contains_checked` already uses, mirroring `len_checked`'s
-    // unconditional post-loop check (no "is this really last" guard
-    // needed there either, for the identical reason).
-    if let Some(last) = &last_key_cursor {
-        if let Some(value_cursor) = last.next_sibling() {
-            if !trailing_element_gap_ok(&value_cursor, b'}') {
-                malformed = true;
-            }
-        }
-    }
+    // file. `walk` finished naturally, so `last_key_cursor` is genuinely
+    // the object's last field; see `last_field_trailing_gap_ok`'s own doc
+    // comment for the O(1) hop and the container-typed-last-child residual
+    // gap (#2243) this inherits.
+    malformed |= !last_field_trailing_gap_ok(last_key_cursor, b'}');
     hashes.sort_unstable();
     let (shared, distinct_hashes) = shared_hashes(&hashes);
     if shared.is_empty() {
@@ -2270,19 +2286,11 @@ impl<F: DocumentFields> DistinctKeyCursors<F> {
     /// one this same walk already flagged malformed for an unrelated
     /// reason) has no reliable "last field" answer to check yet.
     ///
-    /// `last_key_cursor` (this struct's own private field) tracks the key; the value
-    /// this check needs sits at that key's own `next_sibling()` -- an O(1)
-    /// BP hop mirroring how every [`DocumentFields::uncons`] impl derives a
-    /// field's value cursor from its key cursor in the first place (see
-    /// `JsonFields::uncons`), run once here rather than during the walk.
-    /// `None` (an empty object, or a format whose cursor carries no
-    /// position) answers `true` -- nothing to flag, same "can't determine,
-    /// skip" convention every sibling gap check in this module follows.
+    /// `last_key_cursor` (this struct's own private field) tracks the key;
+    /// see `last_field_trailing_gap_ok` (#2307) for how the value cursor
+    /// this check needs is derived from it.
     pub fn trailing_gap_ok(&self, close_char: u8) -> bool {
-        match self.last_key_cursor.and_then(|c| c.next_sibling()) {
-            Some(value_cursor) => trailing_element_gap_ok(&value_cursor, close_char),
-            None => true,
-        }
+        last_field_trailing_gap_ok(self.last_key_cursor, close_char)
     }
 }
 
@@ -2561,13 +2569,16 @@ fn checked_len<F: DocumentFields>(fields: &F) -> Result<usize, EvalError> {
         return Err(walk.malformed_member_error());
     }
     // #2307: trailing stray comma after a real last field (`{"a":1,}`) --
-    // same gap, same fix as `census` above.
-    if let Some(last) = &last_key_cursor {
-        if let Some(value_cursor) = last.next_sibling() {
-            if !trailing_element_gap_ok(&value_cursor, b'}') {
-                return Err(fields.malformed_member_error());
-            }
-        }
+    // same gap, same fix as `census` above; see `last_field_trailing_gap_ok`.
+    // `fields`, not `walk` (unlike every error return above): `walk`'s own
+    // `key_cursor` is already `None` here (the walk just exhausted), which
+    // would fall back to `malformed_member_error`'s generic "Invalid JSON
+    // text" wording instead of the specific, re-validated message `fields`
+    // (still holding its original cursor) produces -- `JsonFields::text()`
+    // reads the whole document regardless of position, so this costs
+    // nothing, only picks the more precise of two equally-cheap cursors.
+    if !last_field_trailing_gap_ok(last_key_cursor, b'}') {
+        return Err(fields.malformed_member_error());
     }
     Ok(count)
 }

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -22558,6 +22558,50 @@ fn test_jq_len_checked_sibling_paths_reject_trailing_comma_2261() -> Result<()> 
     Ok(())
 }
 
+/// #2307: `length` on an object never checked the #2261 trailing-comma gap
+/// at all -- unlike every sibling in this file, `census` (jq mode,
+/// `collapse: true`, reached via `effective_len_checked`) and `checked_len`
+/// (yq mode, `collapse: false`) both walked every key/delimiter pair but
+/// never consulted `trailing_gap_ok` for the object's own real last field.
+/// `{"a":1,} | length` silently answered `1` instead of raising. Verified
+/// live against `/usr/bin/jq` 1.7.1 (`jq: parse error: Expected another
+/// key-value pair`). Reproduces with any number of preceding fields, not
+/// just the single-field case.
+#[test]
+fn test_jq_length_object_rejects_trailing_comma_2307() -> Result<()> {
+    for (input, query) in [(r#"{"a":1,}"#, "length"), (r#"{"a":1,"b":2,}"#, "length")] {
+        let (out, stderr, code) = run_jq_full(&["-c", query], Some(input))?;
+        assert_eq!(
+            code, 5,
+            "input={input} query={query}: out: {out:?}, stderr: {stderr:?}"
+        );
+        assert!(
+            out.trim().is_empty(),
+            "input={input} query={query}: unexpected output {out:?}"
+        );
+        assert!(
+            stderr.contains("Invalid JSON text"),
+            "input={input} query={query}: stderr: {stderr:?}"
+        );
+    }
+
+    // Well-formed input (including a duplicate key, which jq mode's
+    // `collapse: true` path resolves via a different branch of `census`
+    // than the single-field case above) must still answer correctly --
+    // this fix must not turn a valid document malformed.
+    for (input, expected) in [
+        (r#"{"a":1}"#, "1"),
+        (r#"{"a":1,"b":2}"#, "2"),
+        (r#"{"a":1,"a":2}"#, "1"),
+    ] {
+        let (out, _stderr, code) = run_jq_full(&["-c", "length"], Some(input))?;
+        assert_eq!(code, 0, "input={input}: unexpected failure");
+        assert_eq!(out.trim(), expected, "input={input}");
+    }
+
+    Ok(())
+}
+
 /// #2261 follow-up: a systematic sweep for every other unchecked
 /// `DocumentElements::collect_cursors`/`.len()` call site in
 /// `eval_generic.rs`/`document.rs` (prompted by the five paths above)

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -22602,6 +22602,35 @@ fn test_jq_length_object_rejects_trailing_comma_2307() -> Result<()> {
     Ok(())
 }
 
+/// #2307's own remaining, deliberately deferred gap -- inherited from
+/// `trailing_element_gap_ok`'s unconditional `is_container()` early return
+/// (the same #2243 residual `array` `length` (`len_checked`), `has(key)`,
+/// `keys`, and every other #2261-family fix in this file already has, not
+/// something new here): a trailing stray comma is only caught when the
+/// object's real last field's *value* is a scalar. When it's a container
+/// (array/object, empty or not), `census`/`checked_len` never resolve a
+/// text position to check against, so the fault slips through. Real jq
+/// rejects all four (confirmed live against `/usr/bin/jq` 1.7.1). Pinned
+/// here, same discipline as #1676's own known-gap test above, so a future
+/// fix for *this* narrower residual updates this test rather than landing
+/// uncovered.
+#[test]
+fn test_jq_length_object_trailing_comma_container_last_value_still_a_known_gap_2307() -> Result<()>
+{
+    for input in [
+        r#"{"a":{"x":1},}"#,
+        r#"{"a":[1,2],}"#,
+        r#"{"a":{},}"#,
+        r#"{"a":[],}"#,
+    ] {
+        let (out, stderr, code) = run_jq_full(&["-c", "length"], Some(input))?;
+        assert_eq!(code, 0, "input={input}: stderr: {stderr:?}");
+        assert_eq!(out.trim(), "1", "input={input}");
+    }
+
+    Ok(())
+}
+
 /// #2261 follow-up: a systematic sweep for every other unchecked
 /// `DocumentElements::collect_cursors`/`.len()` call site in
 /// `eval_generic.rs`/`document.rs` (prompted by the five paths above)

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -1666,6 +1666,46 @@ fn test_input_format_json_bridge_preserves_decode_failure_key_1642() -> Result<(
     Ok(())
 }
 
+/// #2307: `length` on an object never checked the #2261 trailing-comma gap
+/// in yq mode (`collapse: false`, `checked_len`) either -- the identical
+/// gap #2307's jq-mode fix (`jq_cli_tests.rs`'s
+/// `test_jq_length_object_rejects_trailing_comma_2307`) closes for
+/// `census`. `.[0]`, not bare `length`: `--slurp` wraps the input in an
+/// array, so an un-prefixed `length` would silently answer the array's own
+/// element count (always `1` here) rather than exercising the object's own
+/// field count at all.
+#[test]
+fn test_yq_length_object_rejects_trailing_comma_2307() -> Result<()> {
+    for input in [r#"{"a":1,}"#, r#"{"a":1,"b":2,}"#] {
+        let (out, stderr, code) = run_yq_stdin_with_stderr(
+            ".[0] | length",
+            input,
+            &["--input-format", "json", "--slurp"],
+        )?;
+        assert_eq!(code, 1, "input={input}: out: {out:?}, stderr: {stderr:?}");
+        assert!(
+            out.trim().is_empty(),
+            "input={input}: unexpected output {out:?}"
+        );
+        assert!(
+            stderr.contains("Invalid JSON text"),
+            "input={input}: stderr: {stderr:?}"
+        );
+    }
+
+    for (input, expected) in [(r#"{"a":1}"#, "1"), (r#"{"a":1,"b":2}"#, "2")] {
+        let (output, code) = run_yq_stdin(
+            ".[0] | length",
+            input,
+            &["--input-format", "json", "--slurp"],
+        )?;
+        assert_eq!(code, 0, "input={input}");
+        assert_eq!(output.trim(), expected, "input={input}");
+    }
+
+    Ok(())
+}
+
 /// #1738: the `--input-format json` bridge's own `DisplayKeyGuard` check
 /// was missing entirely -- unlike every other `to_owned`-shaped
 /// materializer (#1642) -- so a decode-failure key colliding with another

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -1706,6 +1706,30 @@ fn test_yq_length_object_rejects_trailing_comma_2307() -> Result<()> {
     Ok(())
 }
 
+/// #2307's own remaining, deliberately deferred gap (yq-mode twin of
+/// `jq_cli_tests.rs`'s `test_jq_length_object_trailing_comma_container_last_value_still_a_known_gap_2307`):
+/// `checked_len` shares `census`'s inherited #2243 residual --
+/// `trailing_element_gap_ok`'s unconditional `is_container()` early return
+/// -- so a trailing stray comma is only caught when the object's real last
+/// field's value is a scalar, not a container. Pinned here so a future fix
+/// for this narrower residual updates this test rather than landing
+/// uncovered.
+#[test]
+fn test_yq_length_object_trailing_comma_container_last_value_still_a_known_gap_2307() -> Result<()>
+{
+    for input in [r#"{"a":{"x":1},}"#, r#"{"a":[1,2],}"#] {
+        let (out, code) = run_yq_stdin(
+            ".[0] | length",
+            input,
+            &["--input-format", "json", "--slurp"],
+        )?;
+        assert_eq!(code, 0, "input={input}");
+        assert_eq!(out.trim(), "1", "input={input}");
+    }
+
+    Ok(())
+}
+
 /// #1738: the `--input-format json` bridge's own `DisplayKeyGuard` check
 /// was missing entirely -- unlike every other `to_owned`-shaped
 /// materializer (#1642) -- so a decode-failure key colliding with another


### PR DESCRIPTION
## Summary
- `length` on an object never checked #2261's trailing-comma gap at all, in either mode:
  - `census` (jq mode, `collapse: true`, reached via `effective_len_checked`): checked key delimiters and `ends_unpaired`, but never `trailing_gap_ok`.
  - `checked_len` (yq mode, `collapse: false`): same gap.
- `{"a":1,} | length` silently returned `1` instead of raising — confirmed live against `/usr/bin/jq` 1.7.1, which raises `Expected another key-value pair`. Reproduces with any number of preceding fields.
- Both walks already retain each visited key's cursor; the fix hops from the last one to its value via `next_sibling()` and checks `trailing_element_gap_ok` on it once, after the loop.
- Verified this doesn't false-positive on well-formed input, including a duplicate-key case that exercises `census`'s other branch (`{"a":1,"a":2}`).
- Verified YAML flow-maps are correctly unaffected: `{a: 1,} | length` still answers `1` in yq's native YAML mode, matching real `yq`'s own behavior live-confirmed against the pinned v4.53.3 (YAML's flow-map grammar tolerates a trailing comma; JSON's does not) — this fix only reaches JSON-format input (`--input-format json`).

Found while writing #2293/#2311's own parity test; filed as its own issue since it's a live, CLI-reachable bug shared by both evaluators, not an `eval.rs`/`eval_generic.rs` parity drift.

## Round-2 review fixes

- **Consolidated duplication**: the new checks were a 4th near-identical copy of the same "hop from last key cursor to its value, check `trailing_element_gap_ok`" shape `DistinctKeyCursors::trailing_gap_ok` and `contains_checked`'s exhaustion path already had. Extracted a shared `last_field_trailing_gap_ok` helper; all four sites now call it.
- **Pinned a real, inherited residual gap**: `trailing_element_gap_ok`'s own unconditional `is_container()` early return means a trailing comma before a *container*-typed last value (`{"a":{"x":1},}`, `{"a":[1,2],}`) still slips through — the same #2243 residual every other #2261-family fix in this file already has (array `length`, `has(key)`, `keys`, ...), not something new here, but previously untested for object `length`. Added `test_jq_length_object_trailing_comma_container_last_value_still_a_known_gap_2307`/`test_yq_length_object_trailing_comma_container_last_value_still_a_known_gap_2307`, matching this file's own established "pin known gaps rather than ship them uncovered" discipline (e.g. #1676's own known-gap test).
- **Fixed a fabricated oracle comparison** in an earlier draft of the yq-side doc addition: real yq has no `--slurp` flag, and its actual JSON-input route (`-p json`) is *lenient* about trailing commas in objects (confirmed live), matching this doc's own pre-existing #1975/#2262 characterization — the yq-mode fix here is internal consistency with the DOM materialization bridge's own established stricter-than-real-yq policy, not a real-yq-parity claim. Corrected both `docs/compliance/{jq,yq}/limitations.md`, including the now-stale "`length` (objects)" writeup in the jq doc, which used to (incorrectly) claim closing this gap would need a larger architectural change.
- Added an explanatory comment for why `checked_len`'s new check uses `fields.malformed_member_error()` rather than the surrounding loop's `walk.malformed_member_error()` (deliberate — `walk`'s cursor is already exhausted at that point, which would degrade to a generic fallback message).

## Test plan
- [x] New CLI tests: `test_jq_length_object_rejects_trailing_comma_2307`/`test_yq_length_object_rejects_trailing_comma_2307` (malformed raises + well-formed still works), plus the two known-gap pinning tests above
- [x] `cargo test --lib jq::` / `cargo test --lib document::`
- [x] `cargo test --test jq_cli_tests --features cli` — 1377 passed
- [x] `cargo test --test yq_cli_tests --features cli` — 1397 passed
- [x] `cargo test --test jq_evaluator_parity_tests --features cli` — 42 passed
- [x] `cargo test --test yq_golden_tests --features cli` / `cargo test --test jq_golden_tests --features cli`
- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings`
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features`
- [x] `cargo test --no-default-features --verbose` (no_std)

Closes #2307.
