### PR TITLE
feat(jq): resolve path nodes through a demand-driven sink (#1952, spine 2416 phase 4)

### DIFF
--- a/docs/compliance/jq/limitations.md
+++ b/docs/compliance/jq/limitations.md
@@ -3194,7 +3194,7 @@ case above).
 
 **Path mode is unchanged and still has the original bug.**
 [#2014](https://github.com/rust-works/succinctly/issues/2014) only touched
-value mode's two evaluators; `resolve_repeat_bounded` (path mode, the
+value mode's two evaluators; `resolve_repeat_sink` (path mode, the
 `path(repeat(f))`/`path(limit(n; repeat(f)))` route added by
 [#1906](https://github.com/rust-works/succinctly/issues/1906)) still runs
 its own flat `MAX_ITERATIONS = 1000` round cap regardless of the wrapping
@@ -3208,7 +3208,7 @@ $ succinctly jq -cn 'path(limit(1500; repeat(.))) | length' # counts output line
 This is the same bug value mode had before #2014, now isolated to path mode
 alone -- left open rather than fixed here since #2014's own scope and
 verification are both about value mode; a follow-up applying the identical
-demand-driven treatment to `resolve_repeat_bounded` would close this the
+demand-driven treatment to `resolve_repeat_sink` would close this the
 same way.
 
 ### `reduce`/`foreach`'s own step budget (#695/#2079): bounds genuine fanout, not ordinary element count
@@ -3412,44 +3412,6 @@ Tracked as [#2152](https://github.com/rust-works/succinctly/issues/2152)
 (array/object accumulation) and noted here rather than filing a third,
 narrower until/while-COND-specific issue for what is the same underlying
 "which `Expr` shapes does `eval_owned_fast_path` cover" question.
-
-### `path(repeat(f))` tracking (#1906/#1935) only reaches `limit`/`first`'s *direct* child, not `nth` or a combinator-nested `repeat`
-
-[#1906](https://github.com/rust-works/succinctly/issues/1906)/PR #1933 added `Expr::Repeat`
-interception for `path(limit(n; repeat(f)))` (`resolve_limit_one_n`);
-[#1935](https://github.com/rust-works/succinctly/issues/1935) extended the identical
-interception to `path(first(repeat(f)))` (`first(f)` being `limit(1; f)` for this purpose).
-Both fixes only fire when `Expr::Repeat` is the *direct* (paren-unwrapped) child of the
-bounded consumer's own body expression:
-
-```console
-$ echo '{"a":{"a":2}}' | jq -c 'path(nth(2; repeat(.a)))'
-["a"]
-$ echo '{"a":{"a":2}}' | succinctly jq -c 'path(nth(2; repeat(.a)))'
-jq: error (at <stdin>:1): Invalid path expression with result {"a":2}
-
-$ echo '{"a":1}' | jq -c 'path(limit(2; if true then repeat(.) else 1 end))'
-[]
-[]
-$ echo '{"a":1}' | succinctly jq -c 'path(limit(2; if true then repeat(.) else 1 end))'
-jq: error (at <stdin>:1): Invalid path expression with result {"a":1}
-```
-
-`nth(n; f)` (`Builtin::NthStream`) has no `resolve_node` arm at all today -- a pre-existing
-gap independent of `repeat` (`path(nth(1; .a,.b))` on an ordinary, non-`repeat` generator
-already diverges the same way). Extending `repeat`-specific interception to `nth` has
-nothing to attach to until `nth` has *any* path-context support to extend. `Expr::If`/
-`Expr::Alternative`/(likely) `Expr::Comma` all recurse into `resolve_node` directly on
-their branches rather than through a bounded consumer, so a `repeat` reached only after
-passing through one of these has no way to know, at that point, how many outputs will
-actually be needed -- closing this generally would need a bound threaded *through*
-arbitrary combinator nesting before ever calling `resolve_node` on the `repeat` itself,
-which its current single `(expr, value, trackable, snapshot) -> Vec<PathBranch>` signature
-has no parameter for. Tracked as its own standalone design question in
-[#1952](https://github.com/rust-works/succinctly/issues/1952) (a general sink/early-stop
-protocol for `resolve_node`, the same shape `eval_each_owned` already gives value-mode
-evaluation) rather than attempted here; the narrow `first`/`limit` fixes already close
-the two shapes named in #1906/#1935's own repros.
 
 ### A generator-argument expression used to fan out normally, then silently narrow to a single array the moment `key`/`parent`/`file_index` showed up anywhere else in the same pipe -- fixed for 3 of 4 sites
 

--- a/docs/compliance/yq/limitations.md
+++ b/docs/compliance/yq/limitations.md
@@ -2171,7 +2171,7 @@ fixed on its own terms (#2375); the second is still open:
   there detaches a container result and passes a scalar through with its position, which
   is the same mechanism seen from both sides — yq never replaced the scalar node, so it
   kept its own path. Pinned in `test_owned_identity_rules_match_yq_2416`.
-- **`first(.a[])` on a genuinely-resolved scalar still raises** (`resolve_iterate_bounded`,
+- **`first(.a[])` on a genuinely-resolved scalar still raises** (`resolve_iterate_sink`,
   shared by `resolve_node`'s own `Expr::Iterate` arm and `first`/`limit`'s fast path) —
   this function is also reached by `resolve_del_path_branches`'s comma-fanout fallback for a
   declined vivify pre-pass, where an out-of-range index read is a placeholder for a write

--- a/docs/plan/jq-generator-argument-fanout.md
+++ b/docs/plan/jq-generator-argument-fanout.md
@@ -321,7 +321,7 @@ cannot bypass the fix silently.
   observable. Own commit, own probe cited, or a bisect blames the wrong change.
 - **Path context** returns `PathResolveResult`, not `QueryResult`, so it cannot use
   `fanout_arg`. Two doc-commented rules point opposite ways and must both be re-read first:
-  `take_path_branches`' "prefix is never longer than jq's" invariant (the exact assumption
+  the "prefix is never longer than jq's" invariant (the exact assumption
   #972/#985 got wrong) and `resolve_leaf`'s halt-*keeping* rule.
 - **`#[cfg]` matrix.** `builtin_test` has a `#[cfg(not(feature = "regex"))]` twin and a regex
   twin, touched in different stages — do not let them drift. `cargo check --no-default-features`

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -22499,6 +22499,203 @@ fn unwrap_paren(expr: &Expr) -> &Expr {
     }
 }
 
+/// The three outcomes of one sink-driven path resolution — the same
+/// three [`Flow`] already has for value-mode evaluation ([`Demand`] is
+/// shared verbatim), minus the `pending` field: a path resolution's
+/// producers are this file, and none of them can hand back a control it
+/// discovered *after* a sink had already stopped, because a stopped sink
+/// is the point at which every one of them returns.
+///
+/// The `(prefix, escape)` tuple [`PathResolveResult`] carries has no
+/// counterpart here on purpose: everything produced before the escape has
+/// already reached the sink, which is exactly jq`s own "never un-emit"
+/// rule the tuple existed to reproduce (see [`PathResolveResult`]'s doc
+/// comment). [`resolve_node`] rebuilds the tuple for the callers that
+/// still want it, by collecting.
+#[derive(Debug)]
+enum ResolveFlow {
+    /// Ran to exhaustion; every branch was delivered.
+    Exhausted,
+    /// A sink answered [`Demand::Stop`].
+    ///
+    /// A trailing escape the producer had already computed is *dropped*
+    /// here rather than carried, matching [`take_path_branches`]'s own
+    /// rule and `def first(f): label $out | (f, break $out);` — once
+    /// the consumer is satisfied, jq never resumes the generator, so an
+    /// error/break/halt after the last delivered branch is never raised.
+    Stopped,
+    /// Terminated in an escape. Everything produced before it was already
+    /// delivered to the sink.
+    Escaped(EvalEscape),
+}
+
+/// Deliver an already-materialized [`PathResolveResult`] to a sink,
+/// checking demand between branches — the fallback for every arm
+/// [`resolve_node_sink`] has no native lazy form for yet.
+///
+/// **The invariant that makes the migration incremental** (the same one
+/// [`drain_result`] states for the value-mode sink): for a sink that
+/// always answers [`Demand::Continue`] this delivers exactly the branches
+/// the eager resolver returned, in the same order, and reports the same
+/// escape. So an un-lazified arm is a missed optimization, never a
+/// behaviour change.
+fn drain_path_result<'a>(
+    result: PathResolveResult<'a>,
+    sink: &mut dyn FnMut(PathBranch<'a>) -> Demand,
+) -> ResolveFlow {
+    let (branches, escape) = match result {
+        Ok(branches) => (branches, None),
+        Err((prefix, e)) => (prefix, Some(e)),
+    };
+    for branch in branches {
+        if sink(branch) == Demand::Stop {
+            return ResolveFlow::Stopped;
+        }
+    }
+    match escape {
+        Some(e) => ResolveFlow::Escaped(e),
+        None => ResolveFlow::Exhausted,
+    }
+}
+
+/// Emit the one branch a "passes the value through without navigating"
+/// arm produces (`select`, the typeof filters, `stderr`/`debug`), and
+/// report the sink's answer.
+fn emit_passthrough<'a>(
+    value: &'a OwnedValue,
+    trackable: bool,
+    snapshot: bool,
+    sink: &mut dyn FnMut(PathBranch<'a>) -> Demand,
+) -> ResolveFlow {
+    let branch = PathBranch::passthrough(
+        PathPrefix::root(),
+        Cow::Borrowed(value),
+        trackable,
+        snapshot,
+    );
+    match sink(branch) {
+        Demand::Continue => ResolveFlow::Exhausted,
+        Demand::Stop => ResolveFlow::Stopped,
+    }
+}
+
+/// Sink-shaped `Select`/`If` "fork on cond, dispatch per output" step —
+/// the sink twin of the eager `resolve_cond_fork` it replaces (#1023).
+/// `dispatch` reports its own [`ResolveFlow`] rather than an optional
+/// escape, so a stop and an escape stay structurally distinct, and the
+/// `cond`-level escape still fires only once the loop drains naturally.
+fn resolve_cond_fork_sink(
+    cond_outputs: Vec<OwnedValue>,
+    cond_escape: Option<EvalEscape>,
+    mut dispatch: impl FnMut(bool) -> ResolveFlow,
+) -> ResolveFlow {
+    for c in cond_outputs {
+        match dispatch(c.is_truthy()) {
+            ResolveFlow::Exhausted => {}
+            other => return other,
+        }
+    }
+    match cond_escape {
+        Some(e) => ResolveFlow::Escaped(e),
+        None => ResolveFlow::Exhausted,
+    }
+}
+
+/// `.[]`'s own path-branch construction (#1850), emitted one element at a
+/// time so a bounded consumer stops the walk instead of truncating it
+/// afterwards. [`resolve_iterate_bounded`] is the collecting wrapper for
+/// the callers that still want a `Vec`.
+///
+/// **Precondition, not re-checked here:** the caller must already know
+/// `value` is trackable (#843) and raise
+/// `invalid_path_expression_near_iterate` itself when it is not.
+fn resolve_iterate_sink<'a, S: EvalSemantics>(
+    value: &'a OwnedValue,
+    sink: &mut dyn FnMut(PathBranch<'a>) -> Demand,
+) -> ResolveFlow {
+    let root = PathPrefix::root();
+    match value {
+        OwnedValue::Array(items) => {
+            for (i, v) in items.iter().enumerate() {
+                let branch = PathBranch::new(
+                    PathPrefix::extend(
+                        &root,
+                        Expr::Index {
+                            idx: i as i64,
+                            key: None,
+                        },
+                    ),
+                    Cow::Borrowed(v),
+                    true,
+                );
+                if sink(branch) == Demand::Stop {
+                    return ResolveFlow::Stopped;
+                }
+            }
+            ResolveFlow::Exhausted
+        }
+        OwnedValue::Object(map) => {
+            for (k, v) in map {
+                let branch = PathBranch::new(
+                    PathPrefix::extend(&root, Expr::Field(k.clone())),
+                    Cow::Borrowed(v),
+                    true,
+                );
+                if sink(branch) == Demand::Stop {
+                    return ResolveFlow::Stopped;
+                }
+            }
+            ResolveFlow::Exhausted
+        }
+        // #2346 considered, deliberately NOT fixed here: real yq's `.[]`
+        // over a genuinely-resolved non-container is a silent no-op
+        // (confirmed live: `first(.a[])` on `{"a":5}` is `[]`, not an
+        // error, against yq v4.53.3), but this function is also reached by
+        // `resolve_del_path_branches`'s comma-fanout fallback (any sibling
+        // with a negative index declines the vivify pre-pass and falls
+        // through to this read-only path-computation machinery, which has
+        // no way to extend/vivify an array the way `delete_at_path`'s own
+        // `real_slot`-gated rule does) -- an out-of-range index read
+        // reaching this arm there is not a genuinely-resolved scalar, it's
+        // a placeholder for a write real yq's own vivify would perform, and
+        // this function has no way to tell the two apart (no `real_slot`
+        // equivalent, unlike `delete_at_path`/`delete_path_steps`).
+        // Silently returning zero branches for that shape regresses an
+        // honest "Cannot iterate" (a documented, tracked coverage gap) into
+        // a silently wrong answer instead -- confirmed live: `del(.[-1],
+        // .[4][])` on `[1,2]` reached this arm and produced `[1]`
+        // (`.[4][]`'s branch silently vanished) where real yq gives `[1,
+        // null, null, []]`. Left as a follow-up (only `first`, real yq
+        // surface, is currently affected) rather than folded into this
+        // fix. Tracked as #2376.
+        other => ResolveFlow::Escaped(EvalError::cannot_iterate_with(S::TAG, other).into()),
+    }
+}
+
+/// Collecting adapter over [`resolve_node_sink`] — the shape every caller
+/// that still wants a materialized `Vec<PathBranch>` uses.
+///
+/// A `Stopped` flow folds to `Ok`: this sink never answers
+/// [`Demand::Stop`], so the only way to reach it is an *inner* bounded
+/// consumer that was already satisfied, which is a success for this call.
+fn resolve_node<'a, S: EvalSemantics>(
+    expr: &Expr,
+    value: &'a OwnedValue,
+    trackable: bool,
+    snapshot: bool,
+    keep: Keep,
+) -> PathResolveResult<'a> {
+    let mut out = Vec::new();
+    let flow = resolve_node_sink::<S>(expr, value, trackable, snapshot, keep, &mut |b| {
+        out.push(b);
+        Demand::Continue
+    });
+    match flow {
+        ResolveFlow::Exhausted | ResolveFlow::Stopped => Ok(out),
+        ResolveFlow::Escaped(e) => Err((out, e)),
+    }
+}
+
 /// Resolve one path node against one value, yielding a branch per output.
 ///
 /// `trackable` is `false` for exactly one caller (`resolve_catch`, for the
@@ -22520,19 +22717,31 @@ fn unwrap_paren(expr: &Expr) -> &Expr {
 /// `path(try (.a, error([1,2,3])) catch getpath(["b"]))` raises the
 /// ordinary `Cannot index array with string "b"`, not a `#843` message),
 /// so that arm never reads `trackable` at all.
-fn resolve_node<'a, S: EvalSemantics>(
+///
+/// Emits each branch to `sink` as it is produced (#1952), so a bounded
+/// consumer answers [`Demand::Stop`] and the generator underneath is
+/// never asked for the branch after it — the path-mode twin of
+/// `eval_each_owned`'s own sink, and the general mechanism #1850/#1906/
+/// #1935 each hand-copied one generator shape at a time. Arms with no
+/// native lazy form yet fall through to [`resolve_node_eager`] and reach
+/// the sink through [`drain_path_result`], which is byte-identical to the
+/// eager result for an always-`Continue` sink.
+fn resolve_node_sink<'a, S: EvalSemantics>(
     expr: &Expr,
     value: &'a OwnedValue,
     trackable: bool,
     snapshot: bool,
     keep: Keep,
-) -> PathResolveResult<'a> {
+    sink: &mut dyn FnMut(PathBranch<'a>) -> Demand,
+) -> ResolveFlow {
     match expr {
         // `None`: an ordinary pipe has no externally-known register to
         // inject (#2046) — see `resolve_seq`'s own doc comment.
-        Expr::Pipe(exprs) => resolve_seq::<S>(exprs, value, trackable, snapshot, keep, None),
-        Expr::Paren(inner) => resolve_node::<S>(inner, value, trackable, snapshot, keep),
-
+        Expr::Pipe(exprs) => drain_path_result(
+            resolve_seq::<S>(exprs, value, trackable, snapshot, keep, None),
+            sink,
+        ),
+        Expr::Paren(inner) => resolve_node_sink::<S>(inner, value, trackable, snapshot, keep, sink),
         // #1371: `path(f)` has to see *through* a call to whatever its body
         // navigates, exactly as it did when the body was substituted in
         // before evaluation began. Binding the call here and resolving the
@@ -22550,45 +22759,290 @@ fn resolve_node<'a, S: EvalSemantics>(
             frames,
             bound,
         } => match bind_def_call(def, args, *frames, bound) {
-            Ok(bound) => resolve_node::<S>(bound, value, trackable, snapshot, keep),
-            Err(e) => Err((Vec::new(), e.into())),
+            Ok(bound) => resolve_node_sink::<S>(bound, value, trackable, snapshot, keep, sink),
+            Err(e) => ResolveFlow::Escaped(e.into()),
         },
         // Transparent, like `Paren`: the wrapped argument is ordinary code
         // whose own navigation is exactly as trackable here as it would be
         // written out in place.
-        Expr::Shared(inner) => resolve_node::<S>(inner, value, trackable, snapshot, keep),
-
+        Expr::Shared(inner) => {
+            resolve_node_sink::<S>(inner, value, trackable, snapshot, keep, sink)
+        }
         Expr::Comma(exprs) => {
-            let mut out = Vec::new();
             for e in exprs {
-                // No `reject_if_untracked` here (#986 Stage 2). It used to
-                // run per sibling, on the premise that a sibling's output is
-                // "final the moment it's produced". That premise is false
-                // whenever the `Comma` is a non-terminal element of a pipe:
-                // in `(.a, 1) | .c` there is very much something left to
-                // navigate into `1`, and checking here reported
-                // `path()`'s own "with result 1" instead of letting `.c`
-                // raise jq's "near attempt to access element \"c\" of 1".
-                //
-                // Each sibling already resolves independently, so its
-                // branches now simply carry their own `trackable` outward
-                // and whoever turns out to be terminal decides — the
-                // enclosing pipe's static tail, `resolve_catch`, or
-                // `resolve_dynamic_indexes`. Streaming order is unaffected:
-                // siblings are still appended to `out` in source order, and
-                // an untracked one still stops everything after it, just at
-                // the point that knows enough to say so.
-                match resolve_node::<S>(e, value, trackable, snapshot, keep) {
-                    Ok(branches) => out.extend(branches),
-                    Err((prefix, e)) => {
-                        out.extend(prefix);
-                        return Err((out, e));
-                    }
+                match resolve_node_sink::<S>(e, value, trackable, snapshot, keep, sink) {
+                    ResolveFlow::Exhausted => {}
+                    other => return other,
                 }
             }
-            Ok(out)
+            ResolveFlow::Exhausted
+        }
+        // `.[]` before a computed key has to be expanded to concrete
+        // components, because each element continues with its own key.
+        // `[path(.xs[] | .[.k])]` is `[["xs",0,"p"],["xs",1,"q"]]` in jq.
+        //
+        // An untracked `value` (#843) raises unconditionally, before even
+        // checking whether `value` is a container at all — confirmed live,
+        // `path(try (.a, error(5)) catch .[])` on a caught *scalar* `5`
+        // still reports "near attempt to iterate through 5", never the
+        // ordinary "Cannot iterate over number".
+        Expr::Iterate => {
+            if !trackable {
+                return ResolveFlow::Escaped(
+                    EvalError::invalid_path_expression_near_iterate(value).into(),
+                );
+            }
+            resolve_iterate_sink::<S>(value, sink)
+        }
+        // `select(f)` and the typeof filters (`objects`, `arrays`, ...) add no
+        // path component of their own — they either pass a branch through
+        // unchanged or prune it, exactly like `Optional` above but driven by a
+        // predicate instead of an error.
+        //
+        // `cond` runs through `eval_owned_multi_keep_partial`, not
+        // `eval_owned_multi`/`eval_owned_expr`, and republishes `value` once
+        // per truthy output rather than collapsing every output into one
+        // always-truthy array (#628, mirroring #627's
+        // `builtin_recurse_cond`/`resolve_recurse` fix): confirmed against jq
+        // 1.7.1, `path(select((false,false)))` is empty (not `[[]]`), and
+        // `path(select((true,true)))` forks into two branches, `[[],[]]`.
+        // Keeping the partial prefix (rather than discarding it on a later
+        // error/break) matches jq's backtracking generator semantics: a
+        // later output of `cond` failing does not retroactively un-emit a
+        // branch an earlier truthy output already produced (#842/#854's
+        // precedent for `recurse`, independently live here too — #896).
+        // Confirmed against jq 1.7.1: `path(select((true, error("x"))))`
+        // prints `[]` (the branch for the already-produced `true`) before
+        // raising `x`.
+        //
+        // Under `S::SELECT_EMITS_ONCE_IF_ANY_TRUTHY` (yq, #1613) this forking
+        // collapses to at most one branch via `select_emits` (see its own
+        // doc comment): live-verified, real yq's
+        // `(.a[] | select((true,true))) |= . + 10` applies the update once
+        // per element (`[11,12,13]`), where the per-truthy-bit fork above
+        // (unpatched) applied it twice (`[21,22,23]`) — the same
+        // value-position bug #1613 found, reached through `resolve_node`'s
+        // independent path-tracking implementation of `select` rather than
+        // `eval_fanout`. `cond` is still walked to completion, so a later
+        // error/break still escapes with the correct (now-capped) prefix.
+        Expr::Builtin(Builtin::Select(cond)) => {
+            let (cond_outputs, escape) = eval_owned_multi_keep_partial::<S>(cond, value);
+            let mut already_emitted = false;
+            resolve_cond_fork_sink(cond_outputs, escape, |truthy| {
+                if select_emits::<S>(truthy, &mut already_emitted) {
+                    emit_passthrough(value, trackable, snapshot, sink)
+                } else {
+                    ResolveFlow::Exhausted
+                }
+            })
+        }
+        Expr::Builtin(
+            builtin @ (Builtin::Values
+            | Builtin::Nulls
+            | Builtin::Booleans
+            | Builtin::Numbers
+            | Builtin::Strings
+            | Builtin::Arrays
+            | Builtin::Objects
+            | Builtin::Iterables
+            | Builtin::Scalars),
+        ) => {
+            if type_filter_matches(builtin, value) {
+                emit_passthrough(value, trackable, snapshot, sink)
+            } else {
+                ResolveFlow::Exhausted
+            }
+        }
+        // `if cond then a else b end`: only the branch the runtime actually
+        // selects is checked for path-ness — the branch not taken is never
+        // evaluated at all, so a non-path `else` that is never reached
+        // raises nothing (matches jq).
+        //
+        // `cond` runs through `eval_owned_multi_keep_partial`, not
+        // `eval_owned_multi`/`eval_owned_expr`, and forks once per output
+        // rather than collapsing every output into one always-truthy array
+        // (#628, mirroring #627): confirmed against jq 1.7.1,
+        // `path(if (false,false) then . else empty end)` is empty (not
+        // `[[]]`), and `path(if (true,true) then . else empty end)`
+        // resolves `then_branch` once per truthy output, `[[],[]]`. Keeping
+        // the partial prefix (rather than discarding it on a later `cond`
+        // error/break) mirrors `Select` above and #842/#854's precedent for
+        // `recurse` — #896. Confirmed against jq 1.7.1:
+        // `path(if (true, error("x")) then . else empty end)` prints `[]`
+        // (the branch for the already-produced `true`) before raising `x`.
+        Expr::If {
+            cond,
+            then_branch,
+            else_branch,
+        } => {
+            let (cond_outputs, escape) = eval_owned_multi_keep_partial::<S>(cond, value);
+            resolve_cond_fork_sink(cond_outputs, escape, |truthy| {
+                let branch = if truthy { then_branch } else { else_branch };
+                resolve_node_sink::<S>(branch, value, trackable, snapshot, keep, sink)
+            })
+        }
+        // `try expr catch handler` (and `expr?`, sugar for `try expr`):
+        // resolve `expr`; if that fails and there is no `catch`, prune the
+        // branch exactly like `Optional`'s blanket arm above. With a
+        // `catch`, jq runs the handler as a path expression too, against the
+        // raised value — confirmed live: `path(try .a catch "x")` on
+        // `{"a":1}` is `[["a"]]` when `.a` does not error, i.e. fully
+        // transparent. `invalid_path_expression` (#530) is neither pruned
+        // nor handed to `catch`, with or without one — confirmed live,
+        // `path(try 1 catch "x")` still raises the same message rather than
+        // running `"x"` — because it is a statement that the filter is not a
+        // path expression at all, not a value `catch` can bind and inspect.
+        // (jq's own wording for the handler's *own* value failing as a path —
+        // `Invalid path expression near attempt to access ...` — used to be a
+        // message shape this resolver did not reproduce at all; `resolve_catch`
+        // below now raises it correctly by marking the handler's payload
+        // untracked, #843.)
+        Expr::Try { expr, catch } => {
+            match resolve_node_sink::<S>(expr, value, trackable, snapshot, keep, sink) {
+                ResolveFlow::Escaped(EvalEscape::Error(e)) if !e.is_uncatchable() => {
+                    drain_path_result(
+                        resolve_catch::<S>(catch.as_deref(), Vec::new(), e.payload(), keep),
+                        sink,
+                    )
+                }
+                ResolveFlow::Escaped(EvalEscape::Break(_)) => drain_path_result(
+                    resolve_catch::<S>(catch.as_deref(), Vec::new(), OwnedValue::Null, keep),
+                    sink,
+                ),
+                other => other,
+            }
+        }
+        // `label $x | body`: catches a `break` targeting this exact label
+        // while resolving `body`, mirroring the value-position `eval_label`'s
+        // `QueryResult::Break`/`Partial(_, Control::Break(_))` handling —
+        // keeping whatever branches already resolved before the break, same
+        // "prefix survives, only the escape is caught" rule every other arm
+        // in this resolver already follows (#824). Confirmed live:
+        // `path(label $out | (.a, break $out))` is `["a"]`, not an error, and
+        // — unlike a label sitting *outside* `path(...)`, which this same fix
+        // lets `EvalEscape::Break` reach — evaluation continues normally
+        // after `path(...)` returns rather than unwinding any further.
+        //
+        // A non-matching break (a different label, still meant for something
+        // further out) is not this arm's to catch, so it propagates
+        // unchanged along with every other escape.
+        Expr::Label { name, body } => {
+            match resolve_node_sink::<S>(body, value, trackable, snapshot, keep, sink) {
+                ResolveFlow::Escaped(EvalEscape::Break(label)) if label == *name => {
+                    ResolveFlow::Exhausted
+                }
+                other => other,
+            }
+        }
+        // `E as $x | body`: bind each output of `E` into `body` by
+        // substitution — reusing `substitute_var`, already relied on for
+        // `FirstExpr`/`IndexExpr` — then resolve the substituted body. This
+        // needs no new environment-threading in the resolver.
+        //
+        // Uses `eval_owned_expr_fork` rather than `eval_owned_multi`: the
+        // latter discards whatever prefix a partially-produced bind stream
+        // already yielded before an error/break/halt (#694's "abort the
+        // whole expression" contract, correct for computed keys but wrong
+        // here), so a source that binds `$x` once and *then* fails never
+        // even ran `body` for that one successful binding. Confirmed live:
+        // `path((1, halt_error(3)) as $x | .a)` on `{"a":1}` prints `["a"]`
+        // before halting — the `$x=1` iteration's own `body` resolution
+        // completing — not nothing.
+        Expr::As { expr, var, body } => {
+            let (bound_values, trailing) = eval_owned_expr_fork::<S>(expr, value, false);
+            for bound in bound_values {
+                let substituted = substitute_bound_var(expr, body, var, &bound);
+                match resolve_node_sink::<S>(&substituted, value, trackable, snapshot, keep, sink) {
+                    ResolveFlow::Exhausted => {}
+                    other => return other,
+                }
+            }
+            match trailing {
+                None => ResolveFlow::Exhausted,
+                Some(control) => ResolveFlow::Escaped(control.into()),
+            }
+        }
+        // #2234: `stderr`/`debug`/`debug(msg)` are true identity passthroughs
+        // in jq -- their value-mode implementations (`builtin_stderr`/
+        // `builtin_debug`/`builtin_debug_msg` below) all decode-then-return
+        // `value` completely unchanged, side effect aside. Before this arm,
+        // none of the three were recognised here, so they fell through to
+        // `resolve_leaf`'s generic "not one of the four primitives" rejection
+        // and raised jq's own `#530` "Invalid path expression" unconditionally
+        // -- even on a bare `path(. | stderr)`, which real jq answers `[]`
+        // (confirmed live against jq 1.7.1). Perform each builtin's own side
+        // effect here (via the shared `write_stderr_value`/`write_debug_line`
+        // helpers their value-mode counterparts also call, so the formatting
+        // rule can't drift between the two), then hand back the same
+        // zero-copy passthrough branch `Select`/the type-filter family above
+        // already use for "navigates nothing, inherits whatever trackability
+        // was already ambient" -- review: an earlier draft delegated to
+        // `resolve_leaf(&Expr::Identity, ...)` instead, which for a
+        // *trackable* branch routes through that function's `is_primitive`
+        // arm and deep-clones `value` via `eval_each_owned`'s own
+        // `Expr::Identity` fast path (`input.clone()`) -- real allocation
+        // this call has no use for, since there is nothing left to decode
+        // that `value` doesn't already hold. Both constructions are provably
+        // equivalent for the `!trackable` case too: `resolve_leaf`'s own
+        // early bare-`.` exemption builds this identical
+        // `PathBranch::passthrough(root, Cow::Borrowed(value), false,
+        // snapshot)` shape.
+        Expr::Builtin(Builtin::Stderr) => {
+            write_stderr_value::<S>(value);
+            emit_passthrough(value, trackable, snapshot, sink)
+        }
+        Expr::Builtin(Builtin::Debug) => {
+            write_debug_line::<S>(value);
+            emit_passthrough(value, trackable, snapshot, sink)
+        }
+        // `debug(msg)`'s own definition is `(msg|debug|empty), .` -- `msg`'s
+        // generator runs for its side effects only, in true per-item order
+        // (mirrors `builtin_debug_msg`'s own doc comment on why an eager
+        // collect would get ordering and partial-output-before-escape both
+        // wrong); the trailing `.` is only reached once `msg` is fully
+        // exhausted without escaping, which is exactly what an `Ok` `Flow`
+        // means here. An escape from `msg` propagates with an empty prefix --
+        // `debug(msg)` itself never produces a real value in that case, so
+        // there is nothing about `expr`'s own passthrough to have resolved
+        // yet (mirrors the identical "nothing built yet, so no prefix to
+        // keep" reasoning `resolve_index_expr`'s own key/target evaluation
+        // escapes already document).
+        Expr::Builtin(Builtin::DebugMsg(msg)) => {
+            let flow = eval_each_owned::<S>(msg, value, false, &mut |msg_value| {
+                write_debug_line::<S>(&msg_value);
+                Demand::Continue
+            });
+            if let Flow::Escaped(control) = flow {
+                return ResolveFlow::Escaped(EvalEscape::from(control));
+            }
+            emit_passthrough(value, trackable, snapshot, sink)
         }
 
+        // Every remaining shape still resolves eagerly and reaches the sink
+        // through `drain_path_result`, which is byte-identical to the eager
+        // result for an always-`Continue` sink -- so this is a missed
+        // optimization for a bounded consumer, never a behaviour change.
+        other => drain_path_result(
+            resolve_node_eager::<S>(other, value, trackable, snapshot, keep),
+            sink,
+        ),
+    }
+}
+
+/// The arms [`resolve_node_sink`] has no native lazy form for yet.
+///
+/// Reached only through that function's fall-through, so its own
+/// recursive calls go back out through [`resolve_node`] (the collecting
+/// adapter) and re-enter the sink dispatch — an arm migrated out of here
+/// therefore takes effect for every nesting of it, not just the outermost.
+fn resolve_node_eager<'a, S: EvalSemantics>(
+    expr: &Expr,
+    value: &'a OwnedValue,
+    trackable: bool,
+    snapshot: bool,
+    keep: Keep,
+) -> PathResolveResult<'a> {
+    match expr {
         Expr::Optional(inner) => match inner.as_ref() {
             // `E[K]?` only covers a failure to *index* — evaluating `E` or `K`
             // is not covered (see `eval_index_expr`'s doc comment, which the
@@ -22747,31 +23201,6 @@ fn resolve_node<'a, S: EvalSemantics>(
             }
         },
 
-        // `.[]` before a computed key has to be expanded to concrete
-        // components, because each element continues with its own key.
-        // `[path(.xs[] | .[.k])]` is `[["xs",0,"p"],["xs",1,"q"]]` in jq.
-        //
-        // An untracked `value` (#843) raises unconditionally, before even
-        // checking whether `value` is a container at all — confirmed live,
-        // `path(try (.a, error(5)) catch .[])` on a caught *scalar* `5`
-        // still reports "near attempt to iterate through 5", never the
-        // ordinary "Cannot iterate over number".
-        Expr::Iterate => {
-            if !trackable {
-                return Err((
-                    Vec::new(),
-                    EvalError::invalid_path_expression_near_iterate(value).into(),
-                ));
-            }
-            // #1850 code review: delegates to `resolve_iterate_bounded`
-            // (`resolve_limit_one_n`'s own fast path) with `n = usize::MAX`
-            // -- a transparent no-op bound -- instead of keeping a second
-            // copy of this Array/Object/other match. One definition means a
-            // future change to how `.[]` builds path branches can't apply
-            // to only one of the two call sites.
-            resolve_iterate_bounded::<S>(value, usize::MAX)
-        }
-
         Expr::IndexExpr { target, key } => {
             resolve_index_expr::<S>(target, key, value, false, trackable, keep)
         }
@@ -22844,83 +23273,6 @@ fn resolve_node<'a, S: EvalSemantics>(
             resolve_recurse::<S>(f, Some(cond), value, trackable, snapshot, keep)
         }
 
-        // `select(f)` and the typeof filters (`objects`, `arrays`, ...) add no
-        // path component of their own — they either pass a branch through
-        // unchanged or prune it, exactly like `Optional` above but driven by a
-        // predicate instead of an error.
-        //
-        // `cond` runs through `eval_owned_multi_keep_partial`, not
-        // `eval_owned_multi`/`eval_owned_expr`, and republishes `value` once
-        // per truthy output rather than collapsing every output into one
-        // always-truthy array (#628, mirroring #627's
-        // `builtin_recurse_cond`/`resolve_recurse` fix): confirmed against jq
-        // 1.7.1, `path(select((false,false)))` is empty (not `[[]]`), and
-        // `path(select((true,true)))` forks into two branches, `[[],[]]`.
-        // Keeping the partial prefix (rather than discarding it on a later
-        // error/break) matches jq's backtracking generator semantics: a
-        // later output of `cond` failing does not retroactively un-emit a
-        // branch an earlier truthy output already produced (#842/#854's
-        // precedent for `recurse`, independently live here too — #896).
-        // Confirmed against jq 1.7.1: `path(select((true, error("x"))))`
-        // prints `[]` (the branch for the already-produced `true`) before
-        // raising `x`.
-        //
-        // Under `S::SELECT_EMITS_ONCE_IF_ANY_TRUTHY` (yq, #1613) this forking
-        // collapses to at most one branch via `select_emits` (see its own
-        // doc comment): live-verified, real yq's
-        // `(.a[] | select((true,true))) |= . + 10` applies the update once
-        // per element (`[11,12,13]`), where the per-truthy-bit fork above
-        // (unpatched) applied it twice (`[21,22,23]`) — the same
-        // value-position bug #1613 found, reached through `resolve_node`'s
-        // independent path-tracking implementation of `select` rather than
-        // `eval_fanout`. `cond` is still walked to completion, so a later
-        // error/break still escapes with the correct (now-capped) prefix.
-        Expr::Builtin(Builtin::Select(cond)) => {
-            let (cond_outputs, escape) = eval_owned_multi_keep_partial::<S>(cond, value);
-            let mut already_emitted = false;
-            resolve_cond_fork(cond_outputs, escape, |truthy, out| {
-                if select_emits::<S>(truthy, &mut already_emitted) {
-                    // `select` filters; it never navigates. The value handed
-                    // back is the caller's own, so its trackability is too —
-                    // and so is its snapshot mark (#1591): `select` cannot
-                    // rebuild a value it never touches, so whatever pointer
-                    // jq is still holding for `value` survives unchanged.
-                    out.push(PathBranch::passthrough(
-                        PathPrefix::root(),
-                        Cow::Borrowed(value),
-                        trackable,
-                        snapshot,
-                    ));
-                }
-                None
-            })
-        }
-        Expr::Builtin(
-            builtin @ (Builtin::Values
-            | Builtin::Nulls
-            | Builtin::Booleans
-            | Builtin::Numbers
-            | Builtin::Strings
-            | Builtin::Arrays
-            | Builtin::Objects
-            | Builtin::Iterables
-            | Builtin::Scalars),
-        ) => {
-            if type_filter_matches(builtin, value) {
-                // A type filter navigates nothing either, so it inherits
-                // both `trackable` and `snapshot` the same way `select`
-                // does just above (#1591).
-                Ok(vec![PathBranch::passthrough(
-                    PathPrefix::root(),
-                    Cow::Borrowed(value),
-                    trackable,
-                    snapshot,
-                )])
-            } else {
-                Ok(Vec::new())
-            }
-        }
-
         // `first(f)` keeps only the first branch `f` resolves to.
         // `Expr::FirstExpr` is what the dedicated `first(...)` parse path
         // builds; `Builtin::FirstStream` is never constructed by the parser
@@ -22939,44 +23291,6 @@ fn resolve_node<'a, S: EvalSemantics>(
         // jq 1.7.1: `{"a":1} | path(first(repeat(.)))` is `[]`.
         Expr::FirstExpr(inner) | Expr::Builtin(Builtin::FirstStream(inner)) => {
             resolve_node_bounded::<S>(inner, value, trackable, snapshot, keep, 1)
-        }
-
-        // `if cond then a else b end`: only the branch the runtime actually
-        // selects is checked for path-ness — the branch not taken is never
-        // evaluated at all, so a non-path `else` that is never reached
-        // raises nothing (matches jq).
-        //
-        // `cond` runs through `eval_owned_multi_keep_partial`, not
-        // `eval_owned_multi`/`eval_owned_expr`, and forks once per output
-        // rather than collapsing every output into one always-truthy array
-        // (#628, mirroring #627): confirmed against jq 1.7.1,
-        // `path(if (false,false) then . else empty end)` is empty (not
-        // `[[]]`), and `path(if (true,true) then . else empty end)`
-        // resolves `then_branch` once per truthy output, `[[],[]]`. Keeping
-        // the partial prefix (rather than discarding it on a later `cond`
-        // error/break) mirrors `Select` above and #842/#854's precedent for
-        // `recurse` — #896. Confirmed against jq 1.7.1:
-        // `path(if (true, error("x")) then . else empty end)` prints `[]`
-        // (the branch for the already-produced `true`) before raising `x`.
-        Expr::If {
-            cond,
-            then_branch,
-            else_branch,
-        } => {
-            let (cond_outputs, escape) = eval_owned_multi_keep_partial::<S>(cond, value);
-            resolve_cond_fork(cond_outputs, escape, |truthy, out| {
-                let branch = if truthy { then_branch } else { else_branch };
-                match resolve_node::<S>(branch, value, trackable, snapshot, keep) {
-                    Ok(branches) => {
-                        out.extend(branches);
-                        None
-                    }
-                    Err((prefix, e)) => {
-                        out.extend(prefix);
-                        Some(e)
-                    }
-                }
-            })
         }
 
         // `a // b`: resolve `a`, keep only its truthy branches — jq's `//`
@@ -23051,118 +23365,6 @@ fn resolve_node<'a, S: EvalSemantics>(
         // coverage-testable through this dispatch.
         Expr::Builtin(Builtin::Limit(n, expr)) => {
             resolve_limit::<S>(n, expr, value, trackable, snapshot, keep)
-        }
-
-        // `try expr catch handler` (and `expr?`, sugar for `try expr`):
-        // resolve `expr`; if that fails and there is no `catch`, prune the
-        // branch exactly like `Optional`'s blanket arm above. With a
-        // `catch`, jq runs the handler as a path expression too, against the
-        // raised value — confirmed live: `path(try .a catch "x")` on
-        // `{"a":1}` is `[["a"]]` when `.a` does not error, i.e. fully
-        // transparent. `invalid_path_expression` (#530) is neither pruned
-        // nor handed to `catch`, with or without one — confirmed live,
-        // `path(try 1 catch "x")` still raises the same message rather than
-        // running `"x"` — because it is a statement that the filter is not a
-        // path expression at all, not a value `catch` can bind and inspect.
-        // (jq's own wording for the handler's *own* value failing as a path —
-        // `Invalid path expression near attempt to access ...` — used to be a
-        // message shape this resolver did not reproduce at all; `resolve_catch`
-        // below now raises it correctly by marking the handler's payload
-        // untracked, #843.)
-        Expr::Try { expr, catch } => {
-            match resolve_node::<S>(expr, value, trackable, snapshot, keep) {
-                Ok(branches) => Ok(branches),
-                // `halt`/`halt_error(n)` is never caught by `try`/`catch`, in
-                // path expressions any more than in value position (#791) —
-                // only a genuine error or a break (below) reaches `catch`;
-                // everything else propagates unchanged, as does an
-                // invalid-path-expression complaint (#530) and, per the same
-                // reasoning, a decode failure (#1247, #1620) — both always
-                // uncatchable, with no positional nuance either shares with
-                // `is_untracked_navigation_error` above.
-                Err((prefix, EvalEscape::Error(e))) if !e.is_uncatchable() => {
-                    resolve_catch::<S>(catch.as_deref(), prefix, e.payload(), keep)
-                }
-                // `catch` catches a `break` the same way it catches a raised
-                // error, regardless of which label it targets — jq's own rule
-                // (#562, already applied by the value-position `eval_try`),
-                // mirrored here for path context (#824): confirmed live,
-                // `label $out | path(try (.a, break $out) catch "x")` prints the
-                // prefix `["a"]` and then raises the catch handler's own
-                // `"x"` as an invalid-path-expression (#530) — the break never
-                // reaches `$out` at all. Real jq binds the handler's input to
-                // its internal break marker, which `null` stands in for here,
-                // same as `eval_try` already does.
-                Err((prefix, EvalEscape::Break(_))) => {
-                    resolve_catch::<S>(catch.as_deref(), prefix, OwnedValue::Null, keep)
-                }
-                Err(escape) => Err(escape),
-            }
-        }
-
-        // `label $x | body`: catches a `break` targeting this exact label
-        // while resolving `body`, mirroring the value-position `eval_label`'s
-        // `QueryResult::Break`/`Partial(_, Control::Break(_))` handling —
-        // keeping whatever branches already resolved before the break, same
-        // "prefix survives, only the escape is caught" rule every other arm
-        // in this resolver already follows (#824). Confirmed live:
-        // `path(label $out | (.a, break $out))` is `["a"]`, not an error, and
-        // — unlike a label sitting *outside* `path(...)`, which this same fix
-        // lets `EvalEscape::Break` reach — evaluation continues normally
-        // after `path(...)` returns rather than unwinding any further.
-        //
-        // A non-matching break (a different label, still meant for something
-        // further out) is not this arm's to catch, so it propagates
-        // unchanged along with every other escape.
-        Expr::Label { name, body } => {
-            match resolve_node::<S>(body, value, trackable, snapshot, keep) {
-                Ok(branches) => Ok(branches),
-                Err((prefix, EvalEscape::Break(label))) if label == *name => Ok(prefix),
-                Err(escape) => Err(escape),
-            }
-        }
-
-        // `E as $x | body`: bind each output of `E` into `body` by
-        // substitution — reusing `substitute_var`, already relied on for
-        // `FirstExpr`/`IndexExpr` — then resolve the substituted body. This
-        // needs no new environment-threading in the resolver.
-        //
-        // Uses `eval_owned_expr_fork` rather than `eval_owned_multi`: the
-        // latter discards whatever prefix a partially-produced bind stream
-        // already yielded before an error/break/halt (#694's "abort the
-        // whole expression" contract, correct for computed keys but wrong
-        // here), so a source that binds `$x` once and *then* fails never
-        // even ran `body` for that one successful binding. Confirmed live:
-        // `path((1, halt_error(3)) as $x | .a)` on `{"a":1}` prints `["a"]`
-        // before halting — the `$x=1` iteration's own `body` resolution
-        // completing — not nothing.
-        Expr::As { expr, var, body } => {
-            let (bound_values, trailing) = eval_owned_expr_fork::<S>(expr, value, false);
-            let mut out = Vec::new();
-            for bound in bound_values {
-                let substituted = substitute_bound_var(expr, body, var, &bound);
-                match resolve_node::<S>(&substituted, value, trackable, snapshot, keep) {
-                    Ok(branches) => out.extend(branches),
-                    Err((body_prefix, escape)) => {
-                        out.extend(body_prefix);
-                        return Err((out, escape));
-                    }
-                }
-            }
-            match trailing {
-                None => Ok(out),
-                // `Control::into()` (via `From<Control> for EvalEscape`)
-                // preserves every variant losslessly, `Break` included —
-                // propagated as a real `EvalEscape::Break` rather than
-                // collapsed into a synthetic "not in label" error, so a
-                // `label` outside this `as`-binding's enclosing `path(...)`
-                // call still catches it (#824) — confirmed live:
-                // `label $out | path((1, break $out) as $x | .a)` on
-                // `{"a":1}` prints `["a"]` (the `$x=1` iteration's own
-                // `body` resolution, already in `out`) and exits cleanly,
-                // never raising the bogus error this arm used to produce.
-                Some(control) => Err((out, control.into())),
-            }
         }
 
         // #1440: `reduce`/`foreach` are real sugar over the same
@@ -23471,77 +23673,6 @@ fn resolve_node<'a, S: EvalSemantics>(
             resolve_leaf::<S>(expr, value, trackable, snapshot, keep)
         }
 
-        // #2234: `stderr`/`debug`/`debug(msg)` are true identity passthroughs
-        // in jq -- their value-mode implementations (`builtin_stderr`/
-        // `builtin_debug`/`builtin_debug_msg` below) all decode-then-return
-        // `value` completely unchanged, side effect aside. Before this arm,
-        // none of the three were recognised here, so they fell through to
-        // `resolve_leaf`'s generic "not one of the four primitives" rejection
-        // and raised jq's own `#530` "Invalid path expression" unconditionally
-        // -- even on a bare `path(. | stderr)`, which real jq answers `[]`
-        // (confirmed live against jq 1.7.1). Perform each builtin's own side
-        // effect here (via the shared `write_stderr_value`/`write_debug_line`
-        // helpers their value-mode counterparts also call, so the formatting
-        // rule can't drift between the two), then hand back the same
-        // zero-copy passthrough branch `Select`/the type-filter family above
-        // already use for "navigates nothing, inherits whatever trackability
-        // was already ambient" -- review: an earlier draft delegated to
-        // `resolve_leaf(&Expr::Identity, ...)` instead, which for a
-        // *trackable* branch routes through that function's `is_primitive`
-        // arm and deep-clones `value` via `eval_each_owned`'s own
-        // `Expr::Identity` fast path (`input.clone()`) -- real allocation
-        // this call has no use for, since there is nothing left to decode
-        // that `value` doesn't already hold. Both constructions are provably
-        // equivalent for the `!trackable` case too: `resolve_leaf`'s own
-        // early bare-`.` exemption builds this identical
-        // `PathBranch::passthrough(root, Cow::Borrowed(value), false,
-        // snapshot)` shape.
-        Expr::Builtin(Builtin::Stderr) => {
-            write_stderr_value::<S>(value);
-            Ok(vec![PathBranch::passthrough(
-                PathPrefix::root(),
-                Cow::Borrowed(value),
-                trackable,
-                snapshot,
-            )])
-        }
-        Expr::Builtin(Builtin::Debug) => {
-            write_debug_line::<S>(value);
-            Ok(vec![PathBranch::passthrough(
-                PathPrefix::root(),
-                Cow::Borrowed(value),
-                trackable,
-                snapshot,
-            )])
-        }
-        // `debug(msg)`'s own definition is `(msg|debug|empty), .` -- `msg`'s
-        // generator runs for its side effects only, in true per-item order
-        // (mirrors `builtin_debug_msg`'s own doc comment on why an eager
-        // collect would get ordering and partial-output-before-escape both
-        // wrong); the trailing `.` is only reached once `msg` is fully
-        // exhausted without escaping, which is exactly what an `Ok` `Flow`
-        // means here. An escape from `msg` propagates with an empty prefix --
-        // `debug(msg)` itself never produces a real value in that case, so
-        // there is nothing about `expr`'s own passthrough to have resolved
-        // yet (mirrors the identical "nothing built yet, so no prefix to
-        // keep" reasoning `resolve_index_expr`'s own key/target evaluation
-        // escapes already document).
-        Expr::Builtin(Builtin::DebugMsg(msg)) => {
-            let flow = eval_each_owned::<S>(msg, value, false, &mut |msg_value| {
-                write_debug_line::<S>(&msg_value);
-                Demand::Continue
-            });
-            if let Flow::Escaped(control) = flow {
-                return Err((Vec::new(), EvalEscape::from(control)));
-            }
-            Ok(vec![PathBranch::passthrough(
-                PathPrefix::root(),
-                Cow::Borrowed(value),
-                trackable,
-                snapshot,
-            )])
-        }
-
         other => resolve_leaf::<S>(other, value, trackable, snapshot, keep),
     }
 }
@@ -23775,84 +23906,33 @@ fn resolve_repeat_bounded<'a, S: EvalSemantics>(
     Ok(branches)
 }
 
-/// `.[]`'s own path-branch construction (#1850), bounded to at most `n`
-/// branches -- both `resolve_node`'s `Expr::Iterate` arm (`n = usize::MAX`,
-/// a transparent no-op bound) and [`resolve_limit_one_n`]'s fast path
-/// (`n` from `limit`) call this instead of keeping two copies of the
-/// `Array`/`Object`/`other` match. `items.iter()`/`map.iter()` are already
-/// lazy; `.take(n)` is the only change from the old unbounded form -- same
-/// `PathBranch`/`PathPrefix` construction, same
-/// [`EvalError::cannot_iterate_with`] for every other value shape,
-/// confirmed live to be byte-identical to the old eager-then-truncate path
-/// for `n` under, at, and over the container's length.
+/// Collecting, `n`-bounded wrapper over [`resolve_iterate_sink`] (#1850) --
+/// [`resolve_node_bounded`]'s `.[]` fast path, the one caller that still
+/// wants a `Vec`. The branch construction itself lives in the sink so the
+/// two cannot drift (#106).
 ///
 /// **Precondition, not re-checked here:** the caller must already know
-/// `value` is trackable (#843) before calling this -- both call sites gate
-/// on `trackable` first and raise `invalid_path_expression_near_iterate`
-/// themselves when it's false, exactly mirroring what the single combined
-/// arm used to do inline. This function has no `trackable` parameter of its
-/// own and never raises that error; a future third call site must add its
-/// own gate rather than assuming this function covers it.
+/// `value` is trackable (#843) and raise
+/// `invalid_path_expression_near_iterate` itself when it is not.
 fn resolve_iterate_bounded<S: EvalSemantics>(
     value: &OwnedValue,
     n: usize,
 ) -> PathResolveResult<'_> {
-    let root = PathPrefix::root();
-    match value {
-        OwnedValue::Array(items) => Ok(items
-            .iter()
-            .enumerate()
-            .take(n)
-            .map(|(i, v)| {
-                PathBranch::new(
-                    PathPrefix::extend(
-                        &root,
-                        Expr::Index {
-                            idx: i as i64,
-                            key: None,
-                        },
-                    ),
-                    Cow::Borrowed(v),
-                    true,
-                )
-            })
-            .collect()),
-        OwnedValue::Object(map) => Ok(map
-            .iter()
-            .take(n)
-            .map(|(k, v)| {
-                PathBranch::new(
-                    PathPrefix::extend(&root, Expr::Field(k.clone())),
-                    Cow::Borrowed(v),
-                    true,
-                )
-            })
-            .collect()),
-        // #2346 considered, deliberately NOT fixed here: real yq's `.[]`
-        // over a genuinely-resolved non-container is a silent no-op
-        // (confirmed live: `first(.a[])` on `{"a":5}` is `[]`, not an
-        // error, against yq v4.53.3), but this function is also reached by
-        // `resolve_del_path_branches`'s comma-fanout fallback (any sibling
-        // with a negative index declines the vivify pre-pass and falls
-        // through to this read-only path-computation machinery, which has
-        // no way to extend/vivify an array the way `delete_at_path`'s own
-        // `real_slot`-gated rule does) -- an out-of-range index read
-        // reaching this arm there is not a genuinely-resolved scalar, it's
-        // a placeholder for a write real yq's own vivify would perform, and
-        // this function has no way to tell the two apart (no `real_slot`
-        // equivalent, unlike `delete_at_path`/`delete_path_steps`).
-        // Silently returning zero branches for that shape regresses an
-        // honest "Cannot iterate" (a documented, tracked coverage gap) into
-        // a silently wrong answer instead -- confirmed live: `del(.[-1],
-        // .[4][])` on `[1,2]` reached this arm and produced `[1]`
-        // (`.[4][]`'s branch silently vanished) where real yq gives `[1,
-        // null, null, []]`. Left as a follow-up (only `first`, real yq
-        // surface, is currently affected) rather than folded into this
-        // fix. Tracked as #2376.
-        other => Err((
-            Vec::new(),
-            EvalError::cannot_iterate_with(S::TAG, other).into(),
-        )),
+    if n == 0 {
+        return Ok(Vec::new());
+    }
+    let mut out = Vec::new();
+    let flow = resolve_iterate_sink::<S>(value, &mut |b| {
+        out.push(b);
+        if out.len() >= n {
+            Demand::Stop
+        } else {
+            Demand::Continue
+        }
+    });
+    match flow {
+        ResolveFlow::Escaped(e) => Err((out, e)),
+        ResolveFlow::Exhausted | ResolveFlow::Stopped => Ok(out),
     }
 }
 
@@ -25785,48 +25865,6 @@ fn eval_recurse_cond<S: EvalSemantics>(
         }
     }
     cond_err
-}
-
-/// Shared `Select`/`If` "fork on cond, dispatch per output" step in path
-/// position (#1023): both arms already evaluate `cond` via
-/// `eval_owned_multi_keep_partial` themselves (the one line the two of them
-/// share verbatim isn't worth extracting on its own), then hand-rolled the
-/// identical "iterate outputs, dispatch per truthiness into the same
-/// collected-branches buffer, propagate a branch's own error immediately,
-/// fall through to the `cond`-level escape only once the loop drains
-/// naturally" loop independently. `dispatch` receives each output's
-/// truthiness plus the shared `out` buffer to push/extend directly (so
-/// `Select`'s zero-or-one-branch case never allocates a throwaway `Vec` of
-/// its own the way an earlier draft of this helper did) and returns just
-/// the escape, if any -- `Select` (which never fails building its own
-/// branch) and `If` (which recurses into `resolve_node` and so genuinely
-/// can) both fit without a bool-parameter thicket.
-///
-/// The value-position analogue of this same `Select`/`If` unification is
-/// [`eval_fanout`], shared by `eval_if`/`builtin_select` (and mirrored a
-/// third time in `eval_pipe_with_path_context_internal`'s own `Select`
-/// arm) -- if a future fix to the fork-on-cond policy needs applying here,
-/// check whether it also needs applying there.
-///
-/// Not a retrofit of [`eval_recurse_cond`] just above: that primitive is a
-/// one-way *gate* (push only on truthy, no way to express an `else` side)
-/// built for `recurse(f; cond)`'s two callers, which need exactly that and
-/// nothing more. `Select`/`If` need genuine two-way dispatch with a
-/// fallible per-branch result, which is a different enough shape that
-/// unifying all four call sites under one signature was tried and
-/// rejected during this issue's own design pass — see #1023.
-fn resolve_cond_fork<'a>(
-    cond_outputs: Vec<OwnedValue>,
-    cond_escape: Option<EvalEscape>,
-    mut dispatch: impl FnMut(bool, &mut Vec<PathBranch<'a>>) -> Option<EvalEscape>,
-) -> PathResolveResult<'a> {
-    let mut out = Vec::new();
-    for c in cond_outputs {
-        if let Some(e) = dispatch(c.is_truthy(), &mut out) {
-            return Err((out, e));
-        }
-    }
-    path_result(out, cond_escape)
 }
 
 /// Item cap shared by every `recurse`-family explicit-stack walker

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -22924,10 +22924,9 @@ fn resolve_node_sink<'a, S: EvalSemantics>(
     match expr {
         // `None`: an ordinary pipe has no externally-known register to
         // inject (#2046) — see `resolve_seq`'s own doc comment.
-        Expr::Pipe(exprs) => drain_path_result(
-            resolve_seq::<S>(exprs, value, trackable, snapshot, keep, None),
-            sink,
-        ),
+        Expr::Pipe(exprs) => {
+            resolve_seq_sink::<S>(exprs, value, trackable, snapshot, keep, None, sink)
+        }
         Expr::Paren(inner) => resolve_node_sink::<S>(inner, value, trackable, snapshot, keep, sink),
         // #1371: `path(f)` has to see *through* a call to whatever its body
         // navigates, exactly as it did when the body was substituted in
@@ -24352,6 +24351,26 @@ fn resolve_against_cow<'a, S: EvalSemantics>(
                 e,
             )),
         },
+    }
+}
+/// [`resolve_against_cow`]'s sink form -- see that function for why the
+/// `Cow` is matched by value rather than through a reference.
+fn resolve_against_cow_sink<'a, S: EvalSemantics>(
+    expr: &Expr,
+    current: Cow<'a, OwnedValue>,
+    trackable: bool,
+    snapshot: bool,
+    keep: Keep,
+    sink: &mut dyn FnMut(PathBranch<'a>) -> Demand,
+) -> ResolveFlow {
+    match current {
+        Cow::Borrowed(r) => resolve_node_sink::<S>(expr, r, trackable, snapshot, keep, sink),
+        // Resolution can only borrow from this local copy, so every branch
+        // is forced back to `Cow::Owned` before it can escape the borrow --
+        // exactly the clone cost this path always paid, neither more nor less.
+        Cow::Owned(v) => resolve_node_sink::<S>(expr, &v, trackable, snapshot, keep, &mut |b| {
+            sink(b.into_owned_value())
+        }),
     }
 }
 
@@ -27061,89 +27080,87 @@ fn resolve_static_tail<'a, S: EvalSemantics>(
     value_after_components::<S>(components, value.clone()).map_err(|e| (Vec::new(), e))
 }
 
-/// Apply a purely-static path tail to every branch, extending each branch's
-/// path with `tail` verbatim and threading its value through
-/// [`resolve_static_tail`]. On the first tail-application failure, returns
-/// whatever branches were already extended, paired with that failure —
-/// `resolve_seq`'s own `Err`-side "keep what already resolved" contract.
+/// Apply a purely-static path tail to one branch, extending its path with
+/// `tail` verbatim and threading its value through
+/// [`resolve_static_tail`].
 ///
-/// `resolve_seq` calls this exactly once, after its fan-out loop finishes —
-/// whether every element resolved cleanly or some element escaped along the
-/// way (#977, #1013). Funneling both outcomes through one call site is what
-/// keeps a purely-static tail (a literal `.foo`/`[N]`/`[N:M]`) from silently
-/// getting dropped off a partial, escaped prefix.
-fn apply_static_tail<'a, S: EvalSemantics>(
-    branches: Vec<PathBranch<'a>>,
+/// `Ok(None)` is a `?`-suppressed step in `tail` pruning the branch (#2124)
+/// -- zero output, not a fabricated `null` one. `Err` is a genuine tail
+/// failure; the caller keeps whatever it had already emitted, which is
+/// `resolve_seq`'s own "keep what already resolved" contract (#977, #1013).
+///
+/// [`resolve_seq_stage`] calls this on every branch that reaches the end of
+/// the fan-out -- whether it got there cleanly or is the partial output of
+/// a stage that then escaped -- which is what keeps a literal
+/// `.foo`/`[N]`/`[N:M]` tail from being dropped off an escaped prefix.
+fn apply_static_tail_one<'a, S: EvalSemantics>(
+    branch: PathBranch<'a>,
     tail: &[Expr],
-) -> PathResolveResult<'a> {
-    let mut out = vec_with_capacity(branches.len());
-    for PathBranch {
+) -> Result<Option<PathBranch<'a>>, EvalEscape> {
+    let PathBranch {
         path: prefix,
         value: current,
         trackable,
         snapshot,
         register,
-    } in branches
-    {
-        // A dynamic element as the pipe's last component (e.g. `.a[.k]`) is
-        // the common, still-trackable shape here, and leaves `tail` empty —
-        // reuse `current` directly rather than paying `resolve_static_tail`/
-        // `value_after_components`'s own clone-then-return-unchanged for a
-        // no-op walk. Anything else — a non-empty `tail`, or an untracked
-        // `current` even with an empty one (#843: `current` may be
-        // `Builtin::GetPath`'s own resolved-but-still-untracked result, see
-        // `resolve_static_tail`'s doc comment) — goes through the shared,
-        // trackable-aware helper.
-        let end: Cow<'a, OwnedValue> = if tail.is_empty() {
-            // #986: with no tail there is nothing to navigate *into*, so an
-            // untracked `current` is not this function's problem to raise —
-            // it passes through carrying its own flag, and whoever turns out
-            // to be the genuinely terminal consumer decides. That is what
-            // lets `path((1|.)[K])` blame `K` (via `resolve_index_expr`'s
-            // post-target check) rather than the literal, while `path(1|2)`
-            // still raises at `resolve_dynamic_indexes`.
-            current
-        } else {
-            match resolve_static_tail::<S>(tail, &current, trackable) {
-                Ok(Some(end)) => Cow::Owned(end),
-                // A `?`-suppressed step in `tail` prunes this branch
-                // entirely (#2124) — the same verdict a plain Comma sibling
-                // with no `?` failure at all would give by simply
-                // contributing zero branches, not one fabricated `null`
-                // branch at a path the value doesn't have this shape at.
-                Ok(None) => continue,
-                Err((_, e)) => return Err((out, e)),
-            }
-        };
-        // #701: no literal in-place `extend_from_slice` equivalent once
-        // `path` is `Rc`-based (a `Node` isn't a growable buffer) — this is
-        // an ordinary `extend_many`, the same class as every other
-        // multi-append site. `tail`'s length is bounded by the filter's own
-        // static suffix, not document depth, so this doesn't reopen an O(d²)
-        // hole; it's a small, honest constant-factor trade against the
-        // amortized `Vec` growth this replaces.
-        let path = PathPrefix::extend_many(&prefix, tail.iter().cloned());
-        out.push(PathBranch {
-            path,
-            value: end,
-            // A non-empty tail navigated successfully, which is only
-            // reachable when `trackable` held; an empty one changes nothing.
-            trackable,
-            // An empty tail hands `current` straight back, so a frozen
-            // variable snapshot survives it unchanged; a non-empty one
-            // navigated *into* the value and so produced a different one,
-            // which is no longer the snapshot (#1466).
-            snapshot: snapshot && tail.is_empty(),
-            // The register survives for exactly the same reason, and fails
-            // to for a different one: an empty tail navigates nothing, so a
-            // register live at `prefix` is still live here; a non-empty one
-            // *did* navigate, which by definition moves the register onto
-            // what it reached — at which point `trackable` already carries
-            // it and this field is not consulted (#1573).
-            register: register.filter(|_| tail.is_empty()),
-        });
-    }
-    Ok(out)
+    } = branch;
+    // A dynamic element as the pipe's last component (e.g. `.a[.k]`) is
+    // the common, still-trackable shape here, and leaves `tail` empty —
+    // reuse `current` directly rather than paying `resolve_static_tail`/
+    // `value_after_components`'s own clone-then-return-unchanged for a
+    // no-op walk. Anything else — a non-empty `tail`, or an untracked
+    // `current` even with an empty one (#843: `current` may be
+    // `Builtin::GetPath`'s own resolved-but-still-untracked result, see
+    // `resolve_static_tail`'s doc comment) — goes through the shared,
+    // trackable-aware helper.
+    let end: Cow<'a, OwnedValue> = if tail.is_empty() {
+        // #986: with no tail there is nothing to navigate *into*, so an
+        // untracked `current` is not this function's problem to raise —
+        // it passes through carrying its own flag, and whoever turns out
+        // to be the genuinely terminal consumer decides. That is what
+        // lets `path((1|.)[K])` blame `K` (via `resolve_index_expr`'s
+        // post-target check) rather than the literal, while `path(1|2)`
+        // still raises at `resolve_dynamic_indexes`.
+        current
+    } else {
+        match resolve_static_tail::<S>(tail, &current, trackable) {
+            Ok(Some(end)) => Cow::Owned(end),
+            // A `?`-suppressed step in `tail` prunes this branch
+            // entirely (#2124) — the same verdict a plain Comma sibling
+            // with no `?` failure at all would give by simply
+            // contributing zero branches, not one fabricated `null`
+            // branch at a path the value doesn't have this shape at.
+            Ok(None) => return Ok(None),
+            Err((_, e)) => return Err(e),
+        }
+    };
+    // #701: no literal in-place `extend_from_slice` equivalent once
+    // `path` is `Rc`-based (a `Node` isn't a growable buffer) — this is
+    // an ordinary `extend_many`, the same class as every other
+    // multi-append site. `tail`'s length is bounded by the filter's own
+    // static suffix, not document depth, so this doesn't reopen an O(d²)
+    // hole; it's a small, honest constant-factor trade against the
+    // amortized `Vec` growth this replaces.
+    let path = PathPrefix::extend_many(&prefix, tail.iter().cloned());
+    Ok(Some(PathBranch {
+        path,
+        value: end,
+        // A non-empty tail navigated successfully, which is only
+        // reachable when `trackable` held; an empty one changes nothing.
+        trackable,
+        // An empty tail hands `current` straight back, so a frozen
+        // variable snapshot survives it unchanged; a non-empty one
+        // navigated *into* the value and so produced a different one,
+        // which is no longer the snapshot (#1466).
+        snapshot: snapshot && tail.is_empty(),
+        // The register survives for exactly the same reason, and fails
+        // to for a different one: an empty tail navigates nothing, so a
+        // register live at `prefix` is still live here; a non-empty one
+        // *did* navigate, which by definition moves the register onto
+        // what it reached — at which point `trackable` already carries
+        // it and this field is not consulted (#1573).
+        register: register.filter(|_| tail.is_empty()),
+    }))
 }
 
 /// The register-relevant facts about one resolved step (#1573), bundled so
@@ -27325,37 +27342,61 @@ fn carry_register<'a>(
     }
 }
 
-/// Resolve a pipe of path nodes, threading the value left to right.
+/// Resolve a pipe of path nodes, threading the value left to right —
+/// depth-first, the way jq's own generator composition does.
 ///
 /// The threading is the whole point: a computed key sees the value reaching
 /// *its* position, which is the document root only when it sits at the top of
 /// the path. `path(.x | .a[.k])` resolves `.k` against `.x`, giving
 /// `["x","a","a"]`.
 ///
+/// **Depth-first, not stage-by-stage (#2178).** Each output of stage `i` is
+/// pushed straight into the *rest* of the pipe ([`resolve_seq_stage`]'s own
+/// recursion) before stage `i` is asked for its next output — where this
+/// function used to rebuild a whole `Vec` of branches per stage. Two
+/// consequences, both of them jq's behaviour:
+///
+/// - A downstream stage that raises stops the upstream generator on the
+///   spot, because the recursion's `Demand::Stop` reaches it. `path(range(3)
+///   | debug | .a)` calls `debug` exactly once, on `0`, then raises — jq's
+///   uncaught error aborts the whole computation rather than making it
+///   backtrack for `range`'s next candidate. The stage-batch form could not
+///   express that and called `debug` once per widened candidate (#2178).
+/// - A downstream *escape* is the one raised, not an earlier stage's, with
+///   no `deferred_escape` bookkeeping to arrange it: the branch that escapes
+///   later is simply reached first. Verified live against jq 1.7.1:
+///   `path(.a[(0,error("t1"))] | .c[(0,error("t2"))] | .foo)` on
+///   `{"a":[{"c":[{"foo":1}]}]}` raises `t2`.
+///
+/// A stage's own partial output still survives its escape and is threaded
+/// through everything after it (#1013) — it reached the sink before the
+/// escape did, which is exactly jq's "never un-emit" rule.
+///
 /// `register` (#2046) is an *externally known* path register, distinct from
-/// the one this function's own fan-out loop already carries stage-to-stage
+/// the one this function's own recursion already carries stage-to-stage
 /// via each [`PathBranch`]'s own `register` field (#1573/#2041) — this
 /// parameter is what seeds that mechanism in the first place, for the one
 /// caller that has a register from *outside* this call to inject:
 /// [`FoldRegister::resolve`], which has no other way to make a fold's own
 /// persistent register visible to a `$var` reference chained inside
 /// UPDATE/EXTRACT (`. as $x | reduce ... (0; $x.a; ...)` — see that
-/// function's own doc comment). `resolve_node`'s ordinary `Expr::Pipe` arm
-/// passes `None`: an ordinary pipe has no such outside register, only
+/// function's own doc comment). `resolve_node_sink`'s ordinary `Expr::Pipe`
+/// arm passes `None`: an ordinary pipe has no such outside register, only
 /// whatever it establishes for itself.
 ///
 /// Only ever consulted at the seed branch below, mirroring `trackable`/
 /// `snapshot`: once seeded, `reestablishes_register`/`carry_register`'s
 /// already-tested stage-to-stage rules take over unchanged, so this adds one
 /// new *source* for the carried register, not a new rule for recognising it.
-fn resolve_seq<'a, S: EvalSemantics>(
+fn resolve_seq_sink<'a, S: EvalSemantics>(
     exprs: &[Expr],
     value: &'a OwnedValue,
     trackable: bool,
     snapshot: bool,
     keep: Keep,
     register: Option<&'a OwnedValue>,
-) -> PathResolveResult<'a> {
+    sink: &mut dyn FnMut(PathBranch<'a>) -> Demand,
+) -> ResolveFlow {
     let mut flat = Vec::new();
     for e in exprs {
         push_path_components(&mut flat, e);
@@ -27366,7 +27407,7 @@ fn resolve_seq<'a, S: EvalSemantics>(
     // resolving those would expand nothing (each is already single-valued),
     // so there's no gain. A bare `.foo[]`/`.foo[]?` is different: it isn't
     // single-valued, so `needs_fanout_pass` (unlike `needs_path_prepass`)
-    // still routes it through the fan-out loop below rather than
+    // still routes it through the fan-out below rather than
     // `value_after_components`'s single-value assumption (#682). The
     // *value* still has to be threaded through a purely static tail, because
     // an enclosing `IndexExpr` indexes it: in `.a[.k].b[.j]`, `.j` applies to
@@ -27395,62 +27436,38 @@ fn resolve_seq<'a, S: EvalSemantics>(
     // bespoke message for it — still a hard error either way, never the
     // silent wrong-success #843 is about.
     let Some(last_dynamic) = flat.iter().rposition(needs_fanout_pass) else {
-        let end = match resolve_static_tail::<S>(&flat, value, trackable)? {
-            Some(end) => end,
+        let end = match resolve_static_tail::<S>(&flat, value, trackable) {
+            Ok(Some(end)) => end,
             // A `?`-suppressed step somewhere in this purely-static pipe
             // prunes the whole branch (#2124) — zero output, not a
             // fabricated `null` one; see `value_after_components`'s own
             // doc comment for why zero can only mean that here.
-            None => return Ok(Vec::new()),
+            Ok(None) => return ResolveFlow::Exhausted,
+            Err((_, e)) => return ResolveFlow::Escaped(e),
         };
         // `resolve_static_tail` above already raised for an untracked
         // value, so this is `true` in practice — carried rather than
         // asserted so the two can't drift.
         //
         // Snapshot survives only when `flat` is empty (#1591), the same
-        // rule `apply_static_tail` already applies for its own tail: an
+        // rule `apply_static_tail_one` already applies for its own tail: an
         // empty `flat` means the whole pipe was a no-op (`.`, `.?`, ...),
         // so `end` is `value` handed straight back, still whatever ambient
         // snapshot it already was. A non-empty `flat` genuinely navigated,
         // which breaks the frozen-pointer identity regardless of ambient.
         let branch_snapshot = snapshot && flat.is_empty();
-        return Ok(vec![PathBranch::passthrough(
+        let branch = PathBranch::passthrough(
             PathPrefix::from_components(flat),
             Cow::Owned(end),
             trackable,
             branch_snapshot,
-        )]);
+        );
+        return match sink(branch) {
+            Demand::Continue => ResolveFlow::Exhausted,
+            Demand::Stop => ResolveFlow::Stopped,
+        };
     };
 
-    // Fan out one pipe element at a time. Note this rebuilds `branches` stage
-    // by stage (every currently-active branch through element N, then all of
-    // those through element N+1, ...) rather than threading each branch
-    // depth-first through the *entire* remaining pipe the way jq's own
-    // generator composition does — so for a pipe with more than one dynamic
-    // element, an escape partway through a stage still drops every
-    // not-yet-reached sibling branch *at that same stage* (branches from an
-    // earlier stage's own fan-out that hadn't reached this stage yet). That
-    // is a known simplification, not a byte-for-byte reproduction of jq's
-    // stream order; the single-dynamic-element case (the overwhelmingly
-    // common one, and the one every #530 sibling repro exercises) is exact.
-    // What *does* survive an escape (#1013): the escaping branch's own
-    // partial output (everything it produced before hitting its escape) is
-    // still threaded through every remaining dynamic stage and the tail,
-    // exactly like a branch that never escaped at all — see below. That is
-    // what makes this function's `Err` *prefix content* faithful to jq's
-    // own pre-escape stream even across multiple dynamic stages (unlike
-    // `resolve_index_expr`/`resolve_slice_expr`'s own pre-#972 gap, a
-    // different failure mode where the prefix was too *long*, not too
-    // short) — confirmed for `first(.[]|.[]|.[])`-shaped multi-stage pipes
-    // by `test_first_path_truncation_keeps_full_multistage_pipe_path_972`.
-    // The stage-by-stage (not depth-first) rebuild above is still a real
-    // divergence, but only in *evaluation order*: a not-yet-reached sibling
-    // this function's own fan-out never gets to is also a sibling jq's real
-    // depth-first generator would never reach either, so no branch either
-    // side actually emits is lost — see #987/#820 for the separate,
-    // still-open question of whether a sibling that's never *reached* was
-    // nonetheless *evaluated* (side effects included) ahead of being pruned.
-    let tail = &flat[last_dynamic + 1..];
     // The root branch inherits this call's own trackability: seeding it
     // `true` regardless is what made `catch (getpath(["other"]) | .qqq)`
     // and `catch (select(true) | .y)` stop raising, since every later
@@ -27467,7 +27484,7 @@ fn resolve_seq<'a, S: EvalSemantics>(
     // the stage-to-stage carrying mechanism below; every subsequent stage
     // reads it as `carried_register`, exactly as it already would for a
     // register `resolve_leaf` established from inside this same call.
-    let mut branches: Vec<PathBranch<'a>> = vec![PathBranch::passthrough(
+    let seed = PathBranch::passthrough(
         PathPrefix::root(),
         Cow::Borrowed(value),
         trackable,
@@ -27477,242 +27494,222 @@ fn resolve_seq<'a, S: EvalSemantics>(
         None
     } else {
         register.map(Cow::Borrowed)
-    })];
-    // Set the first time any stage's branch escapes, and overwritten by any
-    // later stage's own escape (#1013) — mirroring the pre-existing "a later
-    // step's own failure outranks an earlier deferred one" rule this
-    // function already applies between the fan-out loop and
-    // `apply_static_tail` below (also used by `resolve_slice_expr`'s
-    // `target_escape`). This matches jq's real generator order: jq threads
-    // an already-yielded value all the way through the rest of the pipe
-    // (potentially hitting a *later* escape) before it ever backtracks to
-    // try a fan-out's next alternative, so a downstream escape is the one
-    // jq actually raises, not an earlier one it never got back to. Verified
-    // live against jq 1.7.1: `path(.a[(0,error("t1"))] | .c[(0,error("t2"))]
-    // | .foo)` on `{"a":[{"c":[{"foo":1}]}]}` raises `t2`, not `t1`.
-    let mut deferred_escape: Option<EvalEscape> = None;
-    for (stage_index, element) in flat[..=last_dynamic].iter().enumerate() {
-        // #2050: `keep` is this whole call's *terminal* demand (typically
-        // `Keep::First`, #987's "stop a generator after its first output"
-        // rule) — correct only for the position nothing else in this
-        // `resolve_seq` call follows. An earlier stage here is not that
-        // position whenever a *later stage in this same fan-out loop*
-        // still has to run: a `select`/filter downstream may reject that
-        // stage's first output and only accept a later one (`paths |
-        // select(length == 2) | .foo` needs `paths`'s *second* output,
-        // since its first is rejected), so truncating the generator to one
-        // value before the filter ever runs can turn a genuine "later
-        // output survives" pipe into a wrongly-empty result, or a
-        // wrongly-silent one — #1872's `resolve_fold_source` already
-        // established the fix for its own "needs every output" case
-        // (`Keep::AtMost(usize::MAX)`, not `Keep::First`); this reuses the
-        // identical value for the identical reason. Only `resolve_leaf`'s
-        // general non-primitive case actually reads `keep` at all (its own
-        // doc comment), so this widening is a no-op for every other arm
-        // (`Select` included, which ignores `keep` entirely) and only
-        // changes behavior for a bare generator builtin (`paths`, `range`,
-        // `keys`, ...) reached mid-pipe.
-        //
-        // `tail` (this call's own *static* trailing components — `Field`/
-        // `Index`/`Slice`, never `Select` or anything else that can reject
-        // — see `push_path_components`/`needs_path_prepass`) is deliberately
-        // NOT part of this condition, unlike an earlier version of this fix
-        // (#2050 code review): a static component can only either succeed
-        // with exactly one output or *error*, and an uncaught error aborts
-        // the whole evaluation rather than making jq backtrack and try an
-        // earlier stage's next candidate (confirmed live: `path(range(3) |
-        // debug | .a)` calls `debug` exactly once, on `0`, then raises —
-        // `1`/`2` are never even asked for, so `.a` being unconditionally
-        // erroring on a number is not a reason to widen `range`'s own
-        // `keep`). Gating on `tail.is_empty()` too made the truly-last
-        // fan-out stage (whatever precedes a non-empty static tail) widen
-        // unconditionally — silently reintroducing #987's regression
-        // (`path(paths | .a)`/`path(range(1_000_000) | .a)` fully
-        // materializing their generator before the static tail ever runs)
-        // for the overwhelmingly common "one dynamic stage, then a plain
-        // field/index" shape. `stage_index == last_dynamic` alone is sound
-        // regardless of `tail`'s contents: #2050's own repro still widens
-        // correctly, because `select` there occupies `last_dynamic` itself
-        // (not `paths`), so `paths` (`stage_index` 0 of 1) is unaffected by
-        // this change.
-        //
-        // A residual, narrower divergence remains for a *non-rejecting*
-        // builtin (`debug`, `stderr`, ...) sitting between two genuine
-        // fan-out stages with no filter between them (`path(range(3) |
-        // debug | .a)`): `debug` itself, now at `last_dynamic`, correctly
-        // gets the real `keep` regardless of `tail` — but `range` (an
-        // *earlier* fan-out-loop stage) still widens, because nothing here
-        // proves `debug` cannot reject a candidate the way `select` can.
-        // Live-verified this is not merely cosmetic: `path(range(1_000_000)
-        // | debug | .a)` calls `debug` 100,000 times here (a
-        // `RECURSE_MAX_ITEMS`-style cap, not the full million) against
-        // jq's own single call. Distinguishing "can this later stage ever
-        // reject" from "is this just the last static-tail-adjacent stage"
-        // needs a real reachable-rejection analysis this fix does not
-        // attempt — tracked as #2178 rather than folded in here.
-        let stage_keep = if stage_index == last_dynamic {
-            keep
-        } else {
-            Keep::AtMost(usize::MAX)
+    });
+    resolve_seq_stage::<S>(&flat, last_dynamic, 0, seed, keep, sink)
+}
+
+/// Collecting adapter over [`resolve_seq_sink`], for the callers that still
+/// want a materialized `Vec<PathBranch>` ([`FoldRegister::resolve`]).
+fn resolve_seq<'a, S: EvalSemantics>(
+    exprs: &[Expr],
+    value: &'a OwnedValue,
+    trackable: bool,
+    snapshot: bool,
+    keep: Keep,
+    register: Option<&'a OwnedValue>,
+) -> PathResolveResult<'a> {
+    let mut out = Vec::new();
+    let flow = resolve_seq_sink::<S>(
+        exprs,
+        value,
+        trackable,
+        snapshot,
+        keep,
+        register,
+        &mut |b| {
+            out.push(b);
+            Demand::Continue
+        },
+    );
+    match flow {
+        ResolveFlow::Exhausted | ResolveFlow::Stopped => Ok(out),
+        ResolveFlow::Escaped(e) => Err((out, e)),
+    }
+}
+
+/// Thread one branch through `flat[stage_index..]` and the static tail,
+/// depth-first — [`resolve_seq_sink`]'s recursion, one frame per pipe stage.
+///
+/// Each output of this stage is placed onto the incoming branch's prefix and
+/// immediately handed to the *next* stage, so a `Demand::Stop` from anywhere
+/// downstream (a bounded consumer, or an escape) reaches this stage's own
+/// producer before it is asked for another value.
+fn resolve_seq_stage<'a, S: EvalSemantics>(
+    flat: &[Expr],
+    last_dynamic: usize,
+    stage_index: usize,
+    branch: PathBranch<'a>,
+    keep: Keep,
+    sink: &mut dyn FnMut(PathBranch<'a>) -> Demand,
+) -> ResolveFlow {
+    if stage_index > last_dynamic {
+        return match apply_static_tail_one::<S>(branch, &flat[last_dynamic + 1..]) {
+            Ok(Some(b)) => match sink(b) {
+                Demand::Continue => ResolveFlow::Exhausted,
+                Demand::Stop => ResolveFlow::Stopped,
+            },
+            Ok(None) => ResolveFlow::Exhausted,
+            Err(e) => ResolveFlow::Escaped(e),
         };
-        // Whether this stage can carry a live path register across itself
-        // at all (#1573). `false` is the answer for every stage this
-        // resolver cannot see inside, because jq's register moves on any
-        // `INDEX` the stage executes — including the ones hidden in a
-        // jq-defined builtin (`first` is `.[0]`) or a user function body,
-        // which arrive here as one opaque computed value. See
-        // [`cannot_move_register`]: dropping the register merely costs a
-        // refusal, keeping a stale one fabricates a path.
-        let stage_preserves_register = cannot_move_register(element);
-        let mut next = Vec::new();
-        // Consumes `branches` (not `&branches`) so each `current` arrives by
-        // value: only then can `resolve_against_cow` recover the branch's
-        // full `'a` when it's still `Cow::Borrowed`, rather than capping it
-        // at this loop iteration's own short borrow (#668).
-        for PathBranch {
-            path: prefix,
-            value: current,
-            trackable: branch_trackable,
-            snapshot: branch_snapshot,
-            // The path register as it stands *entering* this stage (#1573).
-            //
-            // While `branch_trackable` holds, the register is `current`
-            // itself — but `current` is about to be moved into
-            // `resolve_against_cow`, and the step is the one that knows
-            // whether it navigated off it, so that case is left to the step
-            // (`resolve_leaf` records `current` as the register on the very
-            // transition that drops trackability). What has to be carried
-            // by hand is the *already*-untracked case, where the register
-            // is live somewhere behind us and no step below can see it any
-            // more.
-            register: carried_register,
-        } in branches
-        {
-            // #986: each branch carries its own trackability now, so this
-            // passes *that* rather than the single outer parameter. It is
-            // what makes `1 | .[K]` reach `resolve_index_expr` already
-            // knowing its target is untracked, which is how jq's "near
-            // attempt to access element K of 1" wording gets produced
-            // without any new context parameter (see #989).
-            // Where one step's output lands, for both the `Ok` fan-out and
-            // the partial prefix an escaping stage leaves behind. Written
-            // once rather than twice: the two arms differ only in which
-            // list they walk, and #1573's register re-establishment had
-            // already been fixed in the `Ok` arm alone once before the
-            // `Err` arm's identical omission was noticed.
-            let place_step = |step: PathBranch<'a>| -> PathBranch<'a> {
-                let PathBranch {
-                    path: components,
-                    value: resulting,
-                    trackable: step_trackable,
-                    snapshot: step_snapshot,
-                    register: step_register,
-                } = step;
-                let facts = StepRegisterFacts {
-                    navigated: components.depth() > 0,
-                    stage_preserves_register,
-                    step_snapshot,
-                };
-                // The register entering this step (#2044): while the branch
-                // was still trackable, the register was `current` itself,
-                // and `resolve_leaf` records that value as `step_register`
-                // on exactly the transition that drops trackability --
-                // `carried_register` is only ever populated once already
-                // untracked. Computed once and threaded into both this
-                // check and `carry_register` below, rather than each
-                // re-deriving it, so the jq-only mode gate
-                // (`trackable_step_register_eligible`) cannot drift between
-                // the two the way this file's own history already shows it
-                // can.
-                let trackable_step_eligible =
-                    trackable_step_register_eligible::<S>(branch_trackable);
-                let register_entering = if trackable_step_eligible {
-                    step_register.as_deref()
-                } else {
-                    carried_register.as_deref()
-                };
-                let reestablished = reestablishes_register(facts, register_entering, &resulting);
-                let path = if reestablished {
-                    Rc::clone(&prefix)
-                } else {
-                    PathPrefix::extend_many(&prefix, components.to_vec())
-                };
-                PathBranch {
-                    register: carry_register(
-                        facts,
-                        reestablished,
-                        trackable_step_eligible,
-                        &carried_register,
-                        step_register,
-                    ),
-                    path,
-                    value: resulting,
-                    // Untracked is absorbing: nothing downstream can
-                    // re-certify a value that was computed rather than
-                    // navigated to. Erring toward `false` is also the safe
-                    // direction — it can only turn a silent acceptance into
-                    // a loud error, never the reverse (#985's revert is what
-                    // the reverse looks like).
-                    //
-                    // #1573 adds the one exception jq itself has: untracked
-                    // is absorbing for *navigation*, but a `$var` whose
-                    // frozen value is still identical to the live register
-                    // is not navigation — jq's own `path_intact` compares
-                    // against `value_at_path`, which a literal never moved,
-                    // so the variable re-establishes the register's position
-                    // rather than reaching a new one. See
-                    // `reestablishes_register`.
-                    trackable: reestablished || (branch_trackable && step_trackable),
-                    // Unlike `trackable`, this comes from the *step* alone:
-                    // the value leaving this stage is the step's own output,
-                    // so `.a | $x` still hands back the frozen snapshot
-                    // whatever `.a` was, and `$x | .a` no longer is one
-                    // (#1466).
-                    //
-                    // A re-established branch is `trackable` again, and this
-                    // type's invariant is that `snapshot` implies
-                    // `!trackable`: a certified snapshot has resolved to a
-                    // real path and needs no second marker (#1573).
-                    snapshot: step_snapshot && !reestablished,
-                }
-            };
-            match resolve_against_cow::<S>(
-                element,
-                current,
-                branch_trackable,
-                branch_snapshot,
-                stage_keep,
-            ) {
-                Ok(resolved) => {
-                    for step in resolved {
-                        next.push(place_step(step));
-                    }
-                }
-                Err((partial, e)) => {
-                    for step in partial {
-                        next.push(place_step(step));
-                    }
-                    // Keep whatever this branch produced before its escape,
-                    // record the escape, and stop attempting any
-                    // not-yet-reached sibling at this stage (the "known
-                    // simplification" above) — but do *not* return early:
-                    // `next` still feeds the remaining dynamic stages
-                    // (#1013) exactly like a branch that never escaped,
-                    // since e.g. `.a[(0,error("t"))]`'s successful `0`
-                    // alternative still has to run through everything after
-                    // it (`.c[(0,1)] | .foo`) before jq would ever raise
-                    // `t`.
-                    deferred_escape = Some(e);
-                    break;
-                }
-            }
-        }
-        branches = next;
     }
 
-    match apply_static_tail::<S>(branches, tail) {
-        Ok(tailed) => path_result(tailed, deferred_escape),
-        Err(tail_err) => Err(tail_err),
+    let element = &flat[stage_index];
+    // #2050: `keep` is this whole call's *terminal* demand (typically
+    // `Keep::First`, #987's "stop a generator after its first output"
+    // rule) — correct only for the position nothing else in this pipe
+    // follows. An earlier stage is not that position: a `select`/filter
+    // downstream may reject that stage's first output and only accept a
+    // later one (`paths | select(length == 2) | .foo` needs `paths`'s
+    // *second* output), so truncating the generator to one value before the
+    // filter ever runs turns a genuine "later output survives" pipe into a
+    // wrongly-empty result. Only `resolve_leaf`'s general non-primitive case
+    // reads `keep` at all, so this widening is a no-op for every other arm.
+    //
+    // Widening is now *only* a materialization cost, never a side-effect
+    // one (#2178): the recursion below answers `Demand::Stop` the moment
+    // anything downstream escapes or is satisfied, so an earlier stage's
+    // widened generator stops being drained there. `path(range(1000000) |
+    // debug | .a)` calls `debug` once, matching jq, even though `range`
+    // itself is still resolved eagerly by `resolve_leaf`.
+    let stage_keep = if stage_index == last_dynamic {
+        keep
+    } else {
+        Keep::AtMost(usize::MAX)
+    };
+    // Whether this stage can carry a live path register across itself
+    // at all (#1573). `false` is the answer for every stage this
+    // resolver cannot see inside, because jq's register moves on any
+    // `INDEX` the stage executes — including the ones hidden in a
+    // jq-defined builtin (`first` is `.[0]`) or a user function body,
+    // which arrive here as one opaque computed value. See
+    // [`cannot_move_register`]: dropping the register merely costs a
+    // refusal, keeping a stale one fabricates a path.
+    let stage_preserves_register = cannot_move_register(element);
+
+    let PathBranch {
+        path: prefix,
+        value: current,
+        // #986: each branch carries its own trackability, so this passes
+        // *that* rather than a single outer parameter. It is what makes
+        // `1 | .[K]` reach `resolve_index_expr` already knowing its target
+        // is untracked, which is how jq's "near attempt to access element K
+        // of 1" wording gets produced without any new context parameter
+        // (see #989).
+        trackable: branch_trackable,
+        snapshot: branch_snapshot,
+        // The path register as it stands *entering* this stage (#1573).
+        //
+        // While `branch_trackable` holds, the register is `current`
+        // itself — but `current` is about to be moved into
+        // `resolve_against_cow_sink`, and the step is the one that knows
+        // whether it navigated off it, so that case is left to the step
+        // (`resolve_leaf` records `current` as the register on the very
+        // transition that drops trackability). What has to be carried
+        // by hand is the *already*-untracked case, where the register
+        // is live somewhere behind us and no step below can see it any
+        // more.
+        register: carried_register,
+    } = branch;
+
+    // Set when the recursion below reports anything other than
+    // `Exhausted`, which is also when this stage's own producer is told to
+    // stop. It outranks `flow`: a downstream escape is the one jq raises,
+    // because jq threads an already-yielded value all the way through the
+    // rest of the pipe before it ever backtracks to try this stage's next
+    // alternative.
+    let mut downstream: Option<ResolveFlow> = None;
+    let flow = resolve_against_cow_sink::<S>(
+        element,
+        current,
+        branch_trackable,
+        branch_snapshot,
+        stage_keep,
+        &mut |step| {
+            let PathBranch {
+                path: components,
+                value: resulting,
+                trackable: step_trackable,
+                snapshot: step_snapshot,
+                register: step_register,
+            } = step;
+            let facts = StepRegisterFacts {
+                navigated: components.depth() > 0,
+                stage_preserves_register,
+                step_snapshot,
+            };
+            // The register entering this step (#2044): while the branch
+            // was still trackable, the register was `current` itself,
+            // and `resolve_leaf` records that value as `step_register`
+            // on exactly the transition that drops trackability --
+            // `carried_register` is only ever populated once already
+            // untracked. Computed once and threaded into both this
+            // check and `carry_register` below, rather than each
+            // re-deriving it, so the jq-only mode gate
+            // (`trackable_step_register_eligible`) cannot drift between
+            // the two the way this file's own history already shows it
+            // can.
+            let trackable_step_eligible = trackable_step_register_eligible::<S>(branch_trackable);
+            let register_entering = if trackable_step_eligible {
+                step_register.as_deref()
+            } else {
+                carried_register.as_deref()
+            };
+            let reestablished = reestablishes_register(facts, register_entering, &resulting);
+            let path = if reestablished {
+                Rc::clone(&prefix)
+            } else {
+                PathPrefix::extend_many(&prefix, components.to_vec())
+            };
+            let placed = PathBranch {
+                register: carry_register(
+                    facts,
+                    reestablished,
+                    trackable_step_eligible,
+                    &carried_register,
+                    step_register,
+                ),
+                path,
+                value: resulting,
+                // Untracked is absorbing: nothing downstream can
+                // re-certify a value that was computed rather than
+                // navigated to. Erring toward `false` is also the safe
+                // direction — it can only turn a silent acceptance into
+                // a loud error, never the reverse (#985's revert is what
+                // the reverse looks like).
+                //
+                // #1573 adds the one exception jq itself has: untracked
+                // is absorbing for *navigation*, but a `$var` whose
+                // frozen value is still identical to the live register
+                // is not navigation — jq's own `path_intact` compares
+                // against `value_at_path`, which a literal never moved,
+                // so the variable re-establishes the register's position
+                // rather than reaching a new one. See
+                // `reestablishes_register`.
+                trackable: reestablished || (branch_trackable && step_trackable),
+                // Unlike `trackable`, this comes from the *step* alone:
+                // the value leaving this stage is the step's own output,
+                // so `.a | $x` still hands back the frozen snapshot
+                // whatever `.a` was, and `$x | .a` no longer is one
+                // (#1466).
+                //
+                // A re-established branch is `trackable` again, and this
+                // type's invariant is that `snapshot` implies
+                // `!trackable`: a certified snapshot has resolved to a
+                // real path and needs no second marker (#1573).
+                snapshot: step_snapshot && !reestablished,
+            };
+            match resolve_seq_stage::<S>(flat, last_dynamic, stage_index + 1, placed, keep, sink) {
+                ResolveFlow::Exhausted => Demand::Continue,
+                other => {
+                    downstream = Some(other);
+                    Demand::Stop
+                }
+            }
+        },
+    );
+    match downstream {
+        Some(f) => f,
+        None => flow,
     }
 }
 
@@ -68419,7 +68416,7 @@ mod tests {
         );
         // A different generator builtin (`range`, not `paths`) reproduces
         // the identical shape, confirming this is `resolve_seq`'s own
-        // stage-by-stage `keep` propagation, not something specific to
+        // per-stage `keep` propagation, not something specific to
         // `paths`'s own resolve_node handling. Confirmed live: jq raises
         // on `2` here (the first candidate `select` actually lets
         // through), never on `0` (the generator's own first output).

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -22381,10 +22381,12 @@ type PathResolveResult<'a> = Result<Vec<PathBranch<'a>>, (Vec<PathBranch<'a>>, E
 /// intent at each call site stays readable.
 ///
 /// Count-bounded resolutions narrow it rather than forwarding it
-/// ([`resolve_node_bounded`], [`resolve_repeat_bounded`]): a caller that
-/// wants at most `n` branches can never need more than `n` outputs from
-/// any single leaf, and that cap is what keeps `first(range(2000000000))`
-/// inside a fold source from materializing two billion values.
+/// ([`resolve_bounded_sink`]): a caller that wants at most `n` branches can
+/// never need more than `n` outputs from any single leaf, and that cap is
+/// what keeps `first(range(2000000000))` inside a fold source from
+/// materializing two billion values. It is the one dial left for
+/// [`resolve_leaf`]'s general non-primitive case, the single producer with
+/// no sink of its own to stop.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum Keep {
     /// Stop the leaf's generator after its first output (#987).
@@ -22436,59 +22438,6 @@ fn path_result(branches: Vec<PathBranch<'_>>, escape: Option<EvalEscape>) -> Pat
     }
 }
 
-/// Keep at most `n` resolved branches, dropping a trailing escape the
-/// consumer never reached — jq's own `def first(f): label $out | (f, break
-/// $out);` and `limit`'s identical `break $out` never resume `f`'s generator
-/// once `$out` is satisfied, so an error/break/halt *after* the nth output
-/// is never raised in the first place.
-///
-/// Sound only because no [`PathResolveResult`] producer emits an `Err` side
-/// prefix *longer* than the branches jq's own generator emits before that
-/// escape. That is not decorative — an earlier attempt at this exact fix
-/// (PR #985, issue #972) assumed the stronger "exactly equal" form without
-/// checking, and `resolve_index_expr`/`resolve_slice_expr`'s key/bound ×
-/// target cross product violated it: `del(limit(2; select((true,
-/// error("t")))[("x","y")]))` silently deleted both keys instead of
-/// raising, because the untruncated prefix (length 2) satisfied `limit(2)`.
-/// Both functions were fixed ahead of this helper's reinstatement (see their
-/// own doc comments) to restrict their key/bound loops to a single element
-/// once their `target` has escaped, and that is pinned by
-/// [`test_resolve_index_expr_prefix_matches_jq_when_target_escapes_972`] and
-/// [`test_first_limit_path_truncation_does_not_overreach_index_fanout_972`]
-/// (both in `tests/jq_cli_tests.rs`) rather than merely asserted here.
-///
-/// **Only the "not longer" half holds universally, and only that half is
-/// what this function needs.** A prefix *shorter* than jq's is still
-/// possible — `resolve_slice_expr` drops the bound generator's own partial
-/// prefix, so `[10,20,30] | path(limit(1; .[(0,error("b")):(2,3)]))` raises
-/// here where jq answers `[{"start":0,"end":2}]`, exit 0 (pre-existing, on
-/// `main` too). A short prefix under-satisfies the `>= n` test below, so
-/// the escape propagates and the caller refuses — visibly wrong, never a
-/// false success, and never a write jq would not perform. Do not restate
-/// the invariant as "exactly equal": that is the form PR #985 assumed.
-///
-/// Drops `Halt` along with `Error`/`Break` once satisfied. jq never reaches
-/// it either (`path(first(select((true, ("m"|halt_error(3))))))` is `[]`,
-/// exit 0, confirmed against jq 1.7.1), and the value-position twins
-/// `each_take_first`/`each_take_n` already drop it for the same consumers.
-/// `resolve_leaf`'s opposite Halt-*keeping* rule (relevant to #987) is not a
-/// counterexample: it is a terminal fallback for a value that has no path
-/// shape at all, where no consumer was ever satisfied by an earlier output.
-///
-/// This is not laziness: the resolver underneath is still eager, so a
-/// dropped escape's side effects (`stderr`, a consumed `input`, `halt_error`'s
-/// own write) have already fired by the time this runs — only the escape
-/// itself is discarded, never the work that produced it. Making the
-/// resolver stop pulling early is #987/#820's territory
-/// (`docs/plan/jq-lazy-generator-consumers.md`), not this function's.
-fn take_path_branches(result: PathResolveResult<'_>, n: usize) -> PathResolveResult<'_> {
-    match result {
-        Ok(branches) => Ok(branches.into_iter().take(n).collect()),
-        Err((prefix, _)) if prefix.len() >= n => Ok(prefix.into_iter().take(n).collect()),
-        Err(e) => Err(e),
-    }
-}
-
 /// Peel any wrapping `Expr::Paren` down to the inner expression — `(false)`
 /// and `false` are the same node for a caller that only cares about literal
 /// shape, not surface syntax (`Expr::Alternative`'s `#845` fix, below).
@@ -22519,8 +22468,8 @@ enum ResolveFlow {
     /// A sink answered [`Demand::Stop`].
     ///
     /// A trailing escape the producer had already computed is *dropped*
-    /// here rather than carried, matching [`take_path_branches`]'s own
-    /// rule and `def first(f): label $out | (f, break $out);` — once
+    /// here rather than carried, following `def first(f): label $out | (f,
+    /// break $out);` — once
     /// the consumer is satisfied, jq never resumes the generator, so an
     /// error/break/halt after the last delivered branch is never raised.
     Stopped,
@@ -22603,8 +22552,6 @@ fn resolve_cond_fork_sink(
 
 /// `.[]`'s own path-branch construction (#1850), emitted one element at a
 /// time so a bounded consumer stops the walk instead of truncating it
-/// afterwards. [`resolve_iterate_bounded`] is the collecting wrapper for
-/// the callers that still want a `Vec`.
 ///
 /// **Precondition, not re-checked here:** the caller must already know
 /// `value` is trackable (#843) and raise
@@ -22669,6 +22616,246 @@ fn resolve_iterate_sink<'a, S: EvalSemantics>(
         // surface, is currently affected) rather than folded into this
         // fix. Tracked as #2376.
         other => ResolveFlow::Escaped(EvalError::cannot_iterate_with(S::TAG, other).into()),
+    }
+}
+
+/// Resolve `expr`, delivering at most `n` branches to `sink` (#1952).
+///
+/// The one bounding mechanism every bounded consumer shares — `limit(n; f)`,
+/// `first(f)` (which is `limit(1; f)`) and `nth(n; f)` — replacing the three
+/// hand-copied generator special cases #1850/#1906/#1935 each added
+/// (`resolve_node_bounded`, `resolve_repeat_bounded`, `resolve_iterate_bounded`,
+/// `take_path_branches`). Because the bound is a sink answer rather than a
+/// dispatch on the *outermost* expression's shape, it reaches a generator
+/// through arbitrary combinator nesting: `path(limit(2; if true then
+/// repeat(.) else empty end))` is `[]`, `[]` (jq 1.7.1), where the old
+/// `unwrap_paren`-then-match dispatch saw an `Expr::If` and gave up.
+///
+/// `keep` is still narrowed to `n` alongside the sink: it is the dial
+/// [`resolve_leaf`]'s general non-primitive case reads, which is the one
+/// producer that has no sink of its own to stop yet.
+///
+/// A `Stopped` that this function's *own* counter caused folds to
+/// `Exhausted` — the bound is satisfied, which is a success for the caller,
+/// and it is what drops a trailing escape the consumer never reached
+/// (jq's `def first(f): label $out | (f, break $out);` never resumes `f`).
+/// Only a stop the *downstream* sink asked for propagates.
+fn resolve_bounded_sink<'a, S: EvalSemantics>(
+    expr: &Expr,
+    value: &'a OwnedValue,
+    trackable: bool,
+    snapshot: bool,
+    keep: Keep,
+    n: usize,
+    sink: &mut dyn FnMut(PathBranch<'a>) -> Demand,
+) -> ResolveFlow {
+    if n == 0 {
+        return ResolveFlow::Exhausted;
+    }
+    let mut emitted = 0usize;
+    let mut downstream_stopped = false;
+    let flow = resolve_node_sink::<S>(
+        expr,
+        value,
+        trackable,
+        snapshot,
+        keep.at_most(n),
+        &mut |branch| {
+            emitted += 1;
+            if sink(branch) == Demand::Stop {
+                downstream_stopped = true;
+                return Demand::Stop;
+            }
+            if emitted >= n {
+                Demand::Stop
+            } else {
+                Demand::Continue
+            }
+        },
+    );
+    match flow {
+        ResolveFlow::Stopped if !downstream_stopped => ResolveFlow::Exhausted,
+        other => other,
+    }
+}
+
+/// `repeat(f)`'s own path-branch construction (#1906), emitting each round's
+/// branches as they are produced so a bounded consumer stops the loop.
+///
+/// `repeat(f)` has no base case at all (real jq's `def repeat(f): f,
+/// repeat(f);`, unconditional on how many outputs `f` produced), so an `f`
+/// that never errors loops forever — confirmed live, `limit(3;
+/// repeat(empty))` hangs against pinned jq 1.7.1 too. That is why this arm
+/// cannot be an eager resolution truncated afterwards: the call would never
+/// return.
+///
+/// Each cycle re-resolves `f` against the *same* original `value`, never the
+/// previous cycle's own result — `repeat` has no leading `.,` the way
+/// `recurse`'s `., (f | r)` does, and threads no state between rounds.
+/// Confirmed live against jq 1.7.1: `{"a":{"a":2}} | path(limit(2;
+/// repeat(.a)))` is `["a"]`, `["a"]`, not the progressively deepening
+/// `["a"]`, `["a","a"]` `recurse(.a)` gives.
+///
+/// `MAX_ITERATIONS` (round count) and `budget` ([`REPEAT_WIDTH_BUDGET`],
+/// total branches) are the same two-tier backstop `resolve_repeat_bounded`
+/// carried, kept identical so this migration changes no bounded shape:
+/// exhausting the round cap ends the walk silently (`path(limit(3;
+/// repeat(empty)))` is no output, exit 0) while exhausting the width budget
+/// raises, matching value mode's own "repeat: maximum iterations exceeded"
+/// (`path(limit(50000; repeat(.[])))` on a wide array). Both are documented
+/// divergences from jq's own hang in
+/// [`docs/compliance/jq/limitations.md`](../../docs/compliance/jq/limitations.md).
+fn resolve_repeat_sink<'a, S: EvalSemantics>(
+    f: &Expr,
+    value: &'a OwnedValue,
+    trackable: bool,
+    snapshot: bool,
+    keep: Keep,
+    sink: &mut dyn FnMut(PathBranch<'a>) -> Demand,
+) -> ResolveFlow {
+    const MAX_ITERATIONS: usize = 1000;
+    let mut budget = REPEAT_WIDTH_BUDGET;
+    for _ in 0..MAX_ITERATIONS {
+        let mut stopped = false;
+        let mut over_budget = false;
+        let flow = resolve_node_sink::<S>(f, value, trackable, snapshot, keep, &mut |branch| {
+            if budget == 0 {
+                over_budget = true;
+                return Demand::Stop;
+            }
+            budget -= 1;
+            if sink(branch) == Demand::Stop {
+                stopped = true;
+                Demand::Stop
+            } else {
+                Demand::Continue
+            }
+        });
+        if over_budget {
+            return ResolveFlow::Escaped(
+                EvalError::new("repeat: maximum iterations exceeded".to_string()).into(),
+            );
+        }
+        if stopped {
+            return ResolveFlow::Stopped;
+        }
+        if let ResolveFlow::Escaped(e) = flow {
+            return ResolveFlow::Escaped(e);
+        }
+    }
+    ResolveFlow::Exhausted
+}
+
+/// `path(limit(n; expr))` — `n` is the OUTER loop, exactly as in value
+/// context (#1279): `{"a":1,"b":2} | [path(limit((1,2); .a,.b))]` is
+/// `[["a"],["a"],["b"]]` in jq. One bounded resolution per `n` output, with
+/// `n`'s own trailing escape fired only after the whole prefix.
+///
+/// `classify_limit_n` is shared with value mode's `limit_with_n` so
+/// `path(limit(-1.5; ...))` cannot drift from `limit(-1.5; ...)` — the bug
+/// #1313 already had to fix once. A zero-output `n` produces zero output
+/// rather than collapsing to `Null`'s unlimited passthrough (verified live
+/// against jq 1.7.1: `path(limit(empty; .a,.b))` on `{"a":1,"b":2}` produces
+/// nothing, exit 0).
+fn resolve_limit_sink<'a, S: EvalSemantics>(
+    n_expr: &Expr,
+    expr: &Expr,
+    value: &'a OwnedValue,
+    trackable: bool,
+    snapshot: bool,
+    keep: Keep,
+    sink: &mut dyn FnMut(PathBranch<'a>) -> Demand,
+) -> ResolveFlow {
+    let (n_values, escape) = eval_owned_multi_keep_partial::<S>(n_expr, value);
+    for n_value in n_values {
+        let flow = match classify_limit_n(n_value) {
+            Ok(LimitN::Unlimited) => {
+                resolve_node_sink::<S>(expr, value, trackable, snapshot, keep, sink)
+            }
+            Ok(LimitN::Take(n)) => {
+                resolve_bounded_sink::<S>(expr, value, trackable, snapshot, keep, n, sink)
+            }
+            Err(e) => return ResolveFlow::Escaped(e.into()),
+        };
+        match flow {
+            ResolveFlow::Exhausted => {}
+            other => return other,
+        }
+    }
+    match escape {
+        Some(e) => ResolveFlow::Escaped(e),
+        None => ResolveFlow::Exhausted,
+    }
+}
+
+/// `path(nth(n; expr))` (#1952) — the arm `nth` had none of at all, which is
+/// exactly the "the next bounded consumer will hand-copy the same two
+/// generator special cases a third time" prediction that filed this issue.
+///
+/// jq 1.7.1 defines it as `def nth($n; f): if $n < 0 then error("nth doesn't
+/// support negative indices") else label $out | foreach f as $item (-1; .+1;
+/// if . == $n then $item, break $out else empty end) end;` — so it *skips*
+/// the first `n` outputs, emits the next one, and breaks; a generator with
+/// fewer than `n + 1` outputs emits nothing at all rather than falling back
+/// to the last one. Captured live against jq 1.7.1:
+///
+/// ```console
+/// $ echo '{"a":1,"b":2}' | jq -c 'path(nth(1; .a,.b))'
+/// ["b"]
+/// $ echo '{"a":1,"b":2}' | jq -c '[path(nth(5; .a,.b))]'
+/// []
+/// $ echo '{"a":{"a":2}}' | jq -c 'path(nth(2; repeat(.a)))'
+/// ["a"]
+/// $ echo '{"a":1}' | jq -c 'path(nth(-1; .a))'
+/// jq: error (at <stdin>:1): nth doesn't support negative indices
+/// ```
+///
+/// `n` is the outer loop and `classify_nth_n` is shared with
+/// `builtin_nth_stream`, for the same anti-drift reason
+/// [`resolve_limit_sink`] shares `classify_limit_n`.
+fn resolve_nth_sink<'a, S: EvalSemantics>(
+    n_expr: &Expr,
+    expr: &Expr,
+    value: &'a OwnedValue,
+    trackable: bool,
+    snapshot: bool,
+    keep: Keep,
+    sink: &mut dyn FnMut(PathBranch<'a>) -> Demand,
+) -> ResolveFlow {
+    let (n_values, escape) = eval_owned_multi_keep_partial::<S>(n_expr, value);
+    for n_value in n_values {
+        let n = match classify_nth_n(n_value) {
+            Ok(n) => n,
+            Err(e) => return ResolveFlow::Escaped(e.into()),
+        };
+        let mut skipped = 0usize;
+        let mut downstream_stopped = false;
+        let flow = resolve_node_sink::<S>(
+            expr,
+            value,
+            trackable,
+            snapshot,
+            keep.at_most(n.saturating_add(1)),
+            &mut |branch| {
+                if skipped < n {
+                    skipped += 1;
+                    return Demand::Continue;
+                }
+                if sink(branch) == Demand::Stop {
+                    downstream_stopped = true;
+                }
+                Demand::Stop
+            },
+        );
+        match flow {
+            ResolveFlow::Exhausted => {}
+            ResolveFlow::Stopped if !downstream_stopped => {}
+            other => return other,
+        }
+    }
+    match escape {
+        Some(e) => ResolveFlow::Escaped(e),
+        None => ResolveFlow::Exhausted,
     }
 }
 
@@ -23018,6 +23205,50 @@ fn resolve_node_sink<'a, S: EvalSemantics>(
             emit_passthrough(value, trackable, snapshot, sink)
         }
 
+        // `repeat(f)` (#1906) and the three bounded consumers below all
+        // resolve through the sink now, so a bound threads through arbitrary
+        // combinator nesting rather than only reaching a generator that is
+        // syntactically `limit`/`first`'s direct child (#1952). Verified live
+        // against jq 1.7.1: `{"a":1} | path(limit(2; if true then repeat(.)
+        // else empty end))` is `[]`, `[]`.
+        Expr::Repeat(f) => resolve_repeat_sink::<S>(f, value, trackable, snapshot, keep, sink),
+
+        // `first(f)` keeps only the first branch `f` resolves to, which is
+        // exactly `limit(1; f)` for path-tracking purposes (#1935).
+        // `Expr::FirstExpr` is what the dedicated `first(...)` parse path
+        // builds; `Builtin::FirstStream` is never constructed by the parser
+        // (#1986) -- `parse_first_expr` intercepts `first(...)` before
+        // `try_parse_builtin` ever runs, so this second arm is dead from any
+        // parseable query. Kept anyway as defensive symmetry, the same way
+        // `builtin_first_stream_propagates_bare_halt`'s own doc comment
+        // documents and tests `Builtin::FirstStream` directly.
+        Expr::FirstExpr(inner) | Expr::Builtin(Builtin::FirstStream(inner)) => {
+            resolve_bounded_sink::<S>(inner, value, trackable, snapshot, keep, 1, sink)
+        }
+
+        // `limit(n; f)` uses the same `n`-conversion rule as `eval_limit`, so
+        // `path(limit(...))` agrees with plain `limit(...)` in this
+        // evaluator -- including anywhere `eval_limit` itself still diverges
+        // from jq (e.g. a negative `n`), which is that function's bug to fix,
+        // not this resolver's. `Builtin::Limit` is never constructed by the
+        // parser (a CLI `limit(n; expr)` always parses through
+        // `parse_limit_expr` into `Expr::Limit`, matched first) -- kept for
+        // exhaustiveness/parity with the value-mode arm, not
+        // coverage-testable through this dispatch.
+        Expr::Limit { n, expr } => {
+            resolve_limit_sink::<S>(n, expr, value, trackable, snapshot, keep, sink)
+        }
+        Expr::Builtin(Builtin::Limit(n, expr)) => {
+            resolve_limit_sink::<S>(n, expr, value, trackable, snapshot, keep, sink)
+        }
+
+        // `nth(n; f)` (#1952). `Builtin::NthStream` is what a CLI `nth(n; f)`
+        // parses to; `Expr::NthExpr` is parser-unreachable but constructible
+        // by `eval_generic`'s own rewrites, so both spell the same arm.
+        Expr::NthExpr { n, expr } | Expr::Builtin(Builtin::NthStream(n, expr)) => {
+            resolve_nth_sink::<S>(n, expr, value, trackable, snapshot, keep, sink)
+        }
+
         // Every remaining shape still resolves eagerly and reaches the sink
         // through `drain_path_result`, which is byte-identical to the eager
         // result for an always-`Continue` sink -- so this is a missed
@@ -23273,26 +23504,6 @@ fn resolve_node_eager<'a, S: EvalSemantics>(
             resolve_recurse::<S>(f, Some(cond), value, trackable, snapshot, keep)
         }
 
-        // `first(f)` keeps only the first branch `f` resolves to.
-        // `Expr::FirstExpr` is what the dedicated `first(...)` parse path
-        // builds; `Builtin::FirstStream` is never constructed by the parser
-        // (#1986) -- `parse_first_expr` intercepts `first(...)` before
-        // `try_parse_builtin` ever runs, so this second arm is dead from any
-        // parseable query. Kept anyway as defensive symmetry, the same way
-        // `builtin_first_stream_propagates_bare_halt`'s own doc comment
-        // documents and tests `Builtin::FirstStream` directly rather than
-        // relying on a (nonexistent) parser path to reach it.
-        //
-        // #1935: `first(f)` is exactly `limit(1; f)` for path-tracking
-        // purposes, so it shares `resolve_limit_one_n`'s own bounded
-        // dispatch (`resolve_node_bounded`, which fast-paths `repeat`/`.[]`
-        // the same way `limit` does) rather than `take_path_branches`'s
-        // generic truncate-after-the-fact shape alone. Live-verified against
-        // jq 1.7.1: `{"a":1} | path(first(repeat(.)))` is `[]`.
-        Expr::FirstExpr(inner) | Expr::Builtin(Builtin::FirstStream(inner)) => {
-            resolve_node_bounded::<S>(inner, value, trackable, snapshot, keep, 1)
-        }
-
         // `a // b`: resolve `a`, keep only its truthy branches — jq's `//`
         // filters a multi-output left side rather than choosing all-or-
         // nothing (`retain_truthy` is this rule's value-only twin) — and
@@ -23347,24 +23558,6 @@ fn resolve_node_eager<'a, S: EvalSemantics>(
             } else {
                 Ok(branches)
             }
-        }
-
-        // `limit(n; f)`: same `n`-conversion rule as `eval_limit`, so
-        // `path(limit(...))` agrees with plain `limit(...)` in this
-        // evaluator — including anywhere `eval_limit` itself still diverges
-        // from jq (e.g. a negative `n`), which is that function's bug to
-        // fix, not this resolver's. Both internal spellings reach here for
-        // the same reason as `first` above.
-        Expr::Limit { n, expr } => resolve_limit::<S>(n, expr, value, trackable, snapshot, keep),
-        // `Builtin::Limit` is never constructed by the parser (a CLI
-        // `limit(n; expr)` always parses through `parse_limit_expr` into
-        // `Expr::Limit` above, matched first) -- unreachable from any
-        // parseable query, same as `builtin_limit_propagates_halt_from_expr_argument`'s
-        // own doc comment already establishes for the sibling value-mode
-        // builtin. Kept for exhaustiveness/parity with that arm, not
-        // coverage-testable through this dispatch.
-        Expr::Builtin(Builtin::Limit(n, expr)) => {
-            resolve_limit::<S>(n, expr, value, trackable, snapshot, keep)
         }
 
         // #1440: `reduce`/`foreach` are real sugar over the same
@@ -23674,265 +23867,6 @@ fn resolve_node_eager<'a, S: EvalSemantics>(
         }
 
         other => resolve_leaf::<S>(other, value, trackable, snapshot, keep),
-    }
-}
-
-/// Resolve `n; expr`'s `n` the same way `eval_limit` does, then take that
-/// many resolved branches of `expr`.
-///
-/// Uses `eval_owned_expr_ctrl` (which preserves [`Control`] losslessly, the
-/// same #575 precedent `resolve_node`'s other arms rely on), not the
-/// `eval_owned_expr` that collapses a `break` into a synthetic "not in
-/// label" error — this call sits directly in `resolve_node`'s own domain
-/// (unlike the far more broadly-shared `eval_owned_expr` call sites #833
-/// tracks), so there is no reason to leave `limit(n; f)`'s own `n` bound
-/// carrying #824's bug after every other arm here was fixed: verified live,
-/// `label $out | path(limit(break $out; .a))` on `{"a":1}` now produces no
-/// output, exit 0, matching real jq exactly.
-fn resolve_limit<'a, S: EvalSemantics>(
-    n_expr: &Expr,
-    expr: &Expr,
-    value: &'a OwnedValue,
-    trackable: bool,
-    snapshot: bool,
-    keep: Keep,
-) -> PathResolveResult<'a> {
-    // #1313: `eval_owned_expr_ctrl` (used elsewhere in this file) collapses
-    // a genuinely zero-output bound to `Null` by design -- which would fall
-    // into the `Null`/`Bool` "unlimited passthrough" arm below instead of
-    // jq's own `n as $n | ...` desugaring, where a zero-output `n` never
-    // even reaches `path(paths)` and the whole call produces zero output
-    // (verified live against jq 1.7.1: `path(limit(empty; .a,.b))` on
-    // `{"a":1,"b":2}` produces nothing, exit 0). `eval_owned_expr_full`
-    // keeps that distinction visible.
-    // `n` is the OUTER loop, exactly as in value context (#1279):
-    // `{"a":1,"b":2} | [path(limit((1,2); .a,.b))]` is `[["a"],["a"],["b"]]`
-    // in jq. Path context cannot use `fanout_arg` -- it returns
-    // `PathResolveResult`, not `QueryResult` -- so the loop is written out,
-    // but it follows the same two rules: concatenate one resolution per `n`,
-    // and fire `n`'s own trailing escape only after the whole prefix.
-    //
-    // `take_path_branches`' "the prefix is never *longer* than jq's"
-    // invariant (#972/#985) still holds: it is applied per `n` inside
-    // `resolve_limit_one_n`, capping each resolution at that `n` before the
-    // results are concatenated, so no single resolution can overrun its own
-    // bound.
-    let (n_values, escape) = eval_owned_multi_keep_partial::<S>(n_expr, value);
-    let mut branches = Vec::new();
-    for n_value in n_values {
-        match resolve_limit_one_n::<S>(n_value, expr, value, trackable, snapshot, keep) {
-            Ok(mut b) => branches.append(&mut b),
-            Err((mut b, e)) => {
-                branches.append(&mut b);
-                return Err((branches, e));
-            }
-        }
-    }
-    match escape {
-        Some(e) => Err((branches, e)),
-        None => Ok(branches),
-    }
-}
-
-/// Shared "resolve `expr`, capped at `n` branches" dispatch for every
-/// bounded consumer of a generator (`limit(n; expr)` and, since #1935,
-/// `first(f)` == `limit(1; f)` for path-tracking purposes) -- extracted from
-/// two independent, drifting copies of this same three-way match (#1935's
-/// own code review, echoing the "duplicated predicates diverge silently"
-/// lesson #106 already burned this file on once).
-///
-/// - #1850: bare `.[]` is bounded directly via `.take(n)` on the same
-///   iterator `resolve_node`'s own `Expr::Iterate` arm builds (see
-///   [`resolve_iterate_bounded`]'s own doc comment for the implementation),
-///   making `path(limit(n; .[]))`/`path(first(.[]))` O(n) instead of
-///   O(document size). Scoped to exactly this shape rather than
-///   `resolve_node`'s generator path in general because every other arm
-///   there returns a fully materialized `Vec<PathBranch>` with no
-///   sink/early-stop protocol to plug into -- a fully general fix needs
-///   that protocol threaded through `resolve_node` itself, tracked as its
-///   own open design question in #1952 rather than attempted here.
-/// - #1906: `repeat(f)` needs the same interception, for a correctness
-///   reason rather than a performance one -- see [`resolve_repeat_bounded`]'s
-///   own doc comment. This has to intercept *before* the generic
-///   `resolve_node` call below, not truncate its result afterward the way
-///   `take_path_branches` does for every other shape: an un-intercepted
-///   `Expr::Repeat` falls through to `resolve_leaf`'s general case, which
-///   evaluates it via the ordinary (value-mode) evaluator -- bounded by
-///   `eval_repeat`'s own `MAX_ITERATIONS = 1000` round cap, so it *does*
-///   still return, just slowly and with the wrong answer for a `repeat`
-///   whose body is otherwise perfectly path-trackable (confirmed live: the
-///   pre-#1906 code returned "Invalid path expression" for `path(limit(3;
-///   repeat(.)))` after computing, not hanging on, up to 1000 rounds).
-///   Only a body that never produces *any* output (`repeat(empty)`) comes
-///   close to a true hang, and even that is bounded by the same cap.
-///
-/// Both fast paths are gated the same way their originals were: `Iterate`
-/// requires `trackable` (an untracked value falls through to the generic
-/// path below, which raises the correct error on its own); `Repeat` has no
-/// such gate because `resolve_repeat_bounded` re-threads `trackable` through
-/// its own per-round `resolve_node` call instead.
-fn resolve_node_bounded<'a, S: EvalSemantics>(
-    expr: &Expr,
-    value: &'a OwnedValue,
-    trackable: bool,
-    snapshot: bool,
-    keep: Keep,
-    n: usize,
-) -> PathResolveResult<'a> {
-    match unwrap_paren(expr) {
-        Expr::Repeat(f) => resolve_repeat_bounded::<S>(f, value, trackable, snapshot, keep, n),
-        Expr::Iterate if trackable => resolve_iterate_bounded::<S>(value, n),
-        _ => take_path_branches(
-            resolve_node::<S>(expr, value, trackable, snapshot, keep.at_most(n)),
-            n,
-        ),
-    }
-}
-
-/// `path(limit(n; expr))`'s resolution for one already-resolved `n` — the body
-/// of [`resolve_limit`], run once per output of its `n` generator (#1279).
-fn resolve_limit_one_n<'a, S: EvalSemantics>(
-    n_value: OwnedValue,
-    expr: &Expr,
-    value: &'a OwnedValue,
-    trackable: bool,
-    snapshot: bool,
-    keep: Keep,
-) -> PathResolveResult<'a> {
-    // Uses main's `classify_limit_n` (landed independently while this
-    // branch was in flight) rather than the inline match this commit
-    // originally duplicated here: identical case-for-case, and one
-    // definition shared with `limit_with_n` keeps the two contexts from
-    // drifting -- `path(limit(-1.5; ...))` diverging from value-mode
-    // `limit(-1.5; ...)` is exactly the bug #1313 already had to fix once.
-    let n = match classify_limit_n(n_value) {
-        Ok(LimitN::Unlimited) => return resolve_node::<S>(expr, value, trackable, snapshot, keep),
-        Ok(LimitN::Take(n)) => n,
-        Err(e) => return Err((Vec::new(), e.into())),
-    };
-    if n == 0 {
-        return Ok(Vec::new());
-    }
-    resolve_node_bounded::<S>(expr, value, trackable, snapshot, keep, n)
-}
-
-/// `repeat(f)`'s own path-branch construction (#1906), bounded to at most
-/// `n` branches -- mirroring [`resolve_iterate_bounded`]'s #1850 precedent
-/// in shape, but for a correctness reason rather than a performance one:
-/// `repeat(f)` has no base case at all (real jq's own `def repeat(f): f,
-/// repeat(f);`, unconditional on how many outputs `f` produced), so an `f`
-/// that never errors and never produces a value on some round loops
-/// forever -- confirmed live, `limit(3; repeat(empty))` hangs against
-/// pinned jq 1.7.1 too. `resolve_node`'s other arms all return a fully
-/// materialized `Vec<PathBranch>` for `take_path_branches` to truncate
-/// afterward, which cannot work here: the call would simply never return.
-///
-/// Each cycle re-resolves `f` against the *same* original `value`, never
-/// the previous cycle's own result -- `repeat` has no leading `.,` the way
-/// `recurse`'s `., (f | r)` does, and threads no state between rounds at
-/// all. Confirmed live against jq 1.7.1: `{"a":{"a":2}} | path(limit(2;
-/// repeat(.a)))` is `["a"]`, `["a"]` -- the identical single-level path
-/// twice, not the progressively deepening `["a"]`, `["a","a"]` `recurse(.a)`
-/// gives for the same input -- matching `eval_repeat`'s own identical
-/// value-only semantics (its doc comment: "evaluates `expr` with the
-/// original input each time").
-///
-/// `MAX_ITERATIONS` (round count) and `budget` (total branch count, via
-/// [`REPEAT_WIDTH_BUDGET`]) together mirror `eval_repeat`'s own identical
-/// two-tier backstop
-/// (`src/jq/eval.rs`) -- documented as a deliberate divergence from real
-/// jq's own hang/unbounded-allocation in
-/// [`docs/compliance/jq/limitations.md`](../../docs/compliance/jq/limitations.md),
-/// not new to this fix: `eval_repeat`'s value-mode sibling already
-/// terminates `limit(3; repeat(empty))` with no output instead of hanging
-/// (round cap), and already refuses a wide enough fan-out with "repeat:
-/// maximum iterations exceeded" rather than growing `outputs` unboundedly
-/// (branch-count budget) -- this keeps path-mode consistent with both
-/// rather than reintroducing either gap only here (code review, #1933:
-/// an earlier version of this function had the round cap but not the
-/// branch-count budget, letting `path(limit(50000; repeat(.[])))` on a
-/// wide array allocate 5x what value-mode's identical query allows).
-///
-/// Code review, #1933: an earlier version of the `Err` arm below always
-/// propagated `e`, even when `branches` already satisfied `n` before the
-/// error -- confirmed live to spuriously exit 5 for `path(limit(1;
-/// repeat((., error("boom")))))`, which real jq treats as fully successful
-/// (its own `limit` never asks for a second output once the first
-/// satisfies `n`, so it never reaches the error). Mirrors
-/// [`take_path_branches`]'s own identical `prefix.len() >= n` check for the
-/// same reason.
-fn resolve_repeat_bounded<'a, S: EvalSemantics>(
-    f: &Expr,
-    value: &'a OwnedValue,
-    trackable: bool,
-    snapshot: bool,
-    keep: Keep,
-    n: usize,
-) -> PathResolveResult<'a> {
-    const MAX_ITERATIONS: usize = 1000;
-    let mut budget = REPEAT_WIDTH_BUDGET;
-    let mut branches: Vec<PathBranch<'a>> = Vec::new();
-    for _ in 0..MAX_ITERATIONS {
-        if branches.len() >= n {
-            break;
-        }
-        match resolve_node::<S>(f, value, trackable, snapshot, keep.at_most(n)) {
-            Ok(round) => {
-                for branch in round {
-                    if budget == 0 {
-                        let e: EvalEscape =
-                            EvalError::new("repeat: maximum iterations exceeded".to_string())
-                                .into();
-                        return Err((branches, e));
-                    }
-                    budget -= 1;
-                    branches.push(branch);
-                    if branches.len() >= n {
-                        break;
-                    }
-                }
-            }
-            Err((mut b, e)) => {
-                branches.append(&mut b);
-                if branches.len() >= n {
-                    branches.truncate(n);
-                    return Ok(branches);
-                }
-                return Err((branches, e));
-            }
-        }
-    }
-    branches.truncate(n);
-    Ok(branches)
-}
-
-/// Collecting, `n`-bounded wrapper over [`resolve_iterate_sink`] (#1850) --
-/// [`resolve_node_bounded`]'s `.[]` fast path, the one caller that still
-/// wants a `Vec`. The branch construction itself lives in the sink so the
-/// two cannot drift (#106).
-///
-/// **Precondition, not re-checked here:** the caller must already know
-/// `value` is trackable (#843) and raise
-/// `invalid_path_expression_near_iterate` itself when it is not.
-fn resolve_iterate_bounded<S: EvalSemantics>(
-    value: &OwnedValue,
-    n: usize,
-) -> PathResolveResult<'_> {
-    if n == 0 {
-        return Ok(Vec::new());
-    }
-    let mut out = Vec::new();
-    let flow = resolve_iterate_sink::<S>(value, &mut |b| {
-        out.push(b);
-        if out.len() >= n {
-            Demand::Stop
-        } else {
-            Demand::Continue
-        }
-    });
-    match flow {
-        ResolveFlow::Escaped(e) => Err((out, e)),
-        ResolveFlow::Exhausted | ResolveFlow::Stopped => Ok(out),
     }
 }
 
@@ -24996,9 +24930,9 @@ impl FoldRegister {
 /// once the leaf is allowed to reach its third output.
 ///
 /// **The invariant this now depends on is stronger than the one this file
-/// generally maintains.** `take_path_branches`' own doc comment promises
-/// only that a prefix is never *longer* than jq's; a *shorter* one has
-/// always been acceptable, because branches were previously discarded here.
+/// generally maintains.** A resolved prefix is only ever promised to be no
+/// *longer* than jq's; a *shorter* one has always been acceptable, because
+/// branches were previously discarded here.
 /// They are values now, so a short prefix is a wrong answer rather than a
 /// wrong error message. The `Err(_)` arm below deliberately falls back to
 /// `eval_owned_expr_fork` for any escape that is neither `Halt` nor
@@ -25009,8 +24943,9 @@ impl FoldRegister {
 /// (1,2,error("s"))` prefix intact). It does **not** cover the six places
 /// that launder an `Err` into a short `Ok` below this call -- `Expr::Optional`'s
 /// blanket arm, `resolve_catch`'s no-`catch` case, `Expr::Label` on a
-/// matching break, `take_path_branches`, `resolve_recurse`'s
-/// `RECURSE_MAX_ITEMS` cap, and `resolve_repeat_bounded`. Anyone changing
+/// matching break, `resolve_bounded_sink`'s satisfied-bound fold to
+/// `Exhausted`, `resolve_recurse`'s `RECURSE_MAX_ITEMS` cap, and
+/// `resolve_repeat_sink`'s round cap. Anyone changing
 /// one of those is changing a fold's values here too.
 ///
 /// **`EvalTag::Jq` only.** Real yq's lexer rejects `reduce`, `foreach` *and*
@@ -28781,7 +28716,7 @@ fn eval_as<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
 pub(crate) const REDUCE_FOREACH_MAX_STEPS: usize = 100_000;
 
 /// `repeat(f)`'s own step budget — bounds how many values a *single*
-/// round may fork into at once (`resolve_repeat_bounded`/`each_repeat`),
+/// round may fork into at once (`resolve_repeat_sink`/`each_repeat`),
 /// and separately (`eval_repeat`) the total output size of the eager,
 /// non-demand-driven fallback path. Split from [`REDUCE_FOREACH_MAX_STEPS`]
 /// by #2079 (previously the same constant by coincidence); kept at the
@@ -30392,8 +30327,8 @@ fn limit_with_n<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     // `(value, trailing)` pair now, so the zero-output bound never reaches
     // here as a value at all -- it simply runs this body zero times.
     //
-    // Uses main's `classify_limit_n`, shared with `resolve_limit_one_n`
-    // above, in place of the inline match this commit first duplicated.
+    // Uses main's `classify_limit_n`, shared with `resolve_limit_sink`,
+    // in place of the inline match this commit first duplicated.
     let n = match classify_limit_n(n_value) {
         Ok(LimitN::Unlimited) => return eval_single::<W, S>(expr, value, optional),
         Ok(LimitN::Take(n)) => n,
@@ -30930,7 +30865,7 @@ fn eval_repeat<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     // fall through to `owned_vec_to_result(outputs)` silently, returning a
     // truncated-but-successful result with no signal. Now raises the same
     // way the per-value `budget` two lines below already does, matching
-    // `resolve_repeat_bounded`'s identical guard.
+    // `resolve_repeat_sink`'s identical guard.
     const MAX_ITERATIONS: usize = 1000;
     // Bounds total output size independent of `expr`'s own fan-out (#855
     // follow-up): the per-round loop below used to push at most one
@@ -78852,7 +78787,7 @@ mod tests {
     fn builtin_limit_n_classification_matches_classify_limit_n() {
         // `builtin_limit` used to hand-roll its own `n` classification
         // instead of calling `classify_limit_n` (unlike `each_limit`,
-        // `resolve_limit_one_n`, and `limit_with_n`, all migrated to it in
+        // `resolve_limit_sink`, and `limit_with_n`, all migrated to it in
         // the same change): a positive non-integer float (e.g. `2.9`) was
         // silently truncated to `Take(2)` instead of erroring.
         // `builtin_limit` is parser-unreachable today (see
@@ -81615,7 +81550,7 @@ mod tests {
         );
 
         // ...and a *bounded* one must contribute exactly its bound, which
-        // is why `resolve_node_bounded` narrows `keep` rather than
+        // is why `resolve_bounded_sink` narrows `keep` rather than
         // dropping it: two here, not one (`Keep::First`) and not five
         // (an unnarrowed `Keep::AtMost`).
         query!(

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -6634,7 +6634,7 @@ fn eval_each_generic<S: EvalSemantics, V: DocumentValue>(
 /// across rounds instead of resetting per round was tried and silently
 /// reintroduces the exact `limit(80000; repeat(1))`-style truncation #2014
 /// exists to fix). This *raises* on exhaustion, matching
-/// `resolve_repeat_bounded`'s path-context sibling so `path(repeat(f))`
+/// `resolve_repeat_sink`'s path-context sibling so `path(repeat(f))`
 /// and `repeat(f)` agree on the same wide-round wall at the same count
 /// (`test_path_repeat_width_budget_matches_value_mode_1933`). A separate
 /// per-round-count `MAX_EMPTY_REPEAT_ROUNDS` cap counts consecutive rounds

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -30024,6 +30024,101 @@ fn test_path_single_dynamic_stage_static_tail_does_not_over_materialize_2050() -
     Ok(())
 }
 
+/// #2178: a *non-rejecting* builtin (`debug`, `stderr`, ...) sitting between
+/// two generator stages used to make `resolve_seq` widen the earlier stage's
+/// `keep` to "need every output" -- #2050's fix could not tell "a `select`
+/// follows" from "a passthrough follows", so it widened for both, and the
+/// stage-batch loop had no way to un-ask for a value once the widened stage
+/// had produced it.
+///
+/// Depth-first resolution answers it without any static "can this stage
+/// reject" analysis: the first candidate is threaded through the *rest* of
+/// the pipe before the generator is asked for a second, so the raise from
+/// `.a` stops it there. Captured live against `/usr/bin/jq` 1.7.1:
+///
+/// ```console
+/// $ echo null | jq -c '[path(range(1000000) | debug | .a)]' 2>&1 | grep -c DEBUG
+/// 1
+/// $ echo null | jq -c '[path(range(1000000) | debug | .a)]'
+/// jq: error (at <stdin>:1): Invalid path expression near attempt to access element "a" of 0
+/// ```
+///
+/// (`succinctly` answered 100000 and 1000 respectively for these two sizes
+/// before this fix -- a `RECURSE_MAX_ITEMS`-style cap, not the full million.)
+#[test]
+fn test_path_passthrough_between_generator_stages_calls_debug_once_2178() -> Result<()> {
+    for n in ["1000", "1000000"] {
+        let filter = format!("[path(range({n}) | debug | .a)]");
+        let (stdout, stderr, code) = run_jq_full(&["-c", &filter], Some("null"))?;
+        assert_eq!(code, 5, "n={n}, stdout: {stdout:?} stderr: {stderr:?}");
+        assert_eq!(stdout, "", "n={n}");
+        assert_eq!(
+            stderr.matches("DEBUG").count(),
+            1,
+            "n={n}: jq calls debug exactly once; stderr: {stderr:?}"
+        );
+        assert!(
+            stderr.contains(r#"Invalid path expression near attempt to access element "a" of 0"#),
+            "n={n}: stderr: {stderr:?}"
+        );
+    }
+    Ok(())
+}
+
+/// #2178 companion: a stage that genuinely *can* reject still gets every
+/// candidate it needs, which is the #2050 regression depth-first resolution
+/// must not reintroduce. `select` rejects `paths`'s first output, so jq asks
+/// for the next -- captured live against `/usr/bin/jq` 1.7.1:
+///
+/// ```console
+/// $ echo '{"a":{"b":1}}' | jq -c '[path(paths | select(length == 2))]'
+/// jq: error (at <stdin>:1): Invalid path expression with result ["a","b"]
+/// ```
+///
+/// (The raise is the point: reaching `["a","b"]` at all means `paths` was
+/// asked past its rejected first output. A stage-batch loop truncated to one
+/// value answers `[]`, exit 0.)
+#[test]
+fn test_path_rejecting_stage_still_reaches_a_later_candidate_2178() -> Result<()> {
+    let (stdout, stderr, code) = run_jq_full(
+        &["-c", "[path(paths | select(length == 2))]"],
+        Some(r#"{"a":{"b":1}}"#),
+    )?;
+    assert_eq!(code, 5, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert!(
+        stderr.contains(r#"Invalid path expression with result ["a","b"]"#),
+        "stderr: {stderr:?}"
+    );
+    Ok(())
+}
+
+/// #2178: with the pipe resolved depth-first, a *downstream* escape is the
+/// one raised -- an already-yielded value is threaded all the way through the
+/// rest of the pipe before an earlier stage's next alternative is tried, so
+/// `t2` (the later stage's) supersedes `t1`, and the branch that succeeded is
+/// still printed first. Captured live against `/usr/bin/jq` 1.7.1:
+///
+/// ```console
+/// $ echo '{"a":[{"c":[{"foo":1}]}]}' | jq -c 'path(.a[(0,error("t1"))] | .c[(0,error("t2"))] | .foo)'
+/// ["a",0,"c",0,"foo"]
+/// jq: error (at <stdin>:1): t2
+/// ```
+#[test]
+fn test_path_multistage_escape_order_matches_jq_2178() -> Result<()> {
+    let (stdout, stderr, code) = run_jq_full(
+        &[
+            "-c",
+            r#"path(.a[(0,error("t1"))] | .c[(0,error("t2"))] | .foo)"#,
+        ],
+        Some(r#"{"a":[{"c":[{"foo":1}]}]}"#),
+    )?;
+    assert_eq!(code, 5, "stderr: {stderr:?}");
+    assert_eq!(stdout, "[\"a\",0,\"c\",0,\"foo\"]\n");
+    assert!(stderr.contains("t2"), "stderr: {stderr:?}");
+    assert!(!stderr.contains("t1"), "stderr: {stderr:?}");
+    Ok(())
+}
+
 /// The same eagerness applied to `input`/`inputs` destroys data.
 ///
 /// `input`/`inputs` pop from the process-global queue that the CLI's own
@@ -35786,7 +35881,7 @@ fn test_optional_comma_sibling_prune_holds_across_scalar_shapes_for_assignment_2
 }
 
 /// #2124's fix has two call sites, not one: `resolve_seq`'s fully-static
-/// fast path (every test above) and `apply_static_tail`'s per-branch tail
+/// fast path (every test above) and `apply_static_tail_one`'s per-branch tail
 /// application, reached only once a *real* dynamic/computed element
 /// precedes the `?`-guarded step in the same pipe. `.[(0,1)].a?` fans out
 /// over the computed index first (dynamic), then applies `.a? = 9` as each

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -13054,8 +13054,8 @@ fn test_resolve_limit_path_context_rejects_non_numeric_n() -> Result<()> {
 }
 
 /// #1850: `path(limit(n; .[]))` on a bare `.[]` now resolves via
-/// `resolve_iterate_bounded`'s `.take(n)`-bounded iterator instead of
-/// `resolve_node` + `take_path_branches`'s eager-materialize-then-truncate
+/// `resolve_iterate_sink`'s demand-driven emission instead of
+/// `resolve_node`'s eager-materialize-then-truncate
 /// pattern. Output must stay byte-identical for `n` under, at, and over the
 /// array's length -- the bound only changes how much work is done, never
 /// which branches are produced. Oracle-verified against jq 1.7.1.
@@ -13117,7 +13117,7 @@ fn test_path_limit_bare_iterate_through_parens_bounded_1850() -> Result<()> {
 /// fast path through `limit` must raise the same "near attempt to iterate"
 /// error the plain (non-`limit`) `Expr::Iterate` arm always has -- both call
 /// sites gate on `trackable` themselves before ever calling
-/// `resolve_iterate_bounded`, which has no such check of its own. Oracle-verified
+/// `resolve_iterate_sink`, which has no such check of its own. Oracle-verified
 /// against jq 1.7.1: the caught scalar `5` is the value named, not a
 /// `cannot_iterate_with` "Cannot iterate over number" message.
 #[test]
@@ -13137,7 +13137,7 @@ fn test_path_limit_bare_iterate_untrackable_value_still_near_attempt_error_1850(
 
 /// #1850 companion: a compound expression (`.[] | select(...)`) is not the
 /// bare `Expr::Iterate` shape the fast path targets, so it still takes the
-/// original eager `resolve_node` + `take_path_branches` route -- confirming
+/// original eager `resolve_node` route -- confirming
 /// the fast path's narrower scope doesn't regress the general case.
 #[test]
 fn test_path_limit_compound_iterate_still_correct_1850() -> Result<()> {
@@ -14319,7 +14319,7 @@ fn test_first_limit_path_undersatisfied_still_raises_972() -> Result<()> {
     Ok(())
 }
 
-/// #972 Guard E: `take_path_branches` drops `Halt` along with `Error`/
+/// #972 Guard E: a satisfied bound drops `Halt` along with `Error`/
 /// `Break` once the consumer is satisfied, matching jq
 /// (`path(first(select((true, ("m"|halt_error(3))))))` is `[]`, exit 0).
 /// The `m` payload still reaches stderr — the resolver underneath is still
@@ -14548,7 +14548,7 @@ fn test_resolve_slice_expr_keeps_target_partial_fanout_before_its_own_error_973(
 /// produced some values before escaping (`(0,error("b"))`) reset the whole
 /// prefix to empty instead of keeping what it had already produced --
 /// unlike `target`'s own escape (#973 above), which was already correctly
-/// kept. A short `Err` prefix under-satisfies `take_path_branches`' `>= n`
+/// kept. A short `Err` prefix under-satisfies the bounded consumer's `n`
 /// test, so `first`/`limit` in path position wrongly refused a filter real
 /// jq answers. Both bound axes covered, both verified live against jq
 /// 1.7.1: `start`'s own escape lets `end` (nested inside `start`'s first
@@ -14583,7 +14583,7 @@ fn test_resolve_slice_expr_keeps_bound_partial_fanout_before_its_own_error_1517(
 
     // The issue's own `first`/`limit` repros: previously raised `b` where
     // jq answers cleanly, since the (wrongly empty) prefix under-satisfied
-    // `take_path_branches`' `>= 1` test.
+    // the bounded consumer's `>= 1` test.
     let (stdout, stderr, code) = run_jq_full(
         &["-c", r#"path(limit(1; .[(0,error("b")):(2,3)]))"#],
         Some("[10,20,30]"),
@@ -14686,7 +14686,7 @@ fn test_eval_slice_expr_keeps_bound_partial_fanout_before_its_own_error_1528() -
 
 /// #1517 Guard A (the write-side twin of #972's own Guard A, this time on
 /// the bound axis instead of the key axis): the exact boundary that would
-/// silently over-satisfy `take_path_branches` if the fix above overshot
+/// silently over-satisfy the bounded consumer if the fix above overshot
 /// jq's real pre-escape count instead of matching it exactly. `limit(2; ...)`
 /// on the `start`-escape shape (real prefix length 2, per the test above) is
 /// fully satisfied and must write both; `limit(3; ...)` is still
@@ -15354,7 +15354,7 @@ fn test_path_repeat_tracks_through_trackable_body_1906() -> Result<()> {
 }
 
 /// Code review on PR #1933 (fixing #1906): an earlier version of
-/// `resolve_repeat_bounded` always propagated a later round's error, even
+/// `resolve_repeat_sink` always propagated a later round's error, even
 /// when `limit`'s own `n` was already satisfied by branches produced
 /// before it -- something real jq's own lazy `limit` never even reaches.
 /// Confirmed live against jq 1.7.1: exit 0, `[]`, no error at all.
@@ -15369,7 +15369,7 @@ fn test_path_repeat_error_dropped_once_limit_satisfied_1933() -> Result<()> {
     Ok(())
 }
 
-/// Code review on PR #1933: an earlier version of `resolve_repeat_bounded`
+/// Code review on PR #1933: an earlier version of `resolve_repeat_sink`
 /// had no per-branch budget at all, unlike `eval_repeat`'s value-mode
 /// sibling (`REPEAT_WIDTH_BUDGET`) -- letting a large `limit()`-
 /// supplied `n` combined with a wide-fanning-out body allocate far more
@@ -15423,7 +15423,7 @@ fn test_repeat_limit_n_above_1000_no_longer_truncates_2014() -> Result<()> {
 /// bound it, so it still runs `eval_repeat`'s original capped loop. #2014
 /// changed only how that cap fails on exhaustion: silent truncation to a
 /// short, successful result became a hard error, matching
-/// `resolve_repeat_bounded`'s (path-mode) existing convention instead of
+/// `resolve_repeat_sink`'s (path-mode) existing convention instead of
 /// returning wrong-but-plausible output with no diagnostic. Real jq hangs
 /// on all of these instead (no oracle answer to compare against, same as
 /// `repeat(empty)` above) -- see limitations.md's own writeup of this
@@ -15446,10 +15446,10 @@ fn test_repeat_eager_fallback_raises_instead_of_silently_truncating_2014() -> Re
     Ok(())
 }
 
-/// #1935: `first(f)` needs the same `resolve_node_bounded` dispatch #1906/
-/// #1850 gave `limit` -- `first(f)` is exactly `limit(1; f)` for
-/// path-tracking purposes, but was routing through the generic
-/// `take_path_branches(resolve_node(...), 1)` shape instead, which cannot
+/// #1935: `first(f)` needs the same bounded dispatch #1906/#1850 gave
+/// `limit` -- `first(f)` is exactly `limit(1; f)` for path-tracking
+/// purposes, but was routing through a generic
+/// resolve-everything-then-truncate shape instead, which cannot
 /// fast-path either `repeat` or `.[]` (an un-intercepted `Expr::Repeat`
 /// falls through to `resolve_leaf`'s general case, itself bounded by
 /// `eval_repeat`'s own 1000-round cap -- so it still returns, just slowly
@@ -15489,7 +15489,8 @@ fn test_path_first_repeat_tracks_through_trackable_body_1935() -> Result<()> {
 }
 
 /// #1935 (code review): the `Expr::Iterate` fast path (#1850) is the other
-/// half of `resolve_node_bounded`'s dispatch, reused by `first(f)` alongside
+/// half of the bounded dispatch (`resolve_bounded_sink` since #1952),
+/// reused by `first(f)` alongside
 /// `Expr::Repeat` -- covered separately from the `repeat`-focused test above
 /// since it went unpinned by any of this issue's own tests despite being
 /// live-verified during review. `path(limit(1; .[]))`'s already-established
@@ -15527,22 +15528,173 @@ fn test_path_first_iterate_uses_bounded_fast_path_1935() -> Result<()> {
     Ok(())
 }
 
-/// #1935: `nth(n; repeat(f))` is a documented, deliberately unfixed gap --
-/// `nth` has no `resolve_node` arm at all yet (a pre-existing gap
-/// independent of `repeat`), so `repeat`-specific interception there has
-/// nothing to extend. Pins the current (wrong) behavior as a known-gap
-/// regression guard rather than leaving it silently unverified.
+/// #1952: `nth(n; f)` now has a path-context arm, and it is the *same*
+/// bounded-consumer mechanism `limit`/`first` use ([`resolve_bounded_sink`]),
+/// not a third hand-copy of `Expr::Repeat`/`Expr::Iterate` interception --
+/// which is exactly what this issue was filed to prevent. Closes the
+/// "`nth` has no `resolve_node` arm at all" half of #1935's own known gap
+/// (the other half, a combinator-nested `repeat`, is
+/// `test_path_bounded_consumers_thread_through_combinators_1952` below).
+///
+/// jq 1.7.1 defines `nth($n; f)` as a `foreach`-counter that skips the first
+/// `$n` outputs, emits the next one and breaks -- so a generator with fewer
+/// than `$n + 1` outputs emits *nothing*, rather than falling back to its
+/// last. Captured live against `/usr/bin/jq` 1.7.1:
+///
+/// ```console
+/// $ echo '{"a":{"a":2}}' | jq -c 'path(nth(2; repeat(.a)))'
+/// ["a"]
+/// $ echo '{"a":1,"b":2}' | jq -c 'path(nth(0; .a,.b))'
+/// ["a"]
+/// $ echo '{"a":1,"b":2}' | jq -c 'path(nth(1; .a,.b))'
+/// ["b"]
+/// $ echo '{"a":1,"b":2}' | jq -c '[path(nth(5; .a,.b))]'
+/// []
+/// $ echo '{"a":1,"b":2}' | jq -c '[path(nth((0,1); .a,.b))]'
+/// [["a"],["b"]]
+/// $ echo '[1,2,3]' | jq -c 'path(nth(1; .[]))'
+/// [1]
+/// $ echo '{"a":1}' | jq -c 'path(nth(-1; .a))'
+/// jq: error (at <stdin>:1): nth doesn't support negative indices
+/// ```
 #[test]
-fn test_path_nth_repeat_known_gap_1935() -> Result<()> {
-    let (_, stderr, code) = run_jq_full(
+fn test_path_nth_tracks_like_limit_1952() -> Result<()> {
+    // `repeat` reached as `nth`'s direct child -- the shape #1935 pinned as
+    // a known gap, now answering jq's own value.
+    let (stdout, _, code) = run_jq_full(
         &["-c", "path(nth(2; repeat(.a)))"],
         Some("{\"a\":{\"a\":2}}"),
     )?;
-    assert_ne!(code, 0, "known gap: nth has no path-context support yet");
+    assert_eq!(code, 0);
+    assert_eq!(stdout, "[\"a\"]\n");
+
+    // An ordinary (non-`repeat`) generator: `nth` skips, it does not clamp.
+    for (n, expected) in [("0", "[\"a\"]\n"), ("1", "[\"b\"]\n")] {
+        let (stdout, _, code) = run_jq_full(
+            &["-c", &format!("path(nth({n}; .a,.b))")],
+            Some("{\"a\":1,\"b\":2}"),
+        )?;
+        assert_eq!(code, 0, "n={n}");
+        assert_eq!(stdout, expected, "n={n}");
+    }
+
+    // Fewer outputs than `n + 1`: nothing at all, not the last one.
+    let (stdout, _, code) =
+        run_jq_full(&["-c", "[path(nth(5; .a,.b))]"], Some("{\"a\":1,\"b\":2}"))?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout, "[]\n");
+
+    // `n` is the outer loop, exactly as it is for `limit` (#1279).
+    let (stdout, _, code) = run_jq_full(
+        &["-c", "[path(nth((0,1); .a,.b))]"],
+        Some("{\"a\":1,\"b\":2}"),
+    )?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout, "[[\"a\"],[\"b\"]]\n");
+
+    // `.[]` under `nth`, the other shape #1850 had to hand-copy for `limit`.
+    let (stdout, _, code) = run_jq_full(&["-c", "path(nth(1; .[]))"], Some("[1,2,3]"))?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout, "[1]\n");
+
+    // A negative index is jq's own error, not a silent index 0.
+    let (_, stderr, code) = run_jq_full(&["-c", "path(nth(-1; .a))"], Some("{\"a\":1}"))?;
+    assert_ne!(code, 0);
     assert!(
-        stderr.contains("Invalid path expression"),
+        stderr.contains("nth doesn't support negative indices"),
         "stderr: {stderr}"
     );
+    Ok(())
+}
+
+/// #1952: a bound now reaches a generator through arbitrary combinator
+/// nesting, because it is a sink answer (`Demand::Stop`) rather than a
+/// dispatch on the bounded consumer's *direct* child. The old
+/// `resolve_node_bounded` saw an `Expr::If` here and fell through to the
+/// generic, fully-materializing path, which reported "Invalid path
+/// expression" for every one of these.
+///
+/// Captured live against `/usr/bin/jq` 1.7.1:
+///
+/// ```console
+/// $ echo '{"a":1}' | jq -c 'path(limit(2; if true then repeat(.) else empty end))'
+/// []
+/// []
+/// $ echo '{"a":1}' | jq -c 'path(limit(2; try repeat(.) catch empty))'
+/// []
+/// []
+/// $ echo '[1,2,3]' | jq -c 'path(first(if true then .[] else empty end))'
+/// [0]
+/// $ echo '{"a":{"a":2}}' | jq -c 'path(first(. as $x | repeat(.a)))'
+/// ["a"]
+/// $ echo '{"a":1,"b":2}' | jq -c 'path(nth(1; if true then (.a,.b) else empty end))'
+/// ["b"]
+/// ```
+#[test]
+fn test_path_bounded_consumers_thread_through_combinators_1952() -> Result<()> {
+    let cases: &[(&str, &str, &str)] = &[
+        (
+            "path(limit(2; if true then repeat(.) else empty end))",
+            "{\"a\":1}",
+            "[]\n[]\n",
+        ),
+        (
+            "path(limit(2; try repeat(.) catch empty))",
+            "{\"a\":1}",
+            "[]\n[]\n",
+        ),
+        (
+            "path(first(if true then .[] else empty end))",
+            "[1,2,3]",
+            "[0]\n",
+        ),
+        (
+            "path(first(. as $x | repeat(.a)))",
+            "{\"a\":{\"a\":2}}",
+            "[\"a\"]\n",
+        ),
+        (
+            "path(nth(1; if true then (.a,.b) else empty end))",
+            "{\"a\":1,\"b\":2}",
+            "[\"b\"]\n",
+        ),
+    ];
+    for (query, input, expected) in cases {
+        let (stdout, stderr, code) = run_jq_full(&["-c", query], Some(input))?;
+        assert_eq!(code, 0, "query {query:?}, stderr: {stderr}");
+        assert_eq!(stdout, *expected, "query {query:?}");
+    }
+    Ok(())
+}
+
+/// #1952: an *unbounded* `path(repeat(f))` is the one shape whose answer
+/// this migration changes. It used to fall through to `resolve_leaf`, which
+/// evaluated `repeat` as an opaque value and reported "Invalid path
+/// expression with result ..."; it now resolves as a path like every other
+/// `repeat`, bounded only by the same `MAX_ITERATIONS = 1000` round cap
+/// `path(limit(n; repeat(f)))` has always had.
+///
+/// Real jq hangs here (it emits `[]` forever), so there is no oracle answer
+/// to match either way -- confirmed by running
+/// `echo '{"a":1}' | timeout 5 jq -c 'path(repeat(.))'`, which prints `[]`
+/// until the timeout kills it. The round cap is an already-documented
+/// divergence from that hang (`docs/compliance/jq/limitations.md`), and
+/// 1000 correct paths is the same answer `path(limit(1500; repeat(.)))`
+/// already gave; the old error was not.
+#[test]
+fn test_path_unbounded_repeat_hits_the_round_cap_1952() -> Result<()> {
+    let (stdout, stderr, code) =
+        run_jq_full(&["-c", "[path(repeat(.))] | length"], Some("{\"a\":1}"))?;
+    assert_eq!(code, 0, "stderr: {stderr}");
+    assert_eq!(stdout, "1000\n");
+
+    // The bounded shape the round cap has always governed is unchanged.
+    let (stdout, _, code) = run_jq_full(
+        &["-c", "[path(limit(1500; repeat(.)))] | length"],
+        Some("{\"a\":1}"),
+    )?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout, "1000\n");
     Ok(())
 }
 
@@ -35519,7 +35671,7 @@ fn fold_source_bounded_generator_stays_bounded_1872() -> Result<()> {
 /// `resolve_node`'s own branches, which makes a *short* branch prefix a wrong
 /// answer rather than merely a wrong error message. Several arms below that
 /// call launder an `Err` into a truncated `Ok` -- `Expr::Optional`'s blanket
-/// arm, `Expr::Label` on a matching break, `take_path_branches` -- and none of
+/// arm, `Expr::Label` on a matching break, a satisfied bound -- and none of
 /// them is covered by the `Err(_)` fallback. Each case's value count is
 /// captured from jq 1.7.1.
 #[test]
@@ -35541,7 +35693,7 @@ fn fold_source_laundered_short_prefix_value_counts_1872() -> Result<()> {
             r#"{"a":1}"#,
             "[foreach (limit(2; 1,2,3), 9) as $k (0; .+$k)]",
             "[1,3,12]\n",
-            "take_path_branches truncates to its bound, not to one",
+            "a bounded consumer truncates to its bound, not to one",
         ),
     ] {
         let (stdout, _stderr, code) = run_jq_full(&["-c", filter], Some(input))?;


### PR DESCRIPTION
## Summary

Phase 4 of spine 2416, the second path walker. `resolve_node` returned fully materialized branch vectors bounded by a `Keep` count, `resolve_seq` batched stage by stage, and every bounded consumer hand-copied a generator special case (#1850, #1906, #1935). Three commits, in the order they are safe to land:

1. **Sink protocol** (`refactor`): `resolve_node_sink` emits each `PathBranch` to a `FnMut(PathBranch) -> Demand` sink and returns `Exhausted | Stopped | Escaped`; `resolve_node` is a collecting adapter over it, so every caller kept compiling. Combinator arms (`Pipe`, `Paren`, `Comma`, `Iterate`, `select`, the type filters, `If`, `Try`, `Label`, `As`, `stderr`/`debug`) are native; the rest still resolve eagerly and drain into the sink. Behaviour-preserving: no test changed.
2. **Bounded consumers by demand** (`feat`): `limit`, `first` and a new `nth` path arm share one counting sink. Deleted `resolve_node_bounded`, `resolve_repeat_bounded`, `resolve_iterate_bounded`, `take_path_branches`, `resolve_limit_one_n`, `resolve_limit`, `resolve_cond_fork`, `apply_static_tail`. Closes #1952.
3. **Depth-first `resolve_seq`** (`perf`): each output of a stage is pushed straight into the rest of the pipe, so a rejecting later stage asks for the next output and a non-rejecting one never does. `[path(range(1000000) | debug | .a)]` now calls `debug` once, as jq 1.7.1 does, instead of 100000 times. Closes #2178.

## Behaviour changes, each captured from `/usr/bin/jq` 1.7.1 in the test's doc comment

- `path(nth(2; repeat(.a)))` is `["a"]`, `path(nth(1; .a,.b))` is `["b"]`, `[path(nth(5; .a,.b))]` is `[]`, `path(nth(-1; .a))` raises jq's own error. The known-gap test for this became `test_path_nth_tracks_like_limit_1952`, the only test whose assertions changed.
- `path(limit(2; if true then repeat(.) else empty end))` resolves through the combinator; the limitations section on `repeat` reaching only a direct child is removed.
- Unbounded `path(repeat(f))` used to raise "Invalid path expression"; it now resolves under the same 1000-round cap `limit(n; repeat(f))` always had. jq hangs there, so there is no oracle answer; the cap is an already-documented divergence from that hang.

## Measurements

`path(limit(1; .[]))` on a 21.4 MB array: unchanged (0.24 s, 330 MiB before and after), as the sink replaces the hand-written bound at the same cost. `debug` count for `[path(range(N) | debug | .a)]`: 1 for N of 1000 and 1000000, matching jq; previously 1000 and 100000.

## Left out, with the reason

- #2235 (`resolve_fold_source`): its error arm re-evaluates the source from scratch for most escapes; a streaming source cannot make that decision after emitting, so this needs the fallback contract redesigned, not a sink threaded.
- #2267 (`=` write path): the short-circuit lives above the resolvers, in `resolve_dynamic_indexes` and `fork_rhs_over_paths`, which need the whole path list; both would have to become demand-driven on a data-writing path for one of five callers.
- `Keep` survives as a single dial read in `resolve_leaf`'s general case; removing it needs the terminal `path()` consumers migrated too, or #2050's mid-pipe `select` gap returns.

## Verification

fmt; clippy on all CI legs with `-D warnings`; `cargo test` in the three configurations; `cargo doc -D warnings`; jq goldens 633 and yq goldens 113 up to date; oracle sweep 3168 cases, 0 unexpected.

Part of spine 2416 (Phase 4). Closes #1952. Closes #2178.
