### PR TITLE
feat(jq): add real yq downcase/upcase builtins, gate ascii spellings (#2462)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`succinctly yq` gains real yq's own `downcase`/`upcase` builtins** (#2462).
+  Confirmed live against yq v4.53.3: `downcase`/`upcase` lowercase/uppercase
+  ASCII characters and keep the node's position (`.a.c | downcase | key` is
+  `"c"`), while yq's lexer rejects jq's own `ascii_downcase`/`ascii_upcase`
+  spellings outright (`invalid input text`) — those remain available only
+  behind `--jq-extensions`, like the rest of the jq-only surface (#1512).
+
 ### Changed
 
 - **`succinctly yq --eval-all` now evaluates over the document *list*, not a

--- a/docs/reference/yq-language.md
+++ b/docs/reference/yq-language.md
@@ -193,6 +193,8 @@ succinctly yq --eval-all '[.] | reduce .[] as $item ({}; . * $item)' f1.yaml f2.
 | `load(file)`  | Load external YAML/JSON file                 | `load("config.yaml")`          |
 | `parent`      | Return parent node                           | `.. \| select(.name) \| parent`|
 | `parent(n)`   | Return nth parent node                       | `parent(2)`                    |
+| `downcase`    | Lowercase ASCII characters                   | `"HELLO" \| downcase`          |
+| `upcase`      | Uppercase ASCII characters                   | `"hello" \| upcase`            |
 
 ```bash
 # Remove keys from object
@@ -212,7 +214,17 @@ succinctly yq '. + {config: load("defaults.yaml")}' input.yaml
 
 # Get parent of matching node
 succinctly yq '.. | select(.name == "target") | parent' file.yaml
+
+# Case conversion (real yq spellings, confirmed live against v4.53.3)
+echo '"HELLO"' | succinctly yq 'downcase'
+# Output: hello
 ```
+
+Real yq's lexer rejects jq's own `ascii_downcase`/`ascii_upcase` spellings
+outright (`invalid input text`) -- those are gated behind `--jq-extensions`
+like the rest of the jq-only surface (see
+[Gated jq Builtins](#gated-jq-builtins---jq-extensions)), while `downcase`/
+`upcase` are always on (#2462).
 
 ### Merge-Flag Suffixes on `*`/`*=`
 
@@ -446,6 +458,7 @@ surface (#1512):
 | `sin`, `cos`, `tan`                                  | Trig functions (#1837)                        |
 | `asinh`, `acosh`, `atanh`                            | Inverse hyperbolic trig functions (#1837)     |
 | `skip(n; f)`                                         | Drop the first `n` outputs of `f` (#1882)     |
+| `ascii_downcase`, `ascii_upcase`                     | jq's spellings of `downcase`/`upcase` (#2462) |
 
 ```bash
 echo '{}' | succinctly yq 'paths'

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -14601,8 +14601,12 @@ impl<V: DocumentValue> OwnedIdentity<V> {
 /// step 3). A closed list: a stage with no rule keeps the pipe on the eager
 /// evaluator, exactly as before, so an unlisted builtin can only cost the
 /// migration, never an answer. Every entry is an oracle capture (see
-/// [`OwnedIdentity`]); a builtin real yq's lexer rejects (`add`, `explode`,
-/// `ascii_downcase`) has no row to match and is deliberately absent.
+/// [`OwnedIdentity`]); a builtin real yq's lexer rejects (`add`, `explode`)
+/// has no row to match and is deliberately absent. `Builtin::AsciiDowncase`/
+/// `AsciiUpcase` do have a row below despite the name -- they're reached by
+/// real yq's own `downcase`/`upcase` spellings, not just the jq-only
+/// `ascii_downcase`/`ascii_upcase` ones gated behind `--jq-extensions`
+/// (#2462).
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 enum OwnedIdentityRule {
     /// The output stands where the input stood: `to_entries`, `sort`,
@@ -14651,6 +14655,8 @@ fn owned_identity_rule(stage: &Expr) -> Option<OwnedIdentityRule> {
             Builtin::ToString
             | Builtin::ToJson
             | Builtin::FromJson
+            | Builtin::AsciiDowncase
+            | Builtin::AsciiUpcase
             | Builtin::Length
             | Builtin::Type
             | Builtin::ToEntries
@@ -24022,11 +24028,15 @@ mod tests {
         assert!(!eager(".a | .[0] + .[1] | key"));
         assert!(!eager(".a | min | parent | key"));
         assert!(!eager(".a | to_entries | .[] | select(key == 0)"));
+        // `ascii_downcase`/`ascii_upcase` gained a `Keeps` row (#2462) so
+        // real yq's own `downcase`/`upcase` spellings answer `key`/`path`
+        // through the same rule -- no longer the "no identity rule" example.
+        assert!(!eager(".a | ascii_downcase | key"));
         // ...and stays eager where it has no rule, where path context is
         // read after `key`/`path` already replaced the value, where the
         // stage itself reads path context, or where a later stage does so
         // in a shape the constants cannot express.
-        assert!(eager(".a | ascii_downcase | key"), "no identity rule");
+        assert!(eager(".a | explode | key"), "no identity rule");
         assert!(eager(".a | tostring | key | key"), "key after key");
         assert!(
             eager(".a | [key] | .[0] | path"),

--- a/src/jq/parser.rs
+++ b/src/jq/parser.rs
@@ -3376,12 +3376,30 @@ impl<'a> Parser<'a> {
         }
 
         // Phase 5: String Functions
+        // Real yq's lexer rejects `ascii_downcase`/`ascii_upcase` outright
+        // ("invalid input text") -- they're jq's own spellings, gated behind
+        // `--jq-extensions` like the rest of the jq-only surface (#1512,
+        // #2462).
         if self.matches_keyword("ascii_downcase") {
+            self.reject_unless_jq_extensions("ascii_downcase")?;
             self.consume_keyword("ascii_downcase");
             return Ok(Some(Builtin::AsciiDowncase));
         }
         if self.matches_keyword("ascii_upcase") {
+            self.reject_unless_jq_extensions("ascii_upcase")?;
             self.consume_keyword("ascii_upcase");
+            return Ok(Some(Builtin::AsciiUpcase));
+        }
+        // `downcase`/`upcase` are real yq v4.53.3 builtins (not jq's own --
+        // jq has no such names), so they're reference surface rather than an
+        // extension: always on in yq mode, never recognized in jq mode
+        // (falls through to jq's own "downcase/0 is not defined") (#2462).
+        if self.mode == ParserMode::Yq && self.matches_keyword("downcase") {
+            self.consume_keyword("downcase");
+            return Ok(Some(Builtin::AsciiDowncase));
+        }
+        if self.mode == ParserMode::Yq && self.matches_keyword("upcase") {
+            self.consume_keyword("upcase");
             return Ok(Some(Builtin::AsciiUpcase));
         }
         if self.matches_keyword("ltrimstr") {

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -38242,3 +38242,23 @@ fn test_jq_binary_fanout_stays_right_major_2451() -> Result<()> {
 
     Ok(())
 }
+
+/// #2462: yq's `downcase`/`upcase` builtins are not real jq names -- jq
+/// 1.7.1 has neither spelling (`jq -n 'downcase'` => `downcase/0 is not
+/// defined`). yq's own `downcase`/`upcase` keywords were added only in yq
+/// mode's parser (`src/jq/parser.rs`), so jq mode still resolves them as
+/// ordinary unresolved function calls and reports jq's own error, matching
+/// the oracle -- see `test_yq_downcase_upcase_builtins_2462`
+/// (yq_cli_tests.rs) for the yq-mode captures this leaves unaffected.
+#[test]
+fn test_jq_mode_has_no_downcase_upcase_2462() -> Result<()> {
+    for filter in ["downcase", "upcase"] {
+        let (_out, stderr, code) = run_jq_stdin_streams(filter, "\"x\"", &[])?;
+        assert_ne!(code, 0, "`{filter}` should be rejected in jq mode");
+        assert!(
+            stderr.contains("is not defined"),
+            "`{filter}` stderr should say not defined, got: {stderr}"
+        );
+    }
+    Ok(())
+}

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -1419,6 +1419,12 @@ fn test_yq_default_rejects_jq_only_builtins_1512() -> Result<()> {
         "isnormal",
         "isfinite",
         "nan",
+        // #2462: real yq's lexer rejects these outright ("invalid input
+        // text"); real yq spells the same operation `downcase`/`upcase`,
+        // which are always on (not gated -- see
+        // test_yq_downcase_upcase_builtins_2462).
+        "ascii_downcase",
+        "ascii_upcase",
     ] {
         let (_out, stderr, code) = run_yq_stdin_with_stderr(filter, "a: 1\n", &[])?;
         assert_ne!(code, 0, "filter {filter:?} should be rejected by default");
@@ -1571,6 +1577,8 @@ fn test_yq_jq_extensions_flag_enables_jq_only_builtins_1512() -> Result<()> {
         "1 | isnormal",
         "1 | isfinite",
         "nan",
+        "\"ABC\" | ascii_downcase",
+        "\"abc\" | ascii_upcase",
     ] {
         let (_out, stderr, code) =
             run_yq_stdin_with_stderr(filter, "a: 1\n", &["--jq-extensions"])?;
@@ -33503,5 +33511,45 @@ fn test_yq_binary_operator_fans_out_left_major_2451() -> Result<()> {
         assert_eq!(out.trim(), want, "`{filter}`");
     }
 
+    Ok(())
+}
+
+/// #2462: real yq v4.53.3 has its own `downcase`/`upcase` builtins (jq has
+/// no such names at all -- `downcase`/`upcase` are undefined there too, so
+/// this is reference surface per ADR-0018, not a succinctly extension).
+/// Captured live from yq v4.53.3 (`-o=json -I0`) on `a:\n  c: x\n`:
+///
+/// ```text
+/// $ yq -o=json -I0 '.a.c | downcase'          "x"
+/// $ yq -o=json -I0 '.a.c | upcase'            "X"
+/// $ yq -o=json -I0 '.a.c | downcase | key'    "c"    (keeps the node's position)
+/// $ yq -o=json -I0 '.a.c | upcase | path'     ["a","c"]
+/// $ yq -o=json -I0 '.a.c | ascii_downcase'    Error: 1:10: lexer: invalid input text "cii_downcase"
+/// ```
+///
+/// jq 1.7.1 has neither spelling (`downcase`/1.7.1 is not defined), so
+/// jq mode is unaffected and not asserted against the oracle here --
+/// see `test_jq_mode_has_no_downcase_upcase_2462` (jq_cli_tests.rs).
+#[test]
+fn test_yq_downcase_upcase_builtins_2462() -> Result<()> {
+    let args = &["-o=json", "-I=0"];
+    let doc = "a:\n  c: x\n";
+    for (filter, expected) in [
+        (".a.c | downcase", "\"x\""),
+        (".a.c | upcase", "\"X\""),
+        (".a.c | downcase | key", "\"c\""),
+        (".a.c | upcase | path", "[\"a\",\"c\"]"),
+    ] {
+        let (output, code) = run_yq_stdin(filter, doc, args)?;
+        assert_eq!(code, 0, "`{filter}`: {output:?}");
+        assert_eq!(output.trim(), expected, "`{filter}`");
+    }
+    // Real yq's lexer rejects jq's own spelling outright.
+    let (_out, stderr, code) = run_yq_stdin_with_stderr(".a.c | ascii_downcase", doc, &[])?;
+    assert_ne!(code, 0);
+    assert!(
+        stderr.contains("--jq-extensions"),
+        "stderr should mention --jq-extensions, got: {stderr}"
+    );
     Ok(())
 }


### PR DESCRIPTION
## Summary

Real yq spells these `downcase`/`upcase` and its lexer rejects jq's `ascii_downcase`/`ascii_upcase`. Adds the yq keywords (mapped to the existing builtins), gates the jq spellings behind `--jq-extensions` in yq mode like the rest of the jq-only surface (#1512), and gives both the `Keeps` identity rule so `.a.c | downcase | key` is `"c"`. Rows captured from yq v4.53.3 and `/usr/bin/jq` 1.7.1 in the test doc comments.

## Verification

fmt; clippy `-D warnings`; `cargo test --features cli,simd,regex,serde`; yq goldens 113; jq goldens 633; oracle sweep 0 unexpected.

Closes #2462.