### PR TITLE
feat(jq): carry an owned value's position through the rest of a pipe (spine 2416 step 3)

### DIFF
--- a/docs/adrs/adr-0021.md
+++ b/docs/adrs/adr-0021.md
@@ -93,7 +93,20 @@ in-place transforms *inside owned values*, which have no node to stand on.
    (`path_context_absent_split`) and the rewrite is held equal to the gate by a test.
    (Step 2.)
 
-7. **No regrowth.** `tests/jq_path_context_arm_guard.rs` pins the eager evaluator's named
+7. **An owned value carries its position.** Real yq's nodes carry parent pointers, and a
+   builtin that builds a new value either hands it the input node's position (`to_entries`,
+   `sort`, `tostring`, `[...]`, a slice, a write) or starts a detached tree (`map`, `keys`,
+   `with_entries`, `{...}`, a literal); arithmetic and comparison stand where their left
+   operand stood, `min`/`max` are the child they picked, and navigation inside the new
+   value descends from its position. `OwnedIdentity` (`src/jq/eval_generic.rs`) records
+   that as the base document cursor plus the chain of owned ancestors descended through;
+   `owned_identity_rule` is the closed per-stage list, every entry an oracle capture, and
+   `eval_owned_identity_pipe` threads the identity through the rest of a pipe at the one
+   site where an owned value leaves the cursor domain. `parent` climbs the chain and then
+   continues into the document. A stage with no rule keeps its pipe on the eager
+   evaluator, so an unlisted builtin costs the migration, never an answer. (Step 3.)
+
+8. **No regrowth.** `tests/jq_path_context_arm_guard.rs` pins the eager evaluator's named
    handlers at their exact count (43 at the time of writing); a migration lowers the pin,
    and raising it requires the PR to say why the arm is not a migration. The evaluator is
    deleted, with the guard, when `path_context_needs_eager` never answers `true` and no
@@ -124,11 +137,19 @@ in-place transforms *inside owned values*, which have no node to stand on.
   becomes native inherits it, and a test guarding that construct's *rejection* keeps
   asserting the exit code and diagnostic, not an empty stdout.
 - **What remains on the eager route** is bounded by three reasons, each with a known
-  next step: path tracking through owned containers in the generic evaluator; the absent
-  shapes decision 6 leaves behind (`parent` from a possibly-absent position, navigation
-  after a non-navigational stage, a fan-out head); and native `eval_single` arms for the
-  constructs that still bridge (arithmetic, blocked on #2460; `and`/`or`,
-  `reduce`/`foreach`). The pin cannot be lowered honestly until a reason is removed,
+  next step: the owned-domain stages decision 7's list does not cover (a builtin with no
+  captured rule, path context read after `key`/`path` replaced the value, path context
+  under arithmetic); the absent shapes decision 6 leaves behind (`parent` from a
+  possibly-absent position, navigation after a non-navigational stage, a fan-out head);
+  and native `eval_single` arms for the constructs that still bridge (arithmetic, blocked
+  on #2460; `and`/`or`, `reduce`/`foreach`).
+- **The owned domain was where fidelity was worst.** Of 96 multi-stage owned-domain
+  shapes captured from yq for decision 7, the eager evaluator answered 47 differently:
+  `null` for the `key` of a detached value where yq prints nothing, `["a","b"]` for
+  `min | path` where yq navigates to the child, a `{"start":..}` component for a slice in
+  yq mode, the original document for `parent` inside a `to_entries` result. All 96 now
+  match (`test_owned_identity_rules_match_yq_2416`), and jq mode's relative `path(f)` is
+  unaffected. The pin cannot be lowered honestly until a reason is removed,
   because `path_context_needs_eager` hands whole pipes to the eager evaluator, where any
   arm can run.
 

--- a/docs/compliance/yq/limitations.md
+++ b/docs/compliance/yq/limitations.md
@@ -2163,14 +2163,14 @@ fixed on its own terms (#2375); the second is still open:
   $ printf 'a: 5\n'    | yq -o=json -I=0 '.a | map(. + 1) | key'    # "a"
   ```
 
-  **Residual gap, not yet fixed:** the *container* rows of the same arm diverge in the
-  opposite direction, and are untouched by #2375. yq's `map(f)` over a container builds a
-  new, detached node whose path is `[]`, so a downstream `key` emits nothing at all
-  (`printf 'a: [1,2]\n' | yq -o=json '.a | map(. + 1) | key'` prints nothing, exit 0),
-  where succinctly still reports the *pre-map* node's key (`"a"`). Passing a non-container
-  through with its path intact — which is what makes the scalar rows above correct — is the
-  same mechanism seen from the other side: yq never replaced the scalar node, so it kept
-  its own path.
+  The *container* rows of the same arm used to diverge in the opposite direction: yq's
+  `map(f)` over a container builds a new, detached node whose path is `[]`, so a downstream
+  `key` emits nothing at all (`printf 'a: [1,2]\n' | yq -o=json '.a | map(. + 1) | key'`
+  prints nothing, exit 0), where succinctly reported the *pre-map* node's key (`"a"`).
+  Closed by the owned identity pipe (spine 2416 step 3, ADR-0021 decision 7): `map`'s rule
+  there detaches a container result and passes a scalar through with its position, which
+  is the same mechanism seen from both sides — yq never replaced the scalar node, so it
+  kept its own path. Pinned in `test_owned_identity_rules_match_yq_2416`.
 - **`first(.a[])` on a genuinely-resolved scalar still raises** (`resolve_iterate_bounded`,
   shared by `resolve_node`'s own `Expr::Iterate` arm and `first`/`limit`'s fast path) —
   this function is also reached by `resolve_del_path_branches`'s comma-fanout fallback for a

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -21876,7 +21876,7 @@ pub(crate) fn index_component_value(idx: i64, key: Option<&NumberKey>) -> OwnedV
 /// into the one shared per-number rule rather than a second hand-copied
 /// `match key { ... }`, per CLAUDE.md's "duplicated predicates diverge
 /// silently".
-fn slice_component_value(
+pub(crate) fn slice_component_value(
     start: Option<i64>,
     start_key: Option<&NumberKey>,
     end: Option<i64>,
@@ -74132,14 +74132,30 @@ mod tests {
     // which evaluates via the *plain* (non-path-context) evaluator, losing
     // `key`/`file_index` for anything nested inside.
 
+    // Spine 2416 step 3 re-pinned these three to the reference: a comparison
+    // or arithmetic result stands where its *left operand* stood, and a
+    // literal has no position, so real yq prints nothing for each of them
+    // (captured live from v4.53.3 on `- 10\n- 20`: `.[] | (1==1) | key`,
+    // `.[] | (1+1) | key` and `.[] | (-1) | key` all print nothing, exit 0,
+    // while `.[] | (. == 10) | key` prints `0 1`). `key` is a yq builtin,
+    // so the yq capture is the reference in jq mode too. The `0 1` these
+    // used to pin was this evaluator's own answer.
     #[test]
     fn test_key_survives_comparison_mid_pipe() {
-        assert_eq!(outputs(b"[10,20]", ".[] | (1==1) | key"), vec!["0", "1"]);
+        assert_eq!(
+            outputs(b"[10,20]", ".[] | (1==1) | key"),
+            Vec::<String>::new()
+        );
+        assert_eq!(outputs(b"[10,20]", ".[] | (. == 10) | key"), vec!["0", "1"]);
     }
 
     #[test]
     fn test_key_survives_arithmetic_mid_pipe() {
-        assert_eq!(outputs(b"[10,20]", ".[] | (1+1) | key"), vec!["0", "1"]);
+        assert_eq!(
+            outputs(b"[10,20]", ".[] | (1+1) | key"),
+            Vec::<String>::new()
+        );
+        assert_eq!(outputs(b"[10,20]", ".[] | (. + 1) | key"), vec!["0", "1"]);
     }
 
     /// #1056: `eval_pipe_with_path_context_internal`'s own `Expr::Arithmetic`
@@ -74148,7 +74164,11 @@ mod tests {
     /// minus.
     #[test]
     fn test_key_survives_unary_minus_mid_pipe_1056() {
-        assert_eq!(outputs(b"[10,20]", ".[] | -(1) | key"), vec!["0", "1"]);
+        assert_eq!(
+            outputs(b"[10,20]", ".[] | -(1) | key"),
+            Vec::<String>::new()
+        );
+        assert_eq!(outputs(b"[10,20]", ".[] | -(.) | key"), vec!["0", "1"]);
     }
 
     #[test]

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -43,11 +43,11 @@ use super::eval::{
     has_type_mismatch_is_permissive, index_component_value, index_in_array_bounds,
     index_one_owned as index_owned_by_key, is_pure_chain_link, is_retryable_stop, literal_to_owned,
     needs_path_context, numeric_key_to_array_index, numeric_key_to_index, owned_bound_to_i64,
-    owned_to_string, prefer_pending_control, slice_object_as_yq_children, slice_owned_value_read,
-    streams_escaped_generator_prefix, substitute_bound_var, substitute_vars, suppress_or_raise,
-    suppresses, tonumber_from_str, vec_with_capacity, yq_negative_index_check, Control, Demand,
-    EvalError, EvalSemantics, EvalTag, Flow, JqSemantics, LimitN, PathTrail, QueryResult,
-    YqSemantics,
+    owned_to_string, prefer_pending_control, slice_component_value, slice_object_as_yq_children,
+    slice_owned_value_read, streams_escaped_generator_prefix, substitute_bound_var,
+    substitute_vars, suppress_or_raise, suppresses, tonumber_from_str, vec_with_capacity,
+    yq_negative_index_check, Control, Demand, EvalError, EvalSemantics, EvalTag, Flow, JqSemantics,
+    LimitN, PathTrail, QueryResult, YqSemantics,
 };
 #[cfg(test)]
 use super::expr::FuncDefBound;
@@ -5738,6 +5738,18 @@ fn eval_single<S: EvalSemantics, V: DocumentValue>(
                 return GenericResult::One(value);
             }
 
+            // #2416 step 3: the owned identity pipe lives in the sink route;
+            // the staged fold below would hand its owned values to
+            // `eval_on_owned` with no position.
+            if owned_identity_pipe_applies(exprs) {
+                return collect_each_generic::<S, V>(
+                    &Expr::Pipe(exprs.clone()),
+                    value,
+                    optional,
+                    cursor,
+                );
+            }
+
             let current = eval_single::<S, _>(&exprs[0], value, optional, cursor);
             fold_pipe_stages::<S, V>(current, &exprs[1..], optional)
         }
@@ -7424,12 +7436,41 @@ fn eval_each_pipe_generic<S: EvalSemantics, V: DocumentValue>(
     }
 
     let mut downstream: Option<Flow> = None;
+    // #2416 step 3: an owned value leaving the cursor domain at `first`
+    // carries its identity into the rest of the pipe when a later stage
+    // reads path context. Decided once, statically, so the per-item closure
+    // pays nothing for the ordinary pipe.
+    let identity_from_first = cursor.filter(|_| {
+        rest.iter().any(needs_path_context)
+            && !path_context_is_navigational(first)
+            && !path_context_stage_preserves_node(first)
+            && !needs_path_context(first)
+            && owned_identity_rule(first).is_some()
+            && owned_identity_pipe_supported(rest)
+    });
     // Same once-per-driver cache as `drive_pipe_elements_generic` (#1598):
     // this closure also runs once per item stage 1 produces.
     let mut rest = RestPipe::new(rest);
     let upstream = {
         let mut driver = |item: GenericItem<V>| -> Demand {
-            let flow = continue_pipe_element_generic::<S, V>(item, &mut rest, optional, &mut *sink);
+            let flow = match identity_from_first {
+                Some(c) => match owned_identity_materialize::<V>(item) {
+                    Ok(o) => match owned_identity_leaving_cursor::<S, V>(first, c, &o, optional) {
+                        Ok(id) => eval_owned_identity_pipe::<S, V>(
+                            rest.stages(),
+                            o,
+                            id.unwrap_or_else(OwnedIdentity::detached),
+                            optional,
+                            &mut *sink,
+                        ),
+                        Err(e) => Flow::Escaped(Control::Error(e)),
+                    },
+                    Err(control) => Flow::Escaped(control),
+                },
+                None => {
+                    continue_pipe_element_generic::<S, V>(item, &mut rest, optional, &mut *sink)
+                }
+            };
             match flow {
                 Flow::Exhausted => Demand::Continue,
                 other => {
@@ -11180,6 +11221,12 @@ fn path_context_needs_eager(exprs: &[Expr]) -> bool {
     if !exprs.iter().any(needs_path_context) {
         return false;
     }
+    // #2416 step 3: a pipe that leaves the cursor domain at a stage the
+    // owned identity pipe can follow is answered there, whatever the stages
+    // after it are.
+    if owned_identity_pipe_applies(exprs) {
+        return false;
+    }
     let mut is_node = true;
     let mut can_absent = false;
     // #2416 step 2: a head that can miss no longer sends the pipe here on
@@ -11721,20 +11768,33 @@ fn path_component_literal(component: &OwnedValue) -> Expr {
 /// which is the silent-fallback failure ADR-0021 was written to end. The
 /// `_` arm is reached only for a subtree with no path-context builtin in it.
 fn path_context_resolve_absent<V: DocumentValue>(expr: &Expr, pos: &PathContextPos<V>) -> Expr {
+    // An absent position always has at least one component -- it took a
+    // `.a`/`[i]` step to become absent -- so its key is the walk's own
+    // `path.last()`.
+    path_context_resolve_constants(expr, pos.path.last(), &pos.path)
+}
+
+/// [`path_context_resolve_absent`]'s worker, over the constants themselves:
+/// `key` is `None` where it emits nothing (the document root, #2421, or a
+/// detached owned root, #2416 step 3), and `path` is the full path. Shared
+/// with the owned identity pipe, whose `key`/`path` inside a `select`/`[..]`
+/// are constants for the same reason.
+fn path_context_resolve_constants(
+    expr: &Expr,
+    key: Option<&OwnedValue>,
+    path: &[OwnedValue],
+) -> Expr {
     if !needs_path_context(expr) {
         return expr.clone();
     }
-    let boxed = |e: &Expr| Box::new(path_context_resolve_absent::<V>(e, pos));
+    let boxed = |e: &Expr| Box::new(path_context_resolve_constants(e, key, path));
     match expr {
-        // `key` at the document root emits nothing (#2421). An absent
-        // position always has at least one component -- it took a `.a`/`[i]`
-        // step to become absent -- so this is the walk's own `path.last()`.
-        Expr::Builtin(Builtin::Key) => match pos.path.last() {
+        Expr::Builtin(Builtin::Key) => match key {
             Some(component) => path_component_literal(component),
             None => Expr::Builtin(Builtin::Empty),
         },
         Expr::Builtin(Builtin::PathNoArg) => {
-            let components: Vec<Expr> = pos.path.iter().map(path_component_literal).collect();
+            let components: Vec<Expr> = path.iter().map(path_component_literal).collect();
             Expr::Array(Box::new(match components.len() {
                 0 => Expr::Builtin(Builtin::Empty),
                 1 => components.into_iter().next().expect("len checked"),
@@ -11760,13 +11820,13 @@ fn path_context_resolve_absent<V: DocumentValue>(expr: &Expr, pos: &PathContextP
         Expr::Comma(exprs) => Expr::Comma(
             exprs
                 .iter()
-                .map(|e| path_context_resolve_absent::<V>(e, pos))
+                .map(|e| path_context_resolve_constants(e, key, path))
                 .collect(),
         ),
         Expr::Pipe(exprs) => Expr::Pipe(
             exprs
                 .iter()
-                .map(|e| path_context_resolve_absent::<V>(e, pos))
+                .map(|e| path_context_resolve_constants(e, key, path))
                 .collect(),
         ),
         Expr::Limit { n, expr } => Expr::Limit {
@@ -13186,6 +13246,799 @@ fn eval_builtin<S: EvalSemantics, V: DocumentValue>(
             // callers (tracked separately as #2280).
             let owned = owned_or_suppress!(to_owned_with_cursor(&value, cursor), optional);
             eval_on_owned::<S, _>(&Expr::Builtin(builtin.clone()), owned, optional)
+        }
+    }
+}
+
+// ===========================================================================
+// #2416 step 3: path context through owned containers
+// ===========================================================================
+
+/// Where an owned value stands in the document (#2416 step 3).
+///
+/// Real yq's nodes carry parent pointers, and a builtin that builds a new
+/// value either hands it the input node's *position* (`to_entries`, `sort`,
+/// `tostring`, `[...]`, a slice, a write) or starts a *detached* tree
+/// (`map`, `keys`, `with_entries`, `{...}`, a literal). Navigation inside the
+/// new value then descends from that position, and `parent` climbs back
+/// through the owned value and, at its root, into the document. Every row
+/// below was captured from yq v4.53.3 on `a: {b: [1, 2, 3], c: x, d: {e:
+/// 5}}`; the full capture is `test_owned_identity_rules_match_yq_2416` in
+/// `tests/yq_cli_tests.rs`:
+///
+/// ```text
+/// .a.b | to_entries | .[0].value | path        ["a","b",0,"value"]
+/// .a.b | to_entries | .[0].value | parent(3)   .a   (owned root, then the document)
+/// .a.b | map(. + 1) | .[0] | path              [0]  (detached root)
+/// .a.b | map(. + 1) | .[0] | parent(2)         nothing
+/// .a.b | .[0] + .[1] | key                     0    (the left operand's node)
+/// .a.b | min | path                            ["a","b",0]
+/// ```
+///
+/// `base` is the document node whose position the owned root inherited
+/// (`None` for a detached root); `ancestors` is the chain of owned values
+/// descended through to reach this one, each with the component taken. The
+/// chain holds the ancestor *values* rather than a root plus a relative
+/// path so that a stage rebuilding the value at a position (`to_entries`
+/// twice over) never has to patch a shared root: `parent` is simply the
+/// last link.
+struct OwnedIdentity<V: DocumentValue> {
+    base: Option<V::Cursor>,
+    ancestors: Vec<(Rc<OwnedValue>, OwnedValue)>,
+}
+
+impl<V: DocumentValue> Clone for OwnedIdentity<V> {
+    fn clone(&self) -> Self {
+        Self {
+            base: self.base,
+            ancestors: self.ancestors.clone(),
+        }
+    }
+}
+
+/// One level up from an [`OwnedIdentity`]: a value inside the owned tree,
+/// or the document node above its root.
+enum OwnedParent<V: DocumentValue> {
+    Owned(OwnedValue, OwnedIdentity<V>),
+    Node(V::Cursor),
+}
+
+impl<V: DocumentValue> OwnedIdentity<V> {
+    /// An owned root standing at `base`'s position.
+    fn kept(base: V::Cursor) -> Self {
+        Self {
+            base: Some(base),
+            ancestors: Vec::new(),
+        }
+    }
+
+    /// An owned root with no position at all.
+    fn detached() -> Self {
+        Self {
+            base: None,
+            ancestors: Vec::new(),
+        }
+    }
+
+    /// The identity of `component` inside `parent`, whose identity is `self`.
+    fn child(&self, parent: &Rc<OwnedValue>, component: OwnedValue) -> Self {
+        let mut ancestors = self.ancestors.clone();
+        ancestors.push((Rc::clone(parent), component));
+        Self {
+            base: self.base,
+            ancestors,
+        }
+    }
+
+    /// `key`: the last component taken, else the base node's own key, else
+    /// nothing (a detached root, or the document root -- #2421).
+    fn key(&self) -> Result<Option<OwnedValue>, EvalError> {
+        match self.ancestors.last() {
+            Some((_, component)) => Ok(Some(component.clone())),
+            None => match self.base {
+                Some(c) => cursor_key(&c),
+                None => Ok(None),
+            },
+        }
+    }
+
+    /// `path`: the base node's path, then every component taken.
+    fn path(&self) -> Result<Vec<OwnedValue>, EvalError> {
+        let mut path = match self.base {
+            Some(c) => cursor_path_and_ancestors(&c)?.0,
+            None => Vec::new(),
+        };
+        path.extend(
+            self.ancestors
+                .iter()
+                .map(|(_, component)| component.clone()),
+        );
+        Ok(path)
+    }
+
+    /// `parent`: the last ancestor inside the owned tree, else the document
+    /// node above the base (nothing above a detached root or the document
+    /// root).
+    fn parent(mut self) -> Option<OwnedParent<V>> {
+        match self.ancestors.pop() {
+            Some((value, _)) => Some(OwnedParent::Owned((*value).clone(), self)),
+            None => self
+                .base
+                .and_then(|c| c.document_parent())
+                .map(OwnedParent::Node),
+        }
+    }
+}
+
+/// How a stage that leaves the cursor domain positions its output (#2416
+/// step 3). A closed list: a stage with no rule keeps the pipe on the eager
+/// evaluator, exactly as before, so an unlisted builtin can only cost the
+/// migration, never an answer. Every entry is an oracle capture (see
+/// [`OwnedIdentity`]); a builtin real yq's lexer rejects (`add`, `explode`,
+/// `ascii_downcase`) has no row to match and is deliberately absent.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+enum OwnedIdentityRule {
+    /// The output stands where the input stood: `to_entries`, `sort`,
+    /// `tostring`, `length`, `[...]`, a slice, a write, `not`, `@json`.
+    Keeps,
+    /// The output starts a detached tree: `keys`, `with_entries`, `{...}`,
+    /// a literal.
+    Detaches,
+    /// `map`: a container input yields a detached tree (where `[.[] | f]`
+    /// keeps -- yq's own inconsistency, reproduced), but a scalar or `null`
+    /// passes through with its position (`.a | map(. + 1) | key` on `a: 5`
+    /// is `"a"`; on `a: [1, 2]` it is nothing).
+    DetachesContainer,
+    /// The output stands where the *left operand* stood: arithmetic,
+    /// comparison and unary minus (`.[0] + .[1] | key` is `0`; `1 + .[0] |
+    /// key` and `(1==1) | key` are nothing, a literal having no position).
+    LeftOperand,
+    /// `min`/`max`: the output *is* one of the input's children, at its own
+    /// position.
+    Extremum,
+    /// `a // b`: the output stands where whichever side produced it stood.
+    Alternative,
+    /// A literal slice. Mode decides (ADR-0018): real yq keeps the
+    /// container's position (`.a | .[0:3] | .[0] | path` is `["a",0]`,
+    /// `parent | parent` the root), while jq mode follows jq's own
+    /// `path(.a[0:3])` and takes the `{"start":s,"end":e}` component, the
+    /// model #2215 pinned for the extension builtins there.
+    Slice,
+}
+
+fn owned_identity_rule(stage: &Expr) -> Option<OwnedIdentityRule> {
+    use OwnedIdentityRule::{
+        Alternative, Detaches, DetachesContainer, Extremum, Keeps, LeftOperand, Slice,
+    };
+    Some(match strip_parens(stage) {
+        Expr::Slice { .. } => Slice,
+        Expr::Array(_)
+        | Expr::Not
+        | Expr::Format(FormatType::Json)
+        | Expr::Assign { .. }
+        | Expr::Update { .. } => Keeps,
+        Expr::Object(_) | Expr::Literal(_) => Detaches,
+        Expr::Arithmetic { .. } | Expr::Compare { .. } | Expr::Negate(_) => LeftOperand,
+        Expr::Alternative(..) => Alternative,
+        Expr::Builtin(builtin) => match builtin {
+            Builtin::ToString
+            | Builtin::ToJson
+            | Builtin::FromJson
+            | Builtin::Length
+            | Builtin::Type
+            | Builtin::ToEntries
+            | Builtin::FromEntries
+            | Builtin::Sort
+            | Builtin::SortBy(_)
+            | Builtin::Reverse
+            | Builtin::Unique
+            | Builtin::Flatten
+            | Builtin::Join(_)
+            | Builtin::Split(_)
+            | Builtin::Any
+            | Builtin::Contains(_)
+            | Builtin::Test(_)
+            | Builtin::GroupBy(_)
+            | Builtin::MapValues(_)
+            | Builtin::Has(_)
+            | Builtin::Tag
+            | Builtin::Kind
+            | Builtin::Style
+            | Builtin::Line
+            | Builtin::Column
+            | Builtin::Del(_)
+            | Builtin::Select(_) => Keeps,
+            Builtin::Keys | Builtin::KeysUnsorted | Builtin::WithEntries(_) => Detaches,
+            Builtin::Map(_) => DetachesContainer,
+            Builtin::Min | Builtin::Max => Extremum,
+            _ => return None,
+        },
+        _ => return None,
+    })
+}
+
+/// `((e))` positions its output exactly as `e` does.
+fn strip_parens(mut expr: &Expr) -> &Expr {
+    while let Expr::Paren(inner) = expr {
+        expr = inner;
+    }
+    expr
+}
+
+/// Navigation the owned identity pipe performs itself, so it can name the
+/// component each step takes. `Iterate` fans out, so it is navigation here
+/// but not an *operand* (see [`owned_identity_operand_supported`]).
+fn owned_identity_nav_supported(expr: &Expr) -> bool {
+    match expr {
+        Expr::Identity
+        | Expr::Field(_)
+        | Expr::Index { .. }
+        | Expr::Iterate
+        | Expr::Slice { .. } => true,
+        Expr::Optional(inner) | Expr::Paren(inner) => owned_identity_nav_supported(inner),
+        Expr::Pipe(exprs) => exprs.iter().all(owned_identity_nav_supported),
+        _ => false,
+    }
+}
+
+/// An operand whose identity can be named without evaluating a generator:
+/// `.`, a literal, or single-output navigation.
+fn owned_identity_operand_supported(expr: &Expr) -> bool {
+    match expr {
+        Expr::Identity
+        | Expr::Literal(_)
+        | Expr::Field(_)
+        | Expr::Index { .. }
+        | Expr::Slice { .. } => true,
+        Expr::Optional(inner) | Expr::Paren(inner) => owned_identity_operand_supported(inner),
+        Expr::Pipe(exprs) => exprs.iter().all(owned_identity_operand_supported),
+        _ => false,
+    }
+}
+
+/// The static gate for the owned identity pipe: every stage of `stages` is
+/// navigation, a path-context builtin answered from the identity, or a stage
+/// with an [`owned_identity_rule`] whose own path-context builtins (if any)
+/// resolve to constants. `key`/`path`/`file_index` turn the value into a
+/// fresh scalar, so nothing after one of them may read path context.
+fn owned_identity_pipe_supported(stages: &[Expr]) -> bool {
+    for (i, stage) in stages.iter().enumerate() {
+        let rest = &stages[i + 1..];
+        if owned_identity_nav_supported(stage) {
+            continue;
+        }
+        match strip_parens(stage) {
+            Expr::Builtin(Builtin::Key | Builtin::PathNoArg | Builtin::FileIndex) => {
+                return !rest.iter().any(needs_path_context);
+            }
+            Expr::Builtin(Builtin::Parent) => {}
+            Expr::Builtin(Builtin::ParentN(n)) if matches!(**n, Expr::Literal(_)) => {}
+            Expr::Arithmetic { left, .. } | Expr::Compare { left, .. } | Expr::Negate(left) => {
+                if needs_path_context(stage) || !owned_identity_operand_supported(left) {
+                    return false;
+                }
+            }
+            Expr::Alternative(left, right) => {
+                if needs_path_context(stage)
+                    || !owned_identity_operand_supported(left)
+                    || !owned_identity_operand_supported(right)
+                {
+                    return false;
+                }
+            }
+            _ => match owned_identity_rule(stage) {
+                Some(_) => {
+                    if needs_path_context(stage) && !path_context_absent_resolvable(stage) {
+                        return false;
+                    }
+                }
+                None => return false,
+            },
+        }
+    }
+    true
+}
+
+/// Whether a pipe leaves the cursor domain at a stage the owned identity
+/// pipe can follow: the first non-node-preserving stage has a rule, does not
+/// itself read path context, and everything after it is
+/// [`owned_identity_pipe_supported`]. Decided statically, once, by
+/// [`path_context_needs_eager`]; `false` means the pipe is either entirely
+/// in the cursor domain or still the eager evaluator's.
+fn owned_identity_pipe_applies(exprs: &[Expr]) -> bool {
+    for (i, stage) in exprs.iter().enumerate() {
+        if path_context_is_navigational(stage) || path_context_stage_preserves_node(stage) {
+            continue;
+        }
+        let rest = &exprs[i + 1..];
+        return rest.iter().any(needs_path_context)
+            && !needs_path_context(stage)
+            && owned_identity_rule(stage).is_some()
+            && owned_identity_pipe_supported(rest);
+    }
+    false
+}
+
+/// One navigation step over an owned value, naming the component taken.
+/// The *values* come from the ordinary owned evaluator, so every error
+/// message, `null` on a missing key and yq-mode indexing rule is the one the
+/// rest of the pipeline already produces; only the component is derived
+/// here, and only where a step can name one.
+fn owned_identity_step<S: EvalSemantics, V: DocumentValue>(
+    expr: &Expr,
+    value: &OwnedValue,
+    id: &OwnedIdentity<V>,
+    optional: bool,
+    out: &mut Vec<(OwnedValue, OwnedIdentity<V>)>,
+) -> Result<(), EvalError> {
+    match expr {
+        Expr::Identity => {
+            out.push((value.clone(), id.clone()));
+            Ok(())
+        }
+        Expr::Optional(inner) => owned_identity_step::<S, V>(inner, value, id, true, out),
+        Expr::Paren(inner) => owned_identity_step::<S, V>(inner, value, id, optional, out),
+        Expr::Pipe(exprs) => {
+            let mut current = vec![(value.clone(), id.clone())];
+            for stage in exprs {
+                let mut next = Vec::new();
+                for (v, vid) in &current {
+                    owned_identity_step::<S, V>(stage, v, vid, optional, &mut next)?;
+                }
+                current = next;
+            }
+            out.extend(current);
+            Ok(())
+        }
+        Expr::Slice {
+            start,
+            end,
+            start_key,
+            end_key,
+        } => {
+            let values = owned_identity_values::<S>(expr, value, optional)?;
+            if S::TAG == EvalTag::Yq {
+                out.extend(values.into_iter().map(|v| (v, id.clone())));
+            } else {
+                let parent = Rc::new(value.clone());
+                let component =
+                    slice_component_value(*start, start_key.as_ref(), *end, end_key.as_ref());
+                out.extend(
+                    values
+                        .into_iter()
+                        .map(|v| (v, id.child(&parent, component.clone()))),
+                );
+            }
+            Ok(())
+        }
+        Expr::Field(name) => {
+            let values = owned_identity_values::<S>(expr, value, optional)?;
+            let parent = Rc::new(value.clone());
+            out.extend(
+                values
+                    .into_iter()
+                    .map(|v| (v, id.child(&parent, OwnedValue::String(name.clone())))),
+            );
+            Ok(())
+        }
+        Expr::Index { idx, key } => {
+            let values = owned_identity_values::<S>(expr, value, optional)?;
+            let mut component = index_component_value(*idx, key.as_ref());
+            if let Some(elements) = value.as_array() {
+                if *idx < 0 && S::TAG == EvalTag::Yq {
+                    let resolved = elements.len() as i64 + *idx;
+                    if resolved >= 0 {
+                        component = OwnedValue::Int(resolved);
+                    }
+                }
+            }
+            let parent = Rc::new(value.clone());
+            out.extend(
+                values
+                    .into_iter()
+                    .map(|v| (v, id.child(&parent, component.clone()))),
+            );
+            Ok(())
+        }
+        Expr::Iterate => {
+            let values = owned_identity_values::<S>(expr, value, optional)?;
+            let parent = Rc::new(value.clone());
+            let components: Vec<OwnedValue> = match value {
+                OwnedValue::Array(items) => (0..items.len())
+                    .map(|i| OwnedValue::Int(i as i64))
+                    .collect(),
+                OwnedValue::Object(map) => {
+                    map.keys().map(|k| OwnedValue::String(k.clone())).collect()
+                }
+                _ => Vec::new(),
+            };
+            // The owned evaluator yields exactly one value per member; a
+            // mismatch means the input was not a container after all (an
+            // error or, under `?`, nothing), in which case the components
+            // are unused.
+            out.extend(
+                values
+                    .into_iter()
+                    .zip(components)
+                    .map(|(v, component)| (v, id.child(&parent, component))),
+            );
+            Ok(())
+        }
+        _ => unreachable!("owned_identity_nav_supported admits no other shape"),
+    }
+}
+
+/// Every output of `expr` over `value` in the ordinary owned evaluator.
+fn owned_identity_values<S: EvalSemantics>(
+    expr: &Expr,
+    value: &OwnedValue,
+    optional: bool,
+) -> Result<Vec<OwnedValue>, EvalError> {
+    let mut values = Vec::new();
+    match eval_each_owned::<S>(expr, value, optional, &mut |v| {
+        values.push(v);
+        Demand::Continue
+    }) {
+        Flow::Escaped(Control::Error(e)) => Err(e),
+        // A `break`/`halt` cannot come out of navigation; treat any other
+        // escape as "no more values" the way a collecting sink does.
+        _ => Ok(values),
+    }
+}
+
+/// The value and identity of an operand (`.`, a literal, single-output
+/// navigation) evaluated over `value`; `None` when it produced nothing.
+fn owned_identity_operand<S: EvalSemantics, V: DocumentValue>(
+    expr: &Expr,
+    value: &OwnedValue,
+    id: &OwnedIdentity<V>,
+    optional: bool,
+) -> Result<Option<(OwnedValue, OwnedIdentity<V>)>, EvalError> {
+    let expr = strip_parens(expr);
+    if let Expr::Literal(lit) = expr {
+        return Ok(Some((literal_to_owned(lit), OwnedIdentity::detached())));
+    }
+    let mut out = Vec::new();
+    owned_identity_step::<S, V>(expr, value, id, optional, &mut out)?;
+    Ok(out.into_iter().next())
+}
+
+/// The identity of `output`, an output of `stage` evaluated over `value`
+/// (whose identity is `id`), per the stage's [`OwnedIdentityRule`].
+/// `Alternative` is not answered here: its output is chosen by
+/// [`eval_owned_identity_alternative`], which knows which side produced it.
+fn owned_identity_after_stage<S: EvalSemantics, V: DocumentValue>(
+    stage: &Expr,
+    rule: OwnedIdentityRule,
+    value: &OwnedValue,
+    id: &OwnedIdentity<V>,
+    output: &OwnedValue,
+    optional: bool,
+) -> Result<Option<OwnedIdentity<V>>, EvalError> {
+    Ok(match rule {
+        OwnedIdentityRule::Keeps => Some(id.clone()),
+        OwnedIdentityRule::Slice => {
+            let Expr::Slice {
+                start,
+                end,
+                start_key,
+                end_key,
+            } = strip_parens(stage)
+            else {
+                unreachable!("Slice is assigned to Expr::Slice only")
+            };
+            Some(if S::TAG == EvalTag::Yq {
+                id.clone()
+            } else {
+                id.child(
+                    &Rc::new(value.clone()),
+                    slice_component_value(*start, start_key.as_ref(), *end, end_key.as_ref()),
+                )
+            })
+        }
+        OwnedIdentityRule::Detaches => Some(OwnedIdentity::detached()),
+        OwnedIdentityRule::DetachesContainer => {
+            if value.as_array().is_some() || value.as_object().is_some() {
+                Some(OwnedIdentity::detached())
+            } else {
+                Some(id.clone())
+            }
+        }
+        OwnedIdentityRule::LeftOperand => {
+            let (Expr::Arithmetic { left, .. } | Expr::Compare { left, .. } | Expr::Negate(left)) =
+                strip_parens(stage)
+            else {
+                unreachable!("LeftOperand is assigned to arithmetic, comparison and negation only")
+            };
+            owned_identity_operand::<S, V>(left, value, id, optional)?.map(|(_, oid)| oid)
+        }
+        OwnedIdentityRule::Extremum => {
+            let parent = Rc::new(value.clone());
+            let component = match value {
+                OwnedValue::Array(items) => items
+                    .iter()
+                    .position(|item| {
+                        crate::jq::eval::compare_values(item, output) == core::cmp::Ordering::Equal
+                    })
+                    .map(|i| OwnedValue::Int(i as i64)),
+                OwnedValue::Object(map) => map
+                    .iter()
+                    .find(|(_, item)| {
+                        crate::jq::eval::compare_values(item, output) == core::cmp::Ordering::Equal
+                    })
+                    .map(|(k, _)| OwnedValue::String(k.clone())),
+                _ => None,
+            };
+            component.map(|component| id.child(&parent, component))
+        }
+        OwnedIdentityRule::Alternative => {
+            unreachable!("Alternative is evaluated by eval_owned_identity_alternative")
+        }
+    })
+}
+
+/// Hand a value with no further identity to the rest of the pipe: the
+/// ordinary owned evaluator, or the sink when nothing is left.
+fn continue_owned_identity_plain<S: EvalSemantics, V: DocumentValue>(
+    rest: &[Expr],
+    value: OwnedValue,
+    optional: bool,
+    sink: &mut dyn FnMut(GenericItem<V>) -> Demand,
+) -> Flow {
+    if rest.is_empty() {
+        return push_one_generic(GenericItem::Owned(value), sink);
+    }
+    eval_each_owned::<S>(&Expr::Pipe(rest.to_vec()), &value, optional, &mut |o| {
+        sink(GenericItem::Owned(o))
+    })
+}
+
+/// Continue a pipe from one owned value carrying its identity, honouring
+/// `sink`'s demand. Escapes from a downstream stage are carried out through
+/// `pending`, the same way [`eval_each_pipe_generic`]'s own driver does.
+fn continue_owned_identity_items<S: EvalSemantics, V: DocumentValue>(
+    rest: &[Expr],
+    items: impl IntoIterator<Item = (OwnedValue, OwnedIdentity<V>)>,
+    optional: bool,
+    sink: &mut dyn FnMut(GenericItem<V>) -> Demand,
+) -> Flow {
+    for (v, vid) in items {
+        match eval_owned_identity_pipe::<S, V>(rest, v, vid, optional, sink) {
+            Flow::Exhausted => {}
+            other => return other,
+        }
+    }
+    Flow::Exhausted
+}
+
+/// `a // b` over an owned value with identity: the left operand's value if
+/// it is truthy (errors in it suppressed, as `//` does), else the right's.
+fn eval_owned_identity_alternative<S: EvalSemantics, V: DocumentValue>(
+    left: &Expr,
+    right: &Expr,
+    value: &OwnedValue,
+    id: &OwnedIdentity<V>,
+    optional: bool,
+) -> Result<Option<(OwnedValue, OwnedIdentity<V>)>, EvalError> {
+    if let Some((v, vid)) = owned_identity_operand::<S, V>(left, value, id, true)? {
+        if v.is_truthy() {
+            return Ok(Some((v, vid)));
+        }
+    }
+    owned_identity_operand::<S, V>(right, value, id, optional)
+}
+
+/// The owned identity pipe (#2416 step 3): evaluate `stages` from an owned
+/// `value` whose position is `id`, answering `key`/`path`/`parent`/
+/// `parent(n)`/`file_index` from the identity and threading it through
+/// navigation and every stage with an [`owned_identity_rule`]. A `parent`
+/// that climbs out of the owned tree hands the rest of the pipe back to
+/// [`eval_each_pipe_generic`] with the document cursor it reached.
+///
+/// Only reached for pipes [`owned_identity_pipe_supported`] accepted, so the
+/// `_` arms below are refusals of shapes the gate already declined, never
+/// fallbacks.
+fn eval_owned_identity_pipe<S: EvalSemantics, V: DocumentValue>(
+    stages: &[Expr],
+    value: OwnedValue,
+    id: OwnedIdentity<V>,
+    optional: bool,
+    sink: &mut dyn FnMut(GenericItem<V>) -> Demand,
+) -> Flow {
+    let Some((stage, rest)) = stages.split_first() else {
+        return push_one_generic(GenericItem::Owned(value), sink);
+    };
+    if owned_identity_nav_supported(stage) {
+        let mut out = Vec::new();
+        if let Err(e) = owned_identity_step::<S, V>(stage, &value, &id, optional, &mut out) {
+            return Flow::Escaped(Control::Error(e));
+        }
+        return continue_owned_identity_items::<S, V>(rest, out, optional, sink);
+    }
+    match strip_parens(stage) {
+        Expr::Builtin(Builtin::Key) => match id.key() {
+            Ok(Some(key)) => continue_owned_identity_plain::<S, V>(rest, key, optional, sink),
+            Ok(None) => Flow::Exhausted,
+            Err(e) => Flow::Escaped(Control::Error(e)),
+        },
+        Expr::Builtin(Builtin::PathNoArg) => match id.path() {
+            Ok(path) => {
+                continue_owned_identity_plain::<S, V>(rest, OwnedValue::Array(path), optional, sink)
+            }
+            Err(e) => Flow::Escaped(Control::Error(e)),
+        },
+        // The generic route carries no file-origin table (#2150, #2427).
+        Expr::Builtin(Builtin::FileIndex) => {
+            continue_owned_identity_plain::<S, V>(rest, OwnedValue::Int(0), optional, sink)
+        }
+        Expr::Builtin(Builtin::Parent) => match id.parent() {
+            Some(OwnedParent::Owned(v, vid)) => {
+                eval_owned_identity_pipe::<S, V>(rest, v, vid, optional, sink)
+            }
+            Some(OwnedParent::Node(c)) => {
+                eval_each_pipe_generic::<S, V>(rest, c.value(), optional, Some(c), sink)
+            }
+            None => Flow::Exhausted,
+        },
+        Expr::Builtin(Builtin::ParentN(n_expr)) => {
+            let Expr::Literal(lit) = &**n_expr else {
+                unreachable!("owned_identity_pipe_supported admits a literal n only")
+            };
+            let n = match id
+                .path()
+                .and_then(|path| classify_parent_n::<S>(&literal_to_owned(lit), path.len()))
+            {
+                Ok(n) => n,
+                Err(e) => return Flow::Escaped(Control::Error(e)),
+            };
+            let mut current = (value, id);
+            for climbed in 0..n {
+                match current.1.parent() {
+                    Some(OwnedParent::Owned(v, vid)) => current = (v, vid),
+                    Some(OwnedParent::Node(c)) => {
+                        return match cursor_ancestor(&c, n - climbed - 1) {
+                            Some(a) => eval_each_pipe_generic::<S, V>(
+                                rest,
+                                a.value(),
+                                optional,
+                                Some(a),
+                                sink,
+                            ),
+                            None => Flow::Exhausted,
+                        };
+                    }
+                    None => return Flow::Exhausted,
+                }
+            }
+            eval_owned_identity_pipe::<S, V>(rest, current.0, current.1, optional, sink)
+        }
+        Expr::Alternative(left, right) => {
+            match eval_owned_identity_alternative::<S, V>(left, right, &value, &id, optional) {
+                Ok(Some((v, vid))) => {
+                    eval_owned_identity_pipe::<S, V>(rest, v, vid, optional, sink)
+                }
+                Ok(None) => Flow::Exhausted,
+                Err(e) => Flow::Escaped(Control::Error(e)),
+            }
+        }
+        _ => {
+            let Some(rule) = owned_identity_rule(stage) else {
+                unreachable!("owned_identity_pipe_supported admits ruled stages only")
+            };
+            // A `key`/`path`/`file_index` inside the stage (`select(key ==
+            // 0)`, `[key, path]`) is a constant for a fixed identity, the
+            // same resolution the absent route applies (#2416 step 2).
+            let resolved;
+            let stage_expr = if needs_path_context(stage) {
+                let (key, path) = match (id.key(), id.path()) {
+                    (Ok(key), Ok(path)) => (key, path),
+                    (Err(e), _) | (_, Err(e)) => return Flow::Escaped(Control::Error(e)),
+                };
+                resolved = path_context_resolve_constants(stage, key.as_ref(), &path);
+                &resolved
+            } else {
+                stage
+            };
+            let mut downstream: Option<Flow> = None;
+            let upstream = eval_each_owned::<S>(stage_expr, &value, optional, &mut |output| {
+                let flow = match owned_identity_after_stage::<S, V>(
+                    stage, rule, &value, &id, &output, optional,
+                ) {
+                    Ok(Some(oid)) => {
+                        eval_owned_identity_pipe::<S, V>(rest, output, oid, optional, sink)
+                    }
+                    // The rule could not place the output (a left operand
+                    // that produced nothing, an extremum of a scalar): real
+                    // yq has no position for it either, so it continues
+                    // detached.
+                    Ok(None) => eval_owned_identity_pipe::<S, V>(
+                        rest,
+                        output,
+                        OwnedIdentity::detached(),
+                        optional,
+                        sink,
+                    ),
+                    Err(e) => Flow::Escaped(Control::Error(e)),
+                };
+                match flow {
+                    Flow::Exhausted => Demand::Continue,
+                    other => {
+                        downstream = Some(other);
+                        Demand::Stop
+                    }
+                }
+            });
+            match downstream {
+                Some(flow) => flow,
+                None => upstream,
+            }
+        }
+    }
+}
+
+/// One item produced by a stage leaving the cursor domain, as the owned
+/// value the identity pipe carries. `sort`/`reverse`/`keys` emit lazy
+/// sequences and lazy key lists rather than owned values, and a stage may
+/// hand a document value straight through; all of them stand at the same
+/// position, so all of them materialize here.
+fn owned_identity_materialize<V: DocumentValue>(
+    item: GenericItem<V>,
+) -> Result<OwnedValue, Control> {
+    match generic_item_to_result(item).materialize_lazy() {
+        GenericResult::Owned(o) => Ok(o),
+        GenericResult::One(v) => to_owned(&v).map_err(Control::Error),
+        GenericResult::OneCursor(c) => to_owned_cursor(&c).map_err(Control::Error),
+        GenericResult::Error(e) => Err(Control::Error(e)),
+        GenericResult::Break(label) => Err(Control::Break(label)),
+        GenericResult::Halt(code) => Err(Control::Halt(code)),
+        // `generic_item_to_result` maps one item to `One`/`OneCursor`/
+        // `Owned` or a lazy variant, and `materialize_lazy` maps those to
+        // `Owned` or an escape.
+        _ => unreachable!("a single pipe item never materializes to a stream"),
+    }
+}
+
+/// The identity of `output`, produced by `stage` from the document node at
+/// `cursor` -- the boundary where a value first leaves the cursor domain
+/// (#2416 step 3). Rules that name a *child* of the input (`min`, a left
+/// operand `.[0]`) navigate an owned copy of the node, which the stage has
+/// already materialized to compute its output.
+fn owned_identity_leaving_cursor<S: EvalSemantics, V: DocumentValue>(
+    stage: &Expr,
+    cursor: V::Cursor,
+    output: &OwnedValue,
+    optional: bool,
+) -> Result<Option<OwnedIdentity<V>>, EvalError> {
+    let Some(rule) = owned_identity_rule(stage) else {
+        return Ok(None);
+    };
+    let id = OwnedIdentity::kept(cursor);
+    match rule {
+        OwnedIdentityRule::Keeps => Ok(Some(id)),
+        OwnedIdentityRule::Detaches => Ok(Some(OwnedIdentity::detached())),
+        OwnedIdentityRule::DetachesContainer => Ok(Some(if cursor.is_container() {
+            OwnedIdentity::detached()
+        } else {
+            id
+        })),
+        OwnedIdentityRule::LeftOperand | OwnedIdentityRule::Extremum | OwnedIdentityRule::Slice => {
+            // STYLE-0012: the stage that produced `output` already
+            // materialized this node under the same `optional`, so a decode
+            // failure here cannot be the first one seen; it raises as the
+            // internal invariant it is.
+            let input = to_owned_cursor(&cursor)?;
+            owned_identity_after_stage::<S, V>(stage, rule, &input, &id, output, optional)
+        }
+        OwnedIdentityRule::Alternative => {
+            let Expr::Alternative(left, right) = strip_parens(stage) else {
+                unreachable!("Alternative is assigned to Expr::Alternative only")
+            };
+            // STYLE-0012: same invariant as the arm above.
+            let input = to_owned_cursor(&cursor)?;
+            Ok(
+                eval_owned_identity_alternative::<S, V>(left, right, &input, &id, optional)?
+                    .map(|(_, oid)| oid),
+            )
         }
     }
 }
@@ -21923,10 +22776,30 @@ mod tests {
             eager(".[] | key + 10"),
             "arithmetic still bridges from eval_single"
         );
-        // Reason 1: an owned-domain stage before the builtin.
-        assert!(eager(".a | tostring | key"));
-        assert!(eager("to_entries | .[0] | key"));
-        assert!(eager("[.a] | .[0] | parent"));
+        // Reason 1, an owned-domain stage before the builtin, is answered
+        // by the owned identity pipe (#2416 step 3) wherever the stage has
+        // an `owned_identity_rule` and the rest reads the position it
+        // carries...
+        assert!(!eager(".a | tostring | key"));
+        assert!(!eager("to_entries | .[0] | key"));
+        assert!(!eager("[.a] | .[0] | parent"));
+        assert!(!eager(".a | .[0] + .[1] | key"));
+        assert!(!eager(".a | min | parent | key"));
+        assert!(!eager(".a | to_entries | .[] | select(key == 0)"));
+        // ...and stays eager where it has no rule, where path context is
+        // read after `key`/`path` already replaced the value, where the
+        // stage itself reads path context, or where a later stage does so
+        // in a shape the constants cannot express.
+        assert!(eager(".a | ascii_downcase | key"), "no identity rule");
+        assert!(eager(".a | tostring | key | key"), "key after key");
+        assert!(
+            eager(".a | [key] | .[0] | path"),
+            "the stage reads path context"
+        );
+        assert!(
+            eager(".a | to_entries | .[0] | key + 1"),
+            "path context under arithmetic"
+        );
         // #2416 step 2: a head that can reach an absent node is no longer a
         // reason on its own -- `path_context_absent_split` walks the head as
         // positions and resolves the rest's `key`/`path`/`file_index`

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -12624,11 +12624,19 @@ fn test_path_context_builtins_across_pipe_stages_554() -> Result<()> {
 }
 
 /// yq-mode counterpart to `jq_cli_tests.rs`'s
-/// `test_literal_slice_path_context_resolves_2215` -- the new
-/// `eval_stage_with_path_context` `Expr::Slice` arm lives on the shared
-/// `<S: EvalSemantics>` evaluator, so this file needs its own dedicated
-/// check rather than relying on the jq-mode coverage alone (a jq-scoped fix
-/// to shared evaluator code can silently regress yq without one).
+/// `test_literal_slice_path_context_resolves_2215`. The two modes answer
+/// differently on purpose (ADR-0018): jq mode follows jq's own
+/// `path(.a[0:3])` and names a `{"start":s,"end":e}` component, while real
+/// yq keeps the container's position for a slice. The rows here used to
+/// pin the jq model for yq mode too; spine 2416 step 3 re-pinned them to
+/// the capture (yq v4.53.3, `-o=json -I0`, on `a: [1, 2, 3, 4]`):
+///
+/// ```text
+/// .a | .[0:3] | path          ["a"]
+/// .a | .[0:3] | key           "a"
+/// .a | .[0:3] | .[0]          1
+/// .a | .[0:3] | .[0] | path   ["a",0]
+/// ```
 #[test]
 fn test_literal_slice_path_context_resolves_yq_2215() -> Result<()> {
     let (output, code) = run_yq_stdin(
@@ -12637,7 +12645,7 @@ fn test_literal_slice_path_context_resolves_yq_2215() -> Result<()> {
         &["-o", "json", "-I0"],
     )?;
     assert_eq!(code, 0);
-    assert_eq!(output.trim(), r#"["a",{"start":0,"end":3}]"#);
+    assert_eq!(output.trim(), r#"["a"]"#);
 
     let (output, code) = run_yq_stdin(
         ".a | .[0:3] | key",
@@ -12645,7 +12653,15 @@ fn test_literal_slice_path_context_resolves_yq_2215() -> Result<()> {
         &["-o", "json", "-I0"],
     )?;
     assert_eq!(code, 0);
-    assert_eq!(output.trim(), r#"{"start":0,"end":3}"#);
+    assert_eq!(output.trim(), r#""a""#);
+
+    let (output, code) = run_yq_stdin(
+        ".a | .[0:3] | .[0] | path",
+        "a: [1, 2, 3, 4]\n",
+        &["-o", "json", "-I0"],
+    )?;
+    assert_eq!(code, 0);
+    assert_eq!(output.trim(), r#"["a",0]"#);
 
     let (output, code) = run_yq_stdin(
         ".a | .[0:3] | .[0]",
@@ -31363,3 +31379,275 @@ fn test_absent_position_parent_still_takes_the_eager_route_2416() -> Result<()> 
     assert_eq!(output.trim(), "[[\"a\",\"x\",\"y\"],{}]");
     Ok(())
 }
+
+/// #2416 step 3: path context through owned containers. A builtin that builds
+/// a new value either hands it the input node's position (`to_entries`,
+/// `sort`, `tostring`, `[...]`, a slice, a write) or starts a detached tree
+/// (`map`, `keys`, `with_entries`, `{...}`, a literal); navigation inside the
+/// new value descends from that position, arithmetic and comparison stand
+/// where their *left* operand stood, `min`/`max` are the child they picked,
+/// and `parent` climbs back through the owned value and then into the
+/// document. Every row was captured from yq v4.53.3 (`-o=json -I0`) on
+/// `OWNED_IDENTITY_DOC_2416`; the eager evaluator answered 47 of them
+/// differently before the owned identity pipe (`null` for a detached `key`,
+/// `["a","b"]` for `min | path`, a `{"start":..}` component for a slice).
+#[test]
+fn test_owned_identity_rules_match_yq_2416() -> Result<()> {
+    let args = &["-o", "json", "-I0"];
+    for (filter, expected) in OWNED_IDENTITY_ROWS_2416 {
+        let (output, code) = run_yq_stdin(filter, OWNED_IDENTITY_DOC_2416, args)?;
+        assert_eq!(code, 0, "{filter}");
+        assert_eq!(output.trim_end(), *expected, "{filter}");
+    }
+    // `map` over a scalar or `null` passes the value through with its
+    // position; only a container result is detached (the residual gap
+    // limitations.md recorded against #2375):
+    // $ yq -o=json -I0 '.a | map(. + 1) | key'     =>  "a"    (a: 5)
+    // $ yq -o=json -I0 '.a | map(. + 1) | path'    =>  ["a"]
+    // $ yq -o=json -I0 '.b | map(. + 1) | key'     =>  "b"    (b: null)
+    // $ yq -o=json -I0 '.d | map(. + 1) | key'     =>  (nothing)   (d: [1, 2])
+    // $ yq -o=json -I0 '.e | map(. + 1) | path'    =>  []     (e: {f: 1})
+    // $ yq -o=json -I0 '.d | map(.) | .[0] | path' =>  [0]
+    // A literal left operand has no position (yq lexes `-(1)` differently,
+    // so the unary-minus row is `(-1)`):
+    // $ yq -o=json -I0 '.[] | (1==1) | key'    =>  (nothing)   on `- 10\n- 20`
+    // $ yq -o=json -I0 '.[] | (1+1) | key'     =>  (nothing)
+    // $ yq -o=json -I0 '.[] | (-1) | key'      =>  (nothing)
+    // $ yq -o=json -I0 '.[] | (. == 10) | key' =>  0 / 1
+    for (filter, expected) in [
+        (".[] | (1==1) | key", ""),
+        (".[] | (1+1) | key", ""),
+        (".[] | (-1) | key", ""),
+        (".[] | (. == 10) | key", "0\n1"),
+    ] {
+        let (output, code) = run_yq_stdin(filter, "- 10\n- 20\n", args)?;
+        assert_eq!(code, 0, "{filter}");
+        assert_eq!(output.trim_end(), expected, "{filter}");
+    }
+    let doc = "a: 5\nb: null\nc: s\nd: [1, 2]\ne: {f: 1}\n";
+    for (filter, expected) in [
+        (".a | map(. + 1) | key", "\"a\""),
+        (".a | map(. + 1) | path", "[\"a\"]"),
+        (".b | map(. + 1) | key", "\"b\""),
+        (".b | map(. + 1) | path", "[\"b\"]"),
+        (".c | map(. + 1) | key", "\"c\""),
+        (".d | map(. + 1) | key", ""),
+        (".e | map(. + 1) | key", ""),
+        (".e | map(. + 1) | path", "[]"),
+        (".d | map(.) | .[0] | path", "[0]"),
+        (".e | map(.) | .[0] | path", "[0]"),
+    ] {
+        let (output, code) = run_yq_stdin(filter, doc, args)?;
+        assert_eq!(code, 0, "{filter}");
+        assert_eq!(output.trim_end(), expected, "{filter}");
+    }
+    Ok(())
+}
+
+const OWNED_IDENTITY_DOC_2416: &str = "a:\n  b: [1, 2, 3]\n  c: x\n  d: {e: 5}\nz: 9\n";
+
+/// `(filter, expected stdout)`, captured from yq v4.53.3; an empty expected
+/// string is a filter that printed nothing. yq's `downcase`/`upcase` rows
+/// (`.a.c | downcase | key` is `"c"`) are #2462, not here.
+const OWNED_IDENTITY_ROWS_2416: &[(&str, &str)] = &[
+    (".a.c | tostring | key", r#""c""#),
+    (".a.c | tostring | path", r#"["a","c"]"#),
+    (
+        ".a.c | tostring | parent",
+        r#"{"b":[1,2,3],"c":"x","d":{"e":5}}"#,
+    ),
+    (".a.c | tostring | tostring | key", r#""c""#),
+    (r#".a.c | . + "y" | key"#, r#""c""#),
+    (r#".a.c | . + "y" | path"#, r#"["a","c"]"#),
+    (".a.b | .[0] + 1 | key", "0"),
+    (".a.b | length | key", r#""b""#),
+    (".a.b | length | path", r#"["a","b"]"#),
+    (".a.b | to_entries | key", r#""b""#),
+    (".a.b | to_entries | path", r#"["a","b"]"#),
+    (".a.b | to_entries | .[0] | key", "0"),
+    (".a.b | to_entries | .[0] | path", r#"["a","b",0]"#),
+    (
+        ".a.b | to_entries | .[0] | parent",
+        r#"[{"key":0,"value":1},{"key":1,"value":2},{"key":2,"value":3}]"#,
+    ),
+    (".a.b | to_entries | .[0].value | key", r#""value""#),
+    (
+        ".a.b | to_entries | .[0].value | path",
+        r#"["a","b",0,"value"]"#,
+    ),
+    (
+        ".a.b | to_entries | .[0].value | parent",
+        r#"{"key":0,"value":1}"#,
+    ),
+    (
+        ".a.b | to_entries | .[] | parent | key",
+        r#""b"
+"b"
+"b""#,
+    ),
+    (".a.b | map(. + 1) | key", ""),
+    (".a.b | map(. + 1) | .[0] | key", "0"),
+    (".a.b | map(. + 1) | .[0] | path", "[0]"),
+    (".a.b | map(. + 1) | .[0] | parent", "[2,3,4]"),
+    (".a.b | map(.) | .[1] | path", "[1]"),
+    (".a.d | keys | .[0] | key", "0"),
+    (".a.d | keys | .[0] | path", "[0]"),
+    (".a.b | sort | .[0] | key", "0"),
+    (".a.b | sort | .[0] | path", r#"["a","b",0]"#),
+    (".a.b | reverse | .[0] | path", r#"["a","b",0]"#),
+    (".a.b | reverse | .[0] | key", "0"),
+    (".a.b | unique | .[1] | path", r#"["a","b",1]"#),
+    (".a.d | with_entries(.) | .e | key", r#""e""#),
+    (".a.d | with_entries(.) | .e | path", r#"["e"]"#),
+    (".a.d | with_entries(.) | .e | parent", r#"{"e":5}"#),
+    (".a.b | min | key", "0"),
+    (".a.b | min | path", r#"["a","b",0]"#),
+    (".a.b | min | parent | key", r#""b""#),
+    ("[.a.c] | .[0] | key", "0"),
+    ("[.a.c] | .[0] | path", "[0]"),
+    ("[.a.c] | .[0] | parent", r#"["x"]"#),
+    ("[.a.c] | key", ""),
+    ("[.a.c, .z] | .[1] | path", "[1]"),
+    (".a.b | tojson | key", r#""b""#),
+    (".a.b | tojson | path", r#"["a","b"]"#),
+    (".a.b | flatten | .[0] | path", r#"["a","b",0]"#),
+    (".a.b | flatten | key", r#""b""#),
+    (".a.d | to_entries | from_entries | key", r#""d""#),
+    (
+        ".a.d | to_entries | from_entries | .e | path",
+        r#"["a","d","e"]"#,
+    ),
+    (".a.b | .[0:2] | key", r#""b""#),
+    (".a.b | .[0:2] | .[0] | path", r#"["a","b",0]"#),
+    (".a.b | .[0:2] | path", r#"["a","b"]"#),
+    (r#".a.c | split("") | .[0] | path"#, r#"["a","c",0]"#),
+    (r#".a.b | join(",") | key"#, r#""b""#),
+    (".a.b | [.[] | . * 2] | .[0] | path", r#"["a","b",0]"#),
+    (".a.b | map_values(. + 1) | .[0] | path", r#"["a","b",0]"#),
+    (".a.b | map_values(. + 1) | .[0] | key", "0"),
+    (".a.b | map_values(. + 1) | key", r#""b""#),
+    (r#".a | {"x": .c} | key"#, ""),
+    (r#".a | {"x": .c} | path"#, "[]"),
+    (r#".a | {"x": .c} | .x | key"#, r#""x""#),
+    (r#".a | {"x": .c} | .x | path"#, r#"["x"]"#),
+    (r#".a | {"x": .c} | .x | parent"#, r#"{"x":"x"}"#),
+    (".a.b | 1 | key", ""),
+    (r#".a.b | "s" | path"#, "[]"),
+    (".a.b | [] | key", r#""b""#),
+    (".a.b | {} | path", "[]"),
+    (".a.b | null | key", ""),
+    (".a.b | [.[]] | key", r#""b""#),
+    (".a.b | [.[]] | .[1] | path", r#"["a","b",1]"#),
+    (".a.b | .[0] | . * 2 | key", "0"),
+    (".a.b | 1 + .[0] | key", ""),
+    (".a.b | .[0] + .[1] | key", "0"),
+    (".a.b | .[0] + .[1] | path", r#"["a","b",0]"#),
+    (".a.b | .[1] - .[0] | path", r#"["a","b",1]"#),
+    (".a.b | .[0] == 1 | key", "0"),
+    (".a.b | .[0] == 1 | path", r#"["a","b",0]"#),
+    (".a.b | not | key", r#""b""#),
+    (".a.b | .[-1] | key", "2"),
+    (".a.b | .[-1] | path", r#"["a","b",2]"#),
+    (".a.b | . as $x | $x | key", r#""b""#),
+    (".a.b | . as $x | $x | path", r#"["a","b"]"#),
+    (".a.b | . as $x | $x[0] | path", r#"["a","b",0]"#),
+    (
+        ".a.b | (.[0], .[1]) | key",
+        "0
+1",
+    ),
+    (".a.b | . // 1 | key", r#""b""#),
+    (".a.q // .a.b | key", r#""b""#),
+    (".a.b | .[5] // .[0] | path", r#"["a","b",0]"#),
+    (".a.b | any | key", r#""b""#),
+    (".a.b | contains([1]) | key", r#""b""#),
+    (r#".a.c | test("x") | key"#, r#""c""#),
+    (r#".a.c | sub("x"; "y") | key"#, r#""c""#),
+    (r#".a.c | sub("x"; "y") | path"#, r#"["a","c"]"#),
+    (".a | del(.c) | key", r#""a""#),
+    (".a | del(.c) | .b | path", r#"["a","b"]"#),
+    (".a | .c = 1 | key", r#""a""#),
+    (".a | .c = 1 | .c | path", r#"["a","c"]"#),
+    (
+        ".a | .c = 1 | .c | parent",
+        r#"{"b":[1,2,3],"c":1,"d":{"e":5}}"#,
+    ),
+    (".a | .b[0] = 9 | .b[0] | path", r#"["a","b",0]"#),
+    (".a.b | .[0] |= . + 1 | .[0] | path", r#"["a","b",0]"#),
+    (".a.b | tojson | fromjson | key", r#""b""#),
+    (".a.b | tojson | fromjson | .[0] | path", r#"["a","b",0]"#),
+    (".a.b | @json | key", r#""b""#),
+    (".a.b | sort_by(.) | .[0] | path", r#"["a","b",0]"#),
+    (".a.b | group_by(.) | key", r#""b""#),
+    (".a.b | group_by(.) | .[0] | path", r#"["a","b",0]"#),
+    (".a.b | group_by(.) | .[0][0] | path", r#"["a","b",0,0]"#),
+    (".a | to_entries | map(.key) | .[0] | path", "[0]"),
+    (".a | to_entries | map(.key) | key", ""),
+    (".a | with_entries(.) | key", ""),
+    (
+        ".a.b | to_entries | .[0] | .value | . + 1 | key",
+        r#""value""#,
+    ),
+    (
+        ".a.b | to_entries | .[0] | .value | . + 1 | path",
+        r#"["a","b",0,"value"]"#,
+    ),
+    (".a.b | max | path", r#"["a","b",2]"#),
+    (".a.b | max | parent", "[1,2,3]"),
+    (".a.b | min | parent", "[1,2,3]"),
+    (
+        ".a.d | to_entries | .[0].key | path",
+        r#"["a","d",0,"key"]"#,
+    ),
+    (
+        ".a.d | to_entries | .[0].key | parent",
+        r#"{"key":"e","value":5}"#,
+    ),
+    (".a.b | .[1:] | .[0] | path", r#"["a","b",0]"#),
+    (".a.b | .[1:] | key", r#""b""#),
+    (r#".a.c | split("") | key"#, r#""c""#),
+    (r#".a.c | split("") | .[0] | parent"#, r#"["x"]"#),
+    (r#".a.b | join(",") | path"#, r#"["a","b"]"#),
+    (
+        r#".a.b | join(",") | parent"#,
+        r#"{"b":[1,2,3],"c":"x","d":{"e":5}}"#,
+    ),
+    (".a.b | (.[0] + 1) | key", "0"),
+    (".a.b | [.[] | . + 1] | key", r#""b""#),
+    (".a.b | [.[] | . + 1] | .[0] | parent", "[2,3,4]"),
+    (".a.b | [.[] | . + 1] | .[0] | parent | key", r#""b""#),
+    (".a.b | map(. + 1) | .[0] | parent | key", ""),
+    (".a.b | map(. + 1) | .[0] | parent | path", "[]"),
+    (".a.d | keys | key", ""),
+    (".a.d | keys | path", "[]"),
+    (".a.d | keys | .[0] | parent | path", "[]"),
+    (
+        ".a.b | length | parent",
+        r#"{"b":[1,2,3],"c":"x","d":{"e":5}}"#,
+    ),
+    (".a.b | tostring | .[0:1] | key", r#""b""#),
+    (".a.b | to_entries | .[0].value | parent | key", "0"),
+    (
+        ".a.b | to_entries | .[0].value | parent | path",
+        r#"["a","b",0]"#,
+    ),
+    (
+        ".a.b | to_entries | .[0].value | parent | parent | path",
+        r#"["a","b"]"#,
+    ),
+    (
+        ".a.b | to_entries | .[0].value | parent(2) | path",
+        r#"["a","b"]"#,
+    ),
+    (
+        ".a.b | to_entries | .[0].value | parent(3) | path",
+        r#"["a"]"#,
+    ),
+    (".a.b | to_entries | .[0].value | parent(3) | key", r#""a""#),
+    (".a.b | to_entries | .[0].value | parent(4) | key", ""),
+    (".a.b | map(. + 1) | .[0] | parent(2) | key", ""),
+    (".a.b | map(. + 1) | .[0] | parent(2) | path", ""),
+    (".a.b | map(. + 1) | .[0] | parent | parent | path", ""),
+    (".a.b | sort | .[0] | parent | path", r#"["a","b"]"#),
+    (".a.b | sort | .[0] | parent | parent | key", r#""a""#),
+];


### PR DESCRIPTION
## Summary

Step 3 of spine 2416: an owned value now carries its position through the rest of a pipe, so `.a.b | to_entries | .[0].value | parent(3) | key`, `.a.b | min | path`, `[.a.c] | .[0] | parent` and `.a.b | .[0] + .[1] | key` no longer need the eager evaluator.

Real yq's nodes carry parent pointers. A builtin that builds a new value either hands it the input node's position (`to_entries`, `sort`, `tostring`, `length`, `[...]`, a slice, a write) or starts a detached tree (`keys`, `with_entries`, `{...}`, a literal; `map` over a container, but not over a scalar); arithmetic, comparison and unary minus stand where their left operand stood; `min`/`max` are the child they picked; `a // b` stands where the chosen side stood. A slice splits by mode: real yq keeps the container's position (`.a | .[0:3] | .[0] | path` is `["a",0]`, `parent | parent` the root), while jq mode follows jq's own `path(.a[0:3])` and takes the `{"start":s,"end":e}` component, the model #2215 pinned for the extension builtins there. Navigation inside the new value descends from that position, and `parent` climbs back through the owned value and then into the document.

- `OwnedIdentity` records a base document cursor plus the chain of owned ancestors descended through, so a value rebuilt at a position never patches a shared root. `owned_identity_rule` is the closed per-stage list, every entry an oracle capture; a stage with no rule keeps its pipe on the eager evaluator, so an unlisted builtin costs the migration, never an answer.
- `eval_owned_identity_pipe` threads the identity through navigation, path-context builtins and ruled stages at the one site where an owned value leaves the cursor domain (`eval_each_pipe_generic`'s driver, with `eval_single`'s Pipe arm collecting through it). Lazy sequences and lazy key lists (`sort`, `reverse`, `keys`) are materialized at that boundary. `key`/`path` inside a `select`/`[..]` resolve to constants through the step 2 resolver, now shared as `path_context_resolve_constants`.
- `path_context_needs_eager`'s owned-domain reason is narrowed to stages the rule does not cover, path context read after `key`/`path` replaced the value, and path context under arithmetic. The arm pin stays at 43.
- ADR-0021 gains decision 7; the limitations entry for `map` over a container is closed.

## Fidelity

This is where fidelity was worst. Of 96 multi-stage owned-domain shapes captured from yq v4.53.3 (two batches, both docs in the test), the eager evaluator answered 47 differently: `null` for the `key` of a detached value where yq prints nothing, `["a","b"]` for `min | path` where yq navigates to the child, a `{"start":..,"end":..}` component for a slice in yq mode, the original document for `parent` inside a `to_entries` result, `"b"` for `.[0] + .[1] | key` where yq answers `0`. All 96 now match, pinned in `test_owned_identity_rules_match_yq_2416` (143 rows plus the `map`-over-scalar and literal-operand rows). Three old-evaluator unit tests that pinned `0 1` for `.[] | (1==1) | key` are re-pinned to the capture (nothing; `key` is a yq builtin, so the yq capture is the reference in jq mode too). jq mode's relative `path(f)` is unaffected (seven rows checked against `/usr/bin/jq` 1.7.1). The two `downcase`/`upcase` rows are #2462.

## Verification

fmt; clippy on both CI feature legs with `-D warnings`; `cargo test --features cli,simd,regex,serde`; default `cargo test`; `--no-default-features`; `cargo doc -D warnings`; yq goldens 113 and jq goldens 633 up to date; oracle sweep 3168 cases, 0 unexpected, manifest unchanged.

Part of spine 2416 (step 3).
