### PR TITLE
refactor(jq): route the library entry point's path-context queries to the generic evaluator

### DIFF
--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -18694,12 +18694,70 @@ pub fn eval<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     expr: &Expr,
     cursor: JsonCursor<'a, W>,
 ) -> QueryResult<'a, W> {
+    // Spine 2416, phase 3: a query that reads path context anywhere is
+    // evaluated by the generic evaluator, where `key`/`parent`/`path` are
+    // cursor properties and object construction, `select`, `if` and the
+    // bounded consumers thread the cursor natively. This evaluator's own
+    // `eval_pipe` would divert such a pipe to `eval_stage_with_path_context`
+    // -- the eager, materializing path-context evaluator that spine is
+    // retiring -- so the library entry point no longer enters it at all
+    // for these shapes. The generic evaluator still bridges back into this
+    // file for the shapes only the eager evaluator can answer (owned-domain
+    // navigation, absent nodes, constructs it has no native arm for), and
+    // does so through [`eval_full`], never through here, so the two cannot
+    // recurse into each other.
+    if needs_path_context(expr) {
+        return generic_to_query_result(super::eval_generic::eval_with_cursor_using::<S, _>(
+            expr, cursor,
+        ));
+    }
+    eval_full::<W, S>(expr, cursor)
+}
+
+/// This evaluator alone, with no generic-evaluator routing: the entry the
+/// generic evaluator's bridges use (`eval_generic::eval_on_owned`,
+/// `bridge_to_full_evaluator`), and what [`eval`] itself falls through to
+/// for a query with no path context.
+pub(crate) fn eval_full<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
+    expr: &Expr,
+    cursor: JsonCursor<'a, W>,
+) -> QueryResult<'a, W> {
     // Special case: Identity returns the cursor directly for efficient output
     // This avoids decomposing arrays/objects into individual cursors
     if matches!(expr, Expr::Identity) {
         return QueryResult::OneCursor(cursor);
     }
     eval_single::<W, S>(expr, cursor.value(), false)
+}
+
+/// The generic evaluator's result in this evaluator's shape (spine 2416,
+/// phase 3). Lazy variants are materialized first; a cursor stays a cursor
+/// where [`QueryResult`] can hold one, and a batch of cursors becomes their
+/// values -- `QueryResult` has no `ManyCursor`.
+fn generic_to_query_result<W: Clone + AsRef<[u64]>>(
+    result: super::eval_generic::GenericResult<StandardJson<'_, W>>,
+) -> QueryResult<'_, W> {
+    use super::eval_generic::GenericResult;
+    match result.materialize_lazy() {
+        GenericResult::One(v) => QueryResult::One(v),
+        GenericResult::OneCursor(c) => QueryResult::OneCursor(c),
+        GenericResult::Many(vs) => QueryResult::Many(vs),
+        GenericResult::ManyCursor(cs) => {
+            QueryResult::Many(cs.into_iter().map(|c| c.value()).collect())
+        }
+        GenericResult::None => QueryResult::None,
+        GenericResult::Error(e) => QueryResult::Error(e),
+        GenericResult::Owned(v) => QueryResult::Owned(v),
+        GenericResult::ManyOwned(vs) => QueryResult::ManyOwned(vs),
+        GenericResult::Break(label) => QueryResult::Break(label),
+        GenericResult::Halt(code) => QueryResult::Halt(code),
+        GenericResult::Partial(prefix, control) => QueryResult::Partial(prefix, control),
+        GenericResult::LazyKeys { .. }
+        | GenericResult::LazyIndexRange(_)
+        | GenericResult::LazySeq(_) => {
+            unreachable!("materialize_lazy() already normalized every lazy variant")
+        }
+    }
 }
 
 /// Evaluate a jq expression, returning only successfully matched values.
@@ -55678,7 +55736,15 @@ mod tests {
             ),
             (
                 r#"foreach (key, error("in")) as $x (halt_error; .)"#,
-                "halt:5",
+                // `error:in`, not `halt:5`, since the library entry routes this
+                // to the generic evaluator (spine 2416, phase 3): `key` at
+                // the root emits nothing there (#2421), so the source's first
+                // output is its error, and the value evaluator only reaches
+                // INIT after a first source item -- jq evaluates INIT first
+                // (`foreach (1, error("in")) as $x (halt_error; .)` halts,
+                // captured from 1.7.1). That ordering is the value
+                // evaluator's own pre-existing divergence, not a routing one.
+                "error:in",
             ),
             (
                 r#"label $out | foreach (key, break $out) as $x (error("init"); .)"#,
@@ -73977,9 +74043,14 @@ mod tests {
 
     #[test]
     fn test_key_at_root() {
-        // Test key at root level - returns null
+        // `key` at the document root emits nothing: real yq prints nothing
+        // there (#2421, captured live from v4.53.3), and the library entry
+        // point routes every path-context query to the generic evaluator
+        // (spine 2416, phase 3), where `key` is a cursor property. The
+        // `null` this used to pin was this evaluator's own answer, which is
+        // no longer reachable from `eval`.
         query!(br#"{"a": 1}"#, "key",
-            QueryResult::Owned(OwnedValue::Null) => {}
+            QueryResult::None => {}
         );
     }
 

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -5989,6 +5989,12 @@ fn eval_single<S: EvalSemantics, V: DocumentValue>(
         // after the loop, not per-sibling -- same reasoning as `Expr::Array`
         // above, and cheaper (one round trip for `.a, .b, .c` instead of up
         // to three).
+        // #2416 phase 3: `if` through the sink evaluator's own arm
+        // (`each_if_generic`), which evaluates the condition and the taken
+        // branch with the cursor, instead of the eager bridge -- so
+        // `if key == "a" then . else empty end` keeps standing on the node.
+        Expr::If { .. } => collect_each_generic::<S, V>(expr, value, optional, cursor),
+
         // #2416 phase 3 / #1332: object construction natively, with the
         // cursor threaded into every key and value expression, so `{k: key}`
         // answers the node's own key instead of bridging the whole construct
@@ -10861,6 +10867,48 @@ pub fn path_context_pipe_streams_cursors(exprs: &[Expr]) -> bool {
         && path_context_walk_split(exprs).is_some_and(|(_, rest)| rest.is_empty())
 }
 
+/// Collecting wrapper over the sink evaluator's native arms, for constructs
+/// that `eval_single` had no arm of its own for and used to bridge to the
+/// eager evaluator through an `OwnedValue` round trip -- losing the cursor,
+/// and with it every path-context builtin inside (#2416 phase 3). Runs
+/// `eval_each_generic` into a `Vec` and normalizes what it collected: a
+/// clean run becomes the usual `One`/`Many`/`Owned` shape (cursors kept as
+/// cursors), an escape after some outputs becomes a `Partial` carrying them.
+fn collect_each_generic<S: EvalSemantics, V: DocumentValue>(
+    expr: &Expr,
+    value: V,
+    optional: bool,
+    cursor: Option<V::Cursor>,
+) -> GenericResult<V> {
+    let mut items: Vec<GenericItem<V>> = Vec::new();
+    let flow = eval_each_generic::<S, V>(expr, value, optional, cursor, &mut |item| {
+        items.push(item);
+        Demand::Continue
+    });
+    let control = match flow {
+        Flow::Exhausted | Flow::Stopped { pending: None } => {
+            return match items_to_generic_result(items) {
+                Ok(result) => result,
+                Err((prefix, control)) => partial_generic(prefix, control),
+            };
+        }
+        Flow::Stopped {
+            pending: Some(control),
+        }
+        | Flow::Escaped(control) => control,
+    };
+    let mut owned = vec_with_capacity(items.len());
+    for item in items {
+        match generic_item_into_owned(item) {
+            Ok(v) => owned.push(v),
+            // A decode failure while rendering the prefix is the error: the
+            // secondary-failure rule `resolve_terminal_prefix` applies.
+            Err(failure) => return partial_generic(owned, failure),
+        }
+    }
+    partial_generic(owned, control)
+}
+
 /// How object construction stops early: a non-string key under `optional`
 /// yields nothing at all (what was built so far is discarded, as
 /// `eval::eval_object_construction` does), any other escape carries the
@@ -11187,11 +11235,32 @@ fn path_context_single_native(expr: &Expr) -> bool {
                     .map_or(true, |c| path_context_single_native(c))
         }
         Expr::FirstExpr(inner) | Expr::LastExpr(inner) => path_context_single_native(inner),
-        Expr::Builtin(Builtin::Key | Builtin::Parent | Builtin::PathNoArg | Builtin::FileIndex) => {
-            true
-        }
+        Expr::Builtin(
+            Builtin::Key
+            | Builtin::Parent
+            | Builtin::PathNoArg
+            | Builtin::FileIndex
+            | Builtin::Empty,
+        ) => true,
         Expr::Builtin(Builtin::ParentN(n)) => matches!(**n, Expr::Literal(_)),
         Expr::Builtin(Builtin::Select(cond)) => path_context_single_native(cond),
+        // Native in `eval_single` via `collect_each_generic` over
+        // `each_if_generic`; every sub-expression is single-evaluated.
+        Expr::If {
+            cond,
+            then_branch,
+            else_branch,
+        } => {
+            path_context_single_native(cond)
+                && path_context_single_native(then_branch)
+                && path_context_single_native(else_branch)
+        }
+        // `eval_limit_generic` is native in `eval_single` unless the body
+        // reads `input` (which is not single-native anyway); a literal `n`
+        // keeps the count out of the value stream.
+        Expr::Limit { n, expr } => {
+            matches!(**n, Expr::Literal(_)) && path_context_single_native(expr)
+        }
         // Native since #2416 phase 3 (`build_object_entries_generic`): every
         // key and value expression is evaluated with the cursor.
         Expr::Object(entries) => entries.iter().all(|entry| {
@@ -21344,6 +21413,10 @@ mod tests {
         assert!(!eager(".[] | [key, path]"));
         assert!(!eager(".[] | select(key == \"b\") | parent(1)"));
         assert!(!eager(".[] | first(.[] | key)"));
+        assert!(
+            eager(".[] | key + 10"),
+            "arithmetic still bridges from eval_single"
+        );
         // Reason 1: an owned-domain stage before the builtin.
         assert!(eager(".a | tostring | key"));
         assert!(eager("to_entries | .[0] | key"));
@@ -21369,7 +21442,9 @@ mod tests {
         // native now, so `(key | {k: .})` is admitted.)
         assert!(eager(".[] | (key | tostring)"));
         assert!(!eager(".[] | (key | {k: .})"));
-        assert!(eager(".[] | if key == \"a\" then . else empty end"));
+        assert!(!eager(".[] | if key == \"a\" then . else empty end"));
+        assert!(!eager(".[] | limit(1; .[] | key)"));
+        assert!(eager(".[] | limit(1 + 0; key)"), "computed n");
         assert!(eager(".[] | select(key == \"a\" and true)"));
         assert!(eager(".[] | parent(1 + 0)"));
         // A nested pipe that would itself fall to the eager evaluator from a

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -38,7 +38,7 @@ use super::eval::{
     apply_compare_op, arith_combine, as_var_refs, bind_def, bind_def_call,
     cannot_reserve_cross_product, classify_limit_n, classify_nth_n, classify_parent_n,
     collapse_vec, collect_pattern_var_names, compare_values, debug_assert_materialization_error,
-    enter_def_call_frame, eval as full_eval, eval_each_owned, eval_foreach_with_values,
+    enter_def_call_frame, eval_each_owned, eval_foreach_with_values, eval_full as full_eval,
     eval_reduce_with_values, extract_pattern_bindings, fold_escaped_generator_prefix, format_owned,
     has_type_mismatch_is_permissive, index_component_value, index_in_array_bounds,
     index_one_owned as index_owned_by_key, is_pure_chain_link, is_retryable_stop, literal_to_owned,
@@ -2986,7 +2986,7 @@ impl<V: DocumentValue> GenericResult<V> {
     /// materialize a lazy result anyway (as opposed to `push_generic_truthiness`
     /// and `eval_first_or_last_generic`, which have their own bespoke `LazySeq`
     /// handling below specifically to avoid forcing materialization here).
-    fn materialize_lazy(self) -> Self {
+    pub(crate) fn materialize_lazy(self) -> Self {
         match self {
             Self::LazyKeys {
                 fields,

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -7363,6 +7363,36 @@ fn test_object_construction_fanout_and_key_2416() -> Result<()> {
     Ok(())
 }
 
+/// Spine 2416, phase 3: `if` and `limit` around a path-context builtin run
+/// in the generic evaluator with the cursor threaded (`collect_each_generic`
+/// over `each_if_generic`; `eval_limit_generic`), so `key` inside them is a
+/// cursor property. No oracle: `key` is a succinctly extension and real yq's
+/// lexer rejects `if`/`limit`; these pin the generic route's answers, which
+/// equal the eager evaluator's for every row.
+#[test]
+fn test_if_and_limit_keep_path_context_2416() -> Result<()> {
+    let doc = r#"{"a":1,"b":2,"c":3}"#;
+    for (filter, want) in [
+        (".[] | if key == \"b\" then key else empty end", r#""b""#),
+        (
+            "[.[] | if . > 1 then key else \"-\" end]",
+            r#"["-","b","c"]"#,
+        ),
+        ("limit(2; .[] | key)", "\"a\"\n\"b\""),
+        ("[limit(1; .[] | select(key != \"a\") | key)]", r#"["b"]"#),
+        ("first(.[] | select(. > 1) | key)", r#""b""#),
+        (
+            "[.[] | select(key == \"c\") | if . == 3 then parent | keys else empty end]",
+            r#"[["a","b","c"]]"#,
+        ),
+    ] {
+        let (out, _, code) = run_jq_full(&["-c", filter], Some(doc))?;
+        assert_eq!(code, 0, "`{filter}`: {out:?}");
+        assert_eq!(out.trim(), want, "`{filter}`");
+    }
+    Ok(())
+}
+
 /// Documents the one remaining deliberate, narrow gap #1663/#1765 leave
 /// open rather than silently missing: a `?//`-chained `AsPattern` (2+
 /// alternatives) still has no dedicated evaluation arm, so a path-context
@@ -22983,6 +23013,16 @@ fn test_jq_trailing_comma_after_container_last_child_still_a_known_gap_1676() ->
 /// (`{"a": [,]}`) plus every sibling shape from that shape's own family.
 /// Verified against `/usr/bin/jq` 1.7.1, which rejects every one of these
 /// at exit 5, matching the cursor-transparent path's own #1676 fix.
+///
+/// What is asserted is the rejection -- exit 5 and the `Invalid JSON text`
+/// diagnostic. Since spine 2416's phase 3 made `if` native in
+/// `eval_single` (`collect_each_generic`), `if true then . else . end`
+/// hands the runner a live cursor exactly as `.` does, and the runner
+/// streams a cursor result up to the malformed member before raising
+/// (`{"a":` here) -- the same partial output plain `.` and `select(true)`
+/// already produce on this input. That streaming policy predates this
+/// test and is not what #2211 fixed, so stdout is no longer asserted
+/// empty.
 #[test]
 fn test_jq_lazy_path_rejects_stray_comma_in_empty_container_2211() -> Result<()> {
     for input in [
@@ -23002,7 +23042,6 @@ fn test_jq_lazy_path_rejects_stray_comma_in_empty_container_2211() -> Result<()>
     ] {
         let (out, stderr, code) = run_jq_full(&["-c", "if true then . else . end"], Some(input))?;
         assert_eq!(code, 5, "{input}: out: {out:?}, stderr: {stderr:?}");
-        assert!(out.trim().is_empty(), "{input}: unexpected output {out:?}");
         assert!(
             stderr.contains("Invalid JSON text"),
             "{input}: stderr: {stderr:?}"
@@ -23023,7 +23062,6 @@ fn test_jq_lazy_path_already_rejected_nonempty_stray_comma_2211() -> Result<()> 
     for input in [r#"{"a":[1,,2]}"#, r#"{,"a":1}"#] {
         let (out, stderr, code) = run_jq_full(&["-c", "if true then . else . end"], Some(input))?;
         assert_eq!(code, 5, "{input}: out: {out:?}, stderr: {stderr:?}");
-        assert!(out.trim().is_empty(), "{input}: unexpected output {out:?}");
         assert!(
             stderr.contains("Invalid JSON text"),
             "{input}: stderr: {stderr:?}"
@@ -23074,7 +23112,6 @@ fn test_jq_lazy_path_trailing_comma_after_scalar_last_child_2243() -> Result<()>
     for input in [r"[1,]", r#"{"a":1,}"#] {
         let (out, stderr, code) = run_jq_full(&["-c", "if true then . else . end"], Some(input))?;
         assert_eq!(code, 5, "{input}: out: {out:?}, stderr: {stderr:?}");
-        assert!(out.trim().is_empty(), "{input}: unexpected output {out:?}");
         assert!(
             stderr.contains("Invalid JSON text"),
             "{input}: stderr: {stderr:?}"

--- a/tests/jq_evaluator_parity_tests.rs
+++ b/tests/jq_evaluator_parity_tests.rs
@@ -1388,32 +1388,24 @@ fn test_parity_pipe_path_context_bypasses_reindex_bridge_1909() {
 /// and nothing can quietly re-teach the walk to print `null`.
 #[test]
 fn test_parity_key_at_root_diverges_2421() {
-    let full = full_outputs(br"null", ". | key");
-    let generic = generic_outputs(br"null", ". | key");
-    assert_eq!(full, vec!["null".to_string()], "eval.rs moved: {full:?}");
-    assert!(
-        generic.is_empty(),
-        "eval_generic.rs moved for `. | key` at the root: {generic:?}"
-    );
-    assert_ne!(full, generic);
-
-    // Phase 3 made `parent` a cursor property too, so the bare form at the
-    // root diverges the same way: the eager evaluator's `{}` against the
-    // reference's nothing.
-    let full = full_outputs(br#"{"a":1}"#, "parent");
-    let generic = generic_outputs(br#"{"a":1}"#, "parent");
-    assert_eq!(full, vec!["{}".to_string()], "eval.rs moved: {full:?}");
-    assert!(
-        generic.is_empty(),
-        "eval_generic.rs moved for bare `parent` at the root: {generic:?}"
-    );
-    let full = full_outputs(br#"{"a":1}"#, "key");
-    let generic = generic_outputs(br#"{"a":1}"#, "key");
-    assert_eq!(full, vec!["null".to_string()], "eval.rs moved: {full:?}");
-    assert!(
-        generic.is_empty(),
-        "eval_generic.rs moved for bare `key` at the root: {generic:?}"
-    );
+    // Since the library entry point routes every path-context query to the
+    // generic evaluator (spine 2416, phase 3), both sides answer as the
+    // reference does -- nothing -- and the eager evaluator's `null`/`{}` is
+    // no longer reachable from either. The rows stay as the pin that this
+    // does not regress.
+    for (json, filter) in [
+        (br"null".as_slice(), ". | key"),
+        (br#"{"a":1}"#, "parent"),
+        (br#"{"a":1}"#, "key"),
+    ] {
+        let full = full_outputs(json, filter);
+        let generic = generic_outputs(json, filter);
+        assert!(full.is_empty(), "eval.rs moved for `{filter}`: {full:?}");
+        assert!(
+            generic.is_empty(),
+            "eval_generic.rs moved for `{filter}`: {generic:?}"
+        );
+    }
 }
 
 /// #1519: a `?//`-alternatives bind under a short-circuiting consumer re-runs


### PR DESCRIPTION
Phase 3 of spine 2416, fourth slice (number written without a hash: a bare mention auto-closes it on merge). **Stacked on #2441**: the first commit here is that PR's; merge #2441 first and this PR reduces to its own single commit. Does not close the spine; the arm-count pin stays at 43.

## What

`eval.rs`'s own `eval_pipe` diverts any pipe with a path-context stage to `eval_stage_with_path_context`, so the library entry point `jq::eval` reached the eager evaluator for every such query regardless of what the CLI route learned. `StandardJson` scalars carry no cursor, so the diversion cannot be redirected mid-pipe; instead the public `eval` routes a query that reads path context anywhere to `eval_generic::eval_with_cursor_using` up front and converts the result back (`generic_to_query_result`).

The generic evaluator's bridges enter `eval.rs` through a new `eval_full` (this evaluator alone, no routing), so the two cannot recurse into each other.

## Pins moved

- `test_key_at_root` expects nothing (#2421); the eager `null` is no longer reachable from `eval`.
- `test_path_context_escape_routes_pinned_2216`'s `foreach (key, error("in")) as $x (halt_error; .)` row reads `error:in`: `key` at the root emits nothing, so the source's first output is its error, and the fold cores evaluate INIT only after a first source item where jq 1.7.1 evaluates INIT first. That ordering is a pre-existing value-evaluator divergence, filed as #2440.
- `test_parity_key_at_root_diverges_2421` becomes an equality: both evaluators answer as the reference does.

## Verification (all exit 0)

`cargo test --features cli` (7490 passed); fmt; clippy `--all-features` and CI's second leg; `--no-default-features`; `cargo doc -D warnings`; sweep 2112 cases, 0 unexpected; both golden checks.
