### PR TITLE
fix(yq): one threshold rule for computed floats in [...] and , (#2438)

### DIFF
--- a/docs/compliance/yq/limitations.md
+++ b/docs/compliance/yq/limitations.md
@@ -2204,7 +2204,7 @@ usable output" a real yq user would see, even though the specific error message
 differs (succinctly raises succinctly's own generator-model error; real yq raises its
 own parse-time rejection).
 
-### Float scalars lose their source spelling on the value route (#2419)
+### An integer-shaped overflow float gains a trailing `.0` on the value route (#2419)
 
 This is the yq-mode counterpart to jq mode's
 ["Float literals lose their source spelling"](../jq/limitations.md#float-literals-lose-their-source-spelling)
@@ -2220,42 +2220,41 @@ $ printf 'outer:\n  big: 100000000000000000000\n' | yq '.outer.big | tostring'
 ```
 
 succinctly's value route — `.outer.big | tostring`, which resolves the scalar through
-`OwnedValue::Float` — re-spells the value whenever its shortest rendering differs from its
-source text:
+`OwnedValue` rather than the cursor — used to re-spell *both* of these through the shortest
+`f64` rendering (`1e+19`, `1e+20`), because neither literal survives
+[`is_preservable_float_literal`](../../../src/yaml/scalar.rs) (20 significant digits exceeds
+its cap; the second has no `.`/`e` at all). Since
+[#2438](https://github.com/rust-works/succinctly/issues/2438),
+`OwnedValue::from_document_float` records the document's own decimal spelling at that
+boundary instead, which closes the `.0`-suffixed case and narrows the divergence to the
+integer-shaped one:
 
 ```bash
 $ printf 'outer:\n  big: 10000000000000000000.0\n' | succinctly yq '.outer.big | tostring'
-1e+19
-$ printf 'outer:\n  big: 100000000000000000000\n' | succinctly yq '.outer.big | tostring'
-1e+20
-```
-
-`1.50`, `1e3` and `0.1` are unaffected — their shortest rendering already matches their
-source spelling, so [`is_preservable_float_literal`](../../../src/yaml/scalar.rs) keeps them
-intact on both tools — and so is the plain `.outer.big` identity read, which never goes
-through the value route at all.
-
-The path-context bridge route — `.outer.big | parent | .big | tostring` — sidesteps the
-value route entirely and matches real yq on the `.0`-suffixed spelling, but produces a
-*third*, still-wrong spelling on the integer-looking one, where real yq prints the bare
-integer with no trailing `.0`:
-
-```bash
-$ printf 'outer:\n  big: 10000000000000000000.0\n' | succinctly yq '.outer.big | parent | .big | tostring'
 10000000000000000000.0
-$ printf 'outer:\n  big: 100000000000000000000\n' | succinctly yq '.outer.big | parent | .big | tostring'
+$ printf 'outer:\n  big: 100000000000000000000\n' | succinctly yq '.outer.big | tostring'
 100000000000000000000.0
 ```
 
-`try_path_context_cursor_walk` (#2061) falls back to this bridge specifically to stay
-output-identical with it whenever a value-route emission would otherwise be re-spelled.
-[#2416](https://github.com/rust-works/succinctly/issues/2416) retires the bridge, at which
-point that fallback has nothing left to defer to — this capture is the evidence that the
-re-spelling is succinctly's own artifact rather than a reference behaviour to match, so
-#2416's path-context walk should emit the document's own spelling once the bridge is gone,
-not inherit either of the two wrong spellings shown above.
+`1.50`, `1e3` and `0.1` are unaffected — their source spelling is preserved outright on both
+tools — and so is the plain `.outer.big` identity read, which never goes through the value
+route at all.
+
+What remains is the trailing `.0` on the integer-shaped spelling. It is not removable in
+isolation: that same `100000000000000000000.0` text is exactly what real yq itself prints
+for the same scalar on JSON output (`yq -o json '[.a]'` on `a: 99999999999999999999` answers
+`[100000000000000000000.0]`, oracle-captured), and it is what distinguishes a document-sourced
+float from a computed one of the identical magnitude, which real yq spells `1e+20` instead.
+Dropping the `.0` for `tostring` alone needs a second, output-position-dependent spelling
+that `OwnedValue::NumberLiteral`'s single text field cannot carry.
+
+The path-context route — `.outer.big | parent | .big | tostring` — now answers identically
+to the value route on every row above, where it used to print a third spelling. The
+reindex-identity fallback that `try_path_context_cursor_walk` (#2061) once used to stay
+output-identical with the bridge was removed by the spine 2416 sink walk; the two routes
+agreeing here is what makes that removal safe on the `.0`-suffixed case.
 [#2419](https://github.com/rust-works/succinctly/issues/2419) is the ADR-0018 record for
-this divergence; fixing the re-spelling itself is out of its scope.
+what is left.
 
 ### Comma binds looser than pipe in real yq — succinctly currently applies jq's grouping in both modes (#2420)
 

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -226,7 +226,12 @@ fn to_owned_checked_at_depth<V: DocumentValue>(
     } else if let Some(i) = value.as_i64() {
         Ok(OwnedValue::Int(i))
     } else if let Some(f) = value.as_f64() {
-        Ok(OwnedValue::Float(f))
+        // #2438: a document scalar that got this far has no preservable
+        // literal left (`number_literal()` answered `None` just above), so
+        // this is the boundary where its provenance is still known -- see
+        // `OwnedValue::from_document_float`. Unreachable for JSON input,
+        // whose `number_literal()` override is unconditional.
+        Ok(OwnedValue::from_document_float(f))
     } else if let Some(s) = value.as_str() {
         Ok(OwnedValue::String(s.into_owned()))
     } else if let Some(reason) = value.string_decode_error() {
@@ -414,7 +419,12 @@ fn to_owned_at_depth<V: DocumentValue>(
     } else if let Some(i) = value.as_i64() {
         Ok(OwnedValue::Int(i))
     } else if let Some(f) = value.as_f64() {
-        Ok(OwnedValue::Float(f))
+        // #2438: a document scalar that got this far has no preservable
+        // literal left (`number_literal()` answered `None` just above), so
+        // this is the boundary where its provenance is still known -- see
+        // `OwnedValue::from_document_float`. Unreachable for JSON input,
+        // whose `number_literal()` override is unconditional.
+        Ok(OwnedValue::from_document_float(f))
     } else if let Some(s) = value.as_str() {
         Ok(OwnedValue::String(s.into_owned()))
     } else if let Some(reason) = value.string_decode_error() {
@@ -2139,14 +2149,22 @@ fn reindex_bridge_is_identity(value: &OwnedValue) -> bool {
 /// sourced or genuinely computed (e.g. `1e10 * 2`) -- that distinction isn't
 /// recoverable from a `GenericResult` variant once a value has passed through
 /// even one further construction step (`to_entries`'s object wrapping looks
-/// identical, from here, to freshly computed arithmetic). The trade-off this
-/// accepts, matching an already-documented precedent
-/// (`test_yq_array_wrapped_computed_float_keeps_scientific_notation_known_gap_1168`,
-/// same shape as #1124/#1144's `join` gap): a genuinely computed float
-/// wrapped directly in `[...]`/`,` (`[1e10 * 2]`) also gets its decimal point
-/// forced, when real yq would keep scientific notation there. Getting both
-/// right needs provenance tagged at `OwnedValue::Float`'s own construction
-/// site, not reconstructed after the fact here -- out of scope for this fix.
+/// identical, from here, to freshly computed arithmetic).
+///
+/// #1168 accepted a gap as the price of that: a genuinely computed float
+/// wrapped directly in `[...]`/`,` (`[1e10 * 2]`) also got its decimal point
+/// forced, where real yq keeps scientific notation. #2438 closed it by
+/// tagging the provenance at `OwnedValue`'s own construction site after all
+/// -- [`OwnedValue::from_document_float`], applied at the document boundary
+/// (`to_owned_at_depth`, `ResolvedScalar::to_owned_value`) rather than
+/// reconstructed here -- which let `to_json_for_reindex`'s yq fallback
+/// switch to yq's own magnitude threshold (`format_float_yq`). This function
+/// is unchanged by that and still round-trips the whole result; what changed
+/// is that a document-sourced float now arrives already carrying its
+/// spelling, so the round trip preserves it as a literal instead of having
+/// to synthesize one for everything. `[1e10 * 2]` keeps scientific notation
+/// as a result; the ordinary-magnitude `join` gap (#1124/#1144, `[2.0/2]`)
+/// is below the threshold and is untouched.
 ///
 /// Round-tripping just `values` (not the whole input document, unlike the
 /// old wildcard fallback these two arms replace) keeps `Expr::Array`'s and
@@ -12571,7 +12589,10 @@ fn eval_builtin<S: EvalSemantics, V: DocumentValue>(
             } else if let Some(i) = value.as_i64() {
                 GenericResult::Owned(OwnedValue::Int(i))
             } else if let Some(f) = value.as_f64() {
-                GenericResult::Owned(OwnedValue::Float(f))
+                // #2438: still the document's own value, so it carries the
+                // same provenance the `number_literal()` arm above preserves
+                // -- see `OwnedValue::from_document_float`.
+                GenericResult::Owned(OwnedValue::from_document_float(f))
             } else if let Some(s) = value.as_str() {
                 match tonumber_from_str(s.as_ref()) {
                     Ok(n) => GenericResult::Owned(n),

--- a/src/jq/value.rs
+++ b/src/jq/value.rs
@@ -1385,6 +1385,43 @@ impl OwnedValue {
         Self::Float(f)
     }
 
+    /// A *document-sourced* float with no preservable source literal left,
+    /// materialized so its provenance survives into `OwnedValue` (#2438).
+    ///
+    /// Two document shapes reach `OwnedValue` as a bare `f64` with their
+    /// spelling already gone: a YAML integer-shaped scalar too big for `i64`
+    /// (`a: 99999999999999999999`), and a tag-forced float whose text is
+    /// integer-shaped (`a: !!float 100000000000000000000`). Real yq spells
+    /// both out in full decimal wherever it re-serializes them, at *any*
+    /// magnitude -- `yq -o json '[.a]'` on the first answers
+    /// `[100000000000000000000.0]`, not `[1e+20]` -- while a genuinely
+    /// **computed** float of the identical magnitude gets scientific
+    /// notation there instead (`yq -o json '[1e20 * 1]'` answers `[1e+20]`).
+    /// Both captured live from yq v4.53.3.
+    ///
+    /// Since the two are the same `f64`, no magnitude threshold can separate
+    /// them downstream -- which is exactly what #2438 hit: the reindex
+    /// bridge (`to_json_for_reindex`) used to force the decimal spelling on
+    /// *every* bare yq-mode `Float` so the document cases would survive it,
+    /// which spelled `[.a * 1e100]` as a 101-digit expansion where real yq
+    /// prints `1e+100`. Recording the provenance here, at the one boundary
+    /// that still knows it, lets the bridge apply yq's own threshold
+    /// ([`crate::yaml::yq_float_is_scientific`]) to everything else.
+    ///
+    /// Only above/below yq's threshold: inside the everyday range the
+    /// decimal spelling *is* what the bridge would have produced anyway, and
+    /// baking a literal there would leak into the string builtins that read
+    /// it (`!!float 2 | tostring` must stay `2`, #1090/#1176). Non-finite
+    /// floats have no decimal spelling at all and stay bare.
+    #[must_use]
+    pub fn from_document_float(f: f64) -> Self {
+        if f.is_finite() && crate::yaml::yq_float_is_scientific(f) {
+            Self::from_number_literal(&crate::yaml::format_float_with_fraction(f))
+        } else {
+            Self::Float(f)
+        }
+    }
+
     /// Create a number that carries its document source text.
     ///
     /// Parses `literal` the same way every document-materializing conversion
@@ -1914,12 +1951,19 @@ impl OwnedValue {
     /// evaluator (#561, #472).
     ///
     /// `S: EvalSemantics` picks the plain (non-`NumberLiteral`) `Float`
-    /// fallback's spelling (#953): yq keeps a decimal point regardless of
-    /// magnitude (`format_float_with_fraction`), matching real yq's own
-    /// `-o json '[.a]'` output for a value with no preserved literal (e.g.
-    /// an i64-overflow YAML scalar reaching this bridge via `[...]`/
-    /// `map_values`/`with_entries`, which have no native `eval_generic.rs`
-    /// cursor arm). jq keeps the pre-existing bare `Display` (no forced
+    /// fallback's spelling (#953, #2438): yq applies its own magnitude
+    /// threshold (`format_float_yq` -- decimal-with-point for everyday
+    /// magnitudes, `e+NN`/`e-NN` past it), which is what a *computed* float
+    /// gets from real yq wherever it re-serializes one. This used to be an
+    /// unconditional `format_float_with_fraction` so that a **document**
+    /// float with no preserved literal (an i64-overflow YAML scalar reaching
+    /// this bridge via `[...]`/`map_values`/`with_entries`) would keep the
+    /// full decimal spelling real yq gives *it* at the same magnitude -- the
+    /// two answers genuinely differ for the identical `f64`, so the
+    /// provenance is now recorded upstream instead, at
+    /// [`from_document_float`](Self::from_document_float), leaving this
+    /// fallback free to spell the computed case correctly. jq keeps the
+    /// pre-existing bare `Display` (no forced
     /// point): real jq's own convention drops a computed value's literal
     /// formatting entirely (`1.0 + 4.0` prints `5`, not `5.0`), and a bare
     /// `Float` reaching this fallback is by construction one that already
@@ -2022,7 +2066,7 @@ impl OwnedValue {
             }
             Self::NumberLiteral(NumberRepr::Int(n), _) => format!("{n}"),
             Self::NumberLiteral(NumberRepr::Float(f), _) if S::TAG == EvalTag::Yq => {
-                crate::yaml::format_float_with_fraction(*f)
+                crate::yaml::format_float_yq(*f)
             }
             Self::NumberLiteral(NumberRepr::Float(f), _) => jq_bare_float_display(*f),
             Self::Array(arr) => {
@@ -2045,8 +2089,8 @@ impl OwnedValue {
                     .collect();
                 format!("{{{}}}", entries.join(","))
             }
-            // yq keeps a whole-number `Float`'s decimal point at any
-            // magnitude (#953); jq keeps the original bare `Display` (see
+            // yq spells a computed float by its own magnitude threshold
+            // (#953, #2438); jq keeps the original bare `Display` (see
             // this function's own doc comment for why the fork is required,
             // not optional).
             // `infinite_fmt` is unreachable from here either way -- every
@@ -2056,7 +2100,7 @@ impl OwnedValue {
             other if S::TAG == EvalTag::Yq => other.to_json_at_depth(
                 depth,
                 format_number_jq_compat,
-                crate::yaml::format_float_with_fraction,
+                crate::yaml::format_float_yq,
                 yq_infinite_float_json_text,
             ),
             other => other.to_json_at_depth(
@@ -3080,6 +3124,50 @@ mod tests {
         // legitimately formatted number -- both parses must fail today.
         assert!(NAN_SENTINEL.parse::<f64>().is_err());
         assert!(NAN_SENTINEL.parse::<i64>().is_err());
+    }
+
+    /// #2438: the document boundary bakes yq's own decimal spelling into a
+    /// float that has no source literal left, but only past yq's
+    /// scientific-notation threshold -- inside the everyday range the value
+    /// stays a bare `Float`, which is what keeps `!!float 2 | tostring`
+    /// answering `2` rather than `2.0` (#1090/#1176).
+    #[test]
+    fn test_from_document_float_records_provenance_only_past_the_threshold() {
+        assert_eq!(
+            OwnedValue::from_document_float(1e20),
+            OwnedValue::from_number_literal("100000000000000000000.0")
+        );
+        assert_eq!(
+            OwnedValue::from_document_float(1e-5),
+            OwnedValue::from_number_literal("0.00001")
+        );
+        // Everyday magnitudes, and non-finite values (which have no decimal
+        // spelling at all), stay bare.
+        for f in [2.0, 0.5, -1.0, 99999.0, 0.0, f64::NAN, f64::INFINITY] {
+            assert!(
+                matches!(OwnedValue::from_document_float(f), OwnedValue::Float(_)),
+                "expected a bare Float for {f}"
+            );
+        }
+    }
+
+    /// #2438: the bridge's yq fallback now spells a *computed* float by the
+    /// same threshold the emitters use, rather than forcing a decimal point
+    /// at every magnitude. jq mode's own fallback is untouched.
+    #[test]
+    fn test_to_json_for_reindex_yq_float_uses_the_shared_threshold_2438() {
+        assert_eq!(
+            OwnedValue::Float(1e20).to_json_for_reindex::<YqSemantics>(),
+            "1e+20"
+        );
+        assert_eq!(
+            OwnedValue::Float(2.0).to_json_for_reindex::<YqSemantics>(),
+            "2.0"
+        );
+        assert_eq!(
+            OwnedValue::Float(1e20).to_json_for_reindex::<JqSemantics>(),
+            "100000000000000000000"
+        );
     }
 
     #[test]

--- a/src/yaml/light.rs
+++ b/src/yaml/light.rs
@@ -3591,6 +3591,13 @@ fn format_float_yq_with(f: f64, ordinary_magnitude: impl FnOnce(f64) -> String) 
         "format_float_yq_with requires a finite value; NaN/Infinity have no \
          JSON/YAML spelling here and must be special-cased by the caller"
     );
+    if !yq_float_is_scientific(f) {
+        return ordinary_magnitude(f);
+    }
+    // Only the scientific branch needs the exponential rendering, so the
+    // `format!` stays inside it: `yq_float_is_scientific` decides
+    // arithmetically, and an everyday-magnitude value never pays for a
+    // string it would immediately discard.
     let sci = format!("{f:e}");
     let (mantissa, exp_str) = sci
         .split_once('e')
@@ -3598,12 +3605,67 @@ fn format_float_yq_with(f: f64, ordinary_magnitude: impl FnOnce(f64) -> String) 
     let exp: i32 = exp_str
         .parse()
         .expect("exponent from Rust's exponential formatter is always a valid i32");
-    if (-4..6).contains(&exp) {
-        ordinary_magnitude(f)
-    } else {
-        let sign = if exp < 0 { '-' } else { '+' };
-        format!("{mantissa}e{sign}{:02}", exp.abs())
-    }
+    let sign = if exp < 0 { '-' } else { '+' };
+    format!("{mantissa}e{sign}{:02}", exp.abs())
+}
+
+/// Whether real yq would spell `f` in scientific notation rather than decimally.
+///
+/// The one definition of yq's magnitude threshold (#2438): everything that
+/// formats a computed float ([`format_float_yq`], [`format_float_yq_yaml`],
+/// and the private `format_float_yq_with` they share) and everything that
+/// has to *decide* on the threshold rather than format with it asks this.
+/// The rule used to be
+/// written out twice -- once here and once as the reindex bridge's
+/// unconditional [`format_float_with_fraction`] fallback in
+/// `OwnedValue::to_json_for_reindex` (`src/jq/value.rs`) -- so a computed
+/// float above the threshold came out of `[...]`/`,` as a 100-digit decimal
+/// expansion where a bare one printed `1e+100`.
+///
+/// A document-sourced float that reaches `OwnedValue` with no preservable
+/// source literal left (a YAML integer-shaped scalar too big for `i64`, or
+/// a tag-forced `!!float 100000000000000000000`) needs the full decimal
+/// spelling real yq gives it, while a *computed* float of the very same
+/// magnitude needs scientific -- oracle-confirmed against yq v4.53.3, which
+/// answers `[100000000000000000000.0]` for `-o json '[.a]'` on
+/// `a: 99999999999999999999` and `[1e+20]` for `-o json '[1e20 * 1]'`. No
+/// threshold rule can tell those apart, so provenance is recorded at the
+/// document boundary instead: [`crate::jq::OwnedValue::from_document_float`]
+/// uses this to bake the decimal spelling in as a literal exactly where yq
+/// keeps one,
+/// which frees the reindex bridge to apply the threshold to everything left
+/// (#2438).
+///
+/// Stated arithmetically rather than by reading the exponent back out of
+/// `format!("{f:e}")`, which is where the rule started: this now runs on the
+/// DOM decode path for *every* document float
+/// (`to_owned_at_depth` -> [`crate::jq::OwnedValue::from_document_float`]),
+/// so the string form charged a float-heavy document one allocation per
+/// number just to learn that the number was ordinary.
+///
+/// The two agree exactly. `{:e}`'s exponent is that of the shortest decimal
+/// that round-trips to `f`, so `exp` lands in `-4..6` precisely when
+/// `1e-4 <= |f| < 1e6` (`0.0`/`-0.0` print as `0e0`, exponent `0`, and are
+/// ordinary). Neither boundary can be crossed by the shortest-repr rounding:
+/// printing a double just below `1e6` as `1e6` would round-trip to a
+/// *different* double, and `1e-4` itself is the nearest double to 10^-4, so
+/// it prints as `1e-4` while the double below it prints as
+/// `9.999999999999999e-5`. Pinned by
+/// `yq_float_is_scientific_agrees_with_the_exponent_it_replaces`, which
+/// keeps the `{:e}` form as the test oracle over both boundaries, their
+/// neighbouring doubles, the extremes, and a few hundred pseudorandom
+/// values.
+///
+/// `f` must be finite, like [`format_float_yq`].
+#[must_use]
+pub fn yq_float_is_scientific(f: f64) -> bool {
+    debug_assert!(
+        f.is_finite(),
+        "yq_float_is_scientific requires a finite value; NaN/Infinity have no \
+         JSON/YAML spelling here and must be special-cased by the caller"
+    );
+    let magnitude = f.abs();
+    magnitude != 0.0 && !(1e-4..1e6).contains(&magnitude)
 }
 
 /// If `canonicalize` and `resolved` is a finite `Float`, the value to
@@ -7897,6 +7959,100 @@ fn stream_yaml_single_quoted<Out: core::fmt::Write>(out: &mut Out, s: &str) -> c
 mod tests {
     use super::*;
     use crate::yaml::{YamlError, YamlIndex};
+
+    /// #2438: [`yq_float_is_scientific`] is stated arithmetically because it
+    /// runs once per document float on the DOM decode path, but the rule it
+    /// encodes is "`format!("{f:e}")`'s exponent is outside `-4..6`". This
+    /// keeps that string form as the *oracle* and asserts the two agree.
+    ///
+    /// The grid is boundary-first, because that is the only place the two
+    /// could disagree: both boundaries, the double immediately below each,
+    /// and the extremes at either end of the range. `999999.9999999999` is
+    /// the decimal spelling of the double below `1e6`, kept as a literal so
+    /// the row is readable next to the computed one. The pseudorandom tail
+    /// (a plain LCG, no dev-dependency) covers the interior: half as raw bit
+    /// patterns, which spread over the whole exponent range, and half as
+    /// mantissa-times-power-of-ten values clustered around the boundaries,
+    /// which raw bits essentially never land near.
+    #[test]
+    fn yq_float_is_scientific_agrees_with_the_exponent_it_replaces() {
+        /// The rule as originally written: read the exponent back out of
+        /// Rust's shortest-round-trip exponential rendering.
+        fn exponent_says_scientific(f: f64) -> bool {
+            let sci = format!("{f:e}");
+            let exp: i32 = sci
+                .split_once('e')
+                .expect("always has an 'e'")
+                .1
+                .parse()
+                .expect("always a valid i32");
+            !(-4..6).contains(&exp)
+        }
+
+        let below_1e_minus_4 = f64::from_bits(1e-4f64.to_bits() - 1);
+        let below_1e6 = f64::from_bits(1e6f64.to_bits() - 1);
+        let mut cases = vec![
+            0.0,
+            1e-4,
+            below_1e_minus_4,
+            1e6,
+            below_1e6,
+            999_999.999_999_999_9,
+            5e-324,
+            f64::MIN_POSITIVE,
+            f64::MAX,
+            1.0,
+            0.5,
+            99_999.0,
+            100_000.0,
+            1e-5,
+            1e5,
+        ];
+        // Negatives of every row above: the predicate reads `f.abs()`, so a
+        // sign that leaked into either side would show up only here.
+        for i in 0..cases.len() {
+            cases.push(-cases[i]);
+        }
+        // `-0.0` is not `-(0.0)` as a literal to the parser in every
+        // position, so it is spelled out rather than relied on above.
+        cases.push(-0.0);
+
+        // A plain LCG (Knuth's MMIX constants) -- deterministic, no
+        // dev-dependency, and the seed is fixed so a failure reproduces.
+        let mut state: u64 = 0x2545_F491_4F6C_DD1D;
+        let mut next = || {
+            state = state
+                .wrapping_mul(6_364_136_223_846_793_005)
+                .wrapping_add(1_442_695_040_888_963_407);
+            state
+        };
+        for _ in 0..256 {
+            let f = f64::from_bits(next());
+            if f.is_finite() {
+                cases.push(f);
+            }
+        }
+        for _ in 0..256 {
+            // Mantissa in [1, 10), exponent in -8..=8 -- straddles both
+            // boundaries densely.
+            let mantissa = 1.0 + (next() >> 11) as f64 / (1u64 << 53) as f64 * 9.0;
+            let exp = (next() % 17) as i32 - 8;
+            let f = mantissa * 10f64.powi(exp);
+            if f.is_finite() {
+                cases.push(f);
+                cases.push(-f);
+            }
+        }
+
+        for f in cases {
+            assert_eq!(
+                yq_float_is_scientific(f),
+                exponent_says_scientific(f),
+                "disagreed for {f:e} (bits {:#x})",
+                f.to_bits()
+            );
+        }
+    }
 
     /// Helper to get the first document from the root document array.
     /// All YAML documents are wrapped in a virtual root sequence.

--- a/src/yaml/mod.rs
+++ b/src/yaml/mod.rs
@@ -276,8 +276,8 @@ pub use error::YamlError;
 pub use index::YamlIndex;
 pub use light::{
     format_float_with_fraction, format_float_yq, format_float_yq_yaml, format_float_yq_yaml_nested,
-    stream_json_sequence, stream_yaml_sequence, ChompingIndicator, YamlCursor, YamlElements,
-    YamlField, YamlFields, YamlNumber, YamlString, YamlValue,
+    stream_json_sequence, stream_yaml_sequence, yq_float_is_scientific, ChompingIndicator,
+    YamlCursor, YamlElements, YamlField, YamlFields, YamlNumber, YamlString, YamlValue,
 };
 pub use locate::{locate_offset, locate_offset_detailed, LocateResult};
 pub use scalar::{resolve_plain, resolve_tagged, ResolvedScalar};

--- a/src/yaml/scalar.rs
+++ b/src/yaml/scalar.rs
@@ -140,9 +140,12 @@ impl ResolvedScalar {
     /// (deliberately — `YqSemantics` there re-breaks #978's
     /// JSON-sourced-`1e2`-renders-as-`100` rule), and jq's plain-`Float`
     /// fallback is the one that drops the point. Every other bridge is
-    /// `S`-gated and already spells a bare `Float` with
-    /// `format_float_with_fraction` under `YqSemantics`, so a tag-forced
-    /// float survives those untouched. Handing the re-spelling to
+    /// `S`-gated and spells a bare `Float` with `format_float_yq` under
+    /// `YqSemantics`, whose everyday-magnitude branch is
+    /// `format_float_with_fraction` (#2438) -- and a tag-forced float past
+    /// that magnitude threshold has already picked up its own spelling from
+    /// [`OwnedValue::from_document_float`] in the arm below -- so a
+    /// tag-forced float survives those untouched either way. Handing the re-spelling to
     /// `eval_generic`'s cursor materialization and to `load()` as well
     /// costs real oracle fidelity: their values reach string-producing
     /// builtins, where real yq prints the scalar's own text, so
@@ -183,7 +186,11 @@ impl ResolvedScalar {
                 {
                     OwnedValue::from_number_literal(&super::format_float_with_fraction(f))
                 }
-                None => OwnedValue::Float(f),
+                // #2438: same document boundary as `to_owned_at_depth`'s own
+                // bare-float arm (`src/jq/eval_generic.rs`) -- an explicitly
+                // tagged `!!float 100000000000000000000` reaches `OwnedValue`
+                // here instead, and needs the identical provenance record.
+                None => OwnedValue::from_document_float(f),
             },
             Self::Str => OwnedValue::String(text.into_owned()),
         }

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -8803,58 +8803,64 @@ fn test_yq_tostring_computed_nan_uses_yaml_spelling_1060() -> Result<()> {
     Ok(())
 }
 
-/// #2419: pins a *documented divergence*, not desired behaviour -- see
-/// "Float scalars lose their source spelling on the value route (#2419)" in
+/// #2419, narrowed by #2438: real yq v4.53.3 preserves a float scalar's
+/// source spelling everywhere, including through `tostring`. succinctly's
+/// value route used to re-spell *every* such scalar through the shortest
+/// `f64` rendering (`1e+19`, `1e+20`); #2438's
+/// `OwnedValue::from_document_float` now bakes the decimal spelling in at
+/// the document boundary instead, which closes the `.0`-suffixed case
+/// outright and leaves only the integer-shaped one divergent (`...0.0`
+/// against real yq's bare `...0`). See "An integer-shaped
+/// overflow float gains a trailing `.0` on the value route (#2419)" in
 /// [`docs/compliance/yq/limitations.md`](../docs/compliance/yq/limitations.md).
-/// Real yq v4.53.3 preserves a float scalar's source spelling everywhere,
-/// including through `tostring`; succinctly's value route (`OwnedValue::Float`)
-/// re-spells it whenever the shortest rendering differs from the source text.
-/// `1.50`/`1e3`/`0.1` are unaffected (`is_preservable_float_literal` keeps
-/// them), and the path-context bridge route (`| parent | .big | tostring`)
-/// avoids the value route but produces a third, still-wrong spelling on the
-/// integer-looking case. All four expectations here were captured live from
-/// the pinned binaries and must move together if either tool's behaviour
-/// changes -- see #2416, which retires the bridge and is expected to fix the
-/// value-route case listed here as its side effect.
+///
+/// The value route and the path-context bridge route (`| parent | .big |
+/// tostring`) now agree with each other on all five rows, where they used to
+/// print three different spellings between them. Every expectation here was
+/// captured live from the pinned binaries:
+///
+/// ```console
+/// $ printf 'outer:\n  big: 10000000000000000000.0\n' | yq -r '.outer.big | tostring'
+/// 10000000000000000000.0
+/// $ printf 'outer:\n  big: 100000000000000000000\n' | yq -r '.outer.big | tostring'
+/// 100000000000000000000
+/// ```
 #[test]
 fn test_yq_float_value_route_respelling_2419() -> Result<()> {
-    // Value route: re-spelled by succinctly, preserved by real yq.
-    for (input, want) in [
-        ("outer:\n  big: 10000000000000000000.0\n", "1e+19"),
-        ("outer:\n  big: 100000000000000000000\n", "1e+20"),
-    ] {
-        let (stdout, code) = run_yq_stdin(".outer.big | tostring", input, &["-r"])?;
-        assert_eq!(code, 0, "for {input:?}: {stdout:?}");
-        assert_eq!(stdout.trim_end(), want, "for {input:?}");
-    }
-
-    // Preserved by both tools: shortest rendering already matches source spelling.
-    for (input, want) in [
+    // Preserved by both tools. The first three already matched before #2438
+    // (`is_preservable_float_literal` keeps their source text); the fourth is
+    // #2438's own fix -- 20 significant digits exceed that predicate's cap,
+    // so it reaches `OwnedValue` with no literal left and used to answer
+    // `1e+19`.
+    let agreed = [
         ("outer:\n  big: 1.50\n", "1.50"),
         ("outer:\n  big: 1e3\n", "1e3"),
         ("outer:\n  big: 0.1\n", "0.1"),
-    ] {
-        let (stdout, code) = run_yq_stdin(".outer.big | tostring", input, &["-r"])?;
-        assert_eq!(code, 0, "for {input:?}: {stdout:?}");
-        assert_eq!(stdout.trim_end(), want, "for {input:?}");
-    }
-
-    // Path-context bridge route: matches real yq on the `.0`-suffixed case,
-    // but prints a third spelling (`...0.0` instead of real yq's bare
-    // integer `...0`) on the integer-looking case.
-    for (input, want) in [
         (
             "outer:\n  big: 10000000000000000000.0\n",
             "10000000000000000000.0",
         ),
-        (
-            "outer:\n  big: 100000000000000000000\n",
-            "100000000000000000000.0",
-        ),
-    ] {
+    ];
+    // Still divergent: an integer-shaped overflow scalar has no decimal
+    // point of its own to keep, and the spelling #2438 bakes in is the one
+    // real yq itself uses on `-o json` for the same value
+    // (`100000000000000000000.0`), so the `.0` real yq drops on YAML-side
+    // `tostring` cannot come back off here.
+    let divergent = [(
+        "outer:\n  big: 100000000000000000000\n",
+        "100000000000000000000.0",
+    )];
+
+    for (input, want) in agreed.iter().chain(divergent.iter()) {
+        // Value route.
+        let (stdout, code) = run_yq_stdin(".outer.big | tostring", input, &["-r"])?;
+        assert_eq!(code, 0, "for {input:?}: {stdout:?}");
+        assert_eq!(stdout.trim_end(), *want, "value route, for {input:?}");
+
+        // Path-context bridge route -- same answer as the value route now.
         let (stdout, code) = run_yq_stdin(".outer.big | parent | .big | tostring", input, &["-r"])?;
         assert_eq!(code, 0, "for {input:?}: {stdout:?}");
-        assert_eq!(stdout.trim_end(), want, "for {input:?}");
+        assert_eq!(stdout.trim_end(), *want, "bridge route, for {input:?}");
     }
 
     Ok(())
@@ -11561,6 +11567,84 @@ fn test_computed_float_scientific_notation_yaml_output_997() -> Result<()> {
     let (out, code) = run_yq_stdin(r#"{"a": (.a * 1e100)}"#, "a: 1\n", &[])?;
     assert_eq!(code, 0);
     assert_eq!(out.trim(), "a: 1e+100");
+    Ok(())
+}
+
+/// #2438: `[...]`/`,` used to spell a computed float above yq's
+/// scientific-notation threshold as a full decimal expansion -- `[.a * 1e100]`
+/// printed a 101-digit number where the same value printed `1e+100` bare
+/// (#997 above) or inside an object. Two definitions of the threshold rule:
+/// the emitters' (`format_float_yq`/`format_float_yq_yaml_nested`) and the
+/// reindex bridge's unconditional `format_float_with_fraction` fallback,
+/// which `yq_float_fidelity_fixup`'s round trip baked into synthesized
+/// literal text that the emitters then echoed verbatim.
+///
+/// Every row captured live from yq v4.53.3 on `a: 1`:
+///
+/// ```console
+/// $ yq '[.a * 1e100]' a.yaml      => - 1e+100
+/// $ yq '[.a * 1e15]'  a.yaml      => - 1e+15
+/// $ yq '[.a * 1e16]'  a.yaml      => - 1e+16
+/// $ yq '[.a * 1e21]'  a.yaml      => - 1e+21
+/// $ yq '[.a / 100000]' a.yaml     => - 1e-05
+/// $ yq '[.a * 1000000]' a.yaml    => - 1000000
+/// $ yq '[.a / 3]' a.yaml          => - 0.3333333333333333
+/// $ yq '(.a * 1e100), 1' a.yaml   => 1e+100 / 1
+/// ```
+///
+/// `[.a * 1000000]` is the deliberate control: `1000000` is an *int* literal
+/// in yq, so that row never becomes a float at all and must stay `1000000`
+/// rather than picking up `1e+06` from the threshold. `[.a / 3]` is the
+/// ordinary-magnitude control, and `(.a * 1e100), 1` is the `Expr::Comma`
+/// arm the issue asked to check alongside `Expr::Array`.
+#[test]
+fn test_computed_float_threshold_agrees_inside_array_and_comma_2438() -> Result<()> {
+    for (filter, want_yaml, want_json) in [
+        ("[.a * 1e100]", "- 1e+100", "[1e+100]"),
+        ("[.a * 1e15]", "- 1e+15", "[1e+15]"),
+        ("[.a * 1e16]", "- 1e+16", "[1e+16]"),
+        ("[.a * 1e21]", "- 1e+21", "[1e+21]"),
+        ("[.a / 100000]", "- 1e-05", "[1e-05]"),
+        ("[.a * 1000000]", "- 1000000", "[1000000]"),
+        ("[.a / 3]", "- 0.3333333333333333", "[0.3333333333333333]"),
+        ("(.a * 1e100), 1", "1e+100\n1", "1e+100\n1"),
+    ] {
+        let (out, code) = run_yq_stdin(filter, "a: 1\n", &[])?;
+        assert_eq!(code, 0, "yaml output for {filter:?}: {out:?}");
+        assert_eq!(out.trim_end(), want_yaml, "yaml output for {filter:?}");
+
+        let (out, code) = run_yq_stdin(filter, "a: 1\n", &["-o", "json", "-I0"])?;
+        assert_eq!(code, 0, "json output for {filter:?}: {out:?}");
+        assert_eq!(out.trim_end(), want_json, "json output for {filter:?}");
+    }
+    Ok(())
+}
+
+/// #2438: jq mode must be untouched by the yq-side threshold work -- its own
+/// `to_json_for_reindex` fallback (`jq_bare_float_display`) is `S`-gated
+/// away from `format_float_yq` and stays that way.
+///
+/// This pins the *pre-existing* jq-mode divergence rather than a fix: real
+/// jq 1.7.1 prints `1e+100` here, succinctly prints the full expansion, and
+/// it does so identically for the bare filter and the array-wrapped one --
+/// i.e. the gap is jq mode's own number formatting, not the reindex bridge,
+/// so #2438 neither widens nor closes it. Captured live on `{"a":1}`:
+///
+/// ```console
+/// $ /usr/bin/jq -c '[.a * 1e100]' a.json   => [1e+100]
+/// $ /usr/bin/jq -c '.a * 1e100'   a.json   => 1e+100
+/// ```
+#[test]
+fn test_jq_mode_float_threshold_unchanged_by_2438() -> Result<()> {
+    let expansion = format!("1{}", "0".repeat(100));
+    for (filter, want) in [
+        ("[.a * 1e100]", format!("[{expansion}]")),
+        (".a * 1e100", expansion.clone()),
+    ] {
+        let (out, code) = run_jq_stdin(filter, "{\"a\":1}\n", &["-c"])?;
+        assert_eq!(code, 0, "for {filter:?}: {out:?}");
+        assert_eq!(out.trim_end(), want, "for {filter:?}");
+    }
     Ok(())
 }
 
@@ -17831,28 +17915,42 @@ fn test_yq_comma_multiple_overflow_fields_all_fixed_1168() -> Result<()> {
     Ok(())
 }
 
-/// #1168 review round: `yq_float_fidelity_fixup` first tried scoping itself
-/// to only a direct cursor result (`OneCursor`/`ManyCursor`), leaving an
-/// already-constructed value (`Owned`/`ManyOwned`) untouched on the theory
-/// that it can't be a document literal. That theory was wrong -- code review
-/// found `Builtin::ToEntries` (and any other builtin with its own native
-/// construction around a document value) *also* reaches `Expr::Array` as
-/// `Owned`, so the narrower scoping silently regressed #953 for exactly
-/// that shape (`[to_entries]` on an overflow field, see
-/// `test_yq_array_wrapped_to_entries_overflow_int_keeps_decimal_point_1168`
-/// below) while it was trying to avoid over-forcing a genuinely computed
-/// float like this one. Since a `GenericResult` variant can't distinguish
-/// "builtin construction around a document value" from "genuinely computed"
-/// once a value has passed through even one further construction step, the
-/// fixup now applies uniformly to the whole constructed result -- accepting
-/// this known, pre-existing-class gap (same shape as #1124/#1144's `join`
-/// gap) as the trade-off: a bare computed float wrapped directly in
-/// `[...]`/`,` also gets its decimal point forced, when real yq would keep
-/// scientific notation. Pinned here so a future attempt to "fix" this case
-/// re-checks it doesn't reintroduce the `to_entries` regression instead.
+/// #2438 closes what #1168 pinned here as a known gap: a bare *computed*
+/// float wrapped directly in `[...]`/`,` used to get its decimal point
+/// forced by `yq_float_fidelity_fixup`'s round trip, where real yq keeps
+/// scientific notation.
+///
+/// #1168's reasoning for accepting that -- a `GenericResult` variant can't
+/// tell "builtin construction around a document value" (`[to_entries]` on an
+/// overflow field, `test_yq_array_comma_wrapped_to_entries_overflow_int_keeps_decimal_point_1168`)
+/// apart from "genuinely computed" -- was correct as far as it went, and the
+/// two really are the same `f64` by the time the fixup sees them. #2438's
+/// fix moves the distinction *upstream* of the fixup instead, to the one
+/// boundary that still knows it: `OwnedValue::from_document_float`, applied
+/// where a document scalar with no preservable literal becomes an
+/// `OwnedValue` (`to_owned_at_depth`, `ResolvedScalar::to_owned_value`).
+/// The bridge is then free to apply yq's own magnitude threshold
+/// (`format_float_yq`) to everything else, which is what makes this row and
+/// the `to_entries` row above both correct at the same time.
+///
+/// Both oracle-captured from yq v4.53.3, same magnitude, opposite answers:
+///
+/// ```console
+/// $ printf 'null\n' | yq -o=json -I=0 '[1e20 * 1]'
+/// [1e+20]
+/// $ printf 'a: 99999999999999999999\n' | yq -o=json -I=0 '[.a]'
+/// [100000000000000000000.0]
+/// ```
 #[test]
-fn test_yq_array_wrapped_computed_float_forces_decimal_known_gap_1168() -> Result<()> {
+fn test_yq_array_wrapped_computed_float_keeps_scientific_notation_2438() -> Result<()> {
     let (stdout, code) = run_yq_stdin("[1e20 * 1]", "null\n", &["-o", "json", "-I0"])?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout.trim_end(), "[1e+20]");
+
+    // The document-sourced value of the identical magnitude still keeps the
+    // decimal spelling real yq gives it (#953) -- the pair is the whole
+    // point, so they are pinned together rather than in separate tests.
+    let (stdout, code) = run_yq_stdin("[.a]", "a: 99999999999999999999\n", &["-o", "json", "-I0"])?;
     assert_eq!(code, 0);
     assert_eq!(stdout.trim_end(), "[100000000000000000000.0]");
     Ok(())


### PR DESCRIPTION
## Summary

`[.a * 1e100]` printed the full 101-digit expansion where real yq prints `1e+100`, because two float formatters disagreed above yq's scientific-notation threshold: the emitter used yq's rule and the reindex round trip inside `yq_float_fidelity_fixup` did not.

The issue's ask, "make one formatter agree with the other", is impossible by threshold alone. The oracle shows the same `f64` spelled both ways depending only on provenance:

```console
$ printf 'a: 99999999999999999999\n' | yq -o=json -I=0 '[.a]'    # document-sourced
[100000000000000000000.0]
$ printf 'null\n' | yq -o=json -I=0 '[1e20 * 1]'                 # computed
[1e+20]
```

So provenance is now recorded at the document boundary: `OwnedValue::from_document_float` keeps the document's own decimal spelling as a `NumberLiteral`, but only past the threshold (inside the everyday range it must stay a bare `Float`, #1090/#1176). That frees the reindex fallback to use `format_float_yq`, and the threshold has one definition, `yq_float_is_scientific`, an arithmetic predicate with no allocation on the decode path; a unit test asserts it agrees with the `{:e}` exponent it replaces over the boundaries and ~768 pseudorandom values, and four mutants of the predicate were confirmed to fail it.

Side effect: half of #2419 closes. `.outer.big | tostring` on `big: 10000000000000000000.0` now answers real yq's `10000000000000000000.0`, and the value route and the path-context route agree on every row. The limitations entry is retitled and narrowed to the residual integer-shaped `.0`.

jq mode is untouched, pinned by `test_jq_mode_float_threshold_unchanged_by_2438`; its own pre-existing spelling gap is #2456.

## Verification

Oracle rows (yq v4.53.3, `/usr/bin/jq` 1.7.1) are in the test doc comments: `[.a * 1e100]`, `[.a * 1e15]`, `[.a * 1e16]`, `[.a * 1e21]`, `[.a / 100000]`, `[.a * 1000000]`, `[.a / 3]`, `(.a * 1e100), 1`; `[.a]`/`[to_entries]`/`map_values`/`with_entries` on `a: 99999999999999999999`; `[.a]`/`[.b]`/`tostring` on `!!float` documents; `.outer.big | tostring` on five spellings via both routes.

- fmt; clippy `--all-features` and the two CI feature legs, `-D warnings`; `cargo test --features cli,simd,regex,serde`; default `cargo test`; `--no-default-features`; `cargo doc` with `-D warnings`: all green.
- yq goldens 113 and jq goldens 633 up to date; path-context oracle sweep 0 unexpected.

Not done here: admitting arithmetic to the native path-context gate (spine 2416 step 1b part B) was blocked by #2455 and follows once #2457 lands.

Part of spine 2416 (step 1b). Closes #2438.
