### PR TITLE
fix(jq): eval_format/Path/GetPath now consult optional (#2280)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -289,6 +289,38 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Three more sites ignored `optional`, an asymmetry #2231 already fixed for
+  `debug`/`stderr`/`tostring`/its catch-all fallback** (#2280, follow-up from #2231's own
+  code review): `eval_format` (`src/jq/eval.rs`, gating every `@format` builtin —
+  `@json`, `@csv`, `@tsv`, `@dsv`, `@uri`, `@html`, `@base64`, `@sh`, `@yaml`, `@props`,
+  `@text`) and `eval_generic.rs`'s `Builtin::Path`/`Builtin::GetPath` arms all raised an
+  unconditional error from their own materialization instead of consulting `optional` the
+  #2184/#2015/#2231 lineage's shared macros (`to_owned_or_suppress!`/`owned_or_suppress!`)
+  already provide. `GetPath`'s arm was a particularly sharp inconsistency: its own comment
+  already documents threading `optional` "for real" into `getpath_walk_owned`'s per-step
+  decision, while the initial materialization two lines above stayed on the unconditional
+  macro.
+
+  Like #2231's own findings 1-3, this is defensive rather than a live behavior change
+  today: #2286 tagged every error path these materializations can produce (string decode
+  failure, #1194 malformed member/delimiter)
+  `is_decode_failure()`, and `suppresses(e, optional) = optional && !e.is_decode_failure()`
+  is unconditionally `false` for all of them regardless of `optional` — verified live
+  (`test_optional_ignored_sites_2280`, `tests/jq_cli_tests.rs`), mirroring
+  `test_try_catch_handler_still_runs_under_outer_optional_2231`'s own methodology. Still
+  correct to fix: the macro swap also keeps propagating a genuine decode failure
+  unchanged, and removes the dependency on this reachability analysis staying true if a
+  future error class is ever routed through the same call.
+
+  A fourth review finding — ~85 raw `to_owned(&…)` calls in `eval.rs` and ~12 raw
+  `to_owned_with_cursor(` calls in `eval_generic.rs` still don't route through these
+  macros, with no structural guard (rename, lint, CI grep) to stop the pattern
+  recurring — was left as a judgment call rather than acted on here: the #2286
+  convergence above means most of that remaining surface is likely already
+  decode-failure-only too, lowering the urgency a Low-severity, non-live-reachable
+  defensive-consistency issue justifies for a new CI enforcement mechanism. Noted on the
+  issue for whoever picks up the next installment of this lineage.
+
 - **`--argjson`/`--jsonargs` rejected a leading-dot (`.5`, #1171) or trailing-dot-before-
   exponent (`1.e5`, #2220) number literal outright, where real jq's own number parser
   accepts both** (#2240 Gap 2): a `--argjson`/`--jsonargs` value needing either leniency

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -294,9 +294,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   code review): `eval_generic.rs`'s `Expr::Format` arm (gating every `@format` builtin —
   `@json`, `@csv`, `@tsv`, `@dsv`, `@uri`, `@html`, `@base64`, `@sh`, `@yaml`, `@props`,
   `@text` — for the CLI's default dispatch), its `Builtin::Path`/`Builtin::GetPath` arms,
-  and `eval.rs`'s own `eval_format`/`builtin_path` (reached via the public
-  `succinctly::jq::eval::eval` library API, and via the CLI whenever `eval_generic.rs`'s
-  own fallback re-enters the full evaluator for a non-identity value) all raised an
+  `eval.rs`'s own `builtin_path` (reached via the public `succinctly::jq::eval::eval`
+  library API, and via the CLI whenever `eval_generic.rs`'s own fallback re-enters the full
+  evaluator for a non-identity value — e.g. a document-sourced number literal longer than
+  256 digits), and `eval.rs`'s own `eval_format` (library-API-only: unlike `builtin_path`,
+  `eval_generic.rs`'s reindex-bridge helper short-circuits every `Expr::Format` before it
+  can reach this evaluator at all, so this site is never reached from the CLI) all raised an
   unconditional error from their own materialization instead of consulting `optional` the
   #2184/#2015/#2231 lineage's shared macros (`to_owned_or_suppress!`/`owned_or_suppress!`)
   already provide. `GetPath`'s arm was a particularly sharp inconsistency: its own comment
@@ -316,6 +319,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `Builtin::Path` fallback line it claimed to pin. All three were fixed and the test
   corrected to use a non-cursor-navigable path expression (confirmed with temporary debug
   instrumentation during review that this reaches the intended line).
+
+  A third review round then found the CHANGELOG's own claim that `eval.rs`'s `eval_format`
+  is CLI-reachable via the reindex bridge (the same way `builtin_path` is) was itself
+  wrong: `eval_generic.rs`'s `eval_on_owned` short-circuits any `Expr::Format` before it
+  can reach `eval.rs`'s evaluator at all (the same round trip `format_owned`'s own doc
+  comment already explains avoiding, #124), so `eval_format` is genuinely reachable only
+  via the public library API. The fix itself was already correct either way (still
+  defensive); only the reachability claim in its comment and this entry needed correcting.
+  A parallel sweep from that same round found several more sites sharing this issue's
+  exact pattern outside its own three named findings (`builtin_del`, the
+  `Reverse`/`Sort`/`Unique`/`Min`/`Max` family, `builtin_envvar`, `builtin_transpose`, and
+  a few lower-confidence candidates) — out of scope for this PR, filed as #2327 instead of
+  expanded here.
 
   Like #2231's own findings 1-3, this is defensive rather than a live behavior change
   today: #2286 tagged every error path these materializations can produce (string decode

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -289,11 +289,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- **Three more sites ignored `optional`, an asymmetry #2231 already fixed for
+- **Five sites ignored `optional`, an asymmetry #2231 already fixed for
   `debug`/`stderr`/`tostring`/its catch-all fallback** (#2280, follow-up from #2231's own
-  code review): `eval_format` (`src/jq/eval.rs`, gating every `@format` builtin —
+  code review): `eval_generic.rs`'s `Expr::Format` arm (gating every `@format` builtin —
   `@json`, `@csv`, `@tsv`, `@dsv`, `@uri`, `@html`, `@base64`, `@sh`, `@yaml`, `@props`,
-  `@text`) and `eval_generic.rs`'s `Builtin::Path`/`Builtin::GetPath` arms all raised an
+  `@text` — for the CLI's default dispatch), its `Builtin::Path`/`Builtin::GetPath` arms,
+  and `eval.rs`'s own `eval_format`/`builtin_path` (reached via the public
+  `succinctly::jq::eval::eval` library API, and via the CLI whenever `eval_generic.rs`'s
+  own fallback re-enters the full evaluator for a non-identity value) all raised an
   unconditional error from their own materialization instead of consulting `optional` the
   #2184/#2015/#2231 lineage's shared macros (`to_owned_or_suppress!`/`owned_or_suppress!`)
   already provide. `GetPath`'s arm was a particularly sharp inconsistency: its own comment
@@ -301,12 +304,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   decision, while the initial materialization two lines above stayed on the unconditional
   macro.
 
+  This PR's own first draft fixed only `eval.rs`'s `eval_format`/`Builtin::Path`/
+  `Builtin::GetPath` (the library-API-facing evaluator) and missed that
+  `jq_runner.rs`/`yq_runner.rs` route the CLI's default dispatch through
+  `eval_generic.rs` exclusively, never touching `eval.rs`'s own `eval()` at all for
+  ordinary use — so the headline fix didn't reach the code path a real `succinctly jq`
+  invocation actually takes. Code review caught this, plus that `eval.rs`'s own
+  `builtin_path` carried the identical bug (unlike its sibling `getpath_one_path`, which
+  already consulted `optional` correctly) and that the first draft's own regression test
+  exercised `path(.a)`'s pre-existing cursor-navigable fast path rather than the
+  `Builtin::Path` fallback line it claimed to pin. All three were fixed and the test
+  corrected to use a non-cursor-navigable path expression (confirmed with temporary debug
+  instrumentation during review that this reaches the intended line).
+
   Like #2231's own findings 1-3, this is defensive rather than a live behavior change
   today: #2286 tagged every error path these materializations can produce (string decode
   failure, #1194 malformed member/delimiter)
   `is_decode_failure()`, and `suppresses(e, optional) = optional && !e.is_decode_failure()`
   is unconditionally `false` for all of them regardless of `optional` — verified live
-  (`test_optional_ignored_sites_2280`, `tests/jq_cli_tests.rs`), mirroring
+  (`test_optional_ignored_sites_2280`/`test_eval_rs_only_sites_still_correct_2280`,
+  `tests/jq_cli_tests.rs`), mirroring
   `test_try_catch_handler_still_runs_under_outer_optional_2231`'s own methodology. Still
   correct to fix: the macro swap also keeps propagating a genuine decode failure
   unchanged, and removes the dependency on this reachability analysis staying true if a

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -10773,10 +10773,24 @@ fn eval_format<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     // raise, not silently format `""` (or a container holding `""` for a
     // nested field). Every `@format` function shares this single
     // materialization point via `format_owned`.
-    let owned = match to_owned(&value) {
-        Ok(v) => v,
-        Err(e) => return e.into(),
-    };
+    //
+    // #2280: to_owned_or_suppress!, not a bare `to_owned` match -- `optional`
+    // is a live parameter of this function (passed on to `format_owned`
+    // below), so ignoring it here was a real asymmetry across every
+    // `@format` builtin (`@json`, `@csv`, `@tsv`, `@dsv`, `@uri`, `@html`,
+    // `@base64`, `@sh`, `@yaml`, `@props`, `@text`), not just one site.
+    //
+    // Like #2231's own findings 1-3, this is defensive rather than a live
+    // behavior change today: #2286 tagged every one of `to_owned_at_depth`'s
+    // error paths (string decode failure, #1194 malformed member/delimiter)
+    // `is_decode_failure()`, and `suppresses(e, optional) = optional &&
+    // !e.is_decode_failure()` is unconditionally `false` for all of them
+    // regardless of `optional` -- verified live, see
+    // `test_optional_ignored_sites_2280` below. Still correct to fix: this
+    // macro also propagates a genuine decode failure unchanged, and a
+    // future error class routed through `to_owned` here would otherwise
+    // silently inherit the same asymmetry #2231 already fixed elsewhere.
+    let owned = to_owned_or_suppress!(&value, optional);
     match format_owned::<S>(format_type, &owned, optional) {
         Ok(s) => QueryResult::Owned(OwnedValue::String(s)),
         Err(e) => e.into(),

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -10780,6 +10780,17 @@ fn eval_format<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     // `@format` builtin (`@json`, `@csv`, `@tsv`, `@dsv`, `@uri`, `@html`,
     // `@base64`, `@sh`, `@yaml`, `@props`, `@text`), not just one site.
     //
+    // Unlike this issue's other four sites, this specific function is
+    // reachable ONLY via the public `succinctly::jq::eval::eval` library
+    // API, never via the CLI: `eval_generic.rs`'s own reindex-bridge helper
+    // (`eval_on_owned`) short-circuits any `Expr::Format` before it can ever
+    // re-enter this evaluator (`format_owned`'s own doc comment explains why
+    // -- avoiding a wasted JSON round trip, #124), and the CLI's default
+    // dispatch (`jq_runner.rs`/`yq_runner.rs`) never calls this module's
+    // `eval()` at all. Found and corrected during code review, which
+    // initially assumed (incorrectly) that this site shared `builtin_path`'s
+    // CLI-reachable reindex-bridge path.
+    //
     // Like #2231's own findings 1-3, this is defensive rather than a live
     // behavior change today: #2286 tagged every one of `to_owned_at_depth`'s
     // error paths (string decode failure, #1194 malformed member/delimiter)

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -34859,10 +34859,17 @@ fn builtin_path<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     value: StandardJson<'a, W>,
     optional: bool,
 ) -> QueryResult<'a, W> {
-    let owned = match to_owned(&value) {
-        Ok(owned) => owned,
-        Err(e) => return QueryResult::Error(e),
-    };
+    // #2280: to_owned_or_suppress!, not a bare match -- `optional` is passed
+    // to `builtin_path_on_owned` on the next line, so ignoring it here was
+    // the same asymmetry as this issue's other sites. Sibling to
+    // `getpath_one_path`'s identical materialization, which already
+    // consulted `optional` via `suppress_or_raise` -- this function was the
+    // one place the pattern hadn't been carried over. Reachable both via the
+    // public `succinctly::jq::eval::eval` library API and, via the CLI,
+    // whenever `eval_generic.rs`'s `Builtin::Path` fallback re-enters the
+    // full evaluator for a non-`reindex_bridge_is_identity` value (a `Float`
+    // anywhere in the document).
+    let owned = to_owned_or_suppress!(&value, optional);
     builtin_path_on_owned::<W, S>(expr, &owned, optional)
 }
 

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -5454,9 +5454,19 @@ fn eval_single<S: EvalSemantics, V: DocumentValue>(
         // Formats are pure functions of the value, so evaluate them here rather
         // than falling through to the catch-all, which would serialize the
         // value to JSON and rebuild a `JsonIndex` for every one (#124).
+        //
+        // #2280: owned_or_suppress!, not owned_or_err! -- `optional` is
+        // passed to `format_result` on this very line, so ignoring it in the
+        // materialization one line above was a real asymmetry. This is the
+        // arm the CLI's own default jq/yq dispatch actually reaches for
+        // every `@format` builtin (`jq_runner.rs`/`yq_runner.rs` route
+        // through `eval_generic`, never `eval.rs`'s own sibling
+        // `eval_format`) -- found by code review to have been missed by
+        // this issue's first pass, which fixed `eval_format` without
+        // noticing it isn't on the path ordinary CLI usage takes.
         Expr::Format(format_type) => format_result::<S, _>(
             format_type,
-            &owned_or_err!(to_owned_with_cursor(&value, cursor)),
+            &owned_or_suppress!(to_owned_with_cursor(&value, cursor), optional),
             optional,
         ),
 

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -10974,7 +10974,19 @@ fn eval_builtin<S: EvalSemantics, V: DocumentValue>(
                     Err(e) => partial_generic(out, Control::Error(e)),
                 };
             }
-            let owned = owned_or_err!(to_owned_with_cursor(&value, cursor));
+            // #2280: owned_or_suppress!, not owned_or_err! -- `optional` is a
+            // live parameter of this arm (threaded into `eval_on_owned`
+            // below), so ignoring it in this materialization specifically
+            // was a real asymmetry, matching the sibling fix already applied
+            // to `Builtin::ToString`'s arm and its catch-all fallback (#2231).
+            //
+            // Defensive, not a live behavior change today, for the same
+            // reason #2231's own findings 1-3 became defensive after #2286:
+            // this materialization's only error paths are all
+            // `is_decode_failure()`-tagged now, so `suppresses()` is always
+            // `false` here regardless of `optional` -- verified live, see
+            // `test_optional_ignored_sites_2280`.
+            let owned = owned_or_suppress!(to_owned_with_cursor(&value, cursor), optional);
             if reindex_bridge_is_identity(&owned) {
                 return query_result_to_generic::<V>(crate::jq::eval::builtin_path_on_owned::<
                     Vec<u64>,
@@ -11034,7 +11046,14 @@ fn eval_builtin<S: EvalSemantics, V: DocumentValue>(
         // dependency on that reachability analysis staying true, so it
         // stays -- but it is defensive, not currently load-bearing.
         Builtin::GetPath(path_expr) => {
-            let owned = owned_or_err!(to_owned_with_cursor(&value, cursor));
+            // #2280: owned_or_suppress!, not owned_or_err! -- this arm's own
+            // walk below already threads `optional` "for real" into
+            // `getpath_walk_owned`'s per-step suppress/raise decision, so
+            // leaving the initial materialization unconditional was an
+            // inconsistency inside the very arm whose comment documents the
+            // opposite intent. Defensive today for the same #2286 reason as
+            // the `Path` arm above -- see `test_optional_ignored_sites_2280`.
+            let owned = owned_or_suppress!(to_owned_with_cursor(&value, cursor), optional);
             if reindex_bridge_is_identity(&owned) {
                 return fanout_arg_generic::<S, V, _>(
                     path_expr,

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -29895,6 +29895,58 @@ fn test_getpath_still_raises_on_an_undecodable_sibling_2053() -> Result<()> {
     Ok(())
 }
 
+/// #2280: `eval_format` (every `@format` builtin), and `Builtin::Path`/
+/// `Builtin::GetPath`'s own materialization fallback, all consulted
+/// `optional` for real now (routed through `to_owned_or_suppress!`/
+/// `owned_or_suppress!` instead of a bare `to_owned`/`owned_or_err!` match)
+/// -- following #2231's exact precedent for `debug`/`stderr`/`tostring`/the
+/// catch-all fallback.
+///
+/// Pins that this is defensive, not a behavior change: a document-wide
+/// decode failure (`\ud800`, matching `test_getpath_still_raises_on_an_
+/// undecodable_sibling_2053`'s own repro) still raises -- uncatchable, per
+/// #2286 tagging every one of these materializations' error paths
+/// `is_decode_failure()` -- through a bare call, a trailing `?`, and a
+/// `try`/`catch` wrapped in its own outer `?` (the exact shape #2231's
+/// `test_try_catch_handler_still_runs_under_outer_optional_2231` uses to
+/// rule out a leaf silently self-suppressing ahead of an enclosing catch).
+#[test]
+fn test_optional_ignored_sites_2280() -> Result<()> {
+    let doc = r#"{"a":"\ud800","d":5}"#;
+    for filter in [
+        r".a | @json",
+        r".a | @json?",
+        r#"(try (.a | @json) catch "CAUGHT")?"#,
+        "path(.a)",
+        "path(.a)?",
+        r#"(try path(.a) catch "CAUGHT")?"#,
+        r#"getpath(["a"])"#,
+        r#"getpath(["a"])?"#,
+        r#"(try getpath(["a"]) catch "CAUGHT")?"#,
+    ] {
+        let (stdout, stderr, code) = run_jq_stdin_streams(filter, doc, &["-c"])?;
+        assert_eq!(code, 5, "{filter}: stdout {stdout:?} stderr {stderr:?}");
+        assert_eq!(stdout, "", "{filter}: stderr {stderr:?}");
+    }
+
+    // `@json` is not a blanket rejection of the whole document -- unlike
+    // `path`/`getpath` (whose own whole-document validity gate is pinned by
+    // `test_path_still_raises_on_an_undecodable_sibling_2061`/
+    // `test_getpath_still_raises_on_an_undecodable_sibling_2053`, and still
+    // raises on the decodable `.d` field below, same as those two), `@json`
+    // materializes only the already-navigated sub-cursor, so `.d | @json`
+    // succeeds on this same document even though `.a` is undecodable.
+    let (stdout, code) = run_jq_stdin(".d | @json", doc, &["-c"])?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout.trim(), "\"5\"");
+    let (_, _, code) = run_jq_stdin_streams("path(.d)", doc, &["-c"])?;
+    assert_eq!(code, 5, "path()'s whole-document gate should still fire");
+    let (_, _, code) = run_jq_stdin_streams(r#"getpath(["d"])"#, doc, &["-c"])?;
+    assert_eq!(code, 5, "getpath()'s whole-document gate should still fire");
+
+    Ok(())
+}
+
 /// #2053, constraint 2 from the issue that split this fix off from #1909:
 /// `path_expr` must be evaluated exactly once, on *both* branches
 /// `eval_generic.rs`'s new native `Builtin::GetPath` arm can take -- the

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -29895,12 +29895,23 @@ fn test_getpath_still_raises_on_an_undecodable_sibling_2053() -> Result<()> {
     Ok(())
 }
 
-/// #2280: `eval_format` (every `@format` builtin), and `Builtin::Path`/
-/// `Builtin::GetPath`'s own materialization fallback, all consulted
-/// `optional` for real now (routed through `to_owned_or_suppress!`/
-/// `owned_or_suppress!` instead of a bare `to_owned`/`owned_or_err!` match)
-/// -- following #2231's exact precedent for `debug`/`stderr`/`tostring`/the
-/// catch-all fallback.
+/// #2280: `eval_generic.rs`'s `Expr::Format` arm (every `@format` builtin --
+/// this is the arm the CLI's default jq/yq dispatch actually reaches;
+/// `eval.rs`'s own sibling `eval_format` is library-API/reindex-bridge-only,
+/// see `test_eval_rs_only_sites_still_correct_2280` below), and
+/// `Builtin::Path`/`Builtin::GetPath`'s own materialization fallback, all
+/// consulted `optional` for real now (routed through `owned_or_suppress!`
+/// instead of a bare `owned_or_err!` match) -- following #2231's exact
+/// precedent for `debug`/`stderr`/`tostring`/the catch-all fallback.
+///
+/// `path(.a)` alone would not exercise `Builtin::Path`'s fixed line: a bare
+/// `Expr::Field` is cursor-navigable (`path_expr_is_cursor_navigable`), so
+/// it takes the pre-existing fast path (`push_generic_truthiness_cursor_error`)
+/// instead, never reaching the fallback this PR changed -- confirmed live
+/// with temporary debug instrumentation during review. `path(if true then
+/// .a else null end)` is not cursor-navigable (`Expr::If` isn't in that
+/// function's recognized set), forcing the fallback -- confirmed the same
+/// way.
 ///
 /// Pins that this is defensive, not a behavior change: a document-wide
 /// decode failure (`\ud800`, matching `test_getpath_still_raises_on_an_
@@ -29917,9 +29928,9 @@ fn test_optional_ignored_sites_2280() -> Result<()> {
         r".a | @json",
         r".a | @json?",
         r#"(try (.a | @json) catch "CAUGHT")?"#,
-        "path(.a)",
-        "path(.a)?",
-        r#"(try path(.a) catch "CAUGHT")?"#,
+        "path(if true then .a else null end)",
+        "path(if true then .a else null end)?",
+        r#"(try path(if true then .a else null end) catch "CAUGHT")?"#,
         r#"getpath(["a"])"#,
         r#"getpath(["a"])?"#,
         r#"(try getpath(["a"]) catch "CAUGHT")?"#,
@@ -29944,6 +29955,33 @@ fn test_optional_ignored_sites_2280() -> Result<()> {
     let (_, _, code) = run_jq_stdin_streams(r#"getpath(["d"])"#, doc, &["-c"])?;
     assert_eq!(code, 5, "getpath()'s whole-document gate should still fire");
 
+    Ok(())
+}
+
+/// #2280: `eval.rs`'s own `builtin_path` -- the sibling of
+/// `eval_generic.rs`'s `Builtin::Path` fallback this PR also fixed, reached
+/// only via the public `succinctly::jq::eval::eval` library API or, via the
+/// CLI, when `eval_generic.rs`'s own fallback re-enters the full evaluator
+/// for a non-`reindex_bridge_is_identity` value (any `NumberLiteral` longer
+/// than `REINDEX_LITERAL_LEN_CAP`, or a `Float`).
+///
+/// Confirmed reachable from this exact CLI shape with temporary debug
+/// instrumentation during review. Cannot pin a suppress-vs-raise behavior
+/// difference the way `test_optional_ignored_sites_2280` does for the other
+/// three sites, though: by the time this second materialization runs, the
+/// document has already survived one whole decode (`eval_generic.rs`'s own
+/// fallback materializes first and would raise before ever reaching this
+/// point on truly malformed input) -- there is no error left for `optional`
+/// to suppress or not by the time `builtin_path` gets a turn. This test
+/// only pins that the reindex-bridge round trip through the fixed line
+/// still produces the correct answer, not a live optional-suppression case.
+#[test]
+fn test_eval_rs_only_sites_still_correct_2280() -> Result<()> {
+    let long_number = "1".repeat(300);
+    let doc = format!(r#"{{"f":{long_number}}}"#);
+    let (stdout, code) = run_jq_stdin("path(if true then . else null end)", &doc, &["-c"])?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout.trim(), "[]");
     Ok(())
 }
 


### PR DESCRIPTION
## Summary

Follow-up from #2231's own code review, addressing findings 1-3 (finding 4 is a
structural/judgment-call observation, addressed below without a code change).

`eval_generic.rs`'s `Expr::Format` arm (gating every `@format` builtin for the CLI's
default dispatch — `@json`, `@csv`, `@tsv`, `@dsv`, `@uri`, `@html`, `@base64`, `@sh`,
`@yaml`, `@props`, `@text`), its `Builtin::Path`/`Builtin::GetPath` arms, and `eval.rs`'s
own `eval_format`/`builtin_path` (reached via the public `succinctly::jq::eval::eval`
library API, and via the CLI whenever `eval_generic.rs`'s own fallback re-enters the full
evaluator for a non-identity value) all raised an unconditional error from their own
materialization instead of consulting `optional`, the way #2184/#2015/#2231 already fixed
for `debug`/`stderr`/`tostring`/its catch-all fallback. `GetPath`'s arm was the sharpest
inconsistency: its own comment already documents threading `optional` "for real" into
`getpath_walk_owned`'s per-step suppress/raise decision, while the initial materialization
two lines above stayed on the unconditional macro.

Fixed by swapping in the shared macros this lineage already established:
`to_owned_or_suppress!` (eval.rs) and `owned_or_suppress!` (eval_generic.rs).

## Round 1 → review caught the fix didn't reach the CLI's real dispatch site

The first commit fixed only `eval.rs`'s `eval_format`/`Builtin::Path`/`Builtin::GetPath`.
Code review found this missed the arm ordinary CLI usage actually takes:
`jq_runner.rs`/`yq_runner.rs` route the default dispatch through `eval_generic.rs`
exclusively and never call `eval.rs`'s own `eval()` — confirmed by grepping both runner
files for any `jq::eval::` import (none) vs. their `eval_generic::` imports (used
throughout). So the round-1 fix, while correct in isolation, wasn't the bug a real
`succinctly jq '.a | @json'` invocation hits.

Review also found:
- `eval.rs`'s own `builtin_path` had the identical bug — unlike its sibling
  `getpath_one_path`, which already consulted `optional` correctly via
  `suppress_or_raise`.
- The round-1 regression test's `path(.a)` cases never exercised the changed
  `Builtin::Path` fallback line at all: a bare `Expr::Field` is cursor-navigable
  (`path_expr_is_cursor_navigable`), so it takes the pre-existing fast path
  (`push_generic_truthiness_cursor_error`) instead.

All three fixed in round 2:
- `eval_generic.rs`'s `Expr::Format` arm now also uses `owned_or_suppress!`.
- `eval.rs`'s `builtin_path` now uses `to_owned_or_suppress!`.
- The test's `path(.a)` cases switched to `path(if true then .a else null end)` — not
  cursor-navigable (`Expr::If` isn't in that function's recognized set) — confirmed with
  temporary debug instrumentation (added, verified, removed before this push) that this
  shape actually reaches the fixed line and the old shape didn't.

## Not a live behavior change today (verified, not assumed)

Traced every error path all these materializations (`to_owned`/`to_owned_with_cursor`)
can produce — string decode failure, #1194 malformed member/delimiter — and confirmed all
of them are `is_decode_failure()`-tagged since #2286. `suppresses(e, optional) = optional
&& !e.is_decode_failure()` is therefore unconditionally `false` regardless of `optional`,
the exact same outcome #2231's own findings 1-3 reached after #2286 landed.

Still correct to fix:
- The macro swap also keeps propagating a genuine decode failure unchanged (verified live
  with a lone surrogate, `\ud800`, via `printf` piped to stdin — not `echo`, whose `\u`
  handling differs across shells and silently mangled this exact repro during my own
  manual testing before I caught it).
- It removes the dependency on this reachability analysis staying true if a future error
  class is ever routed through the same call — the whole point of the shared macro over a
  hand-rolled match, per its own doc comment.

New test `test_optional_ignored_sites_2280` (`tests/jq_cli_tests.rs`) pins this for the
three CLI-reachable sites: all stay uncatchable through a bare call, a trailing `?`, and a
`try`/`catch` wrapped in its own outer `?` — mirroring
`test_try_catch_handler_still_runs_under_outer_optional_2231`'s own methodology for ruling
out a leaf silently self-suppressing ahead of an enclosing catch.

`eval.rs`'s own two sites get a separate test, `test_eval_rs_only_sites_still_correct_2280`
— confirmed reachable via a CLI shape that forces `eval_generic.rs`'s reindex-bridge
fallback (a 300-digit number literal, past `REINDEX_LITERAL_LEN_CAP`), but this test can't
pin a suppress-vs-raise difference: by the time this second materialization runs, the
document has already survived one whole decode via `eval_generic.rs`'s own fallback
(which would raise first on genuinely malformed input), so there's no error left for
`optional` to suppress or not once `eval.rs`'s `builtin_path` gets a turn. It only pins
that the reindex-bridge round trip through the fixed line still produces correct output.

## Round 3 → a reachability claim was wrong, and a parallel sweep found more sites

A third review round found round 2's own claim — that `eval.rs`'s `eval_format` is
CLI-reachable via the reindex bridge the same way `builtin_path` is — was itself wrong:
`eval_generic.rs`'s `eval_on_owned` short-circuits every `Expr::Format` before it can
reach `eval.rs`'s evaluator at all (the exact round trip `format_owned`'s own doc comment
already explains avoiding, #124). So `eval_format` is reachable only via the public
library API, never the CLI. The fix itself (`to_owned_or_suppress!`) was already correct
either way — only the reachability claim in its comment and the CHANGELOG needed
correcting, which this round does.

The same round's parallel sweep for other instances of this pattern found several more —
outside this issue's own three named findings — filed as #2327 rather than expanded here:
`builtin_del` (the sharpest case: its own doc comment already promises `optional`
suppression this materialization doesn't honor), the
`Reverse`/`Sort`/`SortBy`/`Unique`/`UniqueBy`/`Min`/`MinBy`/`Max`/`MaxBy` family,
`builtin_envvar`, `builtin_transpose`, and a few lower-confidence candidates
(`eval_array_construction`, `group_by`/`unique_by`/`sort_by`'s own item conversion,
`halt_error`).

## Finding 4 (structural observation, not fixed here)

Review also found ~85 raw `to_owned(&…)` calls in `eval.rs` and ~12 raw
`to_owned_with_cursor(` calls in `eval_generic.rs` that still don't route through
`to_owned_or_suppress!`/`owned_or_suppress!`, with no enforcement (rename, lint, CI grep)
to stop this whack-a-mole pattern recurring — the doc comment on these macros already
names five prior installments before #2184/#2231 made seven and eight.

Judgment call: **not** investing in a structural guard here. The #2286 convergence above
means most of that remaining surface is likely already decode-failure-only too (same as
this PR's five sites), which lowers the urgency a Low-severity, currently-non-live-
reachable defensive-consistency issue justifies for new CI infrastructure. Noted on #2280
for whoever picks up the next installment of this lineage, rather than silently dropped.

## Verification

- New CLI regression tests (`tests/jq_cli_tests.rs`), live-verified against the pinned
  `/usr/bin/jq` 1.7.1 oracle where applicable.
- Full `cargo test --workspace`: all green (57 test binaries).
- `cargo test --no-default-features --verbose` (no_std leg): green.
- `cargo clippy --all-targets --all-features -- -D warnings` and the second CI clippy
  leg (`--features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests`): clean.
- `cargo fmt --check`, `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features`:
  clean.

Fixes #2280
