### PR TITLE
fix(jq): ordering comparisons against null answer false in yq mode (#2483)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`succinctly yq`'s ordering comparisons (`<`/`<=`/`>`/`>=`) against a real
+  `null` now answer `false`, not jq's total order** (#2483). Confirmed live
+  against yq v4.53.3: real yq treats `null` as orderable only against
+  another `null` (`null <= null`/`null >= null` are `true`, matching
+  equality), never against any other value (`null < 1`, `1 < null`, `.zzz <
+  1` are all `false`) -- jq's total order sorts `null` below everything, so
+  `null < 1` is `true` there, which is what succinctly reproduced in yq mode
+  too before this fix. `null` against an array/object remains a residual
+  gap: real yq raises an operand-order-dependent, Go-internal error there
+  instead of answering at all, which this fix does not chase.
+
+### Fixed
+
 - **`succinctly yq` reads a numeric index on a mapping as `null`, not an
   error** (#2459). Confirmed live against yq v4.53.3: `.a[5]` on `a: {b: 1}`
   is `null` (`key`/`path` answer `5`/`["a",5]` for that position, same as any

--- a/docs/compliance/yq/limitations.md
+++ b/docs/compliance/yq/limitations.md
@@ -1887,30 +1887,28 @@ existing one keeps its old value. Only **key** lookups are covered — real yq a
 through arrays even read-only (`.x = (.n[9] | key)` on `n: [1, 2]` is `x: 9`), so an
 out-of-range array index stays the ordinary `null` read.
 
-Five neighbouring shapes were captured alongside and are **not** part of this rule; each
-is a separate divergence:
+Four more neighbouring shapes were captured alongside and are **not** part of this rule;
+each is a separate divergence (a fifth, ordering comparisons against a real `null`, was
+captured here too but is now resolved -- see
+[#2483](https://github.com/rust-works/succinctly/issues/2483) below):
 
 | filter                                    | input             | real yq        | succinctly                             |
 |-------------------------------------------|-------------------|----------------|----------------------------------------|
-| `null < 1`, `.zzz < 1`, `null <= 1`       | `a: 1`            | `false`        | `true`                                 |
 | `.s.zzz`                                  | `s: x`            | *(nothing)*    | `Error: Cannot index string with string "zzz"` |
 | `.a \| with_entries(.value = key)`        | `a: {b: 1, e: 2}` | `{"b":0,"e":1}`| `{"b":1,"e":2}`                        |
 | `.a \|= (1 \| select(false))`             | `a: 1`            | `{"a":1}`      | `{"a":null}`                           |
 | `.x = (keys)`                             | `a: 1`            | `{"a":1,"x":["a","x"]}` | `{"a":1,"x":["a"]}`           |
 
-Row 1 is yq's ordering comparison against a real `null`, which is `false` for every
-operator regardless of the other side — nothing to do with absent reads (`.zzz` is a
-genuine `null` node in that position, since a comparison operand is not read-only).
-Row 2 is yq indexing a *scalar* with a key, which yields nothing everywhere, not only in
-a read-only context — it is what makes `.s.zzz + 1` also `1`. Row 3 is what `key` reports
+Row 1 is yq indexing a *scalar* with a key, which yields nothing everywhere, not only in
+a read-only context — it is what makes `.s.zzz + 1` also `1`. Row 2 is what `key` reports
 for an element of a constructed array: real yq answers the index, succinctly has no path
 context for a value it built itself, so the `=` right side is empty and the write is
-skipped. Row 4 is `|=` with a zero-output *filter*, which real yq no-ops the same way it
+skipped. Row 3 is `|=` with a zero-output *filter*, which real yq no-ops the same way it
 no-ops a zero-output `=` right side — succinctly's `update_path` writes `null` instead.
 `.x |= (1 | select(false))` on an absent `.x` already agrees (`x: null`), so only the
 existing-target half diverges.
 
-Row 5 is an evaluation-*order* divergence that predates all of this and is unrelated to
+Row 4 is an evaluation-*order* divergence that predates all of this and is unrelated to
 absent reads: real yq's `assignUpdateOperator` resolves (and auto-creates) the **left**
 side first, then evaluates the right side against the document that traversal has already
 mutated, so the right side can see the node the assignment is about to write into.
@@ -1933,6 +1931,51 @@ now correctly empty, the underlying order difference is what shows:
 (the `a: 1` prefix elided). Closing these needs the right side evaluated against the
 left-vivified document, which is a change to the assignment model rather than to this
 rule -- and would move `.x = (keys)`/`.x = (length)` at the same time.
+
+### Ordering comparisons against a real `null` -- resolved for scalars ([#2483](https://github.com/rust-works/succinctly/issues/2483)); containers remain a residual gap
+
+Real yq v4.53.3's ordering comparators (`<`/`<=`/`>`/`>=`) treat a real `null` operand as
+orderable only against another `null` -- never against any other value -- unlike jq's
+total order, which sorts `null` below everything (`null < 1` is jq's `true`). succinctly
+reproduced jq's total order in yq mode too before this fix. Captured live (`-o=json -I0`
+on `a: 1`, plus `.zzz` for a genuine `null` *node* rather than a `null` literal --
+comparison operands are not read-only, unlike an arithmetic/`and`/`or` operand under
+`yq_absent_key_read_is_empty`, the previous section's own rule):
+
+| filter                                          | real yq |
+|--------------------------------------------------|---------|
+| `null == 1` / `1 == null`                        | `false` |
+| `null != 1` / `1 != null`                        | `true`  |
+| `null < 1`, `<= 1`, `> 1`, `>= 1` (either order) | `false` |
+| `null == null`                                   | `true`  |
+| `null != null`                                   | `false` |
+| `null < null`, `null > null`                     | `false` |
+| `null <= null`, `null >= null`                   | `true`  |
+| `null <op> "a"`, `null <op> false`               | same as vs a number |
+| `.zzz < 1`                                       | `false` |
+
+Fixed as `eval::yq_null_ordering_is_false`, consulted from `eval::apply_compare_op` --
+the one shared comparison-operator implementation all three evaluators (the ordinary
+cursor evaluator, the eager path-context evaluator, and the generic/CLI evaluator) already
+route through, so this is a single call site, not three.
+
+**Not reproduced: `null` against an array/object.** Real yq raises a Go-internal error
+there instead of answering at all, and the wording depends on operand *order* -- its
+ordering comparator is implemented as a subtraction internally:
+
+```console
+$ yq 'null < []'
+Error: !!seq () cannot be subtracted from !!null
+$ yq '[] < null'
+Error: arrays not yet supported for comparison
+```
+
+That is a materially different, deeper quirk than "ordering against null is false", and
+reproducing it bug-for-bug (order-dependent wording, distinct messages per container
+kind) is out of scope here. succinctly instead falls under the same "`false`
+unconditionally" rule as the scalar case above for a `null`-vs-container ordering
+comparison — an improvement over the pre-fix `true` (jq's total order), but still not a
+byte-for-byte match with real yq's error.
 
 ### A negative out-of-range array index (`.a[-N]`) raises -- resolved for ordinary reads, a few call sites remain
 

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -465,6 +465,57 @@ pub(crate) fn yq_empty_operand_output(
     }
 }
 
+/// yq mode only (#2483): an ordering comparison (`<`/`<=`/`>`/`>=`) against a
+/// **real** `null` operand -- as opposed to [`yq_empty_operand_output`]'s
+/// zero-*output* operand, a distinct "null-ish" category per that function's
+/// own doc comment -- is `false` unconditionally, never jq's total order
+/// (which sorts `null` below everything, so jq's `null < 1` is `true`).
+/// `None` from this function means "the ordinary rule already gives the
+/// right answer" (every non-comparison op, and `null` against `null` itself,
+/// where equality already makes `<=`/`>=` come out `true` the normal way).
+///
+/// Captured live against yq v4.53.3 (`-o=json -I0`) on `a: 1`:
+///
+/// | filter                                    | real yq |
+/// |--------------------------------------------|---------|
+/// | `null == 1` / `1 == null`                  | `false` |
+/// | `null != 1` / `1 != null`                  | `true`  |
+/// | `null < 1`, `<= 1`, `> 1`, `>= 1` (either order) | `false` |
+/// | `null == null`                             | `true`  |
+/// | `null != null`                             | `false` |
+/// | `null < null`, `null > null`               | `false` |
+/// | `null <= null`, `null >= null`              | `true`  |
+/// | `null <op> "a"`, `null <op> false`         | same as vs a number |
+/// | `.zzz < 1` (a genuine `null` *node*, not an empty operand -- comparison operands are not read-only) | `false` |
+///
+/// **Not reproduced here:** `null` against an array/object in real yq
+/// raises a Go-internal error instead of answering `false` at all -- and the
+/// wording depends on operand *order* (`null < []` is `!!seq () cannot be
+/// subtracted from !!null`; `[] < null` is `arrays not yet supported for
+/// comparison`). That is a separate, much deeper quirk (yq's ordering
+/// comparator is implemented as a subtraction internally) than "ordering
+/// against null is false" and is not part of this rule -- see
+/// `docs/compliance/yq/limitations.md`.
+pub(crate) fn yq_null_ordering_is_false<S: EvalSemantics>(
+    op: CompareOp,
+    left: &OwnedValue,
+    right: &OwnedValue,
+) -> Option<bool> {
+    if S::TAG != EvalTag::Yq
+        || !matches!(
+            op,
+            CompareOp::Lt | CompareOp::Le | CompareOp::Gt | CompareOp::Ge
+        )
+    {
+        return None;
+    }
+    match (left, right) {
+        (OwnedValue::Null, OwnedValue::Null) => None,
+        (OwnedValue::Null, _) | (_, OwnedValue::Null) => Some(false),
+        _ => None,
+    }
+}
+
 /// **The one definition of yq's read-only evaluation context** (#2470),
 /// consulted by both evaluators and by every navigation site that has to
 /// decide what a key lookup that found nothing evaluates to.
@@ -6940,6 +6991,10 @@ pub(crate) fn apply_compare_op<S: EvalSemantics>(
     left: &OwnedValue,
     right: &OwnedValue,
 ) -> bool {
+    // #2483: yq mode only -- see `yq_null_ordering_is_false`.
+    if let Some(result) = yq_null_ordering_is_false::<S>(op, left, right) {
+        return result;
+    }
     match op {
         CompareOp::Eq => owned_value_eq::<S>(left, right),
         CompareOp::Ne => !owned_value_eq::<S>(left, right),

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -38279,3 +38279,25 @@ fn test_jq_mode_numeric_index_on_object_still_errors_2459() -> Result<()> {
     }
     Ok(())
 }
+
+/// #2483: yq mode's new "ordering against a real `null` is false"
+/// rule (`eval::yq_null_ordering_is_false`) must not leak into jq mode --
+/// jq 1.7.1's total order still sorts `null` below every other value, so
+/// `null < 1` stays `true` and `1 < null` stays `false`, matching the
+/// pinned oracle.
+#[test]
+fn test_jq_mode_null_ordering_keeps_total_order_2483() -> Result<()> {
+    for (filter, expected) in [
+        ("null < 1", "true"),
+        ("null <= 1", "true"),
+        ("1 < null", "false"),
+        ("1 <= null", "false"),
+        ("null < null", "false"),
+        ("null <= null", "true"),
+    ] {
+        let (out, code) = run_jq_stdin(filter, "null", &["-c"])?;
+        assert_eq!(code, 0, "`{filter}`");
+        assert_eq!(out.trim(), expected, "`{filter}`");
+    }
+    Ok(())
+}

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -33624,3 +33624,81 @@ fn test_yq_numeric_index_on_mapping_is_null_2459() -> Result<()> {
     );
     Ok(())
 }
+
+/// #2483: real yq's ordering comparisons (`<`/`<=`/`>`/`>=`) treat a real
+/// `null` operand as orderable only against another `null` -- never against
+/// any other value -- unlike jq's total order (which sorts `null` below
+/// everything, so jq's `null < 1` is `true`). succinctly reproduced jq's
+/// total order in yq mode too before this fix. Captured live from yq
+/// v4.53.3 (`-o=json -I0`) on `a: 1`:
+///
+/// ```text
+/// $ yq 'null == 1'    false      $ yq '1 == null'    false
+/// $ yq 'null != 1'    true       $ yq '1 != null'    true
+/// $ yq 'null < 1'     false      $ yq '1 < null'     false
+/// $ yq 'null <= 1'    false      $ yq '1 <= null'    false
+/// $ yq 'null > 1'     false      $ yq '1 > null'     false
+/// $ yq 'null >= 1'    false      $ yq '1 >= null'    false
+/// $ yq 'null == null' true
+/// $ yq 'null != null' false
+/// $ yq 'null < null'  false
+/// $ yq 'null > null'  false
+/// $ yq 'null <= null' true
+/// $ yq 'null >= null' true
+/// $ yq '.zzz < 1'     false   (a real null node, not an empty operand)
+/// ```
+///
+/// `null` against `"a"`/`false` gives the same row as `null` against `1`
+/// (also captured live, not shown above for brevity).
+///
+/// Fixed as `eval::yq_null_ordering_is_false`, consulted from the one
+/// shared `eval::apply_compare_op` all three evaluators route every
+/// comparison through -- see `docs/compliance/yq/limitations.md`'s
+/// "Ordering comparisons against a real `null`" entry, which also records
+/// the one residual this fix does not chase: `null` against an array/object
+/// raises a Go-internal, operand-order-dependent error in real yq rather
+/// than answering `false`.
+#[test]
+fn test_yq_null_ordering_comparisons_are_false_2483() -> Result<()> {
+    let args = &["-o=json", "-I=0"];
+    let doc = "a: 1\n";
+    for (filter, expected) in [
+        ("null == 1", "false"),
+        ("null != 1", "true"),
+        ("null < 1", "false"),
+        ("null <= 1", "false"),
+        ("null > 1", "false"),
+        ("null >= 1", "false"),
+        ("1 == null", "false"),
+        ("1 != null", "true"),
+        ("1 < null", "false"),
+        ("1 <= null", "false"),
+        ("1 > null", "false"),
+        ("1 >= null", "false"),
+        ("null == null", "true"),
+        ("null != null", "false"),
+        ("null < null", "false"),
+        ("null > null", "false"),
+        ("null <= null", "true"),
+        ("null >= null", "true"),
+        ("null == \"a\"", "false"),
+        ("null < \"a\"", "false"),
+        ("null <= \"a\"", "false"),
+        ("null > \"a\"", "false"),
+        ("null >= \"a\"", "false"),
+        ("null == false", "false"),
+        ("null < false", "false"),
+        ("null <= false", "false"),
+        ("null > false", "false"),
+        ("null >= false", "false"),
+        (".zzz < 1", "false"),
+        (".zzz <= 1", "false"),
+        (".zzz > 1", "false"),
+        (".zzz >= 1", "false"),
+    ] {
+        let (output, code) = run_yq_stdin(filter, doc, args)?;
+        assert_eq!(code, 0, "`{filter}`: {output:?}");
+        assert_eq!(output.trim(), expected, "`{filter}`");
+    }
+    Ok(())
+}


### PR DESCRIPTION
## Summary

Real yq's `<`, `<=`, `>`, `>=` against a null operand are `false` (except null against null, which is `true` through equality) where jq's total order sorts null first. One function, `yq_null_ordering_is_false`, consulted from the single shared `apply_compare_op` all three evaluators route through; the full null against null/number/string/bool matrix is captured from yq v4.53.3 and pinned, jq mode unchanged. Residual recorded in the limitations doc: null against an array or object raises an order-dependent internal error in real yq rather than answering `false`.

## Verification

fmt; clippy `-D warnings`; `cargo test --features cli,simd,regex,serde`; yq goldens 113; jq goldens 633; oracle sweep 0 unexpected.

Closes #2483.