### PR TITLE
fix(jq): wrong-arity calls to has/select/env/range/limit/... report jq's arity error

### DIFF
--- a/src/jq/parser.rs
+++ b/src/jq/parser.rs
@@ -1699,10 +1699,22 @@ impl<'a> Parser<'a> {
 
     /// Parse a limit expression.
     /// Syntax: limit(N; EXPR)
+    /// #2237: a wrong-arity call (no `(` at all, or a 3rd `;`-separated
+    /// argument) rewinds to `start_pos` and delegates to
+    /// [`Self::rewind_to_wrong_arity_call`], jq mode only -- see that
+    /// function's own doc comment.
     fn parse_limit_expr(&mut self) -> Result<Expr, ParseError> {
+        let start_pos = self.pos;
         self.consume_keyword("limit");
         self.skip_ws();
-        self.expect('(')?;
+        if self.peek() != Some('(') {
+            if self.mode == ParserMode::Jq {
+                return self.rewind_to_wrong_arity_call(start_pos);
+            }
+            self.expect('(')?;
+            unreachable!();
+        }
+        self.next();
         self.skip_ws();
         // `n` deliberately stays restricted to non-comma: real jq's `limit`
         // is defined with the `$n` parameter convention, where a
@@ -1711,11 +1723,31 @@ impl<'a> Parser<'a> {
         // parse but silently misbehave — worse than today's parse error.
         let n = self.parse_pipe_no_comma()?;
         self.skip_ws();
+        // #2237 review: only `)` here is unambiguously a missing-2nd-arg
+        // wrong-arity call -- rewinding on *any* non-`;` character (as an
+        // earlier version of this fix did) also caught a bare `,` right
+        // after `n`, silently defeating the comma restriction above by
+        // reparsing `limit(1,2; .)` through `parse_func_call_or_error`
+        // (whose own `parse_expr` call, unlike `parse_pipe_no_comma`, does
+        // accept commas) instead of raising this function's own intentional
+        // rejection. Anything else (`,` included) falls through to
+        // `expect(';')`, which raises its own natural error for that
+        // specific mismatch, exactly as before this fix.
+        if self.peek() == Some(')') && self.mode == ParserMode::Jq {
+            return self.rewind_to_wrong_arity_call(start_pos);
+        }
         self.expect(';')?;
         self.skip_ws();
         let expr = self.parse_expr()?;
         self.skip_ws();
-        self.expect(')')?;
+        if self.peek() != Some(')') {
+            if self.mode == ParserMode::Jq {
+                return self.rewind_to_wrong_arity_call(start_pos);
+            }
+            self.expect(')')?;
+            unreachable!();
+        }
+        self.next();
 
         Ok(Expr::Limit {
             n: Box::new(n),
@@ -1725,18 +1757,43 @@ impl<'a> Parser<'a> {
 
     /// Parse an until expression.
     /// Syntax: until(COND; UPDATE)
+    ///
+    /// #2237: a wrong-arity call rewinds jq-mode-only, same as
+    /// [`Self::parse_limit_expr`].
     fn parse_until_expr(&mut self) -> Result<Expr, ParseError> {
+        let start_pos = self.pos;
         self.consume_keyword("until");
         self.skip_ws();
-        self.expect('(')?;
+        if self.peek() != Some('(') {
+            if self.mode == ParserMode::Jq {
+                return self.rewind_to_wrong_arity_call(start_pos);
+            }
+            self.expect('(')?;
+            unreachable!();
+        }
+        self.next();
         self.skip_ws();
         let cond = self.parse_expr()?;
         self.skip_ws();
-        self.expect(';')?;
+        if self.peek() != Some(';') {
+            if self.mode == ParserMode::Jq {
+                return self.rewind_to_wrong_arity_call(start_pos);
+            }
+            self.expect(';')?;
+            unreachable!();
+        }
+        self.next();
         self.skip_ws();
         let update = self.parse_expr()?;
         self.skip_ws();
-        self.expect(')')?;
+        if self.peek() != Some(')') {
+            if self.mode == ParserMode::Jq {
+                return self.rewind_to_wrong_arity_call(start_pos);
+            }
+            self.expect(')')?;
+            unreachable!();
+        }
+        self.next();
 
         Ok(Expr::Until {
             cond: Box::new(cond),
@@ -1746,18 +1803,43 @@ impl<'a> Parser<'a> {
 
     /// Parse a while expression.
     /// Syntax: while(COND; UPDATE)
+    ///
+    /// #2237: a wrong-arity call rewinds jq-mode-only, same as
+    /// [`Self::parse_limit_expr`].
     fn parse_while_expr(&mut self) -> Result<Expr, ParseError> {
+        let start_pos = self.pos;
         self.consume_keyword("while");
         self.skip_ws();
-        self.expect('(')?;
+        if self.peek() != Some('(') {
+            if self.mode == ParserMode::Jq {
+                return self.rewind_to_wrong_arity_call(start_pos);
+            }
+            self.expect('(')?;
+            unreachable!();
+        }
+        self.next();
         self.skip_ws();
         let cond = self.parse_expr()?;
         self.skip_ws();
-        self.expect(';')?;
+        if self.peek() != Some(';') {
+            if self.mode == ParserMode::Jq {
+                return self.rewind_to_wrong_arity_call(start_pos);
+            }
+            self.expect(';')?;
+            unreachable!();
+        }
+        self.next();
         self.skip_ws();
         let update = self.parse_expr()?;
         self.skip_ws();
-        self.expect(')')?;
+        if self.peek() != Some(')') {
+            if self.mode == ParserMode::Jq {
+                return self.rewind_to_wrong_arity_call(start_pos);
+            }
+            self.expect(')')?;
+            unreachable!();
+        }
+        self.next();
 
         Ok(Expr::While {
             cond: Box::new(cond),
@@ -1767,21 +1849,45 @@ impl<'a> Parser<'a> {
 
     /// Parse a repeat expression.
     /// Syntax: repeat(EXPR)
+    ///
+    /// #2237: a wrong-arity call rewinds jq-mode-only, same as
+    /// [`Self::parse_limit_expr`].
     fn parse_repeat_expr(&mut self) -> Result<Expr, ParseError> {
+        let start_pos = self.pos;
         self.consume_keyword("repeat");
         self.skip_ws();
-        self.expect('(')?;
+        if self.peek() != Some('(') {
+            if self.mode == ParserMode::Jq {
+                return self.rewind_to_wrong_arity_call(start_pos);
+            }
+            self.expect('(')?;
+            unreachable!();
+        }
+        self.next();
         self.skip_ws();
         let expr = self.parse_expr()?;
         self.skip_ws();
-        self.expect(')')?;
+        if self.peek() != Some(')') {
+            if self.mode == ParserMode::Jq {
+                return self.rewind_to_wrong_arity_call(start_pos);
+            }
+            self.expect(')')?;
+            unreachable!();
+        }
+        self.next();
 
         Ok(Expr::Repeat(Box::new(expr)))
     }
 
     /// Parse a first expression.
     /// Syntax: first or first(expr)
+    ///
+    /// #2237: bare `first` (0 args) is already valid syntax
+    /// (`Builtin::First`), so the only wrong-arity shape here is a 2nd
+    /// `;`-separated argument (`first(1;2)`), which rewinds jq-mode-only,
+    /// same as [`Self::parse_limit_expr`].
     fn parse_first_expr(&mut self) -> Result<Expr, ParseError> {
+        let start_pos = self.pos;
         self.consume_keyword("first");
         self.skip_ws();
         if self.peek() == Some('(') {
@@ -1789,7 +1895,14 @@ impl<'a> Parser<'a> {
             self.skip_ws();
             let expr = self.parse_expr()?;
             self.skip_ws();
-            self.expect(')')?;
+            if self.peek() != Some(')') {
+                if self.mode == ParserMode::Jq {
+                    return self.rewind_to_wrong_arity_call(start_pos);
+                }
+                self.expect(')')?;
+                unreachable!();
+            }
+            self.next();
             Ok(Expr::FirstExpr(Box::new(expr)))
         } else {
             Ok(Expr::Builtin(Builtin::First))
@@ -1798,7 +1911,10 @@ impl<'a> Parser<'a> {
 
     /// Parse a last expression.
     /// Syntax: last or last(expr)
+    ///
+    /// #2237: same shape and fix as [`Self::parse_first_expr`].
     fn parse_last_expr(&mut self) -> Result<Expr, ParseError> {
+        let start_pos = self.pos;
         self.consume_keyword("last");
         self.skip_ws();
         if self.peek() == Some('(') {
@@ -1806,7 +1922,14 @@ impl<'a> Parser<'a> {
             self.skip_ws();
             let expr = self.parse_expr()?;
             self.skip_ws();
-            self.expect(')')?;
+            if self.peek() != Some(')') {
+                if self.mode == ParserMode::Jq {
+                    return self.rewind_to_wrong_arity_call(start_pos);
+                }
+                self.expect(')')?;
+                unreachable!();
+            }
+            self.next();
             Ok(Expr::LastExpr(Box::new(expr)))
         } else {
             Ok(Expr::Builtin(Builtin::Last))
@@ -1815,10 +1938,25 @@ impl<'a> Parser<'a> {
 
     /// Parse a range expression.
     /// Syntax: range(N) or range(A; B) or range(A; B; STEP)
+    ///
+    /// A wrong-arity call -- bare `range` (no `(` at all), or a 4th
+    /// `;`-separated argument -- rewinds to `start_pos` (jq mode only, same
+    /// carve-out as [`Self::zero_arity_or_wrong_arity_call`]/
+    /// [`Self::parse_required_single_arg`]) and delegates to
+    /// [`Self::parse_func_call_or_error`] so #1473/#2037's resolver reports
+    /// "range/N is not defined" instead of a raw parser rejection (#2237).
     fn parse_range_expr(&mut self) -> Result<Expr, ParseError> {
+        let start_pos = self.pos;
         self.consume_keyword("range");
         self.skip_ws();
-        self.expect('(')?;
+        if self.peek() != Some('(') {
+            if self.mode == ParserMode::Jq {
+                return self.rewind_to_wrong_arity_call(start_pos);
+            }
+            self.expect('(')?;
+            unreachable!();
+        }
+        self.next();
         self.skip_ws();
         let first = self.parse_expr()?;
         self.skip_ws();
@@ -1852,7 +1990,14 @@ impl<'a> Parser<'a> {
         self.skip_ws();
         let step = self.parse_expr()?;
         self.skip_ws();
-        self.expect(')')?;
+        if self.peek() != Some(')') {
+            if self.mode == ParserMode::Jq {
+                return self.rewind_to_wrong_arity_call(start_pos);
+            }
+            self.expect(')')?;
+            unreachable!();
+        }
+        self.next();
 
         Ok(Expr::Range {
             from: Box::new(first),
@@ -2218,6 +2363,24 @@ impl<'a> Parser<'a> {
         }
     }
 
+    /// The `Expr`-returning counterpart of
+    /// [`Self::zero_arity_or_wrong_arity_call`]/
+    /// [`Self::parse_required_single_arg`]'s shared "detected wrong arity,
+    /// rewind and delegate" tail, for the dedicated-parse-function family
+    /// (`parse_range_expr`, `parse_first_expr`, `parse_limit_expr`, ...)
+    /// that returns `Expr` directly rather than going through
+    /// [`Self::try_parse_builtin`]'s `Option<Builtin>` fallback protocol
+    /// (#2237). `start_pos` must be the position *before* the keyword was
+    /// consumed. Call only in jq mode -- a non-jq-mode call site keeps
+    /// raising its own original raw `ParseError` unchanged, matching every
+    /// other rewind site's identical carve-out (real yq has no name/arity
+    /// resolution vocabulary at all, so jq's own "X/N is not defined"
+    /// wording would be a new divergence there, not a fix).
+    fn rewind_to_wrong_arity_call(&mut self, start_pos: usize) -> Result<Expr, ParseError> {
+        self.pos = start_pos;
+        self.parse_func_call_or_error()
+    }
+
     /// Parse a format string: @text, @json, @uri, @dsv(delimiter), etc.
     fn parse_format_string(&mut self) -> Result<Expr, ParseError> {
         self.expect('@')?;
@@ -2367,6 +2530,61 @@ impl<'a> Parser<'a> {
         self.parse_postfix(parsed)
     }
 
+    /// The single-required-argument counterpart of
+    /// [`Self::zero_arity_or_wrong_arity_call`] (#2237): a builtin like
+    /// `has(expr)`/`select(expr)` that always requires exactly one
+    /// parenthesized argument currently parses that argument inline (`expect
+    /// ('(')` / `parse_expr` / `expect(')')`, each propagated via `?`), so a
+    /// wrong-arity call -- no `(` at all (`has`), or more than one
+    /// `;`-separated argument (`has(1;2)`) -- raises the raw structural
+    /// ParseError immediately, never reaching #1473/#2037's name/arity
+    /// resolver the way #2110 already routes a *zero*-arity builtin's own
+    /// wrong-arity call.
+    ///
+    /// On the correct shape, returns `Ok(Some(expr))`. On either wrong-arity
+    /// shape, **in jq mode**, rewinds to `start_pos` (the position before
+    /// the keyword was consumed) and returns `Ok(None)` -- deliberately
+    /// reusing [`Self::try_parse_builtin`]'s own "not this builtin after
+    /// all" contract, so the caller's existing `else { self
+    /// .parse_func_call_or_error() }` fallback (already present at every
+    /// call site through [`Self::parse_primary_inner`]) does the delegation,
+    /// with no `Builtin`-vs-`Expr` type mismatch to bridge. A genuine syntax
+    /// error *inside* the argument expression itself (`has(1 +)`) still
+    /// propagates as a raw ParseError unchanged -- only the two structural
+    /// checkpoints below ever trigger a rewind, mirroring
+    /// [`Self::zero_arity_or_wrong_arity_call`]'s own peek-based precision
+    /// rather than a blanket catch-and-retry.
+    ///
+    /// yq mode never rewinds, matching that function's identical carve-out:
+    /// real yq has no name/arity resolution vocabulary at all, so jq's own
+    /// "X/N is not defined" wording would be a new divergence there, not a
+    /// fix -- yq mode keeps the pre-#2237 raw ParseError unchanged.
+    fn parse_required_single_arg(&mut self, start_pos: usize) -> Result<Option<Expr>, ParseError> {
+        self.skip_ws();
+        if self.peek() != Some('(') {
+            if self.mode == ParserMode::Jq {
+                self.pos = start_pos;
+                return Ok(None);
+            }
+            // Not a rewind case (yq mode) -- `expect` raises the identical
+            // error the pre-#2237 unconditional `self.expect('(')?` did.
+            return self.expect('(').map(|()| unreachable!());
+        }
+        self.next();
+        self.skip_ws();
+        let arg = self.parse_expr()?;
+        self.skip_ws();
+        if self.peek() != Some(')') {
+            if self.mode == ParserMode::Jq {
+                self.pos = start_pos;
+                return Ok(None);
+            }
+            return self.expect(')').map(|()| unreachable!());
+        }
+        self.next();
+        Ok(Some(arg))
+    }
+
     /// Try to parse a builtin function.
     /// Returns Some(Builtin) if a builtin was parsed, None if not a builtin.
     fn try_parse_builtin(&mut self) -> Result<Option<Builtin>, ParseError> {
@@ -2475,26 +2693,20 @@ impl<'a> Parser<'a> {
 
         // has(expr) - takes an argument
         if self.matches_keyword("has") {
+            let keyword_start = self.pos;
             self.consume_keyword("has");
-            self.skip_ws();
-            self.expect('(')?;
-            self.skip_ws();
-            let arg = self.parse_expr()?;
-            self.skip_ws();
-            self.expect(')')?;
-            return Ok(Some(Builtin::Has(Box::new(arg))));
+            return Ok(self
+                .parse_required_single_arg(keyword_start)?
+                .map(|arg| Builtin::Has(Box::new(arg))));
         }
 
         // Selection functions
         if self.matches_keyword("select") {
+            let keyword_start = self.pos;
             self.consume_keyword("select");
-            self.skip_ws();
-            self.expect('(')?;
-            self.skip_ws();
-            let cond = self.parse_expr()?;
-            self.skip_ws();
-            self.expect(')')?;
-            return Ok(Some(Builtin::Select(Box::new(cond))));
+            return Ok(self
+                .parse_required_single_arg(keyword_start)?
+                .map(|cond| Builtin::Select(Box::new(cond))));
         }
         if self.matches_keyword("empty") {
             self.consume_keyword("empty");
@@ -2603,14 +2815,11 @@ impl<'a> Parser<'a> {
         if self.matches_keyword("min_by") {
             // Check min_by before min
             self.reject_unless_jq_extensions("min_by")?;
+            let keyword_start = self.pos;
             self.consume_keyword("min_by");
-            self.skip_ws();
-            self.expect('(')?;
-            self.skip_ws();
-            let f = self.parse_expr()?;
-            self.skip_ws();
-            self.expect(')')?;
-            return Ok(Some(Builtin::MinBy(Box::new(f))));
+            return Ok(self
+                .parse_required_single_arg(keyword_start)?
+                .map(|f| Builtin::MinBy(Box::new(f))));
         }
         if self.matches_keyword("min") && !self.peek_after_keyword_is_paren("min") {
             self.consume_keyword("min");
@@ -2619,14 +2828,11 @@ impl<'a> Parser<'a> {
         if self.matches_keyword("max_by") {
             // Check max_by before max
             self.reject_unless_jq_extensions("max_by")?;
+            let keyword_start = self.pos;
             self.consume_keyword("max_by");
-            self.skip_ws();
-            self.expect('(')?;
-            self.skip_ws();
-            let f = self.parse_expr()?;
-            self.skip_ws();
-            self.expect(')')?;
-            return Ok(Some(Builtin::MaxBy(Box::new(f))));
+            return Ok(self
+                .parse_required_single_arg(keyword_start)?
+                .map(|f| Builtin::MaxBy(Box::new(f))));
         }
         if self.matches_keyword("max") && !self.peek_after_keyword_is_paren("max") {
             self.consume_keyword("max");
@@ -2636,14 +2842,11 @@ impl<'a> Parser<'a> {
         // in(obj) - takes an argument (note: "in" is also sometimes used differently in jq)
         // We parse it with required parentheses
         if self.matches_keyword("in") {
+            let keyword_start = self.pos;
             self.consume_keyword("in");
-            self.skip_ws();
-            self.expect('(')?;
-            self.skip_ws();
-            let obj = self.parse_expr()?;
-            self.skip_ws();
-            self.expect(')')?;
-            return Ok(Some(Builtin::In(Box::new(obj))));
+            return Ok(self
+                .parse_required_single_arg(keyword_start)?
+                .map(|obj| Builtin::In(Box::new(obj))));
         }
 
         // IN(s) - true if any output of s equals the current value
@@ -2679,47 +2882,35 @@ impl<'a> Parser<'a> {
         }
         if self.matches_keyword("ltrimstr") {
             self.reject_unless_jq_extensions("ltrimstr")?;
+            let keyword_start = self.pos;
             self.consume_keyword("ltrimstr");
-            self.skip_ws();
-            self.expect('(')?;
-            self.skip_ws();
-            let s = self.parse_expr()?;
-            self.skip_ws();
-            self.expect(')')?;
-            return Ok(Some(Builtin::Ltrimstr(Box::new(s))));
+            return Ok(self
+                .parse_required_single_arg(keyword_start)?
+                .map(|s| Builtin::Ltrimstr(Box::new(s))));
         }
         if self.matches_keyword("rtrimstr") {
             self.reject_unless_jq_extensions("rtrimstr")?;
+            let keyword_start = self.pos;
             self.consume_keyword("rtrimstr");
-            self.skip_ws();
-            self.expect('(')?;
-            self.skip_ws();
-            let s = self.parse_expr()?;
-            self.skip_ws();
-            self.expect(')')?;
-            return Ok(Some(Builtin::Rtrimstr(Box::new(s))));
+            return Ok(self
+                .parse_required_single_arg(keyword_start)?
+                .map(|s| Builtin::Rtrimstr(Box::new(s))));
         }
         if self.matches_keyword("startswith") {
             self.reject_unless_jq_extensions("startswith")?;
+            let keyword_start = self.pos;
             self.consume_keyword("startswith");
-            self.skip_ws();
-            self.expect('(')?;
-            self.skip_ws();
-            let s = self.parse_expr()?;
-            self.skip_ws();
-            self.expect(')')?;
-            return Ok(Some(Builtin::Startswith(Box::new(s))));
+            return Ok(self
+                .parse_required_single_arg(keyword_start)?
+                .map(|s| Builtin::Startswith(Box::new(s))));
         }
         if self.matches_keyword("endswith") {
             self.reject_unless_jq_extensions("endswith")?;
+            let keyword_start = self.pos;
             self.consume_keyword("endswith");
-            self.skip_ws();
-            self.expect('(')?;
-            self.skip_ws();
-            let s = self.parse_expr()?;
-            self.skip_ws();
-            self.expect(')')?;
-            return Ok(Some(Builtin::Endswith(Box::new(s))));
+            return Ok(self
+                .parse_required_single_arg(keyword_start)?
+                .map(|s| Builtin::Endswith(Box::new(s))));
         }
         // Check splits before split since split is a prefix of splits
         if self.matches_keyword("splits") {
@@ -2969,14 +3160,11 @@ impl<'a> Parser<'a> {
         }
         // Check sort_by before sort
         if self.matches_keyword("sort_by") {
+            let keyword_start = self.pos;
             self.consume_keyword("sort_by");
-            self.skip_ws();
-            self.expect('(')?;
-            self.skip_ws();
-            let f = self.parse_expr()?;
-            self.skip_ws();
-            self.expect(')')?;
-            return Ok(Some(Builtin::SortBy(Box::new(f))));
+            return Ok(self
+                .parse_required_single_arg(keyword_start)?
+                .map(|f| Builtin::SortBy(Box::new(f))));
         }
         if self.matches_keyword("sort") {
             self.consume_keyword("sort");
@@ -3503,16 +3691,43 @@ impl<'a> Parser<'a> {
         // env(VAR) - get specific environment variable (yq syntax)
         // env.VAR or env (as builtin)
         if self.matches_keyword("env") {
+            let keyword_start = self.pos;
             self.consume_keyword("env");
             self.skip_ws();
             // Check for env(VAR) syntax - yq style
             if self.peek() == Some('(') {
                 self.next(); // consume '('
                 self.skip_ws();
-                // Parse identifier (unquoted variable name)
-                let var_name = self.parse_ident()?;
+                // Parse identifier (unquoted variable name). Real jq's own
+                // `env` builtin is arity-0 only, so `env(<anything>)` --
+                // this repo's own `env(VAR)` extension syntax given a
+                // non-identifier argument, or more than one argument -- is
+                // always "env/N is not defined" there, not a raw parse
+                // error (#2237). jq mode rewinds to let #1473/#2037's
+                // resolver report that, mirroring
+                // `Self::parse_required_single_arg`'s identical strategy;
+                // yq mode keeps the original raw error unchanged (same
+                // rationale as `Self::zero_arity_or_wrong_arity_call`'s own
+                // carve-out).
+                let var_name = match self.parse_ident() {
+                    Ok(name) => name,
+                    Err(e) => {
+                        if self.mode == ParserMode::Jq {
+                            self.pos = keyword_start;
+                            return Ok(None);
+                        }
+                        return Err(e);
+                    }
+                };
                 self.skip_ws();
-                self.expect(')')?;
+                if self.peek() != Some(')') {
+                    if self.mode == ParserMode::Jq {
+                        self.pos = keyword_start;
+                        return Ok(None);
+                    }
+                    return self.expect(')').map(|()| unreachable!());
+                }
+                self.next();
                 return Ok(Some(Builtin::EnvObject(var_name)));
             }
             return Ok(Some(Builtin::Env));

--- a/src/jq/parser.rs
+++ b/src/jq/parser.rs
@@ -1459,8 +1459,47 @@ impl<'a> Parser<'a> {
                     // `keys[0]`) on whichever `Expr` it ends up returning.
                     self.zero_arity_or_wrong_arity_call(keyword_start, Expr::Builtin(builtin))
                 } else {
-                    // Phase 9: Try to parse as function call
-                    self.parse_func_call_or_error()
+                    // Phase 9: Try to parse as function call.
+                    //
+                    // #2237 review: postfix (`.field`/`[idx]`) should be
+                    // applied to the resolved call here too, exactly like
+                    // the `zero_arity_or_wrong_arity_call` branch above
+                    // already does -- a pre-existing gap, not previously
+                    // scoped to any wrong-arity fix: even a legitimately
+                    // *defined* function call followed by postfix failed to
+                    // parse at all before this (`def f(x): {a:x}; f(1).a`
+                    // raised a raw "unexpected character '.'" instead of
+                    // returning `1`, confirmed against jq 1.7.1). Also
+                    // fixes the same gap for every wrong-arity call that
+                    // reaches this branch via `Ok(None)` from
+                    // `Self::try_parse_builtin` (`Self::parse_required_single_arg`'s
+                    // rewind path -- `has`/`select`/`env`/...).
+                    //
+                    // jq mode only (review, round 2): yq mode's own
+                    // merge-flag scan (`Self::scan_merge_flags`, called from
+                    // the `*`/`*=` operator parsing) silently stops at the
+                    // first unrecognized character rather than erroring,
+                    // leaving it -- and anything after it -- for this exact
+                    // fallback to parse as an ordinary expression. Applying
+                    // postfix unconditionally here let a bare merge-flag
+                    // remnant absorb a trailing `.field` the way `n.b`
+                    // legitimately can as a plain identifier expression,
+                    // producing a full (if semantically wrong-flag) parse
+                    // where real yq's own lexer unconditionally rejects
+                    // *any* non-flag content immediately after `*=`/`*` --
+                    // confirmed live against yq v4.53.3, `.a *= n.b` (an
+                    // ordinary, unrelated identifier reference, not even a
+                    // merge-flag context) is *also* `lexer: invalid input
+                    // text`. Real jq has no such restriction (`.a *=n .b`
+                    // parses as `.a *= (n.b)` there, confirmed live, and
+                    // only fails later at name resolution), so jq mode
+                    // keeps the postfix fix.
+                    let call = self.parse_func_call_or_error()?;
+                    if self.mode == ParserMode::Jq {
+                        self.parse_postfix(call)
+                    } else {
+                        Ok(call)
+                    }
                 }
             }
 
@@ -2376,9 +2415,18 @@ impl<'a> Parser<'a> {
     /// other rewind site's identical carve-out (real yq has no name/arity
     /// resolution vocabulary at all, so jq's own "X/N is not defined"
     /// wording would be a new divergence there, not a fix).
+    ///
+    /// Applies [`Self::parse_postfix`] to the resolved call before
+    /// returning it (review finding): `parse_func_call_or_error` alone
+    /// leaves a trailing `.field`/`[idx]` as a raw "unexpected character"
+    /// parse error, exactly the `null(1).foo` regression
+    /// [`Self::zero_arity_or_wrong_arity_call`]'s own doc comment already
+    /// recounts -- confirmed live against jq 1.7.1: `range(1;2;3;4).foo`
+    /// reports `range/4 is not defined`, not a syntax error.
     fn rewind_to_wrong_arity_call(&mut self, start_pos: usize) -> Result<Expr, ParseError> {
         self.pos = start_pos;
-        self.parse_func_call_or_error()
+        let call = self.parse_func_call_or_error()?;
+        self.parse_postfix(call)
     }
 
     /// Parse a format string: @text, @json, @uri, @dsv(delimiter), etc.
@@ -3709,6 +3757,22 @@ impl<'a> Parser<'a> {
                 // yq mode keeps the original raw error unchanged (same
                 // rationale as `Self::zero_arity_or_wrong_arity_call`'s own
                 // carve-out).
+                //
+                // Review: an empty `env()` must NOT rewind -- unlike
+                // `env(1)`, it has no argument at all to disambiguate from
+                // real jq's own `f()` syntax error (`def f: 1; f()` is a
+                // syntax error there too, not `f/0 is not defined`; see
+                // `Self::zero_arity_or_wrong_arity_call`'s own identical
+                // `()`-exclusion doc comment). Without this guard,
+                // `parse_ident()` on an immediate `)` failed exactly like a
+                // non-identifier argument would, and the rewind turned
+                // `env()` into a *successful* parse of `FuncCall{name:
+                // "env", args: []}` -- changing a jq 1.7.1 compile-time
+                // syntax error (exit 3) into succinctly's own runtime
+                // "undefined function" error (exit 5), confirmed live.
+                if self.peek() == Some(')') {
+                    return self.parse_ident().map(|_| unreachable!());
+                }
                 let var_name = match self.parse_ident() {
                     Ok(name) => name,
                     Err(e) => {
@@ -6990,9 +7054,22 @@ mod tests {
     #[test]
     fn test_jq_mode_rejects_merge_flags() {
         // Real jq has no merge-flag syntax at all — jq mode must not
-        // recognize these tokens, regardless of what yq mode does.
+        // recognize these tokens, regardless of what yq mode does. `+`
+        // can't start an expression, so `.a *+ .b` stays a genuine parse
+        // error.
         assert!(parse(".a *+ .b").is_err());
-        assert!(parse(".a *=n .b").is_err());
+        // `.a *=n .b`, by contrast, is NOT a parse error in jq mode (#2237
+        // review correction, verified live against jq 1.7.1): jq's own
+        // grammar has no flag-scanning special case after `*=` at all, so
+        // `n` simply starts an ordinary expression -- `.a *= (n.b)`, an
+        // identifier call `n` with postfix field access `.b`. Real jq
+        // parses this successfully too and only fails later, at name
+        // resolution (`n/0 is not defined`) -- a stage this `parse()`
+        // function doesn't perform. The pre-#2237 assertion here held only
+        // because of the very postfix-chaining gap #2237's review found and
+        // fixed (`n` parsed, but the trailing `.b` was left unconsumed,
+        // failing the overall parse for an unrelated reason).
+        assert!(parse(".a *=n .b").is_ok());
 
         // Plain `*`/`*=` still work in jq mode, with default (all-false) flags.
         assert_eq!(

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -20081,6 +20081,112 @@ fn test_zero_arity_builtin_empty_parens_stays_compile_error_2110() -> Result<()>
     Ok(())
 }
 
+/// #2237: extends #2110's fix to builtins that always require at least one
+/// argument and parse it inline (`self.expect('(')?`/`self.parse_expr()?`/
+/// `self.expect(')')?`, via the new `parse_required_single_arg` helper) --
+/// before this fix, a wrong-arity call (no `(` at all, or a 2nd
+/// `;`-separated argument) raised a raw structural `ParseError` instead of
+/// #1473/#2037's own "X/N is not defined" compile error. Verified against
+/// the pinned oracle (`/usr/bin/jq`, jq-1.7.1); `env` uses `env(1)` (a
+/// non-identifier argument) instead of a 0-arg call since bare `env` is
+/// itself valid (arity-0) syntax.
+#[test]
+fn test_single_arg_builtin_wrong_arity_reports_not_defined_2237() -> Result<()> {
+    for (filter, name) in [
+        ("has", "has/0"),
+        ("has(1;2)", "has/2"),
+        ("select", "select/0"),
+        ("select(1;2)", "select/2"),
+        ("env(1)", "env/1"),
+        ("env(1;2)", "env/2"),
+        ("min_by", "min_by/0"),
+        ("min_by(1;2)", "min_by/2"),
+        ("max_by", "max_by/0"),
+        ("max_by(1;2)", "max_by/2"),
+        ("in", "in/0"),
+        ("in(1;2)", "in/2"),
+        ("ltrimstr", "ltrimstr/0"),
+        ("ltrimstr(1;2)", "ltrimstr/2"),
+        ("rtrimstr", "rtrimstr/0"),
+        ("rtrimstr(1;2)", "rtrimstr/2"),
+        ("startswith", "startswith/0"),
+        ("startswith(1;2)", "startswith/2"),
+        ("endswith", "endswith/0"),
+        ("endswith(1;2)", "endswith/2"),
+        ("sort_by", "sort_by/0"),
+        ("sort_by(1;2)", "sort_by/2"),
+    ] {
+        let (stdout, stderr, code) = run_jq_full(&["-nc", filter], None)?;
+        assert_eq!(stdout, "", "{filter}: stderr {stderr:?}");
+        assert!(
+            stderr.contains(&format!("{name} is not defined at <top-level>, line 1:")),
+            "{filter}: stderr {stderr:?}"
+        );
+        assert_eq!(code, 3, "{filter}: stdout: {stdout:?} stderr: {stderr:?}");
+    }
+    Ok(())
+}
+
+/// #2237 sibling: the same fix for the "dedicated parse function" family
+/// (`range`/`limit`/`until`/`while`/`repeat`/`first`/`last`), which returns
+/// `Expr` directly rather than going through `try_parse_builtin`'s
+/// `Option<Builtin>` protocol -- the new `rewind_to_wrong_arity_call`
+/// helper. Covers every wrong-arity shape each of these can take: 0 args
+/// (below the minimum), too few (missing a required `;` argument, only
+/// reachable for the 2-required-arg family), and too many. Verified against
+/// the pinned oracle.
+#[test]
+fn test_dedicated_parse_fn_wrong_arity_reports_not_defined_2237() -> Result<()> {
+    for (filter, name) in [
+        ("range", "range/0"),
+        ("range(1;2;3;4)", "range/4"),
+        ("limit", "limit/0"),
+        ("limit(1)", "limit/1"),
+        ("limit(1;2;3)", "limit/3"),
+        ("until", "until/0"),
+        ("until(1)", "until/1"),
+        ("until(1;2;3)", "until/3"),
+        ("while", "while/0"),
+        ("while(1)", "while/1"),
+        ("while(1;2;3)", "while/3"),
+        ("repeat", "repeat/0"),
+        ("repeat(1;2)", "repeat/2"),
+        ("first(1;2)", "first/2"),
+        ("last(1;2)", "last/2"),
+    ] {
+        let (stdout, stderr, code) = run_jq_full(&["-nc", filter], None)?;
+        assert_eq!(stdout, "", "{filter}: stderr {stderr:?}");
+        assert!(
+            stderr.contains(&format!("{name} is not defined at <top-level>, line 1:")),
+            "{filter}: stderr {stderr:?}"
+        );
+        assert_eq!(code, 3, "{filter}: stdout: {stdout:?} stderr: {stderr:?}");
+    }
+    Ok(())
+}
+
+/// #2237 control: a genuine syntax error *inside* a required argument
+/// (unlike a structural arity mismatch) must still raise a raw parse error,
+/// not get rewound into a spurious name/arity resolution attempt -- the
+/// `parse_required_single_arg`/`rewind_to_wrong_arity_call` family only
+/// intervenes at the specific `(`/`)`/`;` structural checkpoints, never on
+/// a `parse_expr()` failure itself. Verified against the pinned oracle:
+/// real jq also raises a (differently-worded) syntax error here, never
+/// "has/N is not defined".
+#[test]
+fn test_single_arg_builtin_internal_syntax_error_stays_parse_error_2237() -> Result<()> {
+    for filter in ["has(1 +)", "range(1;2;3+)"] {
+        let (stdout, stderr, code) = run_jq_full(&["-nc", filter], None)?;
+        assert_eq!(stdout, "", "{filter}: stderr {stderr:?}");
+        assert!(
+            !stderr.contains("is not defined"),
+            "{filter}: stderr {stderr:?}"
+        );
+        assert_eq!(code, 3, "{filter}: stdout: {stdout:?} stderr: {stderr:?}");
+    }
+    Ok(())
+}
+
 /// #1376: `succinctly jq` now supports arity overloading, matching real
 /// jq -- `def f(x): ...` and `def f(x;y): ...` are distinct functions
 /// (`f/1` and `f/2`), and both stay callable after the second definition.

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -20187,6 +20187,63 @@ fn test_single_arg_builtin_internal_syntax_error_stays_parse_error_2237() -> Res
     Ok(())
 }
 
+/// #2237 review: a wrong-arity call's rewound result must still support
+/// postfix (`.field`/`[idx]`) -- `rewind_to_wrong_arity_call` and
+/// `parse_primary_inner`'s own `parse_func_call_or_error` fallback both
+/// left this unwrapped in an earlier version of this fix, exactly the
+/// `null(1).foo` regression `zero_arity_or_wrong_arity_call`'s own doc
+/// comment recounts. Also exercises the same fallback's *pre-existing* gap
+/// (unrelated to arity, present on `main` before #2237 too): a
+/// legitimately-defined function call followed by postfix failed to parse
+/// at all. Verified against jq 1.7.1.
+#[test]
+#[allow(clippy::literal_string_with_formatting_args)]
+fn test_wrong_arity_call_supports_postfix_2237() -> Result<()> {
+    for (filter, name) in [
+        ("range(1;2;3;4).foo", "range/4"),
+        ("has(1;2).foo", "has/2"),
+        ("select(1;2).foo", "select/2"),
+        ("env(1;2).foo", "env/2"),
+        ("limit(1;2;3).foo", "limit/3"),
+        ("undefinedname(1).foo", "undefinedname/1"),
+    ] {
+        let (stdout, stderr, code) = run_jq_full(&["-nc", filter], Some(r#"{"foo":1}"#))?;
+        assert_eq!(stdout, "", "{filter}: stderr {stderr:?}");
+        assert!(
+            stderr.contains(&format!("{name} is not defined at <top-level>, line 1:")),
+            "{filter}: stderr {stderr:?}"
+        );
+        assert_eq!(code, 3, "{filter}: stdout: {stdout:?} stderr: {stderr:?}");
+    }
+
+    // The pre-existing gap this fix incidentally closes too: a
+    // legitimately-defined function call followed by postfix now parses
+    // and evaluates, matching jq 1.7.1 (`f(1).a` => `1`).
+    let (stdout, stderr, code) = run_jq_full(&["-nc", "def f(x): {a:x}; f(1).a"], None)?;
+    assert_eq!(code, 0, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert_eq!(stdout.trim_end(), "1");
+    Ok(())
+}
+
+/// #2237 review: `env()` (truly empty parens, no argument at all) must
+/// stay a compile-time syntax error, not rewind into a *successful* parse
+/// of `env/0` that then fails at runtime -- the same `()`-exclusion
+/// `zero_arity_or_wrong_arity_call`'s own doc comment establishes for
+/// `length()`/`not()`/`keys()`/`null()` (real jq's grammar has no
+/// zero-argument parenthesized call shape at all). Before this fix,
+/// `parse_ident()`'s failure on an immediate `)` was indistinguishable from
+/// its failure on a genuinely wrong-shaped argument (`env(1)`), so `env()`
+/// silently changed from jq 1.7.1's own compile-time syntax error (exit 3)
+/// to succinctly's runtime "undefined function" error (exit 5).
+#[test]
+fn test_env_empty_parens_stays_compile_error_not_runtime_2237() -> Result<()> {
+    let (stdout, stderr, code) = run_jq_full(&["-nc", "env()"], None)?;
+    assert_eq!(stdout, "", "stderr: {stderr:?}");
+    assert!(!stderr.contains("undefined function"), "stderr: {stderr:?}");
+    assert_eq!(code, 3, "stdout: {stdout:?} stderr: {stderr:?}");
+    Ok(())
+}
+
 /// #1376: `succinctly jq` now supports arity overloading, matching real
 /// jq -- `def f(x): ...` and `def f(x;y): ...` are distinct functions
 /// (`f/1` and `f/2`), and both stay callable after the second definition.

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -1455,6 +1455,33 @@ fn test_yq_mode_zero_arity_wrong_arity_call_unaffected_by_2110() -> Result<()> {
     Ok(())
 }
 
+/// #2237's jq-mode fix (a builtin that always requires at least one
+/// argument, called with the wrong arity, reports jq's own "X/N is not
+/// defined" instead of a raw parser rejection) must not leak into yq mode
+/// either -- same rationale as #2110's own identical carve-out immediately
+/// above. `has`/`has(1;2)` (not `range`, which is gated behind
+/// `--jq-extensions` and gives an unrelated "not part of yq's syntax"
+/// message without it) pinned here against succinctly's own wording.
+#[test]
+fn test_yq_mode_single_arg_builtin_wrong_arity_unaffected_by_2237() -> Result<()> {
+    let (out, stderr, code) = run_yq_stdin_with_stderr("has", "a: 1\n", &[])?;
+    assert_eq!(out, "", "stderr: {stderr}");
+    assert!(
+        stderr.contains("parse error: parse error at position 3: expected '(', found end of input"),
+        "stderr: {stderr}"
+    );
+    assert_eq!(code, 1, "stderr: {stderr}");
+
+    let (out, stderr, code) = run_yq_stdin_with_stderr("has(1;2)", "a: 1\n", &[])?;
+    assert_eq!(out, "", "stderr: {stderr}");
+    assert!(
+        stderr.contains("parse error: parse error at position 5: expected ')', found ';'"),
+        "stderr: {stderr}"
+    );
+    assert_eq!(code, 1, "stderr: {stderr}");
+    Ok(())
+}
+
 /// #2225 (review): the read-mode fix reaches yq mode too, not just jq mode
 /// -- `stderr` fires twice, once per start value, confirming `end` is
 /// re-evaluated fresh per `s` through `eval_generic::eval_slice_expr`


### PR DESCRIPTION
Fixes #2237

## Summary

Follow-up to #2110, which fixed a wrong-arity call to a *zero*-arity builtin
(`length(1)`, `not(1)`, ...) reporting a raw parser rejection of the `(` instead of
jq's own compile-time "X/N is not defined". This extends that fix to two families
#2110's own scope explicitly left unaddressed:

**Category 1**: builtins that always require at least one argument and parse it
inline (`has`, `select`, `env`, `min_by`, `max_by`, `in`, `ltrimstr`, `rtrimstr`,
`startswith`, `endswith`, `sort_by`) -- e.g. `has`/`has(1;2)` currently give a raw
`expected '(', found end of input` / `expected ')', found ';'` instead of
`has/0`/`has/2 is not defined`.

**Category 2**: the dedicated-parse-function family (`range`, `limit`, `until`,
`while`, `repeat`, `first`, `last`) -- e.g. bare `range` or `first(1;2)`.

Confirmed live against jq 1.7.1 (issue's own repros):

```console
$ echo null | jq 'has'
jq: error: has/0 is not defined at <top-level>, line 1:
$ echo null | succinctly jq 'has'
jq: compile error: parse error at position 3: expected '(', found end of input

$ echo null | jq 'range'
jq: error: range/0 is not defined at <top-level>, line 1:
$ echo null | succinctly jq 'range'
jq: compile error: parse error at position 5: expected '(', found end of input
```

## Fix

- **Category 1**: new `parse_required_single_arg` helper. Rather than a
  `Builtin`-vs-`Expr` type bridge, it reuses `try_parse_builtin`'s own "not this
  builtin after all" `Option<Builtin>` contract -- on a wrong-arity shape it rewinds
  to before the keyword and returns `Ok(None)`, so the caller's *existing*
  `else { self.parse_func_call_or_error() }` fallback (already present at the one
  call site through `parse_primary_inner`) does the delegation, with zero type
  mismatch to bridge.
- **Category 2**: new `rewind_to_wrong_arity_call` helper -- the `Expr`-returning
  counterpart, since these functions bypass `try_parse_builtin` entirely.

Both only intervene at the exact structural checkpoints #2110's own
`zero_arity_or_wrong_arity_call` established as precise (peek-based, not a blanket
catch-and-retry) -- a genuine syntax error *inside* an argument (`has(1 +)`) still
raises a raw ParseError unchanged, verified against the oracle. jq mode only,
matching #2110's own yq carve-out.

**Regression caught during my own testing**: an early version of `limit`'s fix used
an overly-broad checkpoint that also caught the deliberate, pre-existing restriction
against a comma-valued `n` (`limit(1,2; .)` must stay a parse error -- real jq's
`$n` per-output fanout isn't implemented here). Narrowed to the single unambiguous
case (`)` immediately after `n`) so that restriction's own error is preserved.

## Review round 2

Code review (multiple agents, extensive differential testing against both pinned
oracles) found two more real gaps, and my own follow-up verification pass while
fixing them caught a third:

1. **Missing postfix support on the rewound result.** Neither
   `rewind_to_wrong_arity_call` nor the `try_parse_builtin` fallback applied
   `parse_postfix`, so `range(1;2;3;4).foo`/`has(1;2).foo`/etc. raised a raw
   "unexpected character '.'" instead of the intended arity error -- exactly the
   `null(1).foo` regression `zero_arity_or_wrong_arity_call`'s own doc comment
   already recounts. Fixed by wrapping both in `parse_postfix`, which incidentally
   also fixes a pre-existing, unrelated gap: a legitimately-defined function call
   followed by postfix (`def f(x): {a:x}; f(1).a`) failed to parse at all before
   this.
2. **`env()` (truly empty parens) misfired as a rewind.** `parse_ident()`'s failure
   on an immediate `)` was indistinguishable from its failure on a genuinely
   wrong-shaped argument, silently changing `env()` from jq 1.7.1's own compile-time
   syntax error (exit 3) to a runtime "undefined function" error (exit 5). Fixed
   with an explicit empty-parens guard, matching `zero_arity_or_wrong_arity_call`'s
   own `()`-exclusion for `length()`/`not()`/`keys()`/`null()`.
3. **My own verification caught**: applying postfix at the generic
   `try_parse_builtin` fallback unconditionally broke yq mode's merge-flag scanning
   (`.a *=x .b`). Real yq's own lexer unconditionally rejects anything but a
   recognized flag character immediately after `*=`/`*` -- confirmed live against
   yq v4.53.3, even for `.a *= n.b` (an ordinary identifier reference, no
   merge-flag context at all) -- but succinctly's own `scan_merge_flags` silently
   stops at an unrecognized character rather than erroring, leaving it for this
   fallback to parse; the postfix fix let that now succeed where it used to fail
   (coincidentally, via unconsumed trailing input). Gated the fallback's postfix
   application to jq mode only, and updated the one now-outdated unit test this
   exposed -- `.a *=n .b` genuinely does parse successfully in jq mode (confirmed
   live against jq 1.7.1: it only fails later, at name resolution), so the old
   `is_err()` assertion was pinning a coincidence of the very bug being fixed, not
   a real requirement.

## Scope

This covers every builtin the issue itself named a live repro for. A further ~40
`try_parse_builtin` call sites share the identical inline-`self.expect('(')?` shape
but are unconverted -- several (like `skip`/`nth`) share `limit`'s own
comma-restriction subtlety and need the same careful per-site verification that
caught that regression, making this a materially larger undertaking than fits one
PR; tracked as a follow-up. Also noticed in passing, not touched: `try_parse_builtin`
appears to contain a second, unreachable `limit`/`first`/`last` block (shadowed by
the earlier explicit keyword checks in `parse_primary_inner`) producing different
`Builtin` variants (`FirstStream`/`LastStream` vs `FirstExpr`/`Builtin::First`) --
noted for the same follow-up to investigate. Review also flagged the ~14
structurally-identical checkpoint blocks across the dedicated-parse-fn family as a
duplication/maintainability concern worth a shared helper; not addressed here given
the regression risk already realized twice in this PR from similar-looking code that
turned out to have site-specific subtleties -- tracked as a follow-up too rather than
risking a fourth regression under time pressure.

## Test plan

- [x] `test_single_arg_builtin_wrong_arity_reports_not_defined_2237` -- all 11
      Category 1 builtins, 0-arg and 2-arg wrong-arity shapes, verified against jq
      1.7.1.
- [x] `test_dedicated_parse_fn_wrong_arity_reports_not_defined_2237` -- all 7
      Category 2 builtins, every wrong-arity shape each can take, verified against
      jq 1.7.1.
- [x] `test_single_arg_builtin_internal_syntax_error_stays_parse_error_2237` -- a
      genuine syntax error inside an argument stays a raw parse error.
- [x] `test_wrong_arity_call_supports_postfix_2237` -- postfix chaining after a
      rewound wrong-arity call, plus the incidentally-fixed legit-function-call
      case, verified against jq 1.7.1.
- [x] `test_env_empty_parens_stays_compile_error_not_runtime_2237` -- `env()` stays
      a compile-time error, not a runtime one.
- [x] `test_yq_mode_single_arg_builtin_wrong_arity_unaffected_by_2237` -- yq mode
      keeps the pre-#2237 raw parse error unchanged.
- [x] Updated `test_jq_mode_rejects_merge_flags`'s now-outdated assertion, verified
      against jq 1.7.1 (`.a *=n .b` parses successfully there too).
- [x] Manually verified `limit(1,2; .)` and yq mode's merge-flag suite (`*=+`, the
      full valid-call matrix for every converted builtin) against both oracles to
      confirm no further regressions.
- [x] `cargo build --features cli`
- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings` (ci.yml's 2nd leg)
- [x] Full `cargo test --features cli,simd,regex,serde` (clean build) -- 0 failures
- [x] `cargo test --no-default-features --features std` (no_std-adjacent)
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features`
