### PR TITLE
fix(jq): a user def can now shadow a builtin of the same name (#2036)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -421,25 +421,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
   Every row exited 0 in both tools — there was no diagnostic anywhere, just a silently
   different answer, the most serious class of divergence this project tracks. Shadowing
-  a builtin is a real jq idiom (patching a builtin's behavior for one program, or how
-  `~/.jq` and library modules override defaults), not a curiosity.
+  a builtin is a real jq idiom — patching a builtin's behavior for one program — not a
+  curiosity.
 
   Fixed via a lexical prescan (`collect_def_names`, `src/jq/parser.rs`) that collects
-  every identifier spelled after a `def` keyword anywhere in the program — a cheap,
-  deliberately imprecise over-approximation (it does not track lexical position; a false
-  positive costs one wasted re-parse at that one call site, never a wrong answer). At
-  each keyword choke point that can produce a shadowable builtin or fixed-arity special
-  form (`not`, and everything `try_parse_builtin` recognizes, plus `limit`/`until`/
-  `while`/`repeat`/`range`/`first`/`last`/`error`), a name in that set is parsed *both*
-  ways — the keyword's own dedicated parse, and a rewound generic `NAME(args;args)` call
-  (mirroring #2110's existing wrong-arity rewind) — with the former stashed on the
-  latter's new `Expr::FuncCall::builtin_fallback: Option<Box<Expr>>` field. `resolve.rs`'s
-  existing, already-correct scope-tracking pass (#1473) is the sole consumer: it now
-  rewrites the tree, not just reports on it (`check` took `&mut Expr`) — if the name is
-  genuinely in scope as a `def` at that exact position, the fallback is dropped and the
-  call proceeds normally; otherwise the node is rewritten back to the original
-  builtin/special form. A program with no `def`s anywhere pays for one scan of its own
-  source text and nothing else — every existing call site is otherwise untouched.
+  every identifier spelled after a `def` keyword in the *main filter's own source text*
+  — a cheap, deliberately imprecise over-approximation (it does not track lexical
+  position; a false positive costs nothing beyond one skipped fast-path check, never a
+  wrong answer). At each keyword choke point that can produce a shadowable builtin or
+  fixed-arity special form (`not`, and everything `try_parse_builtin` recognizes, plus
+  `limit`/`until`/`while`/`repeat`/`range`/`first`/`last`/`error`), a name in that set is
+  wrapped as `Expr::FuncCall { name, args: vec![], builtin_fallback: Some(Box::new(original)) }`
+  — `original` being the keyword's own dedicated parse, kept as-is; `args` deliberately
+  starts *empty* rather than populated from `original`'s own children (see below).
+  `resolve.rs`'s existing, already-correct scope-tracking pass (#1473) is the sole
+  consumer: it now rewrites the tree, not just reports on it (`check` took `&mut Expr`)
+  — if the name is genuinely in scope as a `def` at that exact position (computed from
+  `builtin_fallback`'s own shape, not `args.len()`, while `args` is still empty), `args`
+  is populated for real — *moved* out of the fallback, not cloned, since the fallback is
+  discarded immediately after — and the call proceeds; otherwise the *whole* fallback is
+  moved back into the node in one piece, restoring the original builtin/special form. A
+  program with no `def`s anywhere pays for one scan of its own source text and nothing
+  else — every existing call site is otherwise untouched.
 
   A shadowing `def` is not restricted to the arity real jq's own grammar happens to
   accept for that name (confirmed live: `def until(a;b;c): "s"; until(1;2;3)` is `"s"` in
@@ -449,11 +452,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the parser rewinds and falls back to an ordinary generic call with no fallback
   attached, deferring entirely to `resolve.rs` to decide whether the result is the user's
   own def, a real builtin at some *other* arity, or genuinely unresolvable — the same
-  three-way split every ordinary call already gets.
+  three-way split every ordinary call already gets. Two more issues surfaced in that same
+  fallback path during review and were fixed alongside it: a genuinely empty `NAME()`
+  must stay a syntax error rather than silently becoming a valid zero-arg call (matching
+  #2110's own established rule for the non-shadow-candidate case), and the fallback
+  reparse itself is now capped by a small retry budget, since an adversarial program
+  nesting the same arity-mismatched name inside itself could otherwise force the same
+  reparse to repeat at every level.
+
+  **A second, more fundamental performance bug was also found and fixed during review,
+  before this ever reached `main`**: an earlier version of this fix populated `args` by
+  cloning `original`'s own children at parse time. Correct, but with a cost that
+  compounds *exponentially* with nesting depth even though no source text is ever
+  re-parsed — every level's node retains both `args` and `builtin_fallback`, each a full
+  independent copy of everything below it, so a node's own retained size roughly doubles
+  per nesting level. `def first: .; first(first(first(...)))` took ~0.8 seconds just to
+  *parse* at 20 levels of nesting under that version — a real, if narrow, parser-level
+  denial-of-service reachable from a tiny adversarial filter string. Leaving `args` empty
+  until `resolve.rs` actually needs it (as described above) means no sub-expression is
+  ever duplicated at parse time at all; confirmed live that the same 20-level (and much
+  deeper) nesting now parses in single-digit milliseconds.
 
   `null`/`true`/`false` are deliberately excluded: they are literal tokens in jq's own
   grammar, not identifier-based calls (confirmed live, `def null: 1; null` stays `null`
   in real jq too, not `1`) — a `def` of that name parses but can never be reached.
+
+  **Known residual gap, not fixed here** (tracked as #2395): the lexical prescan only
+  ever sees the main filter's own source text — a `def` loaded via `include`, `import`,
+  or `~/.jq` cannot shadow a builtin, since it was never scanned and the module-loading
+  step that inlines it runs well after the main filter has already been fully parsed.
 
 - **`del()`'s trailing `.[]` raised instead of no-oping through a tolerated (rather than
   genuinely found) `null`, in yq mode** (#2347, found during #2324's own implementation).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -406,6 +406,55 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   of the gate the code already claims to run; `select`/`sort_by` and friends walk far
   smaller subtrees per query and are far less affected.
 
+- **A user `def` could not shadow a builtin of the same name — the builtin silently won,
+  producing a wrong value with no error** (#2036). `succinctly jq`'s parser lowers a
+  recognized builtin name to a typed `Expr::Builtin`/special-form node at parse time,
+  before any `def` has been seen, so the user's own definition was parsed, bound, and
+  then never consulted:
+
+  ```console
+  $ jq -nc 'def length: 1; length'
+  1
+  $ succinctly jq -nc 'def length: 1; length'   # before this fix
+  0
+  ```
+
+  Every row exited 0 in both tools — there was no diagnostic anywhere, just a silently
+  different answer, the most serious class of divergence this project tracks. Shadowing
+  a builtin is a real jq idiom (patching a builtin's behavior for one program, or how
+  `~/.jq` and library modules override defaults), not a curiosity.
+
+  Fixed via a lexical prescan (`collect_def_names`, `src/jq/parser.rs`) that collects
+  every identifier spelled after a `def` keyword anywhere in the program — a cheap,
+  deliberately imprecise over-approximation (it does not track lexical position; a false
+  positive costs one wasted re-parse at that one call site, never a wrong answer). At
+  each keyword choke point that can produce a shadowable builtin or fixed-arity special
+  form (`not`, and everything `try_parse_builtin` recognizes, plus `limit`/`until`/
+  `while`/`repeat`/`range`/`first`/`last`/`error`), a name in that set is parsed *both*
+  ways — the keyword's own dedicated parse, and a rewound generic `NAME(args;args)` call
+  (mirroring #2110's existing wrong-arity rewind) — with the former stashed on the
+  latter's new `Expr::FuncCall::builtin_fallback: Option<Box<Expr>>` field. `resolve.rs`'s
+  existing, already-correct scope-tracking pass (#1473) is the sole consumer: it now
+  rewrites the tree, not just reports on it (`check` took `&mut Expr`) — if the name is
+  genuinely in scope as a `def` at that exact position, the fallback is dropped and the
+  call proceeds normally; otherwise the node is rewritten back to the original
+  builtin/special form. A program with no `def`s anywhere pays for one scan of its own
+  source text and nothing else — every existing call site is otherwise untouched.
+
+  A shadowing `def` is not restricted to the arity real jq's own grammar happens to
+  accept for that name (confirmed live: `def until(a;b;c): "s"; until(1;2;3)` is `"s"` in
+  real jq, even though `until/2` is the only shape `parse_until_expr` itself parses) — a
+  gap found during this fix's own review. When the keyword's own dedicated parser fails
+  outright on the written arity, that failure is not propagated for a shadow candidate:
+  the parser rewinds and falls back to an ordinary generic call with no fallback
+  attached, deferring entirely to `resolve.rs` to decide whether the result is the user's
+  own def, a real builtin at some *other* arity, or genuinely unresolvable — the same
+  three-way split every ordinary call already gets.
+
+  `null`/`true`/`false` are deliberately excluded: they are literal tokens in jq's own
+  grammar, not identifier-based calls (confirmed live, `def null: 1; null` stays `null`
+  in real jq too, not `1`) — a `def` of that name parses but can never be reached.
+
 - **`del()`'s trailing `.[]` raised instead of no-oping through a tolerated (rather than
   genuinely found) `null`, in yq mode** (#2347, found during #2324's own implementation).
   A `null` reached by tolerating a step against it — a missing object field, or an

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -458,7 +458,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   #2110's own established rule for the non-shadow-candidate case), and the fallback
   reparse itself is now capped by a small retry budget, since an adversarial program
   nesting the same arity-mismatched name inside itself could otherwise force the same
-  reparse to repeat at every level.
+  reparse to repeat at every level (the budget bounds the *number* of retries to a small
+  constant, not the reparse cost of each one — see the round-2 findings below for where
+  that distinction mattered).
 
   **A second, more fundamental performance bug was also found and fixed during review,
   before this ever reached `main`**: an earlier version of this fix populated `args` by
@@ -481,6 +483,70 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ever sees the main filter's own source text — a `def` loaded via `include`, `import`,
   or `~/.jq` cannot shadow a builtin, since it was never scanned and the module-loading
   step that inlines it runs well after the main filter has already been fully parsed.
+
+  **Four more bugs found and fixed during a second, independent review round, before
+  this ever reached `main`:**
+
+  - A shadow candidate whose dedicated parser hit a wrong-arity call but (per the
+    independently-merged #2237, which touched this exact keyword-dispatch region and was
+    merged during this fix's own rebase) internally rewound to an already-successful,
+    already-generic `Ok(FuncCall{..})` — or a postfix-wrapped one — instead of returning
+    `Err`, had that generic result wrapped as `builtin_fallback` anyway.
+    `builtin_fallback_arity`/`builtin_fallback_into_args` (`resolve.rs`) had no matching
+    arm for that shape and fell to their "unreachable in practice" wildcard, silently
+    computing arity 0 and discarding the real arguments — and their side effects —
+    entirely:
+
+    ```console
+    $ succinctly jq -nc 'def until: "shadowed"; until(error("boom"))'   # before this fix
+    "shadowed"
+    $ jq -nc 'def until: "shadowed"; until(error("boom"))'
+    jq: error: until/1 is not defined at <top-level>, line 1: ...
+    ```
+
+    Fixed by only ever wrapping the exact closed set of shapes
+    `builtin_fallback_arity`/`_into_args` know how to read back (`wrap_shadowable_call`,
+    `parser.rs`) — anything else is returned unwrapped, resolved as an ordinary call like
+    any other, since the dedicated parser itself already gave up on a builtin
+    interpretation in that case.
+  - `range(N)` — the 1-arg sugar for `range(0; N)` — desugars to the exact same
+    `Expr::Range { from: Literal(0), to: Some(_), .. }` shape a genuine 2-arg
+    `range(0; N)` call produces, so computing the shadow-check arity from that shape
+    alone is ambiguous: `def range(a;b): "s"; range(5)` wrongly shadowed at arity 2, and
+    `def range(a): "s"; range(5)` wrongly failed to shadow at arity 1. Fixed by having
+    `parse_range_expr` mark the 1-arg form with an `Expr::Paren` wrapper (a no-op
+    everywhere else in eval/path/walk) so `resolve.rs` can tell the two shapes apart.
+  - `collect_def_names`'s lexical prescan used `str::trim_start`, which skips whitespace
+    but not a `#`-comment between the `def` keyword and its name — reproducing this
+    issue's own bug class for one more spelling: `def #c\nlength: 99; length` returned
+    `0` instead of `99`. Fixed by skipping comments the same way the real parser's own
+    `skip_ws` does.
+  - Unlike the other 7 shadowable special forms, `parse_error_expr`'s own wrong-arity
+    path relied entirely on `retry_shadow_candidate_as_generic_call`'s fallback reparse,
+    which re-parses the whole call from scratch *in addition to* the `parse_expr()` call
+    `parse_error_expr` had already run over the same content — doubling the parse work at
+    every nesting level of a wrong-arity-shadowed, nested `error(...)` chain and
+    exhausting the shared retry budget at a depth as shallow as 7, well within what a
+    real, non-adversarial program could reach (contrary to this entry's own earlier claim
+    above that the budget kept the worst case to "linear instead of exponential" — it
+    bounds the retry *count*, not each retry's cost, and for `error` specifically that
+    cost itself was compounding). Fixed by giving `parse_error_expr` the same internal
+    wrong-arity rewind the other 7 forms already have via #2237, removing it from the
+    budgeted fallback path entirely — a nested shadowed `error(...)` chain now resolves
+    correctly at realistic depths (pinned at 14) rather than erroring at 7. Deeper,
+    adversarial nesting still eventually hits the same pre-existing #2110/#2237
+    exponential-reparse cost the other 7 forms' own wrong-arity case already has —
+    confirmed identical on a fresh `main` build, unrelated to and out of scope for this
+    fix.
+
+  **Known residual gap, not fixed here** (tracked as #2402): evaluating a jq-mode-parsed
+  `Expr` directly via this crate's own public `eval`/`eval_lenient` API, *without* first
+  calling `resolve_func_calls`/`resolve_func_calls_all`, can now wrongly report
+  `undefined function` for a shadow-candidate call whose shadowing is genuinely declined
+  (`def length(x): x; [1,2,3] | length` errors instead of evaluating to `3`) — an honest
+  compile-shaped error, never a silently wrong *value*, and unreachable from the
+  `succinctly` binary itself (both CLI runners already resolve before evaluating), but a
+  real precondition change for an external caller of the library API.
 
 - **`del()`'s trailing `.[]` raised instead of no-oping through a tolerated (rather than
   genuinely found) `null`, in yq mode** (#2347, found during #2324's own implementation).

--- a/src/bin/succinctly/jq_runner.rs
+++ b/src/bin/succinctly/jq_runner.rs
@@ -229,6 +229,10 @@ fn rewrite_namespaced_calls(expr: Expr) -> Expr {
             Expr::FuncCall {
                 name: full_name,
                 args: rewritten_args,
+                // A `namespace::name` call is never itself a candidate for
+                // #2036's shadow-detection (that only wraps bare-identifier
+                // keyword dispatch, never `::`-qualified syntax).
+                builtin_fallback: None,
             }
         }
         // Recursively process all other expression types
@@ -254,11 +258,22 @@ fn rewrite_namespaced_calls(expr: Expr) -> Expr {
                 .collect();
             Expr::Object(new_entries)
         }
-        Expr::FuncCall { name, args } => {
+        Expr::FuncCall {
+            name,
+            args,
+            builtin_fallback,
+        } => {
             let new_args: Vec<Expr> = args.into_iter().map(rewrite_namespaced_calls).collect();
             Expr::FuncCall {
                 name,
                 args: new_args,
+                // #2036: preserved and recursed into -- this pass runs
+                // *before* `resolve.rs`'s own rewrite (see
+                // `process_program`'s ordering doc comment), so a
+                // shadow-candidate's fallback can itself contain a
+                // `namespace::f(...)` call (e.g. inside a shadowed
+                // `limit(n; ns::f)`) that still needs rewriting here too.
+                builtin_fallback: builtin_fallback.map(|b| Box::new(rewrite_namespaced_calls(*b))),
             }
         }
         Expr::FuncDef {
@@ -1218,7 +1233,7 @@ pub fn run_jq(args: JqCommand) -> Result<i32> {
         context.named.iter().map(|(k, v)| (k.as_str(), v)).collect();
     all_vars.push(("ARGS", &args_value));
 
-    let expr = jq::substitute_vars(&expr, all_vars);
+    let mut expr = jq::substitute_vars(&expr, all_vars);
 
     // #1473: resolve every function call against the `def`s, parameters and
     // builtins in scope at its position, exactly as real jq's compiler does —
@@ -1231,7 +1246,7 @@ pub fn run_jq(args: JqCommand) -> Result<i32> {
     // module function as undefined. `substitute_vars` above substitutes
     // `OwnedValue`s, never sub-expressions, so it cannot introduce a call and
     // running after it rather than before is equivalent.
-    let unresolved = jq::resolve_func_calls_all(&expr);
+    let unresolved = jq::resolve_func_calls_all(&mut expr);
     if !unresolved.is_empty() {
         report_unresolved_calls(&unresolved, &filter_str);
         return Ok(exit_codes::COMPILE_ERROR);

--- a/src/bin/succinctly/yq_runner.rs
+++ b/src/bin/succinctly/yq_runner.rs
@@ -4075,7 +4075,7 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
     // unfaithful to here. Reporting only the first is simply what this
     // extension has always done, not a shortcut #2037 introduced or one that
     // needs revisiting alongside it.
-    if let Err(unresolved) = jq::resolve_func_calls(&program.expr) {
+    if let Err(unresolved) = jq::resolve_func_calls(&mut program.expr) {
         anyhow::bail!("{unresolved}");
     }
 
@@ -4089,7 +4089,7 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
         .split_exp
         .as_deref()
         .map(|s| {
-            let expr = jq::parse_program_with_mode_and_extensions(
+            let mut expr = jq::parse_program_with_mode_and_extensions(
                 s,
                 jq::ParserMode::Yq,
                 args.jq_extensions,
@@ -4099,7 +4099,7 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
             // #1473: the filename expression is a second, independently parsed
             // program, so it needs its own resolution pass -- the main
             // filter's says nothing about it.
-            if let Err(unresolved) = jq::resolve_func_calls(&expr) {
+            if let Err(unresolved) = jq::resolve_func_calls(&mut expr) {
                 anyhow::bail!("{unresolved} in --split-exp expression");
             }
             Ok(expr)

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -1413,7 +1413,7 @@ fn eval_single<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
             then,
             bound,
         } => eval_func_def::<W, S>(name, params, body, then, bound, value, optional),
-        Expr::FuncCall { name, args } => eval_func_call::<W>(name, args, value, optional),
+        Expr::FuncCall { name, args, .. } => eval_func_call::<W>(name, args, value, optional),
 
         // #1371: a call already bound to its definition. Unlike `FuncCall`
         // above (which only ever errors, since an unbound call is a compile
@@ -45614,7 +45614,9 @@ pub(crate) fn install_def_calls(
         // -- so expansion is never handed one. Do not read the fallthrough
         // below as *permitting* a forward reference: it is unreachable for
         // one, and would still mis-resolve it if that pass were bypassed.
-        Expr::FuncCall { name, args } if *name == def.name && args.len() == def.params.len() => {
+        Expr::FuncCall { name, args, .. }
+            if *name == def.name && args.len() == def.params.len() =>
+        {
             // #1371: bind the call to its definition, but do **not**
             // substitute yet. Substitution happens in `eval_def_call`, when
             // evaluation actually reaches this node.
@@ -46169,7 +46171,7 @@ fn substitute_func_param_impl(expr: &Expr, param: &str, arg: &Expr, subst_dollar
                 bound: FuncDefBound::default(),
             }
         }
-        Expr::FuncCall { name, args } if name == param && args.is_empty() => {
+        Expr::FuncCall { name, args, .. } if name == param && args.is_empty() => {
             // In jq, function parameters are bare identifiers that parse as
             // zero-arg FuncCalls. This is a reference to the parameter --
             // never gated on `subst_dollar` (see this function's own doc
@@ -46547,6 +46549,7 @@ mod tests {
             body: Expr::FuncCall {
                 name: "f".to_string(),
                 args: vec![],
+                builtin_fallback: None,
             },
         });
         let bound = BoundBody::default();
@@ -75949,6 +75952,7 @@ mod tests {
         let call_f = || Expr::FuncCall {
             name: "f".into(),
             args: Vec::new(),
+            builtin_fallback: None,
         };
         let nth = Expr::NthExpr {
             n: Box::new(call_f()),
@@ -75990,6 +75994,7 @@ mod tests {
             args: vec![Expr::FuncCall {
                 name: "f".into(),
                 args: Vec::new(),
+                builtin_fallback: None,
             }],
         };
 

--- a/src/jq/expr.rs
+++ b/src/jq/expr.rs
@@ -438,6 +438,22 @@ pub enum Expr {
         /// restoring the original builtin/special-form). By the time any
         /// other pass over the tree runs, this field is always `None` --
         /// see `resolve::check`'s own doc comment.
+        ///
+        /// **Library-API precondition (#2036 review, round 2):** while this
+        /// field is still `Some`, `args` is deliberately left empty (see
+        /// above), so evaluating the tree directly ([`crate::jq::eval`]/
+        /// [`crate::jq::eval_lenient`]) *without* first calling
+        /// [`crate::jq::resolve_func_calls`]/[`crate::jq::resolve_func_calls_all`]
+        /// makes a node whose shadowing is genuinely declined -- a program
+        /// with an unrelated-arity `def` of a builtin's name elsewhere,
+        /// e.g. `def length(x): x; [1,2,3] | length` -- report `undefined
+        /// function: length/0` instead of evaluating the real builtin
+        /// (confirmed live via a direct call to `eval`). Both CLI runners
+        /// (`jq_runner.rs`, `yq_runner.rs`) already call one of the resolve
+        /// functions before evaluating, so this is unreachable from the
+        /// `succinctly` binary; it only affects an external caller of this
+        /// crate's own public `jq` API that evaluates a jq-mode-parsed
+        /// `Expr` without resolving it first. Tracked as #2402.
         builtin_fallback: Option<Box<Self>>,
     },
 

--- a/src/jq/expr.rs
+++ b/src/jq/expr.rs
@@ -418,6 +418,27 @@ pub enum Expr {
         name: String,
         /// Arguments (empty for no-arg calls)
         args: Vec<Self>,
+        /// #2036: the parse this exact call site would have produced had
+        /// its name never been shadowable -- a builtin, or one of the
+        /// fixed-arity special forms (`limit`, `until`, `while`, `repeat`,
+        /// `range`, `first`, `last`, `not`) the parser normally lowers
+        /// eagerly, before any `def` has been seen. `None` for an ordinary
+        /// call whose name the parser's own lexical prescan never saw
+        /// `def`'d anywhere in the program (the overwhelming majority of
+        /// calls) -- those parse exactly as before, at no extra cost.
+        ///
+        /// `Some` only ever appears on a node built by the parser
+        /// re-parsing the same source span twice (mirroring `#2110`'s
+        /// existing wrong-arity rewind) once the prescan flags the name as
+        /// possibly shadowed. [`crate::jq::resolve`]'s scope-tracking pass
+        /// is the sole consumer: once it knows whether `name`/`args.len()`
+        /// is genuinely a `def` in scope at this position, it either drops
+        /// this field (a real shadowing call) or substitutes this field's
+        /// value in place of the whole node (not shadowed after all,
+        /// restoring the original builtin/special-form). By the time any
+        /// other pass over the tree runs, this field is always `None` --
+        /// see `resolve::check`'s own doc comment.
+        builtin_fallback: Option<Box<Self>>,
     },
 
     /// A sub-expression that has already had every enclosing substitution

--- a/src/jq/parser.rs
+++ b/src/jq/parser.rs
@@ -208,7 +208,26 @@ fn collect_def_names(input: &str) -> BTreeSet<String> {
         if !before_ok || !after_ok {
             continue;
         }
-        let rest = input[end..].trim_start();
+        // #2036 review round 2: `trim_start()` alone only skips whitespace,
+        // not a `#`-comment between `def` and its name -- real jq's own
+        // `skip_ws` (which this prescan is meant to approximate) skips both,
+        // repeatedly, so a comment here must be skipped too or a `def`
+        // separated from its name by one is invisible to this scan and the
+        // shadow it should have enabled silently never fires. Confirmed
+        // live: `def #c\nlength: 99; length` returned `0` (the real
+        // builtin) instead of `99` before this fix.
+        let mut rest = &input[end..];
+        loop {
+            let trimmed = rest.trim_start();
+            let Some(after_hash) = trimmed.strip_prefix('#') else {
+                rest = trimmed;
+                break;
+            };
+            rest = match after_hash.find('\n') {
+                Some(i) => &after_hash[i..],
+                None => "",
+            };
+        }
         let mut chars = rest.char_indices();
         let Some((_, first)) = chars.next() else {
             continue;
@@ -1802,6 +1821,7 @@ impl<'a> Parser<'a> {
     /// Syntax: error
     ///         error(MESSAGE)
     fn parse_error_expr(&mut self) -> Result<Expr, ParseError> {
+        let start_pos = self.pos;
         self.consume_keyword("error");
         self.skip_ws();
 
@@ -1811,7 +1831,32 @@ impl<'a> Parser<'a> {
             self.skip_ws();
             let msg_expr = self.parse_expr()?;
             self.skip_ws();
-            self.expect(')')?;
+            if self.peek() != Some(')') {
+                // #2036 review round 2: unlike the other 7 shadowable
+                // special forms (until/limit/while/repeat/range/first/last),
+                // this arm used to propagate `Err` straight from `expect`
+                // for a wrong-arity `error(a;b)` call, relying on
+                // `parse_shadowable_special_form`'s own
+                // `retry_shadow_candidate_as_generic_call` fallback to
+                // recover it as a generic call. That fallback re-parses
+                // `input[start_pos..]` from scratch *in addition to* the
+                // `parse_expr()` call just above, which had already fully
+                // (and, for a nested wrong-arity shadow candidate,
+                // recursively-and-also-retried) parsed the same content --
+                // doubling the parse work at every nesting level and
+                // exhausting `shadow_retry_budget` at a depth as shallow as
+                // 7 for a legitimate, non-adversarial nested `def
+                // error(a;b): ...` shadow. Matching #2110/#2237's own
+                // internal-rewind pattern here (`rewind_to_wrong_arity_call`)
+                // instead removes this arm from that fallback path entirely,
+                // exactly as it already does for the other 7 forms.
+                if self.mode == ParserMode::Jq {
+                    return self.rewind_to_wrong_arity_call(start_pos);
+                }
+                self.expect(')')?;
+                unreachable!();
+            }
+            self.next();
             Some(Box::new(msg_expr))
         } else {
             None
@@ -2182,11 +2227,38 @@ impl<'a> Parser<'a> {
         if self.peek() == Some(')') {
             // range(N) - from 0 to N
             self.next();
-            return Ok(Expr::Range {
+            let range = Expr::Range {
                 from: Box::new(Expr::Literal(Literal::Int(0))),
                 to: Some(Box::new(first)),
                 step: None,
-            });
+            };
+            // #2036 review round 2: wrapped in `Paren` -- but *only* when
+            // "range" is a shadow candidate at all (i.e. only on the path
+            // `wrap_shadowable_call` will actually consult) -- so this 1-arg
+            // form stays distinguishable there from a genuine 2-arg
+            // `range(0; N)` call, which desugars to the exact same `Range {
+            // from: Literal(0), .. }` shape otherwise. Needed for
+            // `builtin_fallback_arity`/`_into_args` (`resolve.rs`) to report
+            // the correct real arity (1, not 2) in that case -- confirmed
+            // live before this fix: `def range(a;b): "s"; range(5)` wrongly
+            // shadowed at arity 2, and `def range(a): "s"; range(5)` wrongly
+            // failed to shadow at arity 1.
+            //
+            // An earlier version of this fix wrapped unconditionally,
+            // regardless of whether "range" was ever a shadow candidate --
+            // `Paren` is a transparent no-op at *evaluation*, but it is a
+            // real, observable change to the parsed `Expr` shape, and broke
+            // `walk::tests::map_subexprs_preserves_field_order_three_or_more_children`'s
+            // pre-existing expectation that a plain `range(.a)` (no `def`
+            // anywhere in the filter) parses straight to `Expr::Range`, not
+            // `Expr::Paren(Range(..))`. Gating on `shadowable_defs` keeps
+            // the parsed shape identical to before this issue's fix for
+            // every filter with no `def` of "range" in it at all -- the
+            // overwhelming majority of `range(N)` call sites.
+            if self.shadowable_defs.contains("range") {
+                return Ok(Expr::Paren(Box::new(range)));
+            }
+            return Ok(range);
         }
 
         self.expect(';')?;
@@ -2958,6 +3030,42 @@ impl<'a> Parser<'a> {
     /// `args.len()` whenever `args` is still empty) means no sub-expression
     /// is ever duplicated at parse time at all.
     fn wrap_shadowable_call(name: &str, original: Expr) -> Expr {
+        // #2036 review round 2: only wrap a shape `resolve.rs`'s
+        // `builtin_fallback_arity`/`builtin_fallback_into_args` actually
+        // know how to read back -- the exact set of shapes the 8 dedicated
+        // special-form parsers and `try_parse_builtin` can hand back on
+        // success. `original` is *not* always one of these: #2110/#2237's
+        // own internal `rewind_to_wrong_arity_call` lets a dedicated parser
+        // (e.g. `parse_until_expr` on a wrong-arity call) return `Ok` over
+        // an already-generic `parse_func_call_or_error` + postfix result
+        // instead of `Err` -- a plain `Expr::FuncCall`, or any postfix
+        // wrapping of one (`Expr::IndexExpr`, `Expr::Optional`, ...).
+        // Wrapping *that* as a `builtin_fallback` left no matching arm in
+        // `builtin_fallback_arity`/`_into_args` (both fell to their
+        // wildcard, silently computing arity 0 and discarding the real
+        // args) -- confirmed live: `def until: "s"; until(error("boom"))`
+        // returned `"s"`, discarding the error entirely, where real jq
+        // raises `until/1 is not defined`. There is no builtin
+        // interpretation left to preserve in that case -- the dedicated
+        // parser itself already gave up and fell through to a generic call
+        // -- so it is returned as-is, unwrapped, and resolved exactly like
+        // any other ordinary call site.
+        let is_recognized_special_form_shape = matches!(
+            original,
+            Expr::Not
+                | Expr::Limit { .. }
+                | Expr::Until { .. }
+                | Expr::While { .. }
+                | Expr::Repeat(_)
+                | Expr::FirstExpr(_)
+                | Expr::LastExpr(_)
+                | Expr::Range { .. }
+                | Expr::Error(_)
+                | Expr::Builtin(_)
+        ) || matches!(&original, Expr::Paren(inner) if matches!(**inner, Expr::Range { .. }));
+        if !is_recognized_special_form_shape {
+            return original;
+        }
         Expr::FuncCall {
             name: name.to_string(),
             args: Vec::new(),

--- a/src/jq/parser.rs
+++ b/src/jq/parser.rs
@@ -250,12 +250,23 @@ struct Parser<'a> {
     /// scope-aware check is what actually decides, for each call site,
     /// whether the name is genuinely in scope there. Consulted only at the
     /// keyword choke points that can produce a shadowable builtin/special
-    /// form (see [`Self::maybe_shadow_builtin`] and
+    /// form (see [`Self::parse_shadowable_special_form`] and
     /// [`Self::zero_arity_or_wrong_arity_call`]) -- a program with no
     /// `def`s anywhere pays for one scan of its own source text and
     /// nothing else.
     shadowable_defs: BTreeSet<String>,
+    /// #2036: bounds the total number of times
+    /// [`Self::retry_shadow_candidate_as_generic_call`]'s own fallback
+    /// reparse can fire across this whole parse, so a deeply nested,
+    /// arity-mismatched shadow candidate degrades to "stops shadowing past
+    /// this depth" instead of the `O(2^depth)` blowup that function's own
+    /// doc comment describes. An ordinary, non-adversarial program never
+    /// comes close to this; the exact constant is not load-bearing.
+    shadow_retry_budget: usize,
 }
+
+/// See [`Parser::shadow_retry_budget`].
+const SHADOW_RETRY_BUDGET: usize = 64;
 
 impl<'a> Parser<'a> {
     #[allow(dead_code)] // STYLE-0005: kept for tests and future use
@@ -268,6 +279,7 @@ impl<'a> Parser<'a> {
             pattern_depth: 0,
             expr_depth: 0,
             shadowable_defs: collect_def_names(input),
+            shadow_retry_budget: SHADOW_RETRY_BUDGET,
         }
     }
 
@@ -280,6 +292,7 @@ impl<'a> Parser<'a> {
             pattern_depth: 0,
             expr_depth: 0,
             shadowable_defs: collect_def_names(input),
+            shadow_retry_budget: SHADOW_RETRY_BUDGET,
         }
     }
 
@@ -1643,14 +1656,24 @@ impl<'a> Parser<'a> {
                         // not propagated -- see
                         // `retry_shadow_candidate_as_generic_call`'s own
                         // doc comment for the empty-parens and
-                        // retry-budget safeguards this needs (and for why
-                        // it applies the same jq-mode-only postfix fix as
-                        // the `Ok(None)` arm just above). A non-candidate
-                        // name keeps today's behavior exactly: the parse
-                        // error propagates unchanged.
+                        // retry-budget safeguards this needs. A
+                        // non-candidate name keeps today's behavior
+                        // exactly: the parse error propagates unchanged.
+                        //
+                        // Postfix applied here (jq mode only), matching the
+                        // `Ok(None)` arm's own #2237 fix just above -- this
+                        // is the identical "ends up an ordinary generic
+                        // call" shape, just reached via a failed builtin
+                        // attempt instead of never matching one at all.
                         Err(e) => {
                             if shadow_candidate {
-                                self.retry_shadow_candidate_as_generic_call(keyword_start, e)
+                                let call =
+                                    self.retry_shadow_candidate_as_generic_call(keyword_start, e)?;
+                                if self.mode == ParserMode::Jq {
+                                    self.parse_postfix(call)
+                                } else {
+                                    Ok(call)
+                                }
                             } else {
                                 Err(e)
                             }
@@ -2746,7 +2769,7 @@ impl<'a> Parser<'a> {
         self.pos = after_keyword;
         if let Some(name) = shadow_name {
             if self.shadowable_defs.contains(name) {
-                let wrapped = self.rewind_reparse_as_shadowable_call(start_pos, parsed)?;
+                let wrapped = Self::wrap_shadowable_call(name, parsed);
                 return self.parse_postfix(wrapped);
             }
         }
@@ -2837,47 +2860,109 @@ impl<'a> Parser<'a> {
             return parse_original(self);
         }
         match parse_original(self) {
-            Ok(original) => self.rewind_reparse_as_shadowable_call(start_pos, original),
-            Err(_) => {
-                self.pos = start_pos;
-                self.parse_func_call_or_error()
-            }
+            Ok(original) => Ok(Self::wrap_shadowable_call(name, original)),
+            Err(e) => self.retry_shadow_candidate_as_generic_call(start_pos, e),
         }
     }
 
-    /// #2036 Direction 3: rewind to `start_pos` (before the keyword began)
-    /// and re-parse the same source span as an ordinary `NAME(args;args)`
-    /// call, stashing `original` -- whatever the keyword's own dedicated
-    /// parse produced for that identical span -- as the new node's
-    /// `builtin_fallback`. [`super::resolve::check`] is the sole consumer:
-    /// once it knows whether this exact `(name, arity)` is genuinely a
-    /// `def` in scope at this position, it either keeps the call (real
-    /// shadowing) or substitutes `original` back in (not shadowed after
-    /// all). Shared by every call site that can produce a shadowable
-    /// builtin or fixed-arity special form; see
-    /// [`Self::zero_arity_or_wrong_arity_call`]'s own doc comment for why
-    /// it alone additionally gates this behind `shadow_name`.
-    fn rewind_reparse_as_shadowable_call(
+    /// #2036: shared by every arity-mismatch recovery path (the special
+    /// forms above, and [`Self::try_parse_builtin`]'s own call site) --
+    /// `original_err` is whatever the keyword's own dedicated parser failed
+    /// with. Two safeguards found and fixed during this fix's own review,
+    /// both live-verified against real jq:
+    ///
+    /// - **A genuinely empty `NAME()`** must stay a syntax error, not
+    ///   silently become a valid zero-arg call: [`Self::parse_func_call_or_error`]'s
+    ///   own empty-arg-list leniency exists for the ordinary "just call
+    ///   `foo`" case, not this one -- confirmed live, `def not: 1; not()`
+    ///   parsed as `1` (exit 0) here before this check, where real jq
+    ///   raises `syntax error, unexpected ')'` (exit 3) for *every* name,
+    ///   shadowed or not (matching #2110's own established empty-parens
+    ///   rejection for the non-shadow-candidate case). Detected by peeking
+    ///   for `(` immediately followed by `)` at `start_pos` -- if so,
+    ///   `original_err` (whatever the specialized parser's own failure was,
+    ///   typically an "expected expression" complaint from trying to parse
+    ///   nothing) is propagated instead of attempting the fallback at all.
+    /// - **A bounded retry budget**: unlike the successful-parse path
+    ///   ([`Self::wrap_shadowable_call`]), there is no already-built AST to
+    ///   derive arguments from when the specialized parser fails -- the
+    ///   fallback genuinely has to re-parse `input[start_pos..]` from
+    ///   scratch. If every level of a deeply nested, *arity-mismatched*
+    ///   shadow candidate (`def until(a;b;c): ...` nested inside itself)
+    ///   also fails its own specialized parse, each level's fallback
+    ///   reparse walks every nested level again, compounding into the same
+    ///   `O(2^depth)` blowup [`Self::wrap_shadowable_call`]'s own doc
+    ///   comment describes for the (now-fixed) successful-parse case --
+    ///   confirmed live as a real, if far more contrived, second instance
+    ///   of the same denial-of-service shape. `shadow_retry_budget`
+    ///   (initialized once per `Parser`, decremented every time this
+    ///   fallback is actually attempted) bounds the *total* number of such
+    ///   reparses across the whole program to a small constant, keeping the
+    ///   worst case linear instead of exponential -- past the budget,
+    ///   `original_err` is propagated instead, the same as if `name` had
+    ///   never been a shadow candidate at all. Ordinary, non-adversarial
+    ///   programs never come close to exhausting it.
+    fn retry_shadow_candidate_as_generic_call(
         &mut self,
         start_pos: usize,
-        original: Expr,
+        original_err: ParseError,
     ) -> Result<Expr, ParseError> {
+        if self.peek_after_keyword_at_is_empty_parens(start_pos) {
+            return Err(original_err);
+        }
+        let Some(remaining) = self.shadow_retry_budget.checked_sub(1) else {
+            return Err(original_err);
+        };
+        self.shadow_retry_budget = remaining;
         self.pos = start_pos;
-        let call = self.parse_func_call_or_error()?;
-        Ok(match call {
-            Expr::FuncCall { name, args, .. } => Expr::FuncCall {
-                name,
-                args,
-                builtin_fallback: Some(Box::new(original)),
-            },
-            // `parse_func_call_or_error` can also return a namespaced call
-            // (`NAME::rest`) if the rewound identifier happens to be
-            // followed by `::` -- vanishingly unlikely for a real builtin
-            // name, and there is no `FuncCall` to attach a fallback to in
-            // that shape anyway, so it is returned as-is rather than
-            // forced into one.
-            other => other,
-        })
+        self.parse_func_call_or_error()
+    }
+
+    /// Whether `input[pos..]` is `IDENT` immediately followed by `(` then
+    /// `)` with nothing but whitespace between -- a genuinely empty
+    /// argument list, as opposed to `(` followed by a real (if malformed)
+    /// expression. `pos` must be the position *before* the identifier.
+    fn peek_after_keyword_at_is_empty_parens(&self, pos: usize) -> bool {
+        let after_ident = pos + self.ident_text_at(pos).len();
+        let rest = self.input[after_ident..].trim_start();
+        let Some(rest) = rest.strip_prefix('(') else {
+            return false;
+        };
+        rest.trim_start().starts_with(')')
+    }
+
+    /// #2036 Direction 3: wrap a *successfully*-parsed `original` -- the
+    /// keyword's own dedicated parse -- as `Expr::FuncCall { name, args:
+    /// vec![], builtin_fallback: Some(original) }`. [`super::resolve::check`]
+    /// is the sole consumer: once it knows whether this exact `(name,
+    /// arity)` is genuinely a `def` in scope at this position, it either
+    /// populates `args` for real (moved out of `original`, not cloned --
+    /// see `resolve.rs`'s own `builtin_fallback_into_args`) for a real
+    /// shadowing call, or substitutes `original` back into the node whole
+    /// (not shadowed after all).
+    ///
+    /// **`args` deliberately starts empty here, not populated from
+    /// `original`'s own children.** An earlier version of this function
+    /// cloned them out at parse time instead -- correct, but with a cost
+    /// that compounds *exponentially* with nesting depth even though no
+    /// source text is re-parsed: every nesting level's node holds both
+    /// `args` *and* `builtin_fallback`, each an independent full copy of
+    /// everything below it, so the node's own retained size roughly doubles
+    /// per level, and cloning a subtree of size `2^depth` at each of
+    /// `depth` levels sums back to `O(2^depth)` total. Confirmed live during
+    /// this fix's own review as a genuine parser-level denial-of-service:
+    /// `def first: .; first(first(first(...)))` took ~0.8s to *parse* at 20
+    /// levels of nesting, well under `MAX_EXPR_DEPTH`. Leaving `args` empty
+    /// until `resolve.rs` actually needs it (`super::resolve::UnresolvedCall`'s
+    /// own arity check reads `builtin_fallback`'s shape directly instead of
+    /// `args.len()` whenever `args` is still empty) means no sub-expression
+    /// is ever duplicated at parse time at all.
+    fn wrap_shadowable_call(name: &str, original: Expr) -> Expr {
+        Expr::FuncCall {
+            name: name.to_string(),
+            args: Vec::new(),
+            builtin_fallback: Some(Box::new(original)),
+        }
     }
 
     /// The bare identifier text starting at `pos`, independent of how far

--- a/src/jq/parser.rs
+++ b/src/jq/parser.rs
@@ -29,9 +29,9 @@ use alloc::vec;
 use alloc::vec::Vec;
 
 #[cfg(not(test))]
-use alloc::collections::BTreeMap;
+use alloc::collections::{BTreeMap, BTreeSet};
 #[cfg(test)]
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 
 use super::expr::{
     ArithOp, AssignOp, Builtin, CompareOp, Expr, FormatType, FuncDefBound, Import, Include,
@@ -172,6 +172,58 @@ const MAX_PATTERN_DEPTH: usize = 256;
 /// the same caveat; the two deliberately share one number.
 const MAX_EXPR_DEPTH: usize = 256;
 
+/// #2036 Direction 3: a cheap, deliberately over-approximate scan for every
+/// identifier spelled after a `def` keyword anywhere in `input` -- see
+/// `Parser::shadowable_defs`'s own doc comment for why imprecision here is
+/// safe (a false positive costs one wasted double-parse at one call site; a
+/// false negative is impossible to turn into a wrong *answer* either, since
+/// `resolve.rs`'s own scope-aware pass is what actually decides shadowing,
+/// this is only a hint for which call sites are worth asking it about).
+/// Deliberately not lexically aware -- does not skip string literals or
+/// comments, so `"def foo"` or `# def foo` also add `foo` to the set. Plain
+/// substring scanning, not a real lexer pass, by design.
+fn collect_def_names(input: &str) -> BTreeSet<String> {
+    fn is_ident_start(c: char) -> bool {
+        c.is_alphabetic() || c == '_'
+    }
+    // Yq mode's own `-`-in-identifier extension (`.my-key`) is folded in
+    // unconditionally here too, even though real `def` doesn't exist in yq
+    // at all without succinctly's own extension -- a mode-blind superset
+    // only ever widens the (already-imprecise) set, never narrows it.
+    fn is_ident_continue(c: char) -> bool {
+        c.is_alphanumeric() || c == '_' || c == '-'
+    }
+
+    let mut names = BTreeSet::new();
+    for (start, _) in input.match_indices("def") {
+        let end = start + 3;
+        let before_ok = input[..start]
+            .chars()
+            .next_back()
+            .map_or(true, |c| !is_ident_continue(c) && !is_ident_start(c));
+        let after_ok = input[end..]
+            .chars()
+            .next()
+            .map_or(true, |c| !is_ident_continue(c));
+        if !before_ok || !after_ok {
+            continue;
+        }
+        let rest = input[end..].trim_start();
+        let mut chars = rest.char_indices();
+        let Some((_, first)) = chars.next() else {
+            continue;
+        };
+        if !is_ident_start(first) {
+            continue;
+        }
+        let ident_end = chars
+            .find(|&(_, c)| !is_ident_continue(c))
+            .map_or(rest.len(), |(i, _)| i);
+        names.insert(rest[..ident_end].to_string());
+    }
+    names
+}
+
 /// Parser state.
 struct Parser<'a> {
     input: &'a str,
@@ -186,6 +238,23 @@ struct Parser<'a> {
     pattern_depth: usize,
     /// Current `Expr` recursion depth; see [`MAX_EXPR_DEPTH`].
     expr_depth: usize,
+    /// #2036 Direction 3: every identifier that appears anywhere after a
+    /// `def` keyword in `input`, computed once by [`collect_def_names`] at
+    /// construction. A cheap, deliberately *imprecise* over-approximation
+    /// of "names a `def` in this program might shadow a builtin at" -- it
+    /// does not track lexical scope (that is `resolve.rs`'s job, done
+    /// correctly, once the tree exists) and can include a false positive
+    /// (a `def` spelled inside a string literal, say). A false positive
+    /// only costs one wasted double-parse at that one call site; it can
+    /// never cause an incorrect *answer*, since `resolve.rs`'s own
+    /// scope-aware check is what actually decides, for each call site,
+    /// whether the name is genuinely in scope there. Consulted only at the
+    /// keyword choke points that can produce a shadowable builtin/special
+    /// form (see [`Self::maybe_shadow_builtin`] and
+    /// [`Self::zero_arity_or_wrong_arity_call`]) -- a program with no
+    /// `def`s anywhere pays for one scan of its own source text and
+    /// nothing else.
+    shadowable_defs: BTreeSet<String>,
 }
 
 impl<'a> Parser<'a> {
@@ -198,6 +267,7 @@ impl<'a> Parser<'a> {
             jq_extensions: false,
             pattern_depth: 0,
             expr_depth: 0,
+            shadowable_defs: collect_def_names(input),
         }
     }
 
@@ -209,6 +279,7 @@ impl<'a> Parser<'a> {
             jq_extensions,
             pattern_depth: 0,
             expr_depth: 0,
+            shadowable_defs: collect_def_names(input),
         }
     }
 
@@ -1400,48 +1471,85 @@ impl<'a> Parser<'a> {
                 let keyword_start = self.pos;
                 if self.matches_keyword("null") {
                     self.consume_keyword("null");
-                    self.zero_arity_or_wrong_arity_call(keyword_start, Expr::Literal(Literal::Null))
+                    // #2036: `null`/`true`/`false` are literal tokens in
+                    // jq's own grammar, not shadowable identifier calls --
+                    // `None` here, unlike `not` and every builtin below.
+                    self.zero_arity_or_wrong_arity_call(
+                        keyword_start,
+                        None,
+                        Expr::Literal(Literal::Null),
+                    )
                 } else if self.matches_keyword("true") {
                     self.consume_keyword("true");
                     self.zero_arity_or_wrong_arity_call(
                         keyword_start,
+                        None,
                         Expr::Literal(Literal::Bool(true)),
                     )
                 } else if self.matches_keyword("false") {
                     self.consume_keyword("false");
                     self.zero_arity_or_wrong_arity_call(
                         keyword_start,
+                        None,
                         Expr::Literal(Literal::Bool(false)),
                     )
                 } else if self.matches_keyword("not") {
                     self.consume_keyword("not");
-                    self.zero_arity_or_wrong_arity_call(keyword_start, Expr::Not)
+                    self.zero_arity_or_wrong_arity_call(keyword_start, Some("not"), Expr::Not)
                 } else if self.matches_keyword("if") {
                     self.parse_if_expr()
                 } else if self.matches_keyword("try") {
                     self.parse_try_expr()
                 } else if self.matches_keyword("error") {
-                    self.parse_error_expr()
+                    self.parse_shadowable_special_form(
+                        keyword_start,
+                        "error",
+                        Self::parse_error_expr,
+                    )
                 } else if self.matches_keyword("reduce") {
                     self.parse_reduce_expr()
                 } else if self.matches_keyword("foreach") {
                     self.parse_foreach_expr()
                 } else if self.matches_keyword("limit") {
                     self.reject_unless_jq_extensions("limit")?;
-                    self.parse_limit_expr()
+                    self.parse_shadowable_special_form(
+                        keyword_start,
+                        "limit",
+                        Self::parse_limit_expr,
+                    )
                 } else if self.matches_keyword("until") {
-                    self.parse_until_expr()
+                    self.parse_shadowable_special_form(
+                        keyword_start,
+                        "until",
+                        Self::parse_until_expr,
+                    )
                 } else if self.matches_keyword("while") {
-                    self.parse_while_expr()
+                    self.parse_shadowable_special_form(
+                        keyword_start,
+                        "while",
+                        Self::parse_while_expr,
+                    )
                 } else if self.matches_keyword("repeat") {
-                    self.parse_repeat_expr()
+                    self.parse_shadowable_special_form(
+                        keyword_start,
+                        "repeat",
+                        Self::parse_repeat_expr,
+                    )
                 } else if self.matches_keyword("range") {
                     self.reject_unless_jq_extensions("range")?;
-                    self.parse_range_expr()
+                    self.parse_shadowable_special_form(
+                        keyword_start,
+                        "range",
+                        Self::parse_range_expr,
+                    )
                 } else if self.matches_keyword("first") {
-                    self.parse_first_expr()
+                    self.parse_shadowable_special_form(
+                        keyword_start,
+                        "first",
+                        Self::parse_first_expr,
+                    )
                 } else if self.matches_keyword("last") {
-                    self.parse_last_expr()
+                    self.parse_shadowable_special_form(keyword_start, "last", Self::parse_last_expr)
                 } else if self.matches_keyword("def") {
                     // Phase 9: Function definition
                     self.parse_def_expr()
@@ -1449,56 +1557,104 @@ impl<'a> Parser<'a> {
                     self.parse_label_expr()
                 } else if self.matches_keyword("break") {
                     self.parse_break_expr()
-                } else if let Some(builtin) = self.try_parse_builtin()? {
-                    // #2110: a following `(<args>)` means this was actually
-                    // a wrong-arity call, not a bare builtin reference --
-                    // `zero_arity_or_wrong_arity_call` rewinds and re-parses
-                    // it as one instead of falling into postfix parsing,
-                    // which would just reject the `(` as a stray token; it
-                    // also applies postfix itself (e.g. `env.PATH`,
-                    // `keys[0]`) on whichever `Expr` it ends up returning.
-                    self.zero_arity_or_wrong_arity_call(keyword_start, Expr::Builtin(builtin))
                 } else {
-                    // Phase 9: Try to parse as function call.
-                    //
-                    // #2237 review: postfix (`.field`/`[idx]`) should be
-                    // applied to the resolved call here too, exactly like
-                    // the `zero_arity_or_wrong_arity_call` branch above
-                    // already does -- a pre-existing gap, not previously
-                    // scoped to any wrong-arity fix: even a legitimately
-                    // *defined* function call followed by postfix failed to
-                    // parse at all before this (`def f(x): {a:x}; f(1).a`
-                    // raised a raw "unexpected character '.'" instead of
-                    // returning `1`, confirmed against jq 1.7.1). Also
-                    // fixes the same gap for every wrong-arity call that
-                    // reaches this branch via `Ok(None)` from
-                    // `Self::try_parse_builtin` (`Self::parse_required_single_arg`'s
-                    // rewind path -- `has`/`select`/`env`/...).
-                    //
-                    // jq mode only (review, round 2): yq mode's own
-                    // merge-flag scan (`Self::scan_merge_flags`, called from
-                    // the `*`/`*=` operator parsing) silently stops at the
-                    // first unrecognized character rather than erroring,
-                    // leaving it -- and anything after it -- for this exact
-                    // fallback to parse as an ordinary expression. Applying
-                    // postfix unconditionally here let a bare merge-flag
-                    // remnant absorb a trailing `.field` the way `n.b`
-                    // legitimately can as a plain identifier expression,
-                    // producing a full (if semantically wrong-flag) parse
-                    // where real yq's own lexer unconditionally rejects
-                    // *any* non-flag content immediately after `*=`/`*` --
-                    // confirmed live against yq v4.53.3, `.a *= n.b` (an
-                    // ordinary, unrelated identifier reference, not even a
-                    // merge-flag context) is *also* `lexer: invalid input
-                    // text`. Real jq has no such restriction (`.a *=n .b`
-                    // parses as `.a *= (n.b)` there, confirmed live, and
-                    // only fails later at name resolution), so jq mode
-                    // keeps the postfix fix.
-                    let call = self.parse_func_call_or_error()?;
-                    if self.mode == ParserMode::Jq {
-                        self.parse_postfix(call)
-                    } else {
-                        Ok(call)
+                    // #2036: the shadow-check name is re-derived from
+                    // `input` (`ident_text_at`), not read off whichever
+                    // `Builtin` `try_parse_builtin` might return -- many
+                    // arms consume their own argument list as part of
+                    // recognizing the builtin (`ltrimstr(s)`), so the bare
+                    // keyword text at `keyword_start` is the only reliable
+                    // source for "what identifier was this," and is needed
+                    // even on the `Err` arm below, where there is no
+                    // `Builtin` at all yet to derive it from.
+                    let name = self.ident_text_at(keyword_start).to_string();
+                    let shadow_candidate = self.shadowable_defs.contains(&name);
+                    match self.try_parse_builtin() {
+                        Ok(Some(builtin)) => {
+                            // #2110: a following `(<args>)` means this was
+                            // actually a wrong-arity call, not a bare
+                            // builtin reference -- `zero_arity_or_wrong_
+                            // arity_call` rewinds and re-parses it as one
+                            // instead of falling into postfix parsing,
+                            // which would just reject the `(` as a stray
+                            // token; it also applies postfix itself (e.g.
+                            // `env.PATH`, `keys[0]`) on whichever `Expr` it
+                            // ends up returning.
+                            self.zero_arity_or_wrong_arity_call(
+                                keyword_start,
+                                shadow_candidate.then_some(name.as_str()),
+                                Expr::Builtin(builtin),
+                            )
+                        }
+                        // Not recognized as any builtin at all -- ordinary
+                        // function call, unrelated to #2036 (a name never
+                        // matched here never goes through the shadow path
+                        // either way).
+                        //
+                        // #2237 review: postfix (`.field`/`[idx]`) should be
+                        // applied to the resolved call here too, exactly like
+                        // the `zero_arity_or_wrong_arity_call` branch above
+                        // already does -- a pre-existing gap, not previously
+                        // scoped to any wrong-arity fix: even a legitimately
+                        // *defined* function call followed by postfix failed to
+                        // parse at all before this (`def f(x): {a:x}; f(1).a`
+                        // raised a raw "unexpected character '.'" instead of
+                        // returning `1`, confirmed against jq 1.7.1). Also
+                        // fixes the same gap for every wrong-arity call that
+                        // reaches this branch via `Ok(None)` from
+                        // `Self::try_parse_builtin` (`Self::parse_required_single_arg`'s
+                        // rewind path -- `has`/`select`/`env`/...).
+                        //
+                        // jq mode only (review, round 2): yq mode's own
+                        // merge-flag scan (`Self::scan_merge_flags`, called from
+                        // the `*`/`*=` operator parsing) silently stops at the
+                        // first unrecognized character rather than erroring,
+                        // leaving it -- and anything after it -- for this exact
+                        // fallback to parse as an ordinary expression. Applying
+                        // postfix unconditionally here let a bare merge-flag
+                        // remnant absorb a trailing `.field` the way `n.b`
+                        // legitimately can as a plain identifier expression,
+                        // producing a full (if semantically wrong-flag) parse
+                        // where real yq's own lexer unconditionally rejects
+                        // *any* non-flag content immediately after `*=`/`*` --
+                        // confirmed live against yq v4.53.3, `.a *= n.b` (an
+                        // ordinary, unrelated identifier reference, not even a
+                        // merge-flag context) is *also* `lexer: invalid input
+                        // text`. Real jq has no such restriction (`.a *=n .b`
+                        // parses as `.a *= (n.b)` there, confirmed live, and
+                        // only fails later at name resolution), so jq mode
+                        // keeps the postfix fix.
+                        Ok(None) => {
+                            let call = self.parse_func_call_or_error()?;
+                            if self.mode == ParserMode::Jq {
+                                self.parse_postfix(call)
+                            } else {
+                                Ok(call)
+                            }
+                        }
+                        // #2036: `try_parse_builtin` matched a keyword but
+                        // failed parsing the argument shape it expects for
+                        // it (e.g. `def ltrimstr(a;b): ...; ltrimstr(1;2)`
+                        // -- real `ltrimstr/1`'s own parser only ever
+                        // accepts exactly one argument). Confirmed live
+                        // that real jq still lets this shadow
+                        // (`ltrimstr(a;b)` is a real jq idiom, not an
+                        // error): for a shadow candidate, the failure is
+                        // not propagated -- see
+                        // `retry_shadow_candidate_as_generic_call`'s own
+                        // doc comment for the empty-parens and
+                        // retry-budget safeguards this needs (and for why
+                        // it applies the same jq-mode-only postfix fix as
+                        // the `Ok(None)` arm just above). A non-candidate
+                        // name keeps today's behavior exactly: the parse
+                        // error propagates unchanged.
+                        Err(e) => {
+                            if shadow_candidate {
+                                self.retry_shadow_candidate_as_generic_call(keyword_start, e)
+                            } else {
+                                Err(e)
+                            }
+                        }
                     }
                 }
             }
@@ -2392,14 +2548,11 @@ impl<'a> Parser<'a> {
         // Return as function call - the evaluator will check if it's defined
         // Note: for known identifiers that aren't functions, we'd have returned earlier
         // So if we reach here, it's either a user-defined function call or an error
-        if args.is_empty() {
-            // Zero-arg function call - but this might be an unknown identifier
-            // For now, treat it as a function call; the evaluator will handle errors
-            Ok(Expr::FuncCall { name, args })
-        } else {
-            // Has arguments, definitely a function call
-            Ok(Expr::FuncCall { name, args })
-        }
+        Ok(Expr::FuncCall {
+            name,
+            args,
+            builtin_fallback: None,
+        })
     }
 
     /// The `Expr`-returning counterpart of
@@ -2547,9 +2700,25 @@ impl<'a> Parser<'a> {
     ///
     /// [`try_parse_builtin`]: Self::try_parse_builtin
     /// [`resolve.rs`]: super::resolve
+    ///
+    /// `shadow_name` (#2036): `Some(name)` for a keyword that real jq lets a
+    /// `def` shadow (`not`, and everything [`try_parse_builtin`] recognizes);
+    /// `None` for one it never can (`null`/`true`/`false` are literal tokens
+    /// in jq's own grammar, not identifier-based calls -- confirmed live,
+    /// `def null: 1; null` stays `null` in both jq 1.7.1 and here). Only
+    /// consulted in the tail (bare-keyword) branch below, never the
+    /// wrong-arity rewind above: that branch already unconditionally
+    /// reparses as a generic call with no fallback attached, which is
+    /// already exactly correct here too (`not(x)` where `not/1` is not in
+    /// scope has no zero-arity fallback to offer regardless of shadowing --
+    /// `Expr::Not` only ever represents the arity-0 case). The tail's own
+    /// reparse, by contrast, can only ever yield zero args (having reached
+    /// the tail at all means there was no unconsumed non-empty arg list
+    /// following), so its result's arity always matches `parsed`'s.
     fn zero_arity_or_wrong_arity_call(
         &mut self,
         start_pos: usize,
+        shadow_name: Option<&str>,
         parsed: Expr,
     ) -> Result<Expr, ParseError> {
         let after_keyword = self.pos;
@@ -2575,6 +2744,12 @@ impl<'a> Parser<'a> {
             }
         }
         self.pos = after_keyword;
+        if let Some(name) = shadow_name {
+            if self.shadowable_defs.contains(name) {
+                let wrapped = self.rewind_reparse_as_shadowable_call(start_pos, parsed)?;
+                return self.parse_postfix(wrapped);
+            }
+        }
         self.parse_postfix(parsed)
     }
 
@@ -2631,6 +2806,94 @@ impl<'a> Parser<'a> {
         }
         self.next();
         Ok(Some(arg))
+    }
+
+    /// #2036 Direction 3: entry point for every *fixed*-arity special form
+    /// (`limit`, `until`, `while`, `repeat`, `range`, `first`, `last`,
+    /// `error`). `parse_original` is the keyword's own dedicated parser
+    /// (`Self::parse_limit_expr`, etc.), tried first always -- unaffected
+    /// on a program with no matching `def` anywhere (the `shadowable_defs`
+    /// fast-reject below is the entire cost there, no double-parse at all).
+    ///
+    /// A shadowing `def` is not restricted to the builtin's own arity real
+    /// jq's grammar happens to accept (confirmed live: `def until(a;b;c):
+    /// "s"; until(1;2;3)` is `"s"` in real jq, even though `until/2` is the
+    /// *only* shape `parse_until_expr` itself parses). When `name` is a
+    /// shadow candidate but `parse_original` fails outright -- the written
+    /// arity doesn't match what the dedicated parser accepts -- that
+    /// failure is *not* propagated: this rewinds to `start_pos` and falls
+    /// back to an ordinary generic call with no `builtin_fallback` at all,
+    /// deferring entirely to `resolve.rs` to decide whether the result is
+    /// a real `def` at that arity, a real jq builtin at some *other* arity
+    /// (`is_jq_builtin`), or genuinely unresolvable -- the same three-way
+    /// split every ordinary call already gets.
+    fn parse_shadowable_special_form(
+        &mut self,
+        start_pos: usize,
+        name: &str,
+        parse_original: impl FnOnce(&mut Self) -> Result<Expr, ParseError>,
+    ) -> Result<Expr, ParseError> {
+        if !self.shadowable_defs.contains(name) {
+            return parse_original(self);
+        }
+        match parse_original(self) {
+            Ok(original) => self.rewind_reparse_as_shadowable_call(start_pos, original),
+            Err(_) => {
+                self.pos = start_pos;
+                self.parse_func_call_or_error()
+            }
+        }
+    }
+
+    /// #2036 Direction 3: rewind to `start_pos` (before the keyword began)
+    /// and re-parse the same source span as an ordinary `NAME(args;args)`
+    /// call, stashing `original` -- whatever the keyword's own dedicated
+    /// parse produced for that identical span -- as the new node's
+    /// `builtin_fallback`. [`super::resolve::check`] is the sole consumer:
+    /// once it knows whether this exact `(name, arity)` is genuinely a
+    /// `def` in scope at this position, it either keeps the call (real
+    /// shadowing) or substitutes `original` back in (not shadowed after
+    /// all). Shared by every call site that can produce a shadowable
+    /// builtin or fixed-arity special form; see
+    /// [`Self::zero_arity_or_wrong_arity_call`]'s own doc comment for why
+    /// it alone additionally gates this behind `shadow_name`.
+    fn rewind_reparse_as_shadowable_call(
+        &mut self,
+        start_pos: usize,
+        original: Expr,
+    ) -> Result<Expr, ParseError> {
+        self.pos = start_pos;
+        let call = self.parse_func_call_or_error()?;
+        Ok(match call {
+            Expr::FuncCall { name, args, .. } => Expr::FuncCall {
+                name,
+                args,
+                builtin_fallback: Some(Box::new(original)),
+            },
+            // `parse_func_call_or_error` can also return a namespaced call
+            // (`NAME::rest`) if the rewound identifier happens to be
+            // followed by `::` -- vanishingly unlikely for a real builtin
+            // name, and there is no `FuncCall` to attach a fallback to in
+            // that shape anyway, so it is returned as-is rather than
+            // forced into one.
+            other => other,
+        })
+    }
+
+    /// The bare identifier text starting at `pos`, independent of how far
+    /// parsing may have since advanced past it. Some builtins consume their
+    /// own argument list as part of being recognized (`ltrimstr(s)`), so
+    /// `self.pos` after a successful [`Self::try_parse_builtin`] call can
+    /// cover far more than just the keyword itself -- this re-derives just
+    /// the identifier from `input`, the same span [`collect_def_names`]
+    /// itself would have captured for a `def` of the same name.
+    fn ident_text_at(&self, pos: usize) -> &'a str {
+        let rest = &self.input[pos..];
+        let end = rest
+            .char_indices()
+            .find(|&(_, c)| !(c.is_alphanumeric() || c == '_'))
+            .map_or(rest.len(), |(i, _)| i);
+        &rest[..end]
     }
 
     /// Try to parse a builtin function.

--- a/src/jq/resolve.rs
+++ b/src/jq/resolve.rs
@@ -57,10 +57,11 @@
 //! jq's `def f($a): …` desugars to `def f(a): a as $a | …`, which leaves `a`
 //! callable.
 
+use alloc::rc::Rc;
 use alloc::string::String;
 use alloc::vec::Vec;
 
-use super::walk::{builtin_kids, BuiltinKids};
+use super::walk::map_builtin_subexprs;
 use super::{Expr, ObjectKey, StringPart};
 
 /// A call this pass could not resolve to any in-scope `def`, parameter or
@@ -349,7 +350,7 @@ type Scope = Vec<(String, usize)>;
 /// the program and rewrites `ns::f` into a `FuncCall` named `ns::f`, matching
 /// the wrapper it also creates. Running earlier would report every module
 /// function as undefined.
-pub fn resolve_func_calls(expr: &Expr) -> Result<(), UnresolvedCall> {
+pub fn resolve_func_calls(expr: &mut Expr) -> Result<(), UnresolvedCall> {
     match resolve_func_calls_all(expr).into_iter().next() {
         Some(first) => Err(first),
         None => Ok(()),
@@ -364,7 +365,7 @@ pub fn resolve_func_calls(expr: &Expr) -> Result<(), UnresolvedCall> {
 /// every unresolvable call in one compile pass (`jq: N compile errors`);
 /// this is what lets the jq runner match that instead of always reporting
 /// `jq: 1 compile error` (#2037).
-pub fn resolve_func_calls_all(expr: &Expr) -> Vec<UnresolvedCall> {
+pub fn resolve_func_calls_all(expr: &mut Expr) -> Vec<UnresolvedCall> {
     let mut scope = Scope::new();
     let mut errors = Vec::new();
     check(expr, &mut scope, &mut errors);
@@ -388,7 +389,7 @@ fn in_scope(scope: &Scope, name: &str, arity: usize) -> bool {
 /// unresolvable call to `errors` rather than stopping at the first, matching
 /// how real jq's own compiler keeps going to report every compile error in
 /// one pass (#2037).
-fn check(expr: &Expr, scope: &mut Scope, errors: &mut Vec<UnresolvedCall>) {
+fn check(expr: &mut Expr, scope: &mut Scope, errors: &mut Vec<UnresolvedCall>) {
     match expr {
         // #1371: neither variant can occur here. This pass runs once, on the
         // freshly parsed program, before evaluation begins; both are built
@@ -401,9 +402,19 @@ fn check(expr: &Expr, scope: &mut Scope, errors: &mut Vec<UnresolvedCall>) {
         // definition it resolved to -- so only its arguments can carry an
         // unresolved call, and they are checked in the scope this node sits
         // in. The definition's own body was checked at its `FuncDef`.
-        Expr::Shared(inner) => check(inner, scope, errors),
+        //
+        // `Shared` wraps an `Rc`, which this pass cannot get a unique `&mut`
+        // through if any other owner is alive -- harmless here since the
+        // variant is unreachable in practice (see above); `Rc::get_mut`
+        // silently skips recursion rather than panicking on the
+        // (never-hit) multi-owner case.
+        Expr::Shared(inner) => {
+            if let Some(inner) = Rc::get_mut(inner) {
+                check(inner, scope, errors);
+            }
+        }
         Expr::DefCall { args, .. } => {
-            for arg in args {
+            for arg in args.iter_mut() {
                 check(arg, scope, errors);
             }
         }
@@ -434,7 +445,7 @@ fn check(expr: &Expr, scope: &mut Scope, errors: &mut Vec<UnresolvedCall>) {
         | Expr::Label { body: inner, .. } => check(inner, scope, errors),
 
         Expr::Error(inner) => {
-            if let Some(e) = inner.as_deref() {
+            if let Some(e) = inner.as_deref_mut() {
                 check(e, scope, errors);
             }
         }
@@ -522,7 +533,7 @@ fn check(expr: &Expr, scope: &mut Scope, errors: &mut Vec<UnresolvedCall>) {
             // g(1)` is `g/1 is not defined` in jq, not a call to the outer
             // `g`. Pushed after the function's own name so a parameter
             // shadowing it wins.
-            for p in params {
+            for p in params.iter() {
                 scope.push((p.clone(), 0));
             }
             check(body, scope, errors);
@@ -534,7 +545,7 @@ fn check(expr: &Expr, scope: &mut Scope, errors: &mut Vec<UnresolvedCall>) {
 
         Expr::Try { expr, catch } => {
             check(expr, scope, errors);
-            if let Some(c) = catch.as_deref() {
+            if let Some(c) = catch.as_deref_mut() {
                 check(c, scope, errors);
             }
         }
@@ -551,14 +562,14 @@ fn check(expr: &Expr, scope: &mut Scope, errors: &mut Vec<UnresolvedCall>) {
 
         Expr::SliceExpr { target, start, end } => {
             check(target, scope, errors);
-            check_opt(start.as_deref(), scope, errors);
-            check_opt(end.as_deref(), scope, errors);
+            check_opt(start.as_deref_mut(), scope, errors);
+            check_opt(end.as_deref_mut(), scope, errors);
         }
 
         Expr::Range { from, to, step } => {
             check(from, scope, errors);
-            check_opt(to.as_deref(), scope, errors);
-            check_opt(step.as_deref(), scope, errors);
+            check_opt(to.as_deref_mut(), scope, errors);
+            check_opt(step.as_deref_mut(), scope, errors);
         }
 
         Expr::Reduce {
@@ -582,11 +593,11 @@ fn check(expr: &Expr, scope: &mut Scope, errors: &mut Vec<UnresolvedCall>) {
             check(input, scope, errors);
             check(init, scope, errors);
             check(update, scope, errors);
-            check_opt(extract.as_deref(), scope, errors);
+            check_opt(extract.as_deref_mut(), scope, errors);
         }
 
         Expr::Pipe(exprs) | Expr::Comma(exprs) => {
-            for e in exprs {
+            for e in exprs.iter_mut() {
                 check(e, scope, errors);
             }
         }
@@ -604,9 +615,45 @@ fn check(expr: &Expr, scope: &mut Scope, errors: &mut Vec<UnresolvedCall>) {
         // discard the extra errors by stopping at the first one — would
         // report errors real jq's compiler never reaches once every call is
         // collected instead of just the first (#2037).
-        Expr::FuncCall { name, args } => {
-            if in_scope(scope, name, args.len()) || is_jq_builtin(name, args.len()) {
-                for a in args {
+        //
+        // #2036: `builtin_fallback` is this node's alternate parse -- the
+        // builtin or special form the parser would have produced had the
+        // name never been shadowable -- attached only when the lexical
+        // prescan flagged `name` as possibly `def`'d somewhere in the
+        // program (see `Expr::FuncCall`'s own doc comment). Real shadowing
+        // (`in_scope`) is checked *first* and wins outright: a `def` at
+        // this exact `(name, arity)` always shadows the builtin, matching
+        // real jq. Only once that fails does the fallback matter -- and
+        // only then, because it exists precisely to answer "what if this
+        // name turns out not to be shadowed after all," the same question
+        // `is_jq_builtin`/the error arm below already answer for a call
+        // that was never eligible for a fallback in the first place.
+        // Whichever way it resolves, `builtin_fallback` is always `None`
+        // by the time this function returns for this node -- either
+        // dropped here (shadowing confirmed) or moved out and substituted
+        // (shadowing declined) -- so no other pass over the tree, before
+        // or after this one runs to completion, ever needs to know it
+        // exists.
+        Expr::FuncCall {
+            name,
+            args,
+            builtin_fallback,
+        } => {
+            if in_scope(scope, name, args.len()) {
+                for a in args.iter_mut() {
+                    check(a, scope, errors);
+                }
+                *builtin_fallback = None;
+            } else if let Some(fallback) = builtin_fallback.take() {
+                // Not shadowed after all -- restore the original parse.
+                // Its arity always matches this call site's own (the
+                // parser attaches a fallback only by re-parsing the exact
+                // same source span the fallback itself came from), so this
+                // substitution can never silently discard a real argument.
+                *expr = *fallback;
+                check(expr, scope, errors);
+            } else if is_jq_builtin(name, args.len()) {
+                for a in args.iter_mut() {
                     check(a, scope, errors);
                 }
             } else {
@@ -623,22 +670,22 @@ fn check(expr: &Expr, scope: &mut Scope, errors: &mut Vec<UnresolvedCall>) {
         // to `eval`'s own "module not loaded" reporting rather than claimed
         // undefined here.
         Expr::NamespacedCall { args, .. } => {
-            for a in args {
+            for a in args.iter_mut() {
                 check(a, scope, errors);
             }
         }
 
         Expr::Object(entries) => {
-            for entry in entries {
-                if let ObjectKey::Expr(k) = &entry.key {
+            for entry in entries.iter_mut() {
+                if let ObjectKey::Expr(k) = &mut entry.key {
                     check(k, scope, errors);
                 }
-                check(&entry.value, scope, errors);
+                check(&mut entry.value, scope, errors);
             }
         }
 
         Expr::StringInterpolation(parts) => {
-            for part in parts {
+            for part in parts.iter_mut() {
                 if let StringPart::Expr(e) = part {
                     check(e, scope, errors);
                 }
@@ -646,28 +693,28 @@ fn check(expr: &Expr, scope: &mut Scope, errors: &mut Vec<UnresolvedCall>) {
         }
 
         // No builtin introduces a function binding, so its sub-expressions
-        // inherit the current scope unchanged. Routed through `builtin_kids`
-        // rather than a second 207-arm match: that function has no wildcard, so
-        // a new sub-expression-carrying variant is a compile error there and
-        // this pass picks the fix up for free.
-        Expr::Builtin(builtin) => match builtin_kids(builtin) {
-            BuiltinKids::None => {}
-            BuiltinKids::One(a) => check(a, scope, errors),
-            BuiltinKids::Two(a, b) => {
-                check(a, scope, errors);
-                check(b, scope, errors);
-            }
-            BuiltinKids::Three(a, b, c) => {
-                check(a, scope, errors);
-                check(b, scope, errors);
-                check(c, scope, errors);
-            }
-        },
+        // inherit the current scope unchanged. Rebuilt via
+        // `map_builtin_subexprs` rather than an in-place mutable walker: a
+        // builtin's own operand can itself be a `FuncCall` this same #2036
+        // rewrite needs to reach (`map(length)` where `length` is
+        // shadowed, say), so each sub-expression is cloned, checked (which
+        // may substitute it), and used to rebuild the builtin -- the same
+        // clone-and-rebuild shape `jq_runner.rs`'s `rewrite_namespaced_calls`
+        // already uses for its own builtin arm, reusing this function's
+        // existing, tested infrastructure rather than hand-writing a
+        // second, mutable 207-arm match beside `builtin_kids`.
+        Expr::Builtin(builtin) => {
+            *builtin = map_builtin_subexprs(builtin, &mut |sub| {
+                let mut sub = sub.clone();
+                check(&mut sub, scope, errors);
+                sub
+            });
+        }
     }
 }
 
 /// [`check`] over an optional sub-expression.
-fn check_opt(expr: Option<&Expr>, scope: &mut Scope, errors: &mut Vec<UnresolvedCall>) {
+fn check_opt(expr: Option<&mut Expr>, scope: &mut Scope, errors: &mut Vec<UnresolvedCall>) {
     if let Some(e) = expr {
         check(e, scope, errors);
     }
@@ -683,8 +730,8 @@ mod tests {
     /// expectation in this module was captured from the pinned oracle
     /// (`/usr/bin/jq`, jq-1.7.1), never from succinctly's own output.
     fn resolve(filter: &str) -> Result<(), String> {
-        let expr = parse(filter).expect("filter must parse");
-        resolve_func_calls(&expr).map_err(|e| format!("{e}"))
+        let mut expr = parse(filter).expect("filter must parse");
+        resolve_func_calls(&mut expr).map_err(|e| format!("{e}"))
     }
 
     /// The compiled-in roster must match what `./scripts/sync-jq-builtin-names.sh`
@@ -865,12 +912,13 @@ mod tests {
         let unresolved = || Expr::FuncCall {
             name: "nosuchfn".into(),
             args: Vec::new(),
+            builtin_fallback: None,
         };
 
         let mut scope = Scope::new();
         let mut errors = Vec::new();
         check(
-            &Expr::Shared(Rc::new(unresolved())),
+            &mut Expr::Shared(Rc::new(unresolved())),
             &mut scope,
             &mut errors,
         );
@@ -885,7 +933,7 @@ mod tests {
         let mut scope = Scope::new();
         let mut errors = Vec::new();
         check(
-            &Expr::DefCall {
+            &mut Expr::DefCall {
                 def: Rc::new(crate::jq::FuncDefData {
                     name: "f".into(),
                     params: Vec::new(),

--- a/src/jq/resolve.rs
+++ b/src/jq/resolve.rs
@@ -61,7 +61,7 @@ use alloc::rc::Rc;
 use alloc::string::String;
 use alloc::vec::Vec;
 
-use super::walk::map_builtin_subexprs;
+use super::walk::{builtin_kids, map_builtin_subexprs, BuiltinKids};
 use super::{Expr, ObjectKey, StringPart};
 
 /// A call this pass could not resolve to any in-scope `def`, parameter or
@@ -384,6 +384,79 @@ fn in_scope(scope: &Scope, name: &str, arity: usize) -> bool {
     scope.iter().rev().any(|(n, a)| *a == arity && n == name)
 }
 
+/// #2036: the arity `fallback` -- a successfully-parsed builtin or
+/// fixed-arity special form stashed on `Expr::FuncCall::builtin_fallback` --
+/// represents. Read-only: never clones or allocates, so computing it to
+/// decide `in_scope` costs nothing beyond the match itself, regardless of
+/// how large `fallback`'s own children are.
+fn builtin_fallback_arity(fallback: &Expr) -> usize {
+    match fallback {
+        Expr::Not => 0,
+        Expr::Limit { .. } | Expr::Until { .. } | Expr::While { .. } => 2,
+        Expr::Repeat(_) | Expr::FirstExpr(_) | Expr::LastExpr(_) => 1,
+        Expr::Range { to, step, .. } => 1 + usize::from(to.is_some()) + usize::from(step.is_some()),
+        Expr::Error(msg) => usize::from(msg.is_some()),
+        Expr::Builtin(builtin) => match builtin_kids(builtin) {
+            BuiltinKids::None => 0,
+            BuiltinKids::One(_) => 1,
+            BuiltinKids::Two(_, _) => 2,
+            BuiltinKids::Three(_, _, _) => 3,
+        },
+        // Unreachable in practice -- `wrap_shadowable_call`'s only two
+        // callers only ever hand it one of the shapes above.
+        _ => 0,
+    }
+}
+
+/// #2036: moves `fallback`'s own sub-expressions out as the argument list a
+/// generic `NAME(args;args)` call over the same source span would have
+/// produced -- called only once [`check`] has determined the call is
+/// genuinely shadowed by an in-scope `def`. Takes `fallback` *by value* and
+/// moves its children rather than cloning them: `fallback` is discarded
+/// immediately after this returns (the caller already took it out of
+/// `builtin_fallback` via `Option::take`), so there is nothing left that
+/// would need its own independent copy -- cloning here, even though it
+/// would only run once per confirmed-shadowed node rather than compounding
+/// across every declined one, could still duplicate an arbitrarily large
+/// not-yet-resolved subtree sitting in one of `fallback`'s own arguments.
+fn builtin_fallback_into_args(fallback: Expr) -> Vec<Expr> {
+    match fallback {
+        Expr::Not => Vec::new(),
+        Expr::Limit { n, expr } => alloc::vec![*n, *expr],
+        Expr::Until { cond, update } | Expr::While { cond, update } => {
+            alloc::vec![*cond, *update]
+        }
+        Expr::Repeat(inner) | Expr::FirstExpr(inner) | Expr::LastExpr(inner) => {
+            alloc::vec![*inner]
+        }
+        Expr::Range { from, to, step } => {
+            let mut args = alloc::vec![*from];
+            args.extend(to.map(|b| *b));
+            args.extend(step.map(|b| *b));
+            args
+        }
+        Expr::Error(msg) => msg.into_iter().map(|b| *b).collect(),
+        // `builtin_kids` only ever borrows -- there is no by-value
+        // counterpart, so this one case clones rather than moves. Bounded
+        // even so: it can only fire once per node that check() has just
+        // confirmed is genuinely shadowed, immediately followed by
+        // recursing into (and thereby resolving/shrinking) each cloned
+        // child -- it does not compound across the *declined* case above
+        // (`*expr = *fallback`, always a pure move), which is the shape
+        // nested-but-not-actually-shadowed candidates take and the one
+        // this issue's own review found exponential before this fix.
+        Expr::Builtin(builtin) => match builtin_kids(&builtin) {
+            BuiltinKids::None => Vec::new(),
+            BuiltinKids::One(a) => alloc::vec![a.clone()],
+            BuiltinKids::Two(a, b) => alloc::vec![a.clone(), b.clone()],
+            BuiltinKids::Three(a, b, c) => alloc::vec![a.clone(), b.clone(), c.clone()],
+        },
+        // Unreachable in practice -- see `builtin_fallback_arity`'s own
+        // identical fallback arm, which this must stay consistent with.
+        _ => Vec::new(),
+    }
+}
+
 /// Recurse into `expr` under `scope`, restoring `scope` before returning so a
 /// sibling never sees a binding introduced by its neighbour. Appends every
 /// unresolvable call to `errors` rather than stopping at the first, matching
@@ -403,15 +476,17 @@ fn check(expr: &mut Expr, scope: &mut Scope, errors: &mut Vec<UnresolvedCall>) {
         // unresolved call, and they are checked in the scope this node sits
         // in. The definition's own body was checked at its `FuncDef`.
         //
-        // `Shared` wraps an `Rc`, which this pass cannot get a unique `&mut`
-        // through if any other owner is alive -- harmless here since the
-        // variant is unreachable in practice (see above); `Rc::get_mut`
-        // silently skips recursion rather than panicking on the
-        // (never-hit) multi-owner case.
+        // `Shared` wraps an `Rc`. `resolve_func_calls`/`Expr::Shared` are
+        // both public API, so an external caller can hand this a multi-owner
+        // `Rc` even though this crate's own 3 CLI call sites never do (see
+        // above) -- `Rc::make_mut` (clone-on-write if not uniquely owned,
+        // unlike `Rc::get_mut`'s silent "return None, skip this subtree
+        // entirely" on the same case) keeps recursion unconditional exactly
+        // like the pre-`&mut Expr` version of this arm did, at the cost of
+        // one clone in the (self-inflicted, still never hit by this crate's
+        // own callers) multi-owner case.
         Expr::Shared(inner) => {
-            if let Some(inner) = Rc::get_mut(inner) {
-                check(inner, scope, errors);
-            }
+            check(Rc::make_mut(inner), scope, errors);
         }
         Expr::DefCall { args, .. } => {
             for arg in args.iter_mut() {
@@ -620,46 +695,62 @@ fn check(expr: &mut Expr, scope: &mut Scope, errors: &mut Vec<UnresolvedCall>) {
         // builtin or special form the parser would have produced had the
         // name never been shadowable -- attached only when the lexical
         // prescan flagged `name` as possibly `def`'d somewhere in the
-        // program (see `Expr::FuncCall`'s own doc comment). Real shadowing
-        // (`in_scope`) is checked *first* and wins outright: a `def` at
-        // this exact `(name, arity)` always shadows the builtin, matching
-        // real jq. Only once that fails does the fallback matter -- and
-        // only then, because it exists precisely to answer "what if this
-        // name turns out not to be shadowed after all," the same question
-        // `is_jq_builtin`/the error arm below already answer for a call
-        // that was never eligible for a fallback in the first place.
-        // Whichever way it resolves, `builtin_fallback` is always `None`
-        // by the time this function returns for this node -- either
-        // dropped here (shadowing confirmed) or moved out and substituted
-        // (shadowing declined) -- so no other pass over the tree, before
-        // or after this one runs to completion, ever needs to know it
-        // exists.
+        // program (see `Expr::FuncCall`'s own doc comment). `args` starts
+        // out *empty* whenever `builtin_fallback` is `Some` (the parser
+        // deliberately does not clone the fallback's own children into it
+        // -- see `wrap_shadowable_call`'s own doc comment for why that
+        // duplication made nested shadow candidates an `O(2^depth)`
+        // parser-level denial-of-service), so the arity to check scope
+        // against has to come from the fallback's own shape
+        // (`builtin_fallback_arity`) whenever `args` is still empty, not
+        // from `args.len()` directly.
+        //
+        // Real shadowing (`in_scope`) is checked *first* and wins outright:
+        // a `def` at this exact `(name, arity)` always shadows the
+        // builtin, matching real jq. Only then is `args` actually
+        // populated -- moved out of `fallback` (`builtin_fallback_into_args`),
+        // not cloned, since `fallback` is discarded immediately after and
+        // there is nothing left needing its own copy. If shadowing is
+        // declined instead, the *whole* fallback is moved back into `expr`
+        // in one piece -- again no cloning -- and re-checked so its own
+        // nested children get the identical treatment. Whichever way it
+        // resolves, `builtin_fallback` is always `None` and `args` always
+        // populated by the time this function returns for this node -- so
+        // no other pass over the tree, before or after this one runs to
+        // completion, ever needs to know `builtin_fallback` exists, or
+        // sees a node whose `args` is emptily lying about its real arity.
         Expr::FuncCall {
             name,
             args,
             builtin_fallback,
         } => {
-            if in_scope(scope, name, args.len()) {
+            let arity = if args.is_empty() {
+                builtin_fallback
+                    .as_deref()
+                    .map_or(0, builtin_fallback_arity)
+            } else {
+                args.len()
+            };
+            if in_scope(scope, name, arity) {
+                if let Some(fallback) = builtin_fallback.take() {
+                    *args = builtin_fallback_into_args(*fallback);
+                }
                 for a in args.iter_mut() {
                     check(a, scope, errors);
                 }
-                *builtin_fallback = None;
             } else if let Some(fallback) = builtin_fallback.take() {
-                // Not shadowed after all -- restore the original parse.
-                // Its arity always matches this call site's own (the
-                // parser attaches a fallback only by re-parsing the exact
-                // same source span the fallback itself came from), so this
-                // substitution can never silently discard a real argument.
+                // Not shadowed after all -- restore the original parse in
+                // one move, no cloning.
                 *expr = *fallback;
                 check(expr, scope, errors);
-            } else if is_jq_builtin(name, args.len()) {
+            } else if is_jq_builtin(name, arity) {
                 for a in args.iter_mut() {
                     check(a, scope, errors);
                 }
             } else {
                 errors.push(UnresolvedCall {
                     name: name.clone(),
-                    arity: args.len(),
+                    arity,
                 });
             }
         }

--- a/src/jq/resolve.rs
+++ b/src/jq/resolve.rs
@@ -394,6 +394,15 @@ fn builtin_fallback_arity(fallback: &Expr) -> usize {
         Expr::Not => 0,
         Expr::Limit { .. } | Expr::Until { .. } | Expr::While { .. } => 2,
         Expr::Repeat(_) | Expr::FirstExpr(_) | Expr::LastExpr(_) => 1,
+        // #2036 review round 2: `range(N)` -- the 1-arg sugar form --
+        // desugars to the exact same `Range { from: Literal(0), to:
+        // Some(_), step: None }` shape a genuine 2-arg `range(0; N)` call
+        // produces, so the general `Expr::Range` arm below cannot tell them
+        // apart. `parse_range_expr` (`parser.rs`) marks the 1-arg form by
+        // wrapping it in `Expr::Paren` (otherwise unused for this purpose,
+        // and a no-op everywhere else) precisely so this arm can report the
+        // correct arity of 1 here instead of the wrong 2.
+        Expr::Paren(inner) if matches!(**inner, Expr::Range { .. }) => 1,
         Expr::Range { to, step, .. } => 1 + usize::from(to.is_some()) + usize::from(step.is_some()),
         Expr::Error(msg) => usize::from(msg.is_some()),
         Expr::Builtin(builtin) => match builtin_kids(builtin) {
@@ -402,8 +411,16 @@ fn builtin_fallback_arity(fallback: &Expr) -> usize {
             BuiltinKids::Two(_, _) => 2,
             BuiltinKids::Three(_, _, _) => 3,
         },
-        // Unreachable in practice -- `wrap_shadowable_call`'s only two
-        // callers only ever hand it one of the shapes above.
+        // Genuinely unreachable: `wrap_shadowable_call` (`parser.rs`) only
+        // ever stores one of the shapes matched above in
+        // `builtin_fallback` -- anything else (a plain `Expr::FuncCall`, or
+        // any postfix wrapping of one, produced when a dedicated parser's
+        // own #2110/#2237 wrong-arity rewind fires) is returned unwrapped,
+        // with `builtin_fallback` left `None`, specifically so it can never
+        // reach here. Kept as a defensive fallback rather than `unreachable!()`
+        // since the two functions have no compiler-enforced link to
+        // `wrap_shadowable_call`'s own match -- see that function's doc
+        // comment for the bug this arm used to silently paper over.
         _ => 0,
     }
 }
@@ -429,6 +446,17 @@ fn builtin_fallback_into_args(fallback: Expr) -> Vec<Expr> {
         Expr::Repeat(inner) | Expr::FirstExpr(inner) | Expr::LastExpr(inner) => {
             alloc::vec![*inner]
         }
+        // #2036 review round 2: the 1-arg `range(N)` marker -- see
+        // `builtin_fallback_arity`'s matching arm. The single real argument
+        // the user wrote is `to` (the synthesized `from: Literal(0)` was
+        // never written and must not be surfaced as a second argument).
+        Expr::Paren(inner) if matches!(*inner, Expr::Range { .. }) => match *inner {
+            Expr::Range { to: Some(to), .. } => alloc::vec![*to],
+            // `parse_range_expr` only ever produces this marker with `to:
+            // Some(_)` -- defensive, not reachable.
+            Expr::Range { .. } => Vec::new(),
+            _ => unreachable!("guarded by the outer match arm's pattern"),
+        },
         Expr::Range { from, to, step } => {
             let mut args = alloc::vec![*from];
             args.extend(to.map(|b| *b));
@@ -451,7 +479,7 @@ fn builtin_fallback_into_args(fallback: Expr) -> Vec<Expr> {
             BuiltinKids::Two(a, b) => alloc::vec![a.clone(), b.clone()],
             BuiltinKids::Three(a, b, c) => alloc::vec![a.clone(), b.clone(), c.clone()],
         },
-        // Unreachable in practice -- see `builtin_fallback_arity`'s own
+        // Genuinely unreachable -- see `builtin_fallback_arity`'s own
         // identical fallback arm, which this must stay consistent with.
         _ => Vec::new(),
     }

--- a/src/jq/walk.rs
+++ b/src/jq/walk.rs
@@ -846,9 +846,20 @@ pub fn map_subexprs(expr: &Expr, mut f: &mut dyn FnMut(&Expr) -> Expr) -> Expr {
         // *particular* name/arity (installing a `DefCall`, binding a
         // `$`-parameter reference) does so with its own guarded arm first and
         // reaches this one only once that guard has already failed.
-        Expr::FuncCall { name, args } => Expr::FuncCall {
+        // `builtin_fallback` (#2036) is always `None` by the time any of
+        // this function's callers run -- `resolve.rs`'s compile-time
+        // rewrite consumes it first, over the whole tree, before
+        // evaluation (and so before DefCall installation/param
+        // substitution) ever begins. Recursed into defensively anyway,
+        // matching `args`, rather than assumed away.
+        Expr::FuncCall {
+            name,
+            args,
+            builtin_fallback,
+        } => Expr::FuncCall {
             name: name.clone(),
             args: args.iter().map(&mut f).collect(),
+            builtin_fallback: builtin_fallback.as_deref().map(|b| Box::new(f(b))),
         },
         Expr::NamespacedCall {
             namespace,

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -20445,6 +20445,111 @@ fn test_def_shadow_candidate_empty_parens_stays_syntax_error_2036() -> Result<()
     Ok(())
 }
 
+/// #2036 review, round 2: when a shadow candidate's own dedicated parser
+/// hits a wrong-arity call but (per #2110/#2237) internally rewinds to a
+/// successful, already-generic `Ok(FuncCall{..})`/postfix-wrapped result
+/// instead of returning `Err`, that generic result must not be wrapped as
+/// `builtin_fallback` -- `builtin_fallback_arity`/`_into_args`
+/// (`resolve.rs`) have no matching arm for that shape and fell to their
+/// "unreachable in practice" wildcard, silently computing arity 0 and
+/// discarding the real arguments (and their side effects) entirely.
+/// Confirmed live before this fix: `def until: "s"; until(error("boom"))`
+/// printed `"s"` (exit 0), silently swallowing the `error("boom")`
+/// argument, where real jq raises `until/1 is not defined` (exit 3).
+/// Oracle-verified against jq 1.7.1, including the postfix-wrapped shape.
+#[test]
+fn test_def_shadow_fallback_wrong_arity_not_double_counted_2036() -> Result<()> {
+    for (filter, name) in [
+        (r#"def until: "s"; until(error("boom"))"#, "until/1"),
+        (r#"def limit: "s"; limit(1)"#, "limit/1"),
+        (r#"def while: "s"; while(1)"#, "while/1"),
+        (r#"def repeat: "s"; repeat(1;2)"#, "repeat/2"),
+        (r#"def until: {"a":"s"}; until(0).a"#, "until/1"),
+    ] {
+        let (stdout, stderr, code) = run_jq_full(&["-nc", filter], None)?;
+        assert_eq!(stdout, "", "{filter}: stderr {stderr:?}");
+        assert!(
+            stderr.contains(&format!("{name} is not defined at <top-level>, line 1:")),
+            "{filter}: stderr {stderr:?}"
+        );
+        assert_eq!(code, 3, "{filter}: stdout: {stdout:?} stderr: {stderr:?}");
+    }
+    Ok(())
+}
+
+/// #2036 review, round 2: `range(N)` -- the 1-arg sugar for `range(0; N)`
+/// -- desugars to the exact same `Expr::Range { from: Literal(0), to:
+/// Some(_), .. }` shape a genuine 2-arg `range(0; N)` call produces, so
+/// computing the shadow-check arity straight from that shape is ambiguous.
+/// Confirmed live before this fix: `def range(a;b): "s"; range(5)` wrongly
+/// shadowed at arity 2 (should not shadow at all -- `range(5)` is arity
+/// 1), and `def range(a): "s"; range(5)` wrongly failed to shadow at
+/// arity 1. Oracle-verified against jq 1.7.1.
+#[test]
+fn test_def_shadow_range_one_vs_two_arg_arity_2036() -> Result<()> {
+    // range/2 shadow must not match the 1-arg call.
+    let (stdout, stderr, code) = run_jq_full(&["-nc", r#"def range(a;b): "s"; [range(5)]"#], None)?;
+    assert_eq!(code, 0, "stderr: {stderr:?}");
+    assert_eq!(stdout.trim_end(), "[0,1,2,3,4]");
+
+    // range/1 shadow must match the 1-arg call.
+    let (stdout, stderr, code) = run_jq_full(&["-nc", r#"def range(a): "s"; range(5)"#], None)?;
+    assert_eq!(code, 0, "stderr: {stderr:?}");
+    assert_eq!(stdout.trim_end(), r#""s""#);
+
+    // Unshadowed 1-arg sugar keeps working normally either way.
+    let (stdout, stderr, code) = run_jq_full(&["-nc", "[range(3)]"], None)?;
+    assert_eq!(code, 0, "stderr: {stderr:?}");
+    assert_eq!(stdout.trim_end(), "[0,1,2]");
+    Ok(())
+}
+
+/// #2036 review, round 2: the lexical prescan (`collect_def_names`) used
+/// only `str::trim_start`, which skips whitespace but not a `#`-comment
+/// between the `def` keyword and its name -- real jq's own `skip_ws`
+/// (which this prescan approximates) skips both. A `def` separated from
+/// its name by a comment was therefore invisible to the prescan and never
+/// became a shadow candidate at all, reproducing the exact silent-wrong-
+/// value bug class this issue exists to fix, just for one more spelling.
+/// Confirmed live before this fix: `def #c\nlength: 99; length` printed
+/// `0` (the real builtin) instead of `99`.
+#[test]
+fn test_def_shadow_candidate_comment_before_name_2036() -> Result<()> {
+    let filter = "def #c\nlength: 99; length";
+    let (stdout, stderr, code) = run_jq_full(&["-nc", filter], None)?;
+    assert_eq!(code, 0, "stderr: {stderr:?}");
+    assert_eq!(stdout.trim_end(), "99");
+    Ok(())
+}
+
+/// #2036 review, round 2: unlike the other 7 shadowable special forms,
+/// `parse_error_expr` used to propagate a wrong-arity `error(a;b)` call's
+/// `Err` straight out to `parse_shadowable_special_form`'s own
+/// `retry_shadow_candidate_as_generic_call` fallback, which re-parses the
+/// same span from scratch *in addition to* the `parse_expr()` call
+/// `parse_error_expr` had already run over the same content -- doubling
+/// the parse work at every nesting level of a wrong-arity-shadowed,
+/// nested `error(...)` chain and exhausting the shared
+/// `shadow_retry_budget` (64) at a depth as shallow as 7, well within
+/// what a real (non-adversarial) generated or hand-written program could
+/// reach. Fixed by giving `parse_error_expr` the same internal rewind the
+/// other 7 forms already have. Pinned at depth 14, comfortably past the
+/// old failure point and still fast, not a tight bound -- deeper nesting
+/// still eventually hits the same pre-existing #2110/#2237
+/// exponential-reparse cost the other 7 forms already have for their own
+/// wrong-arity case (out of this issue's scope; confirmed identical on a
+/// fresh `main` build).
+#[test]
+fn test_def_shadow_nested_error_wrong_arity_realistic_depth_2036() -> Result<()> {
+    let depth = 14;
+    let nested = "error(".repeat(depth) + "1" + &";2)".repeat(depth);
+    let filter = format!("def error(a;b): a; {nested}");
+    let (stdout, stderr, code) = run_jq_full(&["-nc", &filter], None)?;
+    assert_eq!(code, 0, "stderr: {stderr:?}");
+    assert_eq!(stdout.trim_end(), "1");
+    Ok(())
+}
+
 /// #1376: `succinctly jq` now supports arity overloading, matching real
 /// jq -- `def f(x): ...` and `def f(x;y): ...` are distinct functions
 /// (`f/1` and `f/2`), and both stay callable after the second definition.

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -20127,6 +20127,29 @@ fn test_single_arg_builtin_wrong_arity_reports_not_defined_2237() -> Result<()> 
     Ok(())
 }
 
+/// #2036: a user `def` can shadow a builtin of the same name, matching
+/// real jq -- the parser previously lowered a recognized builtin name to a
+/// typed `Expr::Builtin`/special-form node at parse time, before any `def`
+/// had been seen, so the user's own definition was silently unreachable.
+/// The issue's own 5-row repro table, oracle-verified against jq 1.7.1.
+/// Before this fix every row here computed the *builtin's* answer instead
+/// (`0`, `3`, `[1,2]`, `true`, `1` respectively).
+#[test]
+fn test_def_shadows_builtin_2036() -> Result<()> {
+    for (filter, want) in [
+        ("def length: 1; length", "1"),
+        ("[1,2,3] | def length: 999; length", "999"),
+        (r#"def map(f): "shadowed"; [1,2] | map(.)"#, r#""shadowed""#),
+        (r#"def not: "shadowed"; false | not"#, r#""shadowed""#),
+        (r#"def first(f): "shadowed"; first(1,2)"#, r#""shadowed""#),
+    ] {
+        let (stdout, stderr, code) = run_jq_full(&["-nc", filter], None)?;
+        assert_eq!(code, 0, "{filter}: stderr {stderr:?}");
+        assert_eq!(stdout.trim_end(), want, "{filter}");
+    }
+    Ok(())
+}
+
 /// #2237 sibling: the same fix for the "dedicated parse function" family
 /// (`range`/`limit`/`until`/`while`/`repeat`/`first`/`last`), which returns
 /// `Expr` directly rather than going through `try_parse_builtin`'s
@@ -20161,6 +20184,32 @@ fn test_dedicated_parse_fn_wrong_arity_reports_not_defined_2237() -> Result<()> 
             "{filter}: stderr {stderr:?}"
         );
         assert_eq!(code, 3, "{filter}: stdout: {stdout:?} stderr: {stderr:?}");
+    }
+    Ok(())
+}
+
+/// #2036: every fixed-arity special form (`limit`, `until`, `while`,
+/// `repeat`, `range`, `first`, `last`, `error`) is shadowable too, not just
+/// the ordinary builtins `try_parse_builtin` recognizes -- each goes
+/// through its own dedicated parser (`parse_limit_expr`, etc.) rather than
+/// that shared function, so each needed its own fix. Oracle-verified
+/// against jq 1.7.1 (`--jq-extensions` not needed here: this is the `jq`
+/// subcommand, which always accepts this surface).
+#[test]
+fn test_def_shadows_special_forms_2036() -> Result<()> {
+    for (filter, want) in [
+        (r#"def limit(a;b): "s"; limit(1;(1,2))"#, r#""s""#),
+        (r#"def until(c;u): "s"; 0 | until(true;.+1)"#, r#""s""#),
+        (r#"def while(c;u): "s"; 0 | while(false;.+1)"#, r#""s""#),
+        (r#"def repeat(e): "s"; 0 | repeat(.)"#, r#""s""#),
+        (r#"def range(a;b): "s"; [range(1;3)]"#, r#"["s"]"#),
+        (r#"def first: "s"; first"#, r#""s""#),
+        (r#"def last(f): "s"; last(1,2)"#, r#""s""#),
+        (r#"def error: "s"; error"#, r#""s""#),
+    ] {
+        let (stdout, stderr, code) = run_jq_full(&["-nc", filter], None)?;
+        assert_eq!(code, 0, "{filter}: stderr {stderr:?}");
+        assert_eq!(stdout.trim_end(), want, "{filter}");
     }
     Ok(())
 }
@@ -20241,6 +20290,99 @@ fn test_env_empty_parens_stays_compile_error_not_runtime_2237() -> Result<()> {
     assert_eq!(stdout, "", "stderr: {stderr:?}");
     assert!(!stderr.contains("undefined function"), "stderr: {stderr:?}");
     assert_eq!(code, 3, "stdout: {stdout:?} stderr: {stderr:?}");
+    Ok(())
+}
+
+/// #2036: a shadowing `def` is not restricted to the arity real jq's own
+/// grammar happens to accept for that name -- `until/2`'s own dedicated
+/// parser (`parse_until_expr`) only ever parses exactly 2 arguments, but
+/// `def until(a;b;c): ...` (arity 3) still shadows correctly. Before this
+/// fix's own review found and fixed this, the specialized parser's own
+/// hard failure on the unexpected 3rd argument was propagated as a raw
+/// parse error instead of falling back to an ordinary generic call for
+/// `resolve.rs` to resolve -- confirmed live this doesn't just apply to
+/// the 8 special forms above but to a `try_parse_builtin`-recognized
+/// builtin too (`ltrimstr/1` -> a 2-arg shadow), which consumes its own
+/// argument list as part of recognizing the keyword in the first place.
+/// Oracle-verified against jq 1.7.1.
+#[test]
+fn test_def_shadows_at_a_different_arity_than_the_builtin_2036() -> Result<()> {
+    for (filter, want) in [
+        (r#"def until(a;b;c): "s"; until(1;2;3)"#, r#""s""#),
+        (r#"def limit(a;b;c): "s"; limit(1;2;3)"#, r#""s""#),
+        (r#"def error(x;y): "s"; error(1;2)"#, r#""s""#),
+        (r#"def ltrimstr(a;b): "s"; ltrimstr(1;2)"#, r#""s""#),
+        (
+            r#"def not(x): "shadow1-" + (x|tostring); not(5)"#,
+            r#""shadow1-5""#,
+        ),
+    ] {
+        let (stdout, stderr, code) = run_jq_full(&["-nc", filter], None)?;
+        assert_eq!(code, 0, "{filter}: stderr {stderr:?}");
+        assert_eq!(stdout.trim_end(), want, "{filter}");
+    }
+    Ok(())
+}
+
+/// #2036: a `def` at one arity for a name that also has a builtin at a
+/// *different* arity leaves the other arity's own builtin meaning
+/// untouched -- `def not(x): ...` (arity 1) does not disturb bare `not`
+/// (arity 0), matching real jq's own per-arity overload resolution.
+/// Oracle-verified against jq 1.7.1.
+#[test]
+fn test_def_shadow_at_one_arity_leaves_other_arity_builtin_intact_2036() -> Result<()> {
+    let (stdout, stderr, code) =
+        run_jq_full(&["-nc", r#"def not(x): "shadow1"; false | not"#], None)?;
+    assert_eq!(code, 0, "stderr: {stderr:?}");
+    assert_eq!(stdout.trim_end(), "true");
+    Ok(())
+}
+
+/// #2036: `null`/`true`/`false` are literal tokens in jq's own grammar,
+/// not identifier-based calls -- a `def` of the same *bare* name parses
+/// (it is not a syntax error) but can never actually be reached, matching
+/// real jq exactly (confirmed live, `def null: 1; null` stays `null` in
+/// both jq 1.7.1 and here, not `1`). Unlike `not`/builtins/special forms,
+/// these three are deliberately excluded from #2036's own shadow-check.
+#[test]
+fn test_null_true_false_never_shadowable_2036() -> Result<()> {
+    for (filter, want) in [
+        ("def null: 1; null", "null"),
+        ("def true: 1; true", "true"),
+        ("def false: 1; false", "false"),
+    ] {
+        let (stdout, stderr, code) = run_jq_full(&["-nc", filter], None)?;
+        assert_eq!(code, 0, "{filter}: stderr {stderr:?}");
+        assert_eq!(stdout.trim_end(), want, "{filter}");
+    }
+    Ok(())
+}
+
+/// #2036: the lexical prescan that flags a name as a shadow *candidate* is
+/// deliberately imprecise (it does not track lexical position) -- the real
+/// scope decision still comes from `resolve.rs`'s own existing, precise
+/// scope walker. A `def` appearing textually *after* a call, or in an
+/// unrelated sibling branch, must not shadow that call -- exactly the same
+/// forward-reference and sibling-visibility rules #1473 already enforces
+/// for ordinary user `def`s, now also exercised through a builtin name.
+/// Oracle-verified against jq 1.7.1.
+#[test]
+fn test_def_shadow_candidate_still_respects_lexical_scope_2036() -> Result<()> {
+    for (filter, want) in [
+        // The def is nested inside `f`'s own body -- only visible there,
+        // not at the top-level `length` after `f`.
+        ("def f: def length: 99; length; f, length", "99\n0"),
+        // The def is in a *later* sibling branch (a parenthesized group
+        // after the comma) -- the earlier `length` is unaffected.
+        ("length, (def length: 99; length)", "0\n99"),
+        // A parameter of the same name does not itself introduce a def
+        // visible to a bare `length` call elsewhere in the same body.
+        ("def f(x): length; f(1)", "0"),
+    ] {
+        let (stdout, stderr, code) = run_jq_full(&["-nc", filter], None)?;
+        assert_eq!(code, 0, "{filter}: stderr {stderr:?}");
+        assert_eq!(stdout.trim_end(), want, "{filter}");
+    }
     Ok(())
 }
 

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -20386,6 +20386,65 @@ fn test_def_shadow_candidate_still_respects_lexical_scope_2036() -> Result<()> {
     Ok(())
 }
 
+/// #2036 review, round 2: an earlier draft populated a shadow candidate's
+/// `builtin_fallback` by cloning its parsed children into `args` too --
+/// correct, but the retained size of a nested chain of the same
+/// shadow-candidate name roughly doubled per nesting level (`args` *and*
+/// `builtin_fallback` each an independent copy of everything below), an
+/// `O(2^depth)` parser-level denial-of-service from a tiny filter string.
+/// Pinned as a timing regression guard: 60 levels of nesting must parse
+/// well under a second, not blow past it -- confirmed live during review
+/// that the pre-fix version took ~5s at 22 levels and did not finish at 24
+/// within a 10s timeout, where the post-fix version parses 500 levels of
+/// nesting (bounded by `MAX_EXPR_DEPTH` past that) in single-digit
+/// milliseconds.
+#[test]
+fn test_def_shadow_deep_nesting_does_not_blow_up_2036() -> Result<()> {
+    let nested = "first(".repeat(60) + "." + &")".repeat(60);
+    let filter = format!("def first: .; {nested}");
+    let start = std::time::Instant::now();
+    let (stdout, stderr, code) = run_jq_full(&["-nc", &filter], Some("null"))?;
+    let elapsed = start.elapsed();
+    assert_eq!(code, 0, "stderr: {stderr:?}");
+    assert_eq!(stdout.trim_end(), "null");
+    // A generous margin, not a tight benchmark: this suite runs with
+    // internal test-level parallelism (many other tests spawn their own
+    // `succinctly` subprocess concurrently), so CPU contention alone can
+    // stretch a normally-instant (~10ms, confirmed live) run to a second
+    // or more under load. What this guards against is the *shape* of the
+    // regression, not its exact timing -- reintroducing the `O(2^depth)`
+    // blowup at 60 levels would take a genuinely astronomical amount of
+    // time (`2^60`), not merely a slow few seconds, so any reasonable
+    // margin here still catches a real regression while tolerating CI
+    // noise.
+    assert!(
+        elapsed < std::time::Duration::from_secs(15),
+        "60 levels of nesting took {elapsed:?} -- exponential blowup regressed"
+    );
+    Ok(())
+}
+
+/// #2036 review, round 2: a genuinely empty `NAME()` must stay a syntax
+/// error even once `NAME` is a shadow candidate -- an earlier draft's
+/// arity-mismatch fallback (`Self::parse_func_call_or_error`) accepted `()`
+/// as a valid zero-arg call, regressing #2110's own established rule for
+/// exactly this shape (`test_zero_arity_builtin_empty_parens_stays_compile_error_2110`,
+/// above). Oracle-verified against jq 1.7.1: `def f: 1; f()` is a syntax
+/// error in real jq for *any* name, shadowed or not.
+#[test]
+fn test_def_shadow_candidate_empty_parens_stays_syntax_error_2036() -> Result<()> {
+    for filter in [
+        "def not: 1; not()",
+        "def length: 1; length()",
+        "def first: 1; first()",
+    ] {
+        let (stdout, stderr, code) = run_jq_full(&["-nc", filter], None)?;
+        assert_eq!(stdout, "", "{filter}: stderr {stderr:?}");
+        assert_eq!(code, 3, "{filter}: stdout: {stdout:?} stderr: {stderr:?}");
+    }
+    Ok(())
+}
+
 /// #1376: `succinctly jq` now supports arity overloading, matching real
 /// jq -- `def f(x): ...` and `def f(x;y): ...` are distinct functions
 /// (`f/1` and `f/2`), and both stay callable after the second definition.

--- a/tests/jq_tests.rs
+++ b/tests/jq_tests.rs
@@ -614,7 +614,7 @@ fn test_parse_func_call_syntax() {
     // It will fail at evaluation time if the function doesn't exist
     use succinctly::jq::Expr;
     let expr = parse("foo").unwrap();
-    assert!(matches!(expr, Expr::FuncCall { name, args } if name == "foo" && args.is_empty()));
+    assert!(matches!(expr, Expr::FuncCall { name, args, .. } if name == "foo" && args.is_empty()));
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Real jq lets a user `def` shadow a builtin of the same name — patching a builtin's
behavior for one program. succinctly's parser lowers a recognized builtin name to a
typed `Expr::Builtin`/special-form node at parse time, before any `def` has been seen,
so the user's own definition was parsed, bound, and then never consulted — the
builtin ran instead, **silently, with no error**:

```console
$ jq -nc 'def length: 1; length'
1
$ succinctly jq -nc 'def length: 1; length'   # before this fix
0
```

Every row of the issue's own repro table exited 0 with a wrong value — the most
serious class of divergence this project tracks.

## Implementation — Direction 3 from the issue's own investigation

1. **Lexical prescan** (`collect_def_names`): collects every identifier spelled after
   a `def` keyword in the main filter's own source text. Cheap and deliberately
   imprecise — a false positive costs nothing beyond one skipped fast-path check.
2. **Wrap at keyword choke points**: at each site that can produce a shadowable
   builtin or fixed-arity special form (`not`, every `try_parse_builtin` arm, and
   `limit`/`until`/`while`/`repeat`/`range`/`first`/`last`/`error`), a name in the
   prescanned set is wrapped as `Expr::FuncCall { name, args: vec![], builtin_fallback: Some(original) }`.
3. **`resolve.rs` picks**: its existing scope-tracking pass (#1473) now rewrites the
   tree (`check` took `&mut Expr`) — if genuinely in scope, the call proceeds;
   otherwise the whole fallback is moved back in.

`null`/`true`/`false` are deliberately excluded — literal tokens in jq's own grammar,
confirmed live real jq itself never lets a `def` of these names be reached either.

## Round 1 review — three bugs found and fixed before merge

**1. A confirmed parser-level denial-of-service (exponential blowup).** The first
draft populated `builtin_fallback`'s sibling `args` by *cloning* the fallback's own
children at parse time. Correct, but a nested chain of the same shadow-candidate name
then roughly doubled its own retained size per level — `def first: .; first(first(first(...)))`
took ~0.8s to *parse* at 20 levels of nesting, and did not finish within a 10s timeout
at 24. Fixed by leaving `args` empty at parse time and deriving the arity `resolve.rs`
needs from `builtin_fallback`'s own shape (read-only, no cloning); once genuinely
shadowed, `args` is populated by *moving* — not cloning — `builtin_fallback`'s children
out. Confirmed live: the same 20-level (and much deeper — 500+) nesting now parses
in single-digit milliseconds.

**2. An empty-parens regression.** `def not: 1; not()` parsed as `1` (exit 0) instead
of staying a syntax error. Fixed by checking for genuinely empty parens before
attempting the arity-mismatch fallback at all.

**3. `Expr::Shared`'s `Rc::get_mut` silently skipped recursion** whenever the wrapped
`Rc` had more than one owner. Unreachable via this crate's own 3 CLI call sites, but
public API for an external caller. Fixed with `Rc::make_mut` instead.

## Round 2 review — four more bugs found and fixed before merge

A second, independent adversarial review round (this PR having sat through an
independently-merged #2237, which touched the exact same keyword-dispatch region and
was merged in during this PR's own rebase) found four more confirmed-live correctness
bugs, all fixed here too:

**4. `builtin_fallback` could itself hold an already-generic call.** #2237 gave the 8
dedicated special-form parsers their own internal wrong-arity rewind, so on a
mismatched arity they now return `Ok(FuncCall{..})` (or a postfix-wrapped one) instead
of `Err`. `wrap_shadowable_call` wrapped that result as `builtin_fallback` anyway, and
`builtin_fallback_arity`/`builtin_fallback_into_args` had no matching arm for it —
silently computing arity 0 and discarding the real arguments, and their side effects,
entirely:

```console
$ succinctly jq -nc 'def until: "shadowed"; until(error("boom"))'   # before this fix
"shadowed"
$ jq -nc 'def until: "shadowed"; until(error("boom"))'
jq: error: until/1 is not defined at <top-level>, line 1: ...
```

Fixed by only ever wrapping the closed set of shapes `builtin_fallback_arity`/
`_into_args` actually know how to read back — anything else (a plain generic call, or
any postfix wrapping of one) passes through unwrapped, resolved like any other call.

**5. `range(N)`'s 1-arg arity was ambiguous.** The 1-arg sugar for `range(0; N)`
desugars to the exact same `Expr::Range { from: Literal(0), to: Some(_), .. }` shape a
genuine 2-arg `range(0; N)` call produces, so computing the shadow-check arity from
that shape alone was ambiguous: `def range(a;b): "s"; range(5)` wrongly shadowed at
arity 2, and `def range(a): "s"; range(5)` wrongly failed to shadow at arity 1. Fixed
by marking the 1-arg form with an `Expr::Paren` wrapper — a no-op everywhere else
(eval/path/walk) — scoped to only the shadow-candidate path, so an ordinary
(non-shadow-candidate) `range(N)` call's parsed shape is unchanged (an earlier version
of this fix wrapped unconditionally and broke a pre-existing `walk.rs` unit test that
asserts `range(N)`'s exact parsed shape).

**6. The lexical prescan missed a `def` separated from its name by a comment.**
`collect_def_names` used `str::trim_start`, which skips whitespace but not a
`#`-comment — `def #c\nlength: 99; length` returned `0` instead of `99`, reproducing
this issue's own bug class for one more spelling. Fixed by skipping comments the same
way the real parser's own `skip_ws` does.

**7. A legitimate nested `error(...)` shadow broke at depth ~7.** Unlike the other 7
special forms, `parse_error_expr`'s wrong-arity path relied entirely on the shared
retry-budget fallback, which re-parses the whole call from scratch *in addition to*
the `parse_expr()` call `parse_error_expr` had already run over the same content —
doubling the parse work at every nesting level and exhausting the budget at a shallow,
non-adversarial depth. Fixed by giving `parse_error_expr` the same internal rewind the
other 7 forms already have. This also corrects an inaccurate claim in this PR's own
CHANGELOG entry about what the retry budget bounds.

**Known, documented, not fixed here** (tracked as #2402): evaluating a jq-mode `Expr`
directly via this crate's public `eval`/`eval_lenient` API, without first calling
`resolve_func_calls`/`resolve_func_calls_all`, can now wrongly report an
`undefined function` error for a shadow candidate whose shadowing is genuinely
declined. An honest error, never a silently wrong *value*, and unreachable from the
`succinctly` binary (both CLI runners already resolve before evaluating) — a
library-API-only precondition change.

## Known residual gap, not fixed here (filed as #2395)

The lexical prescan only ever sees the main filter's own source text — a `def` loaded
via `include`, `import`, or `~/.jq` cannot shadow a builtin, since module loading runs
well after the main filter has already been fully parsed.

## Rebase note

Main advanced with an independently-merged #2237 fix (wrong-arity calls to
`has`/`select`/`env`/`range`/`limit`/... now report jq's own arity error, with a
follow-up postfix fix) that touched the exact same keyword-dispatch region this PR
does. Resolved by hand during rebase — merged both changes together and extended
#2237's own postfix fix to the new #2036 shadow-candidate fallback path too, for
consistency; verified live that both features work correctly together
(`def until(a;b;c): {x:1}; until(1;2;3).x` → `1`, matching real jq).

## Verification

- 16 CLI regression tests (`tests/jq_cli_tests.rs`): the issue's own repro table, every
  special form, cross-arity shadowing, per-arity overload isolation,
  `null`/`true`/`false` non-shadowability, lexical-scope correctness, a timing guard
  for the exponential-blowup fix, correctness checks for the empty-parens fix, and one
  regression test per round-2 bug fixed above.
- Full `cargo test --workspace` (features `cli,simd,regex,serde`): all green, zero
  regressions, run alone (not concurrently) to avoid CPU-contention false timing
  failures on the new timing-guard test.
- `cargo test --no-default-features --verbose` (no_std leg): green.
- `cargo clippy --all-targets --all-features -- -D warnings` and the second CI clippy
  leg (`--features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests`): clean.
- `cargo fmt --check`, `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features`:
  clean.

Fixes #2036