### PR TITLE
fix(jq): eval_slice_bound gates escaped Partial prefix on yq mode

### DIFF
--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -17402,6 +17402,17 @@ fn eval_slice_bound<W: Clone + AsRef<[u64]>, S: EvalSemantics>(
             // prefix (see the function's own doc comment above) -- mirrors
             // #2226's/#2326's identical `S::TAG == EvalTag::Yq` gate on their
             // own target/key `Partial` arms.
+            //
+            // #2351 review: discarding `_vs` here also means the
+            // `owned_bound_to_i64` conversion below never runs on it in yq
+            // mode, which incidentally sidesteps a separate, pre-existing,
+            // unrelated bug: `owned_bound_to_i64`'s `.collect::<Result<...>,
+            // _>>()?` throws away the *whole* prefix (converted values
+            // included) on the first non-numeric bound value, not just the
+            // bad one -- still live in jq mode (`.[(0,"x",error("y")):3]` on
+            // `[10,20,30]` should print `[10,20,30]` per jq 1.7.1 but prints
+            // nothing here) and untouched by this PR. Not a fix for that bug,
+            // just an accident of evaluation order once the prefix is gone.
             QueryResult::Partial(_vs, control) if S::TAG == EvalTag::Yq => {
                 (Vec::new(), Some(control))
             }
@@ -26366,6 +26377,21 @@ type ResolvedSliceBound = (Option<i64>, Option<NumberKey>);
 /// type failure the same keep-partial treatment as a generator escape needs
 /// its own priority-ordering pass against `target_escape`/`bounds_escape`
 /// above, re-verified against jq the same way, not a quick addition here.
+///
+/// #2351 review (Gap 1): jq-only, matching `eval_slice_bound`'s own gate.
+/// `eval_owned_multi_keep_partial` itself can't carry this gate -- it's a
+/// shared helper whose *other* callers (`recurse`'s children evaluation,
+/// `resolve_node`'s `Select`/`If`/`GetPath` arms, `resolve_index_expr`'s own
+/// `key`, ...) must keep their own prefix in yq mode too, so the gate has to
+/// live here, at this specific call site, not inside the helper. Live-
+/// verified against yq v4.53.3: `del(.[(0,1,error("x")):3])` on `[1,2,3]`
+/// prints only `Error: x`, no `{"start":...}` prefix reaching the caller
+/// (the same `resolve_dynamic_indexes` codepath `=`/`path()` also drive).
+/// Discarding the prefix here also means `owned_bound_to_i64` below never
+/// runs on it in yq mode, which incidentally sidesteps the unrelated
+/// non-numeric-bound bug this doc comment's own "Residual" paragraph
+/// describes -- not a fix for that bug, just an accident of evaluation
+/// order once the prefix is gone.
 fn resolve_slice_bound<S: EvalSemantics>(
     bound: &Option<Box<Expr>>,
     value: &OwnedValue,
@@ -26374,7 +26400,10 @@ fn resolve_slice_bound<S: EvalSemantics>(
     let Some(expr) = bound else {
         return Ok((vec![(None, None)], None));
     };
-    let (values, escape) = eval_owned_multi_keep_partial::<S>(expr, value);
+    let (mut values, escape) = eval_owned_multi_keep_partial::<S>(expr, value);
+    if S::TAG == EvalTag::Yq && escape.is_some() {
+        values = Vec::new();
+    }
     let resolved = values
         .iter()
         .map(|v| {
@@ -32621,6 +32650,17 @@ type RawSliceBound = (OwnedValue, Option<i64>);
 /// to build the resulting path component the same way `walk_path`/
 /// `navigation_element` already do for a *literal* slice (#1326's own
 /// representation).
+///
+/// #2351 review (Gap 2): jq-only, matching `eval_slice_bound`'s own gate.
+/// `drain_path_context_stream` itself can't carry this gate -- it's shared
+/// with `eval_index_expr_with_path_context`'s own `key` materialization
+/// above, which (per that function's own #2226-review comment) still
+/// deliberately keeps its prefix in every mode as a separate, untouched
+/// gap; folding the yq-only discard into the shared helper would silently
+/// change that sibling's behavior too. So the gate lives here instead, at
+/// this bound-specific call site. Live-verified against yq v4.53.3:
+/// `.[(0,1,error("x")):3] | key` on `[1,2,3]` (via `--jq-extensions`)
+/// prints only `Error: x`, no `{"start":...,"end":...}` prefix.
 fn eval_slice_bound_with_path_context<W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     bound: &Option<Box<Expr>>,
     value: &OwnedValue,
@@ -32634,7 +32674,10 @@ fn eval_slice_bound_with_path_context<W: Clone + AsRef<[u64]>, S: EvalSemantics>
     };
     let result =
         eval_expr_needing_path_context::<W, S>(expr, value, root, file_origin, current_path, false);
-    let (raw, escape) = drain_path_context_stream(result);
+    let (mut raw, escape) = drain_path_context_stream(result);
+    if S::TAG == EvalTag::Yq && escape.is_some() {
+        raw = Vec::new();
+    }
     let converted = raw
         .into_iter()
         .map(|v| {
@@ -53666,6 +53709,276 @@ mod tests {
         yq_query!(b"[1,2,3]", r#".[0:(1,2,error("x"))]"#,
             QueryResult::Error(e) => {
                 assert_eq!(e.message, "x");
+            }
+        );
+    }
+
+    // #2351 review, Gap 1: `resolve_slice_bound` (the path-mode resolver
+    // behind `path()`/`=`/`del()`, via `resolve_dynamic_indexes`) had the
+    // identical missing-gate bug `eval_slice_bound` (read mode) was fixed
+    // for above -- it fed `eval_owned_multi_keep_partial` unconditionally,
+    // with no `S::TAG == EvalTag::Yq` carve-out at all. Confirmed live
+    // against yq v4.53.3 with `del(...)`, since bare `path(...)` isn't real
+    // yq syntax (`--jq-extensions` only, an internal succinctly extension):
+    // `del(.[(0,1,error("x")):3])` on `[1,2,3]` prints only `Error: x`. The
+    // tests below exercise the underlying resolver directly via `path()`
+    // (parsed with jq extensions unconditionally by `query!`/`yq_query!`,
+    // same as every other `path(...)` test in this file), since `path()`'s
+    // output makes the discarded prefix directly observable.
+
+    /// #2351 review (Gap 1): jq-mode control, start bound (`K1`). Verified
+    /// against jq 1.7.1: `path(.[(0,1,error("x")):3])` on `[1,2,3]` prints
+    /// `[{"start":0,"end":3}]` then `[{"start":1,"end":3}]` before raising
+    /// `x` -- jq mode is unaffected by the new gate.
+    #[test]
+    fn test_resolve_slice_bound_start_own_partial_prefix_preserved_in_jq_mode_2351_review() {
+        query!(b"[1,2,3]", r#"path(.[(0,1,error("x")):3])"#,
+            QueryResult::Partial(vs, Control::Error(e)) => {
+                assert_eq!(prefix_json(&vs), [r#"[{"start":0,"end":3}]"#, r#"[{"start":1,"end":3}]"#]);
+                assert_eq!(e.message, "x");
+            }
+        );
+    }
+
+    /// #2351 review sibling: the end bound (`K2`). Verified against jq
+    /// 1.7.1: `path(.[0:(1,2,error("x"))])` on `[1,2,3]` prints
+    /// `[{"start":0,"end":1}]` then `[{"start":0,"end":2}]` before raising.
+    #[test]
+    fn test_resolve_slice_bound_end_own_partial_prefix_preserved_in_jq_mode_2351_review() {
+        query!(b"[1,2,3]", r#"path(.[0:(1,2,error("x"))])"#,
+            QueryResult::Partial(vs, Control::Error(e)) => {
+                assert_eq!(prefix_json(&vs), [r#"[{"start":0,"end":1}]"#, r#"[{"start":0,"end":2}]"#]);
+                assert_eq!(e.message, "x");
+            }
+        );
+    }
+
+    /// #2351 review (Gap 1): the new yq-mode gate on `resolve_slice_bound`,
+    /// start bound (`K1`). Real `path(...)` has no yq oracle (jq-only
+    /// syntax, gated behind `--jq-extensions`), but the underlying resolver
+    /// this exercises is the same one `del(...)`/`=` reach in yq mode --
+    /// live-verified there instead: `del(.[(0,1,error("x")):3])` on
+    /// `[1,2,3]` prints only `Error: x`, matching this test's own
+    /// `QueryResult::Error` (no `Partial` prefix at all).
+    #[test]
+    fn test_resolve_slice_bound_start_own_partial_prefix_discarded_in_yq_mode_2351_review() {
+        yq_query!(b"[1,2,3]", r#"path(.[(0,1,error("x")):3])"#,
+            QueryResult::Error(e) => {
+                assert_eq!(e.message, "x");
+            }
+        );
+    }
+
+    /// #2351 review sibling: the end bound (`K2`). Live-verified via
+    /// `del(.[0:(1,2,error("x"))])` on `[1,2,3]`: prints only `Error: x`.
+    #[test]
+    fn test_resolve_slice_bound_end_own_partial_prefix_discarded_in_yq_mode_2351_review() {
+        yq_query!(b"[1,2,3]", r#"path(.[0:(1,2,error("x"))])"#,
+            QueryResult::Error(e) => {
+                assert_eq!(e.message, "x");
+            }
+        );
+    }
+
+    // #2351 review, Gap 2: `eval_slice_bound_with_path_context` (the
+    // `key`/`parent`/`path` twin reached via `drain_path_context_stream`)
+    // had the same missing gate. `key` is real, native yq syntax (no
+    // `--jq-extensions` needed), so these have a direct live oracle.
+
+    /// #2351 review (Gap 2): jq-mode control, start bound (`K1`). `key`
+    /// isn't a real jq builtin (a succinctly extension modeled on yq's own
+    /// `key`), so there's no jq oracle for the filter text itself, but the
+    /// values are the same ones `test_resolve_slice_bound_start_own_
+    /// partial_prefix_preserved_in_jq_mode_2351_review` above already
+    /// pins against jq 1.7.1's `path(...)` output, just unwrapped from
+    /// their enclosing one-element array (`key` yields a path's last
+    /// component, not the whole path).
+    #[test]
+    fn test_slice_bound_path_context_start_own_partial_prefix_preserved_in_jq_mode_2351_review() {
+        query!(b"[1,2,3]", r#".[(0,1,error("x")):3] | key"#,
+            QueryResult::Partial(vs, Control::Error(e)) => {
+                assert_eq!(prefix_json(&vs), [r#"{"start":0,"end":3}"#, r#"{"start":1,"end":3}"#]);
+                assert_eq!(e.message, "x");
+            }
+        );
+    }
+
+    /// #2351 review sibling: the end bound (`K2`).
+    #[test]
+    fn test_slice_bound_path_context_end_own_partial_prefix_preserved_in_jq_mode_2351_review() {
+        query!(b"[1,2,3]", r#".[0:(1,2,error("x"))] | key"#,
+            QueryResult::Partial(vs, Control::Error(e)) => {
+                assert_eq!(prefix_json(&vs), [r#"{"start":0,"end":1}"#, r#"{"start":0,"end":2}"#]);
+                assert_eq!(e.message, "x");
+            }
+        );
+    }
+
+    /// #2351 review (Gap 2): the new yq-mode gate, start bound (`K1`).
+    /// Live-verified against yq v4.53.3: `.[(0,1,error("x")):3] | key` on
+    /// `[1,2,3]` prints only `Error: x`, no `{"start":...,"end":...}`
+    /// prefix.
+    #[test]
+    fn test_slice_bound_path_context_start_own_partial_prefix_discarded_in_yq_mode_2351_review() {
+        yq_query!(b"[1,2,3]", r#".[(0,1,error("x")):3] | key"#,
+            QueryResult::Error(e) => {
+                assert_eq!(e.message, "x");
+            }
+        );
+    }
+
+    /// #2351 review sibling: the end bound (`K2`). Live-verified against yq
+    /// v4.53.3: `.[0:(1,2,error("x"))] | key` on `[1,2,3]` prints only
+    /// `Error: x`.
+    #[test]
+    fn test_slice_bound_path_context_end_own_partial_prefix_discarded_in_yq_mode_2351_review() {
+        yq_query!(b"[1,2,3]", r#".[0:(1,2,error("x"))] | key"#,
+            QueryResult::Error(e) => {
+                assert_eq!(e.message, "x");
+            }
+        );
+    }
+
+    // #2351 review, lower-priority coverage: the original 8 tests only ever
+    // drove `eval_slice_bound`'s gate with `error(...)`. The gate itself
+    // (`QueryResult::Partial(_vs, control) if S::TAG == EvalTag::Yq`) is
+    // escape-kind-agnostic -- it doesn't inspect `control` at all -- so the
+    // following pin `Control::Break`/`Control::Halt` through the same arm.
+
+    /// #2351 review: `break` (unlabeled, matching this file's own
+    /// established precedent for testing `eval()` in isolation, e.g.
+    /// `regression_issue_400_boolean_keeps_the_prefix_before_a_control`'s
+    /// `"(true,true) and (1, break $out)"` case above) through the start
+    /// bound in jq mode. Real jq's CLI rejects an unlabeled `break $out` as
+    /// a compile error (`$*label-out is not defined`) rather than letting it
+    /// run as a value-level escape -- there is no live oracle for *this*
+    /// exact raw shape, only for the values it carries, which are the same
+    /// ones `error(...)` already produces for this bound (confirmed live:
+    /// `label $out | ([1,2,3] | .[(0,1,break $out):3])` prints `[1,2,3]`
+    /// then `[2,3]` before the label catches the break, exit 0).
+    #[test]
+    fn test_slice_bound_start_break_escape_preserved_in_jq_mode_2351_review() {
+        query!(b"[1,2,3]", r".[(0,1,break $out):3]",
+            QueryResult::Partial(vs, Control::Break(label)) => {
+                assert_eq!(prefix_json(&vs), ["[1,2,3]", "[2,3]"]);
+                assert_eq!(label, "out");
+            }
+        );
+    }
+
+    /// #2351 review sibling: the same `break` shape in yq mode -- the gate
+    /// discards the prefix regardless of escape kind. With the prefix
+    /// empty, `eval_slice_expr`'s own `starts.is_empty()` short-circuit
+    /// (see `partial`'s "an empty prefix collapses to the bare variant" doc
+    /// comment) means this surfaces as a bare `QueryResult::Break`, not a
+    /// `Partial` with an empty `vs`. `break`/`label` are not real yq syntax
+    /// at all (its lexer rejects them outright, live-verified: `yq 'label
+    /// $out | .[(0,1,break $out):3]'` is a lexer error), so there is no
+    /// oracle to check here; this pins the gate's own internal consistency
+    /// instead -- it must treat `Break` exactly like `Error`.
+    #[test]
+    fn test_slice_bound_start_break_escape_discarded_in_yq_mode_2351_review() {
+        yq_query!(b"[1,2,3]", r".[(0,1,break $out):3]",
+            QueryResult::Break(label) => {
+                assert_eq!(label, "out");
+            }
+        );
+    }
+
+    /// #2351 review: `halt_error` (bare, default exit code) through the
+    /// start bound in jq mode. Verified against jq 1.7.1: `[1,2,3] |
+    /// .[(0,1,halt_error):3]` prints `[1,2,3]` then `[2,3]` to stdout
+    /// (this test's own prefix) and the current input (`[1,2,3]`, `.` at
+    /// the point `halt_error` runs) to stderr, exit 5 --
+    /// `JqSemantics::DEFAULT_HALT_ERROR_CODE`.
+    #[test]
+    fn test_slice_bound_start_halt_escape_preserved_in_jq_mode_2351_review() {
+        query!(b"[1,2,3]", r".[(0,1,halt_error):3]",
+            QueryResult::Partial(vs, Control::Halt(code)) => {
+                assert_eq!(prefix_json(&vs), ["[1,2,3]", "[2,3]"]);
+                assert_eq!(code, 5);
+            }
+        );
+    }
+
+    /// #2351 review sibling: the same `halt_error` shape in yq mode --
+    /// collapses to a bare `QueryResult::Halt`, same reasoning as the
+    /// `break` sibling above. Real yq's lexer rejects `halt_error` outright
+    /// too (live-verified: `yq '.[(0,1,halt_error):3]'` is a lexer error),
+    /// so as with `break` above this pins the gate's own kind-agnostic
+    /// behavior rather than an oracle comparison.
+    /// `YqSemantics::DEFAULT_HALT_ERROR_CODE` is `1` (yq's uniform failure
+    /// code), not jq's `5`.
+    #[test]
+    fn test_slice_bound_start_halt_escape_discarded_in_yq_mode_2351_review() {
+        yq_query!(b"[1,2,3]", r".[(0,1,halt_error):3]",
+            QueryResult::Halt(code) => {
+                assert_eq!(code, 1);
+            }
+        );
+    }
+
+    /// #2351 review: both `K1` and `K2` escaping in the same query. The
+    /// naive expectation ("`K1` evaluates first, so its own error wins") is
+    /// *wrong* -- verified live against jq 1.7.1: `.[(0,1,error("x")):
+    /// (2,3,error("y"))]` on `[1,2,3]` prints `[1,2]` then `[1,2,3]` and
+    /// raises `y`, not `x`. `end` is re-evaluated fresh for every `start`
+    /// output (#2225), and that inner loop runs entirely before `start`'s
+    /// own generator is ever asked for its *second* output -- so for
+    /// `start`'s first output (`0`), `end`'s own generator (`2`, `3`,
+    /// `error("y")`) runs to completion and raises before `start`'s `x`
+    /// would ever surface. `start`'s own `error("x")` is never reached at
+    /// all in jq mode.
+    #[test]
+    fn test_slice_bound_both_bounds_escaping_same_query_jq_mode_2351_review() {
+        query!(b"[1,2,3]", r#".[(0,1,error("x")):(2,3,error("y"))]"#,
+            QueryResult::Partial(vs, Control::Error(e)) => {
+                assert_eq!(prefix_json(&vs), ["[1,2]", "[1,2,3]"]);
+                assert_eq!(e.message, "y");
+            }
+        );
+    }
+
+    /// #2351 review sibling: the same query in yq mode -- and here the
+    /// naive expectation *is* right, for a different reason than assumed.
+    /// Verified live against yq v4.53.3: `.[(0,1,error("x")):(2,3,
+    /// error("y"))]` on `[1,2,3]` prints only `Error: x`, not `y`. This
+    /// falls directly out of the new gate: `start`'s own escape empties
+    /// `starts` (this PR's `resolve_slice_bound`/`eval_slice_bound` fix),
+    /// and `eval_slice_expr`'s `if starts.is_empty() { return ... }`
+    /// short-circuits *before* `end` is ever evaluated for any `s` --
+    /// `error("y")` never runs at all in yq mode, where it's `error("x")`
+    /// that never runs in jq mode (see the jq-mode sibling above). Not a
+    /// coincidence chosen for the test: it's the same mechanism that makes
+    /// yq mode's `Error: x` match yq v4.53.3's own actual output.
+    #[test]
+    fn test_slice_bound_both_bounds_escaping_same_query_yq_mode_2351_review() {
+        yq_query!(b"[1,2,3]", r#".[(0,1,error("x")):(2,3,error("y"))]"#,
+            QueryResult::Error(e) => {
+                assert_eq!(e.message, "x");
+            }
+        );
+    }
+
+    /// #2351 review: a resolved-but-non-numeric bound value combined with
+    /// an escape (`.[(0,"x",error("y")):3]`) in yq mode. Live-verified
+    /// against yq v4.53.3: prints only `Error: y` (no output, no type
+    /// error about "x"). This pins the accidental interaction the new gate
+    /// has with the pre-existing, unrelated `owned_bound_to_i64` bug
+    /// documented on `eval_slice_bound`'s own `#2351 review` comment above
+    /// (and `resolve_slice_bound`'s "Residual" paragraph): with the prefix
+    /// discarded before conversion ever runs on it in yq mode, `"x"` never
+    /// reaches `owned_bound_to_i64` at all, so `error("y")` -- the bound
+    /// generator's own escape -- is what surfaces, matching real yq exactly.
+    /// jq mode still has the underlying bug live (undisturbed by this PR):
+    /// jq 1.7.1 itself prints `[10,20,30]` before its own type error, where
+    /// succinctly's jq mode currently prints nothing -- a separate,
+    /// pre-existing gap, not asserted here.
+    #[test]
+    fn test_slice_bound_non_numeric_prefix_value_sidesteps_conversion_bug_in_yq_mode_2351_review() {
+        yq_query!(b"[10,20,30]", r#".[(0,"x",error("y")):3]"#,
+            QueryResult::Error(e) => {
+                assert_eq!(e.message, "y");
             }
         );
     }

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -17355,6 +17355,18 @@ fn eval_slice_expr<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
 /// Keeps the bound generator's own partial prefix rather than discarding it
 /// on escape (#1528) -- see `eval_generic::eval_slice_bound`'s own doc
 /// comment for the full rationale, shared verbatim here.
+///
+/// #2351: jq-only. Real yq does not stream a slice *bound*'s own escaped
+/// generator's prefix either -- the same carve-out `eval_index_expr`'s
+/// (#2226) and its `eval_slice_expr`/key-shaped sibling's (#2326) own target/
+/// key evaluations already apply, just never wired up here even though this
+/// function feeds both of `E[K1:K2]`'s bounds. Live-verified against yq
+/// v4.53.3, both bounds independently: `.[(0,1,error("x")):3]` on `[1,2,3]`
+/// prints only `Error: x` (`K1`, this repro's own shape), and `.[0:(1,2,
+/// error("x"))]` prints only `Error: x` too (`K2`) -- neither the `[1,2,3]`/
+/// `[2,3]` prefix succinctly used to stream pre-fix. yq mode keeps the old
+/// conservative discard; jq mode is unaffected (matches jq 1.7.1: both
+/// shapes still print their prefix before raising).
 fn eval_slice_bound<W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     bound: &Option<Box<Expr>>,
     value: StandardJson<'_, W>,
@@ -17385,6 +17397,13 @@ fn eval_slice_bound<W: Clone + AsRef<[u64]>, S: EvalSemantics>(
             QueryResult::Halt(code) => (Vec::new(), Some(Control::Halt(code))),
             QueryResult::OneCursor(_) => {
                 unreachable!("materialize_cursor should have converted this")
+            }
+            // #2351: yq mode discards this bound generator's own escaped
+            // prefix (see the function's own doc comment above) -- mirrors
+            // #2226's/#2326's identical `S::TAG == EvalTag::Yq` gate on their
+            // own target/key `Partial` arms.
+            QueryResult::Partial(_vs, control) if S::TAG == EvalTag::Yq => {
+                (Vec::new(), Some(control))
             }
             QueryResult::Partial(vs, control) => (vs, Some(control)),
         };
@@ -53524,6 +53543,26 @@ mod tests {
         );
     }
 
+    /// #2351: unlike #2226/#2326's own target/key gates, `eval_slice_bound`
+    /// had *no* yq-mode gate at all -- it unconditionally kept a slice
+    /// *bound*'s own escaped generator's prefix in both modes. This is the
+    /// issue's own canonical repro, the start bound (`K1`) escaping.
+    /// Verified against jq 1.7.1: `echo '[1,2,3]' | jq -c
+    /// '.[(0,1,error("x")):3]'` prints `[1,2,3]` then `[2,3]` before
+    /// raising -- jq mode is unaffected by this fix.
+    #[test]
+    fn test_slice_bound_start_own_partial_prefix_preserved_in_jq_mode_2351() {
+        query!(b"[1,2,3]", r#".[(0,1,error("x")):3]"#,
+            QueryResult::Partial(vs, Control::Error(e)) => {
+                assert_eq!(vs, vec![
+                    OwnedValue::Array(vec![OwnedValue::Int(1), OwnedValue::Int(2), OwnedValue::Int(3)]),
+                    OwnedValue::Array(vec![OwnedValue::Int(2), OwnedValue::Int(3)]),
+                ]);
+                assert_eq!(e.message, "x");
+            }
+        );
+    }
+
     /// #2326 sibling: `break` instead of `error`, same key-generator shape.
     /// No enclosing `label $out` in the filter itself, so the `Partial`+
     /// `Break` this fix produces propagates uncaught to this query's own
@@ -53549,6 +53588,24 @@ mod tests {
         query!(br"[10,20,30,40]", r#".[(0,1,error("x"))]"#,
             QueryResult::Partial(vs, Control::Error(e)) => {
                 assert_eq!(vs, vec![OwnedValue::Int(10), OwnedValue::Int(20)]);
+                assert_eq!(e.message, "x");
+            }
+        );
+    }
+
+    /// #2351 sibling: the end bound (`K2`) escaping instead of the start
+    /// bound, so both of `eval_slice_bound`'s two call sites (`start` and
+    /// `end` in `eval_slice_expr`) are covered independently. Verified
+    /// against jq 1.7.1: `echo '[1,2,3]' | jq -c '.[0:(1,2,error("x"))]'`
+    /// prints `[1]` then `[1,2]` before raising -- jq mode is unaffected.
+    #[test]
+    fn test_slice_bound_end_own_partial_prefix_preserved_in_jq_mode_2351() {
+        query!(b"[1,2,3]", r#".[0:(1,2,error("x"))]"#,
+            QueryResult::Partial(vs, Control::Error(e)) => {
+                assert_eq!(vs, vec![
+                    OwnedValue::Array(vec![OwnedValue::Int(1)]),
+                    OwnedValue::Array(vec![OwnedValue::Int(1), OwnedValue::Int(2)]),
+                ]);
                 assert_eq!(e.message, "x");
             }
         );
@@ -53581,6 +53638,32 @@ mod tests {
     #[test]
     fn test_index_expr_key_partial_prefix_still_discarded_in_yq_mode_2326() {
         yq_query!(br"[10,20,30]", r#".[(1,error("x"))]"#,
+            QueryResult::Error(e) => {
+                assert_eq!(e.message, "x");
+            }
+        );
+    }
+
+    /// #2351: yq mode's own new gate -- real yq does not stream a slice
+    /// bound's own escaped generator's prefix at all, matching #2226's/
+    /// #2326's identical carve-out for the target/key cases. Verified live
+    /// against yq v4.53.3: `.[(0,1,error("x")):3]` on `[1,2,3]` prints only
+    /// `Error: x`, no `[1,2,3]`/`[2,3]` prefix.
+    #[test]
+    fn test_slice_bound_start_own_partial_prefix_discarded_in_yq_mode_2351() {
+        yq_query!(b"[1,2,3]", r#".[(0,1,error("x")):3]"#,
+            QueryResult::Error(e) => {
+                assert_eq!(e.message, "x");
+            }
+        );
+    }
+
+    /// #2351 sibling: the same yq-mode gate for the end bound (`K2`).
+    /// Verified live against yq v4.53.3: `.[0:(1,2,error("x"))]` on
+    /// `[1,2,3]` prints only `Error: x`, no `[1]`/`[1,2]` prefix.
+    #[test]
+    fn test_slice_bound_end_own_partial_prefix_discarded_in_yq_mode_2351() {
+        yq_query!(b"[1,2,3]", r#".[0:(1,2,error("x"))]"#,
             QueryResult::Error(e) => {
                 assert_eq!(e.message, "x");
             }

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -8874,6 +8874,15 @@ fn eval_slice_expr<S: EvalSemantics, V: DocumentValue>(
 /// still discards any prefix converted cleanly before that one bad value,
 /// a different failure shape from a generator's own escape that needs its
 /// own priority-ordering pass to fix, not a quick addition here.
+///
+/// #2351: jq-only. Real yq does not stream a slice *bound*'s own escaped
+/// generator's prefix either -- the same carve-out `eval::eval_slice_bound`'s
+/// own sibling gate now applies (mirroring #2226's/#2326's identical
+/// `S::TAG == EvalTag::Yq` gate on their own target/key `Partial` arms).
+/// Live-verified against yq v4.53.3, both bounds independently:
+/// `.[(0,1,error("x")):3]` on `[1,2,3]` prints only `Error: x` (`K1`), and
+/// `.[0:(1,2,error("x"))]` prints only `Error: x` too (`K2`) -- yq mode
+/// keeps the old conservative discard; jq mode is unaffected.
 fn eval_slice_bound<S: EvalSemantics, V: DocumentValue>(
     bound: &Option<Box<Expr>>,
     value: V,
@@ -8893,6 +8902,11 @@ fn eval_slice_bound<S: EvalSemantics, V: DocumentValue>(
             // successfully-produced prefix to do so.
             GenericResult::Halt(code) => (Vec::new(), Some(Control::Halt(code))),
             GenericResult::None => (Vec::new(), None),
+            // #2351: yq mode discards this bound generator's own escaped
+            // prefix (see the function's own doc comment above).
+            GenericResult::Partial(_vs, control) if S::TAG == EvalTag::Yq => {
+                (Vec::new(), Some(control))
+            }
             GenericResult::Partial(vs, control) => (vs, Some(control)),
             GenericResult::One(v) => (vec![to_owned_key_shape(&v).map_err(Control::Error)?], None),
             GenericResult::OneCursor(c) => (

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -35044,6 +35044,38 @@ fn test_slice_expr_cli_dispatch_target_own_partial_prefix_preserved_2226() -> Re
     Ok(())
 }
 
+/// #2351: unlike #2226's own target gate above, `eval_generic::
+/// eval_slice_bound` (the resolver for a slice *bound*, `K1`/`K2` in
+/// `E[K1:K2]`, as opposed to `E[K]`'s single key) had no yq-mode gate at
+/// all before this fix -- jq mode is unaffected by adding one, so this is
+/// the jq-mode control confirming the prefix still streams here. This is
+/// the issue's own canonical repro, the start bound (`K1`) escaping: a bare
+/// comma-generator bound with no `as`-binding, so it dispatches through
+/// `eval_generic.rs` rather than `eval.rs`'s sibling. Verified against jq
+/// 1.7.1: `echo '[1,2,3]' | jq -c '.[(0,1,error("x")):3]'` prints
+/// `[1,2,3]` then `[2,3]` before raising.
+#[test]
+fn test_slice_bound_start_cli_dispatch_own_partial_prefix_preserved_2351() -> Result<()> {
+    let (stdout, stderr, code) = run_jq_full(&["-c", ".[(0,1,error(\"x\")):3]"], Some("[1,2,3]"))?;
+    assert_eq!(code, 5, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert_eq!(stdout, "[1,2,3]\n[2,3]\n");
+    assert!(stderr.contains('x'), "stderr: {stderr:?}");
+    Ok(())
+}
+
+/// #2351 sibling: the same jq-mode control for the end bound (`K2`), so
+/// both of `eval_slice_bound`'s two call sites are covered independently.
+/// Verified against jq 1.7.1: `echo '[1,2,3]' | jq -c
+/// '.[0:(1,2,error("x"))]'` prints `[1]` then `[1,2]` before raising.
+#[test]
+fn test_slice_bound_end_cli_dispatch_own_partial_prefix_preserved_2351() -> Result<()> {
+    let (stdout, stderr, code) = run_jq_full(&["-c", ".[0:(1,2,error(\"x\"))]"], Some("[1,2,3]"))?;
+    assert_eq!(code, 5, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert_eq!(stdout, "[1]\n[1,2]\n");
+    assert!(stderr.contains('x'), "stderr: {stderr:?}");
+    Ok(())
+}
+
 /// #2226 review (patch coverage): `eval_generic::eval_slice_expr`'s target
 /// `Partial` arm's `Ok(None)` sub-case -- an earlier-produced value that
 /// legitimately isn't sliceable, suppressed by `optional` rather than

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -35076,6 +35076,44 @@ fn test_slice_bound_end_cli_dispatch_own_partial_prefix_preserved_2351() -> Resu
     Ok(())
 }
 
+/// #2351 review (Gap 1): jq-mode control for `resolve_slice_bound` (the
+/// path-mode resolver behind `path()`/`=`/`del()`), through the real CLI
+/// binary rather than the library `eval()` -- confirms the new yq-mode gate
+/// added to this function doesn't disturb jq mode's own streamed prefix.
+/// Verified against jq 1.7.1: `echo '[1,2,3]' | jq -c
+/// 'path(.[(0,1,error("x")):3])'` prints `[{"start":0,"end":3}]` then
+/// `[{"start":1,"end":3}]` before raising `x`.
+#[test]
+fn test_resolve_slice_bound_cli_dispatch_start_own_partial_prefix_preserved_2351_review(
+) -> Result<()> {
+    let (stdout, stderr, code) =
+        run_jq_full(&["-c", "path(.[(0,1,error(\"x\")):3])"], Some("[1,2,3]"))?;
+    assert_eq!(code, 5, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert_eq!(
+        stdout,
+        "[{\"start\":0,\"end\":3}]\n[{\"start\":1,\"end\":3}]\n"
+    );
+    assert!(stderr.contains('x'), "stderr: {stderr:?}");
+    Ok(())
+}
+
+/// #2351 review (Gap 2): jq-mode control for
+/// `eval_slice_bound_with_path_context` (the `key`/`parent`/`path` twin),
+/// through the real CLI binary. `key` isn't a real jq builtin (a succinctly
+/// extension), so the filter text itself has no jq oracle, but the values
+/// are the same ones the `path()` sibling test above already pins against
+/// jq 1.7.1, unwrapped from their enclosing one-element array.
+#[test]
+fn test_slice_bound_path_context_cli_dispatch_start_own_partial_prefix_preserved_2351_review(
+) -> Result<()> {
+    let (stdout, stderr, code) =
+        run_jq_full(&["-c", ".[(0,1,error(\"x\")):3] | key"], Some("[1,2,3]"))?;
+    assert_eq!(code, 5, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert_eq!(stdout, "{\"start\":0,\"end\":3}\n{\"start\":1,\"end\":3}\n");
+    assert!(stderr.contains('x'), "stderr: {stderr:?}");
+    Ok(())
+}
+
 /// #2226 review (patch coverage): `eval_generic::eval_slice_expr`'s target
 /// `Partial` arm's `Ok(None)` sub-case -- an earlier-produced value that
 /// legitimately isn't sliceable, suppressed by `optional` rather than

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -29446,6 +29446,39 @@ fn test_index_expr_key_partial_prefix_still_discarded_in_yq_mode_2326() -> Resul
     Ok(())
 }
 
+/// #2351: unlike #2226's/#2326's own target/key gates, `eval_generic::
+/// eval_slice_bound` had *no* yq-mode gate at all -- it unconditionally kept
+/// a slice *bound*'s own escaped generator's prefix in both modes. This is
+/// the issue's own canonical repro (the start bound, `K1`, escaping); the
+/// bare comma-generator bounds have no `as`-binding, so this dispatches
+/// through `eval_generic.rs`, same as #2226's own CLI-dispatch tests.
+/// Verified live against yq v4.53.3: `.[(0,1,error("x")):3]` on `[1,2,3]`
+/// prints only `Error: x`, no `[1,2,3]`/`[2,3]` prefix.
+#[test]
+fn test_slice_bound_start_own_partial_prefix_discarded_in_yq_mode_2351() -> Result<()> {
+    let (out, stderr, code) =
+        run_yq_stdin_with_stderr(".[(0,1,error(\"x\")):3]", "[1, 2, 3]\n", &["-o", "json"])?;
+    assert_eq!(code, 1, "out: {out:?} stderr: {stderr:?}");
+    assert_eq!(out, "");
+    assert_eq!(stderr.trim(), "Error: x");
+    Ok(())
+}
+
+/// #2351 sibling: the same yq-mode gate for the end bound (`K2`), so both of
+/// `eval_slice_bound`'s two call sites (`start` and `end`) are covered
+/// independently, exactly as the issue itself calls out. Verified live
+/// against yq v4.53.3: `.[0:(1,2,error("x"))]` on `[1,2,3]` prints only
+/// `Error: x`, no `[1]`/`[1,2]` prefix.
+#[test]
+fn test_slice_bound_end_own_partial_prefix_discarded_in_yq_mode_2351() -> Result<()> {
+    let (out, stderr, code) =
+        run_yq_stdin_with_stderr(".[0:(1,2,error(\"x\"))]", "[1, 2, 3]\n", &["-o", "json"])?;
+    assert_eq!(code, 1, "out: {out:?} stderr: {stderr:?}");
+    assert_eq!(out, "");
+    assert_eq!(stderr.trim(), "Error: x");
+    Ok(())
+}
+
 /// #2264: `keys`/`keys_unsorted`'s own lazy `.[n]` fast path
 /// (`fold_lazy_keys_stage` for object keys, `fold_lazy_index_range_stage`
 /// for array keys) had its own independent negative-index resolution with

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -29479,6 +29479,79 @@ fn test_slice_bound_end_own_partial_prefix_discarded_in_yq_mode_2351() -> Result
     Ok(())
 }
 
+/// #2351 review (Gap 1): `resolve_slice_bound` (the path-mode resolver
+/// behind `path()`/`=`/`del()`, via `resolve_dynamic_indexes`) had no
+/// yq-mode gate at all -- through the real CLI binary via `del(...)` (real
+/// yq syntax, unlike bare `path(...)`, which needs `--jq-extensions` and so
+/// has no yq oracle). Verified live against yq v4.53.3:
+/// `del(.[(0,1,error("x")):3])` on `[1,2,3]` prints only `Error: x`.
+#[test]
+fn test_resolve_slice_bound_start_own_partial_prefix_discarded_in_yq_mode_2351_review() -> Result<()>
+{
+    let (out, stderr, code) = run_yq_stdin_with_stderr(
+        "del(.[(0,1,error(\"x\")):3])",
+        "[1, 2, 3]\n",
+        &["-o", "json"],
+    )?;
+    assert_eq!(code, 1, "out: {out:?} stderr: {stderr:?}");
+    assert_eq!(out, "");
+    assert_eq!(stderr.trim(), "Error: x");
+    Ok(())
+}
+
+/// #2351 review sibling: the end bound (`K2`). Verified live against yq
+/// v4.53.3: `del(.[0:(1,2,error("x"))])` on `[1,2,3]` prints only
+/// `Error: x`.
+#[test]
+fn test_resolve_slice_bound_end_own_partial_prefix_discarded_in_yq_mode_2351_review() -> Result<()>
+{
+    let (out, stderr, code) = run_yq_stdin_with_stderr(
+        "del(.[0:(1,2,error(\"x\"))])",
+        "[1, 2, 3]\n",
+        &["-o", "json"],
+    )?;
+    assert_eq!(code, 1, "out: {out:?} stderr: {stderr:?}");
+    assert_eq!(out, "");
+    assert_eq!(stderr.trim(), "Error: x");
+    Ok(())
+}
+
+/// #2351 review (Gap 2): `eval_slice_bound_with_path_context` (the
+/// `key`/`parent`/`path` twin, via `drain_path_context_stream`) had no
+/// yq-mode gate at all. `key` is real, native yq syntax. Verified live
+/// against yq v4.53.3: `.[(0,1,error("x")):3] | key` on `[1,2,3]` prints
+/// only `Error: x`, no `{"start":...,"end":...}` prefix.
+#[test]
+fn test_slice_bound_path_context_start_own_partial_prefix_discarded_in_yq_mode_2351_review(
+) -> Result<()> {
+    let (out, stderr, code) = run_yq_stdin_with_stderr(
+        ".[(0,1,error(\"x\")):3] | key",
+        "[1, 2, 3]\n",
+        &["-o", "json"],
+    )?;
+    assert_eq!(code, 1, "out: {out:?} stderr: {stderr:?}");
+    assert_eq!(out, "");
+    assert_eq!(stderr.trim(), "Error: x");
+    Ok(())
+}
+
+/// #2351 review sibling: the end bound (`K2`). Verified live against yq
+/// v4.53.3: `.[0:(1,2,error("x"))] | key` on `[1,2,3]` prints only
+/// `Error: x`.
+#[test]
+fn test_slice_bound_path_context_end_own_partial_prefix_discarded_in_yq_mode_2351_review(
+) -> Result<()> {
+    let (out, stderr, code) = run_yq_stdin_with_stderr(
+        ".[0:(1,2,error(\"x\"))] | key",
+        "[1, 2, 3]\n",
+        &["-o", "json"],
+    )?;
+    assert_eq!(code, 1, "out: {out:?} stderr: {stderr:?}");
+    assert_eq!(out, "");
+    assert_eq!(stderr.trim(), "Error: x");
+    Ok(())
+}
+
 /// #2264: `keys`/`keys_unsorted`'s own lazy `.[n]` fast path
 /// (`fold_lazy_keys_stage` for object keys, `fold_lazy_index_range_stage`
 /// for array keys) had its own independent negative-index resolution with


### PR DESCRIPTION
Fixes #2351

## Summary

`E[K1:K2]`-shaped slice expressions where a bound (`K1`/`K2`) is itself an escaping
generator (yields several values before raising via `error(...)`) kept and streamed
the escaped generator's already-produced prefix — real yq does not do this; it
discards the prefix and only propagates the error. Two prior fixes established the
correct gate for adjacent shapes: #2226 (single index key) and #2326 (a sibling
key-shaped case), both gating on `S::TAG == EvalTag::Yq`. `eval_slice_bound` — which
resolves a slice **bound** specifically — had no such gate at all in either evaluator.

Confirmed live against yq v4.53.3:

```console
$ echo '[1,2,3]' | yq -o json '.[(0,1,error("x")):3]'
Error: x
$ echo '[1,2,3]' | succinctly yq '.[(0,1,error("x")):3]' -o json
[1, 2, 3]
[2, 3]
Error: x
```

## Fix

Added the same `S::TAG == EvalTag::Yq` gate ahead of `eval_slice_bound`'s
prefix-keeping logic, in both evaluators this codebase maintains in parallel
(`src/jq/eval.rs` DOM/library route, `src/jq/eval_generic.rs` CLI-dispatch route).
Both bounds (`K1` and `K2`) fixed independently, verified against the oracle for each.

## Review round 2 — two sibling gaps found and fixed

The mandatory multi-agent review found the same class of bug still live at two
sibling call sites that resolve the identical `K1`/`K2` bounds for different
consumers, both live-verified against the oracle:

1. **`resolve_slice_bound`** (used by `path()`/`=`/`del()` via `resolve_dynamic_indexes`)
   — still unconditionally streamed the prefix. **Fixed** at the specific call site
   (not inside the shared `eval_owned_multi_keep_partial` helper, which is also used
   by `recurse`/`resolve_node`'s `Select`/`If`/`GetPath` arms/`resolve_index_expr`'s
   own key — all of which must keep streaming in yq mode).
2. **`eval_slice_bound_with_path_context`** (used for `key`/`parent`/`path` after a
   slice, via `drain_path_context_stream`) — same gap. **Fixed** at the call site
   around `drain_path_context_stream`, for the identical shared-helper reason.

`eval_generic.rs` confirmed to need no twin for either gap (verified by reading the
dispatch code): `path_expr_is_cursor_navigable` excludes `Expr::Slice`, and neither
`del()` nor assignment has its own implementation there — both routes always bridge
into `eval.rs`, so the fixes above are already CLI-reachable.

Also closed several lower-priority test-coverage gaps the review flagged (all
confirmed correct-but-untested before the fix): `Control::Break`/`Control::Halt`
escaping through the gate (previously only `error(...)` was tested), both slice
bounds escaping in the same query (with a genuinely interesting asymmetry between
jq/yq mode mechanics, documented in the new tests), and a non-numeric escaped-prefix
value's accidental interaction with an unrelated pre-existing conversion bug (now
documented with a one-line comment so it doesn't read as unhandled).

## Test plan

- [x] 29 tests total (`_2351`/`_2351_review` suffix) across `src/jq/eval.rs` (DOM
      route), `tests/yq_cli_tests.rs`, and `tests/jq_cli_tests.rs` — both bounds, both
      gaps, both evaluators, both modes, plus the coverage items above.
- [x] Live-oracle verification throughout (Homebrew yq v4.53.3, /usr/bin/jq 1.7.1).
- [x] `cargo build --features cli`
- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] Full `cargo test` (default features) — 0 failures
