### PR TITLE
fix(jq): short-circuit an alias node in the truthiness corruption walk

### DIFF
--- a/docs/compliance/yq/limitations.md
+++ b/docs/compliance/yq/limitations.md
@@ -80,6 +80,28 @@ silently discard the write, so the mark is dropped and the computed value printe
 4(b). True alias node identity remains unimplemented
 ([#1351](https://github.com/rust-works/succinctly/issues/1351)).
 
+A related, narrower gap sits in `select`/`if`'s condition-truthiness check
+(`push_generic_truthiness_cursor_error`, [src/jq/eval_generic.rs](../../../src/jq/eval_generic.rs)):
+it does not walk into a *container* reached through an alias, so a decode failure reachable
+only that way no longer raises
+([#1804](https://github.com/rust-works/succinctly/issues/1804), fixed a real `O(2^N)` cost
+for a document shaped as a chain of anchors each referencing the previous one twice). This
+is not a yq-fidelity divergence — real yq rejects the whole document at parse time, so there
+is no yq behaviour to match either way:
+
+```bash
+$ printf 'a: &a ["bad\\q"]\nb: *a\n' | succinctly yq 'select(.b) | 1'
+1
+$ printf 'a: &a ["bad\\q"]\nb: *a\n' | succinctly yq '.a'
+Error: invalid escape sequence
+$ printf 'a: &a ["bad\\q"]\nb: *a\n' | succinctly yq '.b[0]'
+Error: invalid escape sequence
+```
+
+Scoped to a *container* alias target only: a bare scalar-target alias (`a: &a "bad\q"`)
+still raises from `select`/`if` exactly as before, since resolving one scalar costs `O(1)`
+and was never part of the cost this fix removes.
+
 **Known gap in this rule.** `enforce_anchor_soundness` takes a `sort_keys` argument and
 handles it correctly — but only on the DOM path. The cursor-streaming path never calls it,
 so succinctly currently reproduces the unsound output it is supposed to prevent. The two

--- a/src/jq/document.rs
+++ b/src/jq/document.rs
@@ -410,6 +410,25 @@ pub trait DocumentCursor: Sized + Copy + Clone {
         None
     }
 
+    /// Whether this node is itself an alias (`*name`), without resolving
+    /// through it.
+    ///
+    /// `false` for formats with no alias concept (JSON), where this
+    /// monomorphizes to a constant and costs nothing. Only YAML cursors
+    /// override this, with an O(1) index check rather than [`alias`](Self::alias)'s
+    /// name lookup — a caller that only needs the yes/no answer (not the
+    /// name) should prefer this.
+    ///
+    /// Needed by a subtree walk that must not re-descend into an alias
+    /// target (#1804): a document shaped as a chain of anchors each
+    /// referencing the previous one twice (`aN: &aN [*a(N-1), *a(N-1)]`)
+    /// makes an unconditional per-child walk cost O(2^N) — the walk itself
+    /// is what fans out, not any per-node work, so the only fix is to stop
+    /// before recursing into an alias at all.
+    fn is_alias(&self) -> bool {
+        false
+    }
+
     /// Whether this cursor's *document* declares any `*name` alias at all.
     ///
     /// A whole-document property, not a property of this node, and O(1) --

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -2499,6 +2499,27 @@ fn push_generic_owned_values<V: DocumentValue>(
 /// container-shaped condition is free.
 fn push_generic_truthiness_cursor_error<C: DocumentCursor>(c: &C, depth: usize) -> Option<Control> {
     assert_nesting_depth(depth);
+    // #1804: do not resolve through an alias here. A document shaped as a
+    // chain of anchors each referencing the previous one twice (`aN: &aN
+    // [*a(N-1), *a(N-1)]`) makes descending into every alias target cost
+    // O(2^N) -- the fan-out is the walk's own unconditional per-child
+    // recursion, not any per-node work, so the only fix is to stop before
+    // recursing into an alias at all. `select(.)`/`and`/`or`/`not`/`//`/
+    // `any`/`if` all agree with real yq that a non-null container is
+    // truthy regardless of contents, so skipping the corruption check
+    // inside an alias's target changes no truthiness answer either tool
+    // gives.
+    //
+    // Accepted trade-off: a decode failure reachable *only* through an
+    // alias (`a: &a ["bad\q"]` / `b: *a` with `select(.b)`) no longer
+    // raises from this check. It still raises whenever `.a` is visited
+    // directly, or `.b` is materialized (`.b[0]` keeps erroring) -- this
+    // walk is the only place that stops short. Real yq rejects that whole
+    // document at parse time, so there is no yq behaviour to match either
+    // way.
+    if c.is_alias() {
+        return None;
+    }
     let value = c.value();
     if let Some(fields) = value.as_object() {
         // The #1642 collision map is built lazily, only from the point an

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -2499,29 +2499,40 @@ fn push_generic_owned_values<V: DocumentValue>(
 /// container-shaped condition is free.
 fn push_generic_truthiness_cursor_error<C: DocumentCursor>(c: &C, depth: usize) -> Option<Control> {
     assert_nesting_depth(depth);
-    // #1804: do not resolve through an alias here. A document shaped as a
-    // chain of anchors each referencing the previous one twice (`aN: &aN
-    // [*a(N-1), *a(N-1)]`) makes descending into every alias target cost
-    // O(2^N) -- the fan-out is the walk's own unconditional per-child
-    // recursion, not any per-node work, so the only fix is to stop before
-    // recursing into an alias at all. `select(.)`/`and`/`or`/`not`/`//`/
-    // `any`/`if` all agree with real yq that a non-null container is
-    // truthy regardless of contents, so skipping the corruption check
-    // inside an alias's target changes no truthiness answer either tool
-    // gives.
-    //
-    // Accepted trade-off: a decode failure reachable *only* through an
-    // alias (`a: &a ["bad\q"]` / `b: *a` with `select(.b)`) no longer
-    // raises from this check. It still raises whenever `.a` is visited
-    // directly, or `.b` is materialized (`.b[0]` keeps erroring) -- this
-    // walk is the only place that stops short. Real yq rejects that whole
-    // document at parse time, so there is no yq behaviour to match either
-    // way.
-    if c.is_alias() {
-        return None;
-    }
     let value = c.value();
     if let Some(fields) = value.as_object() {
+        // #1804: do not walk *into* an alias's container target here. A
+        // document shaped as a chain of anchors each referencing the
+        // previous one twice (`aN: &aN [*a(N-1), *a(N-1)]`) makes
+        // descending into every alias target's children cost O(2^N) -- the
+        // fan-out is this walk's own unconditional per-child recursion
+        // cascading through nested aliases, not any per-node work, so the
+        // only fix is to stop before recursing into a container reached
+        // through an alias. `select(.)`/`if` (the constructs that reach
+        // this walk today) agree with real yq that a non-null container is
+        // truthy regardless of contents, so skipping the corruption check
+        // inside an alias's container target changes no truthiness answer.
+        //
+        // Deliberately scoped to *container* targets only -- resolving a
+        // scalar-target alias costs O(1) (no children to cascade through),
+        // so it keeps running the checks below exactly as before #1804;
+        // gating on `c.is_alias()` before this branch split (an earlier,
+        // review-caught version of this fix) also silently swallowed a
+        // decode failure reachable through a bare scalar alias, which
+        // bought no performance -- see `test_select_no_longer_raises_on_decode_failure_reachable_only_via_scalar_alias_1804`
+        // for the case that must keep raising.
+        //
+        // Accepted trade-off: a decode failure reachable *only* through an
+        // alias to a container (`a: &a ["bad\q"]` / `b: *a` with
+        // `select(.b)`) no longer raises from this check. It still raises
+        // whenever `.a` is visited directly, or `.b` is materialized
+        // (`.b[0]` keeps erroring) -- this walk is the only place that
+        // stops short. Real yq rejects that whole document at parse time,
+        // so there is no yq behaviour to match either way. Recorded in
+        // `docs/compliance/yq/limitations.md`.
+        if c.is_alias() {
+            return None;
+        }
         // The #1642 collision map is built lazily, only from the point an
         // undecodable key actually appears (#2061).
         //
@@ -2658,6 +2669,11 @@ fn push_generic_truthiness_cursor_error<C: DocumentCursor>(c: &C, depth: usize) 
         }
         None
     } else if let Some(elements) = value.as_array() {
+        // #1804: same container-target-alias short-circuit as the object
+        // branch above -- see its comment for the full rationale.
+        if c.is_alias() {
+            return None;
+        }
         let mut elems = elements;
         let mut is_first = true;
         let mut last_elem: Option<C> = None;

--- a/src/yaml/light.rs
+++ b/src/yaml/light.rs
@@ -6369,6 +6369,11 @@ impl<'a, W: AsRef<[u64]> + Clone> DocumentCursor for YamlCursor<'a, W> {
     }
 
     #[inline]
+    fn is_alias(&self) -> bool {
+        YamlCursor::is_alias(self)
+    }
+
+    #[inline]
     fn document_has_aliases(&self) -> bool {
         self.index.has_aliases()
     }

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -28194,6 +28194,11 @@ fn test_select_and_if_truthiness_flat_over_alias_fanout_1804() -> Result<()> {
 /// materialized -- this walk is the only place that stops short. Real yq
 /// rejects this whole document at parse time (no yq behaviour to match
 /// either way).
+///
+/// Covers both container shapes -- the object branch and the array branch
+/// each carry their own `c.is_alias()` short-circuit in
+/// `push_generic_truthiness_cursor_error`, so an array-only test would
+/// leave the object branch's check unexercised.
 #[test]
 fn test_select_no_longer_raises_on_decode_failure_reachable_only_via_alias_1804() -> Result<()> {
     let doc = "a: &a [\"b\\qc\"]\nb: *a\n";
@@ -28214,6 +28219,20 @@ fn test_select_no_longer_raises_on_decode_failure_reachable_only_via_alias_1804(
 
     // Materializing through the alias still raises.
     let (_, stderr, code) = run_yq_stdin_with_stderr(".b[0]", doc, &[])?;
+    assert_ne!(code, 0, "stderr: {stderr:?}");
+    assert!(
+        stderr.contains("invalid escape sequence"),
+        "stderr: {stderr}"
+    );
+
+    // Same trade-off, mapping-target alias this time -- exercises the
+    // object branch's own `c.is_alias()` check.
+    let map_doc = "a: &a {x: \"b\\qc\"}\nb: *a\n";
+    let (stdout, stderr, code) = run_yq_stdin_with_stderr("select(.b) | 1", map_doc, &[])?;
+    assert_eq!(code, 0, "stderr: {stderr:?}");
+    assert_eq!(stdout.trim(), "1");
+
+    let (_, stderr, code) = run_yq_stdin_with_stderr(".b.x", map_doc, &[])?;
     assert_ne!(code, 0, "stderr: {stderr:?}");
     assert!(
         stderr.contains("invalid escape sequence"),

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -28131,6 +28131,98 @@ fn test_select_raises_on_yaml_decode_failure_nested_in_container_1645() -> Resul
     Ok(())
 }
 
+/// #1804: a document shaped as a chain of anchors each referencing the
+/// previous one twice (`aN: &aN [*a(N-1), *a(N-1)]`) made
+/// `push_generic_truthiness_cursor_error`'s subtree walk cost `O(2^N)` --
+/// every `select`/`if` condition unconditionally re-descended into both
+/// copies of each alias target. `DocumentCursor::is_alias` now short-circuits
+/// the walk at an alias node instead of resolving through it, since jq's own
+/// truthiness rule (a non-null container is truthy regardless of contents)
+/// needs none of what the walk would find inside.
+///
+/// Pinned as a timing regression guard, following
+/// `test_def_shadow_deep_nesting_does_not_blow_up_2036`'s pattern: 30 levels
+/// is deep enough that a *broken* `O(2^N)` walk would take an astronomical
+/// amount of time (`2^30` node visits), not merely a slow few seconds, so a
+/// generous margin still catches a real regression while tolerating this
+/// suite's own CPU contention (many tests spawn concurrent subprocesses).
+/// Confirmed live pre-fix: `select(.)` at N=24 took 3.07s (this test's
+/// N=30 would not finish within any reasonable bound); post-fix, N=30
+/// completes in single-digit milliseconds.
+///
+/// `if`/`select` only -- `and`/`or`/`not`/`//`/`any` are NOT fixed by this
+/// change (confirmed live: `.a20 and true` still took 109s at N=26) because
+/// `eval_single` has no native arm for them and they bridge through
+/// `full_eval` (the eager/materializing evaluator), which this walk is never
+/// consulted from. That gap is tracked separately, coupled to the #2416
+/// migration that would need to give them a native arm the way `if` already
+/// has one.
+#[test]
+fn test_select_and_if_truthiness_flat_over_alias_fanout_1804() -> Result<()> {
+    let mut doc = String::from("a0: &a0 leaf\n");
+    for i in 1..=30 {
+        doc.push_str(&format!("a{i}: &a{i} [*a{}, *a{}]\n", i - 1, i - 1));
+    }
+
+    let start = std::time::Instant::now();
+    let (stdout, stderr, code) = run_yq_stdin_with_stderr(".a30 | select(.) | length", &doc, &[])?;
+    let elapsed = start.elapsed();
+    assert_eq!(code, 0, "stderr: {stderr:?}");
+    assert_eq!(stdout.trim(), "2");
+    assert!(
+        elapsed < std::time::Duration::from_secs(15),
+        "select(.) over a 30-level alias fan-out took {elapsed:?} -- O(2^N) blowup regressed"
+    );
+
+    let start = std::time::Instant::now();
+    let (stdout, stderr, code) = run_yq_stdin_with_stderr("if .a30 then 1 else 2 end", &doc, &[])?;
+    let elapsed = start.elapsed();
+    assert_eq!(code, 0, "stderr: {stderr:?}");
+    assert_eq!(stdout.trim(), "1");
+    assert!(
+        elapsed < std::time::Duration::from_secs(15),
+        "if over a 30-level alias fan-out took {elapsed:?} -- O(2^N) blowup regressed"
+    );
+
+    Ok(())
+}
+
+/// #1804's accepted trade-off: not descending into an alias inside
+/// `select`'s corruption walk means a decode failure reachable *only*
+/// through an alias no longer raises from `select` itself. It still raises
+/// whenever the aliased field is visited directly, or the alias is
+/// materialized -- this walk is the only place that stops short. Real yq
+/// rejects this whole document at parse time (no yq behaviour to match
+/// either way).
+#[test]
+fn test_select_no_longer_raises_on_decode_failure_reachable_only_via_alias_1804() -> Result<()> {
+    let doc = "a: &a [\"b\\qc\"]\nb: *a\n";
+
+    // select(.b)'s condition walk no longer descends into the alias, so the
+    // nested decode failure inside it is never seen.
+    let (stdout, stderr, code) = run_yq_stdin_with_stderr("select(.b) | 1", doc, &[])?;
+    assert_eq!(code, 0, "stderr: {stderr:?}");
+    assert_eq!(stdout.trim(), "1");
+
+    // Visiting `.a` directly still raises.
+    let (_, stderr, code) = run_yq_stdin_with_stderr(".a", doc, &[])?;
+    assert_ne!(code, 0, "stderr: {stderr:?}");
+    assert!(
+        stderr.contains("invalid escape sequence"),
+        "stderr: {stderr}"
+    );
+
+    // Materializing through the alias still raises.
+    let (_, stderr, code) = run_yq_stdin_with_stderr(".b[0]", doc, &[])?;
+    assert_ne!(code, 0, "stderr: {stderr:?}");
+    assert!(
+        stderr.contains("invalid escape sequence"),
+        "stderr: {stderr}"
+    );
+
+    Ok(())
+}
+
 /// #1813: `colliding_display_key_error`'s uncatchability fix lives in
 /// shared `src/jq/error.rs`/`document.rs` code, reached identically by
 /// both evaluators -- confirms the fix applies to yq mode too, not just

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -28223,6 +28223,34 @@ fn test_select_no_longer_raises_on_decode_failure_reachable_only_via_alias_1804(
     Ok(())
 }
 
+/// Code review on #1804's fix: an earlier version of the alias
+/// short-circuit gated on `c.is_alias()` before knowing whether the
+/// resolved target was a container or a scalar -- so it also swallowed a
+/// decode failure reachable through a bare *scalar*-target alias, even
+/// though resolving a scalar target costs O(1) (no children to cascade
+/// through) and was never part of the O(2^N) fan-out this issue fixes.
+/// Confirmed live against the two binaries either side of that fix: this
+/// exact input raised pre-fix, silently passed with the broad gate, and
+/// raises again with the container-only gate. Unlike the sibling test
+/// above (`b: *a` where `a` is an *array*), this one aliases a bare
+/// scalar directly.
+#[test]
+fn test_select_still_raises_on_decode_failure_reachable_only_via_scalar_alias_1804() -> Result<()> {
+    let doc = "a: &a \"b\\qc\"\nb: *a\n";
+
+    let (stdout, stderr, code) = run_yq_stdin_with_stderr("select(.b) | 1", doc, &[])?;
+    assert_ne!(
+        code, 0,
+        "a decode failure reached through a scalar-target alias must still raise\nstdout: {stdout:?}\nstderr: {stderr:?}"
+    );
+    assert!(
+        stderr.contains("invalid escape sequence"),
+        "stderr: {stderr}"
+    );
+
+    Ok(())
+}
+
 /// #1813: `colliding_display_key_error`'s uncatchability fix lives in
 /// shared `src/jq/error.rs`/`document.rs` code, reached identically by
 /// both evaluators -- confirms the fix applies to yq mode too, not just


### PR DESCRIPTION
## Summary

- A document shaped as a chain of anchors each referencing the previous one twice (`aN: &aN [*a(N-1), *a(N-1)]`) made `push_generic_truthiness_cursor_error`'s subtree walk (`src/jq/eval_generic.rs`) cost `O(2^N)`: `select`/`if` conditions unconditionally re-descended into both copies of each alias target, even though jq's own truthiness rule (a non-null container is truthy regardless of contents) needs none of what lies inside.
- Adds `DocumentCursor::is_alias()` (`src/jq/document.rs`) — a compile-time hook, `false` by default so JSON monomorphizes it away entirely — overridden by `YamlCursor` (`src/yaml/light.rs`) via its existing O(1) `self.index.is_alias(self.bp_pos)` check (cheaper than the value-matching approach originally proposed in the triage, since it needs no `YamlValue` construction).
- `push_generic_truthiness_cursor_error` now returns `None` (does not descend) the moment it's called on an alias cursor, instead of resolving through it.

## Scope correction against the original triage

The 2026-09-04 triage on #1804 assumed `and`, `or`, `not`, `//`, and `any` all shared this same walk and would be fixed alongside `select`/`if`. That does not hold against the current codebase — confirmed live:

| Expr | Pre-fix @ N=24 | Post-fix @ N=24/26/30 |
|---|---|---|
| `select(.) \| length` | 3.07s | 0.00s (flat to N=30) |
| `if . then 1 else 2 end` | 3.16s | 0.00s (flat to N=30) |
| `. and true` | — | **109.35s @ N=26** (unfixed) |
| `(. // 1) \| length`, `[.]\|any`, `.\|not` | — | 1-2s @ N=20, same curve (unfixed) |

Root cause of the gap: `eval_single` has no native arm for `Expr::And`/`Expr::Or` (nor does `not`/`any` appear in a real evaluation arm anywhere in the file) — they fall through to the wildcard fallback, which bridges to `full_eval` (the eager/materializing evaluator) and never consults this walk at all. `Expr::If` was given a native, cursor-threaded arm as part of #2416 phase 3; `And`/`Or`/`Not`/`Alternative`/`Any` were not.

Filed **#2476** for that gap — it's real Tier 2/3 shared-evaluator migration work (giving 5+ more constructs a native arm the way `if` already has one), properly sequenced with/after #2416, not something to fold into this narrow fix.

## Test plan

- [x] `cargo build --features cli`
- [x] `cargo test --features cli,simd,regex,serde` (full workspace, 0 failures)
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings` (non-`scalar-yaml` leg)
- [x] `cargo fmt --check`
- [x] New tests in `tests/yq_cli_tests.rs` beside the #1645 truthiness tests:
  - `test_select_and_if_truthiness_flat_over_alias_fanout_1804`: 30-level alias fan-out, `select(.)`/`if` both correct and complete within a generous 15s bound (mirrors `test_def_shadow_deep_nesting_does_not_blow_up_2036`'s established pattern — deep enough that a broken `O(2^N)` walk would be astronomically slow, not just slow)
  - `test_select_no_longer_raises_on_decode_failure_reachable_only_via_alias_1804`: pins the accepted trade-off (a decode failure reachable *only* through an alias no longer raises from `select`'s condition walk, but still raises when the field is visited directly or the alias is materialized)
- [x] Real before/after timings captured against both the pre-fix (`main`) and post-fix binaries (see table above)

Fixes #1804.