### PR TITLE
fix(jq): yq reads an absent key as nothing in assignment RHS and operator operands (#2470)

### DIFF
--- a/docs/compliance/yq/limitations.md
+++ b/docs/compliance/yq/limitations.md
@@ -1796,47 +1796,92 @@ a value that isn't a snapshot of anything in the document -- a different kind of
 #2213's path-threading fix, which only ever continues with a value already known to be
 correct (`Null`, jq's own answer for what the missing/OOB read itself evaluates to).
 
-### A binary operand that navigated to a missing key: succinctly sees `null`, real yq sees nothing
+### An absent key read inside a read-only context — resolved (#2470); four neighbouring shapes remain
 
 [#2460](https://github.com/rust-works/succinctly/issues/2460) gave yq mode real yq's rule
-for a binary operator whose operand produces **zero outputs** -- `key`, `parent`,
-`parent(1)` at the document root, or any other filter that emits nothing. That rule is
-implemented once (`jq::eval::yq_empty_operand_output`) and is exact for those shapes. Real
-yq has a *second*, wider category of "empty operand" that it does not cover: an operand
-that navigated to a **missing key**. Captured live against yq v4.53.3 on
+for a binary operator whose operand produces **zero outputs**, and left two matrix cells
+open: an operand that navigated to a **missing key** (`.zzz * 2`, `(.zzz | key) + 1`),
+which real yq also treats as empty even though the same read is a `null` node everywhere
+else. [#2470](https://github.com/rust-works/succinctly/issues/2470) closed both, together
+with the whole assignment-side half of the same mechanism.
 
-```yaml
-a:
-  b: 1
-s: x
-n: [1, 2]
-```
+The mechanism is real yq's `Context.DontAutoCreate` (`pkg/yqlib/context.go`), traced to
+source and re-verified live against v4.53.3. `traverse`/`traverseMap`
+(`pkg/yqlib/operator_traverse_path.go`) fabricate a missing child as a real `!!null` node
+with its `Key` set — which is what lets `key`/`path` answer for a position that does not
+exist — only while the flag is off; with it on the miss contributes no candidate at all,
+before `operator_keys.go` is ever reached. Three constructs force it on, and three
+pointedly do not:
 
-| filter                | real yq                                   | succinctly yq                                      |
-|-----------------------|-------------------------------------------|----------------------------------------------------|
-| `.zzz`                | `null`                                    | `null`                                             |
-| `.zzz \| . * 2`       | `Error: cannot multiply !!null with !!int` | `Error: null (null) and number (2) ...`           |
-| `.zzz * 2`            | *(nothing)*, exit 0                       | `Error: null (null) and number (2) cannot be multiplied` |
-| `.zzz / 2`            | *(nothing)*, exit 0                       | `Error: ... cannot be divided`                     |
-| `.zzz - 1`            | *(nothing)*, exit 0                       | `1`                                                |
-| `.zzz + 1`            | `1`                                       | `1` (agrees, for an unrelated reason)              |
-| `.zzz \| key`         | `"zzz"`                                   | `"zzz"`                                            |
-| `(.zzz \| key) + 1`   | `1`                                       | `Error: string ("zzz") and number (1) cannot be added` |
-| `(.zzz \| key) + "!"` | `"!"`                                     | `"zzz!"`                                           |
+| construct                  | probe                       | real yq   | read-only? |
+|----------------------------|-----------------------------|-----------|------------|
+| `=`-family right side      | `.x = (.zzz \| key)`         | `x: null` | yes        |
+| arithmetic operand         | `(.zzz \| key) + 1`          | `1`       | yes        |
+| `and`/`or` operand         | `(.zzz \| key) and true`     | `false`   | yes        |
+| comparison operand         | `(.zzz \| key) == "zzz"`     | `true`    | no         |
+| `//`                       | `(.zzz \| key) // 5`         | `"zzz"`   | no         |
+| `\|=`'s right side         | `.x \|= (.zzz \| key)`       | `x: "zzz"`| no         |
 
-Real yq is inconsistent with itself here, twice over, and both inconsistencies are what
-make this hard rather than mechanical. `.zzz` on its own is a `null` **value** (`.zzz | . *
-2` raises, exactly like `null * 2`), but the same `.zzz` written directly as an operand is
-an empty **candidate list** (`.zzz * 2` yields nothing) -- so yq's traversal answers
-differently depending on whether an operator or a pipe is asking. And `.zzz | key` is
-`"zzz"` standing alone yet contributes nothing as an operand, so the emptiness survives a
-whole pipe once that pipe is an operand.
+`assignUpdateOperator` (`pkg/yqlib/operator_assign.go`) is where the last two rows part:
+plain `=` runs its right side through `crossFunction(d, context.ReadOnlyClone(), ...)`,
+which forces the flag on; `|=` runs it through `context.SingleChildContext(candidate)`,
+which inherits the ordinary auto-creating setting.
 
-succinctly materializes an ordinary `null` for a missing key at every position, so it has
-no way to distinguish the two contexts. Closing this needs an *absent* operand value
-threaded through operand evaluation -- a model change of the same kind ADR-0021 made for
-path context -- not another entry in #2460's table, which is keyed on an operand producing
-no outputs and would answer these shapes the moment the operand actually produced none.
+Implemented once as `jq::eval::yq_read_only_context` (the ambient scope) plus
+`jq::eval::yq_absent_key_read_is_empty` (the mode gate), consulted by every navigation
+site in both evaluators, and `jq::eval::yq_empty_rhs_document` for the other half of the
+assignment rule: a zero-output right side still emits one document, with the target path
+auto-created and never written, so a new target survives as an explicit `null` while an
+existing one keeps its old value. Only **key** lookups are covered — real yq auto-creates
+through arrays even read-only (`.x = (.n[9] | key)` on `n: [1, 2]` is `x: 9`), so an
+out-of-range array index stays the ordinary `null` read.
+
+Five neighbouring shapes were captured alongside and are **not** part of this rule; each
+is a separate divergence:
+
+| filter                                    | input             | real yq        | succinctly                             |
+|-------------------------------------------|-------------------|----------------|----------------------------------------|
+| `null < 1`, `.zzz < 1`, `null <= 1`       | `a: 1`            | `false`        | `true`                                 |
+| `.s.zzz`                                  | `s: x`            | *(nothing)*    | `Error: Cannot index string with string "zzz"` |
+| `.a \| with_entries(.value = key)`        | `a: {b: 1, e: 2}` | `{"b":0,"e":1}`| `{"b":1,"e":2}`                        |
+| `.a \|= (1 \| select(false))`             | `a: 1`            | `{"a":1}`      | `{"a":null}`                           |
+| `.x = (keys)`                             | `a: 1`            | `{"a":1,"x":["a","x"]}` | `{"a":1,"x":["a"]}`           |
+
+Row 1 is yq's ordering comparison against a real `null`, which is `false` for every
+operator regardless of the other side — nothing to do with absent reads (`.zzz` is a
+genuine `null` node in that position, since a comparison operand is not read-only).
+Row 2 is yq indexing a *scalar* with a key, which yields nothing everywhere, not only in
+a read-only context — it is what makes `.s.zzz + 1` also `1`. Row 3 is what `key` reports
+for an element of a constructed array: real yq answers the index, succinctly has no path
+context for a value it built itself, so the `=` right side is empty and the write is
+skipped. Row 4 is `|=` with a zero-output *filter*, which real yq no-ops the same way it
+no-ops a zero-output `=` right side — succinctly's `update_path` writes `null` instead.
+`.x |= (1 | select(false))` on an absent `.x` already agrees (`x: null`), so only the
+existing-target half diverges.
+
+Row 5 is an evaluation-*order* divergence that predates all of this and is unrelated to
+absent reads: real yq's `assignUpdateOperator` resolves (and auto-creates) the **left**
+side first, then evaluates the right side against the document that traversal has already
+mutated, so the right side can see the node the assignment is about to write into.
+succinctly evaluates the right side against the pristine input. `.x = (length)` on `a: 1`
+is `x: 2` in real yq and `x: 1` here for the same reason.
+
+That order is why four shapes that used to agree by coincidence now do not. `.zzz.q =
+(.zzz | key)` on `a: 1` is `zzz: {q: "zzz"}` in real yq because `.zzz` genuinely *exists*
+by the time the right side runs; succinctly's old answer matched only because its absent
+read fabricated a `null` node whose key happened to be spelled the same. With the read
+now correctly empty, the underlying order difference is what shows:
+
+| filter                    | input  | real yq              | succinctly          |
+|---------------------------|--------|----------------------|---------------------|
+| `.zzz.q = (.zzz \| key)`   | `a: 1` | `{"zzz":{"q":"zzz"}}`| `{"zzz":{"q":null}}`|
+| `.zzz.q += (.zzz \| key)`  | `a: 1` | `{"zzz":{"q":"zzz"}}`| `{"zzz":{"q":null}}`|
+| `.zzz.q -= (.zzz \| key)`  | `a: 1` | `{"zzz":{"q":"zzz"}}`| `{"zzz":{"q":null}}`|
+| `.zzz.q *= (.zzz \| key)`  | `a: 1` | *(error, exit 1)*    | `{"zzz":{"q":null}}`|
+
+(the `a: 1` prefix elided). Closing these needs the right side evaluated against the
+left-vivified document, which is a change to the assignment model rather than to this
+rule -- and would move `.x = (keys)`/`.x = (length)` at the same time.
 
 ### A negative out-of-range array index (`.a[-N]`) raises -- resolved for ordinary reads, a few call sites remain
 

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -438,8 +438,12 @@ pub(crate) enum EmptyOperandOp {
 ///    an error) while an empty operand is symmetric.
 /// 6. yq has three distinct "null-ish" categories -- a real `null`, a
 ///    missing-key `null`, and a zero-output filter -- that do not share one
-///    operator branch. Only the third is this function's business; the
-///    missing-key half (`.zzz * 2`) is a separate, still-divergent shape.
+///    operator branch. Only the third is this function's business. The
+///    missing-key half (`.zzz * 2`) is [`yq_read_only_context`]'s (#2470):
+///    an arithmetic or `and`/`or` operand is evaluated read-only, so such a
+///    read produces zero outputs *before* reaching this table, and a
+///    comparison operand -- which is not read-only -- still sees the real
+///    `null` node.
 pub(crate) fn yq_empty_operand_output(
     op: EmptyOperandOp,
     other: Option<&OwnedValue>,
@@ -478,21 +482,28 @@ pub(crate) fn yq_empty_operand_output(
 /// | construct                | probe                    | yq        |
 /// |--------------------------|--------------------------|-----------|
 /// | `=`-family right side    | `.x = (.zzz \| key)`     | `x: null` |
+/// | arithmetic operand       | `(.zzz \| key) + 1`      | `1`       |
+/// | `and`/`or` operand       | `(.zzz \| key) and true` | `false`   |
 ///
-/// and one that pointedly does **not**, which is why this is a scope rather
-/// than a blanket rule: `|=`'s own right side (`.x |= (.zzz | key)` is
-/// `x: "zzz"`, since `assignUpdateOperator` runs it through
-/// `SingleChildContext` instead of `ReadOnlyClone`,
+/// and three that pointedly do **not**, which is why this is a scope rather
+/// than a blanket rule: a comparison operand (`(.zzz | key) == "zzz"` is
+/// `true`), `//` (`(.zzz | key) // 5` is `"zzz"`), and `|=`'s own right side
+/// (`.x |= (.zzz | key)` is `x: "zzz"`, since `assignUpdateOperator` runs it
+/// through `SingleChildContext` instead of `ReadOnlyClone`,
 /// `pkg/yqlib/operator_assign.go`). A bare filter, a collect (`[.zzz]` is
-/// `[null]`) and an object construction outside an assignment's right side
-/// keep the null node too.
+/// `[null]`) and an object construction outside an operand keep the null
+/// node too.
 ///
-/// The scope covers the whole right-hand subexpression, nested pipes
-/// included -- so it is ambient rather than a parameter, the same shape (and
-/// for the same reason) as `eval_generic`'s `path_context_route`/
-/// `with_file_origin`: the sites that consult it are many recursion levels
-/// below the sites that establish it, and this codebase has no
-/// evaluation-environment parameter for it to ride on.
+/// The scope covers the operand's *whole* subexpression, nested pipes
+/// included -- `(.zzz | key) + 1` is `1`, not `"zzz" + 1` -- so it is
+/// ambient rather than a parameter, the same shape (and for the same reason)
+/// as `eval_generic`'s `path_context_route`/`with_file_origin`: the sites
+/// that consult it are many recursion levels below the sites that establish
+/// it, and this codebase has no evaluation-environment parameter for it to
+/// ride on. [`yq_read_only_context::suspend`] is the other half of that:
+/// operand evaluation here is demand-driven, so the *consumer* of an
+/// operand's outputs runs on the stack inside the producing call and must
+/// not inherit the scope.
 ///
 /// `#[cfg(feature = "std")]` only, same limitation as its two siblings named
 /// above: a `no_std` embedding has no `thread_local!`, so the scope is never
@@ -529,6 +540,14 @@ pub(crate) mod yq_read_only_context {
         set(true)
     }
 
+    /// Leave any read-only context for the caller's scope -- what a
+    /// demand-driven operand's *sink* runs under, so that a downstream stage
+    /// (`.zzz + 1 | .yyy`) or the other operand's own pairing work does not
+    /// inherit a scope that belongs to the operand expression alone.
+    pub(crate) fn suspend() -> Guard {
+        set(false)
+    }
+
     impl Drop for Guard {
         fn drop(&mut self) {
             ACTIVE.with(|c| c.set(self.0));
@@ -545,6 +564,10 @@ pub(crate) mod yq_read_only_context {
     pub(crate) struct Guard;
 
     pub(crate) fn enter() -> Guard {
+        Guard
+    }
+
+    pub(crate) fn suspend() -> Guard {
         Guard
     }
 }
@@ -593,13 +616,25 @@ pub(crate) struct BinaryFanoutRules {
     /// left operand outermost (jq short-circuits per left output), which is
     /// already yq's order.
     pub(crate) left_major: bool,
+    /// `true` in yq mode for an **arithmetic** or `and`/`or` operand (#2470):
+    /// the operand expression is evaluated inside a
+    /// [read-only context](yq_read_only_context), so a key lookup that finds
+    /// nothing there produces no output rather than a `null` node -- which is
+    /// then answered by [`yq_empty_operand_output`]'s own zero-output row.
+    ///
+    /// `false` for a **comparison** operand even in yq mode: real yq's
+    /// `compareOperator` does not clone its context read-only, and
+    /// `(.zzz | key) == "zzz"` is `true` there, not `false` (v4.53.3).
+    pub(crate) read_only: bool,
 }
 
-/// The one place either binary-fanout rule is read off `S` (#2460/#2451).
+/// The one place any binary-fanout rule is read off `S` (#2460/#2451/#2470).
 pub(crate) fn binary_fanout_rules<S: EvalSemantics>(op: EmptyOperandOp) -> BinaryFanoutRules {
     BinaryFanoutRules {
         empty: S::EMPTY_OPERAND_BINARY_RULE.then_some(op),
         left_major: S::BINARY_FANOUT_IS_LEFT_MAJOR,
+        read_only: S::READ_ONLY_ABSENT_KEY_IS_EMPTY
+            && matches!(op, EmptyOperandOp::Arith(_) | EmptyOperandOp::Boolean),
     }
 }
 
@@ -5651,6 +5686,12 @@ fn binary_fanout_each<'a, W: Clone + AsRef<[u64]>>(
     mut combine: impl FnMut(OwnedValue, OwnedValue) -> Result<OwnedValue, EvalError>,
     sink: &mut dyn FnMut(Item<'a, W>) -> Demand,
 ) -> Flow {
+    // #2470 (yq mode, arithmetic and `and`/`or` only): every operand below is
+    // enumerated through this wrapper instead of `each_operand` directly, so
+    // the operand *expression* runs inside a read-only context while the sink
+    // it feeds -- the other operand's pairing work and whatever consumes the
+    // result downstream -- does not. See `yq_read_only_context`.
+    let each_operand = read_only_operand_strategy(rules, each_operand);
     // Why the fanout ended, recorded out-of-band because the driver closure
     // can only answer `Demand` — the same shape as `eval_each_pipe`'s
     // `downstream` and `any_all_gen_cond`'s `probe_escape`.
@@ -5809,6 +5850,32 @@ fn binary_fanout_each<'a, W: Clone + AsRef<[u64]>>(
         return empty_outer_operand_pass(&each_operand, inner_expr, op, sink);
     }
     abort.unwrap_or(outer)
+}
+
+/// Wrap an operand-enumeration strategy so the operand expression itself runs
+/// inside a [read-only context](yq_read_only_context) and its sink does not
+/// (#2470).
+///
+/// A pass-through when `rules.read_only` is `false` (jq mode, and a
+/// comparison operand in either mode), so nothing outside yq's arithmetic
+/// and `and`/`or` operands pays for -- or observes -- the scope. The
+/// `suspend` on the way into the sink is what makes `.zzz + 1 | .yyy` keep
+/// reading `.yyy` normally, and what lets the *inner* operand's own wrapped
+/// call re-enter the scope from scratch.
+fn read_only_operand_strategy<'a, W: Clone + AsRef<[u64]>>(
+    rules: BinaryFanoutRules,
+    each_operand: impl Fn(&Expr, &mut dyn FnMut(Item<'a, W>) -> Demand) -> Flow,
+) -> impl Fn(&Expr, &mut dyn FnMut(Item<'a, W>) -> Demand) -> Flow {
+    move |expr: &Expr, sink: &mut dyn FnMut(Item<'a, W>) -> Demand| {
+        if !rules.read_only {
+            return each_operand(expr, sink);
+        }
+        let _scope = yq_read_only_context::enter();
+        each_operand(expr, &mut |item| {
+            let _suspended = yq_read_only_context::suspend();
+            sink(item)
+        })
+    }
 }
 
 /// The `right`-operand-produced-nothing half of [`binary_fanout_each`]'s
@@ -5972,6 +6039,18 @@ fn boolean_fanout_core<'a, W: Clone + AsRef<[u64]>>(
     short_circuit: bool,
     rules: BinaryFanoutRules,
 ) -> QueryResult<'a, W> {
+    // #2470 (yq mode): `and`/`or` evaluate both operands read-only, exactly
+    // like arithmetic -- `(.zzz | key) and true` is `false` in real yq while
+    // `"zzz" and true` is `true`. This operand strategy is eager (a whole
+    // `QueryResult` per call, not a sink), so there is nothing to suspend:
+    // the scope covers only the call itself.
+    let mut eval_operand = move |expr: &Expr| {
+        if !rules.read_only {
+            return eval_operand(expr);
+        }
+        let _scope = yq_read_only_context::enter();
+        eval_operand(expr)
+    };
     let mut left_bools = Vec::new();
     let left_control = push_truthiness(eval_operand(left), &mut left_bools);
     // #2460 (yq mode only): an operand that produced *zero* outputs

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -280,6 +280,20 @@ pub trait EvalSemantics: Copy + Default {
     /// See `BinaryFanoutRules::left_major` (this module, private) for the
     /// captured rows and the yq source this reproduces.
     const BINARY_FANOUT_IS_LEFT_MAJOR: bool;
+
+    /// If true (yq, #2470), a **key lookup that finds nothing** yields zero
+    /// outputs -- instead of the usual `null` node -- while a read-only
+    /// context (`yq_read_only_context`, this module, private) is active. If
+    /// false (jq), the read is `null` everywhere and the scope is never
+    /// entered at all.
+    ///
+    /// Reproduces real yq's `Context.DontAutoCreate`: `traverse`/
+    /// `traverseMap` fabricate the missing child as a real `!!null` node
+    /// (with `Key` set, which is what lets `key`/`path` answer for it) only
+    /// when the flag is *off*; with it on, the miss contributes no candidate
+    /// at all. See `yq_read_only_context`'s own doc comment for which
+    /// contexts force it on and for the captured rows.
+    const READ_ONLY_ABSENT_KEY_IS_EMPTY: bool;
 }
 
 /// jq-compatible evaluation semantics (default).
@@ -310,6 +324,7 @@ impl EvalSemantics for JqSemantics {
     const ROOT_PATH_CONTEXT_YIELDS_NOTHING: bool = false;
     const EMPTY_OPERAND_BINARY_RULE: bool = false;
     const BINARY_FANOUT_IS_LEFT_MAJOR: bool = false;
+    const READ_ONLY_ABSENT_KEY_IS_EMPTY: bool = false;
 }
 
 /// yq-compatible evaluation semantics.
@@ -342,6 +357,7 @@ impl EvalSemantics for YqSemantics {
     const ROOT_PATH_CONTEXT_YIELDS_NOTHING: bool = true;
     const EMPTY_OPERAND_BINARY_RULE: bool = true;
     const BINARY_FANOUT_IS_LEFT_MAJOR: bool = true;
+    const READ_ONLY_ABSENT_KEY_IS_EMPTY: bool = true;
 }
 
 use crate::json::light::{JsonCursor, JsonElements, JsonFields, StandardJson};
@@ -443,6 +459,110 @@ pub(crate) fn yq_empty_operand_output(
         }
         EmptyOperandOp::Boolean => Some(OwnedValue::Bool(false)),
     }
+}
+
+/// **The one definition of yq's read-only evaluation context** (#2470),
+/// consulted by both evaluators and by every navigation site that has to
+/// decide what a key lookup that found nothing evaluates to.
+///
+/// Real yq carries the flag on the `Context` struct it threads through
+/// evaluation (`Context.DontAutoCreate`, `pkg/yqlib/context.go`). With it
+/// off, `traverse`/`traverseMap` (`pkg/yqlib/operator_traverse_path.go`)
+/// fabricate the missing child as a real `!!null` node with its `Key` set,
+/// which is what lets `key`/`path` answer for a position that does not
+/// exist; with it on, the miss contributes no candidate at all and the drop
+/// happens before `key`/`path` are ever reached. Three constructs force it
+/// on, all live-captured against yq v4.53.3 on `a: {b: 1}`, `s: x`,
+/// `n: [1, 2]`:
+///
+/// | construct                | probe                    | yq        |
+/// |--------------------------|--------------------------|-----------|
+/// | `=`-family right side    | `.x = (.zzz \| key)`     | `x: null` |
+///
+/// and one that pointedly does **not**, which is why this is a scope rather
+/// than a blanket rule: `|=`'s own right side (`.x |= (.zzz | key)` is
+/// `x: "zzz"`, since `assignUpdateOperator` runs it through
+/// `SingleChildContext` instead of `ReadOnlyClone`,
+/// `pkg/yqlib/operator_assign.go`). A bare filter, a collect (`[.zzz]` is
+/// `[null]`) and an object construction outside an assignment's right side
+/// keep the null node too.
+///
+/// The scope covers the whole right-hand subexpression, nested pipes
+/// included -- so it is ambient rather than a parameter, the same shape (and
+/// for the same reason) as `eval_generic`'s `path_context_route`/
+/// `with_file_origin`: the sites that consult it are many recursion levels
+/// below the sites that establish it, and this codebase has no
+/// evaluation-environment parameter for it to ride on.
+///
+/// `#[cfg(feature = "std")]` only, same limitation as its two siblings named
+/// above: a `no_std` embedding has no `thread_local!`, so the scope is never
+/// active there and a missing key reads back as the ordinary `null` node.
+#[cfg(feature = "std")]
+pub(crate) mod yq_read_only_context {
+    use std::cell::Cell;
+
+    thread_local! {
+        static ACTIVE: Cell<bool> = const { Cell::new(false) };
+    }
+
+    /// Whether a read-only context is currently active. Callers must still
+    /// gate on [`super::EvalSemantics::READ_ONLY_ABSENT_KEY_IS_EMPTY`] --
+    /// [`super::yq_absent_key_read_is_empty`] is the one place that does
+    /// both.
+    pub(crate) fn active() -> bool {
+        ACTIVE.with(Cell::get)
+    }
+
+    /// Restores the previous state on drop, so a call that has returned
+    /// never leaks its scope into a sibling evaluation.
+    #[must_use]
+    pub(crate) struct Guard(bool);
+
+    fn set(active_now: bool) -> Guard {
+        let previous = active();
+        ACTIVE.with(|c| c.set(active_now));
+        Guard(previous)
+    }
+
+    /// Enter a read-only context for the caller's scope.
+    pub(crate) fn enter() -> Guard {
+        set(true)
+    }
+
+    impl Drop for Guard {
+        fn drop(&mut self) {
+            ACTIVE.with(|c| c.set(self.0));
+        }
+    }
+}
+
+#[cfg(not(feature = "std"))]
+pub(crate) mod yq_read_only_context {
+    pub(crate) fn active() -> bool {
+        false
+    }
+
+    pub(crate) struct Guard;
+
+    pub(crate) fn enter() -> Guard {
+        Guard
+    }
+}
+
+/// Whether a key lookup that found nothing must yield **no output** here,
+/// instead of the `null` node every other context reads back (#2470).
+///
+/// The single gate on [`yq_read_only_context`]: the mode says whether the
+/// rule exists at all, the ambient scope says whether it applies right now.
+/// Deliberately keyed on the *lookup kind*, not on the value: only a key
+/// lookup (`.zzz`, `.["zzz"]`, `.[$k]` with a string `$k`) is covered, on an
+/// object without that key or on a `null` node. An out-of-range **array**
+/// index is not -- real yq auto-creates through arrays even inside a
+/// read-only context (`.x = (.n[9] | key)` on `n: [1, 2]` is `x: 9`, and it
+/// pads `n` out to ten elements while it is at it), so `.n[9]` stays the
+/// ordinary `null` read.
+pub(crate) fn yq_absent_key_read_is_empty<S: EvalSemantics>() -> bool {
+    S::READ_ONLY_ABSENT_KEY_IS_EMPTY && yq_read_only_context::active()
 }
 
 /// The two per-mode rules a binary-operator fanout needs, resolved once from
@@ -1282,7 +1402,7 @@ fn eval_single<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     match expr {
         Expr::Identity => QueryResult::One(value),
 
-        Expr::Field(name) => index_object_by_name::<W>(value, name, optional),
+        Expr::Field(name) => index_object_by_name::<W, S>(value, name, optional),
 
         Expr::Index { idx, .. } => index_array_by_position::<W, S>(value, *idx, optional),
 
@@ -16697,11 +16817,17 @@ fn find_field<'a, W: Clone + AsRef<[u64]>>(
 /// null-input passthrough below is reached *only* for a valid key kind, which is
 /// what makes `null | .["a"]` yield `null` while `null | .[null]` errors.
 #[inline]
-fn index_object_by_name<'a, W: Clone + AsRef<[u64]>>(
+fn index_object_by_name<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     value: StandardJson<'a, W>,
     name: &str,
     optional: bool,
 ) -> QueryResult<'a, W> {
+    // #2470 (yq mode, inside a read-only context only): a key lookup that
+    // finds nothing yields *no* node rather than `null` -- on an object
+    // without the key and on a `null` node alike (real yq's `.a * 2` on a
+    // `null` document is empty, while on `a: null` it raises, so the
+    // distinction is "was a child found", not "is the parent null").
+    let absent_is_empty = yq_absent_key_read_is_empty::<S>();
     match value {
         // #1995: a non-string sibling key (`fields.find`'s own `Err`) is a
         // hard parse-time error in real jq, never suppressed by this
@@ -16715,10 +16841,12 @@ fn index_object_by_name<'a, W: Clone + AsRef<[u64]>>(
         StandardJson::Object(fields) => match find_field::<W>(fields, name) {
             Ok(Some(v)) => QueryResult::One(v),
             // jq returns null for missing fields on objects (not an error)
+            Ok(None) if absent_is_empty => QueryResult::None,
             Ok(None) => QueryResult::One(StandardJson::Null),
             Err(e) => QueryResult::Error(e),
         },
         // jq returns null for field access on null
+        StandardJson::Null if absent_is_empty => QueryResult::None,
         StandardJson::Null => QueryResult::One(StandardJson::Null),
         _ if optional => QueryResult::None,
         _ => QueryResult::Error(EvalError::cannot_index_with_field(type_name(&value), name)),
@@ -16876,7 +17004,7 @@ fn index_one<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
 
     match key {
         OwnedValue::String(s) if indexable_by_string => {
-            index_object_by_name::<W>(target, s, optional)
+            index_object_by_name::<W, S>(target, s, optional)
         }
         OwnedValue::Int(_) | OwnedValue::Float(_) | OwnedValue::NumberLiteral(..)
             if indexable_by_number =>
@@ -19400,11 +19528,12 @@ fn eval_assign<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     // on a clean multi-output completion -- shared with `eval_update_multi`
     // (#1844). See `normalize_rhs_values_for_fork`'s own doc comment for
     // the full rationale of both rules.
-    let (rhs_values, terminal) =
-        match normalize_rhs_values_for_fork::<W, S>(rhs_values, terminal, optional) {
-            Ok(v) => v,
-            Err(early_return) => return early_return,
-        };
+    let (rhs_values, terminal) = match normalize_rhs_values_for_fork::<W, S>(
+        rhs_values, terminal, optional, path_expr, &input,
+    ) {
+        Ok(v) => v,
+        Err(early_return) => return early_return,
+    };
 
     // Resolve computed keys against the *original* document, before any
     // write, then apply them to every RHS output in turn: `.[("a","b")] =
@@ -19586,6 +19715,18 @@ fn collect_rhs_outputs<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     input: &StandardJson<'a, W>,
     optional: bool,
 ) -> Result<(Vec<OwnedValue>, Option<Control>), QueryResult<'a, W>> {
+    // #2470 (yq mode): `assignUpdateOperator` runs a plain `=`'s right side
+    // through `crossFunction(d, context.ReadOnlyClone(), ...)`, which forces
+    // `Context.DontAutoCreate` on for that evaluation -- so a key lookup that
+    // finds nothing in here yields no node at all, and `.x = (.zzz | key)` is
+    // `x: null` rather than `x: "zzz"`. Captured the same way for `+=`/`-=`/
+    // `*=`, which share this prologue (`/=`, `%=` and `//=` share it too;
+    // real yq's parser has no such operators, so those are succinctly
+    // extensions kept consistent with their siblings rather than matched).
+    // `|=` never reaches here: `eval_update` evaluates its filter through
+    // `update_path` instead, matching yq's own `SingleChildContext`, which
+    // leaves `DontAutoCreate` alone. See `yq_read_only_context`.
+    let _scope = S::READ_ONLY_ABSENT_KEY_IS_EMPTY.then(yq_read_only_context::enter);
     match eval_single::<W, S>(value_expr, input.clone(), optional).materialize_cursor() {
         QueryResult::One(v) => match to_owned(&v) {
             Ok(owned) => Ok((vec![owned], None)),
@@ -19612,9 +19753,11 @@ fn collect_rhs_outputs<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
 /// the fork loop runs -- shared by `eval_assign`/`eval_compound_assign`/
 /// `eval_alternative_assign` (#392/#1430/#1844):
 ///
-/// - A zero-output RHS produces zero documents (`Err` short-circuits the
-///   caller directly with that result) -- not `eval_rhs_once`'s old
-///   "collapse empty to `Null`" behavior.
+/// - A zero-output RHS produces zero documents in **jq** mode (`Err`
+///   short-circuits the caller directly with that result) -- not
+///   `eval_rhs_once`'s old "collapse empty to `Null`" behavior. In **yq**
+///   mode it produces exactly one document instead, with the target path
+///   auto-created but never written -- [`yq_empty_rhs_document`], #2470.
 /// - Real yq never forks over a multi-output RHS the way jq's does (#392):
 ///   it applies only the *last* output, once, to every resolved path --
 ///   confirmed live (v4.53.3): `.x = (1,2,3)` on `{"x":0}` is `{"x":3}`,
@@ -19631,9 +19774,14 @@ fn normalize_rhs_values_for_fork<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     mut rhs_values: Vec<OwnedValue>,
     terminal: Option<Control>,
     optional: bool,
+    path_expr: &Expr,
+    input: &StandardJson<'a, W>,
 ) -> Result<(Vec<OwnedValue>, Option<Control>), QueryResult<'a, W>> {
     if rhs_values.is_empty() {
         return Err(match terminal {
+            None if S::READ_ONLY_ABSENT_KEY_IS_EMPTY => {
+                yq_empty_rhs_document::<W, S>(path_expr, input, optional)
+            }
             None => QueryResult::None,
             Some(Control::Error(_)) if optional => QueryResult::None,
             Some(control) => partial(Vec::new(), control), // normalizes to bare Error/Break
@@ -19645,6 +19793,65 @@ fn normalize_rhs_values_for_fork<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
         rhs_values.push(last);
     }
     Ok((rhs_values, terminal))
+}
+
+/// The one document a yq-mode assignment with a **zero-output** right side
+/// still emits (#2470): the target path auto-created, and nothing written
+/// into it.
+///
+/// Real yq's `assignUpdateOperator` navigates the left side with
+/// auto-creation on before it ever looks at the right side's candidates, and
+/// then simply runs its write loop zero times. So a *new* target survives as
+/// an explicit `null` while an *existing* one keeps its old value, and the
+/// document is emitted either way -- where jq mode produces no document at
+/// all (`jq '.x = empty'` is empty output, pinned in jq mode). Live-captured
+/// against yq v4.53.3 with a right side that is empty for reasons of its own
+/// (`1 | select(false)`), so the rule is keyed on "the right side produced
+/// nothing" and not on why:
+///
+/// | filter                     | input        | yq v4.53.3               |
+/// |----------------------------|--------------|--------------------------|
+/// | `.x = (1 \| select(false))` | `a: 1`       | `{"a":1,"x":null}`       |
+/// | `.a = (1 \| select(false))` | `a: 1`       | `{"a":1}`                |
+/// | `.a.b.c = (1 \| select(false))` | `z: 1`  | `{"z":1,"a":{"b":{"c":null}}}` |
+/// | `.a[] = (1 \| select(false))` | `z: 1`     | `{"z":1,"a":[]}`         |
+/// | `.a[] = (1 \| select(false))` | `a: [1,2]` | `{"a":[1,2]}`            |
+/// | `(.a,.b) = (1 \| select(false))` | `a: 1`  | `{"a":1,"b":null}`       |
+///
+/// Implemented as `path |= .` rather than a bespoke "vivify but skip the
+/// write" walk: `update_path` already creates every missing step on the way
+/// down and then writes back whatever the filter returned, so an
+/// `Expr::Identity` filter is exactly "create the path, change nothing" --
+/// including the `Iterate`-autovivifies-`Null`-to-`[]` and slice cases,
+/// which a second hand-written walk would have had to re-derive (and could
+/// then drift from, the #106 failure this file keeps one definition to
+/// avoid).
+fn yq_empty_rhs_document<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
+    path_expr: &Expr,
+    input: &StandardJson<'a, W>,
+    optional: bool,
+) -> QueryResult<'a, W> {
+    // Same `optional` policy, in the same order, as `eval_assign`'s own
+    // `NotChecked` arm: a non-decode-failure `to_owned` error and a path
+    // resolution error are both swallowed by an outer `?`, a halt never is.
+    let mut result = match to_owned(input) {
+        Ok(result) => result,
+        Err(e) => return suppress_or_raise(e, optional),
+    };
+    let paths = match resolve_dynamic_indexes::<S>(path_expr, &result, false) {
+        Ok(paths) => paths,
+        Err((_, EvalEscape::Error(_))) if optional => return QueryResult::None,
+        Err((_, escape)) => return escape.into(),
+    };
+    for path in &paths {
+        if let Err(escape) = update_path::<S>(&mut result, path, &Expr::Identity, false, true) {
+            return match escape {
+                EvalEscape::Error(_) if optional => QueryResult::None,
+                other => other.into(),
+            };
+        }
+    }
+    QueryResult::Owned(result)
 }
 
 /// Shared RHS-fork loop for `eval_assign`/`eval_compound_assign`/
@@ -19734,11 +19941,12 @@ fn eval_update_multi<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     terminal: Option<Control>,
     build_filter: impl FnMut(OwnedValue) -> Expr,
 ) -> QueryResult<'a, W> {
-    let (rhs_values, terminal) =
-        match normalize_rhs_values_for_fork::<W, S>(rhs_values, terminal, optional) {
-            Ok(v) => v,
-            Err(early_return) => return early_return,
-        };
+    let (rhs_values, terminal) = match normalize_rhs_values_for_fork::<W, S>(
+        rhs_values, terminal, optional, path_expr, &input,
+    ) {
+        Ok(v) => v,
+        Err(early_return) => return early_return,
+    };
 
     // #1953: a non-decode-failure to_owned error respects `optional`
     // like the sibling `resolve_dynamic_indexes` arm just below (and
@@ -29618,8 +29826,17 @@ fn eval_owned_navigation<S: EvalSemantics>(
     );
     match expr {
         Expr::Identity => Some(Ok(Some(input.clone()))),
+        // #2470: `Ok(None)` here is this helper's own "no output", which is
+        // exactly what a key lookup that found nothing must produce inside a
+        // read-only context (`yq_absent_key_read_is_empty`) -- the same rule
+        // its cursor-based sibling `index_object_by_name` applies.
         Expr::Field(name) => Some(match input {
-            OwnedValue::Object(map) => Ok(Some(map.get(name).cloned().unwrap_or(OwnedValue::Null))),
+            OwnedValue::Object(map) => Ok(match map.get(name) {
+                Some(v) => Some(v.clone()),
+                None if yq_absent_key_read_is_empty::<S>() => None,
+                None => Some(OwnedValue::Null),
+            }),
+            OwnedValue::Null if yq_absent_key_read_is_empty::<S>() => Ok(None),
             OwnedValue::Null => Ok(Some(OwnedValue::Null)),
             _ if optional => Ok(None),
             _ => Err(EvalError::cannot_index_with_field(
@@ -34485,6 +34702,15 @@ fn eval_stage_with_path_context<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
             let mut new_path = current_path.to_vec();
             new_path.push(OwnedValue::String(name.clone()));
 
+            // #2470 (yq mode, read-only context only): a key lookup that
+            // finds nothing yields *no* node here either, so `rest` never
+            // runs and `key`/`path` have nothing to report -- which is
+            // exactly real yq's ordering, where `traverseMap` drops the
+            // candidate before `operator_keys.go` is ever reached. The same
+            // rule, from the same definition, that `index_object_by_name`
+            // applies on the ordinary read path.
+            let absent_is_empty = yq_absent_key_read_is_empty::<S>();
+
             // Get the field value
             if let OwnedValue::Object(entries) = value {
                 if let Some(v) = entries.get(name) {
@@ -34496,6 +34722,9 @@ fn eval_stage_with_path_context<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
                         &new_path,
                         optional,
                     );
+                }
+                if absent_is_empty {
+                    return QueryResult::None;
                 }
                 // jq returns null for missing fields on objects (not an
                 // error) -- continue `rest` from that `Null` at `new_path`
@@ -34514,6 +34743,9 @@ fn eval_stage_with_path_context<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
             // jq returns null for field access on null, same #2213 fix as
             // the missing-field case just above.
             if matches!(value, OwnedValue::Null) {
+                if absent_is_empty {
+                    return QueryResult::None;
+                }
                 return continue_rest_with_borrowed_value::<W, S>(
                     &OwnedValue::Null,
                     rest,
@@ -53603,7 +53835,9 @@ mod tests {
         let cursor = index.root(json_bytes);
         let result = match expr {
             Expr::Identity => QueryResult::One(cursor.value()),
-            Expr::Field(name) => index_object_by_name::<Vec<u64>>(cursor.value(), name, optional),
+            Expr::Field(name) => {
+                index_object_by_name::<Vec<u64>, JqSemantics>(cursor.value(), name, optional)
+            }
             Expr::Index { idx, .. } => {
                 index_array_by_position::<Vec<u64>, JqSemantics>(cursor.value(), *idx, optional)
             }

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -47,8 +47,8 @@ use super::eval::{
     slice_owned_value_read, streams_escaped_generator_prefix, substitute_bound_var,
     substitute_vars, suppress_or_raise, suppresses, tonumber_from_str, vec_with_capacity,
     yq_absent_key_read_is_empty, yq_empty_operand_output, yq_negative_index_check,
-    BinaryFanoutRules, Control, Demand, EmptyOperandOp, EvalError, EvalSemantics, EvalTag, Flow,
-    JqSemantics, LimitN, PathTrail, QueryResult, YqSemantics,
+    yq_read_only_context, BinaryFanoutRules, Control, Demand, EmptyOperandOp, EvalError,
+    EvalSemantics, EvalTag, Flow, JqSemantics, LimitN, PathTrail, QueryResult, YqSemantics,
 };
 #[cfg(test)]
 use super::expr::FuncDefBound;
@@ -8158,6 +8158,10 @@ fn binary_fanout_each_generic<V: DocumentValue>(
     mut combine: impl FnMut(OwnedValue, OwnedValue) -> Result<OwnedValue, EvalError>,
     sink: &mut dyn FnMut(GenericItem<V>) -> Demand,
 ) -> Flow {
+    // #2470: same wrapper, same rule, same `BinaryFanoutRules::read_only`
+    // flag as `eval::binary_fanout_each` -- see
+    // `eval::read_only_operand_strategy` and `eval::yq_read_only_context`.
+    let each_operand = read_only_operand_strategy_generic(rules, each_operand);
     let mut abort: Option<Flow> = None;
     // #2460: how many outputs each operand produced, so a *zero* count is
     // answered from `yq_empty_operand_output` rather than contributing no
@@ -8257,6 +8261,26 @@ fn binary_fanout_each_generic<V: DocumentValue>(
         return empty_outer_operand_pass_generic::<V>(&each_operand, inner_expr, op, sink);
     }
     abort.unwrap_or(outer)
+}
+
+/// The generic-evaluator twin of `eval::read_only_operand_strategy` (#2470):
+/// wrap an operand-enumeration strategy so the operand expression runs inside
+/// a read-only context and the sink it feeds does not. Pass-through unless
+/// `rules.read_only`.
+fn read_only_operand_strategy_generic<V: DocumentValue>(
+    rules: BinaryFanoutRules,
+    each_operand: impl Fn(&Expr, &mut dyn FnMut(GenericItem<V>) -> Demand) -> Flow,
+) -> impl Fn(&Expr, &mut dyn FnMut(GenericItem<V>) -> Demand) -> Flow {
+    move |expr: &Expr, sink: &mut dyn FnMut(GenericItem<V>) -> Demand| {
+        if !rules.read_only {
+            return each_operand(expr, sink);
+        }
+        let _scope = yq_read_only_context::enter();
+        each_operand(expr, &mut |item| {
+            let _suspended = yq_read_only_context::suspend();
+            sink(item)
+        })
+    }
 }
 
 /// The `right`-operand-produced-nothing half of

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -46,9 +46,9 @@ use super::eval::{
     owned_to_string, prefer_pending_control, slice_component_value, slice_object_as_yq_children,
     slice_owned_value_read, streams_escaped_generator_prefix, substitute_bound_var,
     substitute_vars, suppress_or_raise, suppresses, tonumber_from_str, vec_with_capacity,
-    yq_empty_operand_output, yq_negative_index_check, BinaryFanoutRules, Control, Demand,
-    EmptyOperandOp, EvalError, EvalSemantics, EvalTag, Flow, JqSemantics, LimitN, PathTrail,
-    QueryResult, YqSemantics,
+    yq_absent_key_read_is_empty, yq_empty_operand_output, yq_negative_index_check,
+    BinaryFanoutRules, Control, Demand, EmptyOperandOp, EvalError, EvalSemantics, EvalTag, Flow,
+    JqSemantics, LimitN, PathTrail, QueryResult, YqSemantics,
 };
 #[cfg(test)]
 use super::expr::FuncDefBound;
@@ -5643,10 +5643,16 @@ fn eval_single<S: EvalSemantics, V: DocumentValue>(
         Expr::Identity => cursor.map_or(GenericResult::One(value), GenericResult::OneCursor),
 
         Expr::Field(name) => {
+            // #2470 (yq mode, read-only context only): see
+            // `eval::yq_absent_key_read_is_empty` -- the same rule the eager
+            // evaluator's `index_object_by_name` applies, from the same
+            // definition.
+            let absent_is_empty = yq_absent_key_read_is_empty::<S>();
             if let Some(fields) = value.as_object() {
                 match fields.find_cursor(name) {
                     Ok(Some(c)) => GenericResult::OneCursor(c),
                     // jq returns null for missing fields on objects (not an error)
+                    Ok(None) if absent_is_empty => GenericResult::None,
                     Ok(None) => GenericResult::Owned(OwnedValue::Null),
                     // Either #1677 (the field this lookup resolved to has a
                     // malformed `,`/`:` delimiter) or #1995 (some sibling's
@@ -5656,7 +5662,11 @@ fn eval_single<S: EvalSemantics, V: DocumentValue>(
                 }
             } else if value.is_null() {
                 // jq returns null for field access on null
-                GenericResult::Owned(OwnedValue::Null)
+                if absent_is_empty {
+                    GenericResult::None
+                } else {
+                    GenericResult::Owned(OwnedValue::Null)
+                }
             } else if optional {
                 GenericResult::None
             } else {
@@ -9137,15 +9147,24 @@ fn index_one_generic<S: EvalSemantics, V: DocumentValue>(
 ) -> GenericResult<V> {
     match key {
         OwnedValue::String(s) => {
+            // #2470: same rule as `Expr::Field`'s own arm -- a computed
+            // string key is still a key lookup (`.["zzz"] * 2` and
+            // `"zzz" as $k | .[$k] * 2` are both empty in real yq).
+            let absent_is_empty = yq_absent_key_read_is_empty::<S>();
             if let Some(fields) = target.as_object() {
                 match fields.find_cursor(s) {
                     Ok(Some(c)) => GenericResult::OneCursor(c),
+                    Ok(None) if absent_is_empty => GenericResult::None,
                     Ok(None) => GenericResult::Owned(OwnedValue::Null),
                     // #1677/#1995: same checks as `Expr::Field`'s own arm.
                     Err(err) => GenericResult::Error(err),
                 }
             } else if target.is_null() {
-                GenericResult::Owned(OwnedValue::Null)
+                if absent_is_empty {
+                    GenericResult::None
+                } else {
+                    GenericResult::Owned(OwnedValue::Null)
+                }
             } else if optional {
                 GenericResult::None
             } else {
@@ -10893,6 +10912,16 @@ fn path_step_generic<S: EvalSemantics, V: DocumentValue>(
                     }
                 }
             };
+            // #2470 (yq mode, read-only context only): a key lookup that
+            // found nothing produces no position at all, so the walk has
+            // nothing to continue from and `key`/`path` are never reached --
+            // `(.zzz | key) + 1` is `1` in real yq, not `"zzz" + 1`. Only
+            // `Expr::Field` takes this: the sibling `Expr::Index` arm's own
+            // absent node stays, since real yq auto-creates through arrays
+            // even read-only (`.n[9] | key` is `9` inside an operand too).
+            if matches!(next, PathNode::Absent) && yq_absent_key_read_is_empty::<S>() {
+                return Ok(());
+            }
             out.push((
                 PathTrail::extend(path, OwnedValue::String(name.clone())),
                 next,

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -32144,6 +32144,428 @@ fn test_yq_all_four_empty_operand_shapes_are_indistinguishable_2460() -> Result<
 }
 
 // =============================================================================
+// #2470: yq's read-only evaluation context (`Context.DontAutoCreate`)
+// =============================================================================
+
+/// The document every #2470 assignment-side row runs against. `.a` is an
+/// object with two entries (so `with_entries` has something to walk), `.c` an
+/// array, and `.x`/`.q`/`.zzz` are absent.
+const ABSENT_RHS_DOC_2470: &str = "a:\n  b: 1\n  e: 2\nc: [10, 20]\n";
+
+/// The same document as JSON, for the jq-mode control.
+const ABSENT_RHS_JSON_2470: &str = r#"{"a": {"b": 1, "e": 2}, "c": [10, 20]}"#;
+
+/// A real document that happens to be entry-shaped, so an absent read inside
+/// `=`'s right side can be shown empty without `with_entries` anywhere.
+const ENTRY_SHAPED_DOC_2470: &str = "key: b\nvalue: 1\n";
+
+/// #2470: in yq mode, a key lookup that finds nothing inside `=`'s right
+/// side yields **no node at all**, where the same read anywhere else yields a
+/// `null` node carrying the attempted key.
+///
+/// The mechanism is real yq's `Context.DontAutoCreate`, forced on for this
+/// evaluation by `assignUpdateOperator`'s `crossFunction(d,
+/// context.ReadOnlyClone(), ...)` (`pkg/yqlib/operator_assign.go`); with it
+/// on, `traverse`/`traverseMap` (`pkg/yqlib/operator_traverse_path.go`) never
+/// fabricate the `!!null` child whose `Key` is what `key`/`path` report, and
+/// the candidate is dropped before `operator_keys.go` is reached. Everything
+/// else in the table follows from ordinary generator semantics on a
+/// zero-output right side: `//` never sees a falsy left side, `[..]` collects
+/// `[]`, `length` yields nothing, and the assignment performs zero writes.
+///
+/// Implemented once, as `jq::eval::yq_read_only_context` plus
+/// `jq::eval::yq_absent_key_read_is_empty`, consulted by both evaluators.
+/// Every row is a live capture from Homebrew `yq` v4.53.3, run as
+/// `yq -o=json -I0 FILTER doc.yaml` and re-captured (not transcribed) when
+/// this test was written.
+#[test]
+fn test_yq_absent_key_in_assign_rhs_yields_no_node_2470() -> Result<()> {
+    for (filter, want, want_code) in [
+        (
+            r".a | with_entries(.value = (.a.b | key))",
+            r#"{"b":1,"e":2}"#,
+            0,
+        ),
+        (
+            r".a | with_entries(.value = (.zzz | key))",
+            r#"{"b":1,"e":2}"#,
+            0,
+        ),
+        (
+            r".a | with_entries(.value = (.key | key))",
+            r#"{"b":"key","e":"key"}"#,
+            0,
+        ),
+        (
+            r".a | with_entries(.value = (.value | key))",
+            r#"{"b":"value","e":"value"}"#,
+            0,
+        ),
+        (
+            r".a | with_entries(.value = (.zzz | path))",
+            r#"{"b":1,"e":2}"#,
+            0,
+        ),
+        (r".a | with_entries(.value = (.zzz))", r#"{"b":1,"e":2}"#, 0),
+        (
+            r".a | with_entries(.value = (.zzz | length))",
+            r#"{"b":1,"e":2}"#,
+            0,
+        ),
+        (
+            r".a | with_entries(.value = (.a.zzz | key))",
+            r#"{"b":1,"e":2}"#,
+            0,
+        ),
+        (
+            r".a | with_entries(.value = ([.zzz | key] | length))",
+            r#"{"b":0,"e":0}"#,
+            0,
+        ),
+        (
+            r#".a | with_entries(.value = (.key + "!"))"#,
+            r#"{"b":"b!","e":"e!"}"#,
+            0,
+        ),
+        (
+            r".a | to_entries | map(.value = (.zzz | key)) | from_entries",
+            r#"{"b":1,"e":2}"#,
+            0,
+        ),
+        (
+            r".a | map_values(.value = (.zzz|key))",
+            r#"{"b":1,"e":2}"#,
+            0,
+        ),
+        (
+            r".x = (.a.y | key)",
+            r#"{"a":{"b":1,"e":2},"c":[10,20],"x":null}"#,
+            0,
+        ),
+        (
+            r".x = (.zzz | key)",
+            r#"{"a":{"b":1,"e":2},"c":[10,20],"x":null}"#,
+            0,
+        ),
+        (
+            r".x = (.zzz | path)",
+            r#"{"a":{"b":1,"e":2},"c":[10,20],"x":null}"#,
+            0,
+        ),
+        (
+            r".x = (.a.zzz | key)",
+            r#"{"a":{"b":1,"e":2},"c":[10,20],"x":null}"#,
+            0,
+        ),
+        (
+            r".x = (.a.zzz | parent | length)",
+            r#"{"a":{"b":1,"e":2},"c":[10,20],"x":null}"#,
+            0,
+        ),
+        (
+            r".x = (.zzz | length)",
+            r#"{"a":{"b":1,"e":2},"c":[10,20],"x":null}"#,
+            0,
+        ),
+        (
+            r".x = (.zzz | tostring)",
+            r#"{"a":{"b":1,"e":2},"c":[10,20],"x":null}"#,
+            0,
+        ),
+        (
+            r#".x = ({"k":.zzz})"#,
+            r#"{"a":{"b":1,"e":2},"c":[10,20],"x":null}"#,
+            0,
+        ),
+        (
+            r".x = [.zzz]",
+            r#"{"a":{"b":1,"e":2},"c":[10,20],"x":[]}"#,
+            0,
+        ),
+        (
+            r".x = ([.zzz | key])",
+            r#"{"a":{"b":1,"e":2},"c":[10,20],"x":[]}"#,
+            0,
+        ),
+        (
+            r#".x = (.zzz | key // "dflt")"#,
+            r#"{"a":{"b":1,"e":2},"c":[10,20],"x":null}"#,
+            0,
+        ),
+        (
+            r".x = (.zzz | key, 5)",
+            r#"{"a":{"b":1,"e":2},"c":[10,20],"x":5}"#,
+            0,
+        ),
+        (
+            r".x = (.zzz)",
+            r#"{"a":{"b":1,"e":2},"c":[10,20],"x":null}"#,
+            0,
+        ),
+        (
+            r".x = null",
+            r#"{"a":{"b":1,"e":2},"c":[10,20],"x":null}"#,
+            0,
+        ),
+        (
+            r".x = (.a.b)",
+            r#"{"a":{"b":1,"e":2},"c":[10,20],"x":1}"#,
+            0,
+        ),
+        (
+            r".x = (.a.b | path)",
+            r#"{"a":{"b":1,"e":2},"c":[10,20],"x":["a","b"]}"#,
+            0,
+        ),
+        (
+            r".x = (.a | key)",
+            r#"{"a":{"b":1,"e":2},"c":[10,20],"x":"a"}"#,
+            0,
+        ),
+        (r".x = (.zzz | key) | .x", r"null", 0),
+        (
+            r".a.b = (.q | key)",
+            r#"{"a":{"b":1,"e":2},"c":[10,20]}"#,
+            0,
+        ),
+        (
+            r".a.e = (.zzz | key)",
+            r#"{"a":{"b":1,"e":2},"c":[10,20]}"#,
+            0,
+        ),
+        (
+            r". as $r | .x = (.zzz | key)",
+            r#"{"a":{"b":1,"e":2},"c":[10,20],"x":null}"#,
+            0,
+        ),
+        (
+            r".x += (.zzz | key)",
+            r#"{"a":{"b":1,"e":2},"c":[10,20],"x":null}"#,
+            0,
+        ),
+        (
+            r".x -= (.zzz | key)",
+            r#"{"a":{"b":1,"e":2},"c":[10,20],"x":null}"#,
+            0,
+        ),
+        (
+            r".x += (.zzz)",
+            r#"{"a":{"b":1,"e":2},"c":[10,20],"x":null}"#,
+            0,
+        ),
+        (
+            r".x *= (.zzz)",
+            r#"{"a":{"b":1,"e":2},"c":[10,20],"x":null}"#,
+            0,
+        ),
+        (
+            r".a.e += (.zzz | key)",
+            r#"{"a":{"b":1,"e":2},"c":[10,20]}"#,
+            0,
+        ),
+        (r".a.e -= (.zzz)", r#"{"a":{"b":1,"e":2},"c":[10,20]}"#, 0),
+        (r".a.e *= (.zzz)", r#"{"a":{"b":1,"e":2},"c":[10,20]}"#, 0),
+        (
+            r".x |= (.zzz | key)",
+            r#"{"a":{"b":1,"e":2},"c":[10,20],"x":"zzz"}"#,
+            0,
+        ),
+        (
+            r".x |= (.a.zzz | key)",
+            r#"{"a":{"b":1,"e":2},"c":[10,20],"x":"zzz"}"#,
+            0,
+        ),
+        (
+            r".x |= (.q.zzz | key)",
+            r#"{"a":{"b":1,"e":2},"c":[10,20],"x":"zzz"}"#,
+            0,
+        ),
+    ] {
+        let (out, stderr, code) =
+            run_yq_stdin_with_stderr(filter, ABSENT_RHS_DOC_2470, &["-o", "json", "-I", "0"])?;
+        assert_eq!(
+            (out.trim(), code),
+            (want, want_code),
+            "`{filter}` -- stderr: {stderr}"
+        );
+    }
+
+    // The `with_entries` rows above all read an absent key off a synthesised
+    // entry; this one reads it off a *real* document that happens to be
+    // entry-shaped, so the emptiness cannot be blamed on `with_entries`.
+    let (out, stderr, code) = run_yq_stdin_with_stderr(
+        r".value = (.a.b | key)",
+        ENTRY_SHAPED_DOC_2470,
+        &["-o", "json", "-I", "0"],
+    )?;
+    assert_eq!(
+        (out.trim(), code),
+        (r#"{"key":"b","value":1}"#, 0),
+        "`.value = (.a.b | key)` -- stderr: {stderr}"
+    );
+    Ok(())
+}
+
+/// #2470, the half that is not about absent reads at all: a yq-mode
+/// assignment whose right side produces **zero outputs** still emits one
+/// document, with the target path auto-created and never written.
+///
+/// This is what makes every `x: null` in the test above an assignment that
+/// vivified a *new* target rather than one that wrote a `null`, and every
+/// unchanged row an assignment that skipped the write on an *existing*
+/// target. Captured with `1 | select(false)` -- a right side that is empty
+/// for reasons of its own -- so the rule is keyed on "produced nothing" and
+/// not on why. `jq::eval::yq_empty_rhs_document` implements it; jq mode is
+/// pinned to jq's own opposite answer (no document at all) in
+/// `test_jq_absent_key_and_empty_rhs_keep_jqs_own_answers_2470`.
+#[test]
+fn test_yq_zero_output_assign_rhs_still_emits_one_document_2470() -> Result<()> {
+    for (filter, want, want_code) in [
+        (
+            r".x = (1 | select(false))",
+            r#"{"a":{"b":1,"e":2},"c":[10,20],"x":null}"#,
+            0,
+        ),
+        (
+            r".a.b = (1 | select(false))",
+            r#"{"a":{"b":1,"e":2},"c":[10,20]}"#,
+            0,
+        ),
+        (
+            r".q.r.s = (1 | select(false))",
+            r#"{"a":{"b":1,"e":2},"c":[10,20],"q":{"r":{"s":null}}}"#,
+            0,
+        ),
+        (
+            r".q[] = (1 | select(false))",
+            r#"{"a":{"b":1,"e":2},"c":[10,20],"q":[]}"#,
+            0,
+        ),
+        (
+            r".c[] = (1 | select(false))",
+            r#"{"a":{"b":1,"e":2},"c":[10,20]}"#,
+            0,
+        ),
+        (
+            r"(.x,.y) = (1 | select(false))",
+            r#"{"a":{"b":1,"e":2},"c":[10,20],"x":null,"y":null}"#,
+            0,
+        ),
+        (
+            r". = (1 | select(false))",
+            r#"{"a":{"b":1,"e":2},"c":[10,20]}"#,
+            0,
+        ),
+        (r".x = (1 | select(false)) | .x", r"null", 0),
+        (
+            r".x = (.c[] | select(false))",
+            r#"{"a":{"b":1,"e":2},"c":[10,20],"x":null}"#,
+            0,
+        ),
+    ] {
+        let (out, stderr, code) =
+            run_yq_stdin_with_stderr(filter, ABSENT_RHS_DOC_2470, &["-o", "json", "-I", "0"])?;
+        assert_eq!(
+            (out.trim(), code),
+            (want, want_code),
+            "`{filter}` -- stderr: {stderr}"
+        );
+    }
+    Ok(())
+}
+
+/// #2470's negative half: the read-only context is a *scope*, not a blanket
+/// rule, and these are the constructs real yq pointedly leaves outside it.
+///
+/// A comparison operand keeps the null node (`compareOperator` does not
+/// clone its context read-only), `//` keeps it, `|=`'s right side keeps it
+/// (`SingleChildContext`, not `ReadOnlyClone`), and a bare filter, a collect
+/// and an object construction outside an operand all keep it too. Without
+/// these rows the implementation could pass the two tests above by making
+/// every absent read empty everywhere, which is not what yq does.
+#[test]
+fn test_yq_read_only_context_is_scoped_not_global_2470() -> Result<()> {
+    for (filter, want, want_code) in [
+        (r"(.zzz | key) // 5", r#""zzz""#, 0),
+        (r#"(.zzz | key) == "zzz""#, r"true", 0),
+        (r".zzz | key", r#""zzz""#, 0),
+        (r".zzz | path", r#"["zzz"]"#, 0),
+        (r"[.zzz]", r"[null]", 0),
+        (r"[(.zzz | key)] | length", r"1", 0),
+        (r#"{"k": (.zzz | key)}"#, r#"{"k":"zzz"}"#, 0),
+        (r".n[9] | key", r"9", 0),
+        (r"(.n[9] | key) + 1", r"10", 0),
+        (r".a.b | key", r#""b""#, 0),
+        (r".zzz | length", r"0", 0),
+        (r".zzz", r"null", 0),
+    ] {
+        let (out, stderr, code) =
+            run_yq_stdin_with_stderr(filter, EMPTY_OPERAND_DOC, &["-o", "json", "-I", "0"])?;
+        assert_eq!(
+            (out.trim(), code),
+            (want, want_code),
+            "`{filter}` -- stderr: {stderr}"
+        );
+    }
+    Ok(())
+}
+
+/// #2470's jq-mode control: none of it applies there. jq has no read-only
+/// context, no `key`, and its own answers for every shape the yq rule
+/// changes -- `.x = (.zzz | length)` is `x: 0`, `.x = empty` is no document
+/// at all, `.zzz * 2` raises. Captured live from `/usr/bin/jq` 1.7.1 (the
+/// pinned oracle -- Homebrew's is 1.8.2).
+#[test]
+fn test_jq_absent_key_and_empty_rhs_keep_jqs_own_answers_2470() -> Result<()> {
+    for (filter, want, want_code) in [
+        (
+            r".x = (.zzz | length)",
+            r#"{"a":{"b":1,"e":2},"c":[10,20],"x":0}"#,
+            0,
+        ),
+        (
+            r".x = (.zzz)",
+            r#"{"a":{"b":1,"e":2},"c":[10,20],"x":null}"#,
+            0,
+        ),
+        (r".x = empty", r"", 0),
+        (
+            r#".x = ({"k":.zzz})"#,
+            r#"{"a":{"b":1,"e":2},"c":[10,20],"x":{"k":null}}"#,
+            0,
+        ),
+        (
+            r".x = [.zzz]",
+            r#"{"a":{"b":1,"e":2},"c":[10,20],"x":[null]}"#,
+            0,
+        ),
+        (r".zzz * 2", r"", 5),
+        (r".zzz - 1", r"", 5),
+        (r"1 + .zzz", r"1", 0),
+        (r".zzz + 1", r"1", 0),
+        (r".zzz < 1", r"true", 0),
+        (r"[.zzz]", r"[null]", 0),
+        (r".zzz and true", r"false", 0),
+        (r".zzz // 5", r"5", 0),
+        (
+            r".a.e = (.zzz | tostring)",
+            r#"{"a":{"b":1,"e":"null"},"c":[10,20]}"#,
+            0,
+        ),
+        (r".x += empty", r"", 0),
+        (r".a.e -= (.zzz)", r"", 5),
+    ] {
+        let (out, stderr, code) = run_jq_stdin_with_stderr(filter, ABSENT_RHS_JSON_2470, &["-c"])?;
+        assert_eq!(
+            (out.trim(), code),
+            (want, want_code),
+            "`{filter}` -- stderr: {stderr}"
+        );
+    }
+    Ok(())
+}
+
+// =============================================================================
 // #2451: yq's context-list model for a single document
 // =============================================================================
 

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -32474,6 +32474,72 @@ fn test_yq_zero_output_assign_rhs_still_emits_one_document_2470() -> Result<()> 
     Ok(())
 }
 
+/// #2470's second scope, and #2460's two residual matrix cells: an
+/// **arithmetic** or `and`/`or` operand is evaluated read-only too, so a
+/// missing-key navigation written directly as an operand contributes no
+/// output and #2460's `yq_empty_operand_output` table answers the pairing.
+///
+/// `.zzz * 2` yields nothing while `.zzz | . * 2` raises `cannot multiply
+/// !!null with !!int` -- the same read, answering differently depending on
+/// whether an operator or a pipe is asking, which is exactly the read-only
+/// clone. The scope covers the operand's whole subexpression, which is why
+/// `(.zzz | key) + 1` is `1` rather than `"zzz" + 1`.
+///
+/// Array indexing is deliberately not covered: real yq auto-creates through
+/// arrays even read-only, so `.n[9] + 1` is the ordinary `null + 1`. Every
+/// row is a live capture from yq v4.53.3.
+#[test]
+fn test_yq_absent_key_as_binary_operand_yields_no_node_2470() -> Result<()> {
+    for (filter, want, want_code) in [
+        (r".zzz + 1", r"1", 0),
+        (r"1 + .zzz", r"1", 0),
+        (r".zzz - 1", r"", 0),
+        (r"1 - .zzz", r"", 0),
+        (r".zzz * 2", r"", 0),
+        (r".zzz / 2", r"", 0),
+        (r".zzz % 2", r"", 0),
+        (r".zzz == null", r"true", 0),
+        (r".zzz != null", r"false", 0),
+        (r".zzz // 5", r"5", 0),
+        (r".zzz and true", r"false", 0),
+        (r"true and .zzz", r"false", 0),
+        (r".zzz or false", r"false", 0),
+        (r"false or .zzz", r"false", 0),
+        (r".zzz | . + 1", r"1", 0),
+        (r"(.zzz) + 1", r"1", 0),
+        (r"[.zzz] | .[0] + 1", r"1", 0),
+        (r".a.zzz + 1", r"1", 0),
+        (r".n[9] + 1", r"1", 0),
+        (r"(.zzz | key) + 1", r"1", 0),
+        (r".zzz + .zzz", r"", 0),
+        (r".zzz + .a", r#"{"b":1}"#, 0),
+        (r#"(.zzz | key) + "!""#, r#""!""#, 0),
+        (r"(.zzz | key) * 2", r"", 0),
+        (r"(.zzz | key) and true", r"false", 0),
+        (r"true and (.zzz | key)", r"false", 0),
+        (r"(.zzz | key) or false", r"false", 0),
+        (r#".zzz + "!""#, r#""!""#, 0),
+        (r"[.zzz] + []", r"[]", 0),
+        (r#"{"k": .zzz} + {}"#, r"{}", 0),
+        (r"(.a | .zzz) + 1", r"1", 0),
+        (r".zzz.yyy + 1", r"1", 0),
+        (r".zzz - 1 - 1", r"", 0),
+        (r#".["zzz"] * 2"#, r"", 0),
+        (r#""zzz" as $k | .[$k] * 2"#, r"", 0),
+        (r".zzz[] * 2", r"", 0),
+        (r".a.b * 2", r"2", 0),
+    ] {
+        let (out, stderr, code) =
+            run_yq_stdin_with_stderr(filter, EMPTY_OPERAND_DOC, &["-o", "json", "-I", "0"])?;
+        assert_eq!(
+            (out.trim(), code),
+            (want, want_code),
+            "`{filter}` -- stderr: {stderr}"
+        );
+    }
+    Ok(())
+}
+
 /// #2470's negative half: the read-only context is a *scope*, not a blanket
 /// rule, and these are the constructs real yq pointedly leaves outside it.
 ///


### PR DESCRIPTION
## Summary

In real yq an absent key read yields no node at all inside two read-only contexts, where everywhere else it yields a null node whose `key` is the attempted name: the right-hand side of an assignment, and the operands of arithmetic and boolean operators (`Context.DontAutoCreate`, forced on by `ReadOnlyClone` in yq v4.53.3; cited on #2451). Two commits, one per context, sharing one definition of the rule.

- `yq_read_only_context` is an ambient scope entered by `collect_rhs_outputs` (so `=`, `+=`, `-=`, `*=` and the extension spellings), by both binary fan-outs through a per-operator `read_only` flag (arithmetic and `and`/`or` only: comparison and `//` are captured as not read-only, `(.zzz|key) == "zzz"` is true and `(.zzz|key) // 5` is `"zzz"`), and by `boolean_fanout_core`. Every navigation site in both evaluators consults it through one predicate gated on a new `EvalSemantics` const, so jq mode is untouched.
- A yq-mode assignment whose RHS yields nothing still emits one document with the target vivified but not written (`.x = (.zzz | key)` shows `x: null`; `.a.e = (.zzz | key)` leaves `e` at 2), implemented as `path |= .` over the existing vivification.
- Only key lookups are read-only: yq auto-creates through arrays even here (`.x = (.n[9] | key)` is `x: 9` and pads the array), so an out-of-range index stays a null read.

## Verification

- 103-row matrix re-captured live: 102 of 103 match (the one is `.zzz | type`'s tag spelling, unrelated).
- A/B against the base binary over 2159 yq-mode queries: 332 newly match yq, 23 are extension spellings yq rejects or shapes neither side matched, 4 are shapes that matched only by coincidence through the old fabricated null node and now expose a pre-existing assignment-order divergence, filed as #2481. 1186 jq-mode queries: no change.
- Five new tests with 118 live-captured rows; the #2460 matrix test needed no change. The #2460 limitations entry for the two operand cells is retired and replaced by a resolved section with the five neighbouring divergences captured while probing, now #2481, #2482, #2483, #2484 and a note under #2471.
- fmt; clippy on both CI legs with `-D warnings`; `cargo test` in the three configurations; `cargo doc -D warnings`; yq goldens 113 and jq goldens 633; oracle sweep 3168 cases, 0 unexpected, manifest unchanged.

Behaviour change in yq mode; ships in its own release. Closes #2470.
