### PR TITLE
fix(jq): a fold's SOURCE sees a null ambient on every INIT fork but the first (#2388)

### DIFF
--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -24849,6 +24849,130 @@ fn no_fold_register(values: Vec<OwnedValue>) -> Vec<FoldSourceValue> {
         .collect()
 }
 
+/// The ambient `.` a fold's SOURCE runs against on **one** INIT fork, plus
+/// that ambient's own provenance relative to that fork's own
+/// [`FoldRegister`] -- exactly the trio [`resolve_fold_source`] takes
+/// (#2388).
+struct FoldSourceAmbient<'v> {
+    value: &'v OwnedValue,
+    trackable: bool,
+    snapshot: bool,
+    /// Whether a trackable SOURCE branch's own path is *relative to*
+    /// `reg.path` rather than absolute, so [`relocate_source_registers`]
+    /// has to rebase it. Only ever `true` on a `null`-ambient fork whose
+    /// register sits somewhere other than the root -- on the first fork the
+    /// ambient is the document itself, which is only ever at the register
+    /// when the register is the root.
+    relocate: bool,
+}
+
+/// Which `.` a fold's SOURCE sees on INIT fork `fork_index`, and whether
+/// jq's shared path register still recognises it.
+///
+/// **Only the first INIT fork sees the fold's own input; every later fork
+/// sees `null` (#2388).** Real jq re-runs SOURCE per INIT fork, and its
+/// `DUPN` hands the retained-for-backtracking stack slot back as `jv_null()`
+/// once a fork point is live. Confirmed live against jq 1.7.1 on
+/// `{"a":1,"c":2}`:
+///
+/// ```console
+/// $ jq -c '[foreach (.) as $k ((0,1,2); [$k,.])]'
+/// [[{"a":1,"c":2},0],[null,1],[null,2]]
+/// $ jq -c '[foreach (length) as $k ((0,1); $k)]'
+/// [2,0]
+/// ```
+///
+/// -- the `length` row is what rules out treating this as a mere
+/// trackability question: the *values* SOURCE produces differ per fork too,
+/// so the substituted ambient has to reach [`resolve_fold_source`] itself,
+/// not just its two `bool`s.
+///
+/// In `path()` context that is what makes a navigating SOURCE raise on the
+/// second fork where it resolved cleanly on the first: `null` is not the
+/// value the register holds, so jq's per-navigation
+/// `jv_identical(current_input, value_at_path)` fails --
+/// `path(foreach (.a) as $k ((0,1); $k))` streams `["a"]` and then raises
+/// `Invalid path expression near attempt to access element "a" of null`.
+/// Before #2388 succinctly re-ran SOURCE against the document on every
+/// fork and fabricated a second `["a"]` instead.
+///
+/// The `null` ambient *is* at the register when the register itself holds a
+/// `null` -- [`register_identical`]'s kind-based clause for `null`/`bool`,
+/// the same rule every other register comparison in this file uses.
+/// Confirmed live, both directions:
+///
+/// ```console
+/// $ echo 'null'      | jq -c 'path(foreach (.a) as $k ((0,1);  $k))'   # ["a"] ["a"]
+/// $ echo '{"c":null}'| jq -c 'path(foreach (.a) as $k ((0,.c); $k))'   # ["a"] ["c","a"]
+/// ```
+///
+/// The second row is where `relocate` earns its keep: that fork's register
+/// was moved to `["c"]` by INIT, so SOURCE's own `["a"]` is relative to it.
+fn fold_source_ambient<'v>(
+    fork_index: usize,
+    reg: &FoldRegister,
+    value: &'v OwnedValue,
+    null: &'v OwnedValue,
+    trackable: bool,
+    snapshot: bool,
+) -> FoldSourceAmbient<'v> {
+    if fork_index == 0 {
+        // #2031: `doc_branch` stands for the document itself (SOURCE's own
+        // ambient `.`) at its pre-fold position; comparing it to `reg` via
+        // `branch_provenance` answers exactly "is `.` still where the
+        // register is" -- `true` whenever INIT didn't navigate (`reg.path`
+        // stays root, `FoldRegister::enter`'s untracked branch) or
+        // navigated nowhere (`Expr::Identity`, whose own path is root
+        // too), `false` the moment INIT's own navigation moved the
+        // register elsewhere. Confirmed live: `path(foreach (.a) as $k
+        // (.a; .))` raises "near attempt to access element a of
+        // {\"a\":1}" from SOURCE's own `.a` -- the very same expression
+        // that, run as `path(foreach (.a) as $k (0; .))`, resolves cleanly
+        // -- so this has to be recomputed per INIT fork, not read once
+        // from the fold's own ambient `trackable`/`snapshot`.
+        let doc_branch = PathBranch::passthrough(
+            PathPrefix::root(),
+            Cow::Borrowed(value),
+            trackable,
+            snapshot,
+        );
+        let (source_trackable, source_snapshot) = reg.branch_provenance(Some(&doc_branch));
+        return FoldSourceAmbient {
+            value,
+            trackable: source_trackable,
+            snapshot: source_snapshot,
+            relocate: false,
+        };
+    }
+    // A later fork's ambient is `null`, so `branch_provenance`'s
+    // path-equality shortcut cannot answer this: the question is no longer
+    // "did INIT move the register off the document's own root position" but
+    // "does the register recognise a `null`", which is a *value* question
+    // `register_identical` owns. `snapshot: false` -- a freshly-substituted
+    // `null` is not a frozen `$var` binding.
+    let at_register = reg.trackable && register_identical(&reg.value, null, false);
+    FoldSourceAmbient {
+        value: null,
+        trackable: at_register,
+        snapshot: false,
+        relocate: at_register && reg.path.depth() > 0,
+    }
+}
+
+/// Rebase every trackable SOURCE element's own
+/// [`register_path`](FoldSourceValue::register_path) onto `base`, for the
+/// one ambient shape whose resolved paths come back relative to the
+/// register rather than absolute -- see
+/// [`FoldSourceAmbient::relocate`] (#2388). Mirrors
+/// [`FoldRegister::relocate`]'s own trackable arm exactly.
+fn relocate_source_registers(elements: &mut [FoldSourceValue], base: &Rc<PathPrefix>) {
+    for elem in elements {
+        if let Some(path) = &elem.register_path {
+            elem.register_path = Some(PathPrefix::extend_many(base, path.to_vec()));
+        }
+    }
+}
+
 /// `path()`-tracking counterpart of [`eval_reduce`] — resolves
 /// `reduce EXPR as $var (INIT; UPDATE)` in path context, replicating
 /// `eval_reduce`'s own control flow (INIT forks, per-source-element UPDATE
@@ -24913,31 +25037,18 @@ fn resolve_reduce<'a, S: EvalSemantics>(
     // Shared across every INIT fork (#695), same "whole tree, not
     // per-branch" accounting `eval_reduce` itself uses.
     let mut budget = REDUCE_FOREACH_MAX_STEPS;
-    for init_branch in &init_branches {
+    // #2388: hoisted so `fold_source_ambient` can hand a later fork's
+    // `null` ambient back as a borrow rather than allocating one per fork.
+    let null_ambient = OwnedValue::Null;
+    for (fork_index, init_branch) in init_branches.iter().enumerate() {
         let (reg, acc) = FoldRegister::enter(init_branch, value, trackable);
 
         // #2031: SOURCE runs immediately after INIT against the same
         // shared register real jq threads through the whole construct.
-        // `doc_branch` stands for the document itself (SOURCE's own
-        // ambient `.`) at its pre-fold position; comparing it to `reg` via
-        // `branch_provenance` answers exactly "is `.` still where the
-        // register is" -- `true` whenever INIT didn't navigate (`reg.path`
-        // stays root, `FoldRegister::enter`'s untracked branch) or
-        // navigated nowhere (`Expr::Identity`, whose own path is root
-        // too), `false` the moment INIT's own navigation moved the
-        // register elsewhere. Confirmed live: `path(foreach (.a) as $k
-        // (.a; .))` raises "near attempt to access element a of
-        // {\"a\":1}" from SOURCE's own `.a` -- the very same expression
-        // that, run as `path(foreach (.a) as $k (0; .))`, resolves cleanly
-        // -- so this has to be recomputed per INIT fork, not read once
-        // from the fold's own ambient `trackable`/`snapshot`.
-        let doc_branch = PathBranch::passthrough(
-            PathPrefix::root(),
-            Cow::Borrowed(value),
-            trackable,
-            snapshot,
-        );
-        let (source_trackable, source_snapshot) = reg.branch_provenance(Some(&doc_branch));
+        // #2388: and only the *first* INIT fork sees the fold's own input
+        // as that SOURCE's ambient `.` -- see `fold_source_ambient`.
+        let ambient =
+            fold_source_ambient(fork_index, &reg, value, &null_ambient, trackable, snapshot);
         // Mirrors `eval_reduce`'s own source-stream handling: `reduce`'s
         // output is always single-shot, so a `Partial` input just extracts
         // the control and drops the prefix (there's no path-tracking
@@ -24947,8 +25058,11 @@ fn resolve_reduce<'a, S: EvalSemantics>(
         // `foreach` has a prefix to stream first (#1872). Whatever earlier
         // INIT forks already emitted into `out` survives, same as any
         // other mid-loop abort below.
-        let (input_values, input_escape) =
-            resolve_fold_source::<S>(input, value, source_trackable, source_snapshot);
+        let (mut input_values, input_escape) =
+            resolve_fold_source::<S>(input, ambient.value, ambient.trackable, ambient.snapshot);
+        if ambient.relocate {
+            relocate_source_registers(&mut input_values, &reg.path);
+        }
         if let Some(control) = input_escape {
             return path_result(out, Some(control.into()));
         }
@@ -25143,26 +25257,27 @@ fn resolve_foreach<'a, S: EvalSemantics>(
 
     let mut out: Vec<PathBranch<'a>> = Vec::new();
     let mut budget = REDUCE_FOREACH_MAX_STEPS;
-    for init_branch in &init_branches {
+    // #2388: see `resolve_reduce`'s identical hoist.
+    let null_ambient = OwnedValue::Null;
+    for (fork_index, init_branch) in init_branches.iter().enumerate() {
         let (reg, mut state) = FoldRegister::enter(init_branch, value, trackable);
 
-        // #2031: see `resolve_reduce`'s identical derivation — SOURCE's own
-        // ambient trackable/snapshot is recomputed per INIT fork from
-        // wherever that fork's own register stands after INIT ran.
-        let doc_branch = PathBranch::passthrough(
-            PathPrefix::root(),
-            Cow::Borrowed(value),
-            trackable,
-            snapshot,
-        );
-        let (source_trackable, source_snapshot) = reg.branch_provenance(Some(&doc_branch));
+        // #2031/#2388: see `resolve_reduce`'s identical derivation —
+        // SOURCE's own ambient value, trackability and snapshot mark are
+        // all recomputed per INIT fork from wherever that fork's own
+        // register stands after INIT ran.
+        let ambient =
+            fold_source_ambient(fork_index, &reg, value, &null_ambient, trackable, snapshot);
         // Unlike `reduce`, a `Partial` source stream's own prefix is
         // iterated below — mirrors `eval_foreach`'s identical rule, and
         // #1467's path-check escape is now just another such trailing
         // control rather than a short-circuit ahead of this call, which is
         // what lets the elements produced before it still stream (#1872).
-        let (input_values, input_control) =
-            resolve_fold_source::<S>(input, value, source_trackable, source_snapshot);
+        let (mut input_values, input_control) =
+            resolve_fold_source::<S>(input, ambient.value, ambient.trackable, ambient.snapshot);
+        if ambient.relocate {
+            relocate_source_registers(&mut input_values, &reg.path);
+        }
 
         // `eval_foreach`'s own substitution, minus the two things this
         // function's `[Pattern::Var(_)]` gate (see `resolve_node`'s dispatch

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -36985,3 +36985,254 @@ fn test_map_path_context_scalar_target_still_raises_in_jq_mode_2375() -> Result<
     }
     Ok(())
 }
+/// #2388: a fold's SOURCE is re-run once per INIT fork, and **only the first
+/// fork sees the fold's own input** -- every later fork sees `null`, because
+/// jq's `DUPN` hands a stack slot that is still retained for backtracking
+/// back as `jv_null()`. Confirmed live against jq 1.7.1 on `{"a":1,"c":2}`:
+///
+/// ```console
+/// $ jq -c '[foreach (.) as $k ((0,1,2); [$k,.])]'
+/// [[{"a":1,"c":2},0],[null,1],[null,2]]
+/// ```
+///
+/// In `path()` context that makes a *navigating* SOURCE raise on the second
+/// fork where it resolved cleanly on the first: `null` is not the value jq's
+/// path register holds, so its per-navigation `jv_identical` check fails.
+/// Before this fix succinctly re-ran SOURCE against the document on every
+/// fork and **fabricated** a second (third, ...) copy of the first fork's
+/// path instead:
+///
+/// ```console
+/// $ echo '{"a":1,"c":2}' | jq -c 'path(foreach (.a) as $k ((0,1); $k))'
+/// jq: error (at <stdin>:1): Invalid path expression near attempt to access element "a" of null
+/// ["a"]                                     # exit 5
+/// $ echo '{"a":1,"c":2}' | succinctly jq -c 'path(foreach (.a) as $k ((0,1); $k))'
+/// ["a"]
+/// ["a"]                                     # exit 0  <- fabricated
+/// ```
+///
+/// #2031's `FoldRegister::branch_provenance` restriction already rejected a
+/// *navigating* second fork (`(0,.c)`); this is the non-navigating one it
+/// could not see, since the register never moved.
+///
+/// The partial-output shape is pinned too, and it differs between the two
+/// constructs: `foreach` streams the first fork's outputs *before* raising,
+/// `reduce` emits nothing (its own final-emission check raises on the first
+/// fork already, before the second is ever entered).
+#[test]
+fn test_foreach_init_fork_source_sees_null_ambient_2388() -> Result<()> {
+    const DOC: &str = r#"{"a":1,"c":2}"#;
+    // (filter, stdout jq streams before raising) -- every row captured from
+    // /usr/bin/jq 1.7.1 on DOC, all exit 5 with
+    // `Invalid path expression near attempt to access element "a" of null`.
+    let cases: &[(&str, &str)] = &[
+        // Two forks, neither navigating -- the headline repro.
+        ("path(foreach (.a) as $k ((0,1); $k))", "[\"a\"]\n"),
+        // Identical INIT values: it is the *fork count*, not the values.
+        ("path(foreach (.a) as $k ((0,0); $k))", "[\"a\"]\n"),
+        // Three forks still raise exactly once, on the second.
+        ("path(foreach (.a) as $k ((0,1,2); $k))", "[\"a\"]\n"),
+        // A `null` first fork is no different -- the register holds the
+        // *document*, not INIT's own value.
+        ("path(foreach (.a) as $k ((null,1); $k))", "[\"a\"]\n"),
+        // A navigating second fork raises for the same reason (#2031 already
+        // rejected this one, but its operand wording was wrong -- see below).
+        ("path(foreach (.a) as $k ((0,.c); $k))", "[\"a\"]\n"),
+        // A multi-element SOURCE streams the whole first fork first.
+        (
+            "path(foreach (.a,.c) as $k ((0,1); $k))",
+            "[\"a\"]\n[\"c\"]\n",
+        ),
+        (
+            "path(foreach (.a,.c) as $k ((0,1,2); $k))",
+            "[\"a\"]\n[\"c\"]\n",
+        ),
+        // Collected into an array, jq emits nothing at all: the array
+        // constructor never completes.
+        ("[path(foreach (.a) as $k ((0,1); $k))]", ""),
+        ("[path(foreach (.a) as $k ((0,0); $k))]", ""),
+        ("[path(foreach (.a) as $k ((0,1,2); $k))]", ""),
+        ("[path(foreach (.a) as $k ((null,1); $k))]", ""),
+        ("[path(foreach (.a) as $k ((0,.c); $k))]", ""),
+        ("[path(foreach (.a,.c) as $k ((0,1); $k))]", ""),
+    ];
+    for (filter, want_stdout) in cases {
+        let (stdout, stderr, code) = run_jq_stdin_streams(filter, DOC, &["-c"])?;
+        assert_eq!(code, 5, "`{filter}` should exit 5; stderr: {stderr:?}");
+        assert_eq!(
+            stdout, *want_stdout,
+            "`{filter}` streamed the wrong prefix before raising"
+        );
+        assert!(
+            stderr
+                .contains(r#"Invalid path expression near attempt to access element "a" of null"#),
+            "`{filter}`: wanted jq's `... of null` operand, got {stderr:?}"
+        );
+    }
+
+    // `reduce` never reaches the second fork: its own exit-boundary re-check
+    // raises on the first one. Captured from jq 1.7.1, same DOC.
+    let reduce_cases: &[(&str, &str)] = &[
+        ("path(reduce (.a) as $k ((0,1); $k))", "with result 1"),
+        ("path(reduce (.a) as $k ((0,1,2); $k))", "with result 1"),
+        ("path(reduce (.a) as $k ((0,.c); $k))", "with result 1"),
+        ("path(reduce (.a,.c) as $k ((0,1); $k))", "with result 2"),
+        ("[path(reduce (.a) as $k ((0,1); $k))]", "with result 1"),
+    ];
+    for (filter, want_err) in reduce_cases {
+        let (stdout, stderr, code) = run_jq_stdin_streams(filter, DOC, &["-c"])?;
+        assert_eq!(code, 5, "`{filter}` should exit 5; stderr: {stderr:?}");
+        assert_eq!(
+            stdout, "",
+            "`{filter}`: reduce emits nothing before raising"
+        );
+        assert!(
+            stderr.contains(want_err),
+            "`{filter}`: wanted `{want_err}`, got {stderr:?}"
+        );
+    }
+    Ok(())
+}
+
+/// #2388, the secondary half: the error's *operand*. jq names the ambient
+/// input the failed navigation was attempted on, and on a later INIT fork
+/// that input is `null`, not the document. Succinctly used to name the
+/// document, because it re-ran SOURCE against it:
+///
+/// ```console
+/// $ echo '{"a":1,"c":2}' | jq -c 'path(foreach (.a) as $k ((0,.c); $k))'
+/// jq: error (at <stdin>:1): Invalid path expression near attempt to access element "a" of null
+/// # succinctly, before #2388: `... element "a" of {"a":1,"c":2}`
+/// ```
+///
+/// Pinned separately from the case list above because it is the one row whose
+/// *exit code and stdout were already right* -- only the wording moved, so a
+/// test that checked exit codes alone would not have caught it.
+#[test]
+fn test_foreach_init_fork_error_operand_is_null_2388() -> Result<()> {
+    let (stdout, stderr, code) = run_jq_stdin_streams(
+        "path(foreach (.a) as $k ((0,.c); $k))",
+        r#"{"a":1,"c":2}"#,
+        &["-c"],
+    )?;
+    assert_eq!(code, 5, "stderr: {stderr:?}");
+    assert_eq!(stdout, "[\"a\"]\n");
+    assert!(
+        stderr.contains(r#"element "a" of null"#),
+        "wanted jq's `of null` operand: {stderr:?}"
+    );
+    assert!(
+        !stderr.contains(r#"of {"a":1,"c":2}"#),
+        "the document must not be named as the operand: {stderr:?}"
+    );
+    Ok(())
+}
+
+/// #2388 controls: the rows the null-ambient change must **not** move.
+///
+/// All captured from /usr/bin/jq 1.7.1 on `{"a":1,"c":2}`. A single-fork INIT
+/// never re-runs SOURCE at all, so it keeps resolving against the document; a
+/// *first* fork that navigates raises with the **document** as the operand
+/// (the register moved off root, and the ambient is still the document) and
+/// streams nothing at all, which is the row that proves the change is keyed
+/// on the fork index rather than on "INIT navigated somewhere".
+#[test]
+fn test_fold_init_fork_unchanged_rows_2388() -> Result<()> {
+    const DOC: &str = r#"{"a":1,"c":2}"#;
+
+    // Single-fork INIT: SOURCE still sees the document, path resolves.
+    let ok_cases: &[(&str, &str)] = &[
+        ("path(foreach (.a) as $k (0; $k))", "[\"a\"]\n"),
+        ("path(foreach (.a) as $k (null; $k))", "[\"a\"]\n"),
+        ("path(foreach (.a,.c) as $k (0; $k))", "[\"a\"]\n[\"c\"]\n"),
+        ("[path(foreach (.a) as $k (0; $k))]", "[[\"a\"]]\n"),
+        (
+            "[path(foreach (.a,.c) as $k (null; $k))]",
+            "[[\"a\"],[\"c\"]]\n",
+        ),
+    ];
+    for (filter, want) in ok_cases {
+        let (stdout, stderr, code) = run_jq_stdin_streams(filter, DOC, &["-c"])?;
+        assert_eq!(code, 0, "`{filter}` should succeed; stderr: {stderr:?}");
+        assert_eq!(stdout, *want, "`{filter}`");
+    }
+
+    // A navigating *first* fork: operand is the document, and nothing streams
+    // -- the raise happens before the first fork emits anything.
+    let doc_operand: &[&str] = &[
+        "path(foreach (.a) as $k ((.c,0); $k))",
+        "path(reduce (.a) as $k ((.c,0); $k))",
+        "[path(foreach (.a,.c) as $k ((.c,0); $k))]",
+    ];
+    for filter in doc_operand {
+        let (stdout, stderr, code) = run_jq_stdin_streams(filter, DOC, &["-c"])?;
+        assert_eq!(code, 5, "`{filter}` should exit 5; stderr: {stderr:?}");
+        assert_eq!(stdout, "", "`{filter}` must stream nothing");
+        assert!(
+            stderr.contains(r#"element "a" of {"a":1,"c":2}"#),
+            "`{filter}`: wanted the document as the operand, got {stderr:?}"
+        );
+    }
+
+    // A non-navigating SOURCE never routes through the path resolver at all,
+    // so the fork's ambient only shows up in the raised *value*: jq says
+    // `with result 2` (the first fork's own `length` of the document).
+    let (stdout, stderr, code) =
+        run_jq_stdin_streams("path(foreach (length) as $k ((0,1); $k))", DOC, &["-c"])?;
+    assert_eq!(code, 5, "stderr: {stderr:?}");
+    assert_eq!(stdout, "");
+    assert!(
+        stderr.contains("Invalid path expression with result 2"),
+        "{stderr:?}"
+    );
+    Ok(())
+}
+
+/// #2388: a `null` ambient is not automatically *untrackable* -- jq's
+/// register comparison is kind-based for `null`/`bool`
+/// (`register_identical`), so a later fork resolves cleanly whenever the
+/// register itself holds a `null`. Both directions captured live from
+/// /usr/bin/jq 1.7.1:
+///
+/// ```console
+/// $ echo 'null'       | jq -c 'path(foreach (.a) as $k ((0,1);  $k))'   # ["a"] ["a"], exit 0
+/// $ echo '{"c":null}' | jq -c 'path(foreach (.a) as $k ((0,.c); $k))'   # ["a"] ["c","a"], exit 0
+/// $ echo '{"a":null}' | jq -c 'path(foreach (.a) as $k ((0,1);  $k))'   # ["a"] then raises
+/// ```
+///
+/// The middle row is the one that needs the register's own path rebased onto
+/// SOURCE's result: that fork's INIT navigated to `["c"]`, so SOURCE's own
+/// `["a"]` is relative to it. Without the rebase it would answer `["a"]`
+/// twice -- the same fabrication class, one level down. The third row is the
+/// near-miss control: a `null` *somewhere in* the document is not the same as
+/// a `null` at the register.
+#[test]
+fn test_foreach_init_fork_null_register_still_tracks_2388() -> Result<()> {
+    // Register is the document root, and the document is `null`.
+    let (stdout, stderr, code) =
+        run_jq_stdin_streams("path(foreach (.a) as $k ((0,1); $k))", "null", &["-c"])?;
+    assert_eq!(code, 0, "stderr: {stderr:?}");
+    assert_eq!(stdout, "[\"a\"]\n[\"a\"]\n");
+
+    // Register moved to `["c"]` by INIT, and `.c` is `null`: the second
+    // fork's own path is rebased onto it.
+    let (stdout, stderr, code) = run_jq_stdin_streams(
+        "path(foreach (.a) as $k ((0,.c); $k))",
+        r#"{"c":null}"#,
+        &["-c"],
+    )?;
+    assert_eq!(code, 0, "stderr: {stderr:?}");
+    assert_eq!(stdout, "[\"a\"]\n[\"c\",\"a\"]\n");
+
+    // Control: a `null` elsewhere in the document does not make the ambient
+    // `null` match the register.
+    let (stdout, stderr, code) = run_jq_stdin_streams(
+        "path(foreach (.a) as $k ((0,1); $k))",
+        r#"{"a":null}"#,
+        &["-c"],
+    )?;
+    assert_eq!(code, 5, "stderr: {stderr:?}");
+    assert_eq!(stdout, "[\"a\"]\n");
+    assert!(stderr.contains(r#"element "a" of null"#), "{stderr:?}");
+    Ok(())
+}


### PR DESCRIPTION
Closes #2388 (as re-scoped in its thread after the oracle capture). One of spine 2416's two "fix now, standalone" issues; the spine number is written without a hash on purpose. Touches only the path resolver (`resolve_reduce`/`resolve_foreach`), not `eval_stage_with_path_context` (the arm-count pin stays at 43).

## The bug

```console
$ echo '{"a":1,"c":2}' | jq -c 'path(foreach (.a) as $k ((0,1); $k))'
jq: error (at <stdin>:1): Invalid path expression near attempt to access element "a" of null
["a"]
$ echo '{"a":1,"c":2}' | succinctly jq -c 'path(foreach (.a) as $k ((0,1); $k))'   # before
["a"]
["a"]
```

## Mechanism (jq 1.7.1, captured live)

jq re-runs SOURCE once per INIT fork, and only the **first** fork sees the fold's input; `DUPN` hands the retained-for-backtracking slot back as null, so every later fork's SOURCE runs against `null`. This is a value fact, not just a trackability one:

```console
$ jq -c '[foreach (.) as $k ((0,1,2); [$k,.])]'    # [[{"a":1,"c":2},0],[null,1],[null,2]]
$ jq -c '[foreach (length) as $k ((0,1); $k)]'      # [2,0]
```

In `path()` context, `null` is not what the register holds, so the second fork's `.a` fails jq's per-navigation identity check. succinctly re-ran SOURCE against the document on every fork; #2031's provenance gate caught a *navigating* second fork (`(0,.c)`) but not a non-navigating one (`(0,1)`), which fabricated a duplicate path.

## Change

`fold_source_ambient(fork_index, ..)`: fork 0 keeps #2031's logic verbatim; later forks get a null ambient, trackable only when the register itself holds a null (`register_identical`'s null/bool clause), plus `relocate_source_registers` to rebase a trackable SOURCE path onto a non-root register — the one shape the null ambient newly reaches (`{"c":null}` with INIT `(0,.c)` → `["a"]`, `["c","a"]`, matching jq). The error-operand wording (`of null`, not `of {...}`) falls out of the same change.

## Oracle table

64 rows (`foreach`/`reduce` × SOURCE `.a`/`.a,.c` × 8 INIT shapes × bare/`[..]`-wrapped): 20 diffs before, 0 after. `reduce` already matched jq on every row (its exit-boundary re-check raises on fork 1, so fork 2 is never entered).

## Tests (`tests/jq_cli_tests.rs`, jq captures in doc comments)

`test_foreach_init_fork_source_sees_null_ambient_2388` (13 foreach + 5 reduce rows), `test_foreach_init_fork_error_operand_is_null_2388`, `test_fold_init_fork_unchanged_rows_2388` (must-not-move rows), `test_foreach_init_fork_null_register_still_tracks_2388`. Three of four fail on the pre-fix tree; the controls test passes.

Not changed: the value evaluator's `[1,1]` vs jq's `[1,null]` (#2163/#2386), and `path_ctx_path_foreach_getpath` (single-fork INIT, a different `getpath`-source bug; its known-failure entry in PR #2426 stays).

## Verification

fmt; clippy (`--all-features` and CI's second leg); full `cargo test --features cli`; arm guard; `sync-jq-golden.sh --check` with the pinned jq first on PATH; `cargo doc -D warnings`; `--no-default-features`; default features: all exit 0, re-run after rebasing onto 9f264dd26.
