### PR TITLE
fix(jq): eval.rs's builtin_keys never collapses duplicate keys (#2313)

### DIFF
--- a/docs/compliance/jq/limitations.md
+++ b/docs/compliance/jq/limitations.md
@@ -1769,10 +1769,12 @@ and differently-shaped problem than this section's own fixes):
   genuine new error-type design (its `Result<_, usize>` return already
   carries a distinct, meaningful "negative still negative" signal, #2254 --
   not a drop-in swap like the others), filed as #2312; and `builtin_keys`
-  never collapses duplicate keys in *either* mode (it has no
+  used to never collapse duplicate keys in *either* mode (it had no
   `S: EvalSemantics` parameter to derive `S::COLLAPSE_DUPLICATE_KEYS` from,
-  unlike `eval_generic.rs`'s own `Keys`/`KeysUnsorted` arms), filed as
-  #2313.
+  unlike `eval_generic.rs`'s own `Keys`/`KeysUnsorted` arms) -- filed as
+  #2313 and fixed there, by adding that parameter and its one call site's
+  turbofish. `eval.rs`'s copy of `keys`/`keys_unsorted` now agrees with
+  `eval_generic.rs`'s on this shape in both modes.
 
   Writing that parity test also surfaced a further, unrelated, **live and
   CLI-reachable** bug shared by *both* evaluators: `{"a":1,} | length` in jq

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -7174,6 +7174,27 @@ fn builtin_keys<W: Clone + AsRef<[u64]>, S: EvalSemantics>(
             // live: `{"a":1,"a":2} | keys_unsorted` is `["a"]`), matching
             // `eval_generic.rs`'s already-shipped `Builtin::Keys`/
             // `Builtin::KeysUnsorted` siblings.
+            //
+            // Code review, #2320: `succinctly jq` never reaches this
+            // function at all (routes exclusively through
+            // `eval_generic.rs`), but `succinctly yq`'s `evaluate_input`/
+            // `--eval-all` genuinely do call `jq::eval`/
+            // `eval_owned_with_file_index` directly with `YqSemantics` --
+            // not merely a hypothetical library-only concern the way an
+            // earlier version of this comment claimed. The bug this fix
+            // closes was never externally observable through that path
+            // specifically, though: `YqSemantics::COLLAPSE_DUPLICATE_KEYS`
+            // was already `false` (the old hardcoded value), and yq's own
+            // YAML-to-`OwnedValue` materialization already collapses a
+            // duplicate mapping key before this function ever sees it
+            // (confirmed live, pre- and post-fix binaries agree:
+            // `succinctly yq --slurp '.[0] | keys_unsorted'` on `a: 1\na:
+            // 2` is `["a"]` either way). The behavior this fix actually
+            // changes -- jq mode now collapsing -- is reachable only from
+            // a library caller of `jq::eval::<_, JqSemantics>`/
+            // `jq::eval_lenient`/`eval_owned_with_file_index` directly,
+            // since neither shipped CLI ever supplies `JqSemantics` to
+            // this function.
             let mut keys = match effective_keys(&fields, S::COLLAPSE_DUPLICATE_KEYS) {
                 Ok(keys) => keys,
                 Err(e) => return QueryResult::Error(e),

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -6726,8 +6726,8 @@ fn eval_builtin<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
         // Length & Keys
         Builtin::Length => builtin_length::<W, S>(value, optional),
         Builtin::Utf8ByteLength => builtin_utf8bytelength(value, optional),
-        Builtin::Keys => builtin_keys::<W>(value, optional, true),
-        Builtin::KeysUnsorted => builtin_keys::<W>(value, optional, false),
+        Builtin::Keys => builtin_keys::<W, S>(value, optional, true),
+        Builtin::KeysUnsorted => builtin_keys::<W, S>(value, optional, false),
         Builtin::Has(key_expr) => builtin_has::<W, S>(key_expr, value, optional),
         Builtin::In(obj_expr) => builtin_in::<W, S>(obj_expr, value, optional),
         Builtin::UpperIn(s) => builtin_upper_in::<W, S>(s, value, optional),
@@ -7136,7 +7136,7 @@ fn builtin_utf8bytelength<W: Clone + AsRef<[u64]>>(
 }
 
 /// Builtin: keys / keys_unsorted
-fn builtin_keys<W: Clone + AsRef<[u64]>>(
+fn builtin_keys<W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     value: StandardJson<'_, W>,
     optional: bool,
     sorted: bool,
@@ -7165,17 +7165,16 @@ fn builtin_keys<W: Clone + AsRef<[u64]>>(
             // `keys_unsorted` writer specifically avoids via
             // `DistinctKeyCursors`/`uncons_key`. `effective_keys` is that
             // same cheap path, exposed as a free function for exactly this
-            // kind of caller. `collapse: false` matches this function's own
-            // prior behaviour on both sides of this fix (never collapsed a
-            // duplicate key, in either mode) -- `builtin_keys` has no
-            // `S: EvalSemantics` parameter to derive a mode-correct
-            // `S::COLLAPSE_DUPLICATE_KEYS` from, and real jq *does* collapse
-            // (confirmed live: `{"a":1,"a":2} | keys_unsorted` is `["a"]`).
-            // That divergence predates this fix on both the old hand-rolled
-            // walk and `DocumentFields::keys()` alike, so it isn't
-            // reintroduced or newly widened here -- tracked separately
-            // rather than folded into this fix's own narrower scope.
-            let mut keys = match effective_keys(&fields, false) {
+            // kind of caller.
+            //
+            // #2313: `S::COLLAPSE_DUPLICATE_KEYS`, not a hardcoded `false`
+            // -- this function used to have no `S: EvalSemantics` parameter
+            // to derive a mode-correct value from, so it never collapsed a
+            // duplicate key in either mode, where real jq does (confirmed
+            // live: `{"a":1,"a":2} | keys_unsorted` is `["a"]`), matching
+            // `eval_generic.rs`'s already-shipped `Builtin::Keys`/
+            // `Builtin::KeysUnsorted` siblings.
+            let mut keys = match effective_keys(&fields, S::COLLAPSE_DUPLICATE_KEYS) {
                 Ok(keys) => keys,
                 Err(e) => return QueryResult::Error(e),
             };
@@ -54896,6 +54895,51 @@ mod tests {
             QueryResult::Owned(OwnedValue::Array(arr)) => {
                 assert_eq!(arr.len(), 2);
                 // Note: Order depends on how JSON was parsed
+            }
+        );
+    }
+
+    /// #2313: `builtin_keys` had no `S: EvalSemantics` parameter to derive
+    /// a mode-correct collapse decision from, so it hardcoded `collapse:
+    /// false` and never collapsed a duplicate key in either mode -- wrong
+    /// in jq mode, where real jq *does* collapse (confirmed live:
+    /// `{"a":1,"a":2} | keys_unsorted` is `["a"]` against jq 1.7.1).
+    /// `eval_generic.rs`'s already-shipped `Builtin::Keys`/
+    /// `Builtin::KeysUnsorted` siblings already got this right via
+    /// `S::COLLAPSE_DUPLICATE_KEYS`; this pins `eval.rs`'s own copy now
+    /// agrees, in both modes -- jq collapses, yq (whose own
+    /// `COLLAPSE_DUPLICATE_KEYS` is `false`) still doesn't, unaffected by
+    /// this fix.
+    #[test]
+    fn test_builtin_keys_unsorted_collapses_duplicate_keys_in_jq_mode_2313() {
+        query!(br#"{"a":1,"a":2}"#, "keys_unsorted",
+            QueryResult::Owned(OwnedValue::Array(arr)) => {
+                assert_eq!(arr, vec![OwnedValue::String("a".to_string())]);
+            }
+        );
+        query!(br#"{"a":1,"a":2}"#, "keys",
+            QueryResult::Owned(OwnedValue::Array(arr)) => {
+                assert_eq!(arr, vec![OwnedValue::String("a".to_string())]);
+            }
+        );
+    }
+
+    /// Companion to the test above: yq mode's own `COLLAPSE_DUPLICATE_KEYS
+    /// = false` means this fix leaves yq's `keys_unsorted` unaffected --
+    /// still no collapsing, matching its pre-fix behavior (which was
+    /// coincidentally already correct for yq, since the old hardcoded
+    /// `false` happens to equal yq's own constant).
+    #[test]
+    fn test_builtin_keys_unsorted_does_not_collapse_in_yq_mode_2313() {
+        yq_query!(br#"{"a":1,"a":2}"#, "keys_unsorted",
+            QueryResult::Owned(OwnedValue::Array(arr)) => {
+                assert_eq!(
+                    arr,
+                    vec![
+                        OwnedValue::String("a".to_string()),
+                        OwnedValue::String("a".to_string())
+                    ]
+                );
             }
         );
     }

--- a/tests/jq_evaluator_parity_tests.rs
+++ b/tests/jq_evaluator_parity_tests.rs
@@ -1219,6 +1219,22 @@ fn test_parity_eval_rs_trailing_comma_sibling_gaps_2293() {
     }
 }
 
+/// #2313: `eval.rs`'s `builtin_keys` hardcoded `collapse: false`, no
+/// `S: EvalSemantics` parameter to derive a mode-correct value from --
+/// disagreeing with `eval_generic.rs`'s own `Builtin::Keys`/
+/// `Builtin::KeysUnsorted`, which already collapse via
+/// `S::COLLAPSE_DUPLICATE_KEYS` (`true` in jq mode, matching real jq
+/// 1.7.1: `{"a":1,"a":2} | keys_unsorted` is `["a"]`, confirmed live).
+/// `full_outputs` used `JqSemantics`, so this drift was live for any
+/// library consumer of `jq::eval*` on jq-mode duplicate-key input, not
+/// merely a defensive gap.
+#[test]
+fn test_parity_builtin_keys_collapses_duplicate_keys_2313() {
+    assert_parity(br#"{"a":1,"a":2}"#, "keys");
+    assert_parity(br#"{"a":1,"a":2}"#, "keys_unsorted");
+    assert_parity(br#"{"a":1,"a":2,"b":3,"a":4}"#, "keys_unsorted");
+}
+
 /// `assert_parity` compares only *successful* outputs: `collect_owned`'s
 /// `Error(_) => vec![]` arm swallows the error, so two evaluators that raise
 /// different messages -- or one that raises where the other doesn't -- both


### PR DESCRIPTION
## Summary

- `eval.rs`'s `builtin_keys` (backing `keys`/`keys_unsorted` for the crate's `jq::eval`/`jq::eval_lenient`/`jq::eval_owned_with_file_index` library entry points) had no `S: EvalSemantics` parameter, so its object arm hardcoded `effective_keys(&fields, false)` — never collapsing a duplicate key in either mode, where real jq does (confirmed live: `{"a":1,"a":2} | keys_unsorted` is `["a"]` against jq 1.7.1).
- `eval_generic.rs`'s already-shipped `Builtin::Keys`/`Builtin::KeysUnsorted` siblings both derive `collapse: S::COLLAPSE_DUPLICATE_KEYS` (`true` in jq mode, `false` in yq mode, matching real yq too — confirmed live, `yq`'s `keys` on a duplicate-key document is `["a","a"]`). Adds the same `S: EvalSemantics` parameter to `builtin_keys` and its one call site, so `eval.rs`'s own copy agrees.
- Same reachability status as every other `eval.rs`-parallel-evaluator gap (#2293/#2311/#2302): unreachable from either shipped CLI today (both route through `eval_generic.rs` exclusively), real only for a library consumer of `jq::eval*`.

Fixes #2313

## Test plan

- [x] Direct unit tests in both modes (`test_builtin_keys_unsorted_collapses_duplicate_keys_in_jq_mode_2313`, `test_builtin_keys_unsorted_does_not_collapse_in_yq_mode_2313`)
- [x] `tests/jq_evaluator_parity_tests.rs` case proving `eval.rs`/`eval_generic.rs` now agree on this shape, matching the issue's own suggested test plan
- [x] Fail-without-fix / pass-with-fix verified manually before committing
- [x] Full local test suite (`cargo test --features cli,simd,regex,serde`), both `cargo clippy` legs, `cargo fmt --check`, `cargo test --no-default-features`, and `cargo doc --no-deps --all-features` (`RUSTDOCFLAGS=-D warnings`) all pass