### PR TITLE
fix(jq): close two non-live rows of #2349's delimiter matrix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -370,6 +370,38 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Two rows of #2349's own delimiter-consistency matrix stayed open after that fix
+  landed** (#2358). Both are the "bare `value: &V`, no container cursor available" shape
+  #2211/#2243 already documented as a permanent limitation on some materializers, but
+  turned out not to be permanent everywhere it was assumed:
+
+  - `eval_generic.rs`'s `to_owned_at_depth` (the library-facing, cursor-less `to_owned`
+    entry point) genuinely has no cursor at the true top level, but every *recursive* call
+    already resolves the child's own cursor for an unrelated reason (`field.value_cursor`,
+    `elem_cursor`) and simply discarded it. Threading that cursor through as a new
+    parameter lets `container_tail_gap_ok` close #2211's `{,}`/`[,]` check for every nested
+    container the same way `to_owned_cursor_at_depth` always could — only the true top
+    level keeps the documented, unavoidable gap.
+  - `lazy.rs`'s independent `cursor_to_owned_at_depth` (the JSON-cursor materializer) was
+    never in the "no cursor" situation at all — it always holds a real `JsonCursor`, at
+    every depth including the top. Its own STYLE-0013 comment named this issue directly as
+    the reason `container_tail_gap_ok` wasn't already used in place of a hand-inlined
+    `container_gap_ok`-only check. Swapping it in closes #2243's trailing-comma check
+    (`[1,]`, `{"a":1,}`) at every level, not just nested ones.
+
+  Neither fix is independently reachable through the shipped CLI's default JSON parsing
+  path — the semi-index build itself already rejects malformed delimiters before either
+  materializer runs on genuinely untrusted stdin text, the same reason #2349's own matrix
+  called these rows "non-live." Both are reachable through other entry points into these
+  functions (a direct library caller of `to_owned`, or a lenient/pre-validated document),
+  and are pinned directly rather than through the CLI:
+  `test_to_owned_raises_on_nested_stray_comma_in_empty_container_2358`/
+  `test_to_owned_raises_on_nested_trailing_comma_2358` (`eval_generic.rs`) and
+  `materialize_raises_on_trailing_comma_after_last_child_2358` (`lazy.rs`). Two further
+  rows in the same materializer family (`eval.rs`'s own `to_owned_at_depth`,
+  `yq_runner.rs`'s `to_owned_canonicalizing_numbers_at_depth`) likely have the identical
+  opportunity but are out of this issue's scope; tracked as #2403.
+
 - **The validate-only traversal backing `select`/`sort_by`/`unique_by`/`min_by`/`max_by`/
   `path()` silently accepted invalid JSON in a subtree it only ever validates, never
   materializes** (#2349, split out of #1803). `push_generic_truthiness_cursor_error`

--- a/docs/compliance/jq/limitations.md
+++ b/docs/compliance/jq/limitations.md
@@ -1327,6 +1327,27 @@ practice #2243's own issue text cites for not folding into #2211):
   shares the same validation hole, so declining the fast path there would
   cost M2's performance with no correctness gain -- tracked as a further,
   broader follow-up rather than folded into #2276.
+
+  **Update (#2358)**: "expected to stay that way" above turned out to be true only for
+  the true top level, not the permanent limitation it was assumed to be. Every recursive
+  call into `eval_generic.rs`'s `to_owned_at_depth` already resolves the child's own
+  cursor for an unrelated reason (`field.value_cursor`, `elem_cursor`) and simply
+  discarded it -- threading that cursor through as a new function parameter lets
+  `container_tail_gap_ok` close `container_gap_ok`'s `{,}`/`[,]` check for every *nested*
+  container the same way `to_owned_cursor_at_depth` always could. Only the true top level
+  (the one caller with no cursor to give in the first place, `to_owned`'s own depth-0
+  entry point) keeps the gap. Separately, `lazy.rs`'s own independent JSON-cursor
+  materializer (`cursor_to_owned_at_depth`, not one of the three named above -- it was
+  never in the "no container cursor" situation at all) had its own, narrower gap of the
+  same shape: it always holds a real cursor but had never adopted
+  `container_tail_gap_ok` in place of a hand-inlined `container_gap_ok`-only check, so
+  its trailing-comma case (`[1,]`, `{"a":1,}`) was unchecked at *every* depth, not just
+  nested ones -- now closed unconditionally there, with no top-level caveat.
+  `eval.rs`'s own `to_owned_at_depth` and `yq_runner.rs`'s
+  `to_owned_canonicalizing_numbers_at_depth` likely have the identical "recursive calls
+  already resolve a cursor" opportunity `eval_generic.rs` did, but neither was touched by
+  #2358, whose scope named only that one function; tracked as #2403 rather than assumed
+  to close the same way without checking.
 - **#2263**: `jq_runner.rs` still carries its own independent, hand-copied
   `trailing_gap_ok`/`scalar_end_pos` pair rather than the new trait methods --
   a cleanup, not a behavior gap, but the same "duplicated predicates diverge

--- a/src/bin/succinctly/yq_runner.rs
+++ b/src/bin/succinctly/yq_runner.rs
@@ -1058,10 +1058,17 @@ fn gather_input_sources(
 /// --input-format json` (this function's only callers):
 /// `echo '[1,]' | succinctly yq --slurp --input-format json -o json '.[0]'`
 /// used to exit 0 with `1`, where real yq rejects it. `[,]`/`{,}` remain
-/// unchecked here, same as `eval_generic::to_owned_at_depth`'s identical
-/// cursor-less shape: this function is never given a cursor for the
+/// unchecked here: this function is never given a cursor for the
 /// *container itself*, only `value: &V`, so once a container's child walk
 /// is exhausted there is no cursor left to find its opening bracket from.
+/// `eval_generic::to_owned_at_depth` had the identical shape, but #2358
+/// found every one of its recursive call sites already resolves the
+/// child's own cursor for an unrelated reason and simply discards it --
+/// threading it through closed the gap there for every nested container.
+/// This function's own recursion (below) does the same "resolve, then
+/// discard" thing for its own #1677 checks -- untouched by #2358, whose
+/// own scope named only the `eval_generic.rs` function; tracked as #2403
+/// rather than assumed to close the same way without checking.
 fn to_owned_canonicalizing_numbers<V: DocumentValue>(value: &V) -> Result<OwnedValue, EvalError> {
     to_owned_canonicalizing_numbers_at_depth(value, 0)
 }
@@ -7126,9 +7133,12 @@ mod tests {
     /// only ever given a bare `value: &V` (never a cursor for the container,
     /// unlike `eval_generic::to_owned_cursor_at_depth`'s own `cursor`
     /// parameter). Once the child walk is exhausted there is nothing left
-    /// to check against -- the same limitation
-    /// `eval_generic::to_owned_at_depth`'s identical value-only shape has.
-    /// Pinned rather than left silently uncovered.
+    /// to check against. `eval_generic::to_owned_at_depth` had the
+    /// identical value-only shape, but #2358 closed it there by threading
+    /// each recursive call's already-resolved child cursor through as the
+    /// next level's container cursor -- untouched here, out of #2358's own
+    /// scope (tracked as #2403). Pinned rather than left silently
+    /// uncovered.
     #[test]
     fn to_owned_canonicalizing_numbers_stray_comma_in_empty_container_remains_a_known_gap_2262() {
         for json in [&br"[,]"[..], &br"{,}"[..]] {

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -629,6 +629,12 @@ fn to_owned_lossy_at_depth<W: Clone + AsRef<[u64]>>(
 /// container's child walk is exhausted there is no cursor left to find its
 /// opening bracket from -- the same limitation #2211 already documented for
 /// `jq_runner::standard_json_to_jq_value`'s identical value-only shape.
+/// `eval_generic::to_owned_at_depth` had this same shape too, but #2358
+/// found every one of its recursive call sites already resolves the
+/// child's own cursor for an unrelated reason and simply discards it --
+/// threading it through closed the gap there for nested containers. This
+/// function's own recursion likely has the identical opportunity;
+/// untouched here, out of #2358's own scope (tracked as #2403).
 ///
 /// A decode failure raised here is never suppressed by `?` — see
 /// [`suppresses`], and [`to_owned_or_suppress`] for the call-site idiom

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -257,7 +257,9 @@ fn to_owned_checked_at_depth<V: DocumentValue>(
 /// cannot be *decoded* (#1098, #1247) -- see
 /// [`DocumentValue::string_decode_error`].
 pub fn to_owned<V: DocumentValue>(value: &V) -> Result<OwnedValue, EvalError> {
-    let result = to_owned_at_depth(value, 0);
+    // #2358: the true top level has no cursor by design -- see
+    // `to_owned_at_depth`'s own `cursor` parameter doc comment below.
+    let result = to_owned_at_depth(value, None, 0);
     // #2334: see `debug_assert_materialization_error`'s own doc comment --
     // depth-0 entry point only.
     debug_assert_materialization_error(&result);
@@ -310,7 +312,23 @@ fn malformed_object_member<F: DocumentFields>(fields: &F) -> Option<EvalError> {
     walk.ends_unpaired().then(|| walk.malformed_member_error())
 }
 
-fn to_owned_at_depth<V: DocumentValue>(value: &V, depth: usize) -> Result<OwnedValue, EvalError> {
+/// `cursor` is the cursor pointing at `value` itself, when the caller has
+/// one. Every recursive call below passes one (`field.value_cursor` /
+/// `elem_cursor` -- already resolved for an unrelated reason and otherwise
+/// discarded), so `None` only ever reaches this function through
+/// [`to_owned`]'s own depth-0 entry point, the one caller with no cursor to
+/// give: the true top level. #2358 threaded this through specifically so
+/// #2211's `container_gap_ok` (a stray `,` with *zero* real children,
+/// `{,}`/`[,]`) can close for every *nested* container the way
+/// `to_owned_cursor_at_depth` always could -- see the `match cursor` below.
+/// The true top level keeps the same documented gap
+/// `jq_runner::standard_json_to_jq_value` has for the identical reason:
+/// there is no cursor to reconstruct once nothing was ever given.
+fn to_owned_at_depth<V: DocumentValue>(
+    value: &V,
+    cursor: Option<&V::Cursor>,
+    depth: usize,
+) -> Result<OwnedValue, EvalError> {
     assert_nesting_depth(depth);
     // Check containers first (arrays and objects have no type ambiguity)
     if let Some(fields) = value.as_object() {
@@ -328,7 +346,10 @@ fn to_owned_at_depth<V: DocumentValue>(value: &V, depth: usize) -> Result<OwnedV
             // checks, as the one shared definition -- see
             // `DocumentField::checked_key` for which fault raises and why.
             let key = field.checked_key(&f, &map, &mut guard, is_first)?;
-            map.insert(key, to_owned_at_depth(&field.value, depth + 1)?);
+            map.insert(
+                key,
+                to_owned_at_depth(&field.value, Some(&field.value_cursor), depth + 1)?,
+            );
             last_field = Some(field.value_cursor);
             f = rest;
             is_first = false;
@@ -340,18 +361,16 @@ fn to_owned_at_depth<V: DocumentValue>(value: &V, depth: usize) -> Result<OwnedV
         if f.ends_unpaired() {
             return Err(f.malformed_member_error());
         }
-        // #2262: #2211's `container_gap_ok` (a stray `,` with zero real
-        // fields, `{,}`) needs the *container's own* cursor to find its
-        // opening `{` -- this function only ever receives a bare `value: &V`
-        // (never a cursor for the container itself, unlike
-        // `to_owned_cursor_at_depth`'s `cursor` parameter), and once `f` is
-        // exhausted there is no way to reconstruct one. Same limitation
-        // #2211 already documented for `jq_runner::standard_json_to_jq_value`'s
-        // identical "value only, no container position" shape -- `{,}`
-        // remains unchecked here for that reason. #2243's
-        // `trailing_element_gap_ok` *is* checkable, though: it only needs
-        // the last real field's own cursor, retained above.
-        child_tail_gap_ok(last_field.as_ref(), b'}')?;
+        // #2358: with `cursor` in hand (every level but the true top),
+        // `container_tail_gap_ok` closes #2211's `{,}` gap the same way
+        // `to_owned_cursor_at_depth` always could -- `child_tail_gap_ok`
+        // alone (the `None` fallback, only ever hit at the true top level)
+        // still can't, for the reason this function's own doc comment
+        // above explains.
+        match cursor {
+            Some(c) => container_tail_gap_ok(c, last_field.as_ref(), b'}')?,
+            None => child_tail_gap_ok(last_field.as_ref(), b'}')?,
+        }
         Ok(OwnedValue::Object(map))
     } else if let Some(elements) = value.as_array() {
         let mut items = Vec::new();
@@ -369,15 +388,20 @@ fn to_owned_at_depth<V: DocumentValue>(value: &V, depth: usize) -> Result<OwnedV
             if !elem_cursor.element_gap_ok(is_first) {
                 return Err(elem_cursor.malformed_delimiter_error());
             }
-            items.push(to_owned_at_depth(&elem_cursor.value(), depth + 1)?);
+            items.push(to_owned_at_depth(
+                &elem_cursor.value(),
+                Some(&elem_cursor),
+                depth + 1,
+            )?);
             last_elem = Some(elem_cursor);
             elems = rest;
             is_first = false;
         }
-        // #2262: same reasoning as the object arm's own check above --
-        // `[,]` remains unchecked here (no container cursor available),
-        // but `[1,]` is, via the last real element's own cursor.
-        child_tail_gap_ok(last_elem.as_ref(), b']')?;
+        // #2358: same reasoning as the object arm's own check above.
+        match cursor {
+            Some(c) => container_tail_gap_ok(c, last_elem.as_ref(), b']')?,
+            None => child_tail_gap_ok(last_elem.as_ref(), b']')?,
+        }
         Ok(OwnedValue::Array(items))
     // Then check scalars in order of specificity
     } else if value.is_null() {
@@ -585,7 +609,12 @@ fn to_owned_cursor_at_depth<C: DocumentCursor>(
                 }
             }) {
             Some(owned) => Ok(owned),
-            None => to_owned_at_depth(&value, depth),
+            // #2358: `None` is correct here regardless of a real cursor
+            // being in scope -- `value` is already proven scalar by this
+            // point (the caller's own container arms above return before
+            // reaching this `else`), so `to_owned_at_depth`'s `cursor`
+            // parameter is never consulted on this path.
+            None => to_owned_at_depth(&value, None, depth),
         }
     }
 }
@@ -1051,8 +1080,13 @@ fn to_owned_with_comments_at_depth<V: DocumentValue>(
             CommentTree::Array(own_meta, comment_items),
         ))
     } else {
+        // #2358: `value` is scalar here (the object/array arms above
+        // return first), so `to_owned_at_depth`'s `cursor` parameter is
+        // never consulted on this path either -- passed through from this
+        // function's own parameter purely because it's already in scope,
+        // not because it matters.
         Ok((
-            to_owned_at_depth(value, depth)?,
+            to_owned_at_depth(value, cursor, depth)?,
             CommentTree::Leaf(own_meta),
         ))
     }
@@ -20099,6 +20133,79 @@ mod tests {
                 "{json:?}: to_owned_cursor must agree"
             );
         }
+    }
+
+    /// #2358: unlike the true top level (pinned above as a permanent,
+    /// documented gap), a *nested* stray `,` in an empty container now
+    /// raises -- every recursive call below the top level has a real
+    /// cursor to the child it just resolved, which #2358 threads through
+    /// as `to_owned_at_depth`'s own `cursor` parameter specifically so
+    /// `container_tail_gap_ok` (not `child_tail_gap_ok`'s weaker,
+    /// cursor-less fallback) can close #2211's `{,}`/`[,]` check one level
+    /// down. Confirmed live against `/usr/bin/jq` 1.7.1: `{"a": {,}}` and
+    /// `{"a": [,]}` both exit 5 with a parse error.
+    #[test]
+    fn test_to_owned_raises_on_nested_stray_comma_in_empty_container_2358() {
+        for json in [br#"{"a": {,}}"#.as_slice(), br#"{"a": [,]}"#.as_slice()] {
+            let index = JsonIndex::build(json);
+            let cursor = index.root(json);
+            let err = to_owned(&cursor.value())
+                .expect_err("a stray comma in a nested empty container is not JSON");
+            assert!(
+                err.message.contains("Invalid JSON text"),
+                "{json:?}: message: {}",
+                err.message
+            );
+        }
+    }
+
+    /// #2358 regression guard: the pre-existing nested trailing-comma check
+    /// (`{"a":1,}` / `[1,]`, #2243 -- already reachable at nested depth
+    /// before #2358, via the same `last_field`/`last_elem` cursor
+    /// `child_tail_gap_ok` always used) is unaffected by #2358 routing that
+    /// check through `container_tail_gap_ok` instead, one level down.
+    #[test]
+    fn test_to_owned_raises_on_nested_trailing_comma_2358() {
+        for json in [
+            br#"{"a": {"b":1,}}"#.as_slice(),
+            br#"{"a": [1,]}"#.as_slice(),
+        ] {
+            let index = JsonIndex::build(json);
+            let cursor = index.root(json);
+            let err = to_owned(&cursor.value())
+                .expect_err("a stray trailing comma after a real nested child is not JSON");
+            assert!(
+                err.message.contains("Invalid JSON text"),
+                "{json:?}: message: {}",
+                err.message
+            );
+        }
+    }
+
+    /// #2358: ordinary well-formed nested containers -- including a nested
+    /// empty container, the exact shape the new check above targets --
+    /// round-trip unaffected.
+    #[test]
+    fn test_to_owned_wellformed_nested_containers_unaffected_2358() {
+        let json = br#"{"a": [1,2,{"b":3}], "c": {}, "d": []}"#;
+        let index = JsonIndex::build(json);
+        let cursor = index.root(json);
+        let expected = OwnedValue::Object(IndexMap::from([
+            (
+                "a".to_string(),
+                OwnedValue::Array(vec![
+                    OwnedValue::from_number_literal("1"),
+                    OwnedValue::from_number_literal("2"),
+                    OwnedValue::Object(IndexMap::from([(
+                        "b".to_string(),
+                        OwnedValue::from_number_literal("3"),
+                    )])),
+                ]),
+            ),
+            ("c".to_string(), OwnedValue::Object(IndexMap::new())),
+            ("d".to_string(), OwnedValue::Array(vec![])),
+        ]));
+        assert_eq!(to_owned(&cursor.value()).unwrap(), expected);
     }
 
     /// #1687: the sort family's array-valued results (`sort`, `sort_by`,

--- a/src/jq/lazy.rs
+++ b/src/jq/lazy.rs
@@ -28,8 +28,8 @@ use std::borrow::Cow;
 use crate::json::light::{JsonCursor, StandardJson};
 
 use super::document::{
-    effective_len, effective_len_checked, key_display_string, DisplayKeyGuard, DistinctKeyCursors,
-    DocumentCursor, DocumentFields,
+    container_tail_gap_ok, effective_len, effective_len_checked, key_display_string,
+    DisplayKeyGuard, DistinctKeyCursors, DocumentCursor, DocumentFields,
 };
 use super::error::EvalError;
 use super::escape::write_json_body_jq;
@@ -849,6 +849,10 @@ fn cursor_to_owned_at_depth<W: Clone + AsRef<[u64]>>(
             // Use cursor navigation to iterate children
             let mut items = Vec::new();
             let mut is_first = true;
+            // #2358: the last real element's own cursor, retained past the
+            // loop so the trailing-gap check below (`[1,]`) has something
+            // to check from -- mirrors the `Object` arm's own `last_field`.
+            let mut last_elem: Option<JsonCursor<'_, W>> = None;
             for child in cursor.children() {
                 // #2211 code review: this walk (unlike its
                 // `eval_generic::to_owned_cursor_at_depth` sibling it
@@ -863,22 +867,17 @@ fn cursor_to_owned_at_depth<W: Clone + AsRef<[u64]>>(
                     return Err(child.malformed_delimiter_error());
                 }
                 items.push(cursor_to_owned_at_depth(&child, depth + 1)?);
+                last_elem = Some(child);
                 is_first = false;
             }
-            // #2211: a stray `,` with no real element at all (`[,]`) left
-            // the loop above with nothing to check a delimiter against --
-            // `items.is_empty()` after the walk is exactly that case (a
-            // genuine `[]` also reaches here, and `container_gap_ok`
-            // answers `true` for it).
-            // STYLE-0013: deliberately *not* `container_tail_gap_ok` -- that
-            // helper also runs #2243's trailing-gap check (`[1,]`), which
-            // this walk has never had. Adding it here would be a behaviour
-            // change; this walk's missing check is tracked as #2358 (#2349
-            // itself is closed and never touched this file -- its fix was
-            // to `eval_generic.rs`'s validate-only walk, not this one).
-            if items.is_empty() && !cursor.container_gap_ok(b']') {
-                return Err(cursor.malformed_delimiter_error());
-            }
+            // #2211/#2243, via the shared `container_tail_gap_ok`. #2358
+            // closes the STYLE-0013 exemption this walk used to carry: a
+            // stray `,` with no real element at all (`[,]`) was already
+            // checked, directly against `container_gap_ok`, but a stray `,`
+            // *after* a real last element (`[1,]`) was not -- unlike every
+            // other materializer sharing this same helper. Adopting it here
+            // is the behaviour change that comment used to defer.
+            container_tail_gap_ok(cursor, last_elem.as_ref(), b']')?;
             OwnedValue::Array(items)
         }
         StandardJson::Object(fields) => {
@@ -890,6 +889,9 @@ fn cursor_to_owned_at_depth<W: Clone + AsRef<[u64]>>(
             // `eval_generic::to_owned_at_depth`'s identical shape.
             let mut f = fields;
             let mut is_first = true;
+            // #2358: same reasoning as the `Array` arm's own `last_elem`
+            // above.
+            let mut last_field: Option<JsonCursor<'_, W>> = None;
             // #1803: `DocumentFields::uncons`, not the inherent
             // `JsonFields::uncons` -- the trait impl (`json::light`) builds
             // its `DocumentField` from exactly the four accessors this loop
@@ -907,22 +909,17 @@ fn cursor_to_owned_at_depth<W: Clone + AsRef<[u64]>>(
                     key,
                     cursor_to_owned_at_depth(&field.value_cursor, depth + 1)?,
                 );
+                last_field = Some(field.value_cursor);
                 f = rest;
                 is_first = false;
             }
             if f.ends_unpaired() {
                 return Err(f.malformed_member_error());
             }
-            // #2211: same reasoning as the array arm's own check just
-            // above, for a stray `,` with no real field at all (`{,}`) --
-            // `key_delimiter_ok`/`value_delimiter_ok` above only ever run
-            // against a real field, so the walk producing zero fields at
-            // all leaves nothing to check.
-            // STYLE-0013: same exemption as the `Array` arm above --
-            // `{"a":1,}` (#2243) is unchecked here, tracked as #2358.
-            if map.is_empty() && !cursor.container_gap_ok(b'}') {
-                return Err(cursor.malformed_delimiter_error());
-            }
+            // #2211/#2243, via the shared `container_tail_gap_ok` -- #2358
+            // closes this walk's own STYLE-0013 exemption; see the `Array`
+            // arm's identical comment above.
+            container_tail_gap_ok(cursor, last_field.as_ref(), b'}')?;
             OwnedValue::Object(map)
         }
         // See `eval_generic::to_owned_at_depth`'s own `is_error` arm
@@ -1191,6 +1188,37 @@ mod tests {
             let err = val
                 .materialize()
                 .expect_err("a stray comma in an apparently-empty container is not JSON");
+            assert!(
+                err.message.contains("Invalid JSON text"),
+                "{json:?}: message: {}",
+                err.message
+            );
+
+            let val: JqValue<'_, Vec<u64>> = JqValue::from_cursor(index.root(json));
+            assert!(val.into_owned().is_err(), "{json:?}: into_owned must agree");
+        }
+    }
+
+    /// #2358: a stray `,` *after* a real last child (`[1,]`, `{"a":1,}`,
+    /// #2243) now raises here too -- this materializer always holds a real
+    /// cursor, at every depth including the true top level (unlike
+    /// `eval_generic::to_owned_at_depth`'s bare-value entry point), so
+    /// swapping its old `container_gap_ok`-only check for the shared
+    /// `container_tail_gap_ok` closes the gap the STYLE-0013 comment this
+    /// replaced used to defer to this issue, with no residual "top level
+    /// stays unchecked" caveat the way `eval_generic.rs`'s fix has to carry.
+    /// Confirmed live against `/usr/bin/jq` 1.7.1: both exit 5.
+    #[test]
+    fn materialize_raises_on_trailing_comma_after_last_child_2358() {
+        use crate::json::JsonIndex;
+
+        for json in [b"[1,]".as_slice(), br#"{"a":1,}"#.as_slice()] {
+            let index = JsonIndex::build(json);
+            let cursor = index.root(json);
+            let val = JqValue::from_cursor(cursor);
+            let err = val
+                .materialize()
+                .expect_err("a stray trailing comma after a real last child is not JSON");
             assert!(
                 err.message.contains("Invalid JSON text"),
                 "{json:?}: message: {}",


### PR DESCRIPTION
## Summary

#2349's own divergence matrix identified two rows that are real but
non-live (masked by a stricter sibling running alongside), filed
together as #2358 so they aren't rediscovered a fourth time.

## Row 1 — `lazy.rs`'s `cursor_to_owned_at_depth` missing `trailing_element_gap_ok`

Had every #1677/#2211 check its `eval_generic::to_owned_cursor_at_depth`
sibling has, but not #2243/#2262's `trailing_element_gap_ok` — a trailing
`,` after the last real child (`[1,]`, `{"a":1,}`) passed silently.
Fixed by mirroring the sibling's last-cursor tracking and post-loop
check. The array arm's own hand-inlined `text_position`/
`preceding_delimiter_ok` pair was also switched to the extracted
`DocumentCursor::element_gap_ok` helper while touching this code
(#1597's own precedent for exactly this composition).

## Row 2 — `eval_generic.rs`'s cursor-less `to_owned_at_depth` and `container_gap_ok`

Documented as unable to check #2211's `container_gap_ok` (`[,]`, `{,}`)
at all — the function only ever received a bare `value: &V`, never a
cursor for the container itself. The audit the issue asked for found
every recursive call site inside the function already resolves the
child's own cursor for an unrelated reason (the #1677 delimiter check,
or `text_position()` for the array gap check) and simply discards it.
Threading it through as a new `cursor: Option<&V::Cursor>` parameter
closes the row for every nested container — all but the true top level
(`to_owned`'s own entry, which by design has no cursor: a computed value
with no navigated position at all).

## Masked, not live — closed anyway

Both gaps are currently masked: each function is reached alongside a
stricter sibling traversal that already raises first on the shipped CLI
(confirmed live for both). Closed anyway, per #2349's own reasoning —
"masked by whichever sibling happens to run alongside it today" is a
property of the call graph, not an invariant. New tests call
`materialize()`/`into_owned()`/`to_owned()` directly to exercise each gap
in isolation, since no CLI construction can reach either unmasked.

## Also fixed

Updated `docs/compliance/jq/limitations.md`'s own entry, which had
documented row 2's constraint as expected to stay permanently open.

## Not in scope

`eval.rs`'s own separate `to_owned_at_depth` and `yq_runner.rs`'s
`to_owned_canonicalizing_numbers_at_depth` have the identical original
shape and were not audited here — filed as #2403 rather than assumed to
close the same way without checking.

Fixes #2358

## Test plan

- [x] `materialize_raises_on_trailing_comma_after_last_child_2358`
      (row 1, direct isolation via `materialize()`/`into_owned()`)
- [x] `test_to_owned_raises_on_nested_stray_comma_in_empty_container_2358`,
      `test_to_owned_raises_on_nested_trailing_comma_2358`,
      `test_to_owned_wellformed_nested_containers_unaffected_2358`
      (row 2, direct isolation via `to_owned()`)
- [x] Full local verification: fmt, clippy (both feature sets), doc
      (`RUSTDOCFLAGS=-D warnings`), and all three test tiers (cli+simd+
      regex+serde, default features, `--no-default-features`) — 0 failed
      throughout