### PR TITLE
fix(jq): --argjson accepts leading/trailing-dot number leniency (#2240)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -289,6 +289,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`--argjson`/`--jsonargs` rejected a leading-dot (`.5`, #1171) or trailing-dot-before-
+  exponent (`1.e5`, #2220) number literal outright, where real jq's own number parser
+  accepts both** (#2240 Gap 2): a `--argjson`/`--jsonargs` value needing either leniency
+  failed `serde_json`'s strict validation gate with no retry, unlike plain document input
+  (which already tolerates both). Fixed via a new `normalize_dot_leniency` sibling to
+  #1094's own `normalize_leading_zero_numbers`, composed into the same
+  `normalize_json_leniently` retry pass shared by `--argjson`'s validator, `--seq`'s own
+  per-value check, and yq mode's own `--argjson` — so all three pick up the fix at once,
+  and a value needing more than one leniency at once (e.g. `007.e5`) still gets all of
+  them, matching #2012's own "compose, don't chain independent retries" precedent. A
+  bare `.`/`-.` with digits on *neither* side is still correctly rejected — not a number
+  under any leniency, real jq included — caught by review before merge, since a first
+  draft unconditionally synthesized `0`s around any dot it saw, silently "fixing" a
+  genuinely malformed bare `.` into the valid number `0.0`.
+  Gap 1 in the same issue (an array-navigated `tostring`/`@json` losing an
+  overflow-literal's exact spelling) was investigated and found **not reproducible** on
+  current `main` — both the root-level and array-navigated paths already agree, deferring
+  identically to #1083/#1075's own earlier, deliberate policy of never preserving an
+  infinite-magnitude `NumberLiteral`'s spelling in jq mode (the reindex bridge's own
+  `1e999`/`-1e999` smuggling sentinel for a genuinely *computed* infinity is
+  bit-for-bit indistinguishable from a real document literal of the same spelling once
+  round-tripped, so reformatting either would risk mislabeling the other) — the issue's
+  own "root-level path already matches" claim appears to have been stale by the time this
+  was picked up.
 - **`del()`/`delpaths()` silently no-op on a negative out-of-range array index instead of
   raising** (#2268): #2254 already fixed every ordinary *read* (`.a[-N]`) to raise real yq's
   own "index [N] out of range" error, but `del()`/`delpaths()` shared the identical gap with a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -303,6 +303,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   under any leniency, real jq included — caught by review before merge, since a first
   draft unconditionally synthesized `0`s around any dot it saw, silently "fixing" a
   genuinely malformed bare `.` into the valid number `0.0`.
+
+  A second review round caught a more serious issue with that first draft: accepting a
+  leading-dot literal via `--argjson`'s validation retry, then materializing it from the
+  *original* text, silently lost precision (`--argjson x '.9999999999999999999999'`
+  returned `1`, not jq's own `0.9999999999999999999999`) — `OwnedValue::from_number_bytes`
+  (the primary document-input decoder) already had a leading-dot escape from #1171, but
+  `StandardJson::number_literal()` (the generic evaluator's own materializer, which
+  `--argjson` reaches) never did, so it fell through to a lossy `f64` parse. Fixed by
+  extracting the escape into a new shared `has_leading_dot` helper
+  (`src/json/validate.rs`, alongside the existing `has_trailing_dot_before_exponent`) and
+  adding it to `number_literal()` too — as a side effect, this also fixes the identical
+  precision loss for plain document input routed through any real query
+  (`'.9999999999999999999999' | if true then . else empty end'` reproduced the same bug
+  pre-fix, unrelated to `--argjson`). The same round narrowed `normalize_dot_leniency`'s
+  own trailing-dot acceptance to the exponent-adjacent shape only (`1.e5`), *not* a bare
+  trailing dot with nothing after it (`1.`) — accepting the bare form would trade a clean
+  rejection for a different silent-corruption bug, a large-integer-precision gap
+  `from_number_bytes`/`number_literal()` share and leave deliberately unfixed (confirmed
+  pre-existing via plain document input too: `99999999999999999.` already materializes as
+  `100000000000000000` on `main`). `1.` therefore still rejects via `--argjson`, a narrower
+  divergence from real jq (which accepts it) than #2240's own issue text first suggested,
+  kept rather than risking silent data corruption for a shape #2220's own scope
+  (trailing-dot-*before-exponent*) never actually asked for.
+
   Gap 1 in the same issue (an array-navigated `tostring`/`@json` losing an
   overflow-literal's exact spelling) was investigated and found **not reproducible** on
   current `main` — both the root-level and array-navigated paths already agree, deferring

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -327,6 +327,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   kept rather than risking silent data corruption for a shape #2220's own scope
   (trailing-dot-*before-exponent*) never actually asked for.
 
+  A third review round found a **critical** bug the second round's fix introduced:
+  `succinctly yq --argjson x '.05' '.b = $x'` returned `0.5` — ten times too large.
+  `normalize_json_leniently` composed `normalize_dot_leniency` *after*
+  `normalize_leading_zero_numbers`, whose own number-token-start detection can't see a
+  preceding dot — fed `.05` first, it starts a fresh scan right at the `0` after the dot
+  and mistakes the fraction's own leading zero for a redundant *integer* leading zero,
+  stripping it (`.05` → `.5`) before the dot-leniency pass ever runs. Invisible to jq
+  mode's own tests, since `jq_runner.rs`'s own `parse_json_value` only uses the normalized
+  text as a validation gate and always materializes the *original* text — but
+  `yq_runner.rs`'s own `parse_json_value` reparses the *normalized* text directly as the
+  value (by design, since yq's `--argjson` already discards number fidelity), making it
+  the one place this composition-order bug was reachable. Fixed by reordering the
+  composition: `normalize_dot_leniency` now runs *before*
+  `normalize_leading_zero_numbers`, so a leading-dot token already has its synthesized `0`
+  in front by the time the zero-stripper runs, and its integer part is never empty for the
+  stripper to misinterpret. Verified with 500+ adversarial combinations of all three
+  leniencies, in both jq and yq mode, across `--argjson`/`--jsonargs`/`--seq`.
+
   Gap 1 in the same issue (an array-navigated `tostring`/`@json` losing an
   overflow-literal's exact spelling) was investigated and found **not reproducible** on
   current `main` — both the root-level and array-navigated paths already agree, deferring

--- a/docs/compliance/jq/limitations.md
+++ b/docs/compliance/jq/limitations.md
@@ -3805,6 +3805,47 @@ described:
   jq's own hang, as ADR-0018 does not require — is the worse failure mode
   for the realistic inputs this magnitude range covers).
 
+### `--argjson`/`--jsonargs` still reject a bare trailing decimal point with no exponent (`1.`) — accepted divergence, ADR-0018 rule 4c (#2240)
+
+Real jq's own number reader accepts a bare trailing `.` with nothing after it at all,
+treating it the same as if the dot weren't there:
+
+```console
+$ jq -n --argjson x '1.' '$x'
+1
+$ succinctly jq -n --argjson x '1.' '$x'
+Error: Invalid JSON for --argjson x
+```
+
+#2240 fixed `--argjson`/`--jsonargs` to accept the *other* two number leniencies real jq's
+own parser tolerates that strict RFC 8259 doesn't — a leading decimal point (`.5`, #1171)
+and a trailing decimal point immediately *before an exponent marker* (`1.e5`, #2220) — but
+deliberately not this third, narrower shape. Accepting it would route the literal through
+`OwnedValue::from_number_bytes`/`StandardJson::number_literal()`'s shared, pre-existing
+large-integer-precision gap: a bare trailing dot with no exponent on an integer too large
+for `f64` to represent exactly materializes as the wrong integer regardless of entry point
+(confirmed live via plain document input, unrelated to `--argjson`):
+
+```console
+$ jq -c '.' <<< '99999999999999999.'
+99999999999999999
+$ succinctly jq -c '.' <<< '99999999999999999.'
+100000000000000000
+```
+
+`from_number_bytes`'s own doc comment already documents this trade-off for the *general*
+(non-`--argjson`) case as deliberate, reasoning that real jq doesn't preserve this exact
+spelling either (`[1.] -> [1]` on both sides) — true only for a small value where the lossy
+`f64` round-trip happens to be lossless, not for a large one. Extending `--argjson`'s own
+acceptance to this shape would mean trading a clean rejection (the pre-#2240 status quo)
+for a value that's silently wrong rather than absent, for the one case where the
+underlying gap actually bites. Per ADR-0018 rule 4c: matching real jq's own acceptance here
+would risk corrupting data, the worse failure mode for the input shapes this actually
+covers — so `--argjson x '1.'` stays a clean, catchable error rather than a silent
+magnitude error, a narrower divergence from real jq than #2240's own issue text first
+scoped this fix to. Fixing the underlying large-integer-precision gap itself (so `1.` could
+be accepted safely at every magnitude) is out of scope for #2240 and not separately filed.
+
 ## Provenance
 
 | Artifact           | Path                                                                                                       |

--- a/src/bin/succinctly/jq_runner.rs
+++ b/src/bin/succinctly/jq_runner.rs
@@ -4229,20 +4229,24 @@ fn seq_pending_token_is_terminated(
 }
 
 /// Whether one value out of a `--seq` record is legal JSON, allowing the
-/// same leading-zero form (`007e5`) `--seq` has accepted since #1243, and
-/// the same lone-low-surrogate escape (`\uDC00`-`\uDFFF`) `--argjson`
-/// accepts since #2012 (code review: `validate::validate` -- strict RFC
-/// 8259 -- and `validate_json_str` -- `serde_json` -- both reject a lone
-/// low surrogate, so without this, a `--seq` record real jq accepts
+/// same leading-zero form (`007e5`) `--seq` has accepted since #1243, the
+/// same lone-low-surrogate escape (`\uDC00`-`\uDFFF`) `--argjson` accepts
+/// since #2012 (code review: `validate::validate` -- strict RFC 8259 --
+/// and `validate_json_str` -- `serde_json` -- both reject a lone low
+/// surrogate, so without this, a `--seq` record real jq accepts
 /// [confirmed live: `printf '\x1e"\udc00"\n' | jq --seq -c '.'` =>
 /// `"�"`, exit 0] silently vanished instead, the exact leniency gap
-/// #2012 fixed for `--argjson` reappearing one function over).
+/// #2012 fixed for `--argjson` reappearing one function over), and the
+/// same leading/trailing decimal-point forms (`.5`, `1.e5`) `--argjson`
+/// accepts since #2240 -- all three via the same shared
+/// `normalize_json_leniently`, not enumerated separately here.
 ///
 /// Normalization is needed *here* and only here: the value-building side
 /// ([`json_bytes_to_owned_value_checked`], reached once a record is judged
-/// valid) already reads `0007` as `7` and substitutes U+FFFD for a lone low
-/// surrogate on its own -- so it needs no fallback of its own for either
-/// leniency.
+/// valid) already reads `0007` as `7`, substitutes U+FFFD for a lone low
+/// surrogate, and preserves a leading/trailing-dot literal's own spelling
+/// on its own -- so it needs no fallback of its own for any of the three
+/// leniencies.
 fn seq_value_is_valid(value_text: &str) -> bool {
     if validate::validate(value_text.as_bytes()).is_ok() {
         return true;

--- a/src/bin/succinctly/jq_runner.rs
+++ b/src/bin/succinctly/jq_runner.rs
@@ -3125,8 +3125,32 @@ fn parse_json_value(s: &str) -> Result<OwnedValue> {
 /// this one function keeps the two CLI modes from silently re-diverging on
 /// the same input the way they did between #1094/#2012 landing here and
 /// yq's copy not getting either fix.
+///
+/// `normalize_dot_leniency` runs *before* `normalize_leading_zero_numbers`,
+/// not after -- #2240 code review found this order matters, not just a
+/// style choice: `normalize_leading_zero_numbers`'s own number-token-start
+/// detection (`b == '-' || b.is_ascii_digit()`) has no way to see a
+/// *preceding* dot, so fed a leading-dot literal first, it starts a fresh
+/// scan right after the dot and can mistake a fraction's own leading zero
+/// for a redundant *integer* leading zero to strip -- `.05` corrupted to
+/// `.5` (dropping a real digit, not a redundant one), which
+/// `normalize_dot_leniency` would then only compound by prefixing `0.5`
+/// instead of the correct `0.05`. Harmless for `jq_runner::parse_json_value`
+/// (which only uses the normalized text as a validation gate and always
+/// materializes the *original* `s` afterward, confirmed live:
+/// `--argjson x '.05'` already answered `0.05` correctly even with the
+/// wrong order) but a real, silent 10x-magnitude corruption for
+/// `yq_runner::parse_json_value`, which -- unlike its jq-mode counterpart
+/// -- reparses the *normalized* text directly as the value itself (that
+/// function's own doc comment explains why: yq's `--argjson` already
+/// discards number fidelity by design, so there is no separate original
+/// spelling to fall back to). Running the dot leniency first avoids ever
+/// handing `normalize_leading_zero_numbers` a fraction digit run to
+/// mistake for an integer one: by the time it runs, a leading-dot token
+/// already has its synthesized `0` in front, so the token's own integer
+/// part is never empty.
 pub(crate) fn normalize_json_leniently(s: &str) -> String {
-    normalize_lone_low_surrogates(&normalize_dot_leniency(&normalize_leading_zero_numbers(s)))
+    normalize_lone_low_surrogates(&normalize_leading_zero_numbers(&normalize_dot_leniency(s)))
 }
 
 /// Whether `bytes[i..]` starts with a JSON `\uXXXX` escape -- if so, its
@@ -3494,11 +3518,10 @@ fn normalize_dot_leniency(s: &str) -> String {
         // `.` into `0.0`, silently accepting genuinely invalid input).
         let start = i;
         let mut scan = after_sign;
-        let int_start = scan;
         while scan < bytes.len() && bytes[scan].is_ascii_digit() {
             scan += 1;
         }
-        let has_int_digits = scan > int_start;
+        let has_int_digits = scan > after_sign;
         let has_dot = scan < bytes.len() && bytes[scan] == b'.';
         let frac_start = if has_dot { scan + 1 } else { scan };
         let mut frac_end = frac_start;

--- a/src/bin/succinctly/jq_runner.rs
+++ b/src/bin/succinctly/jq_runner.rs
@@ -3420,12 +3420,32 @@ fn normalize_leading_zero_numbers(s: &str) -> String {
 /// follow-up to #1094's leading-zero fix above, found while verifying
 /// #2220): a **leading** decimal point with no integer digit before it
 /// (`.5` -> `0.5`, `-.5` -> `-0.5`, #1171), and a **trailing** decimal
-/// point with no fraction digit after it, whether or not an exponent
-/// follows (`1.` -> `1.0`, `1.e5` -> `1.0e5`, #2220). Both are already
-/// tolerated on the crate's own document-input path (`json::light`'s
-/// number decoder); this repairs just the `--argjson`/`--jsonargs`
-/// validation-retry gap, the same shape #1094 already closed for leading
-/// zeros.
+/// point immediately before an exponent marker, with no fraction digit
+/// between them (`1.e5` -> `1.0e5`, #2220). Both are already tolerated on
+/// the crate's own document-input path (`json::light`'s number decoder,
+/// via `has_leading_dot`/`has_trailing_dot_before_exponent`); this repairs
+/// just the `--argjson`/`--jsonargs` validation-retry gap, the same shape
+/// #1094 already closed for leading zeros.
+///
+/// Deliberately **not** a bare trailing `.` with nothing after it at all
+/// (`1.`, no exponent) -- narrower than #2240's own issue text first
+/// suggested, and narrower than an earlier draft of this function, which
+/// treated `1.`/`1.e5` identically. `has_trailing_dot_before_exponent`
+/// itself only recognizes the exponent-adjacent shape (checked live: it
+/// returns `false` for a bare `1.`), so accepting the bare form here would
+/// let it through this validation-retry gate only to hit
+/// `number_literal()`'s/`from_number_bytes`'s shared, *pre-existing*
+/// large-integer-precision bug on the other side (`99999999999999999.`
+/// materializing as `100000000000000000`, confirmed live via plain
+/// document input too, not something either shares an escape for --
+/// `from_number_bytes`'s own doc comment already documents this as
+/// deliberately unfixed, correct only for a *small* value where the lossy
+/// `f64` fallback happens to round-trip losslessly). Before this narrowing,
+/// `--argjson` traded a clean rejection of that shape for a silently wrong
+/// value -- caught by code review before merge. `1.` alone is therefore
+/// still rejected via `--argjson`, matching this crate's pre-#2240 behavior
+/// for it exactly; #2220's own scope (trailing-dot-*before-exponent*) is
+/// unaffected either way.
 ///
 /// Written as its own scan rather than reusing [`find_number_end`]: that
 /// function's own doc comment explicitly documents it never sees a bare
@@ -3488,6 +3508,8 @@ fn normalize_dot_leniency(s: &str) -> String {
             }
         }
         let has_frac_digits = frac_end > frac_start;
+        let exponent_follows =
+            frac_end < bytes.len() && (bytes[frac_end] == b'e' || bytes[frac_end] == b'E');
         // `has_int_digits` or `has_dot` is always true here (`starts_number`
         // above already confirmed `bytes[after_sign]` is a digit or `.`,
         // and this scan reaches `bytes[after_sign]` unconditionally as
@@ -3500,6 +3522,16 @@ fn normalize_dot_leniency(s: &str) -> String {
             i += 1;
             continue;
         }
+        if has_dot && !has_frac_digits && !exponent_follows {
+            // Bare trailing `.` with nothing after it at all (`1.`), out of
+            // this function's own narrowed scope -- see its doc comment for
+            // why. Copy the digits and dot verbatim, unfixed, so the
+            // retried validation still rejects this shape exactly as
+            // before #2240.
+            out.extend_from_slice(&bytes[start..frac_start]);
+            i = frac_start;
+            continue;
+        }
         out.extend_from_slice(&bytes[start..scan]);
         if !has_int_digits {
             // Leading-dot case (#1171).
@@ -3510,8 +3542,11 @@ fn normalize_dot_leniency(s: &str) -> String {
             if has_frac_digits {
                 out.extend_from_slice(&bytes[frac_start..frac_end]);
             } else {
-                // Trailing-dot case (#2220): no fraction digit before the
-                // token ends or an exponent begins.
+                // Trailing-dot-before-exponent case (#2220): no fraction
+                // digit between the dot and the exponent marker --
+                // `exponent_follows` is guaranteed true here, the bare
+                // (no-exponent) form having already been filtered out
+                // above.
                 out.push(b'0');
             }
         }

--- a/src/bin/succinctly/jq_runner.rs
+++ b/src/bin/succinctly/jq_runner.rs
@@ -3094,13 +3094,14 @@ fn parse_json_value(s: &str) -> Result<OwnedValue> {
 }
 
 /// Apply every leniency real jq allows that `serde_json`'s own validation
-/// doesn't (#1094's leading zero, #2012's lone low surrogate) in one
-/// composed pass, so a value needing more than one at once still gets all
-/// of them -- code review on #2012: `parse_json_value` and its `--seq`
-/// counterpart `seq_value_is_valid` each once applied the two
-/// normalizations independently against the untouched original, which
-/// missed exactly the value-needs-both case (`[007,"\udc00"]`). A no-op
-/// on text neither normalizer finds anything to fix in.
+/// doesn't (#1094's leading zero, #2012's lone low surrogate, #2240's
+/// leading/trailing decimal point) in one composed pass, so a value
+/// needing more than one at once still gets all of them -- code review on
+/// #2012: `parse_json_value` and its `--seq` counterpart `seq_value_is_valid`
+/// each once applied the two normalizations independently against the
+/// untouched original, which missed exactly the value-needs-both case
+/// (`[007,"\udc00"]`). A no-op on text neither normalizer finds anything to
+/// fix in.
 ///
 /// This grows one normalizer per leniency rather than trusting a grammar
 /// that already agrees with this crate's own decoder -- `parse_json_stream`
@@ -3109,8 +3110,11 @@ fn parse_json_value(s: &str) -> Result<OwnedValue> {
 /// getting every leniency for free with no per-case enumeration), at the
 /// cost of losing `validate_json_str`'s magnitude-overflow rejection
 /// (`1e400`, #1095) that motivated using `serde_json::Value` here in the
-/// first place. Worth revisiting if a third leniency shows up (#2012 code
-/// review, altitude angle).
+/// first place. #2240 is the "third leniency" this doc comment used to say
+/// would be worth revisiting for (#2012 code review, altitude angle) --
+/// still grown as one more composed normalizer rather than switching
+/// shapes, since the alternative's own cost (losing the overflow rejection)
+/// hasn't changed.
 ///
 /// `pub(crate)`: as of #2051, called from three sites total --
 /// `parse_json_value` and `seq_value_is_valid` in this file, plus
@@ -3122,7 +3126,7 @@ fn parse_json_value(s: &str) -> Result<OwnedValue> {
 /// the same input the way they did between #1094/#2012 landing here and
 /// yq's copy not getting either fix.
 pub(crate) fn normalize_json_leniently(s: &str) -> String {
-    normalize_lone_low_surrogates(&normalize_leading_zero_numbers(s))
+    normalize_lone_low_surrogates(&normalize_dot_leniency(&normalize_leading_zero_numbers(s)))
 }
 
 /// Whether `bytes[i..]` starts with a JSON `\uXXXX` escape -- if so, its
@@ -3409,6 +3413,127 @@ fn normalize_leading_zero_numbers(s: &str) -> String {
         i += 1;
     }
     String::from_utf8(out).expect("only ever copies s's own bytes verbatim or drops leading ASCII '0' digits, never splits a multi-byte sequence")
+}
+
+/// Repair the two other number-token leniencies real jq's own parser
+/// accepts that strict RFC 8259 JSON (`serde_json`) doesn't (#2240, a
+/// follow-up to #1094's leading-zero fix above, found while verifying
+/// #2220): a **leading** decimal point with no integer digit before it
+/// (`.5` -> `0.5`, `-.5` -> `-0.5`, #1171), and a **trailing** decimal
+/// point with no fraction digit after it, whether or not an exponent
+/// follows (`1.` -> `1.0`, `1.e5` -> `1.0e5`, #2220). Both are already
+/// tolerated on the crate's own document-input path (`json::light`'s
+/// number decoder); this repairs just the `--argjson`/`--jsonargs`
+/// validation-retry gap, the same shape #1094 already closed for leading
+/// zeros.
+///
+/// Written as its own scan rather than reusing [`find_number_end`]: that
+/// function's own doc comment explicitly documents it never sees a bare
+/// leading `.` (its caller only invokes it when the byte at `pos` is `-`
+/// or an ASCII digit) and has no way to report "the fraction had zero
+/// digits" separately from "there was no fraction at all" -- both
+/// properties this repair needs. A fifth independent number-token scanner
+/// in this crate (#1218's own survey already counted four before this
+/// one), consistent with that issue's own conclusion that blanket
+/// consolidation needs its own design pass rather than forcing one more
+/// caller's genuinely different grammar onto an existing scanner.
+fn normalize_dot_leniency(s: &str) -> String {
+    let bytes = s.as_bytes();
+    let mut out: Vec<u8> = Vec::with_capacity(s.len());
+    let mut i = 0;
+    while i < bytes.len() {
+        let b = bytes[i];
+        if b == b'"' {
+            let end = find_string_end(bytes, i).unwrap_or(bytes.len());
+            out.extend_from_slice(&bytes[i..end]);
+            i = end;
+            continue;
+        }
+        // A lenient number token starts at `i` iff, past an optional sign,
+        // the next byte is a digit (an ordinary token) or `.` itself (the
+        // leading-dot leniency) -- for any other `b` (including a bare `-`
+        // with no digit or dot after it, e.g. `[-,1]`) this is false and
+        // the byte is copied through unexamined below, same as
+        // `normalize_leading_zero_numbers`'s "bare `-`" case.
+        let sign_len = usize::from(b == b'-');
+        let after_sign = i + sign_len;
+        let starts_number = after_sign < bytes.len()
+            && (bytes[after_sign].is_ascii_digit() || bytes[after_sign] == b'.');
+        if !starts_number {
+            out.push(b);
+            i += 1;
+            continue;
+        }
+        // Scan the full token first, without writing anything -- a `.`
+        // with digits on *neither* side (a bare `.`, or `-.` alone) is not
+        // a number at all, real jq's own leniency included, and must be
+        // left untouched for `serde_json`'s retried validation to reject
+        // exactly as before (confirmed live: `--argjson x '.'` still
+        // raises in real jq; an earlier draft here that wrote `0`/`.`/`0`
+        // unconditionally as int/dot/frac were each seen "fixed" a bare
+        // `.` into `0.0`, silently accepting genuinely invalid input).
+        let start = i;
+        let mut scan = after_sign;
+        let int_start = scan;
+        while scan < bytes.len() && bytes[scan].is_ascii_digit() {
+            scan += 1;
+        }
+        let has_int_digits = scan > int_start;
+        let has_dot = scan < bytes.len() && bytes[scan] == b'.';
+        let frac_start = if has_dot { scan + 1 } else { scan };
+        let mut frac_end = frac_start;
+        if has_dot {
+            while frac_end < bytes.len() && bytes[frac_end].is_ascii_digit() {
+                frac_end += 1;
+            }
+        }
+        let has_frac_digits = frac_end > frac_start;
+        // `has_int_digits` or `has_dot` is always true here (`starts_number`
+        // above already confirmed `bytes[after_sign]` is a digit or `.`,
+        // and this scan reaches `bytes[after_sign]` unconditionally as
+        // either the first digit consumed or the dot itself).
+        if !has_int_digits && !has_frac_digits {
+            // Bare `.`/`-.`: not a number under any leniency. Copy just
+            // the sign/dot byte and let the next iteration(s) handle
+            // whatever follows on their own terms.
+            out.push(b);
+            i += 1;
+            continue;
+        }
+        out.extend_from_slice(&bytes[start..scan]);
+        if !has_int_digits {
+            // Leading-dot case (#1171).
+            out.push(b'0');
+        }
+        if has_dot {
+            out.push(b'.');
+            if has_frac_digits {
+                out.extend_from_slice(&bytes[frac_start..frac_end]);
+            } else {
+                // Trailing-dot case (#2220): no fraction digit before the
+                // token ends or an exponent begins.
+                out.push(b'0');
+            }
+        }
+        let mut exp_scan = frac_end;
+        // Exponent, if any -- copied verbatim, including a dangling marker
+        // with no digits after it (`1e`), the same leniency
+        // `find_number_end` extends and leaves for `serde_json`'s
+        // re-validation to reject on its own terms.
+        if exp_scan < bytes.len() && (bytes[exp_scan] == b'e' || bytes[exp_scan] == b'E') {
+            let exp_start = exp_scan;
+            exp_scan += 1;
+            if exp_scan < bytes.len() && (bytes[exp_scan] == b'+' || bytes[exp_scan] == b'-') {
+                exp_scan += 1;
+            }
+            while exp_scan < bytes.len() && bytes[exp_scan].is_ascii_digit() {
+                exp_scan += 1;
+            }
+            out.extend_from_slice(&bytes[exp_start..exp_scan]);
+        }
+        i = exp_scan;
+    }
+    String::from_utf8(out).expect("only ever copies s's own bytes verbatim or inserts an ASCII '0' around an existing '.', never splits a multi-byte sequence")
 }
 
 /// Parse a JSON stream (multiple JSON values) from a string. Backs both

--- a/src/bin/succinctly/yq_runner.rs
+++ b/src/bin/succinctly/yq_runner.rs
@@ -3761,15 +3761,23 @@ fn colorize_yaml(yaml: &str, terminator: Terminator, boundaries: &[usize]) -> St
 ///
 /// On the initial strict parse's failure, retries against
 /// `jq_runner::normalize_json_leniently`'s output (#1094's leading zero,
-/// #2012's lone low surrogate) -- the same two leniencies `succinctly jq`'s
-/// own `--argjson` already accepts (yq mode has no `--jsonargs` at all, see
-/// `build_args_var` below), shared from one definition rather than a
-/// second, independently-maintained copy (#2051: before this, the two
-/// modes had silently drifted apart on this exact input). Reparsing the
-/// *normalized* text directly (not the original, unlike `jq_runner`'s
-/// retry) is sufficient here precisely because this function already
-/// discards number fidelity -- there is no original spelling left to
-/// preserve. That includes *magnitude*, not just cosmetic spelling, for an
+/// #2012's lone low surrogate, #2240's leading/trailing decimal point) --
+/// the same leniencies `succinctly jq`'s own `--argjson` already accepts
+/// (yq mode has no `--jsonargs` at all, see `build_args_var` below), shared
+/// from one definition rather than a second, independently-maintained copy
+/// (#2051: before this, the two modes had silently drifted apart on this
+/// exact input). Reparsing the *normalized* text directly (not the
+/// original, unlike `jq_runner`'s own retry) is sufficient here precisely
+/// because this function already discards number fidelity -- there is no
+/// original spelling left to preserve. This is also exactly what made this
+/// function the one place #2240's own composition-order bug was reachable:
+/// `normalize_json_leniently` composing `normalize_dot_leniency` after,
+/// rather than before, `normalize_leading_zero_numbers` corrupted `.05`
+/// into `.5` before this function ever saw it, silently materializing
+/// `0.5` -- ten times too large -- since this function reparses that
+/// corrupted copy directly. `jq_runner::parse_json_value` never observed
+/// the same corruption, since it always materializes the *original* `s`
+/// regardless of what the normalized copy says. That includes *magnitude*, not just cosmetic spelling, for an
 /// integer too large for `f64` to represent exactly: stripping a leading
 /// zero from `0099999999999999999999999` now reaches the same lossy
 /// `serde_json_to_owned` path a plain `99999999999999999999999` (no

--- a/src/jq/value.rs
+++ b/src/jq/value.rs
@@ -2487,8 +2487,9 @@ mod tests {
     /// #1171: a leading-dot number literal (with or without a `-` sign)
     /// must preserve its own source spelling as a `NumberLiteral`, not
     /// degrade to a plain lossy `Float` -- direct unit coverage of both
-    /// `dot_prefix_len` branches in `from_number_bytes` (0 for `.5`, 1
-    /// for `-.5`), complementing the CLI-level regression tests.
+    /// `has_leading_dot` branches `from_number_bytes` relies on (no sign
+    /// for `.5`, a `-` sign for `-.5`), complementing the CLI-level
+    /// regression tests.
     #[test]
     fn test_from_number_bytes_preserves_leading_dot_spelling() {
         assert_eq!(
@@ -2499,8 +2500,10 @@ mod tests {
             OwnedValue::from_number_bytes(b"-.500"),
             OwnedValue::NumberLiteral(NumberRepr::Float(-0.5), "-.500".into())
         );
-        // A bare `.` (no digit at all) still degrades to Null: `dot_prefix_len`
-        // is set, but prefixing `0` doesn't make it strictly valid either.
+        // A bare `.` (no digit at all) still degrades to Null:
+        // `has_leading_dot` returns `false` for it -- prefixing a `0`
+        // doesn't make it strictly valid either, since there's still no
+        // digit anywhere in the token.
         assert_eq!(OwnedValue::from_number_bytes(b"."), OwnedValue::Null);
         assert_eq!(OwnedValue::from_number_bytes(b"-."), OwnedValue::Null);
     }

--- a/src/jq/value.rs
+++ b/src/jq/value.rs
@@ -1481,27 +1481,16 @@ impl OwnedValue {
         // this leniency shouldn't reach), but a real jq-accepted spelling
         // this crate's own document-input scanners now recognize as a
         // number span (`number_literal_end`, #1171). Preserve it the same
-        // way #1094 preserves a leading zero: check whether inserting `0`
-        // right after any `-` makes the token strictly valid, and if so,
-        // still materialize the *original* (un-inserted) text as the
-        // literal spelling -- `bytes` was already gated by
-        // `number_literal_end` at the scan site, and
+        // way #1094 preserves a leading zero -- `bytes` was already gated
+        // by `number_literal_end` at the scan site, and
         // `Self::from_number_literal` (via `parse_i64_or_f64`) parses a
         // leading-dot float natively, so no separate reparse of the
-        // original text is needed here.
-        let dot_prefix_len = match bytes.first() {
-            Some(b'.') => Some(0),
-            Some(b'-') if bytes.get(1) == Some(&b'.') => Some(1),
-            _ => None,
-        };
-        if let Some(prefix_len) = dot_prefix_len {
-            let mut prefixed = Vec::with_capacity(bytes.len() + 1);
-            prefixed.extend_from_slice(&bytes[..prefix_len]);
-            prefixed.push(b'0');
-            prefixed.extend_from_slice(&bytes[prefix_len..]);
-            if crate::json::validate::is_valid_number(&prefixed) {
-                return core::str::from_utf8(bytes).map_or(Self::Null, Self::from_number_literal);
-            }
+        // original text is needed here. `has_leading_dot`, not a hand-rolled
+        // check inline here: shared with `crate::json::light`'s
+        // `DocumentValue::number_literal` implementation, which needs the
+        // identical escape (#2240 code review).
+        if crate::json::validate::has_leading_dot(bytes) {
+            return core::str::from_utf8(bytes).map_or(Self::Null, Self::from_number_literal);
         }
         // Real jq's own number reader also tolerates a redundant leading
         // zero in the integer part (`007` -> `7`, `007e5` -> `7E+5`,

--- a/src/json/light.rs
+++ b/src/json/light.rs
@@ -2498,6 +2498,24 @@ impl<'a, W: AsRef<[u64]> + Clone> DocumentValue for StandardJson<'a, W> {
                 // reflect (matches `from_number_bytes`'s own leading-dot
                 // and leading-zero handling, both of which store the
                 // original text for the same reason).
+                // Real jq's own number reader also accepts a leading `.`
+                // (with or without a preceding `-`) when at least one digit
+                // follows (`.5` -> `0.5`, `-.5` -> `-0.5`, #1171) -- same
+                // leniency as `OwnedValue::from_number_bytes`'s own
+                // leading-dot handling, shared gate via `has_leading_dot`.
+                // Checked before the leading-zero-strip escape below (no
+                // int digits to strip in the first place for a leading-dot
+                // token, so the two never compose the way the leading-zero
+                // and trailing-dot escapes do) -- missing entirely until
+                // #2240's own code review found it: `--argjson` navigating
+                // through this generic-evaluator path (not
+                // `from_number_bytes`'s own primary document-input path)
+                // silently lost precision on a leading-dot literal instead
+                // of preserving its spelling, once #2240's own fix let
+                // `--argjson` accept one in the first place.
+                if crate::json::validate::has_leading_dot(bytes) {
+                    return core::str::from_utf8(bytes).ok().map(Cow::Borrowed);
+                }
                 let zero_stripped = crate::json::validate::strip_redundant_leading_zeros(bytes);
                 if let Some(stripped) = &zero_stripped {
                     if crate::json::validate::is_valid_number(stripped) {

--- a/src/json/validate.rs
+++ b/src/json/validate.rs
@@ -897,6 +897,51 @@ pub fn has_trailing_dot_before_exponent(bytes: &[u8]) -> bool {
     is_valid_number(&fixed)
 }
 
+/// Whether `bytes` becomes valid RFC 8259 number syntax after inserting a
+/// single `0` right after an optional leading `-` and before a leading `.`
+/// (`.5` -> `0.5`, `-.5` -> `-0.5`).
+///
+/// Real jq's own number reader accepts a leading `.` (with or without a
+/// preceding `-`) when at least one digit follows -- not valid per strict
+/// RFC 8259, but a real jq-accepted spelling this crate's own document-input
+/// scanners recognize as a number span (`number_literal_end`, #1171).
+/// Shared for the identical reason [`has_trailing_dot_before_exponent`]
+/// above is: two independent "recover a lenient-but-invalid number's own
+/// literal spelling" call sites need it
+/// ([`OwnedValue::from_number_bytes`](crate::jq::OwnedValue::from_number_bytes)
+/// and [`crate::json::light`]'s `DocumentValue::number_literal`
+/// implementation) -- previously duplicated inline at the first of those
+/// two, and missing entirely from the second, which is what let a
+/// leading-dot literal reached through the generic evaluator's own
+/// materialization (not just the primary document-input path
+/// `from_number_bytes` backs) silently lose precision instead of
+/// preserving its source spelling (#2240 code review: `--argjson x
+/// '.9999999999999999999999'` returned `1`, not jq's own
+/// `0.9999999999999999999999`, once #2240's own fix let `--argjson`
+/// accept a leading-dot literal in the first place rather than rejecting
+/// it outright).
+///
+/// Returns `bool`, not the fixed-up candidate, for the identical reason
+/// [`has_trailing_dot_before_exponent`] does: both callers always
+/// materialize the *original* `bytes` on success, never this function's
+/// own inserted-`0` candidate.
+#[must_use]
+pub fn has_leading_dot(bytes: &[u8]) -> bool {
+    let dot_pos = match bytes.first() {
+        Some(b'.') => Some(0),
+        Some(b'-') if bytes.get(1) == Some(&b'.') => Some(1),
+        _ => None,
+    };
+    let Some(prefix_len) = dot_pos else {
+        return false;
+    };
+    let mut fixed = Vec::with_capacity(bytes.len() + 1);
+    fixed.extend_from_slice(&bytes[..prefix_len]);
+    fixed.push(b'0');
+    fixed.extend_from_slice(&bytes[prefix_len..]);
+    is_valid_number(&fixed)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -808,39 +808,72 @@ fn test_argjson_negative_leading_zero_when_nested_1094() -> Result<()> {
 
 // -----------------------------------------------------------------------
 // #2240 (Gap 2): `--argjson`/`--jsonargs` now tolerate the same
-// leading-dot (`.5`, #1171) and trailing-dot-before-exponent (`1.e5`,
+// leading-dot (`.5`, #1171) and trailing-dot-*before-exponent* (`1.e5`,
 // #2220) leniencies real jq's own number parser already accepts, via a
 // new `normalize_dot_leniency` sibling to `normalize_leading_zero_numbers`
 // (both composed together in `normalize_json_leniently`). All cases
 // live-verified against jq 1.7.1.
+//
+// Deliberately **not** a bare trailing `.` with no exponent (`1.`) --
+// `normalize_dot_leniency`'s own doc comment explains why: accepting it
+// would route to `number_literal()`/`from_number_bytes`'s shared,
+// pre-existing large-integer-precision bug (confirmed live via plain
+// document input too, not something added or fixed by this issue),
+// trading a clean rejection for a silently wrong value. `1.` stays
+// rejected via `--argjson`, matching pre-#2240 behavior exactly.
 // -----------------------------------------------------------------------
 
-/// The issue's own leading-dot repro, positive and negative.
+/// The issue's own leading-dot repro, positive and negative, plus values
+/// exercising `number_literal()`'s own new leading-dot escape
+/// (`src/json/light.rs`) with real precision/formatting at stake --
+/// code review found a first draft accepted these via `--argjson`'s
+/// validation retry but then silently lost precision materializing them
+/// through the *original* (un-normalized) text, since only
+/// `OwnedValue::from_number_bytes` had the matching escape at the time,
+/// not `number_literal()` (the generic evaluator's own materializer,
+/// which `--argjson` reaches).
 #[test]
 fn test_argjson_tolerates_leading_dot_2240() -> Result<()> {
-    let (stdout, _, code) = run_jq_full(&["-n", "--argjson", "n", ".5", "$n"], None)?;
-    assert_eq!(code, 0);
-    assert_eq!(stdout.trim_end(), "0.5");
-
-    let (stdout, _, code) = run_jq_full(&["-n", "--argjson", "n", "-.5", "$n"], None)?;
-    assert_eq!(code, 0);
-    assert_eq!(stdout.trim_end(), "-0.5");
-    Ok(())
-}
-
-/// The issue's own trailing-dot-before-exponent repro, plus the bare
-/// trailing-dot (no exponent) and signed-exponent variants.
-#[test]
-fn test_argjson_tolerates_trailing_dot_before_exponent_2240() -> Result<()> {
     for (value, expected) in [
-        ("1.e5", "1E+5"),
-        ("-1.e5", "-1E+5"),
-        ("1.e-5", "0.00001"),
-        ("1.", "1"),
+        (".5", "0.5"),
+        ("-.5", "-0.5"),
+        (".9999999999999999999999", "0.9999999999999999999999"),
+        (".100", "0.100"),
+        (".0", "0.0"),
     ] {
         let (stdout, _, code) = run_jq_full(&["-n", "--argjson", "n", value, "$n"], None)?;
         assert_eq!(code, 0, "value {value:?}");
         assert_eq!(stdout.trim_end(), expected, "value {value:?}");
+    }
+    Ok(())
+}
+
+/// The issue's own trailing-dot-before-exponent repro, plus the
+/// signed-exponent variant. The bare (no-exponent) form is covered
+/// separately below, since it's deliberately still rejected.
+#[test]
+fn test_argjson_tolerates_trailing_dot_before_exponent_2240() -> Result<()> {
+    for (value, expected) in [("1.e5", "1E+5"), ("-1.e5", "-1E+5"), ("1.e-5", "0.00001")] {
+        let (stdout, _, code) = run_jq_full(&["-n", "--argjson", "n", value, "$n"], None)?;
+        assert_eq!(code, 0, "value {value:?}");
+        assert_eq!(stdout.trim_end(), expected, "value {value:?}");
+    }
+    Ok(())
+}
+
+/// Regression guard (found by review before merge, round 2): a bare
+/// trailing `.` with no exponent at all is deliberately *not* accepted by
+/// this fix, unlike an earlier draft that treated it the same as the
+/// exponent-adjacent form -- see `normalize_dot_leniency`'s own doc
+/// comment for the precision-loss reasoning. Real jq itself *does* accept
+/// `1.` (giving `1`), so this is a known, deliberate, narrower-than-jq
+/// divergence, not a match -- pinned here as the accepted trade-off
+/// rather than left as an unstated side effect of the narrowing.
+#[test]
+fn test_argjson_bare_trailing_dot_still_rejected_2240() -> Result<()> {
+    for value in ["1.", "99999999999999999."] {
+        let (_, _, code) = run_jq_full(&["-n", "--argjson", "n", value, "$n"], None)?;
+        assert_ne!(code, 0, "value {value:?}");
     }
     Ok(())
 }

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -806,6 +806,105 @@ fn test_argjson_negative_leading_zero_when_nested_1094() -> Result<()> {
     Ok(())
 }
 
+// -----------------------------------------------------------------------
+// #2240 (Gap 2): `--argjson`/`--jsonargs` now tolerate the same
+// leading-dot (`.5`, #1171) and trailing-dot-before-exponent (`1.e5`,
+// #2220) leniencies real jq's own number parser already accepts, via a
+// new `normalize_dot_leniency` sibling to `normalize_leading_zero_numbers`
+// (both composed together in `normalize_json_leniently`). All cases
+// live-verified against jq 1.7.1.
+// -----------------------------------------------------------------------
+
+/// The issue's own leading-dot repro, positive and negative.
+#[test]
+fn test_argjson_tolerates_leading_dot_2240() -> Result<()> {
+    let (stdout, _, code) = run_jq_full(&["-n", "--argjson", "n", ".5", "$n"], None)?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout.trim_end(), "0.5");
+
+    let (stdout, _, code) = run_jq_full(&["-n", "--argjson", "n", "-.5", "$n"], None)?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout.trim_end(), "-0.5");
+    Ok(())
+}
+
+/// The issue's own trailing-dot-before-exponent repro, plus the bare
+/// trailing-dot (no exponent) and signed-exponent variants.
+#[test]
+fn test_argjson_tolerates_trailing_dot_before_exponent_2240() -> Result<()> {
+    for (value, expected) in [
+        ("1.e5", "1E+5"),
+        ("-1.e5", "-1E+5"),
+        ("1.e-5", "0.00001"),
+        ("1.", "1"),
+    ] {
+        let (stdout, _, code) = run_jq_full(&["-n", "--argjson", "n", value, "$n"], None)?;
+        assert_eq!(code, 0, "value {value:?}");
+        assert_eq!(stdout.trim_end(), expected, "value {value:?}");
+    }
+    Ok(())
+}
+
+/// A value needing *both* the leading-zero (#1094) and trailing-dot
+/// (#2240) leniency at once, the same "needs more than one normalizer"
+/// shape #2012's own review caught for the leading-zero/low-surrogate
+/// pair -- confirms the three normalizers still compose correctly now
+/// that there are three of them.
+#[test]
+fn test_argjson_leading_zero_and_trailing_dot_combined_2240() -> Result<()> {
+    let (stdout, _, code) = run_jq_full(&["-n", "--argjson", "n", "007.e5", "$n"], None)?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout.trim_end(), "7E+5");
+    Ok(())
+}
+
+/// A leading/trailing dot leniency nested inside an array, not just a
+/// bare top-level scalar -- mirrors `test_argjson_leading_zero_tolerated_when_nested_1094`.
+#[test]
+fn test_argjson_dot_leniency_tolerated_when_nested_2240() -> Result<()> {
+    let (stdout, _, code) = run_jq_full(&["-cn", "--argjson", "n", "[.5, 1.e5]", "$n"], None)?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout.trim_end(), "[0.5,1E+5]");
+    Ok(())
+}
+
+/// Regression guard (found by review before merge): a bare `.` or `-.`
+/// with digits on *neither* side is not a number under any leniency --
+/// real jq still rejects it outright, and an earlier draft here
+/// unconditionally synthesized `0`s around whatever dot it saw, which
+/// wrongly "fixed" a bare `.` into the valid number `0.0` and let this
+/// genuinely malformed input silently materialize instead of erroring.
+#[test]
+fn test_argjson_bare_dot_rejected_not_fabricated_into_zero_2240() -> Result<()> {
+    for value in [".", "-."] {
+        let (_, _, code) = run_jq_full(&["-n", "--argjson", "n", value, "$n"], None)?;
+        assert_ne!(code, 0, "value {value:?}");
+    }
+    Ok(())
+}
+
+/// Digits that merely *look* like a leading/trailing-dot number, but are
+/// actually inside a string, are left completely untouched -- mirrors
+/// `test_argjson_leading_zero_inside_string_or_key_untouched_1094`.
+#[test]
+fn test_argjson_dot_leniency_inside_string_untouched_2240() -> Result<()> {
+    let (stdout, _, code) = run_jq_full(&["-n", "--argjson", "n", r#""a.5b""#, "$n"], None)?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout.trim_end(), r#""a.5b""#);
+    Ok(())
+}
+
+/// A normal number with no leading/trailing dot at all is completely
+/// unaffected -- confirms the fast path (strict validation succeeds on
+/// the first try) isn't disturbed by this fix.
+#[test]
+fn test_argjson_normal_number_unaffected_by_dot_leniency_2240() -> Result<()> {
+    let (stdout, _, code) = run_jq_full(&["-n", "--argjson", "n", "1.5", "$n"], None)?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout.trim_end(), "1.5");
+    Ok(())
+}
+
 // --- #1150: clap rejected any negative-number (or other hyphen-prefixed)
 // --argjson/--arg/--slurpfile/--rawfile VALUE before it ever reached this
 // crate's own JSON-content validation -- fixed via `allow_hyphen_values`

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -1401,6 +1401,24 @@ fn test_seq_composes_leading_zero_and_low_surrogate_fixes_2012() -> Result<()> {
     Ok(())
 }
 
+/// #2240: `--seq` shares the same leading/trailing-dot leniency
+/// `--argjson`/`--jsonargs` gained, through the identical
+/// `seq_value_is_valid`/`normalize_json_leniently` path #2012's own tests
+/// above already exercise for the other two leniencies. Also composes with
+/// a leading zero in the same value (`.05` sharing a record with `007`),
+/// mirroring the #2012 composed-fix regression guard just above.
+#[test]
+fn test_seq_accepts_dot_leniency_2240() -> Result<()> {
+    let (stdout, stderr, code) = run_jq_full(&["--seq", "-c", "."], Some("\x1e.05\n"))?;
+    assert_eq!(code, 0, "stderr: {stderr}");
+    assert_eq!(stdout.trim_end(), "\x1e0.05", "stdout: {stdout:?}");
+
+    let (stdout, stderr, code) = run_jq_full(&["--seq", "-c", "."], Some("\x1e007.e5\n"))?;
+    assert_eq!(code, 0, "stderr: {stderr}");
+    assert_eq!(stdout.trim_end(), "\x1e7E+5", "stdout: {stdout:?}");
+    Ok(())
+}
+
 /// A hyphen-prefixed `--slurpfile`/`--rawfile` FILE value must reach this
 /// crate's own file-open logic, not get rejected by clap as an unknown
 /// flag first (#1150, same `allow_hyphen_values` fix as `--arg`/

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -9405,6 +9405,51 @@ fn test_argjson_shares_jq_leniency_2051() -> Result<()> {
     Ok(())
 }
 
+/// #2240: `succinctly yq --argjson` shares jq mode's new leading/trailing-
+/// dot leniency the same way #2051 above established for leading-zero/
+/// low-surrogate -- both call `normalize_json_leniently`.
+///
+/// Unlike `jq_runner::parse_json_value` (which only uses the normalized
+/// text as a validation gate and always materializes the *original* text
+/// afterward), `yq_runner::parse_json_value` reparses the *normalized*
+/// text directly as the value -- so a fraction digit beginning with `0`
+/// (`.05`, `.007`) is exactly the shape that would have caught a
+/// composition-order bug code review found and fixed before merge:
+/// running the leading-zero normalizer *before* the dot-leniency one let
+/// it mistake `.05`'s own fraction-leading zero for a redundant *integer*
+/// leading zero and strip it, corrupting `.05` into `.5` before the
+/// dot-leniency pass ever saw it -- a silent 10x magnitude error
+/// (`.05` -> `0.5`) that jq mode's own tests (`tests/jq_cli_tests.rs`)
+/// couldn't have caught, since jq mode never reparses the normalized
+/// text as the value in the first place.
+#[test]
+fn test_argjson_shares_jq_dot_leniency_2240() -> Result<()> {
+    for (value, expected) in [
+        (".5", r#"{"n":0.5}"#),
+        (".05", r#"{"n":0.05}"#),
+        (".007", r#"{"n":0.007}"#),
+        ("-.05", r#"{"n":-0.05}"#),
+        ("1.e5", r#"{"n":100000.0}"#),
+        ("007.e5", r#"{"n":700000.0}"#),
+    ] {
+        let (output, code) = run_yq_stdin(
+            ".n = $n",
+            "{}",
+            &["--argjson", "n", value, "-o=json", "-I=0"],
+        )?;
+        assert_eq!(code, 0, "value {value:?}");
+        assert_eq!(output.trim(), expected, "value {value:?}");
+    }
+
+    // A bare trailing dot (no exponent) is deliberately still rejected,
+    // matching jq mode's own narrower-than-real-jq scope (see
+    // `normalize_dot_leniency`'s own doc comment).
+    let (_, code) = run_yq_stdin(".n = $n", "{}", &["--argjson", "n", "1.", "-o=json"])?;
+    assert_ne!(code, 0);
+
+    Ok(())
+}
+
 #[test]
 fn test_arg_hyphen_prefixed_string_value_1150() -> Result<()> {
     let (output, code) = run_yq_stdin("$n", "a: 1", &["--arg", "n", "-hello"])?;


### PR DESCRIPTION
## Summary

#2240 described two gaps found during #2220's own code review. This PR fixes
Gap 2 and finds Gap 1 not reproducible on current `main`.

### Gap 2 (fixed): `--argjson`/`--jsonargs` reject leading/trailing-dot leniency

```console
$ jq -n --argjson x '.5' '$x'
0.5
$ succinctly jq -n --argjson x '.5' '$x'
Error: Invalid JSON for --argjson x       # WRONG -- before this fix
```

Both leniencies (leading-dot #1171, trailing-dot-before-exponent #2220)
were already tolerated on the plain document-input path — only
`--argjson`'s own `serde_json`-based validation-retry mechanism was missing
them. Fixed via a new `normalize_dot_leniency` function, composed into the
same `normalize_json_leniently` retry pass shared by `--argjson`'s
validator, `--seq`'s own per-value check, and yq mode's own `--argjson`.

### Round 2 (code review): a precision-loss regression, and a scope narrowing

Found and fixed a regression the first draft introduced: accepting a
leading-dot literal via `--argjson`, then materializing it from the
*original* text, silently lost precision (`--argjson x
'.9999999999999999999999'` returned `1`, not `0.9999999999999999999999`).
Root cause: `StandardJson::number_literal()` was missing the leading-dot
escape `OwnedValue::from_number_bytes` already had. Fixed by extracting a
shared `has_leading_dot` helper (`src/json/validate.rs`) and adding it to
both. As a side effect, this also fixes the identical precision loss for
plain document input routed through any real query, not just `--argjson`.

Also narrowed `normalize_dot_leniency`'s trailing-dot acceptance to the
exponent-adjacent shape only (`1.e5`), not a bare trailing dot (`1.`) —
accepting the bare form would trade a clean rejection for a *different*,
pre-existing large-integer-precision bug (confirmed live via plain document
input: `99999999999999999.` already materializes wrong on `main`, unrelated
to this issue). `1.` stays rejected via `--argjson`.

### Round 3 (code review): a critical yq-mode magnitude-corruption bug

A second review round found a **critical** bug the round-2 fix introduced:
`succinctly yq --argjson x '.05' '.b = $x'` returned `0.5` — **10x too
large**. Root cause: `normalize_json_leniently` composed
`normalize_dot_leniency` *after* `normalize_leading_zero_numbers`, whose own
number-token-start detection can't see a preceding dot — fed `.05` first,
it starts a fresh scan right at the `0` after the dot and mistakes the
fraction's own leading zero for a redundant *integer* leading zero,
stripping it (`.05` → `.5`) before the dot-leniency pass ever runs. Invisible
to jq mode's own tests because `jq_runner.rs`'s `parse_json_value` only uses
the normalized text as a validation gate and always materializes the
*original* text — but `yq_runner.rs`'s own `parse_json_value` reparses the
*normalized* text directly as the value (by design, since yq's `--argjson`
already discards number fidelity), making it the one place this
composition-order bug was reachable.

**Fixed by reordering the composition**: `normalize_dot_leniency` now runs
*before* `normalize_leading_zero_numbers`, so a leading-dot token already
has its synthesized `0` in front by the time the zero-stripper runs, and its
integer part is never empty for the stripper to misinterpret.

Also addressed: a stale doc comment referencing a removed variable, a
redundant local alias, a missing yq-mode CLI test (mirroring #2051's own
established pattern, specifically covering the shape that would have caught
this bug), and a missing `docs/compliance/jq/limitations.md` entry for the
deliberate `1.` rejection divergence (per CLAUDE.md's "every divergence must
be recorded" rule).

### Gap 1 (not reproducible, investigated and documented)

The issue describes an array-navigated `tostring`/`@json` losing an
overflow literal's exact spelling, while claiming the root-level path
already correctly preserves it. Live-tested against the pinned oracle and
current `main`: both paths already agree, matching #1083/#1075's own
earlier, deliberate policy of never preserving an infinite-magnitude
`NumberLiteral`'s spelling in jq mode. See the CHANGELOG entry for the full
reasoning.

## Verification

- Live-verified against `/usr/bin/jq` 1.7.1 and yq mode's own consistency
  requirements across all three review rounds.
- New CLI regression tests: jq-mode leading/trailing-dot leniency
  (`tests/jq_cli_tests.rs`), and a dedicated yq-mode test covering the exact
  shape that triggered the critical corruption bug (`tests/yq_cli_tests.rs`).
- Full test suite: 57/57 test binaries, 0 failures.
- `cargo clippy --all-targets --all-features -- -D warnings`, `cargo fmt
  --check`, `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features`:
  all clean.
- Patch coverage: 100% (100/100 new lines, across all 4 changed files).

Fixes #2240
