### PR TITLE
fix(jq): resolve_slice_bound keeps its already-converted prefix (#2385)

### DIFF
--- a/docs/compliance/yq/limitations.md
+++ b/docs/compliance/yq/limitations.md
@@ -2161,6 +2161,29 @@ would be wrong (not just incomplete) or risks a worse regression:
   null, null, []]`). Tracked as
   [#2376](https://github.com/rust-works/succinctly/issues/2376).
 
+### A computed comma-bound slice's own prefix is never streamed in yq mode
+
+`.[(K1,K2,...):E]`/`.[S:(K1,K2,...)]` — a slice bound written as a parenthesized comma
+generator, computed rather than a single literal or expression — streams each
+already-produced bound's own slice result before a later bound's error/break/halt/type
+failure in jq mode (jq's own `S as $s | T as $t | E | .[$s:$t]` desugaring), confirmed
+against jq 1.7.1: `path(.[(0,1,"x"):(2,3)])` on `[10,20,30]` prints all four
+`{start,end}` combinations of the two valid `start` values before raising on `"x"`.
+
+yq mode conservatively discards this prefix at every one of the three sites that
+resolve a computed bound (`eval_slice_bound`, `eval_slice_bound_with_path_context`,
+`resolve_slice_bound` — the read, path-context-read, and `=`/`|=`/`del()`/`path()`
+write-path resolvers respectively, #2372/#2385) instead of streaming it — real yq has
+no clean model for a computed comma-bound at all, confirmed live against yq v4.53.3:
+`.[(0,"x"):3]` on `[10,20,30]` rejects the bound outright ("expected to find 1 number,
+got 2 instead"), not the type-error message succinctly's own comma-bound generator
+model produces. Since real yq's own behavior for this input shape is "reject the query
+before evaluation," not "stream then error," there is no oracle output to match by
+streaming a prefix here — the conservative discard is the closer approximation of "no
+usable output" a real yq user would see, even though the specific error message
+differs (succinctly raises succinctly's own generator-model error; real yq raises its
+own parse-time rejection).
+
 ### Other categories
 
 Float and number formatting ([#1071](https://github.com/rust-works/succinctly/issues/1071),

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -26485,25 +26485,32 @@ type ResolvedSliceBound = (Option<i64>, Option<NumberKey>);
 /// discard-prefix `eval_owned_multi`, mirroring `resolve_index_expr`'s
 /// `key`/`key_escape` split for its own (single) generator argument.
 ///
-/// **Residual, found in #1517's own review, not fixed here.** A
-/// resolved-but-non-numeric bound (e.g. `"x"` in `.[(0,1,"x"):(2,3)]`) is a
-/// genuinely different failure from a generator's own error/break/halt (a
-/// type error on a value the generator already committed to, not an escape
-/// mid-stream) -- but the `.collect::<Result<Vec<_>, _>>()?` below still
-/// discards the *whole* converted prefix on the first such value, including
-/// any that resolved cleanly before it, the same shape of bug #1517 fixes
-/// for a genuine escape. Confirmed against jq 1.7.1: `path(.[(0,1,"x"):(2,3)])`
+/// #2385: a resolved-but-non-numeric bound (e.g. `"x"` in
+/// `.[(0,1,"x"):(2,3)]`) is a genuinely different failure from a
+/// generator's own error/break/halt (a type error on a value the generator
+/// already committed to, not an escape mid-stream) -- the
+/// `.collect::<Result<Vec<_>, _>>()?` this used to end with discarded the
+/// *whole* converted prefix on the first such value, including any that
+/// resolved cleanly before it, the same shape of bug #1517 fixes for a
+/// genuine escape. Fixed the same way #2372 fixed the identical gap in
+/// `eval_slice_bound`/`eval_slice_bound_with_path_context`: convert one
+/// value at a time, and on the first failure, return the successfully-
+/// converted prefix paired with the new error instead of a bare `Err` --
+/// the caller's own `starts`/`ends` (`Vec<ResolvedSliceBound>`) plus
+/// `starts_escape`/`ends_escape` deferred-escape threading already handles
+/// this shape with no changes needed there, same as #2372's own callers.
+/// A conversion failure unconditionally outranks any later-pending
+/// generator escape -- it only ever touches a value already produced,
+/// strictly before whatever triggered the pending escape in true generator
+/// order (#2372's own rationale, re-verified here: `path(.[(0,1,"x"):(2,3)])`
 /// on `[10,20,30]` prints `[{"start":0,"end":2}]`, `[{"start":0,"end":3}]`,
-/// `[{"start":1,"end":2}]`, `[{"start":1,"end":3}]` before raising
-/// `Array/string slice indices must be integers`; this function answers
-/// with none of the four. Not a regression -- confirmed present (with a
-/// *different*, wrong error message) before this fix too, since the old
-/// discard-prefix `eval_owned_multi` already threw the whole prefix away on
-/// any escape, generator or type, before this distinction was even
-/// visible. Left as a known gap rather than folded into this PR: giving a
-/// type failure the same keep-partial treatment as a generator escape needs
-/// its own priority-ordering pass against `target_escape`/`bounds_escape`
-/// above, re-verified against jq the same way, not a quick addition here.
+/// `[{"start":1,"end":2}]`, `[{"start":1,"end":3}]` before raising "Array/
+/// string slice indices must be integers"; adding a trailing `halt` to the
+/// start-bound generator, `.[(0,1,"x",halt):(2,3)]`, produces the identical
+/// four pairs and the identical error -- `halt` is never reached). yq mode
+/// keeps the pre-existing conservative discard (mirrors the generator-
+/// escape gate immediately below): real yq has no clean model for a
+/// computed comma-bound at all, per #2372's own live-verified finding.
 ///
 /// #2351 review (Gap 1): jq-only, matching `eval_slice_bound`'s own gate.
 /// `eval_owned_multi_keep_partial` itself can't carry this gate -- it's a
@@ -26531,14 +26538,14 @@ fn resolve_slice_bound<S: EvalSemantics>(
     if S::TAG == EvalTag::Yq && escape.is_some() {
         values = Vec::new();
     }
-    let resolved = values
-        .iter()
-        .map(|v| {
-            owned_bound_to_i64(v, round)
-                .map(|i| (i, numeric_slice_bound_key(v)))
-                .map_err(EvalEscape::from)
-        })
-        .collect::<Result<Vec<_>, _>>()?;
+    let mut resolved = vec_with_capacity(values.len());
+    for v in &values {
+        match owned_bound_to_i64(v, round) {
+            Ok(i) => resolved.push((i, numeric_slice_bound_key(v))),
+            Err(e) if S::TAG == EvalTag::Yq => return Err(EvalEscape::from(e)),
+            Err(e) => return Ok((resolved, Some(EvalEscape::from(e)))),
+        }
+    }
     Ok((resolved, escape))
 }
 

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -26522,10 +26522,10 @@ type ResolvedSliceBound = (Option<i64>, Option<NumberKey>);
 /// prints only `Error: x`, no `{"start":...}` prefix reaching the caller
 /// (the same `resolve_dynamic_indexes` codepath `=`/`path()` also drive).
 /// Discarding the prefix here also means `owned_bound_to_i64` below never
-/// runs on it in yq mode, which incidentally sidesteps the unrelated
-/// non-numeric-bound bug this doc comment's own "Residual" paragraph
-/// describes -- not a fix for that bug, just an accident of evaluation
-/// order once the prefix is gone.
+/// runs on it in yq mode, so a non-numeric bound alongside a pending
+/// generator escape never reaches the `#2385` conversion-failure gate
+/// above at all in yq mode -- not because that gate excludes it, just
+/// because there's nothing left to convert by the time it would run.
 fn resolve_slice_bound<S: EvalSemantics>(
     bound: &Option<Box<Expr>>,
     value: &OwnedValue,
@@ -54763,17 +54763,18 @@ mod tests {
     /// #2351 review: a resolved-but-non-numeric bound value combined with
     /// an escape (`.[(0,"x",error("y")):3]`) in yq mode. Live-verified
     /// against yq v4.53.3: prints only `Error: y` (no output, no type
-    /// error about "x"). This pins the accidental interaction the new gate
-    /// has with the pre-existing, unrelated `owned_bound_to_i64` bug
-    /// documented on `eval_slice_bound`'s own `#2351 review` comment above
-    /// (and `resolve_slice_bound`'s "Residual" paragraph): with the prefix
-    /// discarded before conversion ever runs on it in yq mode, `"x"` never
-    /// reaches `owned_bound_to_i64` at all, so `error("y")` -- the bound
-    /// generator's own escape -- is what surfaces, matching real yq exactly.
-    /// jq mode still has the underlying bug live (undisturbed by this PR):
-    /// jq 1.7.1 itself prints `[10,20,30]` before its own type error, where
-    /// succinctly's jq mode currently prints nothing -- a separate,
-    /// pre-existing gap, not asserted here.
+    /// error about "x"). This pins the accidental interaction the
+    /// generator-escape gate has with the (now-fixed, #2372)
+    /// `owned_bound_to_i64` conversion step: with the prefix discarded
+    /// before conversion ever runs on it in yq mode, `"x"` never reaches
+    /// `owned_bound_to_i64` at all, so `error("y")` -- the bound
+    /// generator's own escape -- is what surfaces, matching real yq
+    /// exactly. jq mode is unaffected by this yq-only gate either way, and
+    /// (as of #2372) no longer has an underlying conversion-prefix bug to
+    /// sidestep: `echo '[10,20,30]' | succinctly jq -c
+    /// '.[(0,"x",error("y")):3]'` now prints `[10,20,30]` before its own
+    /// type error, matching jq 1.7.1 exactly (this test doesn't assert
+    /// that -- see `eval_slice_bound`'s own `#2372` tests for it).
     #[test]
     fn test_slice_bound_non_numeric_prefix_value_sidesteps_conversion_bug_in_yq_mode_2351_review() {
         yq_query!(b"[10,20,30]", r#".[(0,"x",error("y")):3]"#,

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -14509,24 +14509,63 @@ fn test_first_limit_path_truncation_does_not_overreach_slice_bound_fanout_1517()
     Ok(())
 }
 
-/// #1517 review's own known-gap residual, documented on `resolve_slice_bound`
-/// itself: a resolved-but-non-numeric bound value still discards the whole
-/// converted prefix, including values that resolved cleanly before it --
-/// the same shape of bug #1517 fixes for a genuine generator escape, just
-/// not extended to a type failure in this PR. Not a regression: confirmed
-/// present (with a *different*, wrong error message -- `b` instead of the
-/// correct type-error text) before this fix too. Pinning today's honest,
-/// still-imperfect output rather than asserting nothing here, so a future
-/// fix's diff shows exactly what changes.
+/// #2385: fixes #1517 review's own known-gap residual, previously
+/// documented on `resolve_slice_bound` itself -- a resolved-but-non-numeric
+/// bound value used to discard the whole converted prefix, including
+/// values that resolved cleanly before it, the same shape of bug #1517
+/// fixed for a genuine generator escape. Now matches jq 1.7.1 exactly: all
+/// four combinations of the two valid `start` values (0, 1) against both
+/// `end` values (2, 3) print before raising.
 #[test]
-fn test_resolve_slice_bound_type_error_still_drops_valid_prefix_1517_known_gap() -> Result<()> {
+fn test_resolve_slice_bound_type_error_keeps_valid_prefix_2385() -> Result<()> {
     let (stdout, stderr, code) =
         run_jq_full(&["-c", r#"path(.[(0,1,"x"):(2,3)])"#], Some("[10,20,30]"))?;
     assert_eq!(code, 5, "stdout: {stdout:?} stderr: {stderr:?}");
-    // jq 1.7.1 prints all four combinations of the two valid `start` values
-    // (0, 1) against both `end` values (2, 3) before raising -- this
-    // function currently drops all four instead.
-    assert_eq!(stdout, "");
+    assert_eq!(
+        stdout,
+        "[{\"start\":0,\"end\":2}]\n[{\"start\":0,\"end\":3}]\n[{\"start\":1,\"end\":2}]\n[{\"start\":1,\"end\":3}]\n"
+    );
+    assert!(stderr.contains("must be integers"), "stderr: {stderr:?}");
+
+    Ok(())
+}
+
+/// #2385 sibling: the end bound's own conversion failure (the second
+/// `resolve_slice_bound` call site inside `resolve_slice_expr`). Verified
+/// against jq 1.7.1: `path(.[0:(1,2,"x")])` on `[10,20,30]` prints
+/// `[{"start":0,"end":1}]`, `[{"start":0,"end":2}]` before raising.
+#[test]
+fn test_resolve_slice_bound_end_type_error_keeps_valid_prefix_2385() -> Result<()> {
+    let (stdout, stderr, code) =
+        run_jq_full(&["-c", r#"path(.[0:(1,2,"x")])"#], Some("[10,20,30]"))?;
+    assert_eq!(code, 5, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert_eq!(
+        stdout,
+        "[{\"start\":0,\"end\":1}]\n[{\"start\":0,\"end\":2}]\n"
+    );
+    assert!(stderr.contains("must be integers"), "stderr: {stderr:?}");
+
+    Ok(())
+}
+
+/// #2385: a conversion failure unconditionally outranks a later-pending
+/// generator escape in the start bound's own comma -- it only ever touches
+/// a value already produced, strictly before whatever triggered the
+/// pending escape in true generator order (mirrors #2372's identical
+/// finding for the read-path siblings). Verified against jq 1.7.1: adding
+/// a trailing `halt` to the start-bound generator produces the identical
+/// four pairs and the identical error -- `halt` is never reached.
+#[test]
+fn test_resolve_slice_bound_type_error_outranks_pending_halt_2385() -> Result<()> {
+    let (stdout, stderr, code) = run_jq_full(
+        &["-c", r#"path(.[(0,1,"x",halt):(2,3)])"#],
+        Some("[10,20,30]"),
+    )?;
+    assert_eq!(code, 5, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert_eq!(
+        stdout,
+        "[{\"start\":0,\"end\":2}]\n[{\"start\":0,\"end\":3}]\n[{\"start\":1,\"end\":2}]\n[{\"start\":1,\"end\":3}]\n"
+    );
     assert!(stderr.contains("must be integers"), "stderr: {stderr:?}");
 
     Ok(())

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -29810,6 +29810,24 @@ fn test_resolve_slice_bound_end_own_partial_prefix_discarded_in_yq_mode_2351_rev
     Ok(())
 }
 
+/// #2385: `resolve_slice_bound`'s own new conversion-failure gate keeps
+/// the pre-existing conservative discard in yq mode too, mirroring the
+/// #2351-review generator-escape gate immediately above -- real yq has no
+/// clean model for a computed comma-bound at all (per #2372's own
+/// live-verified finding for the read-path siblings), so there's no oracle
+/// basis for streaming a prefix here. `del(.[(0,1,"x"):3])` (no `error(...)`
+/// at all -- this is a resolved-but-non-numeric bound, not a generator
+/// escape) on `[1,2,3]` prints only the conversion error.
+#[test]
+fn test_resolve_slice_bound_type_error_discarded_in_yq_mode_2385() -> Result<()> {
+    let (out, stderr, code) =
+        run_yq_stdin_with_stderr("del(.[(0,1,\"x\"):3])", "[1, 2, 3]\n", &["-o", "json"])?;
+    assert_eq!(code, 1, "out: {out:?} stderr: {stderr:?}");
+    assert_eq!(out, "");
+    assert!(stderr.contains("must be integers"), "stderr: {stderr:?}");
+    Ok(())
+}
+
 /// #2351 review (Gap 2): `eval_slice_bound_with_path_context` (the
 /// `key`/`parent`/`path` twin, via `drain_path_context_stream`) had no
 /// yq-mode gate at all. `key` is real, native yq syntax. Verified live


### PR DESCRIPTION
## Summary

`resolve_slice_bound`'s bound-to-integer conversion used a bare `.collect::<Result<Vec<_>, _>>()?`, discarding every already-converted bound on the first non-numeric one — the identical gap #2372 fixed for the read-path siblings (`eval_slice_bound`/`eval_slice_bound_with_path_context`). This one was explicitly left open in #1517's own review as "needs its own priority-ordering pass against `target_escape`/`bounds_escape` ... not a quick addition here."

## Fix

Same shape as #2372: convert one value at a time, and on the first failure, return the successfully-converted prefix paired with the new error instead of a bare `Err`. The caller's own `starts`/`ends` (`Vec<ResolvedSliceBound>`) plus `starts_escape`/`ends_escape` deferred-escape threading already handles this shape — no caller-side changes needed, same as #2372's own callers.

## Priority (re-verified, not assumed)

A conversion failure unconditionally outranks a later-pending generator escape — it only ever touches a value already produced, strictly before whatever triggered the pending escape in true generator order (#2372's own rationale). Re-verified live against jq 1.7.1 for this specific function before implementing, including the `halt` case:

```console
$ echo '[10,20,30]' | jq -c 'path(.[(0,1,"x"):(2,3)])'
jq: error (at <stdin>:1): Array/string slice indices must be integers
[{"start":0,"end":2}]
[{"start":0,"end":3}]
[{"start":1,"end":2}]
[{"start":1,"end":3}]
$ echo '[10,20,30]' | jq -c 'path(.[(0,1,"x",halt):(2,3)])'
# identical output -- halt is never reached
```

yq mode keeps the pre-existing conservative discard (mirrors the generator-escape gate immediately above it in the same function): real yq has no clean model for a computed comma-bound at all.

## Test plan
- [x] Updated the pre-existing `1517_known_gap` test (`tests/jq_cli_tests.rs`) that pinned the old, now-fixed behavior — renamed to `test_resolve_slice_bound_type_error_keeps_valid_prefix_2385`
- [x] `test_resolve_slice_bound_end_type_error_keeps_valid_prefix_2385` — the end bound's own call site
- [x] `test_resolve_slice_bound_type_error_outranks_pending_halt_2385` — the `halt`-priority case
- [x] `test_resolve_slice_bound_type_error_discarded_in_yq_mode_2385` (`tests/yq_cli_tests.rs`) — yq-mode carve-out, via real `del(...)`
- [x] Full `cargo test --features cli --no-fail-fast` (the actual CI-equivalent invocation, not just default features) — all green
- [x] `cargo test --no-fail-fast` (default features) — all green
- [x] `cargo test --no-default-features` (no_std) — all green
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings` — clean
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features` — clean
- [x] `cargo fmt --check` — clean

Fixes #2385