### PR TITLE
fix(jq): ensure_owned! keeps the convertible prefix on a double fault (#2340)

### DIFF
--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -8273,34 +8273,54 @@ fn eval_index_expr<S: EvalSemantics, V: DocumentValue>(
     // `cursors` prefix (the #2145 gap `escape_generic!` already closed for
     // its own promotion) but also silently replacing whatever this
     // function's own keys-evaluation phase had already queued in
-    // `pending_halt`/`pending_key_stream_control`. Now uses the
-    // prefix-preserving `to_owned_all_cursors_checked`, same as
-    // `escape_generic!` above.
+    // `pending_halt`/`pending_key_stream_control`. Now uses the same
+    // prefix-preserving `to_owned_all_cursors_checked` and Halt-survives/
+    // Error-Break-downgrades priority `escape_generic!` above already
+    // establishes for this identical cursors -> owned conversion: an
+    // already-pending `Halt` survives unconditionally, anything else (a
+    // pending `Error`/`Break`, or nothing pending at all) downgrades to
+    // this decode failure.
     //
-    // Unlike `escape_generic!`, this decode failure is *not* given
-    // Halt-survives priority over an already-pending `pending_halt`/
-    // `pending_key_stream_control` -- `escape_generic!`'s Halt-survives rule
-    // is about its own `$control` argument (a `Halt` that's already the
-    // live escape at that call site), not about deferring to the separate,
-    // earlier-queued `pending_halt`. The established rule for *that*
-    // question, restated at three other places in this function (the
-    // ordinary per-key `Error` arm's comment a few lines below, and the
-    // `pending_key_stream_control` block's own comment further down), is
-    // the opposite: a later key's own event outranks an earlier still-
-    // pending halt (live-verified against jq 1.7.1/1.8.2: `{"a":1} |
-    // .[("a", 5, halt)]` prints `1`, then the indexing error, and never
-    // reaches `halt`). This decode failure is discovered while processing a
-    // later key than whatever queued `pending_halt`, so it follows that
-    // same rule unconditionally, matching `eval.rs`'s analogous promotion
-    // site (`KeyTargets::Owned`'s `borrowed -> owned` transition), which
-    // has never consulted `pending_halt` here either.
+    // Review round 2 first replaced this with an unconditional
+    // `Control::Error(e)`, reasoning by analogy to the *different* rule a
+    // few lines below ("a later key's own event outranks an earlier still-
+    // pending halt", live-verified via `{"a":1} | .[("a", 5, halt)]`) and
+    // to `eval.rs`'s analogous promotion site (which also never consults
+    // `pending_halt`) -- on the theory that the combined scenario (a
+    // `pending_halt` plus an independently-undecodable cursor still in
+    // `cursors`) was unreachable, since evaluating `halt` bridges through
+    // `bridge_to_full_evaluator`, which eagerly materializes the whole `.`
+    // value first and so would already have surfaced any undecodable
+    // content reachable from it. That reasoning has a real gap: it only
+    // holds when `target`'s cursors are necessarily descendants of `.` --
+    // true for ordinary navigation, but false for `at_offset`/
+    // `at_position`, which navigate the whole document's index independent
+    // of the current `.` narrowing. Confirmed live (debug probe): `.a |
+    // at_offset(N)[("found","missing",halt)]` against `{"a":1,"corrupt":
+    // {"found":"<invalid-utf8>","other":2}}`, where `N` points at
+    // `"corrupt"`'s value, reaches this arm with `pending_halt = Some(0)`
+    // -- `halt`'s bridge only materializes the clean `.a`, while
+    // `at_offset` hands `cursors` a pointer into the untouched, corrupt
+    // sibling. So the "later key's own event" rule doesn't apply here:
+    // that rule is about a key's *own* indexing operation legitimately
+    // failing (a real type/range error for *that* key); this decode
+    // failure instead comes from *rendering* an earlier key's already-
+    // successful result, the same role `escape_generic!` already plays for
+    // its own promotion -- hence the same Halt-survives priority, not the
+    // per-key-error one.
     macro_rules! ensure_owned {
         () => {
             if !any_owned {
                 any_owned = true;
                 owned = match to_owned_all_cursors_checked(&cursors) {
                     Ok(vs) => vs,
-                    Err((prefix, e)) => return partial_generic(prefix, Control::Error(e)),
+                    Err((prefix, e)) => {
+                        let control = match pending_halt {
+                            Some(code) => Control::Halt(code),
+                            None => Control::Error(e),
+                        };
+                        return partial_generic(prefix, control);
+                    }
                 };
                 cursors.clear();
             }
@@ -17466,6 +17486,41 @@ mod tests {
                 assert!(e.message.contains("invalid UTF-8"), "{e:?}");
             }
             other => panic!("expected Partial([\"ok\"], decode Error), got {other:?}"),
+        }
+    }
+
+    /// #2340 review round 2: an earlier fix attempt replaced `ensure_owned!`'s
+    /// Halt-survives priority with an unconditional `Control::Error(e)`,
+    /// reasoning that a `pending_halt` and an independently-undecodable
+    /// `cursors` entry could never coexist -- since evaluating `halt`
+    /// bridges through `bridge_to_full_evaluator`, which eagerly
+    /// materializes the whole `.` value first, so any undecodable content
+    /// reachable from it would already have surfaced there. That holds only
+    /// when `target`'s cursors are necessarily descendants of `.` -- true
+    /// for ordinary navigation, false for `at_offset`/`at_position`, which
+    /// navigate the *whole document's* index independent of `.`'s current
+    /// narrowing (`eval.rs` cannot reach this: its own `at_offset`/
+    /// `at_position` unconditionally return an error, so this is
+    /// `eval_generic.rs`-only). `.a` is a clean scalar, so `halt`'s bridge
+    /// materializes it trivially and `pending_halt` gets set; `at_offset`
+    /// then jumps straight to the untouched, corrupt `corrupt.found` field,
+    /// which `ensure_owned!` only discovers later, while processing key
+    /// `"missing"`. `cursors` holds only that one undecodable entry (no
+    /// earlier successful push to preserve as a prefix), so an empty-prefix
+    /// `Halt(0)` collapses to a bare `GenericResult::Halt` (`partial_generic`'s
+    /// documented empty-prefix behavior) -- the uncatchable exit real jq's
+    /// `halt` guarantees, not a catchable decode `Error` a `try` could
+    /// swallow.
+    #[test]
+    fn generic_ensure_owned_pending_halt_survives_at_offset_double_fault_2340() {
+        let json: &[u8] = b"{\"a\":1,\"corrupt\":{\"found\":\"\xff\xfe\",\"other\":2}}";
+        let offset = json[1..].iter().position(|&b| b == b'{').unwrap() + 1;
+        let index = JsonIndex::build(json);
+        let expr_str = format!(r#".a | at_offset({offset})[("found","missing",halt)]"#);
+        let expr = crate::jq::parse(&expr_str).unwrap();
+        match eval_with_cursor(&expr, index.root(json)) {
+            GenericResult::Halt(0) => {}
+            other => panic!("expected Halt(0), got {other:?}"),
         }
     }
 

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -502,8 +502,9 @@ pub fn to_owned_all_cursors<'a, C: DocumentCursor + 'a>(
 /// the first `Err`, which is fine for a caller with nothing of its own to
 /// lose, but wrong for one folding this conversion's result into an
 /// already-running prefix (`eval_index_expr`'s own `Partial`-folding uses --
-/// `escape_generic!`, the `pending_halt` finalizer, and the target `Partial`
-/// arm's own promotion -- its only callers so far). Mirrors `eval.rs`'s
+/// `escape_generic!`, `ensure_owned!` (#2340), the `pending_halt` and
+/// `pending_key_stream_control` finalizers, and the target `Partial` arm's
+/// own promotion -- its callers so far). Mirrors `eval.rs`'s
 /// `promote_borrowed_checked` (#1897) -- the same fix, and the same `&[C]`
 /// (not a generic `IntoIterator`) so `cursors.len()` is available to
 /// pre-size `acc` via `vec_with_capacity`, same as that sibling does.
@@ -8272,27 +8273,34 @@ fn eval_index_expr<S: EvalSemantics, V: DocumentValue>(
     // `cursors` prefix (the #2145 gap `escape_generic!` already closed for
     // its own promotion) but also silently replacing whatever this
     // function's own keys-evaluation phase had already queued in
-    // `pending_halt`/`pending_key_stream_control` -- worse than #2145's own
-    // gap, since even an uncatchable `Halt` from an earlier key's own
-    // escape was lost. Now uses the same prefix-preserving
-    // `to_owned_all_cursors_checked` and Halt-survives/Error-Break-
-    // downgrades priority `escape_generic!` and the tail resolvers below
-    // both already establish: an already-pending `Halt` survives
-    // unconditionally, anything else (a pending `Error`/`Break`, or
-    // nothing pending at all) downgrades to this decode failure.
+    // `pending_halt`/`pending_key_stream_control`. Now uses the
+    // prefix-preserving `to_owned_all_cursors_checked`, same as
+    // `escape_generic!` above.
+    //
+    // Unlike `escape_generic!`, this decode failure is *not* given
+    // Halt-survives priority over an already-pending `pending_halt`/
+    // `pending_key_stream_control` -- `escape_generic!`'s Halt-survives rule
+    // is about its own `$control` argument (a `Halt` that's already the
+    // live escape at that call site), not about deferring to the separate,
+    // earlier-queued `pending_halt`. The established rule for *that*
+    // question, restated at three other places in this function (the
+    // ordinary per-key `Error` arm's comment a few lines below, and the
+    // `pending_key_stream_control` block's own comment further down), is
+    // the opposite: a later key's own event outranks an earlier still-
+    // pending halt (live-verified against jq 1.7.1/1.8.2: `{"a":1} |
+    // .[("a", 5, halt)]` prints `1`, then the indexing error, and never
+    // reaches `halt`). This decode failure is discovered while processing a
+    // later key than whatever queued `pending_halt`, so it follows that
+    // same rule unconditionally, matching `eval.rs`'s analogous promotion
+    // site (`KeyTargets::Owned`'s `borrowed -> owned` transition), which
+    // has never consulted `pending_halt` here either.
     macro_rules! ensure_owned {
         () => {
             if !any_owned {
                 any_owned = true;
                 owned = match to_owned_all_cursors_checked(&cursors) {
                     Ok(vs) => vs,
-                    Err((prefix, e)) => {
-                        let control = match pending_halt {
-                            Some(code) => Control::Halt(code),
-                            None => Control::Error(e),
-                        };
-                        return partial_generic(prefix, control);
-                    }
+                    Err((prefix, e)) => return partial_generic(prefix, Control::Error(e)),
                 };
                 cursors.clear();
             }
@@ -8342,15 +8350,18 @@ fn eval_index_expr<S: EvalSemantics, V: DocumentValue>(
             // every value in `vs` indexes cleanly does `control` --
             // `target`'s own termination -- get to fire.
             //
-            // Does *not* reuse `ensure_owned!()`: that macro's own
-            // `owned_or_err!`-based promotion bare-returns
-            // `GenericResult::Error` on a decode failure, unconditionally
-            // discarding whatever `control` this arm is holding --
-            // including an uncatchable `Halt`, which `escape_generic!`
-            // above this loop already goes out of its way to preserve
-            // through the identical promotion step. Inlined here instead,
-            // mirroring `escape_generic!`'s own Halt-survives rule exactly
-            // rather than reintroducing the bug it was written to avoid.
+            // Does *not* reuse `ensure_owned!()`: that macro (#2340) always
+            // downgrades a decode failure to `Control::Error(e)`, with no
+            // parameter for a locally-held `control` to preserve -- correct
+            // for its own call sites, which never have one, but wrong here,
+            // where an uncatchable `Halt` this arm is already holding in
+            // `control` (this key's own indexing has already succeeded for
+            // every prior value in `vs`; this promotion failure is
+            // incidental to converting `cursors`, not this arm's own
+            // termination) must still survive a promotion failure, same as
+            // `escape_generic!` above this loop already goes out of its way
+            // to preserve. Inlined here instead, mirroring
+            // `escape_generic!`'s own Halt-survives rule exactly.
             //
             // The `Err` arm below is not live-repro-tested (review): same
             // reasoning as `eval::eval_index_expr`'s identical arm -- an

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -8264,17 +8264,36 @@ fn eval_index_expr<S: EvalSemantics, V: DocumentValue>(
 
     // Promotes `cursors` into `owned` on the first Owned-kind result seen,
     // shared by both `KeyTargets` arms below (#2032 review: this exact
-    // 4-line sequence used to be written out twice). `owned_or_err!`'s bare
-    // return on a promotion failure here is pre-existing, unchanged by
-    // #2032 -- unlike `escape_generic!` above, this path was already
-    // reachable before this fix (any ordinary indexing result could be the
-    // first `Owned` one), so its error-only-ever handling isn't new
-    // territory this fix needs to harden.
+    // 4-line sequence used to be written out twice).
+    //
+    // #2340: used to promote via the all-or-nothing `owned_or_err!(
+    // to_owned_all_cursors(&cursors))` -- a bare `return GenericResult::
+    // Error(e)` on a secondary decode failure here, discarding not just the
+    // `cursors` prefix (the #2145 gap `escape_generic!` already closed for
+    // its own promotion) but also silently replacing whatever this
+    // function's own keys-evaluation phase had already queued in
+    // `pending_halt`/`pending_key_stream_control` -- worse than #2145's own
+    // gap, since even an uncatchable `Halt` from an earlier key's own
+    // escape was lost. Now uses the same prefix-preserving
+    // `to_owned_all_cursors_checked` and Halt-survives/Error-Break-
+    // downgrades priority `escape_generic!` and the tail resolvers below
+    // both already establish: an already-pending `Halt` survives
+    // unconditionally, anything else (a pending `Error`/`Break`, or
+    // nothing pending at all) downgrades to this decode failure.
     macro_rules! ensure_owned {
         () => {
             if !any_owned {
                 any_owned = true;
-                owned = owned_or_err!(to_owned_all_cursors(&cursors));
+                owned = match to_owned_all_cursors_checked(&cursors) {
+                    Ok(vs) => vs,
+                    Err((prefix, e)) => {
+                        let control = match pending_halt {
+                            Some(code) => Control::Halt(code),
+                            None => Control::Error(e),
+                        };
+                        return partial_generic(prefix, control);
+                    }
+                };
                 cursors.clear();
             }
         };
@@ -17384,6 +17403,51 @@ mod tests {
         let json: &[u8] = b"{\"arr\":[{\"bad\":\"ok\"},{\"bad\":\"\xff\xfe\"}]}";
         let index = JsonIndex::build(json);
         let expr = crate::jq::parse(r#"(.arr[0],.arr[1])[("bad",5)]"#).unwrap();
+        match eval_with_cursor(&expr, index.root(json)) {
+            GenericResult::Partial(vs, Control::Error(e)) => {
+                assert_eq!(vs, vec![OwnedValue::String("ok".to_string())]);
+                assert!(e.is_decode_failure(), "{e:?}");
+                assert!(e.message.contains("invalid UTF-8"), "{e:?}");
+            }
+            other => panic!("expected Partial([\"ok\"], decode Error), got {other:?}"),
+        }
+    }
+
+    /// #2340: `eval_index_expr`'s `ensure_owned!` macro -- the promotion
+    /// step shared by the `KeyTargets::Native`/`KeyTargets::Owned` arms --
+    /// used to convert `cursors` via the all-or-nothing
+    /// `owned_or_err!(to_owned_all_cursors(&cursors))`, a bare `return
+    /// GenericResult::Error(e)` on a decode failure that discarded the
+    /// entire already-accumulated `cursors` prefix. Unlike
+    /// `escape_generic!`'s identical gap (#2145, the sibling test above),
+    /// this promotion isn't reached through a *target*-side escape -- it
+    /// fires mid-stream, the moment a later key's own indexing needs an
+    /// owned value while `cursors` still holds an earlier key's undecodable
+    /// one.
+    ///
+    /// The target here is `.arr[]` (a plain `Expr::Iterate`), not a comma
+    /// generator like #2145's -- `.arr[]` collects lazy cursors up front
+    /// with no eager decode (`Expr::Iterate`'s own arm returns
+    /// `GenericResult::ManyCursor` directly), so evaluating it for either
+    /// key never itself fails; a comma target such as `(.arr[0],.arr[1])`
+    /// was tried first and found to *already* fail before indexing ever
+    /// starts, exercising #2145's already-fixed `Partial`-arm promotion
+    /// instead of this macro's.
+    ///
+    /// Key `"bad"` succeeds natively for both array elements, pushing a
+    /// cursor to `"ok"` and one to the undecodable string into `cursors`.
+    /// Key `"missing"` then indexes the first element to `Owned(Null)`
+    /// (absent field), which is the one `GenericResult::Owned` arm that
+    /// calls `ensure_owned!()` -- promoting the two pending cursors while
+    /// `"missing"` is still being processed. `"ok"` must survive into the
+    /// reported prefix. Verified against jq 1.7.1 for the non-corrupted
+    /// shape: `{"arr":[{"bad":"ok"},{"bad":"safe"}]} | .arr[][("bad",
+    /// "missing")]` prints `"ok"`, `"safe"`, `null`, `null`.
+    #[test]
+    fn generic_ensure_owned_keeps_convertible_prefix_on_double_fault_2340() {
+        let json: &[u8] = b"{\"arr\":[{\"bad\":\"ok\"},{\"bad\":\"\xff\xfe\"}]}";
+        let index = JsonIndex::build(json);
+        let expr = crate::jq::parse(r#".arr[][("bad","missing")]"#).unwrap();
         match eval_with_cursor(&expr, index.root(json)) {
             GenericResult::Partial(vs, Control::Error(e)) => {
                 assert_eq!(vs, vec![OwnedValue::String("ok".to_string())]);


### PR DESCRIPTION
## Summary

`eval_index_expr`'s (`src/jq/eval_generic.rs`) `ensure_owned!` macro — the promotion step shared by the `KeyTargets::Native`/`KeyTargets::Owned` arms — used to convert its running `cursors` accumulator into `owned` via the all-or-nothing `owned_or_err!(to_owned_all_cursors(&cursors))`. A decode failure there triggered a bare `return GenericResult::Error(e)`, discarding the entire already-accumulated `cursors` prefix and silently overwriting whatever `pending_halt`/`pending_key_stream_control` this function's own keys-evaluation phase had already queued.

This is the same double-fault gap #2145 fixed for `escape_generic!` in this file — `ensure_owned!` was the one promotion site that fix didn't reach, since it isn't triggered by a *target*-side escape; it fires mid-stream, the moment a later key's own indexing needs an owned value while `cursors` still holds an earlier key's undecodable one.

Fixed by promoting through the prefix-preserving `to_owned_all_cursors_checked` instead, with the same Halt-survives/Error-Break-downgrades priority `escape_generic!` and the function's own tail resolvers already establish.

**Review history**: round 2 briefly simplified the fix to drop the `pending_halt` consultation, reasoning the combined scenario (a pending halt plus an independently-undecodable `cursors` entry) was unreachable. Round 3 found and fixed that reasoning's gap: `at_offset`/`at_position` can hand `ensure_owned!` a cursor outside the subtree `halt`'s own bridging materialized, making the scenario genuinely live — restored with a regression test (`eval.rs`'s analogous site needs no matching fix, since its own `at_offset`/`at_position` are unimplemented there).

## Test plan
- [x] `generic_ensure_owned_keeps_convertible_prefix_on_double_fault_2340` — the core prefix-survival fix, mirroring the #2145 sibling test
- [x] `generic_ensure_owned_pending_halt_survives_at_offset_double_fault_2340` — the round-3 Halt-survives-via-`at_offset` regression
- [x] Repro's non-corrupted shape live-verified against pinned jq 1.7.1
- [x] Full `cargo test --no-fail-fast` (default features) — all green
- [x] `cargo test --no-default-features` (no_std) — all green
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings` — clean
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features` — clean
- [x] `cargo fmt --check` — clean

Fixes #2340