### PR TITLE
fix(jq): yq's context-list rules for a pipe into a union, the identity union, and operator fan-out (#2451)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,43 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **`succinctly yq` now evaluates over a *context list*, as real yq does — a pipe
+  into a union is branch-major, a union of two bare identities yields the list
+  once, and binary operators fan out left-major** (#2451). Real yq has no scalar
+  evaluation mode: `Context.MatchingNodes` (`pkg/yqlib/context.go`, v4.53.3) is
+  always a list, `|` hands its left side's whole list to its right side in one
+  call, and every operator decides for itself how to fan out over it. succinctly
+  piped each value independently, as jq does. Per ADR-0018 rule 2 the mode
+  decides, never the input format, so `succinctly jq` is unchanged:
+
+  ```console
+  $ printf 'a: {c: 3, d: 4}\nb: {c: 5, d: 6}\n' | succinctly yq -o=json -I0 '(.a, .b) | (.c, .d)'
+  3                                  # was: 3 4 5 6
+  5                                  # real yq v4.53.3 prints 3 5 4 6
+  4
+  6
+  $ printf 'a: {c: 3}\nb: {c: 5}\n' | succinctly yq -o=json -I0 '(.a, .b) | (., .)'
+  {"c":3}                            # was: each object twice
+  {"c":5}                            # real yq prints each once
+  $ printf 'a: {c: 3}\nb: {c: 5}\n' | succinctly yq -o=json -I0 '(.a.c, .b.c) + (1, 10)'
+  4                                  # was: 4 6 13 15
+  13                                 # real yq prints 4 13 6 15
+  6
+  15
+  ```
+
+  The three rules are yq's own: `,` runs each branch across the whole list and
+  concatenates branch-major (`operator_union.go`); it appends its right operand
+  only when the two operands return different backing lists, which `.` never
+  does (`operator_self.go` returns its input context verbatim), so `(., .)`
+  de-duplicates and a chain of `n` dots yields `max(1, n - 1)` copies; and
+  `doCrossFunc` (`operators.go`) loops the left operand outermost, re-evaluating
+  the right one per left match, where jq loops the other way. **Any yq-mode
+  filter whose output order or count depended on the old per-element model
+  changes.** `and`/`or` are unaffected (already left-major in both tools), and so
+  is `--eval-all`'s document-level fan-out, which needs a separate mechanism
+  (#2427).
+
 - **`succinctly yq` now ranks `|` above `,`, as real yq does — `A, B | C` means
   `A, (B | C)` in yq mode, not jq's `(A, B) | C`** (#2420). yq's parser is a
   shunting-yard operator-precedence parser and its own table

--- a/docs/compliance/yq/limitations.md
+++ b/docs/compliance/yq/limitations.md
@@ -303,10 +303,13 @@ numbering is right even though the shape of the evaluation is not.
 This is not fixable in the CLI runner alone: a per-document loop would repair `.name`,
 `keys`, `del` and `select(file_index == 1)` but would print `[.]` twice and `. + {"z": 9}`
 twice, both still wrong. The evaluation model is the same one
-[#2451](https://github.com/rust-works/succinctly/issues/2451) records for `(.a, .b) |
+[#2451](https://github.com/rust-works/succinctly/issues/2451) implements for `(.a, .b) |
 (.c, .d)` inside a single document -- yq's `,` and its `ea` both build a context list, and
-every operator is defined over lists -- so the fix is one yq-mode rule for "an expression
-over a context list", decided under #2451 and applied here. Tracked as
+every operator is defined over lists. #2451's three rules already apply on this path
+(`--eval-all`'s union ordering is branch-major with them), but what makes `[.]` collect
+once and `. + {"z": 9}` go cartesian across documents is a *different* mechanism:
+`EvaluateTogether` (`pkg/yqlib/utils.go:85`), a per-node flag set only by the all-at-once
+multi-file reader. Tracked as
 [#2427](https://github.com/rust-works/succinctly/issues/2427); the stray `---` that plain
 multi-file `succinctly yq` prints between files, and the always-0 `file_index` on that
 non-`ea` path, are the same issue's other two divergences.
@@ -2370,7 +2373,7 @@ agreeing here is what makes that removal safe on the `.0`-suffixed case.
 [#2419](https://github.com/rust-works/succinctly/issues/2419) is the ADR-0018 record for
 what is left.
 
-### Comma binds looser than pipe in real yq — the grouping is resolved (#2420); two evaluation-model residuals remain (#2451, #2452)
+### Comma binds looser than pipe in real yq — the grouping is resolved (#2420), the evaluation model with it (#2451); one residual remains (#2452)
 
 Real yq's parser is a shunting-yard operator-precedence parser
 ([`pkg/yqlib/expression_postfix.go`](https://github.com/mikefarah/yq/blob/v4.53.3/pkg/yqlib/expression_postfix.go)),
@@ -2492,16 +2495,18 @@ untouched (`test_jq_comma_still_binds_tighter_than_pipe_2420`). Three
 existing yq-mode tests that had encoded jq's grouping were re-captured against
 the pinned binary rather than kept.
 
-Two divergences the capture exposed are **not** precedence and stay open,
-pinned as residuals in `test_yq_pipe_precedence_residual_divergences_2420`:
+Two divergences the capture exposed are **not** precedence. The first is now
+fixed; the second stays open, pinned as the residual in
+`test_yq_pipe_precedence_residual_divergences_2420`:
 
-- [#2451](https://github.com/rust-works/succinctly/issues/2451): real yq
-  applies a pipe's right side to the whole *list* its left side produced, so
-  `(.a, .b) | (.c, .d)` on `a: {c: 3, d: 4}` / `b: {c: 5, d: 6}` prints
-  `3 5 4 6` in yq and `3 4 5 6` here (jq's per-element order). Both sides are
-  parenthesised, so no grouping rule reaches it; the oracle sweep's
-  `comma_stream` class is this divergence, which is why it did not flip when
-  the precedence fix landed.
+- [#2451](https://github.com/rust-works/succinctly/issues/2451) — **resolved.**
+  Real yq applies a pipe's right side to the whole *list* its left side
+  produced, so `(.a, .b) | (.c, .d)` on `a: {c: 3, d: 4}` / `b: {c: 5, d: 6}`
+  prints `3 5 4 6`; succinctly printed jq's per-element `3 4 5 6`. Both sides
+  are parenthesised, so no grouping rule reaches it — this was the evaluation
+  model, and yq-mode now implements it (see
+  [the context-list section](#yqs-context-list-evaluation-model-in-a-single-document-2451)).
+  The oracle sweep's `comma_stream` class is gone with it.
 - [#2452](https://github.com/rust-works/succinctly/issues/2452): under yq's
   own grouping `.a | .b, .c | . + 1` fails in its first branch; real yq drops
   that branch silently and exits 0, succinctly raises as jq does.
@@ -2510,6 +2515,55 @@ The `length` row above is also two things at once: real yq's rendered-width
 rule for scalars, and a succinctly-internal inconsistency where the comma
 fan-out path still applies jq's absolute-value rule
 ([#2453](https://github.com/rust-works/succinctly/issues/2453)).
+
+### yq's context-list evaluation model in a single document (#2451)
+
+Real yq has no scalar evaluation mode. `Context.MatchingNodes`
+([`pkg/yqlib/context.go`](https://github.com/mikefarah/yq/blob/v4.53.3/pkg/yqlib/context.go))
+is always a *list*, `|` hands its left side's whole list to its right side in one call
+([`operator_pipe.go`](https://github.com/mikefarah/yq/blob/v4.53.3/pkg/yqlib/operator_pipe.go)),
+and each operator decides for itself how to fan out over it.
+[#2451](https://github.com/rust-works/succinctly/issues/2451) implements the three rules
+that follow from that for a single document, in `succinctly yq` only (ADR-0018 rule 2 —
+mode decides; `succinctly jq` keeps jq's model unchanged):
+
+1. **A pipe into a union is branch-major.** `,`
+   ([`operator_union.go`](https://github.com/mikefarah/yq/blob/v4.53.3/pkg/yqlib/operator_union.go))
+   evaluates each of its branches against the same whole list and concatenates the branch
+   results in order, so `(.a, .b) | (.c, .d)` is `3 5 4 6`, not jq's `3 4 5 6`.
+2. **A union of two bare identities yields the list once.** `,` appends its right operand
+   only when the two operands return different backing lists (a Go pointer comparison,
+   there so two self-modifying operands are not double-counted), and `.` returns its input
+   context object verbatim. With right-associative chaining that gives `2 2 4 6 8` output
+   lines for one to five `.` branches over a two-element context.
+3. **Binary operators fan out left-major.** `doCrossFunc`
+   ([`operators.go`](https://github.com/mikefarah/yq/blob/v4.53.3/pkg/yqlib/operators.go))
+   loops the left operand's matches outermost and re-evaluates the right operand inside
+   that loop, so `(.a.c, .b.c) + (1, 10)` is `4 13 6 15` where jq gives `4 6 13 15`.
+
+Three related divergences are **not** covered and stay open:
+
+- **`EvaluateTogether`** ([#2427](https://github.com/rust-works/succinctly/issues/2427)) is
+  what makes `[...]` collect once across documents and binary operators go cartesian under
+  `--eval-all`. It is a flag on the document nodes the all-at-once multi-file reader
+  builds, never set inside a single document, so it changes nothing here — see
+  [the `--eval-all` section](#--eval-all-slurps-the-documents-into-one-array-real-yq-ea-evaluates-over-a-context-list-of-them-2427).
+- **A union of two assignments.** yq's pointer guard also fires for two operands that both
+  hand back the *same, mutated* context, which is the case its own source comment names:
+  `yq '(.a.c = 1), (.b.c = 2)'` prints **one** document carrying both writes. succinctly's
+  assignments each return an independently edited document, so it prints two, each with one
+  write. Collapsing the pair the way rule 2 does would *discard* the second write rather
+  than de-duplicate it, so rule 2 is deliberately restricted to identity-transparent
+  operands. Shared-node assignment is the same missing mechanism as the alias-node identity
+  [the anchor-soundness section](#anchor-soundness-never-emit-yaml-we-cannot-read-back--rule-4a)
+  records.
+- **A missing-key stage in front of a union.** Rule 1 carries its context list as cursors,
+  and an absent position (`.a.x` where `x` is not a key) is not a cursor, so a pipe whose
+  prefix can land on one keeps spine 2416's path-context walk instead — which is exact for
+  those pipes but element-major. `.a.x | (key, path)` is therefore right (`"x"`,
+  `["a","x"]`), while `(.a, .b) | .c | (key, path)` keeps jq's interleaving. Every
+  multi-valued shape the oracle sweep exercises has either an empty prefix or an iterating
+  one (`.a[]`), neither of which can yield an absent node, so the sweep is clean.
 
 ### Other categories
 

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -272,6 +272,14 @@ pub trait EvalSemantics: Copy + Default {
     /// comment carries the table and the six internal yq inconsistencies it
     /// reproduces bug-for-bug (ADR-0018 rule 3).
     const EMPTY_OPERAND_BINARY_RULE: bool;
+
+    /// If true (yq, #2451), a binary operator loops its **left** operand
+    /// outermost and re-evaluates the right one per left match. If false
+    /// (jq), the right operand is the outer loop.
+    ///
+    /// See `BinaryFanoutRules::left_major` (this module, private) for the
+    /// captured rows and the yq source this reproduces.
+    const BINARY_FANOUT_IS_LEFT_MAJOR: bool;
 }
 
 /// jq-compatible evaluation semantics (default).
@@ -301,6 +309,7 @@ impl EvalSemantics for JqSemantics {
     const UTF8_LOSSY_USES_JQ_MAXIMAL_SUBPART_RULE: bool = true;
     const ROOT_PATH_CONTEXT_YIELDS_NOTHING: bool = false;
     const EMPTY_OPERAND_BINARY_RULE: bool = false;
+    const BINARY_FANOUT_IS_LEFT_MAJOR: bool = false;
 }
 
 /// yq-compatible evaluation semantics.
@@ -332,6 +341,7 @@ impl EvalSemantics for YqSemantics {
     const UTF8_LOSSY_USES_JQ_MAXIMAL_SUBPART_RULE: bool = false;
     const ROOT_PATH_CONTEXT_YIELDS_NOTHING: bool = true;
     const EMPTY_OPERAND_BINARY_RULE: bool = true;
+    const BINARY_FANOUT_IS_LEFT_MAJOR: bool = true;
 }
 
 use crate::json::light::{JsonCursor, JsonElements, JsonFields, StandardJson};
@@ -435,11 +445,42 @@ pub(crate) fn yq_empty_operand_output(
     }
 }
 
-/// `Some(op)` in yq mode, `None` in jq mode -- the single per-mode gate on
-/// [`yq_empty_operand_output`], so no call site spells the `S::` const out
-/// itself (#2460).
-pub(crate) fn empty_operand_rule<S: EvalSemantics>(op: EmptyOperandOp) -> Option<EmptyOperandOp> {
-    S::EMPTY_OPERAND_BINARY_RULE.then_some(op)
+/// The two per-mode rules a binary-operator fanout needs, resolved once from
+/// `S` so no call site spells an `S::` const out itself.
+///
+/// One struct rather than two arguments because both are read by the same
+/// loop and every call site supplies both: [`binary_fanout_rules`] is the
+/// single place either is decided.
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct BinaryFanoutRules {
+    /// `Some(op)` in yq mode, `None` in jq mode -- the gate on
+    /// [`yq_empty_operand_output`] (#2460).
+    pub(crate) empty: Option<EmptyOperandOp>,
+    /// `true` in yq mode (#2451): the **left** operand is the outer loop and
+    /// the right is re-evaluated per left match, matching
+    /// `doCrossFunc`/`resultsForRHS` (`pkg/yqlib/operators.go:113-138`,
+    /// v4.53.3). `false` in jq mode, which loops the other way round.
+    ///
+    /// Live-captured on `a: {c: 3, d: 4}\nb: {c: 5, d: 6}\nn: [1, 2, 3]`:
+    ///
+    /// | filter                     | yq v4.53.3      | jq 1.7.1        |
+    /// |----------------------------|-----------------|-----------------|
+    /// | `(.a.c, .b.c) + (1, 10)`   | `4 13 6 15`     | `4 6 13 15`     |
+    /// | `(.n[0], .n[1]) - (1, 2)`  | `0 -1 1 0`      | `0 1 -1 0`      |
+    /// | `.n[] + .n[]`              | `2 3 4 3 4 5 4 5 6` | (identical) |
+    ///
+    /// `and`/`or` need no flag: [`boolean_fanout_core`] has always looped the
+    /// left operand outermost (jq short-circuits per left output), which is
+    /// already yq's order.
+    pub(crate) left_major: bool,
+}
+
+/// The one place either binary-fanout rule is read off `S` (#2460/#2451).
+pub(crate) fn binary_fanout_rules<S: EvalSemantics>(op: EmptyOperandOp) -> BinaryFanoutRules {
+    BinaryFanoutRules {
+        empty: S::EMPTY_OPERAND_BINARY_RULE.then_some(op),
+        left_major: S::BINARY_FANOUT_IS_LEFT_MAJOR,
+    }
 }
 
 /// The value a path-context builtin standing on the document root falls back
@@ -3874,7 +3915,7 @@ fn eval_each<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
             left,
             right,
             optional,
-            empty_operand_rule::<S>(EmptyOperandOp::Compare(*op)),
+            binary_fanout_rules::<S>(EmptyOperandOp::Compare(*op)),
             |left_val, right_val| {
                 Ok(OwnedValue::Bool(apply_compare_op::<S>(
                     *op, &left_val, &right_val,
@@ -3898,7 +3939,7 @@ fn eval_each<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
             left,
             right,
             optional,
-            empty_operand_rule::<S>(EmptyOperandOp::Arith(*op)),
+            binary_fanout_rules::<S>(EmptyOperandOp::Arith(*op)),
             |left_val, right_val| arith_combine::<S>(*op, left_val, right_val),
             sink,
         ),
@@ -5403,7 +5444,7 @@ fn binary_fanout_core<'a, W: Clone + AsRef<[u64]>>(
     left: &Expr,
     right: &Expr,
     optional: bool,
-    empty_rule: Option<EmptyOperandOp>,
+    rules: BinaryFanoutRules,
     combine: impl FnMut(OwnedValue, OwnedValue) -> Result<OwnedValue, EvalError>,
 ) -> QueryResult<'a, W> {
     let mut out: Vec<OwnedValue> = Vec::new();
@@ -5412,7 +5453,7 @@ fn binary_fanout_core<'a, W: Clone + AsRef<[u64]>>(
         left,
         right,
         optional,
-        empty_rule,
+        rules,
         combine,
         &mut |item: Item<'a, W>| {
             out.push(item.into_owned_from_owned_producer());
@@ -5431,7 +5472,9 @@ fn binary_fanout_core<'a, W: Clone + AsRef<[u64]>>(
     }
 }
 
-/// The one definition of jq's right-outer/left-inner fanout loop, written
+/// The one definition of the binary-operator fanout loop -- jq's
+/// right-outer/left-inner, and (since #2451) yq's left-outer/right-inner,
+/// chosen by [`BinaryFanoutRules::left_major`] -- written
 /// against the demand-driven sink (#1459, Stage 4 of
 /// `docs/plan/jq-lazy-generator-consumers.md`) and parameterized over *how*
 /// an operand is enumerated.
@@ -5484,7 +5527,7 @@ fn binary_fanout_each<'a, W: Clone + AsRef<[u64]>>(
     left: &Expr,
     right: &Expr,
     optional: bool,
-    empty_rule: Option<EmptyOperandOp>,
+    rules: BinaryFanoutRules,
     mut combine: impl FnMut(OwnedValue, OwnedValue) -> Result<OwnedValue, EvalError>,
     sink: &mut dyn FnMut(Item<'a, W>) -> Demand,
 ) -> Flow {
@@ -5496,23 +5539,39 @@ fn binary_fanout_each<'a, W: Clone + AsRef<[u64]>>(
     // count can be answered from `yq_empty_operand_output` instead of
     // silently contributing no pairings. `None` in jq mode, where `1 + empty`
     // really is nothing.
-    let mut right_seen = 0usize;
+    let mut outer_seen = 0usize;
+    // #2451: which operand drives the outer loop. jq re-evaluates the *left*
+    // operand per right output; yq re-evaluates the *right* one per left
+    // output (`doCrossFunc`, `pkg/yqlib/operators.go:113-138`). Only the
+    // nesting swaps -- `combine` still receives (left, right) either way, and
+    // #2460's empty-operand rule is symmetric in the two, so it needs no
+    // second spelling here.
+    let (outer_expr, inner_expr) = if rules.left_major {
+        (left, right)
+    } else {
+        (right, left)
+    };
 
-    let outer = each_operand(right, &mut |right_item: Item<'a, W>| {
-        right_seen += 1;
-        let right_val = match checked_fanout_operand(right_item, &mut abort) {
+    let outer = each_operand(outer_expr, &mut |outer_item: Item<'a, W>| {
+        outer_seen += 1;
+        let outer_val = match checked_fanout_operand(outer_item, &mut abort) {
             Ok(v) => v,
             Err(demand) => return demand,
         };
 
-        let mut left_seen = 0usize;
-        let inner = each_operand(left, &mut |left_item: Item<'a, W>| {
-            left_seen += 1;
-            let left_val = match checked_fanout_operand(left_item, &mut abort) {
+        let mut inner_seen = 0usize;
+        let inner = each_operand(inner_expr, &mut |inner_item: Item<'a, W>| {
+            inner_seen += 1;
+            let inner_val = match checked_fanout_operand(inner_item, &mut abort) {
                 Ok(v) => v,
                 Err(demand) => return demand,
             };
-            match combine(left_val, right_val.clone()) {
+            let (left_val, right_val) = if rules.left_major {
+                (outer_val.clone(), inner_val)
+            } else {
+                (inner_val, outer_val.clone())
+            };
+            match combine(left_val, right_val) {
                 Ok(v) => sink(Item::Owned(v)),
                 Err(e) => {
                     // The sink-world spelling of the eager body's
@@ -5555,13 +5614,13 @@ fn binary_fanout_each<'a, W: Clone + AsRef<[u64]>>(
             return Demand::Stop;
         }
 
-        // #2460 (yq mode only): the *left* operand produced nothing for this
-        // right value, so this pairing is answered from the empty-operand
+        // #2460 (yq mode only): the *inner* operand produced nothing for this
+        // outer value, so this pairing is answered from the empty-operand
         // table rather than skipped. Only after `inner` ran to exhaustion --
         // an operand that escaped or was stopped part-way is not "empty".
-        if left_seen == 0 && matches!(inner, Flow::Exhausted) {
-            if let Some(op) = empty_rule {
-                if let Some(v) = yq_empty_operand_output(op, Some(&right_val)) {
+        if inner_seen == 0 && matches!(inner, Flow::Exhausted) {
+            if let Some(op) = rules.empty {
+                if let Some(v) = yq_empty_operand_output(op, Some(&outer_val)) {
                     if matches!(sink(Item::Owned(v)), Demand::Stop) {
                         abort = Some(Flow::Stopped { pending: None });
                         return Demand::Stop;
@@ -5622,12 +5681,12 @@ fn binary_fanout_each<'a, W: Clone + AsRef<[u64]>>(
     // `test_short_circuit_side_effect_shapes_already_match_jq_820`).
     // `foreach` has no Stage 5 arm and still falls back the same way this
     // comment always meant to illustrate.
-    if let (Some(op), 0, None, Flow::Exhausted) = (empty_rule, right_seen, &abort, &outer) {
-        // #2460 (yq mode only): the *right* operand produced nothing, so the
-        // outer loop never ran and `left` was never evaluated at all. Drive
-        // it once here and answer each of its outputs from the same table --
-        // and, if it is empty too, answer the both-empty row once.
-        return empty_outer_operand_pass(&each_operand, left, op, sink);
+    if let (Some(op), 0, None, Flow::Exhausted) = (rules.empty, outer_seen, &abort, &outer) {
+        // #2460 (yq mode only): the *outer* operand produced nothing, so the
+        // loop above never ran and the inner one was never evaluated at all.
+        // Drive it once here and answer each of its outputs from the same
+        // table -- and, if it is empty too, answer the both-empty row once.
+        return empty_outer_operand_pass(&each_operand, inner_expr, op, sink);
     }
     abort.unwrap_or(outer)
 }
@@ -5641,19 +5700,19 @@ fn binary_fanout_each<'a, W: Clone + AsRef<[u64]>>(
 /// reaches `left` at all when `right` is empty.
 fn empty_outer_operand_pass<'a, W: Clone + AsRef<[u64]>>(
     each_operand: &impl Fn(&Expr, &mut dyn FnMut(Item<'a, W>) -> Demand) -> Flow,
-    left: &Expr,
+    other: &Expr,
     op: EmptyOperandOp,
     sink: &mut dyn FnMut(Item<'a, W>) -> Demand,
 ) -> Flow {
     let mut abort: Option<Flow> = None;
-    let mut left_seen = 0usize;
-    let flow = each_operand(left, &mut |left_item: Item<'a, W>| {
-        left_seen += 1;
-        let left_val = match checked_fanout_operand(left_item, &mut abort) {
+    let mut other_seen = 0usize;
+    let flow = each_operand(other, &mut |other_item: Item<'a, W>| {
+        other_seen += 1;
+        let other_val = match checked_fanout_operand(other_item, &mut abort) {
             Ok(v) => v,
             Err(demand) => return demand,
         };
-        match yq_empty_operand_output(op, Some(&left_val)) {
+        match yq_empty_operand_output(op, Some(&other_val)) {
             Some(v) => sink(Item::Owned(v)),
             None => Demand::Continue,
         }
@@ -5661,7 +5720,7 @@ fn empty_outer_operand_pass<'a, W: Clone + AsRef<[u64]>>(
     if let Some(flow) = abort {
         return flow;
     }
-    if left_seen == 0 && matches!(flow, Flow::Exhausted) {
+    if other_seen == 0 && matches!(flow, Flow::Exhausted) {
         // Both operands empty: one pairing, with no "other operand" at all.
         if let Some(v) = yq_empty_operand_output(op, None) {
             return match sink(Item::Owned(v)) {
@@ -5791,7 +5850,7 @@ fn boolean_fanout_core<'a, W: Clone + AsRef<[u64]>>(
     left: &Expr,
     right: &Expr,
     short_circuit: bool,
-    empty_rule: Option<EmptyOperandOp>,
+    rules: BinaryFanoutRules,
 ) -> QueryResult<'a, W> {
     let mut left_bools = Vec::new();
     let left_control = push_truthiness(eval_operand(left), &mut left_bools);
@@ -5803,7 +5862,7 @@ fn boolean_fanout_core<'a, W: Clone + AsRef<[u64]>>(
     // `yq_empty_operand_output`, not here, so `and`/`or` and the arithmetic/
     // comparison fanout share one definition of "this operand was empty".
     if left_bools.is_empty() && left_control.is_none() {
-        left_bools.extend(empty_boolean_operand(empty_rule));
+        left_bools.extend(empty_boolean_operand(rules.empty));
     }
 
     let mut out = vec_with_capacity(left_bools.len());
@@ -5817,7 +5876,7 @@ fn boolean_fanout_core<'a, W: Clone + AsRef<[u64]>>(
             return partial(out.into_iter().map(OwnedValue::Bool).collect(), control);
         }
         if out.len() == before {
-            out.extend(empty_boolean_operand(empty_rule));
+            out.extend(empty_boolean_operand(rules.empty));
         }
     }
 
@@ -5838,7 +5897,7 @@ fn eval_binary_fanout<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     right: &Expr,
     value: StandardJson<'a, W>,
     optional: bool,
-    empty_rule: Option<EmptyOperandOp>,
+    rules: BinaryFanoutRules,
     combine: impl FnMut(OwnedValue, OwnedValue) -> Result<OwnedValue, EvalError>,
 ) -> QueryResult<'a, W> {
     binary_fanout_core(
@@ -5846,7 +5905,7 @@ fn eval_binary_fanout<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
         left,
         right,
         optional,
-        empty_rule,
+        rules,
         combine,
     )
 }
@@ -5895,7 +5954,7 @@ fn eval_arithmetic<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
         right,
         value,
         optional,
-        empty_operand_rule::<S>(EmptyOperandOp::Arith(op)),
+        binary_fanout_rules::<S>(EmptyOperandOp::Arith(op)),
         |left_val, right_val| arith_combine::<S>(op, left_val, right_val),
     )
 }
@@ -6659,7 +6718,7 @@ fn eval_compare<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
         right,
         value,
         optional,
-        empty_operand_rule::<S>(EmptyOperandOp::Compare(op)),
+        binary_fanout_rules::<S>(EmptyOperandOp::Compare(op)),
         |left_val, right_val| {
             Ok(OwnedValue::Bool(apply_compare_op::<S>(
                 op, &left_val, &right_val,
@@ -6832,7 +6891,7 @@ fn eval_boolean<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
         left,
         right,
         short_circuit,
-        empty_operand_rule::<S>(EmptyOperandOp::Boolean),
+        binary_fanout_rules::<S>(EmptyOperandOp::Boolean),
     )
 }
 
@@ -32995,7 +33054,7 @@ fn eval_binary_fanout_with_path_context<'a, W: Clone + AsRef<[u64]>, S: EvalSema
     file_origin: Option<&[usize]>,
     current_path: &[OwnedValue],
     optional: bool,
-    empty_rule: Option<EmptyOperandOp>,
+    rules: BinaryFanoutRules,
     combine: impl FnMut(OwnedValue, OwnedValue) -> Result<OwnedValue, EvalError>,
 ) -> QueryResult<'a, W> {
     binary_fanout_core(
@@ -33021,7 +33080,7 @@ fn eval_binary_fanout_with_path_context<'a, W: Clone + AsRef<[u64]>, S: EvalSema
         left,
         right,
         optional,
-        empty_rule,
+        rules,
         combine,
     )
 }
@@ -33166,7 +33225,7 @@ fn eval_boolean_with_path_context<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>
         left,
         right,
         short_circuit,
-        empty_operand_rule::<S>(EmptyOperandOp::Boolean),
+        binary_fanout_rules::<S>(EmptyOperandOp::Boolean),
     )
 }
 
@@ -34993,7 +35052,7 @@ fn eval_stage_with_path_context<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
                 file_origin,
                 current_path,
                 optional,
-                empty_operand_rule::<S>(EmptyOperandOp::Arith(*op)),
+                binary_fanout_rules::<S>(EmptyOperandOp::Arith(*op)),
                 |left_val, right_val| arith_combine::<S>(*op, left_val, right_val),
             );
             if rest.is_empty() {
@@ -35090,7 +35149,7 @@ fn eval_stage_with_path_context<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
                 file_origin,
                 current_path,
                 optional,
-                empty_operand_rule::<S>(EmptyOperandOp::Compare(*op)),
+                binary_fanout_rules::<S>(EmptyOperandOp::Compare(*op)),
                 |left_val, right_val| {
                     Ok(OwnedValue::Bool(apply_compare_op::<S>(
                         *op, &left_val, &right_val,
@@ -55260,6 +55319,35 @@ mod tests {
                 assert_eq!(e.message, "x");
             }
         );
+    }
+
+    /// #2451: the per-mode fanout rules, pinned at their one definition.
+    ///
+    /// `left_major` has no observable effect on any *single*-output operand,
+    /// so a site that read the wrong const would still pass most of the
+    /// suite; this asserts the definition itself, the way #2374's test
+    /// above does for the empty-operand half it now travels with.
+    #[test]
+    fn binary_fanout_rules_are_per_mode_2451() {
+        let op = EmptyOperandOp::Arith(ArithOp::Add);
+
+        let jq = binary_fanout_rules::<JqSemantics>(op);
+        assert_eq!(jq.empty, None, "jq: `1 + empty` really is nothing");
+        assert!(!jq.left_major, "jq loops the right operand outermost");
+
+        let yq = binary_fanout_rules::<YqSemantics>(op);
+        assert_eq!(
+            yq.empty,
+            Some(op),
+            "yq answers an empty operand from the table"
+        );
+        assert!(yq.left_major, "yq loops the left operand outermost");
+
+        // The two halves are independent knobs on the same struct but come
+        // from the same mode, so they never disagree about which mode they
+        // are describing.
+        assert_eq!(jq.empty.is_some(), jq.left_major);
+        assert_eq!(yq.empty.is_some(), yq.left_major);
     }
 
     /// #2374: the family's shared definition itself, pinned once rather

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -5818,6 +5818,14 @@ fn eval_single<S: EvalSemantics, V: DocumentValue>(
         Expr::Paren(inner) => eval_single::<S, _>(inner, value, optional, cursor),
 
         Expr::Pipe(exprs) => {
+            // #2451 rule 1: the branch-major union walk lives on the sink
+            // route, so the non-sink route reaches the *same* function
+            // through `collect_each_generic` rather than growing a second
+            // copy of it -- the same delegation `Expr::Label`/`Expr::DefCall`
+            // above already use.
+            if yq_context_pipe_applies::<S>(exprs) {
+                return collect_each_generic::<S, V>(expr, value, optional, cursor);
+            }
             // `path`/`parent`/`parent(n)`/`key` need the path accumulated
             // across every stage of this pipe, which only the full evaluator
             // tracks (`eval::eval_pipe`'s own `needs_path_context` routing,
@@ -7577,6 +7585,13 @@ fn eval_each_pipe_generic<S: EvalSemantics, V: DocumentValue>(
     cursor: Option<V::Cursor>,
     sink: &mut dyn FnMut(GenericItem<V>) -> Demand,
 ) -> Flow {
+    // #2451 rule 1: in yq mode a pipe with a union in it is evaluated over a
+    // whole context list, branch-major, by `eval_yq_context_pipe` -- ahead of
+    // the path-context routing below on purpose, since the sub-pipes it drives
+    // are handed a cursor each and reach that routing themselves.
+    if let Some(flow) = try_yq_context_pipe::<S, V>(exprs, value.clone(), optional, cursor, sink) {
+        return flow;
+    }
     if exprs.iter().any(needs_path_context) {
         // #2416 phase 2: the cursor walk emits straight into `sink`, so a
         // path-context pipe is as lazy as any other stage here. Anything the
@@ -7670,6 +7685,313 @@ fn eval_each_pipe_generic<S: EvalSemantics, V: DocumentValue>(
         Some(flow) => flow,
         None => upstream,
     }
+}
+
+/// One entry of a yq-mode *context list* (#2451): the succinctly spelling of
+/// real yq's `Context.MatchingNodes` element.
+///
+/// Deliberately narrower than [`GenericItem`], because a context list is held
+/// across several evaluations of *different* branch expressions and so has to
+/// be re-usable: a cursor (`V::Cursor: Copy`), a borrowed document value, or
+/// an owned one. That is also what keeps rule 1's memory cost bounded by the
+/// number of outputs rather than by the document -- a navigational upstream
+/// contributes one cursor per output, never a materialized subtree.
+///
+/// The three lazy [`GenericItem`] shapes (`LazyKeys`/`LazyIndexRange`/
+/// `LazySeq`) have no re-usable form, so they materialize into `Owned` on the
+/// way in (see [`yq_context_item`]). They stand for a single value each, so
+/// that is a fidelity-neutral loss of laziness on this route only.
+#[derive(Clone)]
+enum YqContextItem<V: DocumentValue> {
+    Cursor(V::Cursor),
+    Value(V),
+    Owned(OwnedValue),
+}
+
+impl<V: DocumentValue> YqContextItem<V> {
+    /// Hand this context entry back to the ordinary item-driven evaluator.
+    /// Takes `&self` because one entry is fed to *every* branch of a union.
+    fn to_generic_item(&self) -> GenericItem<V> {
+        match self {
+            Self::Cursor(c) => GenericItem::OneCursor(*c),
+            Self::Value(v) => GenericItem::One(v.clone()),
+            Self::Owned(o) => GenericItem::Owned(o.clone()),
+        }
+    }
+}
+
+/// Capture one produced [`GenericItem`] as a re-usable context entry.
+///
+/// `OneCursorValue`'s pre-decoded value (#1609) is dropped rather than
+/// carried: this entry may be replayed into many branches, and
+/// `GenericItem::OneCursorValue` is documented as constructible at exactly
+/// one site, so widening [`YqContextItem`] to keep it would trade a real
+/// invariant for one avoided re-decode.
+fn yq_context_item<V: DocumentValue>(item: GenericItem<V>) -> Result<YqContextItem<V>, Control> {
+    Ok(match item {
+        GenericItem::One(v) => YqContextItem::Value(v),
+        GenericItem::OneCursor(c) => YqContextItem::Cursor(c),
+        GenericItem::OneCursorValue(c, _) => YqContextItem::Cursor(c),
+        GenericItem::Owned(o) => YqContextItem::Owned(o),
+        lazy @ (GenericItem::LazyKeys { .. }
+        | GenericItem::LazyIndexRange(_)
+        | GenericItem::LazySeq(_)) => YqContextItem::Owned(generic_item_into_owned(lazy)?),
+    })
+}
+
+/// Does this pipe have a stage that is a union (`,`)?
+///
+/// A stage that is itself a (parenthesized) pipe counts, because `L | (X | Y)`
+/// and `(L | X) | Y` are the same evaluation in yq -- `pipeOperator`
+/// (`pkg/yqlib/operator_pipe.go`, v4.53.3) only threads its left side's whole
+/// node list into its right side, so pipe nesting is associative there. That
+/// is what [`yq_flatten_pipe_stages`] then relies on.
+///
+/// Allocation-free on purpose: this runs on *every* yq-mode pipe, and only
+/// the ones that answer `true` pay for the flattening.
+fn yq_pipe_has_union(stages: &[Expr]) -> bool {
+    stages.iter().any(|stage| match unwrap_paren(stage) {
+        Expr::Comma(_) => true,
+        Expr::Pipe(inner) => yq_pipe_has_union(inner),
+        _ => false,
+    })
+}
+
+/// Splice nested pipes into one flat stage list, stripping parens.
+///
+/// Both rewrites are semantics-preserving for every mode (`Expr::Paren` is
+/// already transparent to both evaluators, and `Expr::Pipe` nesting is
+/// associative), but this is only ever called from the yq-mode union route:
+/// its point is to put a union that sits at the head of a *nested* pipe --
+/// `(.a, .b) | ((.c, .d) | .)` -- at a stage index the union walk can see.
+fn yq_flatten_pipe_stages(stages: &[Expr], out: &mut Vec<Expr>) {
+    for stage in stages {
+        match unwrap_paren(stage) {
+            Expr::Pipe(inner) => yq_flatten_pipe_stages(inner, out),
+            other => out.push(other.clone()),
+        }
+    }
+}
+
+/// Run `stages` over one context entry, honouring `sink`'s demand.
+///
+/// The empty-`stages` case is *not* delegated to
+/// [`continue_pipe_element_generic`]: that would reach
+/// `eval_each_pipe_generic`'s own empty-pipe short-circuit, which drops the
+/// cursor. Here the entry is the answer, cursor and all.
+fn run_yq_stages_over_item<S: EvalSemantics, V: DocumentValue>(
+    stages: &[Expr],
+    item: &YqContextItem<V>,
+    optional: bool,
+    sink: &mut dyn FnMut(GenericItem<V>) -> Demand,
+) -> Flow {
+    if stages.is_empty() {
+        return push_one_generic(item.to_generic_item(), sink);
+    }
+    continue_pipe_element_generic::<S, V>(
+        item.to_generic_item(),
+        &mut RestPipe::new(stages),
+        optional,
+        sink,
+    )
+}
+
+/// Materialize the outputs of `stages` over a whole context list.
+///
+/// A control that ends the run **discards whatever the run already
+/// produced**, rather than handing the prefix on. That is real yq's own
+/// answer, and the same rule
+/// [`eval::streams_escaped_generator_prefix`](super::eval::streams_escaped_generator_prefix)
+/// already carries for the indexing family (#2226/#2326/#2351/#2374): a Go
+/// error aborts the whole expression there, so no partial node list survives
+/// it. Captured live against yq v4.53.3 on `{"a":{"b":1,"c":2},"d":[10,20]}`
+/// -- `(.a, error("e"))`, `(.a, error("e")) | .b`, `(.a, .d, error("e"))`,
+/// `(.a, error("e")) | (.b, .c)` and `.d[] , error("e")` each print nothing
+/// on stdout and `Error: e` on stderr, exit 1. This route is yq-only, so
+/// there is no jq-mode prefix-streaming arm to gate.
+fn collect_yq_context<S: EvalSemantics, V: DocumentValue>(
+    stages: &[Expr],
+    inputs: &[YqContextItem<V>],
+    optional: bool,
+) -> Result<Vec<YqContextItem<V>>, Control> {
+    let mut out: Vec<YqContextItem<V>> = Vec::new();
+    let mut stray: Option<Control> = None;
+    let flow =
+        eval_yq_context_pipe::<S, V>(stages, inputs, optional, &mut |item| match yq_context_item(
+            item,
+        ) {
+            Ok(entry) => {
+                out.push(entry);
+                Demand::Continue
+            }
+            Err(control) => {
+                stray = Some(control);
+                Demand::Stop
+            }
+        });
+    match (stray, flow) {
+        (Some(control), _) | (None, Flow::Escaped(control)) => Err(control),
+        // This sink only ever says `Stop` on the `stray` path handled above,
+        // so a `Stopped` here is one a *nested* consumer raised and already
+        // acted on -- nothing left to report.
+        (None, Flow::Exhausted | Flow::Stopped { .. }) => Ok(out),
+    }
+}
+
+/// Where rule 1's branch-major walk splits a flat pipe: the index of the
+/// first union stage, or `None` when this pipe is not one the walk owns.
+///
+/// The one declining case is an **absent** position: a navigational prefix
+/// that can land on a missing key (`.a.x`) followed by something that reads
+/// path context. Spine 2416's cursor walk and its absent sibling answer those
+/// exactly -- `.a.x | (key, path)` is `"x"`, `["a","x"]` on yq v4.53.3, and
+/// `"x"` is a key no node in the document has -- and a [`YqContextItem`] has
+/// no way to carry an absent position, only a cursor or a value. So the walk
+/// keeps them, and the answer is unchanged from before #2451.
+///
+/// That costs branch-major ordering only where a *missing-key-capable* stage
+/// sits between the multiplicity and the union, since the declining shapes
+/// are otherwise single-position: `head_can_yield_absent` is already `false`
+/// for `.a[]`/`.d[]` (iterating an absent node yields nothing) and for an
+/// empty prefix, which is every multi-element shape the sweep exercises.
+fn yq_union_stage_index(stages: &[Expr]) -> Option<usize> {
+    let at = stages.iter().position(|s| matches!(s, Expr::Comma(_)))?;
+    if stages.iter().any(needs_path_context) && head_can_yield_absent(&stages[..at]) {
+        return None;
+    }
+    Some(at)
+}
+
+/// **The one definition of rule 1 of yq's context-list model** (#2451): a
+/// pipe evaluated over a whole *list* of inputs at once, branch-major
+/// through every union it contains.
+///
+/// Real yq has no scalar evaluation mode. `Context.MatchingNodes`
+/// (`pkg/yqlib/context.go`, v4.53.3) is always a list; `|` hands its left
+/// side's entire list to its right side in one call (`operator_pipe.go`), and
+/// `,` (`operator_union.go`) evaluates *each of its branches against that
+/// whole list independently* and concatenates the branch results in order.
+/// So `(.a, .b) | (.c, .d)` is `3 5 4 6` -- `.c` over both, then `.d` over
+/// both -- where jq (and succinctly everywhere else) pipes each value
+/// independently and interleaves, `3 4 5 6`.
+///
+/// Captured live against Homebrew yq v4.53.3; the rows are in
+/// `test_yq_pipe_into_union_is_branch_major_2451`.
+///
+/// The walk is: find the first union stage; materialize everything before it
+/// over every input (that is the context list the union sees); run each
+/// branch over that whole list, concatenating; then recurse with the
+/// concatenation as the input list for the stages after the union. Recursing
+/// on the *concatenated* list, rather than continuing per branch output, is
+/// what makes a second union downstream see the first one's full result --
+/// `(.a, .b) | (.c, .d) | (. + 1, . + 2)` is `4 6 5 7 5 7 6 8`, which no
+/// per-output continuation produces. A branch that is itself a union recurses
+/// through the same entry point, so nesting needs no separate case.
+///
+/// Cost: one [`YqContextItem`] per output of the stages before each union --
+/// a cursor for a navigational upstream, so the list is bounded by the number
+/// of outputs, not by the document. The loss is demand: a consumer's `Stop`
+/// cannot reach back into a materialized list, so a `limit`/`first` wrapped
+/// around one of these pipes evaluates the union in full. Real yq has no
+/// side-effecting builtin to observe that with (`stderr`/`debug` are lexer
+/// errors there), and materializing is what real yq itself does, so this
+/// costs fidelity nothing on the reference surface.
+///
+/// `stages` must already be flat (see [`yq_flatten_pipe_stages`]).
+fn eval_yq_context_pipe<S: EvalSemantics, V: DocumentValue>(
+    stages: &[Expr],
+    inputs: &[YqContextItem<V>],
+    optional: bool,
+    sink: &mut dyn FnMut(GenericItem<V>) -> Demand,
+) -> Flow {
+    let Some(at) = yq_union_stage_index(stages) else {
+        // No union left -- or one this walk declines (see
+        // [`yq_union_stage_index`]) -- so back to the ordinary per-value
+        // pipe, which is both lazy and identical to yq for every other
+        // operator: they all loop their context list and concatenate.
+        // `run_yq_stages_over_item` re-enters `eval_each_pipe_generic`, whose
+        // own gate consults the same function, so a declined pipe takes the
+        // path-context routes rather than looping back here.
+        for item in inputs {
+            match run_yq_stages_over_item::<S, V>(stages, item, optional, sink) {
+                Flow::Exhausted => {}
+                stopped_or_escaped => return stopped_or_escaped,
+            }
+        }
+        return Flow::Exhausted;
+    };
+    let Expr::Comma(branches) = &stages[at] else {
+        // `yq_union_stage_index` matched this exact pattern to pick `at`.
+        unreachable!("the stage yq_union_stage_index selected is an Expr::Comma")
+    };
+
+    let context = if at == 0 {
+        inputs.to_vec()
+    } else {
+        match collect_yq_context::<S, V>(&stages[..at], inputs, optional) {
+            Ok(context) => context,
+            Err(control) => return Flow::Escaped(control),
+        }
+    };
+
+    let mut united: Vec<YqContextItem<V>> = Vec::new();
+    for branch in branches {
+        let mut flat: Vec<Expr> = Vec::new();
+        yq_flatten_pipe_stages(core::slice::from_ref(branch), &mut flat);
+        // Same as `eval_each_generic`'s own `Comma` arm: a branch that escapes
+        // ends the union, and the branches after it are not evaluated -- with
+        // the whole union's result discarded, per `collect_yq_context`.
+        match collect_yq_context::<S, V>(&flat, &context, optional) {
+            Ok(produced) => united.extend(produced),
+            Err(control) => return Flow::Escaped(control),
+        }
+    }
+
+    eval_yq_context_pipe::<S, V>(&stages[at + 1..], &united, optional, sink)
+}
+
+/// Does rule 1 own this pipe? **Both** routes must ask the same question:
+/// `eval_single`'s `Expr::Pipe` arm delegates here through
+/// `collect_each_generic`, and a pipe the walk declines falls back to the
+/// eager bridge, which re-enters `eval_single` with the very same stages --
+/// so an entry gate that admitted more than [`try_yq_context_pipe`] does is
+/// not a wasted check but an infinite loop between the two.
+fn yq_context_pipe_applies<S: EvalSemantics>(exprs: &[Expr]) -> bool {
+    if S::TAG != EvalTag::Yq || !yq_pipe_has_union(exprs) {
+        return false;
+    }
+    let mut flat: Vec<Expr> = Vec::new();
+    yq_flatten_pipe_stages(exprs, &mut flat);
+    yq_union_stage_index(&flat).is_some()
+}
+
+/// Rule 1's entry point from either evaluator route: `Some(flow)` when this
+/// is a yq-mode pipe with a union in it, `None` when the caller should carry
+/// on exactly as before.
+fn try_yq_context_pipe<S: EvalSemantics, V: DocumentValue>(
+    exprs: &[Expr],
+    value: V,
+    optional: bool,
+    cursor: Option<V::Cursor>,
+    sink: &mut dyn FnMut(GenericItem<V>) -> Demand,
+) -> Option<Flow> {
+    if !yq_context_pipe_applies::<S>(exprs) {
+        return None;
+    }
+    let mut flat: Vec<Expr> = Vec::new();
+    yq_flatten_pipe_stages(exprs, &mut flat);
+    // The cursor, when there is one, so a path-context stage downstream still
+    // has a position to answer from.
+    let root = match cursor {
+        Some(c) => YqContextItem::Cursor(c),
+        None => YqContextItem::Value(value),
+    };
+    Some(eval_yq_context_pipe::<S, V>(
+        &flat,
+        core::slice::from_ref(&root),
+        optional,
+        sink,
+    ))
 }
 
 /// Generic-evaluator twin of `eval::each_take_first` (#1461): pull at most

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -35,20 +35,20 @@ use super::document::{
     DocumentValue, IndentSpec, JsonConvention,
 };
 use super::eval::{
-    apply_compare_op, arith_combine, as_var_refs, bind_def, bind_def_call,
+    apply_compare_op, arith_combine, as_var_refs, binary_fanout_rules, bind_def, bind_def_call,
     cannot_reserve_cross_product, classify_limit_n, classify_nth_n, classify_parent_n,
     collapse_vec, collect_pattern_var_names, compare_values, debug_assert_materialization_error,
-    empty_operand_rule, enter_def_call_frame, eval_each_owned, eval_foreach_with_values,
-    eval_full as full_eval, eval_reduce_with_values, extract_pattern_bindings,
-    fold_escaped_generator_prefix, format_owned, has_type_mismatch_is_permissive,
-    index_component_value, index_in_array_bounds, index_one_owned as index_owned_by_key,
-    is_pure_chain_link, is_retryable_stop, literal_to_owned, needs_path_context,
-    numeric_key_to_array_index, numeric_key_to_index, owned_bound_to_i64, owned_to_string,
-    prefer_pending_control, slice_component_value, slice_object_as_yq_children,
+    enter_def_call_frame, eval_each_owned, eval_foreach_with_values, eval_full as full_eval,
+    eval_reduce_with_values, extract_pattern_bindings, fold_escaped_generator_prefix, format_owned,
+    has_type_mismatch_is_permissive, index_component_value, index_in_array_bounds,
+    index_one_owned as index_owned_by_key, is_pure_chain_link, is_retryable_stop, literal_to_owned,
+    needs_path_context, numeric_key_to_array_index, numeric_key_to_index, owned_bound_to_i64,
+    owned_to_string, prefer_pending_control, slice_component_value, slice_object_as_yq_children,
     slice_owned_value_read, streams_escaped_generator_prefix, substitute_bound_var,
     substitute_vars, suppress_or_raise, suppresses, tonumber_from_str, vec_with_capacity,
-    yq_empty_operand_output, yq_negative_index_check, Control, Demand, EmptyOperandOp, EvalError,
-    EvalSemantics, EvalTag, Flow, JqSemantics, LimitN, PathTrail, QueryResult, YqSemantics,
+    yq_empty_operand_output, yq_negative_index_check, BinaryFanoutRules, Control, Demand,
+    EmptyOperandOp, EvalError, EvalSemantics, EvalTag, Flow, JqSemantics, LimitN, PathTrail,
+    QueryResult, YqSemantics,
 };
 #[cfg(test)]
 use super::expr::FuncDefBound;
@@ -6633,7 +6633,7 @@ fn eval_each_generic<S: EvalSemantics, V: DocumentValue>(
             left,
             right,
             optional,
-            empty_operand_rule::<S>(EmptyOperandOp::Compare(*op)),
+            binary_fanout_rules::<S>(EmptyOperandOp::Compare(*op)),
             |left_val, right_val| {
                 Ok(OwnedValue::Bool(apply_compare_op::<S>(
                     *op, &left_val, &right_val,
@@ -6660,7 +6660,7 @@ fn eval_each_generic<S: EvalSemantics, V: DocumentValue>(
             left,
             right,
             optional,
-            empty_operand_rule::<S>(EmptyOperandOp::Arith(*op)),
+            binary_fanout_rules::<S>(EmptyOperandOp::Arith(*op)),
             |left_val, right_val| arith_combine::<S>(*op, left_val, right_val),
             sink,
         ),
@@ -8107,7 +8107,7 @@ fn binary_fanout_each_generic<V: DocumentValue>(
     left: &Expr,
     right: &Expr,
     optional: bool,
-    empty_rule: Option<EmptyOperandOp>,
+    rules: BinaryFanoutRules,
     mut combine: impl FnMut(OwnedValue, OwnedValue) -> Result<OwnedValue, EvalError>,
     sink: &mut dyn FnMut(GenericItem<V>) -> Demand,
 ) -> Flow {
@@ -8117,11 +8117,19 @@ fn binary_fanout_each_generic<V: DocumentValue>(
     // pairings -- the same rule, from the same definition, that
     // `eval::binary_fanout_each` consults on the eager route. `None` in jq
     // mode, where `1 + empty` really is nothing.
-    let mut right_seen = 0usize;
+    let mut outer_seen = 0usize;
+    // #2451: jq loops the right operand outermost, yq the left -- the same
+    // `BinaryFanoutRules::left_major` the eager loop reads, so the two routes
+    // cannot pick different orders.
+    let (outer_expr, inner_expr) = if rules.left_major {
+        (left, right)
+    } else {
+        (right, left)
+    };
 
-    let outer = each_operand(right, &mut |right_item: GenericItem<V>| {
-        right_seen += 1;
-        let right_val = match generic_item_into_owned(right_item) {
+    let outer = each_operand(outer_expr, &mut |outer_item: GenericItem<V>| {
+        outer_seen += 1;
+        let outer_val = match generic_item_into_owned(outer_item) {
             Ok(v) => v,
             Err(control) => {
                 abort = Some(Flow::Escaped(control));
@@ -8129,17 +8137,22 @@ fn binary_fanout_each_generic<V: DocumentValue>(
             }
         };
 
-        let mut left_seen = 0usize;
-        let inner = each_operand(left, &mut |left_item: GenericItem<V>| {
-            left_seen += 1;
-            let left_val = match generic_item_into_owned(left_item) {
+        let mut inner_seen = 0usize;
+        let inner = each_operand(inner_expr, &mut |inner_item: GenericItem<V>| {
+            inner_seen += 1;
+            let inner_val = match generic_item_into_owned(inner_item) {
                 Ok(v) => v,
                 Err(control) => {
                     abort = Some(Flow::Escaped(control));
                     return Demand::Stop;
                 }
             };
-            match combine(left_val, right_val.clone()) {
+            let (left_val, right_val) = if rules.left_major {
+                (outer_val.clone(), inner_val)
+            } else {
+                (inner_val, outer_val.clone())
+            };
+            match combine(left_val, right_val) {
                 Ok(v) => sink(GenericItem::Owned(v)),
                 // Reached by the `Expr::Arithmetic` caller only: the two
                 // `Expr::Compare` call sites wrap the infallible
@@ -8165,13 +8178,13 @@ fn binary_fanout_each_generic<V: DocumentValue>(
             return Demand::Stop;
         }
 
-        // #2460 (yq mode only): the *left* operand produced nothing for this
-        // right value, so this pairing is answered from the empty-operand
+        // #2460 (yq mode only): the *inner* operand produced nothing for this
+        // outer value, so this pairing is answered from the empty-operand
         // table instead of skipped. Only once `inner` ran to exhaustion -- an
         // operand that escaped or was stopped part-way is not "empty".
-        if left_seen == 0 && matches!(inner, Flow::Exhausted) {
-            if let Some(op) = empty_rule {
-                if let Some(v) = yq_empty_operand_output(op, Some(&right_val)) {
+        if inner_seen == 0 && matches!(inner, Flow::Exhausted) {
+            if let Some(op) = rules.empty {
+                if let Some(v) = yq_empty_operand_output(op, Some(&outer_val)) {
                     if matches!(sink(GenericItem::Owned(v)), Demand::Stop) {
                         abort = Some(Flow::Stopped { pending: None });
                         return Demand::Stop;
@@ -8189,12 +8202,12 @@ fn binary_fanout_each_generic<V: DocumentValue>(
         }
     });
 
-    if let (Some(op), 0, None, Flow::Exhausted) = (empty_rule, right_seen, &abort, &outer) {
-        // #2460 (yq mode only): the *right* operand produced nothing, so the
-        // outer loop never ran and `left` was never evaluated at all -- drive
-        // it once here so `1 + key` and `key + 1` stay symmetric the way real
-        // yq is. Mirrors `eval::empty_outer_operand_pass`.
-        return empty_outer_operand_pass_generic::<V>(&each_operand, left, op, sink);
+    if let (Some(op), 0, None, Flow::Exhausted) = (rules.empty, outer_seen, &abort, &outer) {
+        // #2460 (yq mode only): the *outer* operand produced nothing, so the
+        // loop never ran and the inner one was never evaluated at all --
+        // drive it once here so `1 + key` and `key + 1` stay symmetric the
+        // way real yq is. Mirrors `eval::empty_outer_operand_pass`.
+        return empty_outer_operand_pass_generic::<V>(&each_operand, inner_expr, op, sink);
     }
     abort.unwrap_or(outer)
 }
@@ -8205,22 +8218,22 @@ fn binary_fanout_each_generic<V: DocumentValue>(
 /// `return` shape in the loop above).
 fn empty_outer_operand_pass_generic<V: DocumentValue>(
     each_operand: &impl Fn(&Expr, &mut dyn FnMut(GenericItem<V>) -> Demand) -> Flow,
-    left: &Expr,
+    other: &Expr,
     op: EmptyOperandOp,
     sink: &mut dyn FnMut(GenericItem<V>) -> Demand,
 ) -> Flow {
     let mut abort: Option<Flow> = None;
-    let mut left_seen = 0usize;
-    let flow = each_operand(left, &mut |left_item: GenericItem<V>| {
-        left_seen += 1;
-        let left_val = match generic_item_into_owned(left_item) {
+    let mut other_seen = 0usize;
+    let flow = each_operand(other, &mut |other_item: GenericItem<V>| {
+        other_seen += 1;
+        let other_val = match generic_item_into_owned(other_item) {
             Ok(v) => v,
             Err(control) => {
                 abort = Some(Flow::Escaped(control));
                 return Demand::Stop;
             }
         };
-        match yq_empty_operand_output(op, Some(&left_val)) {
+        match yq_empty_operand_output(op, Some(&other_val)) {
             Some(v) => sink(GenericItem::Owned(v)),
             None => Demand::Continue,
         }
@@ -8228,7 +8241,7 @@ fn empty_outer_operand_pass_generic<V: DocumentValue>(
     if let Some(flow) = abort {
         return flow;
     }
-    if left_seen == 0 && matches!(flow, Flow::Exhausted) {
+    if other_seen == 0 && matches!(flow, Flow::Exhausted) {
         // Both operands empty: one pairing, with no "other operand" at all.
         if let Some(v) = yq_empty_operand_output(op, None) {
             return push_one_generic(GenericItem::Owned(v), sink);
@@ -8268,7 +8281,7 @@ fn eval_compare_generic<S: EvalSemantics, V: DocumentValue>(
         left,
         right,
         optional,
-        empty_operand_rule::<S>(EmptyOperandOp::Compare(op)),
+        binary_fanout_rules::<S>(EmptyOperandOp::Compare(op)),
         |left_val, right_val| {
             Ok(OwnedValue::Bool(apply_compare_op::<S>(
                 op, &left_val, &right_val,

--- a/src/jq/parser.rs
+++ b/src/jq/parser.rs
@@ -5166,6 +5166,44 @@ impl<'a> Parser<'a> {
             self.skip_ws();
         }
 
+        // #2451 rule 2: a union of two identities yields the list *once*.
+        //
+        // Real yq's `,` (`pkg/yqlib/operator_union.go:32`, v4.53.3) appends
+        // its right operand's nodes only `if rhs.MatchingNodes !=
+        // lhs.MatchingNodes` -- a Go pointer comparison on the backing
+        // `*list.List`, there so that two self-modifying operands don't get
+        // double-counted. `.` (`operator_self.go`, `return context, nil`)
+        // hands back its input context object untouched, and so does a pipe
+        // of `.`s (`operator_pipe.go` builds its RHS context with
+        // `ChildContext(lhs.MatchingNodes)`, reusing the same list), so the
+        // guard fires for them too. Every other operator builds a fresh list
+        // via `ChildContext(list.New())` and is always appended.
+        //
+        // Chained `,` is right-associative in yq (`expression_postfix.go`
+        // pops only on *strictly* greater precedence, and `,`'s is equal to
+        // its own), so only the innermost pair can ever collapse -- which,
+        // for the flat operand list this parser builds, is exactly "drop the
+        // last operand when the last two are both identity-transparent",
+        // applied once. Live-captured on `a: {c: 3, d: 4}\nb: {c: 5, d: 6}`,
+        // where `(.a, .b) | (., ., ...)` with 1..7 dots prints
+        // `2, 2, 4, 6, 8, 10, 12` lines -- `2 * max(1, n - 1)`, which is what
+        // one dropped operand and no other change produces.
+        //
+        // The survivor is kept as a **one-branch `Expr::Comma`**, not
+        // unwrapped to the bare operand: a union always builds itself a
+        // *fresh* list, so an enclosing `,` must still append it. Real yq
+        // agrees -- `(.a, .b) | ((., .), .)` and `(.a, .b) | (., (., .))`
+        // both print 4 lines, where unwrapping the inner pair back to `.`
+        // would collapse the outer pair too and print 2. A one-branch union
+        // evaluates to exactly its branch, so nothing else changes.
+        if exprs.len() >= 2 {
+            let tail = &exprs[exprs.len() - 2..];
+            if tail.iter().all(yq_union_returns_input_context) {
+                exprs.pop();
+                return Ok(Expr::Comma(exprs));
+            }
+        }
+
         Ok(Expr::comma(exprs))
     }
 
@@ -5740,6 +5778,33 @@ impl<'a> Parser<'a> {
 /// // Object construction
 /// let expr = parse("{name: .name, age: .age}").unwrap();
 /// ```
+/// Does this yq-mode expression hand its input context object straight back,
+/// unchanged and un-copied?
+///
+/// That is the property real yq's `,` pointer-compares on -- see
+/// [`Parser::parse_yq_comma_expr`] for the mechanism and the captured
+/// sequence. In the surface language only `.` has it, plus the two shapes
+/// that are transparently `.`: parentheses, and a pipe whose every stage is
+/// itself transparent (`. | .`, live-verified to collapse:
+/// `(.a, .b) | ((. | .), .)` prints 2 lines, not 4).
+///
+/// Deliberately *not* extended to assignment operands, which real yq's own
+/// comment names as the guard's intended case (`(.foo = "bar"), (.thing =
+/// "cat")`): succinctly's assignments return an independently-edited document
+/// rather than mutating one shared context, so collapsing the pair would drop
+/// a write rather than de-duplicate one. That is a separate, larger
+/// divergence -- `yq '(.a.c = 1), (.b.c = 2)'` prints **one** document with
+/// both writes where succinctly prints two with one each -- recorded in
+/// docs/compliance/yq/limitations.md rather than half-fixed here.
+fn yq_union_returns_input_context(expr: &Expr) -> bool {
+    match expr {
+        Expr::Identity => true,
+        Expr::Paren(inner) => yq_union_returns_input_context(inner),
+        Expr::Pipe(stages) => stages.iter().all(yq_union_returns_input_context),
+        _ => false,
+    }
+}
+
 pub fn parse(input: &str) -> Result<Expr, ParseError> {
     parse_with_mode(input, ParserMode::Jq)
 }
@@ -6065,6 +6130,71 @@ mod tests {
     /// says the *mode* decides, so the load-bearing assertion here is that the
     /// **same source text parses to two different ASTs** depending on
     /// `ParserMode`, not that either shape exists in isolation.
+    /// #2451 rule 2: in yq mode a union whose *innermost* pair is two
+    /// identity-transparent operands drops the second one at parse time.
+    ///
+    /// Real yq's `,` appends its right operand only when the two operands
+    /// return different backing lists (`operator_union.go:32`, v4.53.3), and
+    /// `.` returns its input context object verbatim. Chained `,` is
+    /// right-associative there, so only the innermost pair can ever collapse
+    /// -- which, over this parser's flat operand list, is one `pop`.
+    ///
+    /// The survivor stays wrapped in a one-branch `Expr::Comma`, because a
+    /// union always builds a fresh list and so an *enclosing* union must
+    /// still append it: `(.a, .b) | ((., .), .)` prints 4 lines in real yq,
+    /// which unwrapping to a bare `Expr::Identity` would turn into 2.
+    ///
+    /// jq mode never collapses -- `jq -c '(.a, .b) | (., .)'` prints four
+    /// lines (captured from /usr/bin/jq 1.7.1).
+    #[test]
+    fn test_yq_union_of_two_identities_yields_the_list_once_2451() {
+        let yq = |s: &str| parse_with_mode(s, ParserMode::Yq).unwrap();
+        let id = Expr::Identity;
+
+        // The innermost pair collapses; the survivor keeps its union wrapper.
+        assert_eq!(yq("., ."), Expr::Comma(vec![id.clone()]));
+        assert_eq!(yq("., ., ."), Expr::Comma(vec![id.clone(), id.clone()]));
+        assert_eq!(
+            yq("., ., ., ."),
+            Expr::Comma(vec![id.clone(), id.clone(), id.clone()])
+        );
+
+        // Transparent through parens and through a pipe of identities --
+        // `pipeOperator` reuses its left side's list rather than copying it.
+        assert_eq!(
+            yq("(.), ."),
+            Expr::Comma(vec![Expr::Paren(Box::new(id.clone()))])
+        );
+        assert_eq!(
+            yq(". | ., ."),
+            Expr::Comma(vec![Expr::Pipe(vec![id.clone(), id.clone()])])
+        );
+
+        // A non-transparent operand on either side of the innermost pair
+        // blocks the collapse; every operand still contributes.
+        assert_eq!(
+            yq("., ., .c"),
+            Expr::Comma(vec![id.clone(), id.clone(), Expr::Field("c".into())])
+        );
+        assert_eq!(
+            yq(".c, ."),
+            Expr::Comma(vec![Expr::Field("c".into()), id.clone()])
+        );
+
+        // A nested union is a fresh list, so the outer pair does not collapse
+        // even though the inner one did.
+        assert_eq!(
+            yq("(., .), ."),
+            Expr::Comma(vec![
+                Expr::Paren(Box::new(Expr::Comma(vec![id.clone()]))),
+                id.clone(),
+            ])
+        );
+
+        // jq mode is untouched: `parse_comma_expr` has no collapse at all.
+        assert_eq!(parse("., .").unwrap(), Expr::Comma(vec![id.clone(), id]));
+    }
+
     #[test]
     fn test_yq_mode_pipe_binds_tighter_than_comma_2420() {
         let int = |i: i64| Expr::Literal(Literal::number_literal(i.to_string()));

--- a/tests/data/jq-path-context-sweep-known-divergences.txt
+++ b/tests/data/jq-path-context-sweep-known-divergences.txt
@@ -34,16 +34,6 @@ yq/*/first/*/*        yq_first        real yq's first(f) ignores its argument an
 # position: `eval_pipe_with_path_context_internal` has no `Expr::Object` arm,
 # so the whole object construction falls to the context-dropping fallback.
 
-# Real yq's comma is stream-level: `.a[] | ((key), 1)` answers `"b" "c" 1 1`
-# (every `key` output, then every `1`), where succinctly interleaves per
-# element (`"b" 1 "c" 1`). Both branches here are parenthesised, so this is
-# *not* #2420's precedence rule -- that is fixed, and yq's grouping is now
-# succinctly yq's. What remains is yq's evaluation model: an operator is
-# applied to the whole context list its left-hand side produced, where
-# succinctly (like jq) pipes each value independently. Separately scoped;
-# #2420 is cited only because it is where the distinction was drawn.
-yq/*/comma/*/*        comma_stream    yq's comma composes at the stream level, succinctly's per element — #2420
-
 # `file_index` answers 0 for every input file. Real yq counts files (`0`,
 # `1`). Surfaced by this sweep — see the #2416 phase 0 report; no issue filed
 # yet.

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -38202,3 +38202,43 @@ fn test_jq_union_of_identities_still_duplicates_2451() -> Result<()> {
 
     Ok(())
 }
+
+/// #2451 rule 3 is yq-only: jq keeps its right-outer/left-inner fanout.
+///
+/// Captured from `/usr/bin/jq` 1.7.1 with `-c` on
+/// `{"a":{"c":3,"d":4},"b":{"c":5,"d":6},"n":[1,2,3]}`; the yq-mode
+/// counterpart is `yq_cli_tests.rs`'s
+/// `test_yq_binary_operator_fans_out_left_major_2451`.
+#[test]
+fn test_jq_binary_fanout_stays_right_major_2451() -> Result<()> {
+    let doc = r#"{"a":{"c":3,"d":4},"b":{"c":5,"d":6},"n":[1,2,3]}"#;
+
+    for (filter, want) in [
+        // $ jq -c '(.a.c, .b.c) + (1, 10)'  =>  4 / 6 / 13 / 15
+        ("(.a.c, .b.c) + (1, 10)", "4\n6\n13\n15"),
+        // $ jq -c '(.n[0], .n[1]) - (1, 2)'  =>  0 / 1 / -1 / 0
+        ("(.n[0], .n[1]) - (1, 2)", "0\n1\n-1\n0"),
+        // $ jq -c '(.a.c, .b.c) * (2, 3)'  =>  6 / 10 / 9 / 15
+        ("(.a.c, .b.c) * (2, 3)", "6\n10\n9\n15"),
+        // $ jq -c '(.a.c, .b.c) / (1, 2)'  =>  3 / 5 / 1.5 / 2.5
+        ("(.a.c, .b.c) / (1, 2)", "3\n5\n1.5\n2.5"),
+        // $ jq -c '(.a.c, .b.c) % (2, 3)'  =>  1 / 1 / 0 / 2
+        ("(.a.c, .b.c) % (2, 3)", "1\n1\n0\n2"),
+        // $ jq -c '(.n[0], .n[1]) < (1, 2)'  =>  false / false / true / false
+        ("(.n[0], .n[1]) < (1, 2)", "false\nfalse\ntrue\nfalse"),
+        // $ jq -c '(.a.c, .b.c) + (1, 10) + (100, 1000)'
+        //     =>  104 / 106 / 113 / 115 / 1004 / 1006 / 1013 / 1015
+        (
+            "(.a.c, .b.c) + (1, 10) + (100, 1000)",
+            "104\n106\n113\n115\n1004\n1006\n1013\n1015",
+        ),
+        // $ jq -c '.n[] + .n[]'  =>  2 3 4 3 4 5 4 5 6  (same as yq)
+        (".n[] + .n[]", "2\n3\n4\n3\n4\n5\n4\n5\n6"),
+    ] {
+        let (out, code) = run_jq_stdin(filter, doc, &["-c"])?;
+        assert_eq!(code, 0, "`{filter}`");
+        assert_eq!(out.trim(), want, "`{filter}`");
+    }
+
+    Ok(())
+}

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -38157,3 +38157,48 @@ fn test_jq_pipe_into_union_stays_element_major_2451() -> Result<()> {
 
     Ok(())
 }
+
+/// #2451 rule 2 is yq-only: jq has no pointer-identity guard on `,`, so a
+/// union of identities duplicates every time. Captured from `/usr/bin/jq`
+/// 1.7.1 with `-c` on `{"a":{"c":3,"d":4},"b":{"c":5,"d":6},"n":[1,2,3]}`;
+/// the yq-mode counterpart is `yq_cli_tests.rs`'s
+/// `test_yq_union_of_two_identities_yields_the_list_once_2451`.
+#[test]
+fn test_jq_union_of_identities_still_duplicates_2451() -> Result<()> {
+    let doc = r#"{"a":{"c":3,"d":4},"b":{"c":5,"d":6},"n":[1,2,3]}"#;
+    let a = r#"{"c":3,"d":4}"#;
+    let b = r#"{"c":5,"d":6}"#;
+
+    // $ jq -c '(.a, .b) | (., .)'                => 4 lines (each doubled)
+    // $ jq -c '(.a, .b) | (., ., .)'             => 6 lines (each tripled)
+    // $ jq -c '(.a, .b) | (., ., ., .)'          => 8 lines
+    // ... i.e. `2n`, never yq's `2 * max(1, n - 1)`.
+    for dots in 1..=4usize {
+        let branches = vec!["."; dots].join(", ");
+        let (out, code) = run_jq_stdin(&format!("(.a, .b) | ({branches})"), doc, &["-c"])?;
+        assert_eq!(code, 0, "{dots} dots");
+        let want = format!("{}\n{}", vec![a; dots].join("\n"), vec![b; dots].join("\n"));
+        assert_eq!(out.trim(), want, "{dots} dots");
+    }
+
+    for (filter, want) in [
+        // $ jq -c '(.a, .b) | (., ., .c)'  =>  {a} / {a} / 3 / {b} / {b} / 5
+        ("(.a, .b) | (., ., .c)", format!("{a}\n{a}\n3\n{b}\n{b}\n5")),
+        // $ jq -c '(.a, .b) | (.c, .)'  =>  3 / {a} / 5 / {b}
+        ("(.a, .b) | (.c, .)", format!("3\n{a}\n5\n{b}")),
+        // $ jq -c '(.a, .b) | ((.), .)'  =>  {a} / {a} / {b} / {b}
+        ("(.a, .b) | ((.), .)", format!("{a}\n{a}\n{b}\n{b}")),
+        // $ jq -c '[.n[] | (., .)]'  =>  [1,1,2,2,3,3]
+        ("[.n[] | (., .)]", "[1,1,2,2,3,3]".to_string()),
+        // $ jq -c '(.n[0], .n[1]) | [., .]'  =>  [1,1] / [2,2]
+        ("(.n[0], .n[1]) | [., .]", "[1,1]\n[2,2]".to_string()),
+        // $ jq -c '(., .) | length'  =>  3 / 3
+        ("(., .) | length", "3\n3".to_string()),
+    ] {
+        let (out, code) = run_jq_stdin(filter, doc, &["-c"])?;
+        assert_eq!(code, 0, "`{filter}`");
+        assert_eq!(out.trim(), want, "`{filter}`");
+    }
+
+    Ok(())
+}

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -38111,3 +38111,49 @@ fn test_jq_mode_has_no_empty_operand_rule_2460() -> Result<()> {
     }
     Ok(())
 }
+
+/// #2451: jq mode keeps jq's **element-major** pipe-into-union order.
+///
+/// The yq-mode counterpart is `yq_cli_tests.rs`'s
+/// `test_yq_pipe_into_union_is_branch_major_2451`; #2451 is a yq-mode rule
+/// (`S::TAG == EvalTag::Yq`), and this is the guard that it stayed there.
+/// Every expectation is a live capture from `/usr/bin/jq` 1.7.1 with `-c` on
+/// `{"a":{"c":3,"d":4},"b":{"c":5,"d":6},"n":[1,2,3]}`.
+#[test]
+fn test_jq_pipe_into_union_stays_element_major_2451() -> Result<()> {
+    let doc = r#"{"a":{"c":3,"d":4},"b":{"c":5,"d":6},"n":[1,2,3]}"#;
+
+    for (filter, want) in [
+        // $ jq -c '(.a, .b) | (.c, .d)'  =>  3 / 4 / 5 / 6
+        ("(.a, .b) | (.c, .d)", "3\n4\n5\n6"),
+        // $ jq -c '(.a, .b) | (.c, .d) | . + 10'  =>  13 / 14 / 15 / 16
+        ("(.a, .b) | (.c, .d) | . + 10", "13\n14\n15\n16"),
+        // $ jq -c '.n[] | (., . * 10)'  =>  1 / 10 / 2 / 20 / 3 / 30
+        (".n[] | (., . * 10)", "1\n10\n2\n20\n3\n30"),
+        // $ jq -c '[(.a, .b) | (.c, .d)]'  =>  [3,4,5,6]
+        ("[(.a, .b) | (.c, .d)]", "[3,4,5,6]"),
+        // $ jq -c '(.a, .b) | with_entries(.) | (.c, .d)'  =>  3 / 4 / 5 / 6
+        ("(.a, .b) | with_entries(.) | (.c, .d)", "3\n4\n5\n6"),
+        // $ jq -c '(.a, .b) | (.c, .d) | (. + 1, . + 2)'
+        //     =>  4 / 5 / 5 / 6 / 6 / 7 / 7 / 8
+        (
+            "(.a, .b) | (.c, .d) | (. + 1, . + 2)",
+            "4\n5\n5\n6\n6\n7\n7\n8",
+        ),
+        // $ jq -c '1 | (. + 1, . + 2) | (. * 10, . * 100)'
+        //     =>  20 / 200 / 30 / 300
+        ("1 | (. + 1, . + 2) | (. * 10, . * 100)", "20\n200\n30\n300"),
+        // $ jq -c '((.a, .b) | (.c, .d)) | (., .)'  =>  3/3/4/4/5/5/6/6
+        ("((.a, .b) | (.c, .d)) | (., .)", "3\n3\n4\n4\n5\n5\n6\n6"),
+        // $ jq -c '(.a, .b) | ((.c, .d) | (., .))'  =>  3/3/4/4/5/5/6/6
+        ("(.a, .b) | ((.c, .d) | (., .))", "3\n3\n4\n4\n5\n5\n6\n6"),
+        // $ jq -c '(.a, .b) | .c | (., .)'  =>  3 / 3 / 5 / 5
+        ("(.a, .b) | .c | (., .)", "3\n3\n5\n5"),
+    ] {
+        let (out, code) = run_jq_stdin(filter, doc, &["-c"])?;
+        assert_eq!(code, 0, "`{filter}`");
+        assert_eq!(out.trim(), want, "`{filter}`");
+    }
+
+    Ok(())
+}

--- a/tests/jq_evaluator_parity_tests.rs
+++ b/tests/jq_evaluator_parity_tests.rs
@@ -1911,26 +1911,30 @@ fn test_target_partial_prefix_yq_gate_family_2374() {
     }
 }
 
-/// The two path-context members of the same family — and they are missing the
-/// gate, which is exactly the recurrence #2374 predicted.
+/// The two path-context members of the same family — they used to *miss* the
+/// gate, and since #2451 they no longer reach the arms that miss it.
 ///
 /// `eval_index_expr_with_path_context` and `eval_slice_expr_with_path_context`
-/// keep the target's already-produced prefix in yq mode, where their
-/// plain-read siblings (pinned as passing in the table above) discard it. Real
-/// yq emits nothing for every row here; succinctly emits the value.
+/// still keep a target's already-produced prefix in yq mode (that ungated
+/// pair is #2431). What changed is which route these shapes take: every row
+/// below has a union (`,`) for its target, so yq mode now evaluates the whole
+/// pipe through #2451's context-list walk (`eval_generic::eval_yq_context_pipe`),
+/// whose own collection step discards a prefix that escaped — the same rule
+/// [`streams_escaped_generator_prefix`] carries for the plain-read siblings in
+/// the table above. Both routes now answer real yq exactly: nothing, exit 1.
 ///
-/// Captured live on 2026-09-05 from yq v4.53.3. Pinned as a divergence rather
-/// than fixed: these are arms of `eval_stage_with_path_context`, the function
-/// #2416 exists to retire, so the fix belongs to the migration that deletes
-/// them — and #2416's own hygiene rule says a PR adding an arm there has to
-/// argue why it is not a migration.
+/// Kept as its own test rather than folded into the table above because that
+/// table's jq column is the *jq oracle*, and jq 1.7.1 has none for these:
+/// `key`, `path` and `parent` are rejected at compile time there
+/// (`key/0 is not defined`, exit 3), so the jq column here is succinctly's own
+/// extension behaviour, captured from succinctly rather than from jq.
 ///
-/// jq mode has no oracle for these at all: jq 1.7.1 rejects `key`, `path` and
-/// `parent` at compile time (`key/0 is not defined`, exit 3), so they are
-/// succinctly extensions there and only yq mode can be checked.
+/// yq column captured live on 2026-09-05 from yq v4.53.3 (`yq -o=json -I=0`
+/// on `{"a":{"b":1,"c":2},"d":[10,20]}`): every row prints nothing on stdout
+/// and `Error: e` on stderr, exit 1.
 #[test]
-fn test_target_partial_prefix_path_context_sites_miss_the_yq_gate_2374() {
-    // (construct, filter, succinctly's current yq-mode output)
+fn test_target_partial_prefix_path_context_sites_match_the_yq_gate_2451() {
+    // (construct, filter, succinctly's jq-mode extension output)
     let rows: &[(&str, &str, &[&str])] = &[
         (
             "index/field + key",
@@ -1964,21 +1968,25 @@ fn test_target_partial_prefix_path_context_sites_miss_the_yq_gate_2374() {
     // before the index/slice ever runs.
     let oracle: Vec<String> = Vec::new();
 
-    for (construct, filter, current) in rows {
+    for (construct, filter, jq_extension) in rows {
         let (full, generic) = both_evaluator_outputs::<YqSemantics>(YQ_GATE_DOC, filter);
         assert_eq!(
-            full, *current,
-            "[{construct}] eval.rs moved for `{filter}` — if this is the #2416 \
-             migration landing, drop the row and add it to the passing table above"
+            full, oracle,
+            "[{construct}] eval.rs disagrees with the yq oracle for `{filter}`"
         );
         assert_eq!(
-            generic, *current,
-            "[{construct}] eval_generic.rs moved for `{filter}`"
+            generic, oracle,
+            "[{construct}] eval_generic.rs disagrees with the yq oracle for `{filter}`"
         );
-        assert_ne!(
-            full, oracle,
-            "[{construct}] `{filter}` now matches real yq — nice; move the row \
-             into test_target_partial_prefix_yq_gate_family_2374"
+
+        let (full, generic) = both_evaluator_outputs::<JqSemantics>(YQ_GATE_DOC, filter);
+        assert_eq!(
+            full, *jq_extension,
+            "[{construct}] eval.rs moved in jq mode for `{filter}`"
+        );
+        assert_eq!(
+            generic, *jq_extension,
+            "[{construct}] eval_generic.rs moved in jq mode for `{filter}`"
         );
     }
 }

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -32345,3 +32345,90 @@ fn test_yq_identity_union_composes_with_branch_major_order_2451() -> Result<()> 
 
     Ok(())
 }
+
+/// #2451 rule 3: a binary operator fans out **left-major** in yq mode.
+///
+/// `doCrossFunc` (`pkg/yqlib/operators.go:113-138`, v4.53.3) evaluates the
+/// left operand once, loops its matches outermost, and re-evaluates the right
+/// operand from scratch inside that loop -- so the *right* operand varies
+/// fastest. jq's own fanout loops the other way round (`(1,2) + (10,20)` is
+/// `11 12 21 22`), so the two disagree on order for any pairing where both
+/// operands produce more than one value.
+///
+/// Every row is a live capture on `CONTEXT_LIST_DOC_2451`; jq's answer is
+/// quoted beside it and pinned in `jq_cli_tests.rs`'s
+/// `test_jq_binary_fanout_stays_right_major_2451`.
+#[test]
+fn test_yq_binary_operator_fans_out_left_major_2451() -> Result<()> {
+    let args = &["-o", "json", "-I0"];
+    let doc = CONTEXT_LIST_DOC_2451;
+
+    for (filter, want) in [
+        // $ yq -o=json -I0 '(.a.c, .b.c) + (1, 10)'  =>  4 / 13 / 6 / 15
+        // $ jq -c        '(.a.c, .b.c) + (1, 10)'    =>  4 / 6 / 13 / 15
+        ("(.a.c, .b.c) + (1, 10)", "4\n13\n6\n15"),
+        // $ yq -o=json -I0 '(.n[0], .n[1]) - (1, 2)'  =>  0 / -1 / 1 / 0
+        // $ jq -c        '(.n[0], .n[1]) - (1, 2)'    =>  0 / 1 / -1 / 0
+        ("(.n[0], .n[1]) - (1, 2)", "0\n-1\n1\n0"),
+        // $ yq -o=json -I0 '(.a.c, .b.c) * (2, 3)'  =>  6 / 9 / 10 / 15
+        // $ jq -c        '(.a.c, .b.c) * (2, 3)'    =>  6 / 10 / 9 / 15
+        ("(.a.c, .b.c) * (2, 3)", "6\n9\n10\n15"),
+        // $ yq -o=json -I0 '(.a.c, .b.c) / (1, 2)'  =>  3.0 / 1.5 / 5.0 / 2.5
+        // $ jq -c        '(.a.c, .b.c) / (1, 2)'    =>  3 / 5 / 1.5 / 2.5
+        // (`3.0` vs `3` is yq's own integer-division rendering, not order.)
+        ("(.a.c, .b.c) / (1, 2)", "3.0\n1.5\n5.0\n2.5"),
+        // $ yq -o=json -I0 '(.a.c, .b.c) % (2, 3)'  =>  1 / 0 / 1 / 2
+        // $ jq -c        '(.a.c, .b.c) % (2, 3)'    =>  1 / 1 / 0 / 2
+        ("(.a.c, .b.c) % (2, 3)", "1\n0\n1\n2"),
+        // $ yq -o=json -I0 '(.n[0], .n[1]) < (1, 2)'
+        //     =>  false / true / false / false
+        // $ jq -c        '(.n[0], .n[1]) < (1, 2)'
+        //     =>  false / false / true / false
+        // Comparisons share the same loop.
+        ("(.n[0], .n[1]) < (1, 2)", "false\ntrue\nfalse\nfalse"),
+        // $ yq -o=json -I0 '(.a.c, .b.c) + (1, 10) + (100, 1000)'
+        //     =>  104 / 1004 / 113 / 1013 / 106 / 1006 / 115 / 1015
+        // $ jq -c        '(.a.c, .b.c) + (1, 10) + (100, 1000)'
+        //     =>  104 / 106 / 113 / 115 / 1004 / 1006 / 1013 / 1015
+        (
+            "(.a.c, .b.c) + (1, 10) + (100, 1000)",
+            "104\n1004\n113\n1013\n106\n1006\n115\n1015",
+        ),
+        // $ yq -o=json -I0 '.n[] + .n[]'  =>  2 3 4 3 4 5 4 5 6
+        // $ jq -c        '.n[] + .n[]'    =>  2 3 4 3 4 5 4 5 6
+        // Identical either way -- the operands are the same generator, so the
+        // two orders transpose onto each other. Pinned so a future change
+        // cannot quietly reorder it.
+        (".n[] + .n[]", "2\n3\n4\n3\n4\n5\n4\n5\n6"),
+        // $ yq -o=json -I0 '(.a, .b) | .c + (.d, 1)'  =>  7 / 4 / 11 / 6
+        // $ jq -c        '(.a, .b) | .c + (.d, 1)'    =>  7 / 4 / 11 / 6
+        // Also identical: a single-output left operand has nothing to
+        // permute. What it does pin is that #2451's rule 1 does not make the
+        // *operator* see the whole context list -- `crossFunctionWithPrefs`
+        // takes its per-node path for `,`-built nodes, so `+` still pairs
+        // within one node (the whole-list case is `EvaluateTogether`, #2427).
+        ("(.a, .b) | .c + (.d, 1)", "7\n4\n11\n6"),
+        // `and`/`or` were already left-major in both tools -- jq
+        // short-circuits per left output, which is the same nesting -- so
+        // they need no flag and did not move.
+        //
+        // $ yq -o=json -I0 '(.a.c > 1, .b.c > 100) and (.n[0] > 0, .n[1] > 100)'
+        //     =>  true / false / false
+        (
+            "(.a.c > 1, .b.c > 100) and (.n[0] > 0, .n[1] > 100)",
+            "true\nfalse\nfalse",
+        ),
+        // $ yq -o=json -I0 '(.a.c > 100, .b.c > 1) or (.n[0] > 100, .n[1] > 0)'
+        //     =>  false / true / true
+        (
+            "(.a.c > 100, .b.c > 1) or (.n[0] > 100, .n[1] > 0)",
+            "false\ntrue\ntrue",
+        ),
+    ] {
+        let (out, code) = run_yq_stdin(filter, doc, args)?;
+        assert_eq!(code, 0, "`{filter}`");
+        assert_eq!(out.trim(), want, "`{filter}`");
+    }
+
+    Ok(())
+}

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -27832,11 +27832,17 @@ fn test_decode_failure_does_not_corrupt_json_output_1247() -> Result<()> {
 
         // Materializing: `--arg` forces the DOM path, and a multi-result
         // filter loses its cursor to `GenericResult::Many`.
+        //
+        // The multi-result spelling is `.,.,.` rather than `.,.`: since
+        // #2451 a union of two bare identities yields the list *once* in yq
+        // mode (real yq's own pointer-identity guard), so `.,.` is no longer
+        // multi-result at all. Three dots is the shortest spelling that
+        // still is -- yq prints the document twice for it.
         for extra in [
             &["-o", "json", "-I", "0", "--arg", "z", "y"][..],
             &["-o", "json", "-I", "0"][..],
         ] {
-            let filter = if extra.len() > 4 { "." } else { ".,." };
+            let filter = if extra.len() > 4 { "." } else { ".,.,." };
             let (output, stderr, exit_code) = run_yq_split(filter, input, extra)?;
             match materialized {
                 None => {
@@ -27848,7 +27854,7 @@ fn test_decode_failure_does_not_corrupt_json_output_1247() -> Result<()> {
                 }
                 Some(expected) => {
                     assert_eq!(exit_code, 0, "args {extra:?}, stderr: {stderr}");
-                    let expected = if filter == ".,." {
+                    let expected = if filter == ".,.,." {
                         format!("{expected}\n{expected}")
                     } else {
                         expected.to_string()
@@ -32207,6 +32213,134 @@ fn test_yq_union_branch_error_discards_the_prefix_2451() -> Result<()> {
         assert_eq!(out, "", "`{filter}` should print nothing");
         assert!(err.contains("Error: e"), "`{filter}` stderr: {err}");
         assert_eq!(code, 1, "`{filter}` exit");
+    }
+
+    Ok(())
+}
+
+/// #2451 rule 2: a union of two bare identities yields the list **once**.
+///
+/// `,` in real yq (`pkg/yqlib/operator_union.go:32`, v4.53.3) appends its
+/// right operand's nodes only `if rhs.MatchingNodes != lhs.MatchingNodes` --
+/// a pointer comparison on the backing list, there so two self-modifying
+/// operands aren't double-counted. `.` (`operator_self.go`) hands its input
+/// context object straight back, so the guard fires for it. Chained `,` is
+/// right-associative (`expression_postfix.go` pops only on strictly greater
+/// precedence), so exactly one operand is ever dropped -- which is what makes
+/// `n` identical `.` branches over a 2-element context print
+/// `2 * max(1, n - 1)` lines.
+///
+/// Every row is a live capture; jq's answer is quoted beside it and pinned in
+/// `jq_cli_tests.rs`'s `test_jq_union_of_identities_still_duplicates_2451`.
+#[test]
+fn test_yq_union_of_two_identities_yields_the_list_once_2451() -> Result<()> {
+    let args = &["-o", "json", "-I0"];
+    let doc = CONTEXT_LIST_DOC_2451;
+    let a = r#"{"c":3,"d":4}"#;
+    let b = r#"{"c":5,"d":6}"#;
+
+    // The `2, 2, 4, 6, 8, 10, 12` sequence for 1..7 identical `.` branches:
+    //
+    // $ yq -o=json -I0 '(.a, .b) | (.)'                    =>  2 lines
+    // $ yq -o=json -I0 '(.a, .b) | (., .)'                 =>  2 lines
+    // $ yq -o=json -I0 '(.a, .b) | (., ., .)'              =>  4 lines
+    // $ yq -o=json -I0 '(.a, .b) | (., ., ., .)'           =>  6 lines
+    // $ yq -o=json -I0 '(.a, .b) | (., ., ., ., .)'        =>  8 lines
+    // $ yq -o=json -I0 '(.a, .b) | (., ., ., ., ., .)'     => 10 lines
+    // $ yq -o=json -I0 '(.a, .b) | (., ., ., ., ., ., .)'  => 12 lines
+    //
+    // jq prints `2n` for all of them (`(.a, .b) | (., .)` is 4 lines).
+    for (dots, groups) in [(1, 1), (2, 1), (3, 2), (4, 3), (5, 4), (6, 5), (7, 6)] {
+        let branches = vec!["."; dots].join(", ");
+        let (out, code) = run_yq_stdin(&format!("(.a, .b) | ({branches})"), doc, args)?;
+        assert_eq!(code, 0, "{dots} dots");
+        let want = vec![format!("{a}\n{b}"); groups].join("\n");
+        assert_eq!(out.trim(), want, "{dots} dots");
+    }
+
+    // $ yq -o=json -I0 '(.a, .b) | (., ., .c)'
+    //     =>  {a} / {b} / {a} / {b} / 3 / 5
+    // $ jq -c        '(.a, .b) | (., ., .c)'
+    //     =>  {a} / {a} / 3 / {b} / {b} / 5
+    // A differing third branch does not un-collapse the leading pair, and it
+    // is not itself dropped: three branches, six lines.
+    let (out, code) = run_yq_stdin("(.a, .b) | (., ., .c)", doc, args)?;
+    assert_eq!(code, 0);
+    assert_eq!(out.trim(), format!("{a}\n{b}\n{a}\n{b}\n3\n5"));
+
+    // $ yq -o=json -I0 '(.a, .b) | (.c, .)'  =>  3 / 5 / {a} / {b}
+    // $ jq -c        '(.a, .b) | (.c, .)'    =>  3 / {a} / 5 / {b}
+    // The *first* operand of the pair is not transparent, so nothing drops.
+    let (out, code) = run_yq_stdin("(.a, .b) | (.c, .)", doc, args)?;
+    assert_eq!(code, 0);
+    assert_eq!(out.trim(), format!("3\n5\n{a}\n{b}"));
+
+    // Transparency reaches through parentheses and through a pipe of
+    // identities -- `pipeOperator` hands its left side's own list to its
+    // right side rather than copying it, so `. | .` is still the same list.
+    //
+    // $ yq -o=json -I0 '(.a, .b) | ((.), .)'    =>  {a} / {b}
+    // $ yq -o=json -I0 '(.a, .b) | (. | ., .)'  =>  {a} / {b}
+    // jq prints 4 lines for both (and reads `(. | ., .)` as `. | (., .)`,
+    // since jq ranks `,` tighter than `|` -- the opposite of yq, #2420).
+    for filter in ["(.a, .b) | ((.), .)", "(.a, .b) | (. | ., .)"] {
+        let (out, code) = run_yq_stdin(filter, doc, args)?;
+        assert_eq!(code, 0, "`{filter}`");
+        assert_eq!(out.trim(), format!("{a}\n{b}"), "`{filter}`");
+    }
+
+    // A *nested* union builds a fresh list, so an enclosing pair does not
+    // collapse even when the inner one did.
+    //
+    // $ yq -o=json -I0 '(.a, .b) | ((., .), .)'  =>  {a} / {b} / {a} / {b}
+    // $ yq -o=json -I0 '(.a, .b) | (., (., .))'  =>  {a} / {b} / {a} / {b}
+    for filter in ["(.a, .b) | ((., .), .)", "(.a, .b) | (., (., .))"] {
+        let (out, code) = run_yq_stdin(filter, doc, args)?;
+        assert_eq!(code, 0, "`{filter}`");
+        assert_eq!(out.trim(), format!("{a}\n{b}\n{a}\n{b}"), "`{filter}`");
+    }
+
+    Ok(())
+}
+
+/// #2451 rule 2 composed with rule 1: the capture's rows 5, 8, N1 and N2,
+/// which need both -- the collapse decides how many branches there are, the
+/// branch-major walk decides their order.
+#[test]
+fn test_yq_identity_union_composes_with_branch_major_order_2451() -> Result<()> {
+    let args = &["-o", "json", "-I0"];
+    let doc = CONTEXT_LIST_DOC_2451;
+
+    for (filter, want) in [
+        // $ yq -o=json -I0 '(.a, .b) | (.c, .d) | (., .)'  =>  3 / 5 / 4 / 6
+        // $ jq -c        '(.a, .b) | (.c, .d) | (., .)'    =>  3/3/4/4/5/5/6/6
+        ("(.a, .b) | (.c, .d) | (., .)", "3\n5\n4\n6"),
+        // $ yq -o=json -I0 '(.a, .b) | .c | (., .)'  =>  3 / 5
+        // $ jq -c        '(.a, .b) | .c | (., .)'    =>  3 / 3 / 5 / 5
+        ("(.a, .b) | .c | (., .)", "3\n5"),
+        // $ yq -o=json -I0 '((.a, .b) | (.c, .d)) | (., .)'  =>  3 / 5 / 4 / 6
+        // $ jq -c        '((.a, .b) | (.c, .d)) | (., .)'    =>  3/3/4/4/5/5/6/6
+        ("((.a, .b) | (.c, .d)) | (., .)", "3\n5\n4\n6"),
+        // $ yq -o=json -I0 '(.a, .b) | ((.c, .d) | (., .))'  =>  3 / 5 / 4 / 6
+        // $ jq -c        '(.a, .b) | ((.c, .d) | (., .))'    =>  3/3/4/4/5/5/6/6
+        ("(.a, .b) | ((.c, .d) | (., .))", "3\n5\n4\n6"),
+        // $ yq -o=json -I0 '.n | (.[0], .[1]) | (., .)'  =>  1 / 2
+        (".n | (.[0], .[1]) | (., .)", "1\n2"),
+        // $ yq -o=json -I0 '[.n[] | (., .)]'  =>  [1,2,3]
+        // $ jq -c        '[.n[] | (., .)]'    =>  [1,1,2,2,3,3]
+        ("[.n[] | (., .)]", "[1,2,3]"),
+        // $ yq -o=json -I0 '(.n[0], .n[1]) | [., .]'  =>  [1] / [2]
+        // $ jq -c        '(.n[0], .n[1]) | [., .]'    =>  [1,1] / [2,2]
+        // `[...]` collects per context node, and within one node the pair
+        // collapses to a single element.
+        ("(.n[0], .n[1]) | [., .]", "[1]\n[2]"),
+        // $ yq -o=json -I0 '(., .) | length'  =>  3
+        // $ jq -c        '(., .) | length'    =>  3 / 3
+        ("(., .) | length", "3"),
+    ] {
+        let (out, code) = run_yq_stdin(filter, doc, args)?;
+        assert_eq!(code, 0, "`{filter}`");
+        assert_eq!(out.trim(), want, "`{filter}`");
     }
 
     Ok(())

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -1651,7 +1651,14 @@ fn test_yq_optional_ambient_no_longer_suppresses_rest_error_2073() -> Result<()>
     )?;
     assert_eq!(code, 1, "stderr: {stderr}");
     assert!(stderr.contains("boom"), "stderr: {stderr}");
-    assert_eq!(stdout, "0\n");
+    // Nothing on stdout since #2451: a union branch that raises discards the
+    // whole expression's output in yq mode. Real yq has no `?` to spell this
+    // exact filter with (`yq '.a | (.[])? | ...'` is a lexer error), but its
+    // closest legal shape agrees -- `yq -o=json -I0 '.a | .[] | (key,
+    // error("boom"))'` on `a: [1, 2, 3]` prints nothing and `Error: boom`,
+    // exit 1 (captured 2026-09-06, v4.53.3). What #2073 pins is unchanged:
+    // the error is *not* suppressed by the ambient `?`.
+    assert_eq!(stdout, "");
 
     Ok(())
 }
@@ -15671,7 +15678,12 @@ fn test_eval_all_arithmetic_fanout_survives_file_index_in_pipe_issue_822() -> Re
         &["--eval-all", "-o", "json"],
     )?;
     assert_eq!(code, 0);
-    assert_eq!(stdout.trim(), "2\n3\n4\n0\n2\n3\n4\n1");
+    // #2451 made this branch-major: the union runs `((1,2,3) + 1)` over the
+    // whole context list `.[]` produced, then `file_index` over the same
+    // list. Still short of yq's 16 lines, which need `EvaluateTogether`
+    // (#2427) to make the *arithmetic* cartesian too -- but the order is
+    // yq's now.
+    assert_eq!(stdout.trim(), "2\n3\n4\n2\n3\n4\n0\n1");
 
     // #2420's shape: unparenthesised, the comma is now the outermost
     // operator, so this is `(.[] | ((1,2,3) + 1)), file_index` -- the
@@ -15707,7 +15719,8 @@ fn test_eval_all_compare_fanout_survives_file_index_in_pipe_issue_822() -> Resul
         &["--eval-all", "-o", "json"],
     )?;
     assert_eq!(code, 0);
-    assert_eq!(stdout.trim(), "false\ntrue\ntrue\n0\nfalse\ntrue\ntrue\n1");
+    // Branch-major since #2451; see the `Expr::Arithmetic` twin above.
+    assert_eq!(stdout.trim(), "false\ntrue\ntrue\nfalse\ntrue\ntrue\n0\n1");
 
     let (stdout, _stderr, code) = run_yq_files(
         ".[] | ((1,2,3) > 1), file_index",
@@ -31283,7 +31296,7 @@ fn test_yq_pipe_precedence_holds_at_every_depth_2420() -> Result<()> {
     Ok(())
 }
 
-/// #2420: two probes where succinctly's post-fix grouping is right but the
+/// #2420: a probe where succinctly's post-fix grouping is right but the
 /// *output* still differs from real yq, for reasons scoped elsewhere. Pinned
 /// so the residue is visible rather than mistaken for a precedence bug.
 #[test]
@@ -31308,22 +31321,10 @@ fn test_yq_pipe_precedence_residual_divergences_2420() -> Result<()> {
         "stderr: {stderr:?}"
     );
 
-    // Both sides fully parenthesised, so #2420's precedence plays no part --
-    // yet the two tools still disagree, on *order*:
-    // $ yq -o=json -I0 '(.a, .b) | (.c, .d)'  on 'a: {c: 3, d: 4}\nb: {c: 5, d: 6}\n'
-    //   =>  3 / 5 / 4 / 6
-    // $ jq -c        '(.a, .b) | (.c, .d)'    =>  3 / 4 / 5 / 6
-    // yq evaluates a `,` over the whole *context list* produced by the pipe's
-    // left side (`.c` over both, then `.d` over both), where jq and succinctly
-    // pipe each left-hand value independently. That is yq's evaluation model,
-    // not its precedence table, and the parser cannot express it.
-    let (output, code) = run_yq_stdin(
-        "(.a, .b) | (.c, .d)",
-        "a: {c: 3, d: 4}\nb: {c: 5, d: 6}\n",
-        args,
-    )?;
-    assert_eq!(code, 0);
-    assert_eq!(output.trim(), "3\n4\n5\n6");
+    // The second residual this test used to carry -- `(.a, .b) | (.c, .d)`
+    // answering `3 4 5 6` where yq answers `3 5 4 6` -- is gone: that was
+    // yq's context-list evaluation model, not its precedence table, and
+    // #2451 implements it. See `test_yq_pipe_into_union_is_branch_major_2451`.
 
     Ok(())
 }
@@ -31994,5 +31995,219 @@ fn test_yq_all_four_empty_operand_shapes_are_indistinguishable_2460() -> Result<
             }
         }
     }
+    Ok(())
+}
+
+// =============================================================================
+// #2451: yq's context-list model for a single document
+// =============================================================================
+
+/// The document every #2451 row was captured against: `yq -o=json -I0 FILTER`
+/// on this YAML, and `/usr/bin/jq 1.7.1 -c FILTER` on the equivalent
+/// `{"a":{"c":3,"d":4},"b":{"c":5,"d":6},"n":[1,2,3]}`.
+const CONTEXT_LIST_DOC_2451: &str = "a: {c: 3, d: 4}\nb: {c: 5, d: 6}\nn: [1, 2, 3]\n";
+
+/// #2451 rule 1: a pipe into a union is **branch-major**.
+///
+/// Real yq has no scalar evaluation mode -- `Context.MatchingNodes`
+/// (`pkg/yqlib/context.go`, v4.53.3) is always a list. `|` hands its left
+/// side's whole list to its right side in one call (`operator_pipe.go`), and
+/// `,` evaluates each of its branches against that same whole list and
+/// concatenates the branch results in order (`operator_union.go`). So `.c`
+/// runs over every value the left side produced, *then* `.d` does -- where jq
+/// pipes each value independently and interleaves.
+///
+/// Every expectation below is a live capture, quoted per assertion. jq's own
+/// answer is quoted beside it and pinned in `jq_cli_tests.rs`'s
+/// `test_jq_pipe_into_union_stays_element_major_2451`, so the divergence is
+/// pinned from both sides.
+#[test]
+fn test_yq_pipe_into_union_is_branch_major_2451() -> Result<()> {
+    let args = &["-o", "json", "-I0"];
+    let doc = CONTEXT_LIST_DOC_2451;
+
+    // $ yq -o=json -I0 '(.a, .b) | (.c, .d)'  =>  3 / 5 / 4 / 6
+    // $ jq -c        '(.a, .b) | (.c, .d)'    =>  3 / 4 / 5 / 6
+    let (out, code) = run_yq_stdin("(.a, .b) | (.c, .d)", doc, args)?;
+    assert_eq!(code, 0);
+    assert_eq!(out.trim(), "3\n5\n4\n6");
+
+    // $ yq -o=json -I0 '(.a, .b) | (.c, .d) | . + 10'  =>  13 / 15 / 14 / 16
+    // $ jq -c        '(.a, .b) | (.c, .d) | . + 10'    =>  13 / 14 / 15 / 16
+    // The stage after the union runs per output, but over the union's own
+    // branch-major order.
+    let (out, code) = run_yq_stdin("(.a, .b) | (.c, .d) | . + 10", doc, args)?;
+    assert_eq!(code, 0);
+    assert_eq!(out.trim(), "13\n15\n14\n16");
+
+    // $ yq -o=json -I0 '.n[] | (., . * 10)'  =>  1 / 2 / 3 / 10 / 20 / 30
+    // $ jq -c        '.n[] | (., . * 10)'    =>  1 / 10 / 2 / 20 / 3 / 30
+    // The multiplicity need not come from a comma: `.[]` splats into one
+    // context list too.
+    let (out, code) = run_yq_stdin(".n[] | (., . * 10)", doc, args)?;
+    assert_eq!(code, 0);
+    assert_eq!(out.trim(), "1\n2\n3\n10\n20\n30");
+
+    // $ yq -o=json -I0 '[(.a, .b) | (.c, .d)]'  =>  [3,5,4,6]
+    // $ jq -c        '[(.a, .b) | (.c, .d)]'    =>  [3,4,5,6]
+    let (out, code) = run_yq_stdin("[(.a, .b) | (.c, .d)]", doc, args)?;
+    assert_eq!(code, 0);
+    assert_eq!(out.trim(), "[3,5,4,6]");
+
+    // $ yq -o=json -I0 '(.a, .b) | with_entries(.) | (.c, .d)'  =>  3/5/4/6
+    // $ jq -c        '(.a, .b) | with_entries(.) | (.c, .d)'    =>  3/4/5/6
+    // The list the union sees is everything *upstream* of it, not just the
+    // stage immediately before: an intervening non-union stage does not
+    // re-split the context.
+    let (out, code) = run_yq_stdin("(.a, .b) | with_entries(.) | (.c, .d)", doc, args)?;
+    assert_eq!(code, 0);
+    assert_eq!(out.trim(), "3\n5\n4\n6");
+
+    // $ yq -o=json -I0 '(.a, .b) | (.c, .d) | (. + 1, . + 2)'
+    //     =>  4 / 6 / 5 / 7 / 5 / 7 / 6 / 8
+    // $ jq -c        '(.a, .b) | (.c, .d) | (. + 1, . + 2)'
+    //     =>  4 / 5 / 5 / 6 / 6 / 7 / 7 / 8
+    // A second union sees the *whole* concatenation the first one produced --
+    // the row no "continue per branch output" model reproduces.
+    let (out, code) = run_yq_stdin("(.a, .b) | (.c, .d) | (. + 1, . + 2)", doc, args)?;
+    assert_eq!(code, 0);
+    assert_eq!(out.trim(), "4\n6\n5\n7\n5\n7\n6\n8");
+
+    // $ yq -o=json -I0 '1 | (. + 1, . + 2) | (. * 10, . * 100)'
+    //     =>  20 / 30 / 200 / 300
+    // $ jq -c        '1 | (. + 1, . + 2) | (. * 10, . * 100)'
+    //     =>  20 / 200 / 30 / 300
+    // Branch-major even when the document root is the only input: the rule is
+    // about the union, not about how many values reached it.
+    let (out, code) = run_yq_stdin("1 | (. + 1, . + 2) | (. * 10, . * 100)", doc, args)?;
+    assert_eq!(code, 0);
+    assert_eq!(out.trim(), "20\n30\n200\n300");
+
+    Ok(())
+}
+
+/// #2451 rule 1, nesting: `|` is associative in yq's model (`pipeOperator`
+/// only threads its left side's node list into its right side), so a union
+/// reached through a *nested* pipe still sees the outer context list.
+///
+/// N1 and N2 print the same thing in real yq despite different bracketing,
+/// which is what a per-element pipe cannot produce for N2: grouping
+/// `(.c, .d) | (., .)` as one parenthesised right-hand stage would evaluate
+/// it once per left value and give `3 4 5 6`.
+#[test]
+fn test_yq_union_under_a_nested_pipe_still_sees_the_outer_list_2451() -> Result<()> {
+    let args = &["-o", "json", "-I0"];
+    let doc = CONTEXT_LIST_DOC_2451;
+
+    // $ yq -o=json -I0 '((.a, .b) | (.c, .d)) | (., . + 100)'
+    //     =>  3 / 5 / 4 / 6 / 103 / 105 / 104 / 106
+    // $ jq -c        '((.a, .b) | (.c, .d)) | (., . + 100)'
+    //     =>  3 / 103 / 4 / 104 / 5 / 105 / 6 / 106
+    let (out, code) = run_yq_stdin("((.a, .b) | (.c, .d)) | (., . + 100)", doc, args)?;
+    assert_eq!(code, 0);
+    assert_eq!(out.trim(), "3\n5\n4\n6\n103\n105\n104\n106");
+
+    // $ yq -o=json -I0 '(.a, .b) | ((.c, .d) | (., . + 100))'
+    //     =>  3 / 5 / 4 / 6 / 103 / 105 / 104 / 106
+    // $ jq -c        '(.a, .b) | ((.c, .d) | (., . + 100))'
+    //     =>  3 / 103 / 4 / 104 / 5 / 105 / 6 / 106
+    // Same output from a different bracketing, which is the point: `|` is
+    // associative in yq's model, so the union sees the outer list either way.
+    let (out, code) = run_yq_stdin("(.a, .b) | ((.c, .d) | (., . + 100))", doc, args)?;
+    assert_eq!(code, 0);
+    assert_eq!(out.trim(), "3\n5\n4\n6\n103\n105\n104\n106");
+
+    // Rule 1 does not reach operators that yq itself applies per node. `[...]`
+    // collects one array per context node unless every node carries
+    // `EvaluateTogether` (`operator_collect.go`), which only `--eval-all`'s
+    // document nodes do (#2427) -- so these two already agreed and still do.
+    //
+    // $ yq -o=json -I0 '(.a, .b) | [.c]'  =>  [3] / [5]
+    let (out, code) = run_yq_stdin("(.a, .b) | [.c]", doc, args)?;
+    assert_eq!(code, 0);
+    assert_eq!(out.trim(), "[3]\n[5]");
+
+    // $ yq -o=json -I0 '(.a, .b) | ((.c, .d) | [.])'  =>  [3] / [5] / [4] / [6]
+    let (out, code) = run_yq_stdin("(.a, .b) | ((.c, .d) | [.])", doc, args)?;
+    assert_eq!(code, 0);
+    assert_eq!(out.trim(), "[3]\n[5]\n[4]\n[6]");
+
+    // Likewise a binary operator: `crossFunctionWithPrefs` takes its
+    // per-node path for `,`-built nodes, so `+` still pairs within one node.
+    //
+    // $ yq -o=json -I0 '(.a, .b) | (.c + .d)'  =>  7 / 11
+    let (out, code) = run_yq_stdin("(.a, .b) | (.c + .d)", doc, args)?;
+    assert_eq!(code, 0);
+    assert_eq!(out.trim(), "7\n11");
+
+    // `as` binds one value at a time (`operator_variables.go`), so its body
+    // sees a one-element context and interleaves like jq.
+    //
+    // $ yq -o=json -I0 '(.a, .b) as $x | ($x.c, $x.d)'  =>  3 / 4 / 5 / 6
+    let (out, code) = run_yq_stdin("(.a, .b) as $x | ($x.c, $x.d)", doc, args)?;
+    assert_eq!(code, 0);
+    assert_eq!(out.trim(), "3\n4\n5\n6");
+
+    Ok(())
+}
+
+/// #2451 rule 1 and path context: `key`/`path`/`parent` after a union are
+/// answered from each value's own cursor, so branch-major ordering reaches
+/// them too. These are the sweep rows
+/// (`scripts/jq-path-context-oracle-sweep.sh`) whose `comma_stream` manifest
+/// entry this change retires.
+#[test]
+fn test_yq_branch_major_order_reaches_path_context_2451() -> Result<()> {
+    let args = &["-o", "json", "-I0"];
+    let doc = CONTEXT_LIST_DOC_2451;
+
+    // $ yq -o=json -I0 '(.a, .b) | (.c, .d) | key'  =>  "c" / "c" / "d" / "d"
+    let (out, code) = run_yq_stdin("(.a, .b) | (.c, .d) | key", doc, args)?;
+    assert_eq!(code, 0);
+    assert_eq!(out.trim(), "\"c\"\n\"c\"\n\"d\"\n\"d\"");
+
+    // $ yq -o=json -I0 '(.a, .b) | (.c, .d) | path'
+    //     =>  ["a","c"] / ["b","c"] / ["a","d"] / ["b","d"]
+    let (out, code) = run_yq_stdin("(.a, .b) | (.c, .d) | path", doc, args)?;
+    assert_eq!(code, 0);
+    assert_eq!(
+        out.trim(),
+        "[\"a\",\"c\"]\n[\"b\",\"c\"]\n[\"a\",\"d\"]\n[\"b\",\"d\"]"
+    );
+
+    // $ yq -o=json -I0 '(.a, .b) | (.c, .d) | parent | key'  =>  "a"/"b"/"a"/"b"
+    let (out, code) = run_yq_stdin("(.a, .b) | (.c, .d) | parent | key", doc, args)?;
+    assert_eq!(code, 0);
+    assert_eq!(out.trim(), "\"a\"\n\"b\"\n\"a\"\n\"b\"");
+
+    Ok(())
+}
+
+/// #2451 rule 1, error handling: a union branch that raises **discards the
+/// whole expression's output**, including whatever earlier branches already
+/// produced. That is the same rule `eval::streams_escaped_generator_prefix`
+/// already carries for the indexing family (#2226/#2326/#2351/#2374) -- real
+/// yq's error is a Go error, so no partial node list survives it.
+///
+/// Captured live on `{"a":{"b":1,"c":2},"d":[10,20]}`: every filter below
+/// prints nothing on stdout and `Error: e` on stderr, exit 1.
+#[test]
+fn test_yq_union_branch_error_discards_the_prefix_2451() -> Result<()> {
+    let args = &["-o", "json", "-I0"];
+    let doc = "a: {b: 1, c: 2}\nd: [10, 20]\n";
+
+    for filter in [
+        r#"(.a, error("e")) | .b"#,
+        r#"(.a, error("e")).b"#,
+        r#"(.a, error("e")) | (.b, .c)"#,
+        r#"(.a, error("e")).b | key"#,
+        r#"(.d, error("e"))[0:1] | path"#,
+    ] {
+        let (out, err, code) = run_yq_stdin_with_stderr(filter, doc, args)?;
+        assert_eq!(out, "", "`{filter}` should print nothing");
+        assert!(err.contains("Error: e"), "`{filter}` stderr: {err}");
+        assert_eq!(code, 1, "`{filter}` exit");
+    }
+
     Ok(())
 }


### PR DESCRIPTION
## Summary

Three yq-mode rules from the source model on #2451 (mikefarah/yq v4.53.3, cited by file and line there), each its own commit, each pinned with live captures from the Homebrew binary and the corresponding `/usr/bin/jq` 1.7.1 row for jq mode:

1. **A pipe into a union is branch-major.** yq hands the left side's whole result list to `,`, which runs each branch over the list. `eval_yq_context_pipe` materialises the upstream outputs once (one small cursor item per output, never the document), runs each branch across the list, and recurses with the concatenation, which is what `(.a,.b) | (.c,.d) | (.+1,.+2)` = `4 6 5 7 5 7 6 8` requires. Both routes go through one gate.
2. **A union of two bare identities yields the list once.** yq's only dedup is pointer identity of the same list object, which only `.` returns. The yq parser drops the last operand when the last two are identity-transparent, keeping a one-branch comma so the next pair does not collapse again: `(., .)` through seven dots gives `2, 2, 4, 6, 8, 10, 12` lines over a two-element context, `(., ., .c)` six.
3. **A binary operator fans out left-major.** `(.a.c,.b.c) + (1,10)` is `4 13 6 15` in yq, `4 6 13 15` in jq. The fan-out rule now carries `empty` (from #2460) and `left_major` together.

jq mode is untouched on every row. Memory: `.[] | (.a, .b)` over a 20 MB array of 557,675 objects grows peak RSS by 32 MB (about 29 bytes per union output, the cursor list), while `.[] | .a` is unchanged. The 28 `comma_stream` rows leave the sweep manifest: 10 now match and 18 were other classes the glob shadowed (their counts rose accordingly); 3168 cases, 0 unexpected.

## Residuals, recorded in the limitations doc

- A union of two assignments: yq's pointer guard makes `(.a.c = 1), (.b.c = 2)` one document with both writes; collapsing the pair here would discard a write, so rule 2 is restricted to identity-transparent operands.
- A missing-key stage in front of a union keeps jq's interleaving, since an absent position is not a cursor and cannot ride the context list; `.a.x | (key, path)` is still exact through the walk.
- `--eval-all`'s `EvaluateTogether` semantics are #2427; rule 1 already moves its union ordering toward yq.
- A materialised context list cannot honour a downstream `first`/`limit` stop; real yq materialises too and has no side-effecting builtin, so nothing observable differs on the reference surface.

Five existing tests moved toward the oracle, each with its capture in place (including the #2420 residual list, which loses this issue).

## Verification

fmt; clippy on both CI legs with `-D warnings`; `cargo test` in the three configurations; `cargo doc -D warnings`; yq goldens 113 and jq goldens 633; oracle sweep 3168 cases, 0 unexpected.

Behaviour change in yq mode; CHANGELOG entry included; ships in its own release. Part of spine 2416's follow-ups. Closes #2451.
