### PR TITLE
fix(jq): validate-only traversal now runs the same delimiter/gap checks its materializing siblings do

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -370,6 +370,42 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **The validate-only traversal backing `select`/`sort_by`/`unique_by`/`min_by`/`max_by`/
+  `path()` silently accepted invalid JSON in a subtree it only ever validates, never
+  materializes** (#2349, split out of #1803). `push_generic_truthiness_cursor_error`
+  (`src/jq/eval_generic.rs`) is the shared validation gate for all six builtins, and both
+  `path()` call sites' own doc comments claim it runs "that same traversal and validation"
+  as the materializing `to_owned_cursor_at_depth` — but three follow-ups since it was
+  written (#1677, #2211, #2243/#2262) each added a delimiter/gap check to the
+  materializing traversals and none reached this one, so a corrupted subtree the query
+  only ever validates (never emits) passed silently where the identical subtree, read
+  directly, correctly raised:
+
+  ```console
+  $ echo '{"c":{"a":1,},"t":5}' | succinctly jq -c 'select(.c) | .t'   # before this fix
+  5
+  $ echo '{"c":{"a":1,},"t":5}' | succinctly jq -c '.c'                # already correct
+  Error: Invalid JSON text: expected string key, found '}'
+  ```
+
+  Fixed by adding the missing checks to `push_generic_truthiness_cursor_error`'s own
+  object/array walk, mirroring `to_owned_cursor_at_depth`'s structure exactly (`is_first`/
+  last-cursor tracking, `key_delimiter_ok`/`value_delimiter_ok` per object field,
+  `preceding_delimiter_ok` per array element, `container_gap_ok`/`trailing_element_gap_ok`
+  after each container's loop) — all four checks reused verbatim from `document.rs`, no
+  new logic. YAML is unaffected: every added check is a JSON-only no-op for a YAML
+  document, matching the issue's own divergence matrix.
+
+  **Performance**: since `path()` runs this gate over the *whole* document on every call
+  (not just the values a query actually reads), the added checks are charged to the
+  entire tree regardless of what's queried. Measured (M-series laptop, interleaved A/B,
+  7 reps, `path(.[0])` on a ~700K-object array — not the pinned bench boxes, indicative
+  only): **+13.1%** with the full fix, of which disabling just the trailing/container-gap
+  checks (`#2211`/`#2243`) recovers **57%** of the regression, confirming those two checks
+  as the dominant cost, as the issue's own investigation predicted. Accepted as the price
+  of the gate the code already claims to run; `select`/`sort_by` and friends walk far
+  smaller subtrees per query and are far less affected.
+
 - **`del()`'s trailing `.[]` raised instead of no-oping through a tolerated (rather than
   genuinely found) `null`, in yq mode** (#2347, found during #2324's own implementation).
   A `null` reached by tolerating a step against it — a missing object field, or an

--- a/docs/compliance/jq/limitations.md
+++ b/docs/compliance/jq/limitations.md
@@ -1794,15 +1794,29 @@ and differently-shaped problem than this section's own fixes):
   entry above for the fix and its residual gap.
 
 Two further leads from the same sweep were investigated and **not**
-reproduced live (so not reported as confirmed bugs, only as ruled out):
-`push_generic_truthiness_cursor_error` (`if COND then ... end` on a
-container condition) and `owned_from_standard_json_at_depth` (the
+reproduced live (so not reported as confirmed bugs, only as ruled out) at
+the time: `push_generic_truthiness_cursor_error` (`if COND then ... end`
+on a container condition) and `owned_from_standard_json_at_depth` (the
 `input`/`inputs`-with-cursor-metadata-builtins bridge, #1504) both lack
 their own internal gap checks by inspection, but every constructed repro
 against each (`{"a":[1,2,3,]} | if .a then ... end`;
 `[1,2,3,] | [inputs, line]` with `-n`) already raised correctly, meaning
 something upstream of either function already validates for the shapes
-tried. Not chased further given no live reproduction.
+tried. Not chased further given no live reproduction *of those specific
+repros* — **update (#2349): a live, CLI-reachable gap in
+`push_generic_truthiness_cursor_error` was found and fixed after all**,
+just not via `if...then...end` (whose own `Control::from(cond)` path
+apparently validates upstream, matching what this entry found). `select`,
+`sort_by`/`unique_by`/`min_by`/`max_by`, and `path()` all route through
+this same function without that upstream validation, and a trailing-comma/
+missing-colon/stray-comma corruption in a subtree the query only ever
+validates (never emits) silently passed — `{"c":{"a":1,},"t":5} |
+select(.c) | .t` answered `5` instead of raising, confirmed live. See
+this doc's "The validate-only traversal..." entry in `CHANGELOG.md` for
+the fix; the underlying lesson stands even though this specific
+conclusion didn't: a function lacking its own checks by inspection can
+still be live-exploitable through a caller this investigation's own
+repro set didn't try.
 
 ## `has(key)`/`contains()` and `find()` get two more pre-existing gaps closed (#2288)
 

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -2524,6 +2524,13 @@ fn push_generic_truthiness_cursor_error<C: DocumentCursor>(c: &C, depth: usize) 
         let mut seen_fallback = false;
         let mut index = 0usize;
         let mut f = fields;
+        // #2349: `last_field` -- the last real field's *value* cursor, not
+        // its key -- feeds the #2243 trailing-gap check once the loop
+        // ends, mirroring `to_owned_cursor_at_depth`'s own tracking. No
+        // separate `is_first` flag: `index == 0` already carries that fact
+        // (both would flip/increment together every iteration with no
+        // path that updates one without the other).
+        let mut last_field: Option<C> = None;
         while let Some((field, rest)) = f.uncons() {
             if !seen_fallback {
                 match key_display_string_kind(&field.key) {
@@ -2566,25 +2573,88 @@ fn push_generic_truthiness_cursor_error<C: DocumentCursor>(c: &C, depth: usize) 
                     Err(e) => return Some(Control::Error(e)),
                 }
             }
+            // #2349: same #1677 key/value delimiter checks
+            // `to_owned_cursor_at_depth`'s own object loop runs -- this
+            // walk had none at all, so `{"a" 1}` (missing `:`) or a
+            // duplicate/missing `,` between fields passed silently here
+            // while the materializing sibling correctly raised.
+            if !key_delimiter_ok::<<C::Value as DocumentValue>::Fields>(
+                &field.key,
+                &field.key_cursor,
+                index == 0,
+            ) || !value_delimiter_ok::<<C::Value as DocumentValue>::Fields>(
+                Some(&field.value),
+                &field.value_cursor,
+            ) {
+                return Some(Control::Error(f.malformed_member_error()));
+            }
             index += 1;
             if let Some(control) =
                 push_generic_truthiness_cursor_error(&field.value_cursor, depth + 1)
             {
                 return Some(control);
             }
+            last_field = Some(field.value_cursor);
             f = rest;
         }
         if f.ends_unpaired() {
             return Some(Control::Error(f.malformed_member_error()));
         }
+        // #2349: same #2211/#2243 container/trailing-gap checks
+        // `to_owned_cursor_at_depth`'s own object arm runs after its loop
+        // -- a stray `,` with no real field (`{,}`) or a trailing `,`
+        // after the last real field (`{"a":1,}`) both passed silently
+        // here before this fix.
+        match last_field {
+            None => {
+                if !c.container_gap_ok(b'}') {
+                    return Some(Control::Error(c.malformed_delimiter_error()));
+                }
+            }
+            Some(value_cursor) => {
+                if !trailing_element_gap_ok(&value_cursor, b'}') {
+                    return Some(Control::Error(c.malformed_delimiter_error()));
+                }
+            }
+        }
         None
     } else if let Some(elements) = value.as_array() {
         let mut elems = elements;
+        let mut is_first = true;
+        let mut last_elem: Option<C> = None;
         while let Some((elem_cursor, rest)) = elems.uncons_cursor() {
+            // #2349/#1677: same gap check `to_owned_cursor_at_depth`'s
+            // array loop runs -- a missing/duplicate `,` between elements
+            // previously passed silently here. `element_gap_ok`, not a
+            // hand-inlined `text_position`/`preceding_delimiter_ok` pair
+            // (the issue's own suggested next step) -- #1597 extracted
+            // this exact composition specifically because independent
+            // copies of it had already drifted apart once.
+            if !elem_cursor.element_gap_ok(is_first) {
+                return Some(Control::Error(elem_cursor.malformed_delimiter_error()));
+            }
             if let Some(control) = push_generic_truthiness_cursor_error(&elem_cursor, depth + 1) {
                 return Some(control);
             }
+            last_elem = Some(elem_cursor);
             elems = rest;
+            is_first = false;
+        }
+        // #2349/#2211/#2243: same container/trailing-gap checks
+        // `to_owned_cursor_at_depth`'s own array arm runs after its loop --
+        // `[,]` (no real element) or `[1,]` (trailing `,`) both passed
+        // silently here before this fix.
+        match last_elem {
+            None => {
+                if !c.container_gap_ok(b']') {
+                    return Some(Control::Error(c.malformed_delimiter_error()));
+                }
+            }
+            Some(last) => {
+                if !trailing_element_gap_ok(&last, b']') {
+                    return Some(Control::Error(c.malformed_delimiter_error()));
+                }
+            }
         }
         None
     } else if let Some(reason) = value.string_decode_error() {

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -36474,3 +36474,99 @@ fn test_seq_wellformed_and_leniency_unaffected_by_checked_swap_2295() -> Result<
     assert_eq!(stdout.trim(), "\x1e7");
     Ok(())
 }
+
+/// #2349: `push_generic_truthiness_cursor_error` -- the shared validation
+/// gate for `select`/`sort_by`/`unique_by`/`min_by`/`max_by`/`path()` -- had
+/// none of the `#1677`/`#2211`/`#2243` delimiter/gap checks its materializing
+/// siblings (`to_owned_cursor_at_depth` and friends) already run, so a
+/// document corrupted in a subtree the query only ever *validates* (never
+/// emits) passed silently instead of raising. Every row here is a document
+/// real jq rejects; before this fix, succinctly accepted all eight (exit 0)
+/// while the materializing control for the identical subtree already
+/// correctly raised. Repros and control verified live against `/usr/bin/jq`
+/// 1.7.1 in the issue's own filing.
+#[test]
+fn test_validate_only_gate_delimiter_checks_2349() -> Result<()> {
+    let cases: &[(&str, &str, &str)] = &[
+        (
+            "trailing comma in nested object, select+field",
+            r#"{"c":{"a":1,},"t":5}"#,
+            "select(.c) | .t",
+        ),
+        (
+            "trailing comma in nested array element, sort_by",
+            r#"[{"a":2,"b":[1,]},{"a":1}]"#,
+            "sort_by(.a) | length",
+        ),
+        (
+            "trailing comma in nested array element, unique_by",
+            r#"[{"a":2,"b":[1,]},{"a":1}]"#,
+            "unique_by(.a) | length",
+        ),
+        (
+            "trailing comma in nested array element, min_by",
+            r#"[{"a":2,"b":[1,]},{"a":1}]"#,
+            "min_by(.a) | .a",
+        ),
+        (
+            "trailing comma in nested object, path()",
+            r#"{"c":{"a":1,}}"#,
+            "path(.c)",
+        ),
+        (
+            "stray comma with no real field, object",
+            r#"{"c":{,},"t":5}"#,
+            "select(.c) | .t",
+        ),
+        (
+            "stray comma with no real element, array",
+            r#"{"c":[,],"t":5}"#,
+            "select(.c) | .t",
+        ),
+        (
+            "missing colon between key and value",
+            r#"{"c":{"a" 1},"t":5}"#,
+            "select(.c) | .t",
+        ),
+    ];
+
+    for (desc, doc, filter) in cases {
+        let (stdout, stderr, code) = run_jq_full(&["-c", filter], Some(doc))?;
+        assert_ne!(
+            code, 0,
+            "{desc}: `{filter}` on `{doc}` should raise, matching real jq \
+             (got exit 0, stdout: {stdout:?})"
+        );
+        assert!(
+            stderr.contains("Invalid JSON"),
+            "{desc}: expected a JSON validity error, stderr: {stderr:?}"
+        );
+    }
+
+    // Well-formed control: the same shape, no corruption, must be unaffected.
+    let (stdout, stderr, code) =
+        run_jq_full(&["-c", "select(.c) | .t"], Some(r#"{"c":{"a":1},"t":5}"#))?;
+    assert_eq!(code, 0, "stderr: {stderr:?}");
+    assert_eq!(stdout.trim(), "5");
+
+    Ok(())
+}
+
+/// #2349 control: the same gate's *array* elements must also validate the
+/// leading-comma/duplicate-comma shape (`[1,,2]`), not just the trailing
+/// stray-comma cases above -- a distinct `#1677` check
+/// (`preceding_delimiter_ok`) from the trailing/#2211 ones.
+#[test]
+fn test_validate_only_gate_array_element_delimiter_2349() -> Result<()> {
+    let (stdout, stderr, code) =
+        run_jq_full(&["-c", "select(.c) | .t"], Some(r#"{"c":[1,,2],"t":5}"#))?;
+    assert_ne!(
+        code, 0,
+        "duplicate comma between array elements should raise (stdout: {stdout:?})"
+    );
+    assert!(
+        stderr.contains("Invalid JSON"),
+        "expected a JSON validity error, stderr: {stderr:?}"
+    );
+    Ok(())
+}


### PR DESCRIPTION
## Summary

`push_generic_truthiness_cursor_error` (`src/jq/eval_generic.rs`) is the
shared validation gate for `select`, `sort_by`/`unique_by`/`min_by`/
`max_by`, and `path()`. Both `path()` call sites' own doc comments claim
it runs "that same traversal and validation" as the materializing
`to_owned_cursor_at_depth` — but three follow-ups since it was written
(#1677, #2211, #2243/#2262) each added a delimiter/gap check to the
materializing traversals, and none reached this validate-only walk. A
document corrupted in a subtree the query only ever *validates* (never
emits) passed silently instead of raising:

```console
$ echo '{"c":{"a":1,},"t":5}' | succinctly jq -c 'select(.c) | .t'   # before this fix
5
$ echo '{"c":{"a":1,},"t":5}' | succinctly jq -c '.c'                # already correct
Error: Invalid JSON text: expected string key, found '}'
```

## Fix

Added the missing checks to `push_generic_truthiness_cursor_error`'s own
object/array walk, mirroring `to_owned_cursor_at_depth`'s structure:
- last-cursor tracking
- `key_delimiter_ok`/`value_delimiter_ok` per object field (#1677)
- `element_gap_ok` per array element (#1677) — not a hand-inlined
  `text_position`/`preceding_delimiter_ok` pair; #1597 extracted that
  composition specifically to stop independent copies drifting apart,
  and code review caught the first draft doing exactly that
- `container_gap_ok` (#2211) / `trailing_element_gap_ok` (#2243/#2262)
  after each container's loop

All checks reused verbatim from `document.rs` — no new logic. YAML is
unaffected: every added check is a JSON-only no-op for a YAML document.
No separate `is_first` flag in the object arm: `index == 0` (pre-existing
state) already carried that fact.

All 8 repro rows from the issue now correctly raise; the well-formed
control is unaffected.

## Performance

`path()` runs this gate over the *whole* document on every call, so the
added checks are charged to the entire tree regardless of what's
queried. Measured locally (M-series laptop, interleaved A/B, 7 reps,
`path(.[0])`-equivalent on a ~700K-object array — **not** the pinned
bench boxes, indicative only; remote access to `johns-mac-mini`/
`terminus` needed interactive re-auth I couldn't complete autonomously):

- Full fix: **+13.1%** vs baseline
- Disabling just the trailing/container-gap checks (#2211/#2243):
  recovers **57%** of that regression

This confirms the issue's own hypothesis that those two checks are the
dominant cost. Accepted as the price of the gate the code already claims
to run — `select`/`sort_by` and friends walk far smaller subtrees per
query and are far less affected. A follow-up to recover some of that
cost (reusing an already-resolved position instead of re-deriving it via
a second cursor lookup) is filed as #2399; pinned-hardware
reconfirmation would also be good follow-up but isn't gating this
correctness fix.

## Also fixed

Corrected a stale `docs/compliance/jq/limitations.md` entry from an
earlier investigation that concluded this exact function had no
live-reproducible gap — true for the `if/then/end` repro it tried, not
for `select`/`sort_by`/`path()`. A second function flagged by the same
investigation with the same "no live repro found yet" reasoning
(`owned_from_standard_json_at_depth`, the `input`/`inputs` bridge) may
have the identical gap; filed as #2400 rather than assumed safe, since
this PR's own review process is what disproved the identical assumption
for this function.

Fixes #2349

## Test plan

- [x] All 8 repro rows from the issue + well-formed control, new test
      `test_validate_only_gate_delimiter_checks_2349`
- [x] Array leading/duplicate-comma control,
      `test_validate_only_gate_array_element_delimiter_2349`
- [x] Full local verification: fmt, clippy (both feature sets), doc
      (`RUSTDOCFLAGS=-D warnings`), and all three test tiers (cli+simd+
      regex+serde, default features, `--no-default-features`) — 0 failed
      throughout, both before and after code review
- [x] Performance attribution per the issue's own protocol (see above)
- [x] Mandatory multi-agent code review completed; all actionable
      findings (commit message length, `element_gap_ok` reuse per the
      issue's own suggested fix, redundant `is_first`/`index` state)
      fixed; deferred findings filed as #2399/#2400