### PR TITLE
docs(adr): ADR-0018 amendment -- the decision order, and performance as the tiebreak

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -263,7 +263,11 @@ included. Divergence is permitted only where the reference emits output it canno
 back, where matching would corrupt data or discard a write, or where matching would take the
 host process down — and every divergence must be recorded in
 [docs/compliance/jq/limitations.md](docs/compliance/jq/limitations.md) or
-[docs/compliance/yq/limitations.md](docs/compliance/yq/limitations.md). Behavioural rules
+[docs/compliance/yq/limitations.md](docs/compliance/yq/limitations.md). A fork between
+candidate behaviours is decided in that order, in both modes: first whether one of those
+conditions lets us refuse the reference's behaviour, then which option matches the pinned
+reference more closely, and only when neither separates them, which option performs better
+or uses less memory (ADR-0018's #2416 amendment). Behavioural rules
 therefore belong on `EvalSemantics` (per-mode), not on per-format traits like
 `DocumentFields`.
 

--- a/docs/adrs/adr-0018.md
+++ b/docs/adrs/adr-0018.md
@@ -321,6 +321,50 @@ for that purpose. Both pages enumerate exceptions to *this* rule and link back h
 divergence that is not written down does not exist as a decision — it is a bug that has not
 been found yet.
 
+### Amendment (#2416, adopted 2026-09-05): the decision order, and performance as the tiebreak
+
+Two forks in [#2416](https://github.com/rust-works/succinctly/issues/2416)'s phase 3 needed
+an owner's decision, and resolving them showed that this ADR states its rules but not the
+*order* they are applied in, and has no tiebreak at all for two options that are equally
+faithful. Both are now explicit. A fork between candidate behaviours is decided in this
+order, identically in jq mode and yq mode:
+
+1. **Is the reference's behaviour one rule 4 permits us to refuse** — output it cannot
+   itself consume (a), matching would corrupt a document or discard a write (b), matching
+   would take the host process down (c), or the (d) bar is cleared with its candidates
+   table? Then choose the option that refuses it, and record the divergence.
+2. **Otherwise, does one option match the pinned reference more closely?** Rule 3: choose
+   it. "The reference is wrong on its own terms" is not a reason to prefer the other; the
+   reference's observable behaviour is the specification.
+3. **Otherwise, choose the option with the better performance or the lower memory use.**
+   This clause can only ever separate options that are *equally* faithful, so it cannot
+   introduce a divergence; rule 4's closed list still governs those.
+
+The word "bug" in step 1 therefore means "behaviour rule 4 permits us to refuse", not
+"behaviour a maintainer would call a defect". A quirk that is readable, harmless and
+survivable is reproduced, however wrong-looking — `sub`'s ignored third argument
+([#1122](https://github.com/rust-works/succinctly/issues/1122)), jq's null ambient on every
+INIT fork but the first ([#2163](https://github.com/rust-works/succinctly/issues/2163)),
+yq's `first(f)` ignoring its argument
+([#2377](https://github.com/rust-works/succinctly/issues/2377)), yq's comma binding looser
+than its pipe ([#2420](https://github.com/rust-works/succinctly/issues/2420)). The
+alternative reading — fix any reference behaviour judged defective — would reverse rule 3
+and leave every such decision with nothing to capture, which is the state this ADR was
+written to leave; it was considered and rejected when this amendment was adopted.
+
+The two forks that prompted it, as worked examples:
+
+- **yq vivifies a missing key on read** ([#2435](https://github.com/rust-works/succinctly/issues/2435)):
+  `.a.b | parent | parent` on `a: {}` prints the whole document with a `b: null` the input
+  never contained. Step 1, condition (b): succinctly keeps the real parent and records the
+  divergence in [compliance/yq/limitations.md](../compliance/yq/limitations.md).
+- **Path context for values with no document node** (`[1,2] | .[0] | key` is `0`,
+  `.a.b | map(.) | key` is nothing, both captured from yq v4.53.3): no rule-4 condition
+  applies, and one option (tracking the path through owned values in the generic
+  evaluator, [ADR-0021](adr-0021.md)) matches the reference where the other (keeping the
+  eager evaluator's accumulated path) does not. Step 2 decides it; step 3 would have
+  pointed the same way, since the eager route materializes the whole document.
+
 ## Consequences
 
 **Positive:**


### PR DESCRIPTION
Adopted 2026-09-05 while executing spine 2416 (number written without a hash: a bare mention auto-closes it on merge). Docs only; no shipped behaviour changes.

ADR-0018 states its rules but not the order they apply in, and has no tiebreak for two equally faithful options. The amendment adds both, identically for jq and yq mode:

1. whether a rule-4 condition permits refusing the reference's behaviour;
2. otherwise, whichever option matches the pinned reference more closely (rule 3);
3. otherwise, the better performance or lower memory use — a clause that can only separate equally faithful options, so it cannot introduce a divergence.

It fixes "bug" in step 1 to mean "behaviour rule 4 permits us to refuse", lists the quirks that stay reproduced bug-for-bug (#1122, #2163, #2377, #2420), records the rejected broad reading, and carries the two forks that prompted it as worked examples (#2435 under condition (b); the owned-domain path tracker under rule 3, ADR-0021). `CLAUDE.md`'s fidelity paragraph gains one sentence stating the order.
