### PR TITLE
fix(yq): del() through a slice-run+field tail on array/null now errors (#2333)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -289,6 +289,40 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`del()` through a chained slice-run followed by more path (`del(.a[0:2].x)`) silently
+  no-op'd instead of erroring when the slice target is an array or `null`** (#2333, found
+  during #2323's own code review). #1219's own "trailing slice-run followed by anything
+  non-slice makes the whole `del()` inert" rule classified every such shape uniformly as a
+  no-op — correct for a string slice (#1219/#1321's own established precedent) and for a
+  bare trailing `Index` (`del(.a[0:2][0])`), but real yq's own generic indexing can't tell
+  an object-field key from an array-index key apart (both are spelled `.key`): once the
+  current node is a sequence, it always tries to parse the key as an integer, which fails
+  for a genuine field name and raises `cannot index array with '<name>'` instead of
+  no-oping. Live-verified:
+
+  ```console
+  $ echo 'null' | yq -o=json 'del(.[0:2].a)'
+  Error: cannot index array with 'a' (strconv.ParseInt: parsing "a": invalid syntax)
+  $ echo '{"a":[1,2,3]}' | yq -o=json 'del(.a[0:2].x)'
+  Error: cannot index array with 'x' (strconv.ParseInt: parsing "x": invalid syntax)
+  ```
+
+  Fixed via a new `yq_del_slice_field_error` check, added to `yq_del_slice_outcome`'s
+  existing "last component isn't a slice" branch as a new `YqDelSliceOutcome::Error`
+  outcome (wired into all 5 of that enum's call sites, one of which —
+  `rewrite_yq_del_comma_branches`, the comma-branch pre-filter — needed its own return
+  type widened from `Option<Expr>` to `Result<Option<Expr>, EvalError>` to propagate it).
+  `null`'s array-shaped treatment is a quirk of being the *direct* slice target only
+  (real yq's null-as-array slice has no actual elements behind it, confirmed live:
+  `null | del(.[0:2][0].a)` stays `null`, not an error) — an `Array` target keeps the
+  error live through arbitrarily deeper `Index` navigation instead, since real document
+  data really is there to walk (confirmed live: `del(.a[0:2][0].x)` errors when index 0
+  holds another array, stays a no-op when it holds a scalar or object). A comma-grouped
+  sibling gets the same error treatment but propagated differently from #1219's own
+  `Noop`-sibling rule: real yq fails the *whole* call, not just the erroring branch
+  (confirmed live: `del(.a[0:2].x, .c)` on `{"a":[1,2,3],"c":9}` leaves `.c` undeleted
+  too).
+
 - **17 more sites ignored `optional`, continuing the #2231/#2280 lineage** (#2327,
   follow-up from #2280's own code review): `eval.rs`'s `builtin_del` (its own doc comment
   already promised "any resulting error is caught right here, turning the whole call's

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -323,6 +323,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (confirmed live: `del(.a[0:2].x, .c)` on `{"a":[1,2,3],"c":9}` leaves `.c` undeleted
   too).
 
+  Code review (round 2) found two real bugs in the first draft, both fixed: (1) the
+  slice-run boundary was computed as the *last* slice's own position rather than the
+  *start* of the maximal contiguous run ending there, so a chained *multi*-slice run
+  before the field tail (`del(.a[0:2][1:3].x)`) left an earlier slice unguarded and
+  silently misclassified back to `Noop` — fixed by walking backward to the run's actual
+  start and applying every slice in it sequentially, matching `yq_del_slice_outcome`'s own
+  established "a run of any length collapses to one target" rule; (2) a `?` on the
+  erroring field step itself (`del(.a[0:2].x?)`, distinct from `del(...)`'s own outer `?`)
+  was never consulted, regressing a case that was already a correct no-op on `main` before
+  this PR (caught by an A/B diff against `main`'s own pre-fix binary, not just the new
+  code in isolation) — fixed by checking `DeleteStep.optional` before raising. The null-
+  handling special case was also refactored away during this round: rather than two
+  hand-rolled checks (one for `null`, one for `Array`), a `Null` pre-slice value is now
+  modeled as an empty `Array` and walked through the exact same suffix logic, since an
+  empty array's own semantics (a `Field` step still hits the "current is an `Array`" arm;
+  an `Index` step always resolves out-of-bounds and gives up) already reproduce the
+  established no-op-past-the-direct-target behavior without a second copy of the walk —
+  closing the "duplicated predicates diverge silently" gap the multi-slice-run bug above
+  was itself an instance of.
+
+  A third, pre-existing (not introduced by this fix, confirmed via an A/B diff against
+  `main`) gap was found and filed separately as #2344 rather than expanding this PR's
+  scope further: a literal `.[]` (`Iterate`) earlier in the path, before the chained
+  slice-run (`del(.a[][0:2].x)`), still silently no-ops — the whole-path classification
+  this fix lives in has no way to defer to `delete_at_path`'s own per-element `Iterate`
+  handling once it's already committed to answering `Noop`/`Error` for the "no slice at
+  the very end" shape.
+
 - **17 more sites ignored `optional`, continuing the #2231/#2280 lineage** (#2327,
   follow-up from #2280's own code review): `eval.rs`'s `builtin_del` (its own doc comment
   already promised "any resulting error is caught right here, turning the whole call's

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -17992,55 +17992,96 @@ fn yq_del_slice_outcome(
 /// never reaches a field access at all, e.g. `del(.a[0:2][0])`) -- this
 /// function only intercepts the one sub-case that isn't inert.
 ///
+/// A `?` on the erroring step itself (`del(.a[0:2].x?)`, distinct from
+/// `del(...)`'s own outer `?` handled by every caller's `suppress_or_raise`)
+/// suppresses the error, same as `?` suppresses any other ordinary
+/// path-step error -- confirmed live (#2333 code review round 2, caught by
+/// a live A/B diff against `main`'s own pre-fix binary):
+/// `del(.a[0:2].x?)` on `{"a":[1,2,3]}` stays unchanged in real yq, but this
+/// function's own first draft raised regardless of the `?`.
+///
 /// `null` gets the identical error only when it is the *direct* target of
 /// the slice-run (`null | del(.[0:2].a)`) -- real yq's own null-as-array
 /// slice quirk has no actual elements behind it, so further navigation past
 /// that point falls through to the ordinary no-op instead (confirmed live:
-/// `null | del(.[0:2][0].a)` stays `null`). An `Array` target keeps the
-/// error live through arbitrarily deeper `Index` navigation, since real
-/// document data really is there to walk (confirmed live for
-/// `del(.a[0:2][0].x)`, both erroring when index 0 holds another array and
-/// staying a no-op when it holds a scalar or object).
+/// `null | del(.[0:2][0].a)` stays `null`). Modeled here by substituting an
+/// empty `Array` for a `Null` pre-slice value rather than special-casing it
+/// separately: an empty array slices to itself under any bounds, a trailing
+/// `Field` step on it hits the exact same "current is an `Array`" arm a real
+/// array does, and a trailing `Index` step on it always resolves
+/// out-of-bounds (`resolve_read_index` against `len() == 0`) and gives up --
+/// which is exactly "further navigation past that point falls through to
+/// the ordinary no-op." One walker, not two, for the same reason
+/// `yq_del_slice_outcome`'s own doc comment gives for not reusing
+/// `through_slice`: two hand-synchronized copies of "what a trailing
+/// `Field`/`Index` step does to a sliced value" is the "duplicated
+/// predicates diverge silently" shape (#106) this exact function's own
+/// multi-slice-run bug (below) was found to already be.
+///
+/// An `Array` target keeps the error live through arbitrarily deeper
+/// `Index` navigation, since real document data really is there to walk
+/// (confirmed live for `del(.a[0:2][0].x)`, both erroring when index 0
+/// holds another array and staying a no-op when it holds a scalar or
+/// object).
+///
+/// The slice-run this walks is the *maximal contiguous run ending at the
+/// last slice in `steps`* -- not just that one slice's own position (#2333
+/// code review, live-verified twice independently: `del(.a[0:2][1:3].x)`
+/// and `del(.a[0:4][0:2].x)` on `{"a":[1,2,3,4,5]}` both raise the same
+/// "cannot index array" error the single-slice case does, matching
+/// `yq_del_slice_outcome`'s own established "a run of any length collapses
+/// to the same target as one slice" rule -- computing `prefix` as only
+/// `steps[..last_slice_pos]` left an *earlier* slice in a multi-slice run
+/// unguarded, since `navigate_owned_value` has no `Expr::Slice` arm and
+/// silently gives up on one, misclassifying back to `Noop`). Every slice in
+/// the run is applied to the same real value in sequence, same as
+/// `yq_del_slice_outcome`'s own `DropParent` rewrite already does for its
+/// half of this rule.
 fn yq_del_slice_field_error(steps: &[DeleteStep], root: &OwnedValue) -> Option<EvalError> {
     let last_slice_pos = steps.iter().rposition(|s| s.component.is_slice())?;
-    let Expr::Slice { start, end, .. } = &steps[last_slice_pos].component else {
-        return None;
-    };
-    let prefix: Vec<Expr> = steps[..last_slice_pos]
+    let mut run_start = last_slice_pos;
+    while run_start > 0 && steps[run_start - 1].component.is_slice() {
+        run_start -= 1;
+    }
+    let prefix: Vec<Expr> = steps[..run_start]
         .iter()
         .map(|s| s.component.clone())
         .collect();
     let pre_slice_value = navigate_owned_value(root, &prefix)?;
-    let suffix = &steps[last_slice_pos + 1..];
 
-    if matches!(pre_slice_value, OwnedValue::Null) {
-        return match suffix {
-            [DeleteStep {
-                component: Expr::Field(name),
-                ..
-            }] => Some(EvalError::cannot_index_with_field("array", name)),
-            _ => None,
+    // Only `Array`/`Null` get this treatment -- `String` (#1219/#1321's own
+    // established no-op precedent) and anything else fall through
+    // unchanged, before ever applying a slice or walking the suffix.
+    let mut sliced = match pre_slice_value {
+        OwnedValue::Null => OwnedValue::Array(Vec::new()),
+        OwnedValue::Array(_) => pre_slice_value.clone(),
+        _ => return None,
+    };
+    for step in &steps[run_start..=last_slice_pos] {
+        let Expr::Slice { start, end, .. } = &step.component else {
+            unreachable!("every step in run_start..=last_slice_pos is_slice() by construction");
+        };
+        sliced = match slice_owned_value(&sliced, *start, *end, false) {
+            Ok(Some(v)) => v,
+            // `Array` always slices to `Ok(Some(_))` -- see
+            // `slice_owned_value`'s own match arm. Unreachable in practice,
+            // but falling through to the pre-existing no-op is the safe
+            // default if that ever changes.
+            _ => return None,
         };
     }
 
-    let OwnedValue::Array(_) = pre_slice_value else {
-        // Only `Array`/`Null` get this treatment -- `String` (#1219/#1321's
-        // own established no-op precedent) and anything else fall through
-        // unchanged.
-        return None;
-    };
-    let sliced = match slice_owned_value(pre_slice_value, *start, *end, false) {
-        Ok(Some(v)) => v,
-        // `Array` always slices to `Ok(Some(_))` -- see `slice_owned_value`'s
-        // own match arm. Unreachable in practice, but falling through to the
-        // pre-existing no-op is the safe default if that ever changes.
-        _ => return None,
-    };
-
     let mut current = &sliced;
-    for step in suffix {
+    for step in &steps[last_slice_pos + 1..] {
         match &step.component {
             Expr::Field(name) => match current {
+                // `step.optional` (a `?` *inside* the path, `del(.a[0:2].x?)`
+                // -- distinct from `del(...)`'s own outer `?`, handled by
+                // `suppress_or_raise` at every caller) suppresses just this
+                // one field access, same as `?` suppresses any other
+                // ordinary path-step error: confirmed live, real yq no-ops
+                // here rather than raising.
+                OwnedValue::Array(_) if step.optional => return None,
                 OwnedValue::Array(_) => {
                     return Some(EvalError::cannot_index_with_field("array", name))
                 }

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -17833,6 +17833,10 @@ enum YqDelSliceOutcome {
     Noop,
     /// This rule doesn't apply at all -- walk `path_expr` normally.
     NotApplicable,
+    /// #2333: what used to be classified `Noop` uniformly is, for this
+    /// specific resolved path, actually a hard type error in real yq -- see
+    /// [`yq_del_slice_field_error`]'s own doc comment.
+    Error(EvalError),
 }
 
 /// Classifies a resolved `del()` path against real yq's chained-slice rules
@@ -17913,7 +17917,15 @@ fn yq_del_slice_outcome(
     }
     if cut == steps.len() {
         // Last component isn't a slice at all -- the whole call/path
-        // no-ops, regardless of what's earlier in the path.
+        // no-ops, regardless of what's earlier in the path... except when
+        // real yq's own generic navigation would hit a hard type error
+        // along the way (#2333): a `Field` step landing on whatever the
+        // trailing slice(s) produced (or, for `null`'s own direct-target
+        // quirk, on `null` itself) isn't inert there, it raises. See
+        // `yq_del_slice_field_error`'s own doc comment.
+        if let Some(e) = yq_del_slice_field_error(&steps, root) {
+            return YqDelSliceOutcome::Error(e);
+        }
         return YqDelSliceOutcome::Noop;
     }
     let prefix = &steps[..cut];
@@ -17957,6 +17969,96 @@ fn yq_del_slice_outcome(
     })
 }
 
+/// Whether `yq_del_slice_outcome`'s "trailing slice-run followed by more
+/// path" shape (`del(.a[0:2].x)`, `del(.a[0:2][0].x)`, ...) is actually a
+/// hard type error in real yq, not simply inert -- #2333, found live:
+///
+/// ```console
+/// $ echo 'null' | yq -o=json 'del(.[0:2].a)'
+/// Error: cannot index array with 'a' (strconv.ParseInt: parsing "a": invalid syntax)
+/// $ echo '{"a":[1,2,3]}' | yq -o=json 'del(.a[0:2].x)'
+/// Error: cannot index array with 'x' (strconv.ParseInt: parsing "x": invalid syntax)
+/// ```
+///
+/// Real yq's own del() walker doesn't classify a chained slice-run the way
+/// this codebase's #1219 rule does -- it navigates the resolved path
+/// against real document data using its ordinary, non-del-specific
+/// indexing, and that indexing can't tell an object-field key from an
+/// array-index key syntactically (both are spelled `.key`): once the
+/// current node is a sequence (array), it always tries to parse the key as
+/// an integer, which fails for a genuine field name and raises. #1219's own
+/// "no-op" classification is correct for *most* of this shape (confirmed
+/// live for a scalar/string slice result, and for an `Index` tail that
+/// never reaches a field access at all, e.g. `del(.a[0:2][0])`) -- this
+/// function only intercepts the one sub-case that isn't inert.
+///
+/// `null` gets the identical error only when it is the *direct* target of
+/// the slice-run (`null | del(.[0:2].a)`) -- real yq's own null-as-array
+/// slice quirk has no actual elements behind it, so further navigation past
+/// that point falls through to the ordinary no-op instead (confirmed live:
+/// `null | del(.[0:2][0].a)` stays `null`). An `Array` target keeps the
+/// error live through arbitrarily deeper `Index` navigation, since real
+/// document data really is there to walk (confirmed live for
+/// `del(.a[0:2][0].x)`, both erroring when index 0 holds another array and
+/// staying a no-op when it holds a scalar or object).
+fn yq_del_slice_field_error(steps: &[DeleteStep], root: &OwnedValue) -> Option<EvalError> {
+    let last_slice_pos = steps.iter().rposition(|s| s.component.is_slice())?;
+    let Expr::Slice { start, end, .. } = &steps[last_slice_pos].component else {
+        return None;
+    };
+    let prefix: Vec<Expr> = steps[..last_slice_pos]
+        .iter()
+        .map(|s| s.component.clone())
+        .collect();
+    let pre_slice_value = navigate_owned_value(root, &prefix)?;
+    let suffix = &steps[last_slice_pos + 1..];
+
+    if matches!(pre_slice_value, OwnedValue::Null) {
+        return match suffix {
+            [DeleteStep {
+                component: Expr::Field(name),
+                ..
+            }] => Some(EvalError::cannot_index_with_field("array", name)),
+            _ => None,
+        };
+    }
+
+    let OwnedValue::Array(_) = pre_slice_value else {
+        // Only `Array`/`Null` get this treatment -- `String` (#1219/#1321's
+        // own established no-op precedent) and anything else fall through
+        // unchanged.
+        return None;
+    };
+    let sliced = match slice_owned_value(pre_slice_value, *start, *end, false) {
+        Ok(Some(v)) => v,
+        // `Array` always slices to `Ok(Some(_))` -- see `slice_owned_value`'s
+        // own match arm. Unreachable in practice, but falling through to the
+        // pre-existing no-op is the safe default if that ever changes.
+        _ => return None,
+    };
+
+    let mut current = &sliced;
+    for step in suffix {
+        match &step.component {
+            Expr::Field(name) => match current {
+                OwnedValue::Array(_) => {
+                    return Some(EvalError::cannot_index_with_field("array", name))
+                }
+                OwnedValue::Object(map) => current = map.get(name)?,
+                _ => return None,
+            },
+            Expr::Index { idx, .. } => match current {
+                OwnedValue::Array(arr) => {
+                    current = &arr[resolve_read_index(&OwnedValue::Int(*idx), arr.len())?];
+                }
+                _ => return None,
+            },
+            _ => return None,
+        }
+    }
+    None
+}
+
 /// Read-only navigation used by [`yq_del_slice_outcome`]'s prefix peek: does
 /// every step of `steps` resolve, through `root`, to an existing value?
 /// Unlike [`set_path_steps`], never autovivifies (a peek must not create
@@ -17987,36 +18089,36 @@ fn yq_del_slice_outcome(
 /// mirror it here too — a drift would make `yq_del_slice_outcome` disagree
 /// with what the real write does.
 fn navigate_read_only(root: &OwnedValue, steps: &[Expr]) -> bool {
+    navigate_owned_value(root, steps).is_some()
+}
+
+/// [`navigate_read_only`]'s own value-returning twin -- same walk, same
+/// "give up" shape (`Field`/`Index` on an incompatible container, an
+/// out-of-range `Index`, or any step this function can't interpret at all,
+/// `Iterate` included per #1298), but hands back the resolved value instead
+/// of collapsing it to a bare `bool`. Used by [`yq_del_slice_field_error`],
+/// which needs to inspect the value the trailing slice-run actually applies
+/// to, not just confirm it exists.
+fn navigate_owned_value<'a>(root: &'a OwnedValue, steps: &[Expr]) -> Option<&'a OwnedValue> {
     let mut current = root;
     for step in steps {
         let (step, _optional) = unwrap_path_component(step);
         current = match step {
             Expr::Field(name) => match current {
-                OwnedValue::Object(map) => match map.get(name) {
-                    Some(v) => v,
-                    None => return false,
-                },
-                _ => return false,
+                OwnedValue::Object(map) => map.get(name)?,
+                _ => return None,
             },
             Expr::Index { idx, .. } => match current {
                 OwnedValue::Array(arr) => {
-                    match resolve_read_index(&OwnedValue::Int(*idx), arr.len()) {
-                        Some(i) => &arr[i],
-                        None => return false,
-                    }
+                    &arr[resolve_read_index(&OwnedValue::Int(*idx), arr.len())?]
                 }
-                _ => return false,
+                _ => return None,
             },
-            // #1298: `Iterate` fans out into every element/value of a real
-            // container -- unlike `Field`/`Index`, there is no single next
-            // `current` to continue this loop with, so any step here means
-            // "give up", same as every other shape this function can't
-            // interpret.
-            Expr::Iterate => return false,
-            _ => return false,
+            Expr::Iterate => return None,
+            _ => return None,
         };
     }
-    true
+    Some(current)
 }
 
 /// Apply a resolved slice directly to an owned value.
@@ -37524,51 +37626,60 @@ fn delete_trie_array(
 /// own answer is itself inconsistent/order-sensitive with no coherent rule
 /// to replicate, the same territory `builtin_del`'s own known-gap test
 /// already documents. See #1223's follow-up discussion.
-fn rewrite_yq_del_comma_branches(expr: &Expr, root: &OwnedValue) -> Option<Expr> {
+fn rewrite_yq_del_comma_branches(
+    expr: &Expr,
+    root: &OwnedValue,
+) -> Result<Option<Expr>, EvalError> {
     match expr {
         Expr::Paren(inner) => {
-            rewrite_yq_del_comma_branches(inner, root).map(|r| Expr::Paren(Box::new(r)))
+            Ok(rewrite_yq_del_comma_branches(inner, root)?.map(|r| Expr::Paren(Box::new(r))))
         }
         Expr::Optional(inner) => {
-            rewrite_yq_del_comma_branches(inner, root).map(|r| Expr::Optional(Box::new(r)))
+            Ok(rewrite_yq_del_comma_branches(inner, root)?.map(|r| Expr::Optional(Box::new(r))))
         }
         Expr::Comma(branches) => {
-            let new_branches: Vec<Expr> = branches
-                .iter()
-                .filter_map(|branch| {
-                    if let Some(nested) = rewrite_yq_del_comma_branches(branch, root) {
-                        Some(nested)
-                    } else if !needs_path_prepass(branch) {
-                        match yq_del_slice_outcome(branch, root, false) {
-                            YqDelSliceOutcome::DropParent(rewritten) => Some(rewritten),
-                            // A `Noop`-classified branch is inert *regardless*
-                            // of what `root` actually contains: every `Noop`
-                            // return in `yq_del_slice_outcome` happens before
-                            // its own `navigate_read_only` call, so the
-                            // classification is pure syntax, decidable without
-                            // ever touching the document. Drop it from the
-                            // comma group entirely here, rather than leaving
-                            // its raw, still-slice-bearing branch in place --
-                            // `resolve_dynamic_indexes`'s navigation has no
-                            // `?`-style tolerance for a type mismatch (`.a[1:3]`
-                            // against an `Object` `.a` hard-errors there), so a
-                            // Noop branch combined with an incompatible sibling
-                            // type used to crash the whole `del()` call instead
-                            // of correctly leaving just this branch untouched
-                            // (`del(.a[1:3][0], .c)` on `{"a":{"x":1},"c":9}` —
-                            // live-verified against yq v4.53.3: `.a` stays put,
-                            // only `.c` is deleted).
-                            YqDelSliceOutcome::Noop => None,
-                            YqDelSliceOutcome::NotApplicable => Some(branch.clone()),
-                        }
-                    } else {
-                        Some(branch.clone())
+            let mut new_branches: Vec<Expr> = vec_with_capacity(branches.len());
+            for branch in branches {
+                if let Some(nested) = rewrite_yq_del_comma_branches(branch, root)? {
+                    new_branches.push(nested);
+                } else if !needs_path_prepass(branch) {
+                    match yq_del_slice_outcome(branch, root, false) {
+                        YqDelSliceOutcome::DropParent(rewritten) => new_branches.push(rewritten),
+                        // A `Noop`-classified branch is inert *regardless*
+                        // of what `root` actually contains: every `Noop`
+                        // return in `yq_del_slice_outcome` happens before
+                        // its own `navigate_read_only` call, so the
+                        // classification is pure syntax, decidable without
+                        // ever touching the document. Drop it from the
+                        // comma group entirely here, rather than leaving
+                        // its raw, still-slice-bearing branch in place --
+                        // `resolve_dynamic_indexes`'s navigation has no
+                        // `?`-style tolerance for a type mismatch (`.a[1:3]`
+                        // against an `Object` `.a` hard-errors there), so a
+                        // Noop branch combined with an incompatible sibling
+                        // type used to crash the whole `del()` call instead
+                        // of correctly leaving just this branch untouched
+                        // (`del(.a[1:3][0], .c)` on `{"a":{"x":1},"c":9}` —
+                        // live-verified against yq v4.53.3: `.a` stays put,
+                        // only `.c` is deleted).
+                        YqDelSliceOutcome::Noop => {}
+                        YqDelSliceOutcome::NotApplicable => new_branches.push(branch.clone()),
+                        // #2333: unlike `Noop`, this one *does* depend on
+                        // `root` -- and real yq's own answer here is to fail
+                        // the whole call, not just this branch (live-
+                        // verified: `del(.a[0:2].x, .c)` on
+                        // `{"a":[1,2,3],"c":9}` raises, `.c` is not
+                        // deleted either) -- so it propagates out instead of
+                        // being folded into this one branch's own fate.
+                        YqDelSliceOutcome::Error(e) => return Err(e),
                     }
-                })
-                .collect();
-            Some(Expr::Comma(new_branches))
+                } else {
+                    new_branches.push(branch.clone());
+                }
+            }
+            Ok(Some(Expr::Comma(new_branches)))
         }
-        _ => None,
+        _ => Ok(None),
     }
 }
 
@@ -37613,11 +37724,13 @@ fn builtin_del<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     // still applies to its resolved output.
     let rewritten_comma_path_expr: Expr;
     let path_expr: &Expr = if S::TAG == EvalTag::Yq {
-        if let Some(rewritten) = rewrite_yq_del_comma_branches(path_expr, &result) {
-            rewritten_comma_path_expr = rewritten;
-            &rewritten_comma_path_expr
-        } else {
-            path_expr
+        match rewrite_yq_del_comma_branches(path_expr, &result) {
+            Ok(Some(rewritten)) => {
+                rewritten_comma_path_expr = rewritten;
+                &rewritten_comma_path_expr
+            }
+            Ok(None) => path_expr,
+            Err(e) => return suppress_or_raise(e, optional),
         }
     } else {
         path_expr
@@ -37692,6 +37805,7 @@ fn builtin_del<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
                         YqDelSliceOutcome::DropParent(rewritten) => builder.insert_expr(&rewritten),
                         YqDelSliceOutcome::Noop => Ok(()),
                         YqDelSliceOutcome::NotApplicable => builder.insert_expr(path),
+                        YqDelSliceOutcome::Error(e) => Err(e),
                     },
                 };
                 if let Err(e) = inserted {
@@ -37790,6 +37904,7 @@ fn builtin_del<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
             // here and get wrong.
             YqDelSliceOutcome::Noop => continue,
             YqDelSliceOutcome::NotApplicable => path,
+            YqDelSliceOutcome::Error(e) => return suppress_or_raise(e.clone(), optional),
         };
         // yq's root-delete rule (#1702): real yq deletes the whole
         // document and emits nothing for a bare `del(.)` (no `?`
@@ -38411,6 +38526,7 @@ fn delete_path_steps(
                                 YqDelSliceOutcome::NotApplicable => {
                                     delete_path_steps(elem, rest, optional, yq_mode, true)?;
                                 }
+                                YqDelSliceOutcome::Error(e) => return Err(e),
                             }
                         }
                         for i in remove_indices.into_iter().rev() {
@@ -38440,6 +38556,7 @@ fn delete_path_steps(
                                 YqDelSliceOutcome::NotApplicable => {
                                     delete_path_steps(value, rest, optional, yq_mode, true)?;
                                 }
+                                YqDelSliceOutcome::Error(e) => return Err(e),
                             }
                         }
                         for key in remove_keys {

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -21545,11 +21545,17 @@ fn test_1219_comma_grouped_noop_sibling_leaves_other_siblings_untouched() -> Res
 /// `Noop`-classified branch was left completely unrewritten, so
 /// `resolve_dynamic_indexes` still tried to navigate `.a[1:3]` against the
 /// `Object` `.a` and hard-errored ("Cannot index object with object")
-/// instead of leaving `.a` untouched and deleting only `.c`. Every `Noop`
-/// classification is decided purely from the path's own shape (never
-/// touches the document), so it's always safe to drop a `Noop` branch from
-/// the comma group before navigation ever sees it — fixed by doing exactly
-/// that. Live-verified against yq v4.53.3.
+/// instead of leaving `.a` untouched and deleting only `.c`. An `Object`
+/// target always classifies `Noop` here, so it's always safe to drop this
+/// branch from the comma group before navigation ever sees it — fixed by
+/// doing exactly that. Live-verified against yq v4.53.3.
+///
+/// (#2333 revises this comment's own claim that every `Noop` classification
+/// never touches the document: an `Array`/`Null` target with a trailing
+/// `Field` step is no longer `Noop` at all, it's `Error` — see
+/// `test_2333_del_slice_array_field_tail_errors` below. `Object` is
+/// unaffected by that fix and still classifies `Noop` exactly as this test
+/// pins.)
 #[test]
 fn test_1219_comma_grouped_noop_sibling_object_target_no_longer_crashes() -> Result<()> {
     let (out, code) = run_yq_stdin(
@@ -21777,6 +21783,153 @@ fn test_1219_interior_slice_separated_by_iterate_is_noop() -> Result<()> {
         out.trim(),
         r#"{"a":[{"b":[1,2,3,4]},{"b":[10,20,30,40]},{"b":[100,200]}]}"#
     );
+    Ok(())
+}
+
+/// #2333: #1219's "trailing slice-run followed by more path" rule
+/// classified *every* such shape as an inert no-op, uniformly, regardless
+/// of what the slice actually targets. Real yq's own del() walker doesn't
+/// special-case slices the way this rule does — it navigates the resolved
+/// path against real document data, and its generic indexing can't tell an
+/// object-field key from an array-index key apart (both are spelled
+/// `.key`): once the current node is a sequence, it always tries to parse
+/// the key as an integer, which fails for a genuine field name and raises.
+/// A bare `null` root gets the identical treatment, live-verified:
+/// `.[0:2]` on `null` reads (and therefore errors) exactly like `.[0:2]`
+/// on an array does, for this one purpose.
+#[test]
+fn test_2333_del_slice_array_field_tail_errors() -> Result<()> {
+    let (out, stderr, code) =
+        run_yq_stdin_with_stderr("del(.a[0:2].x)", r#"{"a":[1,2,3]}"#, &["-o=json", "-I=0"])?;
+    assert_eq!(code, 1, "out: {out:?} stderr: {stderr:?}");
+    assert!(
+        stderr.contains("array") && stderr.contains('x'),
+        "stderr: {stderr:?}"
+    );
+
+    let (out, stderr, code) = run_yq_stdin_with_stderr("del(.[0:2].a)", "null", &["-o=json"])?;
+    assert_eq!(code, 1, "out: {out:?} stderr: {stderr:?}");
+    assert!(
+        stderr.contains("array") && stderr.contains('a'),
+        "stderr: {stderr:?}"
+    );
+    Ok(())
+}
+
+/// #2333: the error propagates even when the array-targeting field access
+/// isn't the step immediately after the slice — `.a[0:2][0].x` slices,
+/// indexes into the (real) sliced array, and *that* element turns out to
+/// be another array, so the trailing `.x` still hits "cannot index array".
+/// Confirms the check walks real document data at arbitrary depth past the
+/// slice, not just the one step directly following it.
+#[test]
+fn test_2333_del_slice_index_then_field_errors_when_element_is_array() -> Result<()> {
+    let (_out, stderr, code) = run_yq_stdin_with_stderr(
+        "del(.a[0:2][0].x)",
+        r#"{"a":[[1,2],[3,4]]}"#,
+        &["-o=json", "-I=0"],
+    )?;
+    assert_eq!(code, 1, "stderr: {stderr:?}");
+    assert!(
+        stderr.contains("array") && stderr.contains('x'),
+        "{stderr:?}"
+    );
+    Ok(())
+}
+
+/// #2333: the same `.a[0:2][0].x` shape stays a no-op (per #1219, unchanged)
+/// once the indexed element is *not* an array — a scalar (already pinned by
+/// `test_1219_chained_slice_then_field_is_noop` above, restated here next to
+/// its #2333 sibling) or an object, neither of which trips the new
+/// array-specific check. The object case additionally confirms `.x` is
+/// never actually deleted even though field-indexing an object would
+/// ordinarily be meaningful — real yq's own no-op here is total, not a
+/// partial/successful delete, live-verified.
+#[test]
+fn test_2333_del_slice_index_then_field_stays_noop_for_non_array_element() -> Result<()> {
+    let (out, code) = run_yq_stdin(
+        "del(.a[0:2][0].x)",
+        r#"{"a":[1,2,3]}"#,
+        &["-o=json", "-I=0"],
+    )?;
+    assert_eq!(code, 0);
+    assert_eq!(out.trim(), r#"{"a":[1,2,3]}"#);
+
+    let (out, code) = run_yq_stdin(
+        "del(.a[0:2][0].x)",
+        r#"{"a":[{"x":1,"y":2},{"z":3}]}"#,
+        &["-o=json", "-I=0"],
+    )?;
+    assert_eq!(code, 0);
+    assert_eq!(out.trim(), r#"{"a":[{"x":1,"y":2},{"z":3}]}"#);
+    Ok(())
+}
+
+/// #2333: `null`'s array-shaped treatment is a quirk of being the *direct*
+/// slice target only — real yq's null-as-array slice has no actual
+/// elements behind it, so navigating one step further (`Index`) before the
+/// trailing `Field` falls through to the ordinary no-op instead of the new
+/// error, unlike a real `Array` target (which keeps erroring at any depth,
+/// per the previous two tests). Live-verified this is a genuine divergence
+/// in kind, not just missing coverage.
+#[test]
+fn test_2333_del_slice_null_only_errors_for_direct_field_tail() -> Result<()> {
+    let (out, code) = run_yq_stdin("del(.[0:2][0].a)", "null", &["-o=json"])?;
+    assert_eq!(code, 0);
+    assert_eq!(out.trim(), "null");
+    Ok(())
+}
+
+/// #2333: an `Index` tail (no `Field` anywhere after the slice) stays a
+/// no-op regardless of target type — #1219's own established rule for this
+/// shape (`test_1219_chained_slice_then_index_is_noop`) is untouched, this
+/// just re-confirms it holds for the array-tail-is-array-itself case the
+/// new check's own walker also has to pass through without misfiring.
+#[test]
+fn test_2333_del_slice_index_only_tail_stays_noop() -> Result<()> {
+    let (out, code) = run_yq_stdin("del(.a[0:2][0])", r#"{"a":[1,2,3]}"#, &["-o=json", "-I=0"])?;
+    assert_eq!(code, 0);
+    assert_eq!(out.trim(), r#"{"a":[1,2,3]}"#);
+    Ok(())
+}
+
+/// #2333: a comma-grouped sibling gets the *same* error treatment as a
+/// single-path `del()`, but propagated differently from #1219's own
+/// `Noop`-sibling rule — real yq fails the *whole* call here, not just the
+/// erroring branch (unlike a `Noop` sibling, which leaves the rest of the
+/// comma group to proceed normally, per the `test_1219_comma_grouped_*`
+/// tests above). Live-verified: `.c` is not deleted either.
+#[test]
+fn test_2333_del_slice_comma_grouped_array_field_tail_fails_whole_call() -> Result<()> {
+    let (out, stderr, code) = run_yq_stdin_with_stderr(
+        "del(.a[0:2].x, .c)",
+        r#"{"a":[1,2,3],"c":9}"#,
+        &["-o=json", "-I=0"],
+    )?;
+    assert_eq!(code, 1, "out: {out:?} stderr: {stderr:?}");
+    assert!(
+        stderr.contains("array") && stderr.contains('x'),
+        "{stderr:?}"
+    );
+    Ok(())
+}
+
+/// #2333: jq mode has no #1116/#1162/#1219 chained-slice rule at all (see
+/// `test_1219_jq_mode_unaffected`'s own sibling note), so it never had the
+/// #1219 no-op bug in the first place -- real jq 1.7.1 already raises
+/// "Cannot index array with string \"x\"" for this exact shape, unrelated
+/// to any yq-specific fix. Confirms this codebase's own jq mode already
+/// matches (unaffected by #2333's yq-only changes, all gated on
+/// `S::TAG == EvalTag::Yq`) and doesn't regress into a no-op or a crash.
+#[test]
+fn test_2333_jq_mode_unaffected() -> Result<()> {
+    let (_out, stderr, code) = run_jq_stdin_with_stderr(
+        "del(.a[0:2].x)",
+        r#"{"a":[{"x":1},{"x":2},{"x":3}]}"#,
+        &["-c"],
+    )?;
+    assert_eq!(code, 5, "stderr: {stderr:?}");
+    assert!(stderr.contains("Cannot index array"), "{stderr:?}");
     Ok(())
 }
 

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -21914,6 +21914,122 @@ fn test_2333_del_slice_comma_grouped_array_field_tail_fails_whole_call() -> Resu
     Ok(())
 }
 
+/// #2333 code review (round 2): the fix's first draft found the *last*
+/// slice's own position, not the *start* of the maximal contiguous slice-run
+/// ending there -- for a run of exactly one slice the two coincide, so every
+/// other test in this file passed, but a chained *two*-slice run before a
+/// trailing `Field` (`.a[0:2][1:3].x`) left the earlier slice unguarded in
+/// the computed prefix, and the prefix-navigation helper has no
+/// `Expr::Slice` arm at all (by design -- its only other caller already
+/// filters those out), so it silently gave up and misclassified the whole
+/// shape back to the pre-#2333 `Noop` bug. Matches
+/// `yq_del_slice_outcome`'s own established "a run of any length collapses
+/// to the same target as one slice" rule (see its own #1219 doc comment) --
+/// this is that same rule, verified for the `Error` half of the
+/// classification, not just the `DropParent`/`Noop` halves #1219 already
+/// covers. Live-verified against yq v4.53.3.
+#[test]
+fn test_2333_del_double_slice_run_then_field_errors() -> Result<()> {
+    let (_out, stderr, code) = run_yq_stdin_with_stderr(
+        "del(.a[0:2][1:3].x)",
+        r#"{"a":[1,2,3,4,5]}"#,
+        &["-o=json", "-I=0"],
+    )?;
+    assert_eq!(code, 1, "stderr: {stderr:?}");
+    assert!(
+        stderr.contains("array") && stderr.contains('x'),
+        "{stderr:?}"
+    );
+
+    // A second independent two-slice shape, different bounds -- both
+    // review rounds each found this bug via a different concrete repro;
+    // keeping both closes the gap either one's own narrower fix would have
+    // left open.
+    let (_out, stderr, code) = run_yq_stdin_with_stderr(
+        "del(.a[0:4][0:2].x)",
+        r#"{"a":[1,2,3,4,5]}"#,
+        &["-o=json", "-I=0"],
+    )?;
+    assert_eq!(code, 1, "stderr: {stderr:?}");
+    assert!(
+        stderr.contains("array") && stderr.contains('x'),
+        "{stderr:?}"
+    );
+    Ok(())
+}
+
+/// #2333 code review (round 2): the same two-slice-run generalization as
+/// the previous test, but for `null`'s own direct-target quirk -- the whole
+/// run still collapses to `null`'s single array-shaped target, so the error
+/// fires exactly as it does for a single slice.
+#[test]
+fn test_2333_del_double_slice_run_null_direct_target_errors() -> Result<()> {
+    let (_out, stderr, code) =
+        run_yq_stdin_with_stderr("del(.[0:2][1:3].a)", "null", &["-o=json"])?;
+    assert_eq!(code, 1, "stderr: {stderr:?}");
+    assert!(
+        stderr.contains("array") && stderr.contains('a'),
+        "{stderr:?}"
+    );
+    Ok(())
+}
+
+/// #2333 code review (round 2): `null`'s "only the *direct* slice target"
+/// rule (see `test_2333_del_slice_null_only_errors_for_direct_field_tail`)
+/// still holds once the slice itself is a two-slice run and an `Index` step
+/// sits between the run and the trailing field -- confirms the multi-slice
+/// fix didn't accidentally widen `null`'s own narrower error condition too.
+#[test]
+fn test_2333_del_double_slice_run_null_through_index_stays_noop() -> Result<()> {
+    let (out, code) = run_yq_stdin("del(.[0:2][1:3][0].a)", "null", &["-o=json"])?;
+    assert_eq!(code, 0);
+    assert_eq!(out.trim(), "null");
+    Ok(())
+}
+
+/// #2333 code review (round 2): the multi-slice-run generalization also
+/// holds through a deeper `Index` navigation into a real array (unlike the
+/// `null` case above) -- `.a[0:3][0:2][0].x` collapses its two-slice run,
+/// indexes into the result, and still raises when that element is itself an
+/// array, matching the single-slice
+/// `test_2333_del_slice_index_then_field_errors_when_element_is_array`
+/// sibling exactly.
+#[test]
+fn test_2333_del_double_slice_run_then_index_then_field_errors_on_array_element() -> Result<()> {
+    let (_out, stderr, code) = run_yq_stdin_with_stderr(
+        "del(.a[0:3][0:2][0].x)",
+        r#"{"a":[[1,2],[3,4],[5,6]]}"#,
+        &["-o=json", "-I=0"],
+    )?;
+    assert_eq!(code, 1, "stderr: {stderr:?}");
+    assert!(
+        stderr.contains("array") && stderr.contains('x'),
+        "{stderr:?}"
+    );
+    Ok(())
+}
+
+/// #2333 code review (round 2): a `?` on the erroring field step itself
+/// (`del(.a[0:2].x?)`) suppresses the new error, same as `?` suppresses any
+/// other ordinary path-step error — distinct from `del(...)`'s own outer
+/// `?` (`del(...)?`), which the pre-existing `test_1219_*` tests already
+/// cover via `optional: bool`. Caught by an A/B diff against `main`'s own
+/// pre-#2333 binary: `del(.a[0:2].x?)` was already a correct no-op there
+/// (real yq agrees), and this fix's first draft regressed it into an
+/// unconditional raise by never reading `DeleteStep.optional` for the
+/// erroring step.
+#[test]
+fn test_2333_del_slice_field_tail_optional_suppresses_error() -> Result<()> {
+    let (out, code) = run_yq_stdin("del(.a[0:2].x?)", r#"{"a":[1,2,3]}"#, &["-o=json", "-I=0"])?;
+    assert_eq!(code, 0);
+    assert_eq!(out.trim(), r#"{"a":[1,2,3]}"#);
+
+    let (out, code) = run_yq_stdin("del(.[0:2].a?)", "null", &["-o=json"])?;
+    assert_eq!(code, 0);
+    assert_eq!(out.trim(), "null");
+    Ok(())
+}
+
 /// #2333: jq mode has no #1116/#1162/#1219 chained-slice rule at all (see
 /// `test_1219_jq_mode_unaffected`'s own sibling note), so it never had the
 /// #1219 no-op bug in the first place -- real jq 1.7.1 already raises


### PR DESCRIPTION
## Summary

Found during #2323's own code review, unrelated to that issue's own null-vivify fix (this
predates it and reproduces identically before #2323 merged). Confirmed live against yq
v4.53.3:

```console
$ echo 'null' | yq -o=json 'del(.[0:2].a)'
Error: cannot index array with 'a' (strconv.ParseInt: parsing "a": invalid syntax)
$ echo '{"a":[1,2,3]}' | yq -o=json 'del(.a[0:2].x)'
Error: cannot index array with 'x' (strconv.ParseInt: parsing "x": invalid syntax)
```

`succinctly yq` silently no-op'd both instead.

## Root cause

`yq_del_slice_outcome`'s "trailing slice-run followed by a non-slice tail"
(`YqDelSliceOutcome::Noop`) applied uniformly regardless of the resolved target's actual
type. Real yq's own del() walker doesn't classify a chained slice-run the way this rule
does — it navigates the resolved path against real document data using its ordinary,
non-del-specific indexing, and that indexing can't tell an object-field key from an
array-index key apart syntactically (both are spelled `.key`): once the current node is a
sequence (array), it always tries to parse the key as an integer, which fails for a
genuine field name and raises. #1219's own "no-op" classification is correct for *most* of
this shape — a string-slice result (#1219/#1321's own established precedent) and a bare
`Index` tail that never reaches a field access — this issue is the sub-case that isn't
inert.

## Fix

New `yq_del_slice_field_error` check, wired in as a new `YqDelSliceOutcome::Error`
outcome on the existing "last component isn't a slice" branch. Navigates the real
pre-slice value (via a new `navigate_owned_value`, `navigate_read_only`'s own
value-returning twin), applies every slice in the trailing run to it for real, then walks
any further `Index`/`Field` steps, raising the moment a `Field` step lands on something
that's an `Array` (`null` models as an empty array for this walk, since an empty array's
own semantics already reproduce its narrower "only the direct target" quirk without a
second hand-rolled check). Wired into all 5 `YqDelSliceOutcome` call sites — one,
`rewrite_yq_del_comma_branches`, needed its own return type widened from `Option<Expr>`
to `Result<Option<Expr>, EvalError>` to propagate the new error.

## Two rounds of code review, three real bugs found and fixed

1. **Multi-slice-run boundary** (found independently by two review passes): the slice-run
   boundary was computed as the *last* slice's own position, not the *start* of the
   maximal contiguous run ending there. `del(.a[0:2][1:3].x)` left the earlier slice
   unguarded and silently misclassified back to `Noop`. Fixed by walking backward to the
   run's actual start and applying every slice in it sequentially — matching
   `yq_del_slice_outcome`'s own established "a run of any length collapses to one target"
   rule.
2. **Per-step `?` regression**: a `?` on the erroring field step itself
   (`del(.a[0:2].x?)`, distinct from `del(...)`'s own outer `?`) was never consulted —
   caught by an A/B diff against `main`'s own pre-fix binary, which showed this exact
   shape was already a correct no-op *before* this PR. Fixed by checking
   `DeleteStep.optional` before raising.
3. **Null-handling duplication** (the root cause enabling bug 1 to slip through): a
   separate hand-rolled check for `Null` alongside the general `Array` walker. Unified by
   modeling a `Null` pre-slice value as an empty `Array` and reusing the same suffix
   logic — closing the "duplicated predicates diverge silently" gap.

A fourth finding — a *pre-existing* gap, confirmed via an A/B diff against `main` (not
introduced or worsened here): a literal `.[]` earlier in the path, before the slice-run
(`del(.a[][0:2].x)`), still silently no-ops. Filed as
[#2344](https://github.com/rust-works/succinctly/issues/2344) rather than expanding this
PR's scope further.

## Verification

- 12 CLI regression tests (`tests/yq_cli_tests.rs`), covering both original repros, the
  deeper index-then-field cases, the `null`-only-direct quirk, the multi-slice-run fix
  (two independent shapes), the per-step `?` suppression, the comma-group propagation
  difference, and jq-mode non-regression.
- Full `cargo test --workspace`: all green.
- `cargo test --no-default-features --verbose` (no_std leg): green.
- `cargo clippy --all-targets --all-features -- -D warnings` and the second CI clippy
  leg: clean.
- `cargo fmt --check`, `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features`:
  clean.

Fixes #2333
