### PR TITLE
feat(jq): construct objects natively in the generic evaluator, cursor threaded (#1332)

### DIFF
--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -50,7 +50,7 @@ use super::eval::{
 };
 #[cfg(test)]
 use super::expr::FuncDefBound;
-use super::expr::{Builtin, CompareOp, Expr, FormatType, Pattern};
+use super::expr::{Builtin, CompareOp, Expr, FormatType, ObjectEntry, ObjectKey, Pattern};
 use super::slice::{slice_str, SliceBounds};
 use super::value::{owned_value_eq, NumberRepr, OwnedValue};
 use crate::json::JsonIndex;
@@ -5989,6 +5989,41 @@ fn eval_single<S: EvalSemantics, V: DocumentValue>(
         // after the loop, not per-sibling -- same reasoning as `Expr::Array`
         // above, and cheaper (one round trip for `.a, .b, .c` instead of up
         // to three).
+        // #2416 phase 3 / #1332: object construction natively, with the
+        // cursor threaded into every key and value expression, so `{k: key}`
+        // answers the node's own key instead of bridging the whole construct
+        // to the eager evaluator (which had no `Expr::Object` arm and lost
+        // the position). Mirrors `eval::build_object_entries` shape for
+        // shape: keys vary slowest, a non-string key errors (or is swallowed
+        // under `optional`, discarding what was built), and a generator's
+        // trailing escape becomes a `Partial` after the objects already
+        // built.
+        Expr::Object(entries) => {
+            let mut objects = Vec::new();
+            let mut acc: Vec<(String, OwnedValue)> = Vec::new();
+            let built = build_object_entries_generic::<S, V>(
+                entries,
+                &value,
+                optional,
+                cursor,
+                true,
+                &mut acc,
+                &mut objects,
+            );
+            // Deliberately *not* passed through `yq_float_fidelity_fixup`: the
+            // bridge this arm replaces returned the eager evaluator's objects
+            // as built, leaving a computed float bare for the YAML emitter's
+            // nested-float rule (`{"a": (.a * 1e100)}` prints `a: 1e+100`,
+            // as real yq does). The fixup's reindex round trip spells that
+            // same float out in full, which is the `Expr::Array` arm's own
+            // pre-existing divergence (`[.a * 1e100]`), not one to inherit.
+            match built {
+                Ok(()) => owned_vec_to_generic_result(objects),
+                Err(ObjectEscapeGeneric::Suppressed) => GenericResult::None,
+                Err(ObjectEscapeGeneric::Control(control)) => partial_generic(objects, control),
+            }
+        }
+
         Expr::Comma(exprs) => {
             let mut out: Vec<OwnedValue> = Vec::new();
             for expr in exprs {
@@ -10826,6 +10861,87 @@ pub fn path_context_pipe_streams_cursors(exprs: &[Expr]) -> bool {
         && path_context_walk_split(exprs).is_some_and(|(_, rest)| rest.is_empty())
 }
 
+/// How object construction stops early: a non-string key under `optional`
+/// yields nothing at all (what was built so far is discarded, as
+/// `eval::eval_object_construction` does), any other escape carries the
+/// control out after the objects already built.
+enum ObjectEscapeGeneric {
+    Suppressed,
+    Control(Control),
+}
+
+/// The generic twin of `eval::build_object_entries` (#2416 phase 3): one
+/// object per combination of key and value outputs, keys varying slowest,
+/// every sub-expression evaluated with `cursor` so path-context builtins
+/// inside the construction answer as cursor properties.
+fn build_object_entries_generic<S: EvalSemantics, V: DocumentValue>(
+    entries: &[ObjectEntry],
+    value: &V,
+    optional: bool,
+    cursor: Option<V::Cursor>,
+    sole: bool,
+    acc: &mut Vec<(String, OwnedValue)>,
+    out: &mut Vec<OwnedValue>,
+) -> Result<(), ObjectEscapeGeneric> {
+    let Some((entry, rest)) = entries.split_first() else {
+        let object = if sole {
+            core::mem::take(acc).into_iter().collect::<IndexMap<_, _>>()
+        } else {
+            acc.iter().cloned().collect::<IndexMap<_, _>>()
+        };
+        out.push(OwnedValue::Object(object));
+        return Ok(());
+    };
+
+    let (keys, key_trailing) = match &entry.key {
+        ObjectKey::Literal(name) => (vec![OwnedValue::String(name.clone())], None),
+        ObjectKey::Expr(key_expr) => {
+            let mut keys = Vec::new();
+            let trailing = push_generic_owned_values(
+                eval_single::<S, V>(key_expr, value.clone(), optional, cursor),
+                &mut keys,
+            );
+            (keys, trailing)
+        }
+    };
+    let sole = sole && keys.len() == 1;
+
+    for key in keys {
+        let mut vals = Vec::new();
+        let val_trailing = push_generic_owned_values(
+            eval_single::<S, V>(&entry.value, value.clone(), optional, cursor),
+            &mut vals,
+        );
+        let sole = sole && vals.len() == 1;
+
+        for val in vals {
+            let OwnedValue::String(key_str) = &key else {
+                return Err(if optional {
+                    ObjectEscapeGeneric::Suppressed
+                } else {
+                    ObjectEscapeGeneric::Control(Control::Error(
+                        EvalError::cannot_use_as_object_key(&key),
+                    ))
+                });
+            };
+            acc.push((key_str.clone(), val));
+            let result =
+                build_object_entries_generic::<S, V>(rest, value, optional, cursor, sole, acc, out);
+            acc.pop();
+            result?;
+        }
+
+        if let Some(control) = val_trailing {
+            return Err(ObjectEscapeGeneric::Control(control));
+        }
+    }
+
+    if let Some(control) = key_trailing {
+        return Err(ObjectEscapeGeneric::Control(control));
+    }
+    Ok(())
+}
+
 /// The key under which `c` sits in its parent -- a field name or an element
 /// index -- or `None` at the document root (#2416 phase 3).
 ///
@@ -11018,19 +11134,20 @@ fn path_context_stage_preserves_node(expr: &Expr) -> bool {
     }
 }
 
-/// A top-level pipe stage the generic *sink* evaluator handles natively with
-/// the cursor threaded through: the bounded consumers (`limit`/`first`/
-/// `last`/`nth`), which `eval_each_generic` drives lazily, around anything
-/// [`path_context_single_native`] admits.
+/// A top-level pipe stage the generic evaluator handles natively with the
+/// cursor threaded through, on *either* route.
+///
+/// Both routes can evaluate a stage: the sink pipeline (`eval_each_generic`)
+/// and the non-sink one (`eval_single` + `fold_pipe_stages`), which is what
+/// the yq CLI's DOM path drives. A construct native in the sink evaluator
+/// only -- `if`, arithmetic, `limit` -- still bridges to the eager evaluator
+/// from `eval_single`, with no cursor, so admitting it here answered
+/// `.[] | key + 10` as `null + 10` on that route. Hence this is exactly
+/// [`path_context_single_native`], plus the two bounded consumers that have
+/// native `eval_single` arms of their own.
 fn path_context_stage_native(expr: &Expr) -> bool {
     match expr {
-        Expr::Limit { n, expr } => {
-            matches!(**n, Expr::Literal(_)) && path_context_stage_native(expr)
-        }
         Expr::FirstExpr(inner) | Expr::LastExpr(inner) => path_context_stage_native(inner),
-        Expr::Builtin(Builtin::FirstStream(inner) | Builtin::LastStream(inner)) => {
-            path_context_stage_native(inner)
-        }
         _ => path_context_single_native(expr),
     }
 }
@@ -11075,6 +11192,15 @@ fn path_context_single_native(expr: &Expr) -> bool {
         }
         Expr::Builtin(Builtin::ParentN(n)) => matches!(**n, Expr::Literal(_)),
         Expr::Builtin(Builtin::Select(cond)) => path_context_single_native(cond),
+        // Native since #2416 phase 3 (`build_object_entries_generic`): every
+        // key and value expression is evaluated with the cursor.
+        Expr::Object(entries) => entries.iter().all(|entry| {
+            path_context_single_native(&entry.value)
+                && match &entry.key {
+                    ObjectKey::Literal(_) => true,
+                    ObjectKey::Expr(key) => path_context_single_native(key),
+                }
+        }),
         _ => false,
     }
 }
@@ -21239,8 +21365,10 @@ mod tests {
         // A stage built from something that bridges mid-expression. (Bare
         // `{k: key}` never reaches the gate at all: `needs_path_context` does
         // not descend into `Expr::Object`, #1332, so that pipe is not seen as
-        // a path-context pipe in the first place.)
-        assert!(eager(".[] | (key | {k: .})"));
+        // a path-context pipe in the first place; and object construction is
+        // native now, so `(key | {k: .})` is admitted.)
+        assert!(eager(".[] | (key | tostring)"));
+        assert!(!eager(".[] | (key | {k: .})"));
         assert!(eager(".[] | if key == \"a\" then . else empty end"));
         assert!(eager(".[] | select(key == \"a\" and true)"));
         assert!(eager(".[] | parent(1 + 0)"));

--- a/tests/data/jq-path-context-sweep-known-divergences.txt
+++ b/tests/data/jq-path-context-sweep-known-divergences.txt
@@ -33,7 +33,6 @@ yq/*/first/*/*        yq_first        real yq's first(f) ignores its argument an
 # `{"k": key}`/`{"k": path}`/`{"k": parent}` answer null/[]/{} at every
 # position: `eval_pipe_with_path_context_internal` has no `Expr::Object` arm,
 # so the whole object construction falls to the context-dropping fallback.
-yq/*/object/*/*       object_arm      no Expr::Object arm in the path-context evaluator, so the leaf loses its path — #1332
 
 # Real yq's comma is stream-level: `.a[] | ((key), 1)` answers `"b" "c" 1 1`
 # (every `key` output, then every `1`), where succinctly interleaves per

--- a/tests/data/yq-golden-known-failures.txt
+++ b/tests/data/yq-golden-known-failures.txt
@@ -31,7 +31,6 @@ seq_item_double_outdent_rejected  yaml_parser  a block sequence continuation tha
 # *silent success* — yq exits 0 having printed nothing — which is why they
 # carry an expected.empty marker (see tests/yq_golden_tests.rs).
 
-path_ctx_object_key         object_arm     `[.a[] | {"k": key}]` is `[{"k":null},{"k":null}]`; the path-context evaluator has no Expr::Object arm, so the leaf loses its path — #1332
 path_ctx_recurse_path       descend_path   `[.. | path]` is all `[]`; recursive descent never threads the accumulated path into its outputs — #2416
 path_ctx_recurse_key        descend_path   `[.. | key]` is all `null`, same cause as path_ctx_recurse_path — #2416
 path_ctx_recurse_kind_path  descend_path   `[.. | select(kind == "scalar") | path]` is all `[]`, same cause as path_ctx_recurse_path — #2416

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -7334,6 +7334,35 @@ fn test_as_path_context_builtin_body_loop_arms_1663() -> Result<()> {
     Ok(())
 }
 
+/// Spine 2416, phase 3: object construction is native in the generic
+/// evaluator (`build_object_entries_generic`), mirroring the eager
+/// `build_object_entries` fan-out -- keys vary slowest. Captured live from
+/// jq 1.7.1: `{a: (1,2), b: (3,4)}` on `{}` is `{"a":1,"b":3}`,
+/// `{"a":1,"b":4}`, `{"a":2,"b":3}`, `{"a":2,"b":4}`. The `key` rows have no
+/// jq oracle (`key` is a succinctly extension) and pin the cursor-property
+/// answer.
+#[test]
+fn test_object_construction_fanout_and_key_2416() -> Result<()> {
+    let (out, _, code) = run_jq_full(&["-c", "{a: (1,2), b: (3,4)}"], Some("{}"))?;
+    assert_eq!(code, 0);
+    assert_eq!(
+        out.trim(),
+        "{\"a\":1,\"b\":3}\n{\"a\":1,\"b\":4}\n{\"a\":2,\"b\":3}\n{\"a\":2,\"b\":4}"
+    );
+    let (out, _, code) = run_jq_full(
+        &["-c", ".a[] | {k: key, v: .}"],
+        Some(r#"{"a":{"b":[1,2],"c":"x"}}"#),
+    )?;
+    assert_eq!(code, 0);
+    assert_eq!(
+        out.trim(),
+        "{\"k\":\"b\",\"v\":[1,2]}\n{\"k\":\"c\",\"v\":\"x\"}"
+    );
+    let (out, _, code) = run_jq_full(&["-c", ".a | {(1): key}"], Some(r#"{"a":1}"#))?;
+    assert_eq!(code, 5, "a non-string key errors: {out:?}");
+    Ok(())
+}
+
 /// Documents the one remaining deliberate, narrow gap #1663/#1765 leave
 /// open rather than silently missing: a `?//`-chained `AsPattern` (2+
 /// alternatives) still has no dedicated evaluation arm, so a path-context

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -9327,15 +9327,19 @@ fn test_line_select_filters_and_keeps_position() -> Result<()> {
 
 #[test]
 fn test_line_column_object_construction_is_a_known_limitation() -> Result<()> {
-    // Object/array construction (`{...}`/`[...]`) isn't natively cursor-aware
-    // in the generic evaluator — it round-trips through OwnedValue, which
-    // has nowhere to carry a position. Documented limitation (#532), pinned
-    // here so a future fix is visible as an intentional test change rather
-    // than a silent behavior shift.
+    // Object construction used to round-trip through OwnedValue, which has
+    // nowhere to carry a position, so `line`/`column` inside `{...}` read
+    // `0` (#532). Spine 2416's phase 3 made object construction native in
+    // the generic evaluator with the cursor threaded into every value
+    // expression, so they now answer from the node: real yq v4.53.3 gives
+    // `.baz | line` as `2` on this document (its lexer rejects the unquoted
+    // object-key spelling, so the construction itself has no oracle). The
+    // `column` value is succinctly's own (yq says `1`), a separate,
+    // pre-existing divergence this test is not about.
     let yaml = "foo: bar\nbaz: qux\n";
     let (output, code) = run_yq_stdin(".baz | {l: line, c: column}", yaml, &["-o=json", "-I=0"])?;
     assert_eq!(code, 0);
-    assert_eq!(output.trim(), r#"{"l":0,"c":0}"#);
+    assert_eq!(output.trim(), r#"{"l":2,"c":6}"#);
     Ok(())
 }
 
@@ -29368,6 +29372,28 @@ fn test_negative_index_path_component_is_resolved_in_yq_mode_2416() -> Result<()
         (".a[-1] | parent | key", r#""a""#),
     ] {
         let (out, code) = run_yq_stdin(filter, "a: [1, 2]\n", &["-o", "json", "-I0"])?;
+        assert_eq!(code, 0, "`{filter}`: {out:?}");
+        assert_eq!(out.trim(), want, "`{filter}`");
+    }
+    Ok(())
+}
+
+/// #1332, closed by spine 2416's phase 3: object construction is native in
+/// the generic evaluator with the cursor threaded into every key and value,
+/// so `key` inside `{..}` answers the node's own key. Every row captured
+/// live from yq v4.53.3 on `a: {b: [1, 2], c: x}`; the last one is the
+/// key-generator fan-out, keys varying slowest.
+#[test]
+fn test_object_construction_keeps_path_context_2416() -> Result<()> {
+    let doc = "a:\n  b: [1, 2]\n  c: x\n";
+    for (filter, want) in [
+        (".a | {\"x\": key}", r#"{"x":"a"}"#),
+        ("[.a[] | {\"k\": key}]", r#"[{"k":"b"},{"k":"c"}]"#),
+        (".a | {(.c, \"q\"): key}", "{\"x\":\"a\"}\n{\"q\":\"a\"}"),
+        (".a.b[] | key + 10", "10\n11"),
+        (".a[] | key + \"!\"", "\"b!\"\n\"c!\""),
+    ] {
+        let (out, code) = run_yq_stdin(filter, doc, &["-o", "json", "-I0"])?;
         assert_eq!(code, 0, "`{filter}`: {out:?}");
         assert_eq!(out.trim(), want, "`{filter}`");
     }


### PR DESCRIPTION
Phase 3 of spine 2416, second slice (number written without a hash: a bare mention auto-closes it on merge). Closes #1332. Does **not** close the spine; `eval_stage_with_path_context` is untouched and the arm-count pin stays at 43.

## What

`Expr::Object` had no path-context arm in either evaluator: the generic evaluator bridged the whole construction to the eager one through an `OwnedValue` round trip, and `needs_path_context` never descended into an object, so `{k: key}` lost the node it stood on and answered `null` (#1332's repro).

- **`build_object_entries_generic`** mirrors `eval::build_object_entries` shape for shape (keys vary slowest; a non-string key errors, or is swallowed under `optional` discarding what was built; a generator's trailing escape becomes a `Partial` after the objects already built) and evaluates every key and value with the cursor, so `key`/`parent`/`path` inside the construction are cursor properties (#2437).
- **Not passed through `yq_float_fidelity_fixup`**, deliberately: the bridge returned the eager evaluator's objects as built, leaving a computed float for the YAML emitter's nested-float rule (`{"a": (.a * 1e100)}` prints `a: 1e+100`, as yq does). The fixup's reindex round trip spells that float out in full, which is the `Expr::Array` arm's own pre-existing divergence, filed as #2438, not one to inherit.
- **`path_context_stage_native` tightened** to exactly the `eval_single`-native set (plus `first`/`last`). Admitting a construct native only in the sink evaluator answered `.[] | key + 10` as `null + 10` on the yq CLI's DOM route, which drives `eval_single` + `fold_pipe_stages`, where `if`/arithmetic/`limit` still bridge with no cursor.

## Oracle-verified

yq v4.53.3: `.a | {"x": key}` → `{"x":"a"}`; `[.a[] | {"k": key}]` → `[{"k":"b"},{"k":"c"}]`; `.a | {(.c, "q"): key}` → `{"x":"a"}`, `{"q":"a"}`; `.a.b[] | key + 10` → `10`, `11`. jq 1.7.1: `{a: (1,2), b: (3,4)}` on `{}` → four objects, `a` varying slowest.

`path_ctx_object_key` passes and leaves the yq known-failures list; the sweep's `yq/*/object/*/*` class (23 cases) leaves its manifest. `line`/`column` inside an object (#532's known limitation) now answer from the node; that test flips with the oracle note.

## Verification (all exit 0)

`cargo test --features cli` (7489 passed); fmt; clippy `--all-features` and CI's second leg; `--no-default-features`; `cargo doc -D warnings`; sweep 2112 cases, 0 unexpected, 0 stale; both golden `--check`s.
