### PR TITLE
fix(jq): yq's binary-operator rule for a zero-output operand (#2460)

### DIFF
--- a/docs/compliance/yq/limitations.md
+++ b/docs/compliance/yq/limitations.md
@@ -1771,6 +1771,48 @@ a value that isn't a snapshot of anything in the document -- a different kind of
 #2213's path-threading fix, which only ever continues with a value already known to be
 correct (`Null`, jq's own answer for what the missing/OOB read itself evaluates to).
 
+### A binary operand that navigated to a missing key: succinctly sees `null`, real yq sees nothing
+
+[#2460](https://github.com/rust-works/succinctly/issues/2460) gave yq mode real yq's rule
+for a binary operator whose operand produces **zero outputs** -- `key`, `parent`,
+`parent(1)` at the document root, or any other filter that emits nothing. That rule is
+implemented once (`jq::eval::yq_empty_operand_output`) and is exact for those shapes. Real
+yq has a *second*, wider category of "empty operand" that it does not cover: an operand
+that navigated to a **missing key**. Captured live against yq v4.53.3 on
+
+```yaml
+a:
+  b: 1
+s: x
+n: [1, 2]
+```
+
+| filter                | real yq                                   | succinctly yq                                      |
+|-----------------------|-------------------------------------------|----------------------------------------------------|
+| `.zzz`                | `null`                                    | `null`                                             |
+| `.zzz \| . * 2`       | `Error: cannot multiply !!null with !!int` | `Error: null (null) and number (2) ...`           |
+| `.zzz * 2`            | *(nothing)*, exit 0                       | `Error: null (null) and number (2) cannot be multiplied` |
+| `.zzz / 2`            | *(nothing)*, exit 0                       | `Error: ... cannot be divided`                     |
+| `.zzz - 1`            | *(nothing)*, exit 0                       | `1`                                                |
+| `.zzz + 1`            | `1`                                       | `1` (agrees, for an unrelated reason)              |
+| `.zzz \| key`         | `"zzz"`                                   | `"zzz"`                                            |
+| `(.zzz \| key) + 1`   | `1`                                       | `Error: string ("zzz") and number (1) cannot be added` |
+| `(.zzz \| key) + "!"` | `"!"`                                     | `"zzz!"`                                           |
+
+Real yq is inconsistent with itself here, twice over, and both inconsistencies are what
+make this hard rather than mechanical. `.zzz` on its own is a `null` **value** (`.zzz | . *
+2` raises, exactly like `null * 2`), but the same `.zzz` written directly as an operand is
+an empty **candidate list** (`.zzz * 2` yields nothing) -- so yq's traversal answers
+differently depending on whether an operator or a pipe is asking. And `.zzz | key` is
+`"zzz"` standing alone yet contributes nothing as an operand, so the emptiness survives a
+whole pipe once that pipe is an operand.
+
+succinctly materializes an ordinary `null` for a missing key at every position, so it has
+no way to distinguish the two contexts. Closing this needs an *absent* operand value
+threaded through operand evaluation -- a model change of the same kind ADR-0021 made for
+path context -- not another entry in #2460's table, which is keyed on an operand producing
+no outputs and would answer these shapes the moment the operand actually produced none.
+
 ### A negative out-of-range array index (`.a[-N]`) raises -- resolved for ordinary reads, a few call sites remain
 
 [#2254](https://github.com/rust-works/succinctly/issues/2254). Real yq disagrees with real

--- a/docs/plan/path-context-arm-reachability.md
+++ b/docs/plan/path-context-arm-reachability.md
@@ -102,9 +102,15 @@ order; the `Gate` column names the first that fired for that query.
 
 R2 dominates the table because the natural probe shape starts `.a.b`, and a
 `.field` step can always miss. The same shapes with a head that cannot miss trip
-R3 instead -- e.g. `.a[] | key + "x"`, `.a[] | if key == "b" then key + "x" else
-"y" end` and `.a[] | reduce (key) as $k (""; . + $k) | . + "x"` all report R3.
-This is an ordering artefact, not a claim that R3 is rare.
+R3 instead -- e.g. `.a[] | (key | tostring)`, `.a[] | reduce (key) as $k (""; . +
+$k) | . + "x"` and `.a[] | select(key == "b" and true)` all report R3. This is an
+ordering artefact, not a claim that R3 is rare.
+
+Step 1b (below) moved two of the three shapes this paragraph used to name --
+`.a[] | key + "x"` and `.a[] | if key == "b" then key + "x" else "y" end` -- off
+R3 and onto the generic route, which is what an admission to
+`path_context_single_native` is *for*. Re-derive this paragraph's examples after
+any further admission rather than trusting them.
 
 ## The 43 handlers
 
@@ -119,7 +125,7 @@ This is an ordering artefact, not a claim that R3 is rare.
 | A02 | `Expr::Field(name)`                                                | REACHABLE | `.a.b \| key + "x"`                                   | R2   |
 | A03 | `Expr::Index { idx, key }`                                         | REACHABLE | `.c[0] \| key + 1`                                    | R2   |
 | A04 | `Expr::Slice { .. }`                                               | REACHABLE | `.c[0:1] \| .[0] \| key + 1`                          | R1   |
-| A05 | `Expr::Iterate`                                                    | REACHABLE | `.a[] \| key + "x"`                                   | R3   |
+| A05 | `Expr::Iterate`                                                    | REACHABLE | `.a[] \| (key \| tostring)`                            | R3   |
 | A06 | `Expr::Paren(inner)`                                               | REACHABLE | `(.a.b) \| key + "x"`                                 | R2   |
 | A07 | `Expr::Optional(inner) if IndexExpr/SliceExpr`                     | REACHABLE | `.c[.n]? \| key + 1`                                  | R1   |
 | A08 | `Expr::Optional(inner)`                                            | REACHABLE | `.a? \| key + "x"`                                    | R2   |
@@ -153,6 +159,38 @@ This is an ordering artefact, not a claim that R3 is rare.
 | A36 | `Expr::Try { .. }`                                                 | REACHABLE | `.a.b \| try (key + "x") catch "e"`                   | R2   |
 | A37 | `Expr::Label { name, body }`                                       | REACHABLE | `.a.b \| label $out \| (key + "x", break $out)`       | R2   |
 | A38 | `Expr::Break(name)`                                                | REACHABLE | `.a.b \| label $out \| (key + "x", break $out)`       | R2   |
+
+## Step 1b: `Expr::Arithmetic` admitted, and the pin holds at 43
+
+Spine 2416 step 1b gave `eval_generic`'s own `eval_single` a native
+`Expr::Arithmetic` arm (`collect_each_generic` over the sink evaluator's
+existing `binary_fanout_each_generic` arm) and added `Expr::Arithmetic` to
+`path_context_single_native`. Two shapes had blocked that admission and both are
+now closed:
+
+- yq's rule for a binary operator whose operand produces *zero* outputs
+  ([#2460](https://github.com/rust-works/succinctly/issues/2460)). `key + 1` at
+  the document root is `1` in real yq, not nothing, and the eager route used to
+  answer it from a `null`/`{}` placeholder. Admitting arithmetic would have moved
+  that shape to a route with a *different* answer. It is now one definition
+  (`jq::eval::yq_empty_operand_output`) that both fanouts consult, so the two
+  routes agree before the move rather than after it.
+- `try (1+1) catch "x"` on a #1194-malformed document (`{123: 1}`), where jq
+  1.7.1 rejects the whole input regardless of what the filter reads. The eager
+  bridge's ambient materialization is what produces that failure, so the new arm
+  is gated on `needs_path_context`: arithmetic that reads no path context stays
+  on the bridge and keeps paying the decode.
+  `test_try_catch_contains_a_genuinely_catchable_malformed_key_error_1812` is
+  the guard.
+
+**`PINNED_ARM_COUNT` stays at 43.** `A11` (`Expr::Arithmetic`) is the arm the
+admission was aimed at and it is still reachable: re-run with the method above,
+its marker fires for 33 of the 36 queries probed, including its own listed proof
+query `.a.b | key + "x"` (R2) and every `.c[...]`-headed R1 row. What the
+admission removes is R3 for an `Expr::Iterate` head, not the arm -- `.a[] | key +
+"x"` no longer reaches the eager evaluator at all, which is why `A05`'s proof
+query above was re-derived (`.a[] | (key | tostring)`, still R3, marker
+confirmed). Nothing became unreachable, so nothing was deleted.
 
 ## Result
 

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -239,6 +239,39 @@ pub trait EvalSemantics: Copy + Default {
     /// replacement-character substitution: matched, at each caller's own
     /// granularity" section for the live-verified detail.
     const UTF8_LOSSY_USES_JQ_MAXIMAL_SUBPART_RULE: bool;
+
+    /// If true (yq), a path-context read that has nothing to read -- `key`,
+    /// `parent`, `parent(n)` standing on the *document root*, where there is
+    /// no enclosing key and no ancestor -- produces **zero outputs**, the
+    /// same as any other filter that emits nothing. If false (jq), the eager
+    /// path-context evaluator substitutes a placeholder value instead
+    /// (`null` for `key`, `{}` for `parent`).
+    ///
+    /// yq's own answer was captured live against v4.53.3 (#2460): `key`,
+    /// `parent`, `parent(1)` and `.[] | select(false)` at the root are
+    /// indistinguishable in real yq across all 13 binary operators and 7
+    /// right-hand shapes -- 196 comparable cells per shape, zero mismatches
+    /// -- so the emptiness is a property of "zero outputs", never of which
+    /// filter produced it. A placeholder is what made succinctly disagree
+    /// with *itself* between `key` (`null`) and `parent` (`{}`). The other
+    /// half of the same rule is `yq_empty_operand_output` (this module,
+    /// private).
+    ///
+    /// jq mode is deliberately untouched: `key`/`parent` are succinctly
+    /// extensions there with no oracle to match, and the placeholder is the
+    /// behavior every existing jq-mode shape was pinned against.
+    const ROOT_PATH_CONTEXT_YIELDS_NOTHING: bool;
+
+    /// If true (yq), a binary operator whose *operand* produced zero outputs
+    /// answers from `yq_empty_operand_output`'s table (this module, private)
+    /// instead of contributing no pairings at all. If false (jq), an empty
+    /// operand makes the whole expression empty -- `1 + empty` is nothing in
+    /// real jq.
+    ///
+    /// Captured live against yq v4.53.3 (#2460); that function's own doc
+    /// comment carries the table and the six internal yq inconsistencies it
+    /// reproduces bug-for-bug (ADR-0018 rule 3).
+    const EMPTY_OPERAND_BINARY_RULE: bool;
 }
 
 /// jq-compatible evaluation semantics (default).
@@ -266,6 +299,8 @@ impl EvalSemantics for JqSemantics {
     const MAX_STRING_REPEAT_BYTES: Option<u128> = None;
     const SELECT_EMITS_ONCE_IF_ANY_TRUTHY: bool = false;
     const UTF8_LOSSY_USES_JQ_MAXIMAL_SUBPART_RULE: bool = true;
+    const ROOT_PATH_CONTEXT_YIELDS_NOTHING: bool = false;
+    const EMPTY_OPERAND_BINARY_RULE: bool = false;
 }
 
 /// yq-compatible evaluation semantics.
@@ -295,6 +330,8 @@ impl EvalSemantics for YqSemantics {
     const MAX_STRING_REPEAT_BYTES: Option<u128> = Some(10 * 1024 * 1024);
     const SELECT_EMITS_ONCE_IF_ANY_TRUTHY: bool = true;
     const UTF8_LOSSY_USES_JQ_MAXIMAL_SUBPART_RULE: bool = false;
+    const ROOT_PATH_CONTEXT_YIELDS_NOTHING: bool = true;
+    const EMPTY_OPERAND_BINARY_RULE: bool = true;
 }
 
 use crate::json::light::{JsonCursor, JsonElements, JsonFields, StandardJson};
@@ -307,6 +344,138 @@ use super::value::{
     assert_value_tree_depth, cmp_f64, infinite_float_preview_text, is_infinity_sentinel,
     is_nan_sentinel, numeric_repr_cmp, owned_value_eq, NumberRepr, OwnedValue,
 };
+
+/// Which binary operator an operand that produced *zero outputs* is being
+/// combined under, for [`yq_empty_operand_output`].
+///
+/// One enum rather than three call-site matches: the whole point of #2460's
+/// rule is that it is keyed on "this operand emitted nothing", never on which
+/// filter produced the emptiness or which of the two evaluators noticed it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum EmptyOperandOp {
+    /// `+`, `-`, `*`, `/`, `%`.
+    Arith(ArithOp),
+    /// `==`, `!=`, `<`, `>`, `<=`, `>=`.
+    Compare(CompareOp),
+    /// `and`/`or`. Unlike the two above, these consume the answer as a
+    /// *truthiness contribution* (one `false` output standing in for the
+    /// empty operand) rather than as a finished pairing -- which is exactly
+    /// what reproduces yq's captured behaviour for both: `and` short-circuits
+    /// to `false` without ever consulting the other operand, and `or` falls
+    /// through to the other operand's own truthiness.
+    Boolean,
+}
+
+/// **The one definition of yq's binary-operator rule for an operand that
+/// produced zero outputs** (#2460), consulted by both evaluators: the
+/// generic/cursor route (`eval_generic::binary_fanout_each_generic`) and the
+/// eager path-context route ([`binary_fanout_each`]/[`boolean_fanout_core`]).
+///
+/// `other` is the *other* operand's value for this pairing, or `None` when
+/// that operand produced zero outputs too. The return is the output to emit,
+/// or `None` to emit nothing for this pairing.
+///
+/// Captured live against Homebrew `yq` v4.53.3 over 515 invocations (#2460's
+/// oracle matrix). `key`, `parent`, `parent(1)` and `.[] | select(false)` --
+/// 196 comparable cells each -- produced **zero mismatches** against one
+/// another, which is why this function takes no producer argument at all.
+///
+/// | op                | one empty operand              | both empty |
+/// |-------------------|--------------------------------|------------|
+/// | `+`               | the other operand, verbatim    | nothing    |
+/// | `-` `*` `/` `%`   | nothing                        | nothing    |
+/// | `==`              | `true` iff the other is `null` | `true`     |
+/// | `!=`              | mirror of `==`                 | `false`    |
+/// | `<` `>`           | `false`                        | `false`    |
+/// | `<=` `>=`         | `false`                        | `true`     |
+/// | `and` / `or`      | one `false` truthiness output  | same       |
+///
+/// `//` needs no entry: an empty operand is already falsy/absent to
+/// `eval_alternative`'s own left-side test, so `E // x` -> `x`, `x // E` ->
+/// `x` and `E // E` -> nothing fall straight out of the existing rule once
+/// the root `key`/`parent` placeholders stop fabricating a *truthy* `{}`
+/// (see [`EvalSemantics::ROOT_PATH_CONTEXT_YIELDS_NOTHING`]).
+///
+/// **Six internal yq inconsistencies are reproduced here bug-for-bug**, per
+/// ADR-0018 rule 3 and its 2026-09-05 decision-order amendment -- none of
+/// them corrupts data, discards a write, emits YAML yq cannot read back, or
+/// takes the host process down, so none qualifies for the narrow refusal
+/// rule:
+///
+/// 1. `+` treats the empty operand as an identity element while `-`/`*`/`/`/
+///    `%` treat the identical condition as "the whole expression is empty".
+/// 2. `==`/`!=` special-case `null`; the four ordering comparisons do not.
+/// 3. Two empty operands compare like `null == null` (`<=`/`>=` -> `true`),
+///    but one empty operand against a literal `null` does not.
+/// 4. `or` defers to the other operand; `and` throws that information away.
+/// 5. A real `null` is asymmetric for `+` (`null + 1` -> `1`, `1 + null` ->
+///    an error) while an empty operand is symmetric.
+/// 6. yq has three distinct "null-ish" categories -- a real `null`, a
+///    missing-key `null`, and a zero-output filter -- that do not share one
+///    operator branch. Only the third is this function's business; the
+///    missing-key half (`.zzz * 2`) is a separate, still-divergent shape.
+pub(crate) fn yq_empty_operand_output(
+    op: EmptyOperandOp,
+    other: Option<&OwnedValue>,
+) -> Option<OwnedValue> {
+    // `None` (the other operand was empty too) counts as null here for
+    // `==`/`!=` and is what flips `<=`/`>=` to `true` -- the two rows the
+    // single-empty rule cannot derive (inconsistency 3 above).
+    let other_is_null = matches!(other, None | Some(OwnedValue::Null));
+    match op {
+        EmptyOperandOp::Arith(ArithOp::Add) => other.cloned(),
+        EmptyOperandOp::Arith(ArithOp::Sub | ArithOp::Mul(_) | ArithOp::Div | ArithOp::Mod) => None,
+        EmptyOperandOp::Compare(CompareOp::Eq) => Some(OwnedValue::Bool(other_is_null)),
+        EmptyOperandOp::Compare(CompareOp::Ne) => Some(OwnedValue::Bool(!other_is_null)),
+        EmptyOperandOp::Compare(CompareOp::Lt | CompareOp::Gt) => Some(OwnedValue::Bool(false)),
+        EmptyOperandOp::Compare(CompareOp::Le | CompareOp::Ge) => {
+            Some(OwnedValue::Bool(other.is_none()))
+        }
+        EmptyOperandOp::Boolean => Some(OwnedValue::Bool(false)),
+    }
+}
+
+/// `Some(op)` in yq mode, `None` in jq mode -- the single per-mode gate on
+/// [`yq_empty_operand_output`], so no call site spells the `S::` const out
+/// itself (#2460).
+pub(crate) fn empty_operand_rule<S: EvalSemantics>(op: EmptyOperandOp) -> Option<EmptyOperandOp> {
+    S::EMPTY_OPERAND_BINARY_RULE.then_some(op)
+}
+
+/// The value a path-context builtin standing on the document root falls back
+/// to, or [`QueryResult::None`] when the mode says such a read produces
+/// nothing (#2460, yq).
+///
+/// One definition for all four sites that had hand-written placeholders
+/// (`key` and `parent`/`parent(n)`, each in both `eval_builtin`'s
+/// no-context fallback and the eager path-context evaluator), so the two
+/// routes cannot answer the root differently again -- which is exactly how
+/// `key` came to be `null` while `parent` was a *truthy* `{}`.
+fn root_path_context_placeholder<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
+    placeholder: OwnedValue,
+) -> QueryResult<'a, W> {
+    if S::ROOT_PATH_CONTEXT_YIELDS_NOTHING {
+        QueryResult::None
+    } else {
+        QueryResult::Owned(placeholder)
+    }
+}
+
+/// The jq-mode placeholder for `parent`/`parent(n)` past the document root.
+fn no_parent_placeholder() -> OwnedValue {
+    OwnedValue::Object(IndexMap::new())
+}
+
+/// [`yq_empty_operand_output`]'s `and`/`or` row, as the `bool` those two
+/// operators actually consume (#2460). `None` in jq mode, and `None` too if
+/// the table ever stops answering for `Boolean` -- the table stays the single
+/// source of truth either way.
+fn empty_boolean_operand(empty_rule: Option<EmptyOperandOp>) -> Option<bool> {
+    match yq_empty_operand_output(empty_rule?, None) {
+        Some(OwnedValue::Bool(b)) => Some(b),
+        _ => None,
+    }
+}
 
 /// Result of evaluating a jq expression.
 #[derive(Debug)]
@@ -3705,6 +3874,7 @@ fn eval_each<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
             left,
             right,
             optional,
+            empty_operand_rule::<S>(EmptyOperandOp::Compare(*op)),
             |left_val, right_val| {
                 Ok(OwnedValue::Bool(apply_compare_op::<S>(
                     *op, &left_val, &right_val,
@@ -3728,6 +3898,7 @@ fn eval_each<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
             left,
             right,
             optional,
+            empty_operand_rule::<S>(EmptyOperandOp::Arith(*op)),
             |left_val, right_val| arith_combine::<S>(*op, left_val, right_val),
             sink,
         ),
@@ -5232,6 +5403,7 @@ fn binary_fanout_core<'a, W: Clone + AsRef<[u64]>>(
     left: &Expr,
     right: &Expr,
     optional: bool,
+    empty_rule: Option<EmptyOperandOp>,
     combine: impl FnMut(OwnedValue, OwnedValue) -> Result<OwnedValue, EvalError>,
 ) -> QueryResult<'a, W> {
     let mut out: Vec<OwnedValue> = Vec::new();
@@ -5240,6 +5412,7 @@ fn binary_fanout_core<'a, W: Clone + AsRef<[u64]>>(
         left,
         right,
         optional,
+        empty_rule,
         combine,
         &mut |item: Item<'a, W>| {
             out.push(item.into_owned_from_owned_producer());
@@ -5311,6 +5484,7 @@ fn binary_fanout_each<'a, W: Clone + AsRef<[u64]>>(
     left: &Expr,
     right: &Expr,
     optional: bool,
+    empty_rule: Option<EmptyOperandOp>,
     mut combine: impl FnMut(OwnedValue, OwnedValue) -> Result<OwnedValue, EvalError>,
     sink: &mut dyn FnMut(Item<'a, W>) -> Demand,
 ) -> Flow {
@@ -5318,14 +5492,22 @@ fn binary_fanout_each<'a, W: Clone + AsRef<[u64]>>(
     // can only answer `Demand` — the same shape as `eval_each_pipe`'s
     // `downstream` and `any_all_gen_cond`'s `probe_escape`.
     let mut abort: Option<Flow> = None;
+    // #2460: how many outputs each operand actually produced, so a *zero*
+    // count can be answered from `yq_empty_operand_output` instead of
+    // silently contributing no pairings. `None` in jq mode, where `1 + empty`
+    // really is nothing.
+    let mut right_seen = 0usize;
 
     let outer = each_operand(right, &mut |right_item: Item<'a, W>| {
+        right_seen += 1;
         let right_val = match checked_fanout_operand(right_item, &mut abort) {
             Ok(v) => v,
             Err(demand) => return demand,
         };
 
+        let mut left_seen = 0usize;
         let inner = each_operand(left, &mut |left_item: Item<'a, W>| {
+            left_seen += 1;
             let left_val = match checked_fanout_operand(left_item, &mut abort) {
                 Ok(v) => v,
                 Err(demand) => return demand,
@@ -5371,6 +5553,21 @@ fn binary_fanout_each<'a, W: Clone + AsRef<[u64]>>(
         // in the inner loop must not overwrite that verdict.
         if abort.is_some() {
             return Demand::Stop;
+        }
+
+        // #2460 (yq mode only): the *left* operand produced nothing for this
+        // right value, so this pairing is answered from the empty-operand
+        // table rather than skipped. Only after `inner` ran to exhaustion --
+        // an operand that escaped or was stopped part-way is not "empty".
+        if left_seen == 0 && matches!(inner, Flow::Exhausted) {
+            if let Some(op) = empty_rule {
+                if let Some(v) = yq_empty_operand_output(op, Some(&right_val)) {
+                    if matches!(sink(Item::Owned(v)), Demand::Stop) {
+                        abort = Some(Flow::Stopped { pending: None });
+                        return Demand::Stop;
+                    }
+                }
+            }
         }
 
         match inner {
@@ -5425,7 +5622,55 @@ fn binary_fanout_each<'a, W: Clone + AsRef<[u64]>>(
     // `test_short_circuit_side_effect_shapes_already_match_jq_820`).
     // `foreach` has no Stage 5 arm and still falls back the same way this
     // comment always meant to illustrate.
+    if let (Some(op), 0, None, Flow::Exhausted) = (empty_rule, right_seen, &abort, &outer) {
+        // #2460 (yq mode only): the *right* operand produced nothing, so the
+        // outer loop never ran and `left` was never evaluated at all. Drive
+        // it once here and answer each of its outputs from the same table --
+        // and, if it is empty too, answer the both-empty row once.
+        return empty_outer_operand_pass(&each_operand, left, op, sink);
+    }
     abort.unwrap_or(outer)
+}
+
+/// The `right`-operand-produced-nothing half of [`binary_fanout_each`]'s
+/// #2460 rule, split out so the loop above keeps one `return` shape.
+///
+/// Real yq's `+`/`//` are symmetric in the empty operand (`key + 1` and
+/// `1 + key` are both `1`), which is only reproducible by evaluating the
+/// *other* operand in this case -- jq's right-outer/left-inner loop never
+/// reaches `left` at all when `right` is empty.
+fn empty_outer_operand_pass<'a, W: Clone + AsRef<[u64]>>(
+    each_operand: &impl Fn(&Expr, &mut dyn FnMut(Item<'a, W>) -> Demand) -> Flow,
+    left: &Expr,
+    op: EmptyOperandOp,
+    sink: &mut dyn FnMut(Item<'a, W>) -> Demand,
+) -> Flow {
+    let mut abort: Option<Flow> = None;
+    let mut left_seen = 0usize;
+    let flow = each_operand(left, &mut |left_item: Item<'a, W>| {
+        left_seen += 1;
+        let left_val = match checked_fanout_operand(left_item, &mut abort) {
+            Ok(v) => v,
+            Err(demand) => return demand,
+        };
+        match yq_empty_operand_output(op, Some(&left_val)) {
+            Some(v) => sink(Item::Owned(v)),
+            None => Demand::Continue,
+        }
+    });
+    if let Some(flow) = abort {
+        return flow;
+    }
+    if left_seen == 0 && matches!(flow, Flow::Exhausted) {
+        // Both operands empty: one pairing, with no "other operand" at all.
+        if let Some(v) = yq_empty_operand_output(op, None) {
+            return match sink(Item::Owned(v)) {
+                Demand::Continue => Flow::Exhausted,
+                Demand::Stop => Flow::Stopped { pending: None },
+            };
+        }
+    }
+    flow
 }
 
 /// Shared unary fork/negate/finish core behind [`eval_negate`] and its
@@ -5546,9 +5791,20 @@ fn boolean_fanout_core<'a, W: Clone + AsRef<[u64]>>(
     left: &Expr,
     right: &Expr,
     short_circuit: bool,
+    empty_rule: Option<EmptyOperandOp>,
 ) -> QueryResult<'a, W> {
     let mut left_bools = Vec::new();
     let left_control = push_truthiness(eval_operand(left), &mut left_bools);
+    // #2460 (yq mode only): an operand that produced *zero* outputs
+    // contributes one `false` truthiness value, which is the whole of yq's
+    // captured `and`/`or` behaviour -- `and` then short-circuits to `false`
+    // without consulting the other side (yq's inconsistency 4), and `or`
+    // falls through to the other operand's own truthiness. The rule lives in
+    // `yq_empty_operand_output`, not here, so `and`/`or` and the arithmetic/
+    // comparison fanout share one definition of "this operand was empty".
+    if left_bools.is_empty() && left_control.is_none() {
+        left_bools.extend(empty_boolean_operand(empty_rule));
+    }
 
     let mut out = vec_with_capacity(left_bools.len());
     for left_bool in left_bools {
@@ -5556,8 +5812,12 @@ fn boolean_fanout_core<'a, W: Clone + AsRef<[u64]>>(
             out.push(short_circuit);
             continue;
         }
+        let before = out.len();
         if let Some(control) = push_truthiness(eval_operand(right), &mut out) {
             return partial(out.into_iter().map(OwnedValue::Bool).collect(), control);
+        }
+        if out.len() == before {
+            out.extend(empty_boolean_operand(empty_rule));
         }
     }
 
@@ -5578,6 +5838,7 @@ fn eval_binary_fanout<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     right: &Expr,
     value: StandardJson<'a, W>,
     optional: bool,
+    empty_rule: Option<EmptyOperandOp>,
     combine: impl FnMut(OwnedValue, OwnedValue) -> Result<OwnedValue, EvalError>,
 ) -> QueryResult<'a, W> {
     binary_fanout_core(
@@ -5585,6 +5846,7 @@ fn eval_binary_fanout<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
         left,
         right,
         optional,
+        empty_rule,
         combine,
     )
 }
@@ -5628,9 +5890,14 @@ fn eval_arithmetic<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     value: StandardJson<'a, W>,
     optional: bool,
 ) -> QueryResult<'a, W> {
-    eval_binary_fanout::<W, S>(left, right, value, optional, |left_val, right_val| {
-        arith_combine::<S>(op, left_val, right_val)
-    })
+    eval_binary_fanout::<W, S>(
+        left,
+        right,
+        value,
+        optional,
+        empty_operand_rule::<S>(EmptyOperandOp::Arith(op)),
+        |left_val, right_val| arith_combine::<S>(op, left_val, right_val),
+    )
 }
 
 /// Add two values (numbers, strings, arrays, objects).
@@ -6387,11 +6654,18 @@ fn eval_compare<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     value: StandardJson<'a, W>,
     optional: bool,
 ) -> QueryResult<'a, W> {
-    eval_binary_fanout::<W, S>(left, right, value, optional, |left_val, right_val| {
-        Ok(OwnedValue::Bool(apply_compare_op::<S>(
-            op, &left_val, &right_val,
-        )))
-    })
+    eval_binary_fanout::<W, S>(
+        left,
+        right,
+        value,
+        optional,
+        empty_operand_rule::<S>(EmptyOperandOp::Compare(op)),
+        |left_val, right_val| {
+            Ok(OwnedValue::Bool(apply_compare_op::<S>(
+                op, &left_val, &right_val,
+            )))
+        },
+    )
 }
 
 /// Apply a comparison operator to two already-evaluated values.
@@ -6558,6 +6832,7 @@ fn eval_boolean<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
         left,
         right,
         short_circuit,
+        empty_operand_rule::<S>(EmptyOperandOp::Boolean),
     )
 }
 
@@ -7099,16 +7374,15 @@ fn eval_builtin<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
             // When called without context, return empty path (root position)
             QueryResult::Owned(OwnedValue::Array(vec![]))
         }
-        Builtin::Parent => {
-            // Parent requires path context which is handled in eval_pipe_with_context
-            // When called without context, return empty object (no parent at root)
-            QueryResult::Owned(OwnedValue::Object(IndexMap::new()))
-        }
+        // `parent`/`parent(n)` with no path context at all is the root
+        // position: there is no ancestor to return. Same #2460 rule, and the
+        // same per-mode gate, as `resolve_ancestor_path`'s own past-the-root
+        // arm -- real yq answers with zero outputs, jq mode keeps the `{}`
+        // placeholder these arms have always returned.
+        Builtin::Parent => root_path_context_placeholder::<W, S>(no_parent_placeholder()),
         Builtin::ParentN(n_expr) => {
-            // ParentN requires path context which is handled in eval_pipe_with_context
-            // When called without context, return empty object
             let _ = n_expr; // Unused here, but evaluated in context version
-            QueryResult::Owned(OwnedValue::Object(IndexMap::new()))
+            root_path_context_placeholder::<W, S>(no_parent_placeholder())
         }
         Builtin::Paths => builtin_paths::<W>(value, optional),
         Builtin::PathsFilter(filter) => builtin_paths_filter::<W, S>(filter, value, optional),
@@ -7208,11 +7482,11 @@ fn eval_builtin<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
             // is handled by the yq runner, not here
             QueryResult::One(value.clone())
         }
-        Builtin::Key => {
-            // Key requires path context which is handled in eval_pipe_with_context
-            // If we reach here without context, return null (at root level)
-            QueryResult::Owned(OwnedValue::Null)
-        }
+        // `key` with no path context at all is the root position: there is no
+        // enclosing key to read. Same #2460 rule and gate as the
+        // `eval_stage_with_path_context` arm -- zero outputs in yq mode, the
+        // historical `null` placeholder in jq mode.
+        Builtin::Key => root_path_context_placeholder::<W, S>(OwnedValue::Null),
 
         // Phase 11: Path manipulation
         Builtin::Del(path) => builtin_del::<W, S>(path, value, optional),
@@ -32655,7 +32929,7 @@ pub(crate) fn classify_parent_n<S: EvalSemantics>(
 /// root) means `&current_path[..len]` is a real path to resolve via
 /// `get_value_at_owned_path`, which already returns `root` itself for an
 /// empty path.
-fn resolve_ancestor_path<'a, 'p, W: Clone + AsRef<[u64]>>(
+fn resolve_ancestor_path<'a, 'p, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     root: &OwnedValue,
     current_path: &'p [OwnedValue],
     n: usize,
@@ -32663,8 +32937,15 @@ fn resolve_ancestor_path<'a, 'p, W: Clone + AsRef<[u64]>>(
     match current_path.len().checked_sub(n) {
         None => (
             &[],
-            // Gone past root - return empty object
-            QueryResult::Owned(OwnedValue::Object(IndexMap::new())),
+            // Climbed past the root, so there is no ancestor to return.
+            // #2460: real yq answers with *zero outputs* (live-verified
+            // against v4.53.3: `parent`, `parent(1)` and `[parent]` on a root
+            // document print nothing, nothing and `[]`). The empty-object
+            // placeholder is worse than merely wrong: `{}` is *truthy*, so it
+            // short-circuited `//` and `or` as well as feeding `+`/`*` an
+            // operand real yq never supplies. jq mode keeps it -- `parent` is
+            // a succinctly extension there with no oracle to match.
+            root_path_context_placeholder::<W, S>(no_parent_placeholder()),
         ),
         Some(len) => {
             let ancestor_path = &current_path[..len];
@@ -32714,6 +32995,7 @@ fn eval_binary_fanout_with_path_context<'a, W: Clone + AsRef<[u64]>, S: EvalSema
     file_origin: Option<&[usize]>,
     current_path: &[OwnedValue],
     optional: bool,
+    empty_rule: Option<EmptyOperandOp>,
     combine: impl FnMut(OwnedValue, OwnedValue) -> Result<OwnedValue, EvalError>,
 ) -> QueryResult<'a, W> {
     binary_fanout_core(
@@ -32739,6 +33021,7 @@ fn eval_binary_fanout_with_path_context<'a, W: Clone + AsRef<[u64]>, S: EvalSema
         left,
         right,
         optional,
+        empty_rule,
         combine,
     )
 }
@@ -32883,6 +33166,7 @@ fn eval_boolean_with_path_context<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>
         left,
         right,
         short_circuit,
+        empty_operand_rule::<S>(EmptyOperandOp::Boolean),
     )
 }
 
@@ -34012,8 +34296,17 @@ fn eval_stage_with_path_context<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     // Position unchanged (#1449).
     if matches!(first, Expr::Builtin(Builtin::Key)) {
         let key_result = if current_path.is_empty() {
-            // At root - return null (yq behavior)
-            QueryResult::Owned(OwnedValue::Null)
+            // At root there is no enclosing key to read. #2460: real yq
+            // answers with *zero outputs* here, not a value -- live-verified
+            // against v4.53.3, where `key`, `[key]` and `key | type` on a
+            // root document print nothing, `[]` and nothing respectively.
+            // The `null` placeholder is what made this evaluator disagree
+            // with its own generic sibling (which already emits nothing) and
+            // with `parent`'s `{}` placeholder next door; see
+            // `EvalSemantics::ROOT_PATH_CONTEXT_YIELDS_NOTHING`. jq mode
+            // keeps the placeholder -- `key` is a succinctly extension there
+            // with no oracle to match.
+            root_path_context_placeholder::<W, S>(OwnedValue::Null)
         } else {
             // Get the last element of the path (the current key)
             QueryResult::Owned(current_path.last().unwrap().clone())
@@ -34060,7 +34353,7 @@ fn eval_stage_with_path_context<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     // routed through the shared helper (#1449), just with a different
     // `current_path` argument for the continuation.
     if matches!(first, Expr::Builtin(Builtin::Parent)) {
-        let (parent_path, parent_result) = resolve_ancestor_path::<W>(root, current_path, 1);
+        let (parent_path, parent_result) = resolve_ancestor_path::<W, S>(root, current_path, 1);
         return continue_rest_with_context::<W, S>(
             parent_result,
             rest,
@@ -34104,7 +34397,7 @@ fn eval_stage_with_path_context<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
         // two arms had each hand-rolled this arithmetic separately, and
         // that divergence (a subtly different boundary condition in this
         // arm alone) was the exact bug #1476 fixed.
-        let (parent_path, parent_result) = resolve_ancestor_path::<W>(root, current_path, n);
+        let (parent_path, parent_result) = resolve_ancestor_path::<W, S>(root, current_path, n);
         return continue_rest_with_context::<W, S>(
             parent_result,
             rest,
@@ -34700,6 +34993,7 @@ fn eval_stage_with_path_context<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
                 file_origin,
                 current_path,
                 optional,
+                empty_operand_rule::<S>(EmptyOperandOp::Arith(*op)),
                 |left_val, right_val| arith_combine::<S>(*op, left_val, right_val),
             );
             if rest.is_empty() {
@@ -34796,6 +35090,7 @@ fn eval_stage_with_path_context<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
                 file_origin,
                 current_path,
                 optional,
+                empty_operand_rule::<S>(EmptyOperandOp::Compare(*op)),
                 |left_val, right_val| {
                     Ok(OwnedValue::Bool(apply_compare_op::<S>(
                         *op, &left_val, &right_val,

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -38,16 +38,17 @@ use super::eval::{
     apply_compare_op, arith_combine, as_var_refs, bind_def, bind_def_call,
     cannot_reserve_cross_product, classify_limit_n, classify_nth_n, classify_parent_n,
     collapse_vec, collect_pattern_var_names, compare_values, debug_assert_materialization_error,
-    enter_def_call_frame, eval_each_owned, eval_foreach_with_values, eval_full as full_eval,
-    eval_reduce_with_values, extract_pattern_bindings, fold_escaped_generator_prefix, format_owned,
-    has_type_mismatch_is_permissive, index_component_value, index_in_array_bounds,
-    index_one_owned as index_owned_by_key, is_pure_chain_link, is_retryable_stop, literal_to_owned,
-    needs_path_context, numeric_key_to_array_index, numeric_key_to_index, owned_bound_to_i64,
-    owned_to_string, prefer_pending_control, slice_component_value, slice_object_as_yq_children,
+    empty_operand_rule, enter_def_call_frame, eval_each_owned, eval_foreach_with_values,
+    eval_full as full_eval, eval_reduce_with_values, extract_pattern_bindings,
+    fold_escaped_generator_prefix, format_owned, has_type_mismatch_is_permissive,
+    index_component_value, index_in_array_bounds, index_one_owned as index_owned_by_key,
+    is_pure_chain_link, is_retryable_stop, literal_to_owned, needs_path_context,
+    numeric_key_to_array_index, numeric_key_to_index, owned_bound_to_i64, owned_to_string,
+    prefer_pending_control, slice_component_value, slice_object_as_yq_children,
     slice_owned_value_read, streams_escaped_generator_prefix, substitute_bound_var,
     substitute_vars, suppress_or_raise, suppresses, tonumber_from_str, vec_with_capacity,
-    yq_negative_index_check, Control, Demand, EvalError, EvalSemantics, EvalTag, Flow, JqSemantics,
-    LimitN, PathTrail, QueryResult, YqSemantics,
+    yq_empty_operand_output, yq_negative_index_check, Control, Demand, EmptyOperandOp, EvalError,
+    EvalSemantics, EvalTag, Flow, JqSemantics, LimitN, PathTrail, QueryResult, YqSemantics,
 };
 #[cfg(test)]
 use super::expr::FuncDefBound;
@@ -6017,6 +6018,33 @@ fn eval_single<S: EvalSemantics, V: DocumentValue>(
             eval_compare_generic::<S, V>(*op, left, right, value, optional, cursor)
         }
 
+        // Spine 2416 step 1b: arithmetic through the sink evaluator's own
+        // `Expr::Arithmetic` arm (`binary_fanout_each_generic`), which
+        // evaluates both operands with the cursor -- so `.[] | key + 10`
+        // answers per-element keys on the non-sink route too, where the
+        // eager bridge used to hand it `null + 10`. That is what admits
+        // `Expr::Arithmetic` to `path_context_single_native`.
+        //
+        // **Gated on `needs_path_context`, unlike the `Expr::Compare` arm
+        // above.** The eager bridge materializes the ambient value on its
+        // way through, and for a #1194-malformed document (`{123: 1}`) that
+        // materialization is the decode failure jq answers *every* query on
+        // that document with -- including one that never reads `.`, like
+        // `try (1+1) catch "x"` (exit 5, live-verified against jq 1.7.1 and
+        // pinned by `test_try_catch_contains_a_genuinely_catchable_malformed_key_error_1812`).
+        // An ungated arm here would answer `2` and lose that. The gate keeps
+        // arithmetic that reads no path context on the bridge, where it
+        // still pays the ambient decode; arithmetic that does read path
+        // context could not have been on a malformed document's root and
+        // survived the walk anyway. (`Expr::Compare`'s own arm already
+        // diverges here -- `1==1` on `{123: 1}` answers `true` -- which is a
+        // pre-existing gap, not one this arm widens.)
+        Expr::Arithmetic { left, right, .. }
+            if needs_path_context(left) || needs_path_context(right) =>
+        {
+            collect_each_generic::<S, V>(expr, value, optional, cursor)
+        }
+
         // Array construction: collect every output of the inner expression
         // into one array. Handled natively (mirrors `eval::eval_array_construction`)
         // so a builtin with its own cursor-native, duplicate-key-preserving fix
@@ -6597,6 +6625,7 @@ fn eval_each_generic<S: EvalSemantics, V: DocumentValue>(
             left,
             right,
             optional,
+            empty_operand_rule::<S>(EmptyOperandOp::Compare(*op)),
             |left_val, right_val| {
                 Ok(OwnedValue::Bool(apply_compare_op::<S>(
                     *op, &left_val, &right_val,
@@ -6623,6 +6652,7 @@ fn eval_each_generic<S: EvalSemantics, V: DocumentValue>(
             left,
             right,
             optional,
+            empty_operand_rule::<S>(EmptyOperandOp::Arith(*op)),
             |left_val, right_val| arith_combine::<S>(*op, left_val, right_val),
             sink,
         ),
@@ -7755,12 +7785,20 @@ fn binary_fanout_each_generic<V: DocumentValue>(
     left: &Expr,
     right: &Expr,
     optional: bool,
+    empty_rule: Option<EmptyOperandOp>,
     mut combine: impl FnMut(OwnedValue, OwnedValue) -> Result<OwnedValue, EvalError>,
     sink: &mut dyn FnMut(GenericItem<V>) -> Demand,
 ) -> Flow {
     let mut abort: Option<Flow> = None;
+    // #2460: how many outputs each operand produced, so a *zero* count is
+    // answered from `yq_empty_operand_output` rather than contributing no
+    // pairings -- the same rule, from the same definition, that
+    // `eval::binary_fanout_each` consults on the eager route. `None` in jq
+    // mode, where `1 + empty` really is nothing.
+    let mut right_seen = 0usize;
 
     let outer = each_operand(right, &mut |right_item: GenericItem<V>| {
+        right_seen += 1;
         let right_val = match generic_item_into_owned(right_item) {
             Ok(v) => v,
             Err(control) => {
@@ -7769,7 +7807,9 @@ fn binary_fanout_each_generic<V: DocumentValue>(
             }
         };
 
+        let mut left_seen = 0usize;
         let inner = each_operand(left, &mut |left_item: GenericItem<V>| {
+            left_seen += 1;
             let left_val = match generic_item_into_owned(left_item) {
                 Ok(v) => v,
                 Err(control) => {
@@ -7803,6 +7843,21 @@ fn binary_fanout_each_generic<V: DocumentValue>(
             return Demand::Stop;
         }
 
+        // #2460 (yq mode only): the *left* operand produced nothing for this
+        // right value, so this pairing is answered from the empty-operand
+        // table instead of skipped. Only once `inner` ran to exhaustion -- an
+        // operand that escaped or was stopped part-way is not "empty".
+        if left_seen == 0 && matches!(inner, Flow::Exhausted) {
+            if let Some(op) = empty_rule {
+                if let Some(v) = yq_empty_operand_output(op, Some(&right_val)) {
+                    if matches!(sink(GenericItem::Owned(v)), Demand::Stop) {
+                        abort = Some(Flow::Stopped { pending: None });
+                        return Demand::Stop;
+                    }
+                }
+            }
+        }
+
         match inner {
             Flow::Exhausted => Demand::Continue,
             other => {
@@ -7812,7 +7867,52 @@ fn binary_fanout_each_generic<V: DocumentValue>(
         }
     });
 
+    if let (Some(op), 0, None, Flow::Exhausted) = (empty_rule, right_seen, &abort, &outer) {
+        // #2460 (yq mode only): the *right* operand produced nothing, so the
+        // outer loop never ran and `left` was never evaluated at all -- drive
+        // it once here so `1 + key` and `key + 1` stay symmetric the way real
+        // yq is. Mirrors `eval::empty_outer_operand_pass`.
+        return empty_outer_operand_pass_generic::<V>(&each_operand, left, op, sink);
+    }
     abort.unwrap_or(outer)
+}
+
+/// The `right`-operand-produced-nothing half of
+/// [`binary_fanout_each_generic`]'s #2460 rule -- the generic-evaluator twin
+/// of `eval::empty_outer_operand_pass`, split out for the same reason (one
+/// `return` shape in the loop above).
+fn empty_outer_operand_pass_generic<V: DocumentValue>(
+    each_operand: &impl Fn(&Expr, &mut dyn FnMut(GenericItem<V>) -> Demand) -> Flow,
+    left: &Expr,
+    op: EmptyOperandOp,
+    sink: &mut dyn FnMut(GenericItem<V>) -> Demand,
+) -> Flow {
+    let mut abort: Option<Flow> = None;
+    let mut left_seen = 0usize;
+    let flow = each_operand(left, &mut |left_item: GenericItem<V>| {
+        left_seen += 1;
+        let left_val = match generic_item_into_owned(left_item) {
+            Ok(v) => v,
+            Err(control) => {
+                abort = Some(Flow::Escaped(control));
+                return Demand::Stop;
+            }
+        };
+        match yq_empty_operand_output(op, Some(&left_val)) {
+            Some(v) => sink(GenericItem::Owned(v)),
+            None => Demand::Continue,
+        }
+    });
+    if let Some(flow) = abort {
+        return flow;
+    }
+    if left_seen == 0 && matches!(flow, Flow::Exhausted) {
+        // Both operands empty: one pairing, with no "other operand" at all.
+        if let Some(v) = yq_empty_operand_output(op, None) {
+            return push_one_generic(GenericItem::Owned(v), sink);
+        }
+    }
+    flow
 }
 
 /// Collecting wrapper over [`binary_fanout_each_generic`] for `eval_single`'s
@@ -7846,6 +7946,7 @@ fn eval_compare_generic<S: EvalSemantics, V: DocumentValue>(
         left,
         right,
         optional,
+        empty_operand_rule::<S>(EmptyOperandOp::Compare(op)),
         |left_val, right_val| {
             Ok(OwnedValue::Bool(apply_compare_op::<S>(
                 op, &left_val, &right_val,
@@ -11516,6 +11617,17 @@ fn path_context_single_native(expr: &Expr) -> bool {
                     || !path_context_needs_eager(exprs))
         }
         Expr::Compare { left, right, .. } => {
+            path_context_single_native(left) && path_context_single_native(right)
+        }
+        // Native since spine 2416 step 1b (`eval_single`'s own
+        // `Expr::Arithmetic` arm, above, over `collect_each_generic`). Two
+        // shapes blocked this admission until now, and both are closed:
+        // yq's rule for an operand that produces zero outputs (#2460,
+        // `jq::eval::yq_empty_operand_output`, consulted by the generic and
+        // eager fanouts alike so the two routes agree on `key + 1`), and the
+        // ambient decode `try (1+1) catch "x"` depends on for a malformed
+        // document, which the arm's own `needs_path_context` gate preserves.
+        Expr::Arithmetic { left, right, .. } => {
             path_context_single_native(left) && path_context_single_native(right)
         }
         Expr::Try { expr, catch } => {
@@ -22949,10 +23061,13 @@ mod tests {
         assert!(!eager(".[] | [key, path]"));
         assert!(!eager(".[] | select(key == \"b\") | parent(1)"));
         assert!(!eager(".[] | first(.[] | key)"));
-        assert!(
-            eager(".[] | key + 10"),
-            "arithmetic still bridges from eval_single"
-        );
+        // Generic since spine 2416 step 1b: `Expr::Arithmetic` has an
+        // `eval_single` arm of its own now, so the non-sink route threads
+        // the cursor into both operands instead of handing the eager
+        // bridge a `null + 10`.
+        assert!(!eager(".[] | key + 10"));
+        assert!(!eager(".[] | (key + 1) * 2"));
+        assert!(!eager(".[] | key + \"!\""));
         // Reason 1, an owned-domain stage before the builtin, is answered
         // by the owned identity pipe (#2416 step 3) wherever the stage has
         // an `owned_identity_rule` and the rest reads the position it
@@ -23026,13 +23141,13 @@ mod tests {
         // fresh `parse()`; `test_def_call_keeps_path_context_2416` (CLI) is
         // its coverage instead.
         assert!(!eager(".[] | (def k: 1; key)"));
-        // Arithmetic still bridges from `eval_single` (unchanged from the
-        // `if`/`limit` rows above), so wrapping one in `as`'s/`label`'s/
-        // `def`'s body keeps the whole pipe eager.
-        assert!(eager(".[] | . as $x | key + 10"));
-        assert!(eager(".[] | . as {a: $a} | key + 10"));
-        assert!(eager(".[] | label $out | key + 10"));
-        assert!(eager(".[] | (def k: 1; key + 10)"));
+        // Arithmetic is single-native since spine 2416 step 1b, so wrapping
+        // one in `as`'s/`label`'s/`def`'s body no longer drags the whole
+        // pipe back to the eager evaluator either.
+        assert!(!eager(".[] | . as $x | key + 10"));
+        assert!(!eager(".[] | . as {a: $a} | key + 10"));
+        assert!(!eager(".[] | label $out | key + 10"));
+        assert!(!eager(".[] | (def k: 1; key + 10)"));
         // `DefCall` is a runtime node the parser never produces, so its
         // argument gate is pinned by the CLI (`f(key + 10)` in
         // `test_shared_keeps_path_context_2416`) rather than here.

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -38062,3 +38062,52 @@ fn test_absent_position_keeps_path_context_2416() -> Result<()> {
     }
     Ok(())
 }
+
+/// #2460 gives *yq mode* a rule for a binary operator whose operand produced
+/// zero outputs (`key + 1` on a root document is `1` there, not nothing).
+/// **jq mode is deliberately untouched**, and this is the pin on that: real
+/// jq has no such rule at all -- an empty operand makes the whole expression
+/// empty, for every operator except `//`, whose own falsy/absent fallback
+/// predates this issue entirely.
+///
+/// Every row captured live from `/usr/bin/jq` 1.7.1 (not Homebrew's 1.8.2).
+/// `empty` is the shape used rather than `key`/`parent`, because those two
+/// are succinctly extensions in jq mode with no oracle to capture -- their
+/// own jq-mode placeholders (`null` and `{}`) are pinned separately, further
+/// up this file, and #2460 left them alone.
+#[test]
+fn test_jq_mode_has_no_empty_operand_rule_2460() -> Result<()> {
+    for (filter, want) in [
+        ("1 + empty", ""),
+        ("empty + 1", ""),
+        ("empty - 1", ""),
+        ("empty * 1", ""),
+        ("empty / 1", ""),
+        ("empty % 1", ""),
+        ("empty == 1", ""),
+        // Not `true`: yq's `==` special-cases a `null` other operand, jq's
+        // does not reach an `==` at all.
+        ("empty == null", ""),
+        ("empty != 1", ""),
+        ("empty < 1", ""),
+        ("empty <= 1", ""),
+        ("empty > 1", ""),
+        ("empty >= 1", ""),
+        ("empty and 1", ""),
+        ("empty or 1", ""),
+        ("empty + empty", ""),
+        ("empty == empty", ""),
+        // The one operator that answers, in both modes and for the same
+        // pre-existing reason: `//` falls through to its right operand when
+        // the left produces no truthy output.
+        ("empty // 1", "1"),
+    ] {
+        let (out, stderr, code) = run_jq_full(&["-c", filter], Some(r#"{"a":1}"#))?;
+        assert_eq!(
+            (out.trim(), code),
+            (want, 0),
+            "`{filter}` -- stderr: {stderr}"
+        );
+    }
+    Ok(())
+}

--- a/tests/jq_evaluator_parity_tests.rs
+++ b/tests/jq_evaluator_parity_tests.rs
@@ -2026,6 +2026,12 @@ fn test_arm_audit_proof_queries_are_unmoved_by_the_gate_2416() {
         (".c[0] | key + 1", &["1"]),
         (".c[0:1] | .[0] | key + 1", &["1"]),
         (r#".a[] | key + "x""#, &[r#""bx""#]),
+        // A05's re-derived proof query: spine 2416 step 1b moved
+        // `.a[] | key + "x"` (the row just above) onto the generic route, so
+        // the audit needed a shape that still reaches `Expr::Iterate`'s eager
+        // arm. Both are pinned, which is what makes the move visible as "same
+        // outputs, different route" rather than as a silent change.
+        (r".a[] | (key | tostring)", &[r#""b""#]),
         (r#"(.a.b) | key + "x""#, &[r#""bx""#]),
         (".c[.n]? | key + 1", &["1"]),
         (r#".a? | key + "x""#, &[r#""ax""#]),

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -25576,11 +25576,22 @@ fn test_yq_string_interpolation_path_context_error_is_atomic_1403() -> Result<()
 
 /// A yq-mode path-context string is still a fresh root for whatever
 /// follows it in the pipe, same as jq mode's identical reset.
+///
+/// #2460 changed what that fresh root *answers*: a `key` standing on the
+/// document root produces zero outputs in yq mode, not the `null`
+/// placeholder this test used to pin. Live-verified against yq v4.53.3 --
+/// `yq -o json '.a | "\(key)" | key'` on `a: 1` prints nothing, exit 0 --
+/// so this row is now an oracle match where it was a divergence.
 #[test]
 fn test_yq_string_interpolation_path_context_resets_root_for_rest_1403() -> Result<()> {
     let (output, code) = run_yq_stdin(r#".a | "\(key)" | key"#, "a: 1\n", &["-o", "json"])?;
     assert_eq!(code, 0, "output: {output:?}");
-    assert_eq!(output.trim(), "null");
+    assert_eq!(output.trim(), "");
+    // The reset itself is what this test is about, and it is still
+    // observable: the interpolated string keeps the *pre*-reset key.
+    let (output, code) = run_yq_stdin(r#".a | "\(key)""#, "a: 1\n", &["-o", "json"])?;
+    assert_eq!(code, 0, "output: {output:?}");
+    assert_eq!(output.trim(), "\"a\"");
     Ok(())
 }
 
@@ -29750,7 +29761,28 @@ fn test_negative_index_out_of_range_survives_try_catch_partial_prefix_2270() -> 
         &["-o", "json", "--eval-all"],
     )?;
     assert_eq!(code, 1, "out: {out:?}");
-    assert_eq!(out.trim(), "null");
+    // #2460 moved this line from `null` to nothing: the surviving prefix
+    // (`1`) is a detached value at the root position, and a `key` there now
+    // produces zero outputs in yq mode instead of the `null` placeholder --
+    // live-verified against yq v4.53.3 on the closest expressible shape,
+    // `.a | "\(key)" | key`, which prints nothing there too (real yq's lexer
+    // rejects `try`/`catch` outright, so this exact filter has no oracle).
+    assert_eq!(out.trim(), "");
+    assert_eq!(
+        stderr.trim(),
+        "Error: index [-5] out of range, array size is 2"
+    );
+
+    // The prefix itself is still delivered -- what changed is only what a
+    // root `key` answers, not whether the `Partial` prefix survives. `[key]`
+    // makes that observable again: one `[]` line, one per prefix output.
+    let (out, stderr, code) = run_yq_stdin_with_stderr(
+        ".[0].a | (try (1, .[-5]) catch \"c\") | [key]",
+        multi_doc,
+        &["-o", "json", "--eval-all"],
+    )?;
+    assert_eq!(code, 1, "out: {out:?}");
+    assert_eq!(out.trim(), "[]");
     assert_eq!(
         stderr.trim(),
         "Error: index [-5] out of range, array size is 2"
@@ -31644,3 +31676,226 @@ const OWNED_IDENTITY_ROWS_2416: &[(&str, &str)] = &[
     (".a.b | sort | .[0] | parent | path", r#"["a","b"]"#),
     (".a.b | sort | .[0] | parent | parent | key", r#""a""#),
 ];
+
+/// #2460: real yq's binary operators when one operand produces **zero
+/// outputs** -- an empty path-context read at the document root (`key`,
+/// `parent`, `parent(1)`) or any other filter that emits nothing
+/// (`.[] | select(false)`).
+///
+/// Every row below is a live capture from Homebrew `yq` v4.53.3 against the
+/// document in `EMPTY_OPERAND_DOC`, run as `yq -o=json -I0 FILTER d.yaml`,
+/// and re-captured (not transcribed) when this test was written: the 515-run
+/// oracle matrix on the issue, its `table.md` sections 2-5. The per-operator
+/// rule that capture derives is implemented once, in
+/// `jq::eval::yq_empty_operand_output`, whose doc comment carries the table
+/// and the six yq inconsistencies it reproduces bug-for-bug (ADR-0018 rule 3
+/// and its 2026-09-05 decision-order amendment).
+///
+/// Rows 1-98 are section 2 (one empty operand, every operator against every
+/// right-hand shape, plus the reversed `1 op E` spelling); rows 99-112 are
+/// section 3 (both operands empty, where `<=`/`>=` flip to `true` and `==`
+/// behaves like `null == null`); the rest are section 4's genuine-`null`
+/// controls and section 5's non-root control, which prove the rule is keyed
+/// on emptiness and not on the `key` builtin.
+const EMPTY_OPERAND_DOC: &str = "a:\n  b: 1\ns: x\nn: [1, 2]\n";
+
+#[test]
+fn test_yq_empty_operand_binary_operator_matrix_2460() -> Result<()> {
+    for (filter, want, want_code) in [
+        (r"(key) + 1", r"1", 0),
+        (r"1 + (key)", r"1", 0),
+        (r#"(key) + "s""#, r#""s""#, 0),
+        (r"(key) + [1]", r"[1]", 0),
+        (r#"(key) + {"k": 1}"#, r#"{"k":1}"#, 0),
+        (r"(key) + null", r"null", 0),
+        (r"(key) + true", r"true", 0),
+        (r"(key) - 1", r"", 0),
+        (r"1 - (key)", r"", 0),
+        (r#"(key) - "s""#, r"", 0),
+        (r"(key) - [1]", r"", 0),
+        (r#"(key) - {"k": 1}"#, r"", 0),
+        (r"(key) - null", r"", 0),
+        (r"(key) - true", r"", 0),
+        (r"(key) * 1", r"", 0),
+        (r"1 * (key)", r"", 0),
+        (r#"(key) * "s""#, r"", 0),
+        (r"(key) * [1]", r"", 0),
+        (r#"(key) * {"k": 1}"#, r"", 0),
+        (r"(key) * null", r"", 0),
+        (r"(key) * true", r"", 0),
+        (r"(key) / 1", r"", 0),
+        (r"1 / (key)", r"", 0),
+        (r#"(key) / "s""#, r"", 0),
+        (r"(key) / [1]", r"", 0),
+        (r#"(key) / {"k": 1}"#, r"", 0),
+        (r"(key) / null", r"", 0),
+        (r"(key) / true", r"", 0),
+        (r"(key) % 1", r"", 0),
+        (r"1 % (key)", r"", 0),
+        (r#"(key) % "s""#, r"", 0),
+        (r"(key) % [1]", r"", 0),
+        (r#"(key) % {"k": 1}"#, r"", 0),
+        (r"(key) % null", r"", 0),
+        (r"(key) % true", r"", 0),
+        (r"(key) == 1", r"false", 0),
+        (r"1 == (key)", r"false", 0),
+        (r#"(key) == "s""#, r"false", 0),
+        (r"(key) == [1]", r"false", 0),
+        (r#"(key) == {"k": 1}"#, r"false", 0),
+        (r"(key) == null", r"true", 0),
+        (r"(key) == true", r"false", 0),
+        (r"(key) != 1", r"true", 0),
+        (r"1 != (key)", r"true", 0),
+        (r#"(key) != "s""#, r"true", 0),
+        (r"(key) != [1]", r"true", 0),
+        (r#"(key) != {"k": 1}"#, r"true", 0),
+        (r"(key) != null", r"false", 0),
+        (r"(key) != true", r"true", 0),
+        (r"(key) < 1", r"false", 0),
+        (r"1 < (key)", r"false", 0),
+        (r#"(key) < "s""#, r"false", 0),
+        (r"(key) < [1]", r"false", 0),
+        (r#"(key) < {"k": 1}"#, r"false", 0),
+        (r"(key) < null", r"false", 0),
+        (r"(key) < true", r"false", 0),
+        (r"(key) > 1", r"false", 0),
+        (r"1 > (key)", r"false", 0),
+        (r#"(key) > "s""#, r"false", 0),
+        (r"(key) > [1]", r"false", 0),
+        (r#"(key) > {"k": 1}"#, r"false", 0),
+        (r"(key) > null", r"false", 0),
+        (r"(key) > true", r"false", 0),
+        (r"(key) <= 1", r"false", 0),
+        (r"1 <= (key)", r"false", 0),
+        (r#"(key) <= "s""#, r"false", 0),
+        (r"(key) <= [1]", r"false", 0),
+        (r#"(key) <= {"k": 1}"#, r"false", 0),
+        (r"(key) <= null", r"false", 0),
+        (r"(key) <= true", r"false", 0),
+        (r"(key) >= 1", r"false", 0),
+        (r"1 >= (key)", r"false", 0),
+        (r#"(key) >= "s""#, r"false", 0),
+        (r"(key) >= [1]", r"false", 0),
+        (r#"(key) >= {"k": 1}"#, r"false", 0),
+        (r"(key) >= null", r"false", 0),
+        (r"(key) >= true", r"false", 0),
+        (r"(key) and 1", r"false", 0),
+        (r"1 and (key)", r"false", 0),
+        (r#"(key) and "s""#, r"false", 0),
+        (r"(key) and [1]", r"false", 0),
+        (r#"(key) and {"k": 1}"#, r"false", 0),
+        (r"(key) and null", r"false", 0),
+        (r"(key) and true", r"false", 0),
+        (r"(key) or 1", r"true", 0),
+        (r"1 or (key)", r"true", 0),
+        (r#"(key) or "s""#, r"true", 0),
+        (r"(key) or [1]", r"true", 0),
+        (r#"(key) or {"k": 1}"#, r"true", 0),
+        (r"(key) or null", r"false", 0),
+        (r"(key) or true", r"true", 0),
+        (r"(key) // 1", r"1", 0),
+        (r"1 // (key)", r"1", 0),
+        (r#"(key) // "s""#, r#""s""#, 0),
+        (r"(key) // [1]", r"[1]", 0),
+        (r#"(key) // {"k": 1}"#, r#"{"k":1}"#, 0),
+        (r"(key) // null", r"null", 0),
+        (r"(key) // true", r"true", 0),
+        (r"key + parent", r"", 0),
+        (r"key - parent", r"", 0),
+        (r"key * parent", r"", 0),
+        (r"key / parent", r"", 0),
+        (r"key % parent", r"", 0),
+        (r"key == parent", r"true", 0),
+        (r"key != parent", r"false", 0),
+        (r"key < parent", r"false", 0),
+        (r"key > parent", r"false", 0),
+        (r"key <= parent", r"true", 0),
+        (r"key >= parent", r"true", 0),
+        (r"key and parent", r"false", 0),
+        (r"key or parent", r"false", 0),
+        (r"key // parent", r"", 0),
+        (r"null + 1", r"1", 0),
+        (r"1 + null", r"", 1),
+        (r"null * 2", r"", 1),
+        (r".zzz + 1", r"1", 0),
+        // Four rows that reach the **eager** path-context evaluator's own copy
+        // of the rule (`eval::binary_fanout_each` / `boolean_fanout_core`)
+        // rather than the generic one: `Expr::And` and `Expr::Alternative`
+        // have no native `eval_single` arm in `eval_generic.rs`, so the whole
+        // expression bridges, and the arithmetic inside is then evaluated by
+        // `eval.rs`. Verified with a temporary marker at each site that these
+        // exercise the inner-empty pass, the outer-empty pass and the
+        // `and`/`or` `false` contribution respectively -- the rows above
+        // mostly take the generic route, so without these the eager half of
+        // "one definition, both routes" would be untested. Captured live from
+        // yq v4.53.3 like every other row.
+        (r"(key + 1) and true", r"true", 0),
+        (r"(1 + key) and true", r"true", 0),
+        (r"(1 - key) and true", r"false", 0),
+        (r#"(key * 2) // "d""#, r#""d""#, 0),
+        (r#".a | key + "!""#, r#""a!""#, 0),
+        (r".a | key * 2", r#""aa""#, 0),
+    ] {
+        let (out, stderr, code) =
+            run_yq_stdin_with_stderr(filter, EMPTY_OPERAND_DOC, &["-o", "json", "-I", "0"])?;
+        assert_eq!(
+            (out.trim(), code),
+            (want, want_code),
+            "`{filter}` -- stderr: {stderr}"
+        );
+    }
+    Ok(())
+}
+
+/// #2460's other half: real yq's rule is keyed on *zero outputs*, never on
+/// which filter produced them. The oracle capture ran all four empty shapes
+/// -- `key`, `parent`, `parent(1)` and `.[] | select(false)` -- against all
+/// 13 operators and 7 right-hand shapes, 196 comparable cells each, and
+/// found **zero mismatches** between them.
+///
+/// That is what `jq::eval::yq_empty_operand_output` takes no producer
+/// argument for, and it is the property the placeholder stubs used to break:
+/// `key` was `null` and `parent` a *truthy* `{}`, so succinctly disagreed
+/// with itself between two shapes real yq cannot tell apart. This test is
+/// the guard on that equivalence -- it compares succinctly against
+/// succinctly, so it keeps holding with no oracle installed.
+#[test]
+fn test_yq_all_four_empty_operand_shapes_are_indistinguishable_2460() -> Result<()> {
+    let empties = ["key", "parent", "parent(1)", ".[] | select(false)"];
+    let ops = [
+        "+", "-", "*", "/", "%", "==", "!=", "<", ">", "<=", ">=", "and", "or", "//",
+    ];
+    let rhs = ["1", "\"s\"", "[1]", "{\"k\": 1}", "null", "true"];
+    for op in ops {
+        for r in rhs {
+            // Forward (`E op r`) and reversed (`r op E`) are compared in
+            // separate buckets: the claim under test is that the four
+            // *producers* agree, not that the operator is symmetric.
+            for reversed in [false, true] {
+                let mut seen: Option<(&str, String, i32)> = None;
+                for e in empties {
+                    let filter = if reversed {
+                        format!("{r} {op} ({e})")
+                    } else {
+                        format!("({e}) {op} {r}")
+                    };
+                    let (out, _, code) = run_yq_stdin_with_stderr(
+                        &filter,
+                        EMPTY_OPERAND_DOC,
+                        &["-o", "json", "-I", "0"],
+                    )?;
+                    let got = (out.trim().to_string(), code);
+                    match &seen {
+                        None => seen = Some((e, got.0, got.1)),
+                        Some((first, want_out, want_code)) => assert_eq!(
+                            (got.0.as_str(), got.1),
+                            (want_out.as_str(), *want_code),
+                            "`{filter}`: `{e}` disagrees with `{first}`"
+                        ),
+                    }
+                }
+            }
+        }
+    }
+    Ok(())
+}


### PR DESCRIPTION
## Summary

Real yq's binary operators have a per-operator rule when one operand yields zero outputs, which is what `key`, `parent`, `parent(n)` or `.[] | select(false)` do at the document root. A 515-run matrix against yq v4.53.3 (on the issue) derived it: `+` and `//` return the other operand verbatim, symmetric; `-` `*` `/` `%` yield nothing; `==`/`!=` special-case only null; ordering comparisons are always false; `and` is always false; `or` defers to the other operand. Six internal inconsistencies of yq's are reproduced bug-for-bug per ADR-0018 rule 3.

- One definition, `yq_empty_operand_output`, keyed on "zero outputs" and never on which filter produced them (the matrix proves the four empty shapes identical); consulted by the generic and eager binary fan-outs and by `and`/`or`. Two `EvalSemantics` consts gate it so jq mode is untouched (`1 + empty` still yields nothing there, pinned from `/usr/bin/jq` 1.7.1).
- `root_path_context_placeholder` replaces four hand-written stubs (`key` to null, `parent` to `{}`) in both evaluators.
- `Expr::Arithmetic` is admitted to the native path-context gate (spine 2416 step 1b part B), gated on `needs_path_context` so the ambient decode failure on a malformed document is kept. All eleven block-and-flow proof rows match yq before and after.
- Differential against yq over the matrix: 88 of 414 cells matched before, 412 after. The two left are a missing-key navigation used directly as an operand, the same read-only-context mechanism #2470 covers; recorded in the limitations doc with the live evidence and folded into #2470.
- Arm pin stays at 43 (the arithmetic arm is still reached through the other two gate reasons); the audit doc and its pinned proof queries are updated.

## Verification

fmt; clippy on both CI legs with `-D warnings`; `cargo test` in the three configurations; `cargo doc -D warnings`; yq goldens 113 and jq goldens 633; oracle sweep 3168 cases, 0 unexpected, no stale manifest rows. The pin test's 118 rows were re-captured live rather than transcribed.

Behaviour change in yq mode; ships in its own release. Part of spine 2416 (step 1b part B and #2473's first item). Closes #2460.
