### PR TITLE
fix(yaml): recurse into a merge source's own nested << during field lookup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -398,6 +398,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **YAML `<<` merge-key field *traversal* now recurses through a merge source's own nested
+  `<<`, instead of silently reading as `null`** (#1318). `resolve_merge_keys`/
+  `merge_field_into` only ever expand a mapping's own merge sources one hop deep — a
+  source's own `<<` field is copied into the merged view as a literal `"<<"` key, not
+  recursively resolved (unchanged; `keys`/`has`/`to_entries`/`.[]`/`-o json` all depend on
+  seeing that literal entry). But `YamlFields::find`/`find_cursor` — the lookup behind
+  every `.field` access — only ever scanned that one-hop view, so a name reachable only
+  two-or-more hops down a merge chain was invisible:
+
+  ```console
+  $ printf 'base: &base {x: 1}\nmid: &mid {<<: *base}\ntop: &top {<<: *mid}\nz: {<<: *top}\n' \
+      | succinctly yq '.z.x'
+  1                                  # was: null
+  ```
+
+  `find`/`find_cursor` now fall back to recursing into each merge source's own nested `<<`
+  (via the same `merge_sources` used for the one-hop case) when a name isn't found in the
+  mapping's own merged view — bounded by the existing `MAX_ALIAS_CHAIN_DEPTH` ceiling as a
+  stack-safety limit, since cycles are already rejected at build time but an acyclic chain
+  of sibling merges has no other bound. Verified live against yq v4.53.3 that when the name
+  is reachable through more than one nested source, the *last*-listed source in a `<<:
+  [...]` sequence wins, and the *last*-declared of two separate `<<:` fields on the same
+  mapping wins — matched by iterating both in reverse and returning the first hit.
+
 - **`succinctly yq`'s default (non-validating) YAML loader now rejects `&anchor *alias`
   (an alias node decorated with its own anchor or tag) at parse time, matching real yq and
   PyYAML** (#1374). Per the YAML 1.2 grammar an alias node carries no properties of its
@@ -405,10 +429,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   enforced this, but the default loader silently accepted it and built a walkable
   alias-to-alias chain from it — the *only* shape that can construct a multi-hop alias
   chain, and the root cause behind every multi-hop-chain bug this codebase has had
-  (#1193's stack-overflow DoS; #1315/#1318/#1319's single-hop-only accessor bugs, now
-  closed alongside this fix). `YamlIndex::build` now returns a new `YamlError::PropertyOnAlias`
-  for every spelling (block value, next line, flow sequence/mapping, mapping key, `!!str`
-  tag) rather than accepting it:
+  (#1193's stack-overflow DoS; #1315/#1319's single-hop-only accessor bugs, now closed
+  alongside this fix — #1318 turned out to be a different bug entirely, not an alias-chain
+  shape at all, and needed its own separate fix above). `YamlIndex::build` now returns a
+  new `YamlError::PropertyOnAlias` for every spelling (block value, next line, flow
+  sequence/mapping, mapping key, `!!str` tag) rather than accepting it:
 
   ```console
   $ printf 'a0: &a0 hello\na1: &a1 *a0\nz: *a1\n' | succinctly yq -o json '.'

--- a/docs/compliance/yaml/limitations.md
+++ b/docs/compliance/yaml/limitations.md
@@ -195,11 +195,13 @@ Three alias forms are refused at index build:
   properties of its own — carved out of the loader's usual "grammar isn't checked" policy
   because leaving it lenient had a specific, concrete cost: `&anchor *alias` is the *only*
   shape that can construct an alias chain more than one hop deep, so every multi-hop-chain
-  bug this codebase has ever had (#1193's stack-overflow DoS, #1315/#1318/#1319's
+  bug this codebase has ever had (#1193's stack-overflow DoS, #1315/#1319's
   single-hop-only accessor bugs) was reachable only through input real `yq` and PyYAML both
   already refuse. Both are confirmed live to reject every spelling (block value, next line,
   flow, mapping key, `!!str`-tagged) — this is not a case where matching means giving up an
-  advantage.
+  advantage. (#1318 looked like the same shape at first report but turned out to be a
+  different bug — nested `<<` merge-key *traversal*, not an alias chain — and needed its
+  own separate fix; see `CHANGELOG.md`.)
 
 ```
 $ printf 'a: &x {self: *x}\n' | succinctly yq '.'

--- a/src/yaml/light.rs
+++ b/src/yaml/light.rs
@@ -4343,6 +4343,15 @@ enum FieldsInner<'a, W> {
     Direct(Option<YamlCursor<'a, W>>),
     Merged {
         entries: Rc<Vec<(YamlCursor<'a, W>, YamlCursor<'a, W>)>>,
+        /// Each `<<` field's own raw value cursor, in encounter order —
+        /// kept alongside the collapsed `entries` so `find`/`find_cursor`
+        /// can recurse into a merge source's *own* nested `<<` when a name
+        /// isn't found in this level's one-hop view (#1318). `entries`
+        /// alone can't support that: when two sources each have their own
+        /// `<<`, both get copied into `entries` under the same literal
+        /// `"<<"` key and the second silently overwrites the first via
+        /// `upsert_field`, discarding one source's chain entirely.
+        merge_value_cursors: Rc<Vec<YamlCursor<'a, W>>>,
         index: usize,
     },
 }
@@ -4351,8 +4360,13 @@ impl<W> Clone for FieldsInner<'_, W> {
     fn clone(&self) -> Self {
         match self {
             FieldsInner::Direct(c) => FieldsInner::Direct(*c),
-            FieldsInner::Merged { entries, index } => FieldsInner::Merged {
+            FieldsInner::Merged {
+                entries,
+                merge_value_cursors,
+                index,
+            } => FieldsInner::Merged {
                 entries: entries.clone(),
+                merge_value_cursors: merge_value_cursors.clone(),
                 index: *index,
             },
         }
@@ -4385,9 +4399,10 @@ impl<'a, W: AsRef<[u64]>> YamlFields<'a, W> {
     pub fn from_mapping_cursor(mapping_cursor: YamlCursor<'a, W>) -> Self {
         let key_cursor = mapping_cursor.first_child();
         match resolve_merge_keys(key_cursor) {
-            Some(entries) => Self {
+            Some((entries, merge_value_cursors)) => Self {
                 inner: FieldsInner::Merged {
                     entries: Rc::new(entries),
+                    merge_value_cursors: Rc::new(merge_value_cursors),
                     index: 0,
                 },
             },
@@ -4414,7 +4429,7 @@ impl<'a, W: AsRef<[u64]>> YamlFields<'a, W> {
     pub fn is_empty(&self) -> bool {
         match &self.inner {
             FieldsInner::Direct(c) => c.is_none(),
-            FieldsInner::Merged { entries, index } => *index >= entries.len(),
+            FieldsInner::Merged { entries, index, .. } => *index >= entries.len(),
         }
     }
 
@@ -4436,12 +4451,17 @@ impl<'a, W: AsRef<[u64]>> YamlFields<'a, W> {
 
                 Some((field, rest))
             }
-            FieldsInner::Merged { entries, index } => {
+            FieldsInner::Merged {
+                entries,
+                merge_value_cursors,
+                index,
+            } => {
                 let &(key_cursor, value_cursor) = entries.get(*index)?;
 
                 let rest = Self {
                     inner: FieldsInner::Merged {
                         entries: entries.clone(),
+                        merge_value_cursors: merge_value_cursors.clone(),
                         index: index + 1,
                     },
                 };
@@ -4461,7 +4481,14 @@ impl<'a, W: AsRef<[u64]>> YamlFields<'a, W> {
     /// YAML permits duplicate mapping keys; per YAML 1.2 and to match `yq`,
     /// the last matching entry wins (see issue #174). A `Merged` list is
     /// already deduplicated, so this loop is a no-op scan for it.
+    ///
+    /// A name absent from this level falls back to recursing into any merge
+    /// source's own nested `<<` (#1318) — see `merge_fallback`'s doc comment.
     pub fn find(&self, name: &str) -> Option<YamlValue<'a, W>> {
+        self.find_at_depth(name, 0)
+    }
+
+    fn find_at_depth(&self, name: &str, depth: usize) -> Option<YamlValue<'a, W>> {
         let mut fields = self.clone();
         let mut result = None;
         while let Some((field, rest)) = fields.uncons() {
@@ -4477,7 +4504,7 @@ impl<'a, W: AsRef<[u64]>> YamlFields<'a, W> {
             }
             fields = rest;
         }
-        result
+        result.or_else(|| self.merge_fallback(name, depth).map(|c| c.value()))
     }
 
     /// Find a field by name and return a cursor to its value.
@@ -4485,7 +4512,14 @@ impl<'a, W: AsRef<[u64]>> YamlFields<'a, W> {
     /// Same last-duplicate-key-wins semantics as [`find`](Self::find) — kept
     /// as a separate loop rather than reusing `find` so the returned cursor
     /// (needed for `line`/`column`) doesn't require re-navigating.
+    ///
+    /// A name absent from this level falls back to recursing into any merge
+    /// source's own nested `<<` (#1318) — see `merge_fallback`'s doc comment.
     pub fn find_cursor(&self, name: &str) -> Option<YamlCursor<'a, W>> {
+        self.find_cursor_at_depth(name, 0)
+    }
+
+    fn find_cursor_at_depth(&self, name: &str, depth: usize) -> Option<YamlCursor<'a, W>> {
         let mut fields = self.clone();
         let mut result = None;
         while let Some((field, rest)) = fields.uncons() {
@@ -4498,7 +4532,65 @@ impl<'a, W: AsRef<[u64]>> YamlFields<'a, W> {
             }
             fields = rest;
         }
-        result
+        result.or_else(|| self.merge_fallback(name, depth))
+    }
+
+    /// Recurse into this mapping's own merge sources' *nested* `<<` when
+    /// `name` isn't found at this level (#1318).
+    ///
+    /// `resolve_merge_keys`/`merge_field_into` only expand a mapping's
+    /// *own* merge sources one hop deep — a source's own `<<` field is
+    /// copied into `entries` verbatim, as a literal `"<<"` key, not
+    /// recursively resolved (see their doc comments; that stays correct
+    /// and unchanged, since `keys`/`has`/`to_entries`/`.[]`/`-o json` all
+    /// depend on seeing that literal `"<<"` entry). So a name that exists
+    /// only two-or-more hops down a merge chain (`z: {<<: *top}`,
+    /// `top: {<<: *mid}`, `mid: {<<: *base}`, name only on `base`) is
+    /// invisible to `entries`'s flat scan above — this walks
+    /// `merge_value_cursors` (each `<<` field's own raw value cursor,
+    /// captured during `resolve_merge_keys`'s single pass) and recurses
+    /// into every source `merge_sources` names for it.
+    ///
+    /// Order matters: when two sources both carry the name only via their
+    /// *own* nested merge, real yq (v4.53.3, default flags) has the
+    /// last-listed source in a `<<: [...]` sequence win, and the
+    /// last-declared of two separate `<<:` fields on the same mapping win
+    /// (verified live; neither is the reverse of what `merge_field_into`'s
+    /// existing one-hop copy gives for a *shallow* conflict on the same
+    /// sources — that shallow-conflict precedence is a separate,
+    /// out-of-scope divergence, since a name present at this level never
+    /// reaches this fallback at all). Iterating both loops in reverse and
+    /// returning the first hit reproduces that: the last-declared `<<:`
+    /// field and its last-listed source are tried first.
+    ///
+    /// `merge_sources` cannot form a cycle (`YamlIndex::build` rejects
+    /// alias cycles before any traversal runs — `validate_alias_acyclicity`
+    /// in `src/yaml/index.rs`), but nothing bounds a long *acyclic* chain
+    /// of sibling merges, so `depth` is checked against the same
+    /// `MAX_ALIAS_CHAIN_DEPTH` ceiling `resolve_alias_chain` uses for the
+    /// same class of hazard, purely as a stack-safety limit.
+    fn merge_fallback(&self, name: &str, depth: usize) -> Option<YamlCursor<'a, W>> {
+        let FieldsInner::Merged {
+            merge_value_cursors,
+            ..
+        } = &self.inner
+        else {
+            return None;
+        };
+
+        assert_depth(depth, MAX_ALIAS_CHAIN_DEPTH);
+
+        for &merge_value_cursor in merge_value_cursors.iter().rev() {
+            for source in merge_sources(merge_value_cursor).into_iter().rev() {
+                if let Some(hit) =
+                    YamlFields::from_mapping_cursor(source).find_cursor_at_depth(name, depth + 1)
+                {
+                    return Some(hit);
+                }
+            }
+        }
+
+        None
     }
 }
 
@@ -4511,6 +4603,15 @@ impl<'a, W: AsRef<[u64]>> Iterator for YamlFields<'a, W> {
         Some(field)
     }
 }
+
+/// `resolve_merge_keys`'s result: the collapsed, deduplicated one-hop field
+/// list, paired with each `<<` field's own raw value cursor in encounter
+/// order (used by `YamlFields::merge_fallback` to recurse into a merge
+/// source's *own* nested `<<` — see that function's doc comment, #1318).
+type MergedFields<'a, W> = (
+    Vec<(YamlCursor<'a, W>, YamlCursor<'a, W>)>,
+    Vec<YamlCursor<'a, W>>,
+);
 
 /// Resolve YAML merge keys (`<<`) into an ordered, deduplicated field list.
 ///
@@ -4538,7 +4639,11 @@ impl<'a, W: AsRef<[u64]>> Iterator for YamlFields<'a, W> {
 ///   folded last).
 /// - A merge source's own fields are taken verbatim: a `<<` key nested
 ///   inside a source is copied as an ordinary key, not expanded recursively.
-///   yq does not recurse into a merged-in mapping's own merge key.
+///   This merged *view* (what `keys`/`has`/`to_entries`/`.[]`/`-o json` see)
+///   is not recursed for the merged-in mapping's own merge key — but name
+///   *traversal* is: `YamlFields::find`/`find_cursor` falls back to
+///   recursing into it when a name isn't found here (`merge_fallback`,
+///   #1318).
 /// - An invalid merge value (null, scalar, an alias that doesn't resolve to
 ///   a mapping, or a non-mapping sequence element) contributes nothing
 ///   rather than erroring, matching yq's silent-skip behavior.
@@ -4572,7 +4677,7 @@ impl<'a, W: AsRef<[u64]>> Iterator for YamlFields<'a, W> {
 /// key is confirmed to exist.
 fn resolve_merge_keys<'a, W: AsRef<[u64]>>(
     first_key: Option<YamlCursor<'a, W>>,
-) -> Option<Vec<(YamlCursor<'a, W>, YamlCursor<'a, W>)>> {
+) -> Option<MergedFields<'a, W>> {
     let mut fields = YamlFields::raw(first_key);
     let mut seen: Vec<(YamlCursor<'a, W>, YamlCursor<'a, W>, YamlValue<'a, W>)> = Vec::new();
 
@@ -4584,16 +4689,23 @@ fn resolve_merge_keys<'a, W: AsRef<[u64]>>(
             let mut entries: Vec<(YamlCursor<'a, W>, YamlCursor<'a, W>)> =
                 Vec::with_capacity(seen.len() + 1);
             let mut positions: BTreeMap<String, usize> = BTreeMap::new();
+            // Each `<<` field's own raw value cursor, in encounter order —
+            // see `FieldsInner::Merged::merge_value_cursors`'s doc comment
+            // for why `entries` alone can't support `find`/`find_cursor`'s
+            // nested-merge fallback (#1318).
+            let mut merge_value_cursors: Vec<YamlCursor<'a, W>> = Vec::new();
 
             for (key, value, key_value) in seen {
                 upsert_field(&mut entries, &mut positions, key, value, &key_value);
             }
+            merge_value_cursors.push(field.value_cursor);
             merge_field_into(&mut entries, &mut positions, field.value_cursor);
 
             fields = rest;
             while let Some((field, rest)) = fields.uncons() {
                 let key_value = field.key_cursor.value();
                 if is_merge_key_value(&key_value) {
+                    merge_value_cursors.push(field.value_cursor);
                     merge_field_into(&mut entries, &mut positions, field.value_cursor);
                 } else {
                     upsert_field(
@@ -4607,7 +4719,7 @@ fn resolve_merge_keys<'a, W: AsRef<[u64]>>(
                 fields = rest;
             }
 
-            return Some(entries);
+            return Some((entries, merge_value_cursors));
         }
 
         seen.push((field.key_cursor, field.value_cursor, key_value));

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -5602,6 +5602,103 @@ fn test_yaml_merge_key_field_access_still_resolves_712() -> Result<()> {
     Ok(())
 }
 
+/// #1318: `resolve_merge_keys`/`merge_field_into` expand a mapping's own
+/// merge sources only one hop deep, copying a source's own `<<` field into
+/// the merged view as a literal `"<<"` key rather than recursively
+/// resolving it - so a name reachable only two-or-more hops down a merge
+/// chain (here, `x`/`y` are only ever explicit on `base`, never on `mid` or
+/// `top`) was silently invisible to `find`/`find_cursor`'s flat scan and
+/// read as `null`, even though real yq (v4.53.3) resolves it. Confirmed
+/// live against real yq for every assertion below, including the ones that
+/// must stay unchanged (`has`, `-o json`'s literal `"<<"` entry).
+#[test]
+fn test_yaml_merge_key_nested_traversal_resolves_1318() -> Result<()> {
+    let input = "base: &base {x: 1, y: 2, q: 0}\nmid: &mid { <<: *base, y: 5 }\ntop: &top { <<: *mid, q: 9 }\nz:   { <<: [*top], y: 99 }\n";
+
+    let (output, exit_code) = run_yq_stdin(".z.x", input, &[])?;
+    assert_eq!(exit_code, 0);
+    assert_eq!(
+        output.trim(),
+        "1",
+        "z.x should resolve through z -> top -> mid -> base"
+    );
+
+    let (output, exit_code) = run_yq_stdin(".top.x", input, &[])?;
+    assert_eq!(exit_code, 0);
+    assert_eq!(
+        output.trim(),
+        "1",
+        "top.x should resolve through top -> mid -> base"
+    );
+
+    let (output, exit_code) = run_yq_stdin(".z.q", input, &[])?;
+    assert_eq!(exit_code, 0);
+    assert_eq!(output.trim(), "9", "top's own override of q must still win");
+
+    let (output, exit_code) = run_yq_stdin(".z[\"x\"]", input, &[])?;
+    assert_eq!(exit_code, 0);
+    assert_eq!(
+        output.trim(),
+        "1",
+        "bracket indexing shares find_cursor with plain field access"
+    );
+
+    // Unchanged: `has` never expands beyond the one-hop merged view.
+    let (output, exit_code) = run_yq_stdin(".z | has(\"x\")", input, &[])?;
+    assert_eq!(exit_code, 0);
+    assert_eq!(output.trim(), "false");
+
+    // Unchanged: the merged view's own literal "<<" entry, and -o json's
+    // rendering of it, are untouched by this fix.
+    let (output, exit_code) = run_yq_stdin(".z", input, &["-o", "json", "-I0"])?;
+    assert_eq!(exit_code, 0);
+    assert_eq!(output.trim(), r#"{"<<":{"x":1,"y":5,"q":0},"q":9,"y":99}"#);
+
+    Ok(())
+}
+
+/// #1318: two sources merged via a `<<: [*a, *b]` sequence, where the
+/// queried field exists only inside each source's *own* nested `<<` (never
+/// copied into the one-hop merged view at all). Real yq (v4.53.3, default
+/// flags) has the last-listed source win here - confirmed live, and
+/// independently verified this is not simply "first-listed wins reversed":
+/// swapping declaration order without changing sequence order left the
+/// result unchanged, and swapping sequence order without changing
+/// declaration order flipped it.
+#[test]
+fn test_yaml_merge_key_nested_multi_source_last_listed_wins_1318() -> Result<()> {
+    let input = "deep1: &deep1 {w: 1}\nmid1: &mid1 {<<: *deep1}\ndeep2: &deep2 {w: 2}\nmid2: &mid2 {<<: *deep2}\nz: {<<: [*mid1, *mid2]}\n";
+    let (output, exit_code) = run_yq_stdin(".z.w", input, &[])?;
+    assert_eq!(exit_code, 0);
+    assert_eq!(output.trim(), "2");
+    Ok(())
+}
+
+/// #1318: two *separate* `<<:` fields on the same mapping (not one
+/// sequence), each resolving to a different nested-only chain. Real yq
+/// (v4.53.3, default flags) has the later-declared `<<:` field win -
+/// confirmed live.
+#[test]
+fn test_yaml_merge_key_nested_duplicate_merge_fields_last_declared_wins_1318() -> Result<()> {
+    let input = "deepA: &deepA {w: 1}\nmidA: &midA {<<: *deepA}\ndeepB: &deepB {w: 2}\nmidB: &midB {<<: *deepB}\nz: {<<: *midA, <<: *midB}\n";
+    let (output, exit_code) = run_yq_stdin(".z.w", input, &[])?;
+    assert_eq!(exit_code, 0);
+    assert_eq!(output.trim(), "2");
+    Ok(())
+}
+
+/// #1318: an own explicit field must still beat a value only reachable via
+/// the nested-merge fallback - the fallback must never even trigger when
+/// the one-hop merged view already has an answer.
+#[test]
+fn test_yaml_merge_key_own_field_beats_nested_fallback_1318() -> Result<()> {
+    let input = "deep1: &deep1 {w: 1}\nmid1: &mid1 {<<: *deep1}\nz: {<<: [*mid1], w: 99}\n";
+    let (output, exit_code) = run_yq_stdin(".z.w", input, &[])?;
+    assert_eq!(exit_code, 0);
+    assert_eq!(output.trim(), "99");
+    Ok(())
+}
+
 #[test]
 fn test_yaml_mapping_anchor_preserved_on_query_result_712() -> Result<()> {
     // A query result whose OWN cursor carries the anchor (not a nested


### PR DESCRIPTION
## Summary

`YamlFields::find`/`find_cursor` in `src/yaml/light.rs` — the lookup behind every `.field` access in `succinctly yq` — only scanned a mapping's own one-hop merged view. `resolve_merge_keys`/`merge_field_into` correctly collapse a mapping's own merge sources one hop deep, but a source's own nested `<<` field is copied into that view as a literal `"<<"` key, not recursively resolved. So a field reachable only two-or-more hops down a merge chain was invisible to the flat scan and silently read as `null`, even though real yq (v4.53.3) resolves it.

```console
$ printf 'base: &base {x: 1}\nmid: &mid {<<: *base}\ntop: &top {<<: *mid}\nz: {<<: *top}\n' | succinctly yq '.z.x'
1                                  # was: null
```

`find`/`find_cursor` now fall back to recursing into each merge source's own nested `<<` (via the same `merge_sources` used for the one-hop case) when a name isn't found in the mapping's own merged view. This requires knowing each `<<` field's own raw value cursor, not just the collapsed entries — a new `merge_value_cursors` list, captured alongside `resolve_merge_keys`'s existing single pass (no new scan), since the existing merged view can lose a source's chain entirely when two sources each have their own `<<` (both get copied under the same literal `"<<"` key, and the second silently overwrites the first).

Recursion is bounded by the existing `MAX_ALIAS_CHAIN_DEPTH` ceiling as a stack-safety limit — cycles are already impossible via `YamlIndex::build`'s acyclicity check, but nothing else bounds a pathologically long acyclic chain of sibling merges.

## Precedence verified live, not assumed

Verified against real yq v4.53.3 (default flags) that when a name is reachable through more than one nested source, the **last**-listed source in a `<<: [...]` sequence wins, and the **last**-declared of two separate `<<:` fields on the same mapping wins — matched by iterating both candidate lists in reverse and returning the first hit. Also confirmed an own explicit/merged field still beats the nested fallback (the fallback only ever triggers when the existing one-hop view has no answer at all).

## Also fixed (same PR)

`CHANGELOG.md` and `docs/compliance/yaml/limitations.md` incorrectly stated #1318 was "closed alongside" #1374 — confirmed live that #1374 (which rejects `&anchor *alias`) never touches this bug's shape (an anchor decorating a mapping that itself contains `<<`, not an alias node). Both corrected, and a fresh `CHANGELOG.md` entry added for the actual fix.

## Out of scope (filed as #2478)

While verifying multi-source precedence I found `merge_field_into`'s existing shallow (non-nested) `<<: [a, b]` conflict resolution matches yq's `--yaml-fix-merge-anchor-to-spec=true` mode (first-listed wins) rather than its actual default (last-listed wins). This is a separate, previously-untracked divergence that lives entirely in code this PR's triage explicitly said not to touch (`merge_field_into`/`resolve_merge_keys`, which `keys`/`has`/`to_entries`/`-o json` all depend on staying unchanged) — filed as #2478 rather than fixed here.

Fixes #1318

## Test plan

- [x] `cargo build --features cli` / `cargo test --features cli` (full suite: 3500+ unit tests, 1482 `yq_cli_tests`, all green)
- [x] `cargo test --no-default-features` (no_std check)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` and the scalar-yaml-covering second feature combo
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features`
- [x] `cargo fmt --check`
- [x] 4 new regression tests: the issue's 3-level chain fixture (plus `has`/`-o json` unchanged-output guards), multi-source-sequence deep-only-conflict precedence, duplicate-`<<`-fields deep-only-conflict precedence, own-field-beats-nested-fallback
- [x] Manually re-verified all repros against the built binary and compared to live `yq` v4.53.3 output