### PR TITLE
fix(jq): slice-bound conversion failure keeps its already-converted prefix (#2372)

### DIFF
--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -17461,10 +17461,33 @@ fn eval_slice_bound<W: Clone + AsRef<[u64]>, S: EvalSemantics>(
             }
             QueryResult::Partial(vs, control) => (vs, Some(control)),
         };
-    let converted = raw
-        .iter()
-        .map(|v| owned_bound_to_i64(v, round).map_err(Control::Error))
-        .collect::<Result<Vec<_>, _>>()?;
+    // #2372: used to be a bare `.collect::<Result<Vec<_>, _>>()?`, which
+    // discarded every already-converted bound (and silently replaced
+    // `escape`, if the raw generator had one pending) on the first
+    // non-numeric bound. A conversion failure only ever touches a value the
+    // generator already produced, strictly before whatever produced
+    // `escape` in true generator order, so it unconditionally outranks
+    // `escape` -- no `Halt`-survives nuance needed here the way a genuine
+    // secondary *rendering* failure elsewhere in this file needs (that
+    // question doesn't arise: this failure IS the primary event, not a
+    // problem rendering one). Confirmed live against jq 1.7.1, including
+    // the `Halt` case: `.[(0,"x",error("y")):3]` on `[10,20,30]` raises
+    // "Array/string slice indices must be integers" (not `y`), and
+    // `.[(0,"x",halt):3]` raises the identical message rather than exiting
+    // silently -- `halt` is never reached either. yq mode keeps the
+    // pre-existing conservative discard (mirrors the generator-escape gate
+    // above): real yq has no clean model for a computed comma-bound at all
+    // (confirmed live against yq v4.53.3 -- `.[(0,"x"):3]` on `[10,20,30]`
+    // rejects the bound outright, "expected to find 1 number, got 2
+    // instead"), so there's no oracle basis for streaming a prefix here.
+    let mut converted = vec_with_capacity(raw.len());
+    for v in &raw {
+        match owned_bound_to_i64(v, round) {
+            Ok(i) => converted.push(i),
+            Err(e) if S::TAG == EvalTag::Yq => return Err(Control::Error(e)),
+            Err(e) => return Ok((converted, Some(Control::Error(e)))),
+        }
+    }
     Ok((converted, escape))
 }
 
@@ -32804,14 +32827,17 @@ fn eval_slice_bound_with_path_context<W: Clone + AsRef<[u64]>, S: EvalSemantics>
     if S::TAG == EvalTag::Yq && escape.is_some() {
         raw = Vec::new();
     }
-    let converted = raw
-        .into_iter()
-        .map(|v| {
-            owned_bound_to_i64(&v, round)
-                .map(|i| (v, i))
-                .map_err(Control::Error)
-        })
-        .collect::<Result<Vec<_>, _>>()?;
+    // #2372: mirrors `eval_slice_bound`'s identical fix (`eval.rs`, above)
+    // exactly -- see that function's own doc comment for the full
+    // rationale and live-oracle verification, not repeated here.
+    let mut converted = vec_with_capacity(raw.len());
+    for v in raw {
+        match owned_bound_to_i64(&v, round) {
+            Ok(i) => converted.push((v, i)),
+            Err(e) if S::TAG == EvalTag::Yq => return Err(Control::Error(e)),
+            Err(e) => return Ok((converted, Some(Control::Error(e)))),
+        }
+    }
     Ok((converted, escape))
 }
 
@@ -53939,6 +53965,63 @@ mod tests {
         );
     }
 
+    /// #2372: `eval_slice_bound`'s own bound *conversion* step (distinct
+    /// from #2351's *generator-escape* fix immediately below) used a bare
+    /// `.collect::<Result<Vec<_>, _>>()?`, discarding every already-
+    /// converted bound on the first non-numeric one. `1` converts to `1`
+    /// fine; `"x"` fails conversion before the generator's own later
+    /// `error("y")` is ever reached. Verified against jq 1.7.1: `echo
+    /// '[10,20,30]' | jq -c '.[(1,"x",error("y")):3]'` prints `[20,30]`
+    /// (from the one successfully-converted bound `1`) then raises "Array/
+    /// string slice indices must be integers" -- *not* `y`, confirming a
+    /// conversion failure unconditionally outranks a later-pending
+    /// generator escape (no `Halt`-survives nuance needed: the failure is
+    /// on a value produced strictly before whatever triggered the pending
+    /// escape, in true generator order).
+    #[test]
+    fn test_slice_bound_conversion_failure_keeps_prefix_in_jq_mode_2372() {
+        query!(b"[10,20,30]", r#".[(1,"x",error("y")):3]"#,
+            QueryResult::Partial(vs, Control::Error(e)) => {
+                assert_eq!(vs, vec![
+                    OwnedValue::Array(vec![OwnedValue::Int(20), OwnedValue::Int(30)]),
+                ]);
+                assert!(e.message.contains("integers"), "{}", e.message);
+            }
+        );
+    }
+
+    /// #2372 sibling: the same conversion-failure priority holds even when
+    /// the generator's later branch is `halt` rather than `error` --
+    /// confirmed live against jq 1.7.1: `.[(1,"x",halt):3]` on `[10,20,30]`
+    /// raises the identical conversion error rather than exiting silently
+    /// (`halt` is never reached).
+    #[test]
+    fn test_slice_bound_conversion_failure_outranks_pending_halt_2372() {
+        query!(b"[10,20,30]", r#".[(1,"x",halt):3]"#,
+            QueryResult::Partial(vs, Control::Error(e)) => {
+                assert_eq!(vs, vec![
+                    OwnedValue::Array(vec![OwnedValue::Int(20), OwnedValue::Int(30)]),
+                ]);
+                assert!(e.message.contains("integers"), "{}", e.message);
+            }
+        );
+    }
+
+    /// #2372: yq mode keeps the pre-fix conservative discard -- real yq has
+    /// no clean model for a computed comma-bound at all (confirmed live
+    /// against yq v4.53.3: `.[(1,"x"):3]` on `[10,20,30]` rejects the bound
+    /// outright, "expected to find 1 number, got 2 instead"), so this
+    /// mirrors the generator-escape gate's own yq carve-out rather than
+    /// streaming a prefix with no oracle basis for it.
+    #[test]
+    fn test_slice_bound_conversion_failure_discarded_in_yq_mode_2372() {
+        yq_query!(b"[10,20,30]", r#".[(1,"x",error("y")):3]"#,
+            QueryResult::Error(e) => {
+                assert_eq!(e.message, "y");
+            }
+        );
+    }
+
     /// #2351: unlike #2226/#2326's own target/key gates, `eval_slice_bound`
     /// had *no* yq-mode gate at all -- it unconditionally kept a slice
     /// *bound*'s own escaped generator's prefix in both modes. This is the
@@ -54129,6 +54212,34 @@ mod tests {
         yq_query!(b"[1,2,3]", r#"path(.[0:(1,2,error("x"))])"#,
             QueryResult::Error(e) => {
                 assert_eq!(e.message, "x");
+            }
+        );
+    }
+
+    /// #2372: `eval_slice_bound_with_path_context`'s identical conversion-
+    /// failure gap (mirrors `eval_slice_bound`'s own #2372 fix above; see
+    /// that function's tests for the live-oracle-verified underlying
+    /// semantics -- `key` itself has no jq oracle, same caveat as the
+    /// #2351-review tests below). One bound (`1`) converts before `"x"`
+    /// fails, so `key` reports that one pair's own path component before
+    /// raising.
+    #[test]
+    fn test_slice_bound_path_context_conversion_failure_keeps_prefix_in_jq_mode_2372() {
+        query!(b"[10,20,30]", r#".[(1,"x",error("y")):3] | key"#,
+            QueryResult::Partial(vs, Control::Error(e)) => {
+                assert_eq!(prefix_json(&vs), [r#"{"start":1,"end":3}"#]);
+                assert!(e.message.contains("integers"), "{}", e.message);
+            }
+        );
+    }
+
+    /// #2372: yq mode keeps the pre-fix conservative discard through the
+    /// path-context dispatch too, same as the plain evaluator's own gate.
+    #[test]
+    fn test_slice_bound_path_context_conversion_failure_discarded_in_yq_mode_2372() {
+        yq_query!(b"[10,20,30]", r#".[(1,"x",error("y")):3] | key"#,
+            QueryResult::Error(e) => {
+                assert_eq!(e.message, "y");
             }
         );
     }

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -54007,17 +54007,46 @@ mod tests {
         );
     }
 
+    /// #2372 review: the same priority holds for `break` too, not just
+    /// `error`/`halt` -- confirmed live against jq 1.7.1: `label $out |
+    /// .[(1,"x",break $out):3]` on `[10,20,30]` raises the identical
+    /// conversion error rather than breaking out silently. Unlabeled
+    /// `break $out` here, matching this file's own established precedent
+    /// for testing `eval()` in isolation (real jq's CLI rejects an
+    /// unlabeled `break $out` as a compile error, so the labeled form is
+    /// what was live-verified above; the unlabeled form is this harness's
+    /// own convention for reaching the same value-level escape).
+    #[test]
+    fn test_slice_bound_conversion_failure_outranks_pending_break_2372() {
+        query!(b"[10,20,30]", r#".[(1,"x",break $out):3]"#,
+            QueryResult::Partial(vs, Control::Error(e)) => {
+                assert_eq!(vs, vec![
+                    OwnedValue::Array(vec![OwnedValue::Int(20), OwnedValue::Int(30)]),
+                ]);
+                assert!(e.message.contains("integers"), "{}", e.message);
+            }
+        );
+    }
+
     /// #2372: yq mode keeps the pre-fix conservative discard -- real yq has
     /// no clean model for a computed comma-bound at all (confirmed live
     /// against yq v4.53.3: `.[(1,"x"):3]` on `[10,20,30]` rejects the bound
     /// outright, "expected to find 1 number, got 2 instead"), so this
     /// mirrors the generator-escape gate's own yq carve-out rather than
     /// streaming a prefix with no oracle basis for it.
+    ///
+    /// Review: no trailing `error(...)`/`halt`/`break` in the bound
+    /// generator, unlike this test's jq-mode sibling above -- a trailing
+    /// escape would trip the *pre-existing* #2351 yq gate first (which
+    /// empties `raw` before conversion ever runs), exercising old behavior
+    /// instead of this fix's own new conversion-failure guard. This shape
+    /// (a clean two-value generator, no escape at all) is what actually
+    /// reaches it.
     #[test]
     fn test_slice_bound_conversion_failure_discarded_in_yq_mode_2372() {
-        yq_query!(b"[10,20,30]", r#".[(1,"x",error("y")):3]"#,
+        yq_query!(b"[10,20,30]", r#".[(1,"x"):3]"#,
             QueryResult::Error(e) => {
-                assert_eq!(e.message, "y");
+                assert!(e.message.contains("integer"), "{}", e.message);
             }
         );
     }
@@ -54235,11 +54264,16 @@ mod tests {
 
     /// #2372: yq mode keeps the pre-fix conservative discard through the
     /// path-context dispatch too, same as the plain evaluator's own gate.
+    ///
+    /// Review: no trailing escape in the bound generator -- see the plain
+    /// evaluator's own sibling test's comment above for why that shape is
+    /// needed to actually reach this fix's new conversion-failure guard
+    /// rather than the pre-existing #2351 yq gate.
     #[test]
     fn test_slice_bound_path_context_conversion_failure_discarded_in_yq_mode_2372() {
-        yq_query!(b"[10,20,30]", r#".[(1,"x",error("y")):3] | key"#,
+        yq_query!(b"[10,20,30]", r#".[(1,"x"):3] | key"#,
             QueryResult::Error(e) => {
-                assert_eq!(e.message, "y");
+                assert!(e.message.contains("integer"), "{}", e.message);
             }
         );
     }

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -17100,6 +17100,27 @@ mod tests {
         }
     }
 
+    /// #2372 review: yq mode keeps the pre-fix conservative discard, same
+    /// as `eval.rs`'s sibling gates. No trailing `error(...)` in the bound
+    /// generator here -- unlike the jq-mode test above, a trailing escape
+    /// would trip the pre-existing #2351 yq gate first (emptying `raw`
+    /// before conversion ever runs), exercising old behavior instead of
+    /// this fix's own new conversion-failure guard.
+    #[test]
+    fn test_json_computed_slice_bounds_conversion_failure_discarded_in_yq_mode_2372() {
+        let json = br#"{"a":[1,2,3]}"#;
+        let index = JsonIndex::build(json);
+
+        let expr = crate::jq::parse(r#".a[(1,"x"):2]"#).unwrap();
+        let result = eval_with_cursor_using::<YqSemantics, _>(&expr, index.root(json));
+        match result {
+            GenericResult::Error(e) => {
+                assert!(e.message.contains("integer"), "{}", e.message);
+            }
+            other => panic!("expected Error, got {other:?}"),
+        }
+    }
+
     #[test]
     fn test_json_computed_slice_bounds_open_start_and_open_end() {
         // A missing bound short-circuits `eval_slice_bound` to a single

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -9044,10 +9044,20 @@ fn eval_slice_bound<S: EvalSemantics, V: DocumentValue>(
             ),
             other => (other.collect_owned().map_err(Control::Error)?, None),
         };
-    let converted = raw
-        .iter()
-        .map(|v| owned_bound_to_i64(v, round).map_err(Control::Error))
-        .collect::<Result<Vec<_>, _>>()?;
+    // #2372: mirrors `eval::eval_slice_bound`'s identical fix exactly -- see
+    // that function's own doc comment for the full rationale and
+    // live-oracle verification, not repeated here. Used to be a bare
+    // `.collect::<Result<Vec<_>, _>>()?`, discarding every already-
+    // converted bound (and silently replacing `escape`) on the first
+    // non-numeric bound.
+    let mut converted = vec_with_capacity(raw.len());
+    for v in &raw {
+        match owned_bound_to_i64(v, round) {
+            Ok(i) => converted.push(i),
+            Err(e) if S::TAG == EvalTag::Yq => return Err(Control::Error(e)),
+            Err(e) => return Ok((converted, Some(Control::Error(e)))),
+        }
+    }
     Ok((converted, escape))
 }
 
@@ -17060,6 +17070,33 @@ mod tests {
                 );
             }
             other => panic!("expected Partial(_, Break), got {other:?}"),
+        }
+    }
+
+    /// #2372: distinct from #1528 above -- this is a bound *conversion*
+    /// failure (a non-numeric value already produced by the generator),
+    /// not the generator's own escape. `1` converts fine; `"x"` fails
+    /// before the generator's own later `error("y")` is ever reached.
+    /// Confirmed against jq 1.7.1: `.a[(1,"x",error("y")):2]` on
+    /// `{"a":[1,2,3]}` prints `[2]` (from the one successfully-converted
+    /// bound) then raises "Array/string slice indices must be integers" --
+    /// not `y`, confirming the conversion failure unconditionally outranks
+    /// the later-pending generator escape.
+    #[test]
+    fn test_json_computed_slice_bounds_conversion_failure_keeps_prefix_2372() {
+        let json = br#"{"a":[1,2,3]}"#;
+        let index = JsonIndex::build(json);
+
+        let expr = crate::jq::parse(r#".a[(1,"x",error("y")):2]"#).unwrap();
+        match eval_with_cursor(&expr, index.root(json)) {
+            GenericResult::Partial(prefix, Control::Error(e)) => {
+                assert_eq!(
+                    prefix.iter().map(OwnedValue::to_json).collect::<Vec<_>>(),
+                    vec!["[2]"]
+                );
+                assert!(e.message.contains("integers"), "{}", e.message);
+            }
+            other => panic!("expected Partial(_, Error), got {other:?}"),
         }
     }
 


### PR DESCRIPTION
## Summary

`eval_slice_bound`'s bound resolution converts a bound generator's raw values to integers via a bare `.collect::<Result<Vec<_>, _>>()?`, so a mid-stream non-numeric bound discards every already-converted bound before it -- and silently replaces any pending generator escape with the conversion's own error, no priority consideration at all.

Filed as #2372, scoped to the path-context twin (`eval_slice_bound_with_path_context`), but the identical bug exists in the plain evaluator's own `eval_slice_bound` (already documented as a known, deferred gap in a #2351-review comment, with its own jq 1.7.1 repro) and in `eval_generic.rs`'s copy of the same function -- the issue's own text explicitly invited checking both evaluators, and the root cause and fix are identical in all three, so this PR fixes all three together.

## Priority reasoning

A conversion failure only ever touches a value the generator already produced, strictly *before* whatever triggered a still-pending escape, in true generator order. So it unconditionally outranks that escape -- unlike some other priority questions in this file, no `Halt`-survives nuance is needed here: this failure *is* the primary event a real jq generator would hit first, not a secondary problem rendering an already-decided one. Confirmed live against jq 1.7.1 for both `Error` and `Halt`:

```console
$ echo '[10,20,30]' | jq -c '.[(1,"x",error("y")):3]'
jq: error (at <stdin>:1): Array/string slice indices must be integers
[20,30]
$ echo '[10,20,30]' | jq -c '.[(1,"x",halt):3]'
jq: error (at <stdin>:1): Array/string slice indices must be integers
[20,30]
```

(`halt` is never reached either -- exit 5, not exit 0.)

yq mode keeps the pre-existing conservative discard: real yq has no clean model for a computed comma-bound at all (`.[(1,"x"):3]` rejects the bound outright, "expected to find 1 number, got 2 instead").

## Implementation

Threaded the successfully-converted prefix through the same `starts_escape`/`ends_escape` deferred-escape channel the callers (`eval_slice_expr`, `eval_slice_expr_with_path_context`) already have for a generator-level `Partial` -- **no caller-side changes were needed at all**, since a conversion failure now produces exactly the same `Ok((converted_prefix, Some(control)))` shape the callers already handle correctly.

## Note on the issue's own repro

Like #2371 and #2328 before it, the issue's filed repro used `key` and claimed "confirmed live against jq 1.7.1" -- that claim is false; `key` is a yq-only/succinctly-extension builtin real jq rejects with a compile error. Re-verified against plain slice syntax instead (no `key`/`file_index`/`parent` needed), including the `Halt`-priority question the issue didn't raise but which needed checking.

## Test plan
- [x] `test_slice_bound_conversion_failure_keeps_prefix_in_jq_mode_2372` — plain evaluator, `Error`
- [x] `test_slice_bound_conversion_failure_outranks_pending_halt_2372` — plain evaluator, `Halt`
- [x] `test_slice_bound_conversion_failure_discarded_in_yq_mode_2372` — plain evaluator, yq carve-out
- [x] `test_slice_bound_path_context_conversion_failure_keeps_prefix_in_jq_mode_2372` / `..._discarded_in_yq_mode_2372` — path-context twin
- [x] `test_json_computed_slice_bounds_conversion_failure_keeps_prefix_2372` — `eval_generic.rs`
- [x] Live-verified via CLI release binary across all three dispatch paths (plain, path-context via `file_index`, yq)
- [x] Full `cargo test --no-fail-fast` (default features) — all green
- [x] `cargo test --no-default-features` (no_std) — all green
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings` — clean
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features` — clean
- [x] `cargo fmt --check` — clean

Fixes #2372