### PR TITLE
fix(yq): del()/delpaths() no-op for a wrong-kind object key (#2353)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -311,13 +311,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   mechanism #2333 above already established), and genuinely can't tell a wrong-kind
   key apart from an object-field key once the target is a sequence.
 
-  **Known residual gap, not fixed here**: a *comma-grouped* `del(.[5], .a)` still
-  raises instead of no-oping `.[5]` and deleting only `.a`, because a `Comma` routes
-  through a different code path (`resolve_node`'s shared leaf resolver, which
-  evaluates via the ordinary value evaluator rather than any of the four functions
-  above) that was found, during this issue's own investigation, to already raise for a
-  **plain read** of `.[5]` against a bare object — a materially larger, read-level
-  divergence rather than a `del()`-specific one. Follow-up filed as #2362.
+  **Known residual gaps, not fixed here** (both tracked as #2362): only the bare
+  integer-literal shorthand (`del(.[5])`, parsed directly as `Expr::Index`) reaches the
+  four fixed sites above.
+  - A *comma-grouped* `del(.[5], .a)` still raises instead of no-oping `.[5]` and
+    deleting only `.a`, because a `Comma` routes through a different code path
+    (`resolve_node`'s shared leaf resolver, which evaluates via the ordinary value
+    evaluator rather than any of the four functions above) that was found, during this
+    issue's own investigation, to already raise for a **plain read** of `.[5]` against a
+    bare object — a materially larger, read-level divergence rather than a
+    `del()`-specific one.
+  - A *computed* index (`del(.[5+0])`, `5 as $i | del(.[$i])`) — or a literal
+    `null`/`true`/`false` key, since only a bare integer literal gets the `Expr::Index`
+    shorthand — is `Expr::IndexExpr`, resolved through `resolve_index_expr`/
+    `key_to_path_component`: generic path-resolution machinery shared by every
+    path-consuming builtin (`path()`, every assignment operator, and `del()` alike, all
+    funneled through the same `resolve_node` dispatcher), found during this PR's own
+    review to still raise the same way. That machinery already has a yq-mode no-op
+    placeholder mechanism (`scalar_noop`, #1181's own precedent) but it's unconditional
+    once triggered, and the correct behavior differs by operation — `del()` should
+    no-op, but assignment should stringify the key and write a new field instead (a
+    separate, pre-existing divergence, unaffected either way) — so extending it here
+    without a way to tell del() apart from assignment would fix one and regress the
+    other.
 
 - **`delpaths([[]])` printed the literal `null` instead of emitting nothing in yq mode**
   (#2352, found while implementing #2306). `del(.)` already special-cases "deleted the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -289,6 +289,36 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`del()`/`delpaths()` against an object with a wrong-kind key (numeric/null/bool)
+  raised instead of no-oping in yq mode** (#2353). Real yq's own object indexing only
+  understands string field names — handed anything else, it silently contributes
+  nothing rather than erroring, unlike succinctly's prior behavior:
+
+  ```console
+  $ echo '{"a":1}' | yq -o=json 'del(.[5])'
+  {"a": 1}
+  $ echo '{"a":1}' | succinctly yq -o json 'del(.[5])'   # before this fix
+  Error: Cannot index object with number
+  ```
+
+  Fixed at 4 sites in `src/jq/eval.rs` — `delete_keys`, `delete_at_path`,
+  `delete_paths_under`, and `delete_path_steps` (the terminal, single-key, mid-chain,
+  and mid-chain-through-`delpaths()` shapes respectively) — each gated on yq mode only;
+  jq mode is unaffected, matching real jq's own unchanged error there. This asymmetric
+  rule is scoped to **objects only**: an `Array` root with a wrong-kind key (string/
+  null/bool) still errors in both tools, since real yq's own array indexing always
+  tries to parse the key as an integer first (the same `strconv.ParseInt`-flavored
+  mechanism #2333 above already established), and genuinely can't tell a wrong-kind
+  key apart from an object-field key once the target is a sequence.
+
+  **Known residual gap, not fixed here**: a *comma-grouped* `del(.[5], .a)` still
+  raises instead of no-oping `.[5]` and deleting only `.a`, because a `Comma` routes
+  through a different code path (`resolve_node`'s shared leaf resolver, which
+  evaluates via the ordinary value evaluator rather than any of the four functions
+  above) that was found, during this issue's own investigation, to already raise for a
+  **plain read** of `.[5]` against a bare object — a materially larger, read-level
+  divergence rather than a `del()`-specific one. Follow-up filed as #2362.
+
 - **`delpaths([[]])` printed the literal `null` instead of emitting nothing in yq mode**
   (#2352, found while implementing #2306). `del(.)` already special-cases "deleted the
   whole document" as no output at all (#1702, real yq's own root-delete rule), but

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -36628,6 +36628,15 @@ fn delete_paths_under(
             }
             // A non-string key names no child at all: jq's `Cannot index
             // object with <kind>`.
+            //
+            // #2353: no-op in yq mode instead -- confirmed live for the
+            // mid-chain case too (`delpaths([["a",5]])` on `{"a":{"x":1}}`
+            // leaves `.a` untouched), matching `delete_keys`'s own identical
+            // carve-out for the terminal case. The array arm below is
+            // unaffected -- real yq's own array indexing always tries to
+            // parse any key as an integer, so a wrong-kind key there still
+            // raises in real yq too, mid-chain or not (confirmed live).
+            _ if yq_mode => Ok(OwnedValue::Object(entries)),
             other => Err(EvalError::cannot_index("object", other)),
         },
         OwnedValue::Array(mut arr) => match key {
@@ -36712,12 +36721,32 @@ fn delete_keys(
             // A non-string key is jq's `Cannot delete <kind> field of object`;
             // checked over every key in the batch, since a run can group
             // several distinct key types together.
+            //
+            // #2353: in yq mode, a non-string key against an object
+            // contributes nothing instead of raising -- confirmed live
+            // against yq v4.53.3 for every key kind (`number`, `null`,
+            // `bool`), both via `del()` and `delpaths()`, on an empty and a
+            // non-empty object alike, and through a comma-grouped `del()`
+            // sibling (`del(.[5], .a)` deletes `.a` and leaves the rest
+            // untouched, not a whole-call error). Asymmetric with the array
+            // arm below on purpose: real yq's own array indexing always
+            // tries to parse *any* key as an integer (the same
+            // `strconv.ParseInt`-flavored "cannot index array with '<key>'"
+            // wording #2333 already established), so a non-numeric key
+            // there still raises in real yq too -- confirmed live, this is
+            // not a symmetric rule. Assignment through a non-string object
+            // key (`.[5] = 9`) is unrelated and left untouched: real yq
+            // neither no-ops nor errors there, it silently stringifies the
+            // key and assigns a new field (`{"a":1,"5":9}`) -- a different
+            // mechanism (`eval_assign`/`set_path_steps`) this issue's own
+            // scope doesn't cover.
             let mut doomed: BTreeSet<&str> = BTreeSet::new();
             for key in keys {
                 match key {
                     OwnedValue::String(name) => {
                         doomed.insert(name.as_str());
                     }
+                    _ if yq_mode => {}
                     other => {
                         return Err(EvalError::cannot_delete_field_of_object(other.type_name()))
                     }
@@ -38503,6 +38532,17 @@ fn delete_at_path(
                 // #2106: same scalar no-op as the `Field` arm above, for an
                 // index key (`2.5 | del(.[0])` stays `2.5` in real yq).
                 _ if yq_mode && is_yq_field_index_noop_scalar(root) => Ok(()),
+                // #2353: an `Object` root (the one `OwnedValue` shape
+                // `is_yq_field_index_noop_scalar` deliberately excludes,
+                // since it's about scalar roots, not a wrong-kind key
+                // against a container) also no-ops in yq mode for a numeric
+                // index key -- confirmed live, matching `delete_keys`'s own
+                // identical carve-out for `delpaths()`'s batch form. Real
+                // yq's own array indexing always tries to parse *any* key
+                // as an integer, so this asymmetry is real: an `Array` root
+                // with a wrong-kind key stays above, still erroring, because
+                // real yq errors there too.
+                OwnedValue::Object(_) if yq_mode => Ok(()),
                 _ => Err(EvalError::cannot_index_with_type(
                     owned_type_name(root),
                     "number",
@@ -38893,6 +38933,11 @@ fn delete_path_steps(
                 // #2106: same mid-chain scalar no-op as `Field` above, for an
                 // index step.
                 _ if yq_mode && is_yq_field_index_noop_scalar(root) => return Ok(()),
+                // #2353: same mid-chain `Object`-with-wrong-kind-key no-op as
+                // `delete_at_path`'s own terminal `Index` arm -- confirmed
+                // live, `del(.a[5].y)` on `{"a":{"x":1}}` leaves `.a`
+                // untouched.
+                OwnedValue::Object(_) if yq_mode => return Ok(()),
                 _ => {
                     return Err(EvalError::cannot_index_with_type(
                         owned_type_name(root),

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -36722,15 +36722,25 @@ fn delete_keys(
             // checked over every key in the batch, since a run can group
             // several distinct key types together.
             //
-            // #2353: in yq mode, a non-string key against an object
-            // contributes nothing instead of raising -- confirmed live
-            // against yq v4.53.3 for every key kind (`number`, `null`,
-            // `bool`), both via `del()` and `delpaths()`, on an empty and a
-            // non-empty object alike, and through a comma-grouped `del()`
-            // sibling (`del(.[5], .a)` deletes `.a` and leaves the rest
-            // untouched, not a whole-call error). Asymmetric with the array
-            // arm below on purpose: real yq's own array indexing always
-            // tries to parse *any* key as an integer (the same
+            // #2353: real yq's own object indexing contributes nothing for a
+            // non-string key -- confirmed live against yq v4.53.3 for every
+            // key kind (`number`, `null`, `bool`), both via `del()` and
+            // `delpaths()`, on an empty and a non-empty object alike, and
+            // through a comma-grouped `del()` sibling (`del(.[5], .a)`
+            // deletes `.a` and leaves the rest untouched, not a whole-call
+            // error). This is the *oracle rule*, not a claim that this fix
+            // reaches every shape below: only the literal-index terminal
+            // and mid-chain paths that dispatch straight to `delete_keys`/
+            // `delete_at_path`/`delete_paths_under`/`delete_path_steps`
+            // actually no-op today. A comma-grouped sibling and any
+            // *computed* index (`.[5+0]`, `5 as $i | .[$i]`, or a literal
+            // `null`/`true`/`false` key, which parses as `Expr::IndexExpr`
+            // rather than the bare-integer-literal `Expr::Index` shorthand)
+            // both resolve through different, shared machinery this fix
+            // does not touch, and still raise -- tracked as a known,
+            // deliberately out-of-scope gap, filed as #2362. Asymmetric with
+            // the array arm below on purpose: real yq's own array indexing
+            // always tries to parse *any* key as an integer (the same
             // `strconv.ParseInt`-flavored "cannot index array with '<key>'"
             // wording #2333 already established), so a non-numeric key
             // there still raises in real yq too -- confirmed live, this is

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -20927,6 +20927,42 @@ fn test_2353_del_comma_grouped_wrong_kind_key_still_errors_residual_gap() -> Res
     Ok(())
 }
 
+/// #2353 review found this second, independent residual gap (scope expanded
+/// on #2362): a *computed* index against an object -- `.[5+0]`, `5 as $i |
+/// .[$i]`, or a literal `null`/`true`/`false` key (only a bare integer
+/// literal gets the `Expr::Index` shorthand this issue's own fix touches;
+/// anything else, including those literals, is `Expr::IndexExpr`) --
+/// resolves through `resolve_index_expr`/`key_to_path_component`, generic
+/// path-resolution machinery shared by every path-consuming builtin
+/// (`path()`, every assignment operator, and `del()` alike), not through
+/// any of this issue's fixed `delete_*` functions. Real yq no-ops all of
+/// these against an object (confirmed live against v4.53.3); succinctly
+/// still raises. Pinning the current (unfixed) behavior rather than
+/// leaving it untested -- see #2362 for why a blanket fix there risks
+/// regressing assignment's own, different "stringify the key" divergence.
+#[test]
+fn test_2353_del_computed_index_wrong_kind_key_still_errors_residual_gap() -> Result<()> {
+    let (_out, code) = run_yq_stdin("del(.[5+0])", r#"{"a":1}"#, &["-o=json", "-I=0"])?;
+    assert_eq!(
+        code, 1,
+        "residual gap: computed-arithmetic index still errors"
+    );
+
+    let (_out, code) = run_yq_stdin("5 as $i | del(.[$i])", r#"{"a":1}"#, &["-o=json", "-I=0"])?;
+    assert_eq!(
+        code, 1,
+        "residual gap: computed-variable index still errors"
+    );
+
+    let (_out, code) = run_yq_stdin("del(.[null])", r#"{"a":1}"#, &["-o=json", "-I=0"])?;
+    assert_eq!(
+        code, 1,
+        "residual gap: literal null key (IndexExpr) still errors"
+    );
+
+    Ok(())
+}
+
 /// #2353: an `Array` root with a wrong-kind key is *not* covered by the
 /// same rule -- real yq's own array indexing always tries to parse the key
 /// as an integer, so a string/null key there still raises (confirmed live

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -20859,6 +20859,126 @@ fn test_delpaths_noop_on_scalar_root_2106() -> Result<()> {
     Ok(())
 }
 
+/// #2353: a wrong-*kind* delete key against a genuine `Object` root (not a
+/// scalar -- #2106's own territory above) also no-ops in yq mode, both for
+/// `del()`'s static-integer index and `delpaths()`'s equivalent JSON
+/// component -- confirmed live against yq v4.53.3, including on an empty
+/// object. This is a real asymmetry, not a blanket "any wrong-kind key
+/// no-ops" rule: an `Array` root with a wrong-kind key still errors (real
+/// yq's own array indexing always tries to parse the key as an integer),
+/// pinned separately below.
+#[test]
+fn test_2353_del_wrong_kind_index_key_noop_on_object_root() -> Result<()> {
+    for input in [r#"{"a":1}"#, "{}"] {
+        let (out, code) = run_yq_stdin("del(.[5])", input, &["-o=json", "-I=0"])?;
+        assert_eq!(code, 0, "del, object root {input}");
+        assert_eq!(out.trim(), input, "del, object root {input}");
+
+        let (out, code) = run_yq_stdin("delpaths([[5]])", input, &["-o=json", "-I=0"])?;
+        assert_eq!(code, 0, "delpaths, object root {input}");
+        assert_eq!(out.trim(), input, "delpaths, object root {input}");
+    }
+    Ok(())
+}
+
+/// #2353: the same no-op applies mid-chain -- a wrong-kind key against a
+/// nested object leaves that whole sub-path untouched, for both `del()`'s
+/// own walker and `delpaths()`'s recursive one, matching `test_1219`'s own
+/// established mid-chain-vs-terminal coverage pattern for the sibling
+/// slice-run rule.
+#[test]
+fn test_2353_del_wrong_kind_index_key_noop_mid_chain() -> Result<()> {
+    let input = r#"{"a":{"x":1}}"#;
+
+    let (out, code) = run_yq_stdin("del(.a[5].y)", input, &["-o=json", "-I=0"])?;
+    assert_eq!(code, 0, "del mid-chain: {out}");
+    assert_eq!(out.trim(), input);
+
+    let (out, code) = run_yq_stdin(r#"delpaths([["a",5]])"#, input, &["-o=json", "-I=0"])?;
+    assert_eq!(code, 0, "delpaths mid-chain: {out}");
+    assert_eq!(out.trim(), input);
+
+    Ok(())
+}
+
+/// #2353: **residual gap, not fixed here** -- unlike the single-path shape
+/// above, a comma-grouped `del(.[5], .a)` still raises instead of no-oping
+/// `.[5]` and deleting only `.a`. A single static path (`del(.[5])` alone)
+/// never needs "path prepass" and reaches `delete_at_path` directly (the
+/// site this issue's own fix touches); a `Comma` always does, routing
+/// through `resolve_node`'s shared leaf resolver (`resolve_leaf`), which
+/// evaluates the branch via the *ordinary value evaluator* to get its
+/// output rather than delegating to any of this issue's fixed `delete_*`
+/// functions. That evaluator was found (during this issue's own
+/// investigation, live-verified) to already raise for a **plain read**
+/// of `.[5]` against a bare object (`{"a":1} | .[5]` raises "Cannot index
+/// object with number" in succinctly, where real yq returns `null`) --
+/// this is a materially larger, read-level divergence, not a del()-specific
+/// one, and out of scope for this fix. Filed as a follow-up, #2362. Pinning
+/// the current (unfixed) behavior here rather than silently leaving it
+/// untested.
+#[test]
+fn test_2353_del_comma_grouped_wrong_kind_key_still_errors_residual_gap() -> Result<()> {
+    let (_out, code) = run_yq_stdin("del(.[5], .a)", r#"{"a":1,"b":2}"#, &["-o=json", "-I=0"])?;
+    assert_eq!(
+        code, 1,
+        "residual gap: comma-grouped form still errors, unlike the single-path fix above"
+    );
+    Ok(())
+}
+
+/// #2353: an `Array` root with a wrong-kind key is *not* covered by the
+/// same rule -- real yq's own array indexing always tries to parse the key
+/// as an integer, so a string/null key there still raises (confirmed live
+/// for `del()`, `delpaths()`, and mid-chain through `delpaths()`'s own
+/// recursive walker). This asymmetry is the reason the fix lives on the
+/// `Object` arms only, not a blanket wrong-kind-key carve-out.
+#[test]
+fn test_2353_del_wrong_kind_key_still_errors_on_array_root() -> Result<()> {
+    let (_out, code) = run_yq_stdin(r#"del(.["a"])"#, "[1,2,3]", &["-o=json", "-I=0"])?;
+    assert_eq!(code, 1, "del, array root, string key");
+
+    let (_out, code) = run_yq_stdin(r#"delpaths([["a"]])"#, "[1,2,3]", &["-o=json", "-I=0"])?;
+    assert_eq!(code, 1, "delpaths, array root, string key");
+
+    let (_out, code) = run_yq_stdin(
+        r#"delpaths([["a","x"]])"#,
+        r#"{"a":[1,2,3]}"#,
+        &["-o=json", "-I=0"],
+    )?;
+    assert_eq!(code, 1, "delpaths, array root mid-chain, string key");
+
+    Ok(())
+}
+
+/// #2353: jq mode is unaffected -- real jq still raises `Cannot index
+/// object with number` (succinctly's existing, unchanged jq-mode wording)
+/// for every shape the yq-mode tests above no-op.
+#[test]
+fn test_2353_jq_mode_unaffected() -> Result<()> {
+    let (_output, code) = spawn_with_signal_retry(
+        || {
+            let mut command = Command::new(env!("CARGO_BIN_EXE_succinctly"));
+            command.arg("jq").arg("del(.[5])");
+            command
+        },
+        Some(br#"{"a":1}"#),
+    )?;
+    assert_eq!(code, 5, "jq mode del must still error");
+
+    let (_output, code) = spawn_with_signal_retry(
+        || {
+            let mut command = Command::new(env!("CARGO_BIN_EXE_succinctly"));
+            command.arg("jq").arg("delpaths([[5]])");
+            command
+        },
+        Some(br#"{"a":1}"#),
+    )?;
+    assert_eq!(code, 5, "jq mode delpaths must still error");
+
+    Ok(())
+}
+
 /// del()'s parent-key rule also applies when the resolved path fans out
 /// into more than one target (a top-level comma, or a computed key with
 /// multiple values) — the multi-path delete walk never sees the original
@@ -22532,22 +22652,41 @@ fn test_1116_chained_scalar_slice_del_nested_index_and_field() -> Result<()> {
     Ok(())
 }
 
-/// `navigate_read_only`'s type-mismatch fallbacks (`Field` against a
-/// non-object, `Index` against a non-array) both bail out to `None`,
-/// deferring to `delete_at_path`'s own pre-existing, unaffected error —
-/// regression guards confirming #1116's rewrite doesn't fire (or change
-/// the error) for these shapes.
+/// `navigate_read_only`'s type-mismatch fallback for `Field` against a
+/// non-object bails out to `None`, deferring to `delete_at_path`'s own
+/// pre-existing, unaffected error — regression guard confirming #1116's
+/// rewrite doesn't fire (or change the error) for this shape. An `Array`
+/// root with a wrong-kind key still errors regardless of mode (#2353's own
+/// established asymmetry: only an `Object` root no-ops for a wrong-kind
+/// key, since real yq's own array indexing always tries to parse the key
+/// as an integer first).
 #[test]
-fn test_1116_chained_scalar_slice_del_navigator_type_mismatches_unaffected() -> Result<()> {
+fn test_1116_chained_scalar_slice_del_navigator_type_mismatch_field_on_array_unaffected(
+) -> Result<()> {
     let (_out, stderr, code) = run_yq_stdin_with_stderr("del(.a.b[0:1])", r#"{"a":[1,2,3]}"#, &[])?;
     assert_ne!(code, 0);
     assert!(stderr.contains("Cannot index array"), "stderr: {stderr}");
+    Ok(())
+}
 
-    let (_out, stderr, code) =
-        run_yq_stdin_with_stderr("del(.a[0].b[0:1])", r#"{"a":{"x":1}}"#, &[])?;
-    assert_ne!(code, 0);
-    assert!(stderr.contains("Cannot index object"), "stderr: {stderr}");
-
+/// `navigate_read_only`'s other type-mismatch fallback -- `Index` against a
+/// non-array (here `.a[0]` against an `Object`) -- also bails out to
+/// `None`, deferring to `delete_at_path`'s own `Expr::Index` arm. That arm
+/// no longer errors here as of #2353: an `Object` root with a numeric key
+/// no-ops in yq mode instead, matching real yq (confirmed live against
+/// v4.53.3 -- `del(.a[0].b[0:1])` on `{"a":{"x":1}}` leaves the document
+/// untouched, exit 0). This test previously asserted the pre-#2353 error;
+/// updated to match the corrected, oracle-verified behavior.
+#[test]
+fn test_1116_chained_scalar_slice_del_navigator_type_mismatch_index_on_object_now_noops(
+) -> Result<()> {
+    let (out, code) = run_yq_stdin(
+        "del(.a[0].b[0:1])",
+        r#"{"a":{"x":1}}"#,
+        &["-o=json", "-I=0"],
+    )?;
+    assert_eq!(code, 0);
+    assert_eq!(out.trim(), r#"{"a":{"x":1}}"#);
     Ok(())
 }
 


### PR DESCRIPTION
## Summary

Real yq's own object indexing only understands string field names -- handed a
numeric/null/bool key instead, it silently contributes nothing rather than raising:

```console
$ echo '{"a":1}' | yq -o=json 'del(.[5])'
{"a": 1}
$ echo '{"a":1}' | succinctly yq -o json 'del(.[5])'   # before this fix
Error: Cannot index object with number
```

## Fix

4 sites in `src/jq/eval.rs`, each gated on yq mode only: `delete_keys` (terminal,
multi-key), `delete_at_path`'s `Expr::Index` arm (terminal, single-key),
`delete_paths_under` (mid-chain), `delete_path_steps`'s mid-chain `Expr::Index` arm
(mid-chain through `delpaths()`'s own recursive walker). jq mode is unaffected --
matching real jq's own unchanged error there.

Scoped to **objects only** -- an `Array` root with a wrong-kind key (string/null/bool)
still errors in both tools, since real yq's own array indexing always tries to parse
the key as an integer first (the same mechanism #2333 established), and genuinely
can't distinguish a wrong-kind key from an object-field key once the target is a
sequence.

## Bonus find: a latent premise bug in #1116's own test

While verifying this change, `test_1116_chained_scalar_slice_del_navigator_type_mismatches_unaffected`
started failing -- not a regression, but a pre-existing test whose second half
asserted `del(.a[0].b[0:1])` on `{"a":{"x":1}}` should error. Live-checked against real
yq v4.53.3: it doesn't -- it no-ops, exit 0, document untouched. Same shape this issue
covers (`.a[0]` = numeric key against an object), just reached through a different
prefix. Split the test into two (one per navigator type-mismatch shape), with the
object case corrected to match live oracle behavior.

## Known residual gaps (not fixed here, follow-up filed as #2362)

Only the bare integer-literal shorthand (`del(.[5])`, parsed directly as
`Expr::Index`) reaches the four fixed sites above.

- A *comma-grouped* `del(.[5], .a)` still raises instead of no-oping `.[5]` and
  deleting only `.a`. Traced during this issue's own investigation: a single static
  path (`del(.[5])` alone) reaches `delete_at_path` directly, but a `Comma` routes
  through `resolve_node`'s shared leaf resolver instead, which evaluates via the
  *ordinary value evaluator* rather than delegating to any of the `delete_*` functions
  here. That evaluator was found to already raise for a **plain read** of `.[5]`
  against a bare object (`{"a":1} | .[5]` raises in succinctly, where real yq returns
  `null`) -- a materially larger, read-level divergence, not a `del()`-specific one.
- Code review found a second, independent gap: a *computed* index (`del(.[5+0])`,
  `5 as $i | del(.[$i])`), or a literal `null`/`true`/`false` key (only a bare integer
  literal gets the `Expr::Index` shorthand), is `Expr::IndexExpr` -- resolved through
  `resolve_index_expr`/`key_to_path_component`, generic path-resolution machinery
  shared by every path-consuming builtin (`path()`, every assignment operator, and
  `del()` alike). That machinery already has a yq-mode no-op placeholder mechanism
  (`scalar_noop`, #1181's precedent), but it's unconditional once triggered, and the
  correct behavior differs by operation -- `del()` should no-op, assignment should
  stringify the key and write a new field instead (separate, pre-existing, unaffected
  either way). Extending it without a way to tell del() apart from assignment would
  fix one and regress the other, so this needs its own design rather than a
  quick extension here.

## Verification

- 9 new/updated CLI regression tests (`tests/yq_cli_tests.rs`): terminal single-path
  del()/delpaths() on an object root, mid-chain del()/delpaths(), array-root still
  errors (both shapes), jq-mode non-regression, the corrected #1116 split, and two
  residual-gap tests pinning the current (unfixed) comma-grouped and computed-index
  behavior rather than leaving them untested.
- Full `cargo test --workspace` (features `cli,simd,regex,serde`): all green (found
  and fixed the #1116 test above along the way).
- `cargo test --no-default-features --verbose` (no_std leg): green.
- `cargo clippy --all-targets --all-features -- -D warnings` and the second CI clippy
  leg (`--features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests`): clean.
- `cargo fmt --check`, `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features`:
  clean.

Fixes #2353