### PR TITLE
fix(jq): keys[-N]/keys_unsorted[-N] now raise on yq out-of-range

### DIFF
--- a/docs/compliance/yq/limitations.md
+++ b/docs/compliance/yq/limitations.md
@@ -1738,10 +1738,23 @@ computed bracket key piped into a path-context builtin, respectively) had the id
 gate-on-`optional` bug and are fixed the same way. This keeps the error unsuppressible the
 same way `is_decode_failure` already does for a decode failure.
 
-A few more independent copies of the same arithmetic remain unfixed, in lower-traffic
-call sites: `path()`'s own walker, `pick(paths)`, `reduce`/`foreach`'s lazy-fold index
-handling, and `getpath`'s own path-array walk (jq-only syntax, so this only matters under
-`--jq-extensions`) -- filed as [#2264](https://github.com/rust-works/succinctly/issues/2264).
+A few more independent copies of the same arithmetic were found, in lower-traffic call
+sites, and tracked as [#2264](https://github.com/rust-works/succinctly/issues/2264).
+Reverification there found `pick(paths)` already matches real yq exactly (both the
+expression form and the array-literal-keys form), not a gap after all. `keys`/
+`keys_unsorted`'s own lazy `.[n]` fast path (`fold_lazy_keys_stage` for object keys,
+`fold_lazy_index_range_stage` for array keys, `src/jq/eval_generic.rs`) *was* a real,
+live-confirmed gap -- `keys[-5]`/`keys_unsorted[-5]` silently answered `null` instead of
+raising, since each already walks (or already knows) the whole container's length to
+resolve a negative index at all, so the check now rides along for free, the same shape
+as every other fix in this section. Three more copies remain genuinely unverified --
+`path()`'s own walker (`navigate_static_component`, `src/jq/eval.rs`; real yq's `path()`
+turns out to reject essentially any bracket-index argument outright, regardless of sign,
+so what "fixed" even means here needs its own grammar investigation first),
+`get_value_at_path` (`src/jq/eval.rs`), and `getpath`'s own path-array walk
+(`resolve_read_index`/`getpath_walk_owned`, `src/jq/eval.rs`; jq-only syntax, so this
+only matters under `--jq-extensions`) -- filed as
+[#2335](https://github.com/rust-works/succinctly/issues/2335).
 `del()`/`delpaths()` silently no-op on this shape instead of raising at all (more severe than
 a suppression gap -- a missing error, not a differently-worded one) -- filed separately as
 [#2268](https://github.com/rust-works/succinctly/issues/2268). `eval_stage_with_path_context`'s

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -4141,7 +4141,19 @@ fn fold_lazy_keys_stage<S: EvalSemantics, V: DocumentValue>(
         Expr::Index { idx, .. } if !sorted && *idx < 0 => {
             match distinct_key_cursors_checked::<V>(&fields, collapse) {
                 Ok(cursors) => {
-                    let target = usize::try_from(cursors.len() as i64 + idx).ok();
+                    // #2264: `yq_negative_index_check`, not a bare
+                    // `None`-on-still-negative fallthrough -- this arm
+                    // already walks the whole object to resolve `idx`
+                    // against its length (see this arm's own #1629
+                    // comment above), so the check rides along for free,
+                    // the same shape #2254 already fixed for ordinary
+                    // `.a[-N]` array/object reads elsewhere in this file.
+                    let len = cursors.len();
+                    let resolved = len as i64 + idx;
+                    if let Some(e) = yq_negative_index_check::<S>(*idx, resolved, len) {
+                        return GenericResult::Error(e);
+                    }
+                    let target = usize::try_from(resolved).ok();
                     match target.and_then(|t| cursors.into_iter().nth(t)) {
                         Some(cursor) => GenericResult::OneCursor(cursor),
                         None => GenericResult::Owned(OwnedValue::Null),
@@ -4289,6 +4301,13 @@ fn fold_lazy_index_range_stage<S: EvalSemantics, V: DocumentValue>(
             // `LazyKeys`'s `Expr::Index` arm above.
             let target = if *idx < 0 {
                 let normalized = len as i64 + idx;
+                // #2264: yq's own negative-index-out-of-range check --
+                // same shape #2254 already established for ordinary
+                // `.a[-N]` array reads, and the sibling fix just above
+                // in `fold_lazy_keys_stage`.
+                if let Some(e) = yq_negative_index_check::<S>(*idx, normalized, len) {
+                    return GenericResult::Error(e);
+                }
                 if normalized < 0 {
                     None
                 } else {

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -5041,11 +5041,19 @@ fn fold_pipe_stages_sink<S: EvalSemantics, V: DocumentValue>(
 /// fix reviewable at the size of a narrow bug fix rather than a `LazyKeys`
 /// redesign.
 ///
-/// `LazyIndexRange` needs no arm at all: its value is fully described by
-/// `len` alone (#684), so unlike `LazyKeys` it can never actually fail --
+/// `LazyIndexRange` needs no arm at all: its own materialization is fully
+/// described by `len` alone (#684) and can never fail on its own, so
 /// forcing it here would cost real allocation for zero correctness
-/// benefit, so it stays on the `other => other` wildcard, exactly as
-/// before this fix.
+/// benefit -- it stays on the `other => other` wildcard, exactly as before
+/// this fix. #2264: `fold_lazy_index_range_stage`'s own negative-index arm
+/// *can* now raise (a yq-mode out-of-range `.[-N]`), but that resolution
+/// always happens upstream, folded into the pipe *before* a `try`/`?`
+/// boundary is reached (`Expr::Pipe`'s own evaluation applies every stage
+/// through `fold_pipe_stages` first) -- so a raw `LazyIndexRange` value
+/// arriving here has already survived any pending index fold, and this
+/// claim is about materializing *that* value, not about whether resolving
+/// an index against it could fail (it can, just never at this point in the
+/// pipeline).
 ///
 /// [`each_try_generic`] below, this function's push-model twin, has a
 /// **similar but distinct, still-open gap**: `eval_each_generic`'s own
@@ -6474,8 +6482,12 @@ fn each_try_generic<S: EvalSemantics, V: DocumentValue>(
 /// materializes via `materialize_atomic` -- matching `try_single_generic`'s
 /// own `LazySeq` arm, and sound for the same reason that one is: a
 /// `try`/`catch`/`?` boundary must know *now* whether its body raised, so
-/// laziness cannot survive past it regardless of push or pull. `LazyIndexRange`
-/// can never fail (`0..len`, pure arithmetic) and passes through unchanged.
+/// laziness cannot survive past it regardless of push or pull. `LazyIndexRange`'s
+/// own materialization can never fail (`0..len`, pure arithmetic) and passes
+/// through unchanged -- see [`try_single_generic`]'s own doc comment (#2264)
+/// for why `fold_lazy_index_range_stage`'s negative-index arm being able to
+/// raise doesn't change that: the fold happens upstream, before a raw
+/// `LazyIndexRange` item can ever reach this check.
 ///
 /// Nested `try`/`catch` boundaries each re-walk the same still-forwarded
 /// `LazyKeys` item once per boundary (`try (try (keys_unsorted) catch empty)

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -29295,6 +29295,44 @@ fn test_keys_negative_index_out_of_range_raises_2264() -> Result<()> {
     Ok(())
 }
 
+/// #2264 review: mirrors #2254's own
+/// `test_negative_index_out_of_range_survives_try_catch_2254` for this
+/// issue's `keys`/`keys_unsorted` lazy fast path specifically -- code
+/// review found `try_single_generic`/`check_lazy_item_for_try`'s own
+/// "`LazyIndexRange` can never fail" doc comments went stale after this
+/// fix, and that no test here actually pinned unsuppressibility through an
+/// explicit `try`/`catch`, only a bare index read. `try`/`catch` is a
+/// succinctly-only extension real yq's lexer rejects outright (confirmed
+/// live against v4.53.3, same as #2254's own precedent test), so this
+/// exercises succinctly's own `try_single_generic` bypass
+/// (`EvalError::is_yq_negative_index_error`), not a real-yq oracle claim.
+#[test]
+fn test_keys_negative_index_out_of_range_survives_try_catch_2264() -> Result<()> {
+    let (out, stderr, code) = run_yq_stdin_with_stderr(
+        "try (.a | keys_unsorted[-5]) catch \"c\"",
+        "a: {x: 1, y: 2}\n",
+        &["-o", "json"],
+    )?;
+    assert_eq!(code, 1, "out: {out:?}");
+    assert_eq!(
+        stderr.trim(),
+        "Error: index [-5] out of range, array size is 2"
+    );
+
+    let (out, stderr, code) = run_yq_stdin_with_stderr(
+        "try (.a | keys[-5]) catch \"c\"",
+        "a: [1, 2]\n",
+        &["-o", "json"],
+    )?;
+    assert_eq!(code, 1, "out: {out:?}");
+    assert_eq!(
+        stderr.trim(),
+        "Error: index [-5] out of range, array size is 2"
+    );
+
+    Ok(())
+}
+
 /// #2264's jq-mode control: jq has no equivalent of this yq-only rule, so
 /// `keys[-N]`/`keys_unsorted[-N]` stay `null`, matching #2254's own
 /// established jq-mode precedent for ordinary `.a[-N]` reads.

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -29235,3 +29235,82 @@ fn test_slice_expr_target_partial_prefix_still_discarded_in_yq_mode_2226() -> Re
     assert_eq!(stderr.trim(), "Error: x");
     Ok(())
 }
+
+/// #2264: `keys`/`keys_unsorted`'s own lazy `.[n]` fast path
+/// (`fold_lazy_keys_stage` for object keys, `fold_lazy_index_range_stage`
+/// for array keys) had its own independent negative-index resolution with
+/// no yq-mode check at all -- confirmed live to silently answer `null`
+/// instead of raising, unlike every other `.a[-N]`-shaped read #2254
+/// already fixed. Both arms already walk (or, for the array-keys case,
+/// already know) the whole container's length to resolve a negative index
+/// at all, so the check rides along for free -- same reasoning as #2254's
+/// own sibling fixes.
+#[test]
+fn test_keys_negative_index_out_of_range_raises_2264() -> Result<()> {
+    // Object keys (`fold_lazy_keys_stage`), both `keys` and `keys_unsorted`.
+    let (out, stderr, code) =
+        run_yq_stdin_with_stderr(".a | keys[-5]", "a: {x: 1, y: 2}\n", &["-o", "json"])?;
+    assert_eq!(code, 1, "out: {out:?}");
+    assert_eq!(
+        stderr.trim(),
+        "Error: index [-5] out of range, array size is 2"
+    );
+    let (out, stderr, code) = run_yq_stdin_with_stderr(
+        ".a | keys_unsorted[-5]",
+        "a: {x: 1, y: 2}\n",
+        &["-o", "json"],
+    )?;
+    assert_eq!(code, 1, "out: {out:?}");
+    assert_eq!(
+        stderr.trim(),
+        "Error: index [-5] out of range, array size is 2"
+    );
+
+    // Array keys (`fold_lazy_index_range_stage`).
+    let (out, stderr, code) =
+        run_yq_stdin_with_stderr(".a | keys[-5]", "a: [1, 2]\n", &["-o", "json"])?;
+    assert_eq!(code, 1, "out: {out:?}");
+    assert_eq!(
+        stderr.trim(),
+        "Error: index [-5] out of range, array size is 2"
+    );
+
+    // In-bounds negative wraparound is unaffected, both container types.
+    let (out, code) = run_yq_stdin(
+        ".a | keys_unsorted[-1]",
+        "a: {x: 1, y: 2}\n",
+        &["-o", "json"],
+    )?;
+    assert_eq!(code, 0);
+    assert_eq!(out.trim(), "\"y\"");
+    let (out, code) = run_yq_stdin(".a | keys[-1]", "a: [1, 2, 3]\n", &["-o", "json"])?;
+    assert_eq!(code, 0);
+    assert_eq!(out.trim(), "2");
+
+    // Positive out-of-range is unaffected -- `null`, not an error.
+    let (out, code) = run_yq_stdin(".a | keys[5]", "a: [1, 2]\n", &["-o", "json"])?;
+    assert_eq!(code, 0);
+    assert_eq!(out.trim(), "null");
+
+    Ok(())
+}
+
+/// #2264's jq-mode control: jq has no equivalent of this yq-only rule, so
+/// `keys[-N]`/`keys_unsorted[-N]` stay `null`, matching #2254's own
+/// established jq-mode precedent for ordinary `.a[-N]` reads.
+#[test]
+fn test_keys_negative_index_out_of_range_unaffected_in_jq_mode_2264() -> Result<()> {
+    let (out, stderr, code) = run_jq_stdin_with_stderr(
+        ".a | keys_unsorted[-5]",
+        "{\"a\":{\"x\":1,\"y\":2}}",
+        &["-c"],
+    )?;
+    assert_eq!(code, 0, "stderr: {stderr}");
+    assert_eq!(out.trim(), "null");
+
+    let (out, stderr, code) = run_jq_stdin_with_stderr(".a | keys[-5]", "{\"a\":[1,2]}", &["-c"])?;
+    assert_eq!(code, 0, "stderr: {stderr}");
+    assert_eq!(out.trim(), "null");
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary

- Real yq raises `index [N] out of range, array size is M` for a negative array index whose magnitude still exceeds the length after resolving against it (#2254). `keys`/`keys_unsorted`'s own lazy `.[n]` fast path had its own independent negative-index resolution with **no yq-mode check at all** — confirmed live to silently answer `null` instead of raising.
- Fixed at both arms: `fold_lazy_keys_stage`'s negative-index arm (object keys, `src/jq/eval_generic.rs`) and `fold_lazy_index_range_stage`'s `Expr::Index` arm (array keys). Both already resolve the index against the container's length to answer at all, so `yq_negative_index_check` rides along for free — the same shape #2254 already established for ordinary `.a[-N]` reads.
- Verified against `yq` v4.53.3 directly (not from memory, per this repo's own rule):

```console
$ echo '{"a":{"x":1,"y":2}}' | yq -o=json '.a | keys[-5]'
Error: index [-5] out of range, array size is 2
$ echo '{"a":{"x":1,"y":2}}' | succinctly yq -o=json '.a | keys[-5]'   # before this fix
null
```
- In-bounds negative wraparound, positive out-of-range (`null` in both tools), and jq mode (no such rule) all confirmed unaffected.

## Scope

This is #2264's own highest-priority item — its "Scope note" explicitly flagged this as "a real, live-confirmed gap and probably the next one worth picking up." Reverification during this PR also found #2264's own `pick(paths)` suspicion was a false alarm (already matches real yq exactly, both forms). The three remaining, genuinely unverified copies (`path()`'s own walker, `get_value_at_path`, `getpath`'s path-array walk) are filed as #2335, since `path()`'s own case needs a grammar investigation before a fix strategy is even clear (real yq's `path()` rejects nearly every bracket-index argument outright).

`docs/compliance/yq/limitations.md`'s existing #2264 section updated to match — it had gone stale from an earlier draft of #2264's own scope (it referenced "reduce/foreach's lazy-fold index handling," which isn't what `fold_lazy_keys_stage`/`fold_lazy_index_range_stage` actually are, and still listed `pick(paths)` as open after #2264's own reverification found it wasn't).

## Round-2 review fixes

5 independent review angles, all clean except one cross-file tracer, which found:

- **Two stale doc comments**: `try_single_generic`'s and `check_lazy_item_for_try`'s own "`LazyIndexRange` can never fail" comments went stale after this fix — still true about that value's own *materialization*, but only because any pending negative-index fold now already happens upstream (via `fold_lazy_index_range_stage`, inside `Expr::Pipe`'s own stage-folding) before either function ever sees a raw `LazyIndexRange`. Clarified both, so a future reader doesn't mistake "can never fail" for a blanket claim and remove the upstream check.
- **A real test coverage gap**: no test here pinned unsuppressibility through an explicit `try`/`catch`, only a bare index read — unlike #2254's own established `test_negative_index_out_of_range_survives_try_catch_2254` precedent for the general array-index fix. Added `test_keys_negative_index_out_of_range_survives_try_catch_2264`.

Closes #2264.

## Test plan
- [x] New tests: `test_keys_negative_index_out_of_range_raises_2264`, `test_keys_negative_index_out_of_range_survives_try_catch_2264`, `test_keys_negative_index_out_of_range_unaffected_in_jq_mode_2264`
- [x] `cargo test --lib jq::` — 2004 passed
- [x] `cargo test --test jq_cli_tests --features cli` — 1388 passed
- [x] `cargo test --test yq_cli_tests --features cli` — 1401 passed
- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings`
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features`
- [x] `cargo test --no-default-features --verbose` (no_std)
