### PR TITLE
fix(yq): .[] over a non-container is a silent no-op, not an error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -467,6 +467,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     without a way to tell del() apart from assignment would fix one and regress the
     other.
 
+- **`.[]` (iterate) over a non-container raised in yq mode where real yq silently produces
+  no output** (#2346). Real yq's `.[]` gives zero output — not an error — for *any*
+  non-container target (number, string, bool, `null`), not just `null`, confirmed live
+  against yq v4.53.3 for plain reads, `del()`, and assignment alike (`echo '{"x":5}' | yq
+  -o=json '.x[]'` is empty, exit 0); jq has no such rule, so this is yq-mode only. Fixed at
+  every `Expr::Iterate` site reachable from a plain read (both evaluators' value-only arms),
+  `del()` (`delete_at_path`'s terminal arm and `delete_path_steps`'s mid-chain arm), and a
+  `path()`-style path computation (`eval_stage_with_path_context`, `path_step_generic`);
+  `=`/`|=`'s own `set_path`/`update_path` machinery already had this right. Two adjacent,
+  structurally-similar sites were deliberately left unfixed rather than given the same
+  widening, since a naive copy would be wrong (`map(f)`'s real yq-mode rule is asymmetric,
+  not uniform) or risks a worse regression (`resolve_iterate_bounded`'s `first(f)` gap is
+  also reached by `del()`'s comma-fanout fallback, where the same widening would turn an
+  honest raise into a silently wrong answer) — see
+  `docs/compliance/yq/limitations.md`'s own entry for both, tracked as
+  [#2375](https://github.com/rust-works/succinctly/issues/2375) and
+  [#2376](https://github.com/rust-works/succinctly/issues/2376).
+
 - **`delpaths([[]])` printed the literal `null` instead of emitting nothing in yq mode**
   (#2352, found while implementing #2306). `del(.)` already special-cases "deleted the
   whole document" as no output at all (#1702, real yq's own root-delete rule), but

--- a/docs/compliance/yq/limitations.md
+++ b/docs/compliance/yq/limitations.md
@@ -2133,6 +2133,34 @@ this gap -- only the comma-grouped combination of "suffix after the tolerated `.
 "another sibling in the same call" is affected. Tracked as
 [#2380](https://github.com/rust-works/succinctly/issues/2380).
 
+### `.[]` over a non-container is now a silent no-op — two residual gaps remain (#2346)
+
+Real yq's `.[]` (iterate) produces zero output — not an error — for *any* non-container
+target (number, string, bool, `null`), not just `null`, confirmed live against yq v4.53.3
+for plain reads, `del()`, and assignment alike (`echo '{"x":5}' | yq -o=json '.x[]'` is
+empty, exit 0). jq has no such rule (`.[]` on a scalar always raises there, confirmed
+against jq 1.7.1), so this is yq-mode only — fixed at every `Expr::Iterate` site reachable
+from a plain read, `del()`, or a `path()`-style path computation (#2346). `=`/`|=`'s own
+`set_path`/`update_path` machinery already had this right beforehand.
+
+Two adjacent sites were deliberately left unfixed, since a naive copy of the same widening
+would be wrong (not just incomplete) or risks a worse regression:
+
+- **`map(f)` still raises** when path-tracking is needed inside `f` (`eval_stage_with_path_
+  context`'s own `Expr::Builtin(Builtin::Map(f))` arm) — `map`'s real yq-mode rule is
+  *asymmetric* (`null` -> `[]`, but any other scalar passes through **unchanged**, confirmed
+  live: `5 | map(.+1)` is `5`, not `[]` or empty), not the uniform "always empty" rule `.[]`
+  itself gets. Tracked as [#2375](https://github.com/rust-works/succinctly/issues/2375).
+- **`first(.a[])` on a genuinely-resolved scalar still raises** (`resolve_iterate_bounded`,
+  shared by `resolve_node`'s own `Expr::Iterate` arm and `first`/`limit`'s fast path) —
+  this function is also reached by `resolve_del_path_branches`'s comma-fanout fallback for a
+  declined vivify pre-pass, where an out-of-range index read is a placeholder for a write
+  real yq's own vivify would perform, not a genuinely-resolved scalar; naively widening this
+  function turns an honest raise (`del(.[-1], .[4][])`, a documented, tracked coverage gap)
+  into a silently wrong answer instead (confirmed live: `[1]` instead of real yq's `[1,
+  null, null, []]`). Tracked as
+  [#2376](https://github.com/rust-works/succinctly/issues/2376).
+
 ### Other categories
 
 Float and number formatting ([#1071](https://github.com/rust-works/succinctly/issues/1071),

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -23560,7 +23560,8 @@ fn resolve_iterate_bounded<S: EvalSemantics>(
         // .[4][])` on `[1,2]` reached this arm and produced `[1]`
         // (`.[4][]`'s branch silently vanished) where real yq gives `[1,
         // null, null, []]`. Left as a follow-up (only `first`, real yq
-        // surface, is currently affected) rather than folded into this fix.
+        // surface, is currently affected) rather than folded into this
+        // fix. Tracked as #2376.
         other => Err((
             Vec::new(),
             EvalError::cannot_iterate_with(S::TAG, other).into(),

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -1226,6 +1226,16 @@ fn eval_single<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
         // substitutes `""` into the message and, worse, would still report
         // "cannot iterate" instead of the real reason, even under `?`, where
         // a decode failure must never be suppressed, #1247/#1620).
+        //
+        // #2346: real yq's `.[]` over *any* non-container (not just `null`)
+        // silently produces zero output, confirmed live against yq v4.53.3
+        // for number/string/bool/null, both bare and through `?`/del()/
+        // assignment. jq has no such rule (`.[]` on a scalar always raises
+        // there, confirmed against jq 1.7.1) -- so this widens the existing
+        // `optional`-suppression `scalar_fallback` already does for `.[]?`
+        // into an unconditional one in yq mode, rather than adding a new
+        // arm: a decode failure still raises either way (`scalar_fallback`
+        // checks that first, unconditionally).
         Expr::Iterate => match value {
             StandardJson::Array(elements) => {
                 let results: Vec<_> = elements.collect();
@@ -1242,7 +1252,7 @@ fn eval_single<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
                     .collect();
                 QueryResult::Many(results)
             }
-            _ => scalar_fallback(&value, optional, || {
+            _ => scalar_fallback(&value, optional || S::TAG == EvalTag::Yq, || {
                 EvalError::cannot_iterate_with(S::TAG, &to_owned_lossy(&value))
             }),
         },
@@ -23531,6 +23541,26 @@ fn resolve_iterate_bounded<S: EvalSemantics>(
                 )
             })
             .collect()),
+        // #2346 considered, deliberately NOT fixed here: real yq's `.[]`
+        // over a genuinely-resolved non-container is a silent no-op
+        // (confirmed live: `first(.a[])` on `{"a":5}` is `[]`, not an
+        // error, against yq v4.53.3), but this function is also reached by
+        // `resolve_del_path_branches`'s comma-fanout fallback (any sibling
+        // with a negative index declines the vivify pre-pass and falls
+        // through to this read-only path-computation machinery, which has
+        // no way to extend/vivify an array the way `delete_at_path`'s own
+        // `real_slot`-gated rule does) -- an out-of-range index read
+        // reaching this arm there is not a genuinely-resolved scalar, it's
+        // a placeholder for a write real yq's own vivify would perform, and
+        // this function has no way to tell the two apart (no `real_slot`
+        // equivalent, unlike `delete_at_path`/`delete_path_steps`).
+        // Silently returning zero branches for that shape regresses an
+        // honest "Cannot iterate" (a documented, tracked coverage gap) into
+        // a silently wrong answer instead -- confirmed live: `del(.[-1],
+        // .[4][])` on `[1,2]` reached this arm and produced `[1]`
+        // (`.[4][]`'s branch silently vanished) where real yq gives `[1,
+        // null, null, []]`. Left as a follow-up (only `first`, real yq
+        // surface, is currently affected) rather than folded into this fix.
         other => Err((
             Vec::new(),
             EvalError::cannot_iterate_with(S::TAG, other).into(),
@@ -33514,10 +33544,15 @@ fn eval_stage_with_path_context<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
                     }
                 }
                 // #2212: `optional` is this arm's own ambient parameter, not
-                // `iterate_element_step`'s per-element `false` above --
-                // currently unreachable with `optional == true`, same
-                // evidence as `catch_error_under_optional`'s doc comment.
-                _ if optional => return QueryResult::None,
+                // `iterate_element_step`'s per-element `false` above -- the
+                // `optional` half is currently unreachable with `optional ==
+                // true`, same evidence as `catch_error_under_optional`'s doc
+                // comment; the `S::TAG == EvalTag::Yq` half is live, though
+                // (#2346: real yq's `.[]` over any non-container is a
+                // silent no-op, not just under `?` -- see the sibling fix
+                // on this file's other `Expr::Iterate` arm for the full
+                // live-oracle evidence).
+                _ if optional || S::TAG == EvalTag::Yq => return QueryResult::None,
                 _ => return QueryResult::Error(EvalError::cannot_iterate_with(S::TAG, value)),
             }
             match stopped {
@@ -38784,7 +38819,17 @@ fn delete_at_path(
                 // (#527), so this arm must stay yq-only rather than becoming
                 // unconditional the way `Index`'s is.
                 OwnedValue::Null if yq_mode => Ok(()),
-                _ if optional => Ok(()),
+                // #2346: real yq's `.[]` over any *other* non-container is
+                // also a silent no-op, `del()` included -- confirmed live,
+                // `del(.[])` on `5` stays `5` against yq v4.53.3. jq has no
+                // such rule (`del(.[])` on a scalar always raises there),
+                // so this stays yq-mode only, same as every other
+                // `is_yq_field_index_noop_scalar` site in this function.
+                // `is_yq_field_index_noop_scalar` itself excludes `Null`
+                // (the sibling arm above already covers it, with its own
+                // narrower `real_slot`-independent rationale), so the two
+                // arms never overlap.
+                _ if optional || (yq_mode && is_yq_field_index_noop_scalar(root)) => Ok(()),
                 _ => Err(EvalError::cannot_iterate_with(
                     if yq_mode { EvalTag::Yq } else { EvalTag::Jq },
                     root,
@@ -39304,7 +39349,14 @@ fn delete_path_steps(
                     // so this stays gated on `yq_mode` rather than becoming
                     // the unconditional `here`-only exemption below.
                     OwnedValue::Null if yq_mode => Ok(()),
-                    _ if here => Ok(()),
+                    // #2346: same yq-mode scalar no-op as `delete_at_path`'s
+                    // own terminal `Expr::Iterate` arm, for any *other*
+                    // non-container -- confirmed live, `del(.a[])` and
+                    // `del(.a[].b)` on `{"a":5}` both stay unchanged against
+                    // yq v4.53.3. `is_yq_field_index_noop_scalar` excludes
+                    // `Null` (the sibling arm above already covers it), so
+                    // the two arms never overlap.
+                    _ if here || (yq_mode && is_yq_field_index_noop_scalar(root)) => Ok(()),
                     _ => Err(EvalError::cannot_iterate_with(
                         if yq_mode { EvalTag::Yq } else { EvalTag::Jq },
                         root,

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -9871,8 +9871,15 @@ fn path_step_generic<S: EvalSemantics, V: DocumentValue>(
             Ok(())
         }
         Expr::Iterate => match node {
-            // `null` and a missing node are not iterable, matching
-            // `path(.[])` on `null` raising rather than yielding nothing.
+            // #2346: real yq's `.[]` over any non-container -- including a
+            // missing/null node here -- is a silent no-op (confirmed live
+            // against yq v4.53.3), matching every other `Expr::Iterate`
+            // site this issue fixed. jq keeps raising (`path(.[])` on
+            // `null` still errors there), so this stays gated on `S::TAG`
+            // -- the arm below is then only ever reached in jq mode, which
+            // is why it can keep hardcoding `EvalTag::Jq` rather than
+            // consulting `S::TAG` itself.
+            PathNode::Absent if S::TAG == EvalTag::Yq => Ok(()),
             PathNode::Absent => Err(EvalError::cannot_iterate_with(
                 EvalTag::Jq,
                 &OwnedValue::Null,
@@ -9912,6 +9919,19 @@ fn path_step_generic<S: EvalSemantics, V: DocumentValue>(
                             PathNode::At(ec),
                         ));
                     }
+                    Ok(())
+                } else if let Some(reason) = v.string_decode_error() {
+                    // #1247/#1620: an undecodable-string scalar must raise
+                    // its own decode failure unconditionally, never
+                    // suppressed by the yq-mode no-op below -- same
+                    // priority order as `scalar_fallback`/
+                    // `decode_failure_or` elsewhere in this fix.
+                    Err(EvalError::decode_failure(reason))
+                } else if S::TAG == EvalTag::Yq {
+                    // #2346: see this arm's `PathNode::Absent` sibling
+                    // above for the full live-oracle evidence -- a
+                    // genuinely-resolved non-container scalar gets the
+                    // same silent no-op here.
                     Ok(())
                 } else {
                     // `to_owned_cursor`, not `to_owned`: only the cursor

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -5358,7 +5358,15 @@ fn eval_single<S: EvalSemantics, V: DocumentValue>(
                     Err(err) => GenericResult::Error(err),
                 }
             } else {
-                decode_failure_or(&value, optional, || {
+                // #2346: real yq's `.[]` over any non-container (not just
+                // `null`) is a silent no-op, confirmed live against yq
+                // v4.53.3 -- see `eval.rs`'s identical fix on its own
+                // `Expr::Iterate` arm for the full live-oracle evidence.
+                // `decode_failure_or`'s own `optional` parameter already
+                // has exactly this "suppress unconditionally" shape, so
+                // widening it covers this without a new branch -- a decode
+                // failure still raises either way, checked first.
+                decode_failure_or(&value, optional || S::TAG == EvalTag::Yq, || {
                     GenericResult::Error(EvalError::cannot_iterate_with(
                         S::TAG,
                         &to_owned_for_diagnostic(&value, cursor),

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -9926,6 +9926,22 @@ fn path_step_generic<S: EvalSemantics, V: DocumentValue>(
                     // suppressed by the yq-mode no-op below -- same
                     // priority order as `scalar_fallback`/
                     // `decode_failure_or` elsewhere in this fix.
+                    //
+                    // Currently unreachable via this function's only caller
+                    // (`Builtin::Path`, `eval_generic.rs`): confirmed via a
+                    // temporary debug probe that `path_step_generic` is
+                    // never even entered for a document containing an
+                    // undecodable scalar, because that caller's own
+                    // `push_generic_truthiness_cursor_error` pre-walk
+                    // (#1755/#1953's "validity gate", a whole-*document*
+                    // check run before any cursor walk) already raises the
+                    // identical `decode_failure` first, regardless of
+                    // whether the query's own path ever touches that
+                    // scalar. Kept anyway, matching the equivalent
+                    // defensive arm in `decode_failure_or`/`scalar_fallback`
+                    // elsewhere in this fix -- correct if a future caller of
+                    // this function ever reaches it without that same
+                    // upfront gate.
                     Err(EvalError::decode_failure(reason))
                 } else if S::TAG == EvalTag::Yq {
                     // #2346: see this arm's `PathNode::Absent` sibling

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -25589,9 +25589,12 @@ fn test_yq_error_value_preview_matches_tostring_number_literal_spelling_1055() -
 /// constructor in yq mode at all. `map(key)` still does -- the path-context
 /// evaluator's own `Expr::Builtin(Builtin::Map(f))` arm (distinct from the
 /// value-only evaluator's `builtin_map`, which #2346 left alone since it
-/// was already yq-gated) has no such gate, a known, narrower, adjacent gap
-/// left open rather than folded into #2346's own scope -- see that arm's
-/// call site for the tracking issue.
+/// was already yq-gated) has no such gate. Deliberately not folded into
+/// #2346's own scope: `map`'s real yq-mode rule is asymmetric (`null` ->
+/// `[]`, any other scalar -> unchanged passthrough, confirmed live), not
+/// the uniform "always empty" rule `.[]` itself gets, so copying #2346's
+/// own widening onto this arm would be wrong, not just incomplete. Tracked
+/// as #2375.
 #[test]
 fn test_yq_cannot_iterate_preview_matches_tostring_number_literal_spelling_1055() -> Result<()> {
     let cases: &[&str] = &["1e2", "1E5", "1.5e-10"];

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -30469,15 +30469,21 @@ fn test_jq_del_iterate_non_container_still_raises_2346() -> Result<()> {
 }
 
 /// #2346's jq-mode control for `delete_path_steps`'s own *mid-chain*
-/// `Expr::Iterate` arm specifically (`del(.a[])`, not the terminal
-/// `del(.[])` above, which instead reaches `delete_at_path`) -- this fix's
-/// own new yq-mode no-op arm sits ahead of that function's final `_ =>
-/// Err(...)` catch-all, so a jq-mode-only repro is needed to keep the
-/// catch-all itself covered (it's otherwise unreachable in yq mode now,
-/// #2346's review round found this exact line lost coverage without it).
+/// `Expr::Iterate` arm specifically. `del(.a[])` alone -- a trailing
+/// iterate with nothing after it -- turns out to still resolve through
+/// `delete_at_path` (the `[last] => delete_at_path(...)` case one loop
+/// iteration up), same as the terminal `del(.[])` control above; only a
+/// *genuinely* mid-chain shape like `del(.a[].b)` (iterate followed by
+/// more path) ever reaches this function's own inline `Expr::Iterate`
+/// match arm at all (confirmed via a temporary debug probe: `del(.a[])`
+/// never printed it, `del(.a[].b)` did). This fix's own new yq-mode no-op
+/// arm sits ahead of that arm's final `_ => Err(...)` catch-all, so a
+/// jq-mode-only repro is needed to keep the catch-all itself covered (it's
+/// otherwise unreachable in yq mode now, #2346's review round found this
+/// exact line lost coverage without it).
 #[test]
 fn test_jq_del_iterate_mid_chain_non_container_still_raises_2346() -> Result<()> {
-    let (out, stderr, code) = run_jq_stdin_with_stderr("del(.a[])", r#"{"a":5}"#, &["-c"])?;
+    let (out, stderr, code) = run_jq_stdin_with_stderr("del(.a[].b)", r#"{"a":5}"#, &["-c"])?;
     assert_ne!(code, 0, "out: {out:?}");
     assert!(stderr.contains("Cannot iterate over number"), "{stderr}");
     Ok(())
@@ -30501,5 +30507,31 @@ fn test_yq_iterate_path_context_non_container_is_noop_2346() -> Result<()> {
     )?;
     assert_eq!(code, 0, "out: {out:?}");
     assert_eq!(out, "");
+    Ok(())
+}
+
+/// #2346, `path_step_generic`: a distinct third `Expr::Iterate` site from
+/// the two above, backing `path(expr)`'s own cursor-native path-computation
+/// walk. `path` is a jq-only builtin succinctly does not gate behind
+/// `--jq-extensions` in yq mode (a separate, pre-existing gap, unrelated to
+/// this fix) -- reachable here without any extension flag.
+#[test]
+fn test_yq_path_step_generic_non_container_is_noop_2346() -> Result<()> {
+    let (out, code) = run_yq_stdin("[path(.a[])]", "a: 5\n", &["-o", "json"])?;
+    assert_eq!(code, 0, "out: {out:?}");
+    assert_eq!(out.trim(), "[]");
+    Ok(())
+}
+
+/// #2346, `path_step_generic`'s decode-failure priority: an undecodable
+/// string scalar reaching this arm must still raise its own decode
+/// failure, never suppressed by the yq-mode no-op just added above --
+/// same `\q` invalid-escape repro `test_decode_failure_not_suppressed_by_
+/// optional_1620` uses elsewhere in this file.
+#[test]
+fn test_yq_path_step_generic_decode_failure_not_suppressed_2346() -> Result<()> {
+    let (out, stderr, code) = run_yq_stdin_with_stderr("[path(.a[])]", "a: \"x\\qy\"\n", &[])?;
+    assert_ne!(code, 0, "out: {out:?}");
+    assert!(stderr.contains("invalid escape sequence"), "{stderr}");
     Ok(())
 }

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -30468,6 +30468,21 @@ fn test_jq_del_iterate_non_container_still_raises_2346() -> Result<()> {
     Ok(())
 }
 
+/// #2346's jq-mode control for `delete_path_steps`'s own *mid-chain*
+/// `Expr::Iterate` arm specifically (`del(.a[])`, not the terminal
+/// `del(.[])` above, which instead reaches `delete_at_path`) -- this fix's
+/// own new yq-mode no-op arm sits ahead of that function's final `_ =>
+/// Err(...)` catch-all, so a jq-mode-only repro is needed to keep the
+/// catch-all itself covered (it's otherwise unreachable in yq mode now,
+/// #2346's review round found this exact line lost coverage without it).
+#[test]
+fn test_jq_del_iterate_mid_chain_non_container_still_raises_2346() -> Result<()> {
+    let (out, stderr, code) = run_jq_stdin_with_stderr("del(.a[])", r#"{"a":5}"#, &["-c"])?;
+    assert_ne!(code, 0, "out: {out:?}");
+    assert!(stderr.contains("Cannot iterate over number"), "{stderr}");
+    Ok(())
+}
+
 /// #2346, path-context evaluator: the same yq-mode no-op has to hold when
 /// something downstream forces path-tracking (`needs_path_context`), not
 /// just on the lighter value-only read path above -- `eval_stage_with_path_

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -22321,30 +22321,27 @@ fn test_yq_del_slice_outcome_iterate_prefix_real_container_1432() -> Result<()> 
 }
 
 /// #1432 (coverage, #1863): the same `navigate_read_only` `Iterate` arm's
-/// scalar-hit branch, reached via `del()`. Pinned as *known-divergent* -- a
-/// pre-existing bug unrelated to #1432's own fix (`navigate_read_only`'s
-/// match arms are byte-for-byte unchanged by that PR), found only while
-/// restoring this coverage, not something this PR fixes. Real yq applies
-/// the same #1181/#1232 "a scalar hit anywhere mid-chain permanently
-/// no-ops" rule `=`'s own write path (and `del()`'s slice-prefix handling
-/// elsewhere in this same file) already get right; `del()`'s own
-/// `Iterate`-then-slice path does not, raising instead. Live-verified
-/// against yq v4.53.3; reported as a follow-up on #1863.
+/// scalar-hit branch, reached via `del()`. Was pinned as *known-divergent*
+/// (real yq no-ops; succinctly raised) -- #2346 closes this as part of its
+/// own broader fix: `delete_path_steps`'s mid-chain `Expr::Iterate` arm now
+/// applies the same `is_yq_field_index_noop_scalar` no-op every sibling
+/// `Field`/`Index` arm in this function already had, so a scalar hit ahead
+/// of a chained slice-run is unaffected all the way through, matching real
+/// yq (confirmed live against v4.53.3, `a: 5 | del(.a[].b[0:1])` stays
+/// `{"a":5}`).
 ///
-/// The sibling `Null` case this test used to pin as equally divergent is
-/// fixed by #2323: `delete_path_steps`'s `Expr::Iterate` arm now vivifies a
+/// The sibling `Null` case this test used to pin as equally divergent was
+/// fixed by #2323: `delete_path_steps`'s `Expr::Iterate` arm vivifies a
 /// `null` root into `[]` in yq mode before matching, the same rule
 /// `delete_at_path`'s terminal arms and `setpath`'s own auto-vivify already
-/// apply -- `a: null | del(.a[].b[0:1])` is `{"a":[]}` now, matching real
-/// yq (an empty array has nothing to fan `.b[0:1]` into).
+/// apply -- `a: null | del(.a[].b[0:1])` is `{"a":[]}` (an empty array has
+/// nothing to fan `.b[0:1]` into).
 #[test]
 fn test_yq_del_slice_outcome_iterate_prefix_scalar_and_null_1432() -> Result<()> {
-    // Scalar hit -- real yq no-ops; succinctly raises. Still divergent,
-    // unaffected by #2323 (a scalar `5` is never a `null` to vivify).
-    let (_out, err, code) =
-        run_yq_stdin_with_stderr("del(.a[].b[0:1])", "a: 5\n", &["-o=json", "-I=0"])?;
-    assert_ne!(code, 0);
-    assert!(err.contains("Cannot iterate"), "err={err}");
+    // Scalar hit -- real yq no-ops, and so does succinctly now (#2346).
+    let (out, code) = run_yq_stdin("del(.a[].b[0:1])", "a: 5\n", &["-o=json", "-I=0"])?;
+    assert_eq!(code, 0);
+    assert_eq!(out.trim(), r#"{"a":5}"#);
 
     // `Null` -- real yq autovivifies to `[]` (nothing left to delete),
     // confirmed live; #2323 closes this.
@@ -25585,6 +25582,16 @@ fn test_yq_error_value_preview_matches_tostring_number_literal_spelling_1055() -
 /// constructor (`cannot_iterate`, triggered by iterating a scalar) rather
 /// than `error(v)` directly -- a different call path through the same
 /// `EvalTag`-dispatched core.
+///
+/// #2346 retired plain `.a[]` as a yq-mode `cannot_iterate` trigger: real
+/// yq's own `.[]` over any non-container is a silent no-op (confirmed live
+/// against yq v4.53.3), not an error, so `.a[]` no longer reaches this
+/// constructor in yq mode at all. `map(key)` still does -- the path-context
+/// evaluator's own `Expr::Builtin(Builtin::Map(f))` arm (distinct from the
+/// value-only evaluator's `builtin_map`, which #2346 left alone since it
+/// was already yq-gated) has no such gate, a known, narrower, adjacent gap
+/// left open rather than folded into #2346's own scope -- see that arm's
+/// call site for the tracking issue.
 #[test]
 fn test_yq_cannot_iterate_preview_matches_tostring_number_literal_spelling_1055() -> Result<()> {
     let cases: &[&str] = &["1e2", "1E5", "1.5e-10"];
@@ -25593,7 +25600,7 @@ fn test_yq_cannot_iterate_preview_matches_tostring_number_literal_spelling_1055(
         let (tostring_out, code) = run_yq_stdin(".a | tostring", &input, &[])?;
         assert_eq!(code, 0, "literal={literal} tostring out: {tostring_out:?}");
         let expected = tostring_out.trim();
-        let (_out, stderr, code) = run_yq_stdin_with_stderr(".a[]", &input, &[])?;
+        let (_out, stderr, code) = run_yq_stdin_with_stderr(".a | map(key)", &input, &[])?;
         assert_ne!(code, 0, "literal={literal} unexpectedly iterated a scalar");
         assert!(
             stderr.contains(expected),
@@ -30057,27 +30064,27 @@ fn test_del_comma_fanout_iterate_over_null_unaffected_in_jq_mode_2324() -> Resul
 }
 
 /// #2324: an ordinary plain read of `.[]` over `null` (not a `del()` target
-/// at all) must be entirely unaffected by this fix -- `resolve_node`'s
-/// shared `Expr::Iterate` arm itself was deliberately left untouched, with
-/// the vivify handled by a `del()`-specific pre-pass instead
+/// at all) must be entirely unaffected by *that* fix -- `resolve_node`'s
+/// shared `Expr::Iterate` arm was deliberately left untouched by #2324
+/// itself, with the vivify handled by a `del()`-specific pre-pass instead
 /// (`vivify_del_comma_iterate_targets`, called only from `builtin_del`).
-/// Confirmed live against yq v4.53.3 that `.a[]` and `.[5][]` (an
-/// out-of-range read, not a delete) both still raise outside of `del()`.
+///
+/// #2346 correction: this test's own original claim -- "confirmed live
+/// against yq v4.53.3 that `.a[]` and `.[5][]` both still raise outside of
+/// `del()`" -- was never actually true; re-verified live just now and both
+/// give silent no-op (exit 0, no output), same as every other non-container
+/// `.[]` target (#2346's own broader finding). Updated to assert the
+/// correct behavior rather than continuing to pin a claim that doesn't hold
+/// against the oracle.
 #[test]
 fn test_plain_iterate_over_null_read_unaffected_by_2324() -> Result<()> {
-    let (out, stderr, code) = run_yq_stdin_with_stderr(".a[]", "a: null\n", &["-o=json"])?;
-    assert_ne!(code, 0, "out: {out:?}");
-    assert!(
-        stderr.contains("Cannot iterate over null"),
-        "stderr={stderr}"
-    );
+    let (out, code) = run_yq_stdin(".a[]", "a: null\n", &["-o=json"])?;
+    assert_eq!(code, 0, "out: {out:?}");
+    assert_eq!(out, "");
 
-    let (out, stderr, code) = run_yq_stdin_with_stderr(".[5][]", "[1, 2]\n", &["-o=json"])?;
-    assert_ne!(code, 0, "out: {out:?}");
-    assert!(
-        stderr.contains("Cannot iterate over null"),
-        "stderr={stderr}"
-    );
+    let (out, code) = run_yq_stdin(".[5][]", "[1, 2]\n", &["-o=json"])?;
+    assert_eq!(code, 0, "out: {out:?}");
+    assert_eq!(out, "");
 
     Ok(())
 }
@@ -30345,6 +30352,41 @@ fn test_2347_jq_mode_mid_chain_iterate_unaffected() -> Result<()> {
     Ok(())
 }
 
+/// #2346: real yq's `.[]` over *any* non-container -- not just `null` --
+/// silently produces zero output, confirmed live against yq v4.53.3 for
+/// number/string/bool/null alike (`echo '{"x":5}' | yq -o=json '.x[]'` is
+/// empty, exit 0). jq has no such rule (`.[]` on a scalar always raises
+/// there, confirmed against jq 1.7.1), so this is yq-mode only. Covers the
+/// value-only evaluator's own `Expr::Iterate` arm (`eval.rs`'s
+/// `scalar_fallback` call) and its `eval_generic.rs` CLI-dispatch
+/// counterpart (`decode_failure_or`), both reached by a plain top-level
+/// read with no path-tracking need.
+#[test]
+fn test_yq_iterate_plain_read_non_container_is_noop_2346() -> Result<()> {
+    for (yaml, query) in [
+        ("5\n", "."),
+        ("\"hi\"\n", "."),
+        ("true\n", "."),
+        ("null\n", "."),
+    ] {
+        let (out, code) = run_yq_stdin(&format!("{query}[]"), yaml, &["-o=json"])?;
+        assert_eq!(code, 0, "yaml={yaml:?} out: {out:?}");
+        assert_eq!(out, "", "yaml={yaml:?}");
+    }
+
+    // Nested field access into a scalar, not just the bare root.
+    let (out, code) = run_yq_stdin(".a[]", "a: 5\n", &["-o=json"])?;
+    assert_eq!(code, 0, "out: {out:?}");
+    assert_eq!(out, "");
+
+    // Array/object controls: unaffected, still iterate normally.
+    let (out, code) = run_yq_stdin(".[]", "[1, 2, 3]\n", &["-o=json"])?;
+    assert_eq!(code, 0);
+    assert_eq!(out, "1\n2\n3\n");
+
+    Ok(())
+}
+
 /// Residual gap, not fixed here (tracked as #2380): a comma-grouped
 /// sibling whose own trailing shape is `.[]` *followed by more path* (not
 /// a bare trailing `.[]`) still raises, because
@@ -30362,5 +30404,84 @@ fn test_2347_del_comma_grouped_tolerated_null_iterate_suffix_residual_gap() -> R
         code, 1,
         "residual gap: comma-grouped .[]-then-more-path sibling still errors"
     );
+    Ok(())
+}
+
+/// #2346's jq-mode control: `.[]` over a non-container must keep raising in
+/// `succinctly jq`, unaffected by the yq-mode-only fix above -- confirmed
+/// against jq 1.7.1, `.[]` on a number/`null` both raise "Cannot iterate
+/// over ...".
+#[test]
+fn test_jq_iterate_plain_read_non_container_still_raises_2346() -> Result<()> {
+    for (json, expect) in [
+        ("5", "Cannot iterate over number"),
+        ("null", "Cannot iterate over null"),
+    ] {
+        let (out, stderr, code) = run_jq_stdin_with_stderr(".[]", json, &["-c"])?;
+        assert_ne!(code, 0, "json={json} out: {out:?}");
+        assert!(stderr.contains(expect), "json={json} stderr={stderr}");
+    }
+    Ok(())
+}
+
+/// #2346, `del()` side: real yq's `del(.[])`/mid-chain `del(.a[]...)` over a
+/// non-container target is a silent no-op (the document comes back
+/// unchanged), confirmed live against yq v4.53.3. Covers `delete_at_path`'s
+/// own terminal `Expr::Iterate` arm (bare `del(.[])`) and
+/// `delete_path_steps`'s mid-chain arm (`del(.a[])`, `del(.a[].b)`) --
+/// distinct functions from the plain-read sites above, and from `=`/`|=`'s
+/// own `set_path`/`update_path` machinery, which was already correct
+/// before this fix (confirmed live and left untouched).
+#[test]
+fn test_yq_del_iterate_non_container_is_noop_2346() -> Result<()> {
+    let (out, code) = run_yq_stdin("del(.[])", "5\n", &["-o=json", "-I=0"])?;
+    assert_eq!(code, 0, "out: {out:?}");
+    assert_eq!(out.trim(), "5");
+
+    let (out, code) = run_yq_stdin("del(.a[])", "a: 5\n", &["-o=json", "-I=0"])?;
+    assert_eq!(code, 0, "out: {out:?}");
+    assert_eq!(out.trim(), r#"{"a":5}"#);
+
+    let (out, code) = run_yq_stdin("del(.a[].b)", "a: 5\n", &["-o=json", "-I=0"])?;
+    assert_eq!(code, 0, "out: {out:?}");
+    assert_eq!(out.trim(), r#"{"a":5}"#);
+
+    // Array/object controls: unaffected, `del(.[])` still clears them.
+    let (out, code) = run_yq_stdin("del(.[])", "[1, 2, 3]\n", &["-o=json", "-I=0"])?;
+    assert_eq!(code, 0);
+    assert_eq!(out.trim(), "[]");
+
+    Ok(())
+}
+
+/// #2346's jq-mode control for the `del()` side: `del(.[])` over a
+/// non-container must keep raising in `succinctly jq`, matching jq 1.7.1
+/// (confirmed live).
+#[test]
+fn test_jq_del_iterate_non_container_still_raises_2346() -> Result<()> {
+    let (out, stderr, code) = run_jq_stdin_with_stderr("del(.[])", "5", &["-c"])?;
+    assert_ne!(code, 0, "out: {out:?}");
+    assert!(stderr.contains("Cannot iterate over number"), "{stderr}");
+    Ok(())
+}
+
+/// #2346, path-context evaluator: the same yq-mode no-op has to hold when
+/// something downstream forces path-tracking (`needs_path_context`), not
+/// just on the lighter value-only read path above -- `eval_stage_with_path_
+/// context`'s own `Expr::Iterate` arm is a distinct function from both the
+/// plain-read sites and `del()`'s own machinery. `key` is a jq-only
+/// path-context builtin, gated behind `--jq-extensions` in yq mode (#1512)
+/// -- irrelevant to whether the underlying `.[]` no-op itself is real yq
+/// surface, which it independently is (verified in the plain-read test
+/// above without any extension flag).
+#[test]
+fn test_yq_iterate_path_context_non_container_is_noop_2346() -> Result<()> {
+    let (out, code) = run_yq_stdin(
+        "(.a)? | .[] | key",
+        "a: 5\n",
+        &["--jq-extensions", "-o", "json"],
+    )?;
+    assert_eq!(code, 0, "out: {out:?}");
+    assert_eq!(out, "");
     Ok(())
 }

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -30522,16 +30522,3 @@ fn test_yq_path_step_generic_non_container_is_noop_2346() -> Result<()> {
     assert_eq!(out.trim(), "[]");
     Ok(())
 }
-
-/// #2346, `path_step_generic`'s decode-failure priority: an undecodable
-/// string scalar reaching this arm must still raise its own decode
-/// failure, never suppressed by the yq-mode no-op just added above --
-/// same `\q` invalid-escape repro `test_decode_failure_not_suppressed_by_
-/// optional_1620` uses elsewhere in this file.
-#[test]
-fn test_yq_path_step_generic_decode_failure_not_suppressed_2346() -> Result<()> {
-    let (out, stderr, code) = run_yq_stdin_with_stderr("[path(.a[])]", "a: \"x\\qy\"\n", &[])?;
-    assert_ne!(code, 0, "out: {out:?}");
-    assert!(stderr.contains("invalid escape sequence"), "{stderr}");
-    Ok(())
-}


### PR DESCRIPTION
## Summary

Real yq's `.[]` (iterate) produces zero output — not an error — for any
non-container target (number, string, bool, `null`), confirmed live
against yq v4.53.3 for plain reads, `del()`, and assignment alike:

```console
$ echo '{"x":5}' | yq -o=json '.x[]'
# (empty output, exit 0)
```

`succinctly yq` previously raised `Cannot iterate over ...` here, matching
jq's own (correctly stricter) model instead. jq has no such permissive
rule, so this fix is yq-mode only.

## Fix sites

- `eval.rs`'s value-only evaluator `Expr::Iterate` arm (`scalar_fallback`)
  and its `eval_generic.rs` CLI-dispatch counterpart (`decode_failure_or`)
  — plain reads.
- `delete_at_path`'s terminal `Expr::Iterate` arm and
  `delete_path_steps`'s mid-chain arm — `del()`.
- `eval_stage_with_path_context`'s own `Expr::Iterate` arm — reads that
  need path-tracking downstream.

`=`/`|=`'s `set_path`/`update_path` machinery was already correct
(confirmed live, left untouched). A decode failure on an undecodable
string still raises unconditionally in every case — checked first, before
the widened no-op condition.

`resolve_iterate_bounded` (used by `first(f)` and, in yq mode, `path()`
under `--jq-extensions`) was deliberately **not** widened: it's also
reached by `del()`'s comma-fanout fallback for a declined vivify pre-pass,
which has no way to extend/vivify an array the way the mutation-side
functions do — widening it there regressed an honest "Cannot iterate"
(a documented, tracked gap) into a silently wrong answer. Left as a
follow-up, scoped to `first`, real yq surface.

## Also fixed

Two pre-existing tests' own doc comments claimed `.[]` over `null` still
raises outside `del()` — re-verified live and that claim was never
actually true; updated to assert the correct no-op. A third test's use of
plain `.a[]` as a yq-mode `cannot_iterate` trigger no longer works now
that it's a no-op; switched to `map(key)` (a distinct, adjacent, still-open
gap in the path-context evaluator's own `Map` arm, noted in the test's
comment as a follow-up rather than folded into this fix).

Fixes #2346

## Test plan

- [x] Live-oracle comparison matrix (yq v4.53.3 + jq 1.7.1) across plain
      read / `del()` / assignment, scalar/null/array/object, with and
      without `?`, jq-mode controls
- [x] Full local verification: fmt, clippy (both feature sets), doc
      (`RUSTDOCFLAGS=-D warnings`), and all three test tiers (cli+simd+
      regex+serde, default features, `--no-default-features`) — 0 failed
      throughout
- [x] New tests added: plain-read, `del()`, and path-context-forced
      variants, plus jq-mode regression controls