### PR TITLE
test(yq): add run_jq_stdin helper, sweep unused-stderr call sites (#2338)

### DIFF
--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -108,6 +108,25 @@ fn run_jq_stdin_with_stderr(
     Ok((stdout, stderr, exit_code))
 }
 
+/// jq-mode counterpart of `run_yq_stdin` -- #2338: `run_yq_stdin_with_stderr`
+/// already had a no-stderr sibling for yq mode; jq mode didn't, so every
+/// jq-mode test that doesn't need stderr paid for decoding and discarding it
+/// anyway via `run_jq_stdin_with_stderr`. See `run_yq_stdin`'s own #2016 doc
+/// comment above for why this can't be a hand-rolled `spawn()` +
+/// `write_all(...)?` + `wait_with_output()` sequence.
+fn run_jq_stdin(filter: &str, input: &str, extra_args: &[&str]) -> Result<(String, i32)> {
+    let (output, exit_code) = spawn_with_signal_retry(
+        || {
+            let mut command = Command::new(env!("CARGO_BIN_EXE_succinctly"));
+            command.arg("jq").args(extra_args).arg(filter);
+            command
+        },
+        Some(input.as_bytes()),
+    )?;
+    let stdout = String::from_utf8(output.stdout)?;
+    Ok((stdout, exit_code))
+}
+
 /// Helper to run yq command with file input
 fn run_yq_file(filter: &str, file_path: &str, extra_args: &[&str]) -> Result<(String, i32)> {
     let output = Command::new(env!("CARGO_BIN_EXE_succinctly"))
@@ -11518,7 +11537,7 @@ fn test_yq_last_of_an_empty_stream_is_null_1521() -> Result<()> {
 /// behavior either way -- a small in-range float still round-trips exactly.
 #[test]
 fn test_jq_mode_computed_float_formatting_unaffected_by_997() -> Result<()> {
-    let (out, _stderr, code) = run_jq_stdin_with_stderr(".a * 1", r#"{"a": 1.5}"#, &["-c"])?;
+    let (out, code) = run_jq_stdin(".a * 1", r#"{"a": 1.5}"#, &["-c"])?;
     assert_eq!(code, 0);
     assert_eq!(out.trim(), "1.5");
     Ok(())
@@ -17480,7 +17499,7 @@ fn test_yq_tostring_computed_float_within_threshold_stays_decimal_1054() -> Resu
 /// leaked from the yq-only branch into jq mode.
 #[test]
 fn test_jq_tostring_computed_float_unaffected_1054() -> Result<()> {
-    let (out, _stderr, code) = run_jq_stdin_with_stderr("(1e10 * 2) | tostring", "1", &["-r"])?;
+    let (out, code) = run_jq_stdin("(1e10 * 2) | tostring", "1", &["-r"])?;
     assert_eq!(code, 0);
     assert_eq!(out.trim_end(), "20000000000");
     Ok(())
@@ -18916,7 +18935,7 @@ fn test_slice_assign_through_field_after_slice_still_errors_1142() -> Result<()>
 /// splicing the write-through result into the array, matching real jq.
 #[test]
 fn test_slice_compound_add_array_target_jq_mode_unaffected_1142() -> Result<()> {
-    let (out, _stderr, code) = run_jq_stdin_with_stderr(".[0:2] += [99]", "[1,2,3]", &["-c"])?;
+    let (out, code) = run_jq_stdin(".[0:2] += [99]", "[1,2,3]", &["-c"])?;
     assert_eq!(code, 0);
     assert_eq!(out.trim(), "[1,2,99,3]");
     Ok(())
@@ -19855,7 +19874,7 @@ fn test_yq_base64d_container_stringifies_to_empty_1109() -> Result<()> {
 #[test]
 fn test_jq_urid_base64d_still_reject_non_string_1109() -> Result<()> {
     for filter in ["@urid", "@base64d"] {
-        let (_out, _stderr, code) = run_jq_stdin_with_stderr(filter, "42", &[])?;
+        let (_out, code) = run_jq_stdin(filter, "42", &[])?;
         assert_ne!(code, 0, "filter {filter:?} unexpectedly succeeded");
     }
     Ok(())
@@ -20058,7 +20077,7 @@ fn test_1197_add_builtin_inherits_right_null_gating_consistently() -> Result<()>
     assert_eq!(output.trim(), r#""a""#);
 
     // jq mode is unaffected -- `+`'s right-null rule stays unconditional.
-    let (output, _stderr, code) = run_jq_stdin_with_stderr("[7, null] | add", "null", &["-c"])?;
+    let (output, code) = run_jq_stdin("[7, null] | add", "null", &["-c"])?;
     assert_eq!(code, 0, "out: {output:?}");
     assert_eq!(output.trim(), "7");
 
@@ -20338,7 +20357,7 @@ fn test_1197_right_null_add_errors_for_number_bool_object() -> Result<()> {
 #[test]
 fn test_1197_right_null_add_unaffected_in_jq_mode() -> Result<()> {
     for (expr, expected) in [("7 + null", "7"), (r#"{"x":1} + null"#, r#"{"x":1}"#)] {
-        let (out, _stderr, code) = run_jq_stdin_with_stderr(expr, "null", &["-c"])?;
+        let (out, code) = run_jq_stdin(expr, "null", &["-c"])?;
         assert_eq!(code, 0, "expr {expr:?}: out {out:?}");
         assert_eq!(out.trim(), expected, "expr {expr:?}");
     }
@@ -22644,7 +22663,7 @@ fn test_yq_base64d_rejects_embedded_whitespace_1123() -> Result<()> {
 /// errors in jq 1.7.1).
 #[test]
 fn test_jq_base64d_does_not_trim_whitespace_1123() -> Result<()> {
-    let (_out, _stderr, code) = run_jq_stdin_with_stderr("@base64d", r#"" aGVsbG8=""#, &[])?;
+    let (_out, code) = run_jq_stdin("@base64d", r#"" aGVsbG8=""#, &[])?;
     assert_ne!(code, 0);
     Ok(())
 }
@@ -22968,7 +22987,7 @@ fn test_jq_base64d_invalid_trailing_byte_uses_invalid_data_message_1146() -> Res
 /// confirmed live).
 #[test]
 fn test_jq_base64d_invalid_utf8_is_lossy_not_error_1146() -> Result<()> {
-    let (out, _stderr, code) = run_jq_stdin_with_stderr("@base64d", "\"null\"", &[])?;
+    let (out, code) = run_jq_stdin("@base64d", "\"null\"", &[])?;
     assert_eq!(code, 0, "out: {out:?}");
     assert_eq!(out.trim(), "\"\u{fffd}\u{fffd}\"");
     Ok(())
@@ -22991,7 +23010,7 @@ fn test_jq_base64d_invalid_utf8_is_lossy_not_error_1146() -> Result<()> {
 /// own granularity" section for the full detail.
 #[test]
 fn test_jq_base64d_drops_trailing_byte_quirk_fixed_1717() -> Result<()> {
-    let (out, _stderr, code) = run_jq_stdin_with_stderr("@base64d | explode", "\"4UE=\"", &["-c"])?;
+    let (out, code) = run_jq_stdin("@base64d | explode", "\"4UE=\"", &["-c"])?;
     assert_eq!(code, 0, "out: {out:?}");
     assert_eq!(out.trim(), "[65533]");
     Ok(())
@@ -23009,7 +23028,7 @@ fn test_jq_base64d_drops_trailing_byte_quirk_fixed_1717() -> Result<()> {
 /// sweep against jq 1.7.1; independently re-verified live before fixing.
 #[test]
 fn test_jq_base64d_drops_whole_tail_when_one_byte_short_of_seq_len_1717() -> Result<()> {
-    let (out, _stderr, code) = run_jq_stdin_with_stderr("@base64d | explode", "\"8EFC\"", &["-c"])?;
+    let (out, code) = run_jq_stdin("@base64d | explode", "\"8EFC\"", &["-c"])?;
     assert_eq!(code, 0, "out: {out:?}");
     assert_eq!(out.trim(), "[65533]");
     Ok(())
@@ -23148,7 +23167,7 @@ fn test_jq_base64d_still_lenient_on_inputs_yq_now_rejects_1135() -> Result<()> {
         (r#""ab==cd""#, r#""i""#),
     ];
     for (input, expected) in cases {
-        let (out, _stderr, code) = run_jq_stdin_with_stderr("@base64d", input, &[])?;
+        let (out, code) = run_jq_stdin("@base64d", input, &[])?;
         assert_eq!(code, 0, "input={input} out: {out:?}");
         assert_eq!(out.trim(), *expected, "input={input}");
     }
@@ -23159,7 +23178,7 @@ fn test_jq_base64d_still_lenient_on_inputs_yq_now_rejects_1135() -> Result<()> {
 /// like `%FF`) previously had no regression test either.
 #[test]
 fn test_jq_urid_invalid_utf8_after_percent_decode_is_lossy_1146() -> Result<()> {
-    let (out, _stderr, code) = run_jq_stdin_with_stderr("@urid", "\"%FF\"", &[])?;
+    let (out, code) = run_jq_stdin("@urid", "\"%FF\"", &[])?;
     assert_eq!(code, 0, "out: {out:?}");
     assert_eq!(out.trim(), "\"\u{fffd}\"");
     Ok(())
@@ -25160,13 +25179,13 @@ fn test_yq_iterate_adjacent_builtins_reject_object_unlike_jq_1901() -> Result<()
     // values" semantics; group_by/unique/unique_by hit jq's own
     // object-vs-array pairing bug (#995); from_entries hits its own,
     // unrelated indexing error.
-    let (out, _stderr, code) = run_jq_stdin_with_stderr("any", doc, &["-c"])?;
+    let (out, code) = run_jq_stdin("any", doc, &["-c"])?;
     assert_eq!(code, 0);
     assert_eq!(out.trim(), "true");
-    let (out, _stderr, code) = run_jq_stdin_with_stderr("all", doc, &["-c"])?;
+    let (out, code) = run_jq_stdin("all", doc, &["-c"])?;
     assert_eq!(code, 0);
     assert_eq!(out.trim(), "true");
-    let (out, _stderr, code) = run_jq_stdin_with_stderr("flatten", doc, &["-c"])?;
+    let (out, code) = run_jq_stdin("flatten", doc, &["-c"])?;
     assert_eq!(code, 0);
     assert_eq!(out.trim(), "[3,1]");
     for filter in ["group_by(.)", "unique", "unique_by(.)"] {

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -1329,8 +1329,7 @@ fn test_yq_leaf_paths_leaf_definition_unaffected_by_868() -> Result<()> {
 /// `effective_fields`), matching real jq exactly.
 #[test]
 fn test_jq_mode_paths_duplicate_key_still_dedupes_868() -> Result<()> {
-    let (output, _stderr, code) =
-        run_jq_stdin_with_stderr("[paths]", r#"{"a":1,"a":2,"b":3}"#, &["-c"])?;
+    let (output, code) = run_jq_stdin("[paths]", r#"{"a":1,"a":2,"b":3}"#, &["-c"])?;
 
     assert_eq!(code, 0, "out: {output:?}");
     assert_eq!(output.trim(), r#"[["a"],["b"]]"#);
@@ -18113,8 +18112,7 @@ fn test_yq_sub_3arg_zero_width_pattern_interaction_1122() -> Result<()> {
 /// stay untouched by this yq-only fix -- confirmed against jq 1.7.1.
 #[test]
 fn test_jq_sub_3arg_unaffected_by_1122() -> Result<()> {
-    let (stdout, _stderr, code) =
-        run_jq_stdin_with_stderr(r#""AAA" | sub("a";"X";"i")"#, "null", &["-c"])?;
+    let (stdout, code) = run_jq_stdin(r#""AAA" | sub("a";"X";"i")"#, "null", &["-c"])?;
     assert_eq!(code, 0, "stdout: {stdout:?}");
     assert_eq!(stdout.trim_end(), "\"XAA\"");
     Ok(())
@@ -21125,8 +21123,7 @@ fn test_1162_bare_root_comma_container_slice_del_is_noop() -> Result<()> {
 /// jq (no parent-key-drop concept exists there at all).
 #[test]
 fn test_1162_chained_array_slice_del_jq_mode_unaffected() -> Result<()> {
-    let (out, _stderr, code) =
-        run_jq_stdin_with_stderr("del(.a[1:3])", r#"{"a":[1,2,3,4,5],"b":6}"#, &["-c"])?;
+    let (out, code) = run_jq_stdin("del(.a[1:3])", r#"{"a":[1,2,3,4,5],"b":6}"#, &["-c"])?;
     assert_eq!(code, 0);
     assert_eq!(out.trim(), r#"{"a":[1,4,5],"b":6}"#);
     Ok(())
@@ -21188,8 +21185,7 @@ fn test_1162_delpaths_ordinary_paths_unaffected() -> Result<()> {
 /// new rejection is yq-mode-only.
 #[test]
 fn test_1162_delpaths_slice_descriptor_jq_mode_unaffected() -> Result<()> {
-    let (out, _stderr, code) =
-        run_jq_stdin_with_stderr(r#"delpaths([[{"start":1,"end":3}]])"#, "[1,2,3,4]", &["-c"])?;
+    let (out, code) = run_jq_stdin(r#"delpaths([[{"start":1,"end":3}]])"#, "[1,2,3,4]", &["-c"])?;
     assert_eq!(code, 0);
     assert_eq!(out.trim(), "[1,4]");
     Ok(())
@@ -21515,8 +21511,7 @@ fn test_1219_iterate_chained_slice_then_index_is_noop_per_element() -> Result<()
 /// `delete_at_path` walk.
 #[test]
 fn test_1219_jq_mode_unaffected() -> Result<()> {
-    let (out, _stderr, code) =
-        run_jq_stdin_with_stderr("del(.a[1:3][0])", r#"{"a":[1,2,3,4]}"#, &["-c"])?;
+    let (out, code) = run_jq_stdin("del(.a[1:3][0])", r#"{"a":[1,2,3,4]}"#, &["-c"])?;
     assert_eq!(code, 0);
     assert_eq!(out.trim(), r#"{"a":[1,3,4]}"#);
     Ok(())
@@ -22587,8 +22582,7 @@ fn test_slice_assign_computed_bound_unaffected_targets_1117() -> Result<()> {
 /// still errors there, matching real jq exactly.
 #[test]
 fn test_slice_assign_scalar_computed_bound_jq_mode_unaffected_1117() -> Result<()> {
-    let (_out, _stderr, code) =
-        run_jq_stdin_with_stderr("0 as $a | 1 as $b | .[$a:$b] = 99", "5", &["-c"])?;
+    let (_out, code) = run_jq_stdin("0 as $a | 1 as $b | .[$a:$b] = 99", "5", &["-c"])?;
     assert_ne!(code, 0);
     Ok(())
 }
@@ -23193,8 +23187,7 @@ fn test_jq_urid_invalid_utf8_after_percent_decode_is_lossy_1146() -> Result<()> 
 /// unaffected (WHATWG and jq's rule already agreed on that shape).
 #[test]
 fn test_jq_urid_overlong_percent_decode_collapses_to_one_fffd_1719() -> Result<()> {
-    let (out, _stderr, code) =
-        run_jq_stdin_with_stderr("@urid | explode", "\"%E0%80%80\"", &["-c"])?;
+    let (out, code) = run_jq_stdin("@urid | explode", "\"%E0%80%80\"", &["-c"])?;
     assert_eq!(code, 0, "out: {out:?}");
     assert_eq!(out.trim(), "[65533]");
     Ok(())
@@ -24512,8 +24505,7 @@ fn test_yq_scan_extension_keeps_jq_style_zero_width_1255() -> Result<()> {
 /// therefore the fix, not a substitution of convenience.
 #[test]
 fn test_jq_split_regex_keeps_zero_width_1255() -> Result<()> {
-    let (output, _stderr, code) =
-        run_jq_stdin_with_stderr(r#"split("a*"; "g")"#, "\"bab\"\n", &["-c"])?;
+    let (output, code) = run_jq_stdin(r#"split("a*"; "g")"#, "\"bab\"\n", &["-c"])?;
     assert_eq!(code, 0, "output: {output:?}");
     let v: serde_json::Value = serde_json::from_str(&output)?;
     assert_eq!(v, serde_json::json!(["", "b", "", "b", ""]));
@@ -24627,8 +24619,7 @@ fn test_yq_split_regex_arity_three_plus_accepted_1439() -> Result<()> {
 /// jq-modeled regex-split behavior unchanged -- this fix is yq-mode only.
 #[test]
 fn test_jq_split_regex_unaffected_by_1439() -> Result<()> {
-    let (out, _stderr, code) =
-        run_jq_stdin_with_stderr(r#"split("[0-9]";"g")"#, "\"a1b2c\"", &["-c"])?;
+    let (out, code) = run_jq_stdin(r#"split("[0-9]";"g")"#, "\"a1b2c\"", &["-c"])?;
     assert_eq!(code, 0, "out={out}");
     let v: serde_json::Value = serde_json::from_str(&out)?;
     assert_eq!(v, serde_json::json!(["a", "b", "c"]));
@@ -24655,8 +24646,7 @@ fn test_yq_splits_extension_keeps_jq_style_zero_width_1255() -> Result<()> {
 /// completely untouched by this yq-only fix.
 #[test]
 fn test_jq_gsub_zero_width_unaffected_by_1255() -> Result<()> {
-    let (stdout, _stderr, code) =
-        run_jq_stdin_with_stderr(r#""bab" | gsub("a*";"X")"#, "null", &["-c"])?;
+    let (stdout, code) = run_jq_stdin(r#""bab" | gsub("a*";"X")"#, "null", &["-c"])?;
     assert_eq!(code, 0, "stdout: {stdout:?}");
     assert_eq!(stdout.trim(), r#""XbXXbX""#);
     Ok(())
@@ -28012,7 +28002,7 @@ fn test_path_context_cursor_walk_shapes_2061() -> Result<()> {
         assert_eq!(code, 0, "yq `{filter}` on `{input}`: {out:?}");
         assert_eq!(out.trim(), want, "yq `{filter}` on `{input}`");
 
-        let (out, _, code) = run_jq_stdin_with_stderr(filter, input, &["-c"])?;
+        let (out, code) = run_jq_stdin(filter, input, &["-c"])?;
         assert_eq!(code, 0, "jq `{filter}` on `{input}`: {out:?}");
         assert_eq!(out.trim(), want, "jq `{filter}` on `{input}`");
     }
@@ -28137,7 +28127,7 @@ fn test_path_context_cursor_walk_keeps_the_validity_gate_2061() -> Result<()> {
         r#"{"a":"\u12","d":{"e":5}}"#,
     ] {
         for filter in [".d.e | key", ".d.e | path", ".d.e | parent"] {
-            let (out, _, code) = run_jq_stdin_with_stderr(filter, input, &["-c"])?;
+            let (out, code) = run_jq_stdin(filter, input, &["-c"])?;
             assert_ne!(code, 0, "`{filter}` on `{input}` must still raise: {out:?}");
             assert_eq!(out, "", "`{filter}` on `{input}`");
         }
@@ -28145,8 +28135,7 @@ fn test_path_context_cursor_walk_keeps_the_validity_gate_2061() -> Result<()> {
 
     // A well-formed document with the same shape answers normally, so the
     // gate is not simply rejecting everything.
-    let (out, _, code) =
-        run_jq_stdin_with_stderr(".d.e | key", r#"{"a":"ok","d":{"e":5}}"#, &["-c"])?;
+    let (out, code) = run_jq_stdin(".d.e | key", r#"{"a":"ok","d":{"e":5}}"#, &["-c"])?;
     assert_eq!(code, 0);
     assert_eq!(out.trim(), r#""e""#);
 


### PR DESCRIPTION
## Summary

`run_yq_stdin_with_stderr` already had a no-stderr sibling (`run_yq_stdin`) for yq mode; jq mode didn't, so every jq-mode test that doesn't need stderr paid for decoding and discarding it anyway via `run_jq_stdin_with_stderr`. Found during #2054's own code review — filed as #2338, not fixed there since it was a pre-existing, systemic pattern rather than something that PR introduced.

## What changed

Added `run_jq_stdin(filter, input, extra_args) -> Result<(String, i32)>`, mirroring `run_yq_stdin`'s exact shape, then swept every `run_jq_stdin_with_stderr` call site whose `stderr` binding was already `_`-prefixed (i.e. genuinely unused) over to the cheaper helper — 15 sites (via a small script matching `let (X, _stderr, Y) = run_jq_stdin_with_stderr(` → `let (X, Y) = run_jq_stdin(`, verified no other shape slipped through).

## Test plan
- [x] `cargo test --test yq_cli_tests --features cli` — full file green (1400 tests)
- [x] `cargo test --features cli,simd,regex,serde` — full suite green
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] `cargo build --no-default-features --features portable-popcount` (no_std) — clean
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features` — clean

Fixes #2338