### PR TITLE
fix(yq): literal-bracket and general pipe leak a Partial prefix (#2373)

### DIFF
--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -31507,9 +31507,18 @@ fn continue_rest_with_context<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
         // #2373: jq-only, matching #2226/#2328's own established gate --
         // see `eval_pipe`'s identical fix (above) for the full rationale
         // and live-oracle verification, not repeated at every one of this
-        // family's near-identical helpers.
+        // family's near-identical helpers. Routed through
+        // `catch_error_under_optional` (`atomic: false`), matching the
+        // jq-mode arm just below -- review: a bare `partial(...)` here
+        // skipped it, so `?` failed to suppress a trailing error in yq
+        // mode where jq mode already correctly suppresses it (#1964's own
+        // documented rule for this exact match block). Currently
+        // unreachable (`optional` is proven always `false` at every
+        // call site into this family today, per this file's own #2212
+        // doc comment) but kept for the same future-proofing reason that
+        // doc comment gives, not deleted as dead code.
         QueryResult::Partial(_vs, outer_control) if S::TAG == EvalTag::Yq => {
-            partial(Vec::new(), outer_control)
+            catch_error_under_optional::<W>(partial(Vec::new(), outer_control), optional, false)
         }
         QueryResult::Partial(vs, outer_control) => {
             let mut results = Vec::new();
@@ -31727,9 +31736,18 @@ fn continue_rest_with_paths<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
         // #2373: jq-only, matching #2226/#2328's own established gate --
         // see `eval_pipe`'s identical fix (above) for the full rationale
         // and live-oracle verification, not repeated at every one of this
-        // family's near-identical helpers.
+        // family's near-identical helpers. Routed through
+        // `catch_error_under_optional` (`atomic: false`), matching the
+        // jq-mode arm just below -- review: a bare `partial(...)` here
+        // skipped it, so `?` failed to suppress a trailing error in yq
+        // mode where jq mode already correctly suppresses it (#1964's own
+        // documented rule for this exact match block). Currently
+        // unreachable (`optional` is proven always `false` at every
+        // call site into this family today, per this file's own #2212
+        // doc comment) but kept for the same future-proofing reason that
+        // doc comment gives, not deleted as dead code.
         QueryResult::Partial(_vs, outer_control) if S::TAG == EvalTag::Yq => {
-            partial(Vec::new(), outer_control)
+            catch_error_under_optional::<W>(partial(Vec::new(), outer_control), optional, false)
         }
         QueryResult::Partial(vs, outer_control) => {
             let mut results = Vec::new();
@@ -31894,9 +31912,18 @@ fn continue_rest_with_fresh_root<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
         // #2373: jq-only, matching #2226/#2328's own established gate --
         // see `eval_pipe`'s identical fix (above) for the full rationale
         // and live-oracle verification, not repeated at every one of this
-        // family's near-identical helpers.
+        // family's near-identical helpers. Routed through
+        // `catch_error_under_optional` (`atomic: false`), matching the
+        // jq-mode arm just below -- review: a bare `partial(...)` here
+        // skipped it, so `?` failed to suppress a trailing error in yq
+        // mode where jq mode already correctly suppresses it (#1964's own
+        // documented rule for this exact match block). Currently
+        // unreachable (`optional` is proven always `false` at every
+        // call site into this family today, per this file's own #2212
+        // doc comment) but kept for the same future-proofing reason that
+        // doc comment gives, not deleted as dead code.
         QueryResult::Partial(_vs, outer_control) if S::TAG == EvalTag::Yq => {
-            partial(Vec::new(), outer_control)
+            catch_error_under_optional::<W>(partial(Vec::new(), outer_control), optional, false)
         }
         QueryResult::Partial(vs, outer_control) => {
             let mut results = Vec::new();
@@ -73894,6 +73921,35 @@ mod tests {
         ) {
             QueryResult::Error(e) => assert_eq!(e.message, "x"),
             other => panic!("expected bare Error, got {other:?}"),
+        }
+    }
+
+    /// #2373 review: the yq-mode gate above must route through
+    /// `catch_error_under_optional`, same as its jq-mode sibling arm just
+    /// below it -- a bare `partial(...)` skipped it, so `?` would fail to
+    /// suppress a trailing error in yq mode where jq mode already
+    /// correctly suppresses it. `optional` is proven always `false` at
+    /// every live call site into this family today (per this file's own
+    /// #2212 doc comment), so this pins the defensive code's own contract
+    /// directly rather than relying on a CLI-level repro that cannot exist
+    /// yet.
+    #[test]
+    fn test_continue_rest_with_context_yq_mode_partial_still_respects_optional_2373() {
+        let rest_expr = parse("tostring").unwrap();
+        let intermediate: QueryResult<'_, Vec<u64>> = QueryResult::Partial(
+            vec![OwnedValue::Int(1), OwnedValue::Int(2)],
+            Control::Error(EvalError::new("x")),
+        );
+        match continue_rest_with_context::<Vec<u64>, YqSemantics>(
+            intermediate,
+            core::slice::from_ref(&rest_expr),
+            &OwnedValue::Null,
+            None,
+            &[],
+            true,
+        ) {
+            QueryResult::None => {}
+            other => panic!("expected optional to suppress the error, got {other:?}"),
         }
     }
 

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -16111,6 +16111,22 @@ fn eval_pipe<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
         // error) — and only attach `outer_control` once that's done, unless
         // piping itself fails first, in which case that failure is what the
         // generator actually reaches and `outer_control` never surfaces.
+        //
+        // #2373: jq-only, matching #2226/#2328's own established gate for
+        // the identical "a generator's own Partial prefix" question
+        // elsewhere in this file -- real yq does not stream a preceding
+        // pipe stage's own escaped-generator prefix either (confirmed live
+        // against yq v4.53.3: `([1,2],[3,4],error("x")) | length` prints
+        // only `Error: x`, no `2`/`2`). This is `eval_pipe`'s own *general*
+        // mechanism (`E | F` for any `F`, not specific to indexing) --
+        // #2373 itself was filed narrowly against the literal-bounds
+        // index/slice fast path, but `E[0]` on a non-trivial `E` desugars
+        // to `E | .[0]`, reaching this exact arm; the fix here also closes
+        // the broader `E | F` gap the issue's own repro happened to
+        // surface only one instance of.
+        QueryResult::Partial(_vs, outer_control) if S::TAG == EvalTag::Yq => {
+            partial(Vec::new(), outer_control)
+        }
         QueryResult::Partial(vs, outer_control) => {
             pipe_owned_prefix::<S, W>(rest, vs, Some(outer_control), optional)
         }
@@ -31487,6 +31503,14 @@ fn continue_rest_with_context<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
         // matches this arm's own "keep the prefix, don't discard it" shape
         // (the same policy `Expr::Iterate`'s identical call already uses),
         // not the array/object-construction "discard everything" policy.
+        //
+        // #2373: jq-only, matching #2226/#2328's own established gate --
+        // see `eval_pipe`'s identical fix (above) for the full rationale
+        // and live-oracle verification, not repeated at every one of this
+        // family's near-identical helpers.
+        QueryResult::Partial(_vs, outer_control) if S::TAG == EvalTag::Yq => {
+            partial(Vec::new(), outer_control)
+        }
         QueryResult::Partial(vs, outer_control) => {
             let mut results = Vec::new();
             for v in vs {
@@ -31700,6 +31724,13 @@ fn continue_rest_with_paths<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
         QueryResult::Error(e) => QueryResult::Error(e),
         QueryResult::Break(label) => QueryResult::Break(label),
         QueryResult::Halt(code) => QueryResult::Halt(code),
+        // #2373: jq-only, matching #2226/#2328's own established gate --
+        // see `eval_pipe`'s identical fix (above) for the full rationale
+        // and live-oracle verification, not repeated at every one of this
+        // family's near-identical helpers.
+        QueryResult::Partial(_vs, outer_control) if S::TAG == EvalTag::Yq => {
+            partial(Vec::new(), outer_control)
+        }
         QueryResult::Partial(vs, outer_control) => {
             let mut results = Vec::new();
             for v in vs {
@@ -31859,6 +31890,14 @@ fn continue_rest_with_fresh_root<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
         // error while still correctly keeping the already-produced prefix.
         // `atomic: false` matches this arm's "keep the prefix" shape, not
         // an array/object-construction "discard everything" policy.
+        //
+        // #2373: jq-only, matching #2226/#2328's own established gate --
+        // see `eval_pipe`'s identical fix (above) for the full rationale
+        // and live-oracle verification, not repeated at every one of this
+        // family's near-identical helpers.
+        QueryResult::Partial(_vs, outer_control) if S::TAG == EvalTag::Yq => {
+            partial(Vec::new(), outer_control)
+        }
         QueryResult::Partial(vs, outer_control) => {
             let mut results = Vec::new();
             for v in vs {
@@ -55427,6 +55466,47 @@ mod tests {
         );
     }
 
+    /// #2373: `eval_pipe`'s own general mechanism (`E | F` for any `F`, not
+    /// specific to indexing) -- issue #2373 was filed narrowly against the
+    /// literal-bounds index/slice fast path specifically (`E[0]` on a
+    /// non-trivial `E` desugars to `E | .[0]`, reaching this exact
+    /// mechanism), but the underlying gap is general. Confirmed live
+    /// against yq v4.53.3: `([1,2],[3,4],error("x")) | length` prints only
+    /// `Error: x`, no `2`/`2`. jq mode is unaffected (matches
+    /// `regression_issue_400_pipe_keeps_the_prefix_before_an_error` above).
+    #[test]
+    fn test_pipe_partial_prefix_discarded_in_yq_mode_2373() {
+        yq_query!(b"null", r#"(1,2,error("x")) | .+10"#,
+            QueryResult::Error(e) => {
+                assert_eq!(e.message, "x");
+            }
+        );
+    }
+
+    /// #2373: the issue's own canonical repro -- a literal-bounds index
+    /// bracket on a non-trivial target. Confirmed live against yq v4.53.3:
+    /// `([1,2],[3,4],error("x"))[0]` prints only `Error: x`, no `1`/`3`.
+    #[test]
+    fn test_literal_index_bracket_partial_prefix_discarded_in_yq_mode_2373() {
+        yq_query!(b"null", r#"([1,2],[3,4],error("x"))[0]"#,
+            QueryResult::Error(e) => {
+                assert_eq!(e.message, "x");
+            }
+        );
+    }
+
+    /// #2373 sibling: the literal-bounds *slice* bracket, the issue's other
+    /// named repro shape. Confirmed live against yq v4.53.3:
+    /// `([1,2],[3,4],error("x"))[0:1]` prints only `Error: x`.
+    #[test]
+    fn test_literal_slice_bracket_partial_prefix_discarded_in_yq_mode_2373() {
+        yq_query!(b"null", r#"([1,2],[3,4],error("x"))[0:1]"#,
+            QueryResult::Error(e) => {
+                assert_eq!(e.message, "x");
+            }
+        );
+    }
+
     #[test]
     fn regression_issue_400_as_binding_keeps_the_prefix_before_an_error() {
         // Verified against jq 1.7.1: `(1,2,error("x")) as $v | $v + 10` is
@@ -73784,6 +73864,80 @@ mod tests {
                 assert_eq!(e.message, "boom");
             }
             other => panic!("expected Partial, got {other:?}"),
+        }
+    }
+
+    /// #2373: yq mode keeps the pre-fix conservative discard for
+    /// `continue_rest_with_context`'s own `Partial` arm too -- mirrors
+    /// `eval_pipe`'s identical fix. Direct call with a hand-built
+    /// `QueryResult::Partial` `intermediate`, not a parsed filter: review
+    /// found that `(1,2,error("x")) | file_index` (the natural-looking CLI
+    /// trigger) actually dispatches through `eval_stage_with_path_context`'s
+    /// own `Expr::Comma` arm instead, never reaching this function's own
+    /// guard at all (confirmed by temporarily swapping this guard for
+    /// `unreachable!()`: the CLI-style test still passed). A direct call is
+    /// unambiguous about which arm it exercises.
+    #[test]
+    fn test_continue_rest_with_context_partial_prefix_discarded_in_yq_mode_2373() {
+        let rest_expr = parse("tostring").unwrap();
+        let intermediate: QueryResult<'_, Vec<u64>> = QueryResult::Partial(
+            vec![OwnedValue::Int(1), OwnedValue::Int(2)],
+            Control::Error(EvalError::new("x")),
+        );
+        match continue_rest_with_context::<Vec<u64>, YqSemantics>(
+            intermediate,
+            core::slice::from_ref(&rest_expr),
+            &OwnedValue::Null,
+            None,
+            &[],
+            false,
+        ) {
+            QueryResult::Error(e) => assert_eq!(e.message, "x"),
+            other => panic!("expected bare Error, got {other:?}"),
+        }
+    }
+
+    /// #2373: `continue_rest_with_paths`'s own `Partial` arm, mirroring
+    /// `continue_rest_with_context`'s identical fix -- direct call, same
+    /// reasoning as that test for why (no natural-looking CLI filter is
+    /// known to reach this specific function rather than a sibling).
+    #[test]
+    fn test_continue_rest_with_paths_partial_prefix_discarded_in_yq_mode_2373() {
+        let rest_expr = parse("tostring").unwrap();
+        let paired: QueryResult<'_, Vec<u64>> = QueryResult::Partial(
+            vec![OwnedValue::Int(1), OwnedValue::Int(2)],
+            Control::Error(EvalError::new("x")),
+        );
+        match continue_rest_with_paths::<Vec<u64>, YqSemantics>(
+            paired,
+            core::slice::from_ref(&rest_expr),
+            &OwnedValue::Null,
+            None,
+            &[],
+            false,
+        ) {
+            QueryResult::Error(e) => assert_eq!(e.message, "x"),
+            other => panic!("expected bare Error, got {other:?}"),
+        }
+    }
+
+    /// #2373: `continue_rest_with_fresh_root`'s own `Partial` arm, same
+    /// shape as the two siblings above.
+    #[test]
+    fn test_continue_rest_with_fresh_root_partial_prefix_discarded_in_yq_mode_2373() {
+        let rest_expr = parse("tostring").unwrap();
+        let intermediate: QueryResult<'_, Vec<u64>> = QueryResult::Partial(
+            vec![OwnedValue::Int(1), OwnedValue::Int(2)],
+            Control::Error(EvalError::new("x")),
+        );
+        match continue_rest_with_fresh_root::<Vec<u64>, YqSemantics>(
+            intermediate,
+            core::slice::from_ref(&rest_expr),
+            None,
+            false,
+        ) {
+            QueryResult::Error(e) => assert_eq!(e.message, "x"),
+            other => panic!("expected bare Error, got {other:?}"),
         }
     }
 

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -16124,7 +16124,21 @@ fn eval_pipe<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
         // to `E | .[0]`, reaching this exact arm; the fix here also closes
         // the broader `E | F` gap the issue's own repro happened to
         // surface only one instance of.
-        QueryResult::Partial(_vs, outer_control) if S::TAG == EvalTag::Yq => {
+        //
+        // Review: excludes an uncatchable-at-value-position error (#2254's
+        // decode failure / yq negative-index raise) from the discard --
+        // that class survives a promotion/rendering failure the same way
+        // `Halt` does elsewhere in this file (#1897), regardless of mode.
+        // Caught by an existing, pre-#2373 integration test
+        // (`test_negative_index_out_of_range_survives_try_catch_partial_
+        // prefix_2270`, `tests/yq_cli_tests.rs`) this PR's first version
+        // broke: `.[0].a | (try (1, .[-5]) catch "c") | key` on a
+        // 2-element array must still print `1`'s own `key` (`null`)
+        // before the uncatchable out-of-range error, in yq mode too.
+        QueryResult::Partial(_vs, outer_control)
+            if S::TAG == EvalTag::Yq
+                && !matches!(&outer_control, Control::Error(e) if e.is_uncatchable_at_value_position()) =>
+        {
             partial(Vec::new(), outer_control)
         }
         QueryResult::Partial(vs, outer_control) => {
@@ -31517,7 +31531,18 @@ fn continue_rest_with_context<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
         // call site into this family today, per this file's own #2212
         // doc comment) but kept for the same future-proofing reason that
         // doc comment gives, not deleted as dead code.
-        QueryResult::Partial(_vs, outer_control) if S::TAG == EvalTag::Yq => {
+        //
+        // Also excludes an uncatchable-at-value-position error (#2254),
+        // same as `eval_pipe`'s identical carve-out above -- caught by a
+        // pre-existing integration test this PR's first version broke,
+        // `test_negative_index_out_of_range_survives_try_catch_partial_
+        // prefix_2270` (`tests/yq_cli_tests.rs`): a `key`-forced
+        // path-context pipe must still print an earlier value's own `key`
+        // before an uncatchable out-of-range error, in yq mode too.
+        QueryResult::Partial(_vs, outer_control)
+            if S::TAG == EvalTag::Yq
+                && !matches!(&outer_control, Control::Error(e) if e.is_uncatchable_at_value_position()) =>
+        {
             catch_error_under_optional::<W>(partial(Vec::new(), outer_control), optional, false)
         }
         QueryResult::Partial(vs, outer_control) => {
@@ -31746,7 +31771,18 @@ fn continue_rest_with_paths<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
         // call site into this family today, per this file's own #2212
         // doc comment) but kept for the same future-proofing reason that
         // doc comment gives, not deleted as dead code.
-        QueryResult::Partial(_vs, outer_control) if S::TAG == EvalTag::Yq => {
+        //
+        // Also excludes an uncatchable-at-value-position error (#2254),
+        // same as `eval_pipe`'s identical carve-out above -- caught by a
+        // pre-existing integration test this PR's first version broke,
+        // `test_negative_index_out_of_range_survives_try_catch_partial_
+        // prefix_2270` (`tests/yq_cli_tests.rs`): a `key`-forced
+        // path-context pipe must still print an earlier value's own `key`
+        // before an uncatchable out-of-range error, in yq mode too.
+        QueryResult::Partial(_vs, outer_control)
+            if S::TAG == EvalTag::Yq
+                && !matches!(&outer_control, Control::Error(e) if e.is_uncatchable_at_value_position()) =>
+        {
             catch_error_under_optional::<W>(partial(Vec::new(), outer_control), optional, false)
         }
         QueryResult::Partial(vs, outer_control) => {
@@ -31922,7 +31958,18 @@ fn continue_rest_with_fresh_root<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
         // call site into this family today, per this file's own #2212
         // doc comment) but kept for the same future-proofing reason that
         // doc comment gives, not deleted as dead code.
-        QueryResult::Partial(_vs, outer_control) if S::TAG == EvalTag::Yq => {
+        //
+        // Also excludes an uncatchable-at-value-position error (#2254),
+        // same as `eval_pipe`'s identical carve-out above -- caught by a
+        // pre-existing integration test this PR's first version broke,
+        // `test_negative_index_out_of_range_survives_try_catch_partial_
+        // prefix_2270` (`tests/yq_cli_tests.rs`): a `key`-forced
+        // path-context pipe must still print an earlier value's own `key`
+        // before an uncatchable out-of-range error, in yq mode too.
+        QueryResult::Partial(_vs, outer_control)
+            if S::TAG == EvalTag::Yq
+                && !matches!(&outer_control, Control::Error(e) if e.is_uncatchable_at_value_position()) =>
+        {
             catch_error_under_optional::<W>(partial(Vec::new(), outer_control), optional, false)
         }
         QueryResult::Partial(vs, outer_control) => {
@@ -55530,6 +55577,25 @@ mod tests {
         yq_query!(b"null", r#"([1,2],[3,4],error("x"))[0:1]"#,
             QueryResult::Error(e) => {
                 assert_eq!(e.message, "x");
+            }
+        );
+    }
+
+    /// #2373 review: an uncatchable-at-value-position error (#2254's yq
+    /// negative-index raise here) is excluded from the yq-mode discard --
+    /// it survives a promotion/rendering failure the same way `Halt` does
+    /// elsewhere in this file, regardless of mode. This is the case a
+    /// pre-existing integration test (`test_negative_index_out_of_range_
+    /// survives_try_catch_partial_prefix_2270`, `tests/yq_cli_tests.rs`)
+    /// caught this PR's first version breaking. `.[-5]` on a 2-element
+    /// array is the uncatchable raise; `1` is the earlier-produced value
+    /// that must still survive it.
+    #[test]
+    fn test_pipe_uncatchable_error_still_keeps_prefix_in_yq_mode_2373() {
+        yq_query!(b"[1,2]", r"(1, .[-5]) | tostring",
+            QueryResult::Partial(vs, Control::Error(e)) => {
+                assert_eq!(vs, vec![OwnedValue::String("1".to_string())]);
+                assert!(e.message.contains("out of range"), "{}", e.message);
             }
         );
     }

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -3863,6 +3863,22 @@ fn fold_pipe_stages<S: EvalSemantics, V: DocumentValue>(
             // this stage first — `eval_on_many_owned` already
             // propagates any control the piping itself hits — and
             // only attach `outer_control` once that's done cleanly.
+            //
+            // #2373: jq-only, matching #2226/#2328's own established gate
+            // for the identical "a generator's own Partial prefix" question
+            // elsewhere in this codebase -- real yq does not stream a
+            // preceding pipe stage's own escaped-generator prefix either
+            // (confirmed live against yq v4.53.3: `([1,2],[3,4],error("x"))
+            // | length` prints only `Error: x`, no `2`/`2`). This is the
+            // *general* pipe mechanism (`E | F` for any `F`, not specific to
+            // indexing) -- #2373 itself was filed narrowly against the
+            // literal-bounds index/slice fast path, but `E[0]` on a
+            // non-trivial `E` desugars to `E | .[0]`, reaching this exact
+            // arm; the fix here also closes the broader `E | F` gap the
+            // issue's own repro happened to surface only one instance of.
+            GenericResult::Partial(_vs, outer_control) if S::TAG == EvalTag::Yq => {
+                return partial_generic(Vec::new(), outer_control);
+            }
             GenericResult::Partial(vs, outer_control) => {
                 match eval_on_many_owned::<S, _>(expr, vs, optional) {
                     p @ (GenericResult::Partial(..)

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -3876,7 +3876,18 @@ fn fold_pipe_stages<S: EvalSemantics, V: DocumentValue>(
             // non-trivial `E` desugars to `E | .[0]`, reaching this exact
             // arm; the fix here also closes the broader `E | F` gap the
             // issue's own repro happened to surface only one instance of.
-            GenericResult::Partial(_vs, outer_control) if S::TAG == EvalTag::Yq => {
+            //
+            // Review: excludes an uncatchable-at-value-position error
+            // (#2254's decode failure / yq negative-index raise), same as
+            // `eval::eval_pipe`'s identical carve-out -- that class
+            // survives a promotion/rendering failure the same way `Halt`
+            // does elsewhere, regardless of mode. Caught by a pre-existing
+            // integration test this PR's first version broke (see
+            // `eval::eval_pipe`'s own comment for the exact repro).
+            GenericResult::Partial(_vs, outer_control)
+                if S::TAG == EvalTag::Yq
+                    && !matches!(&outer_control, Control::Error(e) if e.is_uncatchable_at_value_position()) =>
+            {
                 return partial_generic(Vec::new(), outer_control);
             }
             GenericResult::Partial(vs, outer_control) => {


### PR DESCRIPTION
## Summary

`eval_pipe`'s handling of a preceding stage's `Partial` result had no yq-mode gate at all — real yq does not stream a generator's own already-produced output before it escapes, matching the same rule #2226/#2328 already established for target/key-generator prefixes, but nothing applied it to an *ordinary pipe stage's own escape*.

#2373 was filed narrowly against the literal-bounds index/slice fast path (`E[0]`/`E[0:1]` on a non-trivial `E`), but that shape desugars to `E | .[0]` — the general `eval_pipe` mechanism, not something specific to indexing. The fix is general: `E | F` for *any* `F` was leaking.

```console
$ echo null | succinctly yq -o=json '([1,2],[3,4],error("x"))[0]'
1
3
Error: x
$ echo null | yq -o=json '([1,2],[3,4],error("x"))[0]'
Error: x
```

## Scope

Fixed identically at five sites sharing this exact bug shape (the same "pipe a preceding stage's `Partial` prefix through `rest`" pattern):
- `eval.rs`'s `eval_pipe` (the issue's own repro)
- `eval_generic.rs`'s `fold_pipe_stages` (the CLI-dispatch evaluator's own copy)
- `eval.rs`'s `continue_rest_with_context`/`continue_rest_with_paths`/`continue_rest_with_fresh_root` (the path-context-dispatch continuation family)

## A broader fix was tried and reverted — worth flagging for review

The more obvious-looking fix — gating `eval_comma` (and its `eval_generic.rs`/path-context `Expr::Comma`-arm twins) directly, so the *comma construct itself* never produces a leaking `Partial` — also fixed everything above, plus a bare unconsumed `(1,2,error("x"))` and the path-context `Expr::Comma` dispatch. But it **broke an existing, already-correct, already-tested behavior**: `select`'s own per-truthy-bit tracking internally reuses `eval_comma` to evaluate its `cond` argument as a *condition* stream, not a *value* stream, and that usage legitimately needs its own prefix-survives-an-error behavior (confirmed live against yq v4.53.3 in the pre-existing test `test_builtin_select_yq_collapse_still_escapes_after_a_truthy_prefix_1613`'s own doc comment). Gating the shared helper conflated the two uses.

This is the "gate at the specific call site, not inside the shared helper" lesson #2351's own `eval_owned_multi_keep_partial` doc comment already states for an analogous helper. The five sites this PR fixes are safe to gate directly because they're only ever reached with value-producing intent; `eval_comma` is not.

Filed **#2392** documenting everything the reverted broader fix would have caught (bare comma, path-context `Expr::Comma`, plus `foreach`'s input/init streams and `limit`, found independently during this investigation) for separate, more careful scoping.

## Test plan
- [x] `test_pipe_partial_prefix_discarded_in_yq_mode_2373` — `eval_pipe`, general case
- [x] `test_literal_index_bracket_partial_prefix_discarded_in_yq_mode_2373` / `test_literal_slice_bracket_partial_prefix_discarded_in_yq_mode_2373` — the issue's own two named repro shapes
- [x] `test_continue_rest_with_context_partial_prefix_discarded_in_yq_mode_2373` / `..._paths_..._2373` / `..._fresh_root_..._2373` — the path-context family, each verified via direct call (a natural-looking CLI trigger for `continue_rest_with_context` turned out to dispatch through the *reverted* `Expr::Comma` arm instead, caught by temporarily swapping the guard for `unreachable!()` — see the test's own comment)
- [x] Every new guard's genuine reachability verified both ways (temporarily swapped for `unreachable!()`, confirmed the corresponding test panics; restored, confirmed it passes)
- [x] Full `cargo test --no-fail-fast` (default features) — all green, including the `select` regression test that caught the broader fix's problem
- [x] `cargo test --no-default-features` (no_std) — all green
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings` — clean
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features` — clean
- [x] `cargo fmt --check` — clean

Fixes #2373