### PR TITLE
fix(jq): eval.rs's negative-index resolution now checks #2261's gap

### DIFF
--- a/docs/compliance/jq/limitations.md
+++ b/docs/compliance/jq/limitations.md
@@ -1763,18 +1763,25 @@ and differently-shaped problem than this section's own fixes):
   key in jq mode, any Float key in yq mode) without ever running the gap
   check -- fixed in #2311 itself by reordering to match `eval_generic.rs`'s
   own unconditional-`len_checked`-first shape exactly. Two further siblings
-  sharing the identical unchecked-`.count()` shape were found but
-  deliberately left unfixed: `count_elements` (backs
-  `get_element_at_index`'s negative-index resolution, `.foo[-1]`) needs a
-  genuine new error-type design (its `Result<_, usize>` return already
-  carries a distinct, meaningful "negative still negative" signal, #2254 --
-  not a drop-in swap like the others), filed as #2312; and `builtin_keys`
-  used to never collapse duplicate keys in *either* mode (it had no
-  `S: EvalSemantics` parameter to derive `S::COLLAPSE_DUPLICATE_KEYS` from,
-  unlike `eval_generic.rs`'s own `Keys`/`KeysUnsorted` arms) -- filed as
-  #2313 and fixed there, by adding that parameter and its one call site's
-  turbofish. `eval.rs`'s copy of `keys`/`keys_unsorted` now agrees with
-  `eval_generic.rs`'s on this shape in both modes.
+  sharing the identical unchecked-`.count()` shape were found, both now
+  **fixed**: `builtin_keys` used to never collapse duplicate keys in
+  *either* mode (it had no `S: EvalSemantics` parameter to derive
+  `S::COLLAPSE_DUPLICATE_KEYS` from, unlike `eval_generic.rs`'s own
+  `Keys`/`KeysUnsorted` arms) -- filed as #2313 and fixed there, by adding
+  that parameter and its one call site's turbofish; `eval.rs`'s copy of
+  `keys`/`keys_unsorted` now agrees with `eval_generic.rs`'s on this shape
+  in both modes. `count_elements` (backs `get_element_at_index`'s index
+  resolution, `.foo[N]`/`.foo[-N]`) -- filed as #2312, fixed by
+  restructuring `get_element_at_index` to match `eval_generic.rs`'s own
+  `Expr::Index` arm exactly: `count_elements`/`len_checked()` now runs
+  unconditionally, before branching on sign (a first draft only checked
+  the negative branch, leaving `.[0]` on a malformed array unchecked --
+  found by #2312's own code review), and the negative-still-negative
+  decision (#2254) reuses the same shared `yq_negative_index_check` helper
+  `eval_generic.rs` already calls, rather than a bespoke error type.
+  Parity pinned in `test_parity_negative_index_trailing_comma_2312`
+  (negative) and `test_parity_positive_index_trailing_comma_2312`
+  (positive).
 
   Writing that parity test also surfaced a further, unrelated, **live and
   CLI-reachable** bug shared by *both* evaluators: `{"a":1,} | length` in jq

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -16128,25 +16128,20 @@ fn index_array_by_position<W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     optional: bool,
 ) -> QueryResult<'_, W> {
     match value {
-        StandardJson::Array(elements) => match get_element_at_index::<W>(elements, idx) {
+        StandardJson::Array(elements) => match get_element_at_index::<W, S>(elements, idx) {
             Ok(Some(v)) => QueryResult::One(v),
             // jq returns null for out-of-bounds array access (not an error)
             Ok(None) => QueryResult::One(StandardJson::Null),
-            // #2312: a malformed array (its own `len_checked` rejected a
-            // trailing stray comma resolving the negative index) always
-            // propagates, in both modes -- never gated on `S::TAG`/
-            // `optional`, same as every other decode-failure-class error.
-            Err(NegativeIndexFault::Malformed(e)) => QueryResult::Error(e),
-            Err(NegativeIndexFault::OutOfRange(_len)) if S::TAG != EvalTag::Yq => {
-                QueryResult::One(StandardJson::Null)
-            }
-            // Unconditional, not suppressed by `optional` (#2254) -- see
-            // `EvalError::yq_negative_index_out_of_range`'s own doc comment
-            // and the `eval_try`/`try_single_generic` bypasses that keep it
-            // surviving an outer `?`/`try` too.
-            Err(NegativeIndexFault::OutOfRange(len)) => {
-                QueryResult::Error(EvalError::yq_negative_index_out_of_range(idx, len))
-            }
+            // #2312: unconditional, not suppressed by `optional` -- covers
+            // both a malformed array (its own `len_checked` rejected a
+            // trailing stray comma, #1677/#2261) and yq's own
+            // `yq_negative_index_out_of_range` (#2254; see that
+            // constructor's own doc comment and the `eval_try`/
+            // `try_single_generic` bypasses that keep it surviving an
+            // outer `?`/`try` too) -- both are decode-failure-class errors
+            // `get_element_at_index` itself already resolved correctly per
+            // mode, so this arm just propagates whichever one it returned.
+            Err(e) => QueryResult::Error(e),
         },
         // jq returns null for index on null
         StandardJson::Null => QueryResult::One(StandardJson::Null),
@@ -17932,56 +17927,47 @@ fn slice_object_children_at(
     OwnedValue::Array(children)
 }
 
-/// [`get_element_at_index`]'s negative-index resolution outcomes that
-/// aren't a plain hit/miss.
-///
-/// `OutOfRange(len)` is a negative index still negative after resolving
-/// against the array's length -- distinct from an ordinary miss (`Ok(None)`
-/// from the function itself, the positive-direction case or an
-/// in-range-but-empty read) only so the caller can raise real yq's own
-/// error for it (#2254); jq mode's own caller treats it exactly like
-/// `Ok(None)`. `Malformed` is the array's own `len_checked` (#1677/#2261)
-/// rejecting a trailing stray comma or other structural fault while
-/// resolving that length -- unlike `OutOfRange`, this must always
-/// propagate as an error in *both* modes, the same "decode failure never
-/// suppressed" rule `#2293`'s `has_one_key`/`builtin_length`/`builtin_keys`
-/// fix already established for this file's other `len_checked` callers.
-enum NegativeIndexFault {
-    OutOfRange(usize),
-    Malformed(EvalError),
-}
-
 /// Get element at index (supports negative indexing).
 ///
-/// Uses `get_fast` for O(n) BP operations + O(log n) IB select,
-/// instead of `get` which does O(n) IB selects.
-fn get_element_at_index<W: Clone + AsRef<[u64]>>(
+/// #2312 review: restructured to match `eval_generic.rs`'s own
+/// `Expr::Index` arm exactly -- `count_elements` now runs unconditionally,
+/// *before* branching on `idx`'s sign, closing the #1677/#2261
+/// trailing-comma gap for a *positive* index too, not just a negative
+/// one (a first draft of this fix only checked the negative branch,
+/// leaving `[1,2,3,] | .[0]` unchecked; found live by code review).
+/// `yq_negative_index_check` is the same shared helper
+/// `eval_generic.rs`'s own arm calls, so the two evaluators resolve this
+/// rule identically rather than each re-deriving it.
+///
+/// Still uses `get_fast` for the final O(n) BP operations + O(log n) IB
+/// select once `resolved` is known, instead of `get`'s O(n) IB selects
+/// per lookup.
+fn get_element_at_index<W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     elements: JsonElements<'_, W>,
     idx: i64,
-) -> Result<Option<StandardJson<'_, W>>, NegativeIndexFault> {
-    if idx >= 0 {
-        Ok(elements.get_fast(idx as usize))
-    } else {
-        // Negative index: count from end
-        let len = match count_elements(elements) {
-            Ok(len) => len,
-            Err(e) => return Err(NegativeIndexFault::Malformed(e)),
-        };
-        let positive_idx = len as i64 + idx;
-        if positive_idx >= 0 {
-            Ok(elements.get_fast(positive_idx as usize))
-        } else {
-            Err(NegativeIndexFault::OutOfRange(len))
-        }
+) -> Result<Option<StandardJson<'_, W>>, EvalError> {
+    let len = count_elements(elements)?;
+    let resolved = if idx < 0 { len as i64 + idx } else { idx };
+    if let Some(e) = yq_negative_index_check::<S>(idx, resolved, len) {
+        return Err(e);
     }
+    if resolved < 0 {
+        // jq mode: a negative index still negative after resolving reads
+        // as an ordinary out-of-bounds miss, not an error (#307) --
+        // `yq_negative_index_check` above already handled yq mode's own
+        // unconditional raise for this same condition, so reaching here
+        // means either jq mode, or yq mode with `resolved >= 0`.
+        return Ok(None);
+    }
+    Ok(elements.get_fast(resolved as usize))
 }
 
 /// Count elements in an array (consumes the iterator), refusing a trailing
 /// stray comma after a real last element (#2312) -- the same #1677/#2261
 /// gap check every other array-length call site in this file already has
 /// (`DocumentElements::len_checked`), missed here because this function's
-/// only caller ([`get_element_at_index`]) needed a genuine new error shape
-/// to carry it (see [`NegativeIndexFault`]), not a drop-in swap.
+/// only caller ([`get_element_at_index`]) needed to thread the result
+/// through a genuine `Result`, not a drop-in swap.
 fn count_elements<W: Clone + AsRef<[u64]>>(
     elements: JsonElements<'_, W>,
 ) -> Result<usize, EvalError> {

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -16132,12 +16132,21 @@ fn index_array_by_position<W: Clone + AsRef<[u64]>, S: EvalSemantics>(
             Ok(Some(v)) => QueryResult::One(v),
             // jq returns null for out-of-bounds array access (not an error)
             Ok(None) => QueryResult::One(StandardJson::Null),
-            Err(_len) if S::TAG != EvalTag::Yq => QueryResult::One(StandardJson::Null),
+            // #2312: a malformed array (its own `len_checked` rejected a
+            // trailing stray comma resolving the negative index) always
+            // propagates, in both modes -- never gated on `S::TAG`/
+            // `optional`, same as every other decode-failure-class error.
+            Err(NegativeIndexFault::Malformed(e)) => QueryResult::Error(e),
+            Err(NegativeIndexFault::OutOfRange(_len)) if S::TAG != EvalTag::Yq => {
+                QueryResult::One(StandardJson::Null)
+            }
             // Unconditional, not suppressed by `optional` (#2254) -- see
             // `EvalError::yq_negative_index_out_of_range`'s own doc comment
             // and the `eval_try`/`try_single_generic` bypasses that keep it
             // surviving an outer `?`/`try` too.
-            Err(len) => QueryResult::Error(EvalError::yq_negative_index_out_of_range(idx, len)),
+            Err(NegativeIndexFault::OutOfRange(len)) => {
+                QueryResult::Error(EvalError::yq_negative_index_out_of_range(idx, len))
+            }
         },
         // jq returns null for index on null
         StandardJson::Null => QueryResult::One(StandardJson::Null),
@@ -17923,37 +17932,60 @@ fn slice_object_children_at(
     OwnedValue::Array(children)
 }
 
+/// [`get_element_at_index`]'s negative-index resolution outcomes that
+/// aren't a plain hit/miss.
+///
+/// `OutOfRange(len)` is a negative index still negative after resolving
+/// against the array's length -- distinct from an ordinary miss (`Ok(None)`
+/// from the function itself, the positive-direction case or an
+/// in-range-but-empty read) only so the caller can raise real yq's own
+/// error for it (#2254); jq mode's own caller treats it exactly like
+/// `Ok(None)`. `Malformed` is the array's own `len_checked` (#1677/#2261)
+/// rejecting a trailing stray comma or other structural fault while
+/// resolving that length -- unlike `OutOfRange`, this must always
+/// propagate as an error in *both* modes, the same "decode failure never
+/// suppressed" rule `#2293`'s `has_one_key`/`builtin_length`/`builtin_keys`
+/// fix already established for this file's other `len_checked` callers.
+enum NegativeIndexFault {
+    OutOfRange(usize),
+    Malformed(EvalError),
+}
+
 /// Get element at index (supports negative indexing).
 ///
 /// Uses `get_fast` for O(n) BP operations + O(log n) IB select,
 /// instead of `get` which does O(n) IB selects.
-///
-/// `Err(len)` is a negative index still negative after resolving against the
-/// array's length -- distinct from an ordinary miss (`Ok(None)`, the
-/// positive-direction case or an in-range-but-empty read) only so the caller
-/// can raise real yq's own error for it (#2254); jq mode's own caller treats
-/// `Err` exactly like `Ok(None)`.
 fn get_element_at_index<W: Clone + AsRef<[u64]>>(
     elements: JsonElements<'_, W>,
     idx: i64,
-) -> Result<Option<StandardJson<'_, W>>, usize> {
+) -> Result<Option<StandardJson<'_, W>>, NegativeIndexFault> {
     if idx >= 0 {
         Ok(elements.get_fast(idx as usize))
     } else {
         // Negative index: count from end
-        let len = count_elements(elements);
+        let len = match count_elements(elements) {
+            Ok(len) => len,
+            Err(e) => return Err(NegativeIndexFault::Malformed(e)),
+        };
         let positive_idx = len as i64 + idx;
         if positive_idx >= 0 {
             Ok(elements.get_fast(positive_idx as usize))
         } else {
-            Err(len)
+            Err(NegativeIndexFault::OutOfRange(len))
         }
     }
 }
 
-/// Count elements in an array (consumes the iterator).
-fn count_elements<W: Clone + AsRef<[u64]>>(elements: JsonElements<'_, W>) -> usize {
-    elements.count()
+/// Count elements in an array (consumes the iterator), refusing a trailing
+/// stray comma after a real last element (#2312) -- the same #1677/#2261
+/// gap check every other array-length call site in this file already has
+/// (`DocumentElements::len_checked`), missed here because this function's
+/// only caller ([`get_element_at_index`]) needed a genuine new error shape
+/// to carry it (see [`NegativeIndexFault`]), not a drop-in swap.
+fn count_elements<W: Clone + AsRef<[u64]>>(
+    elements: JsonElements<'_, W>,
+) -> Result<usize, EvalError> {
+    elements.len_checked()
 }
 
 /// Slice elements from an array.

--- a/tests/jq_evaluator_parity_tests.rs
+++ b/tests/jq_evaluator_parity_tests.rs
@@ -1444,3 +1444,18 @@ fn test_parity_pattern_alternatives_short_circuit_over_document_1519() {
         assert_parity(json, filter);
     }
 }
+
+/// #2312: `eval.rs`'s `get_element_at_index`/`count_elements` (negative-index
+/// resolution, `.foo[-1]`) had the same missing #1677/#2261 trailing-comma
+/// gap check `eval_generic.rs`'s own `Expr::Index` arm already closed
+/// (#2261) -- unreachable from either shipped CLI today (same reachability
+/// analysis as #2293/#2311's sibling fixes in this file: `succinctly jq`
+/// never calls into `eval.rs`, and `succinctly yq`'s one call site always
+/// hands it an already-materialized value), but a real gap for a library
+/// consumer of `jq::eval*` building a cursor directly from raw,
+/// unvalidated bytes. Both evaluators already agree (`eval_generic.rs` was
+/// already correct), so `assert_error_parity` pins the fix.
+#[test]
+fn test_parity_negative_index_trailing_comma_2312() {
+    assert_error_parity(br"[1,2,3,]", ".[-1]");
+}

--- a/tests/jq_evaluator_parity_tests.rs
+++ b/tests/jq_evaluator_parity_tests.rs
@@ -1459,3 +1459,13 @@ fn test_parity_pattern_alternatives_short_circuit_over_document_1519() {
 fn test_parity_negative_index_trailing_comma_2312() {
     assert_error_parity(br"[1,2,3,]", ".[-1]");
 }
+
+/// #2312 review: a first draft of this fix only checked the negative-index
+/// branch, leaving a *positive* index (`.[0]`) on the same malformed array
+/// silently unchecked -- found live by code review. Pins both directions,
+/// matching `eval_generic.rs`'s own `Expr::Index` arm, which already
+/// checks unconditionally regardless of sign.
+#[test]
+fn test_parity_positive_index_trailing_comma_2312() {
+    assert_error_parity(br"[1,2,3,]", ".[0]");
+}


### PR DESCRIPTION
## Summary
- `eval.rs`'s `count_elements` (backing `get_element_at_index`'s index resolution, `.foo[N]`/`.foo[-N]`) called a bare `.count()` with none of the #1677/#2261 trailing-comma gap checks `eval_generic.rs`'s own `Expr::Index` arm already has (`elements.len_checked()`).
- `[1,2,3,] | .[-1]` and `[1,2,3,] | .[0]` (via the library API — see reachability below) both silently returned the element instead of raising — confirmed live against `/usr/bin/jq` 1.7.1, which raises `Expected another array element` for either.
- Restructured `get_element_at_index` to match `eval_generic.rs`'s own `Expr::Index` arm exactly: `count_elements`/`len_checked()` now runs unconditionally, before branching on the index's sign, and the negative-still-negative check reuses the same shared `yq_negative_index_check::<S>` helper `eval_generic.rs` already calls — both evaluators now resolve this rule through identical code, not just an identical rule re-derived by hand.
- Verified existing behavior is unchanged: well-formed input still resolves correctly (both directions), jq mode's own out-of-bounds-is-null rule still holds, and yq's own negative-out-of-range error (`.[-10]` on a well-formed 3-element array) still raises exactly as before.

## Reachability

Unreachable from either shipped CLI today, same analysis as #2293/#2311's sibling fixes — `eval.rs` is a second, independently-tested evaluator behind the crate's public `jq::eval`/`jq::eval_lenient`/`jq::eval_owned_with_file_index` entry points, not `eval_generic.rs`. `succinctly jq '.[-1]'`/`'.[0]'` on `[1,2,3,]` already raised correctly *before* this fix — but that's `eval_generic.rs`'s own already-correct `Expr::Index` arm (`succinctly jq` never calls into `eval.rs`). Real for a library consumer of `jq::eval*` building a cursor directly from raw, unvalidated document bytes; pinned via `tests/jq_evaluator_parity_tests.rs`'s `test_parity_negative_index_trailing_comma_2312`/`test_parity_positive_index_trailing_comma_2312`, which call both evaluators directly and assert they now agree.

## Round-2 review fix

Review (6 independent finder angles, all converging on the same finding) found a first draft of this fix only checked the negative-index branch — `get_element_at_index`'s `if idx >= 0` branch called `elements.get_fast` directly with zero validation, since only the negative branch needed to resolve a length at all (to count from the end). `[1,2,3,] | .[0]` stayed silently unchecked. Fixed by the restructure described above, which also eliminated the bespoke `NegativeIndexFault` enum from the first draft in favor of reusing `yq_negative_index_check` directly (a reuse suggestion from the same review round) — `get_element_at_index` now just returns `Result<Option<StandardJson>, EvalError>`.

Closes #2312.

## Test plan
- [x] New parity tests: `test_parity_negative_index_trailing_comma_2312`, `test_parity_positive_index_trailing_comma_2312`
- [x] `cargo test --lib jq::` — 1987 passed
- [x] `cargo test --test jq_cli_tests --features cli` — 1377 passed
- [x] `cargo test --test yq_cli_tests --features cli` — 1397 passed
- [x] `cargo test --test jq_evaluator_parity_tests --features cli` — 44 passed
- [x] `cargo test --test yq_golden_tests --features cli` / `cargo test --test jq_golden_tests --features cli`
- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings`
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features`
- [x] `cargo test --no-default-features --verbose` (no_std)
