### PR TITLE
fix(yq): climb through the block sequence-item wrapper in document_parent (#2455)

### DIFF
--- a/scripts/jq-path-context-oracle-sweep.sh
+++ b/scripts/jq-path-context-oracle-sweep.sh
@@ -360,6 +360,30 @@ cat > "$WORK/two.yaml" <<'JSON'
 {"a":{"b":3,"c":4},"d":[30,40]}
 JSON
 
+# The same two documents in block style. A block sequence item sits behind a
+# `-` wrapper node that the flow form has no counterpart for, and #2455 was a
+# path-context bug only that wrapper could expose (`.d[] | key == 0` answered
+# nothing on `- 10` and `true` on `[10, 20]`), so every yq-mode case runs on
+# both forms. Hand-written rather than derived with `yq -P`, so the sweep
+# does not depend on the oracle's own pretty-printer; the runner checks the
+# block files decode to the flow ones before any case runs.
+cat > "$WORK/one-block.yaml" <<'YAML'
+a:
+  b: 1
+  c: 2
+d:
+  - 10
+  - 20
+YAML
+cat > "$WORK/two-block.yaml" <<'YAML'
+a:
+  b: 3
+  c: 4
+d:
+  - 30
+  - 40
+YAML
+
 # --- runner -----------------------------------------------------------------
 
 esc() {
@@ -443,7 +467,7 @@ S_ERR="$WORK/s.err"
 O_ERR="$WORK/o.err"
 
 run_case() {
-  local mode="$1" class="$2" filter="$3"
+  local mode="$1" class="$2" filter="$3" variant="${4:-}"
   total=$((total + 1))
 
   local s_out s_code o_out o_code s_err o_err
@@ -456,9 +480,9 @@ run_case() {
     # Two input files, deliberately: `file_index` is a leaf in this alphabet
     # and is identically 0 with one file, so a single-file sweep could not
     # tell a correct implementation from a stubbed constant.
-    s_out="$("$SUCC" yq -o=json -I=0 "$filter" "$WORK/one.yaml" "$WORK/two.yaml" 2>"$S_ERR")" && s_code=0 || s_code=$?
+    s_out="$("$SUCC" yq -o=json -I=0 "$filter" "$WORK/one$variant.yaml" "$WORK/two$variant.yaml" 2>"$S_ERR")" && s_code=0 || s_code=$?
     s_err="$(cat "$S_ERR")"
-    o_out="$("$YQ" -o=json -I=0 "$filter" "$WORK/one.yaml" "$WORK/two.yaml" 2>"$O_ERR")" && o_code=0 || o_code=$?
+    o_out="$("$YQ" -o=json -I=0 "$filter" "$WORK/one$variant.yaml" "$WORK/two$variant.yaml" 2>"$O_ERR")" && o_code=0 || o_code=$?
     o_err="$(cat "$O_ERR")"
   fi
 
@@ -468,8 +492,8 @@ run_case() {
       known_labels+=("$CLASSIFY_LABEL")
     else
       unexpected=$((unexpected + 1))
-      unexpected_classes+=("$mode/$class")
-      divergence_log+="[$mode $class] $filter
+      unexpected_classes+=("$mode/$class${variant:+ (block)}")
+      divergence_log+="[$mode $class${variant:+ block}] $filter
   oracle:      out=$(esc "$o_out") err=$(esc "$o_err") exit=$o_code
   succinctly:  out=$(esc "$s_out") err=$(esc "$s_err") exit=$s_code
 "
@@ -477,14 +501,28 @@ run_case() {
   fi
 
   printf '%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n' \
-    "$mode" "$class" "$(esc "$filter")" \
+    "$mode${variant:+ block}" "$class" "$(esc "$filter")" \
     "$s_code" "$(esc "$s_out")" "$(esc "$s_err")" \
     "$o_code" "$(esc "$o_out")" "$(esc "$o_err")"
 }
 
+# The block files must be the same documents as the flow ones, or a block
+# divergence could be the fixture rather than the evaluator.
+if [[ -n "${YQ:-}" ]]; then
+  for f in one two; do
+    if [[ "$("$YQ" -o=json -I=0 . "$WORK/$f-block.yaml")" != "$(cat "$WORK/$f.yaml")" ]]; then
+      echo "error: $WORK/$f-block.yaml does not decode to $WORK/$f.yaml" >&2
+      exit 1
+    fi
+  done
+fi
+
 for line in "${CASES[@]}"; do
   IFS=$'\t' read -r c_mode c_class c_filter <<<"$line"
   run_case "$c_mode" "$c_class" "$c_filter"
+  if [[ "$c_mode" == yq ]]; then
+    run_case "$c_mode" "$c_class" "$c_filter" -block
+  fi
 done
 
 {

--- a/src/yaml/light.rs
+++ b/src/yaml/light.rs
@@ -6119,7 +6119,23 @@ impl<'a, W: AsRef<[u64]> + Clone> DocumentCursor for YamlCursor<'a, W> {
     /// not a parent a query can reach: `parent` from a document root emits
     /// nothing, matching real yq (#2421).
     fn document_parent(&self) -> Option<Self> {
-        let parent = YamlCursor::parent(self)?;
+        let mut parent = YamlCursor::parent(self)?;
+        // A block sequence item's BP parent is its `-` wrapper node, which
+        // never carries a TY bit and whose `value()` resolves to the item
+        // itself -- so a caller asking "which array holds this node" would
+        // see a scalar/mapping where it expects the sequence, and `key`,
+        // `path`, `parent` would all answer as if the item were the root
+        // (#2455). Climb through the wrapper to the sequence that owns it.
+        // `uncons_cursor` already hands out the unwrapped item cursor, so
+        // this is the one place the wrapper is still visible to the
+        // evaluator.
+        if !parent.is_container()
+            && parent
+                .text_position()
+                .is_some_and(|text_pos| starts_seq_entry(parent.text, text_pos))
+        {
+            parent = YamlCursor::parent(&parent)?;
+        }
         (parent.bp_pos != 0).then_some(parent)
     }
 

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -31091,3 +31091,77 @@ fn test_yq_pipe_precedence_residual_divergences_2420() -> Result<()> {
 
     Ok(())
 }
+
+/// #2455: on a block-style sequence, a path-context builtin reached through
+/// the generic evaluator (anything but the bare `.[] | key` cursor walk)
+/// answered as if the item were the document root -- `key` emitted nothing,
+/// `path` was `[]`, `parent` was the item itself. The item's balanced-
+/// parentheses parent is its `-` wrapper node, not the sequence, and
+/// `document_parent` did not climb through it. Every row here was captured
+/// from yq v4.53.3 (`-o=json -I0`) and runs on the block form *and* the
+/// equivalent flow form, which was already right and must stay identical.
+#[test]
+fn test_block_sequence_item_key_path_parent_through_generic_route_2455() -> Result<()> {
+    let args = &["-o", "json", "-I0"];
+    // `- x\n- y\n- z` and `[x, y, z]` are the same document to yq.
+    let block = "- x\n- y\n- z\n";
+    let flow = "[x, y, z]\n";
+    // $ yq -o=json -I0 '.[] | key == 0'          =>  true / false / false
+    // $ yq -o=json -I0 '.[] | select(key == 0)'  =>  "x"
+    // $ yq -o=json -I0 '.[] | parent | length'   =>  3 / 3 / 3
+    // $ yq -o=json -I0 '.[] | [path]'            =>  [[0]] / [[1]] / [[2]]
+    // $ yq -o=json -I0 '.[] | [parent(2)]'       =>  [] / [] / []
+    // $ yq -o=json -I0 '.[] | key | . == 0'      =>  true / false / false
+    for (filter, expected) in [
+        (".[] | key == 0", "true\nfalse\nfalse"),
+        (".[] | select(key == 0)", "\"x\""),
+        (".[] | parent | length", "3\n3\n3"),
+        (".[] | [path]", "[[0]]\n[[1]]\n[[2]]"),
+        (".[] | [parent(2)]", "[]\n[]\n[]"),
+        (".[] | key | . == 0", "true\nfalse\nfalse"),
+    ] {
+        for doc in [block, flow] {
+            let (output, code) = run_yq_stdin(filter, doc, args)?;
+            assert_eq!(code, 0, "{filter} on {doc:?}");
+            assert_eq!(output.trim(), expected, "{filter} on {doc:?}");
+        }
+    }
+
+    // Every block item shape sits behind the same wrapper: a scalar, a
+    // compact mapping, a flow sequence, a nested block sequence, a bare `-`
+    // (null) and a block scalar.
+    // $ yq -o=json -I0 '.[] | key == 0'          =>  true / false x5
+    // $ yq -o=json -I0 '.[] | select(key == 1)'  =>  {"a":1}
+    // $ yq -o=json -I0 '.[] | parent | length'   =>  6 x6
+    // $ yq -o=json -I0 '.[1].a | path'           =>  [1,"a"]
+    // $ yq -o=json -I0 '.[3][0] | parent'        =>  ["p","q"]
+    let shapes = "- x\n- a: 1\n- [1, 2]\n- - p\n  - q\n-\n- |\n  lit\n";
+    for (filter, expected) in [
+        (".[] | key == 0", "true\nfalse\nfalse\nfalse\nfalse\nfalse"),
+        (".[] | select(key == 1)", "{\"a\":1}"),
+        (".[] | parent | length", "6\n6\n6\n6\n6\n6"),
+        (".[1].a | path", "[1,\"a\"]"),
+        (".[3][0] | parent", "[\"p\",\"q\"]"),
+    ] {
+        let (output, code) = run_yq_stdin(filter, shapes, args)?;
+        assert_eq!(code, 0, "{filter}");
+        assert_eq!(output.trim(), expected, "{filter}");
+    }
+
+    // A nested block sequence: the inner items climb through their own
+    // wrapper to the inner sequence, and `parent(2)` reaches the outer one.
+    // $ yq -o=json -I0 '.[] | select(key == 0)'        =>  ["p","q"]
+    // $ yq -o=json -I0 '.[0][] | parent(2) | length'   =>  2 / 2
+    // $ yq -o=json -I0 '.[0][] | [path]'               =>  [[0,0]] / [[0,1]]
+    let nested = "- - p\n  - q\n- - r\n";
+    for (filter, expected) in [
+        (".[] | select(key == 0)", "[\"p\",\"q\"]"),
+        (".[0][] | parent(2) | length", "2\n2"),
+        (".[0][] | [path]", "[[0,0]]\n[[0,1]]"),
+    ] {
+        let (output, code) = run_yq_stdin(filter, nested, args)?;
+        assert_eq!(code, 0, "{filter}");
+        assert_eq!(output.trim(), expected, "{filter}");
+    }
+    Ok(())
+}


### PR DESCRIPTION
## Summary

On a block-style YAML sequence, any path-context builtin reached through the generic evaluator answered as if the item were the document root: `.[] | key == 0` emitted nothing, `.[] | {"k": path}` gave `[]`, `.[] | parent` gave the item itself. The bare `.[] | key` cursor walk hid it, and flow sequences were already right. A regression from the spine 2416 Phase 3 cursor-property work, which routes these shapes through the generic evaluator where they used to take the eager walk.

- Mechanism: a block item's balanced-parentheses parent is its `-` wrapper node, which carries no TY bit and whose value resolves to the item itself, so `cursor_key`'s "is the parent an array" check failed. YAML's `document_parent` now climbs through the wrapper (one function, `src/yaml/light.rs`). `key`, `path`, `parent`, `parent(n)` and the ancestors list all go through it.
- Test: `test_block_sequence_item_key_path_parent_through_generic_route_2455` pins every row in block and flow form, plus a six-shape block list (scalar, compact mapping, flow sequence, nested block sequence, bare `-`, block scalar) and a nested block sequence. All rows captured from yq v4.53.3.
- Sweep: `scripts/jq-path-context-oracle-sweep.sh` now runs every yq-mode case on a hand-written block-style copy of its documents too (checked to decode to the flow copy before any case runs). That is the axis that had no coverage: on main it reports 5 unexpected block-only divergences (`.d[] | {"k": key}`, `select((key) != null)`, `parent`, `{"k": parent}`, `{"k": path}`); on this branch 0 across 3168 cases, with the manifest unchanged.

## Verification

- `cargo test --features cli,simd,regex,serde`, fmt, clippy (`--all-targets --features cli,simd,regex,serde -D warnings`): green.
- `scripts/sync-yq-golden.sh --check`: 113 goldens up to date.
- Oracle sweep: 3168 cases, 0 unexpected on this branch; 5 unexpected on main with the same script.

Not done here: `cursor_key` is still a linear sibling scan per call (`.[] | select(key == 0)` is O(n²) per array), tracked in #2455's second item for a follow-up.

Part of spine 2416 (unblocks step 1b). Closes #2455.
