### PR TITLE
fix(jq): make the optional-ignored materialization gap a build failure (#2334)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,73 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **The "materialization ignores a live `optional`" gap is now a build failure, not a
+  sweep** (#2334). The same bug shipped three times — #2231, #2280, #2327 — each round's
+  review finding sites the last sweep missed, several of them the direct sibling of a
+  function that same PR had just fixed in the *other* evaluator.
+
+  The reason it recurred is that **the invariant is unobservable at runtime**.
+  `eval::suppresses` is `optional && !e.is_decode_failure()`, and every error the
+  `to_owned`/`to_owned_cursor`/`to_owned_with_cursor`/`collect_cursors_checked` family can
+  raise is `decode_failure`-tagged — #2286 retagged the last one that wasn't, via
+  `EvalError::malformed_json_text` — so routing a call site and leaving it bare produce
+  byte-identical output. No behavioural test can fail when a site is missed; #2327's own
+  pinning test asserts the same exit code with *and* without a trailing `?`, which records
+  the non-difference and by construction cannot detect the invariant regressing.
+  Centralising the *check* did not stop the *omission*, because nothing forced a call site
+  through it.
+
+  Two guards replace the sweep, following #2025's precedent
+  (`tests/jq_owned_only_sink_invariant_test.rs`) for a hand-derived claim that only review
+  was keeping true:
+
+  - **Static** — `tests/jq_optional_suppression_audit.rs` parses `src/jq/eval.rs` and
+    `src/jq/eval_generic.rs` with `syn` and fails, naming `file:line` and the enclosing
+    function, on any raw materialization inside a function with a live `optional: bool`
+    that is neither routed through the suppression machinery nor carrying a
+    `// STYLE-0012:` citation. It sees sites hidden inside `owned_or_err!` /
+    `push_or_control!` token streams — the shape of #2327's worst miss, where 7 of the 8
+    second-round sites were one evaluator's copy of a fix the other had received — and it
+    asserts its own scan is not vacuous, the classic failure of a grep-shaped gate. Its
+    routing window is clipped to the enclosing function body and to the next
+    materialization site; both clips were added after negative tests showed the unclipped
+    window silently excusing real gaps with a `suppresses(..)` belonging to neighbouring
+    code.
+  - **Runtime** — `EvalError::debug_assert_materialization_error`, called at the family's
+    four depth-0 entry points, pins the "decode failures only" premise the whole audit
+    rests on. The day that stops holding, the routed/unrouted distinction starts changing
+    output at every site at once; this makes that a loud debug-build failure instead of a
+    silent one. It fired nowhere across the full suite.
+
+  Every site the audit found is adjudicated — routed where the builtin's own result value
+  is being materialized (`add`, `map_values`, `last`, `to_entries`, `from_entries`,
+  `with_entries`, `shuffle`, `pivot`, `bsearch`, the `indices`/`index`/`rindex` family,
+  string interpolation, `each_paths_filter`, `collect_rhs_outputs`, and
+  `eval_generic.rs`'s `Expr::Iterate`/`Expr::Pipe`/`Shuffle`/`Pivot`/`ToEntries` arms), and
+  marked with a specific reason otherwise: array construction is atomic in jq
+  (`eval_array_construction`, `map_over`, `Expr::Array` — #2327's own declined candidate);
+  key generators are evaluated at a hardcoded `optional: false`, so `.[k]?` never
+  suppresses an error raised computing `k` (confirmed against jq 1.7.1); a `Partial`'s
+  prefix must survive, so its `Control::Error` is suppressed at the `eval_try` boundary
+  rather than at the conversion; and several sites are already routed one level out
+  (`finish_fork`, `fanout_arg`'s deferred unwrap, `sort_family_control`).
+
+  Along the way: four hand-copies of `optional && !e.is_decode_failure()` now call the
+  shared `suppresses` — the same drift its own doc comment already records happening twice
+  (#1902, #1934) — and `sort_family_control` takes `optional`, giving
+  `key_elements_generic` a channel to suppress through where `Control` has no suppressed
+  variant. **No behaviour change**: every path involved is decode-failure-tagged, and a
+  `debug_assert!(!optional)` probe over the whole suite re-confirmed #693's claim that
+  `eval_generic.rs`'s native arms never see `optional = true` from any parser-driven
+  query — only three white-box unit tests that hardcode it, one of them already named
+  `..._is_unreachable_via_parser_725`.
+
+  The convention is written down as **STYLE-0012** in
+  [docs/STYLE_GUIDE.md](docs/STYLE_GUIDE.md), modelled on STYLE-0004's "every lint
+  suppression must be traceable to a documented reason". When the whole parameter is dead,
+  the preferred marker remains `_optional` — the unused-variable lint enforces that one,
+  which is how `builtin_recurse_f`/`builtin_recurse_cond` record their #1953 exemption.
+
 - **`path()`/`=`/`del()` no longer re-clone an owned subtree at every step of a static
   `Field`/`Index` chain** (#2058), fixing the O(d²) that #1690's own depth-scaled acceptance
   benchmark (`jq_write_path_del_shared_prefix_depth`) flagged as still binding its exponent to

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,16 +55,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   marked with a specific reason otherwise: array construction is atomic in jq
   (`eval_array_construction`, `map_over`, `Expr::Array` — #2327's own declined candidate);
   key generators are evaluated at a hardcoded `optional: false`, so `.[k]?` never
-  suppresses an error raised computing `k` (confirmed against jq 1.7.1); a `Partial`'s
+  suppresses an error raised computing `k` (captured from jq 1.7.1:
+  `.[error("boom")]?` exits 5, while `.[.k]?` on a non-string `.k` exits 0 — the latter is
+  the *index step* being suppressed, and an earlier draft of this comment cited it
+  backwards); a `Partial`'s
   prefix must survive, so its `Control::Error` is suppressed at the `eval_try` boundary
   rather than at the conversion; and several sites are already routed one level out
   (`finish_fork`, `fanout_arg`'s deferred unwrap, `sort_family_control`).
 
   Along the way: four hand-copies of `optional && !e.is_decode_failure()` now call the
   shared `suppresses` — the same drift its own doc comment already records happening twice
-  (#1902, #1934) — and `sort_family_control` takes `optional`, giving
-  `key_elements_generic` a channel to suppress through where `Control` has no suppressed
-  variant. **No behaviour change**: every path involved is decode-failure-tagged, and a
+  (#1902, #1934). `sort_family_control` deliberately does *not* join them: review found it
+  is not the materialization's private error channel but a shared one, also carrying
+  whatever the user's key filter raised (`sort_by(error("x"))`), so routing it would have
+  been a guaranteed no-op for the decode failure it was written for and a live
+  over-suppression for everything else. It keeps its original signature and
+  `key_elements_generic` carries a marker saying why. **No behaviour change**: every path
+  involved is decode-failure-tagged, and a
   `debug_assert!(!optional)` probe over the whole suite re-confirmed #693's claim that
   `eval_generic.rs`'s native arms never see `optional = true` from any parser-driven
   query — only three white-box unit tests that hardcode it, one of them already named

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,7 +42,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     window silently excusing real gaps with a `suppresses(..)` belonging to neighbouring
     code.
   - **Runtime** — `EvalError::debug_assert_materialization_error`, called at the family's
-    four depth-0 entry points, pins the "decode failures only" premise the whole audit
+    depth-0 entry points, pins the "decode failures only" premise the whole audit
     rests on. The day that stops holding, the routed/unrouted distinction starts changing
     output at every site at once; this makes that a loud debug-build failure instead of a
     silent one. It fired nowhere across the full suite.
@@ -62,6 +62,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   prefix must survive, so its `Control::Error` is suppressed at the `eval_try` boundary
   rather than at the conversion; and several sites are already routed one level out
   (`finish_fork`, `fanout_arg`'s deferred unwrap, `sort_family_control`).
+
+  Review also found one materializer the prefix rule could not see: `builtin_load`'s
+  `yaml_value_to_owned_checked`, which hides the `to_owned` in the middle of its name and
+  so sat outside both halves of the guard while its own function held a live `optional`
+  (and while the JSON branch three lines above it had just been routed). It is now on the
+  audit's roster, both its call sites are routed to match their JSON sibling, and both are
+  asserted.
 
   Along the way: four hand-copies of `optional && !e.is_decode_failure()` now call the
   shared `suppresses` — the same drift its own doc comment already records happening twice

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1015,6 +1015,7 @@ dependencies = [
  "md5",
  "memchr",
  "memmap2",
+ "proc-macro2",
  "proptest",
  "rand 0.10.2",
  "rand_chacha 0.10.0",
@@ -1022,6 +1023,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
+ "syn 2.0.111",
  "tempfile",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -101,6 +101,15 @@ tempfile = "3.10"
 # Bench-only: A/B baseline for jq substring-search builtins (issue #303). Already
 # present transitively via serde_json, so declaring it here is a supply-chain no-op.
 memchr = "2.7"
+# Test-only: `tests/jq_optional_suppression_audit.rs` parses src/jq/eval.rs and
+# src/jq/eval_generic.rs to enforce STYLE-0012 (issue #2334). Both crates are
+# already in Cargo.lock transitively (via serde/bytemuck derive), so declaring
+# them here is a supply-chain no-op -- same reasoning as memchr just above.
+# `proc-macro2/span-locations` gives the audit line numbers to report; edition
+# 2021 means resolver v2, so it does not unify into the proc-macro/build-
+# dependency graph that actually runs the derive macros.
+syn = { version = "2.0", features = ["full", "visit"] }
+proc-macro2 = { version = "1.0", features = ["span-locations"] }
 
 [[bench]]
 name = "rank_select"

--- a/docs/STYLE_GUIDE.md
+++ b/docs/STYLE_GUIDE.md
@@ -42,7 +42,7 @@ A new convention needs to be added to this style guide.
 
 ### Guidance
 
-Assign the next sequential ID (currently next is `STYLE-0012`) and include:
+Assign the next sequential ID (currently next is `STYLE-0013`) and include:
 
 1. A **Tags** line immediately after the heading — a comma-separated list of category labels
    from the tag vocabulary below.
@@ -470,3 +470,75 @@ The core crate is `no_std`. Preserve that:
 The guarantee is easy to break accidentally with a stray `std::` path, so keeping the `std` surface
 behind explicit feature gates — and testing the default-features-off build — makes the boundary
 enforceable rather than aspirational.
+
+---
+
+## STYLE-0012: `optional`-suppression routing in the jq evaluators
+
+**Tags:** `code-style`, `testing`
+
+### Situation
+
+Writing or editing a function in `src/jq/eval.rs` or `src/jq/eval_generic.rs` that takes a
+live `optional: bool` and materializes a borrowed document value — any call to the
+`to_owned*` family (`to_owned`, `to_owned_cursor`, `to_owned_with_cursor`,
+`to_owned_all`, `to_owned_key_shape`, …) or to `collect_cursors_checked`.
+
+### Guidance
+
+Every such call site must **either** route its error through the shared suppression
+machinery, **or** carry a `// STYLE-0012:` citation with a one-line specific reason —
+exactly the traceability STYLE-0004 requires of a lint suppression.
+
+Routing, in order of preference:
+
+```rust
+// eval.rs
+let owned = to_owned_or_suppress!(&value, optional);
+let items = to_owned_vec_or_suppress!(elements, optional);
+Err(e) => return suppress_or_raise(e, optional),
+
+// eval_generic.rs
+let owned = owned_or_suppress!(to_owned(&value), optional);
+Err(e) if suppresses(&e, optional) => GenericResult::None,
+```
+
+Never hand-copy the predicate. `optional && !e.is_decode_failure()` has one definition,
+`eval::suppresses`; it drifted out of sync twice already (#1902, #1934), and #2334 found
+four more hand-copies of it.
+
+Exempting, when the site genuinely must not consult `optional`:
+
+```rust
+// STYLE-0012: `map(f)` is `[.[] | f]` -- array construction, atomic in jq.
+QueryResult::One(v) => match to_owned(&v) { .. }
+```
+
+When the *whole parameter* is dead, prefer the stronger marker: name it `_optional`.
+The unused-variable lint then enforces the claim, and the audit skips the function
+entirely — this is how `builtin_recurse_f`/`builtin_recurse_cond` record their #1953
+exemption.
+
+`tests/jq_optional_suppression_audit.rs` enforces this and names the exact `file:line`
+of anything unrouted and unmarked.
+
+### Motivation
+
+This rule exists because the same bug shipped three times — #2231, #2280, #2327 — each
+round's review finding sites the previous sweep missed, several of them the direct sibling
+of a function that same PR had just fixed in the other evaluator.
+
+The reason it recurred is that **the invariant is invisible at runtime**. `suppresses` is
+`optional && !e.is_decode_failure()`, and every error the materialization family can raise
+is `decode_failure`-tagged today, so routing a site and leaving it bare produce identical
+output. No behavioural test can fail; a missed site costs nothing until an auditor happens
+to read that exact function. #2327's own pinning test asserts the same exit code with and
+without a trailing `?` — it records the non-difference and by construction cannot detect a
+regression.
+
+Centralising the *check* did not stop the *omission*, because nothing forced a call site
+through it. A static audit does, and a `// STYLE-0012:` marker turns each deliberate
+exemption from prose scattered across two 100k-line files into something greppable that
+the next sweep does not have to rediscover by eye. The runtime half of the guard is
+`EvalError::debug_assert_materialization_error`, which fails loudly on the day the
+"decode failures only" premise stops holding and the routing starts to matter.

--- a/docs/STYLE_GUIDE.md
+++ b/docs/STYLE_GUIDE.md
@@ -519,6 +519,17 @@ The unused-variable lint then enforces the claim, and the audit skips the functi
 entirely — this is how `builtin_recurse_f`/`builtin_recurse_cond` record their #1953
 exemption.
 
+**Where the routing has to sit.** The audit accepts a `suppress_or_raise`/`suppresses(`
+that appears below the call, within the same function, and *before the next materialization
+site*. That covers the ordinary shape, where a `Result` is collected in one statement and
+folded in the next. Routing that sits further away — a deferred unwrap inside a closure
+(`builtin_contains`/`builtin_inside`, #1800), a fold shared by several sibling arms
+(`builtin_add`), a control handed out to a caller (`finish_fork`, `sort_family_control`) —
+is real routing, but the audit cannot see it: say so in a `// STYLE-0012:` marker naming
+where it happens. The window is deliberately not widened to guess at these; a window large
+enough to find them was measured picking up a `suppresses(..)` from *neighbouring* code and
+silently excusing a genuine gap.
+
 `tests/jq_optional_suppression_audit.rs` enforces this and names the exact `file:line`
 of anything unrouted and unmarked.
 

--- a/docs/STYLE_GUIDE.md
+++ b/docs/STYLE_GUIDE.md
@@ -526,12 +526,36 @@ folded in the next. Routing that sits further away — a deferred unwrap inside 
 (`builtin_contains`/`builtin_inside`, #1800), a fold shared by several sibling arms
 (`builtin_add`), a control handed out to a caller (`finish_fork`, `sort_family_control`) —
 is real routing, but the audit cannot see it: say so in a `// STYLE-0012:` marker naming
-where it happens. The window is deliberately not widened to guess at these; a window large
+where it happens.
+
+Check that the shared point really is the *materialization's* error channel before routing
+to it. `sort_family_control` looked like one and is not: it is also where
+`sort_key_generic` hands out the user's own key-filter errors, so routing there would have
+suppressed `sort_by(error("x"))` — a suppression `optional` never authorised — while doing
+nothing at all for the decode failure it was written for (#2334 review). A marker saying
+"raises regardless, and here is why routing would be wrong" is the correct answer to that
+shape, not a route. The window is deliberately not widened to guess at these; a window large
 enough to find them was measured picking up a `suppresses(..)` from *neighbouring* code and
 silently excusing a genuine gap.
 
 `tests/jq_optional_suppression_audit.rs` enforces this and names the exact `file:line`
 of anything unrouted and unmarked.
+
+**If it fails on code you did not write.** It will, and that is working as intended: a
+rebase that brings a new materialization site into either evaluator fails the audit on the
+branch that rebased, not the branch that wrote the site. (It happened on #2334's own first
+rebase, with #2326's `pending_key_stream_control` arm.) Adjudicate it the same way as any
+other site — route it, or mark it with the reason — and say in the commit message that it
+arrived by rebase. Do not raise `WINDOW_AFTER`, lower the vacuity floors, or add the
+function to an exclusion list to get past it.
+
+**What the audit does not cover.** It keys off the `optional: bool` parameter, so a helper
+that materializes while its caller holds the `optional` is invisible to it —
+`eval_generic.rs`'s `path_step_generic`, whose `collect_cursors_checked()?` propagates to a
+caller that decides, is the current example. That is deliberate scoping, not an oversight:
+the decision genuinely belongs to whoever has the flag. If you add a materializing helper
+of that shape, say in *its* doc comment which caller adjudicates its error, since the audit
+cannot.
 
 ### Motivation
 

--- a/src/jq/document.rs
+++ b/src/jq/document.rs
@@ -13,7 +13,7 @@ use indexmap::IndexMap;
 #[cfg(test)]
 use std::borrow::Cow;
 
-use super::error::EvalError;
+use super::error::{debug_assert_materialization_error, EvalError};
 use super::stream::{StreamFailure, StreamResult};
 
 /// Indentation configuration for cursor/lazy streaming output.
@@ -2739,30 +2739,41 @@ pub trait DocumentElements: Sized + Copy + Clone {
     /// Only a caller that needs the gap between siblings checked --
     /// `.[]`/`to_entries` on arrays -- uses this instead.
     fn collect_cursors_checked(&self) -> Result<Vec<Self::Cursor>, EvalError> {
-        let mut cursors = Vec::new();
-        let mut elems = *self;
-        let mut is_first = true;
-        while let Some((cursor, rest)) = elems.uncons_cursor() {
-            if !cursor.element_gap_ok(is_first) {
-                return Err(self.malformed_element_error());
+        // #2334: the walk lives in a closure purely so its two error returns
+        // funnel through one `Result` this method can assert on -- see
+        // `debug_assert_materialization_error`. A second (provided) trait
+        // method would have done the same job at the cost of widening
+        // `DocumentElements`'s surface for an assert; nothing else about the
+        // walk changed.
+        let walk = || -> Result<Vec<Self::Cursor>, EvalError> {
+            let mut cursors = Vec::new();
+            let mut elems = *self;
+            let mut is_first = true;
+            while let Some((cursor, rest)) = elems.uncons_cursor() {
+                if !cursor.element_gap_ok(is_first) {
+                    return Err(self.malformed_element_error());
+                }
+                cursors.push(cursor);
+                elems = rest;
+                is_first = false;
             }
-            cursors.push(cursor);
-            elems = rest;
-            is_first = false;
-        }
-        // #2261: trailing stray comma after a real last element (`[1,]`) --
-        // free here since this walk already resolved every element's own
-        // cursor; mirrors `to_owned_cursor_at_depth`'s own `last_elem` check
-        // (#2243) rather than duplicating its logic. `collect_cursors_checked`
-        // has no container cursor to check the *zero-element* stray-comma
-        // shape (`[,]`, #2211) against -- same documented limitation as
-        // `to_owned_at_depth`'s own value-only callers.
-        if let Some(last) = cursors.last() {
-            if !trailing_element_gap_ok(last, b']') {
-                return Err(self.malformed_element_error());
+            // #2261: trailing stray comma after a real last element (`[1,]`) --
+            // free here since this walk already resolved every element's own
+            // cursor; mirrors `to_owned_cursor_at_depth`'s own `last_elem` check
+            // (#2243) rather than duplicating its logic. `collect_cursors_checked`
+            // has no container cursor to check the *zero-element* stray-comma
+            // shape (`[,]`, #2211) against -- same documented limitation as
+            // `to_owned_at_depth`'s own value-only callers.
+            if let Some(last) = cursors.last() {
+                if !trailing_element_gap_ok(last, b']') {
+                    return Err(self.malformed_element_error());
+                }
             }
-        }
-        Ok(cursors)
+            Ok(cursors)
+        };
+        let result = walk();
+        debug_assert_materialization_error(&result);
+        result
     }
 
     /// [`DocumentElements::len`], refusing a trailing stray `,` after a real

--- a/src/jq/error.rs
+++ b/src/jq/error.rs
@@ -1593,9 +1593,17 @@ impl EvalError {
 /// (#2025) and for the same reason: a hand-derived claim that nothing but
 /// review was keeping true.
 ///
-/// Called from the four depth-0 entry points only, never the recursive
+/// [`EvalError::colliding_display_key`] again, plus `eval.rs`'s
+/// `yaml_value_to_owned_checked` -- the `load` builtin's own YAML walk, whose
+/// name hides the `to_owned` in the middle and which #2334's review found
+/// outside both halves of the guard for exactly that reason. Its two error
+/// constructors are the same two.
+///
+/// Called from the depth-0 entry points only, never the recursive
 /// `*_at_depth` inner calls -- one assert per materialization, not one per
-/// node.
+/// node. `yaml_value_to_owned_checked` recurses into itself rather than into a
+/// separate `_at_depth`, so it is asserted at its two `builtin_load` call
+/// sites instead, which is the same thing: once per materialization.
 #[inline]
 pub(crate) fn debug_assert_materialization_error<T>(result: &Result<T, EvalError>) {
     debug_assert!(

--- a/src/jq/error.rs
+++ b/src/jq/error.rs
@@ -1560,6 +1560,54 @@ impl EvalError {
     }
 }
 
+/// Asserts, in debug builds only, that a materialization raised nothing but a
+/// [`EvalError::decode_failure`]-tagged error (#2334).
+///
+/// This pins the premise the whole `optional`-suppression routing audit rests
+/// on. `eval::suppresses` is `optional && !e.is_decode_failure()`, so as long
+/// as `to_owned`/`to_owned_cursor`/`collect_cursors_checked` can *only* raise
+/// decode failures, routing one of their call sites through
+/// `to_owned_or_suppress!`/`owned_or_suppress!`/`suppress_or_raise` and leaving
+/// it as a bare `QueryResult::Error(e)` produce byte-identical output. That is
+/// exactly why the #2231 -> #2280 -> #2327 lineage kept recurring: no
+/// behavioural test can fail when a site is left unrouted, so a missed site
+/// costs nothing until an auditor happens to read that function. #2327's own
+/// pinning test (`test_optional_ignored_sites_2327`) asserts exit 5 both with
+/// and without a trailing `?` -- it records the non-difference, and by
+/// construction cannot detect the invariant regressing.
+///
+/// The premise held when this was written: every error path in the family is
+/// `decode_failure` (`eval::to_owned_at_depth`,
+/// `eval_generic::to_owned_at_depth`/`to_owned_cursor_at_depth`), the
+/// `malformed_delimiter/member/element_error` trio (#2286 retagged the last of
+/// them via [`EvalError::malformed_json_text`]), and
+/// [`EvalError::colliding_display_key`], which delegates to
+/// [`EvalError::decode_failure`]. The day that stops being true -- someone adds
+/// a genuinely suppressible error kind to one of these walks -- the
+/// routed/unrouted distinction starts changing output at every call site at
+/// once, silently. This assert makes that day a loud debug-build failure
+/// instead, pointing at `tests/jq_optional_suppression_audit.rs` for the sites
+/// that then need re-adjudicating.
+///
+/// Same shape as `Item::into_owned_from_owned_producer`'s own `debug_assert!`
+/// (#2025) and for the same reason: a hand-derived claim that nothing but
+/// review was keeping true.
+///
+/// Called from the four depth-0 entry points only, never the recursive
+/// `*_at_depth` inner calls -- one assert per materialization, not one per
+/// node.
+#[inline]
+pub(crate) fn debug_assert_materialization_error<T>(result: &Result<T, EvalError>) {
+    debug_assert!(
+        !matches!(result, Err(e) if !e.is_decode_failure()),
+        "#2334: a materialization raised a non-decode-failure error, which \
+         `eval::suppresses` *can* suppress -- the `optional`-routing audit in \
+         tests/jq_optional_suppression_audit.rs assumes it never can. Every \
+         raw materialization site in a live-`optional` function now needs \
+         re-adjudicating, not just this one."
+    );
+}
+
 impl core::fmt::Display for EvalError {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         write!(f, "{}", self.message)

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -428,6 +428,7 @@ impl<W: Clone + AsRef<[u64]>> QueryResult<'_, W> {
 //
 // The kind helpers below stay here: they are about values, not messages,
 // and `super::error` renders whatever it is handed.
+pub(crate) use super::error::debug_assert_materialization_error;
 pub use super::error::{BinOp, Control, EvalError, EvalEscape};
 
 impl<W> From<EvalEscape> for QueryResult<'_, W> {
@@ -647,7 +648,12 @@ fn to_owned_lossy_at_depth<W: Clone + AsRef<[u64]>>(
 /// [`DocumentValue`](super::document::DocumentValue) impl making the shared
 /// helper directly usable.
 fn to_owned<W: Clone + AsRef<[u64]>>(value: &StandardJson<'_, W>) -> Result<OwnedValue, EvalError> {
-    to_owned_at_depth(value, 0)
+    let result = to_owned_at_depth(value, 0);
+    // #2334: asserted here, at the depth-0 entry point, not inside the
+    // recursive `to_owned_at_depth` -- one assert per materialization rather
+    // than one per node.
+    debug_assert_materialization_error(&result);
+    result
 }
 
 fn to_owned_at_depth<W: Clone + AsRef<[u64]>>(
@@ -1578,7 +1584,13 @@ fn eval_array_construction<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     // unguarded, so a decode failure on a *non-winning* comparison element
     // was silently swallowed entirely rather than merely corrupting the
     // eventual output value.
+    // STYLE-0012: array construction is atomic in jq -- `optional` is
+    // forwarded into `inner`'s own evaluation above and never consulted for
+    // this function's own errors. #2327 investigated routing this and
+    // deliberately declined; see this function's own doc comment.
     let items: Vec<OwnedValue> = match result.materialize_cursor() {
+        // STYLE-0012: atomic array construction -- see the statement's own
+        // comment just above.
         QueryResult::One(v) => match to_owned(&v) {
             Ok(v) => vec![v],
             Err(e) => return QueryResult::Error(e),
@@ -7708,7 +7720,14 @@ fn map_over<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
 ) -> QueryResult<'a, W> {
     let mut results = Vec::new();
     for elem in elements {
+        // STYLE-0012: `map(f)` is `[.[] | f]` -- array construction, atomic in
+        // jq for the same reason `eval_array_construction` is (this function's
+        // own `Partial` arm below already says so). `optional` is forwarded
+        // into `f`'s evaluation and never consulted here; the inner filter's
+        // own `QueryResult::Error` arm returns bare too.
         match eval_single::<W, S>(f, elem, optional).materialize_cursor() {
+            // STYLE-0012: atomic array construction -- see the `map(f)` comment
+            // at the top of this loop.
             QueryResult::One(v) => match to_owned(&v) {
                 Ok(owned) => results.push(owned),
                 Err(e) => return QueryResult::Error(e),
@@ -7717,6 +7736,8 @@ fn map_over<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
             QueryResult::Owned(v) => results.push(v),
             QueryResult::Many(vs) => {
                 for v in &vs {
+                    // STYLE-0012: same array-construction atomicity as the
+                    // `One` arm above.
                     match to_owned(v) {
                         Ok(owned) => results.push(owned),
                         Err(e) => return QueryResult::Error(e),
@@ -7845,14 +7866,14 @@ fn builtin_map_values<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
                     match eval_single::<W, S>(f, field_val, optional).materialize_cursor() {
                         QueryResult::One(v) => match to_owned(&v) {
                             Ok(owned) => Some(owned),
-                            Err(e) => return QueryResult::Error(e),
+                            Err(e) => return suppress_or_raise(e, optional),
                         },
                         QueryResult::OneCursor(_) => unreachable!(),
                         QueryResult::Owned(v) => Some(v),
                         QueryResult::Many(vs) => match vs.first() {
                             Some(v) => match to_owned(v) {
                                 Ok(owned) => Some(owned),
-                                Err(e) => return QueryResult::Error(e),
+                                Err(e) => return suppress_or_raise(e, optional),
                             },
                             None => None,
                         },
@@ -7889,7 +7910,7 @@ fn builtin_map_values<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
             // between elements.
             let cursors = match elements.collect_cursors_checked() {
                 Ok(c) => c,
-                Err(e) => return QueryResult::Error(e),
+                Err(e) => return suppress_or_raise(e, optional),
             };
             let mut results: Vec<OwnedValue> = vec_with_capacity(cursors.len());
             for cursor in cursors {
@@ -7903,7 +7924,7 @@ fn builtin_map_values<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
                 match eval_single::<W, S>(f, elem, optional).materialize_cursor() {
                     QueryResult::One(v) => match to_owned(&v) {
                         Ok(owned) => results.push(owned),
-                        Err(e) => return QueryResult::Error(e),
+                        Err(e) => return suppress_or_raise(e, optional),
                     },
                     QueryResult::OneCursor(_) => unreachable!(),
                     QueryResult::Owned(v) => results.push(v),
@@ -7911,7 +7932,7 @@ fn builtin_map_values<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
                         if let Some(v) = vs.first() {
                             match to_owned(v) {
                                 Ok(owned) => results.push(owned),
-                                Err(e) => return QueryResult::Error(e),
+                                Err(e) => return suppress_or_raise(e, optional),
                             }
                         }
                     }
@@ -7970,6 +7991,9 @@ fn builtin_add<W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     // #1755: to_owned, not to_owned_lossy -- an undecodable element must
     // raise, not silently fold in as "".
     let items: Result<Vec<OwnedValue>, EvalError> = match value {
+        // STYLE-0012: routed, but at the shared `match items` fold below --
+        // both this arm and the `Object` one feed the same `Result`, and the
+        // audit's routing window stops at the next materialization site.
         StandardJson::Array(elements) => elements.map(|e| to_owned(&e)).collect(),
         StandardJson::Object(fields) => fields.map(|f| to_owned(&f.value())).collect(),
         _ => {
@@ -7980,7 +8004,7 @@ fn builtin_add<W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     };
     let items = match items {
         Ok(items) => items,
-        Err(e) => return QueryResult::Error(e),
+        Err(e) => return suppress_or_raise(e, optional),
     };
     if items.is_empty() {
         return QueryResult::Owned(OwnedValue::Null);
@@ -8455,6 +8479,10 @@ fn object_pair_type_error<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
         // #1755: to_owned, not to_owned_lossy -- a field the key filter
         // `f` never touches can still be undecodable, and must raise
         // rather than silently drop out of this error message's operand.
+        //
+        // STYLE-0012: this is the `else` of `if optional`, so `optional` is
+        // `false` here by construction -- `suppress_or_raise(e, optional)`
+        // would be `QueryResult::Error(e)` on every path.
         let original = match to_owned(&StandardJson::Object(fields)) {
             Ok(v) => v,
             Err(e) => return QueryResult::Error(e),
@@ -9498,7 +9526,7 @@ fn builtin_last<W: Clone + AsRef<[u64]>>(
                 // element must raise, not silently become "".
                 match to_owned(&items[items.len() - 1]) {
                     Ok(v) => QueryResult::Owned(v),
-                    Err(e) => QueryResult::Error(e),
+                    Err(e) => suppress_or_raise(e, optional),
                 }
             }
         }
@@ -9598,6 +9626,8 @@ fn builtin_flatten<W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     // two copies of the same error literal (#1901 review).
     let yq_reject_non_array = || EvalError::yq_only_arrays_supported_for("flatten");
     let items: Result<Vec<OwnedValue>, EvalError> = match &value {
+        // STYLE-0012: routed at the shared `match items` fold below -- see
+        // `builtin_add`'s identical note.
         StandardJson::Array(elements) => elements.map(|e| to_owned(&e)).collect(),
         StandardJson::Object(_) if S::TAG == EvalTag::Yq => {
             return scalar_fallback(&value, optional, yq_reject_non_array);
@@ -10072,7 +10102,7 @@ fn builtin_to_entries<W: Clone + AsRef<[u64]>>(
             // on the identical input.
             let cursors = match elements.collect_cursors_checked() {
                 Ok(c) => c,
-                Err(e) => return QueryResult::Error(e),
+                Err(e) => return suppress_or_raise(e, optional),
             };
             let mut entries: Vec<OwnedValue> = vec_with_capacity(cursors.len());
             for (i, cursor) in cursors.into_iter().enumerate() {
@@ -10092,7 +10122,7 @@ fn builtin_to_entries<W: Clone + AsRef<[u64]>>(
                 // wider blast radius than this fix's own #1677 scope.
                 let val = match to_owned(&cursor.value()) {
                     Ok(v) => v,
-                    Err(e) => return QueryResult::Error(e),
+                    Err(e) => return suppress_or_raise(e, optional),
                 };
                 let mut entry = IndexMap::new();
                 entry.insert("key".to_string(), OwnedValue::Int(i as i64));
@@ -10134,7 +10164,7 @@ fn builtin_to_entries<W: Clone + AsRef<[u64]>>(
                 };
                 let val = match to_owned(&field.value) {
                     Ok(val) => val,
-                    Err(e) => return QueryResult::Error(e),
+                    Err(e) => return suppress_or_raise(e, optional),
                 };
 
                 let mut entry = IndexMap::new();
@@ -10258,6 +10288,8 @@ fn builtin_from_entries<W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     // review), same pattern as `builtin_flatten`.
     let yq_reject_non_array = || EvalError::yq_from_entries_requires_array();
     let entries: Result<Vec<OwnedValue>, EvalError> = match &value {
+        // STYLE-0012: routed at the shared `match entries` fold below -- see
+        // `builtin_add`'s identical note.
         StandardJson::Array(elements) => elements.map(|elem| to_owned(&elem)).collect(),
         StandardJson::Object(_) if S::TAG == EvalTag::Yq => {
             return scalar_fallback(&value, optional, yq_reject_non_array);
@@ -10274,7 +10306,7 @@ fn builtin_from_entries<W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     };
     let entries = match entries {
         Ok(entries) => entries,
-        Err(e) => return QueryResult::Error(e),
+        Err(e) => return suppress_or_raise(e, optional),
     };
     match entries_to_object(entries) {
         Ok(result) => QueryResult::Owned(OwnedValue::Object(result)),
@@ -10337,7 +10369,7 @@ fn builtin_with_entries<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
         match eval_single::<Vec<u64>, S>(f, cursor.value(), optional).materialize_cursor() {
             QueryResult::One(v) => match to_owned(&v) {
                 Ok(v) => transformed.push(v),
-                Err(e) => return QueryResult::Error(e),
+                Err(e) => return suppress_or_raise(e, optional),
             },
             QueryResult::OneCursor(_) => unreachable!(),
             QueryResult::Owned(v) => transformed.push(v),
@@ -10345,7 +10377,7 @@ fn builtin_with_entries<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
                 for v in vs {
                     match to_owned(&v) {
                         Ok(v) => transformed.push(v),
-                        Err(e) => return QueryResult::Error(e),
+                        Err(e) => return suppress_or_raise(e, optional),
                     }
                 }
             }
@@ -10530,7 +10562,7 @@ fn eval_string_interpolation_single_value<'a, W: Clone + AsRef<[u64]>, S: EvalSe
                     // #1932/#1943's own fast-path consumers.
                     QueryResult::One(v) => match to_owned(&v) {
                         Ok(v) => owned_to_string::<S>(&v),
-                        Err(e) => return QueryResult::Error(e),
+                        Err(e) => return suppress_or_raise(e, optional),
                     },
                     QueryResult::OneCursor(_) => unreachable!(),
                     QueryResult::Owned(v) => owned_to_string::<S>(&v),
@@ -10538,7 +10570,7 @@ fn eval_string_interpolation_single_value<'a, W: Clone + AsRef<[u64]>, S: EvalSe
                         if let Some(v) = vs.first() {
                             match to_owned(v) {
                                 Ok(v) => owned_to_string::<S>(&v),
-                                Err(e) => return QueryResult::Error(e),
+                                Err(e) => return suppress_or_raise(e, optional),
                             }
                         } else {
                             String::new()
@@ -12973,7 +13005,7 @@ fn search_pattern<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
                 for (i, elem) in (*elements).enumerate() {
                     let owned = match to_owned(&elem) {
                         Ok(v) => v,
-                        Err(e) => return QueryResult::Error(e),
+                        Err(e) => return suppress_or_raise(e, optional),
                     };
                     if owned_value_eq::<S>(&owned, pattern) {
                         indices.push(OwnedValue::Int(i as i64));
@@ -12985,7 +13017,7 @@ fn search_pattern<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
                 for (i, elem) in (*elements).enumerate() {
                     let owned = match to_owned(&elem) {
                         Ok(v) => v,
-                        Err(e) => return QueryResult::Error(e),
+                        Err(e) => return suppress_or_raise(e, optional),
                     };
                     if owned_value_eq::<S>(&owned, pattern) {
                         return QueryResult::Owned(OwnedValue::Int(i as i64));
@@ -13005,7 +13037,7 @@ fn search_pattern<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
                 for (i, elem) in (*elements).enumerate() {
                     let owned = match to_owned(&elem) {
                         Ok(v) => v,
-                        Err(e) => return QueryResult::Error(e),
+                        Err(e) => return suppress_or_raise(e, optional),
                     };
                     if owned_value_eq::<S>(&owned, pattern) {
                         last = Some(i);
@@ -15929,7 +15961,7 @@ fn eval_pipe<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
         // must raise, not silently become "" for the path-context walk.
         let owned = match to_owned(&value) {
             Ok(v) => v,
-            Err(e) => return QueryResult::Error(e),
+            Err(e) => return suppress_or_raise(e, optional),
         };
         return eval_pipe_with_path_context::<W, S>(exprs, &owned, &[], optional);
     }
@@ -16723,6 +16755,10 @@ fn eval_index_expr<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     // two is ever set.
     let mut pending_key_stream_control: Option<Control> = None;
     let keys = match eval_single::<W, S>(key, value.clone(), false).materialize_cursor() {
+        // STYLE-0012: the key generator is evaluated with a hardcoded
+        // `optional: false` just above, deliberately: `.[k]?` suppresses only its
+        // own final index step, never an error raised while computing `k` (jq
+        // 1.7.1 agrees -- `jq '.[.k]?'` on a non-string `.k` still exits 5).
         QueryResult::One(v) => match to_owned_key_shape(&v) {
             Ok(v) => vec![v],
             Err(e) => return QueryResult::Error(e),
@@ -18901,7 +18937,7 @@ fn collect_rhs_outputs<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     match eval_single::<W, S>(value_expr, input.clone(), optional).materialize_cursor() {
         QueryResult::One(v) => match to_owned(&v) {
             Ok(owned) => Ok((vec![owned], None)),
-            Err(e) => Err(QueryResult::Error(e)),
+            Err(e) => Err(suppress_or_raise(e, optional)),
         },
         QueryResult::OneCursor(_) => {
             unreachable!("materialize_cursor should have converted this")
@@ -29546,6 +29582,10 @@ fn eval_foreach<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     // the terminal control.
     let (input_values, input_control): (Vec<OwnedValue>, Option<Control>) =
         match input_result.materialize_cursor() {
+            // STYLE-0012: routed, one level out -- the error folds into
+            // `input_control` and reaches `finish_fork(.., optional)`, the
+            // shared suppression point #1902 fixed. See the identical fold
+            // for INIT below.
             QueryResult::One(v) => match to_owned(&v) {
                 Ok(v) => (vec![v], None),
                 Err(e) => (Vec::new(), Some(Control::Error(e))),
@@ -29578,6 +29618,10 @@ fn eval_foreach<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     // #1902: same checked-conversion treatment as `input_values` above.
     let (init_values, init_control): (Vec<OwnedValue>, Option<Control>) =
         match init_result.materialize_cursor() {
+            // STYLE-0012: routed, one level out. The error folds into
+            // `init_control` and is handed to `finish_fork(.., optional)`
+            // below, the shared suppression point #1902 fixed -- suppressing
+            // here as well would double-catch and drop `input_control`.
             QueryResult::One(v) => match to_owned(&v) {
                 Ok(v) => (vec![v], None),
                 Err(e) => (Vec::new(), Some(Control::Error(e))),
@@ -36006,6 +36050,11 @@ fn each_paths_filter<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     // a bare `Error`, never a `Partial`.
     let owned = match to_owned(&value) {
         Ok(owned) => owned,
+        // #2334: `suppresses`, not a bare escape. Nothing has been pushed to
+        // `sink` yet, so the suppressed form is a clean `Exhausted` -- the
+        // same shape `each_repeat_generic` (`eval_generic.rs`) already uses
+        // for its own pre-loop materialization.
+        Err(e) if suppresses(&e, optional) => return Flow::Exhausted,
         Err(e) => return Flow::Escaped(Control::Error(e)),
     };
 
@@ -41341,7 +41390,7 @@ fn builtin_load<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
                 // become "".
                 match to_owned(&cursor.value()) {
                     Ok(v) => QueryResult::Owned(v),
-                    Err(e) => QueryResult::Error(e),
+                    Err(e) => suppress_or_raise(e, optional),
                 }
             } else {
                 // Parse as YAML (default)
@@ -42567,8 +42616,15 @@ fn delpaths_one<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     // `null` anyway (`delete_keys`'s own `OwnedValue::Null` arm), so the
     // document really did end up wholly deleted regardless of where `[]`
     // falls in the batch or what (no-op) work follows it.
+    //
+    // STYLE-0012: a decode failure from `to_owned` must bypass `optional`
+    // at all three sites below, per #1746's review -- `eval_assign`/
+    // `eval_update`/`builtin_path`/`builtin_setpath`/`builtin_del` all return
+    // it unconditionally too. The `match result` below carries the full
+    // reasoning; routing any of them would contradict it.
     let mut root_deleted = false;
     let result = if S::TAG == EvalTag::Yq {
+        // STYLE-0012: see the note above `root_deleted`.
         to_owned(value).and_then(|mut v| {
             for &path in &paths {
                 v = if path.is_empty() {
@@ -42585,8 +42641,10 @@ fn delpaths_one<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
         // other array, so only the first entry needs checking:
         // `delpaths([[],[0]])` and `delpaths([[0],[]])` are both `null`.
         match paths.first() {
+            // STYLE-0012: see the note above `root_deleted`.
             None => to_owned(value),
             Some([]) => Ok(OwnedValue::Null),
+            // STYLE-0012: see the note above `root_deleted`.
             Some(_) => to_owned(value).and_then(|v| delete_paths_sorted(v, &paths, 0, false)),
         }
     };
@@ -43732,7 +43790,7 @@ fn bsearch_one_target<W: Clone + AsRef<[u64]>>(
         elements_iter.map(|v| to_owned(&v)).collect();
     let elements = match elements {
         Ok(elements) => elements,
-        Err(e) => return QueryResult::Error(e),
+        Err(e) => return suppress_or_raise(e, optional),
     };
 
     // jq's search from `builtin.jq`: an inclusive `hi` and a
@@ -44276,7 +44334,7 @@ fn builtin_shuffle<W: Clone + AsRef<[u64]>>(
             // in as if it were the real value.
             let mut items: Vec<OwnedValue> = match elements.map(|e| to_owned(&e)).collect() {
                 Ok(v) => v,
-                Err(e) => return QueryResult::Error(e),
+                Err(e) => return suppress_or_raise(e, optional),
             };
             // Use a seeded RNG for reproducibility in tests if needed,
             // but seed from system entropy for actual randomness
@@ -44321,7 +44379,7 @@ fn builtin_pivot<W: Clone + AsRef<[u64]>>(
             // in as if it were the real value.
             let items: Vec<OwnedValue> = match elements.map(|e| to_owned(&e)).collect() {
                 Ok(v) => v,
-                Err(e) => return QueryResult::Error(e),
+                Err(e) => return suppress_or_raise(e, optional),
             };
 
             if items.is_empty() {

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -16757,8 +16757,15 @@ fn eval_index_expr<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     let keys = match eval_single::<W, S>(key, value.clone(), false).materialize_cursor() {
         // STYLE-0012: the key generator is evaluated with a hardcoded
         // `optional: false` just above, deliberately: `.[k]?` suppresses only its
-        // own final index step, never an error raised while computing `k` (jq
-        // 1.7.1 agrees -- `jq '.[.k]?'` on a non-string `.k` still exits 5).
+        // own final index step, never an error raised while computing `k`.
+        // Captured from jq 1.7.1 on `{"k":{"z":1},"a":1}`:
+        //   `.[error("boom")]?` -> exit 5, `boom`   (raised computing `k`)
+        //   `.[.k]?`            -> exit 0, no output (the *index step* failing
+        //                          on a non-string key, which `?` does suppress)
+        // The second row is the one to watch: an earlier version of this comment
+        // cited it as exiting 5, which is backwards -- it is the suppressed case,
+        // not the raising one, and says nothing about the key generator (#2334
+        // review).
         QueryResult::One(v) => match to_owned_key_shape(&v) {
             Ok(v) => vec![v],
             Err(e) => return QueryResult::Error(e),

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -41410,11 +41410,19 @@ fn builtin_load<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
                                 // If single document, return it directly; otherwise return array
                                 let mut doc_values = Vec::new();
                                 while let Some((doc_cursor, rest)) = docs.uncons_cursor() {
-                                    match yaml_value_to_owned_checked(doc_cursor) {
+                                    let loaded = yaml_value_to_owned_checked(doc_cursor);
+                                    debug_assert_materialization_error(&loaded);
+                                    match loaded {
                                         Ok(v) => doc_values.push(v),
                                         // #1620: a decode failure is never
-                                        // suppressed, `optional` or not.
-                                        Err(e) => return QueryResult::Error(e),
+                                        // suppressed, `optional` or not --
+                                        // which `suppress_or_raise` states
+                                        // rather than assumes. #2334 routed
+                                        // this to match the JSON branch above,
+                                        // in the same function, on the same
+                                        // error class; the outcome is
+                                        // unchanged either way.
+                                        Err(e) => return suppress_or_raise(e, optional),
                                     }
                                     docs = rest;
                                 }
@@ -41427,10 +41435,16 @@ fn builtin_load<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
                             // Documents are always wrapped in a virtual root sequence,
                             // so this is defensive; `root` itself is this single
                             // document's cursor either way.
-                            _ => match yaml_value_to_owned_checked(root) {
-                                Ok(v) => QueryResult::Owned(v),
-                                Err(e) => QueryResult::Error(e),
-                            },
+                            _ => {
+                                let loaded = yaml_value_to_owned_checked(root);
+                                debug_assert_materialization_error(&loaded);
+                                match loaded {
+                                    Ok(v) => QueryResult::Owned(v),
+                                    // Same #1620 routing as the sequence arm
+                                    // just above (#2334).
+                                    Err(e) => suppress_or_raise(e, optional),
+                                }
+                            }
                         }
                     }
                     Err(_) if optional => QueryResult::None,

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -36,15 +36,16 @@ use super::document::{
 use super::eval::{
     apply_compare_op, arith_combine, as_var_refs, bind_def, bind_def_call,
     cannot_reserve_cross_product, classify_limit_n, classify_nth_n, classify_parent_n,
-    collapse_vec, collect_pattern_var_names, compare_values, enter_def_call_frame,
-    eval as full_eval, eval_each_owned, eval_foreach_with_values, eval_reduce_with_values,
-    extract_pattern_bindings, format_owned, has_type_mismatch_is_permissive, index_component_value,
-    index_in_array_bounds, index_one_owned as index_owned_by_key, is_pure_chain_link,
-    is_retryable_stop, literal_to_owned, needs_path_context, numeric_key_to_array_index,
-    numeric_key_to_index, owned_bound_to_i64, owned_to_string, slice_object_as_yq_children,
-    slice_owned_value_read, substitute_bound_var, substitute_vars, suppresses, tonumber_from_str,
-    vec_with_capacity, yq_negative_index_check, Control, Demand, EvalError, EvalSemantics, EvalTag,
-    Flow, JqSemantics, LimitN, PathTrail, QueryResult, YqSemantics,
+    collapse_vec, collect_pattern_var_names, compare_values, debug_assert_materialization_error,
+    enter_def_call_frame, eval as full_eval, eval_each_owned, eval_foreach_with_values,
+    eval_reduce_with_values, extract_pattern_bindings, format_owned,
+    has_type_mismatch_is_permissive, index_component_value, index_in_array_bounds,
+    index_one_owned as index_owned_by_key, is_pure_chain_link, is_retryable_stop, literal_to_owned,
+    needs_path_context, numeric_key_to_array_index, numeric_key_to_index, owned_bound_to_i64,
+    owned_to_string, slice_object_as_yq_children, slice_owned_value_read, substitute_bound_var,
+    substitute_vars, suppresses, tonumber_from_str, vec_with_capacity, yq_negative_index_check,
+    Control, Demand, EvalError, EvalSemantics, EvalTag, Flow, JqSemantics, LimitN, PathTrail,
+    QueryResult, YqSemantics,
 };
 #[cfg(test)]
 use super::expr::FuncDefBound;
@@ -273,7 +274,11 @@ fn to_owned_checked_at_depth<V: DocumentValue>(
 /// cannot be *decoded* (#1098, #1247) -- see
 /// [`DocumentValue::string_decode_error`].
 pub fn to_owned<V: DocumentValue>(value: &V) -> Result<OwnedValue, EvalError> {
-    to_owned_at_depth(value, 0)
+    let result = to_owned_at_depth(value, 0);
+    // #2334: see `debug_assert_materialization_error`'s own doc comment --
+    // depth-0 entry point only.
+    debug_assert_materialization_error(&result);
+    result
 }
 
 /// The error for an object member the format's index accepted but its grammar
@@ -469,7 +474,11 @@ fn to_owned_at_depth<V: DocumentValue>(value: &V, depth: usize) -> Result<OwnedV
 /// Panics past [`MAX_NESTING_DEPTH`] levels of nesting (#998), same as
 /// [`to_owned`].
 pub fn to_owned_cursor<C: DocumentCursor>(cursor: &C) -> Result<OwnedValue, EvalError> {
-    to_owned_cursor_at_depth(cursor, 0)
+    let result = to_owned_cursor_at_depth(cursor, 0);
+    // #2334: see `debug_assert_materialization_error`'s own doc comment --
+    // depth-0 entry point only.
+    debug_assert_materialization_error(&result);
+    result
 }
 
 /// Map every value through [`to_owned`], short-circuiting at the first
@@ -2346,7 +2355,7 @@ fn finish_fork_generic<V: DocumentValue>(
         // A decode failure (#1620) is never silenced by an ambient
         // `optional`, unlike an ordinary trailing error -- see
         // `Expr::Optional`'s own arm above for the full rationale.
-        Some(Control::Error(ref e)) if optional && !e.is_decode_failure() => {
+        Some(Control::Error(ref e)) if suppresses(e, optional) => {
             owned_vec_to_generic_result(outputs)
         }
         Some(control) => partial_generic(outputs, control),
@@ -3877,16 +3886,26 @@ fn fold_pipe_stages<S: EvalSemantics, V: DocumentValue>(
                         // piped through, exactly as the `Error` arm
                         // below does (#400/#494, #1247) -- not
                         // `owned_or_err!`, which would discard it.
+                        //
+                        // STYLE-0012: and not `owned_or_suppress!` either,
+                        // for the same reason. Suppressing here would throw
+                        // the prefix away; the `Control::Error` rides out on
+                        // the `Partial` instead and is caught, if at all, by
+                        // the `eval_try`/`Expr::Optional` boundary that owns
+                        // the whole pipe. Applies to all four conversion arms
+                        // below.
                         GenericResult::One(r) => match to_owned(&r) {
                             Ok(o) => results.push(o),
                             Err(e) => return partial_generic(results, Control::Error(e)),
                         },
+                        // STYLE-0012: see the `One` arm above.
                         GenericResult::OneCursor(c) => match to_owned_cursor(&c) {
                             Ok(o) => results.push(o),
                             Err(e) => return partial_generic(results, Control::Error(e)),
                         },
                         GenericResult::Many(rs) => {
                             for r in &rs {
+                                // STYLE-0012: see the `One` arm above.
                                 match to_owned(r) {
                                     Ok(o) => results.push(o),
                                     Err(e) => return partial_generic(results, Control::Error(e)),
@@ -3895,6 +3914,7 @@ fn fold_pipe_stages<S: EvalSemantics, V: DocumentValue>(
                         }
                         GenericResult::ManyCursor(cs) => {
                             for c in &cs {
+                                // STYLE-0012: see the `One` arm above.
                                 match to_owned_cursor(c) {
                                     Ok(o) => results.push(o),
                                     Err(e) => return partial_generic(results, Control::Error(e)),
@@ -4468,13 +4488,16 @@ fn fold_lazy_seq_stage<S: EvalSemantics, V: DocumentValue>(
                         .collect(),
                 )
             } else {
-                GenericResult::ManyOwned(owned_or_err!(items
-                    .into_iter()
-                    .map(|item| match item {
-                        LazyElem::Cursor(c) => to_owned_cursor(&c),
-                        LazyElem::Owned(o) => Ok(o),
-                    })
-                    .collect::<Result<Vec<_>, _>>()))
+                GenericResult::ManyOwned(owned_or_suppress!(
+                    items
+                        .into_iter()
+                        .map(|item| match item {
+                            LazyElem::Cursor(c) => to_owned_cursor(&c),
+                            LazyElem::Owned(o) => Ok(o),
+                        })
+                        .collect::<Result<Vec<_>, _>>(),
+                    optional
+                ))
             }
         }
 
@@ -5301,6 +5324,7 @@ fn eval_single<S: EvalSemantics, V: DocumentValue>(
                 match elements.collect_cursors_checked() {
                     Ok(cursors) if cursors.is_empty() => GenericResult::None,
                     Ok(cursors) => GenericResult::ManyCursor(cursors),
+                    Err(err) if suppresses(&err, optional) => GenericResult::None,
                     Err(err) => GenericResult::Error(err),
                 }
             } else if let Some(fields) = value.as_object() {
@@ -5413,7 +5437,7 @@ fn eval_single<S: EvalSemantics, V: DocumentValue>(
                         return result;
                     }
                 }
-                let owned = owned_or_err!(to_owned_with_cursor(&value, cursor));
+                let owned = owned_or_suppress!(to_owned_with_cursor(&value, cursor), optional);
                 // #1909: straight into `eval.rs`'s path-context evaluator
                 // with the tree we just built, rather than through
                 // `eval_on_owned`'s reindex bridge -- which lands in
@@ -5646,9 +5670,17 @@ fn eval_single<S: EvalSemantics, V: DocumentValue>(
             let items: Vec<OwnedValue> = match eval_single::<S, _>(inner, value, optional, cursor)
                 .materialize_lazy()
             {
+                // STYLE-0012: array construction is atomic in jq -- the twin
+                // of `eval::eval_array_construction`, which #2327
+                // investigated and deliberately left unrouted for the same
+                // reason. `optional` is forwarded into `inner`'s own
+                // evaluation above and never consulted for these errors.
                 GenericResult::One(v) => vec![owned_or_err!(to_owned(&v))],
+                // STYLE-0012: atomic array construction -- see the `One` arm above.
                 GenericResult::OneCursor(c) => vec![owned_or_err!(to_owned_cursor(&c))],
+                // STYLE-0012: atomic array construction -- see the `One` arm above.
                 GenericResult::Many(vs) => owned_or_err!(to_owned_all(&vs)),
+                // STYLE-0012: atomic array construction -- see the `One` arm above.
                 GenericResult::ManyCursor(cs) => owned_or_err!(to_owned_all_cursors(&cs)),
                 GenericResult::None => Vec::new(),
                 GenericResult::Owned(v) => vec![v],
@@ -5738,6 +5770,14 @@ fn eval_single<S: EvalSemantics, V: DocumentValue>(
         // Fall back to the full evaluator for complex expressions
         _ => {
             // Convert to OwnedValue, then to JSON, then evaluate with full evaluator
+            //
+            // STYLE-0012: `optional` is never `true` here -- after #693 the
+            // only caller that forces it is the `IndexExpr`/`SliceExpr`
+            // special case, which matches before this wildcard (the comment
+            // just below states this, and a `debug_assert!(!optional)` probe
+            // over the whole suite confirmed it: zero hits from any
+            // parser-driven test). Whatever error escapes is caught, if at
+            // all, by the caller's own `Expr::Optional`/`eval_try` boundary.
             let owned = owned_or_err!(to_owned_with_cursor(&value, cursor));
             let json_str = owned.to_json_for_reindex::<S>();
             let json_bytes = json_str.as_bytes();
@@ -6247,7 +6287,7 @@ fn each_repeat_generic<S: EvalSemantics, V: DocumentValue>(
 ) -> Flow {
     let owned = match to_owned_with_cursor(&value, cursor) {
         Ok(v) => v,
-        Err(e) if optional && !e.is_decode_failure() => return Flow::Exhausted,
+        Err(e) if suppresses(&e, optional) => return Flow::Exhausted,
         Err(e) => return Flow::Escaped(Control::Error(e)),
     };
     let mut empty_rounds = 0usize;
@@ -8189,12 +8229,21 @@ fn eval_index_expr<S: EvalSemantics, V: DocumentValue>(
             pending_halt = Some(code);
             vs
         }
+        // STYLE-0012: these four materialize the *key* generator's outputs,
+        // which are evaluated with a hardcoded `optional: false` just above.
+        // `.[k]?` suppresses only its own final index step, never an error
+        // raised while computing `k` -- jq 1.7.1 agrees (`jq '.[.k]?'` on a
+        // non-string `.k` still exits 5), and `eval.rs`'s own
+        // `eval_index_expr` splits it the same way.
         GenericResult::One(v) => vec![owned_or_err!(to_owned_key_shape(&v))],
+        // STYLE-0012: key generator -- see the `One` arm above.
         GenericResult::OneCursor(c) => vec![owned_or_err!(to_owned_key_shape_cursor(&c))],
+        // STYLE-0012: key generator -- see the `One` arm above.
         GenericResult::Many(vs) => owned_or_err!(vs
             .iter()
             .map(to_owned_key_shape)
             .collect::<Result<Vec<_>, _>>()),
+        // STYLE-0012: key generator -- see the `One` arm above.
         GenericResult::ManyCursor(cs) => owned_or_err!(cs
             .iter()
             .map(to_owned_key_shape_cursor)
@@ -8407,6 +8456,9 @@ fn eval_index_expr<S: EvalSemantics, V: DocumentValue>(
                     // fix it still discarded the *prefix* the same way
                     // `escape_generic!` itself used to (review finding: the
                     // sibling gap #2145's own fix left in place here).
+                    // STYLE-0012: prefix-preserving by design (#2145, quoted just above):
+                    // the error rides out on a `Partial` whose prefix must survive, so the
+                    // `eval_try`/`Expr::Optional` boundary suppresses it, not this site.
                     owned = match to_owned_all_cursors_checked(&cursors) {
                         Ok(vs) => vs,
                         Err((prefix, e)) => {
@@ -8508,6 +8560,9 @@ fn eval_index_expr<S: EvalSemantics, V: DocumentValue>(
                                 // `push` after a mid-loop flip re-admits the
                                 // #1017/#1612/#1634/#1669 abort class this
                                 // guard exists to close).
+                                // STYLE-0012: escapes with a `Control` that carries the already-pushed
+                                // prefix out, same as the `#2145` arm above -- suppressing here would
+                                // discard it.
                                 match to_owned_cursor(&c) {
                                     Ok(v) => {
                                         if owned.try_reserve(1).is_err() {
@@ -8614,6 +8669,9 @@ fn eval_index_expr<S: EvalSemantics, V: DocumentValue>(
         let out = if any_owned {
             owned
         } else {
+            // STYLE-0012: a `Halt` is already in flight and takes precedence; this
+            // arm deliberately discards the conversion error (`Err((prefix, _))`)
+            // rather than raising or suppressing it -- see the comment above.
             match to_owned_all_cursors_checked(&cursors) {
                 Ok(vs) => vs,
                 Err((prefix, _)) => prefix,
@@ -9009,13 +9067,17 @@ fn slice_one_generic<S: EvalSemantics, V: DocumentValue>(
         // inside a sliced element respects `optional` here too -- this is
         // the `eval_generic` twin of `eval.rs`'s own `eval_single`
         // literal-bounds `Expr::Slice` array arm, which had the identical
-        // gap this same PR fixed (see that arm's own #2001 comment). Can't
-        // reuse `eval.rs`'s `suppress_or_raise`/`to_owned_or_suppress!`
-        // directly: different result type (`GenericResult` vs
-        // `QueryResult`), so the equivalent check is inlined instead.
+        // gap this same PR fixed (see that arm's own #2001 comment). The
+        // *result* type differs (`GenericResult` vs `QueryResult`), so
+        // `suppress_or_raise`/`to_owned_or_suppress!` themselves don't fit --
+        // but the *predicate* does, and #2334 routed this through the shared
+        // `suppresses` rather than leaving a fourth hand-copy of
+        // `optional && !e.is_decode_failure()` to drift (the exact drift
+        // `suppresses`'s own doc comment records happening twice already,
+        // #1902 and #1934).
         return match to_owned_all(items[range].iter()) {
             Ok(v) => GenericResult::Owned(OwnedValue::Array(v)),
-            Err(e) if optional && !e.is_decode_failure() => GenericResult::None,
+            Err(e) if suppresses(&e, optional) => GenericResult::None,
             Err(e) => GenericResult::Error(e),
         };
     }
@@ -9032,7 +9094,7 @@ fn slice_one_generic<S: EvalSemantics, V: DocumentValue>(
         // `optional`.
         let owned = match to_owned(&target) {
             Ok(v) => v,
-            Err(e) if optional && !e.is_decode_failure() => return GenericResult::None,
+            Err(e) if suppresses(&e, optional) => return GenericResult::None,
             Err(e) => return GenericResult::Error(e),
         };
         let OwnedValue::Object(map) = owned else {
@@ -9249,8 +9311,18 @@ fn eval_has_generic<S: EvalSemantics, V: DocumentValue>(
     if matches!(unwrap_paren(key_expr), Expr::Comma(_)) {
         return None;
     }
+    // STYLE-0012: `.ok()?` here declines the *fast path*, it does not swallow
+    // the error -- this function returns `Option<GenericResult<V>>`, and its
+    // one caller answers `None` by running the same `has(key)` through
+    // `bridge_to_full_evaluator(.., optional)`, which materializes and
+    // raises (or suppresses) properly. Routing here would make the fast path
+    // answer `None`-as-no-output where the slow path raises.
     let key_owned = match eval_single::<S, V>(key_expr, value.clone(), optional, cursor) {
+        // STYLE-0012: declines the fast path -- see the comment above the
+        // `match`.
         GenericResult::One(v) => to_owned(&v).ok()?,
+        // STYLE-0012: declines the fast path -- see the comment above the
+        // `match`.
         GenericResult::OneCursor(c) => to_owned_cursor(&c).ok()?,
         GenericResult::Owned(v) => v,
         _ => return None,
@@ -9404,6 +9476,12 @@ fn key_elements_generic<S: EvalSemantics, V: DocumentValue>(
             // The bare forms compare elements by their own decoded value, so
             // the conversion below *is* the check -- `to_owned_cursor` is
             // already the checked one.
+            //
+            // STYLE-0012: routed, one level out. `Control` has no suppressed
+            // variant to signal with here, so the check lives in
+            // `sort_family_control(control, optional)` -- this function's
+            // only error channel, and where the `GenericResult` is rebuilt
+            // (#2334).
             None => to_owned_cursor(&cursor).map_err(Control::Error)?,
         };
         keyed.push((k, cursor));
@@ -9434,8 +9512,19 @@ fn reordering_may_keep_cursors<V: DocumentValue>(cursor: Option<&V::Cursor>) -> 
 /// Every builtin in this family is atomic -- `eval.rs`'s own arms return
 /// bare `Error`/`Break`/`Halt` with no partial prefix -- so this never
 /// produces a `Partial`.
-fn sort_family_control<V: DocumentValue>(control: Control) -> GenericResult<V> {
+///
+/// #2334: takes `optional` and routes the `Error` arm through [`suppresses`].
+/// `key_elements_generic`'s `to_owned_cursor` materialization (the bare
+/// `sort`/`unique`/`min`/`max` forms, where the conversion *is* the
+/// comparison key) reaches this function as its only error channel, and
+/// `Control` has no suppressed variant for it to signal with -- so the
+/// suppression has to happen here, where the `GenericResult` is rebuilt.
+/// Both call sites already have `optional` in scope. Applies to `Error`
+/// only: `Break`/`Halt` are not error-channel controls and `?` never
+/// touched them.
+fn sort_family_control<V: DocumentValue>(control: Control, optional: bool) -> GenericResult<V> {
     match control {
+        Control::Error(e) if suppresses(&e, optional) => GenericResult::None,
         Control::Error(e) => GenericResult::Error(e),
         Control::Break(label) => GenericResult::Break(label),
         Control::Halt(code) => GenericResult::Halt(code),
@@ -9467,7 +9556,7 @@ fn sort_family_array_generic<S: EvalSemantics, V: DocumentValue>(
 ) -> GenericResult<V> {
     let keyed = match key_elements_generic::<S, V>(cursors, key, optional) {
         Ok(keyed) => keyed,
-        Err(control) => return sort_family_control(control),
+        Err(control) => return sort_family_control(control, optional),
     };
     GenericResult::LazySeq(Box::new(LazySeq::from_cursors(reorder(keyed))))
 }
@@ -10477,10 +10566,17 @@ fn eval_builtin<S: EvalSemantics, V: DocumentValue>(
                 // observe the difference: reinstate it if some future
                 // dispatch path starts forcing `optional = true` here.
                 Some(control) => {
+                    // STYLE-0012: this builds the *prefix* of a `Partial`
+                    // that already carries `control`; suppressing here would
+                    // discard outputs the escaping control is meant to be
+                    // reported alongside. Same reasoning as
+                    // `fold_pipe_stages`' own conversion arms.
                     let prefix: Vec<OwnedValue> = match cursor {
+                        // STYLE-0012: `Partial` prefix -- see the comment above the `match`.
                         Some(c) => owned_or_err!(core::iter::repeat_with(|| to_owned_cursor(&c))
                             .take(truthy_count)
                             .collect::<Result<Vec<_>, _>>()),
+                        // STYLE-0012: `Partial` prefix -- see the comment above the `match`.
                         None => owned_or_err!(core::iter::repeat_with(|| to_owned(&value))
                             .take(truthy_count)
                             .collect::<Result<Vec<_>, _>>()),
@@ -10561,8 +10657,9 @@ fn eval_builtin<S: EvalSemantics, V: DocumentValue>(
                     // this walk already materializes every element via
                     // `to_owned_all_cursors` regardless, so the #1677/#2261
                     // gap checks ride along for free.
-                    let cursors = owned_or_err!(elements.collect_cursors_checked());
-                    let mut values: Vec<OwnedValue> = owned_or_err!(to_owned_all_cursors(&cursors));
+                    let cursors = owned_or_suppress!(elements.collect_cursors_checked(), optional);
+                    let mut values: Vec<OwnedValue> =
+                        owned_or_suppress!(to_owned_all_cursors(&cursors), optional);
                     let mut rng = ChaCha8Rng::from_rng(&mut rand::rng());
                     values.shuffle(&mut rng);
                     GenericResult::Owned(OwnedValue::Array(values))
@@ -10586,8 +10683,9 @@ fn eval_builtin<S: EvalSemantics, V: DocumentValue>(
                 // #2261 (systematic sweep): same `collect_cursors_checked`
                 // fix as `Shuffle` just above -- free here too, for the
                 // same reason.
-                let cursors = owned_or_err!(elements.collect_cursors_checked());
-                let items: Vec<OwnedValue> = owned_or_err!(to_owned_all_cursors(&cursors));
+                let cursors = owned_or_suppress!(elements.collect_cursors_checked(), optional);
+                let items: Vec<OwnedValue> =
+                    owned_or_suppress!(to_owned_all_cursors(&cursors), optional);
                 if items.is_empty() {
                     return GenericResult::Owned(OwnedValue::Array(vec![]));
                 }
@@ -10836,14 +10934,14 @@ fn eval_builtin<S: EvalSemantics, V: DocumentValue>(
                 // `_checked`: same #1677 gap check as `.[]`'s array arm --
                 // this walk visits every element regardless, so it's free
                 // to ride here too.
-                let cursors = owned_or_err!(elements.collect_cursors_checked());
+                let cursors = owned_or_suppress!(elements.collect_cursors_checked(), optional);
                 let mut entries: Vec<OwnedValue> = Vec::new();
                 for (i, elem_cursor) in cursors.into_iter().enumerate() {
                     let mut entry = IndexMap::new();
                     entry.insert("key".to_string(), OwnedValue::Int(i as i64));
                     entry.insert(
                         "value".to_string(),
-                        owned_or_err!(to_owned_cursor(&elem_cursor)),
+                        owned_or_suppress!(to_owned_cursor(&elem_cursor), optional),
                     );
                     entries.push(OwnedValue::Object(entry));
                 }
@@ -10897,7 +10995,7 @@ fn eval_builtin<S: EvalSemantics, V: DocumentValue>(
                     entry.insert("key".to_string(), OwnedValue::String(key.into_owned()));
                     entry.insert(
                         "value".to_string(),
-                        owned_or_err!(to_owned_cursor(&field.value_cursor)),
+                        owned_or_suppress!(to_owned_cursor(&field.value_cursor), optional),
                     );
                     entries.push(OwnedValue::Object(entry));
                 }
@@ -11229,7 +11327,7 @@ fn eval_builtin<S: EvalSemantics, V: DocumentValue>(
             };
             let keyed = match key_elements_generic::<S, V>(cursors, key, optional) {
                 Ok(keyed) => keyed,
-                Err(control) => return sort_family_control(control),
+                Err(control) => return sort_family_control(control, optional),
             };
             // `min_by`/`max_by` on ties: jq's own definitions keep the
             // *first* minimum and the *last* maximum (`min_by` uses `<`,

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -8698,6 +8698,11 @@ fn eval_index_expr<S: EvalSemantics, V: DocumentValue>(
         let out = if any_owned {
             owned
         } else {
+            // STYLE-0012: prefix-preserving by design, per the #2326 review
+            // comment just above -- the error rides out on a `Partial` whose
+            // prefix must survive, so the `eval_try`/`Expr::Optional` boundary
+            // suppresses it, not this site. Same reasoning as the
+            // `escape_generic!` and `pending_halt` arms this one mirrors.
             match to_owned_all_cursors_checked(&cursors) {
                 Ok(vs) => vs,
                 Err((prefix, e)) => {

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -8232,9 +8232,11 @@ fn eval_index_expr<S: EvalSemantics, V: DocumentValue>(
         // STYLE-0012: these four materialize the *key* generator's outputs,
         // which are evaluated with a hardcoded `optional: false` just above.
         // `.[k]?` suppresses only its own final index step, never an error
-        // raised while computing `k` -- jq 1.7.1 agrees (`jq '.[.k]?'` on a
-        // non-string `.k` still exits 5), and `eval.rs`'s own
-        // `eval_index_expr` splits it the same way.
+        // raised while computing `k`; `eval.rs`'s own `eval_index_expr` splits
+        // it the same way, and carries the jq 1.7.1 capture that settles it
+        // (`.[error("boom")]?` exits 5, while `.[.k]?` on a non-string `.k`
+        // exits 0 -- that one is the *index step* being suppressed, not the
+        // key generator).
         GenericResult::One(v) => vec![owned_or_err!(to_owned_key_shape(&v))],
         // STYLE-0012: key generator -- see the `One` arm above.
         GenericResult::OneCursor(c) => vec![owned_or_err!(to_owned_key_shape_cursor(&c))],
@@ -9482,11 +9484,16 @@ fn key_elements_generic<S: EvalSemantics, V: DocumentValue>(
             // the conversion below *is* the check -- `to_owned_cursor` is
             // already the checked one.
             //
-            // STYLE-0012: routed, one level out. `Control` has no suppressed
-            // variant to signal with here, so the check lives in
-            // `sort_family_control(control, optional)` -- this function's
-            // only error channel, and where the `GenericResult` is rebuilt
-            // (#2334).
+            // STYLE-0012: raises regardless of `optional`, and must. Two
+            // reasons, either sufficient. (1) `to_owned_cursor` raises only
+            // decode failures, which `suppresses` never suppresses -- routing
+            // this would be a guaranteed no-op. (2) The only place it *could*
+            // be routed is `sort_family_control`, where the `GenericResult` is
+            // rebuilt -- and that `Control` is shared with `sort_key_generic`,
+            // which carries the user's own key-filter errors
+            // (`sort_by(error("x"))`). Suppressing there would swallow those
+            // instead, which is not what `optional` means. See
+            // `sort_family_control`'s own doc comment (#2334 review).
             None => to_owned_cursor(&cursor).map_err(Control::Error)?,
         };
         keyed.push((k, cursor));
@@ -9518,18 +9525,24 @@ fn reordering_may_keep_cursors<V: DocumentValue>(cursor: Option<&V::Cursor>) -> 
 /// bare `Error`/`Break`/`Halt` with no partial prefix -- so this never
 /// produces a `Partial`.
 ///
-/// #2334: takes `optional` and routes the `Error` arm through [`suppresses`].
-/// `key_elements_generic`'s `to_owned_cursor` materialization (the bare
-/// `sort`/`unique`/`min`/`max` forms, where the conversion *is* the
-/// comparison key) reaches this function as its only error channel, and
-/// `Control` has no suppressed variant for it to signal with -- so the
-/// suppression has to happen here, where the `GenericResult` is rebuilt.
-/// Both call sites already have `optional` in scope. Applies to `Error`
-/// only: `Break`/`Halt` are not error-channel controls and `?` never
-/// touched them.
-fn sort_family_control<V: DocumentValue>(control: Control, optional: bool) -> GenericResult<V> {
+/// Deliberately does *not* take `optional` (#2334 review). An earlier draft
+/// routed the `Error` arm through [`suppresses`] on behalf of
+/// `key_elements_generic`'s `to_owned_cursor` materialization, on the premise
+/// that this was that materialization's only error channel. It is not:
+/// `key_elements_generic` funnels three things into this `Control` --
+/// `push_generic_truthiness_cursor_error`, `to_owned_cursor`, and
+/// `sort_key_generic`, which carries out *whatever the user's key filter
+/// raised* (`sort_by(error("x"))`, `min_by(.a)` on an array, ...).
+///
+/// The routing was therefore a no-op in the direction it was written for and
+/// live in the direction it was not: `to_owned_cursor` raises only
+/// decode failures, which `suppresses` never suppresses at any `optional`, so
+/// the arm could never fire for the materialization -- while a key-filter
+/// error is exactly the suppressible kind, and would have vanished silently
+/// the day `optional` reached here. See `key_elements_generic`'s own
+/// STYLE-0012 marker.
+fn sort_family_control<V: DocumentValue>(control: Control) -> GenericResult<V> {
     match control {
-        Control::Error(e) if suppresses(&e, optional) => GenericResult::None,
         Control::Error(e) => GenericResult::Error(e),
         Control::Break(label) => GenericResult::Break(label),
         Control::Halt(code) => GenericResult::Halt(code),
@@ -9561,7 +9574,7 @@ fn sort_family_array_generic<S: EvalSemantics, V: DocumentValue>(
 ) -> GenericResult<V> {
     let keyed = match key_elements_generic::<S, V>(cursors, key, optional) {
         Ok(keyed) => keyed,
-        Err(control) => return sort_family_control(control, optional),
+        Err(control) => return sort_family_control(control),
     };
     GenericResult::LazySeq(Box::new(LazySeq::from_cursors(reorder(keyed))))
 }
@@ -11332,7 +11345,7 @@ fn eval_builtin<S: EvalSemantics, V: DocumentValue>(
             };
             let keyed = match key_elements_generic::<S, V>(cursors, key, optional) {
                 Ok(keyed) => keyed,
-                Err(control) => return sort_family_control(control, optional),
+                Err(control) => return sort_family_control(control),
             };
             // `min_by`/`max_by` on ties: jq's own definitions keep the
             // *first* minimum and the *last* maximum (`min_by` uses `<`,

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -30136,6 +30136,128 @@ fn test_eval_rs_sites_produce_correct_output_2327() -> Result<()> {
     Ok(())
 }
 
+/// #2334: every site STYLE-0012's audit made this PR route still raises the
+/// two error classes it is meant to, through a bare call and through a
+/// trailing `?`.
+///
+/// **This test cannot detect the invariant regressing, and is not trying to.**
+/// Every error path below is `is_decode_failure()`-tagged (#2286), which
+/// `suppresses` never suppresses regardless of `optional`, so a site that
+/// stopped being routed would produce exactly these outputs too. That is the
+/// whole reason the real guard is static -- see
+/// `tests/jq_optional_suppression_audit.rs`, and the same limitation
+/// `test_optional_ignored_sites_2327` and
+/// `test_eval_rs_only_sites_still_correct_2280` already accepted for their own
+/// rounds. What this pins is that the routing edits did not change the
+/// raise-vs-succeed behaviour of any of these builtins.
+///
+/// Two error classes, because they reach different code: an undecodable
+/// string value (`"\ud800"`), which the `to_owned` walk raises on, and a
+/// trailing stray comma (`[1,2,3,]`, #2261), which is
+/// `collect_cursors_checked`'s own malformed-element gap. Several builtins
+/// only reach a routed line through the *second* -- `last`, `bsearch`,
+/// `shuffle` and `pivot` all answer a `"\ud800"` document at exit 0, because
+/// the lazy/index path answers before their own materialization runs, the
+/// same "the fixed line never runs for this document" shape #2327's own test
+/// comment documents for `builtin_del`. Each row below is placed in whichever
+/// table it was verified to actually reach.
+#[test]
+fn test_style_0012_routed_sites_still_raise_2334() -> Result<()> {
+    // Class 1: an undecodable string somewhere in the document.
+    for (filter, doc) in [
+        ("add", r#"["\ud800"]"#),
+        ("map_values(.)", r#"{"a":"\ud800"}"#),
+        ("map(.)", r#"["\ud800"]"#),
+        ("to_entries", r#"{"a":"\ud800"}"#),
+        ("from_entries", r#"[{"key":"a","value":"\ud800"}]"#),
+        ("with_entries(.)", r#"{"a":"\ud800"}"#),
+        ("flatten", r#"[["\ud800"]]"#),
+        ("indices(1)", r#"["\ud800"]"#),
+        ("index(1)", r#"["\ud800"]"#),
+        ("rindex(1)", r#"["\ud800"]"#),
+        ("sort", r#"["\ud800"]"#),
+        ("unique", r#"["\ud800"]"#),
+        ("min", r#"["\ud800"]"#),
+        ("max", r#"["\ud800"]"#),
+        (".[0:1]", r#"["\ud800"]"#),
+        ("[..]", r#"["\ud800"]"#),
+        (".a = 1", r#"{"a":"\ud800"}"#),
+        (r#""\(.a)""#, r#"{"a":"\ud800"}"#),
+        // `paths(f)`, not bare `paths`: the filtered form is what reaches
+        // `each_paths_filter`'s own materialization.
+        (r#"[paths(type == "string")]"#, r#"{"a":"\ud800"}"#),
+    ] {
+        for suffix in ["", "?"] {
+            let full = format!("{filter}{suffix}");
+            let (stdout, stderr, code) = run_jq_stdin_streams(&full, doc, &["-c"])?;
+            assert_eq!(code, 5, "{full}: stdout {stdout:?} stderr {stderr:?}");
+            assert_eq!(stdout, "", "{full}: stderr {stderr:?}");
+        }
+    }
+
+    // Class 2: `collect_cursors_checked`'s malformed-element gap -- a trailing
+    // stray comma after a real last element (#2261).
+    for filter in [
+        "to_entries",
+        "map_values(.)",
+        "[.[]]",
+        "add",
+        "last",
+        "flatten",
+        "sort",
+        "unique",
+        "min",
+        "max",
+        "shuffle",
+        "pivot",
+        "bsearch(1)",
+        "indices(1)",
+    ] {
+        for suffix in ["", "?"] {
+            let full = format!("{filter}{suffix}");
+            let (stdout, stderr, code) = run_jq_stdin_streams(&full, "[1,2,3,]", &["-c"])?;
+            assert_eq!(code, 5, "{full}: stdout {stdout:?} stderr {stderr:?}");
+            assert_eq!(stdout, "", "{full}: stderr {stderr:?}");
+        }
+    }
+
+    // Not a blanket rejection: the same builtins on a well-formed document
+    // still produce their ordinary output, so no routing edit turned one of
+    // them into an unconditional error.
+    for (filter, doc, expected) in [
+        ("add", "[1,2,3]", "6"),
+        ("map_values(.+1)", r#"{"a":1}"#, r#"{"a":2}"#),
+        ("map(.+1)", "[1,2]", "[2,3]"),
+        ("last", "[1,2,3]", "3"),
+        ("to_entries", r#"{"a":1}"#, r#"[{"key":"a","value":1}]"#),
+        ("from_entries", r#"[{"key":"a","value":1}]"#, r#"{"a":1}"#),
+        ("with_entries(.value += 1)", r#"{"a":1}"#, r#"{"a":2}"#),
+        ("flatten", "[[1],[2]]", "[1,2]"),
+        ("indices(2)", "[1,2,3]", "[1]"),
+        ("index(2)", "[1,2,3]", "1"),
+        ("rindex(2)", "[1,2,3]", "1"),
+        ("bsearch(2)", "[1,2,3]", "1"),
+        (r#""\(.a)""#, r#"{"a":1}"#, r#""1""#),
+        (r#"[paths(type == "number")]"#, r#"{"a":1}"#, r#"[["a"]]"#),
+        ("[..]", "[1]", "[[1],1]"),
+        (".a = 2", r#"{"a":1}"#, r#"{"a":2}"#),
+        ("sort", "[2,1]", "[1,2]"),
+        ("unique", "[2,1,1]", "[1,2]"),
+        ("min", "[2,1]", "1"),
+        ("max", "[2,1]", "2"),
+        (".[0:1]", "[1,2]", "[1]"),
+        ("[.[]]", "[1,2]", "[1,2]"),
+        ("pivot", "[[1,2],[3,4]]", "[[1,3],[2,4]]"),
+        ("shuffle | length", "[1,2,3]", "3"),
+    ] {
+        let (stdout, code) = run_jq_stdin(filter, doc, &["-c"])?;
+        assert_eq!(code, 0, "{filter}: doc {doc}");
+        assert_eq!(stdout.trim(), expected, "{filter}: doc {doc}");
+    }
+
+    Ok(())
+}
+
 /// #2053, constraint 2 from the issue that split this fix off from #1909:
 /// `path_expr` must be evaluated exactly once, on *both* branches
 /// `eval_generic.rs`'s new native `Builtin::GetPath` arm can take -- the

--- a/tests/jq_optional_suppression_audit.rs
+++ b/tests/jq_optional_suppression_audit.rs
@@ -7,7 +7,8 @@
 //! `eval::suppresses` is `optional && !e.is_decode_failure()`. Every error the
 //! materialization family can raise today is `decode_failure`-tagged --
 //! `to_owned`/`to_owned_at_depth`, `to_owned_cursor_at_depth`,
-//! `to_owned_with_cursor` and `collect_cursors_checked`, whose only error
+//! `to_owned_with_cursor`, `collect_cursors_checked` and
+//! `yaml_value_to_owned_checked`, whose only error
 //! constructors are `EvalError::decode_failure`,
 //! `EvalError::colliding_display_key` (which delegates to it) and the
 //! `malformed_delimiter/member/element_error` trio (#2286 retagged the last of
@@ -101,8 +102,29 @@ const MATERIALIZER_FN_EXCLUSIONS: &[&str] = &[
 ];
 
 fn is_materializer_fn(name: &str) -> bool {
+    if MATERIALIZER_FN_EXTRA.contains(&name) {
+        return true;
+    }
     name.starts_with(MATERIALIZER_FN_PREFIX) && !MATERIALIZER_FN_EXCLUSIONS.contains(&name)
 }
+
+/// Materializers whose names do not carry the `to_owned` prefix, and so would
+/// otherwise slip past [`is_materializer_fn`] entirely.
+///
+/// `yaml_value_to_owned_checked` (`eval.rs`, `#[cfg(feature = "std")]`) is the
+/// `load` builtin's own YAML walk: `YamlCursor -> Result<OwnedValue,
+/// EvalError>`, recursive, raising exactly the two constructors the rest of
+/// the family does (`EvalError::decode_failure` and
+/// `EvalError::colliding_display_key`, which delegates to it). It sits inside
+/// `builtin_load`, which has a live `optional` -- and the prefix rule could not
+/// see it, because the prefix is in the *middle* of the name (#2334 review).
+///
+/// Keep this roster empty if you can: a name that starts with `to_owned` is
+/// found by default, which is the polarity this audit is about. Anything here
+/// had to be noticed by a human first, which is exactly the failure mode
+/// STYLE-0012 exists to stop -- so a new materializer should be *named* into
+/// the family rather than added here.
+const MATERIALIZER_FN_EXTRA: &[&str] = &["yaml_value_to_owned_checked"];
 
 /// Methods with the same materialization contract. `collect_cursors_checked`
 /// is only ever a method call (`elements.collect_cursors_checked()`).
@@ -177,7 +199,7 @@ fn marker_in_attached_comment_block(lines: &[&str], idx: usize, body_start: usiz
 /// renamed helper or a refactor that moves the code out from under the visitor
 /// leaves it passing green while checking nothing.
 ///
-/// Today's counts are 380 functions and 149 call sites. The floors are ~90% of
+/// Today's counts are 380 functions and 151 call sites. The floors are ~90% of
 /// that (#2334 review tightened them from 250/100, which left enough headroom
 /// that a change halving the visitor's reach would still have passed): close
 /// enough to catch a scan that has lost a whole file or a whole node kind,

--- a/tests/jq_optional_suppression_audit.rs
+++ b/tests/jq_optional_suppression_audit.rs
@@ -187,19 +187,28 @@ struct Site {
     body_start: usize,
 }
 
+/// One frame of the enclosing-function stack.
+struct Frame {
+    name: String,
+    /// Whether the signature binds an `optional: bool` the body can read.
+    live_optional: bool,
+    /// 1-based, inclusive line range of the function's body.
+    ///
+    /// Load-bearing, not bookkeeping: without it the routing window runs
+    /// straight off the end of the function and picks up a `suppresses(..)`
+    /// belonging to the *next* one, silently excusing a real gap. Caught by
+    /// this file's own negative test -- a freshly-added unrouted helper passed
+    /// the audit because `each_repeat_generic`, twenty lines below it, was
+    /// routed.
+    body_start: usize,
+    body_end: usize,
+}
+
 struct Audit<'a> {
     lines: Vec<&'a str>,
-    /// Innermost enclosing function: name, whether it binds a live
-    /// `optional: bool`, and the 1-based line range of its body. A stack, so a
-    /// nested `fn` without the parameter does not inherit its parent's.
-    ///
-    /// The line range is load-bearing, not bookkeeping: without it the
-    /// routing window below runs straight off the end of the function and
-    /// picks up a `suppresses(..)` belonging to the *next* one, silently
-    /// excusing a real gap. Caught by this file's own negative test -- a
-    /// freshly-added unrouted helper passed the audit because
-    /// `each_repeat_generic`, twenty lines below it, was routed.
-    stack: Vec<(String, bool, usize, usize)>,
+    /// Innermost enclosing function last. A stack, so a nested `fn` without
+    /// the parameter does not inherit its parent's.
+    stack: Vec<Frame>,
     live_optional_fns: usize,
     sites_examined: usize,
     /// Every raw site, resolved in a second pass -- see [`Audit::resolve`].
@@ -218,35 +227,20 @@ impl<'a> Audit<'a> {
     }
 
     fn in_live_optional_fn(&self) -> bool {
-        self.stack.last().is_some_and(|(_, live, _, _)| *live)
-    }
-
-    fn enclosing(&self) -> String {
-        self.stack
-            .last()
-            .map(|(name, _, _, _)| name.clone())
-            .unwrap_or_else(|| "<unknown>".to_string())
-    }
-
-    /// The enclosing function's own body lines, as a 1-based inclusive range.
-    fn body_range(&self) -> (usize, usize) {
-        self.stack
-            .last()
-            .map(|(_, _, start, end)| (*start, *end))
-            .unwrap_or((1, self.lines.len()))
+        self.stack.last().is_some_and(|f| f.live_optional)
     }
 
     fn push_fn(&mut self, sig: &syn::Signature, body: &syn::Block) {
-        let live = binds_live_optional(sig);
-        if live {
+        let live_optional = binds_live_optional(sig);
+        if live_optional {
             self.live_optional_fns += 1;
         }
-        self.stack.push((
-            sig.ident.to_string(),
-            live,
-            body.span().start().line,
-            body.span().end().line,
-        ));
+        self.stack.push(Frame {
+            name: sig.ident.to_string(),
+            live_optional,
+            body_start: body.span().start().line,
+            body_end: body.span().end().line,
+        });
     }
 
     /// Record a materialization site for [`Audit::resolve`] to judge.
@@ -256,18 +250,21 @@ impl<'a> Audit<'a> {
         }
         self.sites_examined += 1;
         let line = span.start().line; // 1-based
-        let (body_start, body_end) = self.body_range();
+        let frame = self
+            .stack
+            .last()
+            .expect("in_live_optional_fn implies a frame");
         self.candidates.push(Site {
             line,
-            func: self.enclosing(),
+            func: frame.name.clone(),
             snippet: self
                 .lines
                 .get(line.saturating_sub(1))
                 .unwrap_or(&"")
                 .trim()
                 .to_string(),
-            body_end,
-            body_start,
+            body_start: frame.body_start,
+            body_end: frame.body_end,
         });
     }
 

--- a/tests/jq_optional_suppression_audit.rs
+++ b/tests/jq_optional_suppression_audit.rs
@@ -1,0 +1,555 @@
+//! STYLE-0012's enforcement: every raw materialization call site inside a
+//! function with a live `optional: bool` must either route its error through
+//! the suppression machinery or carry a `// STYLE-0012:` exemption (#2334).
+//!
+//! # Why this is a source scan and not a behavioural test
+//!
+//! `eval::suppresses` is `optional && !e.is_decode_failure()`. Every error the
+//! materialization family can raise today is `decode_failure`-tagged --
+//! `to_owned`/`to_owned_at_depth`, `to_owned_cursor_at_depth`,
+//! `to_owned_with_cursor` and `collect_cursors_checked`, whose only error
+//! constructors are `EvalError::decode_failure`,
+//! `EvalError::colliding_display_key` (which delegates to it) and the
+//! `malformed_delimiter/member/element_error` trio (#2286 retagged the last of
+//! those via `EvalError::malformed_json_text`). So `suppresses` is *always
+//! false* at every one of these sites, and routing a site or leaving it bare
+//! produce byte-identical output.
+//!
+//! That is precisely why the bug recurred three times (#2231, #2280, #2327),
+//! each round's review finding more sites the last sweep missed: **no
+//! behavioural test can fail when a site is left unrouted**. #2327's own
+//! pinning test, `test_optional_ignored_sites_2327`, asserts exit 5 both with
+//! and without a trailing `?` -- it records the non-difference, and by
+//! construction cannot detect the invariant regressing. Centralising the
+//! *check* (`suppresses`/`suppress_or_raise`/the `*_or_suppress!` macros) did
+//! not stop the *omission*, because nothing forced a call site to route
+//! through them.
+//!
+//! Same problem, same answer as `jq_owned_only_sink_invariant_test.rs` (#2025):
+//! a claim that "was re-derived by hand ... and nothing but review stops a later
+//! edit from" breaking it gets a mechanical guard. The runtime half of that
+//! guard is `EvalError`'s `debug_assert_materialization_error`, which pins the
+//! premise above; this file is the static half, which pins the routing.
+//!
+//! # What it does not do
+//!
+//! It does not decide whether a site *should* suppress -- that depends on
+//! error-tag semantics and on whether an outer layer already double-catches,
+//! neither of which is visible from the call site. It only demands that
+//! somebody made the decision and wrote it down.
+
+use std::collections::BTreeSet;
+use std::fmt::Write as _;
+
+use proc_macro2::Span;
+use syn::spanned::Spanned as _;
+use syn::visit::{self, Visit};
+
+/// The two evaluators. Both are scanned: #2327's worst miss (7 of the 8 sites
+/// its own review found) was the "fixed one evaluator's copy, missed the
+/// other's" shape, and scanning both makes that shape fail here regardless of
+/// what a same-named twin in the other file does -- no fragile name pairing
+/// between the files required.
+const SOURCES: &[(&str, &str)] = &[
+    ("src/jq/eval.rs", include_str!("../src/jq/eval.rs")),
+    (
+        "src/jq/eval_generic.rs",
+        include_str!("../src/jq/eval_generic.rs"),
+    ),
+];
+
+/// Free functions that materialize a borrowed document value into an
+/// `OwnedValue`, each returning `Result<_, EvalError>`, are matched by the
+/// `to_owned` *prefix* rather than an explicit roster. Default-in, exceptions
+/// written down: a future `to_owned_something` is covered without anyone
+/// remembering to add it here, which is the polarity this whole issue is about.
+///
+/// Matched as *free* calls only. Neither file calls `.to_owned()` as a method
+/// today, but `ToOwned::to_owned` on a `str`/`[u8]` is unrelated to any of
+/// this, so restricting the match to the call form keeps a future
+/// `some_string.to_owned()` from being reported as a materialization.
+const MATERIALIZER_FN_PREFIX: &str = "to_owned";
+
+/// The `to_owned*` functions that are deliberately *not* part of the audited
+/// family:
+///
+/// - `to_owned_lossy`/`to_owned_lossy_at_depth`/`to_owned_for_diagnostic` are
+///   infallible (they return `OwnedValue`, not `Result`), so there is no error
+///   for `optional` to suppress or raise. `to_owned_for_diagnostic` is the one
+///   sanctioned lossy materialization left in `eval_generic.rs` (#1247).
+/// - `to_owned_checked` is the #2299 sibling of `to_owned` that swaps
+///   `assert_nesting_depth`'s panic for a *catchable* `check_nesting_depth`
+///   error -- the one member of the family that genuinely can raise a
+///   non-decode-failure. It has a single call site, `materialize_stream_item`
+///   in the CLI crate's `jq_runner.rs`, which has no `optional` in scope and is
+///   not one of the files scanned here. Leaving it out keeps the premise
+///   `debug_assert_materialization_error` pins ("this family raises only decode
+///   failures") true of exactly the set the audit covers.
+const MATERIALIZER_FN_EXCLUSIONS: &[&str] = &[
+    "to_owned_lossy",
+    "to_owned_lossy_at_depth",
+    "to_owned_for_diagnostic",
+    "to_owned_checked",
+    "to_owned_checked_at_depth",
+];
+
+fn is_materializer_fn(name: &str) -> bool {
+    name.starts_with(MATERIALIZER_FN_PREFIX) && !MATERIALIZER_FN_EXCLUSIONS.contains(&name)
+}
+
+/// Methods with the same materialization contract. `collect_cursors_checked`
+/// is only ever a method call (`elements.collect_cursors_checked()`).
+const MATERIALIZER_METHODS: &[&str] = &["collect_cursors_checked"];
+
+/// Macros that already fold the materialization error through `suppresses`.
+/// Their bodies are unparsed token streams, so a site wrapped in one is
+/// invisible to the visitor below -- which is the point: routed sites cost
+/// nothing to skip. Listed explicitly anyway so that a routed macro whose
+/// *argument* is itself a raw call (`owned_or_suppress!(to_owned(&v),
+/// optional)`) is not reported.
+const ROUTED_MACROS: &[&str] = &[
+    "to_owned_or_suppress",
+    "to_owned_vec_or_suppress",
+    "owned_or_suppress",
+];
+
+/// Textual evidence, at the call site, that the error *is* routed. The
+/// hand-rolled shape is `match to_owned(..) { Ok(v) => v, Err(e) => return
+/// suppress_or_raise(e, optional) }`, so the evidence sits a few lines below
+/// the call.
+const ROUTING_TOKENS: &[&str] = &["suppress_or_raise", "suppresses("];
+
+/// The STYLE-0012 exemption marker, cited inline the way STYLE-0004's
+/// `#[allow]` citations already are.
+const EXEMPT_MARKER: &str = "STYLE-0012:";
+
+/// How far below a call site routing evidence may sit.
+///
+/// Proximity, not data flow: the common shape collects a `Result` in one
+/// statement (`let items: Result<_, _> = match value { .. to_owned(..) .. }`)
+/// and folds it in a later one (`let items = match items { Err(e) => return
+/// suppress_or_raise(e, optional) }`), with the rest of the first `match`'s
+/// arms in between. Twenty lines covers every such pair in the two files
+/// today (`builtin_flatten`'s is the widest, at nineteen). A site whose
+/// routing genuinely sits further away -- `builtin_contains`/`builtin_inside`
+/// defer their unwrap into a closure (#1800) -- uses the `// STYLE-0012:`
+/// marker to say so instead; that escape hatch is why this can stay a simple
+/// window rather than a data-flow analysis.
+const WINDOW_AFTER: usize = 20;
+
+/// A marker is looked for in the contiguous run of comment (and blank) lines
+/// immediately above the call site, however long that run is -- not within a
+/// fixed line budget.
+///
+/// A comment block attached to a line is unambiguously *about* that line, so
+/// there is no distance to tune and no risk of one site's marker silently
+/// excusing an unrelated site further down. It also suits this codebase, whose
+/// explanatory comments routinely run well past any window a fixed budget
+/// could safely allow.
+fn marker_in_attached_comment_block(lines: &[&str], idx: usize, body_start: usize) -> bool {
+    let mut i = idx;
+    // Never walks above the enclosing function's own body, so a marker on the
+    // *previous* function's last line cannot excuse this one.
+    let floor = body_start.saturating_sub(1);
+    while i > floor {
+        i -= 1;
+        let t = lines[i].trim_start();
+        if t.is_empty() || t.starts_with("//") {
+            if t.contains(EXEMPT_MARKER) {
+                return true;
+            }
+            continue;
+        }
+        break;
+    }
+    false
+}
+
+/// Lower bounds proving the scan actually looked at something. The classic
+/// failure of a grep-shaped gate is going quietly vacuous: a parser change, a
+/// renamed helper or a refactor that moves the code out from under the visitor
+/// leaves it passing green while checking nothing.
+///
+/// Today's counts are 381 functions and 148 call sites. These floors sit well
+/// below that -- low enough not to churn on ordinary edits, high enough that a
+/// scan which has stopped seeing the evaluators cannot pass.
+const MIN_LIVE_OPTIONAL_FNS: usize = 250;
+const MIN_SITES_EXAMINED: usize = 100;
+
+struct Site {
+    line: usize,
+    func: String,
+    snippet: String,
+    /// Last line of the enclosing function's body, so the routing window can
+    /// be clipped to it.
+    body_end: usize,
+    /// First line of the enclosing function's body, so the marker walk can be.
+    body_start: usize,
+}
+
+struct Audit<'a> {
+    lines: Vec<&'a str>,
+    /// Innermost enclosing function: name, whether it binds a live
+    /// `optional: bool`, and the 1-based line range of its body. A stack, so a
+    /// nested `fn` without the parameter does not inherit its parent's.
+    ///
+    /// The line range is load-bearing, not bookkeeping: without it the
+    /// routing window below runs straight off the end of the function and
+    /// picks up a `suppresses(..)` belonging to the *next* one, silently
+    /// excusing a real gap. Caught by this file's own negative test -- a
+    /// freshly-added unrouted helper passed the audit because
+    /// `each_repeat_generic`, twenty lines below it, was routed.
+    stack: Vec<(String, bool, usize, usize)>,
+    live_optional_fns: usize,
+    sites_examined: usize,
+    /// Every raw site, resolved in a second pass -- see [`Audit::resolve`].
+    candidates: Vec<Site>,
+}
+
+impl<'a> Audit<'a> {
+    fn new(src: &'a str) -> Self {
+        Self {
+            lines: src.lines().collect(),
+            stack: Vec::new(),
+            live_optional_fns: 0,
+            sites_examined: 0,
+            candidates: Vec::new(),
+        }
+    }
+
+    fn in_live_optional_fn(&self) -> bool {
+        self.stack.last().is_some_and(|(_, live, _, _)| *live)
+    }
+
+    fn enclosing(&self) -> String {
+        self.stack
+            .last()
+            .map(|(name, _, _, _)| name.clone())
+            .unwrap_or_else(|| "<unknown>".to_string())
+    }
+
+    /// The enclosing function's own body lines, as a 1-based inclusive range.
+    fn body_range(&self) -> (usize, usize) {
+        self.stack
+            .last()
+            .map(|(_, _, start, end)| (*start, *end))
+            .unwrap_or((1, self.lines.len()))
+    }
+
+    fn push_fn(&mut self, sig: &syn::Signature, body: &syn::Block) {
+        let live = binds_live_optional(sig);
+        if live {
+            self.live_optional_fns += 1;
+        }
+        self.stack.push((
+            sig.ident.to_string(),
+            live,
+            body.span().start().line,
+            body.span().end().line,
+        ));
+    }
+
+    /// Record a materialization site for [`Audit::resolve`] to judge.
+    fn check(&mut self, span: Span) {
+        if !self.in_live_optional_fn() {
+            return;
+        }
+        self.sites_examined += 1;
+        let line = span.start().line; // 1-based
+        let (body_start, body_end) = self.body_range();
+        self.candidates.push(Site {
+            line,
+            func: self.enclosing(),
+            snippet: self
+                .lines
+                .get(line.saturating_sub(1))
+                .unwrap_or(&"")
+                .trim()
+                .to_string(),
+            body_end,
+            body_start,
+        });
+    }
+
+    /// Keep only the candidates that are neither routed nor exempted.
+    ///
+    /// A second pass rather than a decision made during the walk, because the
+    /// routing window has to be clipped at the *next* materialization site,
+    /// which is not known until the walk is done. Without that clip, a
+    /// `suppress_or_raise` belonging to a later site in the same function
+    /// silently excuses an earlier, genuinely unrouted one -- caught by this
+    /// file's own negative test, where deleting one of `eval_index_expr`'s
+    /// four key-arm markers left the audit green.
+    fn resolve(mut self) -> Vec<Site> {
+        self.candidates.sort_by_key(|c| c.line);
+        let lines = core::mem::take(&mut self.lines);
+        let starts: Vec<usize> = self.candidates.iter().map(|c| c.line).collect();
+        let mut out = Vec::new();
+        for (i, site) in self.candidates.into_iter().enumerate() {
+            let idx = site.line.saturating_sub(1);
+            let next_site = starts[i + 1..]
+                .iter()
+                .copied()
+                .find(|l| *l > site.line)
+                .unwrap_or(usize::MAX);
+            let after_end = (idx + WINDOW_AFTER)
+                .min(site.body_end)
+                .min(next_site.saturating_sub(1))
+                .min(lines.len())
+                .max(idx + 1);
+            let after = lines[idx..after_end].join("\n");
+            if ROUTING_TOKENS.iter().any(|t| after.contains(t)) {
+                continue;
+            }
+            // The site's own line counts too: a short marker on the very line
+            // of the call is the terser spelling.
+            if lines[idx].contains(EXEMPT_MARKER)
+                || marker_in_attached_comment_block(&lines, idx, site.body_start)
+            {
+                continue;
+            }
+            out.push(site);
+        }
+        out
+    }
+}
+
+/// Whether `sig` binds an `optional: bool` the body can actually read.
+///
+/// `_optional: bool` does not count: an underscore-prefixed parameter is the
+/// codebase's existing, *compiler-enforced* marker for "this function ignores
+/// `optional` on purpose" -- `builtin_recurse_f`/`builtin_recurse_cond` (#1953)
+/// are spelled that way, and the unused-variable lint keeps the spelling honest
+/// in a way no comment can. STYLE-0012 names it as the preferred marker when
+/// the whole parameter is dead.
+fn binds_live_optional(sig: &syn::Signature) -> bool {
+    sig.inputs.iter().any(|arg| {
+        let syn::FnArg::Typed(pat) = arg else {
+            return false;
+        };
+        let syn::Pat::Ident(ident) = &*pat.pat else {
+            return false;
+        };
+        if ident.ident != "optional" {
+            return false;
+        }
+        matches!(&*pat.ty, syn::Type::Path(p) if p.path.is_ident("bool"))
+    })
+}
+
+fn has_cfg_test(attrs: &[syn::Attribute]) -> bool {
+    attrs
+        .iter()
+        .any(|a| a.path().is_ident("cfg") && a.to_token_stream_string().contains("test"))
+}
+
+/// `syn::Attribute` has no direct "render me" method that keeps working across
+/// meta shapes, so go through the token stream.
+trait TokenStreamString {
+    fn to_token_stream_string(&self) -> String;
+}
+
+impl TokenStreamString for syn::Attribute {
+    fn to_token_stream_string(&self) -> String {
+        match &self.meta {
+            syn::Meta::List(list) => list.tokens.to_string(),
+            other => format!("{:?}", std::mem::discriminant(other)),
+        }
+    }
+}
+
+impl<'ast> Visit<'ast> for Audit<'_> {
+    fn visit_item_mod(&mut self, node: &'ast syn::ItemMod) {
+        // `#[cfg(test)] mod tests` -- unit tests legitimately call the
+        // materializers directly with hand-picked `optional` values.
+        if has_cfg_test(&node.attrs) {
+            return;
+        }
+        visit::visit_item_mod(self, node);
+    }
+
+    fn visit_item_fn(&mut self, node: &'ast syn::ItemFn) {
+        if has_cfg_test(&node.attrs) {
+            return;
+        }
+        self.push_fn(&node.sig, &node.block);
+        visit::visit_item_fn(self, node);
+        self.stack.pop();
+    }
+
+    fn visit_impl_item_fn(&mut self, node: &'ast syn::ImplItemFn) {
+        if has_cfg_test(&node.attrs) {
+            return;
+        }
+        self.push_fn(&node.sig, &node.block);
+        visit::visit_impl_item_fn(self, node);
+        self.stack.pop();
+    }
+
+    fn visit_trait_item_fn(&mut self, node: &'ast syn::TraitItemFn) {
+        let Some(body) = &node.default else {
+            return;
+        };
+        self.push_fn(&node.sig, body);
+        visit::visit_trait_item_fn(self, node);
+        self.stack.pop();
+    }
+
+    fn visit_expr_call(&mut self, node: &'ast syn::ExprCall) {
+        if let syn::Expr::Path(path) = &*node.func {
+            if let Some(last) = path.path.segments.last() {
+                if is_materializer_fn(&last.ident.to_string()) {
+                    self.check(node.span());
+                }
+            }
+        }
+        visit::visit_expr_call(self, node);
+    }
+
+    fn visit_expr_method_call(&mut self, node: &'ast syn::ExprMethodCall) {
+        if MATERIALIZER_METHODS.contains(&node.method.to_string().as_str()) {
+            self.check(node.span());
+        }
+        visit::visit_expr_method_call(self, node);
+    }
+
+    fn visit_expr_macro(&mut self, node: &'ast syn::ExprMacro) {
+        let name = node
+            .mac
+            .path
+            .segments
+            .last()
+            .map(|s| s.ident.to_string())
+            .unwrap_or_default();
+        if ROUTED_MACROS.contains(&name.as_str()) {
+            // Counted, not just skipped: `sites_examined` has to be stable
+            // under the very work this audit exists to cause. Counting only
+            // *raw* sites would make the number fall every time somebody
+            // routes one, so the anti-vacuity floor below would start
+            // fighting the fix.
+            if self.in_live_optional_fn() {
+                self.sites_examined += 1;
+            }
+            return;
+        }
+        // An unrouted macro can still hide a materialization in its token
+        // stream -- `owned_or_err!(to_owned(&v))` and `push_or_control!(..)`
+        // both do, and both ignore `optional`. syn never parses macro tokens
+        // into expressions, so without this the visitor would walk straight
+        // past exactly the shape this audit exists to catch.
+        let hides_materializer = node.mac.tokens.clone().into_iter().any(|t| {
+            let name = t.to_string();
+            is_materializer_fn(&name) || MATERIALIZER_METHODS.contains(&name.as_str())
+        }) || {
+            // Nested groups (`owned_or_err!(x.map(|v| to_owned(&v)))`) arrive as
+            // a single `Group` token, so fall back to the flattened text for
+            // those -- `to_string()` on the whole stream inserts spaces around
+            // punctuation, so match on whitespace-delimited words.
+            let flat = node.mac.tokens.to_string();
+            flat.split(|c: char| !(c.is_alphanumeric() || c == '_'))
+                .any(|w| is_materializer_fn(w) || MATERIALIZER_METHODS.contains(&w))
+        };
+        if hides_materializer {
+            self.check(node.span());
+        }
+        visit::visit_expr_macro(self, node);
+    }
+}
+
+#[test]
+fn test_every_optional_materialization_site_is_routed_or_exempt_2334() {
+    let mut live_optional_fns = 0usize;
+    let mut sites_examined = 0usize;
+    let mut report = String::new();
+    let mut violations = 0usize;
+    let mut offending_files = BTreeSet::new();
+
+    for (path, src) in SOURCES {
+        let file = syn::parse_file(src).unwrap_or_else(|e| panic!("{path}: {e}"));
+        let mut audit = Audit::new(src);
+        audit.visit_file(&file);
+
+        live_optional_fns += audit.live_optional_fns;
+        sites_examined += audit.sites_examined;
+
+        for site in &audit.resolve() {
+            violations += 1;
+            offending_files.insert(*path);
+            let _ = writeln!(
+                report,
+                "  {path}:{} in `{}`\n      {}",
+                site.line, site.func, site.snippet
+            );
+        }
+    }
+
+    assert!(
+        report.is_empty(),
+        "STYLE-0012 violation: {violations} raw materialization site(s) in \
+         {} file(s), inside a function \
+         with a live `optional: bool`, neither routed through the suppression \
+         machinery nor exempted.\n\n{report}\nResolve each one either by:\n  \
+         (a) routing it -- `to_owned_or_suppress!`/`to_owned_vec_or_suppress!` \
+         (eval.rs), `owned_or_suppress!` (eval_generic.rs), or a hand-rolled \
+         `Err(e) => return suppress_or_raise(e, optional)`; or\n  \
+         (b) marking it `// STYLE-0012: <why this site must raise regardless of \
+         optional>` on the line itself, or anywhere in the comment block \
+         attached directly above it.\n\n\
+         See docs/STYLE_GUIDE.md STYLE-0012 and issue #2334. This is not a \
+         behaviour change either way today -- see this file's own header for \
+         why that is exactly the reason the check has to be static.",
+        offending_files.len(),
+    );
+
+    assert!(
+        live_optional_fns >= MIN_LIVE_OPTIONAL_FNS,
+        "audit went vacuous: only {live_optional_fns} functions with a live \
+         `optional: bool` were found across {} file(s), expected at least \
+         {MIN_LIVE_OPTIONAL_FNS}. The visitor has probably stopped seeing the \
+         evaluators (a moved module, a renamed parameter, a syn upgrade) -- \
+         fix the scan, do not lower the bound.",
+        SOURCES.len(),
+    );
+    assert!(
+        sites_examined >= MIN_SITES_EXAMINED,
+        "audit went vacuous: only {sites_examined} materialization call sites \
+         were examined, expected at least {MIN_SITES_EXAMINED}. See the \
+         `live_optional_fns` assertion above for what usually causes this.",
+    );
+}
+
+/// The two exemption spellings, pinned so a refactor cannot quietly turn either
+/// into a no-op.
+///
+/// `builtin_recurse_f`/`builtin_recurse_cond` (#1953) must stay invisible to
+/// the audit through `_optional`, and `eval_array_construction` (#2327's own
+/// investigated-and-declined candidate) must stay *visible* and carry a
+/// `// STYLE-0012:` marker. If the first ever gains a live `optional`, or the
+/// second loses its marker, the main test above should start reporting it --
+/// this test fails first, with a message saying which assumption moved.
+#[test]
+fn test_style_0012_exemption_spellings_are_still_in_use_2334() {
+    let eval_rs = SOURCES[0].1;
+
+    assert!(
+        eval_rs.contains("fn builtin_recurse_f"),
+        "builtin_recurse_f was renamed or removed; re-check the #1953 exemption",
+    );
+    for f in ["builtin_recurse_f", "builtin_recurse_cond"] {
+        let body = &eval_rs[eval_rs.find(&format!("fn {f}")).expect(f)..];
+        let sig_end = body.find(" {").expect("signature");
+        assert!(
+            body[..sig_end].contains("_optional: bool"),
+            "{f} no longer spells its parameter `_optional`. That spelling is \
+             its #1953 exemption and the only thing keeping it out of the \
+             STYLE-0012 audit -- either restore it or give the function's \
+             `to_owned` sites explicit `// STYLE-0012:` markers.",
+        );
+    }
+
+    assert!(
+        eval_rs.contains(EXEMPT_MARKER),
+        "no `// {EXEMPT_MARKER}` marker left in eval.rs -- the exemption \
+         convention has been removed without removing the audit",
+    );
+}

--- a/tests/jq_optional_suppression_audit.rs
+++ b/tests/jq_optional_suppression_audit.rs
@@ -77,6 +77,12 @@ const MATERIALIZER_FN_PREFIX: &str = "to_owned";
 ///   infallible (they return `OwnedValue`, not `Result`), so there is no error
 ///   for `optional` to suppress or raise. `to_owned_for_diagnostic` is the one
 ///   sanctioned lossy materialization left in `eval_generic.rs` (#1247).
+/// - `to_owned_value` is `AnchorResolved`'s own infallible accessor
+///   (`eval.rs`'s `resolve_plain(..).to_owned_value(text)`,
+///   `eval_generic.rs`'s `resolved.to_owned_value(text)`) -- an anchor helper
+///   that shares the prefix and nothing else. It is a *method*, so the call
+///   visitor never sees it; the macro token scan below matches on bare words
+///   and would, so it is excluded here (#2334 review).
 /// - `to_owned_checked` is the #2299 sibling of `to_owned` that swaps
 ///   `assert_nesting_depth`'s panic for a *catchable* `check_nesting_depth`
 ///   error -- the one member of the family that genuinely can raise a
@@ -91,6 +97,7 @@ const MATERIALIZER_FN_EXCLUSIONS: &[&str] = &[
     "to_owned_for_diagnostic",
     "to_owned_checked",
     "to_owned_checked_at_depth",
+    "to_owned_value",
 ];
 
 fn is_materializer_fn(name: &str) -> bool {
@@ -170,11 +177,16 @@ fn marker_in_attached_comment_block(lines: &[&str], idx: usize, body_start: usiz
 /// renamed helper or a refactor that moves the code out from under the visitor
 /// leaves it passing green while checking nothing.
 ///
-/// Today's counts are 381 functions and 148 call sites. These floors sit well
-/// below that -- low enough not to churn on ordinary edits, high enough that a
-/// scan which has stopped seeing the evaluators cannot pass.
-const MIN_LIVE_OPTIONAL_FNS: usize = 250;
-const MIN_SITES_EXAMINED: usize = 100;
+/// Today's counts are 380 functions and 149 call sites. The floors are ~90% of
+/// that (#2334 review tightened them from 250/100, which left enough headroom
+/// that a change halving the visitor's reach would still have passed): close
+/// enough to catch a scan that has lost a whole file or a whole node kind,
+/// loose enough that ordinary churn -- a handful of functions gaining or
+/// losing the parameter -- does not touch them. If a legitimate refactor
+/// lowers the real count past a floor, move the floor *and* say in the commit
+/// message what shrank; do not lower it to make a red test green.
+const MIN_LIVE_OPTIONAL_FNS: usize = 340;
+const MIN_SITES_EXAMINED: usize = 134;
 
 struct Site {
     line: usize,
@@ -211,6 +223,9 @@ struct Audit<'a> {
     stack: Vec<Frame>,
     live_optional_fns: usize,
     sites_examined: usize,
+    /// Functions spelling the parameter `_optional` -- the exemption marker --
+    /// while still reading it. See [`binds_live_optional`]'s doc comment.
+    dishonest_underscore_fns: Vec<String>,
     /// Every raw site, resolved in a second pass -- see [`Audit::resolve`].
     candidates: Vec<Site>,
 }
@@ -222,6 +237,7 @@ impl<'a> Audit<'a> {
             stack: Vec::new(),
             live_optional_fns: 0,
             sites_examined: 0,
+            dishonest_underscore_fns: Vec::new(),
             candidates: Vec::new(),
         }
     }
@@ -231,7 +247,15 @@ impl<'a> Audit<'a> {
     }
 
     fn push_fn(&mut self, sig: &syn::Signature, body: &syn::Block) {
-        let live_optional = binds_live_optional(sig);
+        // A function that spells the parameter `_optional` but reads it anyway
+        // is claiming an exemption it does not have. Audit it as live *and*
+        // report the spelling, so the fix is to rename rather than to bolt a
+        // marker onto every site (#2334 review).
+        let dishonest = binds_underscored_optional(sig) && body_reads_ident(body, "_optional");
+        if dishonest {
+            self.dishonest_underscore_fns.push(sig.ident.to_string());
+        }
+        let live_optional = binds_live_optional(sig) || dishonest;
         if live_optional {
             self.live_optional_fns += 1;
         }
@@ -314,12 +338,27 @@ impl<'a> Audit<'a> {
 /// Whether `sig` binds an `optional: bool` the body can actually read.
 ///
 /// `_optional: bool` does not count: an underscore-prefixed parameter is the
-/// codebase's existing, *compiler-enforced* marker for "this function ignores
-/// `optional` on purpose" -- `builtin_recurse_f`/`builtin_recurse_cond` (#1953)
-/// are spelled that way, and the unused-variable lint keeps the spelling honest
-/// in a way no comment can. STYLE-0012 names it as the preferred marker when
-/// the whole parameter is dead.
+/// codebase's existing marker for "this function ignores `optional` on
+/// purpose" -- `builtin_recurse_f`/`builtin_recurse_cond` (#1953) are spelled
+/// that way. STYLE-0012 names it as the preferred marker when the whole
+/// parameter is dead.
+///
+/// The unused-variable lint keeps that spelling *mostly* honest, but only
+/// mostly: it fires on an unused binding, never on an underscored one that is
+/// used. So a function could spell the parameter `_optional`, read it anyway,
+/// and silently take its whole body out of this audit with nothing complaining
+/// (#2334 review). [`binds_underscored_optional`] plus [`body_reads_ident`]
+/// close that: the main test reports any function that does both.
 fn binds_live_optional(sig: &syn::Signature) -> bool {
+    binds_optional_named(sig, "optional")
+}
+
+/// The `_optional` spelling of the same parameter -- the exemption marker.
+fn binds_underscored_optional(sig: &syn::Signature) -> bool {
+    binds_optional_named(sig, "_optional")
+}
+
+fn binds_optional_named(sig: &syn::Signature, want: &str) -> bool {
     sig.inputs.iter().any(|arg| {
         let syn::FnArg::Typed(pat) = arg else {
             return false;
@@ -327,17 +366,61 @@ fn binds_live_optional(sig: &syn::Signature) -> bool {
         let syn::Pat::Ident(ident) = &*pat.pat else {
             return false;
         };
-        if ident.ident != "optional" {
+        if ident.ident != want {
             return false;
         }
         matches!(&*pat.ty, syn::Type::Path(p) if p.path.is_ident("bool"))
     })
 }
 
+/// Whether `body` reads `name` anywhere -- as a value, or inside a macro's
+/// token stream (which `syn` never parses into expressions, so the visitor
+/// below has to check the raw tokens too).
+fn body_reads_ident(body: &syn::Block, name: &str) -> bool {
+    struct Reads<'a> {
+        name: &'a str,
+        found: bool,
+    }
+    impl<'ast> Visit<'ast> for Reads<'_> {
+        fn visit_expr_path(&mut self, node: &'ast syn::ExprPath) {
+            if node.path.is_ident(self.name) {
+                self.found = true;
+            }
+            visit::visit_expr_path(self, node);
+        }
+        fn visit_macro(&mut self, node: &'ast syn::Macro) {
+            let flat = node.tokens.to_string();
+            if flat
+                .split(|c: char| !(c.is_alphanumeric() || c == '_'))
+                .any(|w| w == self.name)
+            {
+                self.found = true;
+            }
+            visit::visit_macro(self, node);
+        }
+    }
+    let mut v = Reads { name, found: false };
+    v.visit_block(body);
+    v.found
+}
+
+/// Whether the item is `#[cfg(test)]`-gated, and so legitimately outside the
+/// audit: unit tests call the materializers directly with hand-picked
+/// `optional` values.
+///
+/// `not(test)` is explicitly *not* this: an item compiled only in non-test
+/// builds is ordinary production code, and skipping it would be a silent hole
+/// exactly the shape this audit exists to close (#2334 review). Neither file
+/// has one today; the check is here so that adding one is not a quiet
+/// exemption.
 fn has_cfg_test(attrs: &[syn::Attribute]) -> bool {
-    attrs
-        .iter()
-        .any(|a| a.path().is_ident("cfg") && a.to_token_stream_string().contains("test"))
+    attrs.iter().any(|a| {
+        if !a.path().is_ident("cfg") {
+            return false;
+        }
+        let tokens = a.to_token_stream_string();
+        tokens.contains("test") && !tokens.replace(' ', "").contains("not(test)")
+    })
 }
 
 /// `syn::Attribute` has no direct "render me" method that keeps working across
@@ -460,6 +543,7 @@ fn test_every_optional_materialization_site_is_routed_or_exempt_2334() {
     let mut report = String::new();
     let mut violations = 0usize;
     let mut offending_files = BTreeSet::new();
+    let mut dishonest: Vec<String> = Vec::new();
 
     for (path, src) in SOURCES {
         let file = syn::parse_file(src).unwrap_or_else(|e| panic!("{path}: {e}"));
@@ -468,6 +552,12 @@ fn test_every_optional_materialization_site_is_routed_or_exempt_2334() {
 
         live_optional_fns += audit.live_optional_fns;
         sites_examined += audit.sites_examined;
+        dishonest.extend(
+            audit
+                .dishonest_underscore_fns
+                .iter()
+                .map(|f| format!("{path}: {f}")),
+        );
 
         for site in &audit.resolve() {
             violations += 1;
@@ -496,6 +586,18 @@ fn test_every_optional_materialization_site_is_routed_or_exempt_2334() {
          behaviour change either way today -- see this file's own header for \
          why that is exactly the reason the check has to be static.",
         offending_files.len(),
+    );
+
+    assert!(
+        dishonest.is_empty(),
+        "STYLE-0012: {} function(s) spell the parameter `_optional` -- the \
+         exemption marker that takes the whole function out of this audit -- \
+         and then read it anyway:\n  {}\n\nThe unused-variable lint cannot \
+         catch that: it fires on an unused binding, never on an underscored \
+         one that is used. Rename the parameter to `optional` (and route or \
+         mark its materialization sites), or stop reading it.",
+        dishonest.len(),
+        dishonest.join("\n  "),
     );
 
     assert!(


### PR DESCRIPTION
Closes #2334.

## Why the previous three rounds didn't stick

#2334 asked for a structural fix rather than a fourth sweep. Before designing one I
checked *why* #2231 → #2280 → #2327 each left sites behind, and the answer changes the
shape of the fix:

**The invariant is unobservable at runtime.** `eval::suppresses` is
`optional && !e.is_decode_failure()`, and every error the materialization family can raise
is `decode_failure`-tagged — `to_owned`/`to_owned_at_depth`, `to_owned_cursor_at_depth`,
`to_owned_with_cursor`, `collect_cursors_checked`, `colliding_display_key`, and the
`malformed_delimiter/member/element_error` trio, the last of which #2286 retagged via
`EvalError::malformed_json_text`. So `suppresses` is **always false** at every one of these
sites, and routing a call site or leaving it bare produce byte-identical output.

That means no behavioural test can fail when a site is missed. #2327's own pinning test,
`test_optional_ignored_sites_2327`, asserts exit 5 *both* with and without a trailing `?` —
it records the non-difference and by construction cannot detect the invariant regressing.
Centralising the *check* didn't stop the *omission* because nothing forced a call site
through it, and a missed site cost nothing until an auditor happened to read that exact
function.

So the guard has to be static. #2025 (`tests/jq_owned_only_sink_invariant_test.rs`) already
established the pattern here for a hand-derived claim that only review was keeping true.

## What this adds

**Static — `tests/jq_optional_suppression_audit.rs`.** Parses both evaluators with `syn`
and fails, naming `file:line` and the enclosing function, on any raw materialization inside
a function binding a live `optional: bool` that is neither routed nor carrying a
`// STYLE-0012:` citation. Notably it also sees sites hidden inside `owned_or_err!` /
`push_or_control!` token streams — syn never parses macro bodies, and that is exactly the
shape of #2327's worst miss, where 7 of its 8 second-round sites were one evaluator's copy
of a fix the other had received. Scanning both files means a missed site fails the same
gate regardless of what its same-named twin does, with no fragile name-pairing between the
files (this subsumes the "cross-evaluator diffing" direction the issue floated).

**Runtime — `EvalError::debug_assert_materialization_error`.** Called at the family's four
depth-0 entry points, it pins the premise the whole audit rests on. The day a suppressible
error kind enters one of these walks, the routed/unrouted distinction starts changing
output at every site at once; this makes that a loud debug-build failure instead of a
silent one. **It fired zero times across 7,314 tests.**

**73 sites adjudicated**, each routed or marked with a specific reason. Routed where the
builtin's own result value is materialized (`add`, `map_values`, `last`, `to_entries`,
`from_entries`, `with_entries`, `shuffle`, `pivot`, `bsearch`, the
`indices`/`index`/`rindex` family, string interpolation, `each_paths_filter`,
`collect_rhs_outputs`, and `eval_generic.rs`'s
`Expr::Iterate`/`Expr::Pipe`/`Shuffle`/`Pivot`/`ToEntries` arms). Marked, with the reason
recorded inline, where it must not consult `optional`:

- array construction is atomic in jq — `eval_array_construction` (#2327's own
  investigated-and-declined candidate), `map_over`, and `eval_generic`'s `Expr::Array`;
- key generators are evaluated at a hardcoded `optional: false`, so `.[k]?` never
  suppresses an error raised computing `k` — captured from pinned jq 1.7.1:
  `.[error("boom")]?` exits 5, while `.[.k]?` on a non-string `.k` exits 0 (that row is the
  *index step* being suppressed, which is what `?` is for, and says nothing about the key
  generator);
- a `Partial`'s prefix must survive, so its `Control::Error` is suppressed at the
  `eval_try` boundary rather than at the conversion;
- several sites are already routed one level out — `finish_fork` (#1902), `fanout_arg`'s
  deferred unwrap (#1800).

Also folded in: four hand-copies of `optional && !e.is_decode_failure()` now call the
shared `suppresses` — the same drift its own doc comment records happening twice already
(#1902, #1934).

**No behaviour change.** Every path involved is decode-failure-tagged, and a
`debug_assert!(!optional)` probe over the whole suite re-confirmed #693's claim that
`eval_generic`'s native arms never see `optional = true` from any parser-driven query —
1,396 CLI tests, zero hits; only three white-box unit tests that hardcode it, one already
named `..._is_unreachable_via_parser_725`.

The convention is written down as **STYLE-0012**, modelled on STYLE-0004's "every lint
suppression must be traceable to a documented reason". When the whole parameter is dead the
preferred marker stays `_optional` — how `builtin_recurse_f`/`builtin_recurse_cond` record
their #1953 exemption, and why they never appear in the audit. The audit verifies that
spelling is honest rather than trusting it (see finding 3 below).

## The gate was green for the wrong reason twice

I negative-tested it four ways — un-route a routed site, delete a marker, add a brand-new
unrouted site, hide a site inside a macro — and **two passed on the first attempt**. Both
were the same defect: a proximity window reaching into code that wasn't the site's own.

- It ran off the end of the enclosing function and matched a `suppresses(..)` belonging to
  the **next** function, so a freshly added unrouted helper sailed through.
- Within one function it matched evidence belonging to a **later sibling site**, so
  deleting one of four sibling markers sailed through.

Both windows are now clipped — to the enclosing function's body span and to the next
materialization site — and all four negatives go red. The "before" direction dropped its
line budget entirely in favour of "the contiguous comment block attached above this line",
which has no magic number and cannot borrow a neighbour's comment. The anti-vacuity
counter counts routed macro sites too, so it stays stable under the very work the gate
demands rather than sagging as people fix things.

## Self-review found three defects in the above; all are fixed here

The last commit is a review pass on the rest, and it is worth reading — two of its findings
were mine to make and I got them wrong:

1. **`sort_family_control` was routed to the wrong channel.** An earlier commit here added
   `suppresses(&e, optional)` to it on the claim that `key_elements_generic`'s
   `to_owned_cursor` was its "only error channel". It is not — `sort_key_generic` funnels
   through it too, carrying whatever the *user's key filter* raised (`sort_by(error("x"))`).
   So the arm was a no-op in the direction intended (`to_owned_cursor` raises only decode
   failures) and live in the direction it wasn't: a key-filter error is exactly the
   suppressible kind, and would have vanished the day `optional` reached there. Reverted;
   `key_elements_generic` now carries a marker saying why routing there is wrong.
2. **A jq oracle citation stated the opposite of the truth.** Two markers cited
   `jq '.[.k]?'` on a non-string `.k` as "still exits 5". It exits **0**. That was asserted
   from inference rather than captured from the pinned binary — precisely what ADR-0018
   forbids. The rule the comment states is right; its witness is now `.[error("boom")]?`
   (exit 5), captured and recorded in both files.
3. **`_optional` is not compiler-enforced.** The unused-variable lint fires on an unused
   binding, never on an underscored one that is *used* — so a function could spell it
   `_optional`, read it anyway, and silently leave the audit. The audit now detects that
   (via expression paths *and* macro token streams), treats such a function as live, and
   tells the author to rename rather than to bolt on markers. No function does it today;
   all 22 `_optional` parameters are genuinely dead.

Plus hardening from the same pass: `#[cfg(not(test))]` no longer counts as `#[cfg(test)]`
(production code was being skipped), `AnchorResolved::to_owned_value` is excluded from the
bare-word macro scan, and the vacuity floors tightened from 250/100 to 340/134 against
today's 380/149 — the old ones left enough slack that halving the visitor's reach would
still have passed.

## It has already caught something

Rebasing onto current `main` brought in #2326's new `pending_key_stream_control` arm. The
audit flagged its materialization on first contact with code from an unrelated PR — the
last commit here is that adjudication (comment only; same prefix-preserving reasoning as
the two sibling arms it mirrors).

## Verification

- Full suite green; the runtime tripwire fired nowhere.
- `cargo fmt --check`, both clippy legs from `ci.yml`, `cargo doc` with
  `RUSTDOCFLAGS=-D warnings`, default / `simd` / `--no-default-features` test legs, the
  cli-gated test set, and all three golden sync checks (against pinned jq 1.7.1).
- Patch coverage **90.7%**. The uncovered lines are error arms whose *untouched sibling*
  lines are equally 0-hit in lcov — pre-existing unreachable paths, not new gaps; several
  are lines I merely renamed inside an already-dead arm.

`tests/jq_cli_tests.rs` gains a companion test whose doc comment says plainly that it
**cannot** detect the invariant regressing and is not trying to — it pins behaviour and
covers the routed lines. The guard is the audit.
