### PR TITLE
fix(yq): map(f)'s path-context arm no longer raises on a non-container (#2375)

### DIFF
--- a/docs/compliance/yq/limitations.md
+++ b/docs/compliance/yq/limitations.md
@@ -2144,13 +2144,33 @@ from a plain read, `del()`, or a `path()`-style path computation (#2346). `=`/`|
 `set_path`/`update_path` machinery already had this right beforehand.
 
 Two adjacent sites were deliberately left unfixed, since a naive copy of the same widening
-would be wrong (not just incomplete) or risks a worse regression:
+would be wrong (not just incomplete) or risks a worse regression. The first has since been
+fixed on its own terms (#2375); the second is still open:
 
-- **`map(f)` still raises** when path-tracking is needed inside `f` (`eval_stage_with_path_
-  context`'s own `Expr::Builtin(Builtin::Map(f))` arm) — `map`'s real yq-mode rule is
-  *asymmetric* (`null` -> `[]`, but any other scalar passes through **unchanged**, confirmed
-  live: `5 | map(.+1)` is `5`, not `[]` or empty), not the uniform "always empty" rule `.[]`
-  itself gets. Tracked as [#2375](https://github.com/rust-works/succinctly/issues/2375).
+- **`map(f)` used to still raise** when path-tracking is needed inside `f`
+  (`eval_stage_with_path_context`'s own `Expr::Builtin(Builtin::Map(f))` arm) — `map`'s
+  real yq-mode rule is *asymmetric* (`null` -> `[]`, but any other scalar passes through
+  **unchanged**), not the uniform "always empty" rule `.[]` itself gets, which is why
+  #2346 left it alone rather than copying its own widening onto it. Fixed in #2375 by
+  giving that arm the same rule the value-only `builtin_map` has had since #1907, captured
+  live against yq v4.53.3 (note the spaced `+`: yq's lexer reads the unspaced `map(.+1)`
+  as a different query entirely, yielding `[]` for *any* input):
+
+  ```bash
+  $ printf 'a: null\n' | yq -o=json -I=0 '.a | map(key)'            # []
+  $ printf 'a: 5\n'    | yq -o=json -I=0 '.a | map(key)'            # 5
+  $ printf 'a: 5\n'    | yq -o=json -I=0 '.a | map(key) | . + 100'  # 105
+  $ printf 'a: 5\n'    | yq -o=json -I=0 '.a | map(. + 1) | key'    # "a"
+  ```
+
+  **Residual gap, not yet fixed:** the *container* rows of the same arm diverge in the
+  opposite direction, and are untouched by #2375. yq's `map(f)` over a container builds a
+  new, detached node whose path is `[]`, so a downstream `key` emits nothing at all
+  (`printf 'a: [1,2]\n' | yq -o=json '.a | map(. + 1) | key'` prints nothing, exit 0),
+  where succinctly still reports the *pre-map* node's key (`"a"`). Passing a non-container
+  through with its path intact — which is what makes the scalar rows above correct — is the
+  same mechanism seen from the other side: yq never replaced the scalar node, so it kept
+  its own path.
 - **`first(.a[])` on a genuinely-resolved scalar still raises** (`resolve_iterate_bounded`,
   shared by `resolve_node`'s own `Expr::Iterate` arm and `first`/`limit`'s fast path) —
   this function is also reached by `resolve_del_path_branches`'s comma-fanout fallback for a

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -34281,6 +34281,53 @@ fn eval_stage_with_path_context<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
                         }
                     }
                 }
+                // #2375: the same non-container rule the value-only
+                // `builtin_map` already applies in yq mode (#1907), which
+                // this arm was missing entirely -- so a `map(f)` whose `f`
+                // (or whose downstream `rest`) needed path context still
+                // raised `Cannot iterate over ...` where plain `map(f)` on
+                // the identical input did not. The rule is asymmetric.
+                //
+                // `null` gets yq's usual empty-container treatment: nothing
+                // to iterate, `results` stays empty, and the tail below
+                // yields `[]` exactly as a `[]` input would. Captured live
+                // (yq v4.53.3, `a: null`): `.a | map(key)` => `[]`,
+                // `.a | map(key) | . + 100` => `[100]`.
+                OwnedValue::Null if S::TAG == EvalTag::Yq => {}
+                // Every *other* scalar passes through completely unchanged
+                // -- `f` never runs, and `rest` continues against that
+                // unchanged value rather than against `[]` or no-output.
+                // Captured live (`a: 5`): `.a | map(key)` => `5`,
+                // `.a | map(key) | . + 100` => `105`. `current_path` is
+                // deliberately handed on untouched, which is what keeps a
+                // downstream `key` reporting the *original* node's own key
+                // (`a: 5`, `.a | map(. + 1) | key` => `"a"`) -- yq never
+                // replaced the node, so it never lost its path (#2375's own
+                // review). The container rows of that same review, where yq
+                // instead re-roots the freshly built array's path so a
+                // downstream `key` emits nothing, still diverge and stay out
+                // of scope here -- recorded as a residual gap in
+                // `docs/compliance/yq/limitations.md`.
+                //
+                // This bypasses the `catch_error_under_optional`/array
+                // construction tail below rather than feeding it, since
+                // there is no array to construct and no per-element control
+                // signal to be atomic about.
+                _ if S::TAG == EvalTag::Yq => {
+                    let passthrough = QueryResult::Owned(value.clone());
+                    return if rest.is_empty() {
+                        passthrough
+                    } else {
+                        continue_rest_with_context::<W, S>(
+                            passthrough,
+                            rest,
+                            root,
+                            file_origin,
+                            current_path,
+                            optional,
+                        )
+                    };
+                }
                 // #2212: currently unreachable with `optional == true`, same
                 // evidence as `catch_error_under_optional`'s doc comment.
                 _ if optional => return QueryResult::None,

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -36938,3 +36938,50 @@ fn test_validate_only_gate_array_element_delimiter_2349() -> Result<()> {
     );
     Ok(())
 }
+
+/// #2375 jq-mode counterpart of
+/// `test_map_path_context_scalar_target_noops_in_yq_mode_2375`
+/// (`tests/yq_cli_tests.rs`): the non-container no-op that fix added to
+/// `eval_stage_with_path_context`'s `Builtin::Map` arm is gated on
+/// `S::TAG == EvalTag::Yq`, so jq mode must keep raising. Real jq has no
+/// `key` builtin at all, so the oracle capture uses `map(. + 1)` and jq's
+/// own value path, which reaches the same error (jq 1.7.1):
+///
+/// ```console
+/// $ echo 'null' | jq 'map(. + 1)'
+/// jq: error (at <stdin>:1): Cannot iterate over null (null)
+/// $ echo '5'    | jq 'map(. + 1)'
+/// jq: error (at <stdin>:1): Cannot iterate over number (5)
+/// $ echo '"s"'  | jq 'map(. + 1)'
+/// jq: error (at <stdin>:1): Cannot iterate over string ("s")
+/// $ echo 'true' | jq 'map(. + 1)'
+/// jq: error (at <stdin>:1): Cannot iterate over boolean (true)
+/// ```
+///
+/// `key` is a succinctly extension in jq mode, and it is what routes these
+/// through the path-context arm rather than `builtin_map` -- the whole
+/// point of this counterpart, since the value path was already correct for
+/// jq before #2375.
+#[test]
+fn test_map_path_context_scalar_target_still_raises_in_jq_mode_2375() -> Result<()> {
+    for (input, expected) in [
+        ("null\n", "Cannot iterate over null (null)"),
+        ("5\n", "Cannot iterate over number (5)"),
+        ("\"s\"\n", "Cannot iterate over string (\"s\")"),
+        ("true\n", "Cannot iterate over boolean (true)"),
+    ] {
+        for filter in [".a | map(key)", ".a | map(key) | . + 100"] {
+            let doc = format!("{{\"a\":{}}}", input.trim());
+            let (stdout, stderr, code) = run_jq_stdin_streams(filter, &doc, &["-c"])?;
+            assert_eq!(
+                code, 5,
+                "doc {doc:?}, filter {filter:?}, stdout: {stdout:?}"
+            );
+            assert!(
+                stderr.contains(expected),
+                "doc {doc:?}, filter {filter:?}, stderr: {stderr:?}"
+            );
+        }
+    }
+    Ok(())
+}

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -25613,15 +25613,23 @@ fn test_yq_error_value_preview_matches_tostring_number_literal_spelling_1055() -
 /// #2346 retired plain `.a[]` as a yq-mode `cannot_iterate` trigger: real
 /// yq's own `.[]` over any non-container is a silent no-op (confirmed live
 /// against yq v4.53.3), not an error, so `.a[]` no longer reaches this
-/// constructor in yq mode at all. `map(key)` still does -- the path-context
-/// evaluator's own `Expr::Builtin(Builtin::Map(f))` arm (distinct from the
-/// value-only evaluator's `builtin_map`, which #2346 left alone since it
-/// was already yq-gated) has no such gate. Deliberately not folded into
-/// #2346's own scope: `map`'s real yq-mode rule is asymmetric (`null` ->
-/// `[]`, any other scalar -> unchanged passthrough, confirmed live), not
-/// the uniform "always empty" rule `.[]` itself gets, so copying #2346's
-/// own widening onto this arm would be wrong, not just incomplete. Tracked
-/// as #2375.
+/// constructor in yq mode at all. This test then used `map(key)`, which
+/// #2375 retired the same way -- the path-context evaluator's
+/// `Expr::Builtin(Builtin::Map(f))` arm now applies the same asymmetric
+/// yq rule (`null` -> `[]`, any other scalar -> unchanged passthrough) the
+/// value-only `builtin_map` already had since #1907.
+///
+/// The trigger is now an assignment whose *path* expression iterates:
+/// `.a | (.[] | key) = 1`, which reaches `cannot_iterate_with` through the
+/// path-computation walk rather than through any `map`/`.[]` evaluation
+/// arm. Like every other yq-mode use of jq's "Cannot iterate over ..."
+/// template, that is itself a divergence from real yq (which no-ops and
+/// prints the document unchanged, confirmed live against v4.53.3) -- a
+/// pre-existing one, unrelated to and deliberately out of scope for #2375.
+/// It is what this test needs, though: the invariant under test is that
+/// *whenever* yq mode does build that preview, the number keeps its source
+/// spelling, and there is no shape where real yq emits the template at all
+/// to compare against instead.
 #[test]
 fn test_yq_cannot_iterate_preview_matches_tostring_number_literal_spelling_1055() -> Result<()> {
     let cases: &[&str] = &["1e2", "1E5", "1.5e-10"];
@@ -25630,7 +25638,7 @@ fn test_yq_cannot_iterate_preview_matches_tostring_number_literal_spelling_1055(
         let (tostring_out, code) = run_yq_stdin(".a | tostring", &input, &[])?;
         assert_eq!(code, 0, "literal={literal} tostring out: {tostring_out:?}");
         let expected = tostring_out.trim();
-        let (_out, stderr, code) = run_yq_stdin_with_stderr(".a | map(key)", &input, &[])?;
+        let (_out, stderr, code) = run_yq_stdin_with_stderr(".a | (.[] | key) = 1", &input, &[])?;
         assert_ne!(code, 0, "literal={literal} unexpectedly iterated a scalar");
         assert!(
             stderr.contains(expected),
@@ -30565,5 +30573,87 @@ fn test_yq_path_step_generic_non_container_is_noop_2346() -> Result<()> {
     let (out, code) = run_yq_stdin("[path(.a[])]", "a: 5\n", &["-o", "json"])?;
     assert_eq!(code, 0, "out: {out:?}");
     assert_eq!(out.trim(), "[]");
+    Ok(())
+}
+
+/// #2375: `map(f)`'s *path-context* arm (`eval_stage_with_path_context`,
+/// `src/jq/eval.rs`) still raised `Cannot iterate over ...` on a
+/// non-container in yq mode, where the value-only `builtin_map` a few
+/// thousand lines above already applied #1907's rule. That arm is the one
+/// reached whenever `f` -- or anything downstream of the `map` -- needs
+/// path tracking; `key` inside `f` is a native yq builtin, so no
+/// `--jq-extensions` flag is needed to reach it.
+///
+/// Captured live from the pinned oracle (yq v4.53.3):
+///
+/// ```console
+/// $ printf 'a: null\n' | yq -o=json -I=0 '.a | map(key)'            # []
+/// $ printf 'a: 5\n'    | yq -o=json -I=0 '.a | map(key)'            # 5
+/// $ printf 'a: "s"\n'  | yq -o=json -I=0 '.a | map(key)'            # "s"
+/// $ printf 'a: true\n' | yq -o=json -I=0 '.a | map(key)'            # true
+/// $ printf 'a: null\n' | yq -o=json -I=0 '.a | map(key) | . + 100'  # [100]
+/// $ printf 'a: 5\n'    | yq -o=json -I=0 '.a | map(key) | . + 100'  # 105
+/// $ printf 'a: 5\n'    | yq -o=json -I=0 '.a | map(. + 1) | key'    # "a"
+/// $ printf 'a: [1,2]\n'  | yq -o=json -I=0 '.a | map(key)'          # [0,1]
+/// $ printf 'a: {b: 1}\n' | yq -o=json -I=0 '.a | map(key)'          # ["b"]
+/// ```
+///
+/// `null` behaves as an already-empty container (result `[]`, and the rest
+/// of the pipe continues against that `[]`); every other scalar passes
+/// through completely unchanged, with the rest of the pipe continuing
+/// against *it* rather than against `[]`. The `map(. + 1) | key` row is
+/// what pins the path: yq never replaced the scalar node, so it keeps its
+/// own path and a downstream `key` still reports `"a"`.
+///
+/// Every capture above spaces the `+`: yq's lexer reads the unspaced
+/// `map(.+1)` as a different query entirely, yielding `[]` for *any* input
+/// (see #2375's review comment).
+#[test]
+fn test_map_path_context_scalar_target_noops_in_yq_mode_2375() -> Result<()> {
+    let args = &["-o=json", "-I=0"];
+
+    // `null` is an already-empty container: `[]`, and `rest` continues
+    // against that `[]`.
+    let (out, code) = run_yq_stdin(".a | map(key)", "a: null\n", args)?;
+    assert_eq!(code, 0, "out: {out:?}");
+    assert_eq!(out.trim(), "[]");
+    let (out, code) = run_yq_stdin(".a | map(key) | . + 100", "a: null\n", args)?;
+    assert_eq!(code, 0, "out: {out:?}");
+    assert_eq!(out.trim(), "[100]");
+
+    // Every other scalar passes through unchanged -- `key` inside the
+    // `map` never runs at all.
+    for (doc, expected) in [
+        ("a: 5\n", "5"),
+        ("a: \"s\"\n", "\"s\""),
+        ("a: true\n", "true"),
+    ] {
+        let (out, code) = run_yq_stdin(".a | map(key)", doc, args)?;
+        assert_eq!(code, 0, "doc {doc:?}, out: {out:?}");
+        assert_eq!(out.trim(), expected, "doc {doc:?}");
+    }
+
+    // ... and `rest` continues against that unchanged value, not `[]`.
+    let (out, code) = run_yq_stdin(".a | map(key) | . + 100", "a: 5\n", args)?;
+    assert_eq!(code, 0, "out: {out:?}");
+    assert_eq!(out.trim(), "105");
+
+    // The passthrough keeps the node's own path, so a `key` downstream of
+    // the `map` still names the original node.
+    for doc in ["a: null\n", "a: 5\n", "a: \"s\"\n", "a: true\n"] {
+        let (out, code) = run_yq_stdin(".a | map(. + 1) | key", doc, args)?;
+        assert_eq!(code, 0, "doc {doc:?}, out: {out:?}");
+        assert_eq!(out.trim(), "\"a\"", "doc {doc:?}");
+    }
+
+    // Containers are unaffected -- `f` still runs per element, each with
+    // its own `key`.
+    let (out, code) = run_yq_stdin(".a | map(key)", "a: [1, 2]\n", args)?;
+    assert_eq!(code, 0, "out: {out:?}");
+    assert_eq!(out.trim(), "[0,1]");
+    let (out, code) = run_yq_stdin(".a | map(key)", "a: {b: 1}\n", args)?;
+    assert_eq!(code, 0, "out: {out:?}");
+    assert_eq!(out.trim(), r#"["b"]"#);
+
     Ok(())
 }


### PR DESCRIPTION
Closes #2375. One of spine 2416 (no hash: a bare mention auto-closes it on merge)'s two "fix now, standalone" issues; does not close 2416, and adds no arm to `eval_stage_with_path_context` (the `jq_path_context_arm_guard` pin stays at 43 — both new arms sit inside the existing `Builtin::Map` arm's own `match value`).

## What

In yq mode only, the Map arm's non-container handling now matches the value-only `builtin_map` (#1907): `null` maps to `[]` and `rest` continues against `[]`; any other scalar passes through unchanged with `current_path` untouched, so a downstream `key` still reports the original node's key. jq mode keeps raising `Cannot iterate over ...`.

## Oracle evidence (yq v4.53.3, jq 1.7.1)

| doc | `.a \| map(key)` | `.a \| map(key) \| . + 100` | `.a \| map(. + 1) \| key` |
|---|---|---|---|
| `a: null` | `[]` | `[100]` | `"a"` |
| `a: 5` | `5` | `105` | `"a"` |
| `a: "s"` | `"s"` | `"s100"` | `"a"` |
| `a: true` | `true` | error | `"a"` |

jq: `Cannot iterate over null (null)` / `number (5)` / `string ("s")` / `boolean (true)`, exit 5, unchanged. Note yq's lexer reads the unspaced `map(.+1)` as a different query (always `[]`); every capture uses the spaced form.

## Tests

- `test_map_path_context_scalar_target_noops_in_yq_mode_2375` (yq): failed before the fix with `Cannot iterate over null (null)`, passes after.
- `test_map_path_context_scalar_target_still_raises_in_jq_mode_2375` (jq): negative-tested — removing the `EvalTag::Yq` gate makes it fail.
- `test_yq_cannot_iterate_preview_matches_tostring_number_literal_spelling_1055` used `.a | map(key)` as its yq-mode raise trigger, which this fix removes (its own comment said "Tracked as #2375"); repointed to `.a | (.[] | key) = 1`, the one remaining yq-mode `cannot_iterate` trigger found in a ~50-shape sweep, with the spelling invariant (`1e2`, `1E5`, `1.5e-10`) re-verified.

## Residual, out of scope

The container rows diverge the other way: yq re-roots the freshly built array so `.a | map(. + 1) | key` emits nothing, where succinctly prints `"a"`. Documented in `docs/compliance/yq/limitations.md` and filed separately against 2416, since it is the Map arm's migration that decides it.

## Verification

fmt; clippy `--all-targets --all-features` and CI's second feature leg; full `cargo test --features cli`; `--no-default-features`; default-feature test; `cargo doc` with `-D warnings`; `sync-yq-golden.sh --check` (87 goldens): all exit 0.

