### PR TITLE
fix(yq): del()/delpaths() extend a mid-chain positive out-of-range index too (#2314)

### DIFF
--- a/docs/compliance/yq/limitations.md
+++ b/docs/compliance/yq/limitations.md
@@ -1880,12 +1880,29 @@ $ echo '[1,2]' | yq -o=json 'del(.[5][])'   # [1,2,null,null,null,[]]
 
 Closed across the three sites that resolve a mid-chain array index for a delete --
 `delete_path_steps`'s `Expr::Index` arm (the plain AST walk), `delete_trie_array`'s
-`ArrayStep::Index` arm (the comma-grouped multi-target walk), and `delete_paths_under`'s
-array-key arm (`delpaths`' own recursion) -- all in `src/jq/eval.rs`. The trie walk has no
-`[]`-vivify case to mirror: a bare `.[]` can never reach it as a resolved step (a
-comma-grouped `del()`'s own `.[]` is always fanned out against the real document before the
-trie is built, and an out-of-range mid-chain index has nothing there to fan out over), and
-`delpaths`' own path components are always concrete keys, never a `.[]` wildcard.
+`ArrayStep::Index` arm (the comma-grouped multi-target walk, once that walk's own
+read-based fan-out has already resolved a concrete branch reaching it -- see the residual
+gap below for when it hasn't), and `delete_paths_under`'s array-key arm (`delpaths`' own
+recursion) -- all in `src/jq/eval.rs`. `delpaths`' own path components are always concrete
+keys, never a `.[]` wildcard, so there is no `[]`-vivify case to mirror at that site.
+
+**Two residual gaps found during this fix's own review, not chased here:**
+
+- A **comma-grouped** target whose own `.[]` fan-out crosses the out-of-range index
+  (`del(.[5][], .[0])`) never reaches `delete_trie_array` at all -- the read-based
+  validation that enumerates concrete branches for the trie reads `.[5]` as a plain
+  `null` (correct for an ordinary read) and raises iterating `.[]` over it, rather than
+  extending+vivifying the way the direct, non-comma-grouped form now does. Tracked as
+  [#2324](https://github.com/rust-works/succinctly/issues/2324).
+- The `[]`-vivify rule implemented here is narrowly scoped to a slot this fix *itself*
+  just padded, checked only against a literal `Expr::Iterate` as the very next step.
+  Real yq's actual rule is broader and predates this fix entirely: `null` auto-vivifies
+  into `[]` for **any** subsequent `Index`/`Iterate` del() step, freshly padded or not
+  (`null | del(.[2])` is `[null,null]` in real yq; `{"x":null} | del(.x[2])` is
+  `{"x":[null,null]}`) -- `succinctly yq` gets both wrong today, along with a
+  multi-level chain like `del(.[3][2].a)` (real yq recurses the same rule at each level;
+  this fix's own narrow check only covers one). Tracked as
+  [#2323](https://github.com/rust-works/succinctly/issues/2323).
 
 ### Other categories
 

--- a/docs/compliance/yq/limitations.md
+++ b/docs/compliance/yq/limitations.md
@@ -1857,13 +1857,35 @@ path-array form) shares the same order-dependence.
 A negative out-of-range index is untouched by this fix either way -- it raises instead
 (#2268, the section above, landed separately and already covers it).
 
-Also scoped to a *terminal* index only -- a positive out-of-range index with more path
-after it (`del(.[5].a)`, `del(.[5][])`) extends too in real yq, to `index + 1` rather than
-`index` (there *is* something at the out-of-range position once the rest of the path needs
-to navigate into it), and `del(.[5][])` specifically auto-vivifies `[]` there rather than
-`null` -- a different shape from this fix's own terminal-only rule, confirmed live but not
-implemented; tracked separately as
-[#2314](https://github.com/rust-works/succinctly/issues/2314).
+**Also extended to a mid-chain index, not just a terminal one**
+([#2314](https://github.com/rust-works/succinctly/issues/2314)). A positive out-of-range
+index with more path after it (`del(.[5].a)`, `delpaths([[5,"a"]])`) extends too in real
+yq, but to `index + 1` rather than `index` -- there *is* something at the out-of-range
+position once the rest of the path needs to navigate into it, so this reuses
+`pad_with_nulls` directly (the same `setpath`-side helper #2305's own
+`extend_array_with_nulls_for_delete` wraps) rather than the terminal case's `target_len`
+rule:
+
+```bash
+$ echo '[1,2]' | yq -o=json 'del(.[5].a)'   # [1,2,null,null,null,null] -- index 5 itself now exists
+```
+
+`del(.[5][])` is a further, third shape: the freshly-created slot can't stay `null`, since
+`.[]` never tolerates one (#527) -- real yq auto-vivifies it straight to `[]` instead, the
+same way `setpath` auto-vivifies a `null` into whatever container its own next step needs:
+
+```bash
+$ echo '[1,2]' | yq -o=json 'del(.[5][])'   # [1,2,null,null,null,[]]
+```
+
+Closed across the three sites that resolve a mid-chain array index for a delete --
+`delete_path_steps`'s `Expr::Index` arm (the plain AST walk), `delete_trie_array`'s
+`ArrayStep::Index` arm (the comma-grouped multi-target walk), and `delete_paths_under`'s
+array-key arm (`delpaths`' own recursion) -- all in `src/jq/eval.rs`. The trie walk has no
+`[]`-vivify case to mirror: a bare `.[]` can never reach it as a resolved step (a
+comma-grouped `del()`'s own `.[]` is always fanned out against the real document before the
+trie is built, and an out-of-range mid-chain index has nothing there to fan out over), and
+`delpaths`' own path components are always concrete keys, never a `.[]` wildcard.
 
 ### Other categories
 

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -36175,9 +36175,25 @@ fn delete_paths_under(
                 if let Some(err) = yq_negative_index_error_for_len(yq_mode, key, arr.len()) {
                     return Err(err);
                 }
-                if let Some(index) = resolve_read_index(key, arr.len()) {
-                    let old = core::mem::replace(&mut arr[index], OwnedValue::Null);
-                    arr[index] = delete_paths_sorted(old, paths, start, yq_mode)?;
+                // #2314: same mid-chain extension as `delete_path_steps`'s
+                // own `Expr::Index` arm below -- a positive out-of-range
+                // index still needs to exist so the rest of `paths` can
+                // recurse into it (`index + 1`, `pad_with_nulls`'s own
+                // contract), not skipped as #2305's terminal case is.
+                // `delpaths`' path components are concrete keys, never a
+                // `.[]` wildcard, so there is no auto-vivify-to-`[]` nuance
+                // to mirror here -- the recursive `delete_paths_sorted` call
+                // below only ever sees a `String`/numeric next key.
+                match resolve_delete_index(key, arr.len()) {
+                    DeleteIndexResolution::InRange(index) => {
+                        let old = core::mem::replace(&mut arr[index], OwnedValue::Null);
+                        arr[index] = delete_paths_sorted(old, paths, start, yq_mode)?;
+                    }
+                    DeleteIndexResolution::PositiveOutOfRange(index) if yq_mode => {
+                        pad_with_nulls(&mut arr, index)?;
+                        arr[index] = delete_paths_sorted(OwnedValue::Null, paths, start, yq_mode)?;
+                    }
+                    DeleteIndexResolution::PositiveOutOfRange(_) | DeleteIndexResolution::Skip => {}
                 }
                 Ok(OwnedValue::Array(arr))
             }
@@ -37124,9 +37140,25 @@ fn delete_trie_array(
                     if let Some(err) = yq_negative_index_error_for_len(yq_mode, &key, arr.len()) {
                         return Err(err);
                     }
-                    match resolve_read_index(&key, arr.len()) {
-                        Some(actual) => {
+                    // #2314: same mid-chain extension as `delete_path_steps`'s
+                    // own `Expr::Index` arm -- a positive out-of-range index
+                    // still needs to exist so the rest of this branch's own
+                    // subtree can recurse into it. A bare `.[]` can never be
+                    // `child`'s own step here (comma-grouped `del()` paths
+                    // fan a mid-chain `.[]` out against the real document
+                    // before the trie is built -- see `Expr::Iterate`'s own
+                    // arm in `DeleteTrieBuilder::child_of` -- so unlike
+                    // `delete_path_steps` there is no auto-vivify-to-`[]`
+                    // case to mirror here).
+                    match resolve_delete_index(&key, arr.len()) {
+                        DeleteIndexResolution::InRange(actual) => {
                             let target = &mut arr[actual];
+                            let old = core::mem::replace(target, OwnedValue::Null);
+                            *target = delete_trie_apply(old, trie, child, yq_mode)?;
+                        }
+                        DeleteIndexResolution::PositiveOutOfRange(index) if yq_mode => {
+                            pad_with_nulls(arr, index)?;
+                            let target = &mut arr[index];
                             let old = core::mem::replace(target, OwnedValue::Null);
                             *target = delete_trie_apply(old, trie, child, yq_mode)?;
                         }
@@ -37134,7 +37166,8 @@ fn delete_trie_array(
                         // through, so `delpaths` silently skips the step
                         // itself, `?` or not (#477) — but the tail still
                         // decides (#527/#529).
-                        None => delete_trie_through_absent(trie, child)?,
+                        DeleteIndexResolution::PositiveOutOfRange(_)
+                        | DeleteIndexResolution::Skip => delete_trie_through_absent(trie, child)?,
                     }
                 }
                 // Deleting *through* a slice deletes inside the sub-array and
@@ -37860,13 +37893,42 @@ fn delete_path_steps(
                     if let Some(err) = yq_negative_index_error_for_len(yq_mode, &key, arr.len()) {
                         return Err(err);
                     }
-                    match resolve_read_index(&key, arr.len()) {
-                        Some(actual_idx) => {
+                    match resolve_delete_index(&key, arr.len()) {
+                        DeleteIndexResolution::InRange(actual_idx) => {
                             root = &mut arr[actual_idx];
                             steps = rest;
                             continue;
                         }
-                        None => {
+                        // #2314: a positive out-of-range mid-chain index
+                        // still needs to *exist* -- unlike #2305's terminal
+                        // case, there is more path left to navigate into, so
+                        // this uses `pad_with_nulls`'s own `index + 1`
+                        // contract (same as `setpath`) rather than
+                        // `extend_array_with_nulls_for_delete`'s `target_len`
+                        // one. Confirmed live (yq v4.53.3): `[1,2] |
+                        // del(.[5].a)` is `[1,2,null,null,null,null]`.
+                        DeleteIndexResolution::PositiveOutOfRange(index) if yq_mode => {
+                            pad_with_nulls(arr, index)?;
+                            // The freshly padded slot is `null`, which
+                            // `.[]` never tolerates (#527) -- but real yq
+                            // auto-vivifies it to `[]` instead when `.[]`
+                            // is the very next step, the same way
+                            // `setpath` auto-vivifies a `null` into
+                            // whatever container its own next step needs.
+                            // Confirmed live: `[1,2] | del(.[5][])` is
+                            // `[1,2,null,null,null,[]]`, not an error.
+                            if matches!(
+                                rest.first().map(|s| unwrap_path_component(s).0),
+                                Some(Expr::Iterate)
+                            ) {
+                                arr[index] = OwnedValue::Array(Vec::new());
+                            }
+                            root = &mut arr[index];
+                            steps = rest;
+                            continue;
+                        }
+                        DeleteIndexResolution::PositiveOutOfRange(_)
+                        | DeleteIndexResolution::Skip => {
                             // An out-of-range index resolves to null, and
                             // deleting further into null is a no-op for most
                             // tails, `?` or not (#477) — but not `[]`, which
@@ -68940,6 +69002,106 @@ mod tests {
         yq_query!(br"[1,2,3]", r"delpaths([[0],[5]])",
             QueryResult::Owned(OwnedValue::Array(arr)) => {
                 assert_eq!(arr, vec![OwnedValue::Int(2), OwnedValue::Int(3)]);
+            }
+        );
+    }
+
+    #[test]
+    fn test_del_mid_chain_positive_out_of_range_index_extends_with_null_yq_mode_2314() {
+        // #2314: #2305's follow-up -- a positive out-of-range index that is
+        // *not* the terminal delete step still needs to exist, so the rest
+        // of the path (`.a` here) has something to navigate into. Unlike
+        // #2305's own `target_len` rule, the extension target is
+        // `index + 1` (`pad_with_nulls`'s own contract, same as `setpath`),
+        // since the index itself must be valid, not just the gap before it.
+        // Confirmed live against yq v4.53.3: `[1,2] | del(.[5].a)` is
+        // `[1,2,null,null,null,null]`.
+        yq_query!(br"[1,2]", r"del(.[5].a)",
+            QueryResult::Owned(OwnedValue::Array(arr)) => {
+                assert_eq!(
+                    arr,
+                    vec![
+                        OwnedValue::Int(1), OwnedValue::Int(2),
+                        OwnedValue::Null, OwnedValue::Null, OwnedValue::Null, OwnedValue::Null,
+                    ]
+                );
+            }
+        );
+        // Same shape via `delete_trie_array`'s own comma-grouped path
+        // (`delete_path_steps` above is the non-comma AST walk; a
+        // `del(.a, .b)`-shaped call routes through the trie instead) --
+        // confirmed live to produce the identical result.
+        yq_query!(br"[1,2]", r"del(.[5].a, .[0])",
+            QueryResult::Owned(OwnedValue::Array(arr)) => {
+                assert_eq!(
+                    arr,
+                    vec![
+                        OwnedValue::Int(2),
+                        OwnedValue::Null, OwnedValue::Null, OwnedValue::Null, OwnedValue::Null,
+                    ]
+                );
+            }
+        );
+        // jq has no such rule -- mid-chain stays a plain no-op, same as
+        // #2305's terminal case.
+        query!(br"[1,2]", r"del(.[5].a)",
+            QueryResult::Owned(OwnedValue::Array(arr)) => {
+                assert_eq!(arr, vec![OwnedValue::Int(1), OwnedValue::Int(2)]);
+            }
+        );
+        // A negative out-of-range index still raises (#2268), unaffected by
+        // this fix -- that check runs before `resolve_delete_index` is ever
+        // consulted.
+        yq_query!(br"[1,2]", r"del(.[-5].a)",
+            QueryResult::Error(e) => {
+                assert!(e.message.contains("out of range"), "message: {}", e.message);
+            }
+        );
+    }
+
+    #[test]
+    fn test_del_mid_chain_positive_out_of_range_index_iterate_vivifies_array_yq_mode_2314() {
+        // #2314: `.[]` immediately after the newly-created slot is the one
+        // case that can't stay `null` -- `.[]` never tolerates a `null` root
+        // (#527), so the padded slot is auto-vivified straight to `[]`
+        // instead, the same way `setpath` auto-vivifies `null` into
+        // whatever container its own next step needs. Confirmed live
+        // against yq v4.53.3: `[1,2] | del(.[5][])` is
+        // `[1,2,null,null,null,[]]`, not an error.
+        yq_query!(br"[1,2]", r"del(.[5][])",
+            QueryResult::Owned(OwnedValue::Array(arr)) => {
+                assert_eq!(
+                    arr,
+                    vec![
+                        OwnedValue::Int(1), OwnedValue::Int(2),
+                        OwnedValue::Null, OwnedValue::Null, OwnedValue::Null,
+                        OwnedValue::Array(vec![]),
+                    ]
+                );
+            }
+        );
+    }
+
+    #[test]
+    fn test_delpaths_mid_chain_positive_out_of_range_index_extends_with_null_yq_mode_2314() {
+        // #2314: `delpaths`' own array-key recursion arm shares the same
+        // mid-chain extension -- confirmed live, byte-for-byte the same
+        // result as `del(.[5].a)` above.
+        yq_query!(br"[1,2]", r#"delpaths([[5,"a"]])"#,
+            QueryResult::Owned(OwnedValue::Array(arr)) => {
+                assert_eq!(
+                    arr,
+                    vec![
+                        OwnedValue::Int(1), OwnedValue::Int(2),
+                        OwnedValue::Null, OwnedValue::Null, OwnedValue::Null, OwnedValue::Null,
+                    ]
+                );
+            }
+        );
+        // jq stays a no-op, same as #2305's terminal case.
+        query!(br"[1,2]", r#"delpaths([[5,"a"]])"#,
+            QueryResult::Owned(OwnedValue::Array(arr)) => {
+                assert_eq!(arr, vec![OwnedValue::Int(1), OwnedValue::Int(2)]);
             }
         );
     }

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -22290,10 +22290,19 @@ fn test_1116_chained_scalar_slice_del_navigator_type_mismatches_unaffected() -> 
 /// is unaffected.
 #[test]
 fn test_1116_chained_scalar_slice_del_navigator_out_of_bounds_unaffected() -> Result<()> {
+    // #2314: this used to assert the whole delete was a no-op ("out of
+    // bounds unaffected"), but that predates #2305/#2314's discovery that
+    // real yq extends an array on a positive out-of-range *index* step even
+    // when everything after it turns out to be a no-op through the `null`
+    // it created (`.b[0:1]` on a fresh `null` is itself a no-op, same as
+    // `.b`/`.[0:1]` each are individually) — the extension has already
+    // mutated `.a` by the time the walk reaches that null tail. Confirmed
+    // live against yq v4.53.3: index 99 extends `.a` to length 100.
     let input = r#"{"a":[{"b":5}]}"#;
     let (out, code) = run_yq_stdin("del(.a[99].b[0:1])", input, &["-o=json", "-I=0"])?;
     assert_eq!(code, 0);
-    assert_eq!(out.trim(), input);
+    let expected = format!(r#"{{"a":[{{"b":5}}{}]}}"#, ",null".repeat(99));
+    assert_eq!(out.trim(), expected);
     Ok(())
 }
 


### PR DESCRIPTION
## Summary

#2305 fixed real yq's positive-out-of-range array-extension rule for `del()`/`delpaths()`, but scoped it to the *terminal* delete index (`del(.[N])`) only. A **mid-chain** positive out-of-range index — `del(.[N].a)`, `del(.[N][])`, `delpaths([[N,"a"]])` — still silently no-opped, unaffected by that fix.

Confirmed live against yq v4.53.3 (all three, matching the issue exactly):

```console
$ echo '[1,2]' | yq -o=json 'del(.[5].a)'
[1, 2, null, null, null, null]
$ echo '[1,2]' | succinctly yq 'del(.[5].a)' -o json   # before this fix
[1, 2]
```

## What changed

The extension target for a mid-chain index is `index + 1` (`pad_with_nulls`'s own contract, same as `setpath`), not #2305's `target_len` — the index itself must exist so the rest of the path has something to navigate into. `del(.[N][])` is a further nuance: the freshly-created slot can't stay `null` since `.[]` never tolerates one (#527), so it's auto-vivified straight to `[]` instead, matching real yq.

Fixed across the three sites the issue named:
- `delete_path_steps`'s `Expr::Index` arm (`src/jq/eval.rs`) — the plain AST-walk mid-chain case.
- `delete_trie_array`'s `ArrayStep::Index` arm — the comma-grouped multi-target case (`del(.[5].a, .[0])`).
- `delete_paths_under`'s array-key arm — `delpaths()`'s own recursion.

The trie walk needs no `[]`-auto-vivify case: a bare `.[]` can never reach it as a resolved step (it's always fanned out against the real document before the trie is built, and there's nothing at an out-of-range index to fan out over), and `delpaths`' path components are always concrete keys, never a `.[]` wildcard.

## A pre-existing test's premise didn't survive this

`test_1116_chained_scalar_slice_del_navigator_out_of_bounds_unaffected` asserted `{"a":[{"b":5}]} | del(.a[99].b[0:1])` was a total no-op. Live-checked against real yq: it's *not* — `.a` still grows to length 100, even though everything after the extension (`.b[0:1]` against the freshly-created `null`) is itself a no-op. The array mutation happens before the tail is even reached. Updated the test's expected output to match (confirmed live).

## Docs

Folded #2305's own `limitations.md` entry's "not yet implemented" note about this gap into a description of the fix, since this closes a real yq-compliance gap rather than opening a new divergence.

## Test plan
- [x] `cargo test --features cli,simd,regex,serde` — full suite green (found and fixed one stale pre-existing test along the way)
- [x] `cargo test` (default features) — green
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] `cargo build --no-default-features --features portable-popcount` (no_std) — clean
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features` — clean
- [x] Live-verified all repro shapes + the fix against `yq` v4.53.3, byte-for-byte match
- [x] Confirmed jq mode stays a no-op (real jq has no such rule)
- [x] Confirmed #2268's negative-index error is unaffected

Fixes #2314