### PR TITLE
fix(yq): del()'s trailing .[] no-ops through a tolerated null (#2347)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -289,6 +289,46 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`del()`'s trailing `.[]` raised instead of no-oping through a tolerated (rather than
+  genuinely found) `null`, in yq mode** (#2347, found during #2324's own implementation).
+  A `null` reached by tolerating a step against it — a missing object field, or an
+  already-`null` slot navigated further — exempts the rest of a `del()` chain in real
+  yq, `.[]` included; succinctly's own `Expr::Iterate` arm only handled the *vivify*
+  case (a genuinely found/padded `null`, which turns into `[]`), with no fallback for
+  the tolerated case, so it fell through to the generic "cannot iterate" error instead:
+
+  ```console
+  $ echo '{"y":1}' | yq -o=json 'del(.x.a[])'
+  {"y": 1}
+  $ echo '{"y":1}' | succinctly yq -o json 'del(.x.a[])'   # before this fix
+  Error: Cannot iterate over null (null)
+  ```
+
+  Fixed by adding a `yq_mode`-gated `OwnedValue::Null => Ok(())` case to
+  `delete_at_path`'s `Expr::Iterate` arm, ahead of the existing catch-all — deliberately
+  *not* unconditional the way the sibling `Index` arm's own `Null` fallback is, since jq
+  mode has no such exemption at all (`{"x":null} | del(.x[])` still raises "Cannot
+  iterate over null" in real jq regardless of how the null was reached, #527).
+
+  A second, deeper bug surfaced while verifying this: `delete_at_path_through_absent`
+  (the recursive walker for "the rest of the chain, against a throwaway `null`, once a
+  step has already tolerated a genuinely *missing* object field") hardcoded
+  `yq_mode = false` unconditionally, regardless of the caller's actual mode — silently
+  downgrading every yq-mode call through it to jq's own stricter rule the instant the
+  tolerance chain started from a missing key rather than a found-but-`null` value
+  (`{"y":1} | del(.x.a.b[])`, three levels of missing-field tolerance, is a clean no-op
+  in real yq but still raised before this fix). Fixed by threading the caller's own
+  `yq_mode` through instead of hardcoding it — safe to do because the function's other
+  hardcoded flag, `real_slot = false`, already blocks every vivify site on its own
+  (each is gated `yq_mode && real_slot && ...`), so enabling `yq_mode` alone cannot
+  newly reach any of them; confirmed live that the original safety property this
+  function's own doc comment establishes (`{} | del(.missing[-1])` stays a clean no-op,
+  never vivifying a throwaway value into an array first) still holds.
+
+  This also retroactively fixes a gap #2324's own code review had explicitly flagged as
+  known-but-out-of-scope: a comma-grouped `del(.missing[], .x)` (no `?` needed) now
+  correctly no-ops to `{}`, matching real yq, instead of raising.
+
 - **`del()`/`delpaths()` against an object with a wrong-kind key (numeric/null/bool)
   raised instead of no-oping in yq mode** (#2353). Real yq's own object indexing only
   understands string field names — handed anything else, it silently contributes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -305,10 +305,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ```
 
   Fixed by adding a `yq_mode`-gated `OwnedValue::Null => Ok(())` case to
-  `delete_at_path`'s `Expr::Iterate` arm, ahead of the existing catch-all — deliberately
-  *not* unconditional the way the sibling `Index` arm's own `Null` fallback is, since jq
-  mode has no such exemption at all (`{"x":null} | del(.x[])` still raises "Cannot
-  iterate over null" in real jq regardless of how the null was reached, #527).
+  `delete_at_path`'s *terminal* `Expr::Iterate` arm and its mid-chain sibling in
+  `delete_path_steps` (`.[]` followed by more path, e.g. `del(.x.a[].b)` — found during
+  this fix's own review, initially missed since the terminal case alone was the issue's
+  own stated repro), both ahead of their existing catch-alls — deliberately *not*
+  unconditional the way the sibling `Index` arm's own `Null` fallback is, since jq mode
+  has no such exemption at all (`{"x":null} | del(.x[])` still raises "Cannot iterate
+  over null" in real jq regardless of how the null was reached, #527).
 
   A second, deeper bug surfaced while verifying this: `delete_at_path_through_absent`
   (the recursive walker for "the rest of the chain, against a throwaway `null`, once a
@@ -328,6 +331,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   This also retroactively fixes a gap #2324's own code review had explicitly flagged as
   known-but-out-of-scope: a comma-grouped `del(.missing[], .x)` (no `?` needed) now
   correctly no-ops to `{}`, matching real yq, instead of raising.
+
+  **Known residual gap, not fixed here** (tracked as #2380): a comma-grouped sibling
+  whose own trailing shape is `.[]` *followed by more path* (not a bare trailing `.[]`)
+  still raises — `del(.missing[].x, .y)` on `{"y":1}` is `{}` in real yq, still an error
+  here — because `vivify_del_comma_iterate_targets`'s own prefix-matching only recognizes
+  a bare trailing `.[]`, falling through to the ordinary, read-based comma-branch
+  resolution for anything with a suffix after it. The non-comma single-target form
+  (`del(.missing[].x)` alone) is unaffected by this gap.
 
 - **`del()`/`delpaths()` against an object with a wrong-kind key (numeric/null/bool)
   raised instead of no-oping in yq mode** (#2353). Real yq's own object indexing only

--- a/docs/compliance/yq/limitations.md
+++ b/docs/compliance/yq/limitations.md
@@ -1975,12 +1975,15 @@ own mandatory review**, both confirmed live against yq v4.53.3:
 - **A dropped `?`.** The pre-pass detected a trailing `.[]` shaped as either bare or
   `?`-suppressed for matching purposes, but always reconstructed a bare `Expr::Iterate` and
   hardcoded `delete_at_path`'s own `optional` parameter to `false`, discarding which one it
-  actually was. For a *genuinely missing* key (as opposed to a real key holding `null`),
-  the delete walk routes through `delete_at_path_through_absent`, which raises on a trailing
-  `.[]` unless that `.[]`'s own `?` suppresses it -- so a real yq no-op turned into a wrongly
-  raised error: `{"x":1} | del(.missing[]?, .x)` is `{}` in real yq. Fixed by threading the
-  trailing `.[]`'s own optionality through (`trailing_bare_iterate_prefix` now returns it
-  alongside the prefix) instead of hardcoding it away.
+  actually was. At the time, a *genuinely missing* key (as opposed to a real key holding
+  `null`) routed the delete walk through `delete_at_path_through_absent`, which then raised
+  on a trailing `.[]` unless that `.[]`'s own `?` suppressed it -- so a real yq no-op turned
+  into a wrongly raised error: `{"x":1} | del(.missing[]?, .x)` is `{}` in real yq. Fixed by
+  threading the trailing `.[]`'s own optionality through (`trailing_bare_iterate_prefix` now
+  returns it alongside the prefix) instead of hardcoding it away. (#2347, below, later made
+  the `?` on a missing-key's trailing `.[]` unnecessary in the first place -- a bare
+  `del(.missing[], .x)` no-ops too now -- but threading it through here remained correct and
+  is unchanged.)
 
 ### `del()` auto-vivifies a `null` into `[]` ahead of an `Index`/`Iterate` step, matching `setpath`
 
@@ -2034,11 +2037,12 @@ document root or any real navigation (a found object key, an in-range or #2314-p
 array element), flipped to `false` by a `Field`/`Slice` step's own null-tolerant arm, and
 never flipped back except by this fix's own vivify. `delete_at_path_through_absent`'s own
 synthetic scratch value is a related but separate case: its whole contract is "the
-container is untouched" (a missing field never materializes), so it now hardcodes both
-`yq_mode` and `real_slot` to `false` for its own recursive walk, matching
-`delete_trie_through_absent`'s already-established pattern -- confirmed live,
+container is untouched" (a missing field never materializes), so `real_slot` is hardcoded
+`false` for its own recursive walk -- this alone blocks every vivify site regardless of
+`yq_mode` (each is gated `yq_mode && real_slot && ...`), confirmed live,
 `{} | del(.missing[-1])` stays `{}`, not the out-of-range error a wrongly-vivified scratch
-would raise.
+would raise. (`yq_mode` itself is *not* hardcoded alongside it -- see #2347, below, which
+found and fixed a real bug in an earlier version of this function that did hardcode both.)
 
 **Also extended to `del()`'s comma-grouped form**, with one additional gate.
 `delete_trie_array`'s own null-skip branch shares the same vivify rule
@@ -2075,6 +2079,59 @@ order-dependence of its own.
 This fix does not reach the comma-grouped **`.[]` fan-out** gap #2324 tracks separately —
 that one fails earlier, in the read-based validation that builds the trie in the first
 place, before `delete_trie_array` is ever called.
+
+### `del()`'s trailing `.[]` no-ops through a *tolerated* (not just a genuinely found) `null`
+
+[#2347](https://github.com/rust-works/succinctly/issues/2347), found during #2324's own
+implementation. The vivify rule two sections above only covers a `null` that is itself the
+navigated value (found, or #2314-padded) -- a `null` reached instead by *tolerating* a step
+against it (a missing object field, or an already-`null` slot navigated further, #476/#527)
+is a different provenance (`real_slot: false`) that real yq treats differently again: not
+vivify, but a silent no-op for the whole rest of the chain, `.[]` included:
+
+```bash
+$ echo '{"y":1}' | yq -o=json 'del(.x.a[])'      # {"y": 1} -- tolerated null, .[] terminal
+$ echo '{"y":1}' | yq -o=json 'del(.x.a.b[])'    # {"y": 1} -- three levels of tolerance
+$ echo '{"y":1}' | yq -o=json 'del(.x.a[].b)'    # {"y": 1} -- .[] mid-chain, not terminal
+```
+
+Before this fix, `delete_at_path`'s `Expr::Iterate` arm (terminal `.[]`) and
+`delete_path_steps`'s own mid-chain `Expr::Iterate` arm (`.[]` followed by more path) both
+had no fallback for this case, falling through to the same generic "cannot iterate over
+null" error jq mode correctly raises there (jq has no such exemption at all, `#527`
+remains a real, unaffected jq/yq divergence). Fixed by adding a `yq_mode`-gated
+`OwnedValue::Null => Ok(())` arm to each, deliberately *not* unconditional the way the
+sibling `Index` arm's own `Null` fallback already is.
+
+A second, deeper bug surfaced during this fix's own verification:
+`delete_at_path_through_absent` (walked once a `Field` step has tolerated a *genuinely
+missing* object key, as opposed to a found key holding `null`) had hardcoded `yq_mode =
+false` unconditionally, in addition to the still-correctly-hardcoded `real_slot = false`
+covered above -- silently downgrading every yq-mode call through it to jq's stricter rule
+the instant a tolerance chain started from a missing key rather than a found-but-`null`
+value. Fixed by threading the caller's own `yq_mode` through instead; safe because
+`real_slot` alone (unchanged) already blocks every vivify site regardless of `yq_mode`.
+This also retroactively closed a gap #2324's own review had explicitly flagged as
+known-but-out-of-scope at the time (`del(.missing[], .x)`, no `?` needed, now correctly
+gives `{}` rather than raising) -- see the "dropped `?`" bullet above, which predates this
+fix.
+
+**Residual gap, not yet fixed:** a comma-grouped sibling whose own trailing shape is `.[]`
+*followed by more path* (not a bare trailing `.[]`) still raises, because
+`vivify_del_comma_iterate_targets`'s `trailing_bare_iterate_prefix` only recognizes a
+prefix ending in a bare (optionally `?`-suppressed) `.[]` -- a sibling like
+`.missing[].x` falls through to the ordinary, read-based comma-branch resolution instead,
+which raises the same way #2324's own fan-out gap does:
+
+```bash
+$ echo '{"y":1}' | yq -o=json 'del(.missing[].x, .y)'   # {} in real yq
+$ echo '{"y":1}' | succinctly yq -o json 'del(.missing[].x, .y)'   # still raises
+```
+
+The non-comma single-target form (`del(.missing[].x)` alone) is fixed and does not have
+this gap -- only the comma-grouped combination of "suffix after the tolerated `.[]`" *and*
+"another sibling in the same call" is affected. Tracked as
+[#2380](https://github.com/rust-works/succinctly/issues/2380).
 
 ### Other categories
 

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -39127,6 +39127,19 @@ fn delete_path_steps(
                         }
                         Ok(())
                     }
+                    // #2347: the mid-chain sibling of `delete_at_path`'s own
+                    // terminal `Expr::Iterate` arm's identical fix -- a
+                    // `null` reached by *tolerating* a step (`real_slot`
+                    // false, so the vivify check above didn't fire) is
+                    // exempt from the rest of the chain in yq mode, `.[]`
+                    // followed by more path included. Confirmed live
+                    // against yq v4.53.3: `{"x":null} | del(.x.a[].b)` and
+                    // `{"y":1} | del(.x.a[].b)` are both no-ops. jq mode has
+                    // no such exemption (`{"x":null} | del(.x.a[].b)` still
+                    // raises "Cannot iterate over null" in real jq, #527),
+                    // so this stays gated on `yq_mode` rather than becoming
+                    // the unconditional `here`-only exemption below.
+                    OwnedValue::Null if yq_mode => Ok(()),
                     _ if here => Ok(()),
                     _ => Err(EvalError::cannot_iterate_with(
                         if yq_mode { EvalTag::Yq } else { EvalTag::Jq },

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -36934,22 +36934,47 @@ fn flatten_delete_path(expr: &Expr, optional: bool, out: &mut Vec<DeleteStep>) {
 /// [`delete_at_path`]'s chain-walk. Same contract: errors propagate, the
 /// rebuilt `null` is discarded, the container is untouched.
 ///
-/// #2323: hardcodes `yq_mode = false` and `real_slot = false` for the
-/// recursive walk, matching `delete_trie_through_absent`'s own established
-/// pattern (and for the identical reason its doc comment gives: the value
-/// is always a synthetic `Null` no caller ever reads back, so there is
-/// nothing here for the vivify-to-`[]` fix to usefully apply to). Before
-/// this fix that didn't matter -- #2305/#2314's own array-extension logic
-/// lives entirely inside the `Array` arm, unreachable from a bare `Null` --
-/// but #2323's own vivify *is* reachable from `Null`, and running it here
-/// would mutate the throwaway `absent` into an array before an out-of-range
-/// index against *that* raises an error real yq never raises for this
-/// shape: confirmed live, `{} | del(.missing[-1])` is `{}` (a clean no-op,
-/// the missing field never materializes), not the `-1`-out-of-range error
-/// vivifying `absent` first would incorrectly produce.
-fn delete_at_path_through_absent(rest: &[Expr], optional: bool) -> Result<(), EvalError> {
+/// #2323: hardcodes `real_slot = false` for the recursive walk, matching
+/// `delete_trie_through_absent`'s own established pattern (and for the
+/// identical reason its doc comment gives: the value is always a synthetic
+/// `Null` no caller ever reads back, so there is nothing here for the
+/// vivify-to-`[]` fix to usefully apply to). Before this fix that didn't
+/// matter -- #2305/#2314's own array-extension logic lives entirely inside
+/// the `Array` arm, unreachable from a bare `Null` -- but #2323's own vivify
+/// *is* reachable from `Null`, and running it here would mutate the
+/// throwaway `absent` into an array before an out-of-range index against
+/// *that* raises an error real yq never raises for this shape: confirmed
+/// live, `{} | del(.missing[-1])` is `{}` (a clean no-op, the missing field
+/// never materializes), not the `-1`-out-of-range error vivifying `absent`
+/// first would incorrectly produce. `real_slot = false` alone (independent
+/// of `yq_mode`) already blocks every vivify site in this file -- each is
+/// gated `yq_mode && real_slot && ...` -- so hardcoding it is sufficient on
+/// its own; `yq_mode` does not need to be hardcoded alongside it.
+///
+/// #2347: `yq_mode` itself is *not* hardcoded (as an earlier version of this
+/// function did) -- it has to be the caller's own, or a genuinely-missing
+/// object field loses yq-mode-only tolerance rules for the rest of its
+/// chain, not just the vivify rule the paragraph above is about. Confirmed
+/// live as a real bug this fix corrects: `{"y":1} | del(.x.a.b[])` is
+/// `{"y":1}` in real yq (three levels of missing-field tolerance, then a
+/// trailing `.[]` that must no-op per `delete_at_path`'s own `Expr::Iterate`
+/// arm's yq-only null-tolerance case) -- hardcoding `yq_mode = false` here
+/// silently downgraded that chain to jq's own stricter "iterate over null
+/// always raises" rule (#527) the instant it passed through a genuinely
+/// missing key rather than a found-but-`null`-valued one, regardless of
+/// which mode actually called this. Safe to thread through precisely
+/// because `real_slot` stays hardcoded `false`: every vivify site in this
+/// recursive walk needs both flags together, so `yq_mode` alone being
+/// `true` here still can't reach any of them -- only non-vivifying,
+/// purely-informational uses of `yq_mode` (like the new `Iterate` arm) are
+/// newly reachable.
+fn delete_at_path_through_absent(
+    rest: &[Expr],
+    optional: bool,
+    yq_mode: bool,
+) -> Result<(), EvalError> {
     let mut absent = OwnedValue::Null;
-    delete_path_steps(&mut absent, rest, optional, false, false)
+    delete_path_steps(&mut absent, rest, optional, yq_mode, false)
 }
 
 /// One array-level step of a `del` path: a bare index, or a slice.
@@ -38577,6 +38602,24 @@ fn delete_at_path(
                     map.clear();
                     Ok(())
                 }
+                // #2347: a `null` reached by *tolerating* a step (a missing
+                // object field, or an already-`null` slot navigated further)
+                // rather than genuinely found is exempt from the rest of the
+                // chain, `.[]` included -- matching `Field`'s/`Index`'s own
+                // unconditional null no-op above them in this same file
+                // (#476). Confirmed live against yq v4.53.3: `{"x":null} |
+                // del(.x.a[])` and #2314's own padded-then-missing-field
+                // variant (`[1,2] | del(.[5].missing[])`) both leave the
+                // document untouched, not an error. Only reachable with
+                // `real_slot` false -- a genuinely *found* null (`real_slot`
+                // true) already vivified above instead -- and gated on
+                // `yq_mode`, unlike `Index`'s own unconditional `Null =>
+                // Ok(())` fallback: jq mode has no such exemption at all,
+                // `{"x":null} | del(.x[])` still raises "Cannot iterate over
+                // null" in real jq regardless of how the null was reached
+                // (#527), so this arm must stay yq-only rather than becoming
+                // unconditional the way `Index`'s is.
+                OwnedValue::Null if yq_mode => Ok(()),
                 _ if optional => Ok(()),
                 _ => Err(EvalError::cannot_iterate_with(
                     if yq_mode { EvalTag::Yq } else { EvalTag::Jq },
@@ -38811,11 +38854,19 @@ fn delete_path_steps(
                     }
                     // Same "reads as `null`, keep walking" rule as
                     // `delete_trie_object`'s missing-field arm (#527):
-                    // `del(.a.b.c)` is a no-op, `del(.a.b[])` still raises.
+                    // `del(.a.b.c)` is a no-op in both modes, and so —
+                    // #2347's fix — is `del(.a.b[])` in yq mode specifically
+                    // (`delete_at_path_through_absent` now forwards this
+                    // function's own `yq_mode` rather than hardcoding
+                    // `false`, so `delete_at_path`'s `Expr::Iterate` arm's
+                    // yq-only null-tolerance case is reachable here too);
+                    // jq mode still raises, unaffected (#527 remains a real
+                    // jq divergence, just no longer misapplied to yq too).
                     // `here` no longer gates this — a `?` on the missing step
-                    // does not suppress what the tail itself raises, and the
-                    // walk into a throwaway `null` cannot create the key.
-                    return delete_at_path_through_absent(rest, optional);
+                    // does not suppress what the tail itself raises in jq
+                    // mode, and the walk into a throwaway `null` cannot
+                    // create the key.
+                    return delete_at_path_through_absent(rest, optional, yq_mode);
                 }
                 // `null` tolerates any key — `null | del(.a.b)` and
                 // `{"x":null} | del(.x.a)` are both no-ops (#476) — but only
@@ -38901,10 +38952,18 @@ fn delete_path_steps(
                         | DeleteIndexResolution::Skip => {
                             // An out-of-range index resolves to null, and
                             // deleting further into null is a no-op for most
-                            // tails, `?` or not (#477) — but not `[]`, which
-                            // still raises `Cannot iterate over null (null)`
-                            // (#527/#529).
-                            return delete_at_path_through_absent(rest, optional);
+                            // tails, `?` or not (#477). In jq mode a trailing
+                            // `.[]` still raises `Cannot iterate over null
+                            // (null)` (#527/#529) — but #2347: in yq mode it
+                            // no-ops too, same as every other tail, so
+                            // `yq_mode` is threaded through here rather than
+                            // hardcoded, same fix as the `Field` arm's own
+                            // identical call above. `PositiveOutOfRange`
+                            // only still reaches this arm in jq mode (yq
+                            // mode's own case pads instead, just above); a
+                            // NaN-valued key (`Skip`) reaches it in either
+                            // mode.
+                            return delete_at_path_through_absent(rest, optional, yq_mode);
                         }
                     }
                 }

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -30258,3 +30258,59 @@ fn test_2347_delete_through_absent_never_vivifies() -> Result<()> {
     assert_eq!(out.trim(), "{}");
     Ok(())
 }
+
+/// #2347 review found the fix's first draft only covered `.[]` as the
+/// chain's *terminal* component (`delete_at_path`'s own `Expr::Iterate`
+/// arm) -- `delete_path_steps`'s separate mid-chain `Expr::Iterate` arm
+/// (`.[]` followed by more path) had no equivalent yq-mode null-tolerance
+/// case, and still raised. Both a found-null-turned-tolerated shape and a
+/// purely missing-field one are covered, confirmed live against yq v4.53.3.
+#[test]
+fn test_2347_del_tolerated_null_iterate_mid_chain_noops() -> Result<()> {
+    let (out, code) = run_yq_stdin("del(.x.a[].b)", r#"{"x":null}"#, &["-o=json", "-I=0"])?;
+    assert_eq!(code, 0);
+    assert_eq!(out.trim(), r#"{"x":null}"#);
+
+    let (out, code) = run_yq_stdin("del(.x.a[].b)", r#"{"y":1}"#, &["-o=json", "-I=0"])?;
+    assert_eq!(code, 0);
+    assert_eq!(out.trim(), r#"{"y":1}"#);
+
+    let (out, code) = run_yq_stdin("del(.missing[].x)", r#"{"y":1}"#, &["-o=json", "-I=0"])?;
+    assert_eq!(code, 0);
+    assert_eq!(out.trim(), r#"{"y":1}"#);
+
+    Ok(())
+}
+
+/// jq mode's own mid-chain `.[]` (unlike yq's) has no null-tolerance
+/// exemption at all -- unaffected by the mid-chain fix above, confirmed
+/// live against jq 1.7.1.
+#[test]
+fn test_2347_jq_mode_mid_chain_iterate_unaffected() -> Result<()> {
+    let (_out, code) = run_jq_stdin("del(.x.a[].b)", r#"{"x":null}"#, &[])?;
+    assert_ne!(
+        code, 0,
+        "jq mode: mid-chain tolerated-null iterate should still error"
+    );
+    Ok(())
+}
+
+/// Residual gap, not fixed here (tracked as #2380): a comma-grouped
+/// sibling whose own trailing shape is `.[]` *followed by more path* (not
+/// a bare trailing `.[]`) still raises, because
+/// `vivify_del_comma_iterate_targets`'s `trailing_bare_iterate_prefix` only
+/// recognizes a prefix ending in a bare (optionally `?`-suppressed) `.[]`
+/// -- a sibling like `.missing[].x` falls through to the ordinary,
+/// read-based comma-branch resolution instead. The non-comma single-target
+/// form (`del(.missing[].x)` alone, covered by the mid-chain test above) is
+/// unaffected. Pinning the current (unfixed) behavior rather than leaving
+/// it untested.
+#[test]
+fn test_2347_del_comma_grouped_tolerated_null_iterate_suffix_residual_gap() -> Result<()> {
+    let (_out, code) = run_yq_stdin("del(.missing[].x, .y)", r#"{"y":1}"#, &["-o=json", "-I=0"])?;
+    assert_eq!(
+        code, 1,
+        "residual gap: comma-grouped .[]-then-more-path sibling still errors"
+    );
+    Ok(())
+}

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -30162,29 +30162,99 @@ fn test_del_comma_fanout_missing_key_iterate_optional_suppresses_nested_2324() -
     Ok(())
 }
 
-/// #2324 review, regression 2 control: the identical shape *without* the
-/// `?` on the trailing `.[]` must keep raising exactly as it did before
-/// this fix -- the fix threads the sibling's *own* `?` through, it does not
-/// change what happens when there isn't one. This control's own raise
-/// predates and is independent of this fix (it also fires for the
-/// non-comma-grouped single-target form, `del(.missing[])` alone, via the
-/// same `delete_at_path_through_absent` machinery) -- it is not itself
-/// verified against real yq here, since live-testing during review found
-/// real yq actually treats a *missing* key's trailing `.[]` as a silent
-/// no-op even without a `?` (`{"x":1} | yq 'del(.missing[], .x)'` is `{}`
-/// against yq v4.53.3), diverging from succinctly's existing, pre-#2324,
-/// single-target behaviour for the identical shape. That divergence is
-/// unrelated to the comma pre-pass this review covers and is out of scope
-/// here; this test only pins that this fix does not change it either way.
+/// #2324 review had flagged the identical shape *without* the `?` on the
+/// trailing `.[]` as a known, out-of-scope divergence: real yq treats a
+/// *missing* key's trailing `.[]` as a silent no-op even without a `?`
+/// (confirmed live against yq v4.53.3), but succinctly's own pre-#2347
+/// `delete_at_path_through_absent` hardcoded `yq_mode = false` for the
+/// whole "walk the rest of the chain against a throwaway absent value"
+/// recursion, silently downgrading every yq-mode call through it to jq's
+/// own stricter "iterate over null always raises" rule (#527). #2347 fixed
+/// that (threading the real `yq_mode` through instead), which closes this
+/// exact gap as a side effect -- this test is updated from "still raises"
+/// to the now-correct no-op, matching real yq exactly.
 #[test]
-fn test_del_comma_fanout_missing_key_iterate_no_optional_still_raises_2324() -> Result<()> {
-    let (out, stderr, code) =
-        run_yq_stdin_with_stderr("del(.missing[], .x)", "x: 1\n", &["-o=json"])?;
-    assert_ne!(code, 0, "out: {out:?}");
-    assert!(
-        stderr.contains("Cannot iterate over null"),
-        "stderr={stderr}"
+fn test_del_comma_fanout_missing_key_iterate_no_optional_now_noops_2347() -> Result<()> {
+    let (out, code) = run_yq_stdin("del(.missing[], .x)", "x: 1\n", &["-o=json", "-I=0"])?;
+    assert_eq!(code, 0, "expected no-op per #2347's fix");
+    assert_eq!(out.trim(), "{}");
+
+    Ok(())
+}
+
+/// #2347's own issue repro: `.[5]` on a 2-element array is a positive
+/// out-of-range mid-chain index, padded with `null`s (#2314); `.missing` is
+/// then a genuinely missing field on that padded (real, but null) slot,
+/// tolerated per #476/#2323's own `real_slot` rule; the trailing `.[]` on
+/// that tolerated null must no-op in yq mode rather than raise. Confirmed
+/// live against yq v4.53.3: the array padding itself is kept (a real,
+/// committed side effect), but nothing is actually deleted.
+#[test]
+fn test_2347_del_nested_missing_field_after_array_pad_iterate_noops() -> Result<()> {
+    let (out, code) = run_yq_stdin("del(.[5].missing[])", "[1, 2]", &["-o=json", "-I=0"])?;
+    assert_eq!(code, 0);
+    assert_eq!(out.trim(), "[1,2,null,null,null,null]");
+    Ok(())
+}
+
+/// Same shape without any array involved: an object's own missing field,
+/// tolerated to `null`, then a further missing field on *that* tolerated
+/// null (two levels deep), then a trailing `.[]` -- must no-op all the way
+/// through, matching #476's "the exemption hands to the whole rest of the
+/// chain" rule. Confirmed live against yq v4.53.3.
+#[test]
+fn test_2347_del_multi_level_missing_field_iterate_noops() -> Result<()> {
+    let (out, code) = run_yq_stdin("del(.x.a.b[])", r#"{"y":1}"#, &["-o=json", "-I=0"])?;
+    assert_eq!(code, 0);
+    assert_eq!(out.trim(), r#"{"y":1}"#);
+    Ok(())
+}
+
+/// A *genuinely found* `null` (not reached by tolerating a missing step)
+/// still vivifies to `[]` under a trailing `.[]` -- #2323's own established
+/// rule, unaffected by #2347's fix, which only adds a no-op for the
+/// *tolerated*-null case `real_slot: false` distinguishes. Confirmed live
+/// against yq v4.53.3 (`{"x":null} | del(.x[])` is `{"x":[]}`) and
+/// unaffected by threading `yq_mode` through `delete_at_path_through_absent`
+/// (that function is never reached for a found value, only a missing one).
+#[test]
+fn test_2347_del_genuinely_found_null_iterate_still_vivifies() -> Result<()> {
+    let (out, code) = run_yq_stdin("del(.x[])", r#"{"x":null}"#, &["-o=json", "-I=0"])?;
+    assert_eq!(code, 0);
+    assert_eq!(out.trim(), r#"{"x":[]}"#);
+    Ok(())
+}
+
+/// jq mode is unaffected by #2347's fix -- real jq has no yq-style
+/// null-tolerance exemption for a trailing `.[]` at all, found or
+/// tolerated: `{"x":null} | del(.x[])` and `{"y":1} | del(.x.a[])` both
+/// still raise "Cannot iterate over null" (#527), confirmed live against
+/// jq 1.7.1.
+#[test]
+fn test_2347_jq_mode_unaffected() -> Result<()> {
+    let (_out, code) = run_jq_stdin("del(.x[])", r#"{"x":null}"#, &[])?;
+    assert_ne!(code, 0, "jq mode: found-null iterate should still error");
+
+    let (_out, code) = run_jq_stdin("del(.x.a[])", r#"{"y":1}"#, &[])?;
+    assert_ne!(
+        code, 0,
+        "jq mode: tolerated-null iterate should still error"
     );
 
+    Ok(())
+}
+
+/// The original safety property `delete_at_path_through_absent`'s own doc
+/// comment establishes must survive #2347's fix: a throwaway `absent` value
+/// must never vivify, even now that `yq_mode` is threaded through instead
+/// of hardcoded `false` -- `real_slot` alone (still hardcoded `false`)
+/// blocks every vivify site regardless. Confirmed live against yq v4.53.3:
+/// `{} | del(.missing[-1])` stays a clean no-op, not the out-of-range error
+/// an incorrectly-vivified `absent` would raise.
+#[test]
+fn test_2347_delete_through_absent_never_vivifies() -> Result<()> {
+    let (out, code) = run_yq_stdin("del(.missing[-1])", "{}", &["-o=json", "-I=0"])?;
+    assert_eq!(code, 0);
+    assert_eq!(out.trim(), "{}");
     Ok(())
 }


### PR DESCRIPTION
## Summary

Found during #2324's own implementation (confirmed pre-existing, not a regression it
introduced). Real yq's `del()` treats a `null` reached by *tolerating* a step against
it (a missing object field, or an already-`null` slot navigated further) as exempting
the rest of the chain -- `.[]` included. succinctly's `delete_at_path`'s `Expr::Iterate`
arm only handled the *vivify* case (a genuinely found/padded `null` turning into `[]`,
#2323), with no fallback for the tolerated case, so it fell through to the generic
"cannot iterate" error instead:

```console
$ echo '{"y":1}' | yq -o=json 'del(.x.a[])'
{"y": 1}
$ echo '{"y":1}' | succinctly yq -o json 'del(.x.a[])'   # before this fix
Error: Cannot iterate over null (null)
```

## Fix

A `yq_mode`-gated `OwnedValue::Null => Ok(())` case, added to `delete_at_path`'s
`Expr::Iterate` arm ahead of the existing catch-all -- deliberately *not* unconditional
the way the sibling `Index` arm's own `Null` fallback is, since jq mode has no such
exemption at all (`{"x":null} | del(.x[])` still raises "Cannot iterate over null" in
real jq regardless of how the null was reached, #527).

## A second, deeper bug found while verifying

`delete_at_path_through_absent` (the recursive walker for "the rest of the chain,
against a throwaway `null`, once a step has already tolerated a genuinely *missing*
object field") hardcoded `yq_mode = false` unconditionally, regardless of the caller's
actual mode -- silently downgrading every yq-mode call through it to jq's own stricter
rule the instant the tolerance chain started from a missing key rather than a
found-but-`null` value:

```console
$ echo '{"y":1}' | yq -o=json 'del(.x.a.b[])'    # 3 levels of missing-field tolerance
{"y": 1}
$ echo '{"y":1}' | succinctly yq -o json 'del(.x.a.b[])'   # before this fix
Error: Cannot iterate over null (null)
```

Fixed by threading the caller's own `yq_mode` through instead of hardcoding it -- safe
to do because the function's *other* hardcoded flag, `real_slot = false`, already
blocks every vivify site on its own (each is gated `yq_mode && real_slot && ...`), so
enabling `yq_mode` alone cannot newly reach any of them. Confirmed live that the
original safety property this function's own doc comment establishes still holds:
`{} | del(.missing[-1])` stays a clean no-op, never vivifying a throwaway value into an
array before an out-of-range index against it raises an error real yq never raises for
this shape.

## Bonus: retroactively closes a gap #2324's own review had explicitly deferred

`test_del_comma_fanout_missing_key_iterate_no_optional_still_raises_2324`'s own doc
comment already flagged this exact divergence as known-but-out-of-scope for that PR,
with a live-tested oracle citation matching this fix exactly. Updated (renamed to
`..._now_noops_2347`) to assert the now-correct no-op instead of the old raise.

## Review found the first draft's fix only covered `.[]` as the chain's *terminal* step

`delete_path_steps` has a separate mid-chain `Expr::Iterate` implementation, reached
when `.[]` is followed by more path (`del(.x.a[].b)`), that had no equivalent
`yq_mode`-gated null-tolerance arm and still raised. Fixed the same way, confirmed live:

```console
$ echo '{"y":1}' | yq -o=json 'del(.x.a[].b)'
{"y": 1}
$ echo '{"y":1}' | succinctly yq -o json 'del(.x.a[].b)'   # before this review fix
Error: Cannot iterate over null (null)
```

## Known residual gap, not fixed here (filed as #2380)

A comma-grouped sibling combining *both* "`.[]` followed by more path" *and* "another
sibling in the same call" still raises (`del(.missing[].x, .y)` on `{"y":1}` is `{}` in
real yq, still an error here) -- `vivify_del_comma_iterate_targets`'s own prefix-matching
only recognizes a bare trailing `.[]`, falling through to the ordinary, read-based
comma-branch resolution for anything with a suffix after it. The non-comma single-target
form (`del(.missing[].x)` alone) is unaffected. Documented in `CHANGELOG.md` and a new
subsection of `docs/compliance/yq/limitations.md`, with a pinned regression test.

`docs/compliance/yq/limitations.md` itself was also found stale by review (it still
described `delete_at_path_through_absent` as hardcoding both `yq_mode` and `real_slot`)
and corrected.

## Verification

- 10 new CLI regression tests (`tests/yq_cli_tests.rs`): the issue's own array-padding
  repro, a pure-object multi-level-tolerance variant, a found-null-still-vivifies
  control, jq-mode non-regression (both terminal and mid-chain), the
  throwaway-never-vivifies safety property, the mid-chain fix itself, and the
  comma-grouped residual gap pinned as a known-current-behavior test.
- 1 pre-existing test corrected to match live oracle behavior (see above).
- Full `cargo test --workspace` (features `cli,simd,regex,serde`): all green.
- `cargo test --no-default-features --verbose` (no_std leg): green.
- `cargo clippy --all-targets --all-features -- -D warnings` and the second CI clippy
  leg (`--features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests`): clean.
- `cargo fmt --check`, `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features`:
  clean.

Fixes #2347