### PR TITLE
fix(jq): index/slice path-context evaluators keep target's Partial prefix

### DIFF
--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -32442,14 +32442,21 @@ fn eval_index_expr_with_path_context<'a, W: Clone + AsRef<[u64]>, S: EvalSemanti
             // real jq's key-outer/target-inner model indexes each
             // already-produced value by `k` as it flows out, so `target`'s
             // own escaped generator's prefix is real jq output too here as
-            // well (confirmed live: `0 as $k | ([1,2],[3,4],error("x"))[$k]
-            // | key` prints `0` then `0` before raising -- the same values
-            // #2226 already established one level up for the plain-read
-            // sibling, just routed through path-context here). jq-only,
-            // matching #2226's own yq carve-out: real yq does not stream a
-            // target's own escaped generator's prefix at all (live-verified
-            // against yq v4.53.3, same query prints only the error, no
-            // prefix), so yq mode keeps the old conservative discard.
+            // well. Unlike #2226's own plain-read fix, this function is
+            // reached only via `key`/`parent`/`file_index` (or one nested
+            // inside a comma/pipe/etc. -- see `needs_path_context`), never
+            // `path()`/`del()`/assignment, which dispatch through the
+            // wholly separate `resolve_index_expr`/`resolve_dynamic_indexes`
+            // resolver instead (that resolver already threads a target's
+            // own escape-with-prefix correctly, via `resolve_node`'s own
+            // `Err((prefix, e))` arm) -- so there is no jq oracle for a
+            // query that exercises this exact arm (`key` is a succinctly
+            // extension). jq-only, matching #2226's own yq carve-out: real
+            // yq does not stream a target's own escaped generator's prefix
+            // at all (live-verified against yq v4.53.3, which does support
+            // `key`: `(.a,.b,error("x"))[(0+0)] | key` prints only the
+            // error, no `0`/`0` prefix), so yq mode keeps the old
+            // conservative discard.
             QueryResult::Partial(vs, control) => {
                 if S::TAG == EvalTag::Yq {
                     return partial(core::mem::take(&mut results), control);
@@ -32825,15 +32832,19 @@ fn eval_slice_expr_with_path_context<'a, W: Clone + AsRef<[u64]>, S: EvalSemanti
                 // `vs` before its own mid-stream escape; real jq's
                 // pair-outer/target-inner model slices each already-produced
                 // value by `(s, e)` as it flows out, so `target`'s own
-                // escaped generator's prefix is real jq output too here
-                // (confirmed live: `1 as $s | 3 as $e | ([1,2,3,4],[5,6,7,8],
-                // error("x"))[$s:$e] | key` prints `0` then `0` before
-                // raising, same values `eval_slice_expr`'s own #2226-derived
-                // gate already established for the plain-read sibling). jq
-                // -only, matching that gate: real yq does not stream a
-                // target's own escaped generator's prefix at all
-                // (live-verified against yq v4.53.3), so yq mode keeps the
-                // old conservative discard.
+                // escaped generator's prefix is real jq output too here.
+                // Same routing caveat as the index arm above: reached only
+                // via `key`/`parent`/`file_index`, never `path()`/`del()`/
+                // assignment (those route through `resolve_index_expr`/
+                // `resolve_dynamic_indexes` instead), so no jq oracle for a
+                // query exercising this exact arm. jq-only, matching that
+                // gate: real yq does not stream a target's own escaped
+                // generator's prefix at all (live-verified against yq
+                // v4.53.3, via a computed bound in its own supported
+                // `N as $v | ...` spelling -- yq's grammar rejects bare
+                // arithmetic inside slice brackets: `0 as $s | 2 as $e |
+                // (.a,.b,error("x"))[$s:$e] | key` prints only the error,
+                // no prefix), so yq mode keeps the old conservative discard.
                 QueryResult::Partial(vs, control) => {
                     if S::TAG == EvalTag::Yq {
                         return partial(core::mem::take(&mut results), control);

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -32411,6 +32411,12 @@ fn eval_index_expr_with_path_context<'a, W: Clone + AsRef<[u64]>, S: EvalSemanti
             current_path,
             false,
         );
+        // #2328: set only by the `Partial` arm below (jq mode) -- deferred
+        // until after `target_outputs` has been walked through the same
+        // per-output loop as a clean `ManyOwned` result, so a later output's
+        // own indexing failure still outranks `control`, exactly like
+        // `eval_index_expr`'s identical priority rule.
+        let mut target_escape: Option<Control> = None;
         let target_outputs = match target_result {
             QueryResult::Owned(v) => vec![v],
             QueryResult::ManyOwned(vs) => vs,
@@ -32431,17 +32437,25 @@ fn eval_index_expr_with_path_context<'a, W: Clone + AsRef<[u64]>, S: EvalSemanti
             QueryResult::Halt(code) => {
                 return partial(core::mem::take(&mut results), Control::Halt(code));
             }
-            // Unlike the arms above, this one no longer matches
-            // `eval_index_expr`'s own identical arm (#2226 review finding):
-            // `_` here still discards the target's own already-produced
-            // values before its own mid-stream escape, the exact bug #2226
-            // fixed for `eval_index_expr`'s value-mode counterpart. Left
-            // unaddressed here -- this path-context evaluator backs
-            // assignment/`del()`/`path()` through a computed key, not plain
-            // reads, and #2226's own scope was the plain-read evaluators
-            // only; tracked as a follow-up.
-            QueryResult::Partial(_, control) => {
-                return partial(core::mem::take(&mut results), control);
+            // #2328: mirrors `eval_index_expr`'s own #2226 fix -- `target`'s
+            // own generator produced `vs` before its own mid-stream escape;
+            // real jq's key-outer/target-inner model indexes each
+            // already-produced value by `k` as it flows out, so `target`'s
+            // own escaped generator's prefix is real jq output too here as
+            // well (confirmed live: `0 as $k | ([1,2],[3,4],error("x"))[$k]
+            // | key` prints `0` then `0` before raising -- the same values
+            // #2226 already established one level up for the plain-read
+            // sibling, just routed through path-context here). jq-only,
+            // matching #2226's own yq carve-out: real yq does not stream a
+            // target's own escaped generator's prefix at all (live-verified
+            // against yq v4.53.3, same query prints only the error, no
+            // prefix), so yq mode keeps the old conservative discard.
+            QueryResult::Partial(vs, control) => {
+                if S::TAG == EvalTag::Yq {
+                    return partial(core::mem::take(&mut results), control);
+                }
+                target_escape = Some(control);
+                vs
             }
             QueryResult::One(_) | QueryResult::Many(_) | QueryResult::OneCursor(_) => unreachable!(
                 "eval_stage_with_path_context only ever produces \
@@ -32494,6 +32508,17 @@ fn eval_index_expr_with_path_context<'a, W: Clone + AsRef<[u64]>, S: EvalSemanti
                 // accumulated across every earlier key/output.
                 Err(e) => return partial(core::mem::take(&mut results), Control::Error(e)),
             }
+        }
+
+        // #2328: `target`'s own generator escaped after producing
+        // `target_outputs` above (jq mode only, see the `Partial` arm) --
+        // every one of those outputs has now been indexed and folded into
+        // `results` (or already escaped this function via its own index
+        // error, which outranks `control`), so `control` -- `target`'s own
+        // termination -- gets to fire now, exactly `escape_with_prefix!`'s
+        // ordering in `eval_index_expr`.
+        if let Some(control) = target_escape {
+            return partial(core::mem::take(&mut results), control);
         }
     }
 
@@ -32767,6 +32792,13 @@ fn eval_slice_expr_with_path_context<'a, W: Clone + AsRef<[u64]>, S: EvalSemanti
                 current_path,
                 false,
             );
+            // #2328: set only by the `Partial` arm below (jq mode) --
+            // deferred until after `target_outputs` has been walked through
+            // the same per-output loop as a clean `ManyOwned` result, so a
+            // later output's own slicing failure still outranks `control`,
+            // mirroring `eval_index_expr_with_path_context`'s identical
+            // priority rule.
+            let mut target_escape: Option<Control> = None;
             let target_outputs = match target_result {
                 QueryResult::Owned(v) => vec![v],
                 QueryResult::ManyOwned(vs) => vs,
@@ -32788,14 +32820,26 @@ fn eval_slice_expr_with_path_context<'a, W: Clone + AsRef<[u64]>, S: EvalSemanti
                 QueryResult::Halt(code) => {
                     return partial(core::mem::take(&mut results), Control::Halt(code));
                 }
-                // `_` here still discards the target's own already-produced
-                // values before its own mid-stream escape -- the identical,
-                // still-open gap `eval_index_expr_with_path_context`'s own
-                // sibling arm now documents (#2226 review finding); see that
-                // comment for why this path-context evaluator was left out
-                // of #2226's own scope.
-                QueryResult::Partial(_, control) => {
-                    return partial(core::mem::take(&mut results), control);
+                // #2328: mirrors `eval_index_expr_with_path_context`'s own
+                // fix immediately above -- `target`'s own generator produced
+                // `vs` before its own mid-stream escape; real jq's
+                // pair-outer/target-inner model slices each already-produced
+                // value by `(s, e)` as it flows out, so `target`'s own
+                // escaped generator's prefix is real jq output too here
+                // (confirmed live: `1 as $s | 3 as $e | ([1,2,3,4],[5,6,7,8],
+                // error("x"))[$s:$e] | key` prints `0` then `0` before
+                // raising, same values `eval_slice_expr`'s own #2226-derived
+                // gate already established for the plain-read sibling). jq
+                // -only, matching that gate: real yq does not stream a
+                // target's own escaped generator's prefix at all
+                // (live-verified against yq v4.53.3), so yq mode keeps the
+                // old conservative discard.
+                QueryResult::Partial(vs, control) => {
+                    if S::TAG == EvalTag::Yq {
+                        return partial(core::mem::take(&mut results), control);
+                    }
+                    target_escape = Some(control);
+                    vs
                 }
                 QueryResult::One(_) | QueryResult::Many(_) | QueryResult::OneCursor(_) => {
                     unreachable!(
@@ -32844,6 +32888,16 @@ fn eval_slice_expr_with_path_context<'a, W: Clone + AsRef<[u64]>, S: EvalSemanti
                         return partial(core::mem::take(&mut results), Control::Error(e));
                     }
                 }
+            }
+
+            // #2328: `target`'s own generator escaped after producing
+            // `target_outputs` above (jq mode only, see the `Partial` arm)
+            // -- every one of those outputs has now been sliced and folded
+            // into `results` (or already escaped this function via its own
+            // slicing error, which outranks `control`), so `control` --
+            // `target`'s own termination -- gets to fire now.
+            if let Some(control) = target_escape {
+                return partial(core::mem::take(&mut results), control);
             }
         }
         // #2225: this `s`'s own `end` evaluation may have escaped after

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -9629,11 +9629,11 @@ fn test_computed_bracket_path_context_coverage_gaps_2100() -> Result<()> {
     // `break` is the one control variant real jq itself never lets a
     // Partial-target's own prefix survive past (verified directly against
     // real jq's plain-read evaluator too, the #2226-fixed ground truth:
-    // `label $out | [(([1,2],break $out))[(0.5):(1.5)]]` prints `[]`, no
-    // `[1,2]`) -- not a special case this function's own #2328 fix has to
-    // encode, since the `label`/array-constructor machinery that catches
-    // `break $out` discards whatever `Partial` prefix it carries regardless
-    // of which evaluator produced it.
+    // `label $out | [(([1,2],break $out))[(0.5):(1.5)]]` prints nothing at
+    // all -- no `[]`, no `[1,2]`) -- not a special case this function's own
+    // #2328 fix has to encode, since the `label`/array-constructor
+    // machinery that catches `break $out` discards whatever `Partial`
+    // prefix it carries regardless of which evaluator produced it.
     let (stdout, _, code) = run_jq_full(
         &[
             "-c",
@@ -12108,22 +12108,38 @@ fn test_eval_index_expr_with_path_context_target_partial_no_longer_discards_pref
 ) -> Result<()> {
     // `eval_index_expr_with_path_context`'s target-side
     // `QueryResult::Partial(vs, control)` arm -- the path-context sibling of
-    // `test_eval_index_expr_target_partial_halt_no_longer_discards_prefix_2226`,
-    // reached via `path(...)` instead of a plain read. Before #2328 this arm
-    // discarded `target`'s own already-produced values outright (the
-    // identical bug #2226 fixed one level up in the plain-read evaluator);
-    // #2328 applies the same fix here, indexing each already-produced
-    // target value first before `control` fires. `.a`/`.b` (not array
-    // literals) so the target stays a valid `path()` argument, matching
-    // real jq 1.7.1 exactly: `{"a":[1,2],"b":[3,4]} | path((.a,.b,
-    // halt_error(6))[(0+0)])` streams `["a",0]` then `["b",0]` (indexing
-    // each of `.a`/`.b`'s own values by key `0`) before exiting 6.
+    // `test_eval_index_expr_target_partial_halt_no_longer_discards_prefix_2226`.
+    // Before #2328 this arm discarded `target`'s own already-produced
+    // values outright (the identical bug #2226 fixed one level up in the
+    // plain-read evaluator); #2328 applies the same fix here, indexing each
+    // already-produced target value first before `control` fires.
+    //
+    // Reached via `| key`, not `path(...)`/`del(...)`/assignment (review
+    // finding, correcting #2328's own body): `path(EXPR)` dispatches
+    // through `Builtin::Path` -> `builtin_path_on_owned` ->
+    // `resolve_dynamic_indexes`/`resolve_index_expr`, and `del()`/`=`/`|=`
+    // through `builtin_del`/`resolve_index_expr` -- a wholly separate
+    // resolver that already threads a target's own escape-with-prefix
+    // through `resolve_node`'s `Err((prefix, e))` arm (see
+    // `resolve_index_expr`'s own comment at its `target_escape` binding).
+    // This function is reached only via `needs_path_context`'s actual
+    // trigger set (`key`/`parent`/`file_index`, or one of those nested
+    // inside a comma/pipe/etc.) -- confirmed by instrumenting both `Partial`
+    // arms with a debug probe: `path(...)`/`del(...)` never fired it,
+    // `| key` did, in both jq and yq mode.
+    //
+    // No jq oracle for `key` itself (a succinctly extension, `jq:
+    // error: key/0 is not defined`) -- internal consistency instead,
+    // matching every other `key`-based case already in
+    // `test_computed_bracket_path_context_coverage_gaps_2100`: `0` is the
+    // index each of `.a`'s/`.b`'s own values was read by, matching that
+    // test's own `(.a,.b)[if true then 0 else 1 end] | key` => `0\n0`.
     let (stdout, stderr, code) = run_jq_full(
-        &["-c", "path((.a,.b,halt_error(6))[(0+0)])"],
+        &["-c", "(.a,.b,halt_error(6))[(0+0)] | key"],
         Some(r#"{"a":[1,2],"b":[3,4]}"#),
     )?;
     assert_eq!(code, 6, "stdout: {stdout:?} stderr: {stderr:?}");
-    assert_eq!(stdout, "[\"a\",0]\n[\"b\",0]\n");
+    assert_eq!(stdout, "0\n0\n");
     Ok(())
 }
 
@@ -12134,18 +12150,17 @@ fn test_eval_slice_expr_with_path_context_target_partial_no_longer_discards_pref
     // the slice sibling of the index test immediately above, and the
     // path-context sibling of
     // `test_eval_slice_expr_target_partial_halt_no_longer_discards_prefix_2226`.
-    // Verified against jq 1.7.1: `{"a":[1,2,3],"b":[4,5,6]} |
-    // path((.a,.b,halt_error(6))[(1-1):2])` streams `["a",{"start":0,
-    // "end":2}]` then `["b",{"start":0,"end":2}]` before exiting 6.
+    // Same routing correction and no-oracle caveat as that test: reached
+    // via `| key`, not `path(...)`. `{"start":0,"end":2}` is `key`'s own
+    // established shape for a slice step, matching this file's other slice
+    // `| key` cases (e.g. `test_computed_bracket_path_context_coverage_gaps_2100`'s
+    // `(.a,.b)[(0.5):(1.5)] | key` => `{"start":0.5,"end":1.5}` per value).
     let (stdout, stderr, code) = run_jq_full(
-        &["-c", "path((.a,.b,halt_error(6))[(1-1):2])"],
+        &["-c", "(.a,.b,halt_error(6))[(1-1):2] | key"],
         Some(r#"{"a":[1,2,3],"b":[4,5,6]}"#),
     )?;
     assert_eq!(code, 6, "stdout: {stdout:?} stderr: {stderr:?}");
-    assert_eq!(
-        stdout,
-        "[\"a\",{\"start\":0,\"end\":2}]\n[\"b\",{\"start\":0,\"end\":2}]\n"
-    );
+    assert_eq!(stdout, "{\"start\":0,\"end\":2}\n{\"start\":0,\"end\":2}\n");
     Ok(())
 }
 

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -9463,10 +9463,14 @@ fn test_computed_bracket_path_context_coverage_gaps_2100() -> Result<()> {
     // Index twin's target-result match: `ManyOwned` (a multi-valued
     // target re-run per key), `None` (this key's target evaluates to
     // nothing, but the loop must still continue for later keys, #2032),
-    // `Error`/`Break`/`Halt`/`Partial` (every target-level escape, each
-    // discarding this key's own output and returning whatever earlier
-    // keys already accumulated). `if true then 0 else 1 end` keeps the key
-    // a runtime `0` without folding to a literal `Expr::Index`.
+    // `Error`/`Break`/`Halt` (a bare target-level escape with no output of
+    // its own, discarding this key's own output and returning whatever
+    // earlier keys already accumulated). `Partial` (#2328, jq mode) is its
+    // own case further below -- unlike the bare escapes, it indexes its own
+    // already-produced prefix before `control` gets to fire, so it survives
+    // only when every value in that prefix indexes cleanly. `if true then 0
+    // else 1 end` keeps the key a runtime `0` without folding to a literal
+    // `Expr::Index`.
     let (stdout, _, code) = run_jq_full(
         &["-c", "(.a,.b)[if true then 0 else 1 end] | key"],
         Some(r#"{"a":[1,2],"b":[3,4]}"#),
@@ -9604,19 +9608,32 @@ fn test_computed_bracket_path_context_coverage_gaps_2100() -> Result<()> {
     assert_eq!(code, 0);
     assert_eq!(stdout.trim(), "");
 
-    // Partial-target arms discard the *target's own* partial prefix
-    // entirely, exactly like the index twin's identical rule -- so a
-    // successful `[1,2]` ahead of the escape contributes nothing to
-    // stdout. This is distinct from a mid-loop slice-*application* error,
-    // covered further below, which keeps whatever earlier `(s, e)` pairs
-    // already contributed.
-    let (_, stderr, code) = run_jq_full(
+    // Partial-target arms (#2328, jq mode): a successful `[1,2]` ahead of
+    // the escape is sliced by `(0.5, 1.5)` and folded into `results` before
+    // `control` fires, exactly like the index twin's own #2328 fix and
+    // `eval_slice_expr`'s pre-existing #2226 rule for the plain-read
+    // sibling -- confirmed against real jq via `path(.)` (no oracle for
+    // `key`, a succinctly extension): `{}  | (([1,2],error("x")))
+    // [(0.5):(1.5)] | path(.)` prints `[]` (one output) before raising.
+    // This is distinct from a mid-loop slice-*application* error, covered
+    // further below, which keeps whatever earlier `(s, e)` pairs already
+    // contributed.
+    let (stdout, stderr, code) = run_jq_full(
         &["-c", "(([1,2],error(\"x\")))[(0.5):(1.5)] | key"],
         Some(r"{}"),
     )?;
     assert_eq!(code, 5);
     assert!(stderr.contains('x'), "stderr: {stderr}");
+    assert_eq!(stdout.trim(), "{\"start\":0.5,\"end\":1.5}");
 
+    // `break` is the one control variant real jq itself never lets a
+    // Partial-target's own prefix survive past (verified directly against
+    // real jq's plain-read evaluator too, the #2226-fixed ground truth:
+    // `label $out | [(([1,2],break $out))[(0.5):(1.5)]]` prints `[]`, no
+    // `[1,2]`) -- not a special case this function's own #2328 fix has to
+    // encode, since the `label`/array-constructor machinery that catches
+    // `break $out` discards whatever `Partial` prefix it carries regardless
+    // of which evaluator produced it.
     let (stdout, _, code) = run_jq_full(
         &[
             "-c",
@@ -9629,7 +9646,7 @@ fn test_computed_bracket_path_context_coverage_gaps_2100() -> Result<()> {
 
     let (stdout, _, code) = run_jq_full(&["-c", "(([1,2],halt))[(0.5):(1.5)] | key"], Some(r"{}"))?;
     assert_eq!(code, 0);
-    assert_eq!(stdout.trim(), "");
+    assert_eq!(stdout.trim(), "{\"start\":0.5,\"end\":1.5}");
 
     // Unpaired target output (#2100's own charged-only-where-read
     // optimization): the bracket's local `rest` is empty (nothing chains
@@ -12083,6 +12100,52 @@ fn test_eval_slice_expr_target_partial_halt_no_longer_discards_prefix_2226() -> 
     )?;
     assert_eq!(code, 6, "stdout: {stdout:?} stderr: {stderr:?}");
     assert_eq!(stdout, "[1,2]\n[4,5]\n");
+    Ok(())
+}
+
+#[test]
+fn test_eval_index_expr_with_path_context_target_partial_no_longer_discards_prefix_2328(
+) -> Result<()> {
+    // `eval_index_expr_with_path_context`'s target-side
+    // `QueryResult::Partial(vs, control)` arm -- the path-context sibling of
+    // `test_eval_index_expr_target_partial_halt_no_longer_discards_prefix_2226`,
+    // reached via `path(...)` instead of a plain read. Before #2328 this arm
+    // discarded `target`'s own already-produced values outright (the
+    // identical bug #2226 fixed one level up in the plain-read evaluator);
+    // #2328 applies the same fix here, indexing each already-produced
+    // target value first before `control` fires. `.a`/`.b` (not array
+    // literals) so the target stays a valid `path()` argument, matching
+    // real jq 1.7.1 exactly: `{"a":[1,2],"b":[3,4]} | path((.a,.b,
+    // halt_error(6))[(0+0)])` streams `["a",0]` then `["b",0]` (indexing
+    // each of `.a`/`.b`'s own values by key `0`) before exiting 6.
+    let (stdout, stderr, code) = run_jq_full(
+        &["-c", "path((.a,.b,halt_error(6))[(0+0)])"],
+        Some(r#"{"a":[1,2],"b":[3,4]}"#),
+    )?;
+    assert_eq!(code, 6, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert_eq!(stdout, "[\"a\",0]\n[\"b\",0]\n");
+    Ok(())
+}
+
+#[test]
+fn test_eval_slice_expr_with_path_context_target_partial_no_longer_discards_prefix_2328(
+) -> Result<()> {
+    // `eval_slice_expr_with_path_context`'s target-side `Partial` arm --
+    // the slice sibling of the index test immediately above, and the
+    // path-context sibling of
+    // `test_eval_slice_expr_target_partial_halt_no_longer_discards_prefix_2226`.
+    // Verified against jq 1.7.1: `{"a":[1,2,3],"b":[4,5,6]} |
+    // path((.a,.b,halt_error(6))[(1-1):2])` streams `["a",{"start":0,
+    // "end":2}]` then `["b",{"start":0,"end":2}]` before exiting 6.
+    let (stdout, stderr, code) = run_jq_full(
+        &["-c", "path((.a,.b,halt_error(6))[(1-1):2])"],
+        Some(r#"{"a":[1,2,3],"b":[4,5,6]}"#),
+    )?;
+    assert_eq!(code, 6, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert_eq!(
+        stdout,
+        "[\"a\",{\"start\":0,\"end\":2}]\n[\"b\",{\"start\":0,\"end\":2}]\n"
+    );
     Ok(())
 }
 

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -29446,6 +29446,47 @@ fn test_index_expr_key_partial_prefix_still_discarded_in_yq_mode_2326() -> Resul
     Ok(())
 }
 
+/// #2328: `eval_index_expr_with_path_context`'s target `Partial` fix is
+/// jq-only, mirroring #2226's own carve-out one level up -- real yq does
+/// not stream a target's own escaped generator's prefix through `del()`
+/// either. `del()` (not `path()`, which isn't native yq surface) is what
+/// forces path-context routing here; `.a`/`.b` are deleted only if the
+/// gate is missed. Verified live against yq v4.53.3:
+/// `del((.a,.b,error("x"))[(0)])` on `{a: [1,2], b: [3,4]}` prints only
+/// `Error: x`, with neither `.a` nor `.b` touched (the whole command
+/// errors before producing any output document).
+#[test]
+fn test_index_expr_with_path_context_target_partial_prefix_still_discarded_in_yq_mode_2328(
+) -> Result<()> {
+    let (out, stderr, code) = run_yq_stdin_with_stderr(
+        "del((.a,.b,error(\"x\"))[(0)])",
+        "a:\n  - 1\n  - 2\nb:\n  - 3\n  - 4\n",
+        &["-o", "json"],
+    )?;
+    assert_eq!(code, 1, "out: {out:?} stderr: {stderr:?}");
+    assert_eq!(out, "");
+    assert_eq!(stderr.trim(), "Error: x");
+    Ok(())
+}
+
+/// #2328 sibling: the identical yq-mode carve-out for
+/// `eval_slice_expr_with_path_context`. Verified live against yq v4.53.3:
+/// `del((.a,.b,error("x"))[(0):(2)])` on `{a: [1,2,3], b: [4,5,6]}` prints
+/// only `Error: x`.
+#[test]
+fn test_slice_expr_with_path_context_target_partial_prefix_still_discarded_in_yq_mode_2328(
+) -> Result<()> {
+    let (out, stderr, code) = run_yq_stdin_with_stderr(
+        "del((.a,.b,error(\"x\"))[(0):(2)])",
+        "a:\n  - 1\n  - 2\n  - 3\nb:\n  - 4\n  - 5\n  - 6\n",
+        &["-o", "json"],
+    )?;
+    assert_eq!(code, 1, "out: {out:?} stderr: {stderr:?}");
+    assert_eq!(out, "");
+    assert_eq!(stderr.trim(), "Error: x");
+    Ok(())
+}
+
 /// #2351: unlike #2226's/#2326's own target/key gates, `eval_generic::
 /// eval_slice_bound` had *no* yq-mode gate at all -- it unconditionally kept
 /// a slice *bound*'s own escaped generator's prefix in both modes. This is

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -29448,18 +29448,21 @@ fn test_index_expr_key_partial_prefix_still_discarded_in_yq_mode_2326() -> Resul
 
 /// #2328: `eval_index_expr_with_path_context`'s target `Partial` fix is
 /// jq-only, mirroring #2226's own carve-out one level up -- real yq does
-/// not stream a target's own escaped generator's prefix through `del()`
-/// either. `del()` (not `path()`, which isn't native yq surface) is what
-/// forces path-context routing here; `.a`/`.b` are deleted only if the
-/// gate is missed. Verified live against yq v4.53.3:
-/// `del((.a,.b,error("x"))[(0)])` on `{a: [1,2], b: [3,4]}` prints only
-/// `Error: x`, with neither `.a` nor `.b` touched (the whole command
-/// errors before producing any output document).
+/// not stream a target's own escaped generator's prefix through `key`
+/// either. `key` (not `del()`/`path()`, which route through the wholly
+/// separate `resolve_index_expr`/`resolve_dynamic_indexes` resolver --
+/// correcting #2328's own body, a review finding) is what forces
+/// path-context routing through this function; confirmed by instrumenting
+/// both `Partial` arms with a debug probe: `del(...)` never fired it in
+/// this build, `| key` did. Verified live against real yq v4.53.3 too
+/// (which does support `key`, unlike computed-bound `del()`'s own
+/// syntax restrictions): `(.a,.b,error("x"))[(0+0)] | key` on
+/// `{a: [1,2], b: [3,4]}` prints only `Error: x`, no `0`/`0` prefix.
 #[test]
 fn test_index_expr_with_path_context_target_partial_prefix_still_discarded_in_yq_mode_2328(
 ) -> Result<()> {
     let (out, stderr, code) = run_yq_stdin_with_stderr(
-        "del((.a,.b,error(\"x\"))[(0)])",
+        "(.a,.b,error(\"x\"))[(0+0)] | key",
         "a:\n  - 1\n  - 2\nb:\n  - 3\n  - 4\n",
         &["-o", "json"],
     )?;
@@ -29470,14 +29473,20 @@ fn test_index_expr_with_path_context_target_partial_prefix_still_discarded_in_yq
 }
 
 /// #2328 sibling: the identical yq-mode carve-out for
-/// `eval_slice_expr_with_path_context`. Verified live against yq v4.53.3:
-/// `del((.a,.b,error("x"))[(0):(2)])` on `{a: [1,2,3], b: [4,5,6]}` prints
+/// `eval_slice_expr_with_path_context`. `0 as $s | 2 as $e | ...[$s:$e]`
+/// (not a bare literal bound, which constant-folds to `Expr::Slice`'s
+/// static fast path and never reaches this function at all, #1326) is
+/// real yq's own supported spelling for a computed slice bound -- yq
+/// rejects `[(1-1):2]`'s bare-arithmetic-in-brackets form outright
+/// (`bad expression, please check expression syntax`), confirmed live.
+/// Verified live against yq v4.53.3: `0 as $s | 2 as $e |
+/// (.a,.b,error("x"))[$s:$e] | key` on `{a: [1,2,3], b: [4,5,6]}` prints
 /// only `Error: x`.
 #[test]
 fn test_slice_expr_with_path_context_target_partial_prefix_still_discarded_in_yq_mode_2328(
 ) -> Result<()> {
     let (out, stderr, code) = run_yq_stdin_with_stderr(
-        "del((.a,.b,error(\"x\"))[(0):(2)])",
+        "0 as $s | 2 as $e | (.a,.b,error(\"x\"))[$s:$e] | key",
         "a:\n  - 1\n  - 2\n  - 3\nb:\n  - 4\n  - 5\n  - 6\n",
         &["-o", "json"],
     )?;


### PR DESCRIPTION
Fixes #2328

## Summary

`eval_index_expr_with_path_context`/`eval_slice_expr_with_path_context`'s own
target-evaluation `Partial` arms discarded the target's own already-produced values
outright before escaping with `control` -- a structurally identical gap to the one
#2226 fixed one level up in the plain-read `eval_index_expr`/`eval_slice_expr`
evaluators, and left open there as a documented follow-up.

**Correction to the issue's own body (review finding):** these two functions are
reached only via a pipe ending in `key`/`parent`/`file_index` (or one of those nested
inside a comma/pipe/etc. -- see `needs_path_context`) through a computed index/slice
-- **not** `path()`, `del()`, or assignment as originally claimed. Those three
dispatch through a wholly separate resolver, `resolve_index_expr`/
`resolve_dynamic_indexes` (via `Builtin::Path`/`builtin_del`), which already threads a
target's own escape-with-prefix correctly (see `resolve_index_expr`'s own
`target_escape` handling around its `resolve_node`'s `Err((prefix, e))` arm) -- so
this bug never reached them. Confirmed by instrumenting both `Partial` arms with a
debug probe: `path(...)`/`del(...)` never fired it, `| key` did, in both jq and yq
mode.

Since `key` is a succinctly extension (no jq oracle -- real jq: `key/0 is not
defined`), the repro is stated in terms of value counts surviving vs. not, verified
internally consistent with `path()`'s own already-correct behavior on the equivalent
navigable construct:

```console
$ echo '{"a":[1,2],"b":[3,4]}' | succinctly jq -c '(.a,.b,halt_error(6))[(0+0)] | key'
{"a":[1,2],"b":[3,4]}   # halt_error's own stderr echo
# 0/0 lost -- the target's own generator produced two indexable values
# before halting, same shape #2226 fixed for the plain-read case
```

## Fix

Applied the identical fix #2226 already established: index/slice each
already-produced target value first (folding successes into `results`, an indexing
failure on one of them still outranking `control`, exactly `eval_index_expr`'s own
priority rule), then escape with `control` -- gated to jq mode only, matching #2226's
own yq carve-out. Real yq does not stream a target's own escaped generator's prefix
at all -- live-verified against yq v4.53.3, which does support `key`:
`(.a,.b,error("x"))[(0+0)] | key` prints only the error.

`eval_generic.rs` needs no twin: confirmed by reading the dispatch code that neither
`del()` nor assignment has its own implementation there, and a computed
index/slice (`Expr::IndexExpr`/`Expr::SliceExpr`) is not `path_expr_is_cursor_navigable`
-- both routes always bridge into these two `eval.rs` functions unconditionally.

## Fixing an existing test that pinned the bug

`test_computed_bracket_path_context_coverage_gaps_2100`'s slice-twin halt case
explicitly asserted the pre-fix discard-everything behavior with a comment stating
this was intentional -- it wasn't; it was the same gap #2226 already fixed one level
up. Updated that assertion (and its now-inaccurate comment) to the fixed value, and
corrected the general preamble comment above it that lumped `Partial` in with the
bare `Error`/`Break`/`Halt` escape arms as all "discarding this key's own output" --
true for the bare escapes, no longer true for `Partial`.

## Review round 2

Code review (5 agents, extensive differential fuzzing against both pinned oracles --
~2000 combined probe queries across two independent agents, 0 unexplained diffs)
confirmed the fix itself is correct in both modes. It found the new dedicated tests
were vacuous (used `path(...)`/`del(...)`, which -- per the routing correction above
-- never reach the changed code, so they passed identically pre-fix) and two comments
overclaimed "confirmed live against real jq" for a `key`-based query real jq can't
run. Fixed:

- Rewrote all 4 new dedicated tests to use `| key` (the construct that actually
  reaches these functions), with a non-foldable slice bound spelled as `N as $v |
  ...` for the yq-mode case -- real yq's own grammar rejects bare arithmetic inside
  slice brackets.
- Corrected the two "confirmed live" comments, including a copy-paste error on the
  slice arm that cited the index arm's own repro output instead of the slice's.
- Fixed a stale comment on the pre-existing coverage test's `break` case, which
  claimed real jq prints `[]`; it prints nothing at all.

## Test plan

- [x] 4 tests (`_2328` suffix): index + slice path-context target-Partial fix in
      `tests/jq_cli_tests.rs`, index + slice yq-mode gate in `tests/yq_cli_tests.rs`
      -- all via `| key`, verified live against yq v4.53.3 for the yq-mode pair.
- [x] Updated `test_computed_bracket_path_context_coverage_gaps_2100`'s stale
      pre-fix assertion/comments.
- [x] Live-oracle verification throughout (`/usr/bin/jq` 1.7.1, Homebrew `yq`
      v4.53.3).
- [x] `cargo build --features cli`
- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings` (ci.yml's 2nd leg, avoids the `--all-features` scalar-yaml blind spot)
- [x] Full `cargo test --features cli,simd,regex,serde` (clean build) -- 0 failures
- [x] `cargo test --no-default-features --features std` (no_std-adjacent)
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features`

## Follow-ups filed from review (pre-existing, out of scope here)

Review surfaced several genuine, live-verified gaps in code this PR doesn't touch --
filed separately rather than expanding this PR's scope.
