### PR TITLE
fix(yq): rank pipe above comma in yq mode, matching real yq's precedence table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **`succinctly yq` now ranks `|` above `,`, as real yq does — `A, B | C` means
+  `A, (B | C)` in yq mode, not jq's `(A, B) | C`** (#2420). yq's parser is a
+  shunting-yard operator-precedence parser and its own table
+  (`pkg/yqlib/operation.go`, v4.53.3) gives `pipeOpType` precedence **30** and
+  `unionOpType` (`,`) precedence **10** — pipe binds *tighter*. jq's `parser.y`
+  ranks them the other way (`%right '|'` declared before `%left ','`), and
+  succinctly applied jq's ranking in *both* modes. Per ADR-0018 rule 2 the mode
+  decides, never the input format, so `succinctly jq` is unchanged and
+  `succinctly yq` follows yq here whether the input is YAML or JSON:
+
+  ```console
+  $ printf 'a: 1\nb: 2\n' | succinctly yq -o=json -I0 '.a, .b | . + 10'
+  1                                  # was: 11
+  12                                 # real yq v4.53.3 prints 1 then 12
+  $ echo '{"a":1,"b":2}' | succinctly jq -c '.a, .b | . + 10'
+  11                                 # unchanged; real jq 1.7.1 prints 11 then 12
+  12
+  ```
+
+  This is a fixed entry in yq's operator table, so it holds at every nesting
+  depth rather than only at top level. Explicit parentheses restore jq's
+  grouping (`(.a, .b) | . + 10` is `11`/`12` in both modes) because they are a
+  boundary the shunting yard cannot see across; **construction brackets do
+  not** — `[.a, .b | . + 10]` is `[1,12]` in yq mode and `[11,12]` in jq mode.
+  Any existing yq-mode filter that combines an unparenthesised `,` and `|` at
+  the same bracket depth changes meaning; parenthesise the comma branch to keep
+  the old grouping.
+
 - **The "materialization ignores a live `optional`" gap is now a build failure, not a
   sweep** (#2334). The same bug shipped three times — #2231, #2280, #2327 — each round's
   review finding sites the last sweep missed, several of them the direct sibling of a

--- a/docs/compliance/yq/limitations.md
+++ b/docs/compliance/yq/limitations.md
@@ -2257,7 +2257,7 @@ not inherit either of the two wrong spellings shown above.
 [#2419](https://github.com/rust-works/succinctly/issues/2419) is the ADR-0018 record for
 this divergence; fixing the re-spelling itself is out of its scope.
 
-### Comma binds looser than pipe in real yq — succinctly currently applies jq's grouping in both modes (#2420)
+### Comma binds looser than pipe in real yq — the grouping is resolved (#2420); two evaluation-model residuals remain (#2451, #2452)
 
 Real yq's parser is a shunting-yard operator-precedence parser
 ([`pkg/yqlib/expression_postfix.go`](https://github.com/mikefarah/yq/blob/v4.53.3/pkg/yqlib/expression_postfix.go)),
@@ -2265,9 +2265,13 @@ and its own precedence table
 ([`pkg/yqlib/operation.go`](https://github.com/mikefarah/yq/blob/v4.53.3/pkg/yqlib/operation.go))
 assigns `pipeOpType` precedence 30 and `unionOpType` (`,`) precedence 10 —
 **pipe binds *tighter* than comma**. jq's grammar ranks the two operators the
-other way around (comma binds tighter than pipe), and `succinctly` currently
-applies jq's ranking in *both* modes, not yq's own, in `succinctly yq`.
-Confirmed live against the pinned v4.53.3 binary and `/usr/bin/jq` 1.7.1 on
+other way around (comma binds tighter than pipe), and until
+[#2420](https://github.com/rust-works/succinctly/issues/2420) `succinctly`
+applied jq's ranking in *both* modes. `succinctly yq`'s parser now uses yq's
+own table (`parse_yq_comma_expr` in `src/jq/parser.rs`: a comma of
+pipe-without-comma operands, in `ParserMode::Yq` only); the `succinctly yq`
+rows below record the pre-fix output and are kept so the capture stays
+readable next to the two references. Confirmed live against the pinned v4.53.3 binary and `/usr/bin/jq` 1.7.1 on
 `printf 'a: 1\nb: 2\nc: 3\n'`:
 
 ```bash
@@ -2366,18 +2370,33 @@ comma/pipe precedence inside them, so `[.a, .b | . + 10]` is
 `[.a, (.b | . + 10)]` = `[1,12]`, not jq's `[11,12]`.
 
 Per [ADR-0018](../../adrs/adr-0018.md) rule 2, mode decides: `succinctly yq`
-must follow yq's grammar here, not jq's. It currently does not —
-`succinctly` parses `,` as binding tighter than `|` **in both modes** (jq's
-ranking), so any yq-mode filter that combines an unparenthesised `,` and `|`
-at the same bracket depth risks silently picking up jq's grouping in place of
-yq's own. This is filed as
-[#2420](https://github.com/rust-works/succinctly/issues/2420); this entry
-only records the divergence per ADR-0018 rule 6. Implementing yq's own
-precedence table in `succinctly yq`'s parser is a separate, out-of-scope
-change — see the issue for the parser-change plan and the test-surface audit
-of `tests/yq_cli_tests.rs` and the yq golden corpus that motivated capturing
-this before the Phase 0 corpus for [#2416](https://github.com/rust-works/succinctly/issues/2416)
-grew any larger.
+follows yq's grammar here, not jq's. The parser change landed under
+[#2420](https://github.com/rust-works/succinctly/issues/2420): `,` now binds
+looser than `|` in yq mode at every depth (pinned by
+`test_yq_pipe_precedence_holds_at_every_depth_2420`), parentheses and
+construction brackets behave as captured above, and `succinctly jq` is
+untouched (`test_jq_comma_still_binds_tighter_than_pipe_2420`). Three
+existing yq-mode tests that had encoded jq's grouping were re-captured against
+the pinned binary rather than kept.
+
+Two divergences the capture exposed are **not** precedence and stay open,
+pinned as residuals in `test_yq_pipe_precedence_residual_divergences_2420`:
+
+- [#2451](https://github.com/rust-works/succinctly/issues/2451): real yq
+  applies a pipe's right side to the whole *list* its left side produced, so
+  `(.a, .b) | (.c, .d)` on `a: {c: 3, d: 4}` / `b: {c: 5, d: 6}` prints
+  `3 5 4 6` in yq and `3 4 5 6` here (jq's per-element order). Both sides are
+  parenthesised, so no grouping rule reaches it; the oracle sweep's
+  `comma_stream` class is this divergence, which is why it did not flip when
+  the precedence fix landed.
+- [#2452](https://github.com/rust-works/succinctly/issues/2452): under yq's
+  own grouping `.a | .b, .c | . + 1` fails in its first branch; real yq drops
+  that branch silently and exits 0, succinctly raises as jq does.
+
+The `length` row above is also two things at once: real yq's rendered-width
+rule for scalars, and a succinctly-internal inconsistency where the comma
+fan-out path still applies jq's absolute-value rule
+([#2453](https://github.com/rust-works/succinctly/issues/2453)).
 
 ### Other categories
 

--- a/docs/reference/yq-language.md
+++ b/docs/reference/yq-language.md
@@ -63,6 +63,29 @@ All features from the [jq Language Reference](jq-language.md) work with yq, incl
 - Format strings (`@json`, `@csv`, `@base64`, etc.)
 - Module system (`import`, `include`)
 
+### Operator precedence differs on `|` vs `,`
+
+The [jq operator-precedence table](jq-language.md#operator-precedence) applies in
+yq mode **except for its two loosest levels, which are swapped** (#2420). Real
+yq's parser is a shunting-yard operator-precedence parser and its own table
+(`pkg/yqlib/operation.go`, v4.53.3) gives `pipeOpType` precedence 30 and
+`unionOpType` (`,`) precedence 10 — pipe binds *tighter* than comma, the
+opposite of jq's `parser.y`. `succinctly yq` follows yq, `succinctly jq`
+follows jq (ADR-0018 rule 2: the mode decides, not the input format):
+
+| Filter               | `succinctly yq` / `yq` | `succinctly jq` / `jq` |
+|----------------------|------------------------|------------------------|
+| `.a, .b \| . + 10`   | `1` `12`               | `11` `12`              |
+| `[.a, .b \| . + 10]` | `[1,12]`               | `[11,12]`              |
+| `(.a, .b) \| . + 10` | `11` `12`              | `11` `12`              |
+| `.a, (.b \| . + 10)` | `1` `12`               | `1` `12`               |
+
+(on `a: 1`/`b: 2`.) It is a fixed entry in yq's operator table, so it holds at
+every nesting depth. Explicit parentheses restore jq's grouping, on either side
+of the comma, because they are a boundary the shunting yard cannot see across;
+construction brackets do not, since `[...]` scopes evaluation rather than
+precedence.
+
 ---
 
 ## YAML-Specific Features

--- a/scripts/jq-path-context-oracle-sweep.sh
+++ b/scripts/jq-path-context-oracle-sweep.sh
@@ -31,13 +31,14 @@
 # combination class is present, so a future alphabet shrink fails loudly.
 #
 # **yq comma/pipe precedence (#2420).** Real yq v4.53.3 parses `a, b | c` as
-# `a, (b | c)`; jq and succinctly (both modes) parse it as `(a, b) | c`.
-# Verified live: `printf 'a: 1\nb: 2\n' | yq -o=json -I0 '.a, .b | . + 10'`
-# prints `1` then `12`, where `succinctly yq` prints `11` then `12`. Every
-# yq-mode case must therefore parenthesise each comma branch, or the sweep
-# records a parser divergence that has nothing to do with path context.
-# `--self-test` enforces it mechanically: no yq-mode filter may contain a `,`
-# and a `|` at the same bracket depth.
+# `a, (b | c)`, where jq parses it as `(a, b) | c`. succinctly used to apply
+# jq's grouping in both modes; since #2420 `succinctly yq` follows yq's own
+# precedence table (`pipeOpType` 30, `unionOpType` 10) and the two agree.
+# Every yq-mode case here nevertheless parenthesises each comma branch, so
+# that a case's meaning does not silently depend on which grouping rule is in
+# force — the corpus is about path context, not about parsing. `--self-test`
+# enforces it mechanically: no yq-mode filter may contain a `,` and a `|` at
+# the same bracket depth.
 #
 # Usage:
 #   cargo build --release --features cli,simd,regex,serde

--- a/src/jq/parser.rs
+++ b/src/jq/parser.rs
@@ -5098,14 +5098,17 @@ impl<'a> Parser<'a> {
 
     /// Parse a complete expression — jq's `Exp`, and this grammar's entry point.
     ///
-    /// The precedence order below `Exp` is, loosest first:
+    /// **The relative precedence of `|` and `,` is mode-dependent**, because the
+    /// two reference tools rank them the opposite way round (ADR-0018 rule 2:
+    /// mode decides, never the input format). In jq mode the order below `Exp`
+    /// is, loosest first:
     ///
     /// ```text
     /// parse_expr        Exp   := parse_pipe_expr
-    /// parse_pipe_expr         := parse_comma_expr ( '|' parse_comma_expr )*
-    /// parse_comma_expr        := parse_binding    ( ',' parse_binding    )*
+    /// parse_pipe_expr         := parse_comma_expr    ( '|' parse_comma_expr    )*
+    /// parse_comma_expr        := parse_binding       ( ',' parse_binding       )*
     /// parse_binding           := parse_assignment [ "as" Patterns '|' parse_expr ]
-    /// parse_obj_val     ExpD  := parse_binding    ( '|' parse_binding    )*
+    /// parse_obj_val     ExpD  := parse_binding       ( '|' parse_binding       )*
     /// ```
     ///
     /// `|` is the *loosest* operator and `,` binds tighter, matching jq's
@@ -5113,12 +5116,64 @@ impl<'a> Parser<'a> {
     /// the wrong way round made `1,2,3 | . * 2` mean `1, 2, (3 | . * 2)` and
     /// print `1 2 6` instead of `2 4 6` — silent data loss, since every
     /// comma branch but the last lost its transformation (#462).
+    ///
+    /// In yq mode the two levels are **swapped**:
+    ///
+    /// ```text
+    /// parse_expr        Exp   := parse_yq_comma_expr
+    /// parse_yq_comma_expr     := parse_pipe_no_comma ( ',' parse_pipe_no_comma )*
+    /// parse_pipe_no_comma     := parse_binding       ( '|' parse_binding       )*
+    /// ```
+    ///
+    /// Real yq's parser is a shunting-yard operator-precedence parser whose own
+    /// table (`pkg/yqlib/operation.go`, v4.53.3) gives `pipeOpType` precedence
+    /// **30** and `unionOpType` (`,`) precedence **10** — pipe binds *tighter*
+    /// than comma, so `A, B | C` is `A, (B | C)`, not jq's `(A, B) | C`. This is
+    /// a fixed entry in that table, so it holds at every nesting depth: explicit
+    /// parentheses restore jq's grouping (they are a boundary the shunting yard
+    /// cannot see across), construction brackets do not — `[.a, .b | . + 10]` is
+    /// `[1,12]` on real yq where jq gives `[11,12]` (#2420). Note that
+    /// `parse_pipe_no_comma` is literally jq's own `ExpD` production, reused
+    /// here: "a pipe chain that stops at a comma" is exactly what yq's higher
+    /// pipe precedence makes each comma operand.
     fn parse_expr(&mut self) -> Result<Expr, ParseError> {
-        self.parse_pipe_expr()
+        match self.mode {
+            ParserMode::Jq => self.parse_pipe_expr(),
+            ParserMode::Yq => self.parse_yq_comma_expr(),
+        }
+    }
+
+    /// Parse a yq-mode expression: `chain , chain , ...`, where each operand is
+    /// a whole pipe chain rather than jq's single comma operand.
+    ///
+    /// The mirror image of [`Self::parse_pipe_expr`], and reached only from
+    /// [`Self::parse_expr`] under [`ParserMode::Yq`]. See that method's doc for
+    /// the precedence numbers this encodes.
+    fn parse_yq_comma_expr(&mut self) -> Result<Expr, ParseError> {
+        let first = self.parse_pipe_no_comma()?;
+        self.skip_ws();
+
+        if self.peek() != Some(',') {
+            return Ok(first);
+        }
+
+        let mut exprs = vec![first];
+
+        while self.peek() == Some(',') {
+            self.next();
+            self.skip_ws();
+            exprs.push(self.parse_pipe_no_comma()?);
+            self.skip_ws();
+        }
+
+        Ok(Expr::comma(exprs))
     }
 
     /// Parse a pipe expression: `stage | stage | ...`, where each stage is a
     /// comma list.
+    ///
+    /// jq mode only — yq ranks the two operators the other way round and goes
+    /// through [`Self::parse_yq_comma_expr`] instead (#2420).
     fn parse_pipe_expr(&mut self) -> Result<Expr, ParseError> {
         let first = self.parse_comma_expr()?;
         self.skip_ws();
@@ -5140,6 +5195,8 @@ impl<'a> Parser<'a> {
     }
 
     /// Parse one pipe stage: `expr, expr, ...`.
+    ///
+    /// jq mode only, as the sole caller [`Self::parse_pipe_expr`] is.
     fn parse_comma_expr(&mut self) -> Result<Expr, ParseError> {
         let first = self.parse_binding()?;
         self.skip_ws();
@@ -5247,7 +5304,7 @@ impl<'a> Parser<'a> {
     /// Parse a pipe expression that stops at a `,` — deliberately *not* a full
     /// [`Self::parse_expr`].
     ///
-    /// Exactly two kinds of position want this, and no others:
+    /// Exactly three kinds of position want this, and no others:
     ///
     /// 1. **Object-construction values**, jq's `ExpD` production. Inside
     ///    `{...}` a `,` separates entries, so `{a: 1, b: 2}` must not read
@@ -5256,6 +5313,10 @@ impl<'a> Parser<'a> {
     ///    crate's rather than jq's: jq's `$n` parameter convention fans the
     ///    whole call out once per output of `n`, which is not implemented here,
     ///    so `n` stays single-valued instead of silently taking one branch.
+    /// 3. **Every comma operand in yq mode** ([`Self::parse_yq_comma_expr`]),
+    ///    where real yq's own precedence table ranks `|` (30) above `,` (10),
+    ///    making "a pipe chain that stops at a comma" the whole of one comma
+    ///    operand rather than a restricted sub-position (#2420).
     ///
     /// Every *other* body that once called this — `if` branches, `def` bodies,
     /// `reduce`/`foreach` slots, `label` bodies, string interpolation — is a
@@ -5994,6 +6055,77 @@ mod tests {
 
         // A comma with no pipe is still a bare comma — no spurious Pipe wrapper.
         assert_eq!(parse("1,2").unwrap(), Expr::Comma(vec![int(1), int(2)]));
+    }
+
+    /// The mirror image of the test above, for yq mode (#2420).
+    ///
+    /// Real yq's precedence table (`pkg/yqlib/operation.go`, v4.53.3) gives
+    /// `pipeOpType` **30** and `unionOpType` (`,`) **10**, so `A, B | C` is
+    /// `A, (B | C)` there — the opposite of jq's `parser.y`. ADR-0018 rule 2
+    /// says the *mode* decides, so the load-bearing assertion here is that the
+    /// **same source text parses to two different ASTs** depending on
+    /// `ParserMode`, not that either shape exists in isolation.
+    #[test]
+    fn test_yq_mode_pipe_binds_tighter_than_comma_2420() {
+        let int = |i: i64| Expr::Literal(Literal::number_literal(i.to_string()));
+        let yq = |s: &str| parse_with_mode(s, ParserMode::Yq).unwrap();
+
+        // One text, two modes, two shapes.
+        assert_eq!(
+            parse("1,2 | 3").unwrap(),
+            Expr::Pipe(vec![Expr::Comma(vec![int(1), int(2)]), int(3)])
+        );
+        assert_eq!(
+            yq("1,2 | 3"),
+            Expr::Comma(vec![int(1), Expr::Pipe(vec![int(2), int(3)])])
+        );
+
+        // The comma stays n-ary at the top and every operand is a whole pipe
+        // chain, so `1,2 | 3,4` is three operands, not two comma stages.
+        assert_eq!(
+            yq("1,2 | 3,4"),
+            Expr::Comma(vec![int(1), Expr::Pipe(vec![int(2), int(3)]), int(4)])
+        );
+
+        // `.a | 1,2 | .b` is `(.a | 1), (2 | .b)` — two independent chains.
+        assert_eq!(
+            yq(".a | 1,2 | .b"),
+            Expr::Comma(vec![
+                Expr::Pipe(vec![Expr::Field("a".into()), int(1)]),
+                Expr::Pipe(vec![int(2), Expr::Field("b".into())]),
+            ])
+        );
+
+        // Parentheses are a boundary the shunting yard cannot see across, so
+        // they restore jq's grouping in yq mode too.
+        assert_eq!(
+            yq("(1,2) | 3"),
+            Expr::Pipe(vec![
+                Expr::Paren(Box::new(Expr::Comma(vec![int(1), int(2)]))),
+                int(3),
+            ])
+        );
+
+        // Construction brackets are *not* such a boundary: they scope
+        // evaluation, not precedence.
+        assert_eq!(
+            yq("[1,2 | 3]"),
+            Expr::Array(Box::new(Expr::Comma(vec![
+                int(1),
+                Expr::Pipe(vec![int(2), int(3)]),
+            ])))
+        );
+        assert_eq!(
+            parse("[1,2 | 3]").unwrap(),
+            Expr::Array(Box::new(Expr::Pipe(vec![
+                Expr::Comma(vec![int(1), int(2)]),
+                int(3),
+            ])))
+        );
+
+        // Neither operator alone changes shape, in either mode.
+        assert_eq!(yq("1,2"), Expr::Comma(vec![int(1), int(2)]));
+        assert_eq!(yq("1 | 2"), Expr::Pipe(vec![int(1), int(2)]));
     }
 
     /// `as` binds below the comma: its body swallows the rest of the

--- a/tests/data/jq-path-context-sweep-known-divergences.txt
+++ b/tests/data/jq-path-context-sweep-known-divergences.txt
@@ -36,7 +36,12 @@ yq/*/first/*/*        yq_first        real yq's first(f) ignores its argument an
 
 # Real yq's comma is stream-level: `.a[] | ((key), 1)` answers `"b" "c" 1 1`
 # (every `key` output, then every `1`), where succinctly interleaves per
-# element (`"b" 1 "c" 1`). Same root cause as the `a, b | c` grouping.
+# element (`"b" 1 "c" 1`). Both branches here are parenthesised, so this is
+# *not* #2420's precedence rule -- that is fixed, and yq's grouping is now
+# succinctly yq's. What remains is yq's evaluation model: an operator is
+# applied to the whole context list its left-hand side produced, where
+# succinctly (like jq) pipes each value independently. Separately scoped;
+# #2420 is cited only because it is where the distinction was drawn.
 yq/*/comma/*/*        comma_stream    yq's comma composes at the stream level, succinctly's per element — #2420
 
 # `file_index` answers 0 for every input file. Real yq counts files (`0`,

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -37687,3 +37687,87 @@ fn test_fold_init_before_source_escape_matrix_2440() -> Result<()> {
     }
     Ok(())
 }
+
+/// #2420's jq-mode side: nothing changes here.
+///
+/// The parser now ranks `|` above `,` in **yq** mode, matching real yq's own
+/// precedence table (`pipeOpType` 30, `unionOpType` 10 in
+/// `pkg/yqlib/operation.go`, v4.53.3). jq's `parser.y` ranks them the other
+/// way (`%right '|'` declared before `%left ','`), and ADR-0018 rule 2 says
+/// the mode decides -- so every filter below must keep jq's grouping. Rows
+/// captured live from `/usr/bin/jq` 1.7.1 on `{"a":1,"b":2,"c":3}`; the
+/// yq-mode answers for the same texts are in `yq_cli_tests.rs`'s
+/// `test_yq_pipe_binds_tighter_than_comma_2420`.
+#[test]
+fn test_jq_comma_still_binds_tighter_than_pipe_2420() -> Result<()> {
+    let doc = r#"{"a":1,"b":2,"c":3}"#;
+    let args = &["-c"];
+
+    // $ jq -c '.a, .b | . + 10'  =>  11 / 12   (yq: 1 / 12)
+    let (output, code) = run_jq_stdin(".a, .b | . + 10", doc, args)?;
+    assert_eq!(code, 0);
+    assert_eq!(output, "11\n12\n");
+
+    // $ jq -c '[.a, .b | . + 10]'  =>  [11,12]   (yq: [1,12])
+    let (output, code) = run_jq_stdin("[.a, .b | . + 10]", doc, args)?;
+    assert_eq!(code, 0);
+    assert_eq!(output, "[11,12]\n");
+
+    // $ jq -c '[.a, .b | . * 2]'  =>  [2,4]   (yq: [1,4])
+    let (output, code) = run_jq_stdin("[.a, .b | . * 2]", doc, args)?;
+    assert_eq!(code, 0);
+    assert_eq!(output, "[2,4]\n");
+
+    // $ jq -c '.a, .b | length'  =>  1 / 2   (yq: 1 / 1)
+    let (output, code) = run_jq_stdin(".a, .b | length", doc, args)?;
+    assert_eq!(code, 0);
+    assert_eq!(output, "1\n2\n");
+
+    // $ jq -c '.a, .b | select(. > 1)'  =>  2   (yq: 1 / 2)
+    let (output, code) = run_jq_stdin(".a, .b | select(. > 1)", doc, args)?;
+    assert_eq!(code, 0);
+    assert_eq!(output, "2\n");
+
+    // $ jq -c '{"x": (.a, .b | . + 1)}'  =>  {"x":2} / {"x":3}
+    //                                       (yq: {"x":1} / {"x":3})
+    let (output, code) = run_jq_stdin(r#"{"x": (.a, .b | . + 1)}"#, doc, args)?;
+    assert_eq!(code, 0);
+    assert_eq!(output, "{\"x\":2}\n{\"x\":3}\n");
+
+    // $ jq -c '.a as $x | $x, .b | . + 1'  =>  2 / 3   (yq: 1 / 3)
+    let (output, code) = run_jq_stdin(".a as $x | $x, .b | . + 1", doc, args)?;
+    assert_eq!(code, 0);
+    assert_eq!(output, "2\n3\n");
+
+    // $ jq -c '.a, .b | limit(1; . + 10)'  =>  11 / 12
+    //   (yq mode, with --jq-extensions: 1 / 12; real yq cannot lex `limit`)
+    let (output, code) = run_jq_stdin(".a, .b | limit(1; . + 10)", doc, args)?;
+    assert_eq!(code, 0);
+    assert_eq!(output, "11\n12\n");
+
+    // Grouping the jq way explicitly is a no-op in jq mode, and parentheses
+    // still bind what they enclose.
+    // $ jq -c '(.a, .b) | . + 10'  =>  11 / 12
+    // $ jq -c '.a, (.b | . + 10)'  =>  1 / 12
+    let (output, code) = run_jq_stdin("(.a, .b) | . + 10", doc, args)?;
+    assert_eq!(code, 0);
+    assert_eq!(output, "11\n12\n");
+    let (output, code) = run_jq_stdin(".a, (.b | . + 10)", doc, args)?;
+    assert_eq!(code, 0);
+    assert_eq!(output, "1\n12\n");
+
+    // jq's grouping pipes a scalar into a field access and fails loudly.
+    // $ jq -c '.a | ., .b'
+    //   1
+    //   jq: error (at <stdin>:0): Cannot index number with string "b"   (exit 5)
+    // (yq: 1 / 2, exit 0.)
+    let (stdout, stderr, code) = run_jq_stdin_streams(".a | ., .b", doc, args)?;
+    assert_eq!(code, 5, "stderr: {stderr:?}");
+    assert_eq!(stdout, "1\n");
+    assert!(
+        stderr.contains("Cannot index number with string \"b\""),
+        "stderr: {stderr:?}"
+    );
+
+    Ok(())
+}

--- a/tests/jq_path_context_alphabet_tests.rs
+++ b/tests/jq_path_context_alphabet_tests.rs
@@ -24,10 +24,12 @@
 //!    construction/`select`/comma/`if`/`try`/`label`, and each of those again
 //!    under `path(...)` and `?`.
 //! 2. **yq comma/pipe precedence (#2420).** Real yq v4.53.3 groups `a, b | c`
-//!    as `a, (b | c)`; jq and succinctly (both modes) group it as
-//!    `(a, b) | c`. A yq-mode case holding a `,` and a `|` at the same bracket
-//!    depth therefore records a *parser* divergence that says nothing about
-//!    path context, so no such case may be generated.
+//!    as `a, (b | c)` where jq groups it as `(a, b) | c`. succinctly used to
+//!    apply jq's grouping in both modes; since #2420 `succinctly yq` follows
+//!    yq's own precedence table and the two agree. The rule is kept all the
+//!    same: a yq-mode case holding a `,` and a `|` at the same bracket depth
+//!    would make its meaning depend on which grouping rule is in force, which
+//!    says nothing about path context, so no such case may be generated.
 //!
 //! `--list-cases` needs neither the succinctly binary nor an oracle, so this
 //! test is hermetic and runs on every CI leg.
@@ -200,9 +202,10 @@ fn no_yq_case_mixes_comma_and_pipe_at_one_depth() {
     assert!(
         offenders.is_empty(),
         "{} yq-mode case(s) mix `,` and `|` at one bracket depth. Real yq v4.53.3 \
-         groups `a, b | c` as `a, (b | c)` where succinctly groups `(a, b) | c` \
-         (#2420), so these record a parser divergence, not a path-context one — \
-         parenthesise each comma branch:\n  {}",
+         groups `a, b | c` as `a, (b | c)` where jq groups `(a, b) | c` (#2420, \
+         now matched in yq mode), so these would make a case's meaning depend on \
+         the grouping rule rather than on path context — parenthesise each comma \
+         branch:\n  {}",
         offenders.len(),
         offenders.join("\n  ")
     );

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -12625,6 +12625,31 @@ fn test_mid_chain_identity_does_not_discard_rest_of_write_path_yq_2241() -> Resu
 /// evaluator #554's fix above already established this file needs its own
 /// coverage for, not just `jq_cli_tests.rs`'s (a jq-scoped fix to shared
 /// evaluator code can silently regress yq without a dedicated check).
+///
+/// #2420's audit flagged the `def f: 5; f, key` case as depending on jq's
+/// comma/pipe grouping. Re-captured against yq v4.53.3 on this test's own
+/// input, it does not: real yq has no `def` at all, and rejects the whole
+/// filter before precedence is ever consulted --
+///
+/// ```console
+/// $ printf 'a: 1\n' | yq -o=json -I0 '.a | def f: 5; f, key'
+/// Error: 1:6: lexer: invalid input text "def f: 5; f, key"   (exit 1)
+/// $ printf 'a: 1\n' | yq -o=json -I0 '.a | def f: 5; f'
+/// Error: 1:6: lexer: invalid input text "def f: 5; f"        (exit 1)
+/// ```
+///
+/// -- with or without the comma. `def` in yq mode is a pre-existing,
+/// separately-scoped succinctly extension (an ungated one, unlike #1512's
+/// family), and `Expr::FuncDef`'s `then` clause is a full `Exp` in both
+/// modes, so the comma lands *inside* the pipe's right-hand side either way
+/// and #2420's precedence swap leaves the expectations below unchanged. The
+/// row is recorded here rather than silently left as an unverified
+/// assertion. The one line real yq does answer is the interpolation:
+///
+/// ```console
+/// $ printf 'a: 1\n' | yq -o=json -I0 '.a | "k=\(key)"'
+/// "k=a"
+/// ```
 #[test]
 fn test_string_interpolation_and_func_def_path_context_yq_1334_1306() -> Result<()> {
     let (output, code) = run_yq_stdin(r#".a | "k=\(key)""#, "a: 1\n", &["-o", "json", "-I0"])?;
@@ -15398,30 +15423,89 @@ fn test_eval_all_file_index_bare() -> Result<()> {
 /// operand to its first value whenever the pipe also needed path context
 /// (e.g. shared a comma with `file_index`) -- the same #768 bug class, in a
 /// call site #768 didn't touch.
+///
+/// #2420 moved the unparenthesised spelling's comma *outside* the pipe in yq
+/// mode, which would have retired the #822 coverage entirely (`file_index`
+/// would no longer share a pipe with the fan-out). The original shape is
+/// therefore kept, spelled with the parentheses that now express it, and the
+/// unparenthesised text is pinned alongside it for the new grouping.
+///
+/// Re-captured on this test's own two fixtures against real yq v4.53.3.
+/// succinctly's `--eval-all` is real yq's `eval-all`/`ea` subcommand (v4.53.3
+/// has no such *flag*), so `yq ea` is the oracle:
+///
+/// ```console
+/// $ yq ea -o=json -I0 '.[] | ((1,2,3) + 1), file_index'         f1 f2
+/// 2 3 4 2 3 4 2 3 4 2 3 4 0 1        # 14 lines
+/// $ yq ea -o=json -I0 '.[] | (((1,2,3) + 1), file_index)'       f1 f2
+/// 2 3 4 2 3 4 2 3 4 2 3 4 0 0 1 1    # 16 lines
+/// ```
+///
+/// succinctly's counts differ from both -- yq evaluates each operator over
+/// the whole *context list* the pipe's left side produced, so its `(1,2,3)`
+/// fan-out and its `file_index` are each replayed once per context, where
+/// succinctly (like jq) pipes each left-hand value independently. That
+/// evaluation-model divergence is separate from #2420's precedence table and
+/// is not what this test pins; what it pins is that the fan-out is not
+/// collapsed to its first value, which is #822's actual subject.
 #[test]
 fn test_eval_all_arithmetic_fanout_survives_file_index_in_pipe_issue_822() -> Result<()> {
     let (f1, f2) = two_doc_fixtures()?;
+
+    // #822's shape: the comma shares a pipe with `file_index`, so the
+    // path-context walk must not collapse `(1,2,3) + 1` to `2`.
+    let (stdout, _stderr, code) = run_yq_files(
+        ".[] | (((1,2,3) + 1), file_index)",
+        &[f1.path(), f2.path()],
+        &["--eval-all", "-o", "json"],
+    )?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout.trim(), "2\n3\n4\n0\n2\n3\n4\n1");
+
+    // #2420's shape: unparenthesised, the comma is now the outermost
+    // operator, so this is `(.[] | ((1,2,3) + 1)), file_index` -- the
+    // fan-out still survives (twice, once per document), and `file_index`
+    // is evaluated against the combined input rather than per document.
     let (stdout, _stderr, code) = run_yq_files(
         ".[] | ((1,2,3) + 1), file_index",
         &[f1.path(), f2.path()],
         &["--eval-all", "-o", "json"],
     )?;
     assert_eq!(code, 0);
-    assert_eq!(stdout.trim(), "2\n3\n4\n0\n2\n3\n4\n1");
+    assert_eq!(stdout.trim(), "2\n3\n4\n2\n3\n4\n0");
+
     Ok(())
 }
 
-/// Same #822 gap, for `Expr::Compare`.
+/// Same #822 gap, for `Expr::Compare` -- and the same #2420 re-capture as the
+/// test above, whose doc comment carries the full oracle rows:
+///
+/// ```console
+/// $ yq ea -o=json -I0 '.[] | ((1,2,3) > 1), file_index'   f1 f2
+/// false true true (x4) 0 1              # 14 lines
+/// $ yq ea -o=json -I0 '.[] | (((1,2,3) > 1), file_index)' f1 f2
+/// false true true (x4) 0 0 1 1          # 16 lines
+/// ```
 #[test]
 fn test_eval_all_compare_fanout_survives_file_index_in_pipe_issue_822() -> Result<()> {
     let (f1, f2) = two_doc_fixtures()?;
+
+    let (stdout, _stderr, code) = run_yq_files(
+        ".[] | (((1,2,3) > 1), file_index)",
+        &[f1.path(), f2.path()],
+        &["--eval-all", "-o", "json"],
+    )?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout.trim(), "false\ntrue\ntrue\n0\nfalse\ntrue\ntrue\n1");
+
     let (stdout, _stderr, code) = run_yq_files(
         ".[] | ((1,2,3) > 1), file_index",
         &[f1.path(), f2.path()],
         &["--eval-all", "-o", "json"],
     )?;
     assert_eq!(code, 0);
-    assert_eq!(stdout.trim(), "false\ntrue\ntrue\n0\nfalse\ntrue\ntrue\n1");
+    assert_eq!(stdout.trim(), "false\ntrue\ntrue\nfalse\ntrue\ntrue\n0");
+
     Ok(())
 }
 
@@ -30776,6 +30860,234 @@ fn test_map_path_context_scalar_target_noops_in_yq_mode_2375() -> Result<()> {
     let (out, code) = run_yq_stdin(".a | map(key)", "a: {b: 1}\n", args)?;
     assert_eq!(code, 0, "out: {out:?}");
     assert_eq!(out.trim(), r#"["b"]"#);
+
+    Ok(())
+}
+
+// =============================================================================
+// #2420: yq ranks `|` (precedence 30) above `,` (precedence 10)
+// =============================================================================
+
+/// Every filter below was captured live from the pinned oracles before the
+/// parser change landed: Homebrew `yq` v4.53.3 on `a: 1\nb: 2\nc: 3\n` with
+/// `-o=json -I0`, and `/usr/bin/jq` 1.7.1 on the equivalent
+/// `{"a":1,"b":2,"c":3}` with `-c`. The captures are quoted per-assertion.
+const PRECEDENCE_DOC_2420: &str = "a: 1\nb: 2\nc: 3\n";
+
+/// #2420: in yq mode `A, B | C` is `A, (B | C)`, not jq's `(A, B) | C`.
+///
+/// Real yq's parser is a shunting-yard operator-precedence parser whose own
+/// table (`pkg/yqlib/operation.go`, v4.53.3) gives `pipeOpType` **30** and
+/// `unionOpType` (`,`) **10** — pipe binds *tighter*. jq's `parser.y` ranks
+/// them the other way (`%right '|'` before `%left ','`), and succinctly used
+/// to apply jq's ranking in both modes. ADR-0018 rule 2: the mode decides.
+///
+/// The parser-level counterpart is
+/// `jq::parser::tests::test_yq_mode_pipe_binds_tighter_than_comma_2420`; the
+/// jq-mode side is pinned in `jq_cli_tests.rs`'s
+/// `test_jq_comma_still_binds_tighter_than_pipe_2420`.
+#[test]
+fn test_yq_pipe_binds_tighter_than_comma_2420() -> Result<()> {
+    let args = &["-o", "json", "-I0"];
+
+    // $ yq -o=json -I0 '.a, .b | . + 10'  =>  1 / 12
+    // $ jq -c        '.a, .b | . + 10'    =>  11 / 12
+    let (output, code) = run_yq_stdin(".a, .b | . + 10", PRECEDENCE_DOC_2420, args)?;
+    assert_eq!(code, 0);
+    assert_eq!(output.trim(), "1\n12");
+
+    // $ yq -o=json -I0 '.a | ., .b'  =>  1 / 2
+    // $ jq -c        '.a | ., .b'    =>  1, then "Cannot index number with
+    //                                    string \"b\"" on stderr (exit 5)
+    // `.b` runs against the *original* document, not against `.a`'s value,
+    // which is why yq raises nothing where jq errors.
+    let (output, code) = run_yq_stdin(".a | ., .b", PRECEDENCE_DOC_2420, args)?;
+    assert_eq!(code, 0);
+    assert_eq!(output.trim(), "1\n2");
+
+    // $ yq -o=json -I0 '.a, .b | ., .c'  =>  1 / 2 / 3
+    // $ jq -c        '.a, .b | ., .c'    =>  1, then the same jq error
+    // Three comma operands, each its own pipe chain: `.a`, `.b | .`, `.c`.
+    let (output, code) = run_yq_stdin(".a, .b | ., .c", PRECEDENCE_DOC_2420, args)?;
+    assert_eq!(code, 0);
+    assert_eq!(output.trim(), "1\n2\n3");
+
+    // $ yq -o=json -I0 '(.a, .b) | . + 10'  =>  11 / 12
+    // $ jq -c        '(.a, .b) | . + 10'    =>  11 / 12
+    // Parentheses are a hard boundary the shunting yard cannot see across,
+    // so they restore jq's grouping in yq mode.
+    let (output, code) = run_yq_stdin("(.a, .b) | . + 10", PRECEDENCE_DOC_2420, args)?;
+    assert_eq!(code, 0);
+    assert_eq!(output.trim(), "11\n12");
+
+    // $ yq -o=json -I0 '.a, (.b | . + 10)'  =>  1 / 12
+    // $ jq -c        '.a, (.b | . + 10)'    =>  1 / 12
+    // ... on either side of the comma.
+    let (output, code) = run_yq_stdin(".a, (.b | . + 10)", PRECEDENCE_DOC_2420, args)?;
+    assert_eq!(code, 0);
+    assert_eq!(output.trim(), "1\n12");
+
+    // $ yq -o=json -I0 '.a, .b | key'  =>  1 / "b"
+    // $ jq -c        '.a, .b | key'    =>  "key/0 is not defined" (exit 3)
+    let (output, code) = run_yq_stdin(".a, .b | key", PRECEDENCE_DOC_2420, args)?;
+    assert_eq!(code, 0);
+    assert_eq!(output.trim(), "1\n\"b\"");
+
+    // $ yq -o=json -I0 '.a, .b | length'  =>  1 / 1
+    // $ jq -c        '.a, .b | length'    =>  1 / 2
+    // yq's `length` on a scalar is its rendered width (`2 | length` is 1,
+    // not jq's absolute value 2) -- a separate, already-documented
+    // divergence that happens to agree here once the grouping is right.
+    let (output, code) = run_yq_stdin(".a, .b | length", PRECEDENCE_DOC_2420, args)?;
+    assert_eq!(code, 0);
+    assert_eq!(output.trim(), "1\n1");
+
+    Ok(())
+}
+
+/// #2420: the precedence is a fixed entry in yq's operator table, so it holds
+/// at **every** nesting depth -- construction brackets, object values,
+/// `as` bodies and gated-extension call sites all inherit it -- and it is the
+/// *mode* that decides, not the input format (ADR-0018 rule 2).
+#[test]
+fn test_yq_pipe_precedence_holds_at_every_depth_2420() -> Result<()> {
+    let args = &["-o", "json", "-I0"];
+
+    // $ yq -o=json -I0 '[.a, .b | . + 10]'  =>  [1,12]
+    // $ jq -c        '[.a, .b | . + 10]'    =>  [11,12]
+    // `[...]` scopes evaluation, not precedence.
+    let (output, code) = run_yq_stdin("[.a, .b | . + 10]", PRECEDENCE_DOC_2420, args)?;
+    assert_eq!(code, 0);
+    assert_eq!(output.trim(), "[1,12]");
+
+    // $ yq -o=json -I0 '[.a, .b | . * 2]'  =>  [1,4]
+    // $ jq -c        '[.a, .b | . * 2]'    =>  [2,4]
+    let (output, code) = run_yq_stdin("[.a, .b | . * 2]", PRECEDENCE_DOC_2420, args)?;
+    assert_eq!(code, 0);
+    assert_eq!(output.trim(), "[1,4]");
+
+    // $ yq -o=json -I0 '{"x": (.a, .b | . + 1)}'  =>  {"x":1} / {"x":3}
+    // $ jq -c        '{"x": (.a, .b | . + 1)}'    =>  {"x":2} / {"x":3}
+    // Object-value position: the parens bound the value, but *inside* them
+    // yq's own ranking still applies.
+    let (output, code) = run_yq_stdin(r#"{"x": (.a, .b | . + 1)}"#, PRECEDENCE_DOC_2420, args)?;
+    assert_eq!(code, 0);
+    assert_eq!(output.trim(), "{\"x\":1}\n{\"x\":3}");
+
+    // $ yq -o=json -I0 '.a as $x | $x, .b | . + 1'  =>  1 / 3
+    // $ jq -c        '.a as $x | $x, .b | . + 1'    =>  2 / 3
+    // `as` still swallows everything to its right, and what it swallows is
+    // now a comma of pipe chains: `.a as $x | ($x, (.b | . + 1))`.
+    let (output, code) = run_yq_stdin(".a as $x | $x, .b | . + 1", PRECEDENCE_DOC_2420, args)?;
+    assert_eq!(code, 0);
+    assert_eq!(output.trim(), "1\n3");
+
+    // $ yq -o=json -I0 '.[] | key, path'  on 'a: 1\nb: 2\n'  =>  "a" / "b" / []
+    // Groups as `(.[] | key), path`, so `path` names the *root*, not the
+    // iterated members. (jq 1.7.1 has no `key`, so there is no jq row.)
+    let (output, code) = run_yq_stdin(".[] | key, path", "a: 1\nb: 2\n", args)?;
+    assert_eq!(code, 0);
+    assert_eq!(output.trim(), "\"a\"\n\"b\"\n[]");
+
+    // Three pipes deep, on 'a: 1\nb: {c: 3, d: 4}\nc: 5\nd: 6\n':
+    // $ yq -o=json -I0 '.a, .b | .c, .d | . + 1'  =>  1 / 3 / 7
+    // $ jq -c        '.a, .b | .c, .d | . + 1'    =>  "Cannot index number
+    //                                                 with string \"c\""
+    // Three comma operands: `.a`, `.b | .c`, `.d | . + 1`.
+    let (output, code) = run_yq_stdin(
+        ".a, .b | .c, .d | . + 1",
+        "a: 1\nb: {c: 3, d: 4}\nc: 5\nd: 6\n",
+        args,
+    )?;
+    assert_eq!(code, 0);
+    assert_eq!(output.trim(), "1\n3\n7");
+
+    // $ yq -o=json -I0 '.a | .b, .c | . + 1'  on 'a: {b: 9}\nc: 3\n'  =>  9 / 4
+    // $ jq -c        '.a | .b, .c | . + 1'                            =>  10 / 1
+    // Two independent chains, `(.a | .b)` and `(.c | . + 1)`, not one
+    // three-stage chain rooted at `.a`.
+    let (output, code) = run_yq_stdin(".a | .b, .c | . + 1", "a: {b: 9}\nc: 3\n", args)?;
+    assert_eq!(code, 0);
+    assert_eq!(output.trim(), "9\n4");
+
+    // The *mode* decides, not the format: JSON input through `-p json` gets
+    // yq's grouping too.
+    // $ yq -p=json -o=json -I0 '.a, .b | . + 10'  on {"a":1,"b":2,"c":3}  =>  1 / 12
+    let (output, code) = run_yq_stdin(
+        ".a, .b | . + 10",
+        r#"{"a":1,"b":2,"c":3}"#,
+        &["-p", "json", "-o", "json", "-I0"],
+    )?;
+    assert_eq!(code, 0);
+    assert_eq!(output.trim(), "1\n12");
+
+    // A gated jq-only extension inherits the same grouping. Real yq cannot
+    // lex `limit` at all --
+    // $ yq -o=json -I0 '.a, .b | limit(1; . + 10)'
+    //   Error: 1:10: lexer: invalid input text "limit(1; . + 10)"   (exit 1)
+    // -- so there is no oracle row for the extension itself, only for the
+    // grouping it must be spelled with (`.a, (.b | limit(1; . + 10))`).
+    // $ jq -c '.a, .b | limit(1; . + 10)'  =>  11 / 12
+    let (output, code) = run_yq_stdin(
+        ".a, .b | limit(1; . + 10)",
+        PRECEDENCE_DOC_2420,
+        &["-o", "json", "-I0", "--jq-extensions"],
+    )?;
+    assert_eq!(code, 0);
+    assert_eq!(output.trim(), "1\n12");
+
+    // ... and stays rejected without the flag, grouping or no grouping.
+    let (_output, code) = run_yq_stdin(
+        ".a, .b | limit(1; . + 10)",
+        PRECEDENCE_DOC_2420,
+        &["-o", "json", "-I0"],
+    )?;
+    assert_ne!(code, 0);
+
+    Ok(())
+}
+
+/// #2420: two probes where succinctly's post-fix grouping is right but the
+/// *output* still differs from real yq, for reasons scoped elsewhere. Pinned
+/// so the residue is visible rather than mistaken for a precedence bug.
+#[test]
+fn test_yq_pipe_precedence_residual_divergences_2420() -> Result<()> {
+    let args = &["-o", "json", "-I0"];
+
+    // Grouping is `(.a | .b), (.c | . + 1)`; `.a | .b` indexes the number 1
+    // and fails in both tools. Real yq *drops* the failing comma branch
+    // silently and prints only the second:
+    // $ yq -o=json -I0 '.a | .b, .c | . + 1'  =>  4   (exit 0, empty stderr)
+    // succinctly is fail-loud here, as jq is:
+    // $ jq -c '.a | .b, .c | . + 1'  =>  "Cannot index number with string
+    //                                     \"b\"" (exit 5, no stdout)
+    // That silent-drop behaviour is a separate divergence from #2420's
+    // grouping, and is not what this change is about.
+    let (stdout, stderr, code) =
+        run_yq_stdin_with_stderr(".a | .b, .c | . + 1", PRECEDENCE_DOC_2420, args)?;
+    assert_eq!(code, 1);
+    assert_eq!(stdout, "");
+    assert!(
+        stderr.contains("Cannot index number with string \"b\""),
+        "stderr: {stderr:?}"
+    );
+
+    // Both sides fully parenthesised, so #2420's precedence plays no part --
+    // yet the two tools still disagree, on *order*:
+    // $ yq -o=json -I0 '(.a, .b) | (.c, .d)'  on 'a: {c: 3, d: 4}\nb: {c: 5, d: 6}\n'
+    //   =>  3 / 5 / 4 / 6
+    // $ jq -c        '(.a, .b) | (.c, .d)'    =>  3 / 4 / 5 / 6
+    // yq evaluates a `,` over the whole *context list* produced by the pipe's
+    // left side (`.c` over both, then `.d` over both), where jq and succinctly
+    // pipe each left-hand value independently. That is yq's evaluation model,
+    // not its precedence table, and the parser cannot express it.
+    let (output, code) = run_yq_stdin(
+        "(.a, .b) | (.c, .d)",
+        "a: {c: 3, d: 4}\nb: {c: 5, d: 6}\n",
+        args,
+    )?;
+    assert_eq!(code, 0);
+    assert_eq!(output.trim(), "3\n4\n5\n6");
 
     Ok(())
 }


### PR DESCRIPTION
## Summary

`succinctly yq` parsed `,` as binding tighter than `|` in both modes (jq's ranking). Real yq's operator table ranks pipe (30) above union (10), so `A, B | C` is `A, (B | C)` there. Per ADR-0018 rule 2, mode decides.

- `parse_expr` now dispatches on `ParserMode`: jq mode is unchanged; yq mode parses a comma of pipe-without-comma operands (`parse_yq_comma_expr`), so the yq grouping holds at every bracket depth, and explicit parentheses still restore jq's grouping (a hard boundary, as captured on the issue).
- Three existing yq-mode tests that had encoded jq's grouping were re-captured against the pinned yq v4.53.3 rather than kept.
- `docs/compliance/yq/limitations.md`'s #2420 entry is rewritten as resolved; `docs/reference/yq-language.md` and `CHANGELOG.md` describe the new precedence. This changes the meaning of unparenthesised `a, b | c` in yq mode, so it should ship in its own release.

## Residuals, not fixed here

The capture exposed two evaluation-model divergences that are not precedence (both sides parenthesised). Pinned as residuals in `test_yq_pipe_precedence_residual_divergences_2420`:

- #2451: real yq applies a pipe's right side to the whole list its left side produced, so `(.a, .b) | (.c, .d)` is `3 5 4 6` there and `3 4 5 6` here.
- #2452: a failing comma branch is dropped silently by real yq (exit 0); succinctly raises as jq does.

Also filed #2453: yq-mode `length` on the comma fan-out path uses jq's absolute-value rule.

## Verification

- `cargo test --features cli,simd,regex,serde`: all green; `scripts/sync-yq-golden.sh --check`: 113 goldens up to date.
- `scripts/jq-path-context-oracle-sweep.sh`: 0 unexpected; the `comma_stream` class did not flip because it is #2451, not precedence.
- fmt and clippy (`--all-targets --features cli,simd,regex,serde -D warnings`) clean.

Part of spine 2416 (step 5b). Closes #2420.
