### PR TITLE
fix(jq): E[K]/E[S:T] keeps E's own partial prefix on its mid-stream error

### DIFF
--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -16837,6 +16837,25 @@ fn eval_index_expr<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
                             // #1832); `vs` is never attempted here either
                             // way, matching that helper's own `extra` never
                             // being touched on its `Err` branch.
+                            //
+                            // Not live-repro-tested (review): `target` is one
+                            // fixed expression re-evaluated fresh per key
+                            // against the same document, so whether a given
+                            // key's evaluation is a clean success (populating
+                            // `borrowed`) or a `Partial` (reaching this arm)
+                            // is a deterministic function of `(target, value)`
+                            // alone, not of which key is current -- an
+                            // *earlier* key populating `borrowed` and a
+                            // *later* key hitting this arm therefore requires
+                            // `target` itself to behave non-deterministically
+                            // across the two calls. The one stateful builtin
+                            // that could do that, `input`, always returns an
+                            // owned value (`builtin_input`'s own
+                            // `owned_vec_to_result`), so it can never
+                            // populate `borrowed` in the first place. Kept
+                            // anyway, matching `resolve_terminal_prefix`'s
+                            // own identical defensive handling, in case a
+                            // future stateful mechanism changes this.
                             Err((prefix, e)) => {
                                 let control = match control {
                                     Control::Halt(_) => control,
@@ -52702,6 +52721,23 @@ mod tests {
         );
     }
 
+    /// #2226 review (patch coverage): the target's own `Partial` arm's
+    /// `Ok(None)` sub-case -- an earlier-produced value that legitimately
+    /// isn't indexable, suppressed by `optional` rather than erroring
+    /// (`true` here; `?` only gates *this* per-value type mismatch, not
+    /// `target`'s own trailing `error("x")`). Verified against jq 1.7.1:
+    /// `0 as $k | (true, [7], error("x"))[$k]?` prints `7` then still
+    /// raises `x`.
+    #[test]
+    fn test_index_expr_target_own_partial_prefix_ok_none_suppressed_by_optional_2226() {
+        query!(b"null", r#"0 as $k | (true, [7], error("x"))[$k]?"#,
+            QueryResult::Partial(vs, Control::Error(e)) => {
+                assert_eq!(vs, vec![OwnedValue::Int(7)]);
+                assert_eq!(e.message, "x");
+            }
+        );
+    }
+
     /// #2226 sibling: the same target-own-prefix fix for `eval_slice_expr`.
     /// Both bounds are `(N+0)` rather than bare literals -- a slice whose
     /// bounds both fully fold to constants never reaches `eval_slice_expr`
@@ -52723,6 +52759,23 @@ mod tests {
                     OwnedValue::Array(vec![OwnedValue::Int(1)]),
                     OwnedValue::Array(vec![OwnedValue::Int(3)]),
                 ]);
+                assert_eq!(e.message, "x");
+            }
+        );
+    }
+
+    /// #2226 review (patch coverage): the target's own `Partial` arm's
+    /// `Ok(None)` sub-case -- an earlier-produced value that legitimately
+    /// isn't sliceable, suppressed by `optional` rather than erroring (`1`
+    /// is a number here, `[7]` an array; `?` only gates *this* per-value
+    /// type mismatch, not `target`'s own trailing `error("x")`). Verified
+    /// against jq 1.7.1: `(1, [7], error("x"))[(0+0):(1+0)]?` prints `[7]`
+    /// then still raises `x`.
+    #[test]
+    fn test_slice_expr_target_own_partial_prefix_ok_none_suppressed_by_optional_2226() {
+        query!(b"null", r#"(1, [7], error("x"))[(0+0):(1+0)]?"#,
+            QueryResult::Partial(vs, Control::Error(e)) => {
+                assert_eq!(vs, vec![OwnedValue::Array(vec![OwnedValue::Int(7)])]);
                 assert_eq!(e.message, "x");
             }
         );

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -16790,15 +16790,49 @@ fn eval_index_expr<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
             QueryResult::OneCursor(_) => {
                 unreachable!("materialize_cursor should have converted this")
             }
-            // Same conservative treatment the old once-for-all-keys
-            // evaluation already gave a target's own mid-stream escape:
-            // discard whatever this key's own target generator produced
-            // before its escape (never part of the indexed output either
-            // way, since indexing an escaped generator's partial prefix
-            // isn't a jq behavior at all), but now fold the *running*
-            // prefix from every earlier key in, instead of assuming it was
-            // empty.
-            QueryResult::Partial(_, control) => escape_with_prefix!(control),
+            // #2226: `target`'s own generator produced `vs` before its own
+            // mid-stream escape -- real jq's key-outer/target-inner model
+            // indexes each already-produced value by `k` as it flows out,
+            // the same per-value operation the `Owned`/`Borrowed` arms
+            // below already apply to a *successful* target result, so
+            // indexing an escaped generator's own partial prefix *is* real
+            // jq behavior (confirmed live: `0 as $k | ([1,2],[3,4],
+            // error("x"))[$k]` prints `1` then `3` before raising).
+            // Mirrors `KeyTargets::Owned`'s own loop below exactly (this
+            // prefix is already `Vec<OwnedValue>`, the same shape `Owned`
+            // handles, `yq_negative_index_error` check included): an
+            // indexing failure on an earlier-produced value fires before
+            // `target`'s own later escape ever would in the real generator
+            // order, so it outranks `control` here the same way a later
+            // key's index error already outranks an earlier key's pending
+            // halt in the `Owned`/`Borrowed` arms; only once every value in
+            // `vs` indexes cleanly does `control` -- `target`'s own
+            // termination -- get to fire.
+            QueryResult::Partial(vs, control) => {
+                if owned.is_none() {
+                    owned = Some(
+                        match promote_borrowed_checked(core::mem::take(&mut borrowed)) {
+                            Ok(v) => v,
+                            Err((prefix, e)) => return partial(prefix, Control::Error(e)),
+                        },
+                    );
+                }
+                let acc = owned.as_mut().expect("just ensured Some");
+                if acc.try_reserve(vs.len()).is_err() {
+                    escape_with_prefix!(Control::Error(cannot_reserve_cross_product(&[vs.len()])));
+                }
+                for t in &vs {
+                    if let Some(e) = yq_negative_index_error::<S>(t, k) {
+                        escape_with_prefix!(Control::Error(e));
+                    }
+                    match index_one_owned(t, k, optional) {
+                        Ok(Some(v)) => owned.as_mut().expect("still Some").push(v),
+                        Ok(None) => {}
+                        Err(e) => escape_with_prefix!(Control::Error(e)),
+                    }
+                }
+                escape_with_prefix!(control)
+            }
         };
         match key_targets {
             KeyTargets::Borrowed(ts) => {
@@ -17043,12 +17077,42 @@ fn eval_slice_expr<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
                 QueryResult::OneCursor(_) => {
                     unreachable!("materialize_cursor should have converted this")
                 }
-                // Same conservative Error/Break/Halt-only handling as
-                // before, now folding the running `out` in as the prefix
-                // instead of discarding it (unreachable before this fix,
-                // since `out` was always empty at this point -- E was
-                // evaluated before the loop could produce anything).
-                QueryResult::Partial(_, control) => escape!(control),
+                // #2226: `target`'s (E's) own generator produced `vs`
+                // before its own mid-stream escape -- real jq's
+                // S-outer/T-middle/E-inner model slices each
+                // already-produced value as it flows out, the same
+                // per-value operation `Targets::Owned`'s own loop below
+                // already applies to a *successful* target result.
+                // Mirrors that loop exactly (this prefix is already
+                // `Vec<OwnedValue>`, the same shape `Owned` handles): a
+                // slicing failure on an earlier-produced value fires
+                // before `target`'s own later escape ever would in the
+                // real generator order, so it outranks `control` here the
+                // same way a later target's slice error already outranks
+                // an earlier one's pending halt in the `Borrowed`/`Owned`
+                // arms below; only once every value in `vs` slices
+                // cleanly does `control` -- `target`'s own termination --
+                // get to fire. Confirmed live: `[1,2,3,4] |
+                // (.,5,error("x"))[1:3]` prints `[2,3]` (sliced from `.`,
+                // this arm's own loop) then raises "Cannot index number
+                // with object" -- `5`'s own slice attempt *does* run (it's
+                // the second value in `vs`, since `target` materializes
+                // every value it produced up through its own escape) and
+                // its failure outranks the original `x` from `control`,
+                // exactly the precedent this arm's own doc comment states.
+                QueryResult::Partial(vs, control) => {
+                    if out.try_reserve(vs.len()).is_err() {
+                        escape!(Control::Error(cannot_reserve_cross_product(&[vs.len()])));
+                    }
+                    for t in &vs {
+                        match slice_owned_value_read::<S>(t, *s, *e, optional) {
+                            Ok(Some(v)) => out.push(v),
+                            Ok(None) => {}
+                            Err(e) => escape!(Control::Error(e)),
+                        }
+                    }
+                    escape!(control)
+                }
             };
             match &targets {
                 Targets::Borrowed(ts) => {
@@ -52556,6 +52620,44 @@ mod tests {
         );
     }
 
+    /// #2226: `eval_index_expr`'s target-evaluation `Partial` arm used to
+    /// discard `E`'s own already-produced prefix (`_`) and keep only the
+    /// escaping `control`. `0 as $k | ([1,2],[3,4],error("x"))[$k]` makes
+    /// `E` itself the multi-output `([1,2],[3,4],error("x"))` generator: its
+    /// first two branches each index cleanly at `$k`=0 (`1`, then `3`)
+    /// before the third branch errors. Verified against jq 1.7.1: `echo
+    /// null | jq -c '0 as $k | ([1,2],[3,4],error("x"))[$k]'` prints `1`
+    /// then `3` before raising.
+    #[test]
+    fn test_index_expr_target_own_partial_prefix_preserved_2226() {
+        query!(b"null", r#"0 as $k | ([1,2],[3,4],error("x"))[$k]"#,
+            QueryResult::Partial(vs, Control::Error(e)) => {
+                assert_eq!(vs, vec![OwnedValue::Int(1), OwnedValue::Int(3)]);
+                assert_eq!(e.message, "x");
+            }
+        );
+    }
+
+    /// #2226 sibling: the same target-own-prefix fix for `eval_slice_expr`.
+    /// `([1,2],[3,4],error("x"))[(0,1)-1:(1,2)-0]` simplifies to a plain
+    /// `[0:1]` slice per `(s, e)` pair below, but the point is `E` itself
+    /// (the `([1,2],[3,4],error("x"))` target) producing two clean slices
+    /// before erroring on its third branch. Verified against jq 1.7.1: `echo
+    /// null | jq -c '([1,2],[3,4],error("x"))[0:1]'` prints `[1]` then
+    /// `[3]` before raising.
+    #[test]
+    fn test_slice_expr_target_own_partial_prefix_preserved_2226() {
+        query!(b"null", r#"([1,2],[3,4],error("x"))[0:1]"#,
+            QueryResult::Partial(vs, Control::Error(e)) => {
+                assert_eq!(vs, vec![
+                    OwnedValue::Array(vec![OwnedValue::Int(1)]),
+                    OwnedValue::Array(vec![OwnedValue::Int(3)]),
+                ]);
+                assert_eq!(e.message, "x");
+            }
+        );
+    }
+
     #[test]
     fn test_yq_merge_flags() {
         // Unflagged array `*`/`*=` is yq-only: rhs replaces lhs wholesale,
@@ -53826,17 +53928,27 @@ mod tests {
             // before failing, the same as jq 1.7.1. See
             // `partial_prefix_survives_the_stream_forwarding_constructs`
             // for its coverage.
+            //
+            // `(.[0],(.[1],error("x")))[(0+0)]` *used* to be listed here
+            // too, but #2226 fixed `eval_index_expr`'s *target* `Partial`
+            // arm to apply the per-key index to each already-produced value
+            // instead of discarding them — it now agrees with jq 1.7.1
+            // exactly. See `partial_prefix_survives_the_stream_forwarding_
+            // constructs` for its coverage.
+            //
+            // `.[(1,error("x"))]` stays here: unlike the case above, the
+            // *key* stream `(1,error("x"))` is the multi-output generator
+            // here, not the target (`.` is a single value) — a distinct,
+            // still-open gap in the *keys*-evaluation `Partial` arm
+            // (conservatively documented in `eval_index_expr`'s own body as
+            // "not part of #400/#494's verified semantics"), out of #2226's
+            // scope (which is about `E`'s own prefix, not `K`'s) and tracked
+            // separately.
             (
                 b"[10,20,30]",
                 r#".[(1,error("x"))]"#,
                 "x",
                 "jq 1.7.1 prints 20, then fails",
-            ),
-            (
-                b"[[7],[8]]",
-                r#"(.[0],(.[1],error("x")))[(0+0)]"#,
-                "x",
-                "jq 1.7.1 prints 7 and 8, then fails",
             ),
             // `map_values` keeps only each key's first output, so jq 1.7.1
             // never reaches the error at all and exits 0.
@@ -53871,10 +53983,9 @@ mod tests {
             (b"null", "[1,(2,break $out),3]"),
             (b"[1,2]", "map((.,break $out))"),
             (br#"{"a":1}"#, "with_entries((.,break $out))"),
-            // `select`/`if`, string interpolation: see the comment in
-            // `atomic` above.
+            // `select`/`if`, string interpolation, target-generator index/
+            // slice: see the comment in `atomic` above.
             (b"[10,20,30]", ".[(1,break $out)]"),
-            (b"[[7],[8]]", "(.[0],(.[1],break $out))[(0+0)]"),
             (br#"{"a":1}"#, "map_values((.,break $out))"),
             (b"[1,2]", "map_values((.,break $out))"),
             (b"null", "reduce (1,2,break $out) as $v (0;.+$v)"),
@@ -54074,6 +54185,50 @@ mod tests {
             QueryResult::Partial(vs, Control::Error(e)) => {
                 assert_eq!(prefix_json(&vs), [r#""1-3""#]);
                 assert_eq!(e.message, "x");
+            }
+        );
+
+        // #2226: `(.[0],(.[1],error("x")))[(0+0)]` *used* to be listed in
+        // `partial_in_value_position_collapses_to_its_control`'s `atomic`
+        // table (labelled as a documented divergence from jq 1.7.1, which
+        // the old comment already recorded as printing `7` and `8` then
+        // failing); `eval_index_expr`'s *target* `Partial` arm now applies
+        // the per-key index to each already-produced value instead of
+        // discarding them, so it now agrees with jq 1.7.1 exactly. (The
+        // sibling shape `.[(1,error("x"))]`, where the *key* stream is the
+        // generator instead, stays in `atomic` -- that's a distinct,
+        // still-open gap outside this issue's scope; see the comment there.)
+        query!(b"[[7],[8]]", r#"(.[0],(.[1],error("x")))[(0+0)]"#,
+            QueryResult::Partial(vs, Control::Error(e)) => {
+                assert_eq!(prefix_json(&vs), ["7", "8"]);
+                assert_eq!(e.message, "x");
+            }
+        );
+        query!(b"[[7],[8]]", r"(.[0],(.[1],break $out))[(0+0)]",
+            QueryResult::Partial(vs, Control::Break(label)) => {
+                assert_eq!(prefix_json(&vs), ["7", "8"]);
+                assert_eq!(label, "out");
+            }
+        );
+
+        // #2226 sibling: `eval_slice_expr`'s identical fix. Verified against
+        // jq 1.7.1: `label $out | (1,2,break $out)[(0+0):(2+0)]` and
+        // `(1,2,error("boom"))[(0+0):(2+0)]` both raise "Cannot index
+        // number with object" on the target's own first produced value
+        // (`1`) -- slicing a number is never valid, so the target's break/
+        // error is never even reached. This also corrects
+        // `test_computed_slice_bounds_read_mode`'s prior (unverified)
+        // expectation that these silently produced no output/echoed
+        // "boom" -- the old code's target-`Partial` arm never attempted to
+        // slice the prefix at all, so it never discovered this error either.
+        query!(b"null", r"label $out | (1,2,break $out)[(0+0):(2+0)]",
+            QueryResult::Error(e) => {
+                assert_eq!(e.message, "Cannot index number with object");
+            }
+        );
+        query!(b"null", r#"(1,2,error("boom"))[(0+0):(2+0)]"#,
+            QueryResult::Error(e) => {
+                assert_eq!(e.message, "Cannot index number with object");
             }
         );
     }
@@ -68589,21 +68744,30 @@ mod tests {
             ),
             // A target with no output at all.
             (b"null", "empty[(0+0):(2+0)]", Ok("")),
-            // A target that breaks out of an enclosing label — the whole
-            // slice contributes nothing, same as `IndexExpr`'s identically
-            // conservative target handling (see `eval_index_expr`'s key
-            // stream, which this mirrors).
+            // A target that breaks out of an enclosing label with no prior
+            // output at all — the whole slice contributes nothing.
             (b"null", "label $out | (break $out)[(0+0):(2+0)]", Ok("")),
+            // #2226 (corrected — see `partial_prefix_survives_the_stream_
+            // forwarding_constructs` for the `Partial`-preserving coverage
+            // of this fix): a target whose stream produces values before
+            // breaking/erroring now actually attempts to slice each one,
+            // same as any other target stream. Slicing a *number* is never
+            // valid in jq, so both raise "Cannot index number with object"
+            // on the target's first produced value (`1`) before its
+            // break/error is ever reached — this test harness's `outcome()`
+            // only distinguishes `Ok`/`Err`, so both read as `Err` here
+            // regardless of which control the target would otherwise have
+            // carried. Verified against jq 1.7.1: both raise the same way.
             (
                 b"null",
                 "label $out | (1,2,break $out)[(0+0):(2+0)]",
-                Ok(""),
+                Err("Cannot index number with object"),
             ),
-            // A target whose stream errors part-way through: the error wins,
-            // and (like the break case above) the values already produced
-            // are not carried forward — the same conservative trade-off
-            // `eval_index_expr` already makes for its key/target streams.
-            (b"null", "(1,2,error(\"boom\"))[(0+0):(2+0)]", Err("boom")),
+            (
+                b"null",
+                "(1,2,error(\"boom\"))[(0+0):(2+0)]",
+                Err("Cannot index number with object"),
+            ),
             // Owned targets of every slice-able kind, plus the two ways an
             // unsliceable one is refused.
             (b"null", "(null)[(0+0):(2+0)]", Ok("null")),

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -16797,10 +16797,21 @@ fn eval_index_expr<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
             // below already apply to a *successful* target result, so
             // indexing an escaped generator's own partial prefix *is* real
             // jq behavior (confirmed live: `0 as $k | ([1,2],[3,4],
-            // error("x"))[$k]` prints `1` then `3` before raising).
+            // error("x"))[$k]` prints `1` then `3` before raising). This is
+            // jq-only (review finding): real yq does *not* stream a target's
+            // own escaped generator's prefix at all -- live-verified against
+            // yq v4.53.3, `0 as $k | ([1,2],[3,4],error("x"))[$k]` prints
+            // only `Error: x`, no prefix -- so yq mode keeps the old
+            // conservative discard here, exactly like the Error/Break/Halt
+            // arms above (matches ADR-0018's "the mode decides" rule; the
+            // pre-#2226 code's discard-everything behavior happened to
+            // already agree with real yq here, which this gate now
+            // preserves deliberately instead of by accident).
+            //
             // Mirrors `KeyTargets::Owned`'s own loop below exactly (this
             // prefix is already `Vec<OwnedValue>`, the same shape `Owned`
-            // handles, `yq_negative_index_error` check included): an
+            // handles, `yq_negative_index_error` check included -- always a
+            // no-op past the gate above, kept for structural parity): an
             // indexing failure on an earlier-produced value fires before
             // `target`'s own later escape ever would in the real generator
             // order, so it outranks `control` here the same way a later
@@ -16809,11 +16820,30 @@ fn eval_index_expr<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
             // `vs` indexes cleanly does `control` -- `target`'s own
             // termination -- get to fire.
             QueryResult::Partial(vs, control) => {
+                if S::TAG == EvalTag::Yq {
+                    escape_with_prefix!(control);
+                }
                 if owned.is_none() {
                     owned = Some(
                         match promote_borrowed_checked(core::mem::take(&mut borrowed)) {
                             Ok(v) => v,
-                            Err((prefix, e)) => return partial(prefix, Control::Error(e)),
+                            // An earlier key's own undecodable value predates
+                            // this key's target generator in real evaluation
+                            // order, so it outranks `control` too -- except
+                            // when `control` is an uncatchable `Halt`, which
+                            // must survive a promotion failure untouched,
+                            // same rule `resolve_terminal_prefix` enforces
+                            // for every other escape in this function (#987/
+                            // #1832); `vs` is never attempted here either
+                            // way, matching that helper's own `extra` never
+                            // being touched on its `Err` branch.
+                            Err((prefix, e)) => {
+                                let control = match control {
+                                    Control::Halt(_) => control,
+                                    Control::Error(_) | Control::Break(_) => Control::Error(e),
+                                };
+                                return partial(prefix, control);
+                            }
                         },
                     );
                 }
@@ -16983,11 +17013,12 @@ fn eval_index_expr<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
 /// rather than once overall, mirroring #2032/#2142's identical fix for
 /// `eval_index_expr` one nesting level deeper — see
 /// `eval_generic::eval_slice_expr`'s own copy of this comment for the full
-/// rationale, live-verified repro, and the "cross-pair `out` vs. `target`'s
-/// own within-pair `Partial` prefix" distinction (not repeated here) that
-/// this file's copy folds `out` in for but deliberately still doesn't
-/// address the latter — same pre-existing, unaddressed gap
-/// `eval_index_expr` already carries.
+/// rationale and live-verified repro. #2226 later closed the "cross-pair
+/// `out` vs. `target`'s own within-pair `Partial` prefix" gap this comment
+/// used to describe as unaddressed: `out` now folds in `target`'s own
+/// already-produced values too (jq mode only — see the `Partial` arm's own
+/// comment below for the yq-mode carve-out), not just the cross-pair
+/// accumulator.
 fn eval_slice_expr<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     target: &Expr,
     start: &Option<Box<Expr>>,
@@ -17092,15 +17123,31 @@ fn eval_slice_expr<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
                 // an earlier one's pending halt in the `Borrowed`/`Owned`
                 // arms below; only once every value in `vs` slices
                 // cleanly does `control` -- `target`'s own termination --
-                // get to fire. Confirmed live: `[1,2,3,4] |
-                // (.,5,error("x"))[1:3]` prints `[2,3]` (sliced from `.`,
-                // this arm's own loop) then raises "Cannot index number
-                // with object" -- `5`'s own slice attempt *does* run (it's
-                // the second value in `vs`, since `target` materializes
-                // every value it produced up through its own escape) and
-                // its failure outranks the original `x` from `control`,
-                // exactly the precedent this arm's own doc comment states.
+                // get to fire. Confirmed live (review finding: bounds must
+                // stay non-foldable, `1:3` collapses to the static
+                // `Expr::Slice` fast path per #1326 and never reaches this
+                // function at all -- reached here instead via an `as`-bound
+                // pair, which forces this file's `eval_slice_expr` rather
+                // than `eval_generic.rs`'s CLI-dispatch sibling): `[1,2,3,4]
+                // | 1 as $s | 3 as $e | (.,5,error("x"))[$s:$e]` prints
+                // `[2,3]` (sliced from `.`, this arm's own loop) then raises
+                // "Cannot index number with object" -- `5`'s own slice
+                // attempt *does* run (it's the second value in `vs`, since
+                // `target` materializes every value it produced up through
+                // its own escape) and its failure outranks the original `x`
+                // from `control`, exactly the precedent this arm's own doc
+                // comment states.
+                //
+                // jq-only (review finding, same as `eval_index_expr`'s
+                // identical gate): real yq does not stream a target's own
+                // escaped generator's prefix -- live-verified against yq
+                // v4.53.3, `([1,2],[3,4],error("x"))[(0,1):(1,2)]` prints
+                // only `Error: x`. yq mode keeps the old conservative
+                // discard.
                 QueryResult::Partial(vs, control) => {
+                    if S::TAG == EvalTag::Yq {
+                        escape!(control);
+                    }
                     if out.try_reserve(vs.len()).is_err() {
                         escape!(Control::Error(cannot_reserve_cross_product(&[vs.len()])));
                     }
@@ -32105,9 +32152,10 @@ fn eval_index_expr_with_path_context<'a, W: Clone + AsRef<[u64]>, S: EvalSemanti
             // Zero outputs for *this* key contributes nothing -- not every
             // other key is empty too (#2032).
             QueryResult::None => continue,
-            // Any target-level escape discards *this key's own* target
-            // output and escapes immediately with whatever earlier keys
-            // already accumulated -- matches `eval_index_expr`'s own
+            // A direct target-level escape (no output at all from this
+            // key's own target) discards *this key's own* target output and
+            // escapes immediately with whatever earlier keys already
+            // accumulated -- matches `eval_index_expr`'s own
             // `escape_with_prefix!` arms exactly.
             QueryResult::Error(e) => {
                 return partial(core::mem::take(&mut results), Control::Error(e));
@@ -32118,6 +32166,15 @@ fn eval_index_expr_with_path_context<'a, W: Clone + AsRef<[u64]>, S: EvalSemanti
             QueryResult::Halt(code) => {
                 return partial(core::mem::take(&mut results), Control::Halt(code));
             }
+            // Unlike the arms above, this one no longer matches
+            // `eval_index_expr`'s own identical arm (#2226 review finding):
+            // `_` here still discards the target's own already-produced
+            // values before its own mid-stream escape, the exact bug #2226
+            // fixed for `eval_index_expr`'s value-mode counterpart. Left
+            // unaddressed here -- this path-context evaluator backs
+            // assignment/`del()`/`path()` through a computed key, not plain
+            // reads, and #2226's own scope was the plain-read evaluators
+            // only; tracked as a follow-up.
             QueryResult::Partial(_, control) => {
                 return partial(core::mem::take(&mut results), control);
             }
@@ -32439,7 +32496,8 @@ fn eval_slice_expr_with_path_context<'a, W: Clone + AsRef<[u64]>, S: EvalSemanti
                 // `eval_index_expr_with_path_context`'s identical
                 // per-key/per-pair treatment).
                 QueryResult::None => continue,
-                // Any target-level escape discards *this pair's* own target
+                // A direct target-level escape (no output at all from this
+                // pair's own target) discards *this pair's* own target
                 // output and escapes immediately with whatever earlier
                 // pairs already accumulated.
                 QueryResult::Error(e) => {
@@ -32451,6 +32509,12 @@ fn eval_slice_expr_with_path_context<'a, W: Clone + AsRef<[u64]>, S: EvalSemanti
                 QueryResult::Halt(code) => {
                     return partial(core::mem::take(&mut results), Control::Halt(code));
                 }
+                // `_` here still discards the target's own already-produced
+                // values before its own mid-stream escape -- the identical,
+                // still-open gap `eval_index_expr_with_path_context`'s own
+                // sibling arm now documents (#2226 review finding); see that
+                // comment for why this path-context evaluator was left out
+                // of #2226's own scope.
                 QueryResult::Partial(_, control) => {
                     return partial(core::mem::take(&mut results), control);
                 }
@@ -52639,20 +52703,52 @@ mod tests {
     }
 
     /// #2226 sibling: the same target-own-prefix fix for `eval_slice_expr`.
-    /// `([1,2],[3,4],error("x"))[(0,1)-1:(1,2)-0]` simplifies to a plain
-    /// `[0:1]` slice per `(s, e)` pair below, but the point is `E` itself
-    /// (the `([1,2],[3,4],error("x"))` target) producing two clean slices
-    /// before erroring on its third branch. Verified against jq 1.7.1: `echo
-    /// null | jq -c '([1,2],[3,4],error("x"))[0:1]'` prints `[1]` then
-    /// `[3]` before raising.
+    /// Both bounds are `(N+0)` rather than bare literals -- a slice whose
+    /// bounds both fully fold to constants never reaches `eval_slice_expr`
+    /// at all (`Expr::SliceExpr`'s own doc comment, #1326): the parser
+    /// keeps producing the static `Expr::Slice` fast path instead, which
+    /// this function's own `[0:1]`-bounds predecessor of this test
+    /// (correctness-equivalent, but silently exercising the unrelated,
+    /// already-fixed-pre-#2226 `eval_pipe`/`pipe_owned_prefix` machinery
+    /// instead of this fix -- review finding) accidentally did. `E`
+    /// (the `([1,2],[3,4],error("x"))` target) still produces two clean
+    /// slices before erroring on its third branch. Verified against jq
+    /// 1.7.1: `echo null | jq -c '([1,2],[3,4],error("x"))[(0+0):(1+0)]'`
+    /// prints `[1]` then `[3]` before raising.
     #[test]
     fn test_slice_expr_target_own_partial_prefix_preserved_2226() {
-        query!(b"null", r#"([1,2],[3,4],error("x"))[0:1]"#,
+        query!(b"null", r#"([1,2],[3,4],error("x"))[(0+0):(1+0)]"#,
             QueryResult::Partial(vs, Control::Error(e)) => {
                 assert_eq!(vs, vec![
                     OwnedValue::Array(vec![OwnedValue::Int(1)]),
                     OwnedValue::Array(vec![OwnedValue::Int(3)]),
                 ]);
+                assert_eq!(e.message, "x");
+            }
+        );
+    }
+
+    /// #2226 review finding: the fix above is jq-only. Real yq does not
+    /// stream a target's own escaped generator's prefix at all -- verified
+    /// live against yq v4.53.3: `([1,2],[3,4],error("x"))[(0+0)]` prints
+    /// only `Error: x`, no prefix. yq mode must keep the pre-#2226
+    /// conservative discard here.
+    #[test]
+    fn test_index_expr_target_partial_prefix_still_discarded_in_yq_mode_2226() {
+        yq_query!(b"null", r#"([1,2],[3,4],error("x"))[(0+0)]"#,
+            QueryResult::Error(e) => {
+                assert_eq!(e.message, "x");
+            }
+        );
+    }
+
+    /// #2226 sibling: the identical yq-mode carve-out for `eval_slice_expr`.
+    /// Verified live against yq v4.53.3:
+    /// `([1,2],[3,4],error("x"))[(0+0):(1+0)]` prints only `Error: x`.
+    #[test]
+    fn test_slice_expr_target_partial_prefix_still_discarded_in_yq_mode_2226() {
+        yq_query!(b"null", r#"([1,2],[3,4],error("x"))[(0+0):(1+0)]"#,
+            QueryResult::Error(e) => {
                 assert_eq!(e.message, "x");
             }
         );

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -8231,6 +8231,17 @@ fn eval_index_expr<S: EvalSemantics, V: DocumentValue>(
             // through the identical promotion step. Inlined here instead,
             // mirroring `escape_generic!`'s own Halt-survives rule exactly
             // rather than reintroducing the bug it was written to avoid.
+            //
+            // The `Err` arm below is not live-repro-tested (review): same
+            // reasoning as `eval::eval_index_expr`'s identical arm -- an
+            // *earlier* key populating `cursors` and a *later* key reaching
+            // this `Partial` arm both require the one fixed `target`
+            // expression to behave non-deterministically across two fresh
+            // evaluations against the same document, and the only stateful
+            // builtin that could do that (`input`) always resolves to an
+            // owned value, never a cursor. Kept for the same defensive,
+            // future-proofing reason `resolve_terminal_prefix` keeps its own
+            // identical handling.
             GenericResult::Partial(vs, control) => {
                 if S::TAG == EvalTag::Yq {
                     escape_generic!(control);

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -8197,13 +8197,37 @@ fn eval_index_expr<S: EvalSemantics, V: DocumentValue>(
             // the old once-for-all-keys evaluation, this no longer implies
             // every other key is empty too).
             GenericResult::None => continue,
-            // Same conservative treatment the old once-for-all-keys
-            // evaluation already gave a target's own mid-stream escape:
-            // discard this key's own target prefix (never part of the
-            // indexed output either way), but now fold the *running*
-            // prefix from every earlier key in, instead of assuming it was
-            // empty.
-            GenericResult::Partial(_, control) => escape_generic!(control),
+            // #2226: `target`'s own generator produced `vs` before its own
+            // mid-stream escape -- real jq's key-outer/target-inner model
+            // indexes each already-produced value by `k` as it flows out,
+            // the same per-value operation the `Owned`/`Native` arms below
+            // already apply to a *successful* target result, so those
+            // values are not "never part of the indexed output either
+            // way" the way the old comment here assumed; only `target`'s
+            // own escape stops it from producing more. Mirrors
+            // `KeyTargets::Owned`'s own loop below exactly (this prefix is
+            // already `Vec<OwnedValue>`, the same shape `Owned` handles):
+            // an indexing failure on an earlier-produced value fires
+            // before `target`'s own later escape ever would in the real
+            // generator order, so it outranks `control` here the same way
+            // a later key's index error already outranks an earlier key's
+            // pending halt in the `Owned`/`Native` arms; only once every
+            // value in `vs` indexes cleanly does `control` -- `target`'s
+            // own termination -- get to fire.
+            GenericResult::Partial(vs, control) => {
+                ensure_owned!();
+                if owned.try_reserve(vs.len()).is_err() {
+                    escape_generic!(Control::Error(cannot_reserve_cross_product(&[vs.len()])));
+                }
+                for t in &vs {
+                    match index_owned_by_key(t, k, optional) {
+                        Ok(Some(v)) => owned.push(v),
+                        Ok(None) => {}
+                        Err(e) => escape_generic!(Control::Error(e)),
+                    }
+                }
+                escape_generic!(control)
+            }
             GenericResult::One(v) => KeyTargets::Native(vec![v]),
             GenericResult::Many(vs) => KeyTargets::Native(vs),
             GenericResult::OneCursor(c) => KeyTargets::Native(vec![c.value()]),
@@ -8507,10 +8531,26 @@ fn eval_slice_expr<S: EvalSemantics, V: DocumentValue>(
                 // output count can vary across pairs (mirrors
                 // `eval_index_expr`'s identical per-key treatment).
                 GenericResult::None => continue,
-                // Same conservative Error/Break/Halt-only handling as
-                // `eval_index_expr`'s target `Partial` arm, now folding the
-                // running `out` in as the prefix instead of discarding it.
-                GenericResult::Partial(_, control) => escape!(control),
+                // #2226: this (s, e) pair's own target generator may have
+                // produced some values before escaping (a break/halt/error
+                // partway through its own stream) -- apply the slice to each
+                // of those already-produced values and fold them into `out`
+                // before escaping, mirroring `eval_index_expr`'s identical
+                // fix for its own target `Partial` arm, rather than
+                // discarding them.
+                GenericResult::Partial(vs, control) => {
+                    if out.try_reserve(vs.len()).is_err() {
+                        escape!(Control::Error(cannot_reserve_cross_product(&[vs.len()])));
+                    }
+                    for t in &vs {
+                        match slice_owned_value_read::<S>(t, *s, *e, optional) {
+                            Ok(Some(v)) => out.push(v),
+                            Ok(None) => {}
+                            Err(e) => escape!(Control::Error(e)),
+                        }
+                    }
+                    escape!(control)
+                }
                 GenericResult::One(v) => Targets::Borrowed(vec![v]),
                 GenericResult::Many(vs) => Targets::Borrowed(vs),
                 GenericResult::OneCursor(c) => Targets::Borrowed(vec![c.value()]),
@@ -17031,37 +17071,36 @@ mod tests {
             summarize(b"5", r#"select((true,error("x")))?"#),
             Summary::Values(vec!["5".to_string()])
         );
-    }
 
-    #[test]
-    fn generic_value_position_partial_collapses_to_its_control() {
-        // Computed indexing and `select` each consult their operand once, so
-        // a `Partial` there is reduced the same way a multi-output operand
-        // already is. Comparison used to share this reduction too, but now
-        // forks over every output instead (#768) — see
-        // `generic_compare_partial_operand_keeps_prefix_768` below.
-
-        // A computed *target* that is a `Partial` surfaces the control alone.
-        // (jq 1.7.1 prints 7 and 8 first; pinned here, not endorsed.)
+        // #2226: a computed *target* that is itself a multi-output generator
+        // and is `Partial` used to surface the control alone, discarding
+        // whatever `E` had already produced this key/pair — pinned in a
+        // dedicated `generic_value_position_partial_collapses_to_its_control`
+        // test, not endorsed, before the fix. `eval_index_expr`'s/
+        // `eval_slice_expr`'s target `Partial` arm now applies the per-key
+        // index/slice to each already-produced value instead, matching jq
+        // 1.7.1 exactly (`(.[0],(.[1],error("x")))[(0+0)]` prints `7` then
+        // `8` before failing; the slice sibling below prints `[7]` then
+        // `[8]`, since `.[0]`/`.[1]` here are the one-element arrays `[7]`/
+        // `[8]`, not the bare numbers).
         assert_eq!(
             summarize(b"[[7],[8]]", r#"(.[0],(.[1],error("x")))[(0+0)]"#),
-            Summary::Error("x".to_string())
+            partial_err(&["7", "8"], "x")
         );
         assert_eq!(
             summarize(b"[[7],[8]]", "(.[0],(.[1],break $out))[(0+0)]"),
-            Summary::Break("out".to_string())
+            partial_break(&["7", "8"])
         );
-
         // Computed slicing (#615) shares the same target-position `Partial`
-        // reduction as computed indexing above — one bound (`(0+0)`) is
-        // enough to force `eval_slice_expr`'s fast path.
+        // fix as computed indexing above — one bound (`(0+0)`) is enough to
+        // force `eval_slice_expr`'s fast path.
         assert_eq!(
             summarize(b"[[7],[8]]", r#"(.[0],(.[1],error("x")))[(0+0):2]"#),
-            Summary::Error("x".to_string())
+            partial_err(&["[7]", "[8]"], "x")
         );
         assert_eq!(
             summarize(b"[[7],[8]]", "(.[0],(.[1],break $out))[(0+0):2]"),
-            Summary::Break("out".to_string())
+            partial_break(&["[7]", "[8]"])
         );
     }
 

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -8204,18 +8204,51 @@ fn eval_index_expr<S: EvalSemantics, V: DocumentValue>(
             // already apply to a *successful* target result, so those
             // values are not "never part of the indexed output either
             // way" the way the old comment here assumed; only `target`'s
-            // own escape stops it from producing more. Mirrors
-            // `KeyTargets::Owned`'s own loop below exactly (this prefix is
-            // already `Vec<OwnedValue>`, the same shape `Owned` handles):
-            // an indexing failure on an earlier-produced value fires
-            // before `target`'s own later escape ever would in the real
-            // generator order, so it outranks `control` here the same way
-            // a later key's index error already outranks an earlier key's
-            // pending halt in the `Owned`/`Native` arms; only once every
-            // value in `vs` indexes cleanly does `control` -- `target`'s
-            // own termination -- get to fire.
+            // own escape stops it from producing more. This is jq-only
+            // (review finding): real yq does not stream a target's own
+            // escaped generator's prefix at all -- live-verified against yq
+            // v4.53.3, `([1,2],[3,4],error("x"))[(0,1)]` prints only
+            // `Error: x`, no prefix -- so yq mode keeps the old
+            // conservative discard here (matches ADR-0018's "the mode
+            // decides" rule; see `eval::eval_index_expr`'s identical gate).
+            //
+            // Mirrors `KeyTargets::Owned`'s own loop below exactly (this
+            // prefix is already `Vec<OwnedValue>`, the same shape `Owned`
+            // handles): an indexing failure on an earlier-produced value
+            // fires before `target`'s own later escape ever would in the
+            // real generator order, so it outranks `control` here the same
+            // way a later key's index error already outranks an earlier
+            // key's pending halt in the `Owned`/`Native` arms; only once
+            // every value in `vs` indexes cleanly does `control` --
+            // `target`'s own termination -- get to fire.
+            //
+            // Does *not* reuse `ensure_owned!()`: that macro's own
+            // `owned_or_err!`-based promotion bare-returns
+            // `GenericResult::Error` on a decode failure, unconditionally
+            // discarding whatever `control` this arm is holding --
+            // including an uncatchable `Halt`, which `escape_generic!`
+            // above this loop already goes out of its way to preserve
+            // through the identical promotion step. Inlined here instead,
+            // mirroring `escape_generic!`'s own Halt-survives rule exactly
+            // rather than reintroducing the bug it was written to avoid.
             GenericResult::Partial(vs, control) => {
-                ensure_owned!();
+                if S::TAG == EvalTag::Yq {
+                    escape_generic!(control);
+                }
+                if !any_owned {
+                    any_owned = true;
+                    owned = match to_owned_all_cursors(&cursors) {
+                        Ok(vs) => vs,
+                        Err(e) => {
+                            let control = match control {
+                                Control::Halt(code) => Control::Halt(code),
+                                Control::Error(_) | Control::Break(_) => Control::Error(e),
+                            };
+                            return partial_generic(Vec::new(), control);
+                        }
+                    };
+                    cursors.clear();
+                }
                 if owned.try_reserve(vs.len()).is_err() {
                     escape_generic!(Control::Error(cannot_reserve_cross_product(&[vs.len()])));
                 }
@@ -8420,18 +8453,16 @@ fn eval_index_expr<S: EvalSemantics, V: DocumentValue>(
 /// used to be evaluated once, before the loop could produce anything), so
 /// there was nothing to lose by discarding it there; now there can be. The
 /// per-target slice-application escape one level in got the identical
-/// cross-pair fix for the identical reason (review). Left deliberately
-/// unaddressed, matching `eval_index_expr`'s own identical, pre-existing
-/// gap (confirmed live on `main`, not introduced or worsened by this fix):
-/// a `Partial(prefix, control)` result still discards `prefix` itself —
-/// the values `E`'s *own* generator produced before erroring *within* one
-/// (s, e) pair (as opposed to the cross-pair `out` this fix does thread
-/// through) — e.g. `E = ([1,2],[3,4],error("x"))` loses the `[1]`/`[3]`
-/// slices it should still emit before raising `x`. Real fix needs applying
-/// the pair's own slice/index operation to each of `prefix`'s values before
-/// folding them into `out`, not just discarding `prefix`; tracked
-/// separately (issue filed alongside this fix) since it's a pre-existing
-/// gap shared with `eval_index_expr`, not something #2143 introduces.
+/// cross-pair fix for the identical reason (review). #2226 later closed the
+/// sibling gap this comment used to describe as left deliberately
+/// unaddressed here: a `Partial(prefix, control)` target result no longer
+/// just discards `prefix` — the values `E`'s *own* generator produced
+/// before erroring *within* one (s, e) pair (as opposed to the cross-pair
+/// `out` this fix already threads through) are now sliced and folded into
+/// `out` too, in jq mode (real yq does not stream this prefix at all; see
+/// the `Partial` arm's own comment for the live-verified yq-mode carve-out)
+/// — e.g. `E = ([1,2],[3,4],error("x"))` now emits the `[1]`/`[3]` slices
+/// before raising `x`, matching jq 1.7.1.
 ///
 /// #2225: `T` (`end`) is *also* now re-evaluated fresh for every `s`, not
 /// once overall as an earlier revision of this doc comment claimed ("its
@@ -8537,8 +8568,16 @@ fn eval_slice_expr<S: EvalSemantics, V: DocumentValue>(
                 // of those already-produced values and fold them into `out`
                 // before escaping, mirroring `eval_index_expr`'s identical
                 // fix for its own target `Partial` arm, rather than
-                // discarding them.
+                // discarding them. jq-only (review finding, same gate as
+                // `eval_index_expr` above): real yq does not stream a
+                // target's own escaped generator's prefix -- live-verified
+                // against yq v4.53.3, `([1,2],[3,4],error("x"))[(0,1):(1,2)]`
+                // prints only `Error: x`. yq mode keeps the old conservative
+                // discard.
                 GenericResult::Partial(vs, control) => {
+                    if S::TAG == EvalTag::Yq {
+                        escape!(control);
+                    }
                     if out.try_reserve(vs.len()).is_err() {
                         escape!(Control::Error(cannot_reserve_cross_product(&[vs.len()])));
                     }

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -34848,6 +34848,23 @@ fn test_index_expr_cli_dispatch_target_own_partial_prefix_preserved_2226() -> Re
     Ok(())
 }
 
+/// #2226 review (patch coverage): `eval_generic::eval_index_expr`'s target
+/// `Partial` arm's `Ok(None)` sub-case -- an earlier-produced value that
+/// legitimately isn't indexable, suppressed by `optional` rather than
+/// erroring (`true` here; `?` only gates *this* per-value type mismatch,
+/// not `target`'s own trailing `error("x")`). Verified against jq 1.7.1:
+/// `(true, [7], error("x"))[(0+0)]?` prints `7` then still raises `x`.
+#[test]
+fn test_index_expr_cli_dispatch_target_own_partial_prefix_ok_none_suppressed_by_optional_2226(
+) -> Result<()> {
+    let (stdout, stderr, code) =
+        run_jq_full(&["-c", "(true, [7], error(\"x\"))[(0+0)]?"], Some("null"))?;
+    assert_eq!(code, 5, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert_eq!(stdout, "7\n");
+    assert!(stderr.contains('x'), "stderr: {stderr:?}");
+    Ok(())
+}
+
 /// #2226 sibling: the same target-own-prefix fix for
 /// `eval_generic::eval_slice_expr` -- the issue's own canonical repro.
 /// `(0,1):(1,2)` are bare computed bounds (no `as`-binding), so this
@@ -34865,6 +34882,26 @@ fn test_slice_expr_cli_dispatch_target_own_partial_prefix_preserved_2226() -> Re
     )?;
     assert_eq!(code, 5, "stdout: {stdout:?} stderr: {stderr:?}");
     assert_eq!(stdout, "[1]\n[3]\n");
+    assert!(stderr.contains('x'), "stderr: {stderr:?}");
+    Ok(())
+}
+
+/// #2226 review (patch coverage): `eval_generic::eval_slice_expr`'s target
+/// `Partial` arm's `Ok(None)` sub-case -- an earlier-produced value that
+/// legitimately isn't sliceable, suppressed by `optional` rather than
+/// erroring (`1` is a number, `[7]` an array; `?` only gates *this*
+/// per-value type mismatch, not `target`'s own trailing `error("x")`).
+/// Verified against jq 1.7.1: `(1, [7], error("x"))[(0+0):(1+0)]?` prints
+/// `[7]` then still raises `x`.
+#[test]
+fn test_slice_expr_cli_dispatch_target_own_partial_prefix_ok_none_suppressed_by_optional_2226(
+) -> Result<()> {
+    let (stdout, stderr, code) = run_jq_full(
+        &["-c", "(1, [7], error(\"x\"))[(0+0):(1+0)]?"],
+        Some("null"),
+    )?;
+    assert_eq!(code, 5, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert_eq!(stdout, "[7]\n");
     assert!(stderr.contains('x'), "stderr: {stderr:?}");
     Ok(())
 }

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -34865,6 +34865,26 @@ fn test_index_expr_cli_dispatch_target_own_partial_prefix_ok_none_suppressed_by_
     Ok(())
 }
 
+/// #2226 review (patch coverage): `eval_generic::eval_index_expr`'s target
+/// `Partial` arm's `Err` sub-case -- an earlier-produced value that isn't
+/// indexable, with no `?` to suppress it, so the per-value index failure
+/// fires (and outranks `target`'s own trailing `error("x")`, which is never
+/// reached). Verified against jq 1.7.1: `(true, [7], error("x"))[(0+0)]`
+/// raises "Cannot index boolean with number", not `x`.
+#[test]
+fn test_index_expr_cli_dispatch_target_own_partial_prefix_err_outranks_control_2226() -> Result<()>
+{
+    let (stdout, stderr, code) =
+        run_jq_full(&["-c", "(true, [7], error(\"x\"))[(0+0)]"], Some("null"))?;
+    assert_eq!(code, 5, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert_eq!(stdout, "");
+    assert!(
+        stderr.contains("Cannot index boolean with number"),
+        "stderr: {stderr:?}"
+    );
+    Ok(())
+}
+
 /// #2226 sibling: the same target-own-prefix fix for
 /// `eval_generic::eval_slice_expr` -- the issue's own canonical repro.
 /// `(0,1):(1,2)` are bare computed bounds (no `as`-binding), so this
@@ -34903,6 +34923,26 @@ fn test_slice_expr_cli_dispatch_target_own_partial_prefix_ok_none_suppressed_by_
     assert_eq!(code, 5, "stdout: {stdout:?} stderr: {stderr:?}");
     assert_eq!(stdout, "[7]\n");
     assert!(stderr.contains('x'), "stderr: {stderr:?}");
+    Ok(())
+}
+
+/// #2226 review (patch coverage): `eval_generic::eval_slice_expr`'s target
+/// `Partial` arm's `Err` sub-case -- an earlier-produced value that isn't
+/// sliceable, with no `?` to suppress it, so the per-value slice failure
+/// fires (and outranks `target`'s own trailing `error("x")`, which is never
+/// reached). Verified against jq 1.7.1: `(1, [7], error("x"))[(0+0):(1+0)]`
+/// raises "Cannot index number with object", not `x`.
+#[test]
+fn test_slice_expr_cli_dispatch_target_own_partial_prefix_err_outranks_control_2226() -> Result<()>
+{
+    let (stdout, stderr, code) =
+        run_jq_full(&["-c", "(1, [7], error(\"x\"))[(0+0):(1+0)]"], Some("null"))?;
+    assert_eq!(code, 5, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert_eq!(stdout, "");
+    assert!(
+        stderr.contains("Cannot index number with object"),
+        "stderr: {stderr:?}"
+    );
     Ok(())
 }
 

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -10883,16 +10883,25 @@ fn test_eval_index_expr_target_direct_halt_reached_through_group_by_key_fn() -> 
 
 #[test]
 fn test_eval_index_expr_target_partial_halt_reached_through_group_by_key_fn() -> Result<()> {
-    // `eval_index_expr`'s target-materialization match, `Partial(_,
+    // `eval_index_expr`'s target-materialization match, `Partial(vs,
     // Control::Halt(code))` arm: the target (`1,2,halt`) produces two real
-    // outputs before halting -- conservatively treated the same as a direct
-    // halt (the already-produced prefix is discarded, matching the key
-    // stream's own conservative `Error`/`Break` treatment right above it in
-    // the source). Verified against jq 1.7.1: `jq -c 'group_by((1,2,halt)[.])'`
-    // on `[5]` exits 0 with no output.
+    // outputs (`1`, `2`) before halting. #2226 now applies the per-key index
+    // to each before propagating the held control -- indexing `1` by key `.`
+    // (`5`, a number) is never valid regardless of what `.` resolves to, so
+    // that index attempt raises before `halt` is ever reached. Corrected
+    // from this test's own prior (unverified) expectation that it exits 0
+    // with no output: live-checked against jq 1.7.1, `jq -c
+    // 'group_by((1,2,halt)[.])'` on `[5]` actually raises "Cannot index
+    // number with number" too -- the old succinctly behavior (discard the
+    // prefix outright, never attempt the index) was the one exiting 0, not
+    // real jq.
     let (stdout, stderr, code) = run_jq_full(&["-c", "group_by((1,2,halt)[.])"], Some("[5]"))?;
-    assert_eq!(code, 0, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert_eq!(code, 5, "stdout: {stdout:?} stderr: {stderr:?}");
     assert_eq!(stdout, "");
+    assert!(
+        stderr.contains("Cannot index number with number"),
+        "stderr: {stderr:?}"
+    );
     Ok(())
 }
 
@@ -10963,16 +10972,23 @@ fn test_eval_slice_expr_target_halt_reached_through_group_by_key_fn() -> Result<
 
 #[test]
 fn test_eval_slice_expr_target_partial_halt_reached_through_group_by_key_fn() -> Result<()> {
-    // `eval_slice_expr`'s target-materialization match, `Partial(_,
+    // `eval_slice_expr`'s target-materialization match, `Partial(vs,
     // Control::Halt(code))` arm -- the `eval_slice_expr` sibling of
     // `test_eval_index_expr_target_partial_halt_reached_through_group_by_key_fn`.
-    // The target (`1,2,halt`) produces two real outputs before halting;
-    // like the index-expr case, the already-produced prefix is discarded
-    // rather than sliced. Verified against jq 1.7.1: `jq -c
-    // 'group_by((1,2,halt)[0:.])'` on `[5]` exits 0 with no output.
+    // The target (`1,2,halt`) produces two real outputs (`1`, `2`) before
+    // halting; #2226 now attempts to slice each before propagating the held
+    // control -- slicing a *number* is never valid in jq, so slicing `1`
+    // raises before `halt` is ever reached. Corrected from this test's own
+    // prior (unverified) expectation that it exits 0 with no output:
+    // live-checked against jq 1.7.1, `jq -c 'group_by((1,2,halt)[0:.])'` on
+    // `[5]` actually raises "Cannot index number with object" too.
     let (stdout, stderr, code) = run_jq_full(&["-c", "group_by((1,2,halt)[0:.])"], Some("[5]"))?;
-    assert_eq!(code, 0, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert_eq!(code, 5, "stdout: {stdout:?} stderr: {stderr:?}");
     assert_eq!(stdout, "");
+    assert!(
+        stderr.contains("Cannot index number with object"),
+        "stderr: {stderr:?}"
+    );
     Ok(())
 }
 
@@ -11963,26 +11979,20 @@ fn test_eval_index_expr_target_propagates_direct_halt() -> Result<()> {
 }
 
 #[test]
-fn test_eval_index_expr_target_partial_halt_discards_prefix() -> Result<()> {
-    // `eval_index_expr`'s target-side `QueryResult::Partial(_, Control::
-    // Halt(code))` arm: unlike the *key*-side `pending_halt` handling
-    // (#791, see `test_eval_index_expr_owned_target_flushes_prior_keys_
-    // before_halting`), the *target* side has no equivalent bookkeeping --
-    // it is the same conservative treatment this function's own doc
-    // comment gives the target's `Error`/`Break` arms right above it
-    // ("conservatively matching the existing Error/Break arms rather than
-    // inventing new partial-key behavior"), just extended uniformly to
-    // `Halt`. The already-produced target values (`[1,2]` and `[3,4]`, the
-    // first two comma operands, evaluated before the third one halts) are
-    // discarded rather than flushed -- a real, pre-existing divergence from
-    // jq 1.7.1, which streams `1` then `3` (`[1,2][0]` then `[3,4][0]`)
-    // before halting: `([1,2],[3,4],halt_error(6))[(0,0)]` on real jq exits
-    // 6 with stdout "1\n3\n"; succinctly exits 6 with no output at all,
-    // since it evaluates the whole target stream up front rather than
-    // interleaving it with indexing.
+fn test_eval_index_expr_target_partial_halt_no_longer_discards_prefix_2226() -> Result<()> {
+    // `eval_index_expr`'s target-side `QueryResult::Partial(vs, control)`
+    // arm (`control` including `Control::Halt`, not just `Error`/`Break`):
+    // this test used to pin a real, documented divergence from jq 1.7.1 --
+    // the already-produced target values (`[1,2]` and `[3,4]`, the first
+    // two comma operands, evaluated before the third one halts) were
+    // discarded rather than indexed and flushed. #2226 fixed the target
+    // `Partial` arm to apply the per-key index to each already-produced
+    // value first, uniformly for every held control including `Halt`, so
+    // this now matches jq 1.7.1 exactly: `([1,2],[3,4],halt_error(6))[(0,0)]`
+    // streams `1` then `3` (`[1,2][0]` then `[3,4][0]`) before exiting 6.
     let (stdout, stderr, code) = run_jq_full(&["-n", "([1,2],[3,4],halt_error(6))[(0,0)]"], None)?;
     assert_eq!(code, 6, "stdout: {stdout:?} stderr: {stderr:?}");
-    assert_eq!(stdout, "");
+    assert_eq!(stdout, "1\n3\n");
     Ok(())
 }
 
@@ -12050,21 +12060,24 @@ fn test_eval_slice_expr_target_propagates_direct_halt() -> Result<()> {
 }
 
 #[test]
-fn test_eval_slice_expr_target_partial_halt_discards_prefix() -> Result<()> {
-    // `eval_slice_expr`'s target-side `QueryResult::Partial(_, Control::
-    // Halt(code))` arm: the same conservative "discard the already-
-    // produced prefix" treatment `eval_index_expr`'s analogous target-side
-    // arm has (see `test_eval_index_expr_target_partial_halt_discards_
-    // prefix`), and the same real divergence from jq 1.7.1 follows: real
-    // jq streams `[1,2]` then `[4,5]` (slicing each of the two arrays
-    // before the third comma operand halts) before exiting 6, while
-    // succinctly evaluates the whole target stream up front, sees it end
-    // in `Partial(_, Halt(6))`, and discards the buffered `[1,2,3]`/
-    // `[4,5,6]` entirely -- exit 6, no output at all.
-    let (stdout, stderr, code) =
-        run_jq_full(&["-n", "([1,2,3],[4,5,6],halt_error(6))[(1-1):2]"], None)?;
+fn test_eval_slice_expr_target_partial_halt_no_longer_discards_prefix_2226() -> Result<()> {
+    // `eval_slice_expr`'s target-side `QueryResult::Partial(vs, control)`
+    // arm (the `eval_slice_expr` sibling of
+    // `test_eval_index_expr_target_partial_halt_no_longer_discards_prefix_2226`):
+    // this test used to pin a real, documented divergence from jq 1.7.1 --
+    // succinctly evaluated the whole target stream up front, saw it end in
+    // `Partial(_, Halt(6))`, and discarded the buffered `[1,2,3]`/`[4,5,6]`
+    // entirely. #2226 fixed the target `Partial` arm to slice each
+    // already-produced value first, uniformly for every held control
+    // including `Halt`, so this now matches jq 1.7.1 exactly: real jq
+    // streams `[1,2]` then `[4,5]` (slicing each of the two arrays before
+    // the third comma operand halts) before exiting 6.
+    let (stdout, stderr, code) = run_jq_full(
+        &["-c", "-n", "([1,2,3],[4,5,6],halt_error(6))[(1-1):2]"],
+        None,
+    )?;
     assert_eq!(code, 6, "stdout: {stdout:?} stderr: {stderr:?}");
-    assert_eq!(stdout, "");
+    assert_eq!(stdout, "[1,2]\n[4,5]\n");
     Ok(())
 }
 
@@ -34813,6 +34826,46 @@ fn test_slice_expr_one_empty_pair_does_not_short_circuit_others_2143() -> Result
         run_jq_full(&["-c", "-n", "inputs[(0,1):(1,2)]"], Some("[10,20]\n"))?;
     assert_eq!(code, 0, "stdout: {stdout:?} stderr: {stderr:?}");
     assert_eq!(stdout, "[10]\n");
+    Ok(())
+}
+
+/// #2226: `eval_generic::eval_index_expr`'s target-evaluation `Partial` arm
+/// used to discard `E`'s own already-produced prefix and keep only the
+/// escaping control. `([1,2],[3,4],error("x"))[(0,1)]` makes both the key
+/// (`(0,1)`, a bare computed generator with no `as`-binding, so this
+/// dispatches through `eval_generic.rs` rather than `eval.rs`'s sibling)
+/// *and* the target multi-output: `E`'s first two branches each index
+/// cleanly at key `0` (`1`, then `3`) before the third branch errors.
+/// Verified against jq 1.7.1: `echo null | jq -c
+/// '([1,2],[3,4],error("x"))[(0,1)]'` prints `1` then `3` before raising.
+#[test]
+fn test_index_expr_cli_dispatch_target_own_partial_prefix_preserved_2226() -> Result<()> {
+    let (stdout, stderr, code) =
+        run_jq_full(&["-c", "([1,2],[3,4],error(\"x\"))[(0,1)]"], Some("null"))?;
+    assert_eq!(code, 5, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert_eq!(stdout, "1\n3\n");
+    assert!(stderr.contains('x'), "stderr: {stderr:?}");
+    Ok(())
+}
+
+/// #2226 sibling: the same target-own-prefix fix for
+/// `eval_generic::eval_slice_expr` -- the issue's own canonical repro.
+/// `(0,1):(1,2)` are bare computed bounds (no `as`-binding), so this
+/// dispatches through `eval_generic.rs` rather than `eval.rs`'s sibling
+/// (see `test_slice_expr_eval_rs_dispatch_target_reevaluated_per_pair_2143`
+/// above for the `eval.rs`-reaching counterpart shape via `input`). Verified
+/// against jq 1.7.1: `echo null | jq -c
+/// '([1,2],[3,4],error("x"))[(0,1):(1,2)]'` prints `[1]` then `[3]` before
+/// raising.
+#[test]
+fn test_slice_expr_cli_dispatch_target_own_partial_prefix_preserved_2226() -> Result<()> {
+    let (stdout, stderr, code) = run_jq_full(
+        &["-c", "([1,2],[3,4],error(\"x\"))[(0,1):(1,2)]"],
+        Some("null"),
+    )?;
+    assert_eq!(code, 5, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert_eq!(stdout, "[1]\n[3]\n");
+    assert!(stderr.contains('x'), "stderr: {stderr:?}");
     Ok(())
 }
 

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -29194,3 +29194,38 @@ fn test_del_and_delpaths_negative_index_unaffected_in_jq_mode_2268() -> Result<(
 
     Ok(())
 }
+
+/// #2226 review finding: `eval_generic::eval_index_expr`'s target `Partial`
+/// fix (the actual CLI-dispatch path a real `.[$keys]` read hits) is
+/// jq-only. Real yq does not stream a target's own escaped generator's
+/// prefix at all -- verified live against yq v4.53.3:
+/// `([1,2],[3,4],error("x"))[(0,1)]` prints only `Error: x`, no prefix.
+/// Confirms the pre-#2226 conservative discard survives in yq mode.
+#[test]
+fn test_index_expr_target_partial_prefix_still_discarded_in_yq_mode_2226() -> Result<()> {
+    let (out, stderr, code) = run_yq_stdin_with_stderr(
+        "([1,2],[3,4],error(\"x\"))[(0,1)]",
+        "null\n",
+        &["-o", "json"],
+    )?;
+    assert_eq!(code, 1, "out: {out:?} stderr: {stderr:?}");
+    assert_eq!(out, "");
+    assert_eq!(stderr.trim(), "Error: x");
+    Ok(())
+}
+
+/// #2226 sibling: the identical yq-mode carve-out for
+/// `eval_generic::eval_slice_expr`. Verified live against yq v4.53.3:
+/// `([1,2],[3,4],error("x"))[(0,1):(1,2)]` prints only `Error: x`.
+#[test]
+fn test_slice_expr_target_partial_prefix_still_discarded_in_yq_mode_2226() -> Result<()> {
+    let (out, stderr, code) = run_yq_stdin_with_stderr(
+        "([1,2],[3,4],error(\"x\"))[(0,1):(1,2)]",
+        "null\n",
+        &["-o", "json"],
+    )?;
+    assert_eq!(code, 1, "out: {out:?} stderr: {stderr:?}");
+    assert_eq!(out, "");
+    assert_eq!(stderr.trim(), "Error: x");
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- `eval_index_expr`/`eval_slice_expr` (both `src/jq/eval.rs` and `src/jq/eval_generic.rs`, 4 call sites total) re-evaluate the target `E` once per key/`(s, e)` pair, but discarded `E`'s own already-produced values whenever `E` itself is a multi-output generator that errors/breaks/halts partway through its own stream.
- Applies the per-key index/slice operation to each already-produced value before propagating the held control — mirroring the pre-existing successful-target arms — matching jq 1.7.1 exactly (live-verified against the pinned `/usr/bin/jq` 1.7.1 oracle for every repro below).
- Corrects several pre-existing tests that pinned the old (buggy, some explicitly documented-as-divergence) behavior as expected, including two `group_by`-key-fn cases whose "exits 0, no output" expectation was itself never actually verified against real jq (indexing/slicing a *number* is never valid regardless of the trailing halt, so real jq raises before the halt is ever reached).

Fixes #2226

## Follow-up filed
A structurally similar but distinct gap survives out of scope: `eval_index_expr`'s **key**-stream (not target-stream) `Partial` arm also discards its own prefix on `Error`/`Break` (confirmed live: `jq -c '.[(1,error("x"))]'` on `[10,20,30]` prints `20` then fails; succinctly still collapses to a bare error). Filed as a follow-up issue.

## Test plan
- [x] `cargo build --features cli`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings`
- [x] `cargo fmt --check`
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features`
- [x] `cargo test --features cli,simd,regex,serde --no-fail-fast`
- [x] `cargo test --no-fail-fast` (default features)
- [x] `cargo test --no-default-features --verbose` (no_std)
- [x] All 4 fixed call sites live-verified against `/usr/bin/jq` 1.7.1, including confirming (via temporary debug probes) which repro shape actually routes through which of the 4 functions
