### PR TITLE
ci(coverage): bump omni-dev-coverage-check to 0.42.0 for the diff-algorithm fix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -733,7 +733,16 @@ jobs:
           # which is how the CPU-conditional `src/bits/popcount.rs` flap (#302)
           # is silenced. The action does not thread `--ignore-filename-regex`,
           # so config-file discovery from the checkout is the only route.
-          version: 0.38.0
+          # Bumped to 0.42.0 for #1554: that release carries omni-dev#1580's
+          # fix (PR rust-works/omni-dev#1586, switching `coverage diff`'s
+          # internal git diff to libgit2's patience algorithm), which resolves
+          # the patch-coverage misattribution this repo hit on refactor-shaped
+          # diffs with long runs of near-duplicate lines (src/jq/eval.rs on
+          # PR #1551) -- verified locally against that PR's exact base/head
+          # commits with the 0.42.0 binary: patch coverage now reports 7/7
+          # new lines for eval.rs, not the pre-fix "5161/6070 new lines"
+          # spanning nearly the whole file.
+          version: 0.42.0
           use-prebuilt-binary: ${{ matrix.use-prebuilt }}
           test-args: --features cli,simd,regex,serde --workspace
           fail-under-lines: 55   # floor a few pts below local llvm-cov (ARM: 59.58% lines)


### PR DESCRIPTION
Fixes #1554

## Summary

`omni-dev coverage diff`'s posted sticky "Coverage" PR comment badly misattributed
patch-coverage line ranges on refactor-shaped diffs with long runs of near-duplicate
lines. #1554's own repro (PR #1551, a ~2200-line hand-expanded-match-arms-to-3-
wrapper-functions refactor in `src/jq/eval.rs`) reported "85.02% (5161/6070 new lines
covered)" spanning nearly the entire file between the two edited functions, instead
of the ~25 genuinely new lines.

## Root cause and fix

Root cause was `omni-dev coverage diff`'s own internal diff (via libgit2/`git2`)
using no explicit algorithm, defaulting to Myers-style, which is known to misalign on
files with long runs of near-identical lines -- confirmed and fixed upstream in
`rust-works/omni-dev#1580` (PR `rust-works/omni-dev#1586`, switched to libgit2's
`patience` algorithm), released in `v0.42.0` (2026-09-04), which had not yet shipped
when this issue was last checked and moved to `Blocked`.

## Verification

Bumped the pinned `action-works/omni-dev-coverage-check@v1` `version` input from
`0.38.0` to `0.42.0`. Confirmed the fix locally against the *exact* repro from
#1554's own body -- checked out PR #1551's head commit
(`1d9cbc6f9452dd9925c689043820cd3da939b6d8`), generated a real `cargo llvm-cov` lcov
report, and re-ran `omni-dev coverage diff --base-ref 379d437af74daa00d47f072760e8f59df77e1642`
with the local `omni-dev 0.42.0` binary:

```console
### Patch coverage

Patch: **98.11%** (52/53 new lines covered)

| File | Patch | Uncovered new lines |
|------|------:|---------------------|
| `src/jq/eval.rs` | 100% (7/7) | — |
| `src/jq/walk.rs` | 97.83% (45/46) | 908 |
```

`src/jq/eval.rs` now reports **7 new lines** (100% covered) -- matching the issue's
own "~25 genuinely new lines" ballpark across both touched files -- instead of the
pre-fix 6070-line span. This PR's own CI run will also post a fresh sticky Coverage
comment under `0.42.0` (a small, non-refactor-shaped diff, so not itself a
misattribution stress test, but confirms the action still runs cleanly end-to-end
post-bump).

## Test plan

- [x] Reproduced #1554's exact scenario locally against PR #1551's base/head with the
      fixed `omni-dev` binary -- patch coverage line count now sane.
- [x] `actionlint .github/workflows/ci.yml` -- clean except one pre-existing,
      unrelated shellcheck warning at line 607 (confirmed present on `main` too).
- [x] `cargo build --features cli`
- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
