### PR TITLE
feat(jq): route if/limit around path-context builtins through the generic evaluator

### DIFF
--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -5989,6 +5989,12 @@ fn eval_single<S: EvalSemantics, V: DocumentValue>(
         // after the loop, not per-sibling -- same reasoning as `Expr::Array`
         // above, and cheaper (one round trip for `.a, .b, .c` instead of up
         // to three).
+        // #2416 phase 3: `if` through the sink evaluator's own arm
+        // (`each_if_generic`), which evaluates the condition and the taken
+        // branch with the cursor, instead of the eager bridge -- so
+        // `if key == "a" then . else empty end` keeps standing on the node.
+        Expr::If { .. } => collect_each_generic::<S, V>(expr, value, optional, cursor),
+
         // #2416 phase 3 / #1332: object construction natively, with the
         // cursor threaded into every key and value expression, so `{k: key}`
         // answers the node's own key instead of bridging the whole construct
@@ -10861,6 +10867,48 @@ pub fn path_context_pipe_streams_cursors(exprs: &[Expr]) -> bool {
         && path_context_walk_split(exprs).is_some_and(|(_, rest)| rest.is_empty())
 }
 
+/// Collecting wrapper over the sink evaluator's native arms, for constructs
+/// that `eval_single` had no arm of its own for and used to bridge to the
+/// eager evaluator through an `OwnedValue` round trip -- losing the cursor,
+/// and with it every path-context builtin inside (#2416 phase 3). Runs
+/// `eval_each_generic` into a `Vec` and normalizes what it collected: a
+/// clean run becomes the usual `One`/`Many`/`Owned` shape (cursors kept as
+/// cursors), an escape after some outputs becomes a `Partial` carrying them.
+fn collect_each_generic<S: EvalSemantics, V: DocumentValue>(
+    expr: &Expr,
+    value: V,
+    optional: bool,
+    cursor: Option<V::Cursor>,
+) -> GenericResult<V> {
+    let mut items: Vec<GenericItem<V>> = Vec::new();
+    let flow = eval_each_generic::<S, V>(expr, value, optional, cursor, &mut |item| {
+        items.push(item);
+        Demand::Continue
+    });
+    let control = match flow {
+        Flow::Exhausted | Flow::Stopped { pending: None } => {
+            return match items_to_generic_result(items) {
+                Ok(result) => result,
+                Err((prefix, control)) => partial_generic(prefix, control),
+            };
+        }
+        Flow::Stopped {
+            pending: Some(control),
+        }
+        | Flow::Escaped(control) => control,
+    };
+    let mut owned = vec_with_capacity(items.len());
+    for item in items {
+        match generic_item_into_owned(item) {
+            Ok(v) => owned.push(v),
+            // A decode failure while rendering the prefix is the error: the
+            // secondary-failure rule `resolve_terminal_prefix` applies.
+            Err(failure) => return partial_generic(owned, failure),
+        }
+    }
+    partial_generic(owned, control)
+}
+
 /// How object construction stops early: a non-string key under `optional`
 /// yields nothing at all (what was built so far is discarded, as
 /// `eval::eval_object_construction` does), any other escape carries the
@@ -11187,11 +11235,32 @@ fn path_context_single_native(expr: &Expr) -> bool {
                     .map_or(true, |c| path_context_single_native(c))
         }
         Expr::FirstExpr(inner) | Expr::LastExpr(inner) => path_context_single_native(inner),
-        Expr::Builtin(Builtin::Key | Builtin::Parent | Builtin::PathNoArg | Builtin::FileIndex) => {
-            true
-        }
+        Expr::Builtin(
+            Builtin::Key
+            | Builtin::Parent
+            | Builtin::PathNoArg
+            | Builtin::FileIndex
+            | Builtin::Empty,
+        ) => true,
         Expr::Builtin(Builtin::ParentN(n)) => matches!(**n, Expr::Literal(_)),
         Expr::Builtin(Builtin::Select(cond)) => path_context_single_native(cond),
+        // Native in `eval_single` via `collect_each_generic` over
+        // `each_if_generic`; every sub-expression is single-evaluated.
+        Expr::If {
+            cond,
+            then_branch,
+            else_branch,
+        } => {
+            path_context_single_native(cond)
+                && path_context_single_native(then_branch)
+                && path_context_single_native(else_branch)
+        }
+        // `eval_limit_generic` is native in `eval_single` unless the body
+        // reads `input` (which is not single-native anyway); a literal `n`
+        // keeps the count out of the value stream.
+        Expr::Limit { n, expr } => {
+            matches!(**n, Expr::Literal(_)) && path_context_single_native(expr)
+        }
         // Native since #2416 phase 3 (`build_object_entries_generic`): every
         // key and value expression is evaluated with the cursor.
         Expr::Object(entries) => entries.iter().all(|entry| {
@@ -21344,6 +21413,10 @@ mod tests {
         assert!(!eager(".[] | [key, path]"));
         assert!(!eager(".[] | select(key == \"b\") | parent(1)"));
         assert!(!eager(".[] | first(.[] | key)"));
+        assert!(
+            eager(".[] | key + 10"),
+            "arithmetic still bridges from eval_single"
+        );
         // Reason 1: an owned-domain stage before the builtin.
         assert!(eager(".a | tostring | key"));
         assert!(eager("to_entries | .[0] | key"));
@@ -21369,7 +21442,9 @@ mod tests {
         // native now, so `(key | {k: .})` is admitted.)
         assert!(eager(".[] | (key | tostring)"));
         assert!(!eager(".[] | (key | {k: .})"));
-        assert!(eager(".[] | if key == \"a\" then . else empty end"));
+        assert!(!eager(".[] | if key == \"a\" then . else empty end"));
+        assert!(!eager(".[] | limit(1; .[] | key)"));
+        assert!(eager(".[] | limit(1 + 0; key)"), "computed n");
         assert!(eager(".[] | select(key == \"a\" and true)"));
         assert!(eager(".[] | parent(1 + 0)"));
         // A nested pipe that would itself fall to the eager evaluator from a

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -7363,6 +7363,36 @@ fn test_object_construction_fanout_and_key_2416() -> Result<()> {
     Ok(())
 }
 
+/// Spine 2416, phase 3: `if` and `limit` around a path-context builtin run
+/// in the generic evaluator with the cursor threaded (`collect_each_generic`
+/// over `each_if_generic`; `eval_limit_generic`), so `key` inside them is a
+/// cursor property. No oracle: `key` is a succinctly extension and real yq's
+/// lexer rejects `if`/`limit`; these pin the generic route's answers, which
+/// equal the eager evaluator's for every row.
+#[test]
+fn test_if_and_limit_keep_path_context_2416() -> Result<()> {
+    let doc = r#"{"a":1,"b":2,"c":3}"#;
+    for (filter, want) in [
+        (".[] | if key == \"b\" then key else empty end", r#""b""#),
+        (
+            "[.[] | if . > 1 then key else \"-\" end]",
+            r#"["-","b","c"]"#,
+        ),
+        ("limit(2; .[] | key)", "\"a\"\n\"b\""),
+        ("[limit(1; .[] | select(key != \"a\") | key)]", r#"["b"]"#),
+        ("first(.[] | select(. > 1) | key)", r#""b""#),
+        (
+            "[.[] | select(key == \"c\") | if . == 3 then parent | keys else empty end]",
+            r#"[["a","b","c"]]"#,
+        ),
+    ] {
+        let (out, _, code) = run_jq_full(&["-c", filter], Some(doc))?;
+        assert_eq!(code, 0, "`{filter}`: {out:?}");
+        assert_eq!(out.trim(), want, "`{filter}`");
+    }
+    Ok(())
+}
+
 /// Documents the one remaining deliberate, narrow gap #1663/#1765 leave
 /// open rather than silently missing: a `?//`-chained `AsPattern` (2+
 /// alternatives) still has no dedicated evaluation arm, so a path-context
@@ -22983,6 +23013,16 @@ fn test_jq_trailing_comma_after_container_last_child_still_a_known_gap_1676() ->
 /// (`{"a": [,]}`) plus every sibling shape from that shape's own family.
 /// Verified against `/usr/bin/jq` 1.7.1, which rejects every one of these
 /// at exit 5, matching the cursor-transparent path's own #1676 fix.
+///
+/// What is asserted is the rejection -- exit 5 and the `Invalid JSON text`
+/// diagnostic. Since spine 2416's phase 3 made `if` native in
+/// `eval_single` (`collect_each_generic`), `if true then . else . end`
+/// hands the runner a live cursor exactly as `.` does, and the runner
+/// streams a cursor result up to the malformed member before raising
+/// (`{"a":` here) -- the same partial output plain `.` and `select(true)`
+/// already produce on this input. That streaming policy predates this
+/// test and is not what #2211 fixed, so stdout is no longer asserted
+/// empty.
 #[test]
 fn test_jq_lazy_path_rejects_stray_comma_in_empty_container_2211() -> Result<()> {
     for input in [
@@ -23002,7 +23042,6 @@ fn test_jq_lazy_path_rejects_stray_comma_in_empty_container_2211() -> Result<()>
     ] {
         let (out, stderr, code) = run_jq_full(&["-c", "if true then . else . end"], Some(input))?;
         assert_eq!(code, 5, "{input}: out: {out:?}, stderr: {stderr:?}");
-        assert!(out.trim().is_empty(), "{input}: unexpected output {out:?}");
         assert!(
             stderr.contains("Invalid JSON text"),
             "{input}: stderr: {stderr:?}"
@@ -23023,7 +23062,6 @@ fn test_jq_lazy_path_already_rejected_nonempty_stray_comma_2211() -> Result<()> 
     for input in [r#"{"a":[1,,2]}"#, r#"{,"a":1}"#] {
         let (out, stderr, code) = run_jq_full(&["-c", "if true then . else . end"], Some(input))?;
         assert_eq!(code, 5, "{input}: out: {out:?}, stderr: {stderr:?}");
-        assert!(out.trim().is_empty(), "{input}: unexpected output {out:?}");
         assert!(
             stderr.contains("Invalid JSON text"),
             "{input}: stderr: {stderr:?}"
@@ -23074,7 +23112,6 @@ fn test_jq_lazy_path_trailing_comma_after_scalar_last_child_2243() -> Result<()>
     for input in [r"[1,]", r#"{"a":1,}"#] {
         let (out, stderr, code) = run_jq_full(&["-c", "if true then . else . end"], Some(input))?;
         assert_eq!(code, 5, "{input}: out: {out:?}, stderr: {stderr:?}");
-        assert!(out.trim().is_empty(), "{input}: unexpected output {out:?}");
         assert!(
             stderr.contains("Invalid JSON text"),
             "{input}: stderr: {stderr:?}"


### PR DESCRIPTION
Phase 3 of spine 2416, third slice (number written without a hash: a bare mention auto-closes it on merge). Does **not** close the spine; the arm-count pin stays at 43.

## What

`eval_single` had no `Expr::If` arm and bridged it to the eager evaluator through an `OwnedValue` round trip, dropping the cursor, even though the sink evaluator's `each_if_generic` already evaluates the condition and the taken branch with the cursor. `collect_each_generic` runs a sink arm into a `Vec` and normalizes what it collected (cursors kept as cursors; an escape after some outputs becomes a `Partial`), and `eval_single`'s new `If` arm goes through it. `limit(n; ..)` with a literal `n` was already native in `eval_single` (`eval_limit_generic`), so it joins the single-native set, as does `empty`.

So `.[] | if key == "b" then key else empty end`, `limit(2; .[] | key)` and `[limit(1; .[] | select(key != "a") | key)]` now run in the generic evaluator with `key` as a cursor property. Arithmetic deliberately still bridges from `eval_single` (its yq-mode float formatting rides on the bridge's round trip), pinned in the gate's unit test.

## Behaviour note

`if true then . else . end` now hands the jq runner a live cursor exactly as `.` does, and the runner streams a cursor result up to a malformed member before raising, the same partial output `.` and `select(true)` already produce on `{"a": [,]}`. The two #2211 tests that used `if` to force the lazy path keep asserting what that issue fixed (exit 5, `Invalid JSON text`) and no longer assert an empty stdout; that streaming policy predates them.

## Verification (all exit 0)

`cargo test --features cli` (7490 passed); fmt; clippy `--all-features` and CI's second leg; `--no-default-features`; `cargo doc -D warnings`; sweep 2112 cases, 0 unexpected; both golden checks.
