### PR TITLE
fix(jq): more optional-ignored materialization sites (#2327)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -289,27 +289,54 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- **Six more sites ignored `optional`, continuing the #2231/#2280 lineage** (#2327,
+- **17 more sites ignored `optional`, continuing the #2231/#2280 lineage** (#2327,
   follow-up from #2280's own code review): `eval.rs`'s `builtin_del` (its own doc comment
   already promised "any resulting error is caught right here, turning the whole call's
   output into empty when `optional` is set" — the code wasn't honoring it for this
-  particular materialization), `builtin_envvar`, `builtin_transpose`,
-  `builtin_group_by`/`unique_by`/`sort_by`'s shared per-item conversion, and
-  `builtin_halt_error`, plus `eval_generic.rs`'s `Reverse`/`Sort`/`SortBy`/`Unique`/
-  `UniqueBy`/`Min`/`MinBy`/`Max`/`MaxBy` family (`collect_cursors_checked`). All now route
-  through `to_owned_or_suppress!`/`owned_or_suppress!`/`suppress_or_raise` instead of a
-  bare match, matching every site had a genuinely live `optional` consulted elsewhere in
-  the same function — verified per-site before fixing, to rule out the false positives
-  that pattern otherwise produces.
+  particular materialization), `builtin_transpose`, `builtin_group_by`/`unique_by`/
+  `sort_by`'s shared per-item conversion, `builtin_halt_error`, `builtin_min`/`max`/
+  `min_by`/`max_by`, `builtin_reverse`/`unique`/`sort`, `builtin_flatten`, plus
+  `eval_generic.rs`'s `Reverse`/`Sort`/`SortBy`/`Unique`/`UniqueBy`/`Min`/`MinBy`/`Max`/
+  `MaxBy` family (`collect_cursors_checked`) and its `bridge_to_full_evaluator`/`_flow`
+  (the shared reindex-bridge helper several of those same arms fall back to). All now
+  route through `to_owned_or_suppress!`/`to_owned_vec_or_suppress!`/`owned_or_suppress!`/
+  `suppress_or_raise` instead of a bare match, matching every site had a genuinely live
+  `optional` consulted elsewhere in the same function.
 
-  Same defensive character as #2280's own sites: every error path these materializations
-  can produce (string decode failure, #1194 malformed member/delimiter/element-gap) is
-  `is_decode_failure()`-tagged since #2286, so `suppresses()` is unconditionally `false`
-  regardless of `optional` — verified live (`test_optional_ignored_sites_2327`,
-  `tests/jq_cli_tests.rs`) for all seven fixed shapes, including the `Reverse`/`Sort`/…
-  family's distinct trailing-comma error class (`[1,2,3,]`, matching
-  `test_jq_collect_cursors_checked_sibling_paths_reject_trailing_comma_2261`'s own
-  fixture).
+  **A first round of this fix (7 builtins) shipped with a test that didn't prove what it
+  claimed.** Code review found `test_optional_ignored_sites_2327`'s use of a whole-document
+  decode failure (`\ud800`) passed for `del`/`transpose`/`group_by`/`halt_error`/
+  `sort_by`/`unique_by` for the wrong reason: `eval_generic.rs` is the CLI's real entry
+  point (`jq_runner.rs`/`yq_runner.rs` never call `eval.rs`'s `eval()` directly), and every
+  one of these `eval.rs` functions is reached from there only through a reindex-bridge
+  mechanism (`eval_builtin`'s `_` catch-all arm, or `bridge_to_full_evaluator`/a native
+  arm's own inlined equivalent) that calls `to_owned_with_cursor` on the *whole* document
+  **before** ever reaching `eval.rs` — so a real decode failure always raises at the
+  bridge, never at the site this PR fixed. Confirmed for `builtin_del` with temporary
+  debug instrumentation (added and removed during review): its fixed line simply never
+  runs for a `\ud800` document. The same review round also found `builtin_envvar` is a
+  step further — unreachable through any parsed CLI syntax *at all* (`env.VAR` resolves
+  through a different code path entirely), a fact this codebase already documented before
+  this PR (`test_builtin_envvar_raises_on_decode_failure_1820`'s own comment) — so its fix
+  is dropped from CLI-level test claims entirely and exercised only by that pre-existing
+  unit test.
+
+  The review round also found 8 more sibling functions with the identical unfixed
+  asymmetry (`builtin_min`/`max`/`min_by`/`max_by`/`reverse`/`unique`/`sort`/`flatten`,
+  all `eval.rs` — several of them the direct siblings of `eval_generic.rs` arms this PR's
+  first round *did* fix, a direct instance of this project's own documented "two separate
+  jq/yq evaluators" hazard) and one more shared bridge site
+  (`bridge_to_full_evaluator`/`_flow`) — all now fixed too.
+
+  Tests were restructured accordingly: `test_optional_ignored_sites_2327` now covers only
+  the `Reverse`/`Sort`/… family's own `collect_cursors_checked` fix, the one part of this
+  PR with genuine CLI-observable coverage (via the same trailing-comma fixture
+  `test_jq_collect_cursors_checked_sibling_paths_reject_trailing_comma_2261` established,
+  now also asserting the same `stderr` content that test does, not just the exit code). A
+  new `test_eval_rs_sites_produce_correct_output_2327` covers every `eval.rs`-only site
+  instead — proving the macro-swap refactor didn't change the success path's output, the
+  same honest scope `test_eval_rs_only_sites_still_correct_2280` already accepted for
+  `builtin_path`/`eval_format` in #2280.
 
   `eval.rs`'s `eval_array_construction` (#2327's own "plausible, higher-impact" candidate)
   was investigated and deliberately left unchanged: unlike the sites above, its own
@@ -322,6 +349,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   unlike the confirmed sites it isn't clearly *correcting an inconsistency the surrounding
   code already established* — so it was left alone rather than changed on pattern-match
   alone.
+
+  Roughly 58 more raw `to_owned`/`collect_cursors_checked` call sites remain unaudited in
+  `eval.rs`/`eval_generic.rs` after this PR — review flagged the recurring #2231→#2280→
+  #2327 pattern itself as the real problem (a sweep-and-patch cycle that keeps finding a
+  few more sites each time, with no mechanism stopping the next one from being missed the
+  same way), and a structural fix (CI/audit tooling, not another manual list) was filed
+  as #2334 rather than continuing the same cycle here.
 
 - **Five sites ignored `optional`, an asymmetry #2231 already fixed for
   `debug`/`stderr`/`tostring`/its catch-all fallback** (#2280, follow-up from #2231's own

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -289,6 +289,40 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Six more sites ignored `optional`, continuing the #2231/#2280 lineage** (#2327,
+  follow-up from #2280's own code review): `eval.rs`'s `builtin_del` (its own doc comment
+  already promised "any resulting error is caught right here, turning the whole call's
+  output into empty when `optional` is set" — the code wasn't honoring it for this
+  particular materialization), `builtin_envvar`, `builtin_transpose`,
+  `builtin_group_by`/`unique_by`/`sort_by`'s shared per-item conversion, and
+  `builtin_halt_error`, plus `eval_generic.rs`'s `Reverse`/`Sort`/`SortBy`/`Unique`/
+  `UniqueBy`/`Min`/`MinBy`/`Max`/`MaxBy` family (`collect_cursors_checked`). All now route
+  through `to_owned_or_suppress!`/`owned_or_suppress!`/`suppress_or_raise` instead of a
+  bare match, matching every site had a genuinely live `optional` consulted elsewhere in
+  the same function — verified per-site before fixing, to rule out the false positives
+  that pattern otherwise produces.
+
+  Same defensive character as #2280's own sites: every error path these materializations
+  can produce (string decode failure, #1194 malformed member/delimiter/element-gap) is
+  `is_decode_failure()`-tagged since #2286, so `suppresses()` is unconditionally `false`
+  regardless of `optional` — verified live (`test_optional_ignored_sites_2327`,
+  `tests/jq_cli_tests.rs`) for all seven fixed shapes, including the `Reverse`/`Sort`/…
+  family's distinct trailing-comma error class (`[1,2,3,]`, matching
+  `test_jq_collect_cursors_checked_sibling_paths_reject_trailing_comma_2261`'s own
+  fixture).
+
+  `eval.rs`'s `eval_array_construction` (#2327's own "plausible, higher-impact" candidate)
+  was investigated and deliberately left unchanged: unlike the sites above, its own
+  surrounding code has no local precedent of consulting `optional` to suppress *this*
+  function's own error — `optional` there is only ever forwarded into the inner
+  expression's evaluation, and the function's own comment states array construction is
+  atomic in jq ("a `Partial` inner stream just surfaces its control, same as a bare one"),
+  i.e. every error always propagates regardless of `optional`. Applying the same macro
+  swap here would still be a no-op today (same `is_decode_failure()` reasoning), but
+  unlike the confirmed sites it isn't clearly *correcting an inconsistency the surrounding
+  code already established* — so it was left alone rather than changed on pattern-match
+  alone.
+
 - **Five sites ignored `optional`, an asymmetry #2231 already fixed for
   `debug`/`stderr`/`tostring`/its catch-all fallback** (#2280, follow-up from #2231's own
   code review): `eval_generic.rs`'s `Expr::Format` arm (gating every `@format` builtin —

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -8345,12 +8345,11 @@ fn builtin_min<W: Clone + AsRef<[u64]>>(
         StandardJson::Array(elements) => {
             // #1755: to_owned, not to_owned_lossy -- an undecodable
             // string element must raise, not silently sort in as "".
-            let items: Result<Vec<OwnedValue>, EvalError> =
-                elements.map(|e| to_owned(&e)).collect();
-            let items = match items {
-                Ok(items) => items,
-                Err(e) => return QueryResult::Error(e),
-            };
+            // #2327: to_owned_vec_or_suppress!, not a bare match -- see
+            // `builtin_del`'s doc comment for the shared "consult optional
+            // like the sibling scalar arm below" reasoning and reachability
+            // caveat.
+            let items = to_owned_vec_or_suppress!(elements, optional);
             if items.is_empty() {
                 return QueryResult::Owned(OwnedValue::Null);
             }
@@ -8376,12 +8375,9 @@ fn builtin_max<W: Clone + AsRef<[u64]>>(
         StandardJson::Array(elements) => {
             // #1755: to_owned, not to_owned_lossy -- an undecodable
             // string element must raise, not silently sort in as "".
-            let items: Result<Vec<OwnedValue>, EvalError> =
-                elements.map(|e| to_owned(&e)).collect();
-            let items = match items {
-                Ok(items) => items,
-                Err(e) => return QueryResult::Error(e),
-            };
+            // #2327: to_owned_vec_or_suppress!, not a bare match -- see
+            // `builtin_min`'s sibling comment above.
+            let items = to_owned_vec_or_suppress!(elements, optional);
             if items.is_empty() {
                 return QueryResult::Owned(OwnedValue::Null);
             }
@@ -8497,13 +8493,15 @@ fn builtin_min_by<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
 
             // #1755: to_owned, not to_owned_lossy -- an undecodable
             // string result must raise, not silently return "".
+            // #2327: suppress_or_raise, not a bare match -- see
+            // `builtin_del`'s doc comment for the shared reasoning.
             let (_, v) = keyed
                 .into_iter()
                 .min_by(|(a, _), (b, _)| compare_values(a, b))
                 .unwrap();
             let min = match to_owned(&v) {
                 Ok(v) => v,
-                Err(e) => return QueryResult::Error(e),
+                Err(e) => return suppress_or_raise(e, optional),
             };
             QueryResult::Owned(min)
         }
@@ -8559,13 +8557,15 @@ fn builtin_max_by<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
 
             // #1755: to_owned, not to_owned_lossy -- an undecodable
             // string result must raise, not silently return "".
+            // #2327: suppress_or_raise, not a bare match -- see
+            // `builtin_min_by`'s sibling comment above.
             let (_, v) = keyed
                 .into_iter()
                 .max_by(|(a, _), (b, _)| compare_values(a, b))
                 .unwrap();
             let max = match to_owned(&v) {
                 Ok(v) => v,
-                Err(e) => return QueryResult::Error(e),
+                Err(e) => return suppress_or_raise(e, optional),
             };
             QueryResult::Owned(max)
         }
@@ -9551,13 +9551,10 @@ fn builtin_reverse<W: Clone + AsRef<[u64]>>(
     match value {
         // #1755: to_owned, not to_owned_lossy -- an undecodable element
         // must raise, not silently reverse in as "".
+        // #2327: to_owned_vec_or_suppress!, not a bare match -- see
+        // `builtin_del`'s doc comment for the shared reasoning.
         StandardJson::Array(elements) => {
-            let items: Result<Vec<OwnedValue>, EvalError> =
-                elements.map(|e| to_owned(&e)).collect();
-            let mut items = match items {
-                Ok(items) => items,
-                Err(e) => return QueryResult::Error(e),
-            };
+            let mut items = to_owned_vec_or_suppress!(elements, optional);
             items.reverse();
             QueryResult::Owned(OwnedValue::Array(items))
         }
@@ -9615,9 +9612,13 @@ fn builtin_flatten<W: Clone + AsRef<[u64]>, S: EvalSemantics>(
             });
         }
     };
+    // #2327: suppress_or_raise, not a bare match -- `optional` is
+    // genuinely consulted above (the yq-reject/scalar-fallback branches),
+    // so ignoring it here was the same asymmetry #2280/#2327's other sites
+    // fixed elsewhere.
     let items = match items {
         Ok(items) => items,
-        Err(e) => return QueryResult::Error(e),
+        Err(e) => return suppress_or_raise(e, optional),
     };
     let flattened = flatten_owned(items, depth);
     QueryResult::Owned(OwnedValue::Array(flattened))
@@ -9824,12 +9825,9 @@ fn builtin_unique<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
         StandardJson::Array(elements) => {
             // #1755: to_owned, not to_owned_lossy -- an undecodable
             // string element must raise, not silently sort in as "".
-            let items: Result<Vec<OwnedValue>, EvalError> =
-                elements.map(|e| to_owned(&e)).collect();
-            let mut items = match items {
-                Ok(items) => items,
-                Err(e) => return QueryResult::Error(e),
-            };
+            // #2327: to_owned_vec_or_suppress!, not a bare match -- see
+            // `builtin_del`'s doc comment for the shared reasoning.
+            let mut items = to_owned_vec_or_suppress!(elements, optional);
 
             // Sort first (jq's unique returns sorted unique values)
             items.sort_by(compare_values);
@@ -9962,12 +9960,9 @@ fn builtin_sort<W: Clone + AsRef<[u64]>>(
         StandardJson::Array(elements) => {
             // #1755: to_owned, not to_owned_lossy -- an undecodable
             // string element must raise, not silently sort in as "".
-            let items: Result<Vec<OwnedValue>, EvalError> =
-                elements.map(|e| to_owned(&e)).collect();
-            let mut items = match items {
-                Ok(items) => items,
-                Err(e) => return QueryResult::Error(e),
-            };
+            // #2327: to_owned_vec_or_suppress!, not a bare match -- see
+            // `builtin_del`'s doc comment for the shared reasoning.
+            let mut items = to_owned_vec_or_suppress!(elements, optional);
             items.sort_by(compare_values);
             QueryResult::Owned(OwnedValue::Array(items))
         }

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -9730,9 +9730,18 @@ fn builtin_group_by<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
                 };
                 // #1755: to_owned, not to_owned_lossy -- an undecodable
                 // string element must raise, not silently sort in as "".
+                //
+                // #2327: suppress_or_raise, not a bare `QueryResult::Error`
+                // -- `optional` is genuinely consulted elsewhere in this
+                // function (the non-array value-shape arms below), so
+                // ignoring it here was the same asymmetry #2280 fixed for
+                // Format/Path/GetPath. Defensive today, not a live behavior
+                // change: `to_owned`'s only error path is
+                // `is_decode_failure()`-tagged, which `suppress_or_raise`
+                // never suppresses regardless of `optional`.
                 let owned_item = match to_owned(&item) {
                     Ok(v) => v,
-                    Err(e) => return QueryResult::Error(e),
+                    Err(e) => return suppress_or_raise(e, optional),
                 };
                 keyed.push((key, owned_item));
             }
@@ -9894,9 +9903,18 @@ fn builtin_unique_by<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
                 };
                 // #1755: to_owned, not to_owned_lossy -- an undecodable
                 // string element must raise, not silently sort in as "".
+                //
+                // #2327: suppress_or_raise, not a bare `QueryResult::Error`
+                // -- `optional` is genuinely consulted elsewhere in this
+                // function (the non-array value-shape arms below), so
+                // ignoring it here was the same asymmetry #2280 fixed for
+                // Format/Path/GetPath. Defensive today, not a live behavior
+                // change: `to_owned`'s only error path is
+                // `is_decode_failure()`-tagged, which `suppress_or_raise`
+                // never suppresses regardless of `optional`.
                 let owned_item = match to_owned(&item) {
                     Ok(v) => v,
-                    Err(e) => return QueryResult::Error(e),
+                    Err(e) => return suppress_or_raise(e, optional),
                 };
                 keyed.push((key, owned_item));
             }
@@ -9989,9 +10007,18 @@ fn builtin_sort_by<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
                 };
                 // #1755: to_owned, not to_owned_lossy -- an undecodable
                 // string element must raise, not silently sort in as "".
+                //
+                // #2327: suppress_or_raise, not a bare `QueryResult::Error`
+                // -- `optional` is genuinely consulted elsewhere in this
+                // function (the non-array value-shape arms below), so
+                // ignoring it here was the same asymmetry #2280 fixed for
+                // Format/Path/GetPath. Defensive today, not a live behavior
+                // change: `to_owned`'s only error path is
+                // `is_decode_failure()`-tagged, which `suppress_or_raise`
+                // never suppresses regardless of `optional`.
                 let owned_item = match to_owned(&item) {
                     Ok(v) => v,
-                    Err(e) => return QueryResult::Error(e),
+                    Err(e) => return suppress_or_raise(e, optional),
                 };
                 keyed.push((key, owned_item));
             }
@@ -37409,12 +37436,11 @@ fn builtin_del<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     value: StandardJson<'a, W>,
     optional: bool,
 ) -> QueryResult<'a, W> {
-    // Convert to owned and delete the path
-    let result = match to_owned(&value) {
-        Ok(result) => result,
-        Err(e) => return QueryResult::Error(e),
-    };
-
+    // #2327: to_owned_or_suppress!, not a bare match -- this function's own
+    // comment below already promises "any resulting error is caught right
+    // here, turning the whole call's output into empty when `optional` is
+    // set", which this first materialization wasn't honoring.
+    //
     // `optional` here is `del(...)`'s *own* `?` (`del(.a)?`), i.e. jq's
     // `try del(.a) catch empty` around the whole call — not a per-step
     // tolerance. It must never reach the walkers below as their starting
@@ -37426,6 +37452,7 @@ fn builtin_del<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     // path (`del(.a?)`) is unaffected — it's already a distinct
     // `Expr::Optional` node baked into `path_expr`, which the walkers still
     // honor on their own.
+    let result = to_owned_or_suppress!(&value, optional);
 
     // yq's comma-grouped chained-slice del() pre-rewrite (#1223):
     // `resolve_dynamic_indexes`'s own generic navigation raises a hard type
@@ -42561,9 +42588,16 @@ fn builtin_halt_error<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     // #1755: to_owned, not to_owned_lossy -- an undecodable value must
     // raise a normal, catchable error rather than halting the process with
     // a corrupted "" message in its place.
+    //
+    // #2327: suppress_or_raise, not a bare `QueryResult::Error` -- `optional`
+    // is genuinely consulted earlier in this function (threaded into
+    // `each_take_first` for the code-expr), so ignoring it here was the same
+    // asymmetry #2280 fixed for Format/Path/GetPath. Defensive today: this
+    // materialization's only error path is `is_decode_failure()`-tagged,
+    // which is never suppressed regardless of `optional` either way.
     let owned = match to_owned(&value) {
         Ok(v) => v,
-        Err(e) => return QueryResult::Error(e),
+        Err(e) => return suppress_or_raise(e, optional),
     };
     match &owned {
         OwnedValue::Null => {}
@@ -42625,10 +42659,12 @@ fn builtin_envvar<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     // #1820: to_owned, not to_owned_lossy -- `value` (`.`, the binding
     // `var` is evaluated against) used to silently become `""` on an
     // undecodable string instead of raising.
-    let owned_value = match to_owned(&value) {
-        Ok(v) => v,
-        Err(e) => return QueryResult::Error(e),
-    };
+    //
+    // #2327: to_owned_or_suppress!, not a bare match -- `optional` is
+    // consulted twice below (the non-string-name fallback and the
+    // variable-not-set case), so ignoring it here was the same asymmetry
+    // #2280 fixed for Format/Path/GetPath.
+    let owned_value = to_owned_or_suppress!(&value, optional);
     let var_result = eval_owned_expr_ctrl_full::<S>(var, &owned_value, optional);
     let (var_name, trailing) = match var_result {
         Ok((OwnedValue::String(s), trailing)) => (s, trailing),
@@ -42790,17 +42826,22 @@ fn builtin_transpose<W: Clone + AsRef<[u64]>>(
     // Collect all inner arrays
     // #1755: to_owned, not to_owned_lossy -- an undecodable element must
     // raise, not silently become "" and take part in the transpose.
+    //
+    // #2327: suppress_or_raise, not a bare `QueryResult::Error(e)` -- the
+    // top-level non-array check above already consults `optional`, so
+    // ignoring it for these two element-level materializations was the same
+    // asymmetry #2280 fixed for Format/Path/GetPath.
     let mut inner_arrays: Vec<Vec<OwnedValue>> = Vec::new();
     for item in elements {
         match item {
             StandardJson::Array(inner) => match inner.map(|v| to_owned(&v)).collect() {
                 Ok(row) => inner_arrays.push(row),
-                Err(e) => return QueryResult::Error(e),
+                Err(e) => return suppress_or_raise(e, optional),
             },
             // Non-array elements are treated as single-element arrays
             _ => match to_owned(&item) {
                 Ok(owned) => inner_arrays.push(vec![owned]),
-                Err(e) => return QueryResult::Error(e),
+                Err(e) => return suppress_or_raise(e, optional),
             },
         }
     }

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -10787,7 +10787,15 @@ fn eval_builtin<S: EvalSemantics, V: DocumentValue>(
                 // the unchecked `collect_cursors` this arm used -- this
                 // walk already resolves every element's cursor to reverse
                 // them, so the #1677/#2261 gap checks ride along for free.
-                let mut cursors = owned_or_err!(elements.collect_cursors_checked());
+                //
+                // #2327: owned_or_suppress!, not owned_or_err! -- `optional`
+                // is consulted one arm below (the non-array fallback), so
+                // ignoring it here was the same asymmetry #2280 fixed for
+                // Format/Path/GetPath. Defensive today, not a live behavior
+                // change: `collect_cursors_checked`'s only error
+                // (`malformed_element_error`) is `is_decode_failure()`-tagged
+                // since #2286.
+                let mut cursors = owned_or_suppress!(elements.collect_cursors_checked(), optional);
                 cursors.reverse();
                 GenericResult::LazySeq(Box::new(LazySeq::from_cursors(cursors)))
             } else if optional {
@@ -10837,7 +10845,13 @@ fn eval_builtin<S: EvalSemantics, V: DocumentValue>(
             // these builtins already resolves each element's cursor to
             // sort/dedup them, so the #1677/#2261 gap checks ride along
             // for free.
-            let cursors = owned_or_err!(elements.collect_cursors_checked());
+            //
+            // #2327: owned_or_suppress!, not owned_or_err! -- `optional` is
+            // passed to `sort_family_array_generic` on the very next line,
+            // so ignoring it here was the same asymmetry #2280 fixed for
+            // Format/Path/GetPath. Defensive today (see `Reverse`'s sibling
+            // comment above for why).
+            let cursors = owned_or_suppress!(elements.collect_cursors_checked(), optional);
             sort_family_array_generic::<S, _>(cursors, key, optional, |mut keyed| {
                 sort_keyed_elements::<V>(&mut keyed);
                 if dedup {
@@ -10874,7 +10888,13 @@ fn eval_builtin<S: EvalSemantics, V: DocumentValue>(
             // these builtins already resolves each element's cursor to
             // compare them, so the #1677/#2261 gap checks ride along for
             // free.
-            let cursors = owned_or_err!(elements.collect_cursors_checked());
+            //
+            // #2327: owned_or_suppress!, not owned_or_err! -- `optional` is
+            // passed to `key_elements_generic` a few lines below, so
+            // ignoring it here was the same asymmetry #2280 fixed for
+            // Format/Path/GetPath. Defensive today (see `Reverse`'s sibling
+            // comment above for why).
+            let cursors = owned_or_suppress!(elements.collect_cursors_checked(), optional);
             // jq answers `null` for an empty array, for all four spellings.
             if cursors.is_empty() {
                 return GenericResult::Owned(OwnedValue::Null);

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -1917,11 +1917,21 @@ fn bridge_to_full_evaluator<S: EvalSemantics, V: DocumentValue>(
     cursor: Option<V::Cursor>,
     optional: bool,
 ) -> GenericResult<V> {
-    // Spelled as a `match` rather than `owned_or_err!`: this function sits
-    // above that macro's own definition point in the file, and `macro_rules!`
-    // is only in scope textually after it.
+    // Spelled as a `match` rather than `owned_or_suppress!`: this function
+    // sits above that macro's own definition point in the file, and
+    // `macro_rules!` is only in scope textually after it -- inlines the
+    // same `suppresses`-gated logic instead.
+    //
+    // #2327: consults `optional` via `suppresses`, not an unconditional
+    // `GenericResult::Error` -- `optional` is passed to `eval_on_owned` on
+    // the success arm right below, so ignoring it on the error arm was the
+    // same asymmetry #2280/#2327's other sites fixed elsewhere. Defensive
+    // today: `to_owned_with_cursor`'s only error paths are
+    // `is_decode_failure()`-tagged, never suppressed regardless of
+    // `optional`.
     match to_owned_with_cursor(&value, cursor) {
         Ok(owned) => eval_on_owned::<S, V>(expr, owned, optional),
+        Err(e) if suppresses(&e, optional) => GenericResult::None,
         Err(e) => GenericResult::Error(e),
     }
 }
@@ -1939,8 +1949,13 @@ fn bridge_to_full_evaluator_flow<S: EvalSemantics, V: DocumentValue>(
     optional: bool,
     sink: &mut dyn FnMut(GenericItem<V>) -> Demand,
 ) -> Flow {
+    // #2327: consults `optional` via `suppresses`, matching
+    // `bridge_to_full_evaluator`'s own sibling fix above -- a suppressed
+    // error produces zero items (the sink is never called), same as
+    // `GenericResult::None`'s sink-free semantics elsewhere in this file.
     match to_owned_with_cursor(&value, cursor) {
         Ok(owned) => drain_result_generic(eval_on_owned::<S, V>(expr, owned, optional), sink),
+        Err(e) if suppresses(&e, optional) => Flow::Exhausted,
         Err(e) => Flow::Escaped(Control::Error(e)),
     }
 }

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -29985,50 +29985,32 @@ fn test_eval_rs_only_sites_still_correct_2280() -> Result<()> {
     Ok(())
 }
 
-/// #2327: `builtin_del` (`eval.rs`), `builtin_envvar` (`eval.rs`),
-/// `builtin_transpose` (`eval.rs`), `builtin_group_by`/`unique_by`/`sort_by`'s
-/// own per-item conversion (`eval.rs`), and `builtin_halt_error` (`eval.rs`)
-/// all consulted `optional` for real now (routed through
-/// `to_owned_or_suppress!`/`suppress_or_raise` instead of a bare
-/// `to_owned`/`QueryResult::Error` match) -- following #2280's exact
+/// #2327: `eval_generic.rs`'s `Reverse`/`Sort`/`SortBy`/`Unique`/`UniqueBy`/
+/// `Min`/`MinBy`/`Max`/`MaxBy` family now consults `optional` for real
+/// (routed through `owned_or_suppress!` instead of `owned_or_err!`) on its
+/// own `collect_cursors_checked` materialization -- following #2280's exact
 /// precedent, itself following #2231's.
 ///
-/// `builtin_del`'s own case is the sharpest: its doc comment already
-/// promised this exact suppression ("any resulting error is caught right
-/// here, turning the whole call's output into empty when `optional` is
-/// set") without the code actually doing it.
+/// This is the one #2327 site with genuine CLI-level coverage: these are
+/// the arms `succinctly jq`'s default dispatch actually reaches for a plain
+/// array input (confirmed by `test_jq_collect_cursors_checked_sibling_
+/// paths_reject_trailing_comma_2261`'s own fixture, reused here with a
+/// trailing `?` added). Every *other* function this PR touches is fixed but
+/// not independently CLI-testable this way -- see
+/// `test_eval_rs_sites_produce_correct_output_2327`'s own doc comment for
+/// why, and why that matters.
 ///
-/// Pins that this is defensive, not a behavior change: a document-wide
-/// decode failure (`\ud800`) still raises -- uncatchable, per #2286 tagging
-/// every one of these materializations' error paths `is_decode_failure()`
-/// -- through a bare call and a trailing `?`.
+/// Pins that this is defensive, not a behavior change:
+/// `collect_cursors_checked`'s only error (a malformed element *gap* --
+/// trailing comma, not a value decode failure) is `is_decode_failure()`-
+/// tagged per #2286, so it still raises -- uncatchable -- through both a
+/// bare call and a trailing `?`. Asserts the same `stderr` content
+/// `test_jq_collect_cursors_checked_sibling_paths_reject_trailing_comma_2261`
+/// does, not just the exit code, so a future change to a *different*,
+/// non-decode-failure error class that happens to also exit 5 would still
+/// be caught here.
 #[test]
 fn test_optional_ignored_sites_2327() -> Result<()> {
-    for (filter, doc) in [
-        ("del(.d)", r#"{"a":"\ud800","d":5}"#),
-        ("env.HOME", r#"{"a":"\ud800"}"#),
-        ("transpose", r#"[[1,"\ud800"],[2,3]]"#),
-        ("group_by(.a)", r#"[{"a":1,"b":"\ud800"},{"a":2}]"#),
-        ("unique_by(.a)", r#"[{"a":1,"b":"\ud800"},{"a":2}]"#),
-        ("sort_by(.a)", r#"[{"a":1,"b":"\ud800"},{"a":2}]"#),
-        ("halt_error", r#"{"a":"\ud800"}"#),
-    ] {
-        for suffix in ["", "?"] {
-            let full_filter = format!("{filter}{suffix}");
-            let (stdout, stderr, code) = run_jq_stdin_streams(&full_filter, doc, &["-c"])?;
-            assert_eq!(
-                code, 5,
-                "{full_filter}: stdout {stdout:?} stderr {stderr:?}"
-            );
-            assert_eq!(stdout, "", "{full_filter}: stderr {stderr:?}");
-        }
-    }
-
-    // The `Reverse`/`Sort`/`SortBy`/`Unique`/`UniqueBy`/`Min`/`MinBy`/`Max`/
-    // `MaxBy` family's own `collect_cursors_checked` error class is a
-    // malformed element *gap* (trailing comma), not a value decode failure
-    // -- matching `test_jq_collect_cursors_checked_sibling_paths_reject_
-    // trailing_comma_2261`'s own fixture (`[1,2,3,]`).
     for filter in [
         "reverse",
         "sort",
@@ -30048,20 +30030,90 @@ fn test_optional_ignored_sites_2327() -> Result<()> {
                 "{full_filter}: stdout {stdout:?} stderr {stderr:?}"
             );
             assert_eq!(stdout, "", "{full_filter}: stderr {stderr:?}");
+            assert!(
+                stderr.contains("Invalid JSON text"),
+                "{full_filter}: stderr {stderr:?}"
+            );
         }
     }
+    Ok(())
+}
 
-    // Not a blanket rejection: the same builtins on a decodable document
-    // still succeed.
-    let (stdout, code) = run_jq_stdin("del(.a)", r#"{"a":1,"d":5}"#, &["-c"])?;
-    assert_eq!(code, 0);
-    assert_eq!(stdout.trim(), r#"{"d":5}"#);
-    let (stdout, code) = run_jq_stdin("transpose", "[[1,2],[3,4]]", &["-c"])?;
-    assert_eq!(code, 0);
-    assert_eq!(stdout.trim(), "[[1,3],[2,4]]");
-    let (stdout, code) = run_jq_stdin("group_by(.a)", r#"[{"a":1},{"a":2}]"#, &["-c"])?;
-    assert_eq!(code, 0);
-    assert_eq!(stdout.trim(), r#"[[{"a":1}],[{"a":2}]]"#);
+/// #2327's remaining fixed sites -- `builtin_del`, `builtin_transpose`,
+/// `builtin_group_by`/`unique_by`/`sort_by`'s per-item conversion,
+/// `builtin_halt_error`, `builtin_min`/`max`/`min_by`/`max_by`,
+/// `builtin_reverse`/`unique`/`sort`, `builtin_flatten` (all `eval.rs`), and
+/// `eval_generic.rs`'s `bridge_to_full_evaluator`/`_flow` -- have **no CLI
+/// path that can observe a live behavior difference**, discovered during
+/// this PR's own code review the same way #2280's round 1 was caught: a
+/// naive test using a whole-document decode failure (`\ud800`) passed for
+/// all of them, but for the wrong reason.
+///
+/// `eval_generic.rs`'s own dispatch is the CLI's real entry point
+/// (`jq_runner.rs`/`yq_runner.rs` never call `eval.rs`'s `eval()` directly).
+/// Every one of these `eval.rs` functions is reached from there only
+/// through a reindex-bridge mechanism -- the `eval_builtin` `_` catch-all
+/// arm (`del`/`transpose`/`group_by`/`halt_error`, which have no native
+/// `eval_generic.rs` arm at all), or `bridge_to_full_evaluator`/a native
+/// arm's own inlined equivalent (`min`/`max`/`min_by`/`max_by`/`reverse`/
+/// `unique`/`sort`/`sort_by`/`unique_by`, whose `eval_generic.rs` siblings
+/// already have a native arm and only bridge on non-array/non-cursor-safe
+/// input) -- and *every one* of those bridges calls `to_owned_with_cursor`
+/// on the *whole* value **before** ever re-entering `eval.rs`, exactly the
+/// same "already fully decoded once, cannot fail a second time" situation
+/// `builtin_path`'s own fix documents in `test_eval_rs_only_sites_still_
+/// correct_2280`. Confirmed for `builtin_del` specifically with temporary
+/// debug instrumentation during review (removed before this push): its
+/// fixed line never runs for a `\ud800` document, because the bridge's own
+/// (already-`#2231`-fixed) materialization raises first.
+///
+/// `builtin_envvar` is a step further: it is not merely bridge-intercepted,
+/// it is **unreachable through any parsed CLI syntax at all** --
+/// `env.VAR`/`$ENV.VAR` resolve through a different code path entirely, a
+/// fact this codebase already documented before this PR
+/// (`test_builtin_envvar_raises_on_decode_failure_1820`'s own comment). Not
+/// included below for that reason; its fix is exercised solely by that
+/// pre-existing direct-call unit test, unchanged by this PR.
+///
+/// So this test cannot pin a suppress-vs-raise difference for any of these
+/// sites, the same limitation `test_eval_rs_only_sites_still_correct_2280`
+/// already accepted for `builtin_path`/`eval_format`. What it pins instead:
+/// the macro-swap refactor didn't change the *success* path's output.
+#[test]
+fn test_eval_rs_sites_produce_correct_output_2327() -> Result<()> {
+    for (filter, doc, expected) in [
+        ("del(.a)", r#"{"a":1,"d":5}"#, r#"{"d":5}"#),
+        ("transpose", "[[1,2],[3,4]]", "[[1,3],[2,4]]"),
+        (
+            "group_by(.a)",
+            r#"[{"a":1},{"a":2}]"#,
+            r#"[[{"a":1}],[{"a":2}]]"#,
+        ),
+        ("unique_by(.a)", r#"[{"a":1},{"a":1}]"#, r#"[{"a":1}]"#),
+        (
+            "sort_by(.a)",
+            r#"[{"a":2},{"a":1}]"#,
+            r#"[{"a":1},{"a":2}]"#,
+        ),
+        ("min", "[3,1,2]", "1"),
+        ("max", "[3,1,2]", "3"),
+        ("min_by(.a)", r#"[{"a":3},{"a":1}]"#, r#"{"a":1}"#),
+        ("max_by(.a)", r#"[{"a":3},{"a":1}]"#, r#"{"a":3}"#),
+        ("reverse", "[1,2,3]", "[3,2,1]"),
+        ("unique", "[3,1,1,2]", "[1,2,3]"),
+        ("sort", "[3,1,2]", "[1,2,3]"),
+        ("flatten", "[[1,2],[3]]", "[1,2,3]"),
+    ] {
+        let (stdout, code) = run_jq_stdin(filter, doc, &["-c"])?;
+        assert_eq!(code, 0, "{filter}: doc {doc}");
+        assert_eq!(stdout.trim(), expected, "{filter}: doc {doc}");
+    }
+
+    // `halt_error` doesn't fit the table above (it writes to stderr and
+    // halts rather than returning a value) -- checked separately.
+    let (stdout, stderr, code) = run_jq_stdin_streams("halt_error", r#""boom""#, &["-c"])?;
+    assert_eq!(code, 5, "stdout {stdout:?} stderr {stderr:?}");
+    assert_eq!(stderr.trim(), "boom");
 
     Ok(())
 }

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -29985,6 +29985,87 @@ fn test_eval_rs_only_sites_still_correct_2280() -> Result<()> {
     Ok(())
 }
 
+/// #2327: `builtin_del` (`eval.rs`), `builtin_envvar` (`eval.rs`),
+/// `builtin_transpose` (`eval.rs`), `builtin_group_by`/`unique_by`/`sort_by`'s
+/// own per-item conversion (`eval.rs`), and `builtin_halt_error` (`eval.rs`)
+/// all consulted `optional` for real now (routed through
+/// `to_owned_or_suppress!`/`suppress_or_raise` instead of a bare
+/// `to_owned`/`QueryResult::Error` match) -- following #2280's exact
+/// precedent, itself following #2231's.
+///
+/// `builtin_del`'s own case is the sharpest: its doc comment already
+/// promised this exact suppression ("any resulting error is caught right
+/// here, turning the whole call's output into empty when `optional` is
+/// set") without the code actually doing it.
+///
+/// Pins that this is defensive, not a behavior change: a document-wide
+/// decode failure (`\ud800`) still raises -- uncatchable, per #2286 tagging
+/// every one of these materializations' error paths `is_decode_failure()`
+/// -- through a bare call and a trailing `?`.
+#[test]
+fn test_optional_ignored_sites_2327() -> Result<()> {
+    for (filter, doc) in [
+        ("del(.d)", r#"{"a":"\ud800","d":5}"#),
+        ("env.HOME", r#"{"a":"\ud800"}"#),
+        ("transpose", r#"[[1,"\ud800"],[2,3]]"#),
+        ("group_by(.a)", r#"[{"a":1,"b":"\ud800"},{"a":2}]"#),
+        ("unique_by(.a)", r#"[{"a":1,"b":"\ud800"},{"a":2}]"#),
+        ("sort_by(.a)", r#"[{"a":1,"b":"\ud800"},{"a":2}]"#),
+        ("halt_error", r#"{"a":"\ud800"}"#),
+    ] {
+        for suffix in ["", "?"] {
+            let full_filter = format!("{filter}{suffix}");
+            let (stdout, stderr, code) = run_jq_stdin_streams(&full_filter, doc, &["-c"])?;
+            assert_eq!(
+                code, 5,
+                "{full_filter}: stdout {stdout:?} stderr {stderr:?}"
+            );
+            assert_eq!(stdout, "", "{full_filter}: stderr {stderr:?}");
+        }
+    }
+
+    // The `Reverse`/`Sort`/`SortBy`/`Unique`/`UniqueBy`/`Min`/`MinBy`/`Max`/
+    // `MaxBy` family's own `collect_cursors_checked` error class is a
+    // malformed element *gap* (trailing comma), not a value decode failure
+    // -- matching `test_jq_collect_cursors_checked_sibling_paths_reject_
+    // trailing_comma_2261`'s own fixture (`[1,2,3,]`).
+    for filter in [
+        "reverse",
+        "sort",
+        "unique",
+        "min",
+        "max",
+        "sort_by(.)",
+        "unique_by(.)",
+        "min_by(.)",
+        "max_by(.)",
+    ] {
+        for suffix in ["", "?"] {
+            let full_filter = format!("{filter}{suffix}");
+            let (stdout, stderr, code) = run_jq_stdin_streams(&full_filter, "[1,2,3,]", &["-c"])?;
+            assert_eq!(
+                code, 5,
+                "{full_filter}: stdout {stdout:?} stderr {stderr:?}"
+            );
+            assert_eq!(stdout, "", "{full_filter}: stderr {stderr:?}");
+        }
+    }
+
+    // Not a blanket rejection: the same builtins on a decodable document
+    // still succeed.
+    let (stdout, code) = run_jq_stdin("del(.a)", r#"{"a":1,"d":5}"#, &["-c"])?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout.trim(), r#"{"d":5}"#);
+    let (stdout, code) = run_jq_stdin("transpose", "[[1,2],[3,4]]", &["-c"])?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout.trim(), "[[1,3],[2,4]]");
+    let (stdout, code) = run_jq_stdin("group_by(.a)", r#"[{"a":1},{"a":2}]"#, &["-c"])?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout.trim(), r#"[[{"a":1}],[{"a":2}]]"#);
+
+    Ok(())
+}
+
 /// #2053, constraint 2 from the issue that split this fix off from #1909:
 /// `path_expr` must be evaluated exactly once, on *both* branches
 /// `eval_generic.rs`'s new native `Builtin::GetPath` arm can take -- the


### PR DESCRIPTION
## Summary

Continues the #2231/#2280 lineage: found during #2280's own code review (a parallel
sweep for other instances of the "materialization ignores a live `optional`" pattern),
filed as #2327, fixed here across two review rounds.

**Total: 18 call sites fixed** (all verified per-site to have a genuinely live `optional`
consulted elsewhere in the *same* function, ruling out the false positives a naive
`owned_or_err!`/bare-`to_owned` grep otherwise produces):

- `eval.rs`: `builtin_del` (its own doc comment already promised the suppression the code
  wasn't providing), `builtin_transpose`, `builtin_group_by`/`unique_by`/`sort_by`'s
  shared per-item conversion, `builtin_halt_error`, `builtin_min`/`max`/`min_by`/`max_by`,
  `builtin_reverse`/`unique`/`sort`, `builtin_flatten`.
- `eval_generic.rs`: the `Reverse`/`Sort`/`SortBy`/`Unique`/`UniqueBy`/`Min`/`MinBy`/`Max`/
  `MaxBy` family (`collect_cursors_checked`), and `bridge_to_full_evaluator`/`_flow` (the
  shared reindex-bridge helper several of those arms fall back to).

All routed through `to_owned_or_suppress!`/`to_owned_vec_or_suppress!`/
`owned_or_suppress!`/`suppress_or_raise`.

## Round 1 → shipped with a test that didn't prove what it claimed

Round 1 fixed 7 builtins (`del`, `envvar`, `transpose`, `group_by`/`unique_by`/`sort_by`,
`halt_error`, plus the `eval_generic.rs` family) with a test using a whole-document decode
failure (`\ud800`). Code review found this passed for the wrong reason:

`eval_generic.rs` is the CLI's real dispatch entry point — `jq_runner.rs`/`yq_runner.rs`
never call `eval.rs`'s `eval()` directly. Every `eval.rs` function this PR touches is
reached from there only through a reindex-bridge mechanism (`eval_builtin`'s `_`
catch-all arm for builtins with no native `eval_generic.rs` arm, or
`bridge_to_full_evaluator`/a native arm's own inlined equivalent for builtins that do) —
and *every one* of those bridges calls `to_owned_with_cursor` on the whole document
**before** ever reaching `eval.rs`. So a real decode failure always raises at the bridge,
never at the site round 1 fixed. Confirmed for `builtin_del` with temporary debug
instrumentation (added and removed before this push): its fixed line never runs for a
`\ud800` document — only for a decodable one.

`builtin_envvar` is a step further: **unreachable through any parsed CLI syntax at all**
(`env.VAR`/`$ENV.VAR` resolve through a different code path entirely) — a fact this
codebase already documented before this PR
(`test_builtin_envvar_raises_on_decode_failure_1820`'s own comment says exactly this).
Dropped from CLI-level test claims entirely; its fix is exercised only by that
pre-existing direct-call unit test.

Review also found **8 more sibling functions** with the identical unfixed asymmetry —
`builtin_min`/`max`/`min_by`/`max_by`/`reverse`/`unique`/`sort`/`flatten` (all `eval.rs`)
— several of them the *direct sibling* of an `eval_generic.rs` arm round 1 had just
fixed, a textbook instance of this project's own documented "two separate jq/yq
evaluators, both need any reindex-bridge fix" hazard. Fixed in round 2, along with
`bridge_to_full_evaluator`/`_flow`.

## Tests, restructured

- `test_optional_ignored_sites_2327` now covers only the `Reverse`/`Sort`/… family's own
  `collect_cursors_checked` fix — the one part of this PR with genuine CLI-observable
  coverage (a malformed element gap, `[1,2,3,]`, matching
  `test_jq_collect_cursors_checked_sibling_paths_reject_trailing_comma_2261`'s own
  fixture). Strengthened to check the same `stderr` content that test does, not just the
  exit code (round 1's version only checked exit code + empty stdout).
- New `test_eval_rs_sites_produce_correct_output_2327` covers every `eval.rs`-only site
  honestly: it proves the macro-swap refactor didn't change the success-path output, the
  same scope `test_eval_rs_only_sites_still_correct_2280` already accepted for
  `builtin_path`/`eval_format` in #2280 — it does **not** claim to prove a
  suppress-vs-raise difference these sites can't observe via the CLI.

## `eval_array_construction` deliberately left unchanged

Investigated (flagged in #2327's own issue as "plausible, higher-impact") and NOT fixed:
unlike the confirmed sites, `optional` here is only ever *forwarded* into the inner
expression's own evaluation — no local precedent of consulting it to suppress *this*
function's own error — and the function's own comment states array construction is
atomic in jq ("a `Partial` inner stream just surfaces its control, same as a bare one").
Applying the same swap would still be a no-op today, but it isn't clearly *correcting an
inconsistency the surrounding code already established* — left alone rather than changed
on pattern-match alone.

## Not fixed here: filed #2334 instead of another manual sweep

Roughly 58 more raw `to_owned`/`collect_cursors_checked` call sites remain in
`eval.rs`/`eval_generic.rs`. Round 2's own review named the real problem: this is the
*third* round of "fix a few sites, review finds a few more" (#2231→#2280→#2327), and
centralizing the suppress macros hasn't stopped the omission from recurring — nothing
forces a call site to route through them. Filed
[#2334](https://github.com/rust-works/succinctly/issues/2334) proposing a structural fix
(CI-enforced audit / cross-evaluator diffing) instead of continuing to hand-list sites
each round.

## Verification

- New/restructured CLI regression tests (`tests/jq_cli_tests.rs`).
- Full `cargo test --workspace`: all green.
- `cargo test --no-default-features --verbose` (no_std leg): green.
- `cargo clippy --all-targets --all-features -- -D warnings` and the second CI clippy
  leg: clean.
- `cargo fmt --check`, `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features`:
  clean.

Fixes #2327
