### PR TITLE
docs(yq): record float value-route re-spelling as an ADR-0018 divergence (#2419)

### DIFF
--- a/docs/compliance/yq/limitations.md
+++ b/docs/compliance/yq/limitations.md
@@ -2184,6 +2184,59 @@ usable output" a real yq user would see, even though the specific error message
 differs (succinctly raises succinctly's own generator-model error; real yq raises its
 own parse-time rejection).
 
+### Float scalars lose their source spelling on the value route (#2419)
+
+This is the yq-mode counterpart to jq mode's
+["Float literals lose their source spelling"](../jq/limitations.md#float-literals-lose-their-source-spelling)
+— except real yq holds a line real jq does not: real *yq*'s `tostring` echoes a float
+scalar's source text verbatim, with no shortest-rendering exception. Confirmed live against
+the pinned v4.53.3 binary:
+
+```bash
+$ printf 'outer:\n  big: 10000000000000000000.0\n' | yq '.outer.big | tostring'
+10000000000000000000.0
+$ printf 'outer:\n  big: 100000000000000000000\n' | yq '.outer.big | tostring'
+100000000000000000000
+```
+
+succinctly's value route — `.outer.big | tostring`, which resolves the scalar through
+`OwnedValue::Float` — re-spells the value whenever its shortest rendering differs from its
+source text:
+
+```bash
+$ printf 'outer:\n  big: 10000000000000000000.0\n' | succinctly yq '.outer.big | tostring'
+1e+19
+$ printf 'outer:\n  big: 100000000000000000000\n' | succinctly yq '.outer.big | tostring'
+1e+20
+```
+
+`1.50`, `1e3` and `0.1` are unaffected — their shortest rendering already matches their
+source spelling, so [`is_preservable_float_literal`](../../../src/yaml/scalar.rs) keeps them
+intact on both tools — and so is the plain `.outer.big` identity read, which never goes
+through the value route at all.
+
+The path-context bridge route — `.outer.big | parent | .big | tostring` — sidesteps the
+value route entirely and matches real yq on the `.0`-suffixed spelling, but produces a
+*third*, still-wrong spelling on the integer-looking one, where real yq prints the bare
+integer with no trailing `.0`:
+
+```bash
+$ printf 'outer:\n  big: 10000000000000000000.0\n' | succinctly yq '.outer.big | parent | .big | tostring'
+10000000000000000000.0
+$ printf 'outer:\n  big: 100000000000000000000\n' | succinctly yq '.outer.big | parent | .big | tostring'
+100000000000000000000.0
+```
+
+`try_path_context_cursor_walk` (#2061) falls back to this bridge specifically to stay
+output-identical with it whenever a value-route emission would otherwise be re-spelled.
+[#2416](https://github.com/rust-works/succinctly/issues/2416) retires the bridge, at which
+point that fallback has nothing left to defer to — this capture is the evidence that the
+re-spelling is succinctly's own artifact rather than a reference behaviour to match, so
+#2416's path-context walk should emit the document's own spelling once the bridge is gone,
+not inherit either of the two wrong spellings shown above.
+[#2419](https://github.com/rust-works/succinctly/issues/2419) is the ADR-0018 record for
+this divergence; fixing the re-spelling itself is out of its scope.
+
 ### Other categories
 
 Float and number formatting ([#1071](https://github.com/rust-works/succinctly/issues/1071),

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -8803,6 +8803,63 @@ fn test_yq_tostring_computed_nan_uses_yaml_spelling_1060() -> Result<()> {
     Ok(())
 }
 
+/// #2419: pins a *documented divergence*, not desired behaviour -- see
+/// "Float scalars lose their source spelling on the value route (#2419)" in
+/// [`docs/compliance/yq/limitations.md`](../docs/compliance/yq/limitations.md).
+/// Real yq v4.53.3 preserves a float scalar's source spelling everywhere,
+/// including through `tostring`; succinctly's value route (`OwnedValue::Float`)
+/// re-spells it whenever the shortest rendering differs from the source text.
+/// `1.50`/`1e3`/`0.1` are unaffected (`is_preservable_float_literal` keeps
+/// them), and the path-context bridge route (`| parent | .big | tostring`)
+/// avoids the value route but produces a third, still-wrong spelling on the
+/// integer-looking case. All four expectations here were captured live from
+/// the pinned binaries and must move together if either tool's behaviour
+/// changes -- see #2416, which retires the bridge and is expected to fix the
+/// value-route case listed here as its side effect.
+#[test]
+fn test_yq_float_value_route_respelling_2419() -> Result<()> {
+    // Value route: re-spelled by succinctly, preserved by real yq.
+    for (input, want) in [
+        ("outer:\n  big: 10000000000000000000.0\n", "1e+19"),
+        ("outer:\n  big: 100000000000000000000\n", "1e+20"),
+    ] {
+        let (stdout, code) = run_yq_stdin(".outer.big | tostring", input, &["-r"])?;
+        assert_eq!(code, 0, "for {input:?}: {stdout:?}");
+        assert_eq!(stdout.trim_end(), want, "for {input:?}");
+    }
+
+    // Preserved by both tools: shortest rendering already matches source spelling.
+    for (input, want) in [
+        ("outer:\n  big: 1.50\n", "1.50"),
+        ("outer:\n  big: 1e3\n", "1e3"),
+        ("outer:\n  big: 0.1\n", "0.1"),
+    ] {
+        let (stdout, code) = run_yq_stdin(".outer.big | tostring", input, &["-r"])?;
+        assert_eq!(code, 0, "for {input:?}: {stdout:?}");
+        assert_eq!(stdout.trim_end(), want, "for {input:?}");
+    }
+
+    // Path-context bridge route: matches real yq on the `.0`-suffixed case,
+    // but prints a third spelling (`...0.0` instead of real yq's bare
+    // integer `...0`) on the integer-looking case.
+    for (input, want) in [
+        (
+            "outer:\n  big: 10000000000000000000.0\n",
+            "10000000000000000000.0",
+        ),
+        (
+            "outer:\n  big: 100000000000000000000\n",
+            "100000000000000000000.0",
+        ),
+    ] {
+        let (stdout, code) = run_yq_stdin(".outer.big | parent | .big | tostring", input, &["-r"])?;
+        assert_eq!(code, 0, "for {input:?}: {stdout:?}");
+        assert_eq!(stdout.trim_end(), want, "for {input:?}");
+    }
+
+    Ok(())
+}
+
 #[test]
 fn test_build_configuration_flag() -> Result<()> {
     // --build-configuration prints diagnostics and exits successfully.


### PR DESCRIPTION
Closes #2419. Part of the #2416 spine's Phase 2 groundwork (the re-spelling decision); does not close #2416.

## What

- `docs/compliance/yq/limitations.md`: new section "Float scalars lose their source spelling on the value route (#2419)", the yq-mode counterpart of the jq file's "Float literals lose their source spelling". Every output in it was captured live from the pinned yq v4.53.3 and the current succinctly binary.
- `tests/yq_cli_tests.rs`: `test_yq_float_value_route_respelling_2419` pins the current outputs on both routes (value route re-spells `10000000000000000000.0` to `1e+19` and `100000000000000000000` to `1e+20`; bridge route prints a third spelling `100000000000000000000.0`), so a change in either direction is visible. The doc comment says it pins a documented divergence, not desired behaviour.

## Why now

`try_path_context_cursor_walk` falls back to the bridge whenever an emitted value would be re-spelled, purely to stay output-identical with the bridge. #2416 deletes the bridge. This capture shows the re-spelling is succinctly's own artefact, not the reference's, so the walk should emit the document's spelling once the bridge goes. Recording the divergence per ADR-0018 before that change is the prerequisite.

## Verification

- `cargo fmt -- --check`, `cargo clippy --all-targets --all-features -- -D warnings`: clean
- `cargo test --features cli --test yq_cli_tests test_yq_float_value_route_respelling_2419`: 1 passed
