### PR TITLE
feat(jq): --eval-all evaluates over the document list; file_index counts files (#2427)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,48 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **`succinctly yq --eval-all` now evaluates over the document *list*, not a
+  slurped array of the documents — and `file_index` counts input files on the
+  ordinary multi-file path too** (#2427). Real yq's `ea`
+  (`all_at_once_evaluator.go`, v4.53.3) reads every document of every file into
+  one node list and runs the expression once against it; only two operators
+  behave differently from the per-document case, and both gate on the
+  `EvaluateTogether` flag `readDocuments` stamps on those initial nodes
+  (`utils.go:85`) — `[E]` collects `E`'s outputs across the whole list into one
+  array, and a binary operator evaluates both operands over the whole list and
+  emits every pairing. succinctly slurped instead, so the expression saw an
+  array it should never have seen:
+
+  ```console
+  $ succinctly yq --eval-all -o=json -I0 '.name' f1.yaml f2.yaml
+  "first"                            # was: Cannot index array with string "name"
+  "second"
+  $ succinctly yq --eval-all -o=json -I0 'keys' f1.yaml f2.yaml
+  ["a","name"]                       # was: [0,1]
+  ["b","name"]
+  $ succinctly yq --eval-all -o=json -I0 '[.]' f1.yaml f2.yaml
+  [{"a":1,"name":"first"},{"b":2,"name":"second"}]   # was: an array of that array
+  $ succinctly yq --eval-all -o=json -I0 '. + {"z": 9}' f1.yaml f2.yaml
+  {"a":1,"name":"first","z":9}       # was: a three-element array
+  {"a":1,"name":"first","z":9}       # four outputs, matching real yq
+  {"b":2,"name":"second","z":9}
+  {"b":2,"name":"second","z":9}
+  $ succinctly yq 'file_index' f1.yaml f2.yaml
+  0                                  # was: 0 for every file
+  1
+  ```
+
+  **Every `--eval-all` filter written against the old model changes.** The
+  `.[]`-over-documents idiom the previous release documented
+  (`--eval-all '.[] | select(file_index == 0)'`) now iterates each *document's*
+  own members, exactly as real yq's does; drop the `.[] |` prefix
+  (`--eval-all 'select(file_index == 0)'`). `path`, `key` and `parent` answer
+  relative to their own document now rather than to the vanished array, and
+  `document_index` counts documents within their file. Two `ea` shapes are still
+  short of real yq and are recorded in
+  [docs/compliance/yq/limitations.md](docs/compliance/yq/limitations.md): the
+  `---` separator between results, and `. as $x | [$x]`.
+
 - **`succinctly yq` now evaluates over a *context list*, as real yq does — a pipe
   into a union is branch-major, a union of two bare identities yields the list
   once, and binary operators fan out left-major** (#2451). Real yq has no scalar

--- a/docs/compliance/yq/limitations.md
+++ b/docs/compliance/yq/limitations.md
@@ -296,45 +296,69 @@ at all. The justification is the spec target, which is why the case belongs here
 Representative cases, each live-verified. These are gaps to close, listed here so they are
 not rediscovered from scratch.
 
-### `--eval-all` slurps the documents into one array; real `yq ea` evaluates over a context list of them (#2427)
+### The `---` between results is per-run, not per-node as real yq's printer makes it (#2427)
 
-`succinctly yq --eval-all` collects every document of every input file into one array and
-evaluates the expression once against that array. Real yq's `ea` evaluates the expression
-once with the *list of documents* as its input: navigation maps over the list, `[E]`
-collects E's whole output list into one array, `length`/`keys`/`del` apply per document,
-and a binary operator is cartesian over both operands' lists. Only a filter that happens to
-treat its input as an array agrees between the two. Captured from the pinned v4.53.3 binary
-with `yq ea -o=json -I0` on `f1.yaml` (`a: 1`, `name: first`) and `f2.yaml` (`b: 2`,
-`name: second`):
+Real yq's printer decides the `---` separator **per output node**, from two fields the node
+carries — `document` (its index within its own file) and `fileIndex`
+([`printer.go`](https://github.com/mikefarah/yq/blob/v4.53.3/pkg/yqlib/printer.go), the
+`p.previousDocIndex != mappedDoc.GetDocument() || p.previousFileIndex != mappedDoc.GetFileIndex()`
+test). Two things follow that succinctly does not reproduce:
+
+1. **`previousFileIndex` is set once and never updated inside the loop** (only
+   `p.previousDocIndex` is assigned at the bottom of the iteration), so every node whose
+   file differs from the *first printed node's* file gets a separator, however many have
+   already been printed from that same file.
+2. **Whether a node has a file/document at all is a per-operator property.**
+   `CandidateNode.Copy` carries `document`/`fileIndex` across, but `CreateReplacement`
+   builds a fresh node and starts both at `0`
+   ([`candidate_node.go`](https://github.com/mikefarah/yq/blob/v4.53.3/pkg/yqlib/candidate_node.go)),
+   and the choice between the two is made independently by each operator. So `.`, `.name`,
+   `select`, `del`, `=`, `{...}` and `+` all keep it, while `keys`, `length`, `type`,
+   `tostring`, `to_entries`, `map`, `[...]`, `has`, `path`, `key`, `parent`, `line`,
+   `column`, `filename`, `file_index`, `document_index` and every literal do not.
+
+succinctly's values carry no such field, and there is no unifying rule to derive one from —
+so it writes `---` between successive results whenever the output is YAML and there is more
+than one. That agrees with real yq for every filter in group (2)'s first list and for
+one-document-per-file input, and diverges for the second list. Live-verified against
+v4.53.3 on `f1.yaml` (`a: 1`, `name: first`) and `f2.yaml` (`b: 2`, `name: second`):
 
 ```bash
-$ yq ea -o=json -I0 '.name' f1.yaml f2.yaml            # "first" / "second"
-$ succinctly yq --eval-all -o=json '.name' f1.yaml f2.yaml
-Error: Cannot index array with string "name"
-$ yq ea -o=json -I0 '[.]' f1.yaml f2.yaml              # one array of both documents
-$ succinctly yq --eval-all -o=json '[.]' f1.yaml f2.yaml   # an array holding that array
-$ yq ea -o=json -I0 '. + {"z": 9}' f1.yaml f2.yaml     # four outputs (2 documents x 2)
-$ yq ea -o=json -I0 'keys' f1.yaml f2.yaml             # ["a","name"] / ["b","name"]
-$ succinctly yq --eval-all -o=json 'keys' f1.yaml f2.yaml  # [0,1]
+$ yq '.'      f1.yaml f2.yaml    # a: 1 / name: first / --- / b: 2 / name: second   (agrees)
+$ yq 'length' f1.yaml f2.yaml    # 2 / 2
+$ succinctly yq 'length' f1.yaml f2.yaml           # 2 / --- / 2
+$ yq 'file_index' f1.yaml f2.yaml                  # 0 / 1
+$ succinctly yq 'file_index' f1.yaml f2.yaml       # 0 / --- / 1
+$ yq '.name, .name' f1.yaml f2.yaml   # first / first / --- / second / --- / second
+$ succinctly yq '.name, .name' f1.yaml f2.yaml     # first / first / --- / second / second
 ```
 
-`file_index`/`document_index` on this path count files and documents as yq does since
-#2469 (`0 0 1` and `0 1 0` for a two-document file followed by a one-document file), so the
-numbering is right even though the shape of the evaluation is not.
+Same on the `--eval-all` path, which since #2427 also produces one result per document:
+`yq ea 'file_index' f1.yaml f2.yaml` prints `0` and `1` with no separator where succinctly
+writes one between them. Closing this needs per-node file/document provenance threaded from
+the evaluator to the printer, plus yq's own per-operator table for which operators set it —
+tracked on [#2427](https://github.com/rust-works/succinctly/issues/2427).
 
-This is not fixable in the CLI runner alone: a per-document loop would repair `.name`,
-`keys`, `del` and `select(file_index == 1)` but would print `[.]` twice and `. + {"z": 9}`
-twice, both still wrong. The evaluation model is the same one
-[#2451](https://github.com/rust-works/succinctly/issues/2451) implements for `(.a, .b) |
-(.c, .d)` inside a single document -- yq's `,` and its `ea` both build a context list, and
-every operator is defined over lists. #2451's three rules already apply on this path
-(`--eval-all`'s union ordering is branch-major with them), but what makes `[.]` collect
-once and `. + {"z": 9}` go cartesian across documents is a *different* mechanism:
-`EvaluateTogether` (`pkg/yqlib/utils.go:85`), a per-node flag set only by the all-at-once
-multi-file reader. Tracked as
-[#2427](https://github.com/rust-works/succinctly/issues/2427); the stray `---` that plain
-multi-file `succinctly yq` prints between files, and the always-0 `file_index` on that
-non-`ea` path, are the same issue's other two divergences.
+### `. as $x | [$x]` under `--eval-all` collects one copy per document, not one per binding (#2427)
+
+`--eval-all` follows real yq's `EvaluateTogether` rules for `[E]` and for binary operators
+(see [the context-list section](#yqs-context-list-evaluation-model-in-a-single-document-2451)), but not for
+variable binding. `operator_variables.go` consults the same flag, and the observable effect
+is that the *body* of an `as` binding keeps seeing the whole document list even though the
+binding itself is per document — so a `[...]` in the body collects one entry per document
+in context rather than one per binding. Live against v4.53.3, `f1.yaml`/`f2.yaml` as above:
+
+```bash
+$ yq ea -o=json -I0 '. as $x | [$x]' f1.yaml f2.yaml
+[{"a":1,"name":"first"},{"a":1,"name":"first"}]
+[{"b":2,"name":"second"},{"b":2,"name":"second"}]
+$ succinctly yq --eval-all -o=json -I0 '. as $x | [$x]' f1.yaml f2.yaml
+[{"a":1,"name":"first"}]
+[{"b":2,"name":"second"}]
+```
+
+`. as $d | $d` (no collect in the body) agrees, as does every other row of #2427's own
+capture table.
 
 ### `-j`/`--join-output` collides with real yq's own `-j`
 
@@ -2613,8 +2637,10 @@ Three related divergences are **not** covered and stay open:
 - **`EvaluateTogether`** ([#2427](https://github.com/rust-works/succinctly/issues/2427)) is
   what makes `[...]` collect once across documents and binary operators go cartesian under
   `--eval-all`. It is a flag on the document nodes the all-at-once multi-file reader
-  builds, never set inside a single document, so it changes nothing here — see
-  [the `--eval-all` section](#--eval-all-slurps-the-documents-into-one-array-real-yq-ea-evaluates-over-a-context-list-of-them-2427).
+  builds, never set inside a single document, so it changes nothing here. Implemented for
+  `[...]` and for binary operators by #2427; `as` still consults it in real yq and does not
+  here, which is the one row of that issue's capture table still open (see
+  [that section](#-as-x--x-under---eval-all-collects-one-copy-per-document-not-one-per-binding-2427)).
 - **A union of two assignments.** yq's pointer guard also fires for two operands that both
   hand back the *same, mutated* context, which is the case its own source comment names:
   `yq '(.a.c = 1), (.b.c = 2)'` prints **one** document carrying both writes. succinctly's

--- a/docs/guides/cli.md
+++ b/docs/guides/cli.md
@@ -435,7 +435,7 @@ succinctly yq '.users[]' input.yaml
 - `--validate`: Validate YAML strictly (opt-in) before processing; reports line:column errors and bails without producing output (see [YAML Validation](#yaml-validation))
 - `-i, --inplace`: Update the file in place
 - `--doc <N>`: Select specific document by 0-based index from multi-document stream
-- `--eval-all`, `--ea`: Combine all documents from all files into one evaluation context, exposing `file_index`/`fileIndex`/`fi` for cross-file merges (e.g. `.[] | select(file_index == 0)`). Requires explicit `.[]` iteration, unlike real yq's bare `select(fileIndex == 0)` — see [yq Language Reference](../reference/yq-language.md#cross-file-operations) for the full deviation (#715). Combines documents through the `OwnedValue` DOM, same as `--slurp`, so output carries no comments regardless of the input. Incompatible with `--slurp`, `--inplace`, `--raw-input`, `--split-exp`, `--front-matter`
+- `--eval-all`, `--ea`: Evaluate the filter once over the list of every document of every file, exposing `file_index`/`fileIndex`/`fi` for cross-file merges (e.g. `select(file_index == 0)`). The filter never sees a containing array, so it applies per document; `[E]` collects across the whole list and a binary operator pairs both operands over it, matching real yq — see [yq Language Reference](../reference/yq-language.md#cross-file-operations) (#715, #2427). Reads documents through the `OwnedValue` DOM, same as `--slurp`, so output carries no comments regardless of the input. Incompatible with `--slurp`, `--inplace`, `--raw-input`, `--split-exp`, `--front-matter`
 - `--front-matter <MODE>`: Treat input as text with a `---`-fenced YAML front matter header (e.g. Markdown). `extract` evaluates only the front matter, discarding the body; `process` re-emits the transformed front matter followed by the untouched body. Incompatible with `--doc`, `--null-input`, `--raw-input`, `--eval-all`, an explicit `--input-format json` (front matter is YAML by definition); `process` mode also requires YAML output and is incompatible with `--slurp`; `extract` mode is incompatible with `--inplace` (it captures no body to reattach, so `-i` would discard everything after the closing fence). Position builtins (`at_offset`, `at_position`, `line`, `column`) resolve against the extracted YAML block's own coordinates, not the original file — a `line`/`column` reported under `--front-matter` does not match the file's line/column
 
 ### Variables
@@ -498,7 +498,7 @@ cat data.yaml | succinctly yq '.items[]'
 succinctly yq '.' multi-doc.yaml
 
 # Combine documents across files, merge by file origin
-succinctly yq --eval-all '(.[] | select(file_index == 0)) * (.[] | select(file_index == 1))' base.yaml override.yaml
+succinctly yq --eval-all 'select(file_index == 0) * select(file_index == 1)' base.yaml override.yaml
 
 # Extract/rewrite YAML front matter in a Markdown file
 succinctly yq --front-matter extract '.title' post.md

--- a/docs/reference/yq-language.md
+++ b/docs/reference/yq-language.md
@@ -145,30 +145,42 @@ succinctly yq '.items[] | split_doc' file.yaml
 
 **Real yq surface, not a succinctly invention** — cross-file evaluation is real yq (`eval-all`), filed by [#715](https://github.com/rust-works/succinctly/issues/715) as a feature to implement, not as an extension. It carries an ordinary fidelity obligation under ADR-0018 rule 4, and the deviation noted below is tracked accordingly, not exempted under rule 5.
 
-`--eval-all`/`--ea` combines every document from every input file into one evaluation context (default `eval` mode evaluates each document independently, low memory). `file_index`/`fileIndex`/`fi` returns the 0-indexed origin file position, resolvable only within that combined context.
+`--eval-all`/`--ea` evaluates the filter **once over the list of every document of every input file** (the default `eval` mode evaluates each document independently, low memory). That is real yq's own model, not a slurp: the filter never sees a containing array, so `.name`, `keys`, `length` and `del(.name)` all apply per document, and one output is printed per document.
 
-| Function/Flag        | Description                                                      |
-|----------------------|------------------------------------------------------------------|
-| `--eval-all`, `--ea` | Combine all documents from all files into one evaluation context |
-| `file_index`         | 0-indexed origin file position (within `--eval-all`)             |
-| `fileIndex`          | Alias for `file_index` (real yq's own spelling)                  |
-| `fi`                 | Short alias for `file_index`                                     |
+Two operators behave differently under `--eval-all` than they do per document, and both for the same reason — real yq flags the initial document nodes `EvaluateTogether` (`pkg/yqlib/utils.go:85`) and only these two consult it:
+
+- **`[E]` collects across the whole list**: `--eval-all '[.]'` is one array of every document. Anything that builds a new node clears the flag, so `--eval-all '.name | [.]'` is back to one array per document.
+- **A binary operator runs both operands over the whole list** and emits every pairing: `--eval-all '. + {"z": 9}'` on two files prints four documents.
+
+`file_index`/`fileIndex`/`fi` returns the 0-indexed origin file position, and `document_index`/`documentIndex`/`di` the document's index within that file. Both answer on the ordinary multi-file path too, not just under `--eval-all`.
+
+| Function/Flag        | Description                                                          |
+|----------------------|----------------------------------------------------------------------|
+| `--eval-all`, `--ea` | Evaluate once over every document of every file, as one context list |
+| `file_index`         | 0-indexed origin file position                                       |
+| `fileIndex`          | Alias for `file_index` (real yq's own spelling)                      |
+| `fi`                 | Short alias for `file_index`                                         |
 
 ```bash
-# Combine documents across files, count them
+# One field count per document
 succinctly yq --eval-all 'length' f1.yaml f2.yaml
 
 # Select only documents from the first file
-succinctly yq --eval-all '.[] | select(file_index == 0)' f1.yaml f2.yaml
+succinctly yq --eval-all 'select(file_index == 0)' f1.yaml f2.yaml
 
-# General merge across any number of files
-succinctly yq --eval-all 'reduce .[] as $item ({}; . * $item)' f1.yaml f2.yaml f3.yaml
+# Every document, in one array
+succinctly yq --eval-all '[.]' f1.yaml f2.yaml
 
 # Merge exactly two files (correct only when each contributes one document)
-succinctly yq --eval-all '(.[] | select(file_index == 0)) * (.[] | select(file_index == 1))' f1.yaml f2.yaml
+succinctly yq --eval-all 'select(file_index == 0) * select(file_index == 1)' f1.yaml f2.yaml
+
+# General merge across any number of files: collect the documents into one
+# array first, then fold it (`reduce` is a succinctly extension here -- real
+# yq's lexer rejects it)
+succinctly yq --eval-all '[.] | reduce .[] as $item ({}; . * $item)' f1.yaml f2.yaml f3.yaml
 ```
 
-**Deviation from real yq**: real yq's `eval-all` treats the combined documents as an implicit node list that most operators broadcast over, so `select(fileIndex == 0) * select(fileIndex == 1)` works with no `.[]`. succinctly's evaluator has one scalar value per evaluation instead, so `.[]` must be explicit — `.[] | select(file_index == 0)`, not the bare `select(fileIndex == 0)`. `file_index`/`key`/`document_index` resolve correctly through `.`/`.[]`/`.field` navigation, comparisons, `select(...)`, `map(...)`, `if/then/else`, `try/catch`, comma, `label`, array literals (`[...]`), and user-defined functions — but not inside object literals (`{...}`) or `any`/`all`, where they fall back to `0` (see [Known Limitations](#known-limitations)). `--eval-all` is incompatible with `--slurp`, `--inplace`, `--raw-input`, `--split-exp`, and `--front-matter`.
+**Changed in this release**: the `.[] |` prefix the previous version of this section used (`--eval-all '.[] | select(file_index == 0)'`) is no longer the idiom — `.[]` now iterates each *document's* own members, exactly as real yq's does. `file_index`/`key`/`document_index`/`path`/`parent` resolve relative to their own document through `.`/`.[]`/`.field` navigation, comparisons, `select(...)`, `map(...)`, `if/then/else`, `try/catch`, comma, `label`, array literals (`[...]`), and user-defined functions — but not inside object literals (`{...}`) or `any`/`all`, where they fall back to `0` (see [Known Limitations](#known-limitations)). `--eval-all` is incompatible with `--slurp`, `--inplace`, `--raw-input`, `--split-exp`, and `--front-matter`.
 
 ### yq-Specific Operators
 

--- a/src/bin/succinctly/main.rs
+++ b/src/bin/succinctly/main.rs
@@ -1085,12 +1085,13 @@ pub struct YqCommand {
     #[arg(short = 's', long, overrides_with = "slurp")]
     pub slurp: bool,
 
-    /// Combine all documents from all files into one evaluation context
-    /// (yq-compatible name: `eval-all`/`ea`), exposing `file_index`/
-    /// `fileIndex`/`fi` for cross-file merges. Unlike real yq, expressions
-    /// must use explicit `.[]` iteration (e.g. `.[] | select(file_index ==
-    /// 0)`) rather than a bare top-level `select(...)` -- see
-    /// docs/reference/yq-language.md for the full deviation (#715).
+    /// Evaluate the filter once over the list of every document of every
+    /// file (yq-compatible name: `eval-all`/`ea`), exposing `file_index`/
+    /// `fileIndex`/`fi` for cross-file merges. The filter never sees a
+    /// containing array, so it applies per document (`select(file_index ==
+    /// 0)`, not `.[] | select(...)`); `[E]` collects across the whole list
+    /// and a binary operator pairs both operands over it, matching real yq
+    /// (#715, #2427). See docs/reference/yq-language.md.
     #[arg(long = "eval-all", alias = "ea", overrides_with = "eval_all")]
     pub eval_all: bool,
 

--- a/src/bin/succinctly/yq_runner.rs
+++ b/src/bin/succinctly/yq_runner.rs
@@ -4878,7 +4878,15 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
                 }
             }
         } else {
-            'm2_files: for file_path in &input_files {
+            'm2_files: for (file_index, file_path) in input_files.iter().enumerate() {
+                // #2427: `file_index` is a per-file constant on this path -- each
+                // file is evaluated independently, so there is no combined
+                // array whose top-level index could stand in for it. Real yq
+                // stamps the number on every node as it decodes the file
+                // (`pkg/yqlib/utils.go:60-89`); this scope is succinctly's
+                // equivalent, and `yq 'file_index' f1 f2` prints `0` then `1`
+                // on both binaries because of it.
+                let _file_index_scope = jq::enter_file_index_scope(file_index);
                 let path = Path::new(file_path);
                 // A later file's read failure can fire after `writer`
                 // already buffered real output from earlier files in this
@@ -5212,7 +5220,16 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
             deferred_validate_exit_code = validate_exit_code;
 
             let mut global_doc_index: usize = 0;
-            'files: for (bytes, format, _) in &input_sources {
+            'files: for (file_index, (bytes, format, _)) in input_sources.iter().enumerate() {
+                // #2427: `file_index` is a per-file constant on this path -- each
+                // file is evaluated independently, so there is no combined
+                // array whose top-level index could stand in for it. Real yq
+                // stamps the number on every node as it decodes the file
+                // (`pkg/yqlib/utils.go:60-89`); this scope is succinctly's
+                // equivalent, and `yq 'file_index' f1 f2` prints `0` then `1`
+                // on both binaries because of it.
+                let _file_index_scope = jq::enter_file_index_scope(file_index);
+
                 // Yaml/Auto and Json both go through the same cursor-native
                 // evaluator now (#1398) -- JSON is a YAML subset, and
                 // routing it through `YamlIndex`/`mark_json_sourced` here
@@ -5569,7 +5586,16 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
         }
 
         let mut global_doc_index: usize = 0;
-        'inplace_files: for file_path in &input_files {
+        'inplace_files: for (file_index, file_path) in input_files.iter().enumerate() {
+            // #2427: `file_index` is a per-file constant on this path -- each
+            // file is evaluated independently, so there is no combined
+            // array whose top-level index could stand in for it. Real yq
+            // stamps the number on every node as it decodes the file
+            // (`pkg/yqlib/utils.go:60-89`); this scope is succinctly's
+            // equivalent, and `yq 'file_index' f1 f2` prints `0` then `1`
+            // on both binaries because of it.
+            let _file_index_scope = jq::enter_file_index_scope(file_index);
+
             let path = Path::new(file_path);
             let raw_bytes = read_file(path)?;
             let resolved_format = resolve_input_format(args.input_format, Some(path));
@@ -6001,7 +6027,16 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
         // gate below.
         let mut all_results: Vec<Vec<Vec<ResultWithComments>>> = Vec::new();
         let mut global_doc_index: usize = 0;
-        'collect: for (bytes, format, _) in &input_sources {
+        'collect: for (file_index, (bytes, format, _)) in input_sources.iter().enumerate() {
+            // #2427: `file_index` is a per-file constant on this path -- each
+            // file is evaluated independently, so there is no combined
+            // array whose top-level index could stand in for it. Real yq
+            // stamps the number on every node as it decodes the file
+            // (`pkg/yqlib/utils.go:60-89`); this scope is succinctly's
+            // equivalent, and `yq 'file_index' f1 f2` prints `0` then `1`
+            // on both binaries because of it.
+            let _file_index_scope = jq::enter_file_index_scope(file_index);
+
             // Yaml/Auto and Json both go through the same cursor-native
             // evaluator now (#1398) -- see the matching comment on the
             // `--split-exp` loop above for why (JSON is a YAML subset;

--- a/src/bin/succinctly/yq_runner.rs
+++ b/src/bin/succinctly/yq_runner.rs
@@ -1537,7 +1537,7 @@ fn evaluate_input(
 /// error/break through `sink` (evaluation continues past one, per yq's
 /// convention -- see `ErrorSink`'s own doc comment) rather than failing the
 /// whole run. Factored out of [`evaluate_input`] so `--eval-all`'s
-/// `eval_owned_with_file_index` call site (#715) shares the exact same
+/// `eval_documents_together` call site (#715, #2427) shares the exact same
 /// conversion/error-reporting policy instead of a second, divergence-prone
 /// copy.
 fn query_result_to_owned_values(
@@ -1548,7 +1548,7 @@ fn query_result_to_owned_values(
     // other (#1247): report it and yield nothing, exactly as the
     // `QueryResult::Error` arm below does.
     //
-    // Both callers ([`evaluate_input`] above, `eval_owned_with_file_index`
+    // Both callers ([`evaluate_input`] above, `eval_documents_together`
     // below) only ever produce a `result` rooted in an already-decoded
     // `OwnedValue` re-serialized to JSON and reindexed -- `eval_owned_input`
     // (this function's non-path-context caller) explicitly converts every
@@ -5036,14 +5036,15 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
             }
         }
     } else if args.eval_all {
-        // Handle --eval-all: combine every document from every file into one
-        // evaluation context, exposing `file_index`/`fileIndex`/`fi` (#715).
-        // Input-gathering mirrors --slurp's DOM path (all_docs collection),
-        // but tracks each document's origin file index alongside it and
-        // evaluates via `eval_owned_with_file_index` instead of plain
-        // `evaluate_input`, so `file_index` resolves against that side table.
-        // `--front-matter` is rejected in combination above, so every
-        // gathered body is `None` here.
+        // Handle --eval-all: evaluate the filter once over the list of every
+        // document of every file, exposing `file_index`/`fileIndex`/`fi`
+        // (#715). Input-gathering mirrors --slurp's DOM path (all_docs
+        // collection), but tracks each document's origin file and
+        // within-file document index alongside it, and evaluates via
+        // `eval_documents_together` -- which builds one context-list entry
+        // per document rather than handing the expression an array of them
+        // (#2427). `--front-matter` is rejected in combination above, so
+        // every gathered body is `None` here.
         let (input_sources, validate_exit_code) = gather_input_sources(
             &input_files,
             args.input_format,
@@ -5074,8 +5075,14 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
         };
         let output_config = output_config.for_source(&args, uniform_format);
 
-        let mut all_docs: Vec<OwnedValue> = Vec::new();
-        let mut file_origin: Vec<usize> = Vec::new();
+        // #2427: the document *list*, not a slurped array. Real `ea` is the
+        // ordinary evaluator with the initial context set to every document
+        // of every file, each one flagged `EvaluateTogether`
+        // (`pkg/yqlib/utils.go:85`) -- so `.name`, `keys`, `length` and
+        // `del(.name)` all apply per document, while `[.]` collects across
+        // the whole list. Each entry carries its own `(file, document)`
+        // origin, which is what `file_index`/`document_index` read back.
+        let mut all_docs: Vec<(OwnedValue, usize, usize)> = Vec::new();
         let mut global_doc_index: usize = 0;
         for (file_idx, (bytes, format, _)) in input_sources.iter().enumerate() {
             // #2282: `to_owned_canonicalizing_numbers_at_depth` (reached via
@@ -5083,25 +5090,19 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
             // own nesting-depth violations as a catchable error rather than
             // panicking -- see that function's own doc comment for why.
             let inputs = parse_input(bytes, *format)?;
-            for input in inputs {
+            for (doc_idx, input) in inputs.into_iter().enumerate() {
                 let should_include = args
                     .document
                     .map_or(true, |target| target == global_doc_index);
                 if should_include {
-                    all_docs.push(input);
-                    file_origin.push(file_idx);
+                    all_docs.push((input, file_idx, doc_idx));
                 }
                 global_doc_index += 1;
             }
         }
 
-        let combined = OwnedValue::Array(all_docs);
-        let query_result: QueryResult<'_, Vec<u64>> = jq::eval_owned_with_file_index::<
-            Vec<u64>,
-            YqSemantics,
-        >(
-            &program.expr, &combined, &file_origin
-        );
+        let query_result: QueryResult<'_, Vec<u64>> =
+            jq::eval_documents_together::<Vec<u64>, YqSemantics>(&program.expr, &all_docs);
         let results = query_result_to_owned_values(query_result, &mut sink);
 
         let mut split_doc_state = SplitDocState::new(has_split_doc);

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -7726,12 +7726,15 @@ fn eval_builtin<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
         Builtin::DocumentIndex => builtin_document_index::<W>(),
         Builtin::LineComment => builtin_line_comment::<W>(),
         Builtin::FileIndex => {
-            // Requires the `--eval-all` path-context evaluator to resolve to
-            // anything but 0; reached here means either outside `--eval-all`
-            // or nested in a shape that evaluator doesn't cover (#715), the
-            // same documented "0 outside supported context" contract
-            // `document_index` already has.
-            QueryResult::Owned(OwnedValue::Int(0))
+            // The ambient node origin (#2427) when the CLI installed one --
+            // the ordinary multi-file path and `--eval-all` both do, per
+            // input document. Without it, `0`: reached here means either a
+            // single-file run or a shape the path-context evaluator doesn't
+            // cover (#715), the same documented "0 outside supported
+            // context" contract `document_index` already has.
+            QueryResult::Owned(OwnedValue::Int(
+                super::eval_generic::ambient_file_index().unwrap_or(0),
+            ))
         }
         Builtin::Shuffle => builtin_shuffle::<W>(value, optional),
         Builtin::Pivot => builtin_pivot::<W>(value, optional),
@@ -19323,6 +19326,13 @@ pub fn eval_lenient<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
 /// Evaluate `expr` against a combined `--eval-all` array (succinctly
 /// extension, #715).
 ///
+/// **No longer the CLI's `--eval-all` route.** Since #2427 that is
+/// [`eval_documents_together`], which hands the expression the document list
+/// real yq's `ea` evaluates over rather than an array wrapping it. This entry
+/// point, and the file-origin table it installs, remain the library-level
+/// spelling for "evaluate against a combined array, resolving `file_index`
+/// from a per-top-level-element side table".
+///
 /// Makes `file_index`/`fileIndex`/`fi` resolve via `file_origin` -- a side
 /// table mapping each top-level array position to its originating file
 /// index, built by the yq CLI driver -- wherever
@@ -19374,6 +19384,69 @@ pub fn eval_owned_with_file_index<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>
             Some(file_origin),
         )
     })
+}
+
+/// Evaluate `expr` once over every document of every `--eval-all` input file
+/// (#2427) -- succinctly's `allAtOnceEvaluator.EvaluateFiles`.
+///
+/// `documents` is `(value, file index, document index within that file)`, in
+/// the order real yq reads them: every document of file 0, then of file 1, and
+/// so on. Each one becomes a context-list entry carrying real yq's
+/// `EvaluateTogether` flag and its own origin, and
+/// `eval_generic::eval_yq_documents_together` (private, so named rather than
+/// linked) runs the expression once over that list -- see its doc comment for
+/// the evaluation model, which is where the fidelity claim lives.
+///
+/// Each document is reindexed into its own throwaway JSON document so the
+/// entry can be a cursor: that is what lets `path`/`key`/`parent` answer
+/// relative to *that document* (`yq ea 'path' f1 f2` is `[]` twice, and
+/// `parent` at the root yields nothing) rather than relative to a containing
+/// array, which is exactly what the previous slurp got wrong. A document the
+/// round-trip would not preserve (`reindex_bridge_is_identity`) stays an owned
+/// value and loses only the position, not the value.
+pub fn eval_documents_together<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
+    expr: &Expr,
+    documents: &[(OwnedValue, usize, usize)],
+) -> QueryResult<'a, W> {
+    use super::eval_generic::{reindex_bridge_is_identity, NodeOrigin, YqDocument};
+    use crate::json::JsonIndex;
+
+    // Same throwaway document `eval_owned_input_reindexed` builds, and the
+    // same `to_json_for_reindex` (not `to_json`) for the same reason (#561) --
+    // one per input document rather than one for a combined array.
+    let texts: Vec<String> = documents
+        .iter()
+        .map(|(value, _, _)| {
+            if reindex_bridge_is_identity(value) {
+                value.to_json_for_reindex::<S>()
+            } else {
+                String::new()
+            }
+        })
+        .collect();
+    let indexes: Vec<Option<JsonIndex>> = documents
+        .iter()
+        .zip(&texts)
+        .map(|((value, _, _), text)| {
+            reindex_bridge_is_identity(value).then(|| JsonIndex::build(text.as_bytes()))
+        })
+        .collect();
+    let inputs: Vec<YqDocument<_>> = documents
+        .iter()
+        .zip(&texts)
+        .zip(&indexes)
+        .map(|(((value, file, document), text), index)| YqDocument {
+            cursor: index.as_ref().map(|index| index.root(text.as_bytes())),
+            value: value.clone(),
+            origin: NodeOrigin {
+                file: *file,
+                document: Some(*document),
+            },
+        })
+        .collect();
+
+    let result = super::eval_generic::eval_yq_documents_together::<S, _>(expr, &inputs);
+    detach_from_temp_document(generic_to_query_result(result))
 }
 
 // =============================================================================
@@ -34686,13 +34759,20 @@ fn eval_stage_with_path_context<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     // `document_index`'s existing "0 outside supported context" contract.
     // Position unchanged (#1449).
     if matches!(first, Expr::Builtin(Builtin::FileIndex)) {
-        let file_idx = current_path
-            .first()
-            .and_then(OwnedValue::as_i64)
-            .and_then(|i| usize::try_from(i).ok())
-            .and_then(|i| file_origin.and_then(|origins| origins.get(i).copied()))
-            .unwrap_or(0);
-        let file_index_result = QueryResult::Owned(OwnedValue::Int(file_idx as i64));
+        // #2427: the ambient node origin outranks the table, for the same
+        // reason `eval_generic::file_index_for_path` consults it first --
+        // the origin is a property of the node, the table a property of a
+        // position inside one combined array, and only one is ever
+        // installed at a time.
+        let file_idx = super::eval_generic::ambient_file_index().unwrap_or_else(|| {
+            current_path
+                .first()
+                .and_then(OwnedValue::as_i64)
+                .and_then(|i| usize::try_from(i).ok())
+                .and_then(|i| file_origin.and_then(|origins| origins.get(i).copied()))
+                .unwrap_or(0) as i64
+        });
+        let file_index_result = QueryResult::Owned(OwnedValue::Int(file_idx));
         return continue_rest_with_context::<W, S>(
             file_index_result,
             rest,
@@ -46125,8 +46205,12 @@ fn builtin_column<'a, W: Clone + AsRef<[u64]>>() -> QueryResult<'a, W> {
 /// when processing YAML directly.
 fn builtin_document_index<'a, W: Clone + AsRef<[u64]>>() -> QueryResult<'a, W> {
     // For JSON input or when document context is lost, return 0 (single document assumed).
-    // The generic evaluator handles this properly for YAML with cursor metadata.
-    QueryResult::Owned(OwnedValue::Int(0))
+    // The generic evaluator handles this properly for YAML with cursor metadata,
+    // and `--eval-all` installs an ambient node origin per input document
+    // (#2427) because its throwaway per-document JSON indexes each answer 0.
+    QueryResult::Owned(OwnedValue::Int(
+        super::eval_generic::ambient_document_index().unwrap_or(0),
+    ))
 }
 
 /// `line_comment` - returns the trailing same-line comment text, or `""` (yq, #710)

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -19386,6 +19386,33 @@ pub fn eval_owned_with_file_index<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>
     })
 }
 
+/// Make `file_index`/`fileIndex`/`fi` answer `file_index` for every evaluation
+/// until the returned guard is dropped (#2427).
+///
+/// Real yq stamps `fileIndex` on every node as it decodes each file
+/// (`pkg/yqlib/utils.go:60-89`), so `file_index` is a plain node read on both
+/// its evaluators -- including the ordinary per-document streaming one, which
+/// evaluates each file independently and so has no combined array to index
+/// into. succinctly's values carry no such field; the CLI's per-file loop
+/// installs this scope around each file's evaluation instead, which is exactly
+/// the granularity `file_index` varies at.
+///
+/// The guard restores whatever was installed before, so nesting is safe.
+#[must_use = "the scope ends when the guard is dropped"]
+pub fn enter_file_index_scope(file_index: usize) -> FileIndexScope {
+    FileIndexScope(super::eval_generic::enter_node_origin(
+        super::eval_generic::NodeOrigin {
+            file: file_index,
+            // The ordinary path's cursor answers `document_index` from the
+            // YAML index itself, so only the file number is missing there.
+            document: None,
+        },
+    ))
+}
+
+/// The scope [`enter_file_index_scope`] opens; dropping it closes the scope.
+pub struct FileIndexScope(#[allow(dead_code)] super::eval_generic::NodeOriginGuard);
+
 /// Evaluate `expr` once over every document of every `--eval-all` input file
 /// (#2427) -- succinctly's `allAtOnceEvaluator.EvaluateFiles`.
 ///

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -4081,16 +4081,24 @@ mod node_origin {
         CURRENT.with(Cell::get)
     }
 
+    /// Restores the previous ambient origin when dropped -- including when
+    /// the scope is left by an early `return`/`break`/`?`.
+    pub struct Guard(Option<NodeOrigin>);
+
+    impl Drop for Guard {
+        fn drop(&mut self) {
+            CURRENT.with(|c| c.set(self.0.take()));
+        }
+    }
+
+    pub(crate) fn enter(origin: NodeOrigin) -> Guard {
+        Guard(CURRENT.with(|c| c.replace(Some(origin))))
+    }
+
     /// Installs `origin` for `f`'s dynamic extent, restoring the previous
     /// value on the way out -- including when `f` escapes with a control.
     pub(crate) fn with<R>(origin: NodeOrigin, f: impl FnOnce() -> R) -> R {
-        struct Restore(Option<NodeOrigin>);
-        impl Drop for Restore {
-            fn drop(&mut self) {
-                CURRENT.with(|c| c.set(self.0.take()));
-            }
-        }
-        let _restore = Restore(CURRENT.with(|c| c.replace(Some(origin))));
+        let _guard = enter(origin);
         f()
     }
 }
@@ -4103,6 +4111,14 @@ mod node_origin {
         None
     }
 
+    /// Same shape as the `std` guard, but there is nowhere to store the
+    /// ambient origin without a `thread_local!`, so it restores nothing.
+    pub struct Guard;
+
+    pub(crate) fn enter(_origin: NodeOrigin) -> Guard {
+        Guard
+    }
+
     pub(crate) fn with<R>(_origin: NodeOrigin, f: impl FnOnce() -> R) -> R {
         f()
     }
@@ -4112,6 +4128,18 @@ mod node_origin {
 pub(crate) fn with_node_origin<R>(origin: NodeOrigin, f: impl FnOnce() -> R) -> R {
     node_origin::with(origin, f)
 }
+
+/// Install `origin` until the returned guard is dropped (#2427).
+///
+/// The guard spelling, rather than [`with_node_origin`]'s closure, is what the
+/// yq CLI's per-file loops need: their bodies `continue`/`break 'label` out,
+/// which a closure cannot do.
+pub(crate) fn enter_node_origin(origin: NodeOrigin) -> NodeOriginGuard {
+    node_origin::enter(origin)
+}
+
+/// The RAII guard [`enter_node_origin`] returns.
+pub(crate) type NodeOriginGuard = node_origin::Guard;
 
 /// `file_index` from the ambient node origin, if one is installed.
 ///

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -4043,6 +4043,94 @@ pub(crate) fn current_file_origin() -> Option<alloc::rc::Rc<[usize]>> {
     file_origin::current()
 }
 
+/// Where one input node came from: the index of the file it was read from
+/// and, when the caller tracks it, the index of the document *within* that
+/// file (#2427).
+///
+/// Real yq carries both on every `CandidateNode` (`fileIndex`/`document`,
+/// `pkg/yqlib/candidate_node.go`, v4.53.3), stamped by `readDocuments`
+/// (`utils.go:60-89`) as each document is decoded, and `file_index`/
+/// `document_index` are plain reads of those two fields. succinctly's
+/// documents are `OwnedValue`s with no room for a per-node field, so the
+/// origin rides an ambient scope instead -- installed around the evaluation
+/// of one document (the ordinary multi-file path) or of one context-list
+/// entry (`--eval-all`), which is exactly the granularity at which it varies.
+///
+/// `document` is `Option` because the ordinary path's cursor already answers
+/// `document_index` from the YAML index itself; only the file number is
+/// missing there.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) struct NodeOrigin {
+    pub(crate) file: usize,
+    pub(crate) document: Option<usize>,
+}
+
+/// The ambient [`NodeOrigin`]. Same `thread_local!`-with-restore shape, and
+/// the same `no_std` degradation, as [`file_origin`] above -- see its doc
+/// comment for why an ambient rather than a parameter.
+#[cfg(feature = "std")]
+mod node_origin {
+    use super::NodeOrigin;
+    use std::cell::Cell;
+
+    thread_local! {
+        static CURRENT: Cell<Option<NodeOrigin>> = const { Cell::new(None) };
+    }
+
+    pub(crate) fn current() -> Option<NodeOrigin> {
+        CURRENT.with(Cell::get)
+    }
+
+    /// Installs `origin` for `f`'s dynamic extent, restoring the previous
+    /// value on the way out -- including when `f` escapes with a control.
+    pub(crate) fn with<R>(origin: NodeOrigin, f: impl FnOnce() -> R) -> R {
+        struct Restore(Option<NodeOrigin>);
+        impl Drop for Restore {
+            fn drop(&mut self) {
+                CURRENT.with(|c| c.set(self.0.take()));
+            }
+        }
+        let _restore = Restore(CURRENT.with(|c| c.replace(Some(origin))));
+        f()
+    }
+}
+
+#[cfg(not(feature = "std"))]
+mod node_origin {
+    use super::NodeOrigin;
+
+    pub(crate) fn current() -> Option<NodeOrigin> {
+        None
+    }
+
+    pub(crate) fn with<R>(_origin: NodeOrigin, f: impl FnOnce() -> R) -> R {
+        f()
+    }
+}
+
+/// Install `origin` as the ambient node origin for `f` (#2427).
+pub(crate) fn with_node_origin<R>(origin: NodeOrigin, f: impl FnOnce() -> R) -> R {
+    node_origin::with(origin, f)
+}
+
+/// `file_index` from the ambient node origin, if one is installed.
+///
+/// Consulted *before* [`file_index_for_path`]'s own table: the origin is a
+/// property of the node being evaluated, where the table is a property of a
+/// position inside one combined array, and only one of the two is ever
+/// installed at a time.
+pub(crate) fn ambient_file_index() -> Option<i64> {
+    node_origin::current().and_then(|o| i64::try_from(o.file).ok())
+}
+
+/// `document_index` from the ambient node origin, if one is installed and
+/// carries a document number.
+pub(crate) fn ambient_document_index() -> Option<i64> {
+    node_origin::current()
+        .and_then(|o| o.document)
+        .and_then(|d| i64::try_from(d).ok())
+}
+
 /// `file_index` for a node at `path`: the origin file of the top-level
 /// element `path` descends from (#715).
 ///
@@ -4053,6 +4141,9 @@ pub(crate) fn current_file_origin() -> Option<alloc::rc::Rc<[usize]>> {
 /// expression `eval::eval_stage_with_path_context`'s own `Builtin::FileIndex`
 /// handler computes from its `file_origin` parameter.
 fn file_index_for_path(path: &[OwnedValue]) -> i64 {
+    if let Some(file) = ambient_file_index() {
+        return file;
+    }
     let Some(table) = file_origin::current() else {
         return 0;
     };
@@ -7749,20 +7840,46 @@ fn eval_each_pipe_generic<S: EvalSemantics, V: DocumentValue>(
 /// way in (see [`yq_context_item`]). They stand for a single value each, so
 /// that is a fidelity-neutral loss of laziness on this route only.
 #[derive(Clone)]
-enum YqContextItem<V: DocumentValue> {
+enum YqContextNode<V: DocumentValue> {
     Cursor(V::Cursor),
     Value(V),
     Owned(OwnedValue),
 }
 
+/// What a context entry carries *besides* its node -- the two per-node fields
+/// real yq's `CandidateNode` has that succinctly's values do not (#2427).
+///
+/// `together` is real yq's `EvaluateTogether` (`pkg/yqlib/candidate_node.go`,
+/// set at `pkg/yqlib/utils.go:85` by `readDocuments` and nowhere else, so only
+/// `--eval-all`'s initial document nodes have it). `origin` is the
+/// `fileIndex`/`document` pair `file_index`/`document_index` read back.
+///
+/// Both are dropped by anything that builds a new node and preserved by
+/// anything that hands the same node on -- see [`yq_stage_preserves_node`].
+#[derive(Clone, Copy, Default)]
+struct YqContextTag {
+    together: bool,
+    origin: Option<NodeOrigin>,
+}
+
+#[derive(Clone)]
+struct YqContextItem<V: DocumentValue> {
+    node: YqContextNode<V>,
+    tag: YqContextTag,
+}
+
 impl<V: DocumentValue> YqContextItem<V> {
+    fn new(node: YqContextNode<V>, tag: YqContextTag) -> Self {
+        Self { node, tag }
+    }
+
     /// Hand this context entry back to the ordinary item-driven evaluator.
     /// Takes `&self` because one entry is fed to *every* branch of a union.
     fn to_generic_item(&self) -> GenericItem<V> {
-        match self {
-            Self::Cursor(c) => GenericItem::OneCursor(*c),
-            Self::Value(v) => GenericItem::One(v.clone()),
-            Self::Owned(o) => GenericItem::Owned(o.clone()),
+        match &self.node {
+            YqContextNode::Cursor(c) => GenericItem::OneCursor(*c),
+            YqContextNode::Value(v) => GenericItem::One(v.clone()),
+            YqContextNode::Owned(o) => GenericItem::Owned(o.clone()),
         }
     }
 }
@@ -7774,16 +7891,22 @@ impl<V: DocumentValue> YqContextItem<V> {
 /// `GenericItem::OneCursorValue` is documented as constructible at exactly
 /// one site, so widening [`YqContextItem`] to keep it would trade a real
 /// invariant for one avoided re-decode.
-fn yq_context_item<V: DocumentValue>(item: GenericItem<V>) -> Result<YqContextItem<V>, Control> {
-    Ok(match item {
-        GenericItem::One(v) => YqContextItem::Value(v),
-        GenericItem::OneCursor(c) => YqContextItem::Cursor(c),
-        GenericItem::OneCursorValue(c, _) => YqContextItem::Cursor(c),
-        GenericItem::Owned(o) => YqContextItem::Owned(o),
-        lazy @ (GenericItem::LazyKeys { .. }
-        | GenericItem::LazyIndexRange(_)
-        | GenericItem::LazySeq(_)) => YqContextItem::Owned(generic_item_into_owned(lazy)?),
-    })
+fn yq_context_item<V: DocumentValue>(
+    item: GenericItem<V>,
+    tag: YqContextTag,
+) -> Result<YqContextItem<V>, Control> {
+    Ok(YqContextItem::new(
+        match item {
+            GenericItem::One(v) => YqContextNode::Value(v),
+            GenericItem::OneCursor(c) => YqContextNode::Cursor(c),
+            GenericItem::OneCursorValue(c, _) => YqContextNode::Cursor(c),
+            GenericItem::Owned(o) => YqContextNode::Owned(o),
+            lazy @ (GenericItem::LazyKeys { .. }
+            | GenericItem::LazyIndexRange(_)
+            | GenericItem::LazySeq(_)) => YqContextNode::Owned(generic_item_into_owned(lazy)?),
+        },
+        tag,
+    ))
 }
 
 /// Does this pipe have a stage that is a union (`,`)?
@@ -7820,13 +7943,56 @@ fn yq_flatten_pipe_stages(stages: &[Expr], out: &mut Vec<Expr>) {
     }
 }
 
+/// Does running `stage` over a node hand *that same node* back?
+///
+/// Real yq's per-node flags ride the `CandidateNode`, so they survive exactly
+/// the operators that return their input node: `.` (`operator_self.go:3-5`,
+/// `return context, nil`), `select` (`operator_select.go`, which pushes the
+/// candidate itself), and grouping. Everything else -- navigation into a
+/// child, a collect, a literal, an arithmetic result -- produces a node the
+/// document reader never stamped, so `EvaluateTogether` is false on it and
+/// `file_index`/`document_index` read whatever the constructing operator
+/// happened to copy.
+///
+/// Conservative in the safe direction: an unlisted stage is treated as
+/// building a new node, which drops the flags rather than propagating them
+/// too far.
+fn yq_stage_preserves_node(stage: &Expr) -> bool {
+    match unwrap_paren(stage) {
+        Expr::Identity => true,
+        Expr::Builtin(Builtin::Select(_)) => true,
+        Expr::Pipe(inner) => inner.iter().all(yq_stage_preserves_node),
+        Expr::Comma(branches) => branches.iter().all(yq_stage_preserves_node),
+        _ => false,
+    }
+}
+
 /// Run `stages` over one context entry, honouring `sink`'s demand.
+///
+/// The entry's [`NodeOrigin`], when it has one, is made ambient for the run --
+/// that is how `file_index`/`document_index` answer per document under
+/// `--eval-all` and per file on the ordinary multi-file path (#2427), where
+/// real yq reads two fields off the `CandidateNode` itself.
 ///
 /// The empty-`stages` case is *not* delegated to
 /// [`continue_pipe_element_generic`]: that would reach
 /// `eval_each_pipe_generic`'s own empty-pipe short-circuit, which drops the
 /// cursor. Here the entry is the answer, cursor and all.
 fn run_yq_stages_over_item<S: EvalSemantics, V: DocumentValue>(
+    stages: &[Expr],
+    item: &YqContextItem<V>,
+    optional: bool,
+    sink: &mut dyn FnMut(GenericItem<V>) -> Demand,
+) -> Flow {
+    match item.tag.origin {
+        Some(origin) => with_node_origin(origin, || {
+            run_yq_stages_bare::<S, V>(stages, item, optional, sink)
+        }),
+        None => run_yq_stages_bare::<S, V>(stages, item, optional, sink),
+    }
+}
+
+fn run_yq_stages_bare<S: EvalSemantics, V: DocumentValue>(
     stages: &[Expr],
     item: &YqContextItem<V>,
     optional: bool,
@@ -7845,6 +8011,12 @@ fn run_yq_stages_over_item<S: EvalSemantics, V: DocumentValue>(
 
 /// Materialize the outputs of `stages` over a whole context list.
 ///
+/// Each captured entry inherits the [`YqContextTag`] the walk published in
+/// `cur` immediately before the run that produced it -- the walk is
+/// synchronous, so "the tag in `cur` when the sink fires" is exactly "the tag
+/// of the input entry this output came from", with the per-node flags already
+/// dropped by [`yq_stage_preserves_node`] where the stages build new nodes.
+///
 /// A control that ends the run **discards whatever the run already
 /// produced**, rather than handing the prefix on. That is real yq's own
 /// answer, and the same rule
@@ -7860,13 +8032,12 @@ fn collect_yq_context<S: EvalSemantics, V: DocumentValue>(
     stages: &[Expr],
     inputs: &[YqContextItem<V>],
     optional: bool,
+    cur: &core::cell::Cell<YqContextTag>,
 ) -> Result<Vec<YqContextItem<V>>, Control> {
     let mut out: Vec<YqContextItem<V>> = Vec::new();
     let mut stray: Option<Control> = None;
-    let flow =
-        eval_yq_context_pipe::<S, V>(stages, inputs, optional, &mut |item| match yq_context_item(
-            item,
-        ) {
+    let flow = eval_yq_context_pipe::<S, V>(stages, inputs, optional, cur, &mut |item| {
+        match yq_context_item(item, cur.get()) {
             Ok(entry) => {
                 out.push(entry);
                 Demand::Continue
@@ -7875,7 +8046,8 @@ fn collect_yq_context<S: EvalSemantics, V: DocumentValue>(
                 stray = Some(control);
                 Demand::Stop
             }
-        });
+        }
+    });
     match (stray, flow) {
         (Some(control), _) | (None, Flow::Escaped(control)) => Err(control),
         // This sink only ever says `Stop` on the `stray` path handled above,
@@ -7885,8 +8057,32 @@ fn collect_yq_context<S: EvalSemantics, V: DocumentValue>(
     }
 }
 
-/// Where rule 1's branch-major walk splits a flat pipe: the index of the
-/// first union stage, or `None` when this pipe is not one the walk owns.
+/// Which stage of a flat pipe the context-list walk owns, and under which of
+/// yq's rules.
+#[derive(Clone, Copy)]
+enum YqListStage {
+    /// A union (`,`): #2451 rule 1, branch-major over the whole list.
+    Union,
+    /// `[E]` over inputs that *all* carry `EvaluateTogether`: real yq's
+    /// `collectOperator` (`pkg/yqlib/operator_collect.go:33-49`) checks that
+    /// flag on every node of its context and, when they all have it, builds
+    /// **one** array from `E`'s outputs over the whole list instead of one
+    /// array per node (#2427).
+    Collect,
+    /// A binary operator over inputs that all carry `EvaluateTogether`:
+    /// `crossFunctionWithPrefs` (`pkg/yqlib/operators.go:145-172`) makes the
+    /// same check and then runs `doCrossFunc` **once** over the whole
+    /// context, so both operands see the full list and every pairing is
+    /// emitted (#2427).
+    Binary,
+}
+
+/// Where the walk splits a flat pipe: the first stage it owns, or `None` when
+/// this pipe is not one the walk owns at all.
+///
+/// `together` is whether every input entry carries `EvaluateTogether` on the
+/// way in; it is dropped at the first stage that builds a new node, so
+/// `.a | [.]` is per document where `[.]` is one array.
 ///
 /// The one declining case is an **absent** position: a navigational prefix
 /// that can land on a missing key (`.a.x`) followed by something that reads
@@ -7901,17 +8097,47 @@ fn collect_yq_context<S: EvalSemantics, V: DocumentValue>(
 /// are otherwise single-position: `head_can_yield_absent` is already `false`
 /// for `.a[]`/`.d[]` (iterating an absent node yields nothing) and for an
 /// empty prefix, which is every multi-element shape the sweep exercises.
-fn yq_union_stage_index(stages: &[Expr]) -> Option<usize> {
-    let at = stages.iter().position(|s| matches!(s, Expr::Comma(_)))?;
+fn yq_list_stage(stages: &[Expr], together: bool) -> Option<(usize, YqListStage)> {
+    let mut together = together;
+    let mut found: Option<(usize, YqListStage)> = None;
+    for (i, stage) in stages.iter().enumerate() {
+        if matches!(stage, Expr::Comma(_)) {
+            found = Some((i, YqListStage::Union));
+            break;
+        }
+        if together {
+            match stage {
+                Expr::Array(_) => {
+                    found = Some((i, YqListStage::Collect));
+                    break;
+                }
+                Expr::Arithmetic { .. } | Expr::Compare { .. } => {
+                    found = Some((i, YqListStage::Binary));
+                    break;
+                }
+                _ => {}
+            }
+            together = yq_stage_preserves_node(stage);
+        }
+    }
+    let (at, kind) = found?;
     if stages.iter().any(needs_path_context) && head_can_yield_absent(&stages[..at]) {
         return None;
     }
-    Some(at)
+    Some((at, kind))
 }
 
-/// **The one definition of rule 1 of yq's context-list model** (#2451): a
-/// pipe evaluated over a whole *list* of inputs at once, branch-major
-/// through every union it contains.
+/// Rule 1's stage index alone, for the entry gate -- see [`yq_list_stage`].
+fn yq_union_stage_index(stages: &[Expr]) -> Option<usize> {
+    yq_list_stage(stages, false).map(|(at, _)| at)
+}
+
+/// **The one definition of rules 1 and 3 of yq's context-list model**
+/// (#2451, #2427): a pipe evaluated over a whole *list* of inputs at once,
+/// branch-major through every union it contains, and -- for a list whose
+/// entries all came straight out of the `--eval-all` reader -- collecting and
+/// cross-multiplying over the whole list where real yq's `EvaluateTogether`
+/// flag says to.
 ///
 /// Real yq has no scalar evaluation mode. `Context.MatchingNodes`
 /// (`pkg/yqlib/context.go`, v4.53.3) is always a list; `|` hands its left
@@ -7923,43 +8149,56 @@ fn yq_union_stage_index(stages: &[Expr]) -> Option<usize> {
 /// independently and interleaves, `3 4 5 6`.
 ///
 /// Captured live against Homebrew yq v4.53.3; the rows are in
-/// `test_yq_pipe_into_union_is_branch_major_2451`.
+/// `test_yq_pipe_into_union_is_branch_major_2451` and, for the
+/// `EvaluateTogether` rules, `tests/yq_cli_tests.rs`'s `--eval-all` cases.
 ///
-/// The walk is: find the first union stage; materialize everything before it
-/// over every input (that is the context list the union sees); run each
-/// branch over that whole list, concatenating; then recurse with the
-/// concatenation as the input list for the stages after the union. Recursing
-/// on the *concatenated* list, rather than continuing per branch output, is
-/// what makes a second union downstream see the first one's full result --
-/// `(.a, .b) | (.c, .d) | (. + 1, . + 2)` is `4 6 5 7 5 7 6 8`, which no
-/// per-output continuation produces. A branch that is itself a union recurses
-/// through the same entry point, so nesting needs no separate case.
+/// The walk is: find the first stage the walk owns; materialize everything
+/// before it over every input (that is the context list that stage sees); run
+/// that stage's own rule; then recurse with its result as the input list for
+/// the stages after it. Recursing on the *concatenated* list, rather than
+/// continuing per branch output, is what makes a second union downstream see
+/// the first one's full result -- `(.a, .b) | (.c, .d) | (. + 1, . + 2)` is
+/// `4 6 5 7 5 7 6 8`, which no per-output continuation produces. A branch that
+/// is itself a union recurses through the same entry point, so nesting needs
+/// no separate case.
 ///
-/// Cost: one [`YqContextItem`] per output of the stages before each union --
-/// a cursor for a navigational upstream, so the list is bounded by the number
-/// of outputs, not by the document. The loss is demand: a consumer's `Stop`
-/// cannot reach back into a materialized list, so a `limit`/`first` wrapped
-/// around one of these pipes evaluates the union in full. Real yq has no
-/// side-effecting builtin to observe that with (`stderr`/`debug` are lexer
-/// errors there), and materializing is what real yq itself does, so this
-/// costs fidelity nothing on the reference surface.
+/// Cost: one [`YqContextItem`] per output of the stages before each owned
+/// stage -- a cursor for a navigational upstream, so the list is bounded by
+/// the number of outputs, not by the document. The loss is demand: a
+/// consumer's `Stop` cannot reach back into a materialized list, so a
+/// `limit`/`first` wrapped around one of these pipes evaluates the stage in
+/// full. Real yq has no side-effecting builtin to observe that with
+/// (`stderr`/`debug` are lexer errors there), and materializing is what real
+/// yq itself does, so this costs fidelity nothing on the reference surface.
 ///
-/// `stages` must already be flat (see [`yq_flatten_pipe_stages`]).
+/// `stages` must already be flat (see [`yq_flatten_pipe_stages`]). `cur`
+/// carries the tag of the entry currently being run, for
+/// [`collect_yq_context`]'s sink to read back.
 fn eval_yq_context_pipe<S: EvalSemantics, V: DocumentValue>(
     stages: &[Expr],
     inputs: &[YqContextItem<V>],
     optional: bool,
+    cur: &core::cell::Cell<YqContextTag>,
     sink: &mut dyn FnMut(GenericItem<V>) -> Demand,
 ) -> Flow {
-    let Some(at) = yq_union_stage_index(stages) else {
-        // No union left -- or one this walk declines (see
-        // [`yq_union_stage_index`]) -- so back to the ordinary per-value
-        // pipe, which is both lazy and identical to yq for every other
-        // operator: they all loop their context list and concatenate.
+    // `collectOperator`'s own `evaluateAllTogether` fold
+    // (`operator_collect.go:33-38`): every node must carry the flag, and an
+    // empty context list is not a together context at all.
+    let together = !inputs.is_empty() && inputs.iter().all(|item| item.tag.together);
+    let Some((at, kind)) = yq_list_stage(stages, together) else {
+        // No stage left for the walk -- or one it declines (see
+        // [`yq_list_stage`]) -- so back to the ordinary per-value pipe, which
+        // is both lazy and identical to yq for every other operator: they all
+        // loop their context list and concatenate.
         // `run_yq_stages_over_item` re-enters `eval_each_pipe_generic`, whose
         // own gate consults the same function, so a declined pipe takes the
         // path-context routes rather than looping back here.
+        let preserves = stages.iter().all(yq_stage_preserves_node);
         for item in inputs {
+            cur.set(YqContextTag {
+                together: item.tag.together && preserves,
+                origin: item.tag.origin,
+            });
             match run_yq_stages_over_item::<S, V>(stages, item, optional, sink) {
                 Flow::Exhausted => {}
                 stopped_or_escaped => return stopped_or_escaped,
@@ -7967,34 +8206,192 @@ fn eval_yq_context_pipe<S: EvalSemantics, V: DocumentValue>(
         }
         return Flow::Exhausted;
     };
-    let Expr::Comma(branches) = &stages[at] else {
-        // `yq_union_stage_index` matched this exact pattern to pick `at`.
-        unreachable!("the stage yq_union_stage_index selected is an Expr::Comma")
-    };
 
     let context = if at == 0 {
         inputs.to_vec()
     } else {
-        match collect_yq_context::<S, V>(&stages[..at], inputs, optional) {
+        match collect_yq_context::<S, V>(&stages[..at], inputs, optional, cur) {
             Ok(context) => context,
             Err(control) => return Flow::Escaped(control),
         }
     };
+    let rest = &stages[at + 1..];
 
-    let mut united: Vec<YqContextItem<V>> = Vec::new();
-    for branch in branches {
-        let mut flat: Vec<Expr> = Vec::new();
-        yq_flatten_pipe_stages(core::slice::from_ref(branch), &mut flat);
-        // Same as `eval_each_generic`'s own `Comma` arm: a branch that escapes
-        // ends the union, and the branches after it are not evaluated -- with
-        // the whole union's result discarded, per `collect_yq_context`.
-        match collect_yq_context::<S, V>(&flat, &context, optional) {
-            Ok(produced) => united.extend(produced),
-            Err(control) => return Flow::Escaped(control),
+    let produced = match kind {
+        YqListStage::Union => {
+            let Expr::Comma(branches) = &stages[at] else {
+                // `yq_list_stage` matched this exact pattern to pick `at`.
+                unreachable!("the stage yq_list_stage selected as a union is an Expr::Comma")
+            };
+            let mut united: Vec<YqContextItem<V>> = Vec::new();
+            for branch in branches {
+                let mut flat: Vec<Expr> = Vec::new();
+                yq_flatten_pipe_stages(core::slice::from_ref(branch), &mut flat);
+                // Same as `eval_each_generic`'s own `Comma` arm: a branch that
+                // escapes ends the union, and the branches after it are not
+                // evaluated -- with the whole union's result discarded, per
+                // `collect_yq_context`.
+                match collect_yq_context::<S, V>(&flat, &context, optional, cur) {
+                    Ok(branch_items) => united.extend(branch_items),
+                    Err(control) => return Flow::Escaped(control),
+                }
+            }
+            united
+        }
+        YqListStage::Collect => {
+            match collect_together::<S, V>(&stages[at], &context, optional, cur) {
+                Ok(item) => vec![item],
+                Err(flow) => return flow,
+            }
+        }
+        YqListStage::Binary => match cross_together::<S, V>(&stages[at], &context, optional, cur) {
+            Ok(items) => items,
+            Err(flow) => return flow,
+        },
+    };
+
+    eval_yq_context_pipe::<S, V>(rest, &produced, optional, cur, sink)
+}
+
+/// `[E]` over a context list whose entries all carry `EvaluateTogether`:
+/// **one** array holding `E`'s outputs over every entry, in order.
+///
+/// Real yq's `collectTogether` (`pkg/yqlib/operator_collect.go:7-22`) loops
+/// the context, evaluates `E` against each node as its own single read-only
+/// child context, and appends every result into one sequence node. Reproduced
+/// by running the *ordinary* per-node `[E]` over each entry -- which is
+/// already that same single-node collect, read-only rule included -- and
+/// splicing the one-array-per-entry results together. Doing it that way is
+/// what keeps `[.a]`'s absent-key rule identical on both paths instead of
+/// re-deriving it here.
+///
+/// The array is a node real yq builds from scratch, so it carries neither the
+/// flag nor an origin: `[.] | [.]` is an array of one array, and
+/// `[.] | file_index` is `0`.
+fn collect_together<S: EvalSemantics, V: DocumentValue>(
+    stage: &Expr,
+    context: &[YqContextItem<V>],
+    optional: bool,
+    cur: &core::cell::Cell<YqContextTag>,
+) -> Result<YqContextItem<V>, Flow> {
+    let single = core::slice::from_ref(stage);
+    let mut merged: Vec<OwnedValue> = Vec::new();
+    for item in context {
+        cur.set(item.tag);
+        let mut stray: Option<Control> = None;
+        let flow = run_yq_stages_over_item::<S, V>(single, item, optional, &mut |produced| {
+            match generic_item_into_owned(produced) {
+                // The per-node collect always yields exactly one array; the
+                // non-array arm is unreachable defensive splicing rather than
+                // a second rule.
+                Ok(OwnedValue::Array(elements)) => {
+                    merged.extend(elements);
+                    Demand::Continue
+                }
+                Ok(other) => {
+                    merged.push(other);
+                    Demand::Continue
+                }
+                Err(control) => {
+                    stray = Some(control);
+                    Demand::Stop
+                }
+            }
+        });
+        if let Some(control) = stray {
+            return Err(Flow::Escaped(control));
+        }
+        match flow {
+            Flow::Exhausted | Flow::Stopped { pending: None } => {}
+            Flow::Stopped {
+                pending: Some(control),
+            }
+            | Flow::Escaped(control) => return Err(Flow::Escaped(control)),
         }
     }
+    Ok(YqContextItem::new(
+        YqContextNode::Owned(OwnedValue::Array(merged)),
+        YqContextTag::default(),
+    ))
+}
 
-    eval_yq_context_pipe::<S, V>(&stages[at + 1..], &united, optional, sink)
+/// A binary operator over a context list whose entries all carry
+/// `EvaluateTogether`: **both** operands are evaluated over the whole list,
+/// and every pairing is emitted.
+///
+/// Real yq's `doCrossFunc` (`pkg/yqlib/operators.go:113-138`) loops the LHS
+/// matches and re-evaluates the RHS from scratch against the *same shared
+/// context* for each one (`operators.go:73`), so a context-size-sensitive RHS
+/// multiplies: `yq ea '. + {"z": 9}' f1.yaml f2.yaml` prints four documents,
+/// two copies of each file's merged with `z`. Both operands being pure, "run
+/// each operand once over the whole list and pair every combination" is
+/// observationally the same nested loop.
+///
+/// The pairing order, the read-only operand rule and the zero-output-operand
+/// table all come from [`binary_fanout_each_generic`] unchanged -- the only
+/// thing this function supplies is an operand strategy that evaluates over the
+/// context *list* instead of over one value.
+fn cross_together<S: EvalSemantics, V: DocumentValue>(
+    stage: &Expr,
+    context: &[YqContextItem<V>],
+    optional: bool,
+    cur: &core::cell::Cell<YqContextTag>,
+) -> Result<Vec<YqContextItem<V>>, Flow> {
+    let each_operand = |operand: &Expr, operand_sink: &mut dyn FnMut(GenericItem<V>) -> Demand| {
+        let mut flat: Vec<Expr> = Vec::new();
+        yq_flatten_pipe_stages(core::slice::from_ref(operand), &mut flat);
+        eval_yq_context_pipe::<S, V>(&flat, context, false, cur, operand_sink)
+    };
+    let mut produced: Vec<YqContextItem<V>> = Vec::new();
+    let mut stray: Option<Control> = None;
+    // Every pairing is a value the operator computed, so it carries neither
+    // `EvaluateTogether` nor an origin -- `. + {"z": 9} | [.]` is one array
+    // per result, matching real yq.
+    let mut collect = |item: GenericItem<V>| match yq_context_item(item, YqContextTag::default()) {
+        Ok(entry) => {
+            produced.push(entry);
+            Demand::Continue
+        }
+        Err(control) => {
+            stray = Some(control);
+            Demand::Stop
+        }
+    };
+    let flow = match stage {
+        Expr::Compare { op, left, right } => binary_fanout_each_generic::<V>(
+            each_operand,
+            left,
+            right,
+            optional,
+            binary_fanout_rules::<S>(EmptyOperandOp::Compare(*op)),
+            |left_val, right_val| {
+                Ok(OwnedValue::Bool(apply_compare_op::<S>(
+                    *op, &left_val, &right_val,
+                )))
+            },
+            &mut collect,
+        ),
+        Expr::Arithmetic { op, left, right } => binary_fanout_each_generic::<V>(
+            each_operand,
+            left,
+            right,
+            optional,
+            binary_fanout_rules::<S>(EmptyOperandOp::Arith(*op)),
+            |left_val, right_val| arith_combine::<S>(*op, left_val, right_val),
+            &mut collect,
+        ),
+        _ => unreachable!("yq_list_stage selects only Compare/Arithmetic as a binary stage"),
+    };
+    if let Some(control) = stray {
+        return Err(Flow::Escaped(control));
+    }
+    match flow {
+        Flow::Exhausted | Flow::Stopped { pending: None } => Ok(produced),
+        Flow::Stopped {
+            pending: Some(control),
+        }
+        | Flow::Escaped(control) => Err(Flow::Escaped(control)),
+    }
 }
 
 /// Does rule 1 own this pipe? **Both** routes must ask the same question:
@@ -8015,6 +8412,10 @@ fn yq_context_pipe_applies<S: EvalSemantics>(exprs: &[Expr]) -> bool {
 /// Rule 1's entry point from either evaluator route: `Some(flow)` when this
 /// is a yq-mode pipe with a union in it, `None` when the caller should carry
 /// on exactly as before.
+///
+/// The root entry is never `EvaluateTogether`: that flag is stamped only by
+/// real yq's all-at-once multi-document reader, whose succinctly counterpart
+/// is [`eval_yq_documents_together`].
 fn try_yq_context_pipe<S: EvalSemantics, V: DocumentValue>(
     exprs: &[Expr],
     value: V,
@@ -8029,16 +8430,96 @@ fn try_yq_context_pipe<S: EvalSemantics, V: DocumentValue>(
     yq_flatten_pipe_stages(exprs, &mut flat);
     // The cursor, when there is one, so a path-context stage downstream still
     // has a position to answer from.
-    let root = match cursor {
-        Some(c) => YqContextItem::Cursor(c),
-        None => YqContextItem::Value(value),
-    };
+    let root = YqContextItem::new(
+        match cursor {
+            Some(c) => YqContextNode::Cursor(c),
+            None => YqContextNode::Value(value),
+        },
+        YqContextTag::default(),
+    );
+    let cur = core::cell::Cell::new(YqContextTag::default());
     Some(eval_yq_context_pipe::<S, V>(
         &flat,
         core::slice::from_ref(&root),
         optional,
+        &cur,
         sink,
     ))
+}
+
+/// One `--eval-all` input document: its value, a cursor into a document the
+/// caller keeps alive for the evaluation, and where it was read from (#2427).
+pub(crate) struct YqDocument<C: DocumentCursor> {
+    pub(crate) cursor: Option<C>,
+    pub(crate) value: OwnedValue,
+    pub(crate) origin: NodeOrigin,
+}
+
+/// Evaluate `expr` **once** over every document of every input file, the way
+/// real yq's `--eval-all` does (#2427).
+///
+/// `allAtOnceEvaluator.EvaluateFiles` (`pkg/yqlib/all_at_once_evaluator.go:47-75`,
+/// v4.53.3) reads every document of every file into one node list via
+/// `readDocuments` -- which stamps each one `EvaluateTogether: true`
+/// (`pkg/yqlib/utils.go:85`) -- and runs the expression once against that
+/// whole list as the initial context. It is the ordinary evaluator throughout;
+/// the flag is the only difference, and only `[...]` and binary operators
+/// consult it. So `yq ea '.name' f1 f2` is one output per document, while
+/// `yq ea '[.]' f1 f2` is a single array of both -- and `.name | [.]` is back
+/// to one array per document, because navigation produced nodes the reader
+/// never stamped.
+///
+/// Not a slurp: the expression never sees a containing array, so `.name`,
+/// `keys`, `length` and `del(.name)` all apply per document.
+pub(crate) fn eval_yq_documents_together<S: EvalSemantics, C: DocumentCursor>(
+    expr: &Expr,
+    documents: &[YqDocument<C>],
+) -> GenericResult<C::Value> {
+    let inputs: Vec<YqContextItem<C::Value>> = documents
+        .iter()
+        .map(|doc| {
+            YqContextItem::new(
+                match doc.cursor {
+                    Some(cursor) => YqContextNode::Cursor(cursor),
+                    None => YqContextNode::Owned(doc.value.clone()),
+                },
+                YqContextTag {
+                    together: true,
+                    origin: Some(doc.origin),
+                },
+            )
+        })
+        .collect();
+    let mut flat: Vec<Expr> = Vec::new();
+    yq_flatten_pipe_stages(core::slice::from_ref(expr), &mut flat);
+    let cur = core::cell::Cell::new(YqContextTag::default());
+    let mut items: Vec<GenericItem<C::Value>> = Vec::new();
+    let flow = eval_yq_context_pipe::<S, C::Value>(&flat, &inputs, false, &cur, &mut |item| {
+        items.push(item);
+        Demand::Continue
+    });
+    // Same tail as `collect_each_generic`: a clean run answers with the items,
+    // a control keeps whatever was already produced as a `Partial`.
+    let control = match flow {
+        Flow::Exhausted | Flow::Stopped { pending: None } => {
+            return match items_to_generic_result(items) {
+                Ok(result) => result,
+                Err((prefix, control)) => partial_generic(prefix, control),
+            };
+        }
+        Flow::Stopped {
+            pending: Some(control),
+        }
+        | Flow::Escaped(control) => control,
+    };
+    let mut owned = vec_with_capacity(items.len());
+    for item in items {
+        match generic_item_into_owned(item) {
+            Ok(v) => owned.push(v),
+            Err(failure) => return partial_generic(owned, failure),
+        }
+    }
+    partial_generic(owned, control)
 }
 
 /// Generic-evaluator twin of `eval::each_take_first` (#1461): pull at most
@@ -12505,7 +12986,9 @@ fn path_context_resolve_constants(
         // than switched to an unexercised `file_index_for_path(path)` call --
         // `path` here is absolute, so that is the one-line change to make the
         // moment a route does arrive with a table (#2427).
-        Expr::Builtin(Builtin::FileIndex) => Expr::Literal(Literal::Int(0)),
+        Expr::Builtin(Builtin::FileIndex) => {
+            Expr::Literal(Literal::Int(ambient_file_index().unwrap_or(0)))
+        }
         Expr::Paren(inner) => Expr::Paren(boxed(inner)),
         Expr::Array(inner) => Expr::Array(boxed(inner)),
         Expr::Optional(inner) => Expr::Optional(boxed(inner)),
@@ -12679,8 +13162,13 @@ fn eval_builtin<S: EvalSemantics, V: DocumentValue>(
         }
 
         Builtin::DocumentIndex => {
-            let doc_index = cursor.and_then(|c| c.document_index()).unwrap_or(0);
-            GenericResult::Owned(OwnedValue::Int(doc_index as i64))
+            // #2427: the ambient origin wins where one is installed --
+            // `--eval-all` reindexes each input document into its own
+            // throwaway single-document JSON index, whose own
+            // `document_index()` is 0 for every one of them.
+            let doc_index = ambient_document_index()
+                .unwrap_or_else(|| cursor.and_then(|c| c.document_index()).unwrap_or(0) as i64);
+            GenericResult::Owned(OwnedValue::Int(doc_index))
         }
 
         Builtin::Anchor => {
@@ -14582,9 +15070,12 @@ fn eval_owned_identity_pipe<S: EvalSemantics, V: DocumentValue>(
         // `FileIndex` arm (see its comment): the table exists now, this route
         // is not reached with one installed, and `id.path()` is what to feed
         // `file_index_for_path` when it is.
-        Expr::Builtin(Builtin::FileIndex) => {
-            continue_owned_identity_plain::<S, V>(rest, OwnedValue::Int(0), optional, sink)
-        }
+        Expr::Builtin(Builtin::FileIndex) => continue_owned_identity_plain::<S, V>(
+            rest,
+            OwnedValue::Int(ambient_file_index().unwrap_or(0)),
+            optional,
+            sink,
+        ),
         Expr::Builtin(Builtin::Parent) => match id.parent() {
             Some(OwnedParent::Owned(v, vid)) => {
                 eval_owned_identity_pipe::<S, V>(rest, v, vid, optional, sink)

--- a/src/jq/mod.rs
+++ b/src/jq/mod.rs
@@ -87,8 +87,9 @@ pub mod walk;
 
 pub use error::{BinOp, Control, ErrorKind, EvalError, EvalErrorPayload};
 pub use eval::{
-    eval, eval_lenient, eval_owned_with_file_index, nonfinite_display_string, substitute_vars,
-    sync_aliased_paths, EvalSemantics, JqSemantics, QueryResult, YqSemantics,
+    eval, eval_documents_together, eval_lenient, eval_owned_with_file_index,
+    nonfinite_display_string, substitute_vars, sync_aliased_paths, EvalSemantics, JqSemantics,
+    QueryResult, YqSemantics,
 };
 // `input`/`inputs`/`input_line_number`'s CLI-facing seam (#723) -- only
 // exists under `eval.rs`'s own `#[cfg(feature = "std")]` gate (a `thread_local!`

--- a/src/jq/mod.rs
+++ b/src/jq/mod.rs
@@ -87,9 +87,9 @@ pub mod walk;
 
 pub use error::{BinOp, Control, ErrorKind, EvalError, EvalErrorPayload};
 pub use eval::{
-    eval, eval_documents_together, eval_lenient, eval_owned_with_file_index,
-    nonfinite_display_string, substitute_vars, sync_aliased_paths, EvalSemantics, JqSemantics,
-    QueryResult, YqSemantics,
+    enter_file_index_scope, eval, eval_documents_together, eval_lenient,
+    eval_owned_with_file_index, nonfinite_display_string, substitute_vars, sync_aliased_paths,
+    EvalSemantics, FileIndexScope, JqSemantics, QueryResult, YqSemantics,
 };
 // `input`/`inputs`/`input_line_number`'s CLI-facing seam (#723) -- only
 // exists under `eval.rs`'s own `#[cfg(feature = "std")]` gate (a `thread_local!`

--- a/tests/data/jq-path-context-sweep-known-divergences.txt
+++ b/tests/data/jq-path-context-sweep-known-divergences.txt
@@ -34,22 +34,16 @@ yq/*/first/*/*        yq_first        real yq's first(f) ignores its argument an
 # position: `eval_pipe_with_path_context_internal` has no `Expr::Object` arm,
 # so the whole object construction falls to the context-dropping fallback.
 
-# `file_index` answers 0 for every input file. Real yq counts files (`0`,
-# `1`). Surfaced by this sweep — see the #2416 phase 0 report; no issue filed
-# yet.
-#
-# Scoped, not stale: this row is the *ordinary* multi-file path, which is what
-# the yq-mode cases here run (`succinctly yq FILTER one.yaml two.yaml`, no
-# `--eval-all`). That path evaluates each document independently through
-# `evaluate_input`, which has no file-origin table to install, and answering
-# `file_index` there needs a per-file scalar rather than the top-level-index
-# table `--eval-all` uses — a node's own `path.first()` is a key of its
-# document, not a file number. `--eval-all` itself answers `file_index`
-# correctly on both its routes since spine 2416 step 5 (see
-# tests/yq_cli_tests.rs::test_eval_all_file_index_agrees_across_both_routes_2416),
-# and diverges from yq for a different reason: succinctly slurps the files
-# into one array where yq keeps them a document stream (#2427).
-yq/file_index/*       file_index      file_index is always 0 across multiple input files, outside --eval-all — #2416 phase 0
+# `file_index` itself agrees everywhere since #2427: the ordinary multi-file
+# path installs a per-file scope (`jq::enter_file_index_scope`) around each
+# file's evaluation, the way real yq stamps `fileIndex` on every node as it
+# decodes the file (`pkg/yqlib/utils.go:60-89`), and `--eval-all` carries the
+# same origin per document. What is left under `..` is not a `file_index`
+# question at all but the *comma ordering* one below: `.. | ((file_index), 1)`
+# needs #2451's branch-major union over the whole `..` result list, which the
+# context-list walk declines for a recursive-descent head for the same reason
+# the three rows below exist.
+yq/file_index/*/descend  descend_path  `..` into a union is element-major, so file_index interleaves — #2451
 
 # `parent`/`key` at the document root: real yq emits nothing (exit 0),
 # succinctly prints `{}` and `null`. These are the positions the #2061 walk

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -16155,6 +16155,57 @@ fn test_eval_all_position_builtins_answer_per_document_2427() -> Result<()> {
     Ok(())
 }
 
+/// #2427 divergence 1: `file_index` counts files on the **ordinary** multi-file
+/// path too, not only under `--eval-all`. That path evaluates each file
+/// independently, so there is no combined array whose top-level index could
+/// stand in for the file number; the CLI installs a per-file scope
+/// (`jq::enter_file_index_scope`) around each file's evaluation instead, the
+/// way real yq stamps `fileIndex` on every node as it decodes the file
+/// (`pkg/yqlib/utils.go:60-89`).
+///
+/// Rows from `yq -o=json -I0 FILTER f1.yaml f2.yaml` on v4.53.3.
+#[test]
+fn test_file_index_counts_files_outside_eval_all_2427() -> Result<()> {
+    let (f1, f2) = two_doc_fixtures()?;
+    let rows: &[(&str, &str)] = &[
+        ("file_index", "0\n1"),
+        ("fileIndex", "0\n1"),
+        ("fi", "0\n1"),
+        ("[file_index]", "[0]\n[1]"),
+        ("file_index + 1", "1\n2"),
+        ("select(file_index == 1)", "{\"b\":2,\"name\":\"second\"}"),
+        (".name, file_index", "\"first\"\n0\n\"second\"\n1"),
+    ];
+    for (filter, expected) in rows {
+        let (stdout, stderr, code) =
+            run_yq_files(filter, &[f1.path(), f2.path()], &["-o", "json", "-I", "0"])?;
+        assert_eq!(code, 0, "`{filter}` exited {code}, stderr: {stderr}");
+        assert_eq!(stdout.trim(), *expected, "filter: {filter}");
+    }
+
+    // A single file still answers 0, and a multi-document file does not make
+    // the number advance -- it counts files, not documents.
+    let mut multi = NamedTempFile::new()?;
+    write!(multi, "x: 1\n---\ny: 2\n")?;
+    let (stdout, _stderr, code) = run_yq_files(
+        "file_index",
+        &[multi.path(), f1.path()],
+        &["-o", "json", "-I", "0"],
+    )?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout.trim(), "0\n0\n1");
+
+    // ... and `document_index`, which the cursor answers, is unaffected.
+    let (stdout, _stderr, code) = run_yq_files(
+        "document_index",
+        &[multi.path(), f1.path()],
+        &["-o", "json", "-I", "0"],
+    )?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout.trim(), "0\n1\n0");
+    Ok(())
+}
+
 #[test]
 fn test_eval_all_rejects_slurp() -> Result<()> {
     let (f1, _f2) = two_doc_fixtures()?;

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -1707,11 +1707,10 @@ fn test_input_format_json_bridge_preserves_decode_failure_key_1642() -> Result<(
     assert_eq!(code, 0);
     assert_eq!(output.trim(), r#"["a\\q","b"]"#, "--slurp keys");
 
-    let (output, code) = run_yq_stdin(
-        ".[0] | length",
-        json,
-        &["--input-format", "json", "--eval-all"],
-    )?;
+    // #2427: `--eval-all` is a document *stream*, not a slurped array, so
+    // the document itself is the input -- no `.[0]` unwrap (real yq's own
+    // `ea 'length'` answers the document's field count too).
+    let (output, code) = run_yq_stdin("length", json, &["--input-format", "json", "--eval-all"])?;
     assert_eq!(code, 0);
     assert_eq!(output.trim(), "2", "--eval-all length");
 
@@ -3028,9 +3027,12 @@ fn test_integer_valued_float_survives_slurp_eval_all_load_907() -> Result<()> {
     assert_eq!(code, 0, "out: {out:?}");
     assert_eq!(out.trim(), "[2.0]");
 
+    // #2427: `--eval-all` no longer slurps into an array, so `.` is the one
+    // document itself -- `2.0`, not `[2.0]`. Live-verified against yq
+    // v4.53.3: `yq ea -o=json -I0 '.'` on `2.0` prints `2`.
     let (out, code) = run_yq_stdin(".", "2.0", &["--eval-all", "-o", "json", "-I", "0"])?;
     assert_eq!(code, 0, "out: {out:?}");
-    assert_eq!(out.trim(), "[2.0]");
+    assert_eq!(out.trim(), "2.0");
 
     let mut input_file = NamedTempFile::new()?;
     writeln!(input_file, "a: 2.0")?;
@@ -4641,12 +4643,13 @@ fn test_nul_output_dom_path_no_separator_leak_on_later_doc_failure_1709() -> Res
 
 /// Same fix, `--eval-all` -- deferred separately from the standard loop
 /// above (own call site, own `results.len() > 1 && i > 0` condition).
-/// `--eval-all` combines every document into one array context, so `.[]`
-/// yields each *whole document* as its own result (`a: 1`, not `1`).
+/// Since #2427 `--eval-all` evaluates over the document *list*, so `.`
+/// already yields each whole document as its own result (`a: 1`, not `1`);
+/// `.[]` would iterate each document's members instead.
 #[test]
 fn test_nul_output_eval_all_no_separator_leak_on_later_doc_failure_1709() -> Result<()> {
     let input = "a: 1\n---\nb: \"x\\0y\"\n";
-    let (output, stderr, code) = run_yq_stdin_with_stderr(".[]", input, &["--eval-all", "-0"])?;
+    let (output, stderr, code) = run_yq_stdin_with_stderr(".", input, &["--eval-all", "-0"])?;
     assert_eq!(code, 1);
     assert_eq!(output, "a: 1\0");
     assert!(stderr.contains("NUL"), "got: {stderr}");
@@ -5130,17 +5133,14 @@ fn test_nul_output_multidoc_dom_path_does_not_corrupt_1701() -> Result<()> {
     Ok(())
 }
 
-/// Same fix, `--eval-all` (#1701 code review round 2). `.[]` (not `.`)
-/// is required to actually exercise the between-results `---` guard
-/// (`yq_runner.rs`'s `results.len() > 1 && i > 0` arm) -- `.` combines
-/// every document into a single array result under `--eval-all`, so it
-/// never reaches that branch at all (found by a round-4 gap sweep: the
-/// original version of this test round-tripped cleanly but tested a
-/// strictly weaker property than its own doc comment claimed).
+/// Same fix, `--eval-all` (#1701 code review round 2). The between-results
+/// `---` guard (`yq_runner.rs`'s `results.len() > 1 && i > 0` arm) needs a
+/// multi-result filter: before #2427 that meant `.[]` over the slurped
+/// array, and since #2427 plain `.` is already one result per document.
 #[test]
 fn test_join_output_eval_all_does_not_corrupt_1701() -> Result<()> {
     let input = "a: 1\n---\nb: 2\n";
-    let (output, code) = run_yq_stdin(".[]", input, &["--eval-all", "--join-output"])?;
+    let (output, code) = run_yq_stdin(".", input, &["--eval-all", "--join-output"])?;
     assert_eq!(code, 0);
     assert_eq!(output, "a: 1\n---\nb: 2");
     Ok(())
@@ -5150,7 +5150,7 @@ fn test_join_output_eval_all_does_not_corrupt_1701() -> Result<()> {
 #[test]
 fn test_nul_output_eval_all_does_not_corrupt_1701() -> Result<()> {
     let input = "a: 1\n---\nb: 2\n";
-    let (output, code) = run_yq_stdin(".[]", input, &["--eval-all", "-0"])?;
+    let (output, code) = run_yq_stdin(".", input, &["--eval-all", "-0"])?;
     assert_eq!(code, 0);
     assert_eq!(output, "a: 1\0\n---\nb: 2\0");
     Ok(())
@@ -11819,7 +11819,7 @@ fn test_computed_whole_float_json_sourced_input_unaffected_by_949() -> Result<()
 #[test]
 fn test_eval_all_applies_json_sourced_floats_1498() -> Result<()> {
     let (out, code) = run_yq_stdin(
-        ".[0].a",
+        ".a",
         r#"{"a":1.0}"#,
         &["--input-format", "json", "--eval-all", "-o=json"],
     )?;
@@ -11834,7 +11834,7 @@ fn test_eval_all_applies_json_sourced_floats_1498() -> Result<()> {
 #[test]
 fn test_eval_all_json_sourced_float_strips_trailing_zero_not_the_fraction_1498() -> Result<()> {
     let (out, code) = run_yq_stdin(
-        ".[0].a",
+        ".a",
         r#"{"a":2.50}"#,
         &["--input-format", "json", "--eval-all", "-o=json"],
     )?;
@@ -11848,7 +11848,7 @@ fn test_eval_all_json_sourced_float_strips_trailing_zero_not_the_fraction_1498()
 #[test]
 fn test_eval_all_json_sourced_int_unaffected_1498() -> Result<()> {
     let (out, code) = run_yq_stdin(
-        ".[0].a",
+        ".a",
         r#"{"a":5}"#,
         &["--input-format", "json", "--eval-all", "-o=json"],
     )?;
@@ -11864,7 +11864,7 @@ fn test_eval_all_json_sourced_int_unaffected_1498() -> Result<()> {
 /// `1.50` must not be affected by this fix at all.
 #[test]
 fn test_eval_all_yaml_sourced_float_keeps_literal_spelling_1498() -> Result<()> {
-    let (out, code) = run_yq_stdin(".[0].a", "a: 1.50\n", &["--eval-all", "-o=json"])?;
+    let (out, code) = run_yq_stdin(".a", "a: 1.50\n", &["--eval-all", "-o=json"])?;
     assert_eq!(code, 0, "out: {out:?}");
     assert_eq!(out.trim(), "1.50");
     Ok(())
@@ -12276,16 +12276,18 @@ fn test_yq_halt_not_caught_by_try_catch_or_label() -> Result<()> {
 /// must discard the whole array, same as error/break.
 #[test]
 fn test_map_with_path_context_discards_partial_array_on_halt() -> Result<()> {
+    // #2427: `--eval-all` hands the expression each document, not a slurped
+    // array of them, so the array `map` walks has to be inside a document.
+    // The halt is in the *first* document's own map, so nothing at all may
+    // reach stdout.
     let mut f1 = NamedTempFile::new()?;
-    writeln!(f1, "1")?;
+    writeln!(f1, "[1, 2]")?;
     let mut f2 = NamedTempFile::new()?;
-    writeln!(f2, "2")?;
-    let mut f3 = NamedTempFile::new()?;
-    writeln!(f3, "3")?;
+    writeln!(f2, "[3, 4]")?;
 
     let (stdout, stderr, code) = run_yq_files(
         "map(if . == 2 then halt else . + 10 + file_index end)",
-        &[f1.path(), f2.path(), f3.path()],
+        &[f1.path(), f2.path()],
         &["--eval-all"],
     )?;
     assert_eq!(code, 0, "stderr: {stderr}");
@@ -15511,12 +15513,20 @@ fn two_doc_fixtures() -> Result<(NamedTempFile, NamedTempFile)> {
     Ok((f1, f2))
 }
 
+/// #2427: `--eval-all` evaluates the expression once over the *list* of every
+/// document of every file, not over a slurped array of them, so `length` is
+/// each document's own field count -- two files, two answers. Live-verified:
+/// `yq ea -o=json -I0 'length' f1.yaml f2.yaml` prints `2` twice.
 #[test]
 fn test_eval_all_combines_documents_across_files() -> Result<()> {
     let (f1, f2) = two_doc_fixtures()?;
-    let (stdout, _stderr, code) = run_yq_files("length", &[f1.path(), f2.path()], &["--eval-all"])?;
+    let (stdout, _stderr, code) = run_yq_files(
+        "length",
+        &[f1.path(), f2.path()],
+        &["--eval-all", "-o", "json", "-I", "0"],
+    )?;
     assert_eq!(code, 0);
-    assert_eq!(stdout.trim(), "2");
+    assert_eq!(stdout.trim(), "2\n2");
     Ok(())
 }
 
@@ -15528,24 +15538,33 @@ fn test_eval_all_works_from_stdin() -> Result<()> {
     let (stdout, stderr, code) =
         run_yq_stdin_with_stderr(".", "a: 1\n", &["--eval-all", "-o", "json", "-I0"])?;
     assert_eq!(code, 0, "stderr: {stderr}");
-    assert_eq!(stdout.trim(), r#"[{"a":1}]"#);
+    // #2427: one document in, one document out -- no array wrapper. Real yq
+    // agrees: `yq ea -o=json -I0 '.'` on `a: 1` prints `{"a":1}`.
+    assert_eq!(stdout.trim(), r#"{"a":1}"#);
     Ok(())
 }
 
 #[test]
 fn test_eval_all_ea_alias() -> Result<()> {
     let (f1, f2) = two_doc_fixtures()?;
-    let (stdout, _stderr, code) = run_yq_files("length", &[f1.path(), f2.path()], &["--ea"])?;
+    let (stdout, _stderr, code) = run_yq_files(
+        "length",
+        &[f1.path(), f2.path()],
+        &["--ea", "-o", "json", "-I", "0"],
+    )?;
     assert_eq!(code, 0);
-    assert_eq!(stdout.trim(), "2");
+    assert_eq!(stdout.trim(), "2\n2");
     Ok(())
 }
 
+/// Bare `file_index` -- one answer per document since #2427, where before it
+/// needed a `.[]` to iterate the slurped array. `yq ea -o=json 'file_index'
+/// f1.yaml f2.yaml` prints `0` then `1`.
 #[test]
 fn test_eval_all_file_index_bare() -> Result<()> {
     let (f1, f2) = two_doc_fixtures()?;
     let (stdout, _stderr, code) = run_yq_files(
-        ".[] | file_index",
+        "file_index",
         &[f1.path(), f2.path()],
         &["--eval-all", "-o", "json"],
     )?;
@@ -15571,51 +15590,48 @@ fn test_eval_all_file_index_bare() -> Result<()> {
 /// cursor-threading arm yet (ADR-0021's remaining list). A regression that
 /// dropped the table on either side shows up as a `0` for the second file.
 ///
-/// **`--eval-all` slurps where real yq streams (#2427).** succinctly combines
-/// every document into one array, so `.[]` iterates *documents*; real yq
-/// keeps them a document stream, so its `.[]` iterates each document's own
-/// members. Both binaries answer the same question about which file a node
-/// came from -- they just disagree about what `.[]` selects. Captured live
-/// from yq v4.53.3 on 2026-09-05, on this test's own two fixtures
-/// (`a: 1 / name: first` and `b: 2 / name: second`):
+/// **Every row below is real yq's own answer since #2427**, which replaced the
+/// slurp with the document-list evaluation real `ea` performs, so `.[]` now
+/// iterates each *document's* members in both binaries rather than the
+/// documents themselves. Captured live from yq v4.53.3 on this test's own two
+/// fixtures (`a: 1 / name: first` and `b: 2 / name: second`):
 ///
 /// ```console
-/// $ yq ea -o=json -I0 '.[] | file_index'        f1 f2   # 0 0 1 1
-/// $ yq ea -o=json -I0 '[.[] | file_index]'      f1 f2   # [0,0,1,1]
-/// $ yq ea -o=json -I0 'file_index'              f1 f2   # 0 1
-/// $ yq ea -o=json -I0 '.[] | file_index + 1'    f1 f2   # 1 1 2 2
-/// $ yq ea -o=json -I0 '.[] | select(file_index == 1)' f1 f2
-/// 2
-/// "second"
-/// $ yq ea -o=json -I0 '.[].name | file_index'   f1 f2   # (no output)
+/// $ yq ea -o=json -I0 '.[] | file_index'              f1 f2   # 0 0 1 1
+/// $ yq ea -o=json -I0 '[.[] | file_index]'            f1 f2   # [0,0,1,1]
+/// $ yq ea -o=json -I0 'file_index'                    f1 f2   # 0 1
+/// $ yq ea -o=json -I0 '.name | file_index'            f1 f2   # 0 1
+/// $ yq ea -o=json -I0 '.[] | [file_index, key]'       f1 f2
+/// [0,"a"] [0,"name"] [1,"b"] [1,"name"]
+/// $ yq ea -o=json -I0 'select(file_index == 1) | .name' f1 f2 # "second"
+/// $ yq ea -o=json -I0 '.[] | file_index + 1'          f1 f2   # 1 1 2 2
 /// ```
 ///
-/// yq's counts are succinctly's doubled because each of its documents has two
-/// members; the file numbering itself (`0` then `1`) is the same, and that is
-/// the property this door closure had to preserve.
+/// The last row is a succinctly extension (real yq's lexer rejects
+/// `if`/`then`/`else` outright, #1512), kept because it is the shape that
+/// forces the eager route.
 #[test]
 fn test_eval_all_file_index_agrees_across_both_routes_2416() -> Result<()> {
     let (f1, f2) = two_doc_fixtures()?;
     // (filter, expected stdout, which route answers `file_index`)
     let rows: &[(&str, &str, &str)] = &[
-        (".[] | file_index", "0\n1", "cursor"),
-        ("[.[] | file_index]", "[0,1]", "cursor"),
-        ("file_index", "0", "cursor (root: no top-level index)"),
-        (".[].name | file_index", "0\n1", "cursor"),
-        (".[] | .name | file_index", "0\n1", "cursor"),
-        (".[] | [file_index, key]", "[0,0]\n[1,1]", "cursor"),
+        (".[] | file_index", "0\n0\n1\n1", "cursor"),
+        ("[.[] | file_index]", "[0,0,1,1]", "cursor"),
+        ("file_index", "0\n1", "cursor (document root)"),
+        (".name | file_index", "0\n1", "cursor"),
         (
-            ".[] | select(file_index == 1) | .name",
-            "\"second\"",
+            ".[] | [file_index, key]",
+            "[0,\"a\"]\n[0,\"name\"]\n[1,\"b\"]\n[1,\"name\"]",
             "cursor",
         ),
+        ("select(file_index == 1) | .name", "\"second\"", "cursor"),
         (
             ".[] | file_index + 1",
-            "1\n2",
+            "1\n1\n2\n2",
             "eager (no native arithmetic arm)",
         ),
         (
-            r#".[] | if file_index == 1 then "f2" else "f1" end"#,
+            r#"if file_index == 1 then "f2" else "f1" end"#,
             "\"f1\"\n\"f2\"",
             "cursor",
         ),
@@ -15650,7 +15666,8 @@ fn test_eval_all_file_index_agrees_across_both_routes_2416() -> Result<()> {
 ///
 /// Re-captured on this test's own two fixtures against real yq v4.53.3.
 /// succinctly's `--eval-all` is real yq's `eval-all`/`ea` subcommand (v4.53.3
-/// has no such *flag*), so `yq ea` is the oracle:
+/// has no such *flag*), so `yq ea` is the oracle -- and since #2427 both
+/// counts match it exactly:
 ///
 /// ```console
 /// $ yq ea -o=json -I0 '.[] | ((1,2,3) + 1), file_index'         f1 f2
@@ -15658,14 +15675,6 @@ fn test_eval_all_file_index_agrees_across_both_routes_2416() -> Result<()> {
 /// $ yq ea -o=json -I0 '.[] | (((1,2,3) + 1), file_index)'       f1 f2
 /// 2 3 4 2 3 4 2 3 4 2 3 4 0 0 1 1    # 16 lines
 /// ```
-///
-/// succinctly's counts differ from both -- yq evaluates each operator over
-/// the whole *context list* the pipe's left side produced, so its `(1,2,3)`
-/// fan-out and its `file_index` are each replayed once per context, where
-/// succinctly (like jq) pipes each left-hand value independently. That
-/// evaluation-model divergence is separate from #2420's precedence table and
-/// is not what this test pins; what it pins is that the fan-out is not
-/// collapsed to its first value, which is #822's actual subject.
 #[test]
 fn test_eval_all_arithmetic_fanout_survives_file_index_in_pipe_issue_822() -> Result<()> {
     let (f1, f2) = two_doc_fixtures()?;
@@ -15680,22 +15689,24 @@ fn test_eval_all_arithmetic_fanout_survives_file_index_in_pipe_issue_822() -> Re
     assert_eq!(code, 0);
     // #2451 made this branch-major: the union runs `((1,2,3) + 1)` over the
     // whole context list `.[]` produced, then `file_index` over the same
-    // list. Still short of yq's 16 lines, which need `EvaluateTogether`
-    // (#2427) to make the *arithmetic* cartesian too -- but the order is
-    // yq's now.
-    assert_eq!(stdout.trim(), "2\n3\n4\n2\n3\n4\n0\n1");
+    // list. #2427 made `.[]` iterate each document's own members, so the
+    // context list is four nodes and the count is real yq's 16.
+    assert_eq!(
+        stdout.trim(),
+        "2\n3\n4\n2\n3\n4\n2\n3\n4\n2\n3\n4\n0\n0\n1\n1"
+    );
 
     // #2420's shape: unparenthesised, the comma is now the outermost
     // operator, so this is `(.[] | ((1,2,3) + 1)), file_index` -- the
-    // fan-out still survives (twice, once per document), and `file_index`
-    // is evaluated against the combined input rather than per document.
+    // fan-out still survives (once per member of each document), and
+    // `file_index` is evaluated against the document list itself.
     let (stdout, _stderr, code) = run_yq_files(
         ".[] | ((1,2,3) + 1), file_index",
         &[f1.path(), f2.path()],
         &["--eval-all", "-o", "json"],
     )?;
     assert_eq!(code, 0);
-    assert_eq!(stdout.trim(), "2\n3\n4\n2\n3\n4\n0");
+    assert_eq!(stdout.trim(), "2\n3\n4\n2\n3\n4\n2\n3\n4\n2\n3\n4\n0\n1");
 
     Ok(())
 }
@@ -15720,7 +15731,10 @@ fn test_eval_all_compare_fanout_survives_file_index_in_pipe_issue_822() -> Resul
     )?;
     assert_eq!(code, 0);
     // Branch-major since #2451; see the `Expr::Arithmetic` twin above.
-    assert_eq!(stdout.trim(), "false\ntrue\ntrue\nfalse\ntrue\ntrue\n0\n1");
+    assert_eq!(
+        stdout.trim(),
+        "false\ntrue\ntrue\nfalse\ntrue\ntrue\nfalse\ntrue\ntrue\nfalse\ntrue\ntrue\n0\n0\n1\n1"
+    );
 
     let (stdout, _stderr, code) = run_yq_files(
         ".[] | ((1,2,3) > 1), file_index",
@@ -15728,7 +15742,10 @@ fn test_eval_all_compare_fanout_survives_file_index_in_pipe_issue_822() -> Resul
         &["--eval-all", "-o", "json"],
     )?;
     assert_eq!(code, 0);
-    assert_eq!(stdout.trim(), "false\ntrue\ntrue\nfalse\ntrue\ntrue\n0");
+    assert_eq!(
+        stdout.trim(),
+        "false\ntrue\ntrue\nfalse\ntrue\ntrue\nfalse\ntrue\ntrue\nfalse\ntrue\ntrue\n0\n1"
+    );
 
     Ok(())
 }
@@ -15739,7 +15756,7 @@ fn test_eval_all_compare_fanout_survives_file_index_in_pipe_issue_822() -> Resul
 fn test_eval_all_file_index_select() -> Result<()> {
     let (f1, f2) = two_doc_fixtures()?;
     let (stdout, _stderr, code) = run_yq_files(
-        ".[] | select(file_index == 0)",
+        "select(file_index == 0)",
         &[f1.path(), f2.path()],
         &["--eval-all"],
     )?;
@@ -15752,7 +15769,7 @@ fn test_eval_all_file_index_select() -> Result<()> {
 fn test_eval_all_file_index_select_then_field() -> Result<()> {
     let (f1, f2) = two_doc_fixtures()?;
     let (stdout, _stderr, code) = run_yq_files(
-        ".[] | select(file_index == 0) | .name",
+        "select(file_index == 0) | .name",
         &[f1.path(), f2.path()],
         &["--eval-all"],
     )?;
@@ -15769,7 +15786,7 @@ fn test_eval_all_file_index_select_then_field() -> Result<()> {
 fn test_eval_all_file_index_in_if_then_else() -> Result<()> {
     let (f1, f2) = two_doc_fixtures()?;
     let (stdout, _stderr, code) = run_yq_files(
-        r#".[] | if file_index == 0 then "from-f1" else "from-f2" end"#,
+        r#"if file_index == 0 then "from-f1" else "from-f2" end"#,
         &[f1.path(), f2.path()],
         &["--eval-all"],
     )?;
@@ -15784,7 +15801,7 @@ fn test_eval_all_file_index_in_if_then_else() -> Result<()> {
 fn test_eval_all_file_index_in_try_catch() -> Result<()> {
     let (f1, f2) = two_doc_fixtures()?;
     let (stdout, _stderr, code) = run_yq_files(
-        r#".[] | try select(file_index == 1) catch "err""#,
+        r#"try select(file_index == 1) catch "err""#,
         &[f1.path(), f2.path()],
         &["--eval-all"],
     )?;
@@ -15800,7 +15817,7 @@ fn test_eval_all_file_index_in_try_catch() -> Result<()> {
 fn test_eval_all_file_index_survives_label_wrapper() -> Result<()> {
     let (f1, f2) = two_doc_fixtures()?;
     let (stdout, _stderr, code) = run_yq_files(
-        "label $out | .[] | file_index",
+        "label $out | file_index",
         &[f1.path(), f2.path()],
         &["--eval-all", "-o", "json"],
     )?;
@@ -15823,9 +15840,13 @@ fn test_eval_all_file_index_in_map() -> Result<()> {
         &["--eval-all"],
     )?;
     assert_eq!(code, 0);
-    // Renders in real yq's "compact" form (#785): `- ` shares its line
-    // with the mapping's own first field.
-    assert_eq!(stdout, "- a: 1\n  name: first\n");
+    // #2427: `map(f)` is `[.[] | f]` applied to each *document*, so it walks
+    // that document's own values -- file 0's document keeps both of them and
+    // file 1's keeps none. Real yq prints the same two arrays (`- 1 / - first`
+    // then `[]`); the `---` between them is succinctly's own separator
+    // divergence, which needs per-node document/file provenance real yq's
+    // printer reads and succinctly does not carry (#2427 divergence 2).
+    assert_eq!(stdout, "- 1\n- first\n---\n[]\n");
     Ok(())
 }
 
@@ -15860,7 +15881,7 @@ fn test_eval_all_file_index_camelcase_and_short_alias() -> Result<()> {
     let (f1, f2) = two_doc_fixtures()?;
     for keyword in ["fileIndex", "fi"] {
         let (stdout, _stderr, code) = run_yq_files(
-            &format!(".[] | {keyword}"),
+            keyword,
             &[f1.path(), f2.path()],
             &["--eval-all", "-o", "json"],
         )?;
@@ -15874,7 +15895,7 @@ fn test_eval_all_file_index_camelcase_and_short_alias() -> Result<()> {
 fn test_eval_all_reduce_merge() -> Result<()> {
     let (f1, f2) = two_doc_fixtures()?;
     let (stdout, _stderr, code) = run_yq_files(
-        "reduce .[] as $item ({}; . * $item)",
+        "[.] | reduce .[] as $item ({}; . * $item)",
         &[f1.path(), f2.path()],
         &["--eval-all", "-o", "json", "-I0"],
     )?;
@@ -15892,7 +15913,7 @@ fn test_eval_all_reduce_merge() -> Result<()> {
 fn test_eval_all_select_star_merge_single_doc_per_file() -> Result<()> {
     let (f1, f2) = two_doc_fixtures()?;
     let (stdout, _stderr, code) = run_yq_files(
-        "(.[] | select(file_index == 0)) * (.[] | select(file_index == 1))",
+        "(select(file_index == 0)) * (select(file_index == 1))",
         &[f1.path(), f2.path()],
         &["--eval-all", "-o", "json", "-I0"],
     )?;
@@ -15904,7 +15925,7 @@ fn test_eval_all_select_star_merge_single_doc_per_file() -> Result<()> {
 #[test]
 fn test_eval_all_doc_separator_between_results() -> Result<()> {
     let (f1, f2) = two_doc_fixtures()?;
-    let (stdout, _stderr, code) = run_yq_files(".[]", &[f1.path(), f2.path()], &["--eval-all"])?;
+    let (stdout, _stderr, code) = run_yq_files(".", &[f1.path(), f2.path()], &["--eval-all"])?;
     assert_eq!(code, 0);
     assert_eq!(stdout, "a: 1\nname: first\n---\nb: 2\nname: second\n");
     Ok(())
@@ -15919,7 +15940,7 @@ fn test_eval_all_doc_separator_between_results() -> Result<()> {
 fn test_eval_all_split_doc_emits_separators() -> Result<()> {
     let (f1, f2) = two_doc_fixtures()?;
     let (stdout, _stderr, code) =
-        run_yq_files(".[] | split_doc", &[f1.path(), f2.path()], &["--eval-all"])?;
+        run_yq_files("split_doc", &[f1.path(), f2.path()], &["--eval-all"])?;
     assert_eq!(code, 0);
     assert_eq!(stdout, "a: 1\nname: first\n---\nb: 2\nname: second\n");
     Ok(())
@@ -15930,9 +15951,207 @@ fn test_eval_all_doc_flag_interaction() -> Result<()> {
     let mut multi = NamedTempFile::new()?;
     write!(multi, "x: 1\n---\nx: 2\n")?;
     let (stdout, _stderr, code) =
-        run_yq_files(".[] | .x", &[multi.path()], &["--eval-all", "--doc", "1"])?;
+        run_yq_files(".x", &[multi.path()], &["--eval-all", "--doc", "1"])?;
     assert_eq!(code, 0);
     assert_eq!(stdout.trim(), "2");
+    Ok(())
+}
+
+/// #2427: `--eval-all` is the ordinary evaluator run once over the *list* of
+/// every document of every file -- real yq's `allAtOnceEvaluator.EvaluateFiles`
+/// (`pkg/yqlib/all_at_once_evaluator.go:47-75`, v4.53.3) -- not a slurp of them
+/// into one array. The filter never sees a containing array, so navigation,
+/// `keys`, `length` and `del` all apply per document.
+///
+/// Every row is `yq ea -o=json -I0 FILTER f1.yaml f2.yaml` against the pinned
+/// v4.53.3 binary, on this module's own `two_doc_fixtures`.
+#[test]
+fn test_eval_all_is_a_document_list_not_a_slurp_2427() -> Result<()> {
+    let (f1, f2) = two_doc_fixtures()?;
+    let rows: &[(&str, &str)] = &[
+        (
+            ".",
+            "{\"a\":1,\"name\":\"first\"}\n{\"b\":2,\"name\":\"second\"}",
+        ),
+        (".name", "\"first\"\n\"second\""),
+        ("keys", "[\"a\",\"name\"]\n[\"b\",\"name\"]"),
+        ("length", "2\n2"),
+        (".[]", "1\n\"first\"\n2\n\"second\""),
+        ("del(.name)", "{\"a\":1}\n{\"b\":2}"),
+        (
+            "to_entries",
+            concat!(
+                "[{\"key\":\"a\",\"value\":1},{\"key\":\"name\",\"value\":\"first\"}]\n",
+                "[{\"key\":\"b\",\"value\":2},{\"key\":\"name\",\"value\":\"second\"}]",
+            ),
+        ),
+        (".[0:1]", "[\"a\"]\n[\"b\"]"),
+        ("{\"n\": .name}", "{\"n\":\"first\"}\n{\"n\":\"second\"}"),
+        ("select(.a) | .a", "1"),
+        (
+            ". as $d | $d",
+            "{\"a\":1,\"name\":\"first\"}\n{\"b\":2,\"name\":\"second\"}",
+        ),
+        ("(. , .) | .name", "\"first\"\n\"second\""),
+    ];
+    for (filter, expected) in rows {
+        let (stdout, stderr, code) = run_yq_files(
+            filter,
+            &[f1.path(), f2.path()],
+            &["--eval-all", "-o", "json", "-I", "0"],
+        )?;
+        assert_eq!(code, 0, "`{filter}` exited {code}, stderr: {stderr}");
+        assert_eq!(stdout.trim(), *expected, "filter: {filter}");
+    }
+    Ok(())
+}
+
+/// #2427: the two operators that consult real yq's `EvaluateTogether` flag.
+/// `readDocuments` (`pkg/yqlib/utils.go:85`) stamps it on the initial document
+/// nodes and nothing else ever sets it, so `[E]` collects `E`'s outputs across
+/// the whole list into **one** array (`operator_collect.go:33-49`) and a binary
+/// operator runs both operands over the whole list and emits every pairing
+/// (`operators.go:113-172`) -- `. + {"z": 9}` over two documents is four
+/// outputs, each document merged with `z` twice.
+///
+/// Rows captured from `yq ea -o=json -I0` on the same two fixtures.
+#[test]
+fn test_eval_all_collect_and_binary_evaluate_together_2427() -> Result<()> {
+    let (f1, f2) = two_doc_fixtures()?;
+    let rows: &[(&str, &str)] = &[
+        (
+            "[.]",
+            "[{\"a\":1,\"name\":\"first\"},{\"b\":2,\"name\":\"second\"}]",
+        ),
+        ("[.[]]", "[1,\"first\",2,\"second\"]"),
+        ("[.name]", "[\"first\",\"second\"]"),
+        ("[.[] | file_index]", "[0,0,1,1]"),
+        ("[.] | length", "2"),
+        ("[.name] | length", "2"),
+        ("[.] | map(.name)", "[\"first\",\"second\"]"),
+        (
+            ". + {\"z\": 9}",
+            concat!(
+                "{\"a\":1,\"name\":\"first\",\"z\":9}\n",
+                "{\"a\":1,\"name\":\"first\",\"z\":9}\n",
+                "{\"b\":2,\"name\":\"second\",\"z\":9}\n",
+                "{\"b\":2,\"name\":\"second\",\"z\":9}",
+            ),
+        ),
+        (
+            ". + .",
+            concat!(
+                "{\"a\":1,\"name\":\"first\"}\n",
+                "{\"a\":1,\"name\":\"second\",\"b\":2}\n",
+                "{\"b\":2,\"name\":\"first\",\"a\":1}\n",
+                "{\"b\":2,\"name\":\"second\"}",
+            ),
+        ),
+        // The left operand is read-only (#2470), so `.a` contributes only
+        // file 1's `1` -- but the literal right operand is re-run over the
+        // whole two-node context, so there are still two pairings.
+        (".a + 1", "2\n2"),
+        (
+            ".name + \"X\"",
+            "\"firstX\"\n\"firstX\"\n\"secondX\"\n\"secondX\"",
+        ),
+    ];
+    for (filter, expected) in rows {
+        let (stdout, stderr, code) = run_yq_files(
+            filter,
+            &[f1.path(), f2.path()],
+            &["--eval-all", "-o", "json", "-I", "0"],
+        )?;
+        assert_eq!(code, 0, "`{filter}` exited {code}, stderr: {stderr}");
+        assert_eq!(stdout.trim(), *expected, "filter: {filter}");
+    }
+    Ok(())
+}
+
+/// #2427: the flag rides the node, so anything that *builds* a node clears it
+/// and anything that hands the same node on keeps it. `.` , `select` and a
+/// parenthesised group keep it; `.name`, `keys` and a previous `[...]` do not.
+/// Live rows from `yq ea -o=json -I0` on the same two fixtures.
+#[test]
+fn test_eval_all_navigation_clears_evaluate_together_2427() -> Result<()> {
+    let (f1, f2) = two_doc_fixtures()?;
+    let both = "[{\"a\":1,\"name\":\"first\"},{\"b\":2,\"name\":\"second\"}]";
+    let rows: &[(&str, &str)] = &[
+        // Preserved.
+        (". | [.]", both),
+        ("(.) | [.]", both),
+        ("select(true) | [.]", both),
+        // Cleared: one array per document.
+        (".name | [.]", "[\"first\"]\n[\"second\"]"),
+        ("keys | [.]", "[[\"a\",\"name\"]]\n[[\"b\",\"name\"]]"),
+        (
+            "[.] | [.]",
+            "[[{\"a\":1,\"name\":\"first\"},{\"b\":2,\"name\":\"second\"}]]",
+        ),
+    ];
+    for (filter, expected) in rows {
+        let (stdout, stderr, code) = run_yq_files(
+            filter,
+            &[f1.path(), f2.path()],
+            &["--eval-all", "-o", "json", "-I", "0"],
+        )?;
+        assert_eq!(code, 0, "`{filter}` exited {code}, stderr: {stderr}");
+        assert_eq!(stdout.trim(), *expected, "filter: {filter}");
+    }
+    Ok(())
+}
+
+/// #2427: each `--eval-all` document is reindexed into its own throwaway
+/// document, so `path`/`key`/`parent` answer relative to *that document*
+/// rather than to the array the old slurp wrapped them in -- `path` is `[]` at
+/// the root and `parent` there yields nothing, exactly as real yq's do.
+/// `file_index`/`document_index` come from the entry's own origin instead.
+///
+/// ```console
+/// $ yq ea -o=json -I0 'path'                f1 f2                  # [] []
+/// $ yq ea -o=json -I0 'parent'              f1 f2                  # (nothing)
+/// $ yq ea -o=json -I0 '.name | path'        f1 f2                  # ["name"] x2
+/// $ yq ea -o=json -I0 '.name | file_index'  f1 f2                  # 0 1
+/// $ yq ea -o=json -I0 'document_index'      multi.yaml f1.yaml     # 0 1 0
+/// ```
+#[test]
+fn test_eval_all_position_builtins_answer_per_document_2427() -> Result<()> {
+    let (f1, f2) = two_doc_fixtures()?;
+    let rows: &[(&str, &str)] = &[
+        ("path", "[]\n[]"),
+        ("parent", ""),
+        (".name | path", "[\"name\"]\n[\"name\"]"),
+        (".name | key", "\"name\"\n\"name\""),
+        (
+            ".name | parent",
+            "{\"a\":1,\"name\":\"first\"}\n{\"b\":2,\"name\":\"second\"}",
+        ),
+        (".name | file_index", "0\n1"),
+        ("line", "1\n1"),
+    ];
+    for (filter, expected) in rows {
+        let (stdout, stderr, code) = run_yq_files(
+            filter,
+            &[f1.path(), f2.path()],
+            &["--eval-all", "-o", "json", "-I", "0"],
+        )?;
+        assert_eq!(code, 0, "`{filter}` exited {code}, stderr: {stderr}");
+        assert_eq!(stdout.trim(), *expected, "filter: {filter}");
+    }
+
+    // Two documents from one file, then one from another: `file_index` counts
+    // files and `document_index` counts documents within their own file.
+    let mut multi = NamedTempFile::new()?;
+    write!(multi, "x: 1\n---\ny: 2\n")?;
+    for (filter, expected) in [("file_index", "0\n0\n1"), ("document_index", "0\n1\n0")] {
+        let (stdout, stderr, code) = run_yq_files(
+            filter,
+            &[multi.path(), f1.path()],
+            &["--eval-all", "-o", "json", "-I", "0"],
+        )?;
+        assert_eq!(code, 0, "`{filter}` exited {code}, stderr: {stderr}");
+        assert_eq!(stdout.trim(), expected, "filter: {filter}");
+    }
     Ok(())
 }
 
@@ -26475,7 +26694,7 @@ fn test_yq_auto_output_eval_all_matches_yaml_input_1493() -> Result<()> {
         .arg("yq")
         .arg("--eval-all")
         .arg("-o=auto")
-        .arg(".[0]")
+        .arg(".")
         .arg(input_file.path())
         .stdin(Stdio::null())
         .output()?;
@@ -29976,7 +30195,7 @@ fn test_negative_index_out_of_range_survives_try_catch_under_eval_all_2270() -> 
     let multi_doc = "a: [1, 2]\n---\na: [3, 4]\n";
 
     let (out, stderr, code) = run_yq_stdin_with_stderr(
-        "(try .[0].a[-5] catch \"c\"), file_index",
+        "(try .a[-5] catch \"c\"), file_index",
         multi_doc,
         &["-o", "json", "--eval-all"],
     )?;
@@ -29987,7 +30206,7 @@ fn test_negative_index_out_of_range_survives_try_catch_under_eval_all_2270() -> 
     );
 
     let (out, stderr, code) = run_yq_stdin_with_stderr(
-        "(.[0].a[-5]?, file_index)",
+        "(.a[-5]?, file_index)",
         multi_doc,
         &["-o", "json", "--eval-all"],
     )?;
@@ -30011,7 +30230,7 @@ fn test_negative_index_out_of_range_survives_try_catch_partial_prefix_2270() -> 
     let multi_doc = "a: [1, 2]\n---\na: [3, 4]\n";
 
     let (out, stderr, code) = run_yq_stdin_with_stderr(
-        ".[0].a | (try (1, .[-5]) catch \"c\") | key",
+        ".a | (try (1, .[-5]) catch \"c\") | key",
         multi_doc,
         &["-o", "json", "--eval-all"],
     )?;
@@ -30032,7 +30251,7 @@ fn test_negative_index_out_of_range_survives_try_catch_partial_prefix_2270() -> 
     // root `key` answers, not whether the `Partial` prefix survives. `[key]`
     // makes that observable again: one `[]` line, one per prefix output.
     let (out, stderr, code) = run_yq_stdin_with_stderr(
-        ".[0].a | (try (1, .[-5]) catch \"c\") | [key]",
+        ".a | (try (1, .[-5]) catch \"c\") | [key]",
         multi_doc,
         &["-o", "json", "--eval-all"],
     )?;


### PR DESCRIPTION
## Summary

Two of #2427's three divergences, each its own commit.

1. **`--eval-all` evaluates over the document list, not a slurp.** Real `yq ea` runs the expression once with the list of every document as its input; the initial nodes carry `EvaluateTogether`, which makes `[E]` collect across the whole list and a binary operator pair every LHS match with every RHS output, while everything else is per node (source model on #2451). `eval_documents_together` builds one context-list entry per document, each reindexed into its own document so `path`/`key`/`parent` answer relative to it, and drives the #2451 context pipe extended with those two rules; a `NodeOrigin` scope carries `(file, document)` for `file_index`/`document_index`. 36 of the 41 captured `ea` rows now match byte for byte; the CHANGELOG flags that every `--eval-all` filter written against the old slurp changes, and the reference docs drop the `.[] |` idiom from every example.
2. **`file_index` counts files on the plain multi-file path too**, through a per-file scope installed by the four per-file loops in the yq runner. The sweep's broad `yq/file_index/*` manifest row (36 hits) is deleted; two hits remain and are re-filed narrowly under the existing recursive-descent class they belong to.

## A/B against the base binary

86 `--eval-all` and multi-file shapes: 13 unchanged, 62 newly matching yq, 0 regressions, 11 where neither matches, each accounted for in the report (jq-only surface yq's lexer rejects, the `-0` rule-4 divergence, a non-yq flag, and the two items below).

## Left open on #2427, recorded in the limitations doc with the source citation

- **The stray `---`** between files. yq decides the separator per output node from `document`/`fileIndex` provenance (`printer.go` v4.53.3), and whether a node carries them is a per-operator property: present for `.`, `.name`, writes, `select`, `sort`, and absent for `keys`, `length`, `[...]`, `map`, `path`, `key`, `file_index` and every literal. succinctly's values carry no such field. All four shapes the issue enumerated already match; `file_index`, `length` and `.name, .name` across two files do not.
- **`. as $x | [$x]` under `ea`**: `as` also consults the flag; `. as $d | $d` agrees.

## Verification

fmt; clippy on both CI legs with `-D warnings`; `cargo test` in the three configurations; `cargo doc -D warnings`; yq goldens 113 and jq goldens 633; oracle sweep 3168 cases, 0 unexpected.

Behaviour change in yq mode; ships in its own release. Part of #2427, which stays open for the separator and `as`.
