### PR TITLE
ci(coverage): adopt omni-dev source markers to tolerate the x86.rs CPU-gated flap

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -792,7 +792,16 @@ jobs:
           # commits with the 0.42.0 binary: patch coverage now reports 7/7
           # new lines for eval.rs, not the pre-fix "5161/6070 new lines"
           # spanning nearly the whole file.
-          version: 0.42.0
+          # Bumped to 0.43.0 for #2467: that release adds source-comment
+          # coverage markers (rust-works/omni-dev#1593) -- `tolerate`/`ignore`
+          # regions delimited by `// omni-dev: coverage tolerate reason="..."`
+          # ... `// omni-dev: coverage end`, scanned from each revision's own
+          # source. On an older binary a marker comment is inert and nothing
+          # is silenced, so this pin must stay >= 0.43.0. This is what lets
+          # `src/util/simd/x86.rs` mask its CPU-gated `detect_fast_bmi2` flap
+          # (10 lines, net 9 covered, #2449) via an in-source marker instead
+          # of a file-level exclusion.
+          version: 0.43.0
           use-prebuilt-binary: ${{ matrix.use-prebuilt }}
           test-args: --features cli,simd,regex,serde --workspace
           fail-under-lines: 55   # floor a few pts below local llvm-cov (ARM: 59.58% lines)

--- a/.omni-dev/coverage.yaml
+++ b/.omni-dev/coverage.yaml
@@ -35,10 +35,17 @@ diff:
   #     they are deterministic on the runner fleet, not CPU-conditional noise.
   #
   #   src/util/simd/x86.rs
-  #     Has an `avx512f` arm (the `has_fast_bmi2` early return), so it flaps by
-  #     the same mechanism — but only by ~1-2 lines in a large file, below the
-  #     threshold that surfaces the "also moved" note. Excluding the whole file
-  #     would hide far more real coverage than noise.
+  #     Has an `avx512f` arm inside `detect_fast_bmi2` (the `has_fast_bmi2`
+  #     early return) that flaps by the same runtime-CPU-detection mechanism —
+  #     10 lines flip, net 9 covered lines, depending on whether the runner
+  #     draws a host with avx512f (#2449; this paragraph previously
+  #     understated the flap as "~1-2 lines"). Rather than excluding the whole
+  #     ~230-line file, the flapping region is wrapped in a
+  #     `// omni-dev: coverage tolerate` marker directly in
+  #     src/util/simd/x86.rs (requires omni-dev >= 0.43.0, see the version pin
+  #     comment in ci.yml; rust-works/omni-dev#1593, succinctly#2467): the file
+  #     keeps contributing its real coverage to the total, and only the
+  #     CPU-gated delta is masked.
   #
   # Keep this list to files with *observed* flap: an entry here removes the file
   # from the reported total as well, so over-excluding quietly shrinks what the

--- a/src/util/simd/x86.rs
+++ b/src/util/simd/x86.rs
@@ -205,6 +205,7 @@ pub fn has_fast_bmi2() -> bool {
     }
 }
 
+// omni-dev: coverage tolerate reason="CPU-gated: the avx512f early-return only executes on Zen 4+ / Skylake-X runners, and its absence changes which AMD/Intel branch below executes too (#2449)"
 #[cfg(all(target_arch = "x86_64", any(feature = "std", test)))]
 fn detect_fast_bmi2() -> bool {
     // First check if BMI2 is supported at all
@@ -254,6 +255,7 @@ fn detect_fast_bmi2() -> bool {
     // Family 0x1A = Zen 5+ (fast BMI2)
     family >= 0x19
 }
+// omni-dev: coverage end
 
 #[cfg(all(test, target_arch = "x86_64"))]
 mod tests {


### PR DESCRIPTION
## Summary
- Bumps the `omni-dev-coverage-check` pin from 0.42.0 to 0.43.0, which adds source-comment coverage markers (rust-works/omni-dev#1593)
- Wraps `detect_fast_bmi2` in `src/util/simd/x86.rs` in a `// omni-dev: coverage tolerate` region so its `avx512f`-gated flap (10 lines, net 9 covered — #2449) stops moving the headline delta on docs-only PRs, while the file keeps contributing its real coverage to the reported total
- Corrects `.omni-dev/coverage.yaml`'s stale "~1-2 lines" figure for this flap

Narrowing `src/bits/popcount.rs` from a file-level exclusion to a region marker (issue task 5) is deliberately left for a separate PR, since it changes the reported total and needs its own `fail-under-lines` re-check.

Closes #2449.

## Test plan
- [x] `cargo build`, `cargo fmt --all -- --check`, `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings` all pass
- [x] Built omni-dev 0.43.0 from source locally and ran `coverage diff` against synthetic lcov reports modeling the exact avx512f-present vs. AMD-CPUID-path flap: without the marker this reproduces `Total: 🔴 -33.33 pp`; with the marker it correctly masks to `Total: ⚪ 0 pp` with a collapsed note listing the tolerated region and reason
- [ ] Confirm the `Coverage (x86_64)` / `Coverage (ARM64)` CI jobs on this PR show the marker note and no spurious per-file entry for `src/util/simd/x86.rs`