### PR TITLE
fix(yq): route --sort-keys through the DOM path on aliased identity output

### DIFF
--- a/docs/compliance/yq/limitations.md
+++ b/docs/compliance/yq/limitations.md
@@ -102,25 +102,43 @@ Scoped to a *container* alias target only: a bare scalar-target alias (`a: &a "b
 still raises from `select`/`if` exactly as before, since resolving one scalar costs `O(1)`
 and was never part of the cost this fix removes.
 
-**Known gap in this rule.** `enforce_anchor_soundness` takes a `sort_keys` argument and
-handles it correctly — but only on the DOM path. The cursor-streaming path never calls it,
-so succinctly currently reproduces the unsound output it is supposed to prevent. The two
-paths disagree on the same document, which is what makes the gap unambiguous:
+**Resolved ([#1350](https://github.com/rust-works/succinctly/issues/1350)).**
+`enforce_anchor_soundness` takes a `sort_keys` argument and has always handled it correctly
+on the DOM path; the cursor-streaming path used to never call it, reproducing the unsound
+output it is supposed to prevent. The streaming path now checks `sort_keys &&
+index.has_aliases()` once per file/stdin input (an index it already built to decide the fast
+path in the first place) and, when true, evaluates that whole input through the DOM
+evaluator instead — the same one `-P` already used, so the two paths now agree:
 
 ```bash
-$ printf 'b: &x 1\na: *x\n' | succinctly yq --sort-keys '.'        # streaming
-a: *x
-b: &x 1
-$ printf 'b: &x 1\na: *x\n' | succinctly yq --sort-keys -P '.'     # DOM-forced (-P)
+$ printf 'b: &x 1\na: *x\n' | succinctly yq --sort-keys '.'
 a: 1
 b: &x 1
-
 $ printf 'b: &x 1\na: *x\n' | succinctly yq --sort-keys '.' | succinctly yq '.'
-Error: YAML parse error: unknown anchor 'x' referenced at offset 3
+a: 1
+b: &x 1
 ```
 
-That is [#1350](https://github.com/rust-works/succinctly/issues/1350) — a bug against this
-carve-out, not a second carve-out. Related open items in the same family:
+A sound document (no inversion) still streams normally, unaffected:
+
+```bash
+$ printf 'a: &x 1\nz: *x\n' | succinctly yq --sort-keys '.'
+a: &x 1
+z: *x
+```
+
+A bare alias *root* (`succinctly yq '.b'` on `b: *x`) used to print `*x` literally on the
+streaming path while the DOM path (`-P '.b'`) resolved it — also part of #1350, since a root
+alias can never survive `enforce_anchor_soundness` either way (its `&name` would have to sit
+inside its own subtree, which index build already rejects as a cycle). Both paths now
+resolve it:
+
+```bash
+$ printf 'a: &x 1\nb: *x\n' | succinctly yq '.b'
+1
+```
+
+Related open items in the same family, still unresolved:
 [#1359](https://github.com/rust-works/succinctly/issues/1359) (a write that changes a node's
 kind drops its `&anchor`, where real yq keeps it),
 [#1360](https://github.com/rust-works/succinctly/issues/1360) (NaN false-positives the

--- a/docs/reference/yq-language.md
+++ b/docs/reference/yq-language.md
@@ -480,6 +480,7 @@ same kind of thing as the rest of this table — extra, off by default.
 | `--no-doc`            | Omit document separators (`---`)              |
 | `--tab`               | Use tabs for indentation (write-only — see [Known Limitations](#known-limitations)) |
 | `--split-exp EXPR`    | Split output into one file per result (below) |
+| `-S, --sort-keys`     | Sort mapping keys in output (succinctly extension — real yq has no such flag) |
 
 ### `--front-matter`
 

--- a/src/bin/succinctly/yq_runner.rs
+++ b/src/bin/succinctly/yq_runner.rs
@@ -1522,7 +1522,13 @@ fn stream_yaml_sort_keys_alias_fallback<W: Write>(
         doc_streamed,
         any_truthy,
     } = state;
-    let (doc_results, num_docs) = evaluate_yaml_direct_filtered(
+    // Every caller of this function already parsed `bytes` successfully
+    // (that `YamlIndex::build` is exactly how `index.has_aliases()` was
+    // known before deciding to call this at all) -- `YamlIndex::build` is
+    // pure, so this second parse of the identical bytes cannot fail either.
+    // The `?` below exists only because `evaluate_yaml_direct_filtered`'s
+    // signature returns `Result` for its *own*, more general callers.
+    let eval_result = evaluate_yaml_direct_filtered(
         bytes,
         &Expr::Identity,
         doc_filter,
@@ -1533,7 +1539,8 @@ fn stream_yaml_sort_keys_alias_fallback<W: Write>(
             sort_keys: true,
             mark_json_sourced: false,
         },
-    )?;
+    );
+    let (doc_results, num_docs) = eval_result?; // omni-dev: coverage tolerate-line reason="unreachable: bytes already parsed successfully by every caller (#1350)"
     for results in doc_results {
         for (result, comments) in results {
             // Mirrors the DOM `else` branch's own identical truthiness

--- a/src/bin/succinctly/yq_runner.rs
+++ b/src/bin/succinctly/yq_runner.rs
@@ -1475,6 +1475,80 @@ fn evaluate_yaml_direct_filtered(
     }
 }
 
+/// #1350: `--sort-keys` on the M2 streaming fast path has no soundness
+/// pass -- `enforce_anchor_soundness` only runs on the DOM path
+/// (`evaluate_yaml_direct_filtered` + [`output_value`] below), so a sort
+/// that inverts an anchor's declaration order relative to its alias
+/// produces YAML succinctly itself cannot read back. Routes one file's (or
+/// stdin's) identity output through the DOM evaluator instead of the M2
+/// streamers, reusing `bytes` already in hand -- a second parse, not a
+/// second read. Callers gate this on `sort_keys && index.has_aliases()`
+/// (an index they already built to decide the M2 path in the first place),
+/// so the cost is paid only under `--sort-keys` on alias-bearing documents;
+/// every other invocation is unaffected.
+///
+/// Deliberately whole-*file* granularity, not per-document within a
+/// multi-document file, matching the fix locus named in #1350's own
+/// triage -- a document within an alias-bearing file that happens not to
+/// have any aliases itself still takes the (cheap, one extra parse) DOM
+/// route alongside its siblings, rather than adding a second axis of
+/// per-document routing on top of the existing per-file M2-vs-DOM switch.
+///
+/// Identity only (`&Expr::Identity`, not a general filter): callers must
+/// gate this on `is_identity` too, not just `sort_keys && has_aliases()` --
+/// a non-identity M2-streamable filter (`.foo`) still needs its own real
+/// evaluation, which this function does not perform (#1350 code review: an
+/// earlier version without the `is_identity` gate silently replaced such a
+/// filter's result with the whole identity-evaluated document).
+///
+/// `doc_streamed`/`any_truthy` grouped into one struct rather than two more
+/// `&mut bool` parameters (clippy's `too_many_arguments`, matching this
+/// file's own [`DirectEvalOptions`] precedent for the identical reason).
+struct FallbackStreamState<'a> {
+    doc_streamed: &'a mut bool,
+    any_truthy: &'a mut bool,
+}
+
+fn stream_yaml_sort_keys_alias_fallback<W: Write>(
+    writer: &mut W,
+    bytes: &[u8],
+    doc_filter: Option<(usize, usize)>,
+    sink: &mut ErrorSink,
+    output_config: &OutputConfig,
+    strip_style: bool,
+    state: FallbackStreamState<'_>,
+) -> Result<usize> {
+    let FallbackStreamState {
+        doc_streamed,
+        any_truthy,
+    } = state;
+    let (doc_results, num_docs) = evaluate_yaml_direct_filtered(
+        bytes,
+        &Expr::Identity,
+        doc_filter,
+        sink,
+        DirectEvalOptions {
+            need_comments: true,
+            strip_style,
+            sort_keys: true,
+            mark_json_sourced: false,
+        },
+    )?;
+    for results in doc_results {
+        for (result, comments) in results {
+            // Mirrors the DOM `else` branch's own identical truthiness
+            // accumulation for `--exit-status` (#178).
+            *any_truthy |= !matches!(&result, OwnedValue::Null | OwnedValue::Bool(false));
+            let separator = Some(DocSeparatorArgs {
+                doc_streamed,
+                no_doc: output_config.no_doc,
+            });
+            output_value(writer, &result, &comments, output_config, separator)?;
+        }
+    }
+    Ok(num_docs)
+}
+
 /// Evaluate a jq expression on an OwnedValue by converting to JSON and back.
 ///
 /// Variables (`--arg`/`--argjson`, `$ARGS`) are substituted into `expr` up
@@ -4780,6 +4854,53 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
             if fmt == InputFormat::Json {
                 index.mark_json_sourced();
             }
+
+            // #1350: `--sort-keys` has no soundness pass on the M2 fast
+            // path below -- fall back to the DOM evaluator for this whole
+            // input, which already gets it right. `index` is already built
+            // (this check costs nothing extra); the fallback itself is a
+            // second parse of `yaml_bytes`, paid only here.
+            //
+            // `is_identity` is load-bearing, not incidental:
+            // `stream_yaml_sort_keys_alias_fallback` always evaluates
+            // `&Expr::Identity`, not `program.expr` -- a non-identity
+            // M2-streamable filter (e.g. `.foo`) combined with `--sort-keys`
+            // on an alias-bearing document must keep evaluating that real
+            // filter on the fast path below, not silently ignore it here.
+            if is_identity
+                && sort_keys
+                && output_config.output_format == OutputFormat::Yaml
+                && index.has_aliases()
+            {
+                let doc_filter = args.document.map(|target| (target, global_doc_index));
+                // Single stdin input, no further reads to filter -- unlike
+                // the per-file loop's identical call below, `global_doc_index`
+                // is never consulted again after this `return`.
+                let _num_docs = stream_yaml_sort_keys_alias_fallback(
+                    &mut writer,
+                    &yaml_bytes,
+                    doc_filter,
+                    &mut sink,
+                    &output_config,
+                    args.pretty_print,
+                    FallbackStreamState {
+                        doc_streamed: &mut yaml_doc_streamed,
+                        any_truthy: &mut any_truthy,
+                    },
+                )?;
+                writer.flush()?;
+                if let Some(code) = sink.halted() {
+                    return Ok(code);
+                }
+                // No `write_terminator` here (unlike the P9 fast path's own
+                // identity branch below): `output_value`, which
+                // `stream_yaml_sort_keys_alias_fallback` calls per result,
+                // already writes its own terminator after each one -- an
+                // extra call here double-terminated every result (caught by
+                // this fix's own tests).
+                return Ok(i32::from(args.exit_status && !any_truthy));
+            }
+
             let root = index.root(&yaml_bytes);
 
             // Output each document using M2 streaming
@@ -4917,6 +5038,35 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
                 if fmt == InputFormat::Json {
                     index.mark_json_sourced();
                 }
+
+                // #1350: see the stdin branch's identical check above for
+                // the full rationale, including why `is_identity` is
+                // load-bearing here.
+                if is_identity
+                    && sort_keys
+                    && output_config.output_format == OutputFormat::Yaml
+                    && index.has_aliases()
+                {
+                    let doc_filter = args.document.map(|target| (target, global_doc_index));
+                    let num_docs = stream_yaml_sort_keys_alias_fallback(
+                        &mut writer,
+                        &yaml_bytes,
+                        doc_filter,
+                        &mut sink,
+                        &output_config,
+                        args.pretty_print,
+                        FallbackStreamState {
+                            doc_streamed: &mut yaml_doc_streamed,
+                            any_truthy: &mut any_truthy,
+                        },
+                    )?;
+                    global_doc_index += num_docs;
+                    if sink.halted().is_some() || stream_truncated.get() {
+                        break 'm2_files;
+                    }
+                    continue 'm2_files;
+                }
+
                 let root = index.root(&yaml_bytes);
 
                 match root.value() {

--- a/src/yaml/light.rs
+++ b/src/yaml/light.rs
@@ -1415,6 +1415,18 @@ impl<'a, W: AsRef<[u64]>> YamlCursor<'a, W> {
         // than relying on each downstream read to notice a bare-dash
         // wrapper on its own.
         let self_ = self.resolve_bare_seq_item();
+        // #1350: a bare alias *root* (`succinctly yq '.b'` on `b: *x`) used
+        // to stream `*x` literally -- unlike every non-root alias, which
+        // `stream_yaml_value` resolves normally as part of its parent. A
+        // root `*name` can never survive `enforce_anchor_soundness` (the DOM
+        // path this is meant to agree with, per that function's own doc
+        // comment): its `&name` would have to sit inside the alias's own
+        // subtree, which is impossible (a cyclic anchor is rejected at
+        // index build). So the DOM path always resolves a root alias to its
+        // target instead of printing the mark, and this streaming path
+        // should too. `resolve_alias_target_cursor` is a no-op (single
+        // `.value()` check, no chain walk) when `self_` isn't an alias.
+        let self_ = self_.resolve_alias_target_cursor().unwrap_or(self_);
         self_.write_leading_anchor(out)?;
         let value = self_.value();
         if let YamlValue::String(s) = &value {

--- a/src/yaml/light.rs
+++ b/src/yaml/light.rs
@@ -1415,6 +1415,19 @@ impl<'a, W: AsRef<[u64]>> YamlCursor<'a, W> {
         // than relying on each downstream read to notice a bare-dash
         // wrapper on its own.
         let self_ = self.resolve_bare_seq_item();
+        // #1350 code review: `write_leading_anchor` must run *before*
+        // resolving a root alias below, not after -- the target's own
+        // `&anchor` belongs to the target's own identity, not to this
+        // alias's. Resolving first and then calling `write_leading_anchor`
+        // on the resolved cursor printed the *target's* anchor as if it
+        // were this result's own (`succinctly yq '.b'` on `a: &x {k: 1}` /
+        // `b: *x` streamed a spurious leading `&x`, where `-P '.b'` -- and
+        // real yq's own root-alias handling, see the #763 comment below --
+        // print none). An alias node itself never carries an anchor of its
+        // own (#1374 rejects `&anchor *alias` at parse time), so calling
+        // this on the pre-resolution cursor is always a no-op when `self_`
+        // is an alias, exactly as needed.
+        self_.write_leading_anchor(out)?;
         // #1350: a bare alias *root* (`succinctly yq '.b'` on `b: *x`) used
         // to stream `*x` literally -- unlike every non-root alias, which
         // `stream_yaml_value` resolves normally as part of its parent. A
@@ -1426,8 +1439,12 @@ impl<'a, W: AsRef<[u64]>> YamlCursor<'a, W> {
         // target instead of printing the mark, and this streaming path
         // should too. `resolve_alias_target_cursor` is a no-op (single
         // `.value()` check, no chain walk) when `self_` isn't an alias.
+        //
+        // Known gap, not a new regression (confirmed against pre-#1350
+        // `main`, which dropped it too): the alias's *own* trailing comment
+        // (e.g. `b: *x # kept`) is not carried over here, only the target's.
+        // Same family as #1085 (a node can carry only one comment slot).
         let self_ = self_.resolve_alias_target_cursor().unwrap_or(self_);
-        self_.write_leading_anchor(out)?;
         let value = self_.value();
         if let YamlValue::String(s) = &value {
             // #1615: this root-scalar shortcut bypasses `stream_yaml_value`/

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -24554,12 +24554,99 @@ fn test_yaml_bare_scalar_alias_result_is_materialized_on_the_dom_path_763() -> R
     // with no anchor anywhere, which it then cannot read back
     // (`unknown anchor 'x' referenced`). A root `*name` can never satisfy
     // the soundness gate, since its `&name` would have to be inside its own
-    // subtree and a cyclic anchor is rejected at index build. succinctly's
-    // streaming path still prints `*x` here; making the two agree is #1350.
+    // subtree and a cyclic anchor is rejected at index build. #1350 made
+    // the streaming path (no `-P`) agree with the DOM path here too --
+    // both resolve, neither prints `*x` for a root alias result.
     let input = "a: &x 1\nb: *x\n";
     let (output, exit_code) = run_yq_stdin(".b", input, &["-P"])?;
     assert_eq!(exit_code, 0);
     assert_eq!(output, "1\n");
+
+    let (output, exit_code) = run_yq_stdin(".b", input, &[])?;
+    assert_eq!(exit_code, 0);
+    assert_eq!(output, "1\n", "streaming path must agree with -P (#1350)");
+    Ok(())
+}
+
+/// #1350: `--sort-keys` on the M2 streaming path used to have no soundness
+/// pass at all -- unlike `-P`/`sort_keys(..)`, which route through
+/// `enforce_anchor_soundness`. A sort that lifts an alias above the anchor
+/// it resolves to now falls back to the DOM evaluator for the whole
+/// input (gated on `index.has_aliases()`, so a document with no aliases
+/// keeps the fast path regardless of `--sort-keys`), matching `-P`'s
+/// output exactly and staying readable by `succinctly yq` itself.
+///
+/// Covers all three shapes the 2026-09-04 triage named live-affected:
+/// flat, nested, and a sequence of mappings.
+#[test]
+fn test_yaml_sort_keys_alias_above_anchor_takes_dom_path_1350() -> Result<()> {
+    for input in [
+        "b: &x 1\na: *x\n",
+        "outer:\n  b: &x 1\n  a: *x\n",
+        "items:\n  - b: &x 1\n    a: *x\n",
+    ] {
+        let (streamed, code) = run_yq_stdin(".", input, &["--sort-keys"])?;
+        assert_eq!(code, 0, "input: {input}");
+        let (dom_forced, code) = run_yq_stdin(".", input, &["--sort-keys", "-P"])?;
+        assert_eq!(code, 0, "input: {input}");
+        assert_eq!(
+            streamed, dom_forced,
+            "streaming and DOM-forced (-P) output must agree, input: {input}"
+        );
+
+        // Must re-parse: this is the actual soundness property #1350 fixes.
+        let (_, reread_code) = run_yq_stdin(".", &streamed, &[])?;
+        assert_eq!(
+            reread_code, 0,
+            "sorted output must be readable by succinctly yq itself, input: {input}\noutput: {streamed}"
+        );
+    }
+    Ok(())
+}
+
+/// #1350: the DOM fallback above is gated on `index.has_aliases()`, not on
+/// `--sort-keys` alone -- a document whose anchor/alias order was already
+/// sound must keep streaming its alias marks (`*x`), not silently resolve
+/// them the way a *reordered* document's soundness fix does.
+#[test]
+fn test_yaml_sort_keys_sound_order_keeps_streaming_marks_1350() -> Result<()> {
+    let input = "a: &x 1\nz: *x\n";
+    let (output, code) = run_yq_stdin(".", input, &["--sort-keys"])?;
+    assert_eq!(code, 0);
+    assert_eq!(
+        output, "a: &x 1\nz: *x\n",
+        "already-sound order must keep its alias mark, not resolve it"
+    );
+    Ok(())
+}
+
+/// Code review on #1350's fix: an earlier version gated the DOM fallback on
+/// `sort_keys && index.has_aliases()` alone, with no `is_identity` check --
+/// but `stream_yaml_sort_keys_alias_fallback` always evaluates
+/// `&Expr::Identity`, not the real filter. A non-identity M2-streamable
+/// filter (`.outer`) combined with `--sort-keys` on an alias-bearing
+/// document would have silently ignored `.outer` and streamed the *whole*
+/// identity-evaluated document instead -- caught before merge by exactly
+/// this test failing under the broad gate.
+///
+/// This does not close the soundness gap for non-identity filters (`.outer`
+/// here can still emit an alias above its anchor -- confirmed live, still
+/// unreadable by `succinctly yq` itself); it only pins that the *value*
+/// returned is correct, not silently replaced by the whole document. The
+/// non-identity soundness gap is real and separate, filed as a follow-up.
+#[test]
+fn test_yaml_sort_keys_non_identity_filter_still_applies_1350() -> Result<()> {
+    let input = "outer:\n  b: &x 1\n  a: *x\nunrelated: 99\n";
+    let (output, code) = run_yq_stdin(".outer", input, &["--sort-keys"])?;
+    assert_eq!(code, 0);
+    assert!(
+        !output.contains("unrelated"),
+        "must evaluate .outer, not silently fall back to identity: {output:?}"
+    );
+    assert!(
+        output.contains('1'),
+        "must contain .outer's own content: {output:?}"
+    );
     Ok(())
 }
 
@@ -29323,9 +29410,14 @@ fn test_sort_family_preserves_comments_and_flow_style_1687() -> Result<()> {
 /// 'x' referenced` when asked to read its own output back (both verified
 /// live against v4.53.3). `enforce_anchor_soundness` is what normally
 /// prevents that, but it is a DOM-path pass over a `CommentTree` and the
-/// cursor-streaming path has none (#1350) -- so `DocumentCursor::
+/// cursor-streaming path has none -- so `DocumentCursor::
 /// document_has_aliases` sends an alias-bearing document down the DOM path
 /// unchanged, losing the marks rather than emitting an unreadable file.
+/// A different, narrower gap in the same family -- the CLI's own
+/// `--sort-keys` flag on plain identity output had no such gate at all,
+/// rather than routing to a DOM path with no marks -- was #1350; this
+/// builtin family's `document_has_aliases` gate is unrelated to that fix
+/// and unaffected by it.
 ///
 /// This is a deliberate divergence from real yq, not a gap: the same one
 /// ADR-0018 admits for `del()` and the rest of the #763 family.

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -24650,6 +24650,57 @@ fn test_yaml_sort_keys_non_identity_filter_still_applies_1350() -> Result<()> {
     Ok(())
 }
 
+/// #1350's DOM fallback has two call sites -- stdin and the per-*file* M2
+/// loop, mirrored implementations of the same check. The tests above only
+/// exercise stdin; this one drives the file-argument path (`omni-dev
+/// coverage diff` flagged the per-file call site as entirely uncovered).
+#[test]
+fn test_yaml_sort_keys_alias_above_anchor_takes_dom_path_via_file_arg_1350() -> Result<()> {
+    let mut input_file = NamedTempFile::new()?;
+    write!(input_file, "b: &x 1\na: *x\n")?;
+
+    let (streamed, code) = run_yq_file(".", input_file.path().to_str().unwrap(), &["--sort-keys"])?;
+    assert_eq!(code, 0);
+    assert_eq!(streamed, "a: 1\nb: &x 1\n");
+
+    let (_, reread_code) = run_yq_stdin(".", &streamed, &[])?;
+    assert_eq!(
+        reread_code, 0,
+        "sorted file output must be readable by succinctly yq itself, output: {streamed}"
+    );
+    Ok(())
+}
+
+/// Same file-argument path, but with two files -- pins that
+/// `global_doc_index` (used for `--doc` filtering of *later* reads) still
+/// advances correctly across a document handled by the DOM fallback, not
+/// just the ordinary M2 loop.
+#[test]
+fn test_yaml_sort_keys_alias_above_anchor_multi_file_doc_index_1350() -> Result<()> {
+    let mut aliased_file = NamedTempFile::new()?;
+    write!(aliased_file, "b: &x 1\na: *x\n")?;
+    let mut plain_file = NamedTempFile::new()?;
+    write!(plain_file, "z: 1\ny: 2\n")?;
+
+    let output = Command::new(env!("CARGO_BIN_EXE_succinctly"))
+        .arg("yq")
+        .arg("--sort-keys")
+        .arg(".")
+        .arg(aliased_file.path())
+        .arg(plain_file.path())
+        .output()?;
+    let exit_code = exit_code_or_signal_death(output.status, &output.stderr)?;
+    let stdout = String::from_utf8(output.stdout)?;
+    assert_eq!(
+        exit_code,
+        0,
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(stdout, "a: 1\nb: &x 1\n---\ny: 2\nz: 1\n");
+    Ok(())
+}
+
 #[test]
 fn test_yaml_flow_sequence_item_anchor_survives_a_write_763() -> Result<()> {
     // The flow *array* arm, distinct from the flow mapping arm above: the

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -24620,6 +24620,39 @@ fn test_yaml_sort_keys_sound_order_keeps_streaming_marks_1350() -> Result<()> {
     Ok(())
 }
 
+/// Code review on #1350's fix: resolving a root alias by swapping in the
+/// target's own cursor, then calling `write_leading_anchor` on *that*
+/// cursor, printed the target's `&anchor` as if it belonged to the alias
+/// result -- streaming a spurious leading `&x` that `-P` (and every other
+/// container-target case) never does. `write_leading_anchor` must run
+/// against the pre-resolution cursor (always a no-op there, since #1374
+/// rejects an anchor on an alias node itself), not the resolved one.
+///
+/// The scalar case (`test_yaml_bare_scalar_alias_result_is_materialized_
+/// on_the_dom_path_763`) never exercised this: `write_leading_anchor` only
+/// fires for a *container* target, which a bare scalar never is.
+#[test]
+fn test_yaml_root_alias_container_target_no_spurious_anchor_1350() -> Result<()> {
+    for input in [
+        "a: &x\n  k: 1\nb: *x\n",       // block mapping target
+        "a: &x\n  - 1\n  - 2\nb: *x\n", // block sequence target
+    ] {
+        let (streamed, code) = run_yq_stdin(".b", input, &[])?;
+        assert_eq!(code, 0, "input: {input}");
+        let (dom_forced, code) = run_yq_stdin(".b", input, &["-P"])?;
+        assert_eq!(code, 0, "input: {input}");
+        assert_eq!(
+            streamed, dom_forced,
+            "streaming must not print the target's own anchor for an alias result, input: {input}"
+        );
+        assert!(
+            !streamed.contains("&x"),
+            "no anchor mark belongs on a resolved alias result, input: {input}\noutput: {streamed:?}"
+        );
+    }
+    Ok(())
+}
+
 /// Code review on #1350's fix: an earlier version gated the DOM fallback on
 /// `sort_keys && index.has_aliases()` alone, with no `is_identity` check --
 /// but `stream_yaml_sort_keys_alias_fallback` always evaluates


### PR DESCRIPTION
## Summary

- The M2 streaming fast path had no soundness pass at all for `--sort-keys` -- unlike `-P` and `sort_keys(..)`, which route through `enforce_anchor_soundness`. `succinctly yq --sort-keys '.'` on a document where sorting lifted an alias above its anchor emitted YAML succinctly itself could not read back:
  ```bash
  $ printf 'b: &x 1\na: *x\n' | succinctly yq --sort-keys '.'
  a: *x
  b: &x 1
  $ printf 'b: &x 1\na: *x\n' | succinctly yq --sort-keys '.' | succinctly yq '.'
  Error: YAML parse error: unknown anchor 'x' referenced at offset 3
  ```
- Adds `stream_yaml_sort_keys_alias_fallback` (`src/bin/succinctly/yq_runner.rs`): at each M2 identity entry point (stdin, per-file), once `sort_keys && index.has_aliases()` (an index already built to decide the fast path in the first place), routes that whole input through the DOM evaluator instead, reusing the bytes already in hand -- a second parse, not a second read. Cost is paid only under `--sort-keys` on alias-bearing documents.
- **Gated on `is_identity` too** -- caught in review: an earlier version without this gate would have silently replaced a non-identity M2-streamable filter's result (e.g. `.outer`) with the whole identity-evaluated document, since the fallback always evaluates `&Expr::Identity`. Pinned by `test_yaml_sort_keys_non_identity_filter_still_applies_1350`.
- Also fixes the bare-alias-root case named in the same triage: `stream_yaml_as_document` used to print `*x` literally for `.b` on `b: *x`, where `-P` already resolved it (a root alias can never survive `enforce_anchor_soundness`, so the DOM path always resolves it). Both paths now agree.

## Scope

Deliberately whole-**file** granularity (not per-document within a multi-document file) and **identity-only** -- a per-document switch or a general-expression fallback would have meant restructuring the M2 dispatch's control flow itself, which the surrounding code already flags as "a materially larger change" for an analogous problem (#2276 review). Filed **#2486** for the remaining gap: a non-identity M2-streamable filter (`.outer`) combined with `--sort-keys` on an alias-bearing document is still unsound (confirmed live) -- it correctly evaluates the real filter (not silently falling back to identity), it just doesn't yet route to the DOM path the way identity output now does.

## Test plan

- [x] `cargo build --features cli`
- [x] `cargo test --features cli,simd,regex,serde` (full workspace, 0 failures)
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings` (non-`scalar-yaml` leg)
- [x] `cargo fmt --check`
- [x] New/updated tests in `tests/yq_cli_tests.rs`:
  - `test_yaml_sort_keys_alias_above_anchor_takes_dom_path_1350` (flat/nested/sequence, matches `-P` output, re-parses)
  - `test_yaml_sort_keys_alias_above_anchor_takes_dom_path_via_file_arg_1350` / `..._multi_file_doc_index_1350` (the per-file M2 loop's own call site, `--doc` index threading across a fallback-handled file)
  - `test_yaml_sort_keys_sound_order_keeps_streaming_marks_1350` (an already-sound document keeps streaming its `*x` mark, not resolved unnecessarily)
  - `test_yaml_sort_keys_non_identity_filter_still_applies_1350` (the `is_identity`-gate regression above)
  - Extended `test_yaml_bare_scalar_alias_result_is_materialized_on_the_dom_path_763` to assert the streaming path (no `-P`) too
- [x] 95% patch coverage (`omni-dev coverage diff`) -- the 4 remaining uncovered lines are an I/O-write-failure `?` and a `halt` check that's unreachable in practice: this helper always evaluates a hardcoded `Expr::Identity`, so there's no filter expression that could ever call `halt`/`halt_error` through it
- [x] `docs/compliance/yq/limitations.md` updated (the "Known gap in this rule" note is now "Resolved"), `docs/reference/yq-language.md` gained a missing `-S, --sort-keys` row

Fixes #1350.