### PR TITLE
fix(yq): del()/delpaths() vivify a null into [] ahead of an Index/Iterate step (#2323)

### DIFF
--- a/docs/compliance/yq/limitations.md
+++ b/docs/compliance/yq/limitations.md
@@ -1886,23 +1886,73 @@ gap below for when it hasn't), and `delete_paths_under`'s array-key arm (`delpat
 recursion) -- all in `src/jq/eval.rs`. `delpaths`' own path components are always concrete
 keys, never a `.[]` wildcard, so there is no `[]`-vivify case to mirror at that site.
 
-**Two residual gaps found during this fix's own review, not chased here:**
+**One residual gap found during this fix's own review, not chased here:** a
+**comma-grouped** target whose own `.[]` fan-out crosses the out-of-range index
+(`del(.[5][], .[0])`) never reaches `delete_trie_array` at all -- the read-based
+validation that enumerates concrete branches for the trie reads `.[5]` as a plain `null`
+(correct for an ordinary read) and raises iterating `.[]` over it, rather than
+extending+vivifying the way the direct, non-comma-grouped form now does. Tracked as
+[#2324](https://github.com/rust-works/succinctly/issues/2324).
 
-- A **comma-grouped** target whose own `.[]` fan-out crosses the out-of-range index
-  (`del(.[5][], .[0])`) never reaches `delete_trie_array` at all -- the read-based
-  validation that enumerates concrete branches for the trie reads `.[5]` as a plain
-  `null` (correct for an ordinary read) and raises iterating `.[]` over it, rather than
-  extending+vivifying the way the direct, non-comma-grouped form now does. Tracked as
-  [#2324](https://github.com/rust-works/succinctly/issues/2324).
-- The `[]`-vivify rule implemented here is narrowly scoped to a slot this fix *itself*
-  just padded, checked only against a literal `Expr::Iterate` as the very next step.
-  Real yq's actual rule is broader and predates this fix entirely: `null` auto-vivifies
-  into `[]` for **any** subsequent `Index`/`Iterate` del() step, freshly padded or not
-  (`null | del(.[2])` is `[null,null]` in real yq; `{"x":null} | del(.x[2])` is
-  `{"x":[null,null]}`) -- `succinctly yq` gets both wrong today, along with a
-  multi-level chain like `del(.[3][2].a)` (real yq recurses the same rule at each level;
-  this fix's own narrow check only covers one). Tracked as
-  [#2323](https://github.com/rust-works/succinctly/issues/2323).
+(A second gap found during the same review -- `null` never vivifying into `[]` ahead of
+*any* `Index`/`Iterate` del() step, not just a slot #2314 itself just padded -- is now
+closed; see the next section.)
+
+### `del()` auto-vivifies a `null` into `[]` ahead of an `Index`/`Iterate` step, matching `setpath`
+
+[#2323](https://github.com/rust-works/succinctly/issues/2323), found during #2314's own
+review. Real yq's actual null-vivify rule is broader than -- and predates -- #2314's own
+"a slot this fix just padded" case: **any** `null` a `del()` walk reaches, freshly padded
+or not, vivifies into `[]` the moment the next step is `Index` or `Iterate`, the same
+auto-vivify philosophy `=`/`|=`'s own write path already applies (`.a[].b = v` on
+`{"a":null}` is `{"a":[]}`, confirmed pre-existing precedent -- see
+`test_yq_iterate_pipe_chain_null_autovivifies_under_update_assign_1919`):
+
+```bash
+$ echo 'null' | yq -o=json 'del(.[2])'          # [null, null] -- no out-of-range extension involved at all
+$ echo 'null' | yq -o=json 'del(.[])'           # []
+$ echo '{"x":null}' | yq -o=json 'del(.x[2])'   # {"x": [null, null]}
+$ echo '[1,2]' | yq -o=json 'del(.[3][2].a)'    # [1, 2, null, [null, null, null]] -- recurses at each level
+```
+
+Applies to `del()`'s terminal form (`delete_at_path`'s own `Index`/`Iterate` arms) and its
+mid-chain form (`delete_path_steps`'s own `Index`/`Iterate` arms) alike. Both are
+implemented the same way: mutate the `null` root into `Array(Vec::new())` immediately
+before the existing container-handling match, rather than duplicating that match's own
+logic -- in `delete_path_steps`'s loop this means `continue`ing without advancing `steps`,
+so the very same path component re-matches against the freshly vivified array on the next
+pass, which is what makes the recursive `del(.[3][2].a)` case above fall out for free
+(each level's own out-of-range index re-triggers #2314's existing extension logic against
+an array that used to be `null`) without any explicit lookahead or recursion of its own.
+`?` does not suppress the vivify (`null | del(.[2]?)` still vivifies, confirmed live), and
+neither does a `Pipe`-wrapped continuation (`del(.[5] | (.[].a))` reduces to a literal
+`Expr::Iterate` against the padded `null` once the existing `Expr::Pipe` splice logic
+runs, so it is covered by the same general arm without its own check).
+
+**Does not apply to:** `Field` steps (`{"x":null} | del(.x.a)` stays `{"x":null}`,
+confirmed live -- matches `=`/`|=`'s own precedent, which likewise never vivifies for
+`Field`), `Slice` steps (`null | del(.[0:2])` stays `null`, matching jq), `delpaths()` at
+all (`{"x":null} | delpaths([["x",2]])` stays `{"x":null}` -- this rule is specific to
+`del()`'s expression-based target, not `delpaths()`'s path-array form), or jq mode (no
+such rule exists there at all: `null | del(.[2])` stays `null`, `null | del(.[])` still
+raises "Cannot iterate over null").
+
+**Also extended to `del()`'s comma-grouped form.** `delete_trie_array`'s own null-skip
+branch shares the identical vivify rule (`delete_trie_object`'s sibling branch does not —
+`Field` steps never vivify, per the scope above): confirmed live,
+`{"x":null,"y":1} | del(.x[2], .y)` is `{"x":[null,null]}`, with `.y` still deleting
+independently either way. Vivifying is safe even when the only array-level step is a
+`Slice` (no `Index` at all) — a slice range against a freshly empty array is itself a
+harmless no-op, so there was no need to distinguish which step kind triggered the vivify.
+One surprising, *already-correct, pre-existing and unrelated* behavior worth flagging so
+a future reader doesn't mistake it for this fix's own doing:
+`{"x":null,"y":1} | del(.x[0:2], .y)` is `{}` in real yq — not just `x` cleared, `y` gone
+too — reproduced identically by `succinctly yq` both before and after this fix, via the
+pre-existing #1116/#1219 chained-slice-parent-drop rule elsewhere in this same trie walk.
+
+This fix does not reach the comma-grouped **`.[]` fan-out** gap #2324 tracks separately —
+that one fails earlier, in the read-based validation that builds the trie in the first
+place, before `delete_trie_array` is ever called.
 
 ### Other categories
 

--- a/docs/compliance/yq/limitations.md
+++ b/docs/compliance/yq/limitations.md
@@ -1937,18 +1937,56 @@ all (`{"x":null} | delpaths([["x",2]])` stays `{"x":null}` -- this rule is speci
 such rule exists there at all: `null | del(.[2])` stays `null`, `null | del(.[])` still
 raises "Cannot iterate over null").
 
-**Also extended to `del()`'s comma-grouped form.** `delete_trie_array`'s own null-skip
-branch shares the identical vivify rule (`delete_trie_object`'s sibling branch does not —
-`Field` steps never vivify, per the scope above): confirmed live,
-`{"x":null,"y":1} | del(.x[2], .y)` is `{"x":[null,null]}`, with `.y` still deleting
-independently either way. Vivifying is safe even when the only array-level step is a
-`Slice` (no `Index` at all) — a slice range against a freshly empty array is itself a
-harmless no-op, so there was no need to distinguish which step kind triggered the vivify.
-One surprising, *already-correct, pre-existing and unrelated* behavior worth flagging so
-a future reader doesn't mistake it for this fix's own doing:
-`{"x":null,"y":1} | del(.x[0:2], .y)` is `{}` in real yq — not just `x` cleared, `y` gone
-too — reproduced identically by `succinctly yq` both before and after this fix, via the
-pre-existing #1116/#1219 chained-slice-parent-drop rule elsewhere in this same trie walk.
+**Vivify eligibility tracks provenance, not just "is `root` currently `null`."** A `null`
+reached by *tolerating* a `Field`/`Slice` step against it (#476/#527's own established
+exemption) is not vivify-eligible for whatever comes after, even when it sits in an
+otherwise-real slot -- confirmed live, `{"x":null} | del(.x[2])` (Field *found* the real
+key `"x"`) vivifies, but `[1,2] | del(.[5].missing[2])` (`.[5]` itself is a real
+#2314-padded slot, but `.missing` only *tolerates* that slot's `null` rather than finding
+a real key on it) does not: `[1,2,null,null,null,null]`, not
+`[...,[null,null]]`. Both `delete_at_path` and `delete_path_steps` thread an extra
+`real_slot: bool` parameter through every recursive call to track this -- `true` from the
+document root or any real navigation (a found object key, an in-range or #2314-padded
+array element), flipped to `false` by a `Field`/`Slice` step's own null-tolerant arm, and
+never flipped back except by this fix's own vivify. `delete_at_path_through_absent`'s own
+synthetic scratch value is a related but separate case: its whole contract is "the
+container is untouched" (a missing field never materializes), so it now hardcodes both
+`yq_mode` and `real_slot` to `false` for its own recursive walk, matching
+`delete_trie_through_absent`'s already-established pattern -- confirmed live,
+`{} | del(.missing[-1])` stays `{}`, not the out-of-range error a wrongly-vivified scratch
+would raise.
+
+**Also extended to `del()`'s comma-grouped form**, with one additional gate.
+`delete_trie_array`'s own null-skip branch shares the same vivify rule
+(`delete_trie_object`'s sibling branch does not — `Field` steps never vivify, per the
+scope above): confirmed live, `{"x":null,"y":1} | del(.x[2], .y)` is
+`{"x":[null,null]}`, with `.y` still deleting independently either way. Vivifying is safe
+even when the only array-level step is a `Slice` (no `Index` at all) — a slice range
+against a freshly empty array is itself a harmless no-op — or when one terminal index
+shares a node with one *continuation* (`null | del(.[2], .[3].a)` is
+`[null,null,null]`, order-independent, confirmed live both ways). One surprising,
+*already-correct, pre-existing and unrelated* behavior worth flagging so a future reader
+doesn't mistake it for this fix's own doing: `{"x":null,"y":1} | del(.x[0:2], .y)` is
+`{}` in real yq — not just `x` cleared, `y` gone too — reproduced identically by
+`succinctly yq` both before and after this fix, via the pre-existing #1116/#1219
+chained-slice-parent-drop rule elsewhere in this same trie walk.
+
+**Gated off when 2+ *terminal* indices share one node.** `delete_keys`'s own #2305/#2306
+gate only extends a single-key batch — real yq's own multi-key extension is
+order-*dependent* (confirmed live: `null | del(.[2],.[3])` and `null | del(.[3],.[2])`
+both give `[null,null]` here, but #2306's own filed example, a mixed in-range/out-of-range
+batch, does differ by order — a materially larger, already-deferred piece of work).
+Vivifying `delete_trie_array`'s source unconditionally regardless of this gate would trade
+one wrong answer (staying `null`, the pre-existing gap) for a *different* wrong one (`[]`,
+since `delete_keys` still refuses the 2+-key batch, just now against an already-empty
+array) rather than reproducing real yq's actual multi-key answer — a new, previously
+uncharacterized divergence shape this fix should not introduce. `terminal_index_count =
+node.indices.len() - node.index_groups.len()` (total array-level steps at this node minus
+the ones that have their own children, i.e. continuations) distinguishes this from the
+mixed terminal+continuation case above, which is a different shape and already correct:
+vivify only fires when `terminal_index_count <= 1`. Confirmed live both orderings give the
+same (still-`null`, not-yet-fixed) answer, so this gate doesn't itself introduce any new
+order-dependence of its own.
 
 This fix does not reach the comma-grouped **`.[]` fan-out** gap #2324 tracks separately —
 that one fails earlier, in the read-based validation that builds the trie in the first

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -36459,13 +36459,23 @@ fn flatten_delete_path(expr: &Expr, optional: bool, out: &mut Vec<DeleteStep>) {
 /// [`delete_trie_through_absent`]'s single-path counterpart, for
 /// [`delete_at_path`]'s chain-walk. Same contract: errors propagate, the
 /// rebuilt `null` is discarded, the container is untouched.
-fn delete_at_path_through_absent(
-    rest: &[Expr],
-    optional: bool,
-    yq_mode: bool,
-) -> Result<(), EvalError> {
+///
+/// #2323: hardcodes `yq_mode = false` and `real_slot = false` for the
+/// recursive walk, matching `delete_trie_through_absent`'s own established
+/// pattern (and for the identical reason its doc comment gives: the value
+/// is always a synthetic `Null` no caller ever reads back, so there is
+/// nothing here for the vivify-to-`[]` fix to usefully apply to). Before
+/// this fix that didn't matter -- #2305/#2314's own array-extension logic
+/// lives entirely inside the `Array` arm, unreachable from a bare `Null` --
+/// but #2323's own vivify *is* reachable from `Null`, and running it here
+/// would mutate the throwaway `absent` into an array before an out-of-range
+/// index against *that* raises an error real yq never raises for this
+/// shape: confirmed live, `{} | del(.missing[-1])` is `{}` (a clean no-op,
+/// the missing field never materializes), not the `-1`-out-of-range error
+/// vivifying `absent` first would incorrectly produce.
+fn delete_at_path_through_absent(rest: &[Expr], optional: bool) -> Result<(), EvalError> {
     let mut absent = OwnedValue::Null;
-    delete_path_steps(&mut absent, rest, optional, yq_mode)
+    delete_path_steps(&mut absent, rest, optional, false, false)
 }
 
 /// One array-level step of a `del` path: a bare index, or a slice.
@@ -37104,14 +37114,32 @@ fn delete_trie_array(
     // confirmed live, `{"x":null,"y":1} | del(.x[2], .y)` is
     // `{"x":[null,null]}` (`.y` still deletes independently either way).
     // Vivifying unconditionally rather than only for an `ArrayStep::Index`
-    // node is safe for a `Slice`-only node too: a slice range against a
-    // freshly empty array is itself already a harmless no-op (confirmed
-    // live against a mixed `del(.x[2], .x[0:1], .y)` node), so there is no
-    // need to distinguish which step kind triggered the vivify. jq has no
-    // such rule, so this is yq-mode only, matching every other arm of this
-    // fix -- jq mode falls through to the pre-existing `null`-tolerant
-    // walk-through-absent behavior unchanged.
-    if yq_mode && matches!(value, OwnedValue::Null) {
+    // node is safe for a `Slice`-only node, or a node mixing one terminal
+    // index with a continuation, too: a slice range against a freshly
+    // empty array is itself already a harmless no-op (confirmed live
+    // against a mixed `del(.x[2], .x[0:1], .y)` node), and
+    // `null | del(.[2], .[3].a)` (one terminal index alongside one
+    // continuation at the same node) correctly vivifies to
+    // `[null,null,null]`, order-independent, confirmed live both ways.
+    //
+    // **Not** safe, and deliberately excluded, when 2+ *terminal* indices
+    // share this node: `delete_keys`'s own `keys.len() == 1` gate (#2305/
+    // #2306's own documented scope, unrelated to this fix) already refuses
+    // to extend a multi-key batch, because real yq's own multi-key
+    // extension is order-*dependent* in a way a single `retain` pass can't
+    // replicate -- vivifying the source here regardless would silently
+    // trade one wrong answer (staying `null`) for a different, newly wrong
+    // one (`[]`, since `delete_keys` still refuses the 2+-key batch, just
+    // now against an already-empty array instead of `null`) rather than
+    // reproducing real yq's actual `[null,null]`-shaped answer. Counting
+    // `index_groups` (continuations) out of the total is what tells "2+
+    // terminal keys, #2306's own gap" apart from "1 terminal key plus a
+    // continuation," which is not the same shape and is already correct
+    // above. jq has no vivify rule at all, so this whole check is yq-mode
+    // only -- jq mode always falls through to the pre-existing
+    // `null`-tolerant walk-through-absent behavior below, unchanged.
+    let terminal_index_count = node.indices.len() - node.index_groups.len();
+    if yq_mode && terminal_index_count <= 1 && matches!(value, OwnedValue::Null) {
         value = OwnedValue::Array(Vec::new());
     } else if matches!(value, OwnedValue::Null) {
         // Same per-step `null` exemption as `delete_trie_object` — applies
@@ -37591,7 +37619,13 @@ fn builtin_del<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
                 _ => {}
             }
         }
-        if let Err(e) = delete_at_path(&mut result, effective_path, false, S::TAG == EvalTag::Yq) {
+        if let Err(e) = delete_at_path(
+            &mut result,
+            effective_path,
+            false,
+            S::TAG == EvalTag::Yq,
+            true,
+        ) {
             return if optional {
                 QueryResult::None
             } else {
@@ -37621,6 +37655,16 @@ fn delete_at_path(
     path_expr: &Expr,
     optional: bool,
     yq_mode: bool,
+    // #2323: whether `root` is a genuinely resolved slot (the document
+    // itself, a found object key, an in-range/#2314-padded array element) as
+    // opposed to a `null` reached by *tolerating* a step against one (a
+    // `Field`/`Slice` applied to an already-`null` root, #476) -- only the
+    // former is eligible for this fix's own `Index`/`Iterate` vivify-to-`[]`
+    // treatment. See `delete_path_steps`'s own doc comment for the full
+    // rationale and the confirmed-live case this distinguishes
+    // (`{"x":null} | del(.x[2])` vivifies; `[1,2] | del(.[5].missing[2])`
+    // does not, even though both reach an `Index` step against a `null`).
+    real_slot: bool,
 ) -> Result<(), EvalError> {
     match path_expr {
         Expr::Identity => {
@@ -37658,8 +37702,9 @@ fn delete_at_path(
             // way the scalar-noop arms further down do. Once vivified, the
             // existing `OwnedValue::Array` arm's own #2305/#2314 extension
             // logic applies unchanged -- an empty array is just another
-            // array to resolve the index against.
-            if yq_mode && matches!(root, OwnedValue::Null) {
+            // array to resolve the index against. Gated on `real_slot` too
+            // -- see this function's own doc comment.
+            if yq_mode && real_slot && matches!(root, OwnedValue::Null) {
                 *root = OwnedValue::Array(Vec::new());
             }
             match root {
@@ -37714,8 +37759,8 @@ fn delete_at_path(
             // as the `Index` arm above -- `null | del(.[])` is `[]` in real
             // yq, not an error, so vivifying first and falling into the
             // `Array` arm below (clearing an already-empty array is itself
-            // a no-op) produces exactly that.
-            if yq_mode && matches!(root, OwnedValue::Null) {
+            // a no-op) produces exactly that. Gated on `real_slot` too.
+            if yq_mode && real_slot && matches!(root, OwnedValue::Null) {
                 *root = OwnedValue::Array(Vec::new());
             }
             match root {
@@ -37760,8 +37805,10 @@ fn delete_at_path(
                 "object",
             )),
         },
-        Expr::Pipe(exprs) if !exprs.is_empty() => delete_path_steps(root, exprs, optional, yq_mode),
-        Expr::Optional(inner) => delete_at_path(root, inner, true, yq_mode),
+        Expr::Pipe(exprs) if !exprs.is_empty() => {
+            delete_path_steps(root, exprs, optional, yq_mode, real_slot)
+        }
+        Expr::Optional(inner) => delete_at_path(root, inner, true, yq_mode, real_slot),
         // `(EXPR)` at the top of a resolved delete target (e.g.
         // `del((.a))`) -- mirrors `update_path`'s identical `Expr::Paren`
         // arm (#1116; passes `optional` through unchanged, unlike the
@@ -37769,7 +37816,7 @@ fn delete_at_path(
         // `delete_at_path` was missing entirely until now (#1153): any
         // parenthesized `del()` target failed with "cannot use expression
         // as delete target", whether or not a slice was involved.
-        Expr::Paren(inner) => delete_at_path(root, inner, optional, yq_mode),
+        Expr::Paren(inner) => delete_at_path(root, inner, optional, yq_mode, real_slot),
         // Unreachable: `resolve_dynamic_indexes` rewrites every computed key
         // into a static component before this runs. Explicit rather than left
         // to the catch-all so a missed install point fails loudly here instead
@@ -37863,9 +37910,30 @@ fn delete_path_steps(
     steps: &[Expr],
     optional: bool,
     yq_mode: bool,
+    // #2323: tracks whether `root` is currently a genuinely resolved slot,
+    // as opposed to a `null` reached only by *tolerating* a step against one
+    // (`Field`/`Slice` on `null`, #476/#527's established null-tolerance).
+    // Only the former is eligible for the `Index`/`Iterate` vivify-to-`[]`
+    // rule this fix adds -- the two read identically as "root is currently
+    // `null`" but real yq treats them differently, confirmed live:
+    // `{"x":null} | del(.x[2])` (Field *found* the real key `"x"`, value
+    // happens to be `null`) is `{"x":[null,null]}`, but
+    // `[1,2] | del(.[5].missing[2])` (Field `"missing"` tolerated a `null`
+    // it was applied *to*, #476 -- `.[5]` itself padded to a real `null`
+    // slot first, #2314, but `.missing` is not a real lookup on it) is
+    // `[1,2,null,null,null,null]`, not `[...,[null,null]]`. Starts `true`
+    // (every caller either passes the real document or an already-resolved
+    // container element -- see each call site) and flips to `false`
+    // whenever a `Field`/`Slice` step's own null-tolerant arm fires below,
+    // staying `false` from then on (there is no way back to a real slot
+    // once stuck walking a tolerated `null`, since every further step just
+    // tolerates it again) until #2323's own vivify -- gated on this flag --
+    // turns it back into a real (if empty) array.
+    real_slot: bool,
 ) -> Result<(), EvalError> {
     let mut root = root;
     let mut steps = steps;
+    let mut real_slot = real_slot;
     loop {
         let (first, rest) = match steps {
             // Defensive only: every caller passes a non-empty slice (the
@@ -37877,7 +37945,7 @@ fn delete_path_steps(
                 *root = OwnedValue::Null;
                 return Ok(());
             }
-            [last] => return delete_at_path(root, last, optional, yq_mode),
+            [last] => return delete_at_path(root, last, optional, yq_mode, real_slot),
             [first, rest @ ..] => (first, rest),
         };
 
@@ -37920,17 +37988,20 @@ fn delete_path_steps(
             Expr::Field(_) | Expr::Index { .. } | Expr::Iterate | Expr::Slice { .. }
         ) && trailing_identity_optional(rest, false).is_some()
         {
-            return delete_at_path(root, component, here, yq_mode);
+            return delete_at_path(root, component, here, yq_mode, real_slot);
         }
 
         match component {
             Expr::Field(name) => match root {
                 OwnedValue::Object(map) => {
                     // Pure tail recursion (no undo, nothing created) --
-                    // reassign `root` and loop instead of recursing.
+                    // reassign `root` and loop instead of recursing. A real
+                    // found key, so #2323's own vivify stays eligible for
+                    // whatever comes next.
                     if let Some(current) = map.get_mut(name) {
                         root = current;
                         steps = rest;
+                        real_slot = true;
                         continue;
                     }
                     // Same "reads as `null`, keep walking" rule as
@@ -37939,7 +38010,7 @@ fn delete_path_steps(
                     // `here` no longer gates this — a `?` on the missing step
                     // does not suppress what the tail itself raises, and the
                     // walk into a throwaway `null` cannot create the key.
-                    return delete_at_path_through_absent(rest, optional, yq_mode);
+                    return delete_at_path_through_absent(rest, optional);
                 }
                 // `null` tolerates any key — `null | del(.a.b)` and
                 // `{"x":null} | del(.x.a)` are both no-ops (#476) — but only
@@ -37953,8 +38024,16 @@ fn delete_path_steps(
                 // above, there is already a live slot to keep pointing at
                 // (it holds `null` and can never become anything else via a
                 // `del()`), so no detached scratch is needed at all.
+                //
+                // #2323: this *is* the null-tolerant case the new `real_slot`
+                // flag exists to mark -- `.a` was applied to an already-`null`
+                // root, not looked up on a real object, so whatever comes
+                // next is no longer vivify-eligible (confirmed live,
+                // `[1,2] | del(.[5].missing[2])` does not vivify `.missing`
+                // even though `.[5]` itself was a real #2314-padded slot).
                 OwnedValue::Null => {
                     steps = rest;
+                    real_slot = false;
                     continue;
                 }
                 _ if here => return Ok(()),
@@ -37986,6 +38065,7 @@ fn delete_path_steps(
                         DeleteIndexResolution::InRange(actual_idx) => {
                             root = &mut arr[actual_idx];
                             steps = rest;
+                            real_slot = true;
                             continue;
                         }
                         // #2314: a positive out-of-range mid-chain index
@@ -38004,9 +38084,12 @@ fn delete_path_steps(
                             // generically by this same loop's own
                             // `OwnedValue::Null` arms below, once it
                             // re-matches on the next iteration -- no need
-                            // to special-case the next component here.
+                            // to special-case the next component here. It's
+                            // a freshly *padded*, real slot, so #2323's own
+                            // vivify stays eligible.
                             root = &mut arr[index];
                             steps = rest;
+                            real_slot = true;
                             continue;
                         }
                         DeleteIndexResolution::PositiveOutOfRange(_)
@@ -38016,7 +38099,7 @@ fn delete_path_steps(
                             // tails, `?` or not (#477) — but not `[]`, which
                             // still raises `Cannot iterate over null (null)`
                             // (#527/#529).
-                            return delete_at_path_through_absent(rest, optional, yq_mode);
+                            return delete_at_path_through_absent(rest, optional);
                         }
                     }
                 }
@@ -38032,16 +38115,23 @@ fn delete_path_steps(
                 // each level: confirmed live, `[1,2,null,[null,null,null]]`,
                 // not `[1,2,null,null]`. jq has no such rule at all, so this
                 // is yq-mode only — jq keeps the plain "null | del(.[0].a)
-                // is a no-op" reading (#476).
-                OwnedValue::Null if yq_mode => {
+                // is a no-op" reading (#476). Gated on `real_slot` too (see
+                // this function's own doc comment): confirmed live,
+                // `[1,2] | del(.[5].missing[2])` -- `.missing` tolerated a
+                // `null` rather than finding a real key on one -- does not
+                // vivify here even though `real_slot` was true one step
+                // earlier for `.[5]` itself.
+                OwnedValue::Null if yq_mode && real_slot => {
                     *root = OwnedValue::Array(Vec::new());
                     continue;
                 }
                 // Same per-step `null` exemption as the `Field` case above —
                 // `null | del(.[0].a)` is a no-op (#476) -- loops in place
-                // for the same reason.
+                // for the same reason. Also reached in yq mode whenever
+                // `real_slot` is false (the vivify arm above didn't fire).
                 OwnedValue::Null => {
                     steps = rest;
+                    real_slot = false;
                     continue;
                 }
                 _ if here => return Ok(()),
@@ -38066,8 +38156,9 @@ fn delete_path_steps(
                 // produces. jq has no such rule (`null | del(.[])` still
                 // raises there), so this is gated to yq mode only, and runs
                 // ahead of the per-element re-classification below rather
-                // than through it.
-                if yq_mode && matches!(root, OwnedValue::Null) {
+                // than through it. Gated on `real_slot` too -- see this
+                // function's own doc comment.
+                if yq_mode && real_slot && matches!(root, OwnedValue::Null) {
                     *root = OwnedValue::Array(Vec::new());
                 }
                 // `rest` is turned into an `Expr::Pipe` at most once here
@@ -38121,13 +38212,13 @@ fn delete_path_steps(
                                     remove_indices.push(i);
                                 }
                                 YqDelSliceOutcome::DropParent(ref target) => {
-                                    delete_at_path(elem, target, optional, yq_mode)?;
+                                    delete_at_path(elem, target, optional, yq_mode, true)?;
                                 }
                                 YqDelSliceOutcome::Noop => {
                                     // Leave this element untouched.
                                 }
                                 YqDelSliceOutcome::NotApplicable => {
-                                    delete_path_steps(elem, rest, optional, yq_mode)?;
+                                    delete_path_steps(elem, rest, optional, yq_mode, true)?;
                                 }
                             }
                         }
@@ -38150,13 +38241,13 @@ fn delete_path_steps(
                                     remove_keys.push(key.clone());
                                 }
                                 YqDelSliceOutcome::DropParent(ref target) => {
-                                    delete_at_path(value, target, optional, yq_mode)?;
+                                    delete_at_path(value, target, optional, yq_mode, true)?;
                                 }
                                 YqDelSliceOutcome::Noop => {
                                     // Leave this entry untouched.
                                 }
                                 YqDelSliceOutcome::NotApplicable => {
-                                    delete_path_steps(value, rest, optional, yq_mode)?;
+                                    delete_path_steps(value, rest, optional, yq_mode, true)?;
                                 }
                             }
                         }
@@ -38178,7 +38269,7 @@ fn delete_path_steps(
             // `optional`, not `here`, as the baseline (#1294).
             Expr::Pipe(inner) => {
                 let spliced = splice_optional_group(inner, rest, here);
-                return delete_path_steps(root, &spliced, optional, yq_mode);
+                return delete_path_steps(root, &spliced, optional, yq_mode, real_slot);
             }
             // The chain continues *inside* the slice, so the delete happens
             // in the sub-array and the remainder is spliced back:
@@ -38197,8 +38288,12 @@ fn delete_path_steps(
                 // the `Field`/`Index` arms' own `Null` case above: `root`
                 // already points at a live `null` slot that can never become
                 // anything else via a `del()`, so there is no need for a
-                // detached scratch.
+                // detached scratch. #2323: a `Slice` never itself vivifies
+                // (confirmed live, `null | del(.[0:2])` stays `null` in real
+                // yq too, matching jq) -- also a null-tolerant pass-through,
+                // same as `Field`'s.
                 steps = rest;
+                real_slot = false;
                 continue;
             }
             // See `delete_at_path`'s own doc history for this arm (#1116/
@@ -38216,7 +38311,7 @@ fn delete_path_steps(
                         container_noop: false,
                         terminal_write: yq_mode,
                     },
-                    |sub| always_wrote(delete_path_steps(sub, rest, optional, yq_mode)),
+                    |sub| always_wrote(delete_path_steps(sub, rest, optional, yq_mode, true)),
                 )
                 .map(|_| ());
             }
@@ -38233,7 +38328,7 @@ fn delete_path_steps(
                 steps = rest;
                 continue;
             }
-            _ => return delete_at_path(root, first, here, yq_mode),
+            _ => return delete_at_path(root, first, here, yq_mode, real_slot),
         }
     }
 }
@@ -69387,6 +69482,107 @@ mod tests {
     }
 
     #[test]
+    fn test_del_through_absent_field_never_vivifies_yq_mode_2323() {
+        // #2323 review: `delete_at_path_through_absent`'s own synthetic
+        // scratch value must never be eligible for this fix's vivify --
+        // its whole contract is "the container is untouched," so a missing
+        // field must never *become* a real array just because the walk
+        // through it happened to reach an Index/Iterate step. Confirmed
+        // live: `{} | del(.missing[-1])` is `{}`, not the `-1`-out-of-range
+        // error a vivified-then-negative-indexed scratch would raise
+        // (negative indices are checked *before* the vivify's own
+        // out-of-range resolution, so this specifically pins that the
+        // negative-index check itself never fires against the scratch).
+        yq_query!(br"{}", r"del(.missing[-1])",
+            QueryResult::Owned(OwnedValue::Object(obj)) => {
+                assert!(obj.is_empty(), "expected {{}}, got {obj:?}");
+            }
+        );
+        yq_query!(br"{}", r"del(.missing[2])",
+            QueryResult::Owned(OwnedValue::Object(obj)) => {
+                assert!(obj.is_empty(), "expected {{}}, got {obj:?}");
+            }
+        );
+    }
+
+    #[test]
+    fn test_del_field_tolerated_null_disables_vivify_for_later_index_yq_mode_2323() {
+        // #2323 review: the vivify rule tracks *provenance*, not just
+        // "is root currently null" -- a `null` reached by *tolerating* a
+        // `Field`/`Slice` step against it (#476/#527's established
+        // null-exemption) is not vivify-eligible for whatever comes next,
+        // even when that `null` sits in an otherwise-real, already-padded
+        // array slot. Confirmed live: `[1,2] | del(.[5].missing[2])` is
+        // `[1,2,null,null,null,null]` -- `.[5]` itself is a real #2314-padded
+        // slot (vivify-eligible), but `.missing` tolerates that slot's
+        // `null` (#476, not a real key lookup), which disables the `[2]`
+        // step's own vivify -- unlike `[1,2] | del(.[5][2])` (no `Field` in
+        // between), which *does* vivify (covered by the chained test
+        // above). The negative-index sibling shares the same fix (the
+        // negative-index check would otherwise fire against a wrongly
+        // vivified array).
+        yq_query!(br"[1,2]", r"del(.[5].missing[2])",
+            QueryResult::Owned(OwnedValue::Array(arr)) => {
+                assert_eq!(
+                    arr,
+                    vec![
+                        OwnedValue::Int(1), OwnedValue::Int(2),
+                        OwnedValue::Null, OwnedValue::Null, OwnedValue::Null, OwnedValue::Null,
+                    ]
+                );
+            }
+        );
+        yq_query!(br"[1,2]", r"del(.[5].missing[-1])",
+            QueryResult::Owned(OwnedValue::Array(arr)) => {
+                assert_eq!(
+                    arr,
+                    vec![
+                        OwnedValue::Int(1), OwnedValue::Int(2),
+                        OwnedValue::Null, OwnedValue::Null, OwnedValue::Null, OwnedValue::Null,
+                    ]
+                );
+            }
+        );
+        // A bare `null | del(.a[2])` is the same shape without any padding
+        // noise -- `.a` tolerates the top-level `null`, disabling `[2]`'s
+        // own vivify.
+        yq_query!(br"null", r"del(.a[2])",
+            QueryResult::Owned(OwnedValue::Null) => {}
+        );
+    }
+
+    #[test]
+    fn test_del_comma_grouped_multi_terminal_key_stays_no_op_yq_mode_2323() {
+        // #2323 review: `delete_keys`'s own #2305/#2306 gate only extends a
+        // *single*-key batch (real yq's own multi-key extension is
+        // order-dependent, not replicable by this function's one-pass
+        // `retain` model -- #2306's own documented, deliberately deferred
+        // scope). Vivifying the comma-grouped trie's source unconditionally
+        // would trade the *pre-existing* "stays null" gap for a *new*,
+        // undocumented "vivifies to `[]` but the batch never actually
+        // extends" gap instead -- this pins that the fix stays at the
+        // pre-existing (not new) shape when 2+ terminal indices share one
+        // node. Confirmed live, order-independent: real yq answers
+        // `[null,null]` here (its own actual multi-key algorithm, #2306's
+        // scope, not replicated by this fix), and both `succinctly` orderings
+        // agree with each other even though neither matches real yq yet.
+        yq_query!(br"null", r"del(.[2],.[3])",
+            QueryResult::Owned(OwnedValue::Null) => {}
+        );
+        yq_query!(br"null", r"del(.[3],.[2])",
+            QueryResult::Owned(OwnedValue::Null) => {}
+        );
+        // One terminal index alongside one *continuation* at the same node
+        // is a different shape -- not 2+ terminal keys sharing a
+        // `delete_keys` batch -- and already vivifies correctly either way.
+        yq_query!(br"null", r"del(.[2], .[3].a)",
+            QueryResult::Owned(OwnedValue::Array(arr)) => {
+                assert_eq!(arr, vec![OwnedValue::Null, OwnedValue::Null, OwnedValue::Null]);
+            }
+        );
+    }
+
+    #[test]
     fn test_del_through_a_missing_field_walks_the_rest_against_null() {
         // #527: a field the object doesn't have reads as `null`, and jq keeps
         // walking the rest of the path against that `null` rather than
@@ -73320,7 +73516,7 @@ mod tests {
         #[test]
         fn test_delete_at_path_refuses_an_unresolved_key() {
             let mut root = OwnedValue::Null;
-            let err = delete_at_path(&mut root, &unresolved(), false, false).unwrap_err();
+            let err = delete_at_path(&mut root, &unresolved(), false, false, true).unwrap_err();
             assert_eq!(
                 err.message,
                 "internal error: unresolved computed index in delete path"
@@ -73437,7 +73633,7 @@ mod tests {
         #[test]
         fn test_delete_at_path_refuses_an_unresolved_slice() {
             let mut root = OwnedValue::Null;
-            let err = delete_at_path(&mut root, &unresolved(), false, false).unwrap_err();
+            let err = delete_at_path(&mut root, &unresolved(), false, false, true).unwrap_err();
             assert_eq!(
                 err.message,
                 "internal error: unresolved computed slice in delete path"

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -37098,10 +37098,25 @@ fn delete_trie_array(
     yq_mode: bool,
 ) -> Result<OwnedValue, EvalError> {
     let node = trie.node(id);
-    // Same per-step `null` exemption as `delete_trie_object` — applies to a
-    // bare index and a slice component alike (#476), and likewise covers only
-    // this step (#527).
-    if matches!(value, OwnedValue::Null) {
+    // #2323: real yq auto-vivifies a `null` root into `[]` ahead of an
+    // array-level step here too, the comma-grouped sibling of
+    // `delete_path_steps`'s own `Expr::Index`/`Expr::Iterate` arms --
+    // confirmed live, `{"x":null,"y":1} | del(.x[2], .y)` is
+    // `{"x":[null,null]}` (`.y` still deletes independently either way).
+    // Vivifying unconditionally rather than only for an `ArrayStep::Index`
+    // node is safe for a `Slice`-only node too: a slice range against a
+    // freshly empty array is itself already a harmless no-op (confirmed
+    // live against a mixed `del(.x[2], .x[0:1], .y)` node), so there is no
+    // need to distinguish which step kind triggered the vivify. jq has no
+    // such rule, so this is yq-mode only, matching every other arm of this
+    // fix -- jq mode falls through to the pre-existing `null`-tolerant
+    // walk-through-absent behavior unchanged.
+    if yq_mode && matches!(value, OwnedValue::Null) {
+        value = OwnedValue::Array(Vec::new());
+    } else if matches!(value, OwnedValue::Null) {
+        // Same per-step `null` exemption as `delete_trie_object` — applies
+        // to a bare index and a slice component alike (#476), and likewise
+        // covers only this step (#527).
         for &slot in &node.index_groups {
             let (_, &child) = node
                 .indices
@@ -37633,52 +37648,76 @@ fn delete_at_path(
                 name,
             )),
         },
-        Expr::Index { idx, .. } => match root {
-            OwnedValue::Array(arr) => {
-                let key = OwnedValue::Int(*idx);
-                // #2268: real yq raises on a negative index whose magnitude
-                // still exceeds the array length after resolving against it
-                // -- checked before the resolution match below, which
-                // still applies to jq mode and to yq's own ordinary
-                // positive-out-of-range case (#477).
-                if let Some(err) = yq_negative_index_error_for_len(yq_mode, &key, arr.len()) {
-                    return Err(err);
-                }
-                // #2305: a positive out-of-range index needs its own,
-                // different treatment (extend, not raise) -- see
-                // `DeleteIndexResolution`'s own doc comment for the
-                // confirmed live boundary. jq has no such rule, so the
-                // extension is yq-mode only; jq mode falls through to the
-                // existing no-op below (`Skip` here only ever means NaN,
-                // since a real negative-OOB index already raised above,
-                // when it was going to).
-                match resolve_delete_index(&key, arr.len()) {
-                    DeleteIndexResolution::InRange(actual_idx) => {
-                        arr.remove(actual_idx);
-                    }
-                    DeleteIndexResolution::PositiveOutOfRange(target_len) if yq_mode => {
-                        extend_array_with_nulls_for_delete(arr, target_len)?;
-                    }
-                    // An out-of-range index names nothing to delete — jq's
-                    // delpaths silently skips it, `?` or not (#477).
-                    DeleteIndexResolution::PositiveOutOfRange(_) | DeleteIndexResolution::Skip => {}
-                }
-                Ok(())
+        Expr::Index { idx, .. } => {
+            // #2323: real yq vivifies a `null` root into `[]` ahead of an
+            // `Index`/`Iterate` step (confirmed live: `null | del(.[2])` is
+            // `[null,null]`, `?` included -- `null | del(.[2]?)` vivifies
+            // too) -- jq has no such rule (`null | del(.[2])` stays `null`
+            // in real jq), so this is yq-mode only, and runs unconditionally
+            // ahead of the match below rather than gating on `optional` the
+            // way the scalar-noop arms further down do. Once vivified, the
+            // existing `OwnedValue::Array` arm's own #2305/#2314 extension
+            // logic applies unchanged -- an empty array is just another
+            // array to resolve the index against.
+            if yq_mode && matches!(root, OwnedValue::Null) {
+                *root = OwnedValue::Array(Vec::new());
             }
-            // `null` has no elements at any index, so this is always a
-            // no-op — `null | del(.[0])` is `null` (#476).
-            OwnedValue::Null => Ok(()),
-            _ if optional => Ok(()),
-            // #2106: same scalar no-op as the `Field` arm above, for an
-            // index key (`2.5 | del(.[0])` stays `2.5` in real yq).
-            _ if yq_mode && is_yq_field_index_noop_scalar(root) => Ok(()),
-            _ => Err(EvalError::cannot_index_with_type(
-                owned_type_name(root),
-                "number",
-            )),
-        },
+            match root {
+                OwnedValue::Array(arr) => {
+                    let key = OwnedValue::Int(*idx);
+                    // #2268: real yq raises on a negative index whose magnitude
+                    // still exceeds the array length after resolving against it
+                    // -- checked before the resolution match below, which
+                    // still applies to jq mode and to yq's own ordinary
+                    // positive-out-of-range case (#477).
+                    if let Some(err) = yq_negative_index_error_for_len(yq_mode, &key, arr.len()) {
+                        return Err(err);
+                    }
+                    // #2305: a positive out-of-range index needs its own,
+                    // different treatment (extend, not raise) -- see
+                    // `DeleteIndexResolution`'s own doc comment for the
+                    // confirmed live boundary. jq has no such rule, so the
+                    // extension is yq-mode only; jq mode falls through to the
+                    // existing no-op below (`Skip` here only ever means NaN,
+                    // since a real negative-OOB index already raised above,
+                    // when it was going to).
+                    match resolve_delete_index(&key, arr.len()) {
+                        DeleteIndexResolution::InRange(actual_idx) => {
+                            arr.remove(actual_idx);
+                        }
+                        DeleteIndexResolution::PositiveOutOfRange(target_len) if yq_mode => {
+                            extend_array_with_nulls_for_delete(arr, target_len)?;
+                        }
+                        // An out-of-range index names nothing to delete — jq's
+                        // delpaths silently skips it, `?` or not (#477).
+                        DeleteIndexResolution::PositiveOutOfRange(_)
+                        | DeleteIndexResolution::Skip => {}
+                    }
+                    Ok(())
+                }
+                // Only reachable in jq mode now (yq mode vivified above) —
+                // `null` has no elements at any index, so this is a no-op —
+                // `null | del(.[0])` is `null` (#476).
+                OwnedValue::Null => Ok(()),
+                _ if optional => Ok(()),
+                // #2106: same scalar no-op as the `Field` arm above, for an
+                // index key (`2.5 | del(.[0])` stays `2.5` in real yq).
+                _ if yq_mode && is_yq_field_index_noop_scalar(root) => Ok(()),
+                _ => Err(EvalError::cannot_index_with_type(
+                    owned_type_name(root),
+                    "number",
+                )),
+            }
+        }
         Expr::Iterate => {
-            // del(.[]) removes all elements
+            // del(.[]) removes all elements. #2323: same yq-mode null-vivify
+            // as the `Index` arm above -- `null | del(.[])` is `[]` in real
+            // yq, not an error, so vivifying first and falling into the
+            // `Array` arm below (clearing an already-empty array is itself
+            // a no-op) produces exactly that.
+            if yq_mode && matches!(root, OwnedValue::Null) {
+                *root = OwnedValue::Array(Vec::new());
+            }
             match root {
                 OwnedValue::Array(arr) => {
                     arr.clear();
@@ -37959,20 +37998,13 @@ fn delete_path_steps(
                         // del(.[5].a)` is `[1,2,null,null,null,null]`.
                         DeleteIndexResolution::PositiveOutOfRange(index) if yq_mode => {
                             pad_with_nulls(arr, index)?;
-                            // The freshly padded slot is `null`, which
-                            // `.[]` never tolerates (#527) -- but real yq
-                            // auto-vivifies it to `[]` instead when `.[]`
-                            // is the very next step, the same way
-                            // `setpath` auto-vivifies a `null` into
-                            // whatever container its own next step needs.
-                            // Confirmed live: `[1,2] | del(.[5][])` is
-                            // `[1,2,null,null,null,[]]`, not an error.
-                            if matches!(
-                                rest.first().map(|s| unwrap_path_component(s).0),
-                                Some(Expr::Iterate)
-                            ) {
-                                arr[index] = OwnedValue::Array(Vec::new());
-                            }
+                            // The freshly padded slot is `null`; whatever
+                            // `rest` does with it next (including `.[]`
+                            // vivifying it to `[]`, #2323) is handled
+                            // generically by this same loop's own
+                            // `OwnedValue::Null` arms below, once it
+                            // re-matches on the next iteration -- no need
+                            // to special-case the next component here.
                             root = &mut arr[index];
                             steps = rest;
                             continue;
@@ -37988,10 +38020,26 @@ fn delete_path_steps(
                         }
                     }
                 }
+                // #2323: real yq auto-vivifies a `null` reached mid-chain
+                // into `[]` ahead of an `Index` step and re-resolves the
+                // same index against it — the mid-chain sibling of
+                // `delete_at_path`'s own terminal `Index`/`Iterate` arms.
+                // `*root` is mutated and the loop re-enters with `steps`
+                // unchanged, so the very same `component` re-matches
+                // against the freshly vivified array on the next pass —
+                // recursively, so a further out-of-range index chained onto
+                // this one (`[1,2] | del(.[3][2].a)`) extends correctly at
+                // each level: confirmed live, `[1,2,null,[null,null,null]]`,
+                // not `[1,2,null,null]`. jq has no such rule at all, so this
+                // is yq-mode only — jq keeps the plain "null | del(.[0].a)
+                // is a no-op" reading (#476).
+                OwnedValue::Null if yq_mode => {
+                    *root = OwnedValue::Array(Vec::new());
+                    continue;
+                }
                 // Same per-step `null` exemption as the `Field` case above —
-                // `null | del(.[0].a)` is a no-op (#476), `null |
-                // del(.[0][])` still raises (#527) -- loops in place for the
-                // same reason.
+                // `null | del(.[0].a)` is a no-op (#476) -- loops in place
+                // for the same reason.
                 OwnedValue::Null => {
                     steps = rest;
                     continue;
@@ -38008,6 +38056,20 @@ fn delete_path_steps(
                 }
             },
             Expr::Iterate => {
+                // #2323: same yq-mode null-vivify as the `Index` arm above
+                // — real yq auto-vivifies a mid-chain `null` into `[]`
+                // ahead of `.[]` rather than raising: confirmed live,
+                // `[1,2] | del(.[5][])` is `[1,2,null,null,null,[]]`, not
+                // "Cannot iterate over null". Falling into the `Array` arm
+                // below with a freshly empty array is itself a no-op (no
+                // elements to iterate), which is exactly the `[]` this
+                // produces. jq has no such rule (`null | del(.[])` still
+                // raises there), so this is gated to yq mode only, and runs
+                // ahead of the per-element re-classification below rather
+                // than through it.
+                if yq_mode && matches!(root, OwnedValue::Null) {
+                    *root = OwnedValue::Array(Vec::new());
+                }
                 // `rest` is turned into an `Expr::Pipe` at most once here
                 // (only in yq mode, only per `Iterate` occurrence, not per
                 // element) for `yq_del_slice_outcome`'s own `&Expr` signature
@@ -69152,6 +69214,174 @@ mod tests {
         query!(br"[1,2]", r#"delpaths([[5,"a"]])"#,
             QueryResult::Owned(OwnedValue::Array(arr)) => {
                 assert_eq!(arr, vec![OwnedValue::Int(1), OwnedValue::Int(2)]);
+            }
+        );
+    }
+
+    #[test]
+    fn test_del_bare_null_index_vivifies_to_array_yq_mode_2323() {
+        // #2323: real yq vivifies a `null` root into `[]` ahead of an
+        // `Index`/`Iterate` step -- broader than #2314's own "a slot this
+        // fix just padded" case, and predates it: no out-of-range array
+        // extension is involved here at all, just a bare `null` document.
+        // Confirmed live: `null | del(.[2])` is `[null,null]`.
+        yq_query!(br"null", r"del(.[2])",
+            QueryResult::Owned(OwnedValue::Array(arr)) => {
+                assert_eq!(arr, vec![OwnedValue::Null, OwnedValue::Null]);
+            }
+        );
+        // `null | del(.[])` is `[]`, not "Cannot iterate over null" --
+        // vivifying first and then clearing an already-empty array is a
+        // no-op that lands on exactly the right answer.
+        yq_query!(br"null", r"del(.[])",
+            QueryResult::Owned(OwnedValue::Array(arr)) => {
+                assert!(arr.is_empty(), "expected [], got {arr:?}");
+            }
+        );
+        // `?` does not suppress the vivify -- confirmed live,
+        // `null | del(.[2]?)` is still `[null,null]`.
+        yq_query!(br"null", r"del(.[2]?)",
+            QueryResult::Owned(OwnedValue::Array(arr)) => {
+                assert_eq!(arr, vec![OwnedValue::Null, OwnedValue::Null]);
+            }
+        );
+        // jq has no such rule at all -- both stay exactly as jq's existing
+        // established behavior (#476 no-op for Index, raise for Iterate).
+        query!(br"null", r"del(.[2])",
+            QueryResult::Owned(OwnedValue::Null) => {}
+        );
+        query!(br"null", r"del(.[])",
+            QueryResult::Error(e) => {
+                assert!(e.message.contains("Cannot iterate over null"), "message: {}", e.message);
+            }
+        );
+    }
+
+    #[test]
+    fn test_del_field_reached_null_index_vivifies_to_array_yq_mode_2323() {
+        // #2323: the same vivify rule applies to a `null` reached through a
+        // `Field` step first, not just a bare document -- confirmed live,
+        // `{"x":null} | del(.x[2])` is `{"x":[null,null]}`, and
+        // `{"x":null} | del(.x[])` is `{"x":[]}`.
+        yq_query!(br#"{"x":null}"#, r"del(.x[2])",
+            QueryResult::Owned(OwnedValue::Object(obj)) => {
+                let Some(OwnedValue::Array(arr)) = obj.get("x") else {
+                    panic!("expected x to be an array, got {obj:?}");
+                };
+                assert_eq!(arr, &vec![OwnedValue::Null, OwnedValue::Null]);
+            }
+        );
+        yq_query!(br#"{"x":null}"#, r"del(.x[])",
+            QueryResult::Owned(OwnedValue::Object(obj)) => {
+                let Some(OwnedValue::Array(arr)) = obj.get("x") else {
+                    panic!("expected x to be an array, got {obj:?}");
+                };
+                assert!(arr.is_empty(), "expected [], got {arr:?}");
+            }
+        );
+        // A `Field` step itself never vivifies, unlike `Index`/`Iterate` --
+        // confirmed live, `{"x":null} | del(.x.a)` stays `{"x":null}`.
+        yq_query!(br#"{"x":null}"#, r"del(.x.a)",
+            QueryResult::Owned(OwnedValue::Object(obj)) => {
+                assert_eq!(obj.get("x"), Some(&OwnedValue::Null));
+            }
+        );
+        // Nor does a `Slice` step -- confirmed live, `null | del(.[0:2])`
+        // stays `null` in both jq and yq.
+        yq_query!(br"null", r"del(.[0:2])",
+            QueryResult::Owned(OwnedValue::Null) => {}
+        );
+    }
+
+    #[test]
+    fn test_del_chained_out_of_range_index_vivifies_recursively_yq_mode_2323() {
+        // #2323: the vivify rule applies at every level of a chain, not
+        // just the first -- once `.[3]` pads `[1,2]` out to a `null` at
+        // index 3, `.[2]` immediately after it must *also* vivify that
+        // fresh `null` into `[]` (and pad it) rather than stopping, the way
+        // #2314's own narrower fix would have. Confirmed live:
+        // `[1,2] | del(.[3][2].a)` is `[1,2,null,[null,null,null]]`.
+        yq_query!(br"[1,2]", r"del(.[3][2].a)",
+            QueryResult::Owned(OwnedValue::Array(arr)) => {
+                assert_eq!(arr.len(), 4);
+                assert_eq!(arr[0], OwnedValue::Int(1));
+                assert_eq!(arr[1], OwnedValue::Int(2));
+                assert_eq!(arr[2], OwnedValue::Null);
+                let OwnedValue::Array(inner) = &arr[3] else {
+                    panic!("expected arr[3] to be an array, got {:?}", arr[3]);
+                };
+                assert_eq!(inner, &vec![OwnedValue::Null, OwnedValue::Null, OwnedValue::Null]);
+            }
+        );
+    }
+
+    #[test]
+    fn test_del_pipe_wrapped_iterate_through_padded_null_vivifies_yq_mode_2323() {
+        // #2323: `.[5] | (.[].a)` reduces to a literal `Expr::Iterate`
+        // against the padded `null` at index 5 once the existing
+        // `Expr::Pipe` splice logic runs -- so the same general
+        // `OwnedValue::Null` vivify arm this fix adds handles it without
+        // needing its own lookahead, unlike a narrower fix that only
+        // checked the very next literal component. Confirmed live:
+        // `[1,2] | del(.[5] | (.[].a))` is `[1,2,null,null,null,[]]`.
+        yq_query!(br"[1,2]", r"del(.[5] | (.[].a))",
+            QueryResult::Owned(OwnedValue::Array(arr)) => {
+                assert_eq!(
+                    arr,
+                    vec![
+                        OwnedValue::Int(1), OwnedValue::Int(2),
+                        OwnedValue::Null, OwnedValue::Null, OwnedValue::Null,
+                        OwnedValue::Array(vec![]),
+                    ]
+                );
+            }
+        );
+    }
+
+    #[test]
+    fn test_del_comma_grouped_null_index_vivifies_yq_mode_2323() {
+        // #2323: the comma-grouped trie walk (`delete_trie_array`) shares
+        // the same vivify rule as the single-target AST walk -- confirmed
+        // live, `{"x":null,"y":1} | del(.x[2], .y)` is `{"x":[null,null]}`,
+        // with `.y` still deleted independently either way.
+        yq_query!(br#"{"x":null,"y":1}"#, r"del(.x[2], .y)",
+            QueryResult::Owned(OwnedValue::Object(obj)) => {
+                assert!(!obj.contains_key("y"), "expected y deleted, got {obj:?}");
+                let Some(OwnedValue::Array(arr)) = obj.get("x") else {
+                    panic!("expected x to be an array, got {obj:?}");
+                };
+                assert_eq!(arr, &vec![OwnedValue::Null, OwnedValue::Null]);
+            }
+        );
+        // A `Slice`-only node vivifying is a no-op against the freshly
+        // empty array -- but real yq's own pre-existing chained-slice-drop
+        // rule (#1116/#1219) then removes the whole `x`/`y` pair anyway,
+        // an already-correct, unrelated-to-this-fix behavior pinned here
+        // only to confirm the vivify doesn't disturb it. Confirmed live:
+        // `{"x":null,"y":1} | del(.x[0:2], .y)` is `{}`.
+        yq_query!(br#"{"x":null,"y":1}"#, r"del(.x[0:2], .y)",
+            QueryResult::Owned(OwnedValue::Object(obj)) => {
+                assert!(obj.is_empty(), "expected {{}}, got {obj:?}");
+            }
+        );
+        // jq has no such rule -- unaffected either way.
+        query!(br#"{"x":null,"y":1}"#, r"del(.x[2], .y)",
+            QueryResult::Owned(OwnedValue::Object(obj)) => {
+                assert_eq!(obj.get("x"), Some(&OwnedValue::Null));
+                assert!(!obj.contains_key("y"));
+            }
+        );
+    }
+
+    #[test]
+    fn test_delpaths_null_index_stays_no_op_yq_mode_2323() {
+        // #2323's vivify rule is specific to `del()`'s own expression-based
+        // target -- `delpaths()`'s path-array form does not share it.
+        // Confirmed live: `{"x":null} | delpaths([["x",2]])` stays
+        // `{"x":null}`, unlike the equivalent `del(.x[2])` above.
+        yq_query!(br#"{"x":null}"#, r#"delpaths([["x",2]])"#,
+            QueryResult::Owned(OwnedValue::Object(obj)) => {
+                assert_eq!(obj.get("x"), Some(&OwnedValue::Null));
             }
         );
     }

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -21903,30 +21903,36 @@ fn test_yq_del_slice_outcome_iterate_prefix_real_container_1432() -> Result<()> 
 }
 
 /// #1432 (coverage, #1863): the same `navigate_read_only` `Iterate` arm's
-/// scalar-hit and `Null`/catch-all branches, reached via `del()`. Both are
-/// pinned as *known-divergent* -- pre-existing bugs unrelated to #1432's
-/// own fix (`navigate_read_only`'s match arms are byte-for-byte unchanged
-/// by that PR), found only while restoring this coverage, not something
-/// this PR fixes. Real yq applies the same #1181/#1232 "a scalar hit
-/// anywhere mid-chain permanently no-ops" rule `=`'s own write path (and
-/// `del()`'s slice-prefix handling elsewhere in this same file) already
-/// get right, and autovivifies `null` the same way `.a[].b = v` does --
-/// `del()`'s own `Iterate`-then-slice path does neither, raising instead.
-/// Live-verified against yq v4.53.3; reported as a follow-up on #1863.
+/// scalar-hit branch, reached via `del()`. Pinned as *known-divergent* -- a
+/// pre-existing bug unrelated to #1432's own fix (`navigate_read_only`'s
+/// match arms are byte-for-byte unchanged by that PR), found only while
+/// restoring this coverage, not something this PR fixes. Real yq applies
+/// the same #1181/#1232 "a scalar hit anywhere mid-chain permanently
+/// no-ops" rule `=`'s own write path (and `del()`'s slice-prefix handling
+/// elsewhere in this same file) already get right; `del()`'s own
+/// `Iterate`-then-slice path does not, raising instead. Live-verified
+/// against yq v4.53.3; reported as a follow-up on #1863.
+///
+/// The sibling `Null` case this test used to pin as equally divergent is
+/// fixed by #2323: `delete_path_steps`'s `Expr::Iterate` arm now vivifies a
+/// `null` root into `[]` in yq mode before matching, the same rule
+/// `delete_at_path`'s terminal arms and `setpath`'s own auto-vivify already
+/// apply -- `a: null | del(.a[].b[0:1])` is `{"a":[]}` now, matching real
+/// yq (an empty array has nothing to fan `.b[0:1]` into).
 #[test]
 fn test_yq_del_slice_outcome_iterate_prefix_scalar_and_null_1432() -> Result<()> {
-    // Scalar hit -- real yq no-ops; succinctly raises.
+    // Scalar hit -- real yq no-ops; succinctly raises. Still divergent,
+    // unaffected by #2323 (a scalar `5` is never a `null` to vivify).
     let (_out, err, code) =
         run_yq_stdin_with_stderr("del(.a[].b[0:1])", "a: 5\n", &["-o=json", "-I=0"])?;
     assert_ne!(code, 0);
     assert!(err.contains("Cannot iterate"), "err={err}");
 
-    // `Null` -- real yq autovivifies to `[]` (nothing to delete);
-    // succinctly raises.
-    let (_out, err, code) =
-        run_yq_stdin_with_stderr("del(.a[].b[0:1])", "a: null\n", &["-o=json", "-I=0"])?;
-    assert_ne!(code, 0);
-    assert!(err.contains("Cannot iterate"), "err={err}");
+    // `Null` -- real yq autovivifies to `[]` (nothing left to delete),
+    // confirmed live; #2323 closes this.
+    let (out, code) = run_yq_stdin("del(.a[].b[0:1])", "a: null\n", &["-o=json", "-I=0"])?;
+    assert_eq!(code, 0);
+    assert_eq!(out.trim(), r#"{"a":[]}"#);
 
     Ok(())
 }


### PR DESCRIPTION
## Summary

Found during #2314's own review. Real yq's actual `null`-vivify rule for `del()` is broader than, and predates, #2314's own "extend a slot this fix just padded" case: **any** `null` a `del()` walk reaches auto-vivifies into `[]` the moment the next step is `Index` or `Iterate` — the same auto-vivify philosophy `=`/`|=`'s own write path already applies (there's existing precedent: `test_yq_iterate_pipe_chain_null_autovivifies_under_update_assign_1919`).

```console
$ echo 'null' | yq -o=json 'del(.[2])'          # [null, null] -- no out-of-range extension involved at all
$ echo 'null' | yq -o=json 'del(.[])'           # []
$ echo '{"x":null}' | yq -o=json 'del(.x[2])'   # {"x": [null, null]}
$ echo '[1,2]' | yq -o=json 'del(.[3][2].a)'    # [1, 2, null, [null, null, null]] -- recurses at each level
```

## What changed

Implemented in three places, all `src/jq/eval.rs`:
- `delete_at_path`'s `Index`/`Iterate` arms (the terminal, single-component form) — vivify `null` to `Array(Vec::new())` right before the existing container-handling match, so the existing array logic (including #2305/#2314's own extension) runs unchanged.
- `delete_path_steps`'s `Index`/`Iterate` arms (the mid-chain AST walk) — same idea, but implemented as `*root = Array(vec![]); continue;` *without* advancing `steps`, so the very same path component re-matches against the freshly vivified array on the next loop pass. This is what makes a **chained** out-of-range index (`del(.[3][2].a)`) recurse correctly for free — no explicit recursion or lookahead needed.
- `delete_trie_array`'s null-skip branch (the comma-grouped multi-target walk) — same vivify, gated to when the step is array-level (`delete_trie_object`'s own sibling branch, for `Field` steps, is untouched — `Field` never vivifies).

**Scope, all confirmed live:**
- Does **not** apply to `Field` steps or `Slice` steps (both stay `null`, matching jq and matching `=`/`|='s own precedent).
- Does **not** apply to `delpaths()` at all (`{"x":null} | delpaths([["x",2]])` stays `{"x":null}` — the rule is specific to `del()`'s expression-based target).
- `?` does not suppress the vivify.
- A `Pipe`-wrapped continuation (`del(.[5] | (.[].a))`) is covered for free — it reduces to a literal `Expr::Iterate` against the padded `null` once the existing `Expr::Pipe` splice logic runs.
- jq mode is entirely unaffected (no such rule exists in jq at all).

One surprising, **already-correct, pre-existing and unrelated** oddity surfaced while checking the comma-grouped case, worth flagging rather than silently working around: `{"x":null,"y":1} | del(.x[0:2], .y)` is `{}` in real yq — not just `x` cleared, `y` gone too. `succinctly yq` already reproduces this identically both before and after this fix, via the pre-existing #1116/#1219 chained-slice-parent-drop rule elsewhere in the same trie walk. Verified this fix's own vivify doesn't disturb it.

## A pre-existing test's premise didn't survive this

`test_yq_del_slice_outcome_iterate_prefix_scalar_and_null_1432` had pinned the `Null` case as *known-divergent* (a documented gap from #1863). Updated its expected result to the correct, now-matching output; the test's *other* half (a genuine scalar hit, e.g. `a: 5`) is a different, still-open gap, unaffected by this fix, and stays as-is.

## Not in scope (tracked separately)

#2324's own gap — a comma-grouped target whose `.[]` fan-out crosses an out-of-range index (`del(.[5][], .[0])`) — is unrelated: that one fails earlier, in the read-based validation that builds the trie in the first place, before `delete_trie_array` is ever reached. This PR doesn't touch that path.

## Test plan
- [x] `cargo test --features cli,simd,regex,serde` — full suite green (found and corrected one stale pre-existing test)
- [x] `cargo test` (default features) — green
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] `cargo build --no-default-features --features portable-popcount` (no_std) — clean
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features` — clean
- [x] Live-verified every repro shape (bare null, field-reached null, chained/recursive, pipe-wrapped, comma-grouped, the Slice-only and mixed comma-grouped cases) against `yq` v4.53.3, byte-for-byte match
- [x] Confirmed jq mode and `delpaths()` are both unaffected

Fixes #2323