### PR TITLE
feat(jq): route as/label/def calls through the generic evaluator (spine 2416)

### DIFF
--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -6030,6 +6030,15 @@ fn eval_single<S: EvalSemantics, V: DocumentValue>(
             }
         }
 
+        // #2416 phase 3: `EXPR as $x | body` natively via the sink
+        // evaluator's own arm (`each_as_generic`), collected the same way
+        // `Expr::If` is above -- `expr` and `body` both evaluate against the
+        // same ambient cursor (mirroring `eval::eval_as`: `as` leaves `.`
+        // unchanged for `body`, only binding the variable), so a `key`/
+        // `parent`/`path` inside either answers as a cursor property instead
+        // of bridging the whole construct to the eager evaluator.
+        Expr::As { .. } => collect_each_generic::<S, V>(expr, value, optional, cursor),
+
         Expr::Comma(exprs) => {
             let mut out: Vec<OwnedValue> = Vec::new();
             for expr in exprs {
@@ -11270,6 +11279,12 @@ fn path_context_single_native(expr: &Expr) -> bool {
                     ObjectKey::Expr(key) => path_context_single_native(key),
                 }
         }),
+        // Native since #2416 phase 3 (`collect_each_generic` over
+        // `each_as_generic`): `expr` and `body` both evaluate against the
+        // same ambient cursor, mirroring `eval::eval_as`.
+        Expr::As { expr, body, .. } => {
+            path_context_single_native(expr) && path_context_single_native(body)
+        }
         _ => false,
     }
 }
@@ -21428,6 +21443,18 @@ mod tests {
             !eager(".a[] | select(true) | key"),
             "iterate cannot yield absent"
         );
+        // #2416 phase 3, this PR: `as` is now single-native
+        // (`collect_each_generic` over `each_as_generic`), so a pipe with it
+        // as the last stage runs generically -- same admission `if`/`limit`/
+        // `Object` got above. `EXPR as $x | BODY` leaves `.` unchanged for
+        // `BODY` (confirmed live: `.a as $v | .` on `{"a":1}` is the whole
+        // document, not `1`), so this row keeps `key` at the per-element
+        // position `.[]` already put it at.
+        assert!(!eager(".[] | . as $x | key"));
+        // Arithmetic still bridges from `eval_single` (unchanged from the
+        // `if`/`limit` rows above), so wrapping one in `as`'s body keeps the
+        // whole pipe eager.
+        assert!(eager(".[] | . as $x | key + 10"));
         // An emitted `key`/`path` is a computed value: a later builtin no
         // longer stands on a node.
         assert!(eager(".[] | key | key"));

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -6063,6 +6063,12 @@ fn eval_single<S: EvalSemantics, V: DocumentValue>(
         // `eval.rs`'s identical arm.
         Expr::FuncDef { .. } => collect_each_generic::<S, V>(expr, value, optional, cursor),
 
+        // #2416 phase 3: transparent to cursor-based evaluation, same spirit
+        // as `Expr::Paren` above -- native via `eval_each_generic`'s own
+        // `Shared` pair (`is_pure_chain_link`'s split between the cheap
+        // eager path and the lazy one).
+        Expr::Shared(_) => collect_each_generic::<S, V>(expr, value, optional, cursor),
+
         Expr::Comma(exprs) => {
             let mut out: Vec<OwnedValue> = Vec::new();
             for expr in exprs {
@@ -11333,6 +11339,9 @@ fn path_context_single_native(expr: &Expr) -> bool {
         Expr::FuncDef { body, then, .. } => {
             path_context_single_native(body) && path_context_single_native(then)
         }
+        // Native since #2416 phase 3: transparent to evaluation, so whatever
+        // `inner` is decides.
+        Expr::Shared(inner) => path_context_single_native(inner),
         _ => false,
     }
 }

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -6044,6 +6044,12 @@ fn eval_single<S: EvalSemantics, V: DocumentValue>(
         // above, for every `?//`-chained alternative.
         Expr::AsPattern { .. } => collect_each_generic::<S, V>(expr, value, optional, cursor),
 
+        // #2416 phase 3: `label $name | body` natively via
+        // `each_label_generic`, so a `key`/`parent`/`path` reached before or
+        // after a `break` inside the body keeps the ambient cursor instead
+        // of bridging.
+        Expr::Label { .. } => collect_each_generic::<S, V>(expr, value, optional, cursor),
+
         Expr::Comma(exprs) => {
             let mut out: Vec<OwnedValue> = Vec::new();
             for expr in exprs {
@@ -11295,6 +11301,9 @@ fn path_context_single_native(expr: &Expr) -> bool {
         Expr::AsPattern { expr, body, .. } => {
             path_context_single_native(expr) && path_context_single_native(body)
         }
+        // Native since #2416 phase 3 (`each_label_generic`): the body is all
+        // that can carry a path-context builtin.
+        Expr::Label { body, .. } => path_context_single_native(body),
         _ => false,
     }
 }
@@ -21462,11 +21471,13 @@ mod tests {
         // position `.[]` already put it at.
         assert!(!eager(".[] | . as $x | key"));
         assert!(!eager(".[] | . as {a: $a} | key"));
+        assert!(!eager(".[] | label $out | key"));
         // Arithmetic still bridges from `eval_single` (unchanged from the
-        // `if`/`limit` rows above), so wrapping one in `as`'s body keeps the
-        // whole pipe eager.
+        // `if`/`limit` rows above), so wrapping one in `as`'s/`label`'s body
+        // keeps the whole pipe eager.
         assert!(eager(".[] | . as $x | key + 10"));
         assert!(eager(".[] | . as {a: $a} | key + 10"));
+        assert!(eager(".[] | label $out | key + 10"));
         // An emitted `key`/`path` is a computed value: a later builtin no
         // longer stands on a node.
         assert!(eager(".[] | key | key"));

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -6050,6 +6050,12 @@ fn eval_single<S: EvalSemantics, V: DocumentValue>(
         // of bridging.
         Expr::Label { .. } => collect_each_generic::<S, V>(expr, value, optional, cursor),
 
+        // #2416 phase 3: a bound call natively via `eval_each_generic`'s own
+        // `DefCall` arm (`bind_def_call`/`enter_def_call_frame`) -- the same
+        // recursion-depth accounting that arm already does, just reached
+        // through `collect_each_generic` instead of the eager bridge.
+        Expr::DefCall { .. } => collect_each_generic::<S, V>(expr, value, optional, cursor),
+
         Expr::Comma(exprs) => {
             let mut out: Vec<OwnedValue> = Vec::new();
             for expr in exprs {
@@ -11304,6 +11310,13 @@ fn path_context_single_native(expr: &Expr) -> bool {
         // Native since #2416 phase 3 (`each_label_generic`): the body is all
         // that can carry a path-context builtin.
         Expr::Label { body, .. } => path_context_single_native(body),
+        // Native since #2416 phase 3 (`eval_each_generic`'s own `DefCall`
+        // arm, `bind_def_call`). `def.body` is the only field
+        // `needs_path_context`'s own identical arm recurses into --
+        // deliberately cheap and syntax-only: a builtin reaching `body`
+        // solely through a call *argument* is a known, narrower gap, same
+        // scoping precedent as there.
+        Expr::DefCall { def, .. } => path_context_single_native(&def.body),
         _ => false,
     }
 }

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -11329,7 +11329,12 @@ fn path_context_single_native(expr: &Expr) -> bool {
         // deliberately cheap and syntax-only: a builtin reaching `body`
         // solely through a call *argument* is a known, narrower gap, same
         // scoping precedent as there.
-        Expr::DefCall { def, .. } => path_context_single_native(&def.body),
+        // The call's arguments are substituted into the body when the call is
+        // bound, so they have to be single-native too: `f(key + 10)` would
+        // otherwise be admitted while its arithmetic still bridges.
+        Expr::DefCall { def, args, .. } => {
+            path_context_single_native(&def.body) && args.iter().all(path_context_single_native)
+        }
         // Native since #2416 phase 3 (`eval_each_generic`'s own `FuncDef`
         // arm, `bind_def`). `body`/`then` are exactly what
         // `needs_path_context`'s own identical pair of arms recurses into --
@@ -21525,6 +21530,9 @@ mod tests {
         assert!(eager(".[] | . as {a: $a} | key + 10"));
         assert!(eager(".[] | label $out | key + 10"));
         assert!(eager(".[] | (def k: 1; key + 10)"));
+        // `DefCall` is a runtime node the parser never produces, so its
+        // argument gate is pinned by the CLI (`f(key + 10)` in
+        // `test_shared_keeps_path_context_2416`) rather than here.
         // An emitted `key`/`path` is a computed value: a later builtin no
         // longer stands on a node.
         assert!(eager(".[] | key | key"));

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -6056,6 +6056,13 @@ fn eval_single<S: EvalSemantics, V: DocumentValue>(
         // through `collect_each_generic` instead of the eager bridge.
         Expr::DefCall { .. } => collect_each_generic::<S, V>(expr, value, optional, cursor),
 
+        // #2416 phase 3: `def name(params): body; then` is pure AST
+        // substitution -- native via `eval_each_generic`'s own `FuncDef` arm
+        // (`bind_def`), which installs the definition and re-evaluates
+        // `then` through this same collecting wrapper, mirroring
+        // `eval.rs`'s identical arm.
+        Expr::FuncDef { .. } => collect_each_generic::<S, V>(expr, value, optional, cursor),
+
         Expr::Comma(exprs) => {
             let mut out: Vec<OwnedValue> = Vec::new();
             for expr in exprs {
@@ -11317,6 +11324,15 @@ fn path_context_single_native(expr: &Expr) -> bool {
         // solely through a call *argument* is a known, narrower gap, same
         // scoping precedent as there.
         Expr::DefCall { def, .. } => path_context_single_native(&def.body),
+        // Native since #2416 phase 3 (`eval_each_generic`'s own `FuncDef`
+        // arm, `bind_def`). `body`/`then` are exactly what
+        // `needs_path_context`'s own identical pair of arms recurses into --
+        // same deliberately cheap, syntax-only approximation as `DefCall`
+        // above (a builtin reaching `body` solely through a call *argument*
+        // is a known, narrower gap).
+        Expr::FuncDef { body, then, .. } => {
+            path_context_single_native(body) && path_context_single_native(then)
+        }
         _ => false,
     }
 }
@@ -21485,12 +21501,21 @@ mod tests {
         assert!(!eager(".[] | . as $x | key"));
         assert!(!eager(".[] | . as {a: $a} | key"));
         assert!(!eager(".[] | label $out | key"));
+        // A `def` whose `then` uses `key` directly (not through a call to
+        // the def) is single-native the same way: `body`/`then` are exactly
+        // what `path_context_single_native`'s `FuncDef` arm checks.
+        // `Expr::DefCall` has no row here -- it is a runtime-only node
+        // (installed by `bind_def` on first evaluation), never produced by a
+        // fresh `parse()`; `test_def_call_keeps_path_context_2416` (CLI) is
+        // its coverage instead.
+        assert!(!eager(".[] | (def k: 1; key)"));
         // Arithmetic still bridges from `eval_single` (unchanged from the
-        // `if`/`limit` rows above), so wrapping one in `as`'s/`label`'s body
-        // keeps the whole pipe eager.
+        // `if`/`limit` rows above), so wrapping one in `as`'s/`label`'s/
+        // `def`'s body keeps the whole pipe eager.
         assert!(eager(".[] | . as $x | key + 10"));
         assert!(eager(".[] | . as {a: $a} | key + 10"));
         assert!(eager(".[] | label $out | key + 10"));
+        assert!(eager(".[] | (def k: 1; key + 10)"));
         // An emitted `key`/`path` is a computed value: a later builtin no
         // longer stands on a node.
         assert!(eager(".[] | key | key"));

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -6039,6 +6039,11 @@ fn eval_single<S: EvalSemantics, V: DocumentValue>(
         // of bridging the whole construct to the eager evaluator.
         Expr::As { .. } => collect_each_generic::<S, V>(expr, value, optional, cursor),
 
+        // #2416 phase 3: destructuring `as` natively via
+        // `each_as_pattern_generic` -- same cursor-threading as `Expr::As`
+        // above, for every `?//`-chained alternative.
+        Expr::AsPattern { .. } => collect_each_generic::<S, V>(expr, value, optional, cursor),
+
         Expr::Comma(exprs) => {
             let mut out: Vec<OwnedValue> = Vec::new();
             for expr in exprs {
@@ -11283,6 +11288,11 @@ fn path_context_single_native(expr: &Expr) -> bool {
         // `each_as_generic`): `expr` and `body` both evaluate against the
         // same ambient cursor, mirroring `eval::eval_as`.
         Expr::As { expr, body, .. } => {
+            path_context_single_native(expr) && path_context_single_native(body)
+        }
+        // Native since #2416 phase 3 (`each_as_pattern_generic`): same
+        // reasoning as `Expr::As` above, for every `?//`-chained alternative.
+        Expr::AsPattern { expr, body, .. } => {
             path_context_single_native(expr) && path_context_single_native(body)
         }
         _ => false,
@@ -21451,10 +21461,12 @@ mod tests {
         // document, not `1`), so this row keeps `key` at the per-element
         // position `.[]` already put it at.
         assert!(!eager(".[] | . as $x | key"));
+        assert!(!eager(".[] | . as {a: $a} | key"));
         // Arithmetic still bridges from `eval_single` (unchanged from the
         // `if`/`limit` rows above), so wrapping one in `as`'s body keeps the
         // whole pipe eager.
         assert!(eager(".[] | . as $x | key + 10"));
+        assert!(eager(".[] | . as {a: $a} | key + 10"));
         // An emitted `key`/`path` is a computed value: a later builtin no
         // longer stands on a node.
         assert!(eager(".[] | key | key"));

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -7393,6 +7393,30 @@ fn test_if_and_limit_keep_path_context_2416() -> Result<()> {
     Ok(())
 }
 
+/// Spine 2416, phase 3: `EXPR as $x | body` (bare-variable `as`) is now
+/// native in `eval_single` (`collect_each_generic` over `each_as_generic`),
+/// so it no longer bridges the whole construct to the eager evaluator --
+/// mirroring `if`/`limit`/`Object`'s own migration above. No jq oracle:
+/// `key` is a succinctly extension. `EXPR as $x | body` leaves `.` unchanged
+/// for `body` (confirmed live: `.a as $v | .` on `{"a":1}` is the whole
+/// document, not `1`), so both rows below bind `$x`/`$ks` from `.` itself
+/// (`Expr::Identity`/an array construction) rather than navigating away from
+/// the per-element position `key` answers for -- the pre-migration answer
+/// (captured on this PR's own pre-change build) is unchanged.
+#[test]
+fn test_as_keeps_path_context_2416() -> Result<()> {
+    let doc = r#"[{"a":1},{"b":2}]"#;
+    for (filter, want) in [
+        (".[] | . as $x | key", "0\n1"),
+        ("[.[] | key] as $ks | $ks", "[0,1]"),
+    ] {
+        let (out, _, code) = run_jq_full(&["-c", filter], Some(doc))?;
+        assert_eq!(code, 0, "`{filter}`: {out:?}");
+        assert_eq!(out.trim(), want, "`{filter}`");
+    }
+    Ok(())
+}
+
 /// Documents the one remaining deliberate, narrow gap #1663/#1765 leave
 /// open rather than silently missing: a `?//`-chained `AsPattern` (2+
 /// alternatives) still has no dedicated evaluation arm, so a path-context

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -7417,6 +7417,20 @@ fn test_as_keeps_path_context_2416() -> Result<()> {
     Ok(())
 }
 
+/// Spine 2416, phase 3: destructuring `as` (`Expr::AsPattern`) is now native
+/// via `each_as_pattern_generic`, same migration as bare `as` above. No jq
+/// oracle. The pre-migration answer (this PR's own pre-change build) is
+/// unchanged: `expr` is `Expr::Identity`, so `.` for `body` is already the
+/// per-element position `key` answers for.
+#[test]
+fn test_as_pattern_keeps_path_context_2416() -> Result<()> {
+    let doc = r#"{"x":{"p":10},"y":{"p":20}}"#;
+    let (out, _, code) = run_jq_full(&["-c", ".[] | . as {p: $p} | key"], Some(doc))?;
+    assert_eq!(code, 0, "{out:?}");
+    assert_eq!(out.trim(), "\"x\"\n\"y\"");
+    Ok(())
+}
+
 /// Documents the one remaining deliberate, narrow gap #1663/#1765 leave
 /// open rather than silently missing: a `?//`-chained `AsPattern` (2+
 /// alternatives) still has no dedicated evaluation arm, so a path-context
@@ -7977,11 +7991,23 @@ fn test_as_pattern_single_pattern_path_context_resolves_1765() -> Result<()> {
 /// `Many`/`Partial` result into a single `OwnedValue::Array` instead of
 /// streaming it -- silently changing both output count and value shape for
 /// something never even the (broken) `key`/`parent` stub was meant to
-/// affect. Confirmed live against pre-#1765 `main`: both filters below give
-/// two separate `"null"`/`"0"` outputs there, not one collapsed
-/// `"[null,null]"` or a type error. `needs_path_context`'s `AsPattern` arm
-/// now carries the identical `patterns.len() == 1` gate the eval arm does,
-/// closing this before it ever shipped.
+/// affect. `needs_path_context`'s `AsPattern` arm now carries the identical
+/// `patterns.len() == 1` gate the eval arm does, closing this before it ever
+/// shipped. The second filter below still pins that guard: two separate
+/// `"0"` outputs, not one collapsed `"[0,0]"`.
+///
+/// **The first filter's expected value changed under spine 2416's phase 3**
+/// (`Expr::AsPattern` native in `eval_single` via `collect_each_generic`,
+/// closing this same construct's #1332-shaped gap for the `?//`-chain case
+/// too, not just the single-pattern one #1765 fixed). `EXPR as PATTERN |
+/// BODY` leaves `.` unchanged for `BODY` -- confirmed live (`.a as $v | .`
+/// on `{"a":1}` is the whole document, not `1`) -- so `key` in `(.a[] as
+/// {x:$v} ?// [$v] | key)` answers for the *ambient* `.`, the document root,
+/// each of the two times the chain runs, not for the bound `.a[]` element.
+/// `key`/`parent` at or above the root emit nothing (#2421), so the old
+/// stubbed `"null"` pair is now correctly empty. Cardinality is still
+/// preserved -- zero outputs both times, not one array -- just as `"0"\n"0"`
+/// still is when a computed stage keeps the pair alive.
 #[test]
 fn test_as_pattern_qmark_slash_slash_chain_does_not_collapse_cardinality_1765() -> Result<()> {
     let (stdout, _, code) = run_jq_full(
@@ -7989,7 +8015,7 @@ fn test_as_pattern_qmark_slash_slash_chain_does_not_collapse_cardinality_1765() 
         Some(r#"{"a":[{"x":1},{"x":2}]}"#),
     )?;
     assert_eq!(code, 0);
-    assert_eq!(stdout, "\"null\"\n\"null\"\n");
+    assert_eq!(stdout, "");
 
     let (stdout, _, code) = run_jq_full(
         &["-c", "(.a[] as {x:$v} ?// [$v] | key) + 0 | tostring"],

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -7431,6 +7431,21 @@ fn test_as_pattern_keeps_path_context_2416() -> Result<()> {
     Ok(())
 }
 
+/// Spine 2416, phase 3: `label $name | body` is now native via
+/// `each_label_generic`, so a `key` reached before a `break` inside the
+/// label's body keeps the ambient cursor instead of bridging. No jq oracle
+/// (`label`/`break` are real jq, but `key` is a succinctly extension).
+/// `label` doesn't change `.` either, so this pins the pre-migration answer
+/// (this PR's own pre-change build) unchanged.
+#[test]
+fn test_label_keeps_path_context_2416() -> Result<()> {
+    let doc = r#"[{"a":1},{"b":2}]"#;
+    let (out, _, code) = run_jq_full(&["-c", ".[] | label $out | (key, break $out)"], Some(doc))?;
+    assert_eq!(code, 0, "{out:?}");
+    assert_eq!(out.trim(), "0\n1");
+    Ok(())
+}
+
 /// Documents the one remaining deliberate, narrow gap #1663/#1765 leave
 /// open rather than silently missing: a `?//`-chained `AsPattern` (2+
 /// alternatives) still has no dedicated evaluation arm, so a path-context

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -7489,6 +7489,28 @@ fn test_func_def_keeps_path_context_2416() -> Result<()> {
     Ok(())
 }
 
+/// Spine 2416, phase 3: `Expr::Shared` (a call argument captured behind an
+/// `Rc` once substituted into a callee's body, #1371) is now native via
+/// `eval_each_generic`'s own `Shared` pair (`is_pure_chain_link`'s split
+/// between the cheap eager path and the lazy one), reached through
+/// `collect_each_generic` instead of the eager bridge. No jq oracle.
+/// `id(x): x` doesn't change `.`, so this pins the pre-migration answer
+/// (this PR's own pre-change build) unchanged: `key` reaches this arm as
+/// the argument passed into a one-arg identity-shaped def. Like
+/// `Expr::DefCall`, `Expr::Shared` is a runtime-only node (only ever
+/// synthesized when a call's argument is substituted into its callee's
+/// body), never produced by a fresh `parse()`, so it has no row in
+/// `path_context_needs_eager_pins_the_three_reasons_2416`; this CLI test is
+/// its coverage.
+#[test]
+fn test_shared_keeps_path_context_2416() -> Result<()> {
+    let doc = r#"[{"a":1},{"b":2}]"#;
+    let (out, _, code) = run_jq_full(&["-c", "def id(x): x; .[] | id(key)"], Some(doc))?;
+    assert_eq!(code, 0, "{out:?}");
+    assert_eq!(out.trim(), "0\n1");
+    Ok(())
+}
+
 /// Documents the one remaining deliberate, narrow gap #1663/#1765 leave
 /// open rather than silently missing: a `?//`-chained `AsPattern` (2+
 /// alternatives) still has no dedicated evaluation arm, so a path-context

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -7467,6 +7467,28 @@ fn test_def_call_keeps_path_context_2416() -> Result<()> {
     Ok(())
 }
 
+/// Spine 2416, phase 3: `def name(params): body; then` is now native via
+/// `eval_each_generic`'s own `FuncDef` arm (`bind_def`), which installs the
+/// definition and re-evaluates `then` through the same collecting wrapper
+/// used for `Expr::As`/`Expr::Label`/etc. above. No jq oracle. Pre-migration
+/// answer (this PR's own pre-change build) unchanged, for both a `then` that
+/// calls the def (reaching `Expr::DefCall`, same shape as the test above)
+/// and one that merely wraps a bare `key` reference in `then` without ever
+/// calling the def at all.
+#[test]
+fn test_func_def_keeps_path_context_2416() -> Result<()> {
+    let doc = r#"[{"a":1},{"b":2}]"#;
+    for (filter, want) in [
+        (".[] | (def k: .; k, key)", "{\"a\":1}\n0\n{\"b\":2}\n1"),
+        (".[] | (def k: 1; key)", "0\n1"),
+    ] {
+        let (out, _, code) = run_jq_full(&["-c", filter], Some(doc))?;
+        assert_eq!(code, 0, "`{filter}`: {out:?}");
+        assert_eq!(out.trim(), want, "`{filter}`");
+    }
+    Ok(())
+}
+
 /// Documents the one remaining deliberate, narrow gap #1663/#1765 leave
 /// open rather than silently missing: a `?//`-chained `AsPattern` (2+
 /// alternatives) still has no dedicated evaluation arm, so a path-context

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -7508,6 +7508,17 @@ fn test_shared_keeps_path_context_2416() -> Result<()> {
     let (out, _, code) = run_jq_full(&["-c", "def id(x): x; .[] | id(key)"], Some(doc))?;
     assert_eq!(code, 0, "{out:?}");
     assert_eq!(out.trim(), "0\n1");
+    // A call argument is substituted into the body at bind time, so it is
+    // gated too: `key + 10` still bridges from `eval_single` (arithmetic is
+    // not single-native), and losing the cursor there would answer
+    // `null + 10` twice. The eager route answers 10 and 11; so must this one.
+    let (out, _, code) = run_jq_full(
+        &["-c", "def f(x): x; .[] | f(key + 10)"],
+        Some(r#"[{"a":1},{"b":2}]"#),
+    )?;
+    assert_eq!(code, 0);
+    assert_eq!(out.trim(), "10\n11");
+
     Ok(())
 }
 

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -7446,6 +7446,27 @@ fn test_label_keeps_path_context_2416() -> Result<()> {
     Ok(())
 }
 
+/// Spine 2416, phase 3: a bound call (`Expr::DefCall`, installed by
+/// `Expr::FuncDef`'s own arm on first evaluation) is now native via
+/// `eval_each_generic`'s existing `DefCall` arm
+/// (`bind_def_call`/`enter_def_call_frame`), reached through
+/// `collect_each_generic` instead of the eager bridge. No jq oracle. `def
+/// k: key;` doesn't change `.`, so this pins the pre-migration answer (this
+/// PR's own pre-change build) unchanged. `Expr::DefCall` is a runtime-only
+/// node (installed by `bind_def` on first evaluation of the enclosing
+/// `FuncDef`, never produced by the parser), so unlike `As`/`AsPattern`/
+/// `Label` above it cannot be pinned as a bare `Expr::Pipe` stage in
+/// `path_context_needs_eager_pins_the_three_reasons_2416` -- this CLI test
+/// is the construct's coverage.
+#[test]
+fn test_def_call_keeps_path_context_2416() -> Result<()> {
+    let doc = r#"[{"a":1},{"b":2}]"#;
+    let (out, _, code) = run_jq_full(&["-c", "def k: key; .[] | k"], Some(doc))?;
+    assert_eq!(code, 0, "{out:?}");
+    assert_eq!(out.trim(), "0\n1");
+    Ok(())
+}
+
 /// Documents the one remaining deliberate, narrow gap #1663/#1765 leave
 /// open rather than silently missing: a `?//`-chained `AsPattern` (2+
 /// alternatives) still has no dedicated evaluation arm, so a path-context


### PR DESCRIPTION
Spine 2416, phase 3 (number without a hash on purpose): the each-native constructs into `eval_single`, one commit per construct, following the `if` pattern (`collect_each_generic`). Does not close the spine; the arm-count pin stays at 43.

## Admitted (6)

`as`, destructuring `as`, `label`, bound `def` calls, `def` declarations, and substituted call arguments (`Shared`) each get an `eval_single` arm via `collect_each_generic` and an entry in `path_context_single_native`. Every CLI answer was captured on the pre-change build first and is unchanged after (the invariant: same answer, generic route), e.g. `.[] | . as $x | key` → `0`, `1`; `def k: key; .[] | k` → `0`, `1`; `.[] | label $out | (key, break $out)` → `0`, `1`. A bound call's arguments are gated too, since they are substituted into the body at bind time; the discriminating row is `def f(x): x; .[] | f(key + 10)` → `10`, `11`.

## Not admitted: `repeat`

The sink arm `each_repeat_generic` has no iteration cap by design and relies on the consumer's `Demand::Stop`; the bridge reaches `eval.rs`'s `eval_repeat`, which caps at 1000. Measured: `last(repeat(1))` errors in ~8 ms today and hung past 5 s with the arm added. Left on the bridge; noted for a later decision.

## One pre-existing pin moved

`test_as_pattern_qmark_slash_slash_chain_does_not_collapse_cardinality_1765`'s first filter pinned a stubbed `"null"` pair from the eager evaluator (the `?//` chain never reached path-context evaluation). `as` leaves `.` unchanged for its body, so `key` there is `key` at the root, which emits nothing per #2421; the assertion now expects empty output. The second filter, which carries the cardinality claim, is unchanged.

## Verification (all exit 0)

fmt; both clippy legs; full `cargo test --features cli`; `--no-default-features`; arm guard (43); release build + sweep (2112 cases, 0 unexpected, nothing flipped); both golden checks.
