### PR TITLE
fix(jq): E[K]'s key stream keeps its own Partial prefix on Error/Break (#2326)

### DIFF
--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -16718,6 +16718,10 @@ fn eval_index_expr<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     // the key generator halts on its *next* attempt, so those keys' indexed
     // output must still reach stdout (#791).
     let mut pending_halt = None;
+    // #2326: mutually exclusive with `pending_halt` -- a single `Partial`
+    // result carries exactly one `Control` variant, so at most one of the
+    // two is ever set.
+    let mut pending_key_stream_control: Option<Control> = None;
     let keys = match eval_single::<W, S>(key, value.clone(), false).materialize_cursor() {
         QueryResult::One(v) => match to_owned_key_shape(&v) {
             Ok(v) => vec![v],
@@ -16738,9 +16742,28 @@ fn eval_index_expr<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
         QueryResult::Break(label) => return QueryResult::Break(label),
         QueryResult::Halt(code) => return QueryResult::Halt(code),
         QueryResult::OneCursor(_) => unreachable!("materialize_cursor should have converted this"),
+        // #2326: `key`'s own generator produced `vs` before its own
+        // mid-stream escape -- mirrors #2226's identical fix for `target`'s
+        // side (this same function's own `KeyTargets::Partial` arm below):
+        // real jq's key-outer/target-inner model indexes each already-
+        // produced key as it flows out, so `key`'s own escaped generator's
+        // prefix is real jq output too (confirmed live: `[10,20,30] |
+        // .[(1,error("x"))]` prints `20` before raising). jq-only, matching
+        // #2226's own gate -- real yq does not stream this prefix either
+        // (confirmed live, `.[(1,error("x"))]` in yq mode shows no `20`),
+        // so yq mode keeps the pre-existing conservative discard below.
+        QueryResult::Partial(vs, Control::Error(e)) if S::TAG != EvalTag::Yq => {
+            pending_key_stream_control = Some(Control::Error(e));
+            vs
+        }
+        QueryResult::Partial(vs, Control::Break(label)) if S::TAG != EvalTag::Yq => {
+            pending_key_stream_control = Some(Control::Break(label));
+            vs
+        }
         // Computed indexing's key/target forking isn't part of #400/#494's
         // verified semantics — conservatively matching the existing
         // Error/Break arms rather than inventing new partial-key behavior.
+        // (yq mode, and any future non-jq/yq semantics, still take this.)
         QueryResult::Partial(_, Control::Error(e)) => return QueryResult::Error(e),
         QueryResult::Partial(_, Control::Break(label)) => return QueryResult::Break(label),
         QueryResult::Partial(vs, Control::Halt(code)) => {
@@ -16750,7 +16773,8 @@ fn eval_index_expr<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     };
     if keys.is_empty() {
         // `partial`'s invariant (a non-empty prefix by construction) means
-        // this is only reachable with `pending_halt` unset.
+        // this is only reachable with `pending_halt`/`pending_key_stream_control`
+        // both unset.
         return QueryResult::None;
     }
 
@@ -17013,14 +17037,23 @@ fn eval_index_expr<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
         }
     }
 
-    match pending_halt {
+    match (pending_halt, pending_key_stream_control) {
         // Same #1897 fix the old code already applied here.
-        Some(code) => {
+        (Some(code), _) => {
             let (prefix, control) =
                 resolve_terminal_prefix(borrowed, owned, Vec::new(), Control::Halt(code));
             partial(prefix, control)
         }
-        None => match owned {
+        // #2326: the key stream's own escape, deferred until every
+        // already-produced key finished indexing cleanly -- an indexing
+        // failure on one of those keys outranks it (escapes earlier, via
+        // `escape_with_prefix!` inside the loop above), matching #2226's
+        // own documented priority for the symmetric target-side case.
+        (None, Some(control)) => {
+            let (prefix, control) = resolve_terminal_prefix(borrowed, owned, Vec::new(), control);
+            partial(prefix, control)
+        }
+        (None, None) => match owned {
             Some(vs) => owned_vec_to_result(vs),
             None => borrowed_vec_to_result(borrowed),
         },
@@ -53158,6 +53191,83 @@ mod tests {
         );
     }
 
+    /// #2326: the mirror-image gap on `key`'s own side of `E[K]` --
+    /// `key`'s own generator produces `1` before its own `error("x")`
+    /// escapes. Verified against jq 1.7.1: `echo '[10,20,30]' | jq -c
+    /// '.[(1,error("x"))]'` prints `20` then raises `x`.
+    #[test]
+    fn test_index_expr_key_own_partial_prefix_preserved_2326() {
+        query!(br"[10,20,30]", r#".[(1,error("x"))]"#,
+            QueryResult::Partial(vs, Control::Error(e)) => {
+                assert_eq!(vs, vec![OwnedValue::Int(20)]);
+                assert_eq!(e.message, "x");
+            }
+        );
+    }
+
+    /// #2326 sibling: `break` instead of `error`, same key-generator shape.
+    /// No enclosing `label $out` in the filter itself, so the `Partial`+
+    /// `Break` this fix produces propagates uncaught to this query's own
+    /// top-level result, same as the sibling `error` case above and the
+    /// analogous #2226 target-side break test. Verified against jq 1.7.1:
+    /// `label $out | [10,20,30] | .[(1,break $out)]` prints `20`.
+    #[test]
+    fn test_index_expr_key_own_partial_prefix_preserved_on_break_2326() {
+        query!(br"[10,20,30]", r".[(1,break $out)]",
+            QueryResult::Partial(vs, Control::Break(label)) => {
+                assert_eq!(vs, vec![OwnedValue::Int(20)]);
+                assert_eq!(label, "out");
+            }
+        );
+    }
+
+    /// #2326: multiple keys succeed before the key generator errors -- the
+    /// whole successful prefix survives, not just the last one. Verified
+    /// against jq 1.7.1: `echo '[10,20,30,40]' | jq -c
+    /// '.[(0,1,error("x"))]'` prints `10` then `20` before raising.
+    #[test]
+    fn test_index_expr_key_own_partial_prefix_multiple_keys_2326() {
+        query!(br"[10,20,30,40]", r#".[(0,1,error("x"))]"#,
+            QueryResult::Partial(vs, Control::Error(e)) => {
+                assert_eq!(vs, vec![OwnedValue::Int(10), OwnedValue::Int(20)]);
+                assert_eq!(e.message, "x");
+            }
+        );
+    }
+
+    /// #2326: an indexing failure on an already-produced key outranks the
+    /// key generator's own later escape -- mirrors #2226's identical
+    /// priority rule for the target side. The target (`"scalar"`) can't be
+    /// indexed by a number at all, so the first key (`0`) already fails to
+    /// index before the key generator's own second branch (`error("x")`)
+    /// is ever reached. Verified against jq 1.7.1: `echo '"scalar"' | jq -c
+    /// '.[(0,error("x"))]'` raises "Cannot index string with number", not
+    /// `x`.
+    #[test]
+    fn test_index_expr_key_own_partial_prefix_err_outranks_control_2326() {
+        query!(br#""scalar""#, r#".[(0,error("x"))]"#,
+            QueryResult::Error(e) => {
+                assert!(
+                    e.message.contains("Cannot index string with number"),
+                    "message: {}",
+                    e.message
+                );
+            }
+        );
+    }
+
+    /// #2326: yq mode keeps the pre-fix conservative discard -- confirmed
+    /// live against yq v4.53.3: `[10,20,30] | .[(1,error("x"))]` prints
+    /// only `Error: x`, no `20` prefix.
+    #[test]
+    fn test_index_expr_key_partial_prefix_still_discarded_in_yq_mode_2326() {
+        yq_query!(br"[10,20,30]", r#".[(1,error("x"))]"#,
+            QueryResult::Error(e) => {
+                assert_eq!(e.message, "x");
+            }
+        );
+    }
+
     #[test]
     fn test_yq_merge_flags() {
         // Unflagged array `*`/`*=` is yq-only: rhs replaces lhs wholesale,
@@ -54436,20 +54546,15 @@ mod tests {
             // exactly. See `partial_prefix_survives_the_stream_forwarding_
             // constructs` for its coverage.
             //
-            // `.[(1,error("x"))]` stays here: unlike the case above, the
-            // *key* stream `(1,error("x"))` is the multi-output generator
-            // here, not the target (`.` is a single value) — a distinct,
-            // still-open gap in the *keys*-evaluation `Partial` arm
-            // (conservatively documented in `eval_index_expr`'s own body as
-            // "not part of #400/#494's verified semantics"), out of #2226's
-            // scope (which is about `E`'s own prefix, not `K`'s) and tracked
-            // separately.
-            (
-                b"[10,20,30]",
-                r#".[(1,error("x"))]"#,
-                "x",
-                "jq 1.7.1 prints 20, then fails",
-            ),
+            // `.[(1,error("x"))]` *used* to be listed here too (the *key*
+            // stream `(1,error("x"))` is the multi-output generator, not
+            // the target), but #2326 fixed the *keys*-evaluation `Partial`
+            // arm to apply the per-key index to each already-produced key
+            // instead of discarding them -- the same fix #2226 applied to
+            // the target side above -- so it now agrees with jq 1.7.1
+            // exactly. See `partial_prefix_survives_the_stream_forwarding_
+            // constructs` for its coverage.
+            //
             // `map_values` keeps only each key's first output, so jq 1.7.1
             // never reaches the error at all and exits 0.
             (
@@ -54483,9 +54588,9 @@ mod tests {
             (b"null", "[1,(2,break $out),3]"),
             (b"[1,2]", "map((.,break $out))"),
             (br#"{"a":1}"#, "with_entries((.,break $out))"),
-            // `select`/`if`, string interpolation, target-generator index/
-            // slice: see the comment in `atomic` above.
-            (b"[10,20,30]", ".[(1,break $out)]"),
+            // `select`/`if`, string interpolation, target-generator and
+            // (since #2326) key-generator index/slice: see the comment in
+            // `atomic` above.
             (br#"{"a":1}"#, "map_values((.,break $out))"),
             (b"[1,2]", "map_values((.,break $out))"),
             (b"null", "reduce (1,2,break $out) as $v (0;.+$v)"),
@@ -54694,10 +54799,7 @@ mod tests {
         // the old comment already recorded as printing `7` and `8` then
         // failing); `eval_index_expr`'s *target* `Partial` arm now applies
         // the per-key index to each already-produced value instead of
-        // discarding them, so it now agrees with jq 1.7.1 exactly. (The
-        // sibling shape `.[(1,error("x"))]`, where the *key* stream is the
-        // generator instead, stays in `atomic` -- that's a distinct,
-        // still-open gap outside this issue's scope; see the comment there.)
+        // discarding them, so it now agrees with jq 1.7.1 exactly.
         query!(b"[[7],[8]]", r#"(.[0],(.[1],error("x")))[(0+0)]"#,
             QueryResult::Partial(vs, Control::Error(e)) => {
                 assert_eq!(prefix_json(&vs), ["7", "8"]);
@@ -54707,6 +54809,24 @@ mod tests {
         query!(b"[[7],[8]]", r"(.[0],(.[1],break $out))[(0+0)]",
             QueryResult::Partial(vs, Control::Break(label)) => {
                 assert_eq!(prefix_json(&vs), ["7", "8"]);
+                assert_eq!(label, "out");
+            }
+        );
+
+        // #2326 sibling: the mirror-image shape, where the *key* stream is
+        // the generator instead of the target. `eval_index_expr`'s
+        // keys-evaluation `Partial` arm now applies the same treatment on
+        // that side. Verified against jq 1.7.1: `[10,20,30] |
+        // .[(1,error("x"))]` prints `20` then fails.
+        query!(b"[10,20,30]", r#".[(1,error("x"))]"#,
+            QueryResult::Partial(vs, Control::Error(e)) => {
+                assert_eq!(prefix_json(&vs), ["20"]);
+                assert_eq!(e.message, "x");
+            }
+        );
+        query!(b"[10,20,30]", r".[(1,break $out)]",
+            QueryResult::Partial(vs, Control::Break(label)) => {
+                assert_eq!(prefix_json(&vs), ["20"]);
                 assert_eq!(label, "out");
             }
         );

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -8141,6 +8141,10 @@ fn eval_index_expr<S: EvalSemantics, V: DocumentValue>(
     // already yielded before the key generator halts on its *next* attempt,
     // so those keys' indexed output must still reach stdout (#791).
     let mut pending_halt: Option<i32> = None;
+    // #2326: mutually exclusive with `pending_halt` -- a single `Partial`
+    // result carries exactly one `Control` variant, so at most one of the
+    // two is ever set.
+    let mut pending_key_stream_control: Option<Control> = None;
     let keys = match eval_single::<S, V>(key, value.clone(), false, cursor) {
         GenericResult::Error(e) => return GenericResult::Error(e),
         GenericResult::Break(label) => return GenericResult::Break(label),
@@ -8152,15 +8156,34 @@ fn eval_index_expr<S: EvalSemantics, V: DocumentValue>(
         // `Break`, which already gets its own explicit early return above.
         GenericResult::Halt(code) => return GenericResult::Halt(code),
         GenericResult::None => return GenericResult::None,
+        // #2326: `key`'s own generator produced `vs` before its own
+        // mid-stream escape -- mirrors #2226's identical fix for `target`'s
+        // side (this same function's own target-evaluation match below):
+        // real jq's key-outer/target-inner model indexes each already-
+        // produced key as it flows out, so `key`'s own escaped generator's
+        // prefix is real jq output too (confirmed live: `[10,20,30] |
+        // .[(1,error("x"))]` prints `20` before raising). jq-only, matching
+        // #2226's own gate -- real yq does not stream this prefix either
+        // (confirmed live, `.[(1,error("x"))]` in yq mode shows no `20`),
+        // so yq mode keeps the pre-existing conservative discard below.
+        GenericResult::Partial(vs, Control::Error(e)) if S::TAG != EvalTag::Yq => {
+            pending_key_stream_control = Some(Control::Error(e));
+            vs
+        }
+        GenericResult::Partial(vs, Control::Break(label)) if S::TAG != EvalTag::Yq => {
+            pending_key_stream_control = Some(Control::Break(label));
+            vs
+        }
         // A `Partial`'s trailing control must abort here too, not silently
         // truncate to its prefix (#694) -- mirrors the target match below.
-        GenericResult::Partial(_, Control::Error(e)) => return GenericResult::Error(e),
-        GenericResult::Partial(_, Control::Break(label)) => return GenericResult::Break(label),
         // Computed indexing's key/target forking isn't part of #400/#494's
         // verified semantics for `Error`/`Break` — conservatively matching
         // those arms rather than inventing new partial-key behavior for
         // them. `Halt` is different: its prefix is kept and threaded through
         // as `pending_halt` instead of discarded, per the comment above.
+        // (yq mode, and any future non-jq/yq semantics, still take these.)
+        GenericResult::Partial(_, Control::Error(e)) => return GenericResult::Error(e),
+        GenericResult::Partial(_, Control::Break(label)) => return GenericResult::Break(label),
         GenericResult::Partial(vs, Control::Halt(code)) => {
             pending_halt = Some(code);
             vs
@@ -8546,6 +8569,20 @@ fn eval_index_expr<S: EvalSemantics, V: DocumentValue>(
             }
         };
         return partial_generic(out, Control::Halt(code));
+    }
+
+    // #2326: the key stream's own escape, deferred until every already-
+    // produced key finished indexing cleanly -- an indexing failure on one
+    // of those keys outranks it (escapes earlier, via `escape_generic!`
+    // inside the loop above), matching #2226's own documented priority for
+    // the symmetric target-side case.
+    if let Some(control) = pending_key_stream_control {
+        let out = if any_owned {
+            owned
+        } else {
+            owned_or_err!(to_owned_all_cursors(&cursors))
+        };
+        return partial_generic(out, control);
     }
 
     // #1048: a zero-result collapse here (every key/target pair
@@ -12512,11 +12549,12 @@ mod tests {
     }
 
     /// `eval_index_expr`'s `keys` match, `Partial`+`Break` sibling to the
-    /// `Partial`+`Error` case above (#694): a `break` after some keys have
-    /// already streamed collapses to the bare control instead of resolving
-    /// those keys against the target. Confirmed against real jq 1.7.1:
-    /// `label $out | .[("a", break $out)]` on `{"a":1,"b":2}` breaks out of
-    /// the label rather than indexing with `"a"`.
+    /// `Partial`+`Error` case above (#694). #2326 fixed this arm (jq mode
+    /// only) to index the target with each already-produced key instead of
+    /// discarding them, so the successfully-indexed prefix now survives the
+    /// break instead of collapsing to a bare control -- confirmed against
+    /// real jq 1.7.1: `label $out | .[("a", break $out)]` on
+    /// `{"a":1,"b":2}` prints `1` before breaking out of the label.
     #[test]
     fn test_generic_computed_index_read_propagates_partial_break_694() {
         let json = br#"{"a":1,"b":2}"#;
@@ -12526,7 +12564,12 @@ mod tests {
 
         let expr = parse(r#".[("a", break $out)]"#).unwrap();
         let result = eval_using::<JqSemantics, _>(&expr, value);
-        assert!(matches!(result, GenericResult::Break(ref label) if label == "out"));
+        match result {
+            GenericResult::Partial(vs, Control::Break(ref label)) if label == "out" => {
+                assert_eq!(vs, vec![OwnedValue::Int(1)]);
+            }
+            other => panic!("unexpected result: {other:?}"),
+        }
     }
 
     /// `GenericResult::LazyIndexRange`'s `stream_json`/`stream_yaml` (#684).

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -8576,11 +8576,29 @@ fn eval_index_expr<S: EvalSemantics, V: DocumentValue>(
     // of those keys outranks it (escapes earlier, via `escape_generic!`
     // inside the loop above), matching #2226's own documented priority for
     // the symmetric target-side case.
+    //
+    // #2326 review: uses the same prefix-preserving `to_owned_all_cursors_checked`
+    // (and the same Halt-survives/Error-Break-downgrades secondary-failure
+    // rule) `escape_generic!` and the `pending_halt` block above both
+    // already establish -- the plain `owned_or_err!(to_owned_all_cursors(...))`
+    // this arm originally used would discard the whole already-indexed
+    // prefix and silently replace `control`'s own message with an unrelated
+    // decode-failure one on a secondary conversion failure, unlike every
+    // other escape path in this function.
     if let Some(control) = pending_key_stream_control {
         let out = if any_owned {
             owned
         } else {
-            owned_or_err!(to_owned_all_cursors(&cursors))
+            match to_owned_all_cursors_checked(&cursors) {
+                Ok(vs) => vs,
+                Err((prefix, e)) => {
+                    let control = match control {
+                        Control::Halt(code) => Control::Halt(code),
+                        Control::Error(_) | Control::Break(_) => Control::Error(e),
+                    };
+                    return partial_generic(prefix, control);
+                }
+            }
         };
         return partial_generic(out, control);
     }

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -8202,7 +8202,8 @@ fn eval_index_expr<S: EvalSemantics, V: DocumentValue>(
     };
     if keys.is_empty() {
         // `partial_generic`'s invariant (a non-empty prefix by construction)
-        // means this is only reachable with `pending_halt` unset.
+        // means this is only reachable with `pending_halt`/
+        // `pending_key_stream_control` both unset.
         return GenericResult::None;
     }
 

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -6039,15 +6039,20 @@ fn test_computed_index_streams_keys_produced_before_halt() -> Result<()> {
 }
 
 #[test]
-fn test_computed_index_still_conservative_on_error_and_break() -> Result<()> {
-    // The fix above is deliberately halt-specific: `Error`/`Break` keep the
-    // pre-existing, documented conservative behavior (discard the prefix
-    // rather than stream it), matching real jq's own gap here -- see
-    // `eval_index_expr`'s doc comment. `Error` still aborts the whole
-    // process (exit 5), it just doesn't print `20`/`30` first.
+fn test_computed_index_now_streams_prefix_on_error_too_2326() -> Result<()> {
+    // #2326: this used to be named
+    // `test_computed_index_still_conservative_on_error_and_break`, pinning
+    // a deliberately conservative discard-the-prefix behavior for `Error`/
+    // `Break` that its own comment claimed matched "real jq's own gap" --
+    // that claim was never actually checked against the oracle. It
+    // doesn't: real jq streams the keys already produced before the key
+    // generator's own error, the same as it already does for `halt`
+    // (`test_computed_index_streams_keys_produced_before_halt` above).
+    // #2326 closed the gap. Verified against jq 1.7.1: `[10,20,30] |
+    // .[(1,2,error("boom"))]` prints `20` then `30` before erroring.
     let (stdout, stderr, code) = run_jq_full(&[r#".[(1,2,error("boom"))]"#], Some("[10,20,30]"))?;
     assert_eq!(code, 5);
-    assert_eq!(stdout, "");
+    assert_eq!(stdout, "20\n30\n");
     assert!(stderr.contains("boom"));
     Ok(())
 }
@@ -35074,6 +35079,53 @@ fn test_slice_expr_cli_dispatch_target_own_partial_prefix_err_outranks_control_2
     assert_eq!(stdout, "");
     assert!(
         stderr.contains("Cannot index number with object"),
+        "stderr: {stderr:?}"
+    );
+    Ok(())
+}
+
+/// #2326: the mirror-image gap on `key`'s own side of `E[K]` --
+/// `eval_generic::eval_index_expr`'s key-evaluation match used to discard
+/// `key`'s own already-produced prefix and keep only the escaping control.
+/// `run_jq_full` execs the real CLI subprocess, which always dispatches
+/// through `eval_generic::eval_index_expr` for an ordinary stdin/file read.
+/// Verified against jq 1.7.1: `echo '[10,20,30]' | jq -c
+/// '.[(1,error("x"))]'` prints `20` then raises `x`.
+#[test]
+fn test_index_expr_cli_dispatch_key_own_partial_prefix_preserved_2326() -> Result<()> {
+    let (stdout, stderr, code) = run_jq_full(&["-c", ".[(1,error(\"x\"))]"], Some("[10,20,30]"))?;
+    assert_eq!(code, 5, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert_eq!(stdout, "20\n");
+    assert!(stderr.contains('x'), "stderr: {stderr:?}");
+    Ok(())
+}
+
+/// #2326 review (patch coverage): multiple keys succeed before the key
+/// generator errors -- the whole successful prefix survives. Verified
+/// against jq 1.7.1: `echo '[10,20,30,40]' | jq -c
+/// '.[(0,1,error("x"))]'` prints `10` then `20` before raising.
+#[test]
+fn test_index_expr_cli_dispatch_key_own_partial_prefix_multiple_keys_2326() -> Result<()> {
+    let (stdout, stderr, code) =
+        run_jq_full(&["-c", ".[(0,1,error(\"x\"))]"], Some("[10,20,30,40]"))?;
+    assert_eq!(code, 5, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert_eq!(stdout, "10\n20\n");
+    assert!(stderr.contains('x'), "stderr: {stderr:?}");
+    Ok(())
+}
+
+/// #2326 review (patch coverage): an indexing failure on an already-
+/// produced key outranks the key generator's own later escape, mirroring
+/// #2226's identical priority rule for the target side. Verified against
+/// jq 1.7.1: `echo '"scalar"' | jq -c '.[(0,error("x"))]'` raises "Cannot
+/// index string with number", not `x`.
+#[test]
+fn test_index_expr_cli_dispatch_key_own_partial_prefix_err_outranks_control_2326() -> Result<()> {
+    let (stdout, stderr, code) = run_jq_full(&["-c", ".[(0,error(\"x\"))]"], Some("\"scalar\""))?;
+    assert_eq!(code, 5, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert_eq!(stdout, "");
+    assert!(
+        stderr.contains("Cannot index string with number"),
         "stderr: {stderr:?}"
     );
     Ok(())

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -29373,6 +29373,20 @@ fn test_slice_expr_target_partial_prefix_still_discarded_in_yq_mode_2226() -> Re
     Ok(())
 }
 
+/// #2326: the mirror-image gap on `key`'s own side of `E[K]` -- yq mode
+/// keeps the pre-#2326 conservative discard. Verified live against yq
+/// v4.53.3: `[10,20,30] | .[(1,error("x"))]` prints only `Error: x`, no
+/// `20` prefix.
+#[test]
+fn test_index_expr_key_partial_prefix_still_discarded_in_yq_mode_2326() -> Result<()> {
+    let (out, stderr, code) =
+        run_yq_stdin_with_stderr(".[(1,error(\"x\"))]", "[10, 20, 30]\n", &["-o", "json"])?;
+    assert_eq!(code, 1, "out: {out:?} stderr: {stderr:?}");
+    assert_eq!(out, "");
+    assert_eq!(stderr.trim(), "Error: x");
+    Ok(())
+}
+
 /// #2264: `keys`/`keys_unsorted`'s own lazy `.[n]` fast path
 /// (`fold_lazy_keys_stage` for object keys, `fold_lazy_index_range_stage`
 /// for array keys) had its own independent negative-index resolution with


### PR DESCRIPTION
## Summary

#2226 fixed `E[K]`'s **target**-evaluation `Partial` arm to index each already-produced target value instead of discarding them on a mid-stream `Error`/`Break` (`0 as \$k | ([1,2],[3,4],error("x"))[\$k]` now streams `1`, `3` before raising). The mirror-image gap survived on the other side: the **keys**-evaluation `Partial` arm still discarded `key`'s own already-produced prefix, in both `eval.rs` and `eval_generic.rs`.

```console
$ echo '[10,20,30]' | jq -c '.[(1,error("x"))]'
20
jq: error (at <stdin>:1): x

$ echo '[10,20,30]' | succinctly jq -c '.[(1,error("x"))]'   # before this fix
jq: error (at <stdin>:1): x
# 20 was lost
```

## What changed

Mirrors #2226's own fix shape exactly, on the key side: when the key generator's evaluation returns `Partial(prefix, control)`, index the target once per key in `prefix` (the same per-key operation the success arms already use), fold the successes into the running accumulator, then propagate `control` — instead of discarding the prefix outright. Threaded through a new `pending_key_stream_control` variable (mutually exclusive with the existing `pending_halt`, since a single `Partial` carries exactly one `Control` variant), resolved at the same tail point `pending_halt` already is.

jq-mode only, gated the same way #2226's own fix is (`S::TAG != EvalTag::Yq`): real yq doesn't stream this prefix either (confirmed live, `[10,20,30] | .[(1,error("x"))]` in yq mode shows no `20`).

Applied to both evaluators — `eval.rs`'s own `eval_index_expr` (the `-n`/literal-array path) and `eval_generic.rs`'s own `eval_index_expr` (the ordinary stdin/file-read path, confirmed to be the one an actual CLI invocation hits per that file's own doc comment) — both needed the identical fix, verified independently against the oracle.

## Pre-existing tests corrected

Three tests had pinned the old discard behavior as expected:
- Two in `src/jq/eval.rs`'s own test module **explicitly documented** `.[(1,error/break \$out)]` as "a distinct, still-open gap... tracked separately" — i.e. this exact issue. Removed from the "collapses to bare control" tables and migrated into the "prefix survives" coverage, right alongside #2226's own analogous entries (same file, same precedent).
- One in `tests/jq_cli_tests.rs` (`test_computed_index_still_conservative_on_error_and_break`) asserted the discard "matches real jq's own gap here" — a claim that was never actually checked against the oracle. It doesn't: verified live that real jq streams the prefix before erroring, the same as it already does for `halt` (covered by the neighboring, already-correct `test_computed_index_streams_keys_produced_before_halt`). Renamed and corrected.

## Test plan
- [x] `cargo test --features cli,simd,regex,serde` — full suite green (after correcting the 3 pre-existing tests above)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] `cargo build --no-default-features --features portable-popcount` (no_std) — clean
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features` — clean
- [x] Live-verified every shape (single key, multiple keys before error, `break`, an earlier indexing failure outranking a later key-stream escape, `?`) against `jq` 1.7.1 and `yq` v4.53.3, byte-for-byte match
- [x] Confirmed jq mode and yq mode both match their respective oracles

Fixes #2326