### PR TITLE
jq: one definition for the object/array member validation walk (#1803)

### DIFF
--- a/docs/STYLE_GUIDE.md
+++ b/docs/STYLE_GUIDE.md
@@ -616,9 +616,10 @@ reason -- the same traceability STYLE-0004 requires of a lint suppression and ST
 an unrouted materialization. "It is fine" is not a reason; name what the site needs that the
 helper cannot give, or the issue that tracks closing the gap. The exemptions in the tree
 today are `json::light::stream_json_pretty` (needs the resolved position, hence
-`element_gap_ok_at`), `eval_generic`'s validate-only walk (lazy key map, #2061; missing
-delimiter checks tracked as #2349), `lazy.rs`'s missing trailing-gap check (#2349's family),
-and the comment-preserving walk (YAML-only in production).
+`element_gap_ok_at`), `eval_generic`'s validate-only walk (lazy key map, #2061 -- its
+delimiter checks were the #2349 fix, added directly rather than via this route, for the
+same lazy-key reason), `lazy.rs`'s missing trailing-gap check (#2358), and the
+comment-preserving walk (YAML-only in production).
 
 ### Motivation
 

--- a/docs/STYLE_GUIDE.md
+++ b/docs/STYLE_GUIDE.md
@@ -28,6 +28,7 @@ which tags apply to the changes and search this file for those tags. Each rule h
 | Adding or editing a markdown table                | `documentation`                              |
 | Writing commit messages                           | `commits`                                    |
 | Touching `no_std` boundaries or `std`-gated code  | `module-organization`                        |
+| Walking `DocumentFields` / `DocumentElements`      | `code-style`, `testing`                      |
 | Reviewing code for style compliance               | All tags relevant to the changed code        |
 
 ---
@@ -42,7 +43,7 @@ A new convention needs to be added to this style guide.
 
 ### Guidance
 
-Assign the next sequential ID (currently next is `STYLE-0013`) and include:
+Assign the next sequential ID (currently next is `STYLE-0014`) and include:
 
 1. A **Tags** line immediately after the heading — a comma-separated list of category labels
    from the tag vocabulary below.
@@ -577,3 +578,69 @@ exemption from prose scattered across two 100k-line files into something greppab
 the next sweep does not have to rediscover by eye. The runtime half of the guard is
 `EvalError::debug_assert_materialization_error`, which fails loudly on the day the
 "decode failures only" premise stops holding and the routing starts to matter.
+
+---
+
+## STYLE-0013: object/array member validation in a document walk
+
+**Tags:** `code-style`, `testing`
+
+### Situation
+
+Writing or editing a walk that unconses [`DocumentFields`] or [`DocumentElements`] and
+validates what it finds -- any of the `to_owned*_at_depth` family, the `-e`/lazy
+materializers, `document.rs`'s own key walks, or the CLI's `--input-format json` bridge.
+
+### Guidance
+
+Do not hand-copy the validation. Route through the shared definitions:
+
+```rust
+// The whole member rule: #1642/#1194 key resolution + #1677 delimiters.
+let key = field.checked_key(&f, &map, &mut guard, is_first)?;
+
+// The delimiter half alone, for a walk with no display-key map to guard,
+// or one that must not allocate a `String` per key (#2061).
+if !field.delimiters_ok::<F>(is_first) { return Err(f.malformed_member_error()); }
+
+// Array elements (#1677); `element_gap_ok_at` when you still need the position.
+if !elem_cursor.element_gap_ok(is_first) { return Err(elem_cursor.malformed_delimiter_error()); }
+
+// The post-loop tail: `{,}`/`[,]` (#2211) and `{"a":1,}`/`[1,]` (#2243).
+child_tail_gap_ok(last_elem.as_ref(), b']')?;              // no container cursor in hand
+container_tail_gap_ok(cursor, last_elem.as_ref(), b']')?;  // container cursor in hand
+```
+
+A site that genuinely cannot route carries a `// STYLE-0013:` citation with a specific
+reason -- the same traceability STYLE-0004 requires of a lint suppression and STYLE-0012 of
+an unrouted materialization. "It is fine" is not a reason; name what the site needs that the
+helper cannot give, or the issue that tracks closing the gap. The exemptions in the tree
+today are `json::light::stream_json_pretty` (needs the resolved position, hence
+`element_gap_ok_at`), `eval_generic`'s validate-only walk (lazy key map, #2061; missing
+delimiter checks tracked as #2349), `lazy.rs`'s missing trailing-gap check (#2349's family),
+and the comment-preserving walk (YAML-only in production).
+
+### Motivation
+
+This rule exists because the same omission shipped four times. The member rules accumulated
+over #1677, #2211 and #2243/#2262, and **each round added its check to some walks and not
+others** -- #1975 found the CLI bridge with none of them, and #2349 is the wrong-answer bug
+the drift finally produced in `select`/`sort_by`/`path()`.
+
+Extraction alone had already been tried and had already failed to hold:
+[`DocumentCursor::element_gap_ok`] was pulled out by #1597's review for exactly this reason,
+and five sites went on hand-rolling its four lines anyway -- including two written *after*
+it existed. Centralising a check does not stop the omission, because nothing forces a call
+site through it. That is the same finding STYLE-0012 records, and it has the same answer: a
+static audit, plus a greppable marker at each deliberate exemption so the next sweep does
+not have to rediscover it by eye.
+
+Behavioural tests could not close this class either, and not by bad luck. The delimiter
+rules are JSON-only -- every one is a `true`-returning trait default for YAML -- so a walk
+reachable only from YAML shows no difference at all, and a walk whose corrupt subtree is
+merely *validated* rather than emitted shows none either. #1962's cross-site consistency net
+did drive three of the sites, and still missed this: its `FuzzMalformation` alphabet has
+only decode-failure, structural and collision variants, and its generator emits only
+well-formed containers, so it could not express a delimiter or gap corruption at any case
+count (#2350). A static audit does not depend on a corruption being reachable, expressible,
+or observable.

--- a/src/bin/succinctly/jq_runner.rs
+++ b/src/bin/succinctly/jq_runner.rs
@@ -5319,6 +5319,13 @@ fn standard_json_to_jq_value<'a, W: Clone + AsRef<[u64]>>(
     value: StandardJson<'a, W>,
     parent_cursor: &JsonCursor<'a, W>,
 ) -> Result<JqValue<'a, W>, EvalError> {
+    // STYLE-0013: `preceding_gap_ok` directly, not `key_delimiter_ok`/
+    // `value_delimiter_ok` -- this is the CLI-crate lazy materializer, not
+    // `DocumentFields`-generic, and its array/object arms below already
+    // hold the child/key/value cursors' own resolved `text_position()`
+    // rather than an unresolved `DocumentValue`, so routing through the
+    // library-side wrappers would re-derive a position this walk already
+    // has for free.
     Ok(match value {
         StandardJson::Null => JqValue::Null,
         StandardJson::Bool(b) => JqValue::Bool(b),
@@ -5869,6 +5876,12 @@ fn check_preceding_delimiter<W: AsRef<[u64]>>(
     child_cursor: &JsonCursor<'_, W>,
     index: usize,
 ) -> Result<Option<usize>> {
+    // STYLE-0013: `preceding_gap_ok` directly -- this is `print_json`'s
+    // own array-arm helper, returning the resolved position for its
+    // caller to cache and reuse (see this function's own doc comment on
+    // why: a version that re-derived the position instead measured 19-30%
+    // slower, #1643). `key_delimiter_ok`/`value_delimiter_ok` don't return
+    // a position, so adopting either would give that back.
     let Some(start) = child_cursor.text_position() else {
         return Ok(None);
     };
@@ -5917,6 +5930,12 @@ fn validate_json_delimiters<W: AsRef<[u64]>>(
     cursor: &JsonCursor<'_, W>,
     depth: usize,
 ) -> core::result::Result<(), EvalError> {
+    // STYLE-0013: `preceding_gap_ok` directly, in both the array and
+    // object arms below -- this is the CLI's own cold-path validator
+    // (this function's own doc comment above explains why it exists
+    // instead of routing through `print_json`), reusing each child's
+    // already-resolved `text_position()` via `value_at` (see `scalar_end_pos`'s
+    // own doc comment) the same way `check_preceding_delimiter` does.
     check_nesting_depth(depth)?;
     match cursor.value() {
         StandardJson::Array(elements) => {
@@ -6114,6 +6133,14 @@ where
     Out: Write,
     Wrd: Clone + AsRef<[u64]>,
 {
+    // STYLE-0013: the object arm below calls `preceding_gap_ok` directly,
+    // not `key_delimiter_ok`/`value_delimiter_ok` -- this is the streaming
+    // writer's own single-walk validate-then-write pass (#1643), reusing
+    // `k.start()`/`field.value_cursor().text_position()` this same walk
+    // already resolved to build the output rather than a second decode.
+    // Routing through the library-side wrappers only accepts an
+    // already-resolved `DocumentValue`/cursor pair, which is exactly what
+    // this walk is resolving for the first time as it goes.
     anyhow::ensure!(
         level < MAX_VALUE_TREE_DEPTH,
         "{}",

--- a/src/bin/succinctly/yq_runner.rs
+++ b/src/bin/succinctly/yq_runner.rs
@@ -10,9 +10,8 @@ use std::io::{BufWriter, IsTerminal, Read, Write};
 use std::path::Path;
 
 use succinctly::jq::document::{
-    effective_keys, key_delimiter_ok, resolve_display_key, trailing_element_gap_ok,
-    value_delimiter_ok, DisplayKeyGuard, DocumentCursor, DocumentElements, DocumentFields,
-    DocumentValue, IndentSpec, JsonConvention,
+    child_tail_gap_ok, effective_keys, DisplayKeyGuard, DocumentCursor, DocumentElements,
+    DocumentFields, DocumentValue, IndentSpec, JsonConvention,
 };
 use succinctly::jq::escape::AsciiEscapeWriter;
 use succinctly::jq::eval_generic::{
@@ -1113,36 +1112,17 @@ fn to_owned_canonicalizing_numbers_at_depth<V: DocumentValue>(
         // (#2243).
         let mut last_field: Option<V::Cursor> = None;
         while let Some((field, rest)) = f.uncons() {
-            // `resolve_display_key`, not `field.key_str()`: a key that will
-            // not *decode* (#1247/#1385) is preserved via its raw source
-            // span rather than dropped (#1642) -- this loop used to
-            // silently drop such a field under `--slurp`/`--eval-all`/
-            // `--inplace` (the only callers of `parse_input`, hence of this
-            // function), one short of `length`'s real field count. A key
-            // that will not *stringify* at all -- a key JSON's grammar never
-            // allowed (`{123: 1}`) -- is a different, structural fault
-            // (#1194) and now raises instead of silently dropping the whole
-            // field (#1975: this used to be an `if let Some(key) = ... {}`
-            // with no `else`, the exact pattern #1679 already fixed at five
-            // other call sites, but missed here). Two colliding
-            // decode-failure keys now raise instead of silently overwriting
-            // one another (#1642/#1738), matching every other materializer.
-            let Some(key) = resolve_display_key(&field.key, &map, &mut guard)? else {
-                return Err(f.malformed_member_error());
-            };
-            // #1975: this walk was missing the #1677 malformed-`,`/`:`
-            // delimiter check entirely -- unlike its
-            // `eval_generic::to_owned_at_depth` sibling it otherwise
-            // mirrors, which has always had it. This is why
-            // `--input-format json --slurp`/`--eval-all`/`--inplace`
-            // (the only callers of `parse_input`, hence of this
-            // function) silently accepted `{"a" 1, "b": 2}` when every
-            // other route into the evaluator correctly raised.
-            if !key_delimiter_ok::<V::Fields>(&field.key, &field.key_cursor, is_first)
-                || !value_delimiter_ok::<V::Fields>(Some(&field.value), &field.value_cursor)
-            {
-                return Err(f.malformed_member_error());
-            }
+            // #1803: `DocumentField::checked_key` -- the key resolution
+            // (#1642/#1194) and the `,`/`:` delimiter checks (#1677) as one
+            // shared definition, which is exactly what this site needed. It
+            // is the walk that has fallen behind twice: #1975 found it
+            // dropping undecodable keys *and* missing the delimiter checks
+            // its `eval_generic::to_owned_at_depth` sibling had always had,
+            // so `--input-format json --slurp`/`--eval-all`/`--inplace` (the
+            // only callers of `parse_input`, hence of this function)
+            // silently accepted `{"a" 1, "b": 2}` when every other route
+            // into the evaluator correctly raised.
+            let key = field.checked_key(&f, &map, &mut guard, is_first)?;
             map.insert(
                 key,
                 to_owned_canonicalizing_numbers_at_depth(&field.value, depth + 1)?,
@@ -1158,20 +1138,13 @@ fn to_owned_canonicalizing_numbers_at_depth<V: DocumentValue>(
         if f.ends_unpaired() {
             return Err(f.malformed_member_error());
         }
-        // #2262: #2211's `container_gap_ok` (a stray `,` with zero real
-        // fields, `{,}`) needs the *container's own* cursor to find its
-        // opening `{` -- this function only ever receives a bare
-        // `value: &V` (never a cursor for the container itself), and once
-        // `f` is exhausted there is no way to reconstruct one. Same
-        // limitation `eval_generic::to_owned_at_depth`'s identical
-        // value-only shape has -- `{,}` remains unchecked here for that
-        // reason. #2243's `trailing_element_gap_ok` *is* checkable, though:
-        // it only needs the last real field's own cursor, retained above.
-        if let Some(last) = &last_field {
-            if !trailing_element_gap_ok(last, b'}') {
-                return Err(last.malformed_delimiter_error());
-            }
-        }
+        // #2262/#1803: `child_tail_gap_ok` is the value-domain tail --
+        // `{"a":1,}` checked via the last real field's own cursor, `{,}`
+        // left unchecked because #2211's `container_gap_ok` needs a cursor
+        // for the container itself that this signature never receives. Its
+        // doc comment carries the full reasoning, which this site and
+        // `eval_generic::to_owned_at_depth` used to state twice.
+        child_tail_gap_ok(last_field.as_ref(), b'}')?;
         OwnedValue::Object(map)
     } else if let Some(elements) = value.as_array() {
         let mut items = Vec::new();
@@ -1202,11 +1175,7 @@ fn to_owned_canonicalizing_numbers_at_depth<V: DocumentValue>(
         // but `[1,]` is, via the last real element's own cursor. This is
         // the live, CLI-reachable fix: `echo '[1,]' | succinctly yq --slurp
         // --input-format json -o json '.[0]'` used to exit 0 with `1`.
-        if let Some(last) = &last_elem {
-            if !trailing_element_gap_ok(last, b']') {
-                return Err(last.malformed_delimiter_error());
-            }
-        }
+        child_tail_gap_ok(last_elem.as_ref(), b']')?;
         OwnedValue::Array(items)
     } else if value.is_null() {
         OwnedValue::Null

--- a/src/jq/document.rs
+++ b/src/jq/document.rs
@@ -3316,3 +3316,114 @@ mod key_display_string_tests {
         assert!(err.message.contains("Invalid JSON text"), "{err:?}");
     }
 }
+
+/// The receiver equivalence [`container_tail_gap_ok`] relies on when it
+/// delegates its `Some(last_child)` arm to [`child_tail_gap_ok`].
+///
+/// That delegation swaps which cursor the error is raised *from*: the
+/// container's, as the cursor-domain call sites originally wrote it, for the
+/// last child's. It is sound only because `JsonCursor::malformed_delimiter_error`
+/// reports `self.text` -- the whole document slice, identical for every
+/// cursor into it -- and because YAML reaches neither raise at all
+/// (`container_gap_ok`/`trailing_element_gap_ok` are `true`-returning
+/// defaults there).
+///
+/// That is an argument about JSON's error being document-scoped, not a
+/// property of the abstraction, so it is pinned here rather than left in a
+/// doc comment: a format whose `malformed_delimiter_error` named the node
+/// would make the delegation change which node is blamed, silently.
+#[cfg(test)]
+mod tail_gap_receiver_tests {
+    use super::{
+        child_tail_gap_ok, container_tail_gap_ok, DocumentCursor, DocumentFields, DocumentValue,
+    };
+    use crate::json::JsonIndex;
+
+    /// A trailing `,` after a real last field (`{"a":1,}`, #2243) raises the
+    /// same error whichever cursor reports it, so delegating the
+    /// `Some(last_child)` arm is invisible to a caller.
+    #[test]
+    fn container_and_child_receivers_agree_on_a_trailing_comma_1803() {
+        let json: &[u8] = br#"{"a":1,}"#;
+        let index = JsonIndex::build(json);
+        let container = index.root(json);
+        let fields = container.value().as_object().expect("an object");
+        // `DocumentFields::uncons`, not the inherent `JsonFields::uncons`:
+        // only the trait form yields a `DocumentField` with a public
+        // `value_cursor` -- the same distinction #1803's `lazy.rs`/`eval.rs`
+        // call sites turn on.
+        let (field, _) = DocumentFields::uncons(&fields).expect("one field");
+        let last_child = field.value_cursor;
+
+        let via_container = container_tail_gap_ok(&container, Some(&last_child), b'}')
+            .expect_err("a trailing comma must raise");
+        let via_child =
+            child_tail_gap_ok(Some(&last_child), b'}').expect_err("a trailing comma must raise");
+
+        assert_eq!(
+            via_container, via_child,
+            "the delegation in `container_tail_gap_ok` changes the raising cursor, so the two \
+             must produce an identical error"
+        );
+        assert_eq!(
+            via_container,
+            last_child.malformed_delimiter_error(),
+            "and both must be the raise the child's own cursor produces"
+        );
+        assert_eq!(
+            container.malformed_delimiter_error(),
+            last_child.malformed_delimiter_error(),
+            "the premise the delegation rests on: for JSON, `malformed_delimiter_error` reports \
+             the whole document, so the receiver cannot matter"
+        );
+    }
+
+    /// The zero-child arm (`{,}`, #2211) is the one
+    /// [`container_tail_gap_ok`] does *not* delegate -- only the container's
+    /// own cursor can find the opening brace -- so it must still raise, and
+    /// [`child_tail_gap_ok`] must still be blind to it. This is what makes
+    /// the two helpers genuinely different rather than one wrapping the
+    /// other.
+    #[test]
+    fn empty_container_arm_is_not_delegated_1803() {
+        let json: &[u8] = br#"{,}"#;
+        let index = JsonIndex::build(json);
+        let container = index.root(json);
+
+        container_tail_gap_ok(&container, None, b'}')
+            .expect_err("a stray comma with no real field must raise (#2211)");
+        child_tail_gap_ok(
+            None::<&crate::json::light::JsonCursor<'_, alloc::vec::Vec<u64>>>,
+            b'}',
+        )
+        .expect("the value domain has no container cursor, so it cannot see `{,}`");
+    }
+
+    /// A well-formed object raises from neither -- the false-positive guard
+    /// for both helpers.
+    #[test]
+    fn wellformed_object_raises_from_neither_1803() {
+        let json: &[u8] = br#"{"a":1}"#;
+        let index = JsonIndex::build(json);
+        let container = index.root(json);
+        let fields = container.value().as_object().expect("an object");
+        // `DocumentFields::uncons`, not the inherent `JsonFields::uncons`:
+        // only the trait form yields a `DocumentField` with a public
+        // `value_cursor` -- the same distinction #1803's `lazy.rs`/`eval.rs`
+        // call sites turn on.
+        let (field, _) = DocumentFields::uncons(&fields).expect("one field");
+        let last_child = field.value_cursor;
+
+        container_tail_gap_ok(&container, Some(&last_child), b'}').expect("well-formed");
+        child_tail_gap_ok(Some(&last_child), b'}').expect("well-formed");
+
+        // A genuinely empty `{}` -- its own document, not `container` with
+        // `None` passed for a field it actually has. That combination would
+        // (correctly) raise: `container_gap_ok` would find `"a"` in the gap
+        // after the brace, which is what it is for.
+        let empty: &[u8] = br#"{}"#;
+        let empty_index = JsonIndex::build(empty);
+        let empty_root = empty_index.root(empty);
+        container_tail_gap_ok(&empty_root, None, b'}').expect("an empty `{}` is well-formed");
+    }
+}

--- a/src/jq/document.rs
+++ b/src/jq/document.rs
@@ -213,12 +213,28 @@ pub trait DocumentCursor: Sized + Copy + Clone {
     /// extraction).
     fn element_gap_ok(&self, is_first: bool) -> bool {
         match self.text_position() {
-            Some(pos) => {
-                let expected = if is_first { None } else { Some(b',') };
-                self.preceding_delimiter_ok(pos, expected)
-            }
+            Some(pos) => self.element_gap_ok_at(pos, is_first),
             None => true,
         }
+    }
+
+    /// [`element_gap_ok`](Self::element_gap_ok), for a caller that has
+    /// already resolved this cursor's own `text_position()` and still needs
+    /// it afterwards.
+    ///
+    /// `crate::json::light`'s `stream_json_pretty` is the one such caller
+    /// (#1803): it reuses the same `pos` for `value_at(pos)` and
+    /// `scalar_end_pos(pos, ..)` immediately below the check, so routing it
+    /// through `element_gap_ok` -- which resolves the position internally
+    /// and hands back only a `bool` -- would cost a second
+    /// `text_position()` per element, exactly what
+    /// [`preceding_delimiter_ok`](Self::preceding_delimiter_ok)'s own doc
+    /// comment says not to pay. Splitting the check here rather than leaving
+    /// that site with a fifth inline copy keeps the `is_first` ->
+    /// `Option<b','>` mapping at **one** definition, which is the whole
+    /// point of #1597's original extraction and of #1803's follow-through.
+    fn element_gap_ok_at(&self, text_pos: usize, is_first: bool) -> bool {
+        self.preceding_delimiter_ok(text_pos, if is_first { None } else { Some(b',') })
     }
 
     /// The error to raise when [`preceding_delimiter_ok`](Self::preceding_delimiter_ok)
@@ -1182,9 +1198,7 @@ pub trait DocumentFields: Sized + Clone {
             // #1677: this walk already resolved both the key and the value
             // (`uncons` does), so both checks reuse an existing decode
             // rather than deriving a new position.
-            if !key_delimiter_ok::<Self>(&field.key, &field.key_cursor, is_first)
-                || !value_delimiter_ok::<Self>(Some(&field.value), &field.value_cursor)
-            {
+            if !field.delimiters_ok::<Self>(is_first) {
                 return Err(fields.malformed_member_error());
             }
             keys.push(key.into_owned());
@@ -1557,6 +1571,68 @@ pub fn trailing_element_gap_ok<C: DocumentCursor>(last_cursor: &C, close_char: u
             None => true,
         },
         None => true,
+    }
+}
+
+/// The whole post-loop tail check for a container walk that holds only its
+/// children, never a cursor for the container itself -- the value-domain
+/// half of #1803's extraction.
+///
+/// `last_child` is the last real child's own cursor, or `None` when the
+/// walk produced no child at all. Raises on a stray `,` *after* a real last
+/// child (`{"a":1,}` / `[1,]`, #2243/#2262).
+///
+/// # What it deliberately does not check
+///
+/// #2211's [`DocumentCursor::container_gap_ok`] -- a stray `,` with *no*
+/// real child (`{,}` / `[,]`) -- needs the container's own cursor to find
+/// its opening bracket. A caller that only ever receives a bare
+/// `value: &V` never has one, and once the child list is exhausted there is
+/// no way to reconstruct it. That shape stays unchecked on this path; a
+/// caller that *does* hold a container cursor must use
+/// [`container_tail_gap_ok`] instead, which closes it.
+pub fn child_tail_gap_ok<C: DocumentCursor>(
+    last_child: Option<&C>,
+    close_char: u8,
+) -> Result<(), EvalError> {
+    match last_child {
+        Some(last) if !trailing_element_gap_ok(last, close_char) => {
+            Err(last.malformed_delimiter_error())
+        }
+        _ => Ok(()),
+    }
+}
+
+/// The whole post-loop tail check for a container walk that *does* hold the
+/// container's own cursor -- the cursor-domain half of #1803's extraction,
+/// and strictly stronger than [`child_tail_gap_ok`].
+///
+/// Splits on whether the walk produced a real child at all, because the two
+/// cases need different evidence and neither subsumes the other:
+///
+/// - **No child** -- [`DocumentCursor::container_gap_ok`] against the
+///   container, which is the only thing that can tell a genuine `{}`/`[]`
+///   apart from a stray `,` with nothing in it (`{,}` / `[,]`, #2211).
+/// - **At least one child** -- [`trailing_element_gap_ok`] against that last
+///   child, for a stray `,` after it (`{"a":1,}` / `[1,]`, #2243).
+///
+/// Both raise `container.malformed_delimiter_error()`, preserving what the
+/// cursor-domain call sites already did; for JSON that is
+/// `malformed_json_text` over the whole document text, so it reads
+/// identically to the child-receiver form [`child_tail_gap_ok`] uses.
+pub fn container_tail_gap_ok<C: DocumentCursor>(
+    container: &C,
+    last_child: Option<&C>,
+    close_char: u8,
+) -> Result<(), EvalError> {
+    let ok = match last_child {
+        None => container.container_gap_ok(close_char),
+        Some(last) => trailing_element_gap_ok(last, close_char),
+    };
+    if ok {
+        Ok(())
+    } else {
+        Err(container.malformed_delimiter_error())
     }
 }
 
@@ -2057,9 +2133,7 @@ pub fn effective_fields_checked<F: DocumentFields>(
         }
         // #1677: free here too -- `uncons` already resolved both key and
         // value, so both checks reuse an existing decode.
-        if !key_delimiter_ok::<F>(&field.key, &field.key_cursor, is_first)
-            || !value_delimiter_ok::<F>(Some(&field.value), &field.value_cursor)
-        {
+        if !field.delimiters_ok::<F>(is_first) {
             return Err(walk.malformed_member_error());
         }
         last_value_cursor = Some(field.value_cursor);
@@ -2644,6 +2718,93 @@ impl<V: DocumentValue, C: DocumentCursor> DocumentField<V, C> {
     /// complex keys) stringify rather than dropping the entry (issue #222).
     pub fn key_str(&self) -> Option<Cow<'_, str>> {
         self.key.key_string()
+    }
+
+    /// Whether both delimiters around this member are well-formed:
+    /// nothing before the key if it is the object's first, exactly one `,`
+    /// otherwise, and exactly one `:` before the value (#1677).
+    ///
+    /// The `bool` half of [`checked_key`](Self::checked_key), split out for
+    /// the walks that cannot take the whole of it (#1803):
+    ///
+    /// - [`DocumentFields::keys`] and `effective_fields_checked` resolve
+    ///   their keys with [`key_display_string`]/[`key_is_malformed`] and
+    ///   hold no `IndexMap` for the #1642 collision guard to check against.
+    /// - `eval_generic`'s validate-only walk (a private function, not
+    ///   linkable here) builds its #1642 collision map *lazily*, from the
+    ///   first undecodable key onward: eagerly resolving a display `String`
+    ///   per key is what made `path(.[0])` over a 1,000,000-object array
+    ///   cost 577 ms against 50 ms (#2061). This half allocates nothing, so
+    ///   that walk can adopt the delimiter rules without the key rules --
+    ///   which is what #2349 needs, and why the split exists.
+    ///
+    /// Free for every caller: a full [`DocumentFields::uncons`] walk has
+    /// already resolved both key and value, so each check reuses an
+    /// existing decode (`text_start`) rather than deriving a position. Every
+    /// check is a no-op for YAML, whose parser validates delimiters as it
+    /// goes, so [`DocumentCursor::preceding_delimiter_ok`]'s `true`-returning
+    /// default stands and the whole conjunction folds away.
+    pub fn delimiters_ok<F>(&self, is_first: bool) -> bool
+    where
+        F: DocumentFields<Value = V, Cursor = C>,
+    {
+        key_delimiter_ok::<F>(&self.key, &self.key_cursor, is_first)
+            && value_delimiter_ok::<F>(Some(&self.value), &self.value_cursor)
+    }
+
+    /// Resolves this member's display key and validates the delimiters
+    /// around it, as the one definition every object walk shares (#1803).
+    ///
+    /// `Ok(key)` is the string to insert; every failure mode raises, and a
+    /// caller has nothing left to decide:
+    ///
+    /// - A key that will not **decode** (#1247/#1385) is preserved via its
+    ///   lossily-decoded raw source span rather than raised on (#1642),
+    ///   matching `length`/`keys_unsorted`/`.`.
+    /// - A key that will not **stringify at all** -- a key JSON's grammar
+    ///   never allowed (`{123: 1}`), which the semi-index accepted because
+    ///   `:` and `,` mean the same nothing to it -- is a different,
+    ///   structural fault and raises (#1194). Dropping the field silently
+    ///   is the disagreement #1385's postmortem names as the thing to avoid.
+    /// - Two colliding decode-failure spellings raise rather than one
+    ///   silently overwriting the other in `map` (#1642's [`DisplayKeyGuard`]).
+    /// - A missing or doubled `,` before the key, or `:` before the value,
+    ///   raises (#1677) -- free here, since a full [`DocumentFields::uncons`]
+    ///   walk has already resolved both.
+    ///
+    /// # Why this is a shared method and not five hand-copied blocks
+    ///
+    /// It was five hand-copied blocks, and the set drifted three times:
+    /// #1677 reached some sites, #2211 two, #2243/#2262 five, each round
+    /// leaving a sibling behind (#1975 found this walk missing from the CLI
+    /// bridge; #2349 tracks the live bug the validate-only walk still has).
+    /// `resolve_display_key`'s own doc already tracked the key half as a
+    /// recurring cost; this method covers the delimiter half with it, so a
+    /// future rule lands in one place. Enforced by STYLE-0013.
+    ///
+    /// Generic over `F: DocumentFields` rather than taking the pieces
+    /// separately, for the same reason [`key_delimiter_ok`] is: naming `F`
+    /// sidesteps needing `DocumentFields` to bind `Self::Cursor` to
+    /// `Self::Value::Cursor`, which it does not. `F` is inferred from
+    /// `fields`, so call sites lose the fully-qualified
+    /// `::<<C::Value as DocumentValue>::Fields>` spelling entirely.
+    pub fn checked_key<F, T>(
+        &self,
+        fields: &F,
+        map: &IndexMap<String, T>,
+        guard: &mut DisplayKeyGuard,
+        is_first: bool,
+    ) -> Result<String, EvalError>
+    where
+        F: DocumentFields<Value = V, Cursor = C>,
+    {
+        let Some(key) = resolve_display_key(&self.key, map, guard)? else {
+            return Err(fields.malformed_member_error());
+        };
+        if !self.delimiters_ok::<F>(is_first) {
+            return Err(fields.malformed_member_error());
+        }
+        Ok(key)
     }
 }
 

--- a/src/jq/document.rs
+++ b/src/jq/document.rs
@@ -3386,7 +3386,7 @@ mod tail_gap_receiver_tests {
     /// other.
     #[test]
     fn empty_container_arm_is_not_delegated_1803() {
-        let json: &[u8] = br#"{,}"#;
+        let json: &[u8] = br"{,}";
         let index = JsonIndex::build(json);
         let container = index.root(json);
 
@@ -3421,7 +3421,7 @@ mod tail_gap_receiver_tests {
         // `None` passed for a field it actually has. That combination would
         // (correctly) raise: `container_gap_ok` would find `"a"` in the gap
         // after the brace, which is what it is for.
-        let empty: &[u8] = br#"{}"#;
+        let empty: &[u8] = br"{}";
         let empty_index = JsonIndex::build(empty);
         let empty_root = empty_index.root(empty);
         container_tail_gap_ok(&empty_root, None, b'}').expect("an empty `{}` is well-formed");

--- a/src/jq/document.rs
+++ b/src/jq/document.rs
@@ -1613,26 +1613,30 @@ pub fn child_tail_gap_ok<C: DocumentCursor>(
 /// - **No child** -- [`DocumentCursor::container_gap_ok`] against the
 ///   container, which is the only thing that can tell a genuine `{}`/`[]`
 ///   apart from a stray `,` with nothing in it (`{,}` / `[,]`, #2211).
-/// - **At least one child** -- [`trailing_element_gap_ok`] against that last
-///   child, for a stray `,` after it (`{"a":1,}` / `[1,]`, #2243).
+/// - **At least one child** -- delegates to [`child_tail_gap_ok`], the exact
+///   same [`trailing_element_gap_ok`] check against that last child, for a
+///   stray `,` after it (`{"a":1,}` / `[1,]`, #2243).
 ///
-/// Both raise `container.malformed_delimiter_error()`, preserving what the
-/// cursor-domain call sites already did; for JSON that is
-/// `malformed_json_text` over the whole document text, so it reads
-/// identically to the child-receiver form [`child_tail_gap_ok`] uses.
+/// The two branches raise from different cursors (`container` vs. the last
+/// child), which only matters if their `malformed_delimiter_error()`s could
+/// differ -- for JSON, both read `self.text`, the same whole-document slice
+/// regardless of which node's cursor calls it, so the two are
+/// byte-identical; YAML never reaches either raise (`container_gap_ok`/
+/// `trailing_element_gap_ok` are `true`-returning defaults there).
 pub fn container_tail_gap_ok<C: DocumentCursor>(
     container: &C,
     last_child: Option<&C>,
     close_char: u8,
 ) -> Result<(), EvalError> {
-    let ok = match last_child {
-        None => container.container_gap_ok(close_char),
-        Some(last) => trailing_element_gap_ok(last, close_char),
-    };
-    if ok {
-        Ok(())
-    } else {
-        Err(container.malformed_delimiter_error())
+    match last_child {
+        None => {
+            if container.container_gap_ok(close_char) {
+                Ok(())
+            } else {
+                Err(container.malformed_delimiter_error())
+            }
+        }
+        Some(_) => child_tail_gap_ok(last_child, close_char),
     }
 }
 
@@ -2737,7 +2741,7 @@ impl<V: DocumentValue, C: DocumentCursor> DocumentField<V, C> {
     ///   per key is what made `path(.[0])` over a 1,000,000-object array
     ///   cost 577 ms against 50 ms (#2061). This half allocates nothing, so
     ///   that walk can adopt the delimiter rules without the key rules --
-    ///   which is what #2349 needs, and why the split exists.
+    ///   which is what #2349 needed, and why the split exists.
     ///
     /// Free for every caller: a full [`DocumentFields::uncons`] walk has
     /// already resolved both key and value, so each check reuses an
@@ -2778,7 +2782,10 @@ impl<V: DocumentValue, C: DocumentCursor> DocumentField<V, C> {
     /// It was five hand-copied blocks, and the set drifted three times:
     /// #1677 reached some sites, #2211 two, #2243/#2262 five, each round
     /// leaving a sibling behind (#1975 found this walk missing from the CLI
-    /// bridge; #2349 tracks the live bug the validate-only walk still has).
+    /// bridge; #2349 fixed the validate-only walk's own delimiter gap,
+    /// directly via `key_delimiter_ok`/`value_delimiter_ok` rather than
+    /// through this method -- see `push_generic_truthiness_cursor_error`'s
+    /// own STYLE-0013 note for why it still can't take the key half).
     /// `resolve_display_key`'s own doc already tracked the key half as a
     /// recurring cost; this method covers the delimiter half with it, so a
     /// future rule lands in one place. Enforced by STYLE-0013.

--- a/src/jq/document.rs
+++ b/src/jq/document.rs
@@ -2728,7 +2728,8 @@ impl<V: DocumentValue, C: DocumentCursor> DocumentField<V, C> {
     /// the walks that cannot take the whole of it (#1803):
     ///
     /// - [`DocumentFields::keys`] and `effective_fields_checked` resolve
-    ///   their keys with [`key_display_string`]/[`key_is_malformed`] and
+    ///   their keys with [`key_display_string`]/`key_is_malformed` (the
+    ///   latter private, not linkable here) and
     ///   hold no `IndexMap` for the #1642 collision guard to check against.
     /// - `eval_generic`'s validate-only walk (a private function, not
     ///   linkable here) builds its #1642 collision map *lazily*, from the

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -39,10 +39,9 @@ use std::rc::Rc;
 use indexmap::IndexMap;
 
 use super::document::{
-    effective_fields, effective_fields_checked, effective_keys, effective_len_checked,
-    key_delimiter_ok, key_display_string, key_display_string_kind, resolve_display_key,
-    trailing_element_gap_ok, value_delimiter_ok, DisplayKeyGuard, DocumentCursor, DocumentElements,
-    DocumentFields,
+    child_tail_gap_ok, effective_fields, effective_fields_checked, effective_keys,
+    effective_len_checked, key_display_string, key_display_string_kind, DisplayKeyGuard,
+    DocumentCursor, DocumentElements, DocumentFields,
 };
 use super::slice::{self, SliceBounds};
 use super::walk::{any_subexpr, map_builtin_subexprs, map_subexprs};
@@ -690,16 +689,11 @@ fn to_owned_at_depth<W: Clone + AsRef<[u64]>>(
                 elems = rest;
                 is_first = false;
             }
-            // #2262: see this function's own doc comment above -- `[,]`
-            // (#2211's `container_gap_ok`) can't be checked here, no
-            // container cursor is ever in hand. `[1,]` (#2243) can: it
-            // only needs the last real element's own cursor, retained
-            // above.
-            if let Some(last) = &last_elem {
-                if !trailing_element_gap_ok(last, b']') {
-                    return Err(last.malformed_delimiter_error());
-                }
-            }
+            // #2262/#1803: the value-domain tail -- `[1,]` (#2243) checked
+            // via the last real element's own cursor, `[,]` (#2211) not,
+            // because no container cursor is ever in hand here. See
+            // `child_tail_gap_ok`'s own doc comment.
+            child_tail_gap_ok(last_elem.as_ref(), b']')?;
             OwnedValue::Array(items)
         }
         StandardJson::Object(fields) => {
@@ -719,34 +713,20 @@ fn to_owned_at_depth<W: Clone + AsRef<[u64]>>(
             // #2262: same reasoning as the array arm's own `last_elem`
             // above.
             let mut last_field: Option<JsonCursor<'_, W>> = None;
-            while let Some((field, rest)) = f.uncons() {
-                let key_val = field.key();
-                // `resolve_display_key` covers both key axes in one call
-                // (#1734): `Ok(None)` is a structurally non-string key
-                // (#1194) and raises here, matching
-                // `eval_generic::to_owned_at_depth`'s own handling of the
-                // identical case; `Err` is a collision between two
-                // decode-failure fallback spellings, which also raises
-                // rather than silently overwriting an entry in `map`
-                // (#1642's `DisplayKeyGuard`); `Ok(Some(key))` covers both
-                // an ordinary key and a decode-failure key preserved via
-                // its lossily-decoded raw source span.
-                let Some(key) = resolve_display_key(&key_val, &map, &mut guard)? else {
-                    return Err(f.malformed_member_error());
-                };
-                // #1677/#2262: same delimiter checks as
-                // `eval_generic::to_owned_at_depth`'s object loop -- this
-                // function had none of it before #2262.
-                if !key_delimiter_ok::<JsonFields<'_, W>>(&key_val, &field.key_cursor(), is_first)
-                    || !value_delimiter_ok::<JsonFields<'_, W>>(
-                        Some(&field.value()),
-                        &field.value_cursor(),
-                    )
-                {
-                    return Err(f.malformed_member_error());
-                }
-                map.insert(key, to_owned_at_depth(&field.value(), depth + 1)?);
-                last_field = Some(field.value_cursor());
+            // #1803: `DocumentFields::uncons`, not the inherent
+            // `JsonFields::uncons` -- the trait's own impl (`json::light`)
+            // builds its `DocumentField` from exactly the four accessors
+            // this loop already called by hand (`key`/`value`/`key_cursor`/
+            // `value_cursor`), so nothing extra is resolved, and it is what
+            // lets this walk share `checked_key` with its generic siblings
+            // instead of hand-copying their checks a third time.
+            while let Some((field, rest)) = DocumentFields::uncons(&f) {
+                // #1734/#1677/#2262: key resolution and delimiter checks in
+                // one shared call -- see `DocumentField::checked_key`. This
+                // function had none of the delimiter half before #2262.
+                let key = field.checked_key(&f, &map, &mut guard, is_first)?;
+                map.insert(key, to_owned_at_depth(&field.value, depth + 1)?);
+                last_field = Some(field.value_cursor);
                 f = rest;
                 is_first = false;
             }
@@ -754,11 +734,7 @@ fn to_owned_at_depth<W: Clone + AsRef<[u64]>>(
                 return Err(f.malformed_member_error());
             }
             // #2262: same reasoning as the array arm's own check above.
-            if let Some(last) = &last_field {
-                if !trailing_element_gap_ok(last, b'}') {
-                    return Err(last.malformed_delimiter_error());
-                }
-            }
+            child_tail_gap_ok(last_field.as_ref(), b'}')?;
             OwnedValue::Object(map)
         }
         // #2286 review: this arm used to silently substitute `Null` for a

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -27,11 +27,12 @@ use std::rc::Rc;
 use indexmap::IndexMap;
 
 use super::document::{
-    collapsed_fields, collapsed_fields_if, effective_fields_checked,
-    effective_fields_with_raw_last, effective_keys, effective_len_checked, key_delimiter_ok,
-    key_display_string, key_display_string_kind, key_is_malformed, resolve_display_key,
-    trailing_element_gap_ok, value_delimiter_ok, DisplayKeyGuard, DistinctKeyCursors,
-    DocumentCursor, DocumentElements, DocumentFields, DocumentValue, IndentSpec, JsonConvention,
+    child_tail_gap_ok, collapsed_fields, collapsed_fields_if, container_tail_gap_ok,
+    effective_fields_checked, effective_fields_with_raw_last, effective_keys,
+    effective_len_checked, key_delimiter_ok, key_display_string, key_display_string_kind,
+    key_is_malformed, resolve_display_key, trailing_element_gap_ok, value_delimiter_ok,
+    DisplayKeyGuard, DistinctKeyCursors, DocumentCursor, DocumentElements, DocumentFields,
+    DocumentValue, IndentSpec, JsonConvention,
 };
 use super::eval::{
     apply_compare_op, arith_combine, as_var_refs, bind_def, bind_def_call,
@@ -188,14 +189,7 @@ fn to_owned_checked_at_depth<V: DocumentValue>(
         let mut is_first = true;
         let mut last_field: Option<V::Cursor> = None;
         while let Some((field, rest)) = f.uncons() {
-            let Some(key) = resolve_display_key(&field.key, &map, &mut guard)? else {
-                return Err(f.malformed_member_error());
-            };
-            if !key_delimiter_ok::<V::Fields>(&field.key, &field.key_cursor, is_first)
-                || !value_delimiter_ok::<V::Fields>(Some(&field.value), &field.value_cursor)
-            {
-                return Err(f.malformed_member_error());
-            }
+            let key = field.checked_key(&f, &map, &mut guard, is_first)?;
             map.insert(key, to_owned_checked_at_depth(&field.value, depth + 1)?);
             last_field = Some(field.value_cursor);
             f = rest;
@@ -204,11 +198,7 @@ fn to_owned_checked_at_depth<V: DocumentValue>(
         if f.ends_unpaired() {
             return Err(f.malformed_member_error());
         }
-        if let Some(last) = &last_field {
-            if !trailing_element_gap_ok(last, b'}') {
-                return Err(last.malformed_delimiter_error());
-            }
-        }
+        child_tail_gap_ok(last_field.as_ref(), b'}')?;
         Ok(OwnedValue::Object(map))
     } else if let Some(elements) = value.as_array() {
         let mut items = Vec::new();
@@ -216,22 +206,15 @@ fn to_owned_checked_at_depth<V: DocumentValue>(
         let mut is_first = true;
         let mut last_elem: Option<V::Cursor> = None;
         while let Some((elem_cursor, rest)) = elems.uncons_cursor() {
-            if let Some(pos) = elem_cursor.text_position() {
-                let expected = if is_first { None } else { Some(b',') };
-                if !elem_cursor.preceding_delimiter_ok(pos, expected) {
-                    return Err(elem_cursor.malformed_delimiter_error());
-                }
+            if !elem_cursor.element_gap_ok(is_first) {
+                return Err(elem_cursor.malformed_delimiter_error());
             }
             items.push(to_owned_checked_at_depth(&elem_cursor.value(), depth + 1)?);
             last_elem = Some(elem_cursor);
             elems = rest;
             is_first = false;
         }
-        if let Some(last) = &last_elem {
-            if !trailing_element_gap_ok(last, b']') {
-                return Err(last.malformed_delimiter_error());
-            }
-        }
+        child_tail_gap_ok(last_elem.as_ref(), b']')?;
         Ok(OwnedValue::Array(items))
     } else if value.is_null() {
         Ok(OwnedValue::Null)
@@ -334,25 +317,10 @@ fn to_owned_at_depth<V: DocumentValue>(value: &V, depth: usize) -> Result<OwnedV
         // `to_owned_cursor_at_depth`'s own `last_field` (#2243).
         let mut last_field: Option<V::Cursor> = None;
         while let Some((field, rest)) = f.uncons() {
-            // A key that will not *decode* (#1247/#1385) is preserved via
-            // its raw source span rather than raised on (#1642), matching
-            // `length`/`keys_unsorted`/`.`. A key that will not stringify
-            // at all is a different, structural fault -- a key JSON's
-            // grammar never allowed (`{123: 1}`), which the semi-index
-            // accepted because `:` and `,` mean the same nothing to it --
-            // and that still raises: dropping the field silently is #1194,
-            // the disagreement #1385's postmortem names as the thing to
-            // avoid.
-            let Some(key) = resolve_display_key(&field.key, &map, &mut guard)? else {
-                return Err(f.malformed_member_error());
-            };
-            // #1677: same delimiter class as #1194 above, one layer up --
-            // free here since `uncons` already resolved both key and value.
-            if !key_delimiter_ok::<V::Fields>(&field.key, &field.key_cursor, is_first)
-                || !value_delimiter_ok::<V::Fields>(Some(&field.value), &field.value_cursor)
-            {
-                return Err(f.malformed_member_error());
-            }
+            // #1803: the #1642 key resolution and the #1677 delimiter
+            // checks, as the one shared definition -- see
+            // `DocumentField::checked_key` for which fault raises and why.
+            let key = field.checked_key(&f, &map, &mut guard, is_first)?;
             map.insert(key, to_owned_at_depth(&field.value, depth + 1)?);
             last_field = Some(field.value_cursor);
             f = rest;
@@ -376,11 +344,7 @@ fn to_owned_at_depth<V: DocumentValue>(value: &V, depth: usize) -> Result<OwnedV
         // remains unchecked here for that reason. #2243's
         // `trailing_element_gap_ok` *is* checkable, though: it only needs
         // the last real field's own cursor, retained above.
-        if let Some(last) = &last_field {
-            if !trailing_element_gap_ok(last, b'}') {
-                return Err(last.malformed_delimiter_error());
-            }
-        }
+        child_tail_gap_ok(last_field.as_ref(), b'}')?;
         Ok(OwnedValue::Object(map))
     } else if let Some(elements) = value.as_array() {
         let mut items = Vec::new();
@@ -392,12 +356,11 @@ fn to_owned_at_depth<V: DocumentValue>(value: &V, depth: usize) -> Result<OwnedV
             // #1677: no bare-value walk over `DocumentElements` carries a
             // position, so this switches to the cursor-yielding sibling of
             // `uncons` -- always available, same navigation underneath --
-            // purely to reach `text_position()` for the gap check.
-            if let Some(pos) = elem_cursor.text_position() {
-                let expected = if is_first { None } else { Some(b',') };
-                if !elem_cursor.preceding_delimiter_ok(pos, expected) {
-                    return Err(elem_cursor.malformed_delimiter_error());
-                }
+            // purely to reach the cursor `element_gap_ok` needs. #1803: the
+            // check itself is `DocumentCursor::element_gap_ok`, not a fourth
+            // inline re-derivation of `text_position()`/`expected`.
+            if !elem_cursor.element_gap_ok(is_first) {
+                return Err(elem_cursor.malformed_delimiter_error());
             }
             items.push(to_owned_at_depth(&elem_cursor.value(), depth + 1)?);
             last_elem = Some(elem_cursor);
@@ -407,11 +370,7 @@ fn to_owned_at_depth<V: DocumentValue>(value: &V, depth: usize) -> Result<OwnedV
         // #2262: same reasoning as the object arm's own check above --
         // `[,]` remains unchecked here (no container cursor available),
         // but `[1,]` is, via the last real element's own cursor.
-        if let Some(last) = &last_elem {
-            if !trailing_element_gap_ok(last, b']') {
-                return Err(last.malformed_delimiter_error());
-            }
-        }
+        child_tail_gap_ok(last_elem.as_ref(), b']')?;
         Ok(OwnedValue::Array(items))
     // Then check scalars in order of specificity
     } else if value.is_null() {
@@ -551,24 +510,12 @@ fn to_owned_cursor_at_depth<C: DocumentCursor>(
         // needs to) once, after the loop, not per field.
         let mut last_field: Option<C> = None;
         while let Some((field, rest)) = f.uncons() {
-            // Same key handling as `to_owned_at_depth` above, same reasons --
-            // these two conversions are copies of each other and a fix that
-            // moved only one would leave the cursor and value domains
-            // disagreeing about whether a document is valid.
-            let Some(key) = resolve_display_key(&field.key, &map, &mut guard)? else {
-                return Err(f.malformed_member_error());
-            };
-            // Same #1677 checks as `to_owned_at_depth` above, same reason.
-            if !key_delimiter_ok::<<C::Value as DocumentValue>::Fields>(
-                &field.key,
-                &field.key_cursor,
-                is_first,
-            ) || !value_delimiter_ok::<<C::Value as DocumentValue>::Fields>(
-                Some(&field.value),
-                &field.value_cursor,
-            ) {
-                return Err(f.malformed_member_error());
-            }
+            // Same key and delimiter handling as `to_owned_at_depth` above,
+            // and since #1803 literally the same call -- these two
+            // conversions were copies of each other, and a fix that moved
+            // only one would leave the cursor and value domains disagreeing
+            // about whether a document is valid.
+            let key = field.checked_key(&f, &map, &mut guard, is_first)?;
             map.insert(
                 key,
                 to_owned_cursor_at_depth(&field.value_cursor, depth + 1)?,
@@ -580,22 +527,12 @@ fn to_owned_cursor_at_depth<C: DocumentCursor>(
         if f.ends_unpaired() {
             return Err(f.malformed_member_error());
         }
-        // #2211: `key_delimiter_ok`/`value_delimiter_ok` above only ever run
-        // against a real field -- a stray `,` with no real field at all
-        // (`{,}`) leaves the loop never having run, so nothing above catches
-        // it. `map.is_empty()` after the walk is exactly that case (a
-        // genuine `{}` also reaches here, and `container_gap_ok` answers
-        // `true` for it -- see that method's own doc comment).
-        if map.is_empty() {
-            if !cursor.container_gap_ok(b'}') {
-                return Err(cursor.malformed_delimiter_error());
-            }
-        } else {
-            let value_cursor = last_field.expect("map non-empty implies a real field was inserted");
-            if !trailing_element_gap_ok(&value_cursor, b'}') {
-                return Err(cursor.malformed_delimiter_error());
-            }
-        }
+        // #2211 (`{,}`) and #2243 (`{"a":1,}`), as the one shared
+        // `container_tail_gap_ok` rather than the two hand-copied arms this
+        // used to be (#1803). `last_field` is `None` on exactly the walks
+        // that left `map` empty -- every iteration sets both -- so the split
+        // that decision used to make on `map.is_empty()` is unchanged.
+        container_tail_gap_ok(cursor, last_field.as_ref(), b'}')?;
         Ok(OwnedValue::Object(map))
     } else if let Some(elements) = value.as_array() {
         let mut items = Vec::new();
@@ -604,30 +541,19 @@ fn to_owned_cursor_at_depth<C: DocumentCursor>(
         // #2243: same reasoning as the object arm's own `last_field` above.
         let mut last_elem: Option<C> = None;
         while let Some((elem_cursor, rest)) = elems.uncons_cursor() {
-            // #1677: same gap check as `to_owned_at_depth`'s array loop.
-            if let Some(pos) = elem_cursor.text_position() {
-                let expected = if is_first { None } else { Some(b',') };
-                if !elem_cursor.preceding_delimiter_ok(pos, expected) {
-                    return Err(elem_cursor.malformed_delimiter_error());
-                }
+            // #1677: same gap check as `to_owned_at_depth`'s array loop --
+            // #1803 made "same" literal, via the shared `element_gap_ok`.
+            if !elem_cursor.element_gap_ok(is_first) {
+                return Err(elem_cursor.malformed_delimiter_error());
             }
             items.push(to_owned_cursor_at_depth(&elem_cursor, depth + 1)?);
             last_elem = Some(elem_cursor);
             elems = rest;
             is_first = false;
         }
-        // #2211: same reasoning as the object arm's own check just above,
-        // for a stray `,` with no real element (`[,]`).
-        if items.is_empty() {
-            if !cursor.container_gap_ok(b']') {
-                return Err(cursor.malformed_delimiter_error());
-            }
-        } else {
-            let last = last_elem.expect("items non-empty implies a real element was pushed");
-            if !trailing_element_gap_ok(&last, b']') {
-                return Err(cursor.malformed_delimiter_error());
-            }
-        }
+        // #2211/#2243: same reasoning as the object arm's own check just
+        // above, and now literally the same call (#1803).
+        container_tail_gap_ok(cursor, last_elem.as_ref(), b']')?;
         Ok(OwnedValue::Array(items))
     } else {
         // An applicable explicit tag resolves from the raw text and so can
@@ -1048,6 +974,21 @@ fn to_owned_with_comments_at_depth<V: DocumentValue>(
             // source span; still raise on a key the format's grammar never
             // allowed at all (#1194) -- this arm used to silently drop such
             // a field instead of raising, the same swallow #1194 names.
+            //
+            // STYLE-0013: `resolve_display_key` directly, not
+            // `DocumentField::checked_key`, because this walk deliberately
+            // omits the delimiter half. Its only *production* caller is
+            // `yq_runner.rs`, where the value is always YAML and every
+            // #1677/#2211/#2243 check is a trait-default no-op (`{a: 1,}`
+            // is valid YAML flow syntax; real yq accepts it). So the
+            // omission is unreachable rather than divergent in shipped
+            // behaviour. It is not *provably* unreachable, though:
+            // `to_owned_with_comments` is `pub` and this file's own
+            // `test_json_to_owned_with_comments_uses_line_comment_raw_default`
+            // drives it with JSON, where those checks would fire. Adopting
+            // `checked_key` here is therefore a behaviour change for a
+            // JSON-typed caller, however desirable -- out of scope for
+            // #1803, which is behaviour-preserving by construction.
             let Some(key) = resolve_display_key(&field.key, &map, &mut guard)? else {
                 return Err(f.malformed_member_error());
             };
@@ -2531,6 +2472,23 @@ fn push_generic_truthiness_cursor_error<C: DocumentCursor>(c: &C, depth: usize) 
         // (both would flip/increment together every iteration with no
         // path that updates one without the other).
         let mut last_field: Option<C> = None;
+        // STYLE-0013: this walk deliberately does not route through
+        // `DocumentField::checked_key`, on two separate counts.
+        //
+        // 1. The key half is the #2061 *lazy* form below, not
+        //    `resolve_display_key` per key: allocating a `String` for every
+        //    key made `path(.[0])` over a 1M-object array cost 577 ms
+        //    against 50 ms. `checked_key` is the eager form, so this site
+        //    cannot adopt it without giving that back.
+        // 2. The delimiter half (#1677/#2211/#2243) is *missing* here, and
+        //    that is a live bug, not a design choice -- tracked as #2349,
+        //    which is where it gets fixed and where the cost of doing so
+        //    gets attributed. Fixing it inside #1803's extraction would have
+        //    made a pure refactor the vehicle for a behaviour change.
+        //
+        // This marker is the point of STYLE-0013: #2211 and #2243 each added
+        // a check to "the materializers" and neither noticed this walk, and
+        // nothing in the source said it should be looked at.
         while let Some((field, rest)) = f.uncons() {
             if !seen_fallback {
                 match key_display_string_kind(&field.key) {

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -294,6 +294,13 @@ fn malformed_object_member<F: DocumentFields>(fields: &F) -> Option<EvalError> {
             return Some(walk.malformed_member_error());
         }
         // #1677: comma-before-key rides this same key-only walk for free.
+        //
+        // STYLE-0013: `key_delimiter_ok` directly, not
+        // `DocumentField::delimiters_ok`. This is a key-*only* walk
+        // (`uncons_key`, never `uncons`), so there is no `DocumentField` to
+        // call it on and no value resolved to check a `:` against -- taking
+        // the shared helper would mean resolving every value, which is the
+        // cost `uncons_key` exists to avoid (#1514).
         if !key_delimiter_ok::<F>(&key, &cursor, is_first) {
             return Some(walk.malformed_member_error());
         }
@@ -2486,9 +2493,9 @@ fn push_generic_truthiness_cursor_error<C: DocumentCursor>(c: &C, depth: usize) 
         //    gets attributed. Fixing it inside #1803's extraction would have
         //    made a pure refactor the vehicle for a behaviour change.
         //
-        // This marker is the point of STYLE-0013: #2211 and #2243 each added
-        // a check to "the materializers" and neither noticed this walk, and
-        // nothing in the source said it should be looked at.
+        // The marker above is what STYLE-0013 is for. #2211 and #2243 each
+        // added a check to "the materializers", neither noticed this walk,
+        // and nothing in the source said it should be looked at.
         while let Some((field, rest)) = f.uncons() {
             if !seen_fallback {
                 match key_display_string_kind(&field.key) {
@@ -11115,6 +11122,16 @@ fn eval_builtin<S: EvalSemantics, V: DocumentValue>(
                     // the comma before each key; this loop already resolves
                     // every field's value regardless (`to_owned_cursor`
                     // below), so the colon check rides along for free.
+                    //
+                    // STYLE-0013: `value_delimiter_ok` directly, not
+                    // `DocumentField::delimiters_ok`. The two halves of the
+                    // member rule are deliberately split across two walks
+                    // here -- the comma half already ran, over key cursors
+                    // only -- so the shared helper would re-check it. The key
+                    // itself comes from `key_display_string`, not
+                    // `resolve_display_key`: `to_entries` builds an array of
+                    // `{key, value}` pairs, which has no display-key map for
+                    // #1642's collision guard to consult.
                     if !value_delimiter_ok::<V::Fields>(Some(&field.value), &field.value_cursor) {
                         return GenericResult::Error(fields.malformed_member_error());
                     }

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -2480,18 +2480,17 @@ fn push_generic_truthiness_cursor_error<C: DocumentCursor>(c: &C, depth: usize) 
         // path that updates one without the other).
         let mut last_field: Option<C> = None;
         // STYLE-0013: this walk deliberately does not route through
-        // `DocumentField::checked_key`, on two separate counts.
+        // `DocumentField::checked_key` -- the key half is the #2061 *lazy*
+        // form below, not `resolve_display_key` per key: allocating a
+        // `String` for every key made `path(.[0])` over a 1M-object array
+        // cost 577 ms against 50 ms. `checked_key` is the eager form, so
+        // this site cannot adopt it without giving that back.
         //
-        // 1. The key half is the #2061 *lazy* form below, not
-        //    `resolve_display_key` per key: allocating a `String` for every
-        //    key made `path(.[0])` over a 1M-object array cost 577 ms
-        //    against 50 ms. `checked_key` is the eager form, so this site
-        //    cannot adopt it without giving that back.
-        // 2. The delimiter half (#1677/#2211/#2243) is *missing* here, and
-        //    that is a live bug, not a design choice -- tracked as #2349,
-        //    which is where it gets fixed and where the cost of doing so
-        //    gets attributed. Fixing it inside #1803's extraction would have
-        //    made a pure refactor the vehicle for a behaviour change.
+        // The delimiter half (#1677/#2211/#2243) *was* missing here until
+        // #2349 fixed it -- see the `key_delimiter_ok`/`value_delimiter_ok`
+        // calls below and the container/trailing-gap checks after each
+        // loop, added by that fix directly (not via `checked_key`/
+        // `delimiters_ok`, for the same eager-allocation reason above).
         //
         // The marker above is what STYLE-0013 is for. #2211 and #2243 each
         // added a check to "the materializers", neither noticed this walk,

--- a/src/jq/lazy.rs
+++ b/src/jq/lazy.rs
@@ -28,9 +28,8 @@ use std::borrow::Cow;
 use crate::json::light::{JsonCursor, StandardJson};
 
 use super::document::{
-    effective_len, effective_len_checked, key_delimiter_ok, key_display_string,
-    resolve_display_key, value_delimiter_ok, DisplayKeyGuard, DistinctKeyCursors, DocumentCursor,
-    DocumentFields,
+    effective_len, effective_len_checked, key_display_string, DisplayKeyGuard, DistinctKeyCursors,
+    DocumentCursor, DocumentFields,
 };
 use super::error::EvalError;
 use super::escape::write_json_body_jq;
@@ -853,17 +852,15 @@ fn cursor_to_owned_at_depth<W: Clone + AsRef<[u64]>>(
             for child in cursor.children() {
                 // #2211 code review: this walk (unlike its
                 // `eval_generic::to_owned_cursor_at_depth` sibling it
-                // otherwise mirrors) never called `preceding_delimiter_ok`
-                // at all -- not even the missing/doubled-comma-between-two-
-                // real-elements check (#1677), which the `Object` arm below
-                // already had. `{"a" 1, "b": 2} | -e` used to silently
-                // succeed for the array shape (`[1 2, 3]`) the same way this
-                // object shape used to before #1956.
-                if let Some(pos) = child.text_position() {
-                    let expected = if is_first { None } else { Some(b',') };
-                    if !child.preceding_delimiter_ok(pos, expected) {
-                        return Err(child.malformed_delimiter_error());
-                    }
+                // otherwise mirrors) never ran this check at all -- not even
+                // the missing/doubled-comma-between-two-real-elements case
+                // (#1677), which the `Object` arm below already had.
+                // `{"a" 1, "b": 2} | -e` used to silently succeed for the
+                // array shape (`[1 2, 3]`) the same way this object shape
+                // used to before #1956. #1803: via the shared
+                // `element_gap_ok` rather than an inline copy of it.
+                if !child.element_gap_ok(is_first) {
+                    return Err(child.malformed_delimiter_error());
                 }
                 items.push(cursor_to_owned_at_depth(&child, depth + 1)?);
                 is_first = false;
@@ -873,6 +870,10 @@ fn cursor_to_owned_at_depth<W: Clone + AsRef<[u64]>>(
             // `items.is_empty()` after the walk is exactly that case (a
             // genuine `[]` also reaches here, and `container_gap_ok`
             // answers `true` for it).
+            // STYLE-0013: deliberately *not* `container_tail_gap_ok` -- that
+            // helper also runs #2243's trailing-gap check (`[1,]`), which
+            // this walk has never had. Adding it here would be a behaviour
+            // change, and this walk's missing checks are tracked as #2349.
             if items.is_empty() && !cursor.container_gap_ok(b']') {
                 return Err(cursor.malformed_delimiter_error());
             }
@@ -887,32 +888,23 @@ fn cursor_to_owned_at_depth<W: Clone + AsRef<[u64]>>(
             // `eval_generic::to_owned_at_depth`'s identical shape.
             let mut f = fields;
             let mut is_first = true;
-            while let Some((field, rest)) = f.uncons() {
-                // A key that isn't a `String` token at all is *structurally*
-                // malformed (#1194) and now raises, matching
-                // `keys()`/`effective_keys`. A key that is a string but
-                // won't decode is preserved via its raw source span rather
-                // than raised on (#1247/#1642), matching
-                // `length`/`keys_unsorted`/`.`.
-                let Some(key) = resolve_display_key(&field.key(), &map, &mut guard)? else {
-                    return Err(f.malformed_member_error());
-                };
-                // #1956: this walk (unlike its `eval_generic::to_owned_at_depth`
-                // sibling it otherwise mirrors) never called `key_delimiter_ok`/
-                // `value_delimiter_ok` -- a missing/doubled `,`/`:` (#1677) with
-                // an otherwise-even member count silently succeeded here.
-                if !key_delimiter_ok::<crate::json::light::JsonFields<'_, W>>(
-                    &field.key(),
-                    &field.key_cursor(),
-                    is_first,
-                ) || !value_delimiter_ok::<crate::json::light::JsonFields<'_, W>>(
-                    Some(&field.value()),
-                    &field.value_cursor(),
-                ) {
-                    return Err(f.malformed_member_error());
-                }
-                let value_cursor = field.value_cursor();
-                map.insert(key, cursor_to_owned_at_depth(&value_cursor, depth + 1)?);
+            // #1803: `DocumentFields::uncons`, not the inherent
+            // `JsonFields::uncons` -- the trait impl (`json::light`) builds
+            // its `DocumentField` from exactly the four accessors this loop
+            // already called by hand, so nothing extra is resolved, and it
+            // is what lets this walk share `checked_key` with its generic
+            // siblings rather than hand-copying their checks again. #1956
+            // is the reminder of why that matters: this walk (unlike the
+            // `eval_generic::to_owned_at_depth` sibling it otherwise
+            // mirrors) had no delimiter checks at all until then, so a
+            // missing or doubled `,`/`:` with an otherwise-even member
+            // count silently succeeded here.
+            while let Some((field, rest)) = DocumentFields::uncons(&f) {
+                let key = field.checked_key(&f, &map, &mut guard, is_first)?;
+                map.insert(
+                    key,
+                    cursor_to_owned_at_depth(&field.value_cursor, depth + 1)?,
+                );
                 f = rest;
                 is_first = false;
             }
@@ -924,6 +916,8 @@ fn cursor_to_owned_at_depth<W: Clone + AsRef<[u64]>>(
             // `key_delimiter_ok`/`value_delimiter_ok` above only ever run
             // against a real field, so the walk producing zero fields at
             // all leaves nothing to check.
+            // STYLE-0013: same exemption as the `Array` arm above --
+            // `{"a":1,}` (#2243) is unchecked here, tracked as #2349.
             if map.is_empty() && !cursor.container_gap_ok(b'}') {
                 return Err(cursor.malformed_delimiter_error());
             }

--- a/src/jq/lazy.rs
+++ b/src/jq/lazy.rs
@@ -873,7 +873,9 @@ fn cursor_to_owned_at_depth<W: Clone + AsRef<[u64]>>(
             // STYLE-0013: deliberately *not* `container_tail_gap_ok` -- that
             // helper also runs #2243's trailing-gap check (`[1,]`), which
             // this walk has never had. Adding it here would be a behaviour
-            // change, and this walk's missing checks are tracked as #2349.
+            // change; this walk's missing check is tracked as #2358 (#2349
+            // itself is closed and never touched this file -- its fix was
+            // to `eval_generic.rs`'s validate-only walk, not this one).
             if items.is_empty() && !cursor.container_gap_ok(b']') {
                 return Err(cursor.malformed_delimiter_error());
             }
@@ -917,7 +919,7 @@ fn cursor_to_owned_at_depth<W: Clone + AsRef<[u64]>>(
             // against a real field, so the walk producing zero fields at
             // all leaves nothing to check.
             // STYLE-0013: same exemption as the `Array` arm above --
-            // `{"a":1,}` (#2243) is unchecked here, tracked as #2349.
+            // `{"a":1,}` (#2243) is unchecked here, tracked as #2358.
             if map.is_empty() && !cursor.container_gap_ok(b'}') {
                 return Err(cursor.malformed_delimiter_error());
             }

--- a/src/json/light.rs
+++ b/src/json/light.rs
@@ -1158,6 +1158,14 @@ impl<'a, W: AsRef<[u64]>> JsonFields<'a, W> {
             fields = rest;
             index += 1;
         }
+        // STYLE-0013: `preceding_gap_ok` directly, not `key_delimiter_ok`/
+        // `value_delimiter_ok` -- both take `is_first`/`text_start` from an
+        // already-decoded key/value, but this walk only knows `key_start`
+        // (captured once, at the moment a candidate becomes `winner`) and
+        // defers the check to the end so only the field that actually wins
+        // last-write-wins gets validated, never a superseded earlier
+        // candidate. Neither primitive has a "check this position against
+        // this cursor" shape that fits a deferred check.
         if let Some((key_start, field, is_first)) = winner {
             let value_cursor = field.value_cursor();
             let comma_expected = if is_first { None } else { Some(b',') };
@@ -1242,6 +1250,9 @@ impl<'a, W: AsRef<[u64]>> JsonFields<'a, W> {
             fields = rest;
             index += 1;
         }
+        // STYLE-0013: same reason as `find`'s own exemption -- only
+        // `key_start` (captured when a candidate becomes `winner`) is kept,
+        // and the check is deferred to the last-write-wins field alone.
         if let Some((key_start, value_cursor, is_first)) = winner {
             let comma_expected = if is_first { None } else { Some(b',') };
             if !preceding_gap_ok(value_cursor.text(), key_start, comma_expected) {

--- a/src/json/light.rs
+++ b/src/json/light.rs
@@ -2857,9 +2857,14 @@ fn stream_json_pretty<W: AsRef<[u64]> + Clone, Out: core::fmt::Write>(
                 // bookkeeping and the recursive render, instead of a second
                 // `elem_cursor.value()` re-deriving the same value (#1576
                 // review).
+                // #1803: `element_gap_ok_at`, not `element_gap_ok` -- this
+                // site needs the resolved `pos` itself for `value_at(pos)`
+                // and `scalar_end_pos(pos, ..)` just below, so it cannot
+                // give up the position the way the `bool`-only sibling does.
+                // Routing through the shared method anyway keeps the
+                // `is_first` -> delimiter mapping at one definition.
                 let elem_value = if let Some(pos) = elem_cursor.text_position() {
-                    let expected = if first { None } else { Some(b',') };
-                    if !elem_cursor.preceding_delimiter_ok(pos, expected) {
+                    if !elem_cursor.element_gap_ok_at(pos, first) {
                         return Err(StreamFailure::Decode(
                             elem_cursor.malformed_delimiter_error(),
                         ));

--- a/tests/jq_member_validation_audit.rs
+++ b/tests/jq_member_validation_audit.rs
@@ -1,0 +1,503 @@
+//! STYLE-0013's enforcement: every call to a member-validation primitive
+//! outside its own definition site must either be inside the shared helper
+//! that owns it, or carry a `// STYLE-0013:` exemption (#1803).
+//!
+//! # Why this is a source scan and not a behavioural test
+//!
+//! The member rules -- #1642's colliding-key guard, #1194's structural-key
+//! check, #1677's `,`/`:` delimiter pair -- accumulated across four issues,
+//! and each round added its check to some of the walks that needed it and
+//! not others. #1975 found the CLI bridge with none of it; #2211 and #2243
+//! each reached a different subset; #2349 is the wrong-answer bug the drift
+//! finally produced in `select`/`sort_by`/`path()`.
+//!
+//! Extraction alone was already tried, and already failed to hold.
+//! `DocumentCursor::element_gap_ok` was pulled out by #1597's review for
+//! exactly this reason, and five sites went on hand-rolling its four lines
+//! -- two of them written *after* it existed. Centralising a check does not
+//! stop the omission, because nothing forces a call site through it.
+//!
+//! And a behavioural test cannot close the gap either, for two structural
+//! reasons rather than by bad luck:
+//!
+//! - **The rules are JSON-only.** Every delimiter check is a
+//!   `true`-returning `DocumentCursor` default, and YAML never overrides
+//!   one, because its parser validates while it parses. A walk reachable
+//!   only from YAML shows no difference whether it checks or not.
+//! - **The corruption need never be emitted.** A subtree a query merely
+//!   *validates* and never prints is where #2349 hid: the materializing
+//!   sibling raises on the same document, so nothing looks wrong until you
+//!   ask that one walk directly.
+//!
+//! #1962's cross-site consistency net did drive three of the sites and still
+//! missed it, because its `FuzzMalformation` alphabet has only
+//! decode-failure, structural and collision variants and its generator emits
+//! only well-formed containers -- it cannot express a delimiter corruption at
+//! any case count (#2350). A static audit does not depend on a corruption
+//! being reachable, expressible, or observable.
+//!
+//! Same answer, same shape as `jq_optional_suppression_audit.rs` (STYLE-0012,
+//! #2334), which this file is modelled on.
+//!
+//! # What it does not do
+//!
+//! It audits the **member** primitives only -- the pair `checked_key` and
+//! `delimiters_ok` own. It deliberately does not audit the post-loop tail
+//! (`container_gap_ok`, `trailing_element_gap_ok`), even though #2211 and
+//! #2243 drifted there too: those have many legitimate direct callers
+//! outside the walk shape (`json::light`'s streaming writers, `document.rs`'s
+//! key-only walks, the tail helpers themselves), so a name-based rule would
+//! be mostly noise and would train readers to add the marker reflexively.
+//! Auditing that half wants a rule shaped around *the walk* -- "a loop that
+//! unconses children must end in a tail helper" -- which is a different and
+//! larger piece of analysis than this file does.
+//!
+//! It also does not decide whether a site *should* route. It only demands
+//! that somebody decided and wrote the reason down.
+
+use proc_macro2::Span;
+use syn::spanned::Spanned as _;
+use syn::visit::{self, Visit};
+
+/// Every file that walks a document's members. `document.rs` is excluded on
+/// purpose: it *defines* the primitives and the helpers that own them, so
+/// every call in it is either a definition or the one legitimate use.
+///
+/// `yq_runner.rs` is in the `succinctly-cli` crate, not this library --
+/// included via `include_str!` for the same reason it is in the audited set
+/// at all: it is the walk that has fallen behind twice (#1975 found it
+/// missing the delimiter checks *and* silently dropping undecodable keys),
+/// and a scan that stopped at the crate boundary would have caught neither.
+const SOURCES: &[(&str, &str)] = &[
+    ("src/jq/eval.rs", include_str!("../src/jq/eval.rs")),
+    (
+        "src/jq/eval_generic.rs",
+        include_str!("../src/jq/eval_generic.rs"),
+    ),
+    ("src/jq/lazy.rs", include_str!("../src/jq/lazy.rs")),
+    ("src/json/light.rs", include_str!("../src/json/light.rs")),
+    (
+        "src/bin/succinctly/yq_runner.rs",
+        include_str!("../src/bin/succinctly/yq_runner.rs"),
+    ),
+];
+
+/// The primitives `DocumentField::checked_key` and
+/// `DocumentField::delimiters_ok` exist to own (#1803).
+///
+/// `preceding_delimiter_ok` is here for the `is_first` -> `Option<b','>`
+/// mapping specifically: `element_gap_ok`/`element_gap_ok_at` are the two
+/// definitions of it, and a third re-derivation at a call site is the shape
+/// #1597 extracted and five sites re-grew anyway.
+const AUDITED: &[&str] = &[
+    "resolve_display_key",
+    "key_delimiter_ok",
+    "value_delimiter_ok",
+    "preceding_delimiter_ok",
+];
+
+/// The STYLE-0013 exemption marker, cited inline the way STYLE-0004's
+/// `#[allow]` citations and STYLE-0012's routing exemptions already are.
+const EXEMPT_MARKER: &str = "STYLE-0013:";
+
+/// Lower bounds proving the scan actually looked at something.
+///
+/// The classic failure of a grep-shaped gate is going quietly vacuous: a
+/// renamed helper, a `syn` upgrade, or a refactor that moves code out from
+/// under the visitor leaves it passing green while checking nothing. Today
+/// the scan sees 5 audited call sites across 5 files (one key-only walk, one
+/// comment-preserving walk, two in the validate-only walk, one in
+/// `to_entries`); the floors sit just
+/// under that. If a legitimate refactor lowers the real count past a floor,
+/// move the floor *and* say in the commit message what shrank -- do not lower
+/// it to make a red test green.
+const MIN_SITES_EXAMINED: usize = 4;
+const MIN_FILES_PARSED: usize = 5;
+
+struct Site {
+    file: &'static str,
+    line: usize,
+    func: String,
+    callee: String,
+}
+
+/// One frame of the enclosing-function stack.
+struct Frame {
+    name: String,
+    /// 1-based, inclusive line range of the function's body.
+    ///
+    /// Load-bearing, not bookkeeping: the marker search is clipped to it, so
+    /// a `// STYLE-0013:` belonging to one walk cannot excuse an unmarked
+    /// call in the next function down. This file's own negative test pins
+    /// that -- see `test_marker_does_not_leak_across_function_boundaries`.
+    body_start: usize,
+    body_end: usize,
+}
+
+struct Audit<'a> {
+    file: &'static str,
+    lines: Vec<&'a str>,
+    /// Innermost enclosing function last, so a nested `fn` does not inherit
+    /// its parent's marker.
+    stack: Vec<Frame>,
+    sites_examined: usize,
+    violations: Vec<Site>,
+}
+
+/// Whether a `// STYLE-0013:` marker appears anywhere inside this function's
+/// own body.
+///
+/// Function-level, not "the comment block attached to the call": a walk that
+/// cannot route is exempt *as a walk*, and its reason is one paragraph, not
+/// one per primitive it touches. `push_generic_truthiness_cursor_error` is
+/// the case that settles it -- one exemption, two `resolve_display_key`
+/// calls, and requiring the paragraph twice would say less, not more.
+///
+/// The clipping to `body_start..=body_end` is what keeps that from being
+/// laxer than the per-call form in the way that matters: the marker must be
+/// inside the *same* function as the call.
+fn marker_in_body(lines: &[&str], frame: &Frame) -> bool {
+    let lo = frame.body_start.saturating_sub(1);
+    let hi = frame.body_end.min(lines.len());
+    lines[lo..hi].iter().any(|l| is_marker_line(l))
+}
+
+/// Whether one line *is* a STYLE-0013 citation, as opposed to prose that
+/// merely mentions the rule.
+///
+/// The marker must **open** the comment -- `// STYLE-0013: <reason>` -- not
+/// appear anywhere in it. That is the documented citation form (STYLE-0004's
+/// `#[allow]` citations and STYLE-0012's exemptions are both written this
+/// way), and requiring it is load-bearing rather than pedantic: the first
+/// draft of this file used `contains`, and a sentence in
+/// `push_generic_truthiness_cursor_error`'s own comment -- "This marker is
+/// the point of STYLE-0013: ..." -- silently exempted that function. The
+/// audit passed with its real marker deleted. A gate that a rule's own
+/// *explanation* can satisfy is not a gate; see
+/// `test_prose_mentioning_the_rule_does_not_exempt`.
+fn is_marker_line(line: &str) -> bool {
+    let t = line.trim_start();
+    let Some(rest) = t.strip_prefix("//") else {
+        return false;
+    };
+    rest.trim_start().starts_with(EXEMPT_MARKER)
+}
+
+/// The bare name a call expression resolves to, for both `foo(..)` /
+/// `path::foo(..)` and `x.foo(..)`.
+fn callee_name(expr: &syn::Expr) -> Option<String> {
+    match expr {
+        syn::Expr::Call(c) => match &*c.func {
+            syn::Expr::Path(p) => p.path.segments.last().map(|s| s.ident.to_string()),
+            _ => None,
+        },
+        syn::Expr::MethodCall(m) => Some(m.method.to_string()),
+        _ => None,
+    }
+}
+
+fn line_of(span: Span) -> usize {
+    span.start().line
+}
+
+impl<'a> Audit<'a> {
+    fn new(file: &'static str, src: &'a str) -> Self {
+        Self {
+            file,
+            lines: src.lines().collect(),
+            stack: Vec::new(),
+            sites_examined: 0,
+            violations: Vec::new(),
+        }
+    }
+
+    fn enter(&mut self, name: String, body: Span) {
+        self.stack.push(Frame {
+            name,
+            body_start: body.start().line,
+            body_end: body.end().line,
+        });
+    }
+
+    fn check_call(&mut self, expr: &syn::Expr) {
+        let Some(callee) = callee_name(expr) else {
+            return;
+        };
+        if !AUDITED.contains(&callee.as_str()) {
+            return;
+        }
+        // A call inside the function that *is* the primitive, or inside a
+        // trait impl of it, is the definition, not a hand-copy.
+        let Some(frame) = self.stack.last() else {
+            return;
+        };
+        if AUDITED.contains(&frame.name.as_str()) {
+            return;
+        }
+        self.sites_examined += 1;
+        if !marker_in_body(&self.lines, frame) {
+            self.violations.push(Site {
+                file: self.file,
+                line: line_of(expr.span()),
+                func: frame.name.clone(),
+                callee,
+            });
+        }
+    }
+}
+
+impl<'ast> Visit<'ast> for Audit<'_> {
+    fn visit_item_fn(&mut self, node: &'ast syn::ItemFn) {
+        self.enter(node.sig.ident.to_string(), node.block.span());
+        visit::visit_item_fn(self, node);
+        self.stack.pop();
+    }
+
+    fn visit_impl_item_fn(&mut self, node: &'ast syn::ImplItemFn) {
+        self.enter(node.sig.ident.to_string(), node.block.span());
+        visit::visit_impl_item_fn(self, node);
+        self.stack.pop();
+    }
+
+    fn visit_trait_item_fn(&mut self, node: &'ast syn::TraitItemFn) {
+        if let Some(block) = &node.default {
+            self.enter(node.sig.ident.to_string(), block.span());
+            visit::visit_trait_item_fn(self, node);
+            self.stack.pop();
+        } else {
+            visit::visit_trait_item_fn(self, node);
+        }
+    }
+
+    fn visit_expr(&mut self, node: &'ast syn::Expr) {
+        self.check_call(node);
+        visit::visit_expr(self, node);
+    }
+}
+
+fn run_audit() -> (Vec<Site>, usize, usize) {
+    let mut violations = Vec::new();
+    let mut examined = 0usize;
+    let mut files = 0usize;
+    for (path, src) in SOURCES {
+        let parsed = syn::parse_file(src)
+            .unwrap_or_else(|e| panic!("STYLE-0013 audit could not parse {path}: {e}"));
+        let mut audit = Audit::new(path, src);
+        audit.visit_file(&parsed);
+        examined += audit.sites_examined;
+        violations.extend(audit.violations);
+        files += 1;
+    }
+    (violations, examined, files)
+}
+
+#[test]
+fn style_0013_member_validation_is_routed_or_exempted() {
+    let (violations, examined, files) = run_audit();
+
+    assert!(
+        files >= MIN_FILES_PARSED,
+        "STYLE-0013 audit parsed only {files} of {MIN_FILES_PARSED} expected files -- the \
+         scan has lost a source, not found a clean tree"
+    );
+    assert!(
+        examined >= MIN_SITES_EXAMINED,
+        "STYLE-0013 audit examined only {examined} call sites, expected at least \
+         {MIN_SITES_EXAMINED}. A vacuous scan passes green: check that the audited names in \
+         `AUDITED` still exist and that the visitor still reaches them, before lowering this \
+         floor."
+    );
+
+    if !violations.is_empty() {
+        let mut report = String::new();
+        for v in &violations {
+            report.push_str(&format!(
+                "\n  {}:{} in `{}` calls `{}`",
+                v.file, v.line, v.func, v.callee
+            ));
+        }
+        panic!(
+            "STYLE-0013 violation: {} member-validation call site(s) neither route through the \
+             shared helper nor carry a `// STYLE-0013:` exemption:{}\n\n\
+             Fix by either (a) routing through `DocumentField::checked_key` (key resolution + \
+             delimiters) or `DocumentField::delimiters_ok` (delimiters only, allocation-free), \
+             or (b) writing `// STYLE-0013: <why this walk cannot route>` inside the function. \
+             See docs/STYLE_GUIDE.md.",
+            violations.len(),
+            report
+        );
+    }
+}
+
+/// The audit must fire on a hand-rolled site. Without this, a visitor that
+/// reaches nothing passes for the same reason a clean tree does.
+#[test]
+fn test_audit_fires_on_an_unmarked_hand_rolled_walk() {
+    let src = r"
+        fn walks_an_object<F: DocumentFields>(fields: &F) -> Result<(), EvalError> {
+            let mut f = fields.clone();
+            while let Some((field, rest)) = f.uncons() {
+                let Some(key) = resolve_display_key(&field.key, &map, &mut guard)? else {
+                    return Err(f.malformed_member_error());
+                };
+                f = rest;
+            }
+            Ok(())
+        }
+    ";
+    let parsed = syn::parse_file(src).expect("fixture parses");
+    let mut audit = Audit::new("fixture.rs", src);
+    audit.visit_file(&parsed);
+    assert_eq!(
+        audit.sites_examined, 1,
+        "the visitor must reach the hand-rolled call"
+    );
+    assert_eq!(
+        audit.violations.len(),
+        1,
+        "an unmarked hand-rolled walk must be reported"
+    );
+    assert_eq!(audit.violations[0].func, "walks_an_object");
+}
+
+/// The same fixture with the marker inside the function must pass -- the
+/// escape hatch has to actually work, or the rule is unusable and people
+/// will delete the test rather than the duplication.
+#[test]
+fn test_audit_accepts_a_marked_walk() {
+    let src = r"
+        fn walks_an_object<F: DocumentFields>(fields: &F) -> Result<(), EvalError> {
+            // STYLE-0013: key-only walk, no value resolved to check a `:` against.
+            let mut f = fields.clone();
+            while let Some((field, rest)) = f.uncons() {
+                let Some(key) = resolve_display_key(&field.key, &map, &mut guard)? else {
+                    return Err(f.malformed_member_error());
+                };
+                f = rest;
+            }
+            Ok(())
+        }
+    ";
+    let parsed = syn::parse_file(src).expect("fixture parses");
+    let mut audit = Audit::new("fixture.rs", src);
+    audit.visit_file(&parsed);
+    assert_eq!(audit.sites_examined, 1);
+    assert!(
+        audit.violations.is_empty(),
+        "a marked walk must be accepted: {:?}",
+        audit.violations.iter().map(|v| v.line).collect::<Vec<_>>()
+    );
+}
+
+/// A marker in one function must not excuse an unmarked call in the next.
+///
+/// This is the failure the STYLE-0012 audit hit for real: without clipping to
+/// the enclosing function's body, a freshly-added unrouted helper passed
+/// because a *neighbour* twenty lines below was routed. Same trap, pinned
+/// here before it can be sprung.
+#[test]
+fn test_marker_does_not_leak_across_function_boundaries() {
+    let src = r"
+        fn exempt_walk<F: DocumentFields>(fields: &F) -> bool {
+            // STYLE-0013: this one has a real reason.
+            key_delimiter_ok::<F>(&key, &cursor, is_first)
+        }
+
+        fn unmarked_walk<F: DocumentFields>(fields: &F) -> bool {
+            value_delimiter_ok::<F>(Some(&field.value), &field.value_cursor)
+        }
+    ";
+    let parsed = syn::parse_file(src).expect("fixture parses");
+    let mut audit = Audit::new("fixture.rs", src);
+    audit.visit_file(&parsed);
+    assert_eq!(audit.sites_examined, 2, "both calls must be examined");
+    assert_eq!(
+        audit.violations.len(),
+        1,
+        "exactly the unmarked function must be reported, not both and not neither"
+    );
+    assert_eq!(audit.violations[0].func, "unmarked_walk");
+}
+
+/// A nested `fn` must not inherit its parent's marker. The stack is what
+/// makes this true; a single "current function" field would not.
+#[test]
+fn test_nested_fn_does_not_inherit_the_parent_marker() {
+    let src = r"
+        fn outer<F: DocumentFields>(fields: &F) -> bool {
+            // STYLE-0013: the outer walk's reason.
+            fn inner<F: DocumentFields>(fields: &F) -> bool {
+                key_delimiter_ok::<F>(&key, &cursor, is_first)
+            }
+            inner(fields)
+        }
+    ";
+    let parsed = syn::parse_file(src).expect("fixture parses");
+    let mut audit = Audit::new("fixture.rs", src);
+    audit.visit_file(&parsed);
+    assert_eq!(
+        audit.violations.len(),
+        1,
+        "the nested fn must be reported despite the parent's marker"
+    );
+    assert_eq!(audit.violations[0].func, "inner");
+}
+
+/// Prose that merely mentions the rule must not exempt a function -- only a
+/// comment that *opens* with the citation does.
+///
+/// Not hypothetical: this is the false negative the first draft of this file
+/// actually had, found by deleting a real marker from
+/// `push_generic_truthiness_cursor_error` and watching the audit stay green,
+/// because that function's own explanation contains the words "the point of
+/// STYLE-0013:". The rule's rationale is exactly the prose most likely to
+/// name the rule, so this is the failure mode a `contains` check is *most*
+/// prone to, not least.
+#[test]
+fn test_prose_mentioning_the_rule_does_not_exempt() {
+    let src = r"
+        fn walks_an_object<F: DocumentFields>(fields: &F) -> bool {
+            // This walk is the reason STYLE-0013: exists, historically.
+            // Some more prose about STYLE-0013: and what it is for.
+            key_delimiter_ok::<F>(&key, &cursor, is_first)
+        }
+    ";
+    let parsed = syn::parse_file(src).expect("fixture parses");
+    let mut audit = Audit::new("fixture.rs", src);
+    audit.visit_file(&parsed);
+    assert_eq!(
+        audit.violations.len(),
+        1,
+        "prose mentioning the rule must not count as a citation"
+    );
+}
+
+/// The citation form itself, pinned in both directions so a future tweak to
+/// [`is_marker_line`] cannot quietly loosen or tighten it.
+#[test]
+fn test_marker_line_recognition() {
+    assert!(is_marker_line("// STYLE-0013: a reason"));
+    assert!(is_marker_line("        // STYLE-0013: indented"));
+    assert!(is_marker_line("//STYLE-0013: no space after slashes"));
+    assert!(!is_marker_line("// see STYLE-0013: for why"));
+    assert!(!is_marker_line("// STYLE-0012: a different rule"));
+    assert!(!is_marker_line("let s = \"STYLE-0013: not a comment\";"));
+}
+
+/// A method call spelling (`cursor.preceding_delimiter_ok(..)`) must be
+/// caught too, not only the free-function form -- three of the five inline
+/// copies #1803 folded were method calls.
+#[test]
+fn test_audit_catches_the_method_call_spelling() {
+    let src = r"
+        fn walks_elements<C: DocumentCursor>(c: &C, is_first: bool) -> bool {
+            let expected = if is_first { None } else { Some(b',') };
+            c.preceding_delimiter_ok(pos, expected)
+        }
+    ";
+    let parsed = syn::parse_file(src).expect("fixture parses");
+    let mut audit = Audit::new("fixture.rs", src);
+    audit.visit_file(&parsed);
+    assert_eq!(audit.violations.len(), 1);
+    assert_eq!(audit.violations[0].callee, "preceding_delimiter_ok");
+}

--- a/tests/jq_member_validation_audit.rs
+++ b/tests/jq_member_validation_audit.rs
@@ -68,6 +68,15 @@ use syn::visit::{self, Visit};
 /// at all: it is the walk that has fallen behind twice (#1975 found it
 /// missing the delimiter checks *and* silently dropping undecodable keys),
 /// and a scan that stopped at the crate boundary would have caught neither.
+///
+/// `jq_runner.rs` (its JSON-only sibling, also `succinctly-cli`) hand-rolls
+/// the same `,`/`:` checks via `preceding_gap_ok` across four functions
+/// (`standard_json_to_jq_value`, `check_preceding_delimiter`,
+/// `validate_json_delimiters`, `print_json`), each with its own
+/// `// STYLE-0013:` exemption citing the perf rationale already documented
+/// beside every one of those calls (#1643/#1676). Left out of `SOURCES`
+/// until now for no recorded reason -- the same "stopped at the crate
+/// boundary" gap `yq_runner.rs`'s own inclusion above exists to close.
 const SOURCES: &[(&str, &str)] = &[
     ("src/jq/eval.rs", include_str!("../src/jq/eval.rs")),
     (
@@ -80,6 +89,10 @@ const SOURCES: &[(&str, &str)] = &[
         "src/bin/succinctly/yq_runner.rs",
         include_str!("../src/bin/succinctly/yq_runner.rs"),
     ),
+    (
+        "src/bin/succinctly/jq_runner.rs",
+        include_str!("../src/bin/succinctly/jq_runner.rs"),
+    ),
 ];
 
 /// The primitives `DocumentField::checked_key` and
@@ -89,11 +102,18 @@ const SOURCES: &[(&str, &str)] = &[
 /// mapping specifically: `element_gap_ok`/`element_gap_ok_at` are the two
 /// definitions of it, and a third re-derivation at a call site is the shape
 /// #1597 extracted and five sites re-grew anyway.
+///
+/// `preceding_gap_ok` is `preceding_delimiter_ok`'s own JSON backing
+/// implementation (`JsonCursor::preceding_delimiter_ok` is a one-line
+/// wrapper around it) -- a call to it outside that wrapper is the exact
+/// same `is_first -> Option<b','>` re-derivation one layer lower, so it
+/// belongs on this list for the same reason `preceding_delimiter_ok` does.
 const AUDITED: &[&str] = &[
     "resolve_display_key",
     "key_delimiter_ok",
     "value_delimiter_ok",
     "preceding_delimiter_ok",
+    "preceding_gap_ok",
 ];
 
 /// The STYLE-0013 exemption marker, cited inline the way STYLE-0004's
@@ -105,14 +125,15 @@ const EXEMPT_MARKER: &str = "STYLE-0013:";
 /// The classic failure of a grep-shaped gate is going quietly vacuous: a
 /// renamed helper, a `syn` upgrade, or a refactor that moves code out from
 /// under the visitor leaves it passing green while checking nothing. Today
-/// the scan sees 5 audited call sites across 5 files (one key-only walk, one
-/// comment-preserving walk, two in the validate-only walk, one in
-/// `to_entries`); the floors sit just
-/// under that. If a legitimate refactor lowers the real count past a floor,
-/// move the floor *and* say in the commit message what shrank -- do not lower
-/// it to make a red test green.
-const MIN_SITES_EXAMINED: usize = 4;
-const MIN_FILES_PARSED: usize = 5;
+/// the scan sees 20 audited call sites across 6 files (verified by
+/// instrumenting `run_audit()` directly, not hand-counted -- the exact
+/// per-walk breakdown drifts too easily to keep current in prose, which is
+/// the same lesson this whole file exists to enforce on the production
+/// code); the floors sit just under that. If a legitimate refactor lowers
+/// the real count past a floor, move the floor *and* say in the commit
+/// message what shrank -- do not lower it to make a red test green.
+const MIN_SITES_EXAMINED: usize = 12;
+const MIN_FILES_PARSED: usize = 6;
 
 struct Site {
     file: &'static str,


### PR DESCRIPTION
## Summary
- `resolve_display_key`/`key_delimiter_ok`/`value_delimiter_ok` + the post-loop `{,}`/`[1,]` tail checks were hand-copied across five call sites in `eval_generic.rs`/`lazy.rs`; unified them behind `DocumentField::checked_key`/`delimiters_ok` and the new `child_tail_gap_ok`/`container_tail_gap_ok` pair (`document.rs`), with each walk that still can't route citing a `// STYLE-0013:` reason.
- Added a static audit (`tests/jq_member_validation_audit.rs`) that scans every source-of-truth file with `syn` and fails if a call to one of the shared primitives sits outside its definition or an exemption comment — closing the class of drift #1803 describes (#1677 → #2211 → #2243/#2262, each round missing a sibling).
- Review pass: fixed a stale/self-contradicting `STYLE-0013` comment claiming the validate-only walk's delimiter checks were still missing (they were fixed by #2349, already landed on this branch); fixed `lazy.rs`'s exemption citing the wrong, closed issue (#2349) instead of its real tracker (#2358); widened the audit itself to see `json/light.rs`'s `find`/`find_cursor` and the previously-unaudited `src/bin/succinctly/jq_runner.rs` (the JSON CLI's own hand-rolled sibling to `yq_runner.rs`); and de-duplicated `container_tail_gap_ok`'s inline check by delegating to `child_tail_gap_ok`, with a pinning test for the receiver-equivalence argument that delegation relies on.

## Test plan
- [x] `cargo test --features cli,simd,regex,serde --lib jq::` (2110 passed)
- [x] `cargo test --features cli,simd,regex,serde --test jq_cli_tests --test jq_golden_tests --test jq_member_validation_audit --test jq_optional_suppression_audit` (all passed)
- [x] `cargo test --features cli,simd,regex,serde --test yq_cli_tests --test yq_golden_tests` (all passed)
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo fmt --check`

Closes #1803.