### PR TITLE
fix(yq): delpaths() applies a multi-key batch sequentially, not as a union

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -577,15 +577,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `yq_negative_index_check`/`yq_negative_index_error` helpers (all five take a plain
   `yq_mode: bool`, not `S: EvalSemantics`). Unlike the read-side fix, not
   suppressible by an earlier `?` in the path chain — confirmed live, real yq's own
-  `del(.a?[-5])` still raises. One residual divergence documented, not chased: when grouped
-  with an earlier same-array deletion in one `delpaths()` call, real yq's own error reports
-  the array's *already-shrunk* size (sequential resolution), where this crate's own
-  `delete_keys` deliberately resolves every key against the array's length on entry (the
-  invariant that makes an overlapping range union rather than compound) — still correctly
-  raises either way, only the reported number can differ, and only in that one
-  multi-key-same-array shape. Also surfaced, and filed separately as #2305 (out of this
-  issue's negative-index scope): real yq's `del()` on a *positive* out-of-range index extends
-  the array with nulls instead of no-op, which succinctly (matching jq) doesn't reproduce.
+  `del(.a?[-5])` still raises. A residual divergence was documented here, not chased at the
+  time: when grouped with an earlier same-array deletion in one `delpaths()` call, real yq's
+  own error reports the array's *already-shrunk* size (sequential resolution), where this
+  crate's own `delete_keys` deliberately resolved every key against the array's length on
+  entry — closed by #2306 below, which now reports the shrunk size too. Also surfaced, and
+  filed separately as #2305 (out of this issue's negative-index scope): real yq's `del()` on
+  a *positive* out-of-range index extends the array with nulls instead of no-op, which
+  succinctly (matching jq) doesn't reproduce.
+- **`delpaths()`'s multi-key batch applied as a union, not sequentially** (#2306): real yq's
+  own `delpaths()` applies a 2+-path batch one path at a time, each seeing whatever state
+  every earlier path already left behind — not jq's own simultaneous/union model this crate's
+  `delete_keys` was built around, which resolves every path against the array's *starting*
+  length. Confirmed live this isn't only about out-of-range indices — even an all-in-range
+  batch is order-dependent (`delpaths([[0],[1]])` on `[1,2,3,4]` is `[2,4]`;
+  `delpaths([[1],[0]])` on the same input is `[3,4]`, where real jq's own `delpaths` gives the
+  order-independent `[3,4]` for both). `delpaths_one` (`src/jq/eval.rs`) now skips its
+  upfront sort in yq mode (the sort exists to support jq's own batch semantics) and applies
+  each path individually instead of handing the whole list to `delete_keys` in one call. jq
+  mode is unaffected. `del()`'s own comma-separated multi-target form shares the same
+  order-dependence in real yq and does not yet reproduce it, since each of its targets already
+  reaches `delete_keys` through its own separate call rather than a shared batch.
 - **`has(key)`/`contains()` on objects didn't raise on a non-string sibling key
   (`{"a":1,123:2}`), and `JsonFields::find` (unlike its `find_cursor` sibling) had neither
   the #1677 `,`/`:` delimiter check nor the #2261 trailing-comma check at all** (#2288,

--- a/docs/compliance/yq/limitations.md
+++ b/docs/compliance/yq/limitations.md
@@ -1805,17 +1805,15 @@ terminal per-container batch, e.g. `delpaths([[-5]])`). Unlike the read-side fix
 still raises the identical error in real yq, matching `del()`'s own `optional` parameter's
 established scope (a `?`/type-mismatch suppression, never extended to this new check).
 
-**One residual divergence, not chased here**: when a negative-out-of-range index is grouped
-in the *same* `delpaths()` call as an earlier deletion on the same array, real yq's own error
-reports the array's size *after* that earlier deletion already happened -- confirmed live,
-`delpaths([[0],[-5]])` on a 2-element array reports "array size is 1", not 2, meaning real
-yq's own `delpaths` resolves indices *sequentially*, not against the array's length on entry.
-`delete_keys`'s own batch invariant is the opposite by design (every key resolves against the
-length the array had on entry, which is what makes an overlapping range union rather than
-compound, per its own doc comment) -- matching real yq's sequential resolution here would mean
-abandoning that invariant, a materially larger change than this fix's own scope. Still
-correctly *raises* either way; only the reported array-size number can differ, and only in
-this one multi-key-same-array shape.
+**Was a residual divergence, closed by [#2306](https://github.com/rust-works/succinctly/issues/2306)**:
+when a negative-out-of-range index is grouped in the *same* `delpaths()` call as an earlier
+deletion on the same array, real yq's own error reports the array's size *after* that earlier
+deletion already happened -- confirmed live, `delpaths([[0],[-5]])` on a 2-element array
+reports "array size is 1", not 2, meaning real yq's own `delpaths` resolves indices
+*sequentially*, not against the array's length on entry. `delpaths_one` (`src/jq/eval.rs`) now
+applies a yq-mode multi-path batch one path at a time instead of handing the whole (sorted)
+list to `delete_keys` in one call -- see the "batch of two or more keys" entry below for the
+fuller writeup -- so this now reports "array size is 1" too, matching real yq exactly.
 
 **A separate, unrelated divergence found investigating this one**: real yq's `del()` on a
 *positive* out-of-range index doesn't no-op the way jq does -- it extends the array with
@@ -1847,28 +1845,44 @@ array-growth helper, #1670) shared by `delete_at_path`'s `Expr::Index` arm (`del
 `delete_keys`'s own single-key case (`delpaths([[N]])`, confirmed live to share the identical
 extension behavior) -- gated on `yq_mode`, since jq has no such rule at all.
 
-**Deliberately not extended to a `delpaths()` batch of two or more keys.** Confirmed live that
-mixing an in-range delete with an out-of-range one in the same `delpaths()` call is
-**order-dependent** in real yq -- the same *set* of keys, given in a different literal order,
-produces a *different*-length result:
+### `delpaths()`'s multi-key batch applies sequentially, not as a union
+
+[#2306](https://github.com/rust-works/succinctly/issues/2306). Real yq's own `delpaths()`
+applies a 2+-path batch **sequentially** -- one path at a time, each seeing whatever state
+every earlier path already left behind -- not jq's own simultaneous/union model, which
+resolves every path against the array's *starting* length. This isn't only about
+out-of-range indices: even an all-in-range batch is order-dependent, confirmed live:
+
+```bash
+$ echo '[1,2,3,4]' | yq -o=json 'delpaths([[0],[1]])'   # [2,4] -- delete index 0, then index 1 of what's left
+$ echo '[1,2,3,4]' | yq -o=json 'delpaths([[1],[0]])'   # [3,4] -- same keys, reversed order, different result
+```
+
+(Real jq's own `delpaths` gives the order-independent `[3,4]` for *both* orderings.) Mixing an
+in-range delete with an out-of-range one shows the same order-dependence -- the same *set* of
+keys, given in a different literal order, produces a *different*-length result:
 
 ```bash
 $ echo '[1,2,3]' | yq -o=json 'delpaths([[0],[5]])'   # [2,3,null,null,null] -- length 5
 $ echo '[1,2,3]' | yq -o=json 'delpaths([[5],[0]])'   # [2,3,null,null]      -- length 4
 ```
 
-`delete_keys`'s array arm resolves every key against the array's length *on entry* and applies
-them all in one batched `retain` pass -- deliberately order-independent, which is what keeps its
-existing (already-correct) in-range-only semantics matching real jq's own order-independent
-`delpaths` union rule. Replicating the order-dependent out-of-range case would need the array
-arm restructured to apply keys sequentially instead, a materially larger change than this fix
-attempts -- tracked separately as
-[#2306](https://github.com/rust-works/succinctly/issues/2306), including whether `del()`'s own
-comma-separated multi-target form (`del(.[0], .[5])`, a different call path than `delpaths()`'s
-path-array form) shares the same order-dependence.
+`delpaths_one` (`src/jq/eval.rs`) used to sort the whole path list before deleting anything --
+a step that exists to support jq's own simultaneous/union model, applied unconditionally
+regardless of mode. It now skips that sort in yq mode and instead applies each path
+individually, via a loop calling the existing `delete_paths_sorted` once per path (in the
+caller's own given order) rather than handing the whole (sorted) list to it in one call. jq
+mode's own code path -- sort, then one batched call -- is unchanged.
 
-A negative out-of-range index is untouched by this fix either way -- it raises instead
-(#2268, the section above, landed separately and already covers it).
+A negative out-of-range index is otherwise unaffected by this fix -- it still raises (#2268,
+the section above), just with an array-size figure that's now correct for a grouped batch too,
+per that section's own updated note.
+
+**Still open: `del()`'s own comma-separated multi-target form** (`del(.[0], .[5])`, a
+different call path than `delpaths()`'s path-array form -- each target reaches `delete_keys`
+through its own separate call, not a shared batch, so #2306's fix above doesn't reach it).
+Confirmed live that real yq's `del()` comma form is *also* order-dependent the identical way,
+which succinctly does not yet reproduce -- not yet filed as its own issue.
 
 **Also extended to a mid-chain index, not just a terminal one**
 ([#2314](https://github.com/rust-works/succinctly/issues/2314)). A positive out-of-range

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -42402,7 +42402,22 @@ fn delpaths_one<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     // comparator growing here to drift from it. The sort has to be stable, as
     // jq's is: two paths can compare equal and still name different keys,
     // `[[1],[1.0]]` being the pair.
-    paths.sort_by(compare_values);
+    //
+    // #2306: yq mode does not sort at all -- real yq's own `delpaths()`
+    // applies paths *sequentially*, in the caller's own order, each one
+    // seeing whatever state every earlier path already left behind, not
+    // jq's simultaneous-batch model this sort exists to support. Confirmed
+    // live (yq v4.53.3) this isn't only about out-of-range indices: even an
+    // all-in-range batch is order-dependent -- `delpaths([[0],[1]])` on
+    // `[1,2,3,4]` is `[2,4]` (delete index 0 -> `[2,3,4]`, then index 1 of
+    // *that* -> `[2,4]`), while `delpaths([[1],[0]])` on the same input is
+    // `[3,4]` instead; real jq's own `delpaths` gives the order-independent
+    // `[3,4]` for *both* orderings. Handled below by looping one path at a
+    // time instead of handing the whole (sorted) batch to
+    // `delete_paths_sorted` in one call.
+    if S::TAG != EvalTag::Yq {
+        paths.sort_by(compare_values);
+    }
 
     // Every survivor of the `retain` is an array, so this only re-borrows.
     let paths: Vec<&[OwnedValue]> = paths
@@ -42413,29 +42428,47 @@ fn delpaths_one<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
         })
         .collect();
 
-    // The empty path names the document itself, and sorts before every other
-    // array, so only the first entry needs checking: `delpaths([[],[0]])` and
-    // `delpaths([[0],[]])` are both `null` in jq mode.
+    // #2306: yq mode applies paths one at a time, in the caller's own
+    // order, each `delete_paths_sorted` call started fresh from what the
+    // previous one left behind -- a single-element path list has no
+    // sort/group ambiguity of its own, so this reuses that function's
+    // existing per-path deletion (including its own recursive handling of
+    // a multi-component path) rather than a second copy of it.
     //
-    // #2352: yq's own root-delete rule (#1702, `builtin_del`'s own
-    // `Expr::Identity` arm above) applies here too -- real yq's
-    // `delpaths([[]])` deletes the whole document and emits nothing, not the
-    // literal `null` jq (and this function's own jq-mode arm just below)
-    // prints. A guarded arm ahead of the plain `Some([])` one, not a
-    // separate `if`, so both share one pattern instead of testing
-    // `paths.first()` against the same shape twice in adjacent statements —
-    // `return`'s `!` type unifies with the `Result<OwnedValue, EvalError>`
-    // every other arm produces, same as the `Some(_)` arm below already
-    // relies on for its own early exits via `?`.
-    let result = match paths.first() {
-        None => to_owned(value),
-        Some([]) if S::TAG == EvalTag::Yq => return QueryResult::None,
-        Some([]) => Ok(OwnedValue::Null),
-        Some(_) => {
-            to_owned(value).and_then(|v| delete_paths_sorted(v, &paths, 0, S::TAG == EvalTag::Yq))
+    // #2352: an empty path names the whole document, and real yq's own
+    // root-delete rule (#1702, `builtin_del`'s own `Expr::Identity` arm)
+    // applies here too -- deleting the root emits *nothing*, not the
+    // literal `null` jq mode (and this function's own jq-mode arm below)
+    // prints for the identical shape. `root_deleted` latches once any path
+    // in the sequence is empty: every path after that is a no-op against
+    // `null` anyway (`delete_keys`'s own `OwnedValue::Null` arm), so the
+    // document really did end up wholly deleted regardless of where `[]`
+    // falls in the batch or what (no-op) work follows it.
+    let mut root_deleted = false;
+    let result = if S::TAG == EvalTag::Yq {
+        to_owned(value).and_then(|mut v| {
+            for &path in &paths {
+                v = if path.is_empty() {
+                    root_deleted = true;
+                    OwnedValue::Null
+                } else {
+                    delete_paths_sorted(v, core::slice::from_ref(&path), 0, true)?
+                };
+            }
+            Ok(v)
+        })
+    } else {
+        // The empty path names the document itself, and sorts before every
+        // other array, so only the first entry needs checking:
+        // `delpaths([[],[0]])` and `delpaths([[0],[]])` are both `null`.
+        match paths.first() {
+            None => to_owned(value),
+            Some([]) => Ok(OwnedValue::Null),
+            Some(_) => to_owned(value).and_then(|v| delete_paths_sorted(v, &paths, 0, false)),
         }
     };
     match result {
+        Ok(_) if root_deleted => QueryResult::None,
         Ok(v) => QueryResult::Owned(v),
         // #1746 review: a decode failure from `to_owned` must bypass
         // `optional` the same way every other converted call site does
@@ -70206,19 +70239,26 @@ mod tests {
     }
 
     #[test]
-    fn test_delpaths_multi_key_out_of_range_stays_noop_known_gap_2305() {
-        // #2306 (deferred from #2305, not this issue's scope): a
-        // multi-key `delpaths()` batch mixing an in-range delete with an
-        // out-of-range one is order-*dependent* in real yq (confirmed
-        // live in #2306's own filing) -- the batch/single-`retain`-pass
-        // model this function uses has no way to replicate that, so a
-        // 2+-key batch's own out-of-range members stay a no-op exactly
-        // like before this fix. Pinned here as a known gap, not a
-        // regression: only the in-range key (index 0) is actually
-        // deleted.
+    fn test_delpaths_multi_key_mixed_in_range_and_out_of_range_sequential_2306() {
+        // #2306 (deferred from #2305, resolved here): a multi-key
+        // `delpaths()` batch mixing an in-range delete with an
+        // out-of-range one is order-*dependent* in real yq -- confirmed
+        // live (yq v4.53.3): delete index 0 from `[1,2,3]` first
+        // (`[2,3]`), then extend *that* to length 5 (`[2,3,null,null,
+        // null]`), since index 5 no longer resolves in-range against the
+        // now-shrunk length. `delpaths_one`'s yq-mode path now applies
+        // each key sequentially (skipping the jq-only upfront sort)
+        // instead of batching the whole list against the array's
+        // original length, matching this exactly.
         yq_query!(br"[1,2,3]", r"delpaths([[0],[5]])",
             QueryResult::Owned(OwnedValue::Array(arr)) => {
-                assert_eq!(arr, vec![OwnedValue::Int(2), OwnedValue::Int(3)]);
+                assert_eq!(
+                    arr,
+                    vec![
+                        OwnedValue::Int(2), OwnedValue::Int(3),
+                        OwnedValue::Null, OwnedValue::Null, OwnedValue::Null,
+                    ]
+                );
             }
         );
     }

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -36689,14 +36689,20 @@ fn delete_keys(
             // gets the same null-extension `delete_at_path`'s `Expr::Index`
             // arm does (`delpaths([[5]])` on `[1,2]` matches `del(.[5])`
             // exactly, confirmed live) -- gated on `keys.len() == 1`
-            // deliberately, not extended to a multi-key batch: confirmed
-            // live that mixing an in-range delete with an out-of-range one
-            // is order-*dependent* in real yq (`delpaths([[0],[5]])` vs
-            // `delpaths([[5],[0]])` on the same `[1,2,3]` give *different*
-            // results, 5 vs 4 elements) -- this batch/single-`retain`-pass
-            // model has no way to replicate that without processing keys
-            // sequentially, a materially larger change; tracked separately
-            // as #2306 rather than guessed at here.
+            // deliberately, not extended to a multi-key batch: real yq's
+            // own multi-key `delpaths()` batch is order-*dependent*
+            // (`delpaths([[0],[5]])` vs `delpaths([[5],[0]])` on the same
+            // `[1,2,3]` give *different* results, 5 vs 4 elements), which
+            // this batch/single-`retain`-pass model has no way to
+            // replicate. #2306 closes that gap for `delpaths()` -- its own
+            // caller, `delpaths_one`, never reaches this function with more
+            // than one key at a time in yq mode anymore, looping over paths
+            // sequentially itself instead -- so a `keys.len() > 1` call
+            // here is now only ever jq mode (unaffected: real jq's own
+            // `delpaths` genuinely is order-independent) or `del()`'s own
+            // comma-separated multi-target form, which still reaches here
+            // batched and still has this same gap (#2306's own "still
+            // open" note).
             let mut indices: Vec<usize> = vec_with_capacity(keys.len());
             let mut single_key_oob_target: Option<usize> = None;
             for key in keys {
@@ -70257,6 +70263,28 @@ mod tests {
                     vec![
                         OwnedValue::Int(2), OwnedValue::Int(3),
                         OwnedValue::Null, OwnedValue::Null, OwnedValue::Null,
+                    ]
+                );
+            }
+        );
+    }
+
+    #[test]
+    fn test_delpaths_multi_key_mixed_reversed_order_gives_a_different_result_2306() {
+        // #2306 sibling: the reversed key order from the test above, same
+        // input, a *different*-length result -- the same pairing
+        // `docs/compliance/yq/limitations.md` uses to demonstrate this
+        // divergence. Confirmed live (yq v4.53.3): extend `[1,2,3]` to
+        // length 5 first (`[1,2,3,null,null]`), then delete index 0 of
+        // *that* (`[2,3,null,null]`), since index 0 is now in-range
+        // against the extended length.
+        yq_query!(br"[1,2,3]", r"delpaths([[5],[0]])",
+            QueryResult::Owned(OwnedValue::Array(arr)) => {
+                assert_eq!(
+                    arr,
+                    vec![
+                        OwnedValue::Int(2), OwnedValue::Int(3),
+                        OwnedValue::Null, OwnedValue::Null,
                     ]
                 );
             }

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -70292,6 +70292,25 @@ mod tests {
     }
 
     #[test]
+    fn test_delpaths_yq_mode_empty_path_mid_sequence_wipes_to_null_2306() {
+        // #2306: the sequential yq-mode loop's own empty-path case, mixed
+        // with an ordinary key rather than appearing alone -- an earlier
+        // key deletes normally, then the empty path (naming the whole
+        // document) wipes the result to `null`, matching the same
+        // "sequential, mutating between each path" model as every other
+        // case in this test group. `[0]` on `[1,2,3]` first gives `[2,3]`,
+        // then `[]` (the whole document at that point) wipes it. Real yq
+        // itself produces *no output at all* here rather than the literal
+        // value `null` (a separate, already-filed divergence, #2352,
+        // shared with `delpaths([[]])` alone) -- this test checks the
+        // owned value this arm actually returns, not the CLI's rendering
+        // of it.
+        yq_query!(br"[1,2,3]", r"delpaths([[0],[]])",
+            QueryResult::Owned(OwnedValue::Null) => {}
+        );
+    }
+
+    #[test]
     fn test_del_mid_chain_positive_out_of_range_index_extends_with_null_yq_mode_2314() {
         // #2314: #2305's follow-up -- a positive out-of-range index that is
         // *not* the terminal delete step still needs to exist, so the rest

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -70292,22 +70292,20 @@ mod tests {
     }
 
     #[test]
-    fn test_delpaths_yq_mode_empty_path_mid_sequence_wipes_to_null_2306() {
+    fn test_delpaths_yq_mode_empty_path_mid_sequence_emits_nothing_2306() {
         // #2306: the sequential yq-mode loop's own empty-path case, mixed
         // with an ordinary key rather than appearing alone -- an earlier
         // key deletes normally, then the empty path (naming the whole
         // document) wipes the result to `null`, matching the same
         // "sequential, mutating between each path" model as every other
         // case in this test group. `[0]` on `[1,2,3]` first gives `[2,3]`,
-        // then `[]` (the whole document at that point) wipes it. Real yq
-        // itself produces *no output at all* here rather than the literal
-        // value `null` (a separate, already-filed divergence, #2352,
-        // shared with `delpaths([[]])` alone) -- this test checks the
-        // owned value this arm actually returns, not the CLI's rendering
-        // of it.
-        yq_query!(br"[1,2,3]", r"delpaths([[0],[]])",
-            QueryResult::Owned(OwnedValue::Null) => {}
-        );
+        // then `[]` (the whole document at that point) wipes it -- and
+        // #2352's own fix (landed after this test was first written)
+        // makes that `root_deleted` state emit nothing at all, matching
+        // real yq's `delpaths([[]])` (alone) and `del(.)` exactly, rather
+        // than the literal value `null`, regardless of what (necessarily
+        // no-op) work follows the empty path in the same batch.
+        yq_query!(br"[1,2,3]", r"delpaths([[0],[]])", QueryResult::None => {});
     }
 
     #[test]

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -21231,12 +21231,45 @@ fn test_1162_delpaths_rejects_nested_slice_descriptor() -> Result<()> {
 }
 
 /// An ordinary (non-slice-descriptor) `delpaths()` call is unaffected by
-/// the new yq-mode check.
+/// the new yq-mode check. Corrected by #2306: this used to assert the
+/// batch/union result (`[2]`, deleting original indices 0 and 2
+/// simultaneously) but real yq applies the two paths *sequentially* --
+/// delete index 0 from `[1,2,3]` first (`[2,3]`), then index 2 of *that*
+/// (out of range for a 2-element array, so a no-op) -- confirmed live
+/// (yq v4.53.3) that `delpaths([[0],[2]])` on `[1,2,3]` is `[2,3]`, not
+/// `[2]`.
 #[test]
 fn test_1162_delpaths_ordinary_paths_unaffected() -> Result<()> {
     let (out, code) = run_yq_stdin("delpaths([[0],[2]])", "[1,2,3]", &["-o=json", "-I=0"])?;
     assert_eq!(code, 0);
-    assert_eq!(out.trim(), "[2]");
+    assert_eq!(out.trim(), "[2,3]");
+    Ok(())
+}
+
+/// #2306: `delpaths()`'s own multi-key batch is order-dependent in real
+/// yq -- not just when out-of-range indices are involved, confirmed live
+/// (yq v4.53.3) even for two all-in-range indices. Deleting index 0 first
+/// from `[1,2,3,4]` gives `[2,3,4]`; deleting index 1 of *that* removes
+/// the (now-shifted) value `3`, giving `[2,4]`. The reversed order
+/// (`test_1162_delpaths_reversed_order_gives_a_different_result_2306`
+/// below) gives `[3,4]` instead on the identical input -- real jq's own
+/// `delpaths` gives the order-independent `[3,4]` for *both* orderings.
+#[test]
+fn test_1162_delpaths_order_dependent_even_when_all_in_range_2306() -> Result<()> {
+    let (out, code) = run_yq_stdin("delpaths([[0],[1]])", "[1,2,3,4]", &["-o=json", "-I=0"])?;
+    assert_eq!(code, 0);
+    assert_eq!(out.trim(), "[2,4]");
+    Ok(())
+}
+
+/// #2306 sibling: the reversed key order from the test above, same input,
+/// different result -- confirming this is genuinely about *sequence*, not
+/// which specific indices are named.
+#[test]
+fn test_1162_delpaths_reversed_order_gives_a_different_result_2306() -> Result<()> {
+    let (out, code) = run_yq_stdin("delpaths([[1],[0]])", "[1,2,3,4]", &["-o=json", "-I=0"])?;
+    assert_eq!(code, 0);
+    assert_eq!(out.trim(), "[3,4]");
     Ok(())
 }
 
@@ -29355,18 +29388,17 @@ fn test_delpaths_negative_index_out_of_range_raises_2268() -> Result<()> {
     Ok(())
 }
 
-/// #2268: a documented, accepted residual divergence -- when a
-/// negative-out-of-range index is grouped in the *same* `delpaths()` call
-/// as an earlier deletion on the same array, real yq's own error reports
-/// the array's size *after* that earlier deletion already happened
-/// (confirmed live, v4.53.3: `delpaths([[0],[-5]])` on a 2-element array
-/// reports "array size is 1", not 2). `delete_keys`'s own batch invariant
-/// -- every key resolves against the length the array had on *entry*, not
-/// a shrinking length as each is processed, which is what makes an
-/// overlapping range union rather than compound -- means this crate always
-/// reports the *entry* length instead. Still correctly raises, which is
-/// this issue's own actual scope; only the reported number can differ in
-/// this one multi-key-same-array shape, not pinned against real yq itself.
+/// #2268, corrected by #2306: when a negative-out-of-range index is grouped
+/// in the *same* `delpaths()` call as an earlier deletion on the same
+/// array, real yq's own error reports the array's size *after* that
+/// earlier deletion already happened (confirmed live, v4.53.3:
+/// `delpaths([[0],[-5]])` on a 2-element array reports "array size is 1",
+/// not 2). This test used to pin the *entry*-length report ("array size is
+/// 2") as a documented, accepted residual divergence from `delete_keys`'s
+/// own batch invariant -- #2306's sequential-per-path fix for yq mode
+/// closes that gap as a side effect (each path now really does see the
+/// length the previous one left behind), so this now matches real yq
+/// exactly.
 #[test]
 fn test_delpaths_grouped_negative_index_reports_entry_length_2268() -> Result<()> {
     let (out, stderr, code) =
@@ -29374,7 +29406,7 @@ fn test_delpaths_grouped_negative_index_reports_entry_length_2268() -> Result<()
     assert_eq!(code, 1, "out: {out:?}");
     assert_eq!(
         stderr.trim(),
-        "Error: index [-5] out of range, array size is 2"
+        "Error: index [-5] out of range, array size is 1"
     );
 
     Ok(())


### PR DESCRIPTION
## Summary
- Real yq's own `delpaths()` applies a 2+-path batch **sequentially** — one path at a time, each seeing whatever state every earlier path already left behind — not jq's own simultaneous/union model, which resolves every path against the array's *starting* length.
- Confirmed live (yq v4.53.3) this isn't only about out-of-range indices, contrary to this issue's own original framing: even an **all-in-range** batch is order-dependent — `delpaths([[0],[1]])` on `[1,2,3,4]` is `[2,4]`, `delpaths([[1],[0]])` on the same input is `[3,4]` — while real jq's own `delpaths` gives the order-independent `[3,4]` for *both* orderings.
- `delpaths_one` now skips the upfront sort in yq mode (which exists to support jq's own batch semantics) and applies each path individually via a loop over the existing `delete_paths_sorted`, rather than handing the whole (sorted) list to it in one call. **jq mode is unaffected.**
- Corrects two pre-existing tests that pinned the old, wrong batch-based expectation — including `test_delpaths_multi_key_out_of_range_stays_noop_known_gap_2305`, which explicitly documented this exact gap as pending this very issue.

Fixes #2306

## Follow-ups filed
Two out-of-scope divergences surfaced during this fix's own live-oracle sweep:
- #2352 — `delpaths([[]])` prints a literal `null` instead of producing no output the way `del(.)` already correctly does.
- #2353 — a wrong-kind delete key (e.g. a numeric key against an object) raises in succinctly's yq mode; real yq treats it as a silent no-op.

## Test plan
- [x] `cargo build --features cli`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings`
- [x] `cargo fmt --check`
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features`
- [x] `cargo test --features cli,simd,regex,serde --no-fail-fast`
- [x] `cargo test --no-fail-fast` (default features)
- [x] `cargo test --no-default-features --verbose` (no_std)
- [x] Live-verified against the pinned yq v4.53.3 oracle across a broad sweep: in-range-only (both orders), pure-OOB (both orders), OOB-mixed (both orders), negative-index-mixed, nested paths, object keys, empty-path-mixed
