### PR TITLE
docs(jq): record .[0]/.[0.0] lazy-fold divergence wrinkle (#2174)

### DIFF
--- a/docs/compliance/jq/limitations.md
+++ b/docs/compliance/jq/limitations.md
@@ -2492,6 +2492,32 @@ Pinned by [`test_generic_lazy_seq_first_after_map_skips_later_error_725`](../../
 [`test_first_over_lazy_seq_iterate_skips_later_error_1565`](../../../tests/jq_cli_tests.rs)
 (the `first(map(f) | .[] | g)` spelling, plus the draining counter-cases above).
 
+**One more wrinkle: `.[0]` and `.[0.0]` don't agree.** `eval_generic.rs`'s lazy-sequence fold
+keys the skip-the-rest fast arm off the literal AST shape `Expr::Index { idx: 0, key: None }`
+(#1401), which only a bare integer-literal `.[0]` parses to -- `.[0.0]` folds to a different
+node and falls through to the eager evaluator instead, so it does *not* get the skip and
+raises exactly like real jq does for both spellings:
+
+```
+$ echo '[1,2,3]' > /tmp/a.json
+$ succinctly jq -c 'map(if . > 1 then error("boom") else . end) | .[0]'   /tmp/a.json   # 1, exit 0
+$ succinctly jq -c 'map(if . > 1 then error("boom") else . end) | .[0.0]' /tmp/a.json   # error, exit 5
+$ jq          -c 'map(if . > 1 then error("boom") else . end) | .[0]'   /tmp/a.json     # error, exit 5 (both spellings)
+```
+
+`.[0]` and `.[0.0]` are equivalent everywhere else in this codebase -- that equivalence is
+the whole premise of #1088's spelling preservation, asserted for reading, `del`,
+`setpath`/`=`/`|=` and `getpath` by
+[`tests/jq_index_number_invariant_tests.rs`](../../../tests/jq_index_number_invariant_tests.rs)
+-- this lazy-fold fast arm is the one place the spelling changes the answer. Left as-is
+rather than widened to also match `.[0.0]` ([#2174](https://github.com/rust-works/succinctly/issues/2174)):
+widening would make both spellings agree, but on the *divergent* side, spreading this
+limitation to a second spelling where ADR-0018 says matching jq is plainly possible instead
+(#1401's own comment on the fast arm records the same reasoning). `Expr::Index { idx: 0, key:
+None }`'s pinning is correct and does not need to change even if this limitation is ever
+lifted for `.[0]` itself -- only then would widening the arm become the right move, not
+before.
+
 ## A truncating consumer of `keys_unsorted[]` skips a malformed member it never needed
 
 Sibling of the `map(f)` divergence directly above, for the same underlying reason: a

--- a/docs/compliance/jq/limitations.md
+++ b/docs/compliance/jq/limitations.md
@@ -2499,17 +2499,18 @@ node and falls through to the eager evaluator instead, so it does *not* get the 
 raises exactly like real jq does for both spellings:
 
 ```
-$ echo '[1,2,3]' > /tmp/a.json
-$ succinctly jq -c 'map(if . > 1 then error("boom") else . end) | .[0]'   /tmp/a.json   # 1, exit 0
-$ succinctly jq -c 'map(if . > 1 then error("boom") else . end) | .[0.0]' /tmp/a.json   # error, exit 5
-$ jq          -c 'map(if . > 1 then error("boom") else . end) | .[0]'   /tmp/a.json     # error, exit 5 (both spellings)
+$ echo '[1,2,3]' | succinctly jq -c 'map(if . > 1 then error("boom") else . end) | .[0]'   # 1, exit 0
+$ echo '[1,2,3]' | succinctly jq -c 'map(if . > 1 then error("boom") else . end) | .[0.0]' # error, exit 5
+$ echo '[1,2,3]' | jq          -c 'map(if . > 1 then error("boom") else . end) | .[0]'     # error, exit 5 (both spellings)
 ```
 
 `.[0]` and `.[0.0]` are equivalent everywhere else in this codebase -- that equivalence is
 the whole premise of #1088's spelling preservation, asserted for reading, `del`,
 `setpath`/`=`/`|=` and `getpath` by
 [`tests/jq_index_number_invariant_tests.rs`](../../../tests/jq_index_number_invariant_tests.rs)
--- this lazy-fold fast arm is the one place the spelling changes the answer. Left as-is
+-- this lazy-fold fast arm is the one place the spelling changes the answer. Pinned by
+[`test_lazy_seq_first_index_zero_vs_float_spelling_disagree_2174`](../../../tests/jq_cli_tests.rs).
+Left as-is
 rather than widened to also match `.[0.0]` ([#2174](https://github.com/rust-works/succinctly/issues/2174)):
 widening would make both spellings agree, but on the *divergent* side, spreading this
 limitation to a second spelling where ADR-0018 says matching jq is plainly possible instead

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -28420,6 +28420,31 @@ fn test_first_over_lazy_seq_iterate_skips_later_error_1565() -> Result<()> {
     Ok(())
 }
 
+/// #2174: `.[0]` and `.[0.0]` are equivalent everywhere else in this codebase
+/// (#1088's spelling preservation), but `eval_generic.rs`'s lazy-sequence
+/// fold keys its `#725` skip-the-rest fast arm off the literal AST shape
+/// `Expr::Index { idx: 0, key: None }` (#1401's own pinning comment), which
+/// only a bare integer-literal `.[0]` parses to -- `.[0.0]` falls through to
+/// the eager evaluator and raises exactly like real jq does for both
+/// spellings. Documented as an accepted, deliberate wrinkle on the already-
+/// accepted #725 divergence in `docs/compliance/jq/limitations.md`, pinned
+/// here so it stays a decision rather than drifting.
+#[test]
+fn test_lazy_seq_first_index_zero_vs_float_spelling_disagree_2174() -> Result<()> {
+    let filter = r#"map(if . > 1 then error("boom") else . end)"#;
+
+    let (stdout, stderr, code) =
+        run_jq_full(&["-c", &format!("{filter} | .[0]")], Some("[1,2,3]"))?;
+    assert_eq!((stdout.as_str(), code), ("1\n", 0), "stderr: {stderr}");
+
+    let (stdout, stderr, code) =
+        run_jq_full(&["-c", &format!("{filter} | .[0.0]")], Some("[1,2,3]"))?;
+    assert_ne!(code, 0, "stdout: {stdout:?}");
+    assert!(stderr.contains("boom"), "stderr={stderr}");
+
+    Ok(())
+}
+
 /// #1597 part 2: `.[]` over a real array now walks lazily
 /// (`each_lazy_array_iterate_sink`), so `first`/`limit` stop pulling cursors
 /// instead of collecting every one up front. Output must stay byte-identical


### PR DESCRIPTION
## Summary

Documentation-only fix, per the [repo owner's own suggested amendment](https://github.com/rust-works/succinctly/issues/2174#issuecomment-5504564344) on this issue: option 1, accepting the `.[0]`/`.[0.0]` asymmetry as a documented wrinkle on the already-accepted #725 divergence, rather than tracking it against a "real fix" that pointed at a closed issue with no open successor.

## Background

`eval_generic.rs`'s lazy-sequence fold keys its skip-the-rest fast arm off the literal AST
shape `Expr::Index { idx: 0, key: None }` (#1401), which only a bare integer-literal `.[0]`
parses to -- `.[0.0]` folds to a different node and falls through to the eager evaluator,
so it raises exactly like real jq does for both spellings, while `.[0]` gets the lazy skip:

```console
$ echo '[1,2,3]' > /tmp/a.json
$ succinctly jq -c 'map(if . > 1 then error("boom") else . end) | .[0]'   /tmp/a.json
1
$ succinctly jq -c 'map(if . > 1 then error("boom") else . end) | .[0.0]' /tmp/a.json
jq: error (at /tmp/a.json:1): boom
$ jq -c 'map(if . > 1 then error("boom") else . end) | .[0]' /tmp/a.json
jq: error (at /tmp/a.json:1): boom
```

`.[0]`/`.[0.0]` are equivalent everywhere else in this codebase (#1088's spelling
preservation, asserted for reading/`del`/`setpath`/`=`/`|=`/`getpath`) -- this lazy-fold
fast arm is the one place the spelling changes the answer.

## Why not fix it instead

Widening the arm to `{ idx: 0, .. }` would make both spellings agree, but on the
*divergent* side (both skipping, neither matching jq) -- ADR-0018 doesn't permit that
while matching jq is plainly possible for `.[0.0]` already. The actual fix would be
resolving the underlying #725 lazy-`map`-truncation divergence itself, which is a
deliberate, accepted, unrelated design choice (not a bug) with no open issue tracking
its reversal -- there's nothing for this issue to wait on.

## Change

Amends `docs/compliance/jq/limitations.md`'s existing #725 divergence section (the
`map(f) | first` skip) with a note on this two-spelling wrinkle, live-verified against
both this branch and `/usr/bin/jq` 1.7.1. No source change -- `Expr::Index { idx: 0, key:
None }`'s pinning (#1401's own comment) is already correct.

Closes #2174
