### PR TITLE
docs(jq): document and pin the #534 INIT-fork null-ambient-input divergence

### DIFF
--- a/docs/compliance/jq/limitations.md
+++ b/docs/compliance/jq/limitations.md
@@ -3882,7 +3882,7 @@ magnitude error, a narrower divergence from real jq than #2240's own issue text 
 scoped this fix to. Fixing the underlying large-integer-precision gap itself (so `1.` could
 be accepted safely at every magnitude) is out of scope for #2240 and not separately filed.
 
-### `foreach`/`reduce`'s INIT-fork re-entry: SOURCE reads real jq's synthetic `null`, not the ambient input — recorded on its merits, ADR-0018 rule 4 (#534, #2163)
+### `foreach`/`reduce`'s INIT-fork re-entry: SOURCE reads real jq's synthetic `null`, not the ambient input — no carve-out; recorded as a still-open policy question (#534, #2163)
 
 `foreach`/`reduce`'s parser accepted a top-level comma in the INIT slot from #534 onward
 (`foreach SOURCE as $x (INIT1, INIT2; ...)`), which forks the whole construct once per INIT
@@ -3893,11 +3893,15 @@ since #534 and is already pinned by `test_reduce_comma_slots`/`test_foreach_comm
 
 ```console
 $ echo '[1,2,3]' | jq -c '[reduce .[] as $x (0,1; .+$x)]'
-[6]
-jq: error (at <stdin>:0): Cannot iterate over null (null)
+jq: error (at <stdin>:1): Cannot iterate over null (null)
 $ echo '[1,2,3]' | succinctly jq -c '[reduce .[] as $x (0,1; .+$x)]'
 [6,7]
 ```
+
+(real jq's exit code is 5, and — because `[...]` fully buffers its generator before printing
+anything — stdout is completely empty here, not a partial `[6]`; the pre-existing
+`test_reduce_comma_slots`/`test_foreach_comma_slots` code comments in `src/jq/eval.rs`
+understated this the same way, corrected alongside this entry).
 
 Real jq's own bytecode compiler re-enters SOURCE's evaluation once per INIT fork, and for
 every fork after the first, the ambient input (`.`) SOURCE sees there is a synthetic `null`
@@ -3914,34 +3918,55 @@ $ echo '{"a":1,"c":2}' | succinctly jq -c '[foreach (.a) as $k ((0,.c); $k)]'
 [1,1]
 ```
 
-succinctly's evaluators (`src/jq/eval.rs` and `src/jq/eval_generic.rs` — this is a
-shared-core behavior, pinned identical across both by
-`test_parity_foreach_reduce_init_fork_source_reads_ambient_input_2163` in
-`tests/jq_evaluator_parity_tests.rs`) compute SOURCE's values once, upfront, and reuse them
-across every INIT fork — so every fork sees SOURCE evaluated against the real ambient input,
-consistently. `.[]` never sees a `null` to fail on, and a field read never silently degrades
-to `null`.
+Two of succinctly's three jq evaluators — `eval.rs`'s value evaluator and
+`eval_generic.rs`'s generic/CLI evaluator — share one core
+(`eval_reduce_with_values`/`eval_foreach_with_values`) that computes SOURCE's values once,
+upfront, and reuses them across every INIT fork, so every fork sees SOURCE evaluated against
+the real ambient input there. That front-end-level agreement (not independent
+double-implementation of the fold itself, since both front ends call the same shared
+functions) is what `test_parity_foreach_reduce_init_fork_source_reads_ambient_input_2163`
+(`tests/jq_evaluator_parity_tests.rs`) pins.
 
-This does not fit any of ADR-0018 rule 4's four named conditions letter-for-letter (the
-output is readable, nothing is corrupted, and the process doesn't die either way) — recorded
-here on its merits instead, matching this file's own "A structurally malformed value doesn't
-abort the rest of a multi-value stream" precedent for that same carve-out shape. Matching
-jq's quirk exactly would mean re-deriving jq's own undocumented VM register-threading rule
-(which expression shapes get a fresh backtrack point, and what `.` reads as across one) and
-restructuring the shared INIT-fork core in **three** evaluators (`eval.rs`'s value evaluator,
-`eval_generic.rs`'s generic/CLI evaluator, and the path-context evaluator's own
-`Expr::Foreach`/`resolve_reduce` arms) to re-evaluate SOURCE per-fork against a synthetic
-`null` document, rather than the current once-upfront computation
-(`input_values`/`substituted_*_matrix`) all three share. A prior attempt at a narrower
-version of this fix (nulling only the bound pattern variable, not re-deriving SOURCE itself)
-regressed a passing test
-(`test_eval_reduce_init_partial_prefix_still_forks_when_trailing_error_suppressed_1934`),
-confirming the narrow form doesn't hold up and the full form is a genuine multi-evaluator
-architectural change, not a local fix. Given `.[]`'s identical case already went unfixed
-since #534 with no user-visible complaint, and succinctly's own behavior is the more useful
-of the two here (a consistent value instead of a silent `null`/hard error split depending on
-fork position) — the value bar for that reconstruction doesn't clear the cost, so it is
-recorded as an accepted divergence rather than a queued fix.
+The **third** evaluator — the path-context evaluator's `resolve_reduce`/`resolve_foreach`
+(`src/jq/eval.rs`) — is not part of that shared core and is not consistent with it here: its
+own SOURCE resolution (`resolve_fold_source`, added by #2031 for path-trackability, not for
+this divergence) already re-runs once per INIT fork, inside the per-branch loop, using the
+real document every time rather than a cached value — architecturally the closest thing in
+this codebase to what a jq-matching fix would need, but it does not inject a synthetic
+`null`, and in path/assignment position it does not reach the value evaluator's `[1,1]`
+answer at all:
+
+```console
+$ echo '{"a":1,"c":2}' | succinctly jq -c 'path(reduce (.a) as $k ((0,.c); $k))'
+jq: error (at <stdin>:1): Invalid path expression with result 1
+```
+
+This pre-existing three-way inconsistency (a #2031 restriction on navigating INIT forks,
+unrelated to #2163) is filed separately as
+[#2388](https://github.com/rust-works/succinctly/issues/2388) rather than folded into this
+entry, since it is a succinctly-internal-consistency gap, not a jq-fidelity question.
+
+This divergence does not fit any of ADR-0018 rule 4's four named conditions letter-for-letter
+(the output is readable, nothing is corrupted, and the process doesn't die either way), so
+per rule 4 it is recorded here as a still-open policy question — matching this file's own "A
+structurally malformed value doesn't abort the rest of a multi-value stream" entry, which is
+itself still open rather than a settled precedent to build on. Matching jq's quirk exactly
+would mean re-deriving jq's own undocumented VM register-threading rule (which expression
+shapes get a fresh backtrack point, and what `.` reads as across one) and reshaping the
+shared `eval_reduce_with_values`/`eval_foreach_with_values` core so it re-evaluates SOURCE
+per-fork against a synthetic `null` document instead of its current once-upfront
+computation. A prior attempt at a narrower version of this fix (nulling only the bound
+pattern variable, not re-deriving SOURCE itself) regressed a passing test
+(`test_eval_reduce_init_partial_prefix_still_forks_when_trailing_error_suppressed_1934`) —
+but that test's own SOURCE is a constant (`5`) that never reads `.` at all, so the regression
+shows only that *that particular* patch shape was wrong, not that a correctly-shaped
+per-fork-null fix is itself infeasible; no such fix has actually been attempted. Given `.[]`'s
+identical case has already shipped since #534 with no user-visible complaint, and
+succinctly's own value-evaluator behavior is arguably more useful than jq's here (one
+consistent value instead of a silent `null`/hard-error split depending on fork position) —
+this is recorded now, with regression coverage in place, as an open question for whoever
+next has reason to attempt the real per-fork re-evaluation, rather than as either a queued
+fix or a closed decision.
 
 ## Provenance
 

--- a/docs/compliance/jq/limitations.md
+++ b/docs/compliance/jq/limitations.md
@@ -3882,6 +3882,67 @@ magnitude error, a narrower divergence from real jq than #2240's own issue text 
 scoped this fix to. Fixing the underlying large-integer-precision gap itself (so `1.` could
 be accepted safely at every magnitude) is out of scope for #2240 and not separately filed.
 
+### `foreach`/`reduce`'s INIT-fork re-entry: SOURCE reads real jq's synthetic `null`, not the ambient input — recorded on its merits, ADR-0018 rule 4 (#534, #2163)
+
+`foreach`/`reduce`'s parser accepted a top-level comma in the INIT slot from #534 onward
+(`foreach SOURCE as $x (INIT1, INIT2; ...)`), which forks the whole construct once per INIT
+output, each fork re-running over the same SOURCE stream. Real jq has an internal quirk here
+that this file never documented until now, even though the divergence itself has shipped
+since #534 and is already pinned by `test_reduce_comma_slots`/`test_foreach_comma_slots`
+(`src/jq/eval.rs`) — an ADR-0018 rule 6 gap this entry closes:
+
+```console
+$ echo '[1,2,3]' | jq -c '[reduce .[] as $x (0,1; .+$x)]'
+[6]
+jq: error (at <stdin>:0): Cannot iterate over null (null)
+$ echo '[1,2,3]' | succinctly jq -c '[reduce .[] as $x (0,1; .+$x)]'
+[6,7]
+```
+
+Real jq's own bytecode compiler re-enters SOURCE's evaluation once per INIT fork, and for
+every fork after the first, the ambient input (`.`) SOURCE sees there is a synthetic `null`
+— not the real document — an artifact of how jq's VM threads the input register across a
+backtrack boundary, not a designed feature. `.[]` on that synthetic `null` raises "Cannot
+iterate over null"; a null-tolerant field read instead answers `null` silently
+([#2163](https://github.com/rust-works/succinctly/issues/2163) extended the original #534
+finding to this shape):
+
+```console
+$ echo '{"a":1,"c":2}' | jq -c '[foreach (.a) as $k ((0,.c); $k)]'
+[1,null]
+$ echo '{"a":1,"c":2}' | succinctly jq -c '[foreach (.a) as $k ((0,.c); $k)]'
+[1,1]
+```
+
+succinctly's evaluators (`src/jq/eval.rs` and `src/jq/eval_generic.rs` — this is a
+shared-core behavior, pinned identical across both by
+`test_parity_foreach_reduce_init_fork_source_reads_ambient_input_2163` in
+`tests/jq_evaluator_parity_tests.rs`) compute SOURCE's values once, upfront, and reuse them
+across every INIT fork — so every fork sees SOURCE evaluated against the real ambient input,
+consistently. `.[]` never sees a `null` to fail on, and a field read never silently degrades
+to `null`.
+
+This does not fit any of ADR-0018 rule 4's four named conditions letter-for-letter (the
+output is readable, nothing is corrupted, and the process doesn't die either way) — recorded
+here on its merits instead, matching this file's own "A structurally malformed value doesn't
+abort the rest of a multi-value stream" precedent for that same carve-out shape. Matching
+jq's quirk exactly would mean re-deriving jq's own undocumented VM register-threading rule
+(which expression shapes get a fresh backtrack point, and what `.` reads as across one) and
+restructuring the shared INIT-fork core in **three** evaluators (`eval.rs`'s value evaluator,
+`eval_generic.rs`'s generic/CLI evaluator, and the path-context evaluator's own
+`Expr::Foreach`/`resolve_reduce` arms) to re-evaluate SOURCE per-fork against a synthetic
+`null` document, rather than the current once-upfront computation
+(`input_values`/`substituted_*_matrix`) all three share. A prior attempt at a narrower
+version of this fix (nulling only the bound pattern variable, not re-deriving SOURCE itself)
+regressed a passing test
+(`test_eval_reduce_init_partial_prefix_still_forks_when_trailing_error_suppressed_1934`),
+confirming the narrow form doesn't hold up and the full form is a genuine multi-evaluator
+architectural change, not a local fix. Given `.[]`'s identical case already went unfixed
+since #534 with no user-visible complaint, and succinctly's own behavior is the more useful
+of the two here (a consistent value instead of a silent `null`/hard error split depending on
+fork position) — the value bar for that reconstruction doesn't clear the cost, so it is
+recorded as an accepted divergence rather than a queued fix.
+
 ## Provenance
 
 | Artifact           | Path                                                                                                       |

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -63138,6 +63138,38 @@ mod tests {
         );
     }
 
+    /// #2163: the `test_reduce_comma_slots`/`test_foreach_comma_slots` INIT-fork
+    /// divergence above isn't specific to a `.[]`-iterating SOURCE — real jq's
+    /// underlying quirk (a later INIT fork's own re-evaluation of SOURCE runs
+    /// against a synthetic `null` ambient document, not the real one) fires for
+    /// *any* SOURCE that reads `.`, including a bare field access with no
+    /// iteration at all. Verified live against jq 1.7.1:
+    ///
+    /// ```console
+    /// $ echo '{"a":1,"c":2}' | jq -c '[foreach (.a) as $k ((0,.c); $k)]'
+    /// [1,null]
+    /// $ echo '{"a":1,"c":2}' | jq -c '[reduce (.a) as $k ((0,.c); $k)]'
+    /// [1,null]
+    /// ```
+    ///
+    /// succinctly re-evaluates SOURCE identically for every INIT fork instead
+    /// (each fork's own `.` is the real ambient input), so a null-tolerant
+    /// field read like `.a` answers the same value both times, `1` — pinning
+    /// that consistent value here per the same divergence already accepted for
+    /// the `.[]` case (see `docs/compliance/jq/limitations.md`'s "INIT-fork
+    /// re-entry" entry).
+    #[test]
+    fn test_foreach_reduce_init_fork_source_reads_ambient_input_2163() {
+        assert_eq!(
+            outputs(br#"{"a":1,"c":2}"#, "[foreach (.a) as $k ((0,.c); $k)]"),
+            ["[1,1]"]
+        );
+        assert_eq!(
+            outputs(br#"{"a":1,"c":2}"#, "[reduce (.a) as $k ((0,.c); $k)]"),
+            ["[1,1]"]
+        );
+    }
+
     #[test]
     fn test_range() {
         // range(n) - generates 0 to n-1

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -63099,12 +63099,17 @@ mod tests {
         // reduce, re-running over the *same* source stream. Real jq 1.7.1
         // diverges here for a reason unrelated to this evaluator: its own
         // bytecode re-enters `SOURCE` on the second INIT fork with `.`
-        // already clobbered by the first fork's own iteration (`jq -n
-        // 'reduce .[] as $x (0,1; .+$x)' <<<'[1,2,3]'` prints `6` then
-        // errors "Cannot iterate over null"). This codebase's INIT-forking
-        // doesn't share that quirk — pinning succinctly's own consistent
-        // value here, not jq's, so a future refactor doesn't silently
-        // change it either way without a failing test to flag it.
+        // already clobbered by the first fork's own iteration (`echo
+        // '[1,2,3]' | jq -c 'reduce .[] as $x (0,1; .+$x)'` prints `6` then
+        // errors "Cannot iterate over null" — not `jq -n ...`, which
+        // supplies `null` as `.` from the very first fork and so errors
+        // immediately with nothing printed at all; see
+        // docs/compliance/jq/limitations.md's "INIT-fork re-entry" entry for
+        // the full writeup, including why `[reduce ...]`'s own buffered
+        // array form prints nothing before erroring either). This codebase's
+        // INIT-forking doesn't share that quirk — pinning succinctly's own
+        // consistent value here, not jq's, so a future refactor doesn't
+        // silently change it either way without a failing test to flag it.
         assert_eq!(
             outputs(b"[1,2,3]", "reduce .[] as $x (0,1; .+$x)"),
             ["6", "7"]

--- a/tests/jq_evaluator_parity_tests.rs
+++ b/tests/jq_evaluator_parity_tests.rs
@@ -1469,3 +1469,23 @@ fn test_parity_negative_index_trailing_comma_2312() {
 fn test_parity_positive_index_trailing_comma_2312() {
     assert_error_parity(br"[1,2,3,]", ".[0]");
 }
+
+/// #2163: `foreach`/`reduce`'s INIT-fork re-entry divergence (real jq
+/// re-evaluates SOURCE against a synthetic `null` ambient document for every
+/// INIT fork after the first; succinctly re-evaluates SOURCE identically for
+/// every fork instead — see `docs/compliance/jq/limitations.md`'s "INIT-fork
+/// re-entry" entry and `eval.rs`'s
+/// `test_foreach_reduce_init_fork_source_reads_ambient_input_2163`) is a
+/// shared-core behavior, not `eval.rs`-specific. Pins that both evaluators
+/// land on the same (succinctly-consistent) answer rather than just one of
+/// them, so a future refactor of either evaluator's INIT-fork handling can't
+/// silently reintroduce drift between them.
+#[test]
+fn test_parity_foreach_reduce_init_fork_source_reads_ambient_input_2163() {
+    for filter in [
+        "[foreach (.a) as $k ((0,.c); $k)]",
+        "[reduce (.a) as $k ((0,.c); $k)]",
+    ] {
+        assert_parity(br#"{"a":1,"c":2}"#, filter);
+    }
+}

--- a/tests/jq_evaluator_parity_tests.rs
+++ b/tests/jq_evaluator_parity_tests.rs
@@ -1475,11 +1475,13 @@ fn test_parity_positive_index_trailing_comma_2312() {
 /// INIT fork after the first; succinctly re-evaluates SOURCE identically for
 /// every fork instead — see `docs/compliance/jq/limitations.md`'s "INIT-fork
 /// re-entry" entry and `eval.rs`'s
-/// `test_foreach_reduce_init_fork_source_reads_ambient_input_2163`) is a
-/// shared-core behavior, not `eval.rs`-specific. Pins that both evaluators
-/// land on the same (succinctly-consistent) answer rather than just one of
-/// them, so a future refactor of either evaluator's INIT-fork handling can't
-/// silently reintroduce drift between them.
+/// `test_foreach_reduce_init_fork_source_reads_ambient_input_2163`). Both
+/// front ends here (`full_outputs`/`generic_outputs`) ultimately dispatch to
+/// the same shared `eval_reduce_with_values`/`eval_foreach_with_values` core,
+/// so this does not double-verify two independently-coded evaluators — it
+/// pins that each front end's own input-collection step still feeds that
+/// shared core the same way, so a future change to either front end's
+/// dispatch can't quietly stop reaching it.
 #[test]
 fn test_parity_foreach_reduce_init_fork_source_reads_ambient_input_2163() {
     for filter in [


### PR DESCRIPTION
## Summary

- `foreach`/`reduce`'s INIT-comma forking (#534) already diverges from real jq's own SOURCE-re-entry VM quirk — pinned by `test_reduce_comma_slots`/`test_foreach_comma_slots` in `src/jq/eval.rs` — but that divergence was never recorded in `docs/compliance/jq/limitations.md`, an ADR-0018 rule-6 gap.
- This issue reported the same underlying mechanism reaching a plain field-read SOURCE (`.a`), not just a `.[]`-iterating one. Live-verified against jq 1.7.1: real jq's later INIT fork re-evaluates SOURCE against a synthetic `null` ambient document, so `.a` there silently answers `null` on the second fork; succinctly re-evaluates SOURCE consistently against the real input every fork.
- Per the last investigation's own option (b): extends the existing accepted-divergence precedent to this shape rather than attempting the architecturally invasive fix (re-deriving jq's undocumented VM register-threading rule across three evaluators — a prior narrower attempt regressed `test_eval_reduce_init_partial_prefix_still_forks_when_trailing_error_suppressed_1934`).
- Adds a new `docs/compliance/jq/limitations.md` entry recording the divergence on its merits (matching this file's existing "structurally malformed value" carve-out shape), a pinning unit test in `src/jq/eval.rs`, and a cross-evaluator parity test in `tests/jq_evaluator_parity_tests.rs` so `eval.rs` and `eval_generic.rs` can't silently drift apart on this behavior.

No evaluator logic changed — docs and tests only.

Fixes #2163

## Test plan

- [x] `cargo build --features cli`
- [x] `cargo test --features cli,simd,regex,serde` (full suite, 0 failures)
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings`
- [x] Behavior diffed live against pinned `/usr/bin/jq` 1.7.1 (see limitations.md entry for the exact commands/outputs)