### PR TITLE
refactor(jq): dedupe builtin_upper_in/any_all_gen_cond's counted-bool shape

### DIFF
--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -46906,6 +46906,30 @@ mod tests {
         }
     }
 
+    #[test]
+    fn test_any_all_cond_ordinary_error_folds_probe_escape_2204() {
+        // #2204 review: patch coverage flagged `any_all_gen_cond`'s own
+        // `probe_escape`-folding line as untested by this fix's own
+        // consolidation -- every pre-existing test above raises through
+        // `gen`'s own decode failure, never through `cond` itself, so
+        // `probe_escape` was never actually set to `Some` and folded into
+        // `Flow::Escaped`. `cond` raising an ordinary (non-decode-failure)
+        // error is that exact path. Confirmed live against jq 1.7.1:
+        // `[any(1,2,3; error("boom"))]`/`[all(1,2,3; error("boom"))]` both
+        // raise "boom" immediately -- `cond` on the very first element
+        // already escapes, so neither ever reaches a second.
+        query!(br"null", r#"any(1,2,3; error("boom"))"#,
+            QueryResult::Error(e) => {
+                assert_eq!(e.message, "boom");
+            }
+        );
+        query!(br"null", r#"all(1,2,3; error("boom"))"#,
+            QueryResult::Error(e) => {
+                assert_eq!(e.message, "boom");
+            }
+        );
+    }
+
     /// #2015: `builtin_upper_in` (`IN(s)`) hardcoded `_optional` unused and
     /// called `to_owned` unconditionally, unlike its sibling `any`/
     /// `all` (`any_all_gen_cond`, fixed by #2001 immediately above) despite

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -4724,12 +4724,15 @@ fn take_stopping_items_to_result<W: Clone + AsRef<[u64]>>(
     flow: Flow,
 ) -> QueryResult<'_, W> {
     match flow {
-        Flow::Escaped(control) if items.is_empty() => control_to_result(control),
         // #1519: items *and* an escape means a later `?//` alternative failed
         // after an earlier one had already answered. jq reaches that failure,
-        // so the prefix is kept and the control still raises.
+        // so the prefix is kept and the control still raises -- `partial`
+        // (#2204 review) already collapses an empty prefix to the bare
+        // `control_to_result` this used to spell out inline, so converting
+        // unconditionally before the call is just as cheap for the empty
+        // case (mapping over nothing) and drops the redundant branch.
         Flow::Escaped(control) => {
-            QueryResult::Partial(items.into_iter().map(Item::into_owned).collect(), control)
+            partial(items.into_iter().map(Item::into_owned).collect(), control)
         }
         // `_checked`, not the unchecked twin it replaced upstream: an
         // undecodable item must raise rather than silently become "", and a
@@ -4763,7 +4766,7 @@ fn take_stopping_items_to_result<W: Clone + AsRef<[u64]>>(
 /// calling this: `Flow::Stopped { .. }` paired with a real out-of-band
 /// escape becomes `Flow::Escaped` first, so this function only ever needs
 /// to reason about one escape channel, not two.
-fn counted_bool_flow_to_result<'a, W: Clone + AsRef<[u64]>>(
+fn counted_bool_flow_to_result<'a, W>(
     count: usize,
     true_val: bool,
     false_val: bool,
@@ -41223,42 +41226,27 @@ fn builtin_isempty<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
         delivered += 1;
         Demand::Stop
     });
-    match flow {
-        // `g` produced an output and we stopped it right there.
-        //
-        // `pending` is deliberately dropped: it is only ever `Some` when an
-        // eager fallback had already raised a trailing control before the
-        // stop, and real jq — which would never have evaluated that far —
-        // answers `false` regardless. Oracle-confirmed for all three shapes:
-        // `isempty(1, error("x"))`, `isempty(1, ("m"|halt_error(3)))` and
-        // `label $o | isempty(1, break $o)` all answer `false`, exit 0.
-        Flow::Stopped { .. } => owned_vec_to_result(vec![OwnedValue::Bool(false); delivered]),
-
-        // `g` ran to exhaustion. The trailing `, true` in jq's definition is
-        // reached exactly when no `break` is left unwinding, so it is appended
-        // to however many `false`s were already emitted -- normally none, but
-        // a `?//` chain whose *last* alternative runs dry after an earlier one
-        // short-circuited answers `false` then `true`
-        // (`isempty([1] as [$x] ?// $x | if ($x|type)=="number" then 9 else
-        // empty end)`, confirmed live against jq 1.7.1).
-        Flow::Exhausted => {
-            let mut out = vec![OwnedValue::Bool(false); delivered];
-            out.push(OwnedValue::Bool(true));
-            owned_vec_to_result(out)
-        }
-
-        // `g`'s own terminator once no further output ever arrived. A *bare*
-        // escape (`delivered == 0`) means there is nothing to answer with and
-        // all three must propagate rather than be reported as "empty" (#882,
-        // #791, #867). `partial` preserves that -- and preserves
-        // `Halt`/`Break` by construction -- while also keeping any prefix a
-        // `?//` retry already delivered: a later alternative's own error is
-        // genuinely reached by jq after an earlier one answered `false`, so
-        // it raises rather than silently discarding that answer (#1519;
-        // `isempty([1] as [$x] ?// $x | if ($x|type)=="number" then 9 else
-        // error("boom") end)` is `false` then an error in real jq).
-        Flow::Escaped(control) => partial(vec![OwnedValue::Bool(false); delivered], control),
-    }
+    // #2204: the identical count-of-matches shape `counted_bool_flow_to_result`
+    // already shares between `builtin_upper_in`/`any_all_gen_cond` -- found in
+    // that fix's own review. `pending` is deliberately dropped on
+    // `Flow::Stopped` (only ever `Some` when an eager fallback had already
+    // raised a trailing control before the stop, and real jq -- which would
+    // never have evaluated that far -- answers `false` regardless;
+    // oracle-confirmed for all three shapes: `isempty(1, error("x"))`,
+    // `isempty(1, ("m"|halt_error(3)))`, `label $o | isempty(1, break $o)` all
+    // answer `false`, exit 0). `Flow::Exhausted`'s appended `true` is jq's
+    // trailing `, true` in `def isempty(g): label $out | (g|false, break
+    // $out), true;`, reached exactly when no `break` is left unwinding -- a
+    // `?//` chain whose *last* alternative runs dry after an earlier one
+    // short-circuited answers `false` then `true` (`isempty([1] as [$x] ?//
+    // $x | if ($x|type)=="number" then 9 else empty end)`, confirmed live
+    // against jq 1.7.1). `Flow::Escaped`'s bare-escape case (`delivered == 0`)
+    // propagates rather than reporting "empty" (#882, #791, #867), and a
+    // non-bare one keeps a `?//` retry's own already-delivered `false` ahead
+    // of a later alternative's genuine error (#1519; `isempty([1] as [$x] ?//
+    // $x | if ($x|type)=="number" then 9 else error("boom") end)` is `false`
+    // then an error in real jq).
+    counted_bool_flow_to_result(delivered, false, true, flow)
 }
 
 /// The YAML type tag (`!!str`, `!!int`, `!!float`, ...) `builtin_delpaths`'s

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -4738,6 +4738,48 @@ fn take_stopping_items_to_result<W: Clone + AsRef<[u64]>>(
     }
 }
 
+/// Shared resolution of [`builtin_upper_in`]'s and [`any_all_gen_cond`]'s
+/// identical count-of-matches shape into a [`QueryResult`] (#2204),
+/// mirroring [`take_stopping_items_to_result`]'s own precedent just above
+/// for the identical duplication risk ("so their call sites cannot drift
+/// on the dropped-versus-raised trailing-control rule").
+///
+/// `count` decisive elements (each already a genuine match) become
+/// `true_val` repeated; on `Flow::Exhausted`, one more `false_val` (the
+/// "no match found" identity element) is appended to however many `count`
+/// already produced -- a `?//` chain can make an earlier alternative's
+/// match and the final alternative's own exhaustion coexist in the same
+/// output (`IN`'s and `any`/`all`'s own doc comments each give a
+/// live-confirmed example). `Flow::Stopped { .. }` answers with `count`
+/// alone, no identity element appended -- a sink that stopped early
+/// already found its decisive answer. `Flow::Escaped` keeps `count`'s
+/// answers as a `Partial` prefix ahead of the raised control (via
+/// [`partial`], which itself collapses to a bare error/break/halt when
+/// `count` is zero).
+///
+/// Callers whose sink can escape through an *out-of-band* channel (not
+/// `Flow` itself -- `any_all_gen_cond`'s own `probe_escape`, set when
+/// `cond` itself raises rather than `gen`) fold that into `flow` before
+/// calling this: `Flow::Stopped { .. }` paired with a real out-of-band
+/// escape becomes `Flow::Escaped` first, so this function only ever needs
+/// to reason about one escape channel, not two.
+fn counted_bool_flow_to_result<'a, W: Clone + AsRef<[u64]>>(
+    count: usize,
+    true_val: bool,
+    false_val: bool,
+    flow: Flow,
+) -> QueryResult<'a, W> {
+    let mut out = vec![OwnedValue::Bool(true_val); count];
+    match flow {
+        Flow::Exhausted => {
+            out.push(OwnedValue::Bool(false_val));
+            owned_vec_to_result(out)
+        }
+        Flow::Stopped { .. } => owned_vec_to_result(out),
+        Flow::Escaped(control) => partial(out, control),
+    }
+}
+
 /// Pull at most `n` outputs, then stop the generator — jq's `limit`.
 ///
 /// Returns the items alongside the terminating [`Flow`], because `limit`'s
@@ -7522,23 +7564,11 @@ fn builtin_upper_in<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
             Demand::Continue
         }
     });
-    let mut out = vec![OwnedValue::Bool(true); found];
-    match flow {
-        Flow::Exhausted => {
-            out.push(OwnedValue::Bool(false));
-            owned_vec_to_result(out)
-        }
-        // Non-empty by construction: this sink only stops on a match. See
-        // `any_all_gen_cond`'s equivalent arm.
-        Flow::Stopped { .. } => owned_vec_to_result(out),
-        Flow::Escaped(control) => {
-            if out.is_empty() {
-                control_to_result(control)
-            } else {
-                QueryResult::Partial(out, control)
-            }
-        }
-    }
+    // #2204: shared with `any_all_gen_cond`'s identical shape via
+    // `counted_bool_flow_to_result` -- this sink has no out-of-band escape
+    // channel of its own (`owned_value_eq` never errors), so `flow` is
+    // passed through unchanged.
+    counted_bool_flow_to_result(found, true, false, flow)
 }
 
 /// Builtin: `IN(src; s)` - true if any output of `src` equals any output of
@@ -8217,40 +8247,38 @@ fn any_all_gen_cond<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
         },
     );
 
-    let mut out = vec![OwnedValue::Bool(target_truthy); matches];
-    match flow {
-        // `gen` exhausted: the identity element (`false` for `any`, `true` for
-        // `all`) is appended to however many decisive answers already fired.
-        // Normally `matches` is 0 here and this is the sole answer; a `?//`
-        // chain whose last alternative runs dry after an earlier one decided
-        // yields both (`[any([1] as [$x] ?// $x | ($x == 1); .)]` is
-        // `[true,false]`, confirmed live against jq 1.7.1).
-        //
-        // A stale `probe_escape` from an earlier, retried-past attempt is
-        // deliberately not consulted here: reaching `Exhausted` at all means
-        // the *terminal* attempt ran clean to completion, so whatever an
-        // earlier attempt's `cond` did is moot -- jq itself never surfaces
-        // it either.
-        Flow::Exhausted => {
-            out.push(OwnedValue::Bool(!target_truthy));
-            owned_vec_to_result(out)
-        }
-        // #1519: `probe_escape` is consulted here, and only here -- not
-        // unconditionally before this match, which is what let a stale
-        // escape from an already-retried-past attempt outrun a later
-        // attempt's real answer (see this function's own doc comment above).
-        // By construction the sink's own last call before this `Stopped`
-        // either bumped `matches` and cleared `probe_escape`, or set
-        // `probe_escape` and nothing else -- so whichever is set here
-        // reflects only the terminal attempt, never an earlier one.
-        Flow::Stopped { .. } => match probe_escape {
-            Some(control) => partial(out, control),
-            None => owned_vec_to_result(out),
-        },
-        // No earlier output matched, so `gen`'s own terminator is the only
-        // verdict left -- oracle-verified: `IN(3, error("boom"))` on `2` raises.
-        Flow::Escaped(control) => partial(out, control),
-    }
+    // #1519: `probe_escape` is folded into `flow` here, and only here --
+    // not consulted unconditionally, which is what let a stale escape from
+    // an already-retried-past attempt outrun a later attempt's real answer
+    // (a `?//` chain can carry this sink through several attempts). By
+    // construction the sink's own last call before a `Stopped` either
+    // bumped `matches` and cleared `probe_escape`, or set `probe_escape`
+    // and nothing else -- so whichever is set here reflects only the
+    // terminal attempt, never an earlier one. `Exhausted` deliberately
+    // does *not* fold `probe_escape` in: reaching it at all means the
+    // *terminal* attempt ran clean to completion, so whatever an earlier
+    // attempt's `cond` did is moot -- jq itself never surfaces it either.
+    //
+    // #2204: this fold is what lets `any_all_gen_cond` share
+    // `counted_bool_flow_to_result` with `builtin_upper_in`'s identical
+    // count-of-matches shape despite having a second, out-of-band escape
+    // channel (`cond`'s own errors) that `IN(s)`'s sink structurally
+    // cannot produce -- folding it into `Flow::Escaped` first means the
+    // shared function only ever has to reason about one escape channel.
+    let effective_flow = match (flow, probe_escape) {
+        (Flow::Stopped { .. }, Some(control)) => Flow::Escaped(control),
+        (flow, _) => flow,
+    };
+    // `gen` exhausted with no fold above: the identity element (`false`
+    // for `any`, `true` for `all`) is appended to however many decisive
+    // answers already fired. Normally `matches` is 0 here and this is the
+    // sole answer; a `?//` chain whose last alternative runs dry after an
+    // earlier one decided yields both (`[any([1] as [$x] ?// $x | ($x ==
+    // 1); .)]` is `[true,false]`, confirmed live against jq 1.7.1). No
+    // earlier `gen` output matched on `Escaped`, so `gen`'s own terminator
+    // is the only verdict left -- oracle-verified: `IN(3, error("boom"))`
+    // on `2` raises.
+    counted_bool_flow_to_result(matches, target_truthy, !target_truthy, effective_flow)
 }
 
 /// Builtin: `any(gen; cond)` - true if cond is truthy for any output of gen.


### PR DESCRIPTION
## Summary

Fixes #2204: `builtin_upper_in` (backs `IN(s)`) and `any_all_gen_cond` (backs
`any(gen;cond)`/`all(gen;cond)`/`IN(src;s)`) both gained the identical
~15-line count-of-matches -> `QueryResult` shape as part of #1519's own fix,
found during code review of that fix's merge -- accumulate a count of
decisive elements, build `vec![Bool(x); count]`, then match the terminating
`Flow` to decide between appending an identity element (`Exhausted`),
returning the count as-is (`Stopped`), or splicing a trailing control onto it
(`Escaped`). Only the two `bool` values differ per call site.

- Extracts `counted_bool_flow_to_result`, mirroring
  `take_stopping_items_to_result`'s own precedent for the identical
  duplication risk in the same file ("so their call sites cannot drift on
  the dropped-versus-raised trailing-control rule").
- `any_all_gen_cond`'s own extra out-of-band escape channel (`probe_escape`,
  set when `cond` itself raises rather than `gen`) is folded into an ordinary
  `Flow::Escaped` before the shared call, so the helper only ever has to
  reason about one escape channel -- the existing `Stopped`-vs-`Escaped`
  precedence this preserves is unchanged, just expressed as a pre-transform
  instead of a second branch inside the match.

Pure refactor, no behavioral change intended or found.

## Test plan

- [x] `cargo build --features cli`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings`
- [x] `cargo fmt --check`
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features`
- [x] `cargo test --features cli,simd,regex,serde --no-fail-fast` (all green, all 34 existing `builtin_upper_in`/`any_all` tests unchanged)
- [x] `cargo test --no-fail-fast` (default features)
- [x] `cargo test --no-default-features --verbose` (no_std)
- [x] Differential-verified 13 cases against the pinned jq 1.7.1 oracle, covering every removed inline comment's own claim: `?//` double-answers, short-circuit side effects past a match, `IN(src;s)`'s nested-loop error ordering, and retry-past-an-earlier-`cond`-error
