### PR TITLE
fix(jq): escape_generic! keeps the convertible prefix on a double fault

### DIFF
--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -495,6 +495,29 @@ pub fn to_owned_all_cursors<'a, C: DocumentCursor + 'a>(
     cursors.into_iter().map(to_owned_cursor).collect()
 }
 
+/// [`to_owned_all_cursors`]'s prefix-preserving sibling (#2145): on a decode
+/// failure, returns whatever converted successfully *before* the failing
+/// cursor instead of discarding it -- `.collect::<Result<Vec<_>, _>>()`
+/// (what `to_owned_all_cursors` uses) drops every already-collected item on
+/// the first `Err`, which is fine for a caller with nothing of its own to
+/// lose, but wrong for one folding this conversion's result into an
+/// already-running prefix (`escape_generic!`'s own `Partial`-folding use,
+/// its sole caller so far). Mirrors `eval.rs`'s `promote_borrowed_checked`
+/// (#1897) -- the same fix, for the cursor-native accumulator instead of
+/// the borrowed-`StandardJson` one.
+fn to_owned_all_cursors_checked<'a, C: DocumentCursor + 'a>(
+    cursors: impl IntoIterator<Item = &'a C>,
+) -> Result<Vec<OwnedValue>, (Vec<OwnedValue>, EvalError)> {
+    let mut acc = Vec::new();
+    for c in cursors {
+        match to_owned_cursor(c) {
+            Ok(v) => acc.push(v),
+            Err(e) => return Err((acc, e)),
+        }
+    }
+    Ok(acc)
+}
+
 fn to_owned_cursor_at_depth<C: DocumentCursor>(
     cursor: &C,
     depth: usize,
@@ -8185,21 +8208,27 @@ fn eval_index_expr<S: EvalSemantics, V: DocumentValue>(
     // live: `jq -n '(input | if . == "STOP" then halt else . end)
     // [("x","y")]'` on a bad-then-STOP input stream exits 0 silently in
     // real jq), while `Error`/`Break` downgrade to the promotion's own
-    // error, same as `resolve_terminal_prefix`'s matching arm.
+    // error, same as `resolve_terminal_prefix`'s matching arm. #2145: the
+    // secondary failure can't discard the *prefix* either -- uses the
+    // prefix-preserving `to_owned_all_cursors_checked` (mirroring `eval.rs`'s
+    // `promote_borrowed_checked`) instead of the all-or-nothing
+    // `to_owned_all_cursors`, so whatever converted before the failing
+    // cursor survives into the reported `Partial` the same way it already
+    // does on `eval.rs`'s equivalent path.
     macro_rules! escape_generic {
         ($control:expr) => {{
             let control = $control;
             let out = if any_owned {
                 owned
             } else {
-                match to_owned_all_cursors(&cursors) {
+                match to_owned_all_cursors_checked(&cursors) {
                     Ok(vs) => vs,
-                    Err(e) => {
+                    Err((prefix, e)) => {
                         let control = match control {
                             Control::Halt(code) => Control::Halt(code),
                             Control::Error(_) | Control::Break(_) => Control::Error(e),
                         };
-                        return partial_generic(Vec::new(), control);
+                        return partial_generic(prefix, control);
                     }
                 }
             };
@@ -17218,6 +17247,36 @@ mod tests {
             summarize(b"[[7],[8]]", "(.[0],(.[1],break $out))[(0+0):2]"),
             partial_break(&["[7]", "[8]"])
         );
+    }
+
+    /// #2145: `eval_index_expr`'s `escape_generic!` macro used to discard
+    /// the *entire* already-accumulated prefix if converting `cursors` to
+    /// owned values itself failed (a "double fault" -- the failure
+    /// converting the prefix, on top of the separate error/break/halt that
+    /// triggered folding it into a `Partial` in the first place). The
+    /// target `(.arr[0],.arr[1])` is a genuine multi-output generator
+    /// (#2032 re-evaluates it fresh per key): key `"bad"` succeeds for
+    /// both elements, pushing a cursor to `"ok"` and one to the
+    /// undecodable string into `cursors`; key `5` then fails to index
+    /// either element (both are objects) on its first target, triggering
+    /// `escape_generic!` while `cursors` still holds both -- `"ok"` must
+    /// survive into the reported prefix, not just `control`. Verified
+    /// against jq 1.7.1 for the non-corrupted shape: `{"arr":[{"bad":"ok"},
+    /// {"bad":"safe"}]} | (.arr[0],.arr[1])[("bad",5)]` prints `"ok"` then
+    /// `"safe"` before raising "Cannot index object with number".
+    #[test]
+    fn generic_escape_generic_keeps_convertible_prefix_on_double_fault_2145() {
+        let json: &[u8] = b"{\"arr\":[{\"bad\":\"ok\"},{\"bad\":\"\xff\xfe\"}]}";
+        let index = JsonIndex::build(json);
+        let expr = crate::jq::parse(r#"(.arr[0],.arr[1])[("bad",5)]"#).unwrap();
+        match eval_with_cursor(&expr, index.root(json)) {
+            GenericResult::Partial(vs, Control::Error(e)) => {
+                assert_eq!(vs, vec![OwnedValue::String("ok".to_string())]);
+                assert!(e.is_decode_failure(), "{e:?}");
+                assert!(e.message.contains("invalid UTF-8"), "{e:?}");
+            }
+            other => panic!("expected Partial([\"ok\"], decode Error), got {other:?}"),
+        }
     }
 
     #[test]

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -501,14 +501,16 @@ pub fn to_owned_all_cursors<'a, C: DocumentCursor + 'a>(
 /// (what `to_owned_all_cursors` uses) drops every already-collected item on
 /// the first `Err`, which is fine for a caller with nothing of its own to
 /// lose, but wrong for one folding this conversion's result into an
-/// already-running prefix (`escape_generic!`'s own `Partial`-folding use,
-/// its sole caller so far). Mirrors `eval.rs`'s `promote_borrowed_checked`
-/// (#1897) -- the same fix, for the cursor-native accumulator instead of
-/// the borrowed-`StandardJson` one.
-fn to_owned_all_cursors_checked<'a, C: DocumentCursor + 'a>(
-    cursors: impl IntoIterator<Item = &'a C>,
+/// already-running prefix (`eval_index_expr`'s own `Partial`-folding uses --
+/// `escape_generic!`, the `pending_halt` finalizer, and the target `Partial`
+/// arm's own promotion -- its only callers so far). Mirrors `eval.rs`'s
+/// `promote_borrowed_checked` (#1897) -- the same fix, and the same `&[C]`
+/// (not a generic `IntoIterator`) so `cursors.len()` is available to
+/// pre-size `acc` via `vec_with_capacity`, same as that sibling does.
+fn to_owned_all_cursors_checked<C: DocumentCursor>(
+    cursors: &[C],
 ) -> Result<Vec<OwnedValue>, (Vec<OwnedValue>, EvalError)> {
-    let mut acc = Vec::new();
+    let mut acc = vec_with_capacity(cursors.len());
     for c in cursors {
         match to_owned_cursor(c) {
             Ok(v) => acc.push(v),
@@ -8323,14 +8325,22 @@ fn eval_index_expr<S: EvalSemantics, V: DocumentValue>(
                 }
                 if !any_owned {
                     any_owned = true;
-                    owned = match to_owned_all_cursors(&cursors) {
+                    // #2145: uses the prefix-preserving
+                    // `to_owned_all_cursors_checked` instead of the
+                    // all-or-nothing `to_owned_all_cursors` -- this arm's
+                    // own doc comment above already claimed to mirror
+                    // `escape_generic!`'s Halt-survives rule, but until this
+                    // fix it still discarded the *prefix* the same way
+                    // `escape_generic!` itself used to (review finding: the
+                    // sibling gap #2145's own fix left in place here).
+                    owned = match to_owned_all_cursors_checked(&cursors) {
                         Ok(vs) => vs,
-                        Err(e) => {
+                        Err((prefix, e)) => {
                             let control = match control {
                                 Control::Halt(code) => Control::Halt(code),
                                 Control::Error(_) | Control::Break(_) => Control::Error(e),
                             };
-                            return partial_generic(Vec::new(), control);
+                            return partial_generic(prefix, control);
                         }
                     };
                     cursors.clear();
@@ -8501,10 +8511,39 @@ fn eval_index_expr<S: EvalSemantics, V: DocumentValue>(
         // carry cursors, not just owned values — the same rework #631 is
         // already deferred on — so this only documents the trade-off rather
         // than papering over it.
+        // #2145: uses the prefix-preserving `to_owned_all_cursors_checked`
+        // instead of `owned_or_err!(to_owned_all_cursors(&cursors))` -- the
+        // latter bare-returns `GenericResult::Error` on a decode failure
+        // here, discarding the accumulated prefix *and* silently downgrading
+        // this arm's own already-uncatchable `Control::Halt(code)` into a
+        // catchable decode error (worse than the `escape_generic!` gap this
+        // issue's own fix closed one block above: there the held `control`
+        // at least survived). The control here is always `Halt` by
+        // construction (this whole block only runs when `pending_halt` is
+        // `Some`), so a promotion failure can only ever keep it, matching
+        // `resolve_terminal_prefix`'s and `escape_generic!`'s own
+        // "Halt survives a promotion failure" rule -- the decode error
+        // itself is discarded, same as those two.
+        //
+        // Not live-repro-tested (review): reaching this arm needs `halt` to
+        // appear in the *key* stream (`.[(1,halt)]`) alongside undecodable
+        // content elsewhere in the same document, but `Builtin::Halt`'s own
+        // evaluation (confirmed live via a debug probe) falls through
+        // `eval_single`'s native dispatch to `bridge_to_full_evaluator`,
+        // which materializes the *entire* document up front -- so any
+        // undecodable content anywhere in it surfaces there first, as the
+        // key stream's own `Partial(_, Control::Error(_))` collapse a few
+        // lines above (the `#2326`-tracked "key stream discards its own
+        // prefix" gap), before `pending_halt` is ever set. Kept for the
+        // same defensive, future-proofing reason `resolve_terminal_prefix`
+        // keeps its own identical handling.
         let out = if any_owned {
             owned
         } else {
-            owned_or_err!(to_owned_all_cursors(&cursors))
+            match to_owned_all_cursors_checked(&cursors) {
+                Ok(vs) => vs,
+                Err((prefix, _)) => prefix,
+            }
         };
         return partial_generic(out, Control::Halt(code));
     }


### PR DESCRIPTION
## Summary
- `eval_generic.rs`'s `eval_index_expr` (its `escape_generic!` macro) discarded the *entire* already-accumulated `cursors` prefix if converting it to owned values itself failed with its own decode error — a "double fault": the failure converting the prefix, on top of the separate error/break/halt that triggered folding it into a `Partial` in the first place.
- `eval.rs`'s equivalent path (`resolve_terminal_prefix` + `promote_borrowed_checked`, #1897) already preserves whatever *did* convert successfully before the failure; this brings `eval_generic.rs` in line.
- Adds `to_owned_all_cursors_checked`, the prefix-preserving sibling of `to_owned_all_cursors` (which unconditionally drops everything on failure via `.collect::<Result<Vec<_>, _>>()`'s short-circuit), and switches `escape_generic!`'s own promotion step to it.
- Not a jq/yq mode-fidelity issue like #2226 — a pure robustness/correctness fix, applies identically to both modes (matches `resolve_terminal_prefix`, which is likewise unconditional).

Fixes #2145

## Follow-up filed
`ensure_owned!` (the sibling promotion macro a few lines below `escape_generic!`, used by the `KeyTargets::Native`/`Owned` success arms) has the *same* underlying flaw via its own `owned_or_err!`-based bare-return — already documented in its own comment as "pre-existing, unchanged by #2032... not new territory this fix needs to harden." It's strictly worse than what this PR fixes: it discards the held `control` entirely (not just the prefix), including an uncatchable `Halt`. Filed as a follow-up, since #2145's own scope was `escape_generic!` specifically.

## Test plan
- [x] `cargo build --features cli`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings`
- [x] `cargo fmt --check`
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features`
- [x] `cargo test --features cli,simd,regex,serde --no-fail-fast`
- [x] `cargo test --no-fail-fast` (default features)
- [x] `cargo test --no-default-features --verbose` (no_std)
- [x] New unit test constructs the double-fault live (a genuinely undecodable document element, reached via a multi-output target + a later key that fails to index it), verifies the convertible prefix survives
