### PR TITLE
refactor(jq): remove dead limit/first/last blocks from try_parse_builtin

### DIFF
--- a/src/jq/parser.rs
+++ b/src/jq/parser.rs
@@ -4454,21 +4454,22 @@ impl<'a> Parser<'a> {
         }
 
         // Phase 13: Iteration control
-        // limit(n; expr) - output at most n values from expr
-        if self.matches_keyword("limit") {
-            self.consume_keyword("limit");
-            self.skip_ws();
-            self.expect('(')?;
-            self.skip_ws();
-            let n = self.parse_pipe_no_comma()?;
-            self.skip_ws();
-            self.expect(';')?;
-            self.skip_ws();
-            let expr = self.parse_expr()?;
-            self.skip_ws();
-            self.expect(')')?;
-            return Ok(Some(Builtin::Limit(Box::new(n), Box::new(expr))));
-        }
+        //
+        // #2390: `limit`/`first`/`last` are each intercepted earlier, in
+        // `parse_primary_inner` (via `parse_limit_expr`/`parse_first_expr`/
+        // `parse_last_expr`), before this function is ever reached for those
+        // keywords -- `matches_keyword` is a stateless lookahead on
+        // `self.pos`/`self.input` alone, so if it were going to match one of
+        // those three names here, it already matched (and was handled) up
+        // there instead. Confirmed unreachable both by that static argument
+        // and empirically (an `unreachable!()` probe here survived the full
+        // `jq_cli_tests`/`yq_cli_tests`/golden/doc-test suites). This mirrors
+        // the already-documented #1986/#1519/#981 fact that `Builtin::Limit`/
+        // `FirstStream`/`LastStream` are never constructed by the parser --
+        // that remains true and those variants stay live (still matched in
+        // `eval.rs`/`eval_generic.rs`/`walk.rs` and constructed directly by
+        // tests); what's removed here is only this function's own dead
+        // second attempt at recognizing the keywords, not the variants.
 
         // skip(n; expr) - skip first n outputs from expr
         if self.matches_keyword("skip") {
@@ -4478,8 +4479,8 @@ impl<'a> Parser<'a> {
             self.expect('(')?;
             self.skip_ws();
             // `n` deliberately stays restricted to non-comma — same rationale
-            // as `limit`'s `n`: real jq's `$n` parameter convention isn't
-            // implemented here.
+            // as `parse_limit_expr`'s own `n`: real jq's `$n` parameter
+            // convention isn't implemented here.
             let n = self.parse_pipe_no_comma()?;
             self.skip_ws();
             self.expect(';')?;
@@ -4488,41 +4489,6 @@ impl<'a> Parser<'a> {
             self.skip_ws();
             self.expect(')')?;
             return Ok(Some(Builtin::Skip(Box::new(n), Box::new(expr))));
-        }
-
-        // first(expr) or first - output only the first value
-        // first without args is already handled by Phase 5 Builtin::First
-        // first(expr) uses stream version
-        if self.matches_keyword("first") {
-            self.consume_keyword("first");
-            self.skip_ws();
-            if self.peek() == Some('(') {
-                self.next();
-                self.skip_ws();
-                let expr = self.parse_expr()?;
-                self.skip_ws();
-                self.expect(')')?;
-                return Ok(Some(Builtin::FirstStream(Box::new(expr))));
-            }
-            // No-arg first is already handled by Phase 5 Builtin::First
-            return Ok(Some(Builtin::First));
-        }
-
-        // last(expr) or last - output only the last value
-        // last without args is already handled by Phase 5 Builtin::Last
-        if self.matches_keyword("last") {
-            self.consume_keyword("last");
-            self.skip_ws();
-            if self.peek() == Some('(') {
-                self.next();
-                self.skip_ws();
-                let expr = self.parse_expr()?;
-                self.skip_ws();
-                self.expect(')')?;
-                return Ok(Some(Builtin::LastStream(Box::new(expr))));
-            }
-            // No-arg last is already handled by Phase 5 Builtin::Last
-            return Ok(Some(Builtin::Last));
         }
 
         // nth(n; expr) or nth(n) - output only the nth value (0-indexed)
@@ -4534,8 +4500,8 @@ impl<'a> Parser<'a> {
             self.expect('(')?;
             self.skip_ws();
             // `n` deliberately stays restricted to non-comma — same rationale
-            // as `limit`'s `n` above: real jq's `$n` parameter convention
-            // (per-output fanout) isn't implemented here.
+            // as `parse_limit_expr`'s own `n` above: real jq's `$n` parameter
+            // convention (per-output fanout) isn't implemented here.
             let n = self.parse_pipe_no_comma()?;
             self.skip_ws();
             if self.peek() == Some(';') {


### PR DESCRIPTION
## Summary

- `try_parse_builtin`'s own `limit`/`first`/`last` blocks (`src/jq/parser.rs`) were dead code — `parse_primary_inner` already intercepts all three keywords earlier (via `parse_limit_expr`/`parse_first_expr`/`parse_last_expr`), before `try_parse_builtin` is ever reached for those names.
- Confirmed unreachable two ways: statically (`matches_keyword` is a stateless lookahead on `self.pos`/`self.input`, and `self.pos` never moves between the earlier check and the `try_parse_builtin` call, so if it would match here it already matched there) and empirically (a temporary `unreachable!()` probe in all three blocks survived the entire `jq_cli_tests`/`yq_cli_tests`/golden/doc-test suite — 0 hits across 1469+3472+1428+... tests).
- `Builtin::Limit`/`FirstStream`/`LastStream` themselves are **not** removed and remain live — they're still matched in `eval.rs`/`eval_generic.rs`/`walk.rs`/`m2_gate.rs` and constructed directly by tests, per the already-established #1986/#1519/#981 precedent documenting the exact same "never constructed by the parser, kept for direct-AST test coverage" fact for these variants.
- Two nearby comments (`skip`, `nth`) referenced "limit's `n` above" — updated to point at `parse_limit_expr` (the actual reachable implementation) instead of the now-deleted block.

## Test plan

- [x] `cargo build --features cli`
- [x] `cargo test --features cli,simd,regex,serde` — full suite green (jq_cli_tests: 3472 passed, yq_cli_tests: 1428 passed, all others green)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings` — clean
- [x] Diffed `limit(n; f)`, `first(f)`, `last(f)`, bare `first`/`last`, `skip`, `nth` output against pinned `/usr/bin/jq` 1.7.1 — all match, no behavior change
- [x] `cargo llvm-cov --features cli,simd,regex,serde --workspace --summary-only` — clean (deleted lines were 0%-covered dead code, so this is a coverage improvement)

Fixes #2390