### PR TITLE
docs(adr): ADR-0021 -- path context as a cursor property, not walk state (#2416)

### DIFF
--- a/docs/adrs/README.md
+++ b/docs/adrs/README.md
@@ -47,6 +47,7 @@ by Michael Nygard.
 | [ADR-0018](adr-0018.md) | ✅ Accepted | 2026-08-22 | Reference-Tool Fidelity, Decided by Mode Rather than Format   |
 | [ADR-0019](adr-0019.md) | ✅ Accepted | 2026-08-22 | Reject Regex-Engine Swap for jq's l/n Flag Gaps (#920, #922)  |
 | [ADR-0020](adr-0020.md) | ✅ Accepted | 2026-09-01 | Evaluate User-Defined `def`s as Runtime Calls (#1371)         |
+| [ADR-0021](adr-0021.md) | ✅ Accepted | 2026-09-05 | Path Context as a Cursor Property, Not Walk State (#2416)     |
 
 The inventory is maintained by the [`update-adr-inventory`](../../.claude/skills/update-adr-inventory/SKILL.md)
 skill, which scans `adr-*.md` for the title and status and derives the date from git history.

--- a/docs/adrs/adr-0021.md
+++ b/docs/adrs/adr-0021.md
@@ -1,0 +1,153 @@
+# ADR-0021: Path Context as a Cursor Property, Not Walk State (#2416)
+
+## Status
+
+✅ Accepted
+
+## Context
+
+`key`, `parent`, `parent(n)`, `path` and `file_index` need to know *where* in the
+document the value they are given sits. succinctly answered that with a fifth walker over
+the same AST: `eval_stage_with_path_context` (`src/jq/eval.rs`), an evaluator over
+`OwnedValue` that carried a `(root, current_path)` pair and re-derived every construct's
+semantics — `select`, `Compare`, `map`, `limit`, `foreach`, `try`, `label`, … — with a path
+threaded through. Its `_` fallback dropped the position silently, so adding an arm was the
+only way to fix a shape, and a missing arm failed nothing. By 2026-09-04 it was 2,378 lines
+with 38 named arms plus the fallback, touched by 61 commits in the preceding five weeks,
+and three defects compounded (#2416):
+
+- **Wrong domain.** Reaching it materialized the whole document into an `OwnedValue` tree
+  and scanned it again for the reindex-identity check. A bridge-shaped query peaked at
+  439 MiB on a 22 MiB array; the cursor walk (#2061) answered the same query in 36 MiB.
+- **Wrong protocol.** It returned materialized vectors, so no `Demand::Stop` could reach
+  it; every laziness and side-effect-ordering issue on the spine (#2129, #2259) was
+  unfixable arm by arm.
+- **Silent fallback.** `.a | {"x": key}` printed `{"x": null}` for a year (#1332) because
+  `Expr::Object` had no arm and nothing noticed.
+
+The oracle-backed differential built as the spine's phase 0 (`scripts/jq-path-context-
+oracle-sweep.sh`, the `path_ctx_*` goldens in both corpora, the walk-vs-bridge axis in
+`tests/jq_evaluator_parity_tests.rs`) then showed that the *model* was also wrong, not
+only the implementation. Real yq's nodes carry parent pointers and keys: `key`/`parent`
+there are properties of the node a value stands on, not state accumulated by the query
+that reached it. Captured live against v4.53.3:
+
+| query | real yq | accumulated-path model |
+|---|---|---|
+| `parent` / `key` at the document root | nothing | `{}` / `null` (#2421) |
+| `.a.b \| map(. + 1) \| key` | nothing — a new node | `"b"` (#2425) |
+| `.a[-1] \| key` on a 2-element sequence | `1`, the resolved index | `-1`, the index as written |
+| `.a \| tostring \| key` | `"a"` — the node kept | `"a"` |
+| `[1,2] \| .[0] \| key` | `0` — navigation inside a constructed container | `0` |
+
+The last two rows are the one place the accumulated-path model is right: navigation and
+in-place transforms *inside owned values*, which have no node to stand on.
+
+## Decision
+
+1. **The walk emits to a sink.** `path_context_walk_generic`/`path_context_walk_pipe`
+   (`src/jq/eval_generic.rs`) deliver each output to a `FnMut(GenericItem<V>) -> Demand`
+   sink as it is produced — the shape `eval_each_generic` already has, plus a position —
+   and values are emitted as live cursors, never as freshly built `OwnedValue`s. The CLI's
+   sink pipeline calls it through `try_path_context_walk_sink`; the non-sink route reuses
+   the same walk under a collecting sink. `PathContextAbort::Unsupported` is deleted: a sink
+   cannot un-emit, so every reason to defer is decided statically by
+   `path_context_is_cursor_walkable` before the first output. Absent nodes are modelled
+   (`PathNode::Absent`) rather than refused. (Phase 2, #2436.)
+
+2. **Path-context builtins are cursor properties.** `DocumentCursor` gains
+   `document_parent` (YAML's stream root is not a parent) and `same_node`; `cursor_key`
+   is a sibling scan of the parent's members, `cursor_path_and_ancestors` the climb to the
+   document root. `eval_builtin` answers `key`/`parent`/`parent(n)`/`path`/`file_index`
+   from the cursor whenever the value has one, so every construct that threads a cursor —
+   `select`, `Compare`, object construction, `if`, `limit`, `first`, `try` — gets path
+   context with no arm of its own, and laziness is the sink pipeline's. (Phase 3, #2437,
+   #2439, #2441.)
+
+3. **The eager evaluator keeps exactly what a cursor cannot answer**, decided statically by
+   `path_context_needs_eager`: a stage before the path-context stage that detaches the
+   value (construction, `tostring`, `to_entries`, an emitted `key`/`path`), a navigational
+   head that can reach an absent node followed by a computed stage, or a construct the
+   generic evaluator has no cursor-threading arm for (`path_context_single_native` is a
+   closed list). Node-preserving stages — `select`, `parent`, `first`, `.a?` — carry the
+   node, and its possible absence, forward.
+
+4. **The library entry point routes too.** `jq::eval` sends any query that reads path
+   context to the generic evaluator up front; the generic evaluator's bridges enter
+   `eval.rs` only through `eval_full`, so the two cannot recurse. (#2442.)
+
+5. **Mode decides the path component** (ADR-0018): a negative index resolves in yq mode
+   (`.a[-1] | path` is `["a",1]`) and stays as written in jq mode (`path(.a[-1])` is
+   `["a",-1]`), in `path_step_generic`.
+
+6. **No regrowth.** `tests/jq_path_context_arm_guard.rs` pins the eager evaluator's named
+   handlers at their exact count (43 at the time of writing); a migration lowers the pin,
+   and raising it requires the PR to say why the arm is not a migration. The evaluator is
+   deleted, with the guard, when `path_context_needs_eager` never answers `true` and no
+   route calls it.
+
+## Consequences
+
+- **Fidelity moved toward the reference where the two models disagree.** `key`/`parent`
+  at or above the root emit nothing; a container `map` re-roots; a negative index resolves
+  in yq mode. Each is captured from the pinned binaries and pinned in the goldens, the
+  sweep manifest, or a CLI test with the capture in its doc comment. Three "known gap"
+  tests (#1306, #1663, #532's `line`/`column` inside an object) closed without being
+  touched.
+- **The bridge's float re-spelling was a coincidence, not fidelity.** Its reindex round trip
+  happened to spell `1e19` as `10000000000000000000.0`; the walk emits the cursor and the
+  CLI streams a whole-walk pipe from the cursor's own text (`can_use_m2_streaming` asks
+  `path_context_pipe_streams_cursors`), which is what preserves the document's spelling —
+  including the integer-looking case the bridge got wrong. The value route's own
+  re-spelling is #2419; the array-construction expansion is #2438.
+- **The net found more than the migration set out to fix.** yq's comma binds looser than
+  its pipe (#2420); `file_index` is always 0 across files and `--eval-all` slurps (#2427);
+  `..` loses path context (#2428); `?` over `getpath` at the root drops `[]` (#2429);
+  `path(f)` is accepted in yq mode (#2430); the two path-context indexing arms lack the yq
+  gate (#2431); reading an absent path vivifies it in yq (#2435); the fold cores evaluate
+  INIT after the first source item (#2440). None was hidden by adjusting a test.
+- **Partial output on malformed input** is the streaming routes' existing policy (`.` and
+  `select(true)` both print up to the malformed member before raising); a construct that
+  becomes native inherits it, and a test guarding that construct's *rejection* keeps
+  asserting the exit code and diagnostic, not an empty stdout.
+- **What remains on the eager route** is bounded by three reasons, each with a known
+  next step: path tracking through owned containers in the generic evaluator; an absent
+  position representable in the sink pipeline; and native `eval_single` arms for the
+  constructs that still bridge (arithmetic, `and`/`or`, `as`, `label`, `def` calls,
+  `reduce`/`foreach`). The pin cannot be lowered honestly until a reason is removed,
+  because `path_context_needs_eager` hands whole pipes to the eager evaluator, where any
+  arm can run.
+
+## Alternatives Considered
+
+- **Keep adding arms** (#2416's option A). Does not touch the domain or the protocol; each
+  arm re-derives semantics the value evaluator already has, and #2388 showed the two
+  disagreeing.
+- **Deduplicate only** (option B, #2374/#2381/#2216). Real, low-risk, and done — but it
+  closes no laziness issue, so it is a step, not a destination.
+- **Rewrite the evaluator from scratch** (option C). Discards dozens of live-verified
+  oracle behaviours whose only record was the arms' comments; the strangler-fig route
+  shipped every intermediate state and let the net judge each one.
+- **An ambient position threaded through the generic evaluator** (thread-local or
+  parameter). Rejected: the cursors are generic over the document type and carry
+  lifetimes, so a type-erased ambient cannot hold them, and threading a parameter through
+  every signature is the rewrite by another name. A cursor already *is* the position.
+- **A cursor-only model with no eager fallback.** Wrong for owned-domain navigation
+  (`[1,2] | .[0] | key` is `0` in real yq), which the accumulated path answers correctly;
+  hence decision 3.
+
+## References
+
+- [#2416](https://github.com/rust-works/succinctly/issues/2416) — the spine, with the phase
+  decisions and their oracle captures in its thread
+- [#2418](https://github.com/rust-works/succinctly/pull/2418) arm-count guard ·
+  [#2426](https://github.com/rust-works/succinctly/pull/2426) phase 0 net ·
+  [#2436](https://github.com/rust-works/succinctly/pull/2436) phase 2 sink ·
+  [#2437](https://github.com/rust-works/succinctly/pull/2437),
+  [#2439](https://github.com/rust-works/succinctly/pull/2439),
+  [#2441](https://github.com/rust-works/succinctly/pull/2441),
+  [#2442](https://github.com/rust-works/succinctly/pull/2442) phase 3
+- [ADR-0018](adr-0018.md) — mode, not format, decides fidelity; every divergence above is
+  recorded under it
+- [`docs/compliance/yq/limitations.md`](../compliance/yq/limitations.md) — the yq-mode
+  divergences this work documented


### PR DESCRIPTION
Step 10 of spine 2416's execution (number written without a hash: a bare mention auto-closes it on merge); the ADR the spine's hygiene rule 4 asked for once phase 2 proved the sink signature. Does not close the spine.

ADR-0021 records: the sink-based walk with a purely static gate (phase 2, #2436); path-context builtins as cursor properties in the generic evaluator (phase 3, #2437/#2439/#2441) with the library entry point routing to it (#2442); the three reasons the eager evaluator is still reached and the next step for each; the mode-decided negative-index path component; the arm-count guard as the regrowth control; and, in the consequences, the divergences the oracle net surfaced (#2419, #2420, #2427–#2431, #2435, #2438, #2440), none of which was hidden by adjusting a test. The alternatives section rejects the ambient-position and cursor-only designs with the captures that ruled them out.

Cites file and symbol names only, no line numbers. Inventory row appended per `update-adr-inventory`.
