### PR TITLE
docs(jq): audit every eager path-context handler for reachability (spine 2416 step 4)

### DIFF
--- a/docs/adrs/adr-0021.md
+++ b/docs/adrs/adr-0021.md
@@ -182,6 +182,9 @@ in-place transforms *inside owned values*, which have no node to stand on.
   [#2439](https://github.com/rust-works/succinctly/pull/2439),
   [#2441](https://github.com/rust-works/succinctly/pull/2441),
   [#2442](https://github.com/rust-works/succinctly/pull/2442) phase 3
+- [`docs/plan/path-context-arm-reachability.md`](../plan/path-context-arm-reachability.md) —
+  the step-4 audit of decision 8's pinned handlers: all 43 are still reachable, with the
+  proof query and gate reason for each, and the three doors into the eager evaluator
 - [ADR-0018](adr-0018.md) — mode, not format, decides fidelity; every divergence above is
   recorded under it
 - [`docs/compliance/yq/limitations.md`](../compliance/yq/limitations.md) — the yq-mode

--- a/docs/plan/README.md
+++ b/docs/plan/README.md
@@ -11,23 +11,24 @@ These plans are kept for:
 
 ## Active Plans
 
-| Plan                                                                 | Status      | Module                            | Description                                       |
-|----------------------------------------------------------------------|-------------|-----------------------------------|---------------------------------------------------|
-| [jq.md](jq.md)                                                       | Implemented | `src/jq/`                         | jq query language for JSON                        |
-| [dsv.md](dsv.md)                                                     | Implemented | `src/dsv/`                        | DSV (CSV/TSV) semi-indexing                       |
-| [yq.md](yq.md)                                                       | Implemented | `src/yaml/`, `yq_runner.rs`       | yq command for YAML                               |
-| [yq-memory-optimization.md](yq-memory-optimization.md)               | Partial     | `yq_runner.rs`, `eval_generic.rs` | yq memory reduction plan                          |
-| [compact-index-investigation.md](compact-index-investigation.md)     | Proposed    | `src/yaml/index.rs`               | Elias-Fano for position arrays                    |
-| [m2-benchmark-improvements.md](m2-benchmark-improvements.md)         | Proposed    | `yq_bench.rs`                     | Benchmark M2 streaming path                       |
-| [simd-features.md](simd-features.md)                                 | Current     | `src/yaml/simd/`                  | YAML SIMD feature flag matrix                     |
-| [cspoppy.md](cspoppy.md)                                             | Implemented | `src/trees/bp.rs`, `src/bits/`    | Combined sampling, BP select                      |
-| [jq-lazy-map-select.md](jq-lazy-map-select.md)                       | Partial     | `src/jq/eval_generic.rs`          | Lazy `map`/`select` chains (`LazySeq`)            |
-| [jq-path-trackability-deferral.md](jq-path-trackability-deferral.md) | Implemented | `src/jq/eval.rs`                  | Deferred path trackability checks                 |
-| [jq-lazy-generator-consumers.md](jq-lazy-generator-consumers.md)     | Partial     | `src/jq/eval.rs`                  | Demand-driven sink for short-circuiting consumers |
-| [jq-duplicate-key-collapse.md](jq-duplicate-key-collapse.md)         | Implemented | `src/jq/`, `jq_runner.rs`         | jq-mode duplicate object key collapse             |
-| [jq-generator-argument-fanout.md](jq-generator-argument-fanout.md)   | Implemented | `src/jq/eval.rs`                  | One builtin result per generator-argument output  |
-| [jq-range-lazy-bounds.md](jq-range-lazy-bounds.md)                   | Implemented | `src/jq/eval.rs`                  | Lazy `range()` bound-argument resolution          |
-| [decode-failure-routing.md](decode-failure-routing.md)               | Proposed    | `src/jq/`, `src/yaml/`            | Decode-failure error routing                      |
+| Plan                                                                 | Status      | Module                            | Description                                         |
+|----------------------------------------------------------------------|-------------|-----------------------------------|-----------------------------------------------------|
+| [jq.md](jq.md)                                                       | Implemented | `src/jq/`                         | jq query language for JSON                          |
+| [dsv.md](dsv.md)                                                     | Implemented | `src/dsv/`                        | DSV (CSV/TSV) semi-indexing                         |
+| [yq.md](yq.md)                                                       | Implemented | `src/yaml/`, `yq_runner.rs`       | yq command for YAML                                 |
+| [yq-memory-optimization.md](yq-memory-optimization.md)               | Partial     | `yq_runner.rs`, `eval_generic.rs` | yq memory reduction plan                            |
+| [compact-index-investigation.md](compact-index-investigation.md)     | Proposed    | `src/yaml/index.rs`               | Elias-Fano for position arrays                      |
+| [m2-benchmark-improvements.md](m2-benchmark-improvements.md)         | Proposed    | `yq_bench.rs`                     | Benchmark M2 streaming path                         |
+| [simd-features.md](simd-features.md)                                 | Current     | `src/yaml/simd/`                  | YAML SIMD feature flag matrix                       |
+| [cspoppy.md](cspoppy.md)                                             | Implemented | `src/trees/bp.rs`, `src/bits/`    | Combined sampling, BP select                        |
+| [jq-lazy-map-select.md](jq-lazy-map-select.md)                       | Partial     | `src/jq/eval_generic.rs`          | Lazy `map`/`select` chains (`LazySeq`)              |
+| [jq-path-trackability-deferral.md](jq-path-trackability-deferral.md) | Implemented | `src/jq/eval.rs`                  | Deferred path trackability checks                   |
+| [jq-lazy-generator-consumers.md](jq-lazy-generator-consumers.md)     | Partial     | `src/jq/eval.rs`                  | Demand-driven sink for short-circuiting consumers   |
+| [jq-duplicate-key-collapse.md](jq-duplicate-key-collapse.md)         | Implemented | `src/jq/`, `jq_runner.rs`         | jq-mode duplicate object key collapse               |
+| [jq-generator-argument-fanout.md](jq-generator-argument-fanout.md)   | Implemented | `src/jq/eval.rs`                  | One builtin result per generator-argument output    |
+| [jq-range-lazy-bounds.md](jq-range-lazy-bounds.md)                   | Implemented | `src/jq/eval.rs`                  | Lazy `range()` bound-argument resolution            |
+| [decode-failure-routing.md](decode-failure-routing.md)               | Proposed    | `src/jq/`, `src/yaml/`            | Decode-failure error routing                        |
+| [path-context-arm-reachability.md](path-context-arm-reachability.md) | Current     | `src/jq/eval.rs`                  | Eager path-context evaluator arm reachability audit |
 
 ## Archived Plans
 

--- a/docs/plan/path-context-arm-reachability.md
+++ b/docs/plan/path-context-arm-reachability.md
@@ -1,0 +1,161 @@
+# Per-arm reachability of the eager path-context evaluator (spine 2416, step 4)
+
+`eval_stage_with_path_context` (`src/jq/eval.rs`) is the eager, materialising
+path-context evaluator ADR-0021 is retiring. It handles 43 expression shapes by
+name -- 5 pre-match `if` handlers plus 38 arms of its top-level `match first`
+(the split `tests/jq_path_context_arm_guard.rs` pins) -- and each one was added
+to fix a shape the generic evaluator could not answer.
+
+Step 4 asks, of every one of those 43: is there still a query that reaches it?
+
+**Answer: all 43 are reachable.** None was deleted; `PINNED_ARM_COUNT` stays at
+43. The rest of this page is the evidence.
+
+## Method
+
+Each of the 43 handlers was instrumented with a temporary
+`eprintln!("ARMHIT <id>")` as the first statement of its body (expression-bodied
+arms -- `Expr::Shared`, `Expr::Break`, the four that tail-call a
+`*_with_path_context` helper, and `Expr::DefCall`'s `match` -- were wrapped in a
+block for the purpose). The instrumented CLI was built with `--features cli` and
+each candidate query run through it, with stderr captured. A handler is
+**REACHABLE** iff its marker appeared. The instrumentation was reverted before
+this document was committed; nothing in the tree carries it.
+
+`path_context_needs_eager` (`src/jq/eval_generic.rs`) was instrumented the same
+way, splitting its single three-way `if` into one `eprintln!` per disjunct, so
+each proof query also records *why* the gate handed the pipe over.
+
+Every query below is jq mode against one document:
+
+```
+D = {"a":{"b":1},"c":[10,20],"n":0,"m":1}
+```
+
+and was run as
+
+```bash
+printf '%s' '{"a":{"b":1},"c":[10,20],"n":0,"m":1}' | succinctly jq '<filter>'
+```
+
+## The three doors into the eager evaluator
+
+The gate is not the only entry, which is why reachability had to be measured
+rather than derived from `path_context_needs_eager` alone:
+
+1. **The gate.** `path_context_needs_eager(exprs)` returning `true` in
+   `eval_single`'s `Expr::Pipe` arm and in `eval_each_pipe_generic`
+   (`src/jq/eval_generic.rs`) bridges the whole pipe to
+   `eval::eval_pipe_with_path_context`. This is the door ADR-0021 decision 3
+   describes and the one step 5 closes.
+2. **`--eval-all`.** `eval::eval_owned_with_file_index` (#715) calls
+   `eval_pipe_with_path_context_internal` directly, on `needs_path_context(expr)`
+   alone, with no gate at all. Verified live:
+   `succinctly yq --eval-all '[.[] | file_index]' f1.yaml f2.yaml` fires
+   `H3`, `A05`, `A09` and `A21` without `path_context_needs_eager` being
+   consulted.
+3. **`eval::eval_pipe`'s own diversion.** `eval_pipe` still routes any pipe with
+   `needs_path_context` into `eval_pipe_with_path_context`. `jq::eval` no longer
+   reaches it (ADR-0021 decision 4 sends path-context queries to the generic
+   evaluator first), but the generic evaluator's own bridges back into this file
+   (`eval_on_owned` / `bridge_to_full_evaluator` -> `eval_full`) can, so the
+   diversion is live code, not a dead branch behind the entry point.
+
+Doors 2 and 3 mean that lowering the arm count is gated on more than
+`path_context_needs_eager`: the arms have to stop being reachable through all
+three.
+
+## Gate reasons
+
+`path_context_needs_eager`'s single condition is three disjuncts, tested in this
+order; the `Gate` column names the first that fired for that query.
+
+| Id  | Disjunct                             | Meaning                                                                             |
+|-----|--------------------------------------|-------------------------------------------------------------------------------------|
+| R1  | `!is_node`                           | the value reaching the path-context stage is detached -- no cursor to read a key from |
+| R2  | `can_absent && !absent_routed`       | the navigational head can miss, and `path_context_absent_split` declined the pipe     |
+| R3  | `!path_context_stage_native(stage)`  | the stage is built from a construct with no native cursor-threading arm               |
+
+R2 dominates the table because the natural probe shape starts `.a.b`, and a
+`.field` step can always miss. The same shapes with a head that cannot miss trip
+R3 instead -- e.g. `.a[] | key + "x"`, `.a[] | if key == "b" then key + "x" else
+"y" end` and `.a[] | reduce (key) as $k (""; . + $k) | . + "x"` all report R3.
+This is an ordering artefact, not a claim that R3 is rare.
+
+## The 43 handlers
+
+| #   | Handler (site in `eval_stage_with_path_context`)                   | Verdict   | Proof query (jq mode, document `D`)                   | Gate |
+|-----|--------------------------------------------------------------------|-----------|-------------------------------------------------------|------|
+| H1  | pre-match `if matches!(first, Expr::Builtin(Builtin::PathNoArg))`  | REACHABLE | `.a.b \| path + []`                                   | R2   |
+| H2  | pre-match `if matches!(first, Expr::Builtin(Builtin::Key))`        | REACHABLE | `.a.b \| key + "x"`                                   | R2   |
+| H3  | pre-match `if matches!(first, Expr::Builtin(Builtin::FileIndex))`  | REACHABLE | `.a.b \| file_index + 1`                              | R2   |
+| H4  | pre-match `if matches!(first, Expr::Builtin(Builtin::Parent))`     | REACHABLE | `.a.b \| parent + {}`                                 | R2   |
+| H5  | pre-match `if let Expr::Builtin(Builtin::ParentN(n_expr)) = first` | REACHABLE | `.a.b \| parent(0+1) + {}`                            | R2   |
+| A01 | `Expr::Identity`                                                   | REACHABLE | `.a.b \| . \| key + "x"`                              | R2   |
+| A02 | `Expr::Field(name)`                                                | REACHABLE | `.a.b \| key + "x"`                                   | R2   |
+| A03 | `Expr::Index { idx, key }`                                         | REACHABLE | `.c[0] \| key + 1`                                    | R2   |
+| A04 | `Expr::Slice { .. }`                                               | REACHABLE | `.c[0:1] \| .[0] \| key + 1`                          | R1   |
+| A05 | `Expr::Iterate`                                                    | REACHABLE | `.a[] \| key + "x"`                                   | R3   |
+| A06 | `Expr::Paren(inner)`                                               | REACHABLE | `(.a.b) \| key + "x"`                                 | R2   |
+| A07 | `Expr::Optional(inner) if IndexExpr/SliceExpr`                     | REACHABLE | `.c[.n]? \| key + 1`                                  | R1   |
+| A08 | `Expr::Optional(inner)`                                            | REACHABLE | `.a? \| key + "x"`                                    | R2   |
+| A09 | `Expr::Pipe(inner) if rest.is_empty()`                             | REACHABLE | `.a.b \| -(key\|length)`                              | R2   |
+| A10 | `Expr::Pipe(inner)`                                                | REACHABLE | `.a.b \| key + "x"`                                   | R2   |
+| A11 | `Expr::Arithmetic { .. }`                                          | REACHABLE | `.a.b \| key + "x"`                                   | R2   |
+| A12 | `Expr::And(..) \| Expr::Or(..)`                                    | REACHABLE | `.a.b \| key == "b" and true`                         | R2   |
+| A13 | `Expr::Negate(operand)`                                            | REACHABLE | `.a.b \| -(key\|length)`                              | R2   |
+| A14 | `Expr::Compare { .. }`                                             | REACHABLE | `.a.b \| (key + "x") \| . == "bx"`                    | R2   |
+| A15 | `Expr::Builtin(Builtin::Select(cond))`                             | REACHABLE | `.a.b \| select(key == "b") \| key + "x"`             | R2   |
+| A16 | `Expr::Builtin(Builtin::Map(f))`                                   | REACHABLE | `.a \| map(key + "x")`                                | R2   |
+| A17 | `Expr::Builtin(Builtin::GetPath(path_expr))`                       | REACHABLE | `.a \| getpath(["b"]) \| . as $x \| key`              | R1   |
+| A18 | `Expr::Builtin(_)`                                                 | REACHABLE | `.a.b \| (key + "x") \| length`                       | R2   |
+| A19 | `Expr::IndexExpr { target, key }`                                  | REACHABLE | `.c[.n] \| key + 1`                                   | R1   |
+| A20 | `Expr::SliceExpr { target, start, end }`                           | REACHABLE | `.c[.n:.m] \| .[0] \| key + 1`                        | R1   |
+| A21 | `Expr::Array(inner) if needs_path_context(inner)`                  | REACHABLE | `.a.b \| [key] + ["x"]`                               | R2   |
+| A22 | `Expr::StringInterpolation(parts) if ..`                           | REACHABLE | `.a.b \| ("\(key)") \| . + "x"`                       | R2   |
+| A23 | `Expr::DefCall { .. }`                                             | REACHABLE | `def f: key; .a.b \| f + "x"`                         | R2   |
+| A24 | `Expr::Shared(inner)`                                              | REACHABLE | `def f(x): x; .a.b \| f(key) + "z"`                   | R2   |
+| A25 | `Expr::FuncDef { .. }`                                             | REACHABLE | `.a.b \| def f: key; f + "x"`                         | R2   |
+| A26 | `Expr::As { .. } if ..`                                            | REACHABLE | `.a.b \| . as $x \| key + "x"`                        | R2   |
+| A27 | `Expr::AsPattern { .. } if ..`                                     | REACHABLE | `.c \| . as [$x] \| key + "x"`                        | R2   |
+| A28 | `Expr::Limit { n, expr } if ..`                                    | REACHABLE | `.a.b \| limit(1; key + "x")`                         | R2   |
+| A29 | `Expr::FirstExpr(expr) if ..`                                      | REACHABLE | `.a.b \| first(key + "x")`                            | R2   |
+| A30 | `Expr::LastExpr(expr) if ..`                                       | REACHABLE | `.a.b \| last(key + "x")`                             | R2   |
+| A31 | `Expr::Reduce { .. } if ..`                                        | REACHABLE | `.a.b \| reduce (key) as $k (""; . + $k) \| . + "x"`  | R2   |
+| A32 | `Expr::Foreach { .. } if ..`                                       | REACHABLE | `.a.b \| foreach (key) as $k (""; . + $k) \| . + "x"` | R2   |
+| A33 | `Expr::Object(_) \| Expr::Array(_) \| Expr::Literal(_)`            | REACHABLE | `.a.b \| (key + "x") \| {z: .}`                       | R2   |
+| A34 | `Expr::If { .. }`                                                  | REACHABLE | `.a.b \| if key == "b" then key + "x" else "y" end`   | R2   |
+| A35 | `Expr::Comma(exprs)`                                               | REACHABLE | `.a.b \| (key + "x"), key`                            | R2   |
+| A36 | `Expr::Try { .. }`                                                 | REACHABLE | `.a.b \| try (key + "x") catch "e"`                   | R2   |
+| A37 | `Expr::Label { name, body }`                                       | REACHABLE | `.a.b \| label $out \| (key + "x", break $out)`       | R2   |
+| A38 | `Expr::Break(name)`                                                | REACHABLE | `.a.b \| label $out \| (key + "x", break $out)`       | R2   |
+
+## Result
+
+| Metric                                            | Before | After |
+|---------------------------------------------------|--------|-------|
+| Named handlers in `eval_stage_with_path_context`  | 43     | 43    |
+| ... proven REACHABLE by a live query               | --     | 43    |
+| ... proven UNREACHABLE                             | --     | 0     |
+| ... neither                                        | --     | 0     |
+| `PINNED_ARM_COUNT`                                 | 43     | 43    |
+
+Nothing is deletable at this point in the spine. The eager evaluator shrinks
+when the generic evaluator gains native arms (widening
+`path_context_single_native`), when the absent route widens, and when doors 2
+and 3 above are closed -- not before.
+
+### Notes for the next migration
+
+- The five `R1` rows (`A04`, `A07`, `A17`, `A19`, `A20`) are the detached-value
+  reason and are the cheapest cluster to attack: `Expr::Slice`, `Expr::IndexExpr`
+  and `Expr::SliceExpr` are missing from `path_context_single_native` even though
+  their literal-bound siblings (`Expr::Index`, `Expr::Slice` with folded bounds)
+  are navigational.
+- `A24` (`Expr::Shared`) is only ever produced by `substitute_func_param`
+  (`src/jq/eval.rs`), so it dies with `A23`/`A25` and not before.
+- `A38` (`Expr::Break`) cannot be reached without `A37` (`Expr::Label`): the
+  proof query is the same one.
+- Reachability here is a property of the current tree. Re-run the method above
+  (instrument, run, revert) rather than trusting this table after the gate or
+  `path_context_single_native` moves.

--- a/tests/jq_path_context_arm_guard.rs
+++ b/tests/jq_path_context_arm_guard.rs
@@ -41,6 +41,13 @@ use syn::visit::{self, Visit};
 /// The pinned count. Lower it in the PR that migrates an arm to the cursor
 /// walk; raise it only in a PR that says why the new arm is not a migration
 /// (#2416, "Hygiene going forward", rule 2).
+///
+/// Step 4 of that spine audited every one of these handlers for reachability
+/// and found no dead ones: `docs/plan/path-context-arm-reachability.md` has a
+/// live proof query and the gate reason for each, plus the three routes that
+/// enter the eager evaluator (the `path_context_needs_eager` bridge is only
+/// one of them -- `--eval-all` and `eval::eval_pipe`'s own diversion have no
+/// gate). Read it before assuming an arm is deletable.
 const PINNED_ARM_COUNT: usize = 43;
 
 const TARGET_FN: &str = "eval_stage_with_path_context";


### PR DESCRIPTION
## Summary

Step 4 of spine 2416: a per-handler reachability audit of the eager path-context evaluator, `eval_stage_with_path_context`. Every one of the 43 pinned handlers was instrumented with a temporary print, driven by a concrete CLI query, and the gate reason recorded; all 43 are still reachable, so nothing is deleted and the pin stays at 43. The table is `docs/plan/path-context-arm-reachability.md`, indexed from the plan README, referenced from ADR-0021 and from the arm guard's doc comment.

## The finding that matters

The gate `path_context_needs_eager` is not the only door into the eager evaluator, so reachability could not be derived from it:

1. `--eval-all` (`eval::eval_owned_with_file_index`, #715) calls the eager pipe directly on `needs_path_context` alone, with no gate. Verified live with `[.[] | file_index]` over two files.
2. `eval::eval_pipe` still diverts any path-context pipe into the eager evaluator; the library entry point no longer reaches it (ADR-0021 decision 4), but the generic evaluator's bridges back into that file can.

So the pin cannot be lowered by widening the native list alone; those two doors have to close first. That is now the next step of the spine.

## Verification

Docs and a doc comment only; the whole gate was run anyway: fmt, clippy on both CI legs, `cargo test` in the three configurations, `cargo doc -D warnings`, both golden checks (113, 633), oracle sweep 3168 cases with 0 unexpected.

Part of spine 2416 (step 4).
