### PR TITLE
fix(jq): a numeric index on a mapping reads null in yq mode (#2459)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **`succinctly yq` reads a numeric index on a mapping as `null`, not an
+  error** (#2459). Confirmed live against yq v4.53.3: `.a[5]` on `a: {b: 1}`
+  is `null` (`key`/`path` answer `5`/`["a",5]` for that position, same as any
+  other missing key), where jq raises `Cannot index object with number` --
+  succinctly reproduced jq's error in both modes before this fix. Read-only:
+  the write side (`.a[5] = 1`) is a distinct, already-tracked divergence
+  (real yq coerces the index to a string key and inserts it, #1863).
+
 ### Added
 
 - **`succinctly yq` gains real yq's own `downcase`/`upcase` builtins** (#2462).

--- a/docs/compliance/yq/limitations.md
+++ b/docs/compliance/yq/limitations.md
@@ -1513,6 +1513,15 @@ Pinned as known-divergent by `test_yq_assign_all_noop_mismatched_element_type_14
 match yq: an `Index` step hitting a genuine scalar mid-chain permanently no-ops the whole
 write (#1232), same as every other position.
 
+**The *read* side of the third bullet is resolved ([#2459](https://github.com/rust-works/succinctly/issues/2459)):**
+a terminal (not mid-chain) numeric index landing on a real `Object` -- `.a[5]` on
+`a: {b: 1}` -- now answers `null` in yq mode, matching real yq's own read (confirmed live:
+`.a[5]` is `null`, `.a[5] | key` is `5`, `.a[5] | path` is `["a",5]`), via
+`eval::yq_numeric_index_on_object_is_null`. The *write* side above is untouched by that
+fix and remains exactly the coercion gap this section describes -- `.a[5] = 1` still
+raises `Cannot index object with number` in succinctly where real yq inserts a string key
+(`{"a":{"b":1,"5":1}}`).
+
 ### `=`'s multi-output RHS: real yq takes only the last value, no fan-out
 
 [#1430](https://github.com/rust-works/succinctly/issues/1430) started as a narrower report

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -16946,6 +16946,12 @@ fn index_object_by_name<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
 /// constructor's own doc comment for the live-confirmed oracle behavior and
 /// `EvalError::is_yq_negative_index_error`, consulted by every `?`/`try`
 /// dispatch point on the read side to keep it that way.
+///
+/// yq mode only (#2459): a numeric index also reaches a real `Object` here
+/// -- `.a[5]` is `Expr::Index { idx: 5 }` once the parser constant-folds a
+/// literal subscript, so this is the one place both that literal form and
+/// `index_one`'s computed-key form (`.a[$k]`) end up, and the one place
+/// [`yq_numeric_index_on_object_is_null`] needs to be checked to cover both.
 #[inline]
 fn index_array_by_position<W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     value: StandardJson<'_, W>,
@@ -16970,6 +16976,9 @@ fn index_array_by_position<W: Clone + AsRef<[u64]>, S: EvalSemantics>(
         },
         // jq returns null for index on null
         StandardJson::Null => QueryResult::One(StandardJson::Null),
+        StandardJson::Object(_) if yq_numeric_index_on_object_is_null::<S>() => {
+            QueryResult::One(StandardJson::Null)
+        }
         _ if optional => QueryResult::None,
         _ => QueryResult::Error(EvalError::cannot_index_with_type(
             type_name(&value),
@@ -17071,6 +17080,29 @@ pub(crate) fn has_type_mismatch_is_permissive<S: EvalSemantics>() -> bool {
     S::NEGATIVE_INDEX_IN_HAS
 }
 
+/// Whether a numeric index on a *mapping* reads as a missing key (null,
+/// with the index itself as the position) instead of raising jq's `Cannot
+/// index object with number`.
+///
+/// Real yq v4.53.3 (confirmed live) has no notion of "wrong key kind" for a
+/// mapping the way jq does: `.a[5]` on `a: {b: 1}` is `null`, and `key`/
+/// `path` answer for that position exactly as they would for a genuinely
+/// absent string field (`.a[5] | key` is `5`, `.a[5] | path` is
+/// `["a", 5]`). jq raises unconditionally, which is what succinctly
+/// reproduced in both modes before this rule (#2459). `S: EvalSemantics`-
+/// generic so `index_one` (below, the borrowed `StandardJson` route) and
+/// `eval_generic::index_one_generic` (the `DocumentValue`-generic route)
+/// consult one definition -- CLAUDE.md's "duplicated predicates diverge
+/// silently" (#106).
+///
+/// Read-only: the write side (`.a[5] = 1`) is a distinct, already-tracked
+/// divergence (real yq coerces the index to a string key and inserts it,
+/// `docs/compliance/yq/limitations.md`'s "mid-chain `Field`/`Index` step"
+/// entry, #1863) that this rule does not touch.
+pub(crate) fn yq_numeric_index_on_object_is_null<S: EvalSemantics>() -> bool {
+    S::TAG == EvalTag::Yq
+}
+
 /// Apply one resolved key to one target value.
 ///
 /// The key kind is dispatched *before* the container is inspected, so the error
@@ -17082,7 +17114,11 @@ fn index_one<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     optional: bool,
 ) -> QueryResult<'a, W> {
     let indexable_by_string = matches!(target, StandardJson::Object(_) | StandardJson::Null);
-    let indexable_by_number = matches!(target, StandardJson::Array(_) | StandardJson::Null);
+    // #2459: yq mode also indexes a mapping by number (into `null`, via
+    // `index_array_by_position`'s own `Object` arm) -- see
+    // `yq_numeric_index_on_object_is_null`.
+    let indexable_by_number = matches!(target, StandardJson::Array(_) | StandardJson::Null)
+        || (matches!(target, StandardJson::Object(_)) && yq_numeric_index_on_object_is_null::<S>());
 
     match key {
         OwnedValue::String(s) if indexable_by_string => {
@@ -30052,6 +30088,11 @@ fn eval_owned_navigation<S: EvalSemantics>(
                 Ok(Some(element))
             }
             OwnedValue::Null => Ok(Some(OwnedValue::Null)),
+            // #2459: yq mode only -- same rule as `index_array_by_position`'s
+            // own `Object` arm. See `yq_numeric_index_on_object_is_null`.
+            OwnedValue::Object(_) if yq_numeric_index_on_object_is_null::<S>() => {
+                Ok(Some(OwnedValue::Null))
+            }
             _ if optional => Ok(None),
             _ => Err(EvalError::cannot_index_with_type(
                 owned_type_name(input),
@@ -34209,7 +34250,26 @@ fn eval_index_expr_with_path_context<'a, W: Clone + AsRef<[u64]>, S: EvalSemanti
             if let Some(e) = yq_negative_index_error::<S>(&t, k) {
                 return partial(core::mem::take(&mut results), Control::Error(e));
             }
-            match index_one_owned(&t, k, bracket_optional) {
+            // #2459: yq mode only -- same rule as `index_array_by_position`'s
+            // own `Object` arm, checked ahead of `index_one_owned` for the
+            // same reason as the `yq_negative_index_error` check just above
+            // (that function has no notion of this yq-only rule either, and
+            // is also reached from the write side, where the rule does not
+            // apply -- see `yq_numeric_index_on_object_is_null`'s own doc
+            // comment). `.a[(EXPR)] | key` on a mapping is `5`, matching
+            // the literal `.a[5] | key` sibling in `path_step_generic`.
+            let numeric_on_object = matches!(t, OwnedValue::Object(_))
+                && matches!(
+                    k,
+                    OwnedValue::Int(_) | OwnedValue::Float(_) | OwnedValue::NumberLiteral(..)
+                )
+                && yq_numeric_index_on_object_is_null::<S>();
+            let indexed = if numeric_on_object {
+                Ok(Some(OwnedValue::Null))
+            } else {
+                index_one_owned(&t, k, bracket_optional)
+            };
+            match indexed {
                 Ok(Some(v)) => {
                     let new_path = target_path.map(|mut path| {
                         path.push(k.clone());
@@ -35007,6 +35067,21 @@ fn eval_stage_with_path_context<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
             // jq treats indexing `null` with an integer the same way
             // (#2213): always `null`, never an error.
             if matches!(value, OwnedValue::Null) {
+                return continue_rest_with_borrowed_value::<W, S>(
+                    &OwnedValue::Null,
+                    rest,
+                    root,
+                    file_origin,
+                    &new_path,
+                    optional,
+                );
+            }
+            // #2459: yq mode only -- a numeric index on a mapping is `null`
+            // too, at the position `new_path` already carries (`.a[5] |
+            // key` is `5`, `.a[5] | path` is `["a", 5]`), same rule as
+            // `eval::index_array_by_position`'s own `Object` arm. See
+            // `yq_numeric_index_on_object_is_null`.
+            if matches!(value, OwnedValue::Object(_)) && yq_numeric_index_on_object_is_null::<S>() {
                 return continue_rest_with_borrowed_value::<W, S>(
                     &OwnedValue::Null,
                     rest,

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -47,8 +47,9 @@ use super::eval::{
     slice_owned_value_read, streams_escaped_generator_prefix, substitute_bound_var,
     substitute_vars, suppress_or_raise, suppresses, tonumber_from_str, vec_with_capacity,
     yq_absent_key_read_is_empty, yq_empty_operand_output, yq_negative_index_check,
-    yq_read_only_context, BinaryFanoutRules, Control, Demand, EmptyOperandOp, EvalError,
-    EvalSemantics, EvalTag, Flow, JqSemantics, LimitN, PathTrail, QueryResult, YqSemantics,
+    yq_numeric_index_on_object_is_null, yq_read_only_context, BinaryFanoutRules, Control, Demand,
+    EmptyOperandOp, EvalError, EvalSemantics, EvalTag, Flow, JqSemantics, LimitN, PathTrail,
+    QueryResult, YqSemantics,
 };
 #[cfg(test)]
 use super::expr::FuncDefBound;
@@ -5839,6 +5840,12 @@ fn eval_single<S: EvalSemantics, V: DocumentValue>(
                 // errored while `null | .[$n]` — the same query, and the same
                 // rule in `index_one_generic` — returned null.
                 GenericResult::Owned(OwnedValue::Null)
+            } else if value.as_object().is_some() && yq_numeric_index_on_object_is_null::<S>() {
+                // #2459: yq mode only -- `.a[5]` on a mapping is `null`, the
+                // same rule `index_one_generic`'s own numeric-key arm
+                // applies for the computed-key sibling `.a[$k]`. See
+                // `eval::yq_numeric_index_on_object_is_null`.
+                GenericResult::Owned(OwnedValue::Null)
             } else {
                 // No `optional`-guarded arm here (unlike `index_one_generic`,
                 // the computed-key sibling this literal `.[N]` form doesn't
@@ -9748,7 +9755,11 @@ fn index_one_generic<S: EvalSemantics, V: DocumentValue>(
                     // Out-of-bounds is null, not an error (#307).
                     None => GenericResult::Owned(OwnedValue::Null),
                 }
-            } else if target.is_null() {
+            // #2459: yq mode only, the `Object` half of this condition --
+            // see `yq_numeric_index_on_object_is_null`.
+            } else if target.is_null()
+                || (target.as_object().is_some() && yq_numeric_index_on_object_is_null::<S>())
+            {
                 GenericResult::Owned(OwnedValue::Null)
             } else if optional {
                 GenericResult::None
@@ -11509,6 +11520,13 @@ fn path_step_generic<S: EvalSemantics, V: DocumentValue>(
                             .ok()
                             .and_then(|i| elements.get_cursor(i))
                             .map_or(PathNode::Absent, PathNode::At)
+                    } else if v.as_object().is_some() && yq_numeric_index_on_object_is_null::<S>() {
+                        // #2459: yq mode only -- a numeric index on a
+                        // mapping is an absent position, same as the
+                        // `Expr::Field` arm's own missing-key case above.
+                        // `.a[5] | key` is `5`, `.a[5] | path` is `["a",5]`.
+                        // See `eval::yq_numeric_index_on_object_is_null`.
+                        PathNode::Absent
                     } else {
                         return Err(EvalError::cannot_index_with_type(
                             path_node_type_name::<V>(node),

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -38262,3 +38262,20 @@ fn test_jq_mode_has_no_downcase_upcase_2462() -> Result<()> {
     }
     Ok(())
 }
+
+/// #2459: yq mode's new "numeric index on a mapping is null" rule
+/// (`eval::yq_numeric_index_on_object_is_null`) must not leak into jq mode
+/// -- jq 1.7.1 raises `Cannot index object with number` here unconditionally,
+/// which succinctly already reproduced and must keep reproducing.
+#[test]
+fn test_jq_mode_numeric_index_on_object_still_errors_2459() -> Result<()> {
+    for filter in [".a[5]", "5 as $y | .a[$y]"] {
+        let (_out, stderr, code) = run_jq_stdin_streams(filter, "{\"a\":{\"b\":1}}", &[])?;
+        assert_ne!(code, 0, "`{filter}` should still error in jq mode");
+        assert!(
+            stderr.contains("Cannot index object with number"),
+            "`{filter}` stderr: {stderr}"
+        );
+    }
+    Ok(())
+}

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -33553,3 +33553,74 @@ fn test_yq_downcase_upcase_builtins_2462() -> Result<()> {
     );
     Ok(())
 }
+
+/// #2459: real yq treats a numeric index on a *mapping* as a missing key --
+/// `null`, at the position the index names -- where jq raises `Cannot index
+/// object with number`, which is what succinctly reproduced in both modes
+/// before this fix. Captured live from yq v4.53.3 (`-o=json -I0`) on
+/// `a:\n  b: 1\n`:
+///
+/// ```text
+/// $ yq -o=json -I0 '.a[5]'          null
+/// $ yq -o=json -I0 '.a | .[5]'      null
+/// $ yq -o=json -I0 '.a[5] | key'    5
+/// $ yq -o=json -I0 '.a[5] | path'   ["a",5]
+/// $ yq -o=json -I0 '.a[-1]'         null
+/// $ yq -o=json -I0 '.a[1.5]'        null
+/// $ yq -o=json -I0 '.a["5"]'        null    (a genuine string-key miss, unrelated)
+/// $ succinctly yq -o=json '.a[5]'   Error: Cannot index object with number  (was, exit 1)
+/// ```
+///
+/// The rule is `eval::yq_numeric_index_on_object_is_null`, consulted by both
+/// evaluators at every site a numeric index reaches a real `Object`:
+/// `eval::index_array_by_position` (the literal-index and computed-key value
+/// route), `eval::eval_owned_navigation` (the pure/reindex-bridge fast
+/// path), `eval::eval_stage_with_path_context`'s and the computed-key loop's
+/// own `Expr::Index`/owned-target arms (the eager path-context evaluator),
+/// and `eval_generic::index_one_generic`/`Expr::Index` inline arm/
+/// `path_step_generic` (the generic route spine 2416 introduced) -- one
+/// definition, several call sites, per CLAUDE.md's "duplicated predicates
+/// diverge silently" (#106).
+///
+/// **Read-only.** The write side (`.a[5] = 1`) is a distinct, already
+/// tracked-but-unfixed divergence: real yq coerces the index to a string key
+/// and inserts it (`{"a":{"b":1,"5":1}}`), where succinctly still raises the
+/// same `Cannot index object with number` -- see
+/// `docs/compliance/yq/limitations.md`'s "mid-chain `Field`/`Index` step"
+/// entry (#1863), which already documents the identical coercion gap for a
+/// mid-chain shape.
+#[test]
+fn test_yq_numeric_index_on_mapping_is_null_2459() -> Result<()> {
+    let args = &["-o=json", "-I=0"];
+    let doc = "a:\n  b: 1\n";
+    for (filter, expected) in [
+        (".a[5]", "null"),
+        (".a | .[5]", "null"),
+        (".a[5] | key", "5"),
+        (".a[5] | path", "[\"a\",5]"),
+        (".a[-1]", "null"),
+        (".a[1.5]", "null"),
+        (".a[\"5\"]", "null"),
+        // Computed-key forms reach a separate set of call sites than the
+        // literal-index forms above (the parser constant-folds a literal
+        // subscript to `Expr::Index`, a computed one stays `Expr::IndexExpr`)
+        // -- both must agree.
+        (".a[(2+3)]", "null"),
+        (".a[(2+3)] | key", "5"),
+        (".a[(2+3)] | path", "[\"a\",5]"),
+        ("5 as $y | .a[$y]", "null"),
+        ("5 as $y | .a[$y] | key", "5"),
+    ] {
+        let (output, code) = run_yq_stdin(filter, doc, args)?;
+        assert_eq!(code, 0, "`{filter}`: {output:?}");
+        assert_eq!(output.trim(), expected, "`{filter}`");
+    }
+    // The write side is unchanged -- still errors, not part of this fix.
+    let (_out, stderr, code) = run_yq_stdin_with_stderr(".a[5] = 1", doc, &[])?;
+    assert_ne!(code, 0, "write side is not part of #2459 -- see #1863");
+    assert!(
+        stderr.contains("Cannot index object with number"),
+        "got: {stderr}"
+    );
+    Ok(())
+}


### PR DESCRIPTION
## Summary

Real yq treats a numeric index on a mapping as a missing key: `.a[5]` is `null`, `.a[5] | key` is `5`, `.a[5] | path` is `["a",5]`; jq 1.7.1 raises, which succinctly reproduced in both modes. One predicate, `yq_numeric_index_on_object_is_null`, consulted from the five read sites across both evaluators (the literal-index, computed-key, path-context and reindex-bridge routes; a property fuzz caught the fifth). The write side is left alone on purpose: real yq coerces the index to a string key and inserts it, the harder divergence already tracked as #1863.

## Verification

fmt; clippy `-D warnings`; `cargo test --features cli,simd,regex,serde`; yq goldens 113; jq goldens 633; oracle sweep 0 unexpected. Rows captured from yq v4.53.3.

Closes #2459.