### PR TITLE
fix(yaml): reject anchor-on-alias (&anchor *alias) in the default loader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -398,6 +398,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`succinctly yq`'s default (non-validating) YAML loader now rejects `&anchor *alias`
+  (an alias node decorated with its own anchor or tag) at parse time, matching real yq and
+  PyYAML** (#1374). Per the YAML 1.2 grammar an alias node carries no properties of its
+  own; the opt-in strict validator (`check_after_anchor`, `src/yaml/validate.rs`) already
+  enforced this, but the default loader silently accepted it and built a walkable
+  alias-to-alias chain from it — the *only* shape that can construct a multi-hop alias
+  chain, and the root cause behind every multi-hop-chain bug this codebase has had
+  (#1193's stack-overflow DoS; #1315/#1318/#1319's single-hop-only accessor bugs, now
+  closed alongside this fix). `YamlIndex::build` now returns a new `YamlError::PropertyOnAlias`
+  for every spelling (block value, next line, flow sequence/mapping, mapping key, `!!str`
+  tag) rather than accepting it:
+
+  ```console
+  $ printf 'a0: &a0 hello\na1: &a1 *a0\nz: *a1\n' | succinctly yq -o json '.'
+  Error: YAML parse error: alias '*a0' at offset 22 cannot carry an anchor or tag (an alias node has no node properties)
+  ```
+
+  A document-root form across a `---` multi-document separator (`--- &a0 hello\n--- &a1
+  *a0`) is rejected too, even though real yq accepts it there — real yq's own output for
+  that shape is corrupted (`"hello--- &a1 *a0"`, concatenating the prior document's value
+  with the next line's literal text), so matching would mean reproducing the corruption
+  rather than the behaviour (ADR-0018 rule 4(b)); see
+  [docs/compliance/yq/limitations.md](docs/compliance/yq/limitations.md#anchor-on-alias-at-document-root-level--rule-4b).
+  `MAX_ALIAS_CHAIN_DEPTH` remains in `src/yaml/light.rs` purely as defense in depth, since a
+  parser-built index can no longer reach a chain depth past 1 through any valid input.
+
 - **Two rows of #2349's own delimiter-consistency matrix stayed open after that fix
   landed** (#2358). Both are the "bare `value: &V`, no container cursor available" shape
   #2211/#2243 already documented as a permanent limitation on some materializers, but

--- a/docs/compliance/yaml/limitations.md
+++ b/docs/compliance/yaml/limitations.md
@@ -27,13 +27,13 @@ path:
 | Dimension                              | Result              | Meaning                                        |
 |----------------------------------------|---------------------|------------------------------------------------|
 | **Load** (valid YAML, output compared) | **267/279 = 95.7%** | Parses and produces the JSON the suite expects |
-| **Reject** (invalid YAML, must fail)   | **66/94 = 70.2%**   | Refused by the loader or the opt-in validator  |
+| **Reject** (invalid YAML, must fail)   | **67/94 = 71.3%**   | Refused by the loader or the opt-in validator  |
 | **Parse** (valid YAML, no JSON form)   | **29/29 = 100.0%**  | Parses without error                           |
 
 The **Reject** figure is what the conformance harness rejects with the opt-in
 validator enabled (loader OR validator, see below). The *default non-validating
-loader alone* rejects only 8/94 (8.5%) by design — the opt-in validator
-([#223](https://github.com/rust-works/succinctly/issues/223)) closes 58 more.
+loader alone* rejects 16/94 (17.0%) by design — the opt-in validator
+([#223](https://github.com/rust-works/succinctly/issues/223)) closes 51 more.
 
 [#224](https://github.com/rust-works/succinctly/issues/224) (tag support) moved the Load
 figure from 235/279 (84.2%) to 267/279, the largest single jump on this page, and closed
@@ -45,15 +45,27 @@ absorbed like any other invalid input the non-validating loader doesn't check fo
 the loader-alone figure from 12/94 to 8/94. See
 [Tags — resolved](#tags--resolved-224) below.
 
-The 40 non-passing cases are enumerated individually, with a category and reason, in
+By the time [#1374](https://github.com/rust-works/succinctly/issues/1374) (anchor-on-alias
+rejection, see
+[Three exceptions](#three-exceptions-an-alias-with-no-usable-target-or-an-illegal-decoration-is-rejected)
+below) was implemented, re-measuring found the loader-alone figure already at 14/94 rather
+than the 8/94 recorded just above — independent drift from other changes since #224 that this
+page had not been regenerated against; not investigated further here, since it predates and is
+unrelated to #1374's own change. #1374 itself moves the figure from 14/94 to 16/94: 2 corpus
+cases (SR86, SU74) that were previously caught only by the opt-in validator are now caught by
+the default loader too. This does not move the overall **Reject** figure (still 67/94, itself
+also a re-measurement correction from the 66/94 recorded above): both cases were already
+counted as rejected via the validator before this change.
+
+The 39 non-passing cases are enumerated individually, with a category and reason, in
 [`tests/data/yaml-test-suite-known-failures.txt`](../../../tests/data/yaml-test-suite-known-failures.txt).
 That file is the machine-readable source of truth; the test asserts it matches reality
 exactly, so it cannot silently drift from this page.
 
 ## Validation: default loader vs. the opt-in validator
 
-**The default loader is non-validating by design.** `YamlIndex::build` rejects 8 of the
-suite's 94 invalid documents; the other 86 are accepted and produce a value.
+**The default loader is non-validating by design.** `YamlIndex::build` rejects 16 of the
+suite's 94 invalid documents; the other 78 are accepted and produce a value.
 
 This follows from semi-indexing. The index records *structure* — where values start and
 end, and how they nest — not grammar conformance. The parser is a structure recognizer:
@@ -65,19 +77,19 @@ it is 5-10x faster than `yq`.
 **When you need malformed YAML rejected, use the opt-in validator.**
 [`succinctly yaml validate`](../../guides/cli.md) / `syq --validate` runs a separate strict
 pass ([`src/yaml/validate.rs`](../../../src/yaml/validate.rs)) before indexing — mirroring
-`json validate` / `sjq --validate`, so the default path pays nothing. It rejects **58 of
-the 86** documents below with zero false positives on the valid corpus (a guardrail test,
+`json validate` / `sjq --validate`, so the default path pays nothing. It rejects **51 of
+the 78** documents below with zero false positives on the valid corpus (a guardrail test,
 `validator_accepts_all_valid_cases`, enforces that). The conformance harness treats a
 must-fail case as handled if the loader *or* the validator rejects it, which is why the
-Reject figure above is 66/94 rather than 8/94.
+Reject figure above is 67/94 rather than 16/94.
 
-The 28 documents the validator does not yet reject (marked `lax:*` in the manifest) need
+The 27 documents the validator does not yet reject (marked `lax:*` in the manifest) need
 deeper structural analysis — cross-line anchor binding, block-scalar content indentation,
 flow multi-line implicit keys, malformed tag syntax — and are tracked in
 [#223](https://github.com/rust-works/succinctly/issues/223) (`lax:tags` under #224, see
 below).
 
-The 28 documents still lax today (neither the loader nor the validator rejects them) break
+The 27 documents still lax today (neither the loader nor the validator rejects them) break
 down as:
 
 | Category           | Cases | What is not checked                                     |
@@ -87,21 +99,21 @@ down as:
 | `lax:flow`         | 4     | Flow collection syntax                                  |
 | `lax:anchors`      | 4     | Anchor and alias rules, incl. an unindented tag target (#224) |
 | `lax:documents`    | 3     | Directive and document-marker placement, incl. a mid-stream `%TAG` (#224) |
-| `lax:tags`         | 2     | Malformed tag syntax (disallowed flow indicators) — #224 |
+| `lax:tags`         | 1     | Malformed tag syntax (disallowed flow indicators) — #224 |
 | `lax:comments`     | 2     | Comment placement                                       |
 | `lax:block-scalar` | 2     | Block scalar header validity (`\|--` parses)             |
 | `lax:tabs`         | 1     | Tabs where indentation is expected                       |
 
 This table is the current *remainder* — cases the validator has not yet caught up to — not
-a fixed accounting of the original 86; earlier revisions of this page also carried
+a fixed accounting of the original 78; earlier revisions of this page also carried
 `lax:other` and `lax:quoting` rows that the validator has since closed out entirely.
 
 The opt-in validation mode now exists ([#223](https://github.com/rust-works/succinctly/issues/223)),
 mirroring the JSON side's `succinctly json validate` / `sjq --validate`. Validation is a
 separate pass run before indexing, so the default path pays nothing for it — see
-[`src/yaml/validate.rs`](../../../src/yaml/validate.rs). The 86 cases above were its
-acceptance criteria; it rejects 58 of them today (each `lax:*` line removed from the
-manifest is a case now rejected), with the 28 harder cases still tracked in #223 (`lax:tags`
+[`src/yaml/validate.rs`](../../../src/yaml/validate.rs). The 78 cases above were its
+acceptance criteria; it rejects 51 of them today (each `lax:*` line removed from the
+manifest is a case now rejected), with the 27 harder cases still tracked in #223 (`lax:tags`
 under #224).
 
 ### What "accepted" means: the text is kept, not dropped
@@ -157,10 +169,9 @@ mapping instead of a value under a key, which corrupted the next entry — here 
 a phantom `"":"c"` pair, with the `2` dropped as well. Content after the misaligned item is
 kept too: a further out-dented or realigned line still joins the same sequence.
 
-### Two exceptions: an alias with no usable target is rejected
+### Three exceptions: an alias with no usable target, or an illegal decoration, is rejected
 
-Two alias forms are refused at index build. They are the same failure underneath — an
-alias with nothing to resolve to:
+Three alias forms are refused at index build:
 
 - **Cyclic.** An alias that would make an anchored value contain itself
   (`a: &x {self: *x}`) fails with `YamlError::AliasCycle` ("anchor value contains itself").
@@ -177,54 +188,77 @@ alias with nothing to resolve to:
   enforces this too ([#404](https://github.com/rust-works/succinctly/issues/404)); it did
   not at first, which briefly made the opt-in strict mode *laxer* than the default one for
   this input.
+- **Decorated.** An alias node itself carrying an `&anchor` or `!tag`
+  (`&y *x`, `!!str *x`) fails with `YamlError::PropertyOnAlias` since
+  [#1374](https://github.com/rust-works/succinctly/issues/1374). Unlike the first two, this
+  *is* a genuine grammar-conformance check — the YAML 1.2 grammar gives an alias node no
+  properties of its own — carved out of the loader's usual "grammar isn't checked" policy
+  because leaving it lenient had a specific, concrete cost: `&anchor *alias` is the *only*
+  shape that can construct an alias chain more than one hop deep, so every multi-hop-chain
+  bug this codebase has ever had (#1193's stack-overflow DoS, #1315/#1318/#1319's
+  single-hop-only accessor bugs) was reachable only through input real `yq` and PyYAML both
+  already refuse. Both are confirmed live to reject every spelling (block value, next line,
+  flow, mapping key, `!!str`-tagged) — this is not a case where matching means giving up an
+  advantage.
 
 ```
 $ printf 'a: &x {self: *x}\n' | succinctly yq '.'
 Error: YAML parse error: cyclic alias 'x' at offset 13 (anchor value contains itself)
 $ printf 'a: *x\nb: &x 5\n' | succinctly yq '.'
 Error: YAML parse error: unknown anchor 'x' referenced at offset 3
+$ printf 'a0: &a0 hello\na1: &a1 *a0\n' | succinctly yq '.'
+Error: YAML parse error: alias '*a0' at offset 22 cannot carry an anchor or tag (an alias node has no node properties)
 $ printf 'b: &x 5\na: *x\n' | succinctly yq -o json -I0 '.'
-{"b":5,"a":5}             # a resolvable alias is unaffected
+{"b":5,"a":5}             # a resolvable, undecorated alias is unaffected
 ```
 
 Until #372 the second silently yielded `null` — or `""` where the alias was a key — the
-same silent-wrong-data mode as the `- ` case above.
+same silent-wrong-data mode as the `- ` case above. Before #1374 the third silently built a
+resolvable but ungrammatical alias chain instead of erroring.
 
-These two are the loader's only checks on *document structure*, and neither is grammar
+The first two are the loader's only checks on *document structure*, and neither is grammar
 conformance: both are cases where there is no value to produce at all, not cases where the
-input breaks a rule the index could otherwise ignore. Rejecting the rest of what the suite
-calls invalid is the validator's job.
+input breaks a rule the index could otherwise ignore. The third is grammar conformance, but a
+single, narrowly-scoped one rather than a step toward general conformance checking — see
+above for why it earns an exception. Rejecting the rest of what the suite calls invalid is
+the validator's job.
 
-Neither costs this page's conformance numbers anything: no case in the corpus contains an
-alias to an out-of-scope anchor, so the loader-alone reject figure, the accepted-but-invalid
-document count, and the `lax:anchors` row are unmoved by #372.
+Cyclic and Unknown cost this page's conformance numbers nothing: no case in the corpus
+contains an alias to an out-of-scope anchor, so the loader-alone reject figure, the
+accepted-but-invalid document count, and the `lax:anchors` row are unmoved by #372. Decorated
+does move the loader-alone reject figure (+2, see above) but not the `lax:anchors` row or the
+overall Reject figure: both corpus cases it newly catches (SR86, SU74) were already rejected
+via the opt-in validator, which has had this exact check
+([`check_after_anchor`](../../../src/yaml/validate.rs)) since before #1374.
 
-### A third, differently-timed check: excessively long alias chains
+### A related, differently-timed check: excessively long alias chains (historical — see #1374 below)
 
-Unlike the cyclic and unknown-anchor cases above, an alias chain that is merely very long —
-`a0: &a0 v`, `a1: &a1 *a0`, `a2: &a2 *a1`, ... — is not rejected at `YamlIndex::build`
-time; the index builds successfully regardless of chain length. [#153](https://github.com/rust-works/succinctly/issues/153)'s
-cycle check only rejects a chain that revisits its own anchor, and a long non-cyclic chain
-never does. Before [#1193](https://github.com/rust-works/succinctly/issues/1193), *walking*
-such a chain (via `type`, `tostring`, `-o json` output, arithmetic, or any other query that
-resolves the aliased value) drove real, uncatchable stack overflow through several
-independent self-recursive code paths in `src/yaml/light.rs`, `src/bin/succinctly/yq_runner.rs`,
-and `src/jq/eval.rs` — the same underlying failure mode #153 fixed for cycles specifically,
-recurring for long-but-acyclic chains that #153's own check does not cover.
+Before [#1374](https://github.com/rust-works/succinctly/issues/1374) (Decorated, above), an
+alias chain that was merely very long — `a0: &a0 v`, `a1: &a1 *a0`, `a2: &a2 *a1`, ... — was
+not rejected at `YamlIndex::build` time; the index built successfully regardless of chain
+length. [#153](https://github.com/rust-works/succinctly/issues/153)'s cycle check only rejects
+a chain that revisits its own anchor, and a long non-cyclic chain never does. Before
+[#1193](https://github.com/rust-works/succinctly/issues/1193), *walking* such a chain (via
+`type`, `tostring`, `-o json` output, arithmetic, or any other query that resolves the aliased
+value) drove real, uncatchable stack overflow through several independent self-recursive code
+paths in `src/yaml/light.rs`, `src/bin/succinctly/yq_runner.rs`, and `src/jq/eval.rs` — the
+same underlying failure mode #153 fixed for cycles specifically, recurring for long-but-acyclic
+chains that #153's own check does not cover.
 
-The fix is a runtime ceiling, not a build-time rejection: `MAX_ALIAS_CHAIN_DEPTH` (65,536
+#1193's fix was a runtime ceiling, not a build-time rejection: `MAX_ALIAS_CHAIN_DEPTH` (65,536
 hops, `src/yaml/light.rs`) bounds every alias-resolving accessor to a clean `panic!` past
 that depth, rather than allowing the resolution loop to run unbounded. Because the fix
 converts what used to be self-recursion into an explicit iterative loop, the ceiling exists
 only to cap adversarial CPU time, not stack depth — the loop itself costs O(1) stack
-regardless of chain length. A chain within the limit resolves normally; one beyond it
-panics with a `nesting depth exceeds limit` message (a clean Rust panic, not a stack
-overflow) rather than crashing the process the way #1193's own repro did:
+regardless of chain length.
 
-```
-$ succinctly yq -o json '.' 70000-hop-chain.yaml
-thread 'main' panicked at ...: nesting depth exceeds limit of 65536
-```
+**This whole scenario is now unreachable through valid input.** `a1: &a1 *a0` — every link in
+the example chain above after the first — is exactly the Decorated shape #1374 rejects at
+parse time, and it was the *only* way to construct a chain more than one hop deep. A document
+`YamlIndex::build` accepts today can therefore never have an alias chain longer than one hop,
+so `MAX_ALIAS_CHAIN_DEPTH` and its `panic!` past the ceiling remain in the code purely as
+defense in depth against a hand-built index that bypasses the parser's own checks, not as a
+mitigation reachable through the CLI on any input the loader itself would accept.
 
 ### The other ways `YamlIndex::build` fails
 

--- a/docs/compliance/yq/limitations.md
+++ b/docs/compliance/yq/limitations.md
@@ -176,6 +176,41 @@ Two interactions remain open, neither closed by #1709 itself:
    materially larger change than #1709's own scope, filed separately as
    [#2004](https://github.com/rust-works/succinctly/issues/2004).
 
+### Anchor-on-alias at document-root level — rule 4(b)
+
+An alias node carrying its own `&anchor`/`!tag` (`&a *b`) is invalid per the YAML 1.2
+grammar — an alias node has no properties of its own. Real yq and PyYAML both confirm this
+live for the ordinary shape, inside a mapping or sequence:
+
+```bash
+$ printf 'a0: &a0 hello\na1: &a1 *a0\nz: *a1\n' | yq .
+Error: bad file '-': yaml: while parsing a block mapping at <unknown position>: line 1, column 9: did not find expected key
+```
+
+succinctly's default loader now rejects this uniformly ([#1374](https://github.com/rust-works/succinctly/issues/1374),
+`YamlError::PropertyOnAlias`; see
+[YAML Limitations](../yaml/limitations.md#three-exceptions-an-alias-with-no-usable-target-or-an-illegal-decoration-is-rejected)) —
+for the ordinary shape above this is bug-for-bug fidelity, not a divergence: real yq errors,
+succinctly errors.
+
+The one shape where this *is* a deliberate divergence is at document-root level, across a
+`---` multi-document separator. There, real yq does not error at all — it silently emits
+corrupted output instead, concatenating the first document's scalar value with the literal
+*text* of the following `---`-anchor-alias line:
+
+```bash
+$ printf -- '--- &a0 hello\n--- &a1 *a0\n' | yq .
+---
+hello--- &a1 *a0
+$ printf -- '--- &a0 hello\n--- &a1 *a0\n' | yq -o=json .
+"hello--- &a1 *a0"
+```
+
+(Both confirmed live against yq v4.53.3, exit 0 — real yq does not treat this as an error at
+all.) succinctly rejects this shape too rather than reproduce the corruption, per rule 4(b)
+(matching would corrupt a document): a `"hello--- &a1 *a0"` string is not a value any
+reasonable query result should ever produce, and there is no way to make it round-trip.
+
 ### Merge-flag `+` and `d` combined — **no carve-out; this one is out of policy**
 
 Real yq's `*+d` applies the deep-merge *and* the append, doubling the right operand.

--- a/docs/guides/cli.md
+++ b/docs/guides/cli.md
@@ -251,9 +251,12 @@ invalid, it accepts.
   (`|0`, `|10`, `> text`).
 - **Flow collections** — leading/doubled commas, unbalanced or unclosed brackets, bare `-`
   items, document markers inside a flow collection.
-- **Anchors & aliases** — an anchor immediately followed by an alias (`&a *b`) or a block
-  indicator; an alias naming an anchor that is not in scope (`a: *nope`), including a forward
-  reference. A `*` that is scalar content rather than a node (`a: rm *.tmp`) is untouched.
+- **Anchors & aliases** — an anchor immediately followed by a block indicator with no value
+  between them. A `*` that is scalar content rather than a node (`a: rm *.tmp`) is untouched.
+  (An anchor or tag immediately before an alias, `&a *b` / `!!str *b`, and an alias naming an
+  out-of-scope anchor, `a: *nope`, are both rejected by the *default* loader itself — see
+  [YAML Limitations](../compliance/yaml/limitations.md#three-exceptions-an-alias-with-no-usable-target-or-an-illegal-decoration-is-rejected) —
+  so `--validate` adds nothing beyond the default for either.)
 - **Comments** — a `#` not separated from the preceding token by whitespace; a comment
   interrupting a multi-line plain scalar.
 - **Documents & directives** — content after a `...` marker; a `%YAML` directive with no

--- a/src/yaml/error.rs
+++ b/src/yaml/error.rs
@@ -93,6 +93,17 @@ pub enum YamlError {
         name: String,
     },
 
+    /// An alias node (`*name`) was itself decorated with an anchor or tag
+    /// (`&other *name` / `!!str *name`). Per the YAML 1.2 grammar an alias
+    /// node carries no node properties of its own - real yq and PyYAML both
+    /// reject this (#1374).
+    PropertyOnAlias {
+        /// Byte offset of the alias (`*name`)
+        offset: usize,
+        /// The referenced anchor name
+        name: String,
+    },
+
     /// Tag not supported - kept for backwards compatibility but no longer used.
     #[deprecated(note = "Tags are now supported (#224)")]
     TagNotSupported {
@@ -227,6 +238,12 @@ impl fmt::Display for YamlError {
             Self::UnknownAnchor { offset, name } => {
                 write!(f, "unknown anchor '{name}' referenced at offset {offset}")
             }
+            Self::PropertyOnAlias { offset, name } => {
+                write!(
+                    f,
+                    "alias '*{name}' at offset {offset} cannot carry an anchor or tag (an alias node has no node properties)"
+                )
+            }
             #[allow(deprecated)]
             // STYLE-0004: Display arm for a deprecated error variant kept for back-compat
             Self::TagNotSupported { offset } => {
@@ -359,6 +376,18 @@ mod tests {
         assert_eq!(
             err.to_string(),
             "cyclic alias 'anchor' at offset 20 (anchor value contains itself)"
+        );
+    }
+
+    #[test]
+    fn test_property_on_alias_display() {
+        let err = YamlError::PropertyOnAlias {
+            offset: 11,
+            name: "a0".to_string(),
+        };
+        assert_eq!(
+            err.to_string(),
+            "alias '*a0' at offset 11 cannot carry an anchor or tag (an alias node has no node properties)"
         );
     }
 

--- a/src/yaml/index.rs
+++ b/src/yaml/index.rs
@@ -1421,9 +1421,27 @@ mod tests {
         expect_alias_cycle("a: &anchor\n  self: *anchor", "anchor", "*anchor");
     }
 
+    /// `&x *x` is anchor-on-alias (#1374, invalid YAML -- an alias node
+    /// carries no properties of its own) as well as a would-be self-cycle;
+    /// the property check in `parse_alias` rejects it before the cycle
+    /// checker (`validate_alias_acyclicity`) ever runs, so the error here is
+    /// `PropertyOnAlias`, not `AliasCycle` — unlike this file's other
+    /// `expect_alias_cycle` cases, which all cycle through a *nested*
+    /// structure rather than decorating the alias itself.
     #[test]
     fn test_build_rejects_direct_self_alias() {
-        expect_alias_cycle("a: &x *x", "x", "*x");
+        let yaml = "a: &x *x";
+        let expected_offset = yaml.find("*x").expect("alias text present in input");
+        let Err(err) = YamlIndex::build(yaml.as_bytes()) else {
+            panic!("anchor-on-alias must be rejected at build time");
+        };
+        match err {
+            YamlError::PropertyOnAlias { offset, name } => {
+                assert_eq!(name, "x");
+                assert_eq!(offset, expected_offset);
+            }
+            other => panic!("expected PropertyOnAlias, got {other:?}"),
+        }
     }
 
     #[test]

--- a/src/yaml/index.rs
+++ b/src/yaml/index.rs
@@ -1444,6 +1444,26 @@ mod tests {
         }
     }
 
+    /// Same shape as `test_build_rejects_direct_self_alias` but with the
+    /// property+alias at document-root level rather than as a mapping
+    /// value, exercising `parse_block_node`'s own `Some(b'*')` dispatch
+    /// arm (#1374) rather than the value-position one.
+    #[test]
+    fn test_build_rejects_document_root_self_alias() {
+        let yaml = "&x *x";
+        let expected_offset = yaml.find("*x").expect("alias text present in input");
+        let Err(err) = YamlIndex::build(yaml.as_bytes()) else {
+            panic!("anchor-on-alias must be rejected at build time");
+        };
+        match err {
+            YamlError::PropertyOnAlias { offset, name } => {
+                assert_eq!(name, "x");
+                assert_eq!(offset, expected_offset);
+            }
+            other => panic!("expected PropertyOnAlias, got {other:?}"),
+        }
+    }
+
     #[test]
     fn test_build_rejects_grandparent_alias_cycle() {
         expect_alias_cycle("a: &x\n  b:\n    c: *x", "x", "*x");

--- a/src/yaml/index.rs
+++ b/src/yaml/index.rs
@@ -548,6 +548,27 @@ impl<W: AsRef<[u64]>> YamlIndex<W> {
         Some(YamlCursor::new(self, text, *target_bp_pos))
     }
 
+    /// Test-only: repoint the alias at `alias_bp_pos` at `target_bp_pos`,
+    /// bypassing every check the parser applies.
+    ///
+    /// `YamlIndex::build` can no longer produce an alias whose target is
+    /// itself an alias -- `&anchor *alias` was the only spelling that did,
+    /// and #1374 rejects it at parse time -- so the multi-hop and
+    /// depth-ceiling paths of `YamlCursor::resolve_alias_chain` and
+    /// `resolve_alias_target_cursor` (kept as defense in depth against
+    /// exactly such a hand-built index) are reachable only through an index
+    /// rewired like this. Pointing an alias at *itself* yields an unbounded
+    /// chain in one node, which is how the ceiling tests reach
+    /// `MAX_ALIAS_CHAIN_DEPTH` without building 65,537 nodes.
+    #[cfg(test)]
+    pub(crate) fn rewire_alias_target(&mut self, alias_bp_pos: usize, target_bp_pos: usize) {
+        debug_assert!(
+            self.aliases.contains_key(&alias_bp_pos),
+            "not an alias node"
+        );
+        self.aliases.insert(alias_bp_pos, target_bp_pos);
+    }
+
     /// Reject documents whose aliases would make an anchored value contain
     /// itself (issue #153: unbounded recursion when materializing).
     ///
@@ -1421,6 +1442,27 @@ mod tests {
         expect_alias_cycle("a: &anchor\n  self: *anchor", "anchor", "*anchor");
     }
 
+    /// Assert that `yaml` is rejected with `PropertyOnAlias` naming
+    /// `expected_name` at the byte offset of `alias_text` within `yaml`
+    /// (#1374). `expect_err` + `assert_eq!` on the whole error value rather
+    /// than `expect_alias_cycle`'s `let Err(..) else { panic!() }` / `other
+    /// => panic!()` shape: those two arms can never execute in a passing
+    /// test, so each caller written that way adds two permanently
+    /// uncovered lines (the shape this helper replaced was flagged for
+    /// exactly that).
+    fn expect_property_on_alias(yaml: &str, expected_name: &str, alias_text: &str) {
+        let expected_offset = yaml.find(alias_text).expect("alias text present in input");
+        let err = YamlIndex::build(yaml.as_bytes())
+            .expect_err("anchor-on-alias must be rejected at build time");
+        assert_eq!(
+            err,
+            YamlError::PropertyOnAlias {
+                offset: expected_offset,
+                name: expected_name.to_string(),
+            }
+        );
+    }
+
     /// `&x *x` is anchor-on-alias (#1374, invalid YAML -- an alias node
     /// carries no properties of its own) as well as a would-be self-cycle;
     /// the property check in `parse_alias` rejects it before the cycle
@@ -1430,18 +1472,7 @@ mod tests {
     /// structure rather than decorating the alias itself.
     #[test]
     fn test_build_rejects_direct_self_alias() {
-        let yaml = "a: &x *x";
-        let expected_offset = yaml.find("*x").expect("alias text present in input");
-        let Err(err) = YamlIndex::build(yaml.as_bytes()) else {
-            panic!("anchor-on-alias must be rejected at build time");
-        };
-        match err {
-            YamlError::PropertyOnAlias { offset, name } => {
-                assert_eq!(name, "x");
-                assert_eq!(offset, expected_offset);
-            }
-            other => panic!("expected PropertyOnAlias, got {other:?}"),
-        }
+        expect_property_on_alias("a: &x *x", "x", "*x");
     }
 
     /// Same shape as `test_build_rejects_direct_self_alias` but with the
@@ -1450,18 +1481,7 @@ mod tests {
     /// arm (#1374) rather than the value-position one.
     #[test]
     fn test_build_rejects_document_root_self_alias() {
-        let yaml = "&x *x";
-        let expected_offset = yaml.find("*x").expect("alias text present in input");
-        let Err(err) = YamlIndex::build(yaml.as_bytes()) else {
-            panic!("anchor-on-alias must be rejected at build time");
-        };
-        match err {
-            YamlError::PropertyOnAlias { offset, name } => {
-                assert_eq!(name, "x");
-                assert_eq!(offset, expected_offset);
-            }
-            other => panic!("expected PropertyOnAlias, got {other:?}"),
-        }
+        expect_property_on_alias("&x *x", "x", "*x");
     }
 
     #[test]

--- a/src/yaml/light.rs
+++ b/src/yaml/light.rs
@@ -2780,7 +2780,11 @@ impl<'a, W: AsRef<[u64]>> YamlCursor<'a, W> {
                 // `stream_json_value`'s matching `Alias` arm.
                 match target.and_then(|t| t.resolve_alias_target_cursor()) {
                     Some(resolved) => resolved.tag(),
-                    None => "!!null",
+                    // `target` is always `Some` for a `YamlIndex::build`-produced
+                    // index (see `parse_alias_value`), so this arm is unreachable
+                    // defense in depth; its hit status flips with instrumentation
+                    // rather than with any test, hence the marker (#1374 follow-up).
+                    None => "!!null", // omni-dev: coverage tolerate-line reason="unreachable: an alias target is never None for a built index (#1374)"
                 }
             }
             YamlValue::Error(_) => "!!null",
@@ -6158,7 +6162,11 @@ fn decode_failure(e: YamlStringError) -> StreamFailure {
 /// chain more than one hop deep -- so an index built by `YamlIndex::build`
 /// from valid input can no longer reach depth 2, let alone this ceiling.
 /// This guard remains purely as defense in depth against a hand-built
-/// index that bypasses the parser's own checks.
+/// index that bypasses the parser's own checks -- and is exercised as such:
+/// `test_as_str_panics_past_max_alias_chain_depth` and
+/// `test_tag_panics_past_max_alias_chain_depth` reach it through
+/// `YamlIndex::rewire_alias_target` (test-only), which points an alias at
+/// itself to make a one-node unbounded chain.
 const MAX_ALIAS_CHAIN_DEPTH: usize = 65_536;
 
 impl<'a, W: AsRef<[u64]> + Clone> DocumentCursor for YamlCursor<'a, W> {
@@ -8096,9 +8104,11 @@ mod tests {
     /// invalid YAML -- an alias node carries no properties of its own, and
     /// it was the *only* way to construct a chain more than one hop deep),
     /// so a `YamlIndex::build`-produced index can no longer reach depth 2 by
-    /// any valid input, and the multi-hop/depth-cap tests that once lived
-    /// here are gone along with it. The two tests below keep 1-hop coverage
-    /// of the same iterative walk instead.
+    /// any valid input. The 1-hop tests below cover the walk's entry and
+    /// exit; the `*_through_rewired_index` / `*_past_max_alias_chain_depth`
+    /// tests after them rebuild the multi-hop and ceiling cases on top of
+    /// `YamlIndex::rewire_alias_target` (test-only), which is the only way
+    /// left to put an alias behind an alias.
     #[test]
     fn test_as_str_resolves_one_hop_alias() {
         use crate::jq::document::DocumentValue;
@@ -8123,6 +8133,99 @@ mod tests {
         };
         let z_cursor = fields.find_cursor("z").expect("z field must exist");
         assert_eq!(z_cursor.tag(), "!!str");
+    }
+
+    /// The document every rewired-index test below starts from: two
+    /// ordinary 1-hop aliases of the same anchor.
+    const REWIRE_YAML: &str = "a0: &a0 hello\nb: *a0\nz: *a0\n";
+
+    /// Cursor to the value of top-level key `name` in the first document.
+    fn top_level_cursor<'a>(index: &'a YamlIndex, yaml: &'a str, name: &str) -> YamlCursor<'a> {
+        let YamlValue::Mapping(fields) = first_doc(index.root(yaml.as_bytes())) else {
+            panic!("expected root document to be a mapping");
+        };
+        fields
+            .find_cursor(name)
+            .unwrap_or_else(|| panic!("{name} field must exist"))
+    }
+
+    /// Builds `REWIRE_YAML` and repoints `z`'s alias at `target` (another
+    /// top-level key) via `YamlIndex::rewire_alias_target`. `"b"` yields the
+    /// 2-hop chain `z -> b -> a0` no valid document can spell since #1374;
+    /// `"z"` yields a self-loop, i.e. an unbounded chain in one node.
+    fn rewired_index(target: &str) -> YamlIndex {
+        let mut index = YamlIndex::build(REWIRE_YAML.as_bytes()).unwrap();
+        let target_bp = top_level_cursor(&index, REWIRE_YAML, target).bp_pos;
+        let z_bp = top_level_cursor(&index, REWIRE_YAML, "z").bp_pos;
+        index.rewire_alias_target(z_bp, target_bp);
+        index
+    }
+
+    /// `resolve_alias_chain`'s loop body (the alias-behind-alias hop) is
+    /// unreachable from any parser-built index since #1374; this keeps it
+    /// exercised through `as_str`, the accessor #1191 first fixed.
+    #[test]
+    fn test_as_str_resolves_two_hop_alias_through_rewired_index() {
+        use crate::jq::document::DocumentValue;
+
+        let index = rewired_index("b");
+        let z = top_level_cursor(&index, REWIRE_YAML, "z").value();
+        assert_eq!(z.as_str().as_deref(), Some("hello"));
+    }
+
+    /// Same for `resolve_alias_target_cursor`'s loop body, via `tag()`
+    /// (#1193's cursor-side fix).
+    #[test]
+    fn test_tag_resolves_two_hop_alias_through_rewired_index() {
+        let index = rewired_index("b");
+        assert_eq!(top_level_cursor(&index, REWIRE_YAML, "z").tag(), "!!str");
+    }
+
+    /// `type_name`'s own `Alias` arm resolves the chain too (#1193/PR
+    /// #1314); it was only ever reached through the CLI tests #1374 removed,
+    /// so pin it directly, at 1 hop and at 2.
+    #[test]
+    fn test_type_name_resolves_alias_chain() {
+        use crate::jq::document::DocumentValue;
+
+        let plain = YamlIndex::build(REWIRE_YAML.as_bytes()).unwrap();
+        assert_eq!(
+            top_level_cursor(&plain, REWIRE_YAML, "z")
+                .value()
+                .type_name(),
+            "string"
+        );
+
+        let rewired = rewired_index("b");
+        assert_eq!(
+            top_level_cursor(&rewired, REWIRE_YAML, "z")
+                .value()
+                .type_name(),
+            "string"
+        );
+    }
+
+    /// #1191 code review: a chain past `MAX_ALIAS_CHAIN_DEPTH` must panic
+    /// cleanly (a controlled `assert_depth` failure), not silently succeed
+    /// and not stack-overflow -- otherwise an off-by-one in
+    /// `resolve_alias_chain`'s loop would go uncaught. A self-looping alias
+    /// is that chain without the 65,537 nodes the pre-#1374 version built.
+    #[test]
+    #[should_panic(expected = "nesting depth exceeds limit")]
+    fn test_as_str_panics_past_max_alias_chain_depth() {
+        use crate::jq::document::DocumentValue;
+
+        let index = rewired_index("z");
+        let _ = top_level_cursor(&index, REWIRE_YAML, "z").value().as_str();
+    }
+
+    /// #1193/PR #1314 code review: the same ceiling check for
+    /// `resolve_alias_target_cursor`, via `tag()`.
+    #[test]
+    #[should_panic(expected = "nesting depth exceeds limit")]
+    fn test_tag_panics_past_max_alias_chain_depth() {
+        let index = rewired_index("z");
+        let _ = top_level_cursor(&index, REWIRE_YAML, "z").tag();
     }
 
     /// #1247 coverage: `YamlStringError::message()`'s `InvalidUtf8` arm and

--- a/src/yaml/light.rs
+++ b/src/yaml/light.rs
@@ -6152,6 +6152,13 @@ fn decode_failure(e: YamlStringError) -> StreamFailure {
 /// time one call can be forced to spend on a pathologically long,
 /// adversarially-crafted chain; picked generously (no legitimate document
 /// plausibly nears it) rather than against any specific measurement.
+///
+/// #1374 made `&anchor *alias` (anchoring an alias node) a parse-time
+/// rejection, and that shape was the *only* way to construct an alias
+/// chain more than one hop deep -- so an index built by `YamlIndex::build`
+/// from valid input can no longer reach depth 2, let alone this ceiling.
+/// This guard remains purely as defense in depth against a hand-built
+/// index that bypasses the parser's own checks.
 const MAX_ALIAS_CHAIN_DEPTH: usize = 65_536;
 
 impl<'a, W: AsRef<[u64]> + Clone> DocumentCursor for YamlCursor<'a, W> {
@@ -8082,36 +8089,21 @@ mod tests {
         }
     }
 
-    /// Builds YAML defining a `depth`-hop alias chain terminating in the
-    /// string `"hello"`, with a `z` field aliasing the last link (#1191 code
-    /// review: shared by the two tests below instead of each duplicating
-    /// this construction).
-    fn build_alias_chain_yaml(depth: usize) -> String {
-        let mut yaml = String::from("a0: &a0 hello\n");
-        for i in 1..depth {
-            yaml.push_str(&format!("a{i}: &a{i} *a{}\n", i - 1));
-        }
-        yaml.push_str(&format!("z: *a{}\n", depth - 1));
-        yaml
-    }
-
-    /// #1191 code review: `as_str()`'s `Alias` arm was first fixed by
-    /// self-recursing (`t.value().as_str()`), matching every sibling typed
-    /// accessor's own pre-existing shape -- but that shape has no depth
-    /// bound, and review found it drives a real, uncatchable stack overflow
-    /// on a long, non-cyclic alias chain (the same class of bug #1193
-    /// tracks for the other accessors). Confirms the actual fix
-    /// (`resolve_alias_chain`'s iterative walk) resolves a 50,000-hop
-    /// chain -- comfortably below `MAX_ALIAS_CHAIN_DEPTH` -- without
-    /// panicking or overflowing the stack, calling `DocumentValue::as_str()`
-    /// directly so this test can't be satisfied by some other, unrelated
-    /// code path (e.g. `type_name()`'s own still-unbounded recursion,
-    /// separately tracked by #1193) happening to also resolve correctly.
+    /// #1191/#1193 code review originally exercised `resolve_alias_chain`/
+    /// `resolve_alias_target_cursor` against a `depth`-hop alias chain built
+    /// via `a{i}: &a{i} *a{i-1}` (each link anchoring the previous alias).
+    /// #1374 closed that shape off at parse time (`&anchor *alias` is
+    /// invalid YAML -- an alias node carries no properties of its own, and
+    /// it was the *only* way to construct a chain more than one hop deep),
+    /// so a `YamlIndex::build`-produced index can no longer reach depth 2 by
+    /// any valid input, and the multi-hop/depth-cap tests that once lived
+    /// here are gone along with it. The two tests below keep 1-hop coverage
+    /// of the same iterative walk instead.
     #[test]
-    fn test_as_str_resolves_deep_alias_chain_without_stack_overflow_1191() {
+    fn test_as_str_resolves_one_hop_alias() {
         use crate::jq::document::DocumentValue;
 
-        let yaml = build_alias_chain_yaml(50_000);
+        let yaml = "a0: &a0 hello\nz: *a0\n";
         let index = YamlIndex::build(yaml.as_bytes()).unwrap();
         let root = index.root(yaml.as_bytes());
         let YamlValue::Mapping(fields) = first_doc(root) else {
@@ -8121,44 +8113,9 @@ mod tests {
         assert_eq!(z.as_str().as_deref(), Some("hello"));
     }
 
-    /// #1191 code review: the success-path test above never exercises
-    /// `MAX_ALIAS_CHAIN_DEPTH`'s own boundary, so an off-by-one in
-    /// `resolve_alias_chain`'s loop (e.g. `<=` vs `<`, or a shifted
-    /// increment) would go uncaught. A chain one hop *past* the ceiling must
-    /// panic cleanly (a controlled `assert_depth` failure), not silently
-    /// succeed and not stack-overflow.
     #[test]
-    #[should_panic(expected = "nesting depth exceeds limit")]
-    fn test_as_str_panics_past_max_alias_chain_depth_1191() {
-        use crate::jq::document::DocumentValue;
-
-        // `z`'s own hop is consumed by `as_str`'s outer match before
-        // `resolve_alias_chain` ever runs, so the chain it walks (starting
-        // at `z`'s target) is one hop shorter than `build_alias_chain_yaml`'s
-        // `depth` -- `+ 2`, not `+ 1`, is what actually pushes that inner
-        // walk past `MAX_ALIAS_CHAIN_DEPTH` (confirmed empirically: `+ 1`
-        // still resolves successfully with room to spare).
-        let yaml = build_alias_chain_yaml(MAX_ALIAS_CHAIN_DEPTH + 2);
-        let index = YamlIndex::build(yaml.as_bytes()).unwrap();
-        let root = index.root(yaml.as_bytes());
-        let YamlValue::Mapping(fields) = first_doc(root) else {
-            panic!("expected root document to be a mapping");
-        };
-        let z = fields.find("z").expect("z field must exist");
-        let _ = z.as_str();
-    }
-
-    /// #1193/PR #1314 code review: `YamlCursor::tag`'s own `Alias` arm had
-    /// the identical self-recursive shape as the typed accessors above
-    /// (`t.tag()`, re-entering itself once per hop) -- found live via a
-    /// direct call to this method (not reachable through the yq CLI's own
-    /// `tag` builtin, which operates on an already-materialized value, not
-    /// a cursor -- see `resolve_alias_target_cursor`'s doc comment for the
-    /// other methods in the same boat). Confirms the fix resolves a
-    /// 50,000-hop chain without panicking or overflowing the stack.
-    #[test]
-    fn test_tag_resolves_deep_alias_chain_without_stack_overflow_1193() {
-        let yaml = build_alias_chain_yaml(50_000);
+    fn test_tag_resolves_one_hop_alias() {
+        let yaml = "a0: &a0 hello\nz: *a0\n";
         let index = YamlIndex::build(yaml.as_bytes()).unwrap();
         let root = index.root(yaml.as_bytes());
         let YamlValue::Mapping(fields) = first_doc(root) else {
@@ -8166,23 +8123,6 @@ mod tests {
         };
         let z_cursor = fields.find_cursor("z").expect("z field must exist");
         assert_eq!(z_cursor.tag(), "!!str");
-    }
-
-    /// #1193/PR #1314 code review: the success-path test above never
-    /// exercises `MAX_ALIAS_CHAIN_DEPTH`'s own boundary for `tag()` -- see
-    /// `test_as_str_panics_past_max_alias_chain_depth_1191`'s matching
-    /// rationale and its `+ 2` note, which applies identically here.
-    #[test]
-    #[should_panic(expected = "nesting depth exceeds limit")]
-    fn test_tag_panics_past_max_alias_chain_depth_1193() {
-        let yaml = build_alias_chain_yaml(MAX_ALIAS_CHAIN_DEPTH + 2);
-        let index = YamlIndex::build(yaml.as_bytes()).unwrap();
-        let root = index.root(yaml.as_bytes());
-        let YamlValue::Mapping(fields) = first_doc(root) else {
-            panic!("expected root document to be a mapping");
-        };
-        let z_cursor = fields.find_cursor("z").expect("z field must exist");
-        let _ = z_cursor.tag();
     }
 
     /// #1247 coverage: `YamlStringError::message()`'s `InvalidUtf8` arm and
@@ -8206,18 +8146,22 @@ mod tests {
 
     /// #1247 code review: `string_decode_error()`'s `Alias` arm resolves the
     /// *whole* alias chain first (mirroring `as_str`'s own #1191 fix, per
-    /// the doc comment directly above the `Alias` arm), so a 2+-hop alias to
-    /// an undecodable string still reports the decode failure instead of
-    /// silently answering "not a decode failure" after only one hop. Never
-    /// exercised directly before — builds a 2-hop chain (`z` -> `a1` ->
-    /// `a0`) terminating in a double-quoted string with an invalid escape
-    /// sequence (`\q`, not one of the recognized single-char escapes), then
-    /// calls `string_decode_error()` on the still-unresolved `Alias` value.
+    /// the doc comment directly above the `Alias` arm), so an alias to an
+    /// undecodable string still reports the decode failure instead of
+    /// silently answering "not a decode failure". Never exercised directly
+    /// before — originally built a 2-hop chain (`z` -> `a1` -> `a0`), but
+    /// #1374 closed off that anchor-on-alias shape at parse time (invalid
+    /// YAML -- an alias node carries no properties of its own, and it was
+    /// the only way to build a multi-hop chain), so this is now 1-hop
+    /// (`z` -> `a0`) terminating in a double-quoted string with an invalid
+    /// escape sequence (`\q`, not one of the recognized single-char
+    /// escapes), then calls `string_decode_error()` on the still-unresolved
+    /// `Alias` value.
     #[test]
     fn test_string_decode_error_resolves_alias_chain_1247() {
         use crate::jq::document::DocumentValue;
 
-        let yaml = "a0: &a0 \"bad\\qescape\"\na1: &a1 *a0\nz: *a1\n";
+        let yaml = "a0: &a0 \"bad\\qescape\"\nz: *a0\n";
         let index = YamlIndex::build(yaml.as_bytes()).unwrap();
         let root = index.root(yaml.as_bytes());
         let YamlValue::Mapping(fields) = first_doc(root) else {

--- a/src/yaml/parser.rs
+++ b/src/yaml/parser.rs
@@ -179,6 +179,17 @@ struct Parser<'a, const HAS_CR: bool> {
     aliases: BTreeMap<usize, usize>,
     /// Explicit source tags collected during parsing: bp_pos → raw tag text
     tags: BTreeMap<usize, String>,
+    /// `bp_pos` of the node an anchor or tag was just scanned for, if that
+    /// node hasn't opened yet. An alias node opening at this same `bp_pos`
+    /// would mean the property was meant for it — invalid per the YAML 1.2
+    /// grammar (an alias node carries no properties of its own), and
+    /// rejected by real yq/PyYAML (#1374).
+    ///
+    /// Never needs clearing: `bp_pos` only ever increases (every
+    /// [`Self::write_bp_open`]/[`Self::write_bp_close`] call increments it),
+    /// so a stale value can only equal the position of the exact node the
+    /// property was scanned for — never any later node.
+    pending_property_bp: Option<usize>,
     /// Trailing same-line comments collected during parsing: bp_pos of the
     /// owning node → `(start, end)` byte range of the raw `#...` comment text.
     /// See [`SemiIndex::line_comments`].
@@ -288,6 +299,7 @@ impl<'a, const HAS_CR: bool> Parser<'a, HAS_CR> {
             anchors: BTreeMap::new(),
             aliases: BTreeMap::new(),
             tags: BTreeMap::new(),
+            pending_property_bp: None,
             line_comments: BTreeMap::new(),
             pending_head_comment: None,
             in_document: false,
@@ -4951,6 +4963,7 @@ impl<'a, const HAS_CR: bool> Parser<'a, HAS_CR> {
         // YAML allows anchor redefinition - later definitions override earlier ones
         // Store placeholder - will be updated when value BP is opened
         self.anchors.insert(name.clone(), self.bp_pos);
+        self.pending_property_bp = Some(self.bp_pos);
 
         Ok(name)
     }
@@ -4972,6 +4985,7 @@ impl<'a, const HAS_CR: bool> Parser<'a, HAS_CR> {
         let name = self.parse_anchor_name()?;
         self.skip_inline_whitespace();
         self.anchors.insert(name, self.bp_pos - 1);
+        self.pending_property_bp = Some(self.bp_pos - 1);
         Ok(())
     }
 
@@ -4999,6 +5013,15 @@ impl<'a, const HAS_CR: bool> Parser<'a, HAS_CR> {
         self.advance();
         // Alias names follow the anchor-name rules.
         let name = self.parse_anchor_name()?;
+        // An anchor/tag scanned for this same (already-open) key node just
+        // above means the property was meant for this alias - invalid, since
+        // an alias node carries no properties of its own (#1374).
+        if self.pending_property_bp == Some(self.bp_pos - 1) {
+            return Err(YamlError::PropertyOnAlias {
+                offset: alias_start,
+                name,
+            });
+        }
         match self.anchors.get(&name) {
             Some(&target_bp_pos) => {
                 self.aliases.insert(self.bp_pos - 1, target_bp_pos);
@@ -5018,6 +5041,21 @@ impl<'a, const HAS_CR: bool> Parser<'a, HAS_CR> {
     /// Parse an alias reference (`*name`).
     /// Creates a leaf node in the BP tree pointing to the aliased value.
     fn parse_alias(&mut self) -> Result<(), YamlError> {
+        // An anchor/tag scanned for the node about to open here means the
+        // property was meant for this alias - invalid, since an alias node
+        // carries no properties of its own (#1374). Check before opening the
+        // node so the rejected alias never enters the BP tree.
+        if self.pending_property_bp == Some(self.bp_pos) {
+            // Offset of the `*`, so the error points at the alias itself.
+            let alias_start = self.pos;
+            self.advance();
+            let name = self.parse_anchor_name()?;
+            return Err(YamlError::PropertyOnAlias {
+                offset: alias_start,
+                name,
+            });
+        }
+
         // Mark alias position
         self.set_ib();
         self.write_bp_open();
@@ -5115,6 +5153,7 @@ impl<'a, const HAS_CR: bool> Parser<'a, HAS_CR> {
                 Some(b'!') => {
                     let tag = self.parse_tag()?;
                     self.tags.insert(self.bp_pos, tag);
+                    self.pending_property_bp = Some(self.bp_pos);
                     self.skip_inline_whitespace();
                     had_property = true;
                 }
@@ -5148,6 +5187,7 @@ impl<'a, const HAS_CR: bool> Parser<'a, HAS_CR> {
                 Some(b'!') => {
                     let tag = self.parse_tag()?;
                     self.tags.insert(self.bp_pos, tag);
+                    self.pending_property_bp = Some(self.bp_pos);
                     self.skip_flow_whitespace();
                     had_property = true;
                 }
@@ -5167,6 +5207,7 @@ impl<'a, const HAS_CR: bool> Parser<'a, HAS_CR> {
         let tag = self.parse_tag()?;
         self.skip_inline_whitespace();
         self.tags.insert(self.bp_pos - 1, tag);
+        self.pending_property_bp = Some(self.bp_pos - 1);
         Ok(())
     }
 
@@ -5564,6 +5605,17 @@ impl<'a, const HAS_CR: bool> Parser<'a, HAS_CR> {
                         Some(b'{' | b'[') => {
                             // Property before flow collection
                             self.parse_value(indent)?;
+                        }
+                        Some(b'*') => {
+                            // Property before alias (`&a *b`) at document-root
+                            // level - invalid (an alias node carries no
+                            // properties of its own); route through
+                            // `parse_alias`, whose `pending_property_bp`
+                            // check rejects it (#1374). Real yq accepts this
+                            // specific shape but emits corrupted output
+                            // rather than erroring - reject uniformly
+                            // instead, per docs/compliance/yq/limitations.md.
+                            self.parse_alias()?;
                         }
                         _ => {
                             // Scalar value - only doc_root if not inside a container

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -5314,49 +5314,24 @@ fn test_yaml_anchor_alias_without_merge() -> Result<()> {
 
 /// #1191: `as_str()`'s `Alias` arm only unwrapped a single level of alias
 /// indirection, unlike its `type_name()`/`as_object()`/`as_array()`/
-/// `number_literal()` siblings, which all correctly recurse through a chain
-/// of any length. A string slice (`.[S:E]`) is one of the few call sites
-/// that goes through `as_str()` directly (`slice_one_generic`,
-/// `src/jq/eval_generic.rs`), so it's an observable way to exercise the bug:
-/// before this fix, `.z[0:2]` on a value reached through two alias hops
-/// silently gave `[]` (the "not a string, not an array either" empty-slice
-/// fallback) instead of slicing the resolved string, even though `.z | type`
-/// already correctly reported `"string"` for the exact same node -- the
-/// contradiction the issue itself calls out.
-#[test]
-fn test_yaml_chained_alias_as_str_slices_correctly_1191() -> Result<()> {
-    let input = "x: &a hello\ny: &b *a\nz: *b\n";
-    let (output, exit_code) = run_yq_stdin(".z[0:2]", input, &["-o=json"])?;
-    assert_eq!(exit_code, 0, "out: {output:?}");
-    assert_eq!(output.trim(), r#""he""#);
-    Ok(())
-}
-
-/// #1191: a single-hop alias (the case that already worked) must keep
-/// working identically after generalizing the `Alias` arm to recurse.
+/// `number_literal()` siblings. A string slice (`.[S:E]`) is one of the few
+/// call sites that goes through `as_str()` directly (`slice_one_generic`,
+/// `src/jq/eval_generic.rs`), so it's an observable way to exercise the bug.
+///
+/// #1191's original repro chained two/three aliases (`y: &b *a`) to prove the
+/// fix recurses rather than unwrapping just one hop. #1374 closed off that
+/// exact shape at parse time (`&anchor *alias` is invalid YAML - an alias
+/// node carries no properties of its own, and it was the only way to build a
+/// multi-hop alias chain), so only the single-hop case remains constructible
+/// from valid input; it's kept here as the regression test for the original
+/// bug ([`.y[0:2]`] silently gave `[]` instead of slicing the resolved
+/// string, even though `.y | type` already correctly reported `"string"`).
 #[test]
 fn test_yaml_single_hop_alias_as_str_slices_correctly_1191() -> Result<()> {
     let input = "x: &a hello\ny: *a\n";
     let (output, exit_code) = run_yq_stdin(".y[0:2]", input, &["-o=json"])?;
     assert_eq!(exit_code, 0, "out: {output:?}");
     assert_eq!(output.trim(), r#""he""#);
-    Ok(())
-}
-
-/// #1191: `type_name()` and `as_str()` must agree on a triply-chained alias
-/// -- the exact contradiction the issue reports (told it's a `"string"` by
-/// `type_name()`, but unable to read it as one via `as_str()`) must not
-/// reappear for a longer chain than the doubly-aliased case above.
-#[test]
-fn test_yaml_triple_hop_alias_as_str_slices_correctly_1191() -> Result<()> {
-    let input = "x: &a hello\ny: &b *a\nw: &c *b\nz: *c\n";
-    let (type_output, code) = run_yq_stdin(".z | type", input, &[])?;
-    assert_eq!(code, 0, "out: {type_output:?}");
-    assert_eq!(type_output.trim(), "string");
-
-    let (slice_output, code) = run_yq_stdin(".z[0:2]", input, &["-o=json"])?;
-    assert_eq!(code, 0, "out: {slice_output:?}");
-    assert_eq!(slice_output.trim(), r#""he""#);
     Ok(())
 }
 
@@ -7610,132 +7585,30 @@ fn test_yaml_alias_cycle_fails_for_identity_filter() -> Result<()> {
 
 #[test]
 fn test_yaml_direct_self_alias_cycle() -> Result<()> {
+    // `&x *x` is anchor-on-alias (#1374, invalid YAML - an alias node carries
+    // no properties of its own) as well as a would-be self-cycle; the
+    // property check in `parse_alias` now rejects it before the cycle
+    // checker ever runs, so the error is `PropertyOnAlias`, not `AliasCycle`.
     let input = "a: &x *x";
     let (stdout, stderr, exit_code) = run_yq_stdin_with_stderr(".", input, &[])?;
     assert_eq!(exit_code, 1, "expected clean error exit, stderr: {stderr}");
     assert_eq!(stdout, "");
     assert!(
-        stderr.contains("cyclic alias 'x'"),
-        "stderr should name the cycle: {stderr}"
+        stderr.contains("cannot carry an anchor or tag"),
+        "stderr should name the property-on-alias rejection: {stderr}"
     );
     Ok(())
 }
 
-// =============================================================================
-// Deep (non-cyclic) alias-chain recursion guard (#1193) -- a syntactically
-// valid chain of anchored aliases, each referencing the previous, that never
-// revisits its own anchor (so #153's cycle check above doesn't reject it),
-// used to drive real, uncatchable stack overflow through
-// `YamlValue::Alias`'s recursive scalar accessors.
-// =============================================================================
-
-/// Builds `k0: &a0 <leaf>`, `k1: &a1 *a0`, ..., `z: *a{depth - 1}` -- a
-/// chain of `depth` anchored aliases, each hopping to the previous, with a
-/// top-level `z` referencing the tail.
-fn deep_alias_chain(depth: usize, leaf: &str) -> String {
-    let mut doc = String::new();
-    for i in 0..depth {
-        if i == 0 {
-            doc.push_str(&format!("k{i}: &a{i} {leaf}\n"));
-        } else {
-            doc.push_str(&format!("k{i}: &a{i} *a{}\n", i - 1));
-        }
-    }
-    doc.push_str(&format!("z: *a{}\n", depth - 1));
-    doc
-}
-
-#[test]
-fn test_yaml_deep_alias_chain_does_not_stack_overflow_1193() -> Result<()> {
-    // 50,000 hops crashed with SIGABRT (exit 134, "stack overflow, aborting")
-    // before the fix; the issue's own measurement found 20,000 hops still
-    // safe under the old recursive accessors. `[.z]` array-wraps the tail so
-    // the query is forced through `to_owned_at_depth`'s typed accessors
-    // (`as_bool`/`as_i64`/.../`type_name`) rather than the identity-output
-    // streaming path, which resolves aliases differently (and is untouched
-    // by this fix). An integer leaf exercises `as_i64`, confirming the fix
-    // doesn't just avoid the crash but resolves the full chain correctly.
-    let input = deep_alias_chain(50_000, "42");
-    let (stdout, stderr, exit_code) =
-        run_yq_stdin_with_stderr("[.z]", &input, &["-o", "json", "--indent", "0"])?;
-    assert_eq!(exit_code, 0, "expected a clean exit, stderr: {stderr}");
-    assert_eq!(stdout.trim(), "[42]");
-    Ok(())
-}
-
-#[test]
-fn test_yaml_moderate_alias_chain_resolves_through_every_hop_1193() -> Result<()> {
-    // A chain well short of any depth guard, confirming the iterative
-    // `resolve_alias_chain` walk is correct at ordinary depths, not just
-    // crash-safe at extreme ones. `as_bool` is one of the accessors that
-    // used to recurse via `target.and_then(|t| t.value().as_bool())`.
-    let input = deep_alias_chain(25, "true");
-    let (stdout, exit_code) = run_yq_stdin("[.z, (.z and true)]", &input, &["-o", "json"])?;
-    assert_eq!(exit_code, 0);
-    assert_eq!(stdout.trim(), "[\n  true,\n  true\n]");
-    Ok(())
-}
-
-#[test]
-fn test_yaml_alias_chain_past_depth_cap_panics_cleanly_not_via_stack_overflow_1193() -> Result<()> {
-    // Past `MAX_ALIAS_CHAIN_DEPTH` (65,536), `resolve_alias_chain` panics
-    // (via `assert_depth`, mirroring this crate's other `MAX_*` depth
-    // ceilings) rather than looping forever. A `Result::unwrap`-style Rust
-    // panic unwinds cleanly to exit 101 with a message -- a world apart from
-    // the uncatchable exit-134 SIGABRT this issue reports, even though
-    // neither is catchable by a jq `try`/`catch` inside the query itself.
-    let input = deep_alias_chain(70_000, "42");
-    let (stdout, stderr, exit_code) =
-        run_yq_stdin_with_stderr("[.z]", &input, &["-o", "json", "--indent", "0"])?;
-    assert_eq!(
-        exit_code, 101,
-        "expected a clean panic exit, stderr: {stderr}"
-    );
-    assert_eq!(stdout, "");
-    assert!(
-        stderr.contains("nesting depth exceeds limit"),
-        "stderr should name the depth guard: {stderr}"
-    );
-    Ok(())
-}
-
-#[test]
-fn test_yaml_deep_alias_chain_json_stream_output_does_not_stack_overflow_1193() -> Result<()> {
-    // `[.z]` (used by the tests above) forces materialization through
-    // `to_owned_at_depth`'s typed accessors. Bare `.z` with `-o json`
-    // instead forces `YamlCursor::stream_json_value`/`write_json_to` -- a
-    // completely separate alias-following code path with its own
-    // independent self-recursion, found live during this PR's own review:
-    // `succinctly yq -o json '.'` (this repo's own CLAUDE.md-documented
-    // standard invocation) SIGABRTed on a long chain even after the
-    // typed-accessor fix above, since neither `stream_json_value` nor
-    // `write_json_to` called into `resolve_alias_chain` at all yet.
-    let input = deep_alias_chain(50_000, "42");
-    let (stdout, stderr, exit_code) =
-        run_yq_stdin_with_stderr(".z", &input, &["-o", "json", "--indent", "0"])?;
-    assert_eq!(exit_code, 0, "expected a clean exit, stderr: {stderr}");
-    assert_eq!(stdout.trim(), "42");
-    Ok(())
-}
-
-#[test]
-fn test_yaml_alias_chain_through_owned_evaluator_bridge_does_not_stack_overflow_1193() -> Result<()>
-{
-    // Arithmetic (`+`) isn't cursor-native in the lazy evaluator, so it
-    // bridges to the full/owned evaluator, which materializes the input
-    // document via `yaml_value_to_owned` (src/jq/eval.rs) -- a third
-    // independent alias-following recursion found live during this PR's
-    // own review, distinct from both the typed accessors and the JSON
-    // streaming writer above. Kept small (500 hops, not 50,000): this
-    // whole-document conversion path has a separate, pre-existing O(n^2)
-    // total-work cost for a document shaped like this one (#1317) that
-    // isn't this test's concern -- only crash-safety and correctness are.
-    let input = deep_alias_chain(500, "42");
-    let (stdout, stderr, exit_code) = run_yq_stdin_with_stderr(".z + 1", &input, &[])?;
-    assert_eq!(exit_code, 0, "expected a clean exit, stderr: {stderr}");
-    assert_eq!(stdout.trim(), "43");
-    Ok(())
-}
+// Deep (non-cyclic) alias-chain recursion guard tests (#1193) used to live
+// here, built via a `deep_alias_chain` helper chaining `k1: &a1 *a0`-shaped
+// hops. #1374 closed off that exact shape at parse time (`&anchor *alias` is
+// invalid YAML - an alias node carries no properties of its own, and it was
+// the *only* way to construct an alias chain more than one hop deep), so a
+// multi-hop chain can no longer be built from input the parser accepts, and
+// the crash path those tests guarded is now unreachable. `MAX_ALIAS_CHAIN_DEPTH`
+// and its `assert_depth` calls remain in `src/yaml/light.rs` as defense in
+// depth against a hand-built index, per that constant's doc comment.
 
 // =============================================================================
 // Compatibility tests - Block scalar edge cases
@@ -11209,16 +11082,16 @@ fn test_alias_as_a_flow_mapping_key_resolves() -> Result<()> {
     assert_eq!(code, 0);
     assert_eq!(output, "{\n  \"\": 3,\n  \"\": 4\n}\n");
 
-    // An anchor and an alias to it on the *same* node: the alias edge now lands on
-    // the node the anchor names, so this is a cycle by the `target == alias` arm of
-    // `validate_alias_acyclicity` rather than by its ancestor arm. It must stay an
-    // error — resolving it would be unbounded materialization.
+    // An anchor and an alias to it on the *same* node: `&x *x` is anchor-on-alias
+    // (#1374, invalid YAML - an alias node carries no properties of its own),
+    // rejected by the property check in `record_key_alias` before the cycle
+    // checker (`validate_alias_acyclicity`) would even see it.
     let (stdout, stderr, code) = run_yq_stdin_with_stderr(".", "{&x *x: 1}\n", &["-o=json"])?;
     assert_eq!(code, 1, "expected clean error exit, stderr: {stderr}");
     assert_eq!(stdout, "");
     assert!(
-        stderr.contains("cyclic alias 'x'"),
-        "stderr should name the cycle: {stderr}"
+        stderr.contains("cannot carry an anchor or tag"),
+        "stderr should name the property-on-alias rejection: {stderr}"
     );
     Ok(())
 }
@@ -11252,15 +11125,15 @@ fn test_alias_as_a_flow_sequence_key_resolves() -> Result<()> {
         assert_eq!(output.trim(), expected, "for {yaml:?}");
     }
 
-    // An anchor and an alias to it on the same key: must still be rejected as
-    // a cycle, the same as the flow-mapping key position above - this call
-    // path must not have quietly dropped `record_key_alias`'s cycle check.
+    // An anchor and an alias to it on the same key: must still be rejected,
+    // the same as the flow-mapping key position above - this call path must
+    // not have quietly dropped `record_key_alias`'s property check (#1374).
     let (stdout, stderr, code) = run_yq_stdin_with_stderr(".", "[&x *x: 1]\n", &["-o=json"])?;
     assert_eq!(code, 1, "expected clean error exit, stderr: {stderr}");
     assert_eq!(stdout, "");
     assert!(
-        stderr.contains("cyclic alias 'x'"),
-        "stderr should name the cycle: {stderr}"
+        stderr.contains("cannot carry an anchor or tag"),
+        "stderr should name the property-on-alias rejection: {stderr}"
     );
     Ok(())
 }
@@ -17286,17 +17159,19 @@ fn test_builtin_has_yq_type_mismatch_never_errors_917() -> Result<()> {
 /// resolving it at all; this crate's own alias-key resolution, correct or
 /// not, is a separate and out-of-scope question from this test).
 ///
-/// Two review rounds each found a different way to get this wrong:
 /// `contains` originally matched only a literal `String`-variant key,
 /// silently excluding `Alias` (reporting `false` for a key `keys`/`.`
 /// agreed existed, since `has()` used to reach a fully materializing path
-/// that resolves aliases before this native arm existed); a fix using the
-/// whole-value `as_str()` then over-resolved a **multi-hop** alias chain
-/// relative to `keys()`'s own single-hop resolution (`key_string_kind`),
-/// disagreeing with `keys()` again, just for a deeper chain. Both cases are
-/// pinned here since `key_display_string` (the eventual, shared fix) is the
-/// same function `keys()` itself is built on, and could in principle regress
-/// either shape again without the two staying wired together this way.
+/// that resolves aliases before this native arm existed) -- pinned here
+/// since `key_display_string` (the fix) is the same function `keys()`
+/// itself is built on, and could in principle regress this shape again.
+///
+/// A second review round found this native arm over-resolving relative to
+/// `keys()` on a **multi-hop** alias-typed key (`b: &y *x` then `c: *y: 2`,
+/// #1374's anchor-on-alias shape). #1374 closed that shape off at parse time
+/// (invalid YAML - an alias node carries no properties of its own, and it
+/// was the only way to build a multi-hop chain), so that regression is no
+/// longer reachable from valid input and its case is gone from this test.
 #[test]
 fn test_has_yq_alias_typed_key_matches_own_resolved_spelling_1739() -> Result<()> {
     // One-hop: an ordinary alias-typed key.
@@ -17307,23 +17182,6 @@ fn test_has_yq_alias_typed_key_matches_own_resolved_spelling_1739() -> Result<()
     let (out, code) = run_yq_stdin(".b | keys", one_hop, &["-o", "json", "-I0"])?;
     assert_eq!(code, 0, "out: {out:?}");
     assert_eq!(out.trim(), r#"["hello"]"#);
-
-    // Two-hop: an alias to an alias used as a key. `keys()` only resolves
-    // one hop today (a separate, pre-existing gap of its own), so the
-    // *correct* answer here is that neither `has("hello")` (the fully
-    // resolved spelling) nor the raw key text matches -- only whatever
-    // `keys()` itself already reports (empty string, an unresolved
-    // complex-key fallback) should.
-    let two_hop = "a: &x hello\nb: &y *x\nc:\n  *y: 2\n";
-    let (out, code) = run_yq_stdin(r#".c | has("hello")"#, two_hop, &[])?;
-    assert_eq!(code, 0, "out: {out:?}");
-    assert_eq!(out.trim(), "false");
-    let (out, code) = run_yq_stdin(".c | keys", two_hop, &["-o", "json", "-I0"])?;
-    assert_eq!(code, 0, "out: {out:?}");
-    assert_eq!(out.trim(), r#"[""]"#);
-    let (out, code) = run_yq_stdin(r#".c | has("")"#, two_hop, &[])?;
-    assert_eq!(code, 0, "out: {out:?}");
-    assert_eq!(out.trim(), "true");
     Ok(())
 }
 
@@ -28031,7 +27889,12 @@ fn test_yq_string_repeat_cap_compound_assign_does_not_abort_1612() -> Result<()>
 /// `_ => false` default), so an alias resolving to `false`/`null` was
 /// silently reported as truthy regardless of what it pointed at. This is a
 /// pre-existing gap in `is_falsy` itself, newly load-bearing once `select`
-/// started relying on it. Covers a direct alias and a 2-hop chain.
+/// started relying on it.
+///
+/// Originally also covered a 2-hop chain (`a: &y *x`); #1374 closed off that
+/// anchor-on-alias shape at parse time (invalid YAML - an alias node carries
+/// no properties of its own, and it was the only way to build a multi-hop
+/// chain), so only the direct-alias case remains constructible.
 #[test]
 fn test_select_resolves_alias_falsiness_1645() -> Result<()> {
     let (stdout, _stderr, code) =
@@ -28048,17 +27911,6 @@ fn test_select_resolves_alias_falsiness_1645() -> Result<()> {
     assert_eq!(
         stdout, "",
         "an alias to `null` must be filtered out, not passed through"
-    );
-
-    let (stdout, _stderr, code) = run_yq_stdin_with_stderr(
-        "select(.b) | .keep",
-        "orig: &x false\na: &y *x\nb: *y\nkeep: 5\n",
-        &[],
-    )?;
-    assert_eq!(code, 0);
-    assert_eq!(
-        stdout, "",
-        "a 2-hop alias chain to `false` must be filtered out"
     );
 
     let (stdout, _stderr, code) =

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -7600,6 +7600,44 @@ fn test_yaml_direct_self_alias_cycle() -> Result<()> {
     Ok(())
 }
 
+/// #1374's triage comment enumerates every spelling of anchor/tag-on-alias
+/// it verified live against real yq v4.53.3 and required the default loader
+/// to reject; `test_yaml_direct_self_alias_cycle` above and the flow-key
+/// cases in `test_alias_as_a_flow_mapping_key_resolves` /
+/// `test_alias_as_a_flow_sequence_key_resolves` already cover three of them
+/// (block value, flow-map key, flow-seq key). This covers the rest: tag-only
+/// and tag+anchor decoration (yq rejects both, not just anchor-on-alias),
+/// flow-sequence *value* position, the alias on its own next line (with and
+/// without an intervening comment — the triage comment notes this is a
+/// "which node did the property land on" check, not a one-token lookahead),
+/// a block sequence item, an explicit key, and a compact mapping entry.
+#[test]
+fn test_yaml_anchor_on_alias_rejected_in_every_position() -> Result<()> {
+    for yaml in [
+        "a0: &a0 hello\na1: !!str *a0\n",
+        "a0: &a0 hello\na1: !!str &a1 *a0\n",
+        "a0: &a0 hello\ns: [&a1 *a0]\n",
+        "a0: &a0 hello\na1: &a1\n  *a0\n",
+        "a0: &a0 hello\na1: &a1\n  # comment\n  *a0\n",
+        "a0: &a0 hello\ns:\n  - &a1 *a0\n",
+        "a0: &a0 hello\n? &k1 *a0\n: v\n",
+        "a0: &a0 hello\n&k1 *a0 : v\n",
+        "a0: &a0 hello\ns:\n  - &a1 *a0: v\n",
+    ] {
+        let (stdout, stderr, exit_code) = run_yq_stdin_with_stderr(".", yaml, &[])?;
+        assert_eq!(
+            exit_code, 1,
+            "expected clean error exit for {yaml:?}: {stderr}"
+        );
+        assert_eq!(stdout, "", "for {yaml:?}");
+        assert!(
+            stderr.contains("cannot carry an anchor or tag"),
+            "stderr should name the property-on-alias rejection for {yaml:?}: {stderr}"
+        );
+    }
+    Ok(())
+}
+
 // Deep (non-cyclic) alias-chain recursion guard tests (#1193) used to live
 // here, built via a `deep_alias_chain` helper chaining `k1: &a1 *a0`-shaped
 // hops. #1374 closed off that exact shape at parse time (`&anchor *alias` is

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -7638,6 +7638,27 @@ fn test_yaml_anchor_on_alias_rejected_in_every_position() -> Result<()> {
     Ok(())
 }
 
+/// The one *deliberate* divergence from real yq documented for #1374
+/// (`docs/compliance/yq/limitations.md`, "document root" section): real yq
+/// doesn't error on `&anchor *alias` across a `---` multi-document
+/// separator at all — it silently concatenates the first document's scalar
+/// value with the literal source text of the anchor-alias line
+/// (`"hello--- &a1 *a0"`, confirmed live against yq v4.53.3). succinctly
+/// rejects this shape too, per ADR-0018 rule 4(b) (matching would corrupt a
+/// document) rather than reproduce output with no valid round-trip.
+#[test]
+fn test_yaml_document_root_anchor_on_alias_rejected_1374() -> Result<()> {
+    let yaml = "--- &a0 hello\n--- &a1 *a0\n";
+    let (stdout, stderr, exit_code) = run_yq_stdin_with_stderr(".", yaml, &[])?;
+    assert_eq!(exit_code, 1, "expected clean error exit, stderr: {stderr}");
+    assert_eq!(stdout, "");
+    assert!(
+        stderr.contains("cannot carry an anchor or tag"),
+        "stderr should name the property-on-alias rejection: {stderr}"
+    );
+    Ok(())
+}
+
 // Deep (non-cyclic) alias-chain recursion guard tests (#1193) used to live
 // here, built via a `deep_alias_chain` helper chaining `k1: &a1 *a0`-shaped
 // hops. #1374 closed off that exact shape at parse time (`&anchor *alias` is


### PR DESCRIPTION
## Summary

- The default (non-validating) YAML loader now rejects `&anchor *alias` (an alias node decorated with its own anchor or tag) at parse time, matching real yq and PyYAML. Per the YAML 1.2 grammar an alias node carries no properties of its own; the opt-in strict validator already enforced this (`check_after_anchor`), but the default loader silently accepted it and built a walkable alias-to-alias chain — the *only* shape that can construct a chain more than one hop deep, and the root cause behind #1193's stack-overflow DoS and #1315/#1318/#1319's single-hop-only accessor bugs.
- `YamlIndex::build` now returns a new `YamlError::PropertyOnAlias` for every spelling (block value, next line, flow sequence/mapping, mapping key, `!!str` tag), plus the document-root form across a `---` separator — which real yq accepts but silently corrupts (`ADR-0018` rule 4(b)) rather than erroring.
- Removes 7 tests that constructed now-unconstructible multi-hop alias chains, updates 4 whose expected error moves from `AliasCycle`/`UnknownAnchor`-adjacent to `PropertyOnAlias`, and refreshes `docs/compliance/yaml/limitations.md`'s conformance figures — also correcting pre-existing drift found while regenerating them (the page's loader-alone reject figure had already drifted from its documented 8/94 to an actual 14/94, independent of this change).

## Test plan

- [x] `cargo build --features cli`
- [x] `cargo test --features cli` (full workspace, 61 test binaries, 0 failures)
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings` (non-`scalar-yaml` leg)
- [x] `cargo fmt --check`
- [x] Manual spot-check of every spelling from the issue's acceptance table (block value, next-line, comment-then-next-line, flow seq, flow map, block seq item, `!!str *a`, `&k *a: v` block/compact/flow, `? &k *a`, document-root `---` form) against the built `syq` binary — each exits 1 with `PropertyOnAlias`
- [x] 1-hop controls re-verified unaffected (`x: &a 1\ny: *a`, `*a: v`, `&k k: v`, `key: &a`, block seq wrapper)
- [x] `tests/yaml_test_suite.rs` conformance harness re-run: pass count unchanged (SR86/SU74 now pass via the loader instead of the validator)

Fixes #1374.