### PR TITLE
ci(perf-guard): give push events the same same-run baseline pull_request has

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -591,6 +591,13 @@ jobs:
       # that already passed this same required CI when it landed. Built into
       # a separate worktree/target dir so it can't collide with (or poison
       # the cache of) the PR-head build below.
+      #
+      # Review (#2117): this step's own `worktree add`/`cd`/`cargo build`
+      # sequence is duplicated (with a different SHA source and dest path)
+      # by the "Build previous-commit binary" step just below -- if you're
+      # changing the build invocation here (a feature flag, the worktree
+      # convention, ...), check whether that step needs the identical change
+      # too, so the two baselines stay built consistently.
       - name: Build merge-base binary
         if: github.event_name == 'pull_request'
         run: |
@@ -600,6 +607,47 @@ jobs:
           cd /tmp/perf-guard-merge-base
           cargo build --release --features cli
 
+      # #2117: the `push` path's own same-run baseline, mirroring #1582's
+      # `pull_request` treatment above -- compares against the single commit
+      # this push landed on top of (`github.event.before`, the SHA `main`
+      # pointed to immediately before this push), cancelling the same
+      # ordinary `Ir` drift #1582 already cancels for `pull_request` runs.
+      # Without this, every `push` (i.e. every commit the merge queue lands
+      # on `main`) fell back to the checked-in
+      # `tests/data/perf-guard-baseline.json` file, which drifts 1-3% across
+      # every query within days at this project's merge cadence (#2059) --
+      # a real staleness incident this closes off at the source rather than
+      # requiring a periodic manual `--update-baseline` refresh.
+      #
+      # Falls back to that same checked-in file (leaving `PERF_GUARD_PREV_BUILT`
+      # unset, so the run step below leaves `EXTRA_ARGS` empty) when `before`
+      # isn't a real, buildable commit -- the all-zeros SHA on a branch's
+      # first push, or a SHA this `fetch-depth: 0` checkout doesn't actually
+      # have (a force-push/history-rewrite edge case) -- rather than
+      # assuming it always is.
+      #
+      # Same `worktree add`/`cd`/`cargo build` sequence as "Build merge-base
+      # binary" above (see its own comment) -- keep the two in sync.
+      - name: Build previous-commit binary
+        if: github.event_name == 'push'
+        env:
+          # Not attacker-influenced (GitHub computes this itself, always a
+          # 40-hex-char SHA or the all-zero SHA) -- routed through `env:`
+          # rather than spliced into the script via `${{ }}` anyway, so this
+          # step isn't a template a future *do* attacker-influenced field
+          # (a branch/tag name, say) could get copy-pasted into unsafely.
+          BEFORE: ${{ github.event.before }}
+        run: |
+          if [ "$BEFORE" != "0000000000000000000000000000000000000000" ] && git cat-file -e "$BEFORE^{commit}" 2>/dev/null; then
+            echo "Building previous-commit binary at $BEFORE for push-relative perf comparison (#2117)"
+            git worktree add --detach /tmp/perf-guard-prev-commit "$BEFORE"
+            cd /tmp/perf-guard-prev-commit
+            cargo build --release --features cli
+            echo "PERF_GUARD_PREV_BUILT=1" >> "$GITHUB_ENV"
+          else
+            echo "::warning::github.event.before ($BEFORE) is not a valid buildable commit -- falling back to the checked-in baseline file for this push"
+          fi
+
       - name: Build release binary
         run: cargo build --release --features cli
 
@@ -607,6 +655,8 @@ jobs:
         run: |
           if [ "${{ github.event_name }}" = "pull_request" ]; then
             EXTRA_ARGS="--baseline-binary /tmp/perf-guard-merge-base/target/release/succinctly"
+          elif [ "${{ github.event_name }}" = "push" ] && [ "$PERF_GUARD_PREV_BUILT" = "1" ]; then
+            EXTRA_ARGS="--baseline-binary /tmp/perf-guard-prev-commit/target/release/succinctly"
           else
             EXTRA_ARGS=""
           fi

--- a/docs/guides/benchmarking.md
+++ b/docs/guides/benchmarking.md
@@ -170,10 +170,13 @@ check while it builds a track record.
 
 On `pull_request` runs, the baseline is a binary built fresh from the PR's own
 `git merge-base` in the same CI run (`--baseline-binary`), not the committed file —
-see #1582 below for why. On other runs (a direct push to `main`) there is no PR to
-build a merge-base from, so it falls back to the checked-in
-`tests/data/perf-guard-baseline.json`. To deliberately update that file after a real,
-understood cost change:
+see #1582 below for why. On `push` runs (every commit the merge queue lands on
+`main`), the baseline is likewise a binary built fresh from `github.event.before`
+(the commit `main` pointed to immediately before that push, #2117) — the checked-in
+`tests/data/perf-guard-baseline.json` is now only a fallback for the rare case
+neither can supply a binary (a branch's first push, or a `before` SHA the checkout
+doesn't have), and a seed for running the script locally with no comparison binary
+of your own. To deliberately update that file after a real, understood cost change:
 
 ```bash
 cargo build --release --features cli

--- a/scripts/perf-guard.py
+++ b/scripts/perf-guard.py
@@ -65,8 +65,7 @@ oversights -- worth revisiting once this guard has a track record:
   or `src/bits/popcount.rs`'s explicit intrinsics is invisible here, the same
   split `bench`'s own default/simd/portable-popcount 3-way matrix exists to
   separate for `rank_select`.
-- The committed `--baseline` file is a *fallback* used only for non-PR runs
-  (a direct push to `main`) and carries a real staleness risk: at this
+- The committed `--baseline` file carries a real staleness risk: at this
   project's merge cadence, `Ir` drifts 1-3% across every query within days
   from ordinary accumulated changes alone (measured directly: baseline
   source commit vs. `main` 3 days/147 commits later, 55 of them touching
@@ -74,9 +73,15 @@ oversights -- worth revisiting once this guard has a track record:
   pinning `codegen-units=1` on both sides of that same comparison left the
   drift the same size or larger, so #1587's fix for a similar-looking
   wall-clock/icache issue does not apply here. It is why `--baseline-binary`
-  exists: a same-run comparison against the PR's own merge-base cancels
-  staleness from any cause, instead of trying to keep a checked-in file
-  fresh against a fast-moving `main`.
+  exists: a same-run comparison cancels staleness from any cause, instead of
+  trying to keep a checked-in file fresh against a fast-moving `main`. `ci.yml`
+  now passes `--baseline-binary` on *every* run this job triggers for --
+  `pull_request` against the PR's own `git merge-base`, and (#2117) `push`
+  against `github.event.before`, the commit `main` pointed to immediately
+  before that push -- so the checked-in file only still matters as a
+  fallback for the rare case neither can supply a binary (a branch's first
+  push, or a `before` SHA this checkout doesn't have), and as a seed for a
+  human running this script locally with no comparison binary of their own.
 
 Standard library only; no third-party dependencies.
 """


### PR DESCRIPTION
Fixes #2117

## Summary

`scripts/perf-guard.py`'s own module doc comment already names the mechanism this
gate is inherently prone to: "at this project's merge cadence, `Ir` drifts 1-3%
across every query within days from ordinary accumulated changes alone." #1582
solved this for `pull_request` runs by comparing against a same-run binary built
from the PR's own `git merge-base` instead of the checked-in
`tests/data/perf-guard-baseline.json` file -- cancelling staleness from any cause.
`push` events (direct commits to `main`, which is how the merge queue's rebase-merge
lands commits) still fell back to the static file, so they remained subject to the
same staleness #1582 already solved for PRs -- the direct cause of #2059's manual
`--update-baseline` refresh.

## Fix

Gives the `push` path the same treatment #1582 gave `pull_request`: a new "Build
previous-commit binary" step, gated to `github.event_name == 'push'`, builds a
binary from `github.event.before` (the commit `main` pointed to immediately before
this push) into its own worktree/target dir (mirroring the existing merge-base
step's own isolation, so it can't collide with or poison the cache of the main
build). The "Run perf guard" step then picks `--baseline-binary` for that build the
same way it already does for `pull_request`'s merge-base build.

**Fallback, per the issue's own caveat**: `github.event.before` is `0000...0` on a
branch's first push, and can reference a commit this checkout doesn't have in a
force-push/history-rewrite edge case. The build step checks for both (`git cat-file
-e "$BEFORE^{commit}"`) before attempting the build, and simply doesn't set the
`PERF_GUARD_PREV_BUILT` env flag if either check fails -- the run step then falls
through to `EXTRA_ARGS=""`, exactly the pre-#2117 behavior (checked-in baseline
file), rather than assuming `before` is always buildable.

## Test plan

- [x] `actionlint .github/workflows/ci.yml` -- clean except one pre-existing,
      unrelated shellcheck warning (confirmed present on `main` too, at the
      original line number before this diff shifted it).
- [x] `python3 -c "import yaml; yaml.safe_load(...)"` -- valid YAML.
- [x] This PR's own CI run will exercise the `pull_request` path unchanged (no
      logic there was touched) and will itself be a real end-to-end test of the
      new `push`-path code once merged and landed on `main` by the queue --
      worth watching that first post-merge run's Perf Regression Guard jobs to
      confirm `github.event.before` resolves and builds as expected.
- [x] `cargo build --features cli`
- [x] `cargo fmt --check`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
