### PR TITLE
refactor(jq): eval_owned_pure's navigation arm skips the fast-path wrapper

### DIFF
--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -28809,7 +28809,9 @@ fn eval_owned_fast_path<S: EvalSemantics>(
         }
     }
     match expr {
-        Expr::Identity => Some(Ok(Some(input.clone()))),
+        Expr::Identity | Expr::Field(_) | Expr::Index { .. } => {
+            eval_owned_navigation::<S>(expr, input, optional)
+        }
         Expr::Builtin(Builtin::ToString) => {
             Some(Ok(Some(OwnedValue::String(owned_to_string::<S>(input)))))
         }
@@ -28841,6 +28843,26 @@ fn eval_owned_fast_path<S: EvalSemantics>(
                 Err(e) => Some(Err(e)),
             }
         }
+        _ => None,
+    }
+}
+
+/// The `Identity`/`Field`/`Index` arms of [`eval_owned_fast_path`], factored
+/// out (#2201 review follow-up to #2048) so [`eval_owned_pure`]'s own
+/// navigation arm can call them directly instead of round-tripping through
+/// the wrapper's `is_owned_pure_composite` pre-check -- a check that arm's
+/// own doc comment already establishes is always cheaply `false` for these
+/// three shapes (`produces_fresh_value` rejects them immediately), so the
+/// round trip cost nothing incorrect, just an unnecessary detour. Behavior
+/// is unchanged: [`eval_owned_fast_path`]'s own match still dispatches here
+/// for exactly the same three shapes it always has.
+fn eval_owned_navigation<S: EvalSemantics>(
+    expr: &Expr,
+    input: &OwnedValue,
+    optional: bool,
+) -> Option<Result<Option<OwnedValue>, EvalError>> {
+    match expr {
+        Expr::Identity => Some(Ok(Some(input.clone()))),
         Expr::Field(name) => Some(match input {
             OwnedValue::Object(map) => Ok(Some(map.get(name).cloned().unwrap_or(OwnedValue::Null))),
             OwnedValue::Null => Ok(Some(OwnedValue::Null)),
@@ -29046,9 +29068,13 @@ fn eval_owned_pure<S: EvalSemantics>(
         // `!optional` gate at its call site), under which those arms answer
         // `Ok(Some(_))` or `Err(_)` and never `Ok(None)`; the `Ok(None)` arm
         // below is a non-panicking fallback to the bridge rather than an
-        // `unreachable!()`.
+        // `unreachable!()`. Calls `eval_owned_navigation` directly (#2201
+        // review follow-up), not `eval_owned_fast_path` -- that wrapper's own
+        // `is_owned_pure_composite` pre-check is always cheaply `false` for
+        // these three shapes anyway (see its own doc comment), so going
+        // through it here was a detour, not a behavior difference.
         Expr::Identity | Expr::Field(_) | Expr::Index { .. } => {
-            match eval_owned_fast_path::<S>(expr, input, false)? {
+            match eval_owned_navigation::<S>(expr, input, false)? {
                 Ok(Some(v)) => Some(Ok(v)),
                 Ok(None) => None,
                 Err(e) => Some(Err(e)),

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -28856,11 +28856,31 @@ fn eval_owned_fast_path<S: EvalSemantics>(
 /// round trip cost nothing incorrect, just an unnecessary detour. Behavior
 /// is unchanged: [`eval_owned_fast_path`]'s own match still dispatches here
 /// for exactly the same three shapes it always has.
+///
+/// `#[inline]`, matching the sibling cursor-based helpers this mirrors
+/// (`index_object_by_name`/`index_array_by_position`, both also `#[inline]`)
+/// -- the code this replaces used to sit directly inline in
+/// `eval_owned_fast_path`'s own match arm, with no call boundary at all, on
+/// what is the single most frequently hit shape in `each`/`map`/streaming
+/// iteration (review finding).
+///
+/// Both call sites already filter to exactly `Identity`/`Field(_)`/
+/// `Index { .. }` before calling; the `debug_assert!` makes that precondition
+/// structural rather than implicit, so a future third call site that forgets
+/// the filter fails loudly in tests instead of silently falling through to
+/// the `_ => None` catch-all (review finding) -- `None` there is otherwise
+/// indistinguishable from every other shape's genuine "not fast-pathable"
+/// answer.
+#[inline]
 fn eval_owned_navigation<S: EvalSemantics>(
     expr: &Expr,
     input: &OwnedValue,
     optional: bool,
 ) -> Option<Result<Option<OwnedValue>, EvalError>> {
+    debug_assert!(
+        matches!(expr, Expr::Identity | Expr::Field(_) | Expr::Index { .. }),
+        "eval_owned_navigation called with a shape it doesn't handle: {expr:?}"
+    );
     match expr {
         Expr::Identity => Some(Ok(Some(input.clone()))),
         Expr::Field(name) => Some(match input {
@@ -52777,6 +52797,23 @@ mod tests {
             )),
             bridge
         );
+    }
+
+    /// #2201 review: pins the invariant `eval_owned_navigation`'s and
+    /// `eval_owned_pure`'s own doc comments both assert in prose --
+    /// `produces_fresh_value` is `false` for the bare `Identity`/`Field`/
+    /// `Index` shapes, not just for a `Pipe` ending in one (the case
+    /// `pipes_ending_in_navigation_are_evaluable_but_not_gated_2048` already
+    /// pins above). This is what makes `eval_owned_pure`'s direct call to
+    /// `eval_owned_navigation` (skipping `is_owned_pure_composite`) provably
+    /// behavior-preserving rather than merely asserted to be.
+    #[test]
+    fn bare_navigation_shapes_are_pure_but_not_freshly_constructed_2201() {
+        for expr in [Expr::Identity, Expr::Field("a".into()), Expr::index(0)] {
+            assert!(is_owned_pure_expr(&expr), "{expr:?}");
+            assert!(!produces_fresh_value(&expr), "{expr:?}");
+            assert!(!is_owned_pure_composite(&expr), "{expr:?}");
+        }
     }
 
     /// #2048: the fast path has to actually *fire* for the issue's own repro


### PR DESCRIPTION
Fixes #2201

## Summary

#2201 bundled four non-blocking observations from #2048's own code review (the
`resolve_node`/`select`-condition reindex-round-trip fast path,
`src/jq/eval.rs`). This PR fixes item 4, the one safe extraction with no behavior
change; items 1-3 need more careful, dedicated design work and are tracked as a
follow-up (#2397) rather than being rushed alongside this.

## Item 4 — `eval_owned_pure`'s navigation arm round-trips through the fast-path wrapper

> Minor indirection in `eval_owned_pure`'s navigation arm. `eval_owned_pure`'s
> `Identity | Field(_) | Index { .. }` arm re-enters `eval_owned_fast_path` (which
> re-runs the top-of-function `is_owned_pure_composite` check, even though the
> arm's own doc comment already establishes these shapes are never composite --
> `produces_fresh_value` returns `false` for them immediately, short-circuiting the
> `&&` cheaply before `is_owned_pure_expr` ever runs). Cheap in practice, but a
> direct call to the three original match arms (or a small shared helper) would
> avoid the round trip through the wrapper's unrelated logic. Readability nit, not
> a perf or correctness issue.

Extracted `eval_owned_fast_path`'s `Identity`/`Field`/`Index` arms into a new
`eval_owned_navigation` helper, called directly from both `eval_owned_fast_path`
(unchanged dispatch, same match arms) and `eval_owned_pure`'s own navigation arm
(skipping `is_owned_pure_composite`'s always-`false`-for-these-shapes detour
entirely).

**No behavior change** -- the extraction moves code verbatim, doesn't alter any
logic. Confirmed by the full existing `eval_owned`/`is_owned_pure` test suite
(`eval_owned_fast_path_agrees_with_index_object_by_name_and_index_array_by_position`,
`is_owned_pure_expr_agrees_with_eval_owned_pure`,
`eval_owned_pure_agrees_with_the_reindex_bridge`, ...) passing unmodified.

## Items 1-3 (deferred, filed as #2397)

- **Item 1**: `is_owned_pure_composite` is re-derived from scratch on every branch
  a filtered recursive descent visits, `O(D x |condition|)` instead of
  `O(D + |condition|)`. A real fix (per-node cache, or hoisting the classification
  above `resolve_node`'s own per-branch loop) requires tracing through
  `resolve_seq`'s generic multi-stage fan-out engine, shared by far more than just
  `select` -- not a localized change.
- **Item 2**: `is_owned_pure_expr` duplicates the shape of an existing, but
  genuinely different-grammar, purity predicate (`is_pure_chain_link`). A naive
  merge risks *creating* the exact "duplicated predicates diverge silently"
  failure CLAUDE.md's #106 lesson warns about, rather than closing it -- needs a
  properly parameterized shared primitive, not a quick unification.
- **Item 3**: `eval_owned_fast_path` is accreting a third fast-path mechanism
  bolted onto one `match` -- a maintenance observation with no concrete fix
  direction yet (a real consolidation would need items 1 and 2 settled first).

## Test plan

- [x] Full existing `eval_owned`/`is_owned_pure` test suite passes unmodified (21
      tests, `cargo test --lib -- eval_owned`).
- [x] `cargo build --features cli`
- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings` (ci.yml's 2nd leg)
- [x] Full `cargo test --features cli,simd,regex,serde` (clean build) -- 0 failures
- [x] `cargo test --no-default-features --features std` (no_std-adjacent)
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features`
