### PR TITLE
fix(jq): make the path-context gate the only door into the eager evaluator (spine 2416)

### DIFF
--- a/docs/adrs/adr-0021.md
+++ b/docs/adrs/adr-0021.md
@@ -70,7 +70,14 @@ in-place transforms *inside owned values*, which have no node to stand on.
    head that can reach an absent node followed by a computed stage, or a construct the
    generic evaluator has no cursor-threading arm for (`path_context_single_native` is a
    closed list). Node-preserving stages — `select`, `parent`, `first`, `.a?` — carry the
-   node, and its possible absence, forward.
+   node, and its possible absence, forward. **The gate is the only entry.**
+   `--eval-all` (`eval_owned_with_file_index`, #715) and `eval::eval_pipe`'s own
+   diversion each reached the eager evaluator without consulting it; both route
+   through it now, and `tests/jq_path_context_single_door_guard.rs` fails on a new
+   ungated call anywhere in `src/`. `--eval-all`'s file-origin table — the reason its
+   call had to be direct — is an ambient scope (`eval_generic::with_file_origin`) the
+   cursor route, the absent route, the owned-identity route and the eager evaluator
+   all read, so `file_index` no longer depends on which one answered (#2427). (Step 5.)
 
 4. **The library entry point routes too.** `jq::eval` sends any query that reads path
    context to the generic evaluator up front; the generic evaluator's bridges enter
@@ -184,7 +191,8 @@ in-place transforms *inside owned values*, which have no node to stand on.
   [#2442](https://github.com/rust-works/succinctly/pull/2442) phase 3
 - [`docs/plan/path-context-arm-reachability.md`](../plan/path-context-arm-reachability.md) —
   the step-4 audit of decision 8's pinned handlers: all 43 are still reachable, with the
-  proof query and gate reason for each, and the three doors into the eager evaluator
+  proof query and gate reason for each, and the three doors into the eager evaluator —
+  two of which step 5 closed, leaving the gate
 - [ADR-0018](adr-0018.md) — mode, not format, decides fidelity; every divergence above is
   recorded under it
 - [`docs/compliance/yq/limitations.md`](../compliance/yq/limitations.md) — the yq-mode

--- a/docs/plan/path-context-arm-reachability.md
+++ b/docs/plan/path-context-arm-reachability.md
@@ -1,4 +1,4 @@
-# Per-arm reachability of the eager path-context evaluator (spine 2416, step 4)
+# Per-arm reachability of the eager path-context evaluator (spine 2416, steps 4-5)
 
 `eval_stage_with_path_context` (`src/jq/eval.rs`) is the eager, materialising
 path-context evaluator ADR-0021 is retiring. It handles 43 expression shapes by
@@ -38,32 +38,56 @@ and was run as
 printf '%s' '{"a":{"b":1},"c":[10,20],"n":0,"m":1}' | succinctly jq '<filter>'
 ```
 
-## The three doors into the eager evaluator
+## The one door into the eager evaluator
 
-The gate is not the only entry, which is why reachability had to be measured
-rather than derived from `path_context_needs_eager` alone:
+Step 4 found three; step 5 closed two of them. What is left is the gate:
 
 1. **The gate.** `path_context_needs_eager(exprs)` returning `true` in
    `eval_single`'s `Expr::Pipe` arm and in `eval_each_pipe_generic`
    (`src/jq/eval_generic.rs`) bridges the whole pipe to
    `eval::eval_pipe_with_path_context`. This is the door ADR-0021 decision 3
-   describes and the one step 5 closes.
-2. **`--eval-all`.** `eval::eval_owned_with_file_index` (#715) calls
+   describes, and it is now the only one.
+2. ~~**`--eval-all`.**~~ *Closed (step 5.)*
+   `eval::eval_owned_with_file_index` (#715) used to call
    `eval_pipe_with_path_context_internal` directly, on `needs_path_context(expr)`
-   alone, with no gate at all. Verified live:
-   `succinctly yq --eval-all '[.[] | file_index]' f1.yaml f2.yaml` fires
+   alone, with no gate at all -- verified live at step 4 that
+   `succinctly yq --eval-all '[.[] | file_index]' f1.yaml f2.yaml` fired
    `H3`, `A05`, `A09` and `A21` without `path_context_needs_eager` being
-   consulted.
-3. **`eval::eval_pipe`'s own diversion.** `eval_pipe` still routes any pipe with
-   `needs_path_context` into `eval_pipe_with_path_context`. `jq::eval` no longer
-   reaches it (ADR-0021 decision 4 sends path-context queries to the generic
-   evaluator first), but the generic evaluator's own bridges back into this file
-   (`eval_on_owned` / `bridge_to_full_evaluator` -> `eval_full`) can, so the
-   diversion is live code, not a dead branch behind the entry point.
+   consulted. It reindexes the combined array and evaluates it through the
+   generic evaluator now, like every other entry. The file-origin table that
+   forced the direct call is an ambient scope (`eval_generic::with_file_origin`)
+   the cursor route, the absent route, the owned-identity route and the eager
+   evaluator all read, so `file_index` is answered the same way wherever the
+   gate sends the pipe (#2427's `file_index` half, for the `--eval-all` route).
+3. ~~**`eval::eval_pipe`'s own diversion.**~~ *Closed (step 5.)*
+   `eval_pipe` used to route any pipe with `needs_path_context` into
+   `eval_pipe_with_path_context`. `jq::eval` does not reach it (ADR-0021
+   decision 4), but the generic evaluator's own bridges back into that file
+   (`eval_on_owned` / `bridge_to_full_evaluator` -> `eval_full`) do, so it was
+   live code rather than a dead branch -- measured, not argued: with the
+   diversion instrumented, `reduce .c[] as $x (.a; [.[] | key])` and
+   `.x = [.a[] | key]` both reach it, because `needs_path_context` deliberately
+   does not recurse into a fold's UPDATE/EXTRACT or an assignment's right-hand
+   side, so the enclosing program's routing decision was made against a
+   `false`. It now hands the pipe to the generic evaluator over a root cursor
+   for a reindexed copy of its input -- the eager evaluator's own
+   "`root` is the value I was handed, `current_path` is `[]`" position,
+   expressed as a node -- and `path_context_needs_eager` decides.
 
-Doors 2 and 3 mean that lowering the arm count is gated on more than
-`path_context_needs_eager`: the arms have to stop being reachable through all
-three.
+`tests/jq_path_context_single_door_guard.rs` is what keeps this section true:
+it scans `src/` and fails if any entry into `eval_pipe_with_path_context`/
+`_internal` from outside `src/jq/eval.rs` is not inside a
+`path_context_needs_eager` branch, and pins that `eval_pipe` and
+`eval_owned_with_file_index` name neither symbol.
+
+**No arm became unreachable.** Every one of the 43 rows below is proved by a
+query that enters through the gate (the `Gate` column names which disjunct
+fired), and step 5 did not touch that route -- the proof queries' outputs are
+pinned unchanged in
+`tests/jq_evaluator_parity_tests.rs::test_arm_audit_proof_queries_are_unmoved_by_the_gate_2416`.
+The four arms step 4 attributed to the `--eval-all` door (`H3`, `A05`, `A09`,
+`A21`) each have a gate-route proof query in the table as well, so closing that
+door removed no arm's only route. `PINNED_ARM_COUNT` therefore stays at 43.
 
 ## Gate reasons
 
@@ -140,10 +164,13 @@ This is an ordering artefact, not a claim that R3 is rare.
 | ... neither                                        | --     | 0     |
 | `PINNED_ARM_COUNT`                                 | 43     | 43    |
 
-Nothing is deletable at this point in the spine. The eager evaluator shrinks
-when the generic evaluator gains native arms (widening
-`path_context_single_native`), when the absent route widens, and when doors 2
-and 3 above are closed -- not before.
+Nothing is deletable at this point in the spine. Doors 2 and 3 are closed as
+of step 5, which is a precondition rather than a deletion: the eager evaluator
+shrinks when the generic evaluator gains native arms (widening
+`path_context_single_native`) and when the absent route widens. What the
+closure buys is that `path_context_needs_eager` is now the whole answer to
+"which pipes reach an arm" -- so a migration that narrows the gate narrows the
+evaluator, with no second route to check.
 
 ### Notes for the next migration
 
@@ -159,3 +186,13 @@ and 3 above are closed -- not before.
 - Reachability here is a property of the current tree. Re-run the method above
   (instrument, run, revert) rather than trusting this table after the gate or
   `path_context_single_native` moves.
+- The step-5 closure did *not* change what the sweep
+  (`scripts/jq-path-context-oracle-sweep.sh`) sees for `file_index`. Its
+  yq-mode cases run `succinctly yq FILTER one.yaml two.yaml` with no
+  `--eval-all`, and that path evaluates each document independently through
+  `evaluate_input`, which has no file-origin table to install -- so the
+  manifest's `yq/file_index/*` row (24 divergences) still stands, and the
+  `--eval-all` half of #2427 is the half this step closed. Answering
+  `file_index` on the ordinary multi-file path needs a per-file scalar, not a
+  top-level-index table: `path.first()` there is a key of the document, not a
+  file number.

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -16114,7 +16114,7 @@ fn eval_pipe<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
             Ok(v) => v,
             Err(e) => return suppress_or_raise(e, optional),
         };
-        return eval_path_context_pipe_owned::<W, S>(exprs, &owned, optional);
+        return eval_path_context_pipe_owned::<W, S>(exprs, &owned, optional, None);
     }
 
     if exprs.is_empty() {
@@ -18807,18 +18807,33 @@ pub fn eval_owned_with_file_index<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>
     input: &OwnedValue,
     file_origin: &[usize],
 ) -> QueryResult<'a, W> {
-    if needs_path_context(expr) {
-        eval_pipe_with_path_context_internal::<W, S>(
+    if !needs_path_context(expr) {
+        return eval_owned_input::<W, S>(expr, input, false);
+    }
+    // Spine 2416 step 5: through the one gate, like every other path-context
+    // entry, instead of straight into the eager evaluator (the audit's
+    // "door 2", `docs/plan/path-context-arm-reachability.md`).
+    // [`eval_path_context_pipe_owned`] reindexes the combined array into a
+    // throwaway document and hands the generic evaluator its root cursor,
+    // where `file_index` is a property of the node like `key` and `path`
+    // are -- so a pipe the gate keeps generic (`.[] | file_index`,
+    // `select(file_index == 1)`) is answered without materializing the whole
+    // combined array a second time, and one it hands back to the eager
+    // evaluator (`.[] | file_index + 1`, which has no native arithmetic arm
+    // yet, ADR-0021) reads the identical table.
+    //
+    // The table is ambient for the whole evaluation rather than a parameter
+    // because the cursor route answers `file_index` in `eval_builtin`, which
+    // has no route-specific argument to carry it -- see
+    // `eval_generic::file_origin`.
+    super::eval_generic::with_file_origin(file_origin, || {
+        eval_path_context_pipe_owned::<W, S>(
             core::slice::from_ref(expr),
             input,
-            input,
-            Some(file_origin),
-            &[],
             false,
+            Some(file_origin),
         )
-    } else {
-        eval_owned_input::<W, S>(expr, input, false)
-    }
+    })
 }
 
 // =============================================================================
@@ -31655,17 +31670,41 @@ fn eval_path_context_pipe_owned<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     exprs: &[Expr],
     owned: &OwnedValue,
     optional: bool,
+    file_origin: Option<&[usize]>,
 ) -> QueryResult<'a, W> {
-    use super::eval_generic::{path_context_needs_eager, reindex_bridge_is_identity};
+    use super::eval_generic::{
+        path_context_needs_eager, reindex_bridge_is_identity, FILE_ORIGIN_SCOPE_AVAILABLE,
+    };
+    // A `--eval-all` table that this build cannot make ambient is the third
+    // reason to stay eager: there the table is an ordinary parameter, so the
+    // answer is the pre-step-5 one rather than a `file_index` silently stubbed
+    // to `0` (see `eval_generic::FILE_ORIGIN_SCOPE_AVAILABLE`). Spelled with
+    // `matches!` rather than `Option::is_none_or`, which postdates this
+    // crate's MSRV.
+    let table_needs_ambient = matches!(file_origin, Some(table) if !table.is_empty());
     // The gate call stays *in the condition* -- `tests/jq_path_context_
     // single_door_guard.rs` reads the `if` itself, and a boolean bound above
-    // it reads as gated to a human but not to that scan. The round-trip test
-    // is bound, because spelling it inline makes
+    // it reads as gated to a human but not to that scan. The other two reasons
+    // are bound, because spelling them inline makes
     // `clippy::suspicious_operation_groupings` read the two different
     // arguments (`exprs`, `owned`) as a typo.
     let round_trip_is_lossless = reindex_bridge_is_identity(owned);
-    if path_context_needs_eager(exprs) || !round_trip_is_lossless {
-        return eval_pipe_with_path_context::<W, S>(exprs, owned, &[], optional);
+    let table_would_be_lost = table_needs_ambient && !FILE_ORIGIN_SCOPE_AVAILABLE;
+    if path_context_needs_eager(exprs) || !round_trip_is_lossless || table_would_be_lost {
+        return match file_origin {
+            // `--eval-all`'s own call: hand the eager evaluator the table
+            // directly rather than making it read back the ambient copy this
+            // same call installed.
+            Some(table) => eval_pipe_with_path_context_internal::<W, S>(
+                exprs,
+                owned,
+                owned,
+                Some(table),
+                &[],
+                optional,
+            ),
+            None => eval_pipe_with_path_context::<W, S>(exprs, owned, &[], optional),
+        };
     }
 
     // Same throwaway document `eval_owned_input_reindexed` builds, and the
@@ -31689,10 +31728,24 @@ pub(crate) fn eval_pipe_with_path_context<'a, W: Clone + AsRef<[u64]>, S: EvalSe
     optional: bool,
 ) -> QueryResult<'a, W> {
     // Call the internal version with root value. `file_origin` is only ever
-    // `Some` for `--eval-all`'s combined-array evaluation, which calls
-    // `eval_pipe_with_path_context_internal` directly (see
-    // `eval_owned_with_file_index`) rather than through this wrapper.
-    eval_pipe_with_path_context_internal::<W, S>(exprs, value, value, None, current_path, optional)
+    // installed for `--eval-all`'s combined-array evaluation (#715), and
+    // since spine 2416 step 5 it arrives as the ambient table
+    // `eval_generic::with_file_origin` scopes rather than as an argument
+    // `eval_owned_with_file_index` threaded by calling
+    // `eval_pipe_with_path_context_internal` directly -- that direct call
+    // was the audit's "door 2", and closing it is what lets `--eval-all`
+    // route through the generic evaluator like every other entry while the
+    // pipes this gate still hands back here keep answering `file_index`
+    // from the same table.
+    let file_origin = super::eval_generic::current_file_origin();
+    eval_pipe_with_path_context_internal::<W, S>(
+        exprs,
+        value,
+        value,
+        file_origin.as_deref(),
+        current_path,
+        optional,
+    )
 }
 
 /// Fold one fan-out step's result into `results`, matching the project's

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -16114,7 +16114,7 @@ fn eval_pipe<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
             Ok(v) => v,
             Err(e) => return suppress_or_raise(e, optional),
         };
-        return eval_pipe_with_path_context::<W, S>(exprs, &owned, &[], optional);
+        return eval_path_context_pipe_owned::<W, S>(exprs, &owned, optional);
     }
 
     if exprs.is_empty() {
@@ -29825,7 +29825,23 @@ fn eval_owned_input_reindexed<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     let index = JsonIndex::build(json_bytes);
     let cursor = index.root(json_bytes);
 
-    match eval_single::<Vec<u64>, S>(expr, cursor.value(), optional).materialize_cursor() {
+    detach_from_temp_document(eval_single::<Vec<u64>, S>(expr, cursor.value(), optional))
+}
+
+/// Own every value in `result` so it stops borrowing the throwaway document
+/// it was evaluated against, and can satisfy any caller's `'a`/`W`.
+///
+/// One definition shared by [`eval_owned_input_reindexed`] and
+/// [`eval_path_context_pipe_owned`] (spine 2416, step 5): both build a
+/// temporary `JsonIndex` over `to_json_for_reindex` output, so both have to
+/// detach before returning, and a second hand-written copy of this match is
+/// exactly the "duplicated predicates diverge silently" shape (#106) --
+/// `Partial` is stream-preserving here and collapsing it would be an easy,
+/// silent way for the two copies to disagree.
+fn detach_from_temp_document<'a, W: Clone + AsRef<[u64]>>(
+    result: QueryResult<'_, Vec<u64>>,
+) -> QueryResult<'a, W> {
+    match result.materialize_cursor() {
         QueryResult::One(v) => QueryResult::Owned(to_owned_lossy(&v)),
         QueryResult::OneCursor(_) => unreachable!("materialize_cursor removes OneCursor"),
         QueryResult::Many(vs) => QueryResult::ManyOwned(vs.iter().map(to_owned_lossy).collect()),
@@ -29835,7 +29851,7 @@ fn eval_owned_input_reindexed<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
         QueryResult::Error(e) => QueryResult::Error(e),
         QueryResult::Break(label) => QueryResult::Break(label),
         QueryResult::Halt(code) => QueryResult::Halt(code),
-        // Stream-preserving, so a `Partial` passes straight through — this
+        // Stream-preserving, so a `Partial` passes straight through -- this
         // function's whole point is keeping the shape intact.
         QueryResult::Partial(vs, control) => QueryResult::Partial(vs, control),
     }
@@ -31590,6 +31606,79 @@ fn builtin_isvalid<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
 // ============================================================================
 // Phase 10: Path Expressions, Math, Environment, etc.
 // ============================================================================
+
+/// Route a path-context pipe reaching [`eval_pipe`] through the one gate
+/// (spine 2416, step 5 -- the audit's "door 3",
+/// `docs/plan/path-context-arm-reachability.md`).
+///
+/// `eval_pipe` used to call [`eval_pipe_with_path_context`] on any pipe with
+/// a `needs_path_context` stage, with no gate at all. `jq::eval` no longer
+/// reaches that (ADR-0021 decision 4), but the generic evaluator's bridges
+/// back into this file do: `needs_path_context` deliberately does not recurse
+/// into `Expr::Object`'s entries, `reduce`/`foreach`'s UPDATE/EXTRACT,
+/// `limit`'s `n`, or a `?//` chain, so a pipe hidden in one of those reaches
+/// this evaluator with the enclosing program's own routing decision already
+/// made against a `false`. Measured, not assumed: `reduce .c[] as $x (.a;
+/// [.[] | key])` and `.x = [.a[] | key]` both arrive here, and
+/// [`crate::jq::eval_generic::path_context_needs_eager`] answers `false` for
+/// both.
+///
+/// **The reindex is what makes the generic route exact here.** The eager
+/// evaluator treats the value it is handed as its own root (`current_path`
+/// is `[]`), while the generic evaluator answers `key`/`parent`/`path` from
+/// a cursor -- and [`eval_pipe`] has no cursor to give it, only a
+/// `StandardJson` that may be a sub-value of a larger document. Serializing
+/// `owned` into a throwaway document and taking *its* root cursor is exactly
+/// the eager evaluator's position, expressed as a node: same round trip
+/// `eval_owned_input_reindexed` and `eval_generic::eval_on_owned` already
+/// make. Handing the pipe over with no cursor instead was tried and is
+/// wrong -- `key` then falls through `eval_builtin`'s cursor-guarded arm to
+/// the `null` stub, and `.x = [.a[] | key]` prints `[null,null]` rather than
+/// `["b","e"]`.
+///
+/// Two conditions keep the eager evaluator, and both are checked *before*
+/// paying for the round trip:
+///
+/// * `path_context_needs_eager` -- the one gate, ADR-0021 decision 3;
+/// * a value the reindex would not round-trip
+///   ([`crate::jq::eval_generic::reindex_bridge_is_identity`]) -- today only
+///   a `NumberLiteral` past `REINDEX_LITERAL_LEN_CAP` (#1211), since a
+///   `StandardJson` sourced number materializes as a `NumberLiteral`, never
+///   a bare `Float`. Sending that through the round trip would silently drop
+///   the literal, which the current eager route does not.
+///
+/// Non-recursive by construction: the eager branch is terminal, and the
+/// generic branch is only taken when the gate said `false`, which is the one
+/// answer that stops `eval_single`'s own `Expr::Pipe` arm from bridging the
+/// same pipe back here through `eval_on_owned`.
+fn eval_path_context_pipe_owned<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
+    exprs: &[Expr],
+    owned: &OwnedValue,
+    optional: bool,
+) -> QueryResult<'a, W> {
+    use super::eval_generic::{path_context_needs_eager, reindex_bridge_is_identity};
+    // The gate call stays *in the condition* -- `tests/jq_path_context_
+    // single_door_guard.rs` reads the `if` itself, and a boolean bound above
+    // it reads as gated to a human but not to that scan. The round-trip test
+    // is bound, because spelling it inline makes
+    // `clippy::suspicious_operation_groupings` read the two different
+    // arguments (`exprs`, `owned`) as a typo.
+    let round_trip_is_lossless = reindex_bridge_is_identity(owned);
+    if path_context_needs_eager(exprs) || !round_trip_is_lossless {
+        return eval_pipe_with_path_context::<W, S>(exprs, owned, &[], optional);
+    }
+
+    // Same throwaway document `eval_owned_input_reindexed` builds, and the
+    // same `to_json_for_reindex` (not `to_json`) for the same reason (#561).
+    let json_str = owned.to_json_for_reindex::<S>();
+    let json_bytes = json_str.as_bytes();
+    let index = crate::json::JsonIndex::build(json_bytes);
+    let cursor = index.root(json_bytes);
+
+    let result =
+        super::eval_generic::eval_path_context_pipe_with_cursor::<S, _>(exprs, cursor, optional);
+    detach_from_temp_document(generic_to_query_result(result))
+}
 
 /// Evaluate a pipe while tracking the traversal path.
 /// This enables PathNoArg and Parent to access the path context.

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -3903,6 +3903,129 @@ mod path_context_route {
     }
 }
 
+/// The `--eval-all` file-origin table for the current thread (#715, #2427).
+///
+/// `--eval-all` combines every document from every input file into one array
+/// and answers `file_index` from a side table mapping each top-level array
+/// position to the file it came from. Before spine 2416 step 5 that table was
+/// a parameter threaded through `eval::eval_pipe_with_path_context_internal`,
+/// which is why `eval::eval_owned_with_file_index` had to call the eager
+/// evaluator directly -- the audit's "door 2"
+/// (`docs/plan/path-context-arm-reachability.md`). The cursor route has no
+/// such parameter to thread: `file_index` is answered in `eval_builtin`,
+/// several recursion levels below any entry point and generic over a cursor
+/// type it cannot carry alongside. Same reasoning, and the same shape, as
+/// [`path_context_route`] above -- see its doc comment.
+///
+/// Scoped by [`with_file_origin`] and read by [`file_index_for_path`] and by
+/// `eval::eval_pipe_with_path_context`, so the cursor route, the absent
+/// route, the owned-identity route and the eager evaluator all answer
+/// `file_index` from one table instead of four.
+///
+/// An `Rc<[usize]>` rather than a borrowed slice: a `thread_local!` cannot
+/// hold a lifetime, and the clone a read costs is a refcount bump, not the
+/// table. Reading never holds the `RefCell` borrow across the evaluation, so
+/// a nested [`with_file_origin`] cannot panic on a double borrow.
+#[cfg(feature = "std")]
+mod file_origin {
+    use alloc::rc::Rc;
+    use std::cell::RefCell;
+
+    thread_local! {
+        static CURRENT: RefCell<Option<Rc<[usize]>>> = const { RefCell::new(None) };
+    }
+
+    pub(crate) fn current() -> Option<Rc<[usize]>> {
+        CURRENT.with(|c| c.borrow().clone())
+    }
+
+    /// Installs `table` for `f`'s dynamic extent, restoring the previous
+    /// value on the way out -- including when `f` escapes with a control.
+    pub(crate) fn with<R>(table: &[usize], f: impl FnOnce() -> R) -> R {
+        struct Restore(Option<Rc<[usize]>>);
+        impl Drop for Restore {
+            fn drop(&mut self) {
+                CURRENT.with(|c| *c.borrow_mut() = self.0.take());
+            }
+        }
+        let installed: Rc<[usize]> = Rc::from(table.to_vec().into_boxed_slice());
+        let _restore = Restore(CURRENT.with(|c| c.borrow_mut().replace(installed)));
+        f()
+    }
+
+    /// Whether `to_vec` above is worth skipping: an empty table answers `0`
+    /// everywhere, which is what no table at all already answers.
+    pub(crate) fn table_is_useful(table: &[usize]) -> bool {
+        !table.is_empty()
+    }
+}
+
+#[cfg(not(feature = "std"))]
+mod file_origin {
+    use alloc::rc::Rc;
+
+    pub(crate) fn current() -> Option<Rc<[usize]>> {
+        None
+    }
+
+    pub(crate) fn with<R>(_table: &[usize], f: impl FnOnce() -> R) -> R {
+        f()
+    }
+
+    pub(crate) fn table_is_useful(_table: &[usize]) -> bool {
+        false
+    }
+}
+
+/// Whether this build can make a file-origin table ambient at all.
+///
+/// `false` without `std`: [`file_origin`]'s storage is a `thread_local!`, and
+/// a `no_std` embedding has none (same limitation as [`path_context_route`]
+/// and `eval.rs`'s `remaining_inputs`). The difference is that those two
+/// degrade into a slower-but-correct default, while an unreadable file-origin
+/// table would answer `file_index` as `0` -- a wrong answer, the #715 failure
+/// class. So `eval::eval_path_context_pipe_owned` consults this and keeps a
+/// pipe that *has* a table on the eager evaluator, where the table is an
+/// ordinary parameter, whenever the ambient cannot be read back.
+pub(crate) const FILE_ORIGIN_SCOPE_AVAILABLE: bool = cfg!(feature = "std");
+
+/// Install `table` as the ambient `--eval-all` file-origin table for `f`
+/// (#715, #2427). See [`file_origin`].
+pub(crate) fn with_file_origin<R>(table: &[usize], f: impl FnOnce() -> R) -> R {
+    if !file_origin::table_is_useful(table) {
+        return f();
+    }
+    file_origin::with(table, f)
+}
+
+/// The ambient `--eval-all` file-origin table, if one is installed --
+/// `eval::eval_pipe_with_path_context`'s bridge into the eager evaluator's
+/// own `file_origin` parameter.
+pub(crate) fn current_file_origin() -> Option<alloc::rc::Rc<[usize]>> {
+    file_origin::current()
+}
+
+/// `file_index` for a node at `path`: the origin file of the top-level
+/// element `path` descends from (#715).
+///
+/// `path.first()`, not `.last()` -- `file_index` answers "which file did this
+/// whole document come from", unaffected by further navigation. `0` with no
+/// table (every route outside `--eval-all`) and `0` at the root, the same
+/// "0 outside supported context" contract `document_index` has, and the same
+/// expression `eval::eval_stage_with_path_context`'s own `Builtin::FileIndex`
+/// handler computes from its `file_origin` parameter.
+fn file_index_for_path(path: &[OwnedValue]) -> i64 {
+    let Some(table) = file_origin::current() else {
+        return 0;
+    };
+    path.first()
+        .and_then(OwnedValue::as_i64)
+        .and_then(|i| usize::try_from(i).ok())
+        .and_then(|i| table.get(i).copied())
+        .and_then(|origin| i64::try_from(origin).ok())
+        .unwrap_or(0)
+}
+
 /// Evaluate against a cursor with an explicit [`PathContextRoute`] (#2416).
 ///
 /// Identical to [`eval_with_cursor_using`] except that `route` decides whether
@@ -11832,8 +11955,19 @@ fn path_context_resolve_constants(
                 _ => Expr::Comma(components),
             }))
         }
-        // The generic route carries no file-origin table (#2150, #2427), so
-        // this is the same `0` the eager arm answers with an empty one.
+        // Still the constant `0`, but no longer for the reason the previous
+        // comment gave: the generic route *does* carry a file-origin table
+        // now (`with_file_origin`, spine 2416 step 5). This arm is simply not
+        // reached with one installed -- measured on 2026-09-05 by
+        // instrumenting it and sweeping the `--eval-all` shapes that could
+        // plausibly take the absent route (`.[] | .nope | file_index`,
+        // `.[] | .a.nope | file_index`, `.[] | .nope | [file_index]`,
+        // `.[] | .nope | select(file_index == 1)`, ...): every one is
+        // answered by `eval_builtin`'s cursor arm or by the eager evaluator
+        // instead, and this arm never fired. Left as the constant rather
+        // than switched to an unexercised `file_index_for_path(path)` call --
+        // `path` here is absolute, so that is the one-line change to make the
+        // moment a route does arrive with a table (#2427).
         Expr::Builtin(Builtin::FileIndex) => Expr::Literal(Literal::Int(0)),
         Expr::Paren(inner) => Expr::Paren(boxed(inner)),
         Expr::Array(inner) => Expr::Array(boxed(inner)),
@@ -13263,9 +13397,18 @@ fn eval_builtin<S: EvalSemantics, V: DocumentValue>(
                 Err(e) => GenericResult::Error(e),
             }
         }
-        // The generic route carries no file-origin table (#2150, #2427), so
-        // this is the same `0` the eager arm answers with an empty one.
-        Builtin::FileIndex if cursor.is_some() => GenericResult::Owned(OwnedValue::Int(0)),
+        // #2427: answered from the ambient `--eval-all` file-origin table
+        // (`with_file_origin`), not the constant `0` this arm used to
+        // return -- `eval::eval_owned_with_file_index` installs the table
+        // and then routes through this evaluator like every other entry
+        // (spine 2416 step 5, the audit's "door 2"). Still `0` everywhere
+        // else, since no other caller installs a table.
+        Builtin::FileIndex if cursor.is_some() => {
+            match cursor_path_and_ancestors(&cursor.expect("guarded")) {
+                Ok((path, _)) => GenericResult::Owned(OwnedValue::Int(file_index_for_path(&path))),
+                Err(e) => GenericResult::Error(e),
+            }
+        }
 
         _ => {
             // #2231: `owned_or_suppress!`, not `owned_or_err!` -- this
@@ -13898,7 +14041,10 @@ fn eval_owned_identity_pipe<S: EvalSemantics, V: DocumentValue>(
             }
             Err(e) => Flow::Escaped(Control::Error(e)),
         },
-        // The generic route carries no file-origin table (#2150, #2427).
+        // Same measured status as `path_context_resolve_constants`'s own
+        // `FileIndex` arm (see its comment): the table exists now, this route
+        // is not reached with one installed, and `id.path()` is what to feed
+        // `file_index_for_path` when it is.
         Expr::Builtin(Builtin::FileIndex) => {
             continue_owned_identity_plain::<S, V>(rest, OwnedValue::Int(0), optional, sink)
         }

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -2109,7 +2109,7 @@ const REINDEX_LITERAL_LEN_CAP: usize = 256;
 /// (`"1e+19"`), while `.outer.big|parent|.big+0` wrongly *gained* it for a
 /// value the pipe had just computed. Only a value the bridge would have left
 /// alone can safely skip the bridge.
-fn reindex_bridge_is_identity(value: &OwnedValue) -> bool {
+pub(crate) fn reindex_bridge_is_identity(value: &OwnedValue) -> bool {
     match value {
         OwnedValue::Float(_) => false,
         OwnedValue::Int(_) => true,
@@ -3954,6 +3954,37 @@ pub fn eval_with_cursor_using<S: EvalSemantics, C: DocumentCursor>(
         return eval_each_owned_collect::<S, C::Value>(expr, &owned, false);
     }
     eval_single::<S, C::Value>(expr, cursor.value(), false, Some(cursor))
+}
+
+/// Evaluate a path-context pipe reaching this module from `eval.rs`'s own
+/// `eval_pipe` (spine 2416, step 5 -- the audit's "door 3").
+///
+/// `eval_pipe` used to send any pipe with a `needs_path_context` stage
+/// straight to `eval::eval_pipe_with_path_context`, bypassing
+/// [`path_context_needs_eager`] entirely. It now hands the pipe here
+/// instead, so the one gate decides which pipes the eager evaluator still
+/// owns -- see `eval::eval_path_context_pipe_owned` for the reindex that
+/// gives this call the root cursor `key`/`parent`/`path` are properties of.
+///
+/// Differs from [`eval_with_cursor_using`] in two ways, both of which the
+/// call site needs: `optional` is the caller's ambient value rather than a
+/// fresh `false` (`eval_pipe` is reached mid-expression, under a `?`/`try`
+/// that has already decided suppression), and the stages arrive as a slice
+/// so the `Expr::Pipe` is rebuilt once here rather than by every caller.
+/// The `takes_input_queue_bridge` carve-out is deliberately not repeated:
+/// that bridge exists for a *top-level* program sharing `jq_runner`'s input
+/// queue, and this entry is never a top-level program.
+pub(crate) fn eval_path_context_pipe_with_cursor<S: EvalSemantics, C: DocumentCursor>(
+    exprs: &[Expr],
+    cursor: C,
+    optional: bool,
+) -> GenericResult<C::Value> {
+    eval_single::<S, C::Value>(
+        &Expr::Pipe(exprs.to_vec()),
+        cursor.value(),
+        optional,
+        Some(cursor),
+    )
 }
 
 /// Streaming counterpart of [`eval_with_cursor`] (#1653): deliver each output
@@ -11217,7 +11248,7 @@ fn cursor_ancestor<C: DocumentCursor>(c: &C, n: usize) -> Option<C> {
 ///
 /// `select(key == "a") | parent` stays generic: `select` emits its input
 /// node unchanged, so `parent` still stands on a live cursor.
-fn path_context_needs_eager(exprs: &[Expr]) -> bool {
+pub(crate) fn path_context_needs_eager(exprs: &[Expr]) -> bool {
     if !exprs.iter().any(needs_path_context) {
         return false;
     }

--- a/tests/data/jq-path-context-sweep-known-divergences.txt
+++ b/tests/data/jq-path-context-sweep-known-divergences.txt
@@ -45,10 +45,21 @@ yq/*/first/*/*        yq_first        real yq's first(f) ignores its argument an
 yq/*/comma/*/*        comma_stream    yq's comma composes at the stream level, succinctly's per element — #2420
 
 # `file_index` answers 0 for every input file. Real yq counts files (`0`,
-# `1`), and `--eval-all` diverges further still (succinctly slurps the files
-# into one array; yq keeps them a stream). Surfaced by this sweep — see the
-# #2416 phase 0 report; no issue filed yet.
-yq/file_index/*       file_index      file_index is always 0 across multiple input files — #2416 phase 0
+# `1`). Surfaced by this sweep — see the #2416 phase 0 report; no issue filed
+# yet.
+#
+# Scoped, not stale: this row is the *ordinary* multi-file path, which is what
+# the yq-mode cases here run (`succinctly yq FILTER one.yaml two.yaml`, no
+# `--eval-all`). That path evaluates each document independently through
+# `evaluate_input`, which has no file-origin table to install, and answering
+# `file_index` there needs a per-file scalar rather than the top-level-index
+# table `--eval-all` uses — a node's own `path.first()` is a key of its
+# document, not a file number. `--eval-all` itself answers `file_index`
+# correctly on both its routes since spine 2416 step 5 (see
+# tests/yq_cli_tests.rs::test_eval_all_file_index_agrees_across_both_routes_2416),
+# and diverges from yq for a different reason: succinctly slurps the files
+# into one array where yq keeps them a document stream (#2427).
+yq/file_index/*       file_index      file_index is always 0 across multiple input files, outside --eval-all — #2416 phase 0
 
 # `parent`/`key` at the document root: real yq emits nothing (exit 0),
 # succinctly prints `{}` and `null`. These are the positions the #2061 walk

--- a/tests/jq_evaluator_parity_tests.rs
+++ b/tests/jq_evaluator_parity_tests.rs
@@ -1982,3 +1982,246 @@ fn test_target_partial_prefix_path_context_sites_miss_the_yq_gate_2374() {
         );
     }
 }
+
+// ---------------------------------------------------------------------------
+// Spine 2416 step 5: `eval::eval_pipe`'s path-context diversion
+//
+// `eval_pipe` used to send any pipe with a `needs_path_context` stage straight
+// to `eval::eval_pipe_with_path_context`, with no gate at all -- the third of
+// the three routes into the eager evaluator that
+// `docs/plan/path-context-arm-reachability.md` found. It now hands the pipe to
+// `eval_generic` with a root cursor over a reindexed copy of its input, so
+// `path_context_needs_eager` decides, and the pipes that decision keeps eager
+// reach the same evaluator by the same values as before.
+//
+// Two things need pinning, and neither is visible to the walk-vs-bridge axis
+// above: the *reachable* shapes (a path-context pipe only reaches `eval_pipe`
+// through a construct `needs_path_context` does not recurse into, so no
+// top-level filter gets there) and the *absence of a loop* (the generic
+// evaluator's own bridge re-enters `eval.rs`; a redirect that bounced back
+// would not fail an assertion, it would not return).
+// ---------------------------------------------------------------------------
+
+/// The document the audit's proof queries were captured against
+/// (`docs/plan/path-context-arm-reachability.md`, "Method").
+const ARM_AUDIT_DOC: &[u8] = br#"{"a":{"b":1},"c":[10,20],"n":0,"m":1}"#;
+
+/// Every proof query from the arm-reachability audit's 43-row table, with the
+/// output it had before `eval_pipe`'s diversion was routed through the gate.
+///
+/// jq 1.7.1 has no `key`/`parent`/`path`/`file_index` at all (`key/0 is not
+/// defined`, exit 3), so there is no oracle for these in jq mode; they are
+/// succinctly extensions and what is asserted is that closing the door moved
+/// none of them. The audit's own table is the index: a row here that changes
+/// invalidates a row there.
+#[test]
+fn test_arm_audit_proof_queries_are_unmoved_by_the_gate_2416() {
+    let rows: &[(&str, &[&str])] = &[
+        ("path + []", &[r#"["a","b"]"#]),
+        (r#".a.b | key + "x""#, &[r#""bx""#]),
+        (".a.b | file_index + 1", &["1"]),
+        (".a.b | parent + {}", &[r#"{"b":1}"#]),
+        (".a.b | parent(0+1) + {}", &[r#"{"b":1}"#]),
+        (r#".a.b | . | key + "x""#, &[r#""bx""#]),
+        (".c[0] | key + 1", &["1"]),
+        (".c[0:1] | .[0] | key + 1", &["1"]),
+        (r#".a[] | key + "x""#, &[r#""bx""#]),
+        (r#"(.a.b) | key + "x""#, &[r#""bx""#]),
+        (".c[.n]? | key + 1", &["1"]),
+        (r#".a? | key + "x""#, &[r#""ax""#]),
+        (".a.b | -(key|length)", &["-1"]),
+        (r#".a.b | key == "b" and true"#, &["true"]),
+        (r#".a.b | (key + "x") | . == "bx""#, &["true"]),
+        (r#".a.b | select(key == "b") | key + "x""#, &[r#""bx""#]),
+        (r#".a | map(key + "x")"#, &[r#"["bx"]"#]),
+        (r#".a | getpath(["b"]) | . as $x | key"#, &[r#""b""#]),
+        (r#".a.b | (key + "x") | length"#, &["2"]),
+        (".c[.n] | key + 1", &["1"]),
+        (".c[.n:.m] | .[0] | key + 1", &["1"]),
+        (r#".a.b | [key] + ["x"]"#, &[r#"["b","x"]"#]),
+        (r#".a.b | ("\(key)") | . + "x""#, &[r#""bx""#]),
+        (r#"def f: key; .a.b | f + "x""#, &[r#""bx""#]),
+        (r#"def f(x): x; .a.b | f(key) + "z""#, &[r#""bz""#]),
+        (r#".a.b | def f: key; f + "x""#, &[r#""bx""#]),
+        (r#".a.b | . as $x | key + "x""#, &[r#""bx""#]),
+        (r#".c | . as [$x] | key + "x""#, &[r#""cx""#]),
+        (r#".a.b | limit(1; key + "x")"#, &[r#""bx""#]),
+        (r#".a.b | first(key + "x")"#, &[r#""bx""#]),
+        (r#".a.b | last(key + "x")"#, &[r#""bx""#]),
+        (
+            r#".a.b | reduce (key) as $k (""; . + $k) | . + "x""#,
+            &[r#""bx""#],
+        ),
+        (
+            r#".a.b | foreach (key) as $k (""; . + $k) | . + "x""#,
+            &[r#""bx""#],
+        ),
+        (r#".a.b | (key + "x") | {z: .}"#, &[r#"{"z":"bx"}"#]),
+        (
+            r#".a.b | if key == "b" then key + "x" else "y" end"#,
+            &[r#""bx""#],
+        ),
+        (r#".a.b | (key + "x"), key"#, &[r#""bx""#, r#""b""#]),
+        (r#".a.b | try (key + "x") catch "e""#, &[r#""bx""#]),
+        (r#".a.b | label $o | ((key + "x"), break $o)"#, &[r#""bx""#]),
+        (
+            r#".a[] | if key == "b" then key + "x" else "y" end"#,
+            &[r#""bx""#],
+        ),
+        (
+            r#".a[] | reduce (key) as $k (""; . + $k) | . + "x""#,
+            &[r#""bx""#],
+        ),
+    ];
+    for (filter, expected) in rows {
+        // `path + []` is the audit's H1 row spelled against `.a.b`.
+        let filter = if *filter == "path + []" {
+            ".a.b | path + []"
+        } else {
+            filter
+        };
+        let full = full_outputs(ARM_AUDIT_DOC, filter);
+        assert_eq!(
+            as_strs(&full),
+            *expected,
+            "arm-audit proof query moved: `{filter}`"
+        );
+        assert_eq!(
+            as_strs(&generic_outputs(ARM_AUDIT_DOC, filter)),
+            *expected,
+            "arm-audit proof query moved in the generic evaluator: `{filter}`"
+        );
+    }
+}
+
+/// The shapes that actually reach `eval::eval_pipe` with a path-context pipe.
+///
+/// Measured, not guessed: with the diversion instrumented, exactly these
+/// constructs got there, because `needs_path_context` deliberately does not
+/// recurse into `reduce`/`foreach`'s UPDATE and EXTRACT, into an assignment's
+/// right-hand side, or into `Expr::Object`'s entries -- so the enclosing
+/// program answers `false` and the inner pipe arrives with no routing
+/// decision made for it. The first four are `path_context_needs_eager ==
+/// false` rows, i.e. the ones the door closure actually moves onto the
+/// generic evaluator.
+///
+/// Two rows are oracle-backed; the rest are succinctly extensions in jq mode
+/// (jq 1.7.1 has no `key`), pinned as unmoved. Captured live from yq v4.53.3
+/// on 2026-09-05, on `{"a":{"b":1,"e":2},"c":[10,20]}` written as YAML:
+///
+/// ```console
+/// $ yq -o=json -I0 '.x = [.a[] | key]' d.yaml
+/// {"a":{"b":1,"e":2},"c":[10,20],"x":["b","e"]}
+/// $ yq -o=json -I0 '.x = (.a.b | key)' d.yaml
+/// {"a":{"b":1,"e":2},"c":[10,20],"x":"b"}
+/// ```
+#[test]
+fn test_path_context_pipes_reaching_eval_pipe_are_unmoved_2416() {
+    const DOC: &[u8] = br#"{"a":{"b":1,"e":2},"c":[10,20]}"#;
+    let rows: &[(&str, &[&str])] = &[
+        // `reduce`'s UPDATE: `.` is the accumulator, so the pipe's position
+        // is the accumulator's own, which is exactly what the reindexed root
+        // cursor expresses.
+        ("reduce .c[] as $x (.a; [.[] | key])", &["[0,1]"]),
+        (
+            "foreach .c[] as $x (.a; .; [.[] | key])",
+            &[r#"["b","e"]"#, r#"["b","e"]"#],
+        ),
+        (
+            "reduce .c[] as $x (.a; . + {\"z\": ([.[] | key] | length)})",
+            &[r#"{"b":1,"e":2,"z":3}"#],
+        ),
+        // Assignment right-hand side -- and real yq agrees, see the captures
+        // in this test's doc comment.
+        (
+            ".x = [.a[] | key]",
+            &[r#"{"a":{"b":1,"e":2},"c":[10,20],"x":["b","e"]}"#],
+        ),
+        (
+            ".x = (.a.b | key)",
+            &[r#"{"a":{"b":1,"e":2},"c":[10,20],"x":"b"}"#],
+        ),
+        // `with_entries`'s inner filter, and `any/2`'s condition: both reach
+        // `eval_pipe` with `path_context_needs_eager == true`, so they still
+        // take the eager evaluator -- pinned so the split between the two
+        // answers is visible if the gate moves.
+        (
+            r".a | with_entries(.value = (.a.b | key))",
+            &[r#"{"b":"b","e":"b"}"#],
+        ),
+    ];
+    for (filter, expected) in rows {
+        assert_eq!(
+            as_strs(&full_outputs(DOC, filter)),
+            *expected,
+            "door-3 shape moved: `{filter}`"
+        );
+        assert_eq!(
+            as_strs(&generic_outputs(DOC, filter)),
+            *expected,
+            "door-3 shape moved in the generic evaluator: `{filter}`"
+        );
+    }
+}
+
+/// The redirect does not recurse.
+///
+/// `eval_pipe` hands its pipe to the generic evaluator, whose own bridges
+/// (`eval_on_owned` -> `eval_full` -> `eval_single`) come straight back into
+/// `eval.rs`. If the gate's `false` answer could be reached a second time for
+/// the same pipe, the two would ping-pong -- and a loop does not fail an
+/// assertion, it hangs or overflows the stack, so the test *completing* is
+/// the assertion. Depth is deliberately past any constant fan-out: a bounded
+/// number of bounces would still finish, a loop would not.
+#[test]
+fn test_eval_pipe_path_context_redirect_does_not_recurse_2416() {
+    const DOC: &[u8] = br#"{"a":{"b":1,"e":2},"c":[10,20]}"#;
+
+    // A path-context pipe nested `depth` levels deep inside `reduce` UPDATEs,
+    // each level re-entering `eval_pipe` with that level's accumulator as its
+    // root. Only depth 1 has a value to pin -- from depth 2 the accumulator
+    // is the inner `reduce`'s own array result, which has no `.a`, so the
+    // filter raises. That is the pre-existing answer (identical on the tree
+    // before this change), and it is still the right shape to run: the
+    // recursion this test is about happens on the way *in*, before the type
+    // error is reached.
+    assert_eq!(
+        as_strs(&full_outputs(DOC, "reduce .c[] as $x (.a; [.[] | key])")),
+        ["[0,1]"]
+    );
+    for depth in [2_usize, 4, 8] {
+        let mut filter = String::from("[.[] | key]");
+        for _ in 0..depth {
+            filter = format!("reduce .c[] as $x (.a; {filter})");
+        }
+        // Returning at all is the assertion; the equality keeps the two
+        // evaluators from drifting into different non-answers.
+        assert_eq!(
+            full_outputs(DOC, &filter),
+            generic_outputs(DOC, &filter),
+            "depth {depth}: `{filter}`"
+        );
+    }
+
+    // A long path-context pipe and a deep parenthesis nest around one, so the
+    // per-stage and per-level recursion inside the redirect are exercised on
+    // a filter that stays well-typed all the way down.
+    //
+    // The depths here (and the fold depths above) are bounded by what a debug
+    // test thread's 2 MiB stack holds, not by what the redirect can take: the
+    // release binary answers all three shapes at 64 folds / 200 stages / 100
+    // parens, identically before and after this change. A loop would not fit
+    // in any of them.
+    let stages: String = core::iter::repeat_n(" | .", 60).collect();
+    let filter = format!(".x = ([.a[] | key]{stages})");
+    assert_eq!(
+        as_strs(&full_outputs(DOC, &filter)),
+        [r#"{"a":{"b":1,"e":2},"c":[10,20],"x":["b","e"]}"#]
+    );
+
+    let filter = format!(".x = {}[.a[] | key]{}", "(".repeat(30), ")".repeat(30));
+    assert_eq!(
+        as_strs(&full_outputs(DOC, &filter)),
+        [r#"{"a":{"b":1,"e":2},"c":[10,20],"x":["b","e"]}"#]
+    );
+}

--- a/tests/jq_path_context_arm_guard.rs
+++ b/tests/jq_path_context_arm_guard.rs
@@ -44,10 +44,13 @@ use syn::visit::{self, Visit};
 ///
 /// Step 4 of that spine audited every one of these handlers for reachability
 /// and found no dead ones: `docs/plan/path-context-arm-reachability.md` has a
-/// live proof query and the gate reason for each, plus the three routes that
-/// enter the eager evaluator (the `path_context_needs_eager` bridge is only
-/// one of them -- `--eval-all` and `eval::eval_pipe`'s own diversion have no
-/// gate). Read it before assuming an arm is deletable.
+/// live proof query and the gate reason for each. Step 5 then closed the two
+/// routes that entered the eager evaluator *without* consulting
+/// `path_context_needs_eager` (`--eval-all` and `eval::eval_pipe`'s own
+/// diversion), so the gate is now the whole answer to which pipes reach an
+/// arm -- `tests/jq_path_context_single_door_guard.rs` keeps it that way.
+/// Closing them removed no arm's only route, so the pin did not move. Read
+/// that page before assuming an arm is deletable.
 const PINNED_ARM_COUNT: usize = 43;
 
 const TARGET_FN: &str = "eval_stage_with_path_context";

--- a/tests/jq_path_context_single_door_guard.rs
+++ b/tests/jq_path_context_single_door_guard.rs
@@ -1,0 +1,542 @@
+//! Spine 2416, step 5: `path_context_needs_eager` is the **only** door into
+//! the eager path-context evaluator.
+//!
+//! # The property
+//!
+//! `eval_stage_with_path_context` (`src/jq/eval.rs`) is reached through
+//! exactly two entry points -- `eval_pipe_with_path_context` and its
+//! `_internal` twin -- and ADR-0021 decision 3 says which pipes belong to it:
+//! whatever `path_context_needs_eager` (`src/jq/eval_generic.rs`) answers
+//! `true` for. `docs/plan/path-context-arm-reachability.md` found that the
+//! gate was one of *three* routes in, not the only one:
+//!
+//! 1. the gate itself, in `eval_single`'s `Expr::Pipe` arm and in
+//!    `eval_each_pipe_generic`;
+//! 2. `eval::eval_owned_with_file_index` (`--eval-all`, #715), which called
+//!    `eval_pipe_with_path_context_internal` directly on
+//!    `needs_path_context(expr)` alone;
+//! 3. `eval::eval_pipe`'s own diversion, which sent any pipe with a
+//!    `needs_path_context` stage to `eval_pipe_with_path_context`, also with
+//!    no gate.
+//!
+//! Doors 2 and 3 are closed, and this file is what keeps them closed. It
+//! matters because a new ungated door is invisible: the eager evaluator
+//! answers everything, so routing a pipe there produces *output*, just
+//! output from the evaluator the spine is retiring -- and the arm-count pin
+//! (`tests/jq_path_context_arm_guard.rs`) cannot be lowered honestly while a
+//! route can reach an arm without the gate having chosen it.
+//!
+//! # How it is checked
+//!
+//! A source scan, like `jq_path_context_arm_guard.rs` and
+//! `jq_member_validation_audit.rs` (STYLE-0013, #1803): the property is about
+//! the call graph, not about any query's output, and a behavioural test would
+//! pass just as happily with a second door open.
+//!
+//! The scan walks `src/` on disk rather than a fixed `include_str!` list, so a
+//! door opened from a *new* file is caught too.
+//!
+//! **The gate call has to appear in the `if` condition itself.** Binding it
+//! first (`let eager = path_context_needs_eager(exprs); if eager { .. }`)
+//! reads as gated to a person and not to this scan, and following the binding
+//! would mean a dataflow pass whose "gate" could then be any boolean named
+//! suggestively -- which is the looseness that lets a door back in. The strict
+//! rule costs one call-site convention, recorded in a comment at the site that
+//! has to keep it.
+
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+
+use syn::visit::{self, Visit};
+
+/// The eager evaluator's two entry points.
+const EAGER_ENTRIES: [&str; 2] = [
+    "eval_pipe_with_path_context",
+    "eval_pipe_with_path_context_internal",
+];
+
+/// The one gate (ADR-0021 decision 3).
+const GATE: &str = "path_context_needs_eager";
+
+/// The file the eager evaluator lives in. Its own recursion into itself is
+/// not a door, so whole-file rules do not apply to it -- see
+/// [`test_eval_rs_has_exactly_one_ungated_free_entry`] for what is pinned
+/// there instead.
+const EAGER_FILE: &str = "src/jq/eval.rs";
+
+/// Functions in [`EAGER_FILE`] that must not name either entry point at all:
+/// each one *was* a door, or is the dispatch that fed one.
+const EVAL_RS_MUST_NOT_CALL: [&str; 2] = ["eval_pipe", "eval_owned_with_file_index"];
+
+/// The single function in [`EAGER_FILE`] allowed to call the eager
+/// evaluator's public wrapper from outside the eager evaluator itself -- and
+/// its call has to be gated like every other.
+const EVAL_RS_SOLE_GATED_ENTRY: &str = "eval_path_context_pipe_owned";
+
+// --- the scan ---------------------------------------------------------------
+
+/// One reference to an eager entry point, and whether it stands inside an
+/// `if` whose condition consults [`GATE`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct CallSite {
+    function: String,
+    callee: String,
+    gated: bool,
+}
+
+/// Whether `expr` mentions the identifier `name` anywhere, macro token
+/// streams included (`matches!(..)` hides its contents from `syn`'s
+/// expression visitor).
+fn mentions(expr: &syn::Expr, name: &str) -> bool {
+    struct V<'a>(&'a str, bool);
+    impl<'ast> Visit<'ast> for V<'_> {
+        fn visit_path(&mut self, path: &'ast syn::Path) {
+            if path.segments.last().is_some_and(|s| s.ident == self.0) {
+                self.1 = true;
+            }
+            visit::visit_path(self, path);
+        }
+        fn visit_macro(&mut self, mac: &'ast syn::Macro) {
+            if mac
+                .tokens
+                .clone()
+                .into_iter()
+                .any(|tt| matches!(&tt, proc_macro2::TokenTree::Ident(id) if id == self.0))
+            {
+                self.1 = true;
+            }
+            visit::visit_macro(self, mac);
+        }
+    }
+    let mut v = V(name, false);
+    v.visit_expr(expr);
+    v.1
+}
+
+/// Collects [`CallSite`]s inside one function body, tracking whether the
+/// cursor is inside a [`GATE`]-conditioned `if`.
+///
+/// Only the `then` branch inherits the gate: an `else` runs precisely when
+/// the gate said `false`, and a *sibling* statement after the `if` runs
+/// either way. Both are pinned by the negative tests below -- a proximity
+/// window over source text gets both wrong (the lesson from the
+/// STYLE-0013 audit's own near-miss).
+struct Collect {
+    function: String,
+    gated: bool,
+    sites: Vec<CallSite>,
+}
+
+impl Collect {
+    fn new(function: &str) -> Self {
+        Self {
+            function: function.to_string(),
+            gated: false,
+            sites: Vec::new(),
+        }
+    }
+
+    fn record(&mut self, path: &syn::Path) {
+        let Some(last) = path.segments.last() else {
+            return;
+        };
+        // Longest name first: `eval_pipe_with_path_context_internal` is a
+        // distinct ident from `eval_pipe_with_path_context`, and `Ident`
+        // comparison is exact, so no prefix confusion is possible -- this
+        // loop only has to try both.
+        for entry in EAGER_ENTRIES {
+            if last.ident == entry {
+                self.sites.push(CallSite {
+                    function: self.function.clone(),
+                    callee: entry.to_string(),
+                    gated: self.gated,
+                });
+            }
+        }
+    }
+}
+
+impl<'ast> Visit<'ast> for Collect {
+    fn visit_expr(&mut self, expr: &'ast syn::Expr) {
+        if let syn::Expr::If(if_expr) = expr {
+            let gate_here = mentions(&if_expr.cond, GATE);
+            self.visit_expr(&if_expr.cond);
+            let outer = self.gated;
+            self.gated = outer || gate_here;
+            for stmt in &if_expr.then_branch.stmts {
+                self.visit_stmt(stmt);
+            }
+            self.gated = outer;
+            if let Some((_, alt)) = &if_expr.else_branch {
+                self.visit_expr(alt);
+            }
+            return;
+        }
+        visit::visit_expr(self, expr);
+    }
+
+    fn visit_path(&mut self, path: &'ast syn::Path) {
+        self.record(path);
+        visit::visit_path(self, path);
+    }
+
+    // A nested `fn` inside a function body is its own scope, so the outer
+    // function's `if` does not gate it -- and [`Functions`] already collects
+    // it as an item in its own right, so descending here would count its
+    // call sites twice. Skipped, not recursed.
+    fn visit_item_fn(&mut self, _item: &'ast syn::ItemFn) {}
+}
+
+/// Every function item in a parsed file, by name, body included.
+struct Functions(Vec<syn::ItemFn>);
+
+impl<'ast> Visit<'ast> for Functions {
+    fn visit_item_fn(&mut self, item: &'ast syn::ItemFn) {
+        self.0.push(item.clone());
+        visit::visit_item_fn(self, item);
+    }
+}
+
+fn call_sites_in_source(src: &str) -> Vec<CallSite> {
+    let file = syn::parse_file(src).expect("source parses");
+    let mut fns = Functions(Vec::new());
+    fns.visit_file(&file);
+    let mut out = Vec::new();
+    for item in fns.0 {
+        // Skip the entry points' own definitions: `fn
+        // eval_pipe_with_path_context` calling `..._internal` is the
+        // evaluator, not a door into it.
+        let name = item.sig.ident.to_string();
+        if EAGER_ENTRIES.contains(&name.as_str()) {
+            continue;
+        }
+        let mut collect = Collect::new(&name);
+        // The signature can name a type, never a call; walk the body only.
+        visit::visit_block(&mut collect, &item.block);
+        out.extend(collect.sites);
+    }
+    out
+}
+
+/// Every `.rs` file under `src/`, relative to the crate root.
+fn source_files() -> Vec<PathBuf> {
+    fn walk(dir: &Path, out: &mut Vec<PathBuf>) {
+        let entries = std::fs::read_dir(dir).expect("src/ is readable");
+        for entry in entries {
+            let path = entry.expect("dir entry").path();
+            if path.is_dir() {
+                walk(&path, out);
+            } else if path.extension().is_some_and(|e| e == "rs") {
+                out.push(path);
+            }
+        }
+    }
+    let root = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let mut out = Vec::new();
+    walk(&root.join("src"), &mut out);
+    out.sort();
+    out.into_iter()
+        .map(|p| {
+            p.strip_prefix(&root)
+                .expect("under the crate root")
+                .to_path_buf()
+        })
+        .collect()
+}
+
+fn call_sites_by_file() -> BTreeMap<String, Vec<CallSite>> {
+    let mut map = BTreeMap::new();
+    for path in source_files() {
+        let src = std::fs::read_to_string(PathBuf::from(env!("CARGO_MANIFEST_DIR")).join(&path))
+            .expect("source file is readable");
+        let sites = call_sites_in_source(&src);
+        if !sites.is_empty() {
+            map.insert(path.to_string_lossy().replace('\\', "/"), sites);
+        }
+    }
+    map
+}
+
+// --- the pins ---------------------------------------------------------------
+
+/// The scan reaches the whole crate, so a door opened from a new file cannot
+/// hide behind a stale `include_str!` list.
+#[test]
+fn test_scan_covers_the_crate_source() {
+    let files = source_files();
+    assert!(
+        files.len() > 30,
+        "src/ walk found only {} files -- the walk is broken, and every rule \
+         below would pass vacuously",
+        files.len()
+    );
+    assert!(
+        files.iter().any(|p| p.to_string_lossy() == EAGER_FILE),
+        "{EAGER_FILE} not found by the walk"
+    );
+}
+
+/// Door 1 of the audit -- and now the only one: every entry into the eager
+/// evaluator from outside the file it lives in stands inside a
+/// `path_context_needs_eager` branch.
+#[test]
+fn test_every_entry_outside_eval_rs_is_gated() {
+    let by_file = call_sites_by_file();
+    let mut external = 0;
+    for (file, sites) in &by_file {
+        if file == EAGER_FILE {
+            continue;
+        }
+        for site in sites {
+            external += 1;
+            assert!(
+                site.gated,
+                "{file}: `{}` calls `{}` without a `{GATE}` branch around it. \
+                 ADR-0021 decision 3 says the gate decides which pipes the eager \
+                 evaluator owns; an ungated call is a new door, and \
+                 docs/plan/path-context-arm-reachability.md has to stop saying \
+                 there is one.",
+                site.function, site.callee,
+            );
+        }
+    }
+    assert!(
+        external > 0,
+        "no call to the eager evaluator found outside {EAGER_FILE} at all -- either \
+         the last one was removed (delete this test with the evaluator, per \
+         ADR-0021 decision 8) or the entry points were renamed and \
+         EAGER_ENTRIES is stale"
+    );
+}
+
+/// `_internal` is private to the eager evaluator's own file. The compiler
+/// already enforces that; pinning it here is what makes the rule above
+/// complete rather than merely true today.
+#[test]
+fn test_internal_entry_is_never_named_outside_eval_rs() {
+    for (file, sites) in call_sites_by_file() {
+        if file == EAGER_FILE {
+            continue;
+        }
+        for site in sites {
+            assert_ne!(
+                site.callee, "eval_pipe_with_path_context_internal",
+                "{file}: `{}` reaches the eager evaluator's internal entry, \
+                 bypassing the `&[]`/ambient-file-origin normalization the public \
+                 wrapper applies",
+                site.function,
+            );
+        }
+    }
+}
+
+/// Inside `eval.rs` the eager evaluator recurses into itself constantly, so
+/// the whole-file rule above would say nothing. What is pinned instead is the
+/// shape of the *doors that used to be here*: the two functions that had one,
+/// and the single replacement that carries the gate.
+#[test]
+fn test_eval_rs_has_exactly_one_ungated_free_entry() {
+    let src = std::fs::read_to_string(PathBuf::from(env!("CARGO_MANIFEST_DIR")).join(EAGER_FILE))
+        .expect("eval.rs is readable");
+    let sites = call_sites_in_source(&src);
+
+    for name in EVAL_RS_MUST_NOT_CALL {
+        let offenders: Vec<&CallSite> = sites.iter().filter(|s| s.function == name).collect();
+        assert!(
+            offenders.is_empty(),
+            "`{name}` reaches the eager evaluator again: {offenders:?}. That was a door \
+             (docs/plan/path-context-arm-reachability.md); it routes through \
+             `{EVAL_RS_SOLE_GATED_ENTRY}` now so the gate decides."
+        );
+    }
+
+    // The public wrapper is the only entry a non-eager caller may use, and
+    // exactly one function in this file is such a caller.
+    let wrapper_callers: Vec<String> = sites
+        .iter()
+        .filter(|s| s.callee == "eval_pipe_with_path_context")
+        .map(|s| s.function.clone())
+        .collect();
+    assert_eq!(
+        wrapper_callers,
+        vec![EVAL_RS_SOLE_GATED_ENTRY.to_string()],
+        "the set of functions calling the eager evaluator's public wrapper moved"
+    );
+    let gated = sites
+        .iter()
+        .filter(|s| s.function == EVAL_RS_SOLE_GATED_ENTRY)
+        .all(|s| s.gated);
+    assert!(
+        gated,
+        "`{EVAL_RS_SOLE_GATED_ENTRY}` no longer consults `{GATE}` before entering the \
+         eager evaluator"
+    );
+}
+
+// --- negative tests: every way the gate could appear to hold ----------------
+
+fn sites(src: &str) -> Vec<CallSite> {
+    call_sites_in_source(src)
+}
+
+#[test]
+fn test_fixture_gated_call_is_gated() {
+    let src = r"
+        fn caller() {
+            if path_context_needs_eager(exprs) {
+                return eval_pipe_with_path_context::<W, S>(exprs);
+            }
+            generic()
+        }
+    ";
+    assert_eq!(sites(src).len(), 1);
+    assert!(sites(src)[0].gated);
+}
+
+#[test]
+fn test_fixture_ungated_call_is_not_gated() {
+    let src = r"
+        fn caller() {
+            eval_pipe_with_path_context::<W, S>(exprs)
+        }
+    ";
+    assert!(!sites(src)[0].gated);
+}
+
+#[test]
+fn test_fixture_a_different_condition_does_not_gate() {
+    let src = r"
+        fn caller() {
+            if needs_path_context(expr) {
+                return eval_pipe_with_path_context::<W, S>(exprs);
+            }
+        }
+    ";
+    assert!(
+        !sites(src)[0].gated,
+        "`needs_path_context` is the *old* condition doors 2 and 3 used; it must \
+         not satisfy the rule"
+    );
+}
+
+/// A sibling `if` is not a gate: this is the case a proximity window over
+/// source text gets wrong, since the gate's text is a few lines above the
+/// call either way.
+#[test]
+fn test_fixture_sibling_if_does_not_gate_a_later_call() {
+    let src = r"
+        fn caller() {
+            if path_context_needs_eager(exprs) {
+                return generic();
+            }
+            eval_pipe_with_path_context::<W, S>(exprs)
+        }
+    ";
+    assert!(!sites(src)[0].gated);
+}
+
+#[test]
+fn test_fixture_else_branch_is_not_gated() {
+    let src = r"
+        fn caller() {
+            if path_context_needs_eager(exprs) {
+                generic()
+            } else {
+                eval_pipe_with_path_context::<W, S>(exprs)
+            }
+        }
+    ";
+    assert!(
+        !sites(src)[0].gated,
+        "the `else` runs precisely when the gate answered `false`"
+    );
+}
+
+#[test]
+fn test_fixture_nesting_inherits_the_gate() {
+    let src = r"
+        fn caller() {
+            if path_context_needs_eager(exprs) {
+                let owned = to_owned(&value)?;
+                if reindex_bridge_is_identity(&owned) {
+                    for _ in 0..1 {
+                        return eval_pipe_with_path_context::<W, S>(exprs);
+                    }
+                }
+            }
+        }
+    ";
+    assert!(sites(src)[0].gated);
+}
+
+/// A disjunction still consults the gate, which is what
+/// `eval_path_context_pipe_owned` spells (`gate || !reindex_identity`): the
+/// eager evaluator is entered when the gate says so *or* when the round trip
+/// would not be lossless.
+#[test]
+fn test_fixture_disjunction_containing_the_gate_counts() {
+    let src = r"
+        fn caller() {
+            if path_context_needs_eager(exprs) || !reindex_bridge_is_identity(owned) {
+                return eval_pipe_with_path_context::<W, S>(exprs);
+            }
+        }
+    ";
+    assert!(sites(src)[0].gated);
+}
+
+#[test]
+fn test_fixture_a_nested_fn_does_not_inherit_the_gate() {
+    let src = r"
+        fn caller() {
+            if path_context_needs_eager(exprs) {
+                fn inner() {
+                    eval_pipe_with_path_context::<W, S>(exprs)
+                }
+                inner()
+            }
+        }
+    ";
+    let found = sites(src);
+    assert_eq!(found.len(), 1);
+    assert_eq!(found[0].function, "inner");
+    assert!(!found[0].gated);
+}
+
+#[test]
+fn test_fixture_the_entry_points_own_recursion_is_not_a_call_site() {
+    let src = r"
+        fn eval_pipe_with_path_context() {
+            eval_pipe_with_path_context_internal(exprs)
+        }
+    ";
+    assert!(sites(src).is_empty());
+}
+
+#[test]
+fn test_fixture_internal_and_wrapper_are_told_apart() {
+    let src = r"
+        fn caller() {
+            eval_pipe_with_path_context_internal::<W, S>(exprs)
+        }
+    ";
+    let found = sites(src);
+    assert_eq!(found.len(), 1, "the two idents must not both match");
+    assert_eq!(found[0].callee, "eval_pipe_with_path_context_internal");
+}
+
+/// A call hidden in a macro's token stream would slip past
+/// `visit_path`; the gate detector reads macro tokens, and so does the
+/// recorder via the tokens `syn` does parse for a call inside `matches!`-style
+/// macros. This pins the gate half, which is the half a door could exploit.
+#[test]
+fn test_fixture_gate_inside_a_macro_condition_counts() {
+    let src = r"
+        fn caller() {
+            if matches!(path_context_needs_eager(exprs), true) {
+                return eval_pipe_with_path_context::<W, S>(exprs);
+            }
+        }
+    ";
+    assert!(sites(src)[0].gated);
+}

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -15518,6 +15518,88 @@ fn test_eval_all_file_index_bare() -> Result<()> {
     Ok(())
 }
 
+/// Spine 2416 step 5: `--eval-all` reaches the eager evaluator only through
+/// `path_context_needs_eager` now, and the file-origin table follows it there.
+///
+/// `eval::eval_owned_with_file_index` used to call
+/// `eval_pipe_with_path_context_internal` directly, passing the table as an
+/// argument -- the audit's "door 2"
+/// (`docs/plan/path-context-arm-reachability.md`). It routes through the
+/// generic evaluator now, where `file_index` is a cursor property like `key`
+/// and `path`, and the table is installed as an ambient scope
+/// (`eval_generic::with_file_origin`) that both the cursor route *and* the
+/// eager evaluator read. So the split matters and is what this test pins:
+/// `.[] | file_index` and `select(file_index == n)` are answered by the
+/// cursor route (the gate keeps them generic), while `.[] | file_index + 1`
+/// still goes to the eager evaluator, because arithmetic has no native
+/// cursor-threading arm yet (ADR-0021's remaining list). A regression that
+/// dropped the table on either side shows up as a `0` for the second file.
+///
+/// **`--eval-all` slurps where real yq streams (#2427).** succinctly combines
+/// every document into one array, so `.[]` iterates *documents*; real yq
+/// keeps them a document stream, so its `.[]` iterates each document's own
+/// members. Both binaries answer the same question about which file a node
+/// came from -- they just disagree about what `.[]` selects. Captured live
+/// from yq v4.53.3 on 2026-09-05, on this test's own two fixtures
+/// (`a: 1 / name: first` and `b: 2 / name: second`):
+///
+/// ```console
+/// $ yq ea -o=json -I0 '.[] | file_index'        f1 f2   # 0 0 1 1
+/// $ yq ea -o=json -I0 '[.[] | file_index]'      f1 f2   # [0,0,1,1]
+/// $ yq ea -o=json -I0 'file_index'              f1 f2   # 0 1
+/// $ yq ea -o=json -I0 '.[] | file_index + 1'    f1 f2   # 1 1 2 2
+/// $ yq ea -o=json -I0 '.[] | select(file_index == 1)' f1 f2
+/// 2
+/// "second"
+/// $ yq ea -o=json -I0 '.[].name | file_index'   f1 f2   # (no output)
+/// ```
+///
+/// yq's counts are succinctly's doubled because each of its documents has two
+/// members; the file numbering itself (`0` then `1`) is the same, and that is
+/// the property this door closure had to preserve.
+#[test]
+fn test_eval_all_file_index_agrees_across_both_routes_2416() -> Result<()> {
+    let (f1, f2) = two_doc_fixtures()?;
+    // (filter, expected stdout, which route answers `file_index`)
+    let rows: &[(&str, &str, &str)] = &[
+        (".[] | file_index", "0\n1", "cursor"),
+        ("[.[] | file_index]", "[0,1]", "cursor"),
+        ("file_index", "0", "cursor (root: no top-level index)"),
+        (".[].name | file_index", "0\n1", "cursor"),
+        (".[] | .name | file_index", "0\n1", "cursor"),
+        (".[] | [file_index, key]", "[0,0]\n[1,1]", "cursor"),
+        (
+            ".[] | select(file_index == 1) | .name",
+            "\"second\"",
+            "cursor",
+        ),
+        (
+            ".[] | file_index + 1",
+            "1\n2",
+            "eager (no native arithmetic arm)",
+        ),
+        (
+            r#".[] | if file_index == 1 then "f2" else "f1" end"#,
+            "\"f1\"\n\"f2\"",
+            "cursor",
+        ),
+    ];
+    for (filter, expected, route) in rows {
+        let (stdout, stderr, code) = run_yq_files(
+            filter,
+            &[f1.path(), f2.path()],
+            &["--eval-all", "-o", "json", "-I", "0"],
+        )?;
+        assert_eq!(code, 0, "`{filter}` exited {code}, stderr: {stderr}");
+        assert_eq!(
+            stdout.trim(),
+            *expected,
+            "`{filter}` ({route}) lost the --eval-all file-origin table"
+        );
+    }
+    Ok(())
+}
+
 /// Regression test for #822: `Expr::Arithmetic` inside
 /// `eval_pipe_with_path_context_internal` used to collapse a multi-output
 /// operand to its first value whenever the pipe also needed path context


### PR DESCRIPTION
## Summary

The step 4 audit found that `path_context_needs_eager` was one of three doors into the eager path-context evaluator; the other two had no gate. Both are closed here, and a guard keeps it that way.

1. **`eval::eval_pipe`'s diversion** (`refactor`). It sent any pipe with `needs_path_context` to the eager evaluator. It was live: `needs_path_context` does not recurse into a fold's update, an assignment's right-hand side or `Expr::Object`, so `reduce .c[] as $x (.a; [.[] | key])`, `.x = [.a[] | key]` and `.a | with_entries(.value = (.a.b | key))` all reached it. `eval_pipe` now consults the gate and, when it says no, reindexes into a throwaway document and evaluates through the generic evaluator over that root cursor. The reindex is load-bearing (with no cursor `key` fell to the null stub). A recursion test pins nested folds, a 60-stage pipe and 30-deep parens.
2. **`--eval-all`** (`fix`). `eval_owned_with_file_index` called the eager pipe directly. It now routes through the same gate, with the file-origin table installed as an ambient scope in the `path_context_route` style, and the generic `file_index` answers from it via the cursor's path instead of the constant 0. Reverting that arm flips eleven `--eval-all` shapes to the wrong file, so it is exercised. Under `no_std` there is no thread-local, so a pipe with a table stays eager with the table passed as a parameter, rather than answering wrongly.
3. **Single-door guard** (`test`). `tests/jq_path_context_single_door_guard.rs` walks `src/` with a `syn` visitor and asserts every reference to the eager pipe outside `eval.rs` sits inside a `path_context_needs_eager` branch, that the internal entry is never named outside that file, and that `eval_pipe` and `eval_owned_with_file_index` name neither; negative fixtures pin that sibling `if`s, `else` branches, other conditions and nested functions do not count. Restoring the old `eval_pipe` call makes it fail.

## Findings

- No arm became unreachable: all 43 have gate-route proof queries, now pinned with exact outputs, so the pin stays at 43. The audit doc's "three doors" section is updated to one.
- The brief assumed the sweep's 24 `yq/file_index/*` manifest rows would go stale; they do not, because the sweep runs the ordinary multi-file path without `--eval-all`, which has no table. The rows are re-scoped in comments only; sweep 3168 cases, 0 unexpected, no stale rows.
- Pre-existing and unmoved, pinned as-is: `.a | with_entries(.value = (.a.b | key))` diverges from yq (filed separately); `{"x": file_index}` still needs `needs_path_context` to descend into `Expr::Object` (#1332).

Oracle captures (yq v4.53.3, `yq ea`) are in the tests; yq keeps documents as a stream where succinctly slurps them (#2427), so its counts are doubled, but the file numbering is identical and is the property preserved.

## Verification

fmt; clippy on all CI legs with `-D warnings`; `cargo test --features cli`, default, `--no-default-features`, the bench-runner orchestrate suite; `cargo doc -D warnings`; yq goldens 113 and jq goldens 633; oracle sweep 0 unexpected. A behavioural differential against a pre-change binary over 115 `--eval-all`, absent, owned-identity and door-reaching shapes: 0 diffs.

Part of spine 2416 (after step 4). #2427 stays open: its slurping half remains, and this only fixes `file_index` numbering on the `--eval-all` path.
