### PR TITLE
fix(yq): del() comma-fanout no longer raises on OOB/null iterate

### DIFF
--- a/docs/compliance/yq/limitations.md
+++ b/docs/compliance/yq/limitations.md
@@ -1918,11 +1918,12 @@ top-level comma branch shaped as a static `Field`/`Index` prefix plus a bare tra
 `.[]` whose prefix currently reads `null` off the comma group, and runs it through the
 very same `delete_at_path` a single-target `del()` call already uses -- before
 `resolve_del_path_branches` ever sees the rest. That ordering matches real yq's own
-observed behaviour: every such branch resolves against the pristine input, in any
-relative order, ahead of any sibling's own structural (index-shifting) deletion --
-confirmed live, `del(.[5][], .[0])` and `del(.[0], .[5][])` give the identical answer
-above regardless of order. The same root cause also covered a genuinely-existing `null`
-(not just an out-of-range index) reached the identical way:
+observed behaviour **when no sibling's own resolution can depend on another sibling's
+array-extending side effect**: every such branch resolves against the pristine input
+ahead of any sibling's own structural (index-shifting) deletion, and, among themselves,
+in any relative order -- confirmed live, `del(.[5][], .[0])` and `del(.[0], .[5][])` give
+the identical answer above regardless of order. The same root cause also covered a
+genuinely-existing `null` (not just an out-of-range index) reached the identical way:
 
 ```bash
 $ echo '{"a":null,"c":9}' | yq -o=json 'del(.a[], .c)'   # {"a": []}
@@ -1937,6 +1938,35 @@ fix, via the same `delete_paths_under` machinery #2314 covers.
 (A second gap found during the same review -- `null` never vivifying into `[]` ahead of
 *any* `Index`/`Iterate` del() step, not just a slot #2314 itself just padded -- is now
 closed; see the next section.)
+
+**Two further regressions this pre-pass itself introduced were found and fixed during its
+own mandatory review**, both confirmed live against yq v4.53.3:
+
+- **Order-dependence when a negative index is mixed in.** A comma sibling containing a
+  negative array index (anywhere in its path, matched-shaped or not) can resolve to a
+  different position depending on whether it is evaluated before or after a sibling
+  elsewhere in the group extends the same array -- real yq itself is order-dependent here,
+  and an earlier version of this pre-pass always applied its own vivify branches first
+  regardless of textual order, silently giving one order's answer for both:
+  `del(.[-1], .[4][])` is `[1, null, null, []]` in real yq but `del(.[4][], .[-1])` is
+  `[1, 2, null, null]` -- genuinely different, not just reordered. Fixed by declining the
+  *whole* pre-pass (`contains_length_dependent_index`, checked over every sibling before
+  any matching or mutation) whenever any sibling anywhere contains a negative index, a
+  negative slice bound, or a computed key/slice that can't be proven non-negative --
+  falling through entirely to the unmodified `resolve_del_path_branches` path, the same
+  fallback every other unrecognized shape here already gets. That path raises the same
+  "Cannot iterate over null" (or a genuine "index out of range") this whole pre-pass exists
+  to avoid for the shapes it *does* handle -- a coverage gap for this specific corner case
+  (never in #2324's own scope to begin with), not a wrong answer.
+- **A dropped `?`.** The pre-pass detected a trailing `.[]` shaped as either bare or
+  `?`-suppressed for matching purposes, but always reconstructed a bare `Expr::Iterate` and
+  hardcoded `delete_at_path`'s own `optional` parameter to `false`, discarding which one it
+  actually was. For a *genuinely missing* key (as opposed to a real key holding `null`),
+  the delete walk routes through `delete_at_path_through_absent`, which raises on a trailing
+  `.[]` unless that `.[]`'s own `?` suppresses it -- so a real yq no-op turned into a wrongly
+  raised error: `{"x":1} | del(.missing[]?, .x)` is `{}` in real yq. Fixed by threading the
+  trailing `.[]`'s own optionality through (`trailing_bare_iterate_prefix` now returns it
+  alongside the prefix) instead of hardcoding it away.
 
 ### `del()` auto-vivifies a `null` into `[]` ahead of an `Index`/`Iterate` step, matching `setpath`
 

--- a/docs/compliance/yq/limitations.md
+++ b/docs/compliance/yq/limitations.md
@@ -1899,13 +1899,40 @@ gap below for when it hasn't), and `delete_paths_under`'s array-key arm (`delpat
 recursion) -- all in `src/jq/eval.rs`. `delpaths`' own path components are always concrete
 keys, never a `.[]` wildcard, so there is no `[]`-vivify case to mirror at that site.
 
-**One residual gap found during this fix's own review, not chased here:** a
-**comma-grouped** target whose own `.[]` fan-out crosses the out-of-range index
-(`del(.[5][], .[0])`) never reaches `delete_trie_array` at all -- the read-based
-validation that enumerates concrete branches for the trie reads `.[5]` as a plain `null`
-(correct for an ordinary read) and raises iterating `.[]` over it, rather than
-extending+vivifying the way the direct, non-comma-grouped form now does. Tracked as
-[#2324](https://github.com/rust-works/succinctly/issues/2324).
+**A residual gap found during this fix's own review is now closed too**
+([#2324](https://github.com/rust-works/succinctly/issues/2324)). A **comma-grouped**
+target whose own `.[]` fan-out crosses the out-of-range index (`del(.[5][], .[0])`) never
+reached `delete_trie_array` at all -- the read-based validation that enumerates concrete
+branches for the trie read `.[5]` as a plain `null` (correct for an ordinary read) and
+raised iterating `.[]` over it, rather than extending+vivifying the way the direct,
+non-comma-grouped form already did:
+
+```bash
+$ echo '[1,2]' | yq -o=json 'del(.[5][], .[0])'   # [2, null, null, null, []]
+```
+
+Fixed not by teaching `resolve_node`'s shared, read-only `Expr::Iterate` arm (or the
+delete trie) a del()-specific exception, but by a narrow pre-pass
+(`vivify_del_comma_iterate_targets`, called from `builtin_del`) that peels every
+top-level comma branch shaped as a static `Field`/`Index` prefix plus a bare trailing
+`.[]` whose prefix currently reads `null` off the comma group, and runs it through the
+very same `delete_at_path` a single-target `del()` call already uses -- before
+`resolve_del_path_branches` ever sees the rest. That ordering matches real yq's own
+observed behaviour: every such branch resolves against the pristine input, in any
+relative order, ahead of any sibling's own structural (index-shifting) deletion --
+confirmed live, `del(.[5][], .[0])` and `del(.[0], .[5][])` give the identical answer
+above regardless of order. The same root cause also covered a genuinely-existing `null`
+(not just an out-of-range index) reached the identical way:
+
+```bash
+$ echo '{"a":null,"c":9}' | yq -o=json 'del(.a[], .c)'   # {"a": []}
+```
+
+`delpaths()`'s own multi-key batch form was checked and confirmed unaffected --
+its path components are always concrete keys, never a `.[]` wildcard (as already noted
+above), so it never reaches `resolve_node`'s `Expr::Iterate` arm at all; the analogous
+mid-chain-index batch shape (`delpaths([[5,0],[0]])`) already matched real yq before this
+fix, via the same `delete_paths_under` machinery #2314 covers.
 
 (A second gap found during the same review -- `null` never vivifying into `[]` ahead of
 *any* `Index`/`Iterate` del() step, not just a slot #2314 itself just padded -- is now

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -37620,9 +37620,22 @@ fn peek_static_prefix<'a>(
 /// -- is shaped as a static `Field`/`Index` prefix (no computed key, no
 /// slice, no nested iterate) followed by a bare, optionally `?`-suppressed,
 /// *trailing* `.[]`. Returns the prefix's own flattened components (may be
-/// empty, for a bare `.[]`/`.[]?` branch) when it is; `None` for every other
-/// shape, which [`vivify_del_comma_iterate_targets`] then leaves completely
+/// empty, for a bare `.[]`/`.[]?` branch) alongside whether the trailing
+/// `.[]` itself carried a `?` when it is; `None` for every other shape,
+/// which [`vivify_del_comma_iterate_targets`] then leaves completely
 /// untouched.
+///
+/// The returned `bool` matters for real correctness, not just style: a
+/// missing (not merely `null`-valued) object key routes
+/// `vivify_del_comma_iterate_targets`'s own `delete_at_path` call through
+/// [`delete_at_path_through_absent`], which -- unlike a genuinely-`null`
+/// value reached via a real lookup -- forces the rest of the chain into
+/// non-real-slot mode, and a trailing `.[]` there raises unless *its own*
+/// `?` suppresses it (`delete_at_path`'s `Expr::Iterate` arm's `_ if
+/// optional`). Dropping this flag on the floor (an earlier version of this
+/// fix always reconstructed a bare, unsuppressed `Iterate`) turned a real
+/// yq no-op into a wrongly-raised error -- confirmed live (yq v4.53.3):
+/// `{"x":1} | del(.missing[]?, .x)` is `{}`, not an error.
 ///
 /// `push_path_components` (already used by `resolve_seq` for the identical
 /// job) does the flattening -- including splicing a `Paren`/nested `Pipe`
@@ -37632,20 +37645,20 @@ fn peek_static_prefix<'a>(
 /// computed one becomes `Expr::IndexExpr` instead, a different variant this
 /// prefix filter already excludes), so there is no "looks static but isn't"
 /// case to worry about here.
-fn trailing_bare_iterate_prefix(sibling: &Expr) -> Option<Vec<Expr>> {
+fn trailing_bare_iterate_prefix(sibling: &Expr) -> Option<(Vec<Expr>, bool)> {
     let mut flat = Vec::new();
     push_path_components(&mut flat, sibling);
     let last = flat.last()?;
-    let is_trailing_iterate = matches!(last, Expr::Iterate)
-        || matches!(last, Expr::Optional(inner) if matches!(inner.as_ref(), Expr::Iterate));
-    if !is_trailing_iterate {
-        return None;
-    }
+    let trailing_optional = match last {
+        Expr::Iterate => false,
+        Expr::Optional(inner) if matches!(inner.as_ref(), Expr::Iterate) => true,
+        _ => return None,
+    };
     let prefix = &flat[..flat.len() - 1];
     prefix
         .iter()
         .all(|e| matches!(e, Expr::Field(_) | Expr::Index { .. }))
-        .then(|| prefix.to_vec())
+        .then(|| (prefix.to_vec(), trailing_optional))
 }
 
 /// #2324's own pre-pass: peel off every top-level `del()` comma branch shaped
@@ -37679,15 +37692,40 @@ fn trailing_bare_iterate_prefix(sibling: &Expr) -> Option<Vec<Expr>> {
 /// offending branch off the comma group and run it through the very same
 /// `delete_at_path` a single-target `del()` call already uses, *before*
 /// `resolve_del_path_branches` ever sees the rest. That ordering matches
-/// real yq's own observed behaviour -- every vivify-eligible branch resolves
-/// against the pristine input, in any relative order, ahead of any sibling's
-/// own structural deletion (an index removal that shifts the array).
-/// Confirmed live against yq v4.53.3: `del(.[5][], .[0])` and
-/// `del(.[0], .[5][])` on `[1,2]` both give `[2, null, null, null, []]` --
-/// same result regardless of which comma position `.[5][]` occupies, and
-/// `del(.[5][], .[2][])`/`del(.[2][], .[5][])` likewise agree
-/// (`[1, 2, [], null, null, []]`) even with two such branches sharing
-/// overlapping padding.
+/// real yq's own observed behaviour **when no sibling's own resolution can
+/// depend on another sibling's array-extending side effect** -- every
+/// vivify-eligible branch resolves against the pristine input, ahead of any
+/// sibling's own structural deletion (an index removal that shifts the
+/// array), and, among themselves, in any relative order. Confirmed live
+/// against yq v4.53.3: `del(.[5][], .[0])` and `del(.[0], .[5][])` on
+/// `[1,2]` both give `[2, null, null, null, []]` -- same result regardless
+/// of which comma position `.[5][]` occupies, and `del(.[5][],
+/// .[2][])`/`del(.[2][], .[5][])` likewise agree (`[1, 2, [], null, null,
+/// []]`) even with two such branches sharing overlapping padding.
+///
+/// That "any relative order" guarantee stops holding the moment *any*
+/// sibling in the group -- matched or not -- carries a negative array index,
+/// a negative slice bound, or a computed key/slice: its resolved value can
+/// itself depend on the document's length at the moment it is evaluated,
+/// which is exactly what textual order controls. Confirmed live (yq
+/// v4.53.3) both as silent wrong-answer risk and as genuine order-dependence
+/// in real yq itself: `del(.[-1], .[4][])` on `[1,2]` is `[1, null, null,
+/// []]`, but `del(.[4][], .[-1])` is `[1, 2, null, null]` -- and
+/// `del(.[-2][], .[5][])`/`del(.[-2][], .[4][])` (a negative index inside a
+/// *matched*-shaped sibling, not just a `remaining` one) diverge from this
+/// pre-pass's own order-blind answer too. [`contains_length_dependent_index`]
+/// is this function's guard against exactly that: any sibling containing one
+/// of those shapes anywhere makes the *whole* pre-pass decline (`Ok(None)`),
+/// falling through entirely to the unmodified `resolve_del_path_branches`
+/// path below -- the same fallback every other unrecognized shape already
+/// gets, and the one this function used unconditionally before this guard
+/// existed. That sacrifices this pre-pass's own coverage for the
+/// negative-index-mixed-with-vivify corner case (never in #2324's own scope
+/// to begin with -- its repros only ever paired a vivify-eligible branch
+/// with a *positive* fixed index like `.[0]`), but never produces a silently
+/// wrong answer: the fallback still raises the same "Cannot iterate over
+/// null" (or a genuine "index out of range") this whole pre-pass exists to
+/// avoid for the shapes it *does* handle.
 ///
 /// A branch this doesn't recognize (a computed key, a slice, a mid-chain
 /// iterate, `Field`/`Index` on a value that isn't currently `null`) is left
@@ -37732,12 +37770,28 @@ fn vivify_del_comma_iterate_targets(
     let Expr::Comma(siblings) = unwrapped else {
         return Ok(None);
     };
+    // Order-safety guard (review of #2324, both regressions confirmed live
+    // against yq v4.53.3) -- see this function's own doc comment for the
+    // repros. Checked over *every* sibling, before any matching or mutation:
+    // a negative index (or anything that could resolve to one) can appear
+    // inside a `trailing_bare_iterate_prefix`-*matched* sibling's own prefix
+    // just as easily as inside a `remaining` one -- `.[-3][]` matches that
+    // shape exactly like `.[5][]` does -- and whichever bucket it lands in
+    // depends on this loop's own progressive mutation, which is precisely
+    // the ambiguity that makes the result order-dependent. Bailing here,
+    // before any sibling has been matched or `result` touched, is what lets
+    // this be a whole-call decline rather than a partial, still-ambiguous
+    // one.
+    if siblings.iter().any(contains_length_dependent_index) {
+        return Ok(None);
+    }
     let mut remaining = vec_with_capacity(siblings.len());
     let mut handled_any = false;
     for sibling in siblings {
-        let prefix = trailing_bare_iterate_prefix(sibling)
-            .filter(|prefix| matches!(peek_static_prefix(result, prefix), Ok(OwnedValue::Null)));
-        let Some(prefix) = prefix else {
+        let prefix = trailing_bare_iterate_prefix(sibling).filter(|(prefix, _)| {
+            matches!(peek_static_prefix(result, prefix), Ok(OwnedValue::Null))
+        });
+        let Some((prefix, trailing_optional)) = prefix else {
             remaining.push(sibling.clone());
             continue;
         };
@@ -37749,9 +37803,45 @@ fn vivify_del_comma_iterate_targets(
         } else {
             Expr::Pipe(components)
         };
-        delete_at_path(result, &branch_expr, false, true, true)?;
+        delete_at_path(result, &branch_expr, trailing_optional, true, true)?;
     }
     Ok(handled_any.then_some(remaining))
+}
+
+/// Whether `expr` contains, anywhere within it -- through any nesting of
+/// `Pipe`/`Comma`/`Paren`/`Optional` -- an array-position component whose
+/// resolution can depend on the length of the array it indexes into at the
+/// moment it is evaluated: a literal negative [`Expr::Index`], a
+/// [`Expr::Slice`] with a negative bound, or a computed
+/// [`Expr::IndexExpr`]/[`Expr::SliceExpr`] key (whose resolved value can't
+/// be proven non-negative statically, so it's treated the same way). Used
+/// by [`vivify_del_comma_iterate_targets`]'s own up-front guard -- see that
+/// function's doc comment for why *any* sibling carrying one of these, not
+/// just a `remaining` (non-vivify-matched) one, forces the whole pre-pass to
+/// decline.
+///
+/// Deliberately scoped to the same path-expression grammar
+/// `push_path_components` already flattens (`Pipe`/`Paren`/`Optional`), plus
+/// `Comma` for a nested group (`del((.a[-1], .b), .c)`) -- a `del()` target
+/// built from a more exotic filter (`if`/`reduce`/a function call) is out of
+/// scope for this guard the same way it already was for
+/// `trailing_bare_iterate_prefix`'s own shape match, which never matches
+/// such a sibling as a vivify candidate in the first place. Not finding a
+/// negative index inside one of those doesn't matter either way: whatever
+/// non-path-shaped expression it evaluates to goes through the ordinary
+/// `resolve_del_path_branches` path exactly as it always has, guard or no
+/// guard.
+fn contains_length_dependent_index(expr: &Expr) -> bool {
+    match expr {
+        Expr::Index { idx, .. } => *idx < 0,
+        Expr::Slice { start, end, .. } => {
+            start.is_some_and(|s| s < 0) || end.is_some_and(|e| e < 0)
+        }
+        Expr::IndexExpr { .. } | Expr::SliceExpr { .. } => true,
+        Expr::Pipe(exprs) | Expr::Comma(exprs) => exprs.iter().any(contains_length_dependent_index),
+        Expr::Paren(inner) | Expr::Optional(inner) => contains_length_dependent_index(inner),
+        _ => false,
+    }
 }
 
 /// Builtin: del(path) - delete a single path
@@ -75630,6 +75720,52 @@ mod tests {
             .map(OwnedValue::to_json)
             .collect();
         assert_eq!(rendered, vec![r#"{"a":1}"#.to_string()]);
+    }
+
+    #[test]
+    fn contains_length_dependent_index_flags_negative_index_anywhere_2324() {
+        // #2324 review, regression 1: a top-level negative `Expr::Index`.
+        assert!(contains_length_dependent_index(&parse(".[-1]").unwrap()));
+        // A positive index is never length-dependent -- must not false-positive.
+        assert!(!contains_length_dependent_index(&parse(".[1]").unwrap()));
+        // Mid-chain, not just the last component (`.a[-1].b`).
+        assert!(contains_length_dependent_index(&parse(".a[-1].b").unwrap()));
+        // Through a nested `Paren`/`Optional`.
+        assert!(contains_length_dependent_index(&parse("(.[-1])?").unwrap()));
+        // Through a nested `Comma` (`del((.a[-1], .b), .c)`'s inner group).
+        assert!(contains_length_dependent_index(
+            &parse("(.a[-1], .b)").unwrap()
+        ));
+        // A negative slice bound, start or end, is length-dependent too.
+        assert!(contains_length_dependent_index(&parse(".[-2:]").unwrap()));
+        assert!(contains_length_dependent_index(&parse(".[:-2]").unwrap()));
+        // A positive-only slice is not.
+        assert!(!contains_length_dependent_index(&parse(".[1:2]").unwrap()));
+        // A computed key/slice can't be proven non-negative statically, so
+        // it's conservatively flagged too.
+        assert!(contains_length_dependent_index(&parse(".[.a]").unwrap()));
+        assert!(contains_length_dependent_index(&parse(".[.a:2]").unwrap()));
+        // A plain field/iterate chain with none of the above is unaffected.
+        assert!(!contains_length_dependent_index(&parse(".a.b[]").unwrap()));
+    }
+
+    #[test]
+    fn trailing_bare_iterate_prefix_threads_optional_flag_2324() {
+        // #2324 review, regression 2: the trailing `.[]`'s own `?` must be
+        // reported back, not silently discarded -- `vivify_del_comma_iterate_targets`
+        // threads it into `delete_at_path`'s `optional` parameter.
+        let (prefix, optional) = trailing_bare_iterate_prefix(&parse(".a[]?").unwrap())
+            .expect("should match trailing-iterate shape");
+        assert_eq!(prefix, vec![Expr::Field("a".to_string())]);
+        assert!(optional, "the `?` on the trailing `.[]` must be reported");
+
+        let (prefix, optional) = trailing_bare_iterate_prefix(&parse(".a[]").unwrap())
+            .expect("should match trailing-iterate shape");
+        assert_eq!(prefix, vec![Expr::Field("a".to_string())]);
+        assert!(!optional, "no `?` was written, so this must be false");
+
+        // A non-trailing-iterate shape still doesn't match at all.
+        assert!(trailing_bare_iterate_prefix(&parse(".a").unwrap()).is_none());
     }
 
     #[test]

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -37572,6 +37572,188 @@ fn rewrite_yq_del_comma_branches(expr: &Expr, root: &OwnedValue) -> Option<Expr>
     }
 }
 
+/// Read-only static walk through a `Field`/`Index`-only prefix (#2324's own
+/// pre-pass detection below), answering exactly what an ordinary read would:
+/// `Null` for a missing object key or an out-of-range array index, matching
+/// `navigate_static_component`'s own read semantics (that function is not
+/// reused directly because it *consumes* its input to avoid a clone on the
+/// hot `=`/`|=` path -- this caller only ever needs to peek, on the rare
+/// error-recovery path below, so borrowing is both simpler and cheaper
+/// here). Returns `Err(())` on a genuine type mismatch -- indexing a
+/// non-container, non-null value -- so the caller can leave that case for
+/// the ordinary `resolve_del_path_branches` path to raise its own
+/// correctly-worded error, exactly as it already does today.
+fn peek_static_prefix<'a>(
+    mut current: &'a OwnedValue,
+    prefix: &[Expr],
+) -> Result<&'a OwnedValue, ()> {
+    const NULL: OwnedValue = OwnedValue::Null;
+    for component in prefix {
+        current = match (component, current) {
+            (Expr::Field(name), OwnedValue::Object(map)) => map.get(name).unwrap_or(&NULL),
+            (Expr::Field(_), OwnedValue::Null) => &NULL,
+            (Expr::Index { idx, .. }, OwnedValue::Array(items)) => {
+                let resolved = if *idx < 0 {
+                    items.len() as i64 + idx
+                } else {
+                    *idx
+                };
+                usize::try_from(resolved)
+                    .ok()
+                    .filter(|&i| i < items.len())
+                    .map_or(&NULL, |i| &items[i])
+            }
+            (Expr::Index { .. }, OwnedValue::Null) => &NULL,
+            // Anything else (a `Field`/`Index` against a scalar) is a
+            // genuine type mismatch -- the caller's own prefix filter
+            // (`trailing_bare_iterate_prefix`) only ever hands this
+            // `Field`/`Index` components, so this arm exists purely so a
+            // future widening of that filter fails closed here instead of
+            // panicking.
+            _ => return Err(()),
+        };
+    }
+    Ok(current)
+}
+
+/// Detect whether `sibling` -- one top-level branch of a `del()` comma group
+/// -- is shaped as a static `Field`/`Index` prefix (no computed key, no
+/// slice, no nested iterate) followed by a bare, optionally `?`-suppressed,
+/// *trailing* `.[]`. Returns the prefix's own flattened components (may be
+/// empty, for a bare `.[]`/`.[]?` branch) when it is; `None` for every other
+/// shape, which [`vivify_del_comma_iterate_targets`] then leaves completely
+/// untouched.
+///
+/// `push_path_components` (already used by `resolve_seq` for the identical
+/// job) does the flattening -- including splicing a `Paren`/nested `Pipe`
+/// and distributing an outer `Optional` over a group -- so this doesn't have
+/// to hand-roll that walk a second time. `Expr::Index`'s own `idx` is always
+/// a resolved literal (the parser folds every constant index into it; a
+/// computed one becomes `Expr::IndexExpr` instead, a different variant this
+/// prefix filter already excludes), so there is no "looks static but isn't"
+/// case to worry about here.
+fn trailing_bare_iterate_prefix(sibling: &Expr) -> Option<Vec<Expr>> {
+    let mut flat = Vec::new();
+    push_path_components(&mut flat, sibling);
+    let last = flat.last()?;
+    let is_trailing_iterate = matches!(last, Expr::Iterate)
+        || matches!(last, Expr::Optional(inner) if matches!(inner.as_ref(), Expr::Iterate));
+    if !is_trailing_iterate {
+        return None;
+    }
+    let prefix = &flat[..flat.len() - 1];
+    prefix
+        .iter()
+        .all(|e| matches!(e, Expr::Field(_) | Expr::Index { .. }))
+        .then(|| prefix.to_vec())
+}
+
+/// #2324's own pre-pass: peel off every top-level `del()` comma branch shaped
+/// as a static `Field`/`Index` prefix followed by a bare trailing `.[]`
+/// ([`trailing_bare_iterate_prefix`]) whose prefix currently reads as `null`
+/// -- genuinely so in the document, or because a positive index along the
+/// way is out of range (an ordinary read answers `null` either way, no error
+/// -- only *iterating* a `null` raises).
+///
+/// `resolve_node`'s own `Expr::Iterate` arm is read-only path-resolution
+/// machinery shared by every other caller (`=`, `|=`, `path()`, an ordinary
+/// read reached through `path()`) and is correct to raise "Cannot iterate
+/// over null" for exactly this value there -- but `del()`'s own comma-
+/// grouped target set is built by feeding the *whole* comma expression
+/// through that same read-based resolver (`resolve_del_path_branches`), so
+/// the same raise fires for a `del()` target too, before the trie this
+/// issue's sibling fixes (#2314/#2323) ever runs. Both of those already
+/// established the correct answer for a *single*, non-comma target
+/// (`delete_path_steps`'s own `Expr::Index`/`Expr::Iterate` arms extend/
+/// vivify instead of raising) -- comma-grouping is what routes around that
+/// machinery entirely (`needs_path_prepass` is unconditionally `true` for
+/// any `Expr::Comma`, so even a single `.[5][]` sibling takes the read-based
+/// `resolve_node` path once it has a comma sibling, where alone it would
+/// have stayed on the `DelPaths::Verbatim` fast path and never touched
+/// `resolve_node` at all).
+///
+/// Rather than teach `resolve_node`'s shared `Expr::Iterate` arm a
+/// del()-specific exception (risking every other path-resolving caller) or
+/// teach the trie a new "vivify but nothing to delete" leaf kind, this
+/// reuses #2314/#2323's own already-correct machinery directly: peel the
+/// offending branch off the comma group and run it through the very same
+/// `delete_at_path` a single-target `del()` call already uses, *before*
+/// `resolve_del_path_branches` ever sees the rest. That ordering matches
+/// real yq's own observed behaviour -- every vivify-eligible branch resolves
+/// against the pristine input, in any relative order, ahead of any sibling's
+/// own structural deletion (an index removal that shifts the array).
+/// Confirmed live against yq v4.53.3: `del(.[5][], .[0])` and
+/// `del(.[0], .[5][])` on `[1,2]` both give `[2, null, null, null, []]` --
+/// same result regardless of which comma position `.[5][]` occupies, and
+/// `del(.[5][], .[2][])`/`del(.[2][], .[5][])` likewise agree
+/// (`[1, 2, [], null, null, []]`) even with two such branches sharing
+/// overlapping padding.
+///
+/// A branch this doesn't recognize (a computed key, a slice, a mid-chain
+/// iterate, `Field`/`Index` on a value that isn't currently `null`) is left
+/// completely untouched and falls through to the unmodified
+/// `resolve_del_path_branches`/trie path exactly as before this fix --
+/// including the case where the prefix isn't even readable without an
+/// actual type error (`peek_static_prefix`'s `Err`), which is left for that
+/// existing path to raise its own correctly-worded complaint.
+///
+/// Returns `Ok(None)` when `path_expr` is not (after unwrapping any
+/// `Expr::Paren`) a `Comma` at all, or no branch in it matched this shape --
+/// the caller uses `path_expr` unchanged. `Ok(Some(remaining))` carries
+/// whatever siblings still need ordinary resolution -- possibly empty,
+/// meaning every branch was consumed here and `result` already holds
+/// `del()`'s complete answer. `Err` is a genuine error surfaced while
+/// applying one of the peeled branches -- propagated exactly like any other
+/// per-step `del()` failure, leaving the caller to turn it into
+/// `QueryResult::None` under the call's own outer `?` exactly as the
+/// ordinary per-path loop already does.
+///
+/// `Expr::Paren` is unwrapped (any nesting depth) before the `Comma` check,
+/// mirroring `rewrite_yq_del_comma_branches`'s own identical unwrap for the
+/// identical reason (#1223): `del((.[5][], .[0]))` parses to
+/// `Expr::Paren(Expr::Comma(...))`, not a bare top-level `Comma`, and is
+/// otherwise syntactically the same query. The returned `remaining` is never
+/// re-wrapped in that `Paren` -- unlike `Expr::Optional`, a bare `Paren` is
+/// fully transparent to every downstream consumer here
+/// (`resolve_node`/`needs_path_prepass`/`delete_at_path` each just recurse
+/// through it), so dropping it changes nothing observable. `Expr::Optional`
+/// itself is deliberately *not* unwrapped the same way: an outer `?` on the
+/// whole comma group is a different, untested shape outside every repro
+/// this issue documents, and isn't obviously transparent the way `Paren`
+/// is.
+fn vivify_del_comma_iterate_targets(
+    path_expr: &Expr,
+    result: &mut OwnedValue,
+) -> Result<Option<Vec<Expr>>, EvalError> {
+    let mut unwrapped = path_expr;
+    while let Expr::Paren(inner) = unwrapped {
+        unwrapped = inner;
+    }
+    let Expr::Comma(siblings) = unwrapped else {
+        return Ok(None);
+    };
+    let mut remaining = vec_with_capacity(siblings.len());
+    let mut handled_any = false;
+    for sibling in siblings {
+        let prefix = trailing_bare_iterate_prefix(sibling)
+            .filter(|prefix| matches!(peek_static_prefix(result, prefix), Ok(OwnedValue::Null)));
+        let Some(prefix) = prefix else {
+            remaining.push(sibling.clone());
+            continue;
+        };
+        handled_any = true;
+        let mut components = prefix;
+        components.push(Expr::Iterate);
+        let branch_expr = if components.len() == 1 {
+            components.into_iter().next().expect("len checked")
+        } else {
+            Expr::Pipe(components)
+        };
+        delete_at_path(result, &branch_expr, false, true, true)?;
+    }
+    Ok(handled_any.then_some(remaining))
+}
+
 /// Builtin: del(path) - delete a single path
 fn builtin_del<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     path_expr: &Expr,
@@ -37594,7 +37776,7 @@ fn builtin_del<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     // path (`del(.a?)`) is unaffected — it's already a distinct
     // `Expr::Optional` node baked into `path_expr`, which the walkers still
     // honor on their own.
-    let result = to_owned_or_suppress!(&value, optional);
+    let mut result = to_owned_or_suppress!(&value, optional);
 
     // yq's comma-grouped chained-slice del() pre-rewrite (#1223):
     // `resolve_dynamic_indexes`'s own generic navigation raises a hard type
@@ -37618,6 +37800,41 @@ fn builtin_del<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
             &rewritten_comma_path_expr
         } else {
             path_expr
+        }
+    } else {
+        path_expr
+    };
+
+    // #2324: peel off every comma branch shaped as a static `Field`/`Index`
+    // prefix plus a bare trailing `.[]` whose prefix currently reads `null`
+    // -- see `vivify_del_comma_iterate_targets`'s own doc comment for why
+    // this has to run as its own pre-pass rather than as a fix inside
+    // `resolve_node`/`resolve_del_path_branches` or the delete trie. Mutates
+    // `result` in place (extending/vivifying exactly as the already-correct
+    // single-target `del(.[5][])` form does) and, when it consumed every
+    // comma branch, returns the whole call's answer immediately.
+    let vivified_comma_path_expr: Expr;
+    let path_expr: &Expr = if S::TAG == EvalTag::Yq {
+        match vivify_del_comma_iterate_targets(path_expr, &mut result) {
+            Ok(None) => path_expr,
+            Ok(Some(remaining)) => {
+                if remaining.is_empty() {
+                    return QueryResult::Owned(result);
+                }
+                vivified_comma_path_expr = if remaining.len() == 1 {
+                    remaining.into_iter().next().expect("len checked")
+                } else {
+                    Expr::Comma(remaining)
+                };
+                &vivified_comma_path_expr
+            }
+            Err(e) => {
+                return if optional {
+                    QueryResult::None
+                } else {
+                    QueryResult::Error(e)
+                };
+            }
         }
     } else {
         path_expr

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -29376,3 +29376,160 @@ fn test_plain_iterate_over_null_read_unaffected_by_2324() -> Result<()> {
 
     Ok(())
 }
+
+/// #2324 review, regression 1: a `remaining` (non-vivify-matched) sibling
+/// containing a negative index resolves against a *different* array length
+/// depending on whether it sits before or after a vivify-matched sibling in
+/// the comma group -- the pre-pass's own mutate-eagerly ordering ignored
+/// that, giving the same (wrong for one of the two orderings) answer either
+/// way. Confirmed live against yq v4.53.3: `del(.[-1], .[4][])` on `[1,2]`
+/// is `[1, null, null, []]`, but `del(.[4][], .[-1])` is `[1, 2, null,
+/// null]` -- genuinely different answers depending on textual order. The
+/// fix declines the whole pre-pass whenever any sibling contains a negative
+/// index anywhere (`contains_length_dependent_index`), falling through to
+/// the unmodified `resolve_del_path_branches` path, which raises "Cannot
+/// iterate over null" for both orderings here -- a coverage gap, not a
+/// wrong answer (this exact shape was never in #2324's own scope, which
+/// only ever paired a vivify-eligible branch with a *positive* fixed
+/// index).
+#[test]
+fn test_del_comma_fanout_negative_index_sibling_declines_prepass_2324() -> Result<()> {
+    let (_, stderr, code) =
+        run_yq_stdin_with_stderr("del(.[-1], .[4][])", "[1, 2]\n", &["-o=json"])?;
+    assert_ne!(code, 0);
+    assert!(
+        stderr.contains("Cannot iterate over null"),
+        "stderr={stderr}"
+    );
+
+    let (_, stderr, code) =
+        run_yq_stdin_with_stderr("del(.[4][], .[-1])", "[1, 2]\n", &["-o=json"])?;
+    assert_ne!(code, 0);
+    assert!(
+        stderr.contains("Cannot iterate over null"),
+        "stderr={stderr}"
+    );
+
+    Ok(())
+}
+
+/// #2324 review, regression 1 (second finder's repro): a negative index can
+/// also appear *inside* a sibling that itself matches
+/// `trailing_bare_iterate_prefix`'s own vivify shape (`.[-3][]` matches
+/// exactly like `.[5][]` does) -- so the order-safety guard has to scan
+/// every sibling up front, not just whichever ones end up in `remaining`
+/// after matching, since which bucket a negative-index sibling lands in is
+/// itself order-dependent. Confirmed live against yq v4.53.3:
+/// `del(.[-2][], .[5][])` on `[1,2]` is `[1, 2, null, null, null, []]`
+/// (`.[-2][]`, read against the *pristine* length-2 array, resolves to a
+/// real value and is silently dropped rather than vivifying), while
+/// `del(.[-2][], .[4][])` is `[1, 2, null, null, []]`. Both are declined by
+/// this pre-pass (raising "Cannot iterate over number" -- `.[-2]` reads a
+/// real, non-null value against the pristine array once the whole comma
+/// group falls through to the unmodified `resolve_del_path_branches`
+/// path), matching the same "coverage gap, not a wrong answer" contract as
+/// the simpler repro above.
+#[test]
+fn test_del_comma_fanout_negative_index_in_matched_shape_sibling_declines_prepass_2324(
+) -> Result<()> {
+    let (_, stderr, code) =
+        run_yq_stdin_with_stderr("del(.[-2][], .[5][])", "[1, 2]\n", &["-o=json"])?;
+    assert_ne!(code, 0);
+    assert!(stderr.contains("Cannot iterate"), "stderr={stderr}");
+
+    let (_, stderr, code) =
+        run_yq_stdin_with_stderr("del(.[-2][], .[4][])", "[1, 2]\n", &["-o=json"])?;
+    assert_ne!(code, 0);
+    assert!(stderr.contains("Cannot iterate"), "stderr={stderr}");
+
+    Ok(())
+}
+
+/// #2324 review, regression 1 control: a `del()` comma sibling carrying a
+/// negative *slice* bound (`.[-2:]`, no trailing `.[]`) rather than a
+/// negative index. This shape never actually reaches
+/// `vivify_del_comma_iterate_targets`'s own siblings at all -- the
+/// pre-existing #1223 `rewrite_yq_del_comma_branches`/`yq_del_slice_outcome`
+/// pass (which runs *before* the #2324 pre-pass in `builtin_del`) already
+/// intercepts and neutralizes every comma branch containing a slice
+/// component, trailing-iterate or not, ahead of it -- so
+/// `contains_length_dependent_index`'s own `Expr::Slice` arm is exercised
+/// directly by a unit test instead (`eval.rs`'s own `#[cfg(test)] mod
+/// tests`), not reachable here. This is pinned as an end-to-end control
+/// confirming the *existing*, already-correct #1223 pipeline still governs
+/// this shape unchanged by the #2324 pre-pass: confirmed live against yq
+/// v4.53.3 that `del(.[-2:], .[4][])` and its reversed sibling order both
+/// give `[1, 2, null, null, []]` -- `.[-2:]` (a bare trailing slice with no
+/// static prefix before it) is a documented #1223 no-op, and only `.[4][]`
+/// takes effect.
+#[test]
+fn test_del_comma_fanout_negative_slice_bound_sibling_2324() -> Result<()> {
+    let (out, code) = run_yq_stdin("del(.[-2:], .[4][])", "[1, 2]\n", &["-o=json", "-I=0"])?;
+    assert_eq!(code, 0, "out: {out:?}");
+    assert_eq!(out.trim(), "[1,2,null,null,[]]");
+
+    let (out, code) = run_yq_stdin("del(.[4][], .[-2:])", "[1, 2]\n", &["-o=json", "-I=0"])?;
+    assert_eq!(code, 0, "out: {out:?}");
+    assert_eq!(out.trim(), "[1,2,null,null,[]]");
+
+    Ok(())
+}
+
+/// #2324 review, regression 2: the `?` on a comma-grouped vivify-eligible
+/// sibling's own trailing `.[]` was being silently discarded by the
+/// pre-pass, which always reconstructed a bare, unsuppressed `Expr::Iterate`
+/// and hardcoded `delete_at_path`'s own `optional` parameter to `false`
+/// regardless. For a *genuinely missing* key (not merely a `null`-valued
+/// one), the delete walk routes through `delete_at_path_through_absent`,
+/// which raises on a trailing `.[]` unless that `.[]`'s own `?` suppresses
+/// it -- so dropping the flag turned a real yq no-op into a wrongly-raised
+/// error. Confirmed live against yq v4.53.3: `{"x":1} | del(.missing[]?,
+/// .x)` is `{}`.
+#[test]
+fn test_del_comma_fanout_missing_key_iterate_optional_suppresses_2324() -> Result<()> {
+    let (out, code) = run_yq_stdin("del(.missing[]?, .x)", "x: 1\n", &["-o=json", "-I=0"])?;
+    assert_eq!(code, 0, "out: {out:?}");
+    assert_eq!(out.trim(), "{}");
+
+    Ok(())
+}
+
+/// #2324 review, regression 2 (nested repro): the same `?`-suppression fix,
+/// through a static `Field`/`Index` prefix deeper than one component
+/// (`.a[2][]?`). Confirmed live against yq v4.53.3: `{"b":1} |
+/// del(.a[2][]?, .b)` is `{}`.
+#[test]
+fn test_del_comma_fanout_missing_key_iterate_optional_suppresses_nested_2324() -> Result<()> {
+    let (out, code) = run_yq_stdin("del(.a[2][]?, .b)", "b: 1\n", &["-o=json", "-I=0"])?;
+    assert_eq!(code, 0, "out: {out:?}");
+    assert_eq!(out.trim(), "{}");
+
+    Ok(())
+}
+
+/// #2324 review, regression 2 control: the identical shape *without* the
+/// `?` on the trailing `.[]` must keep raising exactly as it did before
+/// this fix -- the fix threads the sibling's *own* `?` through, it does not
+/// change what happens when there isn't one. This control's own raise
+/// predates and is independent of this fix (it also fires for the
+/// non-comma-grouped single-target form, `del(.missing[])` alone, via the
+/// same `delete_at_path_through_absent` machinery) -- it is not itself
+/// verified against real yq here, since live-testing during review found
+/// real yq actually treats a *missing* key's trailing `.[]` as a silent
+/// no-op even without a `?` (`{"x":1} | yq 'del(.missing[], .x)'` is `{}`
+/// against yq v4.53.3), diverging from succinctly's existing, pre-#2324,
+/// single-target behaviour for the identical shape. That divergence is
+/// unrelated to the comma pre-pass this review covers and is out of scope
+/// here; this test only pins that this fix does not change it either way.
+#[test]
+fn test_del_comma_fanout_missing_key_iterate_no_optional_still_raises_2324() -> Result<()> {
+    let (out, stderr, code) =
+        run_yq_stdin_with_stderr("del(.missing[], .x)", "x: 1\n", &["-o=json"])?;
+    assert_ne!(code, 0, "out: {out:?}");
+    assert!(
+        stderr.contains("Cannot iterate over null"),
+        "stderr={stderr}"
+    );
+
+    Ok(())
+}

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -29220,3 +29220,159 @@ fn test_keys_negative_index_out_of_range_unaffected_in_jq_mode_2264() -> Result<
 
     Ok(())
 }
+
+/// #2324: a **comma-grouped** `del()` target whose own `.[]` fan-out crosses
+/// a positive out-of-range array index used to raise "Cannot iterate over
+/// null" instead of extending+vivifying the way the direct, non-comma-
+/// grouped form (`del(.[5][])` alone, #2314/#2323) already did -- the
+/// read-based branch-set resolution `resolve_del_path_branches` uses for a
+/// comma group reads `.[5]` as a plain `null` (correct for an ordinary
+/// read) and then raises fanning `.[]` out over it, never reaching the trie
+/// machinery that already knows how to extend. Confirmed live against yq
+/// v4.53.3.
+#[test]
+fn test_del_comma_fanout_positive_out_of_range_iterate_extends_2324() -> Result<()> {
+    let (out, code) = run_yq_stdin("del(.[5][], .[0])", "[1, 2]\n", &["-o=json", "-I=0"])?;
+    assert_eq!(code, 0, "out: {out:?}");
+    assert_eq!(out.trim(), "[2,null,null,null,[]]");
+    Ok(())
+}
+
+/// #2324: the fix must not care which order the two targets appear in --
+/// confirmed live against yq v4.53.3 that both orderings give the identical
+/// answer (the out-of-range extension always resolves against the pristine
+/// input, ahead of any sibling's own index-shifting deletion).
+#[test]
+fn test_del_comma_fanout_positive_out_of_range_iterate_extends_reversed_order_2324() -> Result<()> {
+    let (out, code) = run_yq_stdin("del(.[0], .[5][])", "[1, 2]\n", &["-o=json", "-I=0"])?;
+    assert_eq!(code, 0, "out: {out:?}");
+    assert_eq!(out.trim(), "[2,null,null,null,[]]");
+    Ok(())
+}
+
+/// #2324: the same fix, reached through an explicit outer paren around the
+/// comma group (`del((.[5][], .[0]))`, syntactically the same query --
+/// parses to `Expr::Paren(Expr::Comma(...))`, the same shape #1223 found for
+/// its own, unrelated rewrite). `vivify_del_comma_iterate_targets` unwraps
+/// `Expr::Paren` before its own `Comma` check for exactly this reason.
+#[test]
+fn test_del_comma_fanout_positive_out_of_range_iterate_extends_paren_wrapped_2324() -> Result<()> {
+    let (out, code) = run_yq_stdin("del((.[5][], .[0]))", "[1, 2]\n", &["-o=json", "-I=0"])?;
+    assert_eq!(code, 0, "out: {out:?}");
+    assert_eq!(out.trim(), "[2,null,null,null,[]]");
+    Ok(())
+}
+
+/// #2324: several out-of-range `.[]` targets in the same comma group, all
+/// sharing the same underlying array, still each extend independently --
+/// confirmed live against yq v4.53.3 (`[2, null, null, null, [], null,
+/// null, []]`, i.e. `.[5]` and `.[8]` both become `[]` and `.[0]` is still
+/// removed).
+#[test]
+fn test_del_comma_fanout_multiple_out_of_range_iterate_targets_2324() -> Result<()> {
+    let (out, code) = run_yq_stdin(
+        "del(.[5][], .[8][], .[0])",
+        "[1, 2]\n",
+        &["-o=json", "-I=0"],
+    )?;
+    assert_eq!(code, 0, "out: {out:?}");
+    assert_eq!(out.trim(), "[2,null,null,null,[],null,null,[]]");
+    Ok(())
+}
+
+/// #2324: the `?` (optional) variant on the trailing `.[]` -- reported as
+/// *worse* than the unsuppressed form in the original issue (it silently
+/// dropped the extension entirely instead of raising). Confirmed live
+/// against yq v4.53.3 that real yq's answer for `del(.[5][]?, .[0])` is
+/// identical to the unsuppressed `del(.[5][], .[0])` above -- `?` on a
+/// del() target does not suppress the vivify (matching #2323's own
+/// established `null | del(.[2]?)` precedent).
+#[test]
+fn test_del_comma_fanout_positive_out_of_range_iterate_optional_still_extends_2324() -> Result<()> {
+    let (out, code) = run_yq_stdin("del(.[5][]?, .[0])", "[1, 2]\n", &["-o=json", "-I=0"])?;
+    assert_eq!(code, 0, "out: {out:?}");
+    assert_eq!(out.trim(), "[2,null,null,null,[]]");
+    Ok(())
+}
+
+/// #2324's own second trigger (found during #2323's review, same root
+/// cause): a genuinely-*existing* `null` reached the identical way, not
+/// just a positive-out-of-range index. The single-target form
+/// (`{"a":null} | del(.a[])`) already correctly gave `{"a":[]}` via #2323's
+/// own fix; only the comma-grouped form raised. Confirmed live against yq
+/// v4.53.3.
+#[test]
+fn test_del_comma_fanout_existing_null_iterate_extends_2324() -> Result<()> {
+    let (out, code) = run_yq_stdin("del(.a[], .c)", "a: null\nc: 9\n", &["-o=json", "-I=0"])?;
+    assert_eq!(code, 0, "out: {out:?}");
+    assert_eq!(out.trim(), r#"{"a":[]}"#);
+    Ok(())
+}
+
+/// #2324's own delpaths() check: its own multi-key batch form is structurally
+/// unaffected by this issue's root cause, since a delpaths() path is always
+/// a concrete-key array -- there is no `.[]` wildcard component for
+/// `resolve_node`'s `Expr::Iterate` arm to ever raise on in the first place.
+/// The analogous mid-chain-out-of-range-index batch shape already matched
+/// real yq before this fix too, via #2314's own `delete_paths_under` fix --
+/// pinned here as a `del()`-vs-`delpaths()` control, confirmed live against
+/// yq v4.53.3.
+#[test]
+fn test_delpaths_batch_out_of_range_mid_chain_unaffected_2324() -> Result<()> {
+    let (out, code) = run_yq_stdin("delpaths([[5,0],[0]])", "[1, 2]\n", &["-o=json", "-I=0"])?;
+    assert_eq!(code, 0, "out: {out:?}");
+    assert_eq!(out.trim(), "[2,null,null,null,null]");
+    Ok(())
+}
+
+/// #2324's jq-mode control: jq's `del()` has no vivify rule at all (#2323's
+/// own established precedent, `null | del(.[])` raises rather than
+/// vivifying in real jq) -- the comma-grouped form must keep raising
+/// "Cannot iterate over null" exactly as it did before this fix, both for
+/// the out-of-range-index trigger and the genuinely-existing-null one.
+/// Confirmed live against jq 1.7.1.
+#[test]
+fn test_del_comma_fanout_iterate_over_null_unaffected_in_jq_mode_2324() -> Result<()> {
+    let (out, stderr, code) = run_jq_stdin_with_stderr("del(.[5][], .[0])", "[1,2]", &["-c"])?;
+    assert_ne!(code, 0, "out: {out:?}");
+    assert!(
+        stderr.contains("Cannot iterate over null"),
+        "stderr={stderr}"
+    );
+
+    let (out, stderr, code) =
+        run_jq_stdin_with_stderr("del(.a[], .c)", r#"{"a":null,"c":9}"#, &["-c"])?;
+    assert_ne!(code, 0, "out: {out:?}");
+    assert!(
+        stderr.contains("Cannot iterate over null"),
+        "stderr={stderr}"
+    );
+
+    Ok(())
+}
+
+/// #2324: an ordinary plain read of `.[]` over `null` (not a `del()` target
+/// at all) must be entirely unaffected by this fix -- `resolve_node`'s
+/// shared `Expr::Iterate` arm itself was deliberately left untouched, with
+/// the vivify handled by a `del()`-specific pre-pass instead
+/// (`vivify_del_comma_iterate_targets`, called only from `builtin_del`).
+/// Confirmed live against yq v4.53.3 that `.a[]` and `.[5][]` (an
+/// out-of-range read, not a delete) both still raise outside of `del()`.
+#[test]
+fn test_plain_iterate_over_null_read_unaffected_by_2324() -> Result<()> {
+    let (out, stderr, code) = run_yq_stdin_with_stderr(".a[]", "a: null\n", &["-o=json"])?;
+    assert_ne!(code, 0, "out: {out:?}");
+    assert!(
+        stderr.contains("Cannot iterate over null"),
+        "stderr={stderr}"
+    );
+
+    let (out, stderr, code) = run_yq_stdin_with_stderr(".[5][]", "[1, 2]\n", &["-o=json"])?;
+    assert_ne!(code, 0, "out: {out:?}");
+    assert!(
+        stderr.contains("Cannot iterate over null"),
+        "stderr={stderr}"
+    );
+
+    Ok(())
+}


### PR DESCRIPTION
Fixes #2324

## Summary

`del()`'s comma-grouped target form (`del(.[5][], .[0])`) raised "Cannot iterate over
null" instead of extending+vivifying the array — the read-based branch-set resolution
`resolve_del_path_branches` uses for a comma group reads a positive-out-of-range index
(or a genuinely-existing `null`) as a plain `null` (correct for an ordinary read) and
then raises when fanning `.[]` out over it, never reaching the trie machinery
(#2314/#2323) that already knows how to extend/vivify for the *single*-target form of
the identical shape.

Confirmed live against yq v4.53.3:

```console
$ echo '[1,2]' | yq -o=json 'del(.[5][], .[0])'
[2, null, null, null, []]
$ echo '{"a":null,"c":9}' | yq -o=json 'del(.a[], .c)'
{"a": []}
```

## Fix

A narrow pre-pass (`vivify_del_comma_iterate_targets`, called only from `builtin_del`,
yq mode only) peels off every top-level comma branch shaped as a static `Field`/`Index`
prefix plus a bare trailing `.[]` whose prefix currently reads `null`, and runs each
through the same `delete_at_path` a single-target `del()` call already uses — before
`resolve_del_path_branches` ever sees the rest.

`delpaths()`'s own multi-key batch form was checked and confirmed unaffected — its path
components are always concrete keys, never a `.[]` wildcard.

## Review round 2 — two regressions found and fixed

The mandatory multi-agent review found this pre-pass introduced two genuine correctness
regressions (not just scope gaps), both confirmed live against the pinned oracle:

1. **Order-dependence**: mutating `result` for every pre-pass-matched sibling before
   resolving the "remaining" siblings ignored real yq's strict left-to-right evaluation
   order, so a **negative index** sibling (`del(.[-1], .[4][])`) could resolve against
   the wrong array length depending on textual order — silently wrong output for one
   ordering instead of the old, at-least-consistent error. **Fixed** by declining the
   whole pre-pass (falling through to the pre-existing, still-correct path) whenever
   *any* sibling — matched or not — contains a negative index/slice bound or a computed
   key/slice anywhere in it (`contains_length_dependent_index`). This sacrifices this
   pre-pass's coverage for the negative-index-mixed-with-vivify corner case (never in
   #2324's own scope), but never produces a silently wrong answer again.
2. **Dropped `?` suppression**: the pre-pass always reconstructed a bare, unsuppressed
   `Expr::Iterate`, discarding whether the original had a trailing `?`. For a
   genuinely-*missing* key (not just a `null`-valued one), the delete walk raises unless
   its own `?` suppresses it — so `del(.missing[]?, .x)` on `{"x":1}` wrongly raised
   instead of yq's `{}`. **Fixed** by threading the `?` flag through to `delete_at_path`.

Both fixes verified live against yq v4.53.3, with 8 new regression tests (2 unit tests
in `eval.rs`, 6 CLI tests in `tests/yq_cli_tests.rs`) on top of the original 9.

## Test plan

- [x] 17 tests total (`_2324` suffix) pinned to live oracle output, covering: both
      original repros, argument-order independence, paren-wrapped form, multiple OOB
      targets, the `?` optional variant, a `delpaths()` control, a jq-mode control, a
      plain-read control, both round-2 regressions and their fixes, and controls
      confirming the fixes don't over-correct.
- [x] `cargo build --features cli`
- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] Full `cargo test` (default features) — 0 failures
- [x] `docs/compliance/yq/limitations.md` updated, including correcting an "any relative
      order" overclaim found during review

## Follow-ups filed (not blocking this PR)

- #2346 — yq's `.[]` silently no-ops for *any* non-container, not just `null` (broader
  than this issue's scope)
- #2347 — `del(.[N].missing[])` still raises on unmodified `main`, pre-existing and
  unrelated to the comma-fanout shape this PR covers
