### PR TITLE
fix(jq): |= with a zero-output filter leaves the target untouched in yq mode (#2484)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`succinctly yq`'s `|=` with a zero-output update filter now leaves an
+  already-existing target completely untouched** (#2484). Confirmed live
+  against yq v4.53.3: `.a |= (1 | select(false))` on `a: 1` stays `{"a":1}`,
+  and `.a[] |= select(. > 5)` on `a: [1,6,2,7]` leaves every element as-is
+  rather than removing any — where jq 1.7.1 deletes the key/element and
+  succinctly's pre-fix yq mode wrote `null` in both cases, a three-way
+  divergence. The absent-target half (`.x |= ...`) already agreed (#2470);
+  jq mode is unaffected.
+
+### Fixed
+
 - **`succinctly yq`'s ordering comparisons (`<`/`<=`/`>`/`>=`) against a real
   `null` now answer `false`, not jq's total order** (#2483). Confirmed live
   against yq v4.53.3: real yq treats `null` as orderable only against

--- a/docs/compliance/yq/limitations.md
+++ b/docs/compliance/yq/limitations.md
@@ -1887,28 +1887,25 @@ existing one keeps its old value. Only **key** lookups are covered — real yq a
 through arrays even read-only (`.x = (.n[9] | key)` on `n: [1, 2]` is `x: 9`), so an
 out-of-range array index stays the ordinary `null` read.
 
-Four more neighbouring shapes were captured alongside and are **not** part of this rule;
-each is a separate divergence (a fifth, ordering comparisons against a real `null`, was
-captured here too but is now resolved -- see
-[#2483](https://github.com/rust-works/succinctly/issues/2483) below):
+Three neighbouring shapes were captured alongside and are **not** part of this rule;
+each is a separate divergence (two more, ordering comparisons against a real `null` and
+`|=` with a zero-output filter, were captured here too but are now resolved -- see
+[#2483](https://github.com/rust-works/succinctly/issues/2483) and
+[#2484](https://github.com/rust-works/succinctly/issues/2484) below):
 
 | filter                                    | input             | real yq        | succinctly                             |
 |-------------------------------------------|-------------------|----------------|----------------------------------------|
 | `.s.zzz`                                  | `s: x`            | *(nothing)*    | `Error: Cannot index string with string "zzz"` |
 | `.a \| with_entries(.value = key)`        | `a: {b: 1, e: 2}` | `{"b":0,"e":1}`| `{"b":1,"e":2}`                        |
-| `.a \|= (1 \| select(false))`             | `a: 1`            | `{"a":1}`      | `{"a":null}`                           |
 | `.x = (keys)`                             | `a: 1`            | `{"a":1,"x":["a","x"]}` | `{"a":1,"x":["a"]}`           |
 
 Row 1 is yq indexing a *scalar* with a key, which yields nothing everywhere, not only in
 a read-only context — it is what makes `.s.zzz + 1` also `1`. Row 2 is what `key` reports
 for an element of a constructed array: real yq answers the index, succinctly has no path
 context for a value it built itself, so the `=` right side is empty and the write is
-skipped. Row 3 is `|=` with a zero-output *filter*, which real yq no-ops the same way it
-no-ops a zero-output `=` right side — succinctly's `update_path` writes `null` instead.
-`.x |= (1 | select(false))` on an absent `.x` already agrees (`x: null`), so only the
-existing-target half diverges.
+skipped.
 
-Row 4 is an evaluation-*order* divergence that predates all of this and is unrelated to
+Row 3 is an evaluation-*order* divergence that predates all of this and is unrelated to
 absent reads: real yq's `assignUpdateOperator` resolves (and auto-creates) the **left**
 side first, then evaluates the right side against the document that traversal has already
 mutated, so the right side can see the node the assignment is about to write into.
@@ -1976,6 +1973,42 @@ kind) is out of scope here. succinctly instead falls under the same "`false`
 unconditionally" rule as the scalar case above for a `null`-vs-container ordering
 comparison — an improvement over the pre-fix `true` (jq's total order), but still not a
 byte-for-byte match with real yq's error.
+
+### `|=` with a zero-output update filter -- resolved ([#2484](https://github.com/rust-works/succinctly/issues/2484))
+
+A three-way divergence per ADR-0018 (mode decides): jq 1.7.1 (since jq 1.7) deletes the
+key/element a zero-output `|=` filter targets (`_modify`'s own `delpaths` fallback);
+real yq instead leaves an already-existing target completely untouched; succinctly's
+pre-fix yq mode wrote `null` in both cases, matching neither. Captured live against yq
+v4.53.3 (`-o=json -I0`):
+
+| filter                                  | input          | real yq            |
+|------------------------------------------|----------------|---------------------|
+| `.a \|= (1 \| select(false))`             | `a: 1`         | `{"a":1}` (untouched) |
+| `.x \|= (1 \| select(false))`             | `a: 1`         | `{"a":1,"x":null}` (absent target: already agreed, #2470) |
+| `.a[] \|= select(. > 5)`                  | `a: [1,6,2,7]` | `{"a":[1,6,2,7]}` (every element untouched, none removed) |
+| `.a[0] \|= select(. > 5)`                 | `a: [1,6,2,7]` | `{"a":[1,6,2,7]}` (single index, same rule) |
+| `.a[10] \|= select(. > 5)`                | `a: [1,2,3]`   | padded with `null` out to index 10 (#1916's own bounds rule, not this one -- unaffected) |
+| `.a[1:2] \|= (. \| select(false))`        | `a: [1,2,3]`   | `{"a":[1,2,3]}` (slice form untouched too) |
+
+Fixed in `update_path`'s own terminal `Expr::Identity` arm -- the base case every
+`Field`/`Index`/`Iterate`/`Slice` arm's leaf write already funnels through -- by simply
+not assigning anything when the filter is zero-output in yq mode: `root` at that point
+already *is* the value being updated (the pre-existing one for an already-populated slot,
+or the freshly-autovivified/padded default for one that didn't exist before this write),
+so "leave it as it was" needs no separate before/after snapshot. `update_path_steps`'s own
+terminal case (`.a[N] |=`/`.a.b |=`-style multi-step chains) used to keep an independent,
+identical copy of the same three lines; it now calls into the `Expr::Identity` arm instead
+of duplicating it, so this fix (and any future one) cannot drift between the two the way
+CLAUDE.md's "duplicated predicates diverge silently" warns about.
+
+**Not chased here:** `.a |= (.zzz | key)` on `a: 1` (also asked for in the issue) is not
+part of this fix. Real yq answers `{"a":1}` because `.zzz` on the number `1` -- `|=`'s
+right side runs against the *target's own value*, not the whole document -- yields
+nothing there (yq indexes a scalar with a key as "nothing everywhere", the "Row 2"
+divergence in the entry above); succinctly still raises `Cannot index number with string
+"zzz"` for that shape, so the update filter never gets the chance to become zero-output in
+the first place. That is the pre-existing scalar-indexing gap, not this one.
 
 ### A negative out-of-range array index (`.a[-N]`) raises -- resolved for ordinary reads, a few call sites remain
 

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -21606,15 +21606,30 @@ fn update_path<S: EvalSemantics>(
             // surface -- `.a |= (1, error("x"))` is `{"a":1}` in jq 1.7.1,
             // not an error.
             //
-            // A zero-output filter still falls back to `Null` at *this*
-            // level -- the `Field`/`Index`/`Iterate` arms above are what
+            // A zero-output filter falls back to `Null` at *this* level in
+            // jq mode -- the `Field`/`Index`/`Iterate` arms above are what
             // turn that into a real delete (#1916), by checking the
             // `wrote` bool returned here rather than inspecting the
             // resulting value (a legitimate `.a |= null` also leaves
             // `Null` behind, and must not be deleted).
+            //
+            // yq mode (#2484): a zero-output filter instead leaves `root`
+            // completely untouched -- neither jq's "always null" nor its
+            // "delete" rule (`{"a":1} | .a |= select(false)` stays
+            // `{"a":1}` in real yq v4.53.3, confirmed live). `root` here
+            // already *is* the value being updated -- the pre-existing one
+            // for an already-populated slot, or the freshly-autovivified/
+            // padded default for one that didn't exist before this write
+            // (every caller -- the `Field`/`Index`/`Iterate`/`Slice` arms
+            // below, and `update_path_steps`'s identical terminal case --
+            // autovivifies/pads *before* reaching here) -- so simply
+            // skipping the assignment is exactly "leave it as it was", no
+            // separate before/after snapshot needed.
             let outputs = eval_owned_multi_first::<S>(filter_expr, root)?;
             let wrote = !outputs.is_empty();
-            *root = outputs.into_iter().next().unwrap_or(OwnedValue::Null);
+            if wrote || S::TAG != EvalTag::Yq {
+                *root = outputs.into_iter().next().unwrap_or(OwnedValue::Null);
+            }
             Ok(wrote)
         }
         Expr::Field(name) => {
@@ -21959,13 +21974,14 @@ fn update_path_steps<S: EvalSemantics>(
     loop {
         let (first, rest) = match steps {
             // Only ever reached via the fresh-run shortcut below, standing in
-            // for a chain whose leaf position is `Expr::Identity` -- mirrors
-            // `update_path`'s own terminal `Expr::Identity` arm exactly.
+            // for a chain whose leaf position is `Expr::Identity` -- calls
+            // straight into `update_path`'s own terminal `Expr::Identity`
+            // arm rather than keeping a second copy of it, so a rule that
+            // arm gains (#2484's yq-mode "leave untouched") can't drift
+            // between the two the way CLAUDE.md's "duplicated predicates
+            // diverge silently" warns about.
             [] => {
-                let outputs = eval_owned_multi_first::<S>(filter_expr, root)?;
-                let wrote = !outputs.is_empty();
-                *root = outputs.into_iter().next().unwrap_or(OwnedValue::Null);
-                return Ok(wrote);
+                return update_path::<S>(root, &Expr::Identity, filter_expr, optional, scalar_noop);
             }
             [last] => return update_path::<S>(root, last, filter_expr, optional, scalar_noop),
             [first, rest @ ..] => (first, rest),

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -38301,3 +38301,29 @@ fn test_jq_mode_null_ordering_keeps_total_order_2483() -> Result<()> {
     }
     Ok(())
 }
+
+/// #2484: yq mode's new "leave the target untouched" rule for a zero-output
+/// `|=` filter (`update_path`'s terminal `Expr::Identity` arm) must not
+/// leak into jq mode -- jq 1.7.1 (since 1.7) deletes the key/element
+/// instead, which succinctly already reproduced and must keep reproducing.
+#[test]
+fn test_jq_mode_update_zero_output_filter_still_deletes_2484() -> Result<()> {
+    for (doc, filter, expected) in [
+        ("{\"a\":1}", ".a |= (1 | select(false))", "{}"),
+        (
+            "{\"a\":[1,6,2,7]}",
+            ".a[] |= select(. > 5)",
+            "{\"a\":[6,7]}",
+        ),
+        (
+            "{\"a\":[1,6,2,7]}",
+            ".a[0] |= select(. > 5)",
+            "{\"a\":[6,2,7]}",
+        ),
+    ] {
+        let (out, code) = run_jq_stdin(filter, doc, &["-c"])?;
+        assert_eq!(code, 0, "`{filter}` on {doc:?}");
+        assert_eq!(out.trim(), expected, "`{filter}` on {doc:?}");
+    }
+    Ok(())
+}

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -29103,39 +29103,39 @@ fn test_nth_limit_float_classification_matches_jq_mode_1825() -> Result<()> {
 /// even valid yq syntax -- its lexer rejects the bare keyword, confirmed
 /// live against yq v4.53.3). `select(false)` reaches the same
 /// zero-output-filter shape through ordinary yq syntax, and real yq's own
-/// behavior for it is neither "delete" nor "always leave `null`" -- an
-/// already-existing key/element is left completely untouched, while one
-/// only reached through autovivification still lands `null`. This test
-/// locks in that `update_path`'s `Field`/`Index`/`Iterate` arms keep their
-/// pre-#1916 shape (still-`null`, not deleted) for an *existing* target in
-/// yq mode, guarding against the #1916 fix regressing yq the way an
-/// unconditional (non-`S::TAG`-gated) version of it did during review: it
-/// deleted the key/element outright there instead, which real yq does not
-/// do at all.
+/// behavior for it is neither "delete" nor jq mode's "always leave
+/// `null`" -- an already-existing key/element is left **completely
+/// untouched**, while one only reached through autovivification still lands
+/// `null` (#2484). This test locks in that `update_path`'s
+/// `Field`/`Index`/`Iterate` arms keep an existing target unchanged (not
+/// deleted, and not overwritten with `null` either) in yq mode, guarding
+/// against the #1916 fix regressing yq the way an unconditional
+/// (non-`S::TAG`-gated) version of it did during review: it deleted the
+/// key/element outright there instead, which real yq does not do at all.
 #[test]
 fn test_field_index_iterate_update_path_unaffected_by_1916_in_yq_mode() -> Result<()> {
     let args = &["-o=json", "-I=0"];
 
-    // Field: the key stays present (still `null`, matching this arm's
-    // pre-#1916 shape), not deleted.
+    // Field: the key keeps its original value, untouched -- not deleted,
+    // and (#2484) not overwritten with `null` either.
     let (out, code) = run_yq_stdin(".a |= select(false)", "a: 1\nb: 2\n", args)?;
     assert_eq!(code, 0);
-    assert_eq!(out.trim(), r#"{"a":null,"b":2}"#);
+    assert_eq!(out.trim(), r#"{"a":1,"b":2}"#);
 
-    // Index: the array keeps its length, not shrunk.
+    // Index: the array keeps its length and its original element.
     let (out, code) = run_yq_stdin(".[0] |= select(false)", "[1, 2, 3]\n", args)?;
     assert_eq!(code, 0);
-    assert_eq!(out.trim(), "[null,2,3]");
+    assert_eq!(out.trim(), "[1,2,3]");
 
-    // Iterate over an array: no element removed.
+    // Iterate over an array: no element removed or overwritten.
     let (out, code) = run_yq_stdin(".[] |= select(. != 2)", "[1, 2, 3]\n", args)?;
     assert_eq!(code, 0);
-    assert_eq!(out.trim(), "[1,null,3]");
+    assert_eq!(out.trim(), "[1,2,3]");
 
-    // Iterate over an object: no key removed.
+    // Iterate over an object: no key removed or overwritten.
     let (out, code) = run_yq_stdin(".[] |= select(. != 2)", "a: 1\nb: 2\nc: 3\n", args)?;
     assert_eq!(code, 0);
-    assert_eq!(out.trim(), r#"{"a":1,"b":null,"c":3}"#);
+    assert_eq!(out.trim(), r#"{"a":1,"b":2,"c":3}"#);
 
     // A negative out-of-range index still raises yq's own eager bounds
     // error, not jq mode's deferred one -- unaffected by whether the
@@ -33700,5 +33700,77 @@ fn test_yq_null_ordering_comparisons_are_false_2483() -> Result<()> {
         assert_eq!(code, 0, "`{filter}`: {output:?}");
         assert_eq!(output.trim(), expected, "`{filter}`");
     }
+    Ok(())
+}
+
+/// #2484: real yq's `|=` with a zero-output update filter leaves an
+/// already-existing target completely untouched, where jq 1.7.1 deletes the
+/// key/element (since jq 1.7) and succinctly's pre-fix yq mode wrote `null`
+/// -- a three-way divergence per ADR-0018 (mode decides). Captured live from
+/// yq v4.53.3 (`-o=json -I0`):
+///
+/// ```text
+/// $ yq '.a |= (1 | select(false))'         a: 1          => {"a":1}       (untouched)
+/// $ yq '.x |= (1 | select(false))'         a: 1          => {"a":1,"x":null}  (absent target: already agreed, #2470)
+/// $ yq '.a[] |= select(. > 5)'             a: [1,6,2,7]  => {"a":[1,6,2,7]}   (every element untouched, none removed)
+/// $ yq '.a[0] |= select(. > 5)'            a: [1,6,2,7]  => {"a":[1,6,2,7]}   (single index, same rule)
+/// $ yq '.a[10] |= select(. > 5)'           a: [1,2,3]    => padded with null out to index 10 (unaffected: #1916's own bounds rule, not this one)
+/// $ yq '.a[1:2] |= (. | select(false))'    a: [1,2,3]    => {"a":[1,2,3]}     (slice form untouched too)
+/// $ jq -c '.a |= (1 | select(false))'      {"a":1}       => {}               (jq 1.7.1 deletes the key -- unchanged by this fix, see jq_cli_tests.rs)
+/// ```
+///
+/// `.a |= (.zzz | key)` on `a: 1` (also asked for in the issue) is *not*
+/// pinned here: real yq answers `{"a":1}` (`.zzz` on the number `1` --
+/// `.a`'s own value, since `|=`'s right side runs against the target, not
+/// the whole document -- yields nothing, an already-known, separate
+/// divergence: yq indexes a *scalar* with a key as "nothing everywhere", not
+/// an error; see `docs/compliance/yq/limitations.md`'s "Row 2" under the
+/// absent-key-read entry). succinctly still raises `Cannot index number
+/// with string "zzz"` there today, so the update filter never gets the
+/// chance to be zero-output in the first place -- a pre-existing gap this
+/// fix does not touch.
+///
+/// Fixed in `update_path`'s own terminal `Expr::Identity` arm (the base
+/// case every `Field`/`Index`/`Iterate`/`Slice` arm's leaf write funnels
+/// through, plus `update_path_steps`'s identical terminal case, now a call
+/// into the same arm rather than a second copy of it).
+#[test]
+fn test_yq_update_zero_output_filter_leaves_target_untouched_2484() -> Result<()> {
+    let args = &["-o=json", "-I=0"];
+    for (doc, filter, expected) in [
+        ("a: 1\n", ".a |= (1 | select(false))", "{\"a\":1}"),
+        (
+            "a: 1\n",
+            ".x |= (1 | select(false))",
+            "{\"a\":1,\"x\":null}",
+        ),
+        (
+            "a: [1, 6, 2, 7]\n",
+            ".a[] |= select(. > 5)",
+            "{\"a\":[1,6,2,7]}",
+        ),
+        (
+            "a: [1, 6, 2, 7]\n",
+            ".a[0] |= select(. > 5)",
+            "{\"a\":[1,6,2,7]}",
+        ),
+        (
+            "a: [1, 2, 3]\n",
+            ".a[1:2] |= (. | select(false))",
+            "{\"a\":[1,2,3]}",
+        ),
+    ] {
+        let (output, code) = run_yq_stdin(filter, doc, args)?;
+        assert_eq!(code, 0, "`{filter}` on {doc:?}: {output:?}");
+        assert_eq!(output.trim(), expected, "`{filter}` on {doc:?}");
+    }
+    // #1916's own bounds rule is unaffected: a positive out-of-range index
+    // still pads with `null` all the way out, regardless of the filter.
+    let (output, code) = run_yq_stdin(".a[10] |= select(. > 5)", "a: [1, 2, 3]\n", args)?;
+    assert_eq!(code, 0, "{output:?}");
+    assert_eq!(
+        output.trim(),
+        "{\"a\":[1,2,3,null,null,null,null,null,null,null,null]}"
+    );
     Ok(())
 }


### PR DESCRIPTION
## Summary

Real yq leaves an existing target untouched when a `|=` filter yields nothing (`.a |= (1 | select(false))` stays `{"a":1}`; `.a[] |= select(. > 5)` leaves every element alone); succinctly wrote `null`. Fixed at `update_path`'s terminal identity arm, which every field, index, iterate and slice leaf write funnels through, and the duplicate terminal arm in `update_path_steps` now calls it instead of carrying a second copy. jq mode still deletes the key, as jq 1.7.1 does, and is pinned. One pre-existing test that had pinned the old write is updated with its capture. Not chased: `.a |= (.zzz | key)` on a scalar `a`, blocked by #2482.

## Verification

fmt; clippy on both CI legs `-D warnings`; `cargo test` in the three configurations; `cargo doc -D warnings`; yq goldens 113; jq goldens 633; oracle sweep 0 unexpected.

Closes #2484.