### PR TITLE
fix(yq): delpaths([[]]) emits nothing instead of printing null (#2352)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -289,6 +289,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`delpaths([[]])` printed the literal `null` instead of emitting nothing in yq mode**
+  (#2352, found while implementing #2306). `del(.)` already special-cases "deleted the
+  whole document" as no output at all (#1702, real yq's own root-delete rule), but
+  `delpaths_one`'s own empty-path arm — the JSON-array-of-paths spelling of the identical
+  operation — never picked up the same mechanism, since its own `Ok(OwnedValue::Null)`
+  result had no way to signal "no output" once already wrapped as an ordinary value.
+  Fixed by checking for the empty-path shape ahead of that result, in yq mode only (jq
+  mode is unaffected — real jq's own `delpaths([[]])` already prints `null`, matching
+  succinctly's existing jq-mode behavior). The empty path always sorts first in
+  `delpaths_one`'s own path list (an existing invariant, unchanged), so a multi-path call
+  with an empty path anywhere in it (`delpaths([[],["a"]])`, `delpaths([["a"],[]])`)
+  collapses to the same "emit nothing" outcome regardless of where the empty path
+  appears in the argument — confirmed live against yq v4.53.3 for all three shapes.
+
 - **`del()` through a chained slice-run followed by more path (`del(.a[0:2].x)`) silently
   no-op'd instead of erroring when the slice target is an array or `null`** (#2333, found
   during #2323's own code review). #1219's own "trailing slice-run followed by anything

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -42075,7 +42075,18 @@ fn delpaths_one<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
 
     // The empty path names the document itself, and sorts before every other
     // array, so only the first entry needs checking: `delpaths([[],[0]])` and
-    // `delpaths([[0],[]])` are both `null`.
+    // `delpaths([[0],[]])` are both `null` in jq mode.
+    //
+    // #2352: yq's own root-delete rule (#1702, `builtin_del`'s own
+    // `Expr::Identity` arm above) applies here too -- real yq's
+    // `delpaths([[]])` deletes the whole document and emits nothing, not the
+    // literal `null` jq (and this function, before this fix) prints. Checked
+    // ahead of the `result`/`QueryResult` match below for the same reason
+    // `builtin_del` checks its own analogous case ahead of `delete_at_path`:
+    // there is no way to signal "no output at all" through an `OwnedValue`.
+    if S::TAG == EvalTag::Yq && matches!(paths.first(), Some([])) {
+        return QueryResult::None;
+    }
     let result = match paths.first() {
         None => to_owned(value),
         Some([]) => Ok(OwnedValue::Null),

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -42080,15 +42080,16 @@ fn delpaths_one<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     // #2352: yq's own root-delete rule (#1702, `builtin_del`'s own
     // `Expr::Identity` arm above) applies here too -- real yq's
     // `delpaths([[]])` deletes the whole document and emits nothing, not the
-    // literal `null` jq (and this function, before this fix) prints. Checked
-    // ahead of the `result`/`QueryResult` match below for the same reason
-    // `builtin_del` checks its own analogous case ahead of `delete_at_path`:
-    // there is no way to signal "no output at all" through an `OwnedValue`.
-    if S::TAG == EvalTag::Yq && matches!(paths.first(), Some([])) {
-        return QueryResult::None;
-    }
+    // literal `null` jq (and this function's own jq-mode arm just below)
+    // prints. A guarded arm ahead of the plain `Some([])` one, not a
+    // separate `if`, so both share one pattern instead of testing
+    // `paths.first()` against the same shape twice in adjacent statements —
+    // `return`'s `!` type unifies with the `Result<OwnedValue, EvalError>`
+    // every other arm produces, same as the `Some(_)` arm below already
+    // relies on for its own early exits via `?`.
     let result = match paths.first() {
         None => to_owned(value),
+        Some([]) if S::TAG == EvalTag::Yq => return QueryResult::None,
         Some([]) => Ok(OwnedValue::Null),
         Some(_) => {
             to_owned(value).and_then(|v| delete_paths_sorted(v, &paths, 0, S::TAG == EvalTag::Yq))

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -21087,6 +21087,65 @@ fn test_1702_yq_comma_with_root_del_emits_nothing() -> Result<()> {
     Ok(())
 }
 
+/// #2352: `delpaths([[]])` — the JSON-array-of-paths spelling of "delete the
+/// whole document" — shares #1702's own root-delete rule: real yq emits
+/// nothing, not the literal `null` this codebase printed before this fix
+/// (`del(.)` already got this right; `delpaths_one`'s own empty-path arm
+/// never picked up the same "no output at all" mechanism). Verified live
+/// against yq v4.53.3 on scalar/array/object targets, matching
+/// `test_1702_yq_bare_root_del_emits_nothing`'s own coverage exactly.
+#[test]
+fn test_2352_yq_delpaths_empty_path_emits_nothing() -> Result<()> {
+    for input in [r#"{"a":1}"#, r"[1,2,3]", r"5"] {
+        let (out, code) = run_yq_stdin("delpaths([[]])", input, &["-o=json"])?;
+        assert_eq!(code, 0);
+        assert_eq!(out, "", "input was {input}");
+    }
+    Ok(())
+}
+
+/// #2352: the empty path always sorts before every other path
+/// (`delpaths_one`'s own established invariant), so an empty path anywhere
+/// in a multi-path list collapses the whole call to "emit nothing" in yq
+/// mode too — verified live for both orderings.
+#[test]
+fn test_2352_yq_delpaths_empty_path_among_others_emits_nothing() -> Result<()> {
+    let (out, code) = run_yq_stdin(r#"delpaths([[],["a"]])"#, r#"{"a":1,"b":2}"#, &["-o=json"])?;
+    assert_eq!(code, 0);
+    assert_eq!(out, "");
+
+    let (out, code) = run_yq_stdin(r#"delpaths([["a"],[]])"#, r#"{"a":1,"b":2}"#, &["-o=json"])?;
+    assert_eq!(code, 0);
+    assert_eq!(out, "");
+    Ok(())
+}
+
+/// #2352: jq mode is unaffected by the yq-only widening — real jq's own
+/// `delpaths([[]])` prints the literal `null`, matching succinctly's
+/// existing (unchanged) jq-mode behavior.
+#[test]
+fn test_2352_jq_mode_unaffected() -> Result<()> {
+    let (out, code) = run_jq_stdin("delpaths([[]])", "[1,2,3]", &["-c"])?;
+    assert_eq!(code, 0);
+    assert_eq!(out.trim(), "null");
+    Ok(())
+}
+
+/// #2352 control: a genuinely non-empty `delpaths()` call is unaffected —
+/// this fix's own early return is gated on the empty-path shape specifically,
+/// not on `delpaths()` in general.
+#[test]
+fn test_2352_yq_delpaths_nonempty_path_unaffected() -> Result<()> {
+    let (out, code) = run_yq_stdin(
+        r#"delpaths([["a"]])"#,
+        r#"{"a":1,"b":2}"#,
+        &["-o=json", "-I=0"],
+    )?;
+    assert_eq!(code, 0);
+    assert_eq!(out.trim(), r#"{"b":2}"#);
+    Ok(())
+}
+
 /// A comma-grouped multi-path `del()` (`delete_expr_paths_at`'s own sibling-
 /// grouping walker, a completely separate code path from the single-path
 /// case above) gets the same widened rule for each resolved path


### PR DESCRIPTION
## Summary

Found while implementing #2306. `delpaths()` with an empty path component (`[]`, naming
the whole document) prints the literal string `null` in succinctly's yq mode — real yq
prints *nothing at all* (empty stdout, exit 0), matching `del(.)`'s own already-correct
"deleting the whole document produces no output" behavior. This predates #2306's own
sequential-processing fix entirely.

```console
$ echo '[1,2,3]' | yq -o=json 'delpaths([[]])'
$ echo $?
0
# (nothing printed)

$ echo '[1,2,3]' | succinctly yq -o json 'delpaths([[]])'
null
```

## Root cause

`delpaths_one`'s (`src/jq/eval.rs`) own empty-path handling — `Some([]) =>
Ok(OwnedValue::Null)` — returns `OwnedValue::Null` as an ordinary owned value, which the
caller then prints as `null`. `builtin_del`'s own root-deletion path has a different,
already-correct "produce nothing" mechanism (`return QueryResult::None` ahead of
`delete_at_path`, per #1702) that `delpaths_one` never picked up.

## Fix

Checks for the empty-path shape ahead of the existing `Ok(OwnedValue::Null)` result,
returning `QueryResult::None` directly in yq mode — same mechanism `builtin_del` already
uses for its own analogous case. jq mode is unaffected (real jq's own `delpaths([[]])`
already prints `null`).

The empty path always sorts first in `delpaths_one`'s own path list (an existing,
unchanged invariant — `paths.sort_by(compare_values)` a few lines above), so this single
check also covers a multi-path call with an empty path anywhere in it, regardless of
where it appears in the argument — verified live for both orderings
(`delpaths([[],["a"]])`, `delpaths([["a"],[]])`).

## Verification

- 5 new CLI regression tests (`tests/yq_cli_tests.rs`): the original repro across
  scalar/array/object targets (mirroring `test_1702_yq_bare_root_del_emits_nothing`'s own
  coverage), both multi-path orderings, jq-mode non-regression, and a non-empty-path
  control case.
- Full `cargo test --workspace`: all green.
- `cargo test --no-default-features --verbose` (no_std leg): green.
- `cargo clippy --all-targets --all-features -- -D warnings` and the second CI clippy
  leg: clean.
- `cargo fmt --check`, `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features`:
  clean.

Fixes #2352
