### PR TITLE
feat(jq): computed index/slice, getpath, key-node reads and arithmetic in the owned identity pipe (#2471)

### DIFF
--- a/docs/adrs/adr-0021.md
+++ b/docs/adrs/adr-0021.md
@@ -144,12 +144,19 @@ in-place transforms *inside owned values*, which have no node to stand on.
   becomes native inherits it, and a test guarding that construct's *rejection* keeps
   asserting the exit code and diagnostic, not an empty stdout.
 - **What remains on the eager route** is bounded by three reasons, each with a known
-  next step: the owned-domain stages decision 7's list does not cover (a builtin with no
-  captured rule, path context read after `key`/`path` replaced the value, path context
-  under arithmetic); the absent shapes decision 6 leaves behind (`parent` from a
-  possibly-absent position, navigation after a non-navigational stage, a fan-out head);
-  and native `eval_single` arms for the constructs that still bridge (arithmetic, blocked
-  on #2460; `and`/`or`, `reduce`/`foreach`).
+  next step: the owned-domain stages decision 7's list does not cover; the absent shapes
+  decision 6 leaves behind (`parent` from a possibly-absent position, navigation after a
+  non-navigational stage, a fan-out head); and native `eval_single` arms for the
+  constructs that still bridge (`and`/`or`, `reduce`/`foreach`). #2471 closed four of
+  reason 1's shapes -- a computed `IndexExpr`/`SliceExpr` (and `?` over one) and
+  `getpath(p)` as navigation, a read after `key`/`path`/`file_index` replaced the value,
+  and a read under arithmetic inside a ruled stage -- so `key` gained a rule of its own
+  (`OwnedIdentityRule::KeyNode`: the emitted key stands where the node stood, and a
+  *second* `key` emits nothing) and `path`/`file_index` gained `Keeps`. What is left of
+  reason 1 is a builtin with no captured rule, and the map family (`map_values`,
+  `with_entries`), whose bodies real yq evaluates at each member's own position and which
+  succinctly answers from no position at all -- those need a cursor-threading
+  implementation in the generic evaluator, not a rule.
 - **The owned domain was where fidelity was worst.** Of 96 multi-stage owned-domain
   shapes captured from yq for decision 7, the eager evaluator answered 47 differently:
   `null` for the `key` of a detached value where yq prints nothing, `["a","b"]` for

--- a/docs/plan/path-context-arm-reachability.md
+++ b/docs/plan/path-context-arm-reachability.md
@@ -192,6 +192,44 @@ admission removes is R3 for an `Expr::Iterate` head, not the arm -- `.a[] | key 
 query above was re-derived (`.a[] | (key | tostring)`, still R3, marker
 confirmed). Nothing became unreachable, so nothing was deleted.
 
+## #2471: gate reason 1 narrowed, and the pin still holds at 43
+
+[#2471](https://github.com/rust-works/succinctly/issues/2471) took four of the
+owned-domain shapes gate reason `R1` still hands over -- computed
+`IndexExpr`/`SliceExpr` (and `?` over them) as navigation, `getpath(p)` as a
+navigational stage, a path-context read after `key`/`path`/`file_index`
+replaced the value, and a read under arithmetic inside a ruled stage -- and
+moved them onto the owned identity pipe (ADR-0021 decision 7). Each row is an
+oracle capture; `test_owned_identity_rules_match_yq_2416` (yq mode) and
+`test_computed_navigation_keeps_path_context_2471` /
+`test_path_context_after_key_or_path_2471` (jq mode) carry them.
+
+**`PINNED_ARM_COUNT` stays at 43.** Re-run of the method above, on the
+post-#2471 tree, with the five `R1` arms instrumented and each fed its own
+proof query from the table (document `D`):
+
+| Id  | Proof query                                | Marker  | Output  |
+|-----|--------------------------------------------|---------|---------|
+| A04 | `.c[0:1] \| .[0] \| key + 1`                | fired   | `1`     |
+| A07 | `.c[.n]? \| key + 1`                        | fired   | `1`     |
+| A17 | `.a \| getpath(["b"]) \| . as $x \| key`    | fired   | `"b"`   |
+| A19 | `.c[.n] \| key + 1`                         | fired   | `1`     |
+| A20 | `.c[.n:.m] \| .[0] \| key + 1`              | fired   | `1`     |
+
+All five still fire, with their pinned outputs unchanged
+(`test_arm_audit_proof_queries_are_unmoved_by_the_gate_2416` is green). The
+reason is structural rather than incidental: #2471 widened what the *owned
+identity pipe* accepts once a pipe has already left the cursor domain, but a
+computed bracket or a `getpath` standing at the **head** of a pipe is still a
+detaching stage with no `owned_identity_rule`, so `owned_identity_pipe_applies`
+declines it and `path_context_needs_eager` answers `true` exactly as before.
+Widening that would mean teaching the cursor walk itself
+(`path_context_is_navigational` + `path_step_generic`) to evaluate a computed
+component -- which it cannot do uniformly, because an *absent* position
+(`PathNode::Absent`) carries no cursor to evaluate the component against. That
+is the next step for this cluster, and it is what would make the five `R1` rows
+unreachable.
+
 ## Result
 
 | Metric                                            | Before | After |
@@ -216,7 +254,9 @@ evaluator, with no second route to check.
   reason and are the cheapest cluster to attack: `Expr::Slice`, `Expr::IndexExpr`
   and `Expr::SliceExpr` are missing from `path_context_single_native` even though
   their literal-bound siblings (`Expr::Index`, `Expr::Slice` with folded bounds)
-  are navigational.
+  are navigational. #2471 (section above) took the *owned-domain* half of that
+  cluster and left all five arms reachable: what remains is the head-of-pipe
+  half, which needs the cursor walk to evaluate a computed component.
 - `A24` (`Expr::Shared`) is only ever produced by `substitute_func_param`
   (`src/jq/eval.rs`), so it dies with `A23`/`A25` and not before.
 - `A38` (`Expr::Break`) cannot be reached without `A37` (`Expr::Label`): the

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -54,7 +54,7 @@ use super::eval::{
 #[cfg(test)]
 use super::expr::FuncDefBound;
 use super::expr::{Builtin, CompareOp, Expr, FormatType, Literal, ObjectEntry, ObjectKey, Pattern};
-use super::slice::{slice_str, SliceBounds};
+use super::slice::{literal_component_from_values, slice_str, SliceBounds};
 use super::value::{owned_value_eq, NumberRepr, OwnedValue};
 use crate::json::JsonIndex;
 
@@ -14726,10 +14726,43 @@ fn owned_identity_nav_supported(expr: &Expr) -> bool {
         | Expr::Index { .. }
         | Expr::Iterate
         | Expr::Slice { .. } => true,
+        // #2471: a *computed* component is navigation here too. The
+        // component expression is evaluated against this stage's own input
+        // -- the input whose position `id` describes -- so a `key`/`path`
+        // inside one resolves to a constant exactly as it does inside a
+        // ruled stage, and the target has to be single-output so the
+        // component stream and the value stream pair up (see
+        // [`owned_identity_computed_step`]).
+        Expr::IndexExpr { target, key } => {
+            owned_identity_operand_supported(target) && owned_identity_component_supported(key)
+        }
+        Expr::SliceExpr { target, start, end } => {
+            owned_identity_operand_supported(target)
+                && start
+                    .as_deref()
+                    .map_or(true, owned_identity_component_supported)
+                && end.as_deref().map_or(true, owned_identity_component_supported)
+        }
+        // #2471: `getpath(p)` is navigation by a computed *chain* of
+        // components; jq's own `path(getpath(["a","b"]))` is `["a","b"]`
+        // (captured from jq 1.7.1), i.e. every component is taken.
+        Expr::Builtin(Builtin::GetPath(path_expr)) => {
+            owned_identity_component_supported(path_expr)
+        }
         Expr::Optional(inner) | Expr::Paren(inner) => owned_identity_nav_supported(inner),
         Expr::Pipe(exprs) => exprs.iter().all(owned_identity_nav_supported),
         _ => false,
     }
+}
+
+/// A computed navigation component (`.[K]`, `.[S:T]`, `getpath(P)`) the
+/// owned identity pipe can evaluate: anything the ordinary owned evaluator
+/// understands once this stage's own `key`/`path`/`file_index` reads have
+/// been rewritten to the constants the identity answers -- the same
+/// predicate the absent route uses for the same rewrite
+/// ([`path_context_resolve_constants`]), reused rather than re-derived.
+fn owned_identity_component_supported(expr: &Expr) -> bool {
+    path_context_absent_resolvable(expr)
 }
 
 /// An operand whose identity can be named without evaluating a generator:
@@ -14827,6 +14860,16 @@ fn owned_identity_step<S: EvalSemantics, V: DocumentValue>(
             out.push((value.clone(), id.clone()));
             Ok(())
         }
+        // The bare `E[K]?` / `E[S:T]?` spelling: its `?` covers the
+        // *indexing* step alone, never the target's or the component's own
+        // evaluation (`eval_index_expr`'s rule, which the value evaluator
+        // already honours), so the whole `Expr::Optional` node is what the
+        // values come from rather than its inner node under `optional`.
+        Expr::Optional(inner)
+            if matches!(**inner, Expr::IndexExpr { .. } | Expr::SliceExpr { .. }) =>
+        {
+            owned_identity_computed_step::<S, V>(inner, value, id, true, true, out)
+        }
         Expr::Optional(inner) => owned_identity_step::<S, V>(inner, value, id, true, out),
         Expr::Paren(inner) => owned_identity_step::<S, V>(inner, value, id, optional, out),
         Expr::Pipe(exprs) => {
@@ -14915,7 +14958,223 @@ fn owned_identity_step<S: EvalSemantics, V: DocumentValue>(
             );
             Ok(())
         }
+        Expr::IndexExpr { .. } | Expr::SliceExpr { .. } => {
+            owned_identity_computed_step::<S, V>(expr, value, id, false, optional, out)
+        }
+        Expr::Builtin(Builtin::GetPath(path_expr)) => {
+            owned_identity_getpath_step::<S, V>(path_expr, value, id, optional, out)
+        }
         _ => unreachable!("owned_identity_nav_supported admits no other shape"),
+    }
+}
+
+/// This stage's own `key`/`path`/`file_index` reads, rewritten to the
+/// constants `id` answers (#2471).
+///
+/// A computed component is evaluated against the stage's *input*, whose
+/// position `id` describes, so the rewrite is the same one
+/// [`eval_owned_identity_pipe`]'s ruled-stage arm applies -- one definition
+/// ([`path_context_resolve_constants`]), consulted from both.
+fn owned_identity_resolve_component<V: DocumentValue>(
+    expr: &Expr,
+    id: &OwnedIdentity<V>,
+) -> Result<Expr, EvalError> {
+    if !needs_path_context(expr) {
+        return Ok(expr.clone());
+    }
+    let key = id.key()?;
+    let path = id.path()?;
+    Ok(path_context_resolve_constants(expr, key.as_ref(), &path))
+}
+
+/// `.[K]` / `.[S:T]` / `E[K]` / `E[S:T]` over an owned value, naming the
+/// component each output takes (#2471).
+///
+/// jq compiles `E[K]` as `K as $k | E | .[$k]` and `E[S:T]` as `S as $s | T
+/// as $t | E | .[$s:$t]`: the component streams are *outer* and the target
+/// is innermost, so the values pair up with the components in the order the
+/// nested loops produce them. The values themselves always come from the
+/// ordinary owned evaluator ([`owned_identity_values`]), so every error
+/// text, `null` for a missing key and mode-specific indexing rule is the one
+/// definition the rest of the pipeline already uses; only the component is
+/// derived here.
+///
+/// Mode decides the slice component (ADR-0018), the same split
+/// [`OwnedIdentityRule::Slice`] draws for a *literal* slice: real yq keeps
+/// the container's position (`.a.b | .[(1):(3)] | key` is `"b"`, captured
+/// from v4.53.3), while jq mode takes the `{"start":s,"end":e}` component
+/// jq's own `path(.n[(1):(3)])` reports (captured from jq 1.7.1).
+fn owned_identity_computed_step<S: EvalSemantics, V: DocumentValue>(
+    expr: &Expr,
+    value: &OwnedValue,
+    id: &OwnedIdentity<V>,
+    bracket_optional: bool,
+    optional: bool,
+    out: &mut Vec<(OwnedValue, OwnedIdentity<V>)>,
+) -> Result<(), EvalError> {
+    // `bracket_optional` reproduces the `E[K]?` spelling exactly, so the
+    // suppression the values see is the one the value evaluator applies.
+    let wrap = |node: Expr| -> Expr {
+        if bracket_optional {
+            Expr::Optional(Box::new(node))
+        } else {
+            node
+        }
+    };
+    match expr {
+        Expr::IndexExpr { target, key } => {
+            let key_expr = owned_identity_resolve_component(key, id)?;
+            let keys = owned_identity_values::<S>(&key_expr, value, optional)?;
+            let values = owned_identity_values::<S>(
+                &wrap(Expr::IndexExpr {
+                    target: target.clone(),
+                    key: Box::new(key_expr),
+                }),
+                value,
+                optional,
+            )?;
+            let Some((target_value, target_id)) =
+                owned_identity_operand::<S, V>(target, value, id, optional)?
+            else {
+                return Ok(());
+            };
+            let parent = Rc::new(target_value.clone());
+            // Zipped, like the sibling `Expr::Iterate` arm: the owned
+            // evaluator yields exactly one value per key, and a mismatch
+            // means the indexing raised or was suppressed, in which case the
+            // surplus components are unused.
+            for (v, k) in values.into_iter().zip(keys) {
+                let component = owned_index_component::<S>(&target_value, k);
+                out.push((v, target_id.child(&parent, component)));
+            }
+            Ok(())
+        }
+        Expr::SliceExpr { target, start, end } => {
+            let start_expr = match start {
+                Some(e) => Some(owned_identity_resolve_component(e, id)?),
+                None => None,
+            };
+            let end_expr = match end {
+                Some(e) => Some(owned_identity_resolve_component(e, id)?),
+                None => None,
+            };
+            let values = owned_identity_values::<S>(
+                &wrap(Expr::SliceExpr {
+                    target: target.clone(),
+                    start: start_expr.clone().map(Box::new),
+                    end: end_expr.clone().map(Box::new),
+                }),
+                value,
+                optional,
+            )?;
+            let Some((target_value, target_id)) =
+                owned_identity_operand::<S, V>(target, value, id, optional)?
+            else {
+                return Ok(());
+            };
+            if S::TAG == EvalTag::Yq {
+                out.extend(values.into_iter().map(|v| (v, target_id.clone())));
+                return Ok(());
+            }
+            let bound = |e: &Option<Expr>| -> Result<Vec<OwnedValue>, EvalError> {
+                match e {
+                    Some(e) => owned_identity_values::<S>(e, value, optional),
+                    None => Ok(vec![OwnedValue::Null]),
+                }
+            };
+            let starts = bound(&start_expr)?;
+            let ends = bound(&end_expr)?;
+            let parent = Rc::new(target_value.clone());
+            // `S` outer, `T` middle, `E` inner -- jq's own desugaring, which
+            // is also the order the value evaluator emits in (confirmed
+            // live: `[1,2,3] | .[(0,1):(2,3)]` is `[1,2] [1,2,3] [2] [2,3]`
+            // against jq 1.7.1).
+            let components = starts.iter().flat_map(|s| {
+                ends.iter()
+                    .map(|e| literal_component_from_values(s.clone(), e.clone()))
+            });
+            for (v, component) in values.into_iter().zip(components) {
+                out.push((v, target_id.child(&parent, component)));
+            }
+            Ok(())
+        }
+        other => unreachable!("not a computed navigation step: {other:?}"),
+    }
+}
+
+/// The path component a computed index leaves behind.
+///
+/// Mode decides a negative array index (ADR-0018), the same rule
+/// [`owned_identity_step`]'s literal `Expr::Index` arm and
+/// `path_step_generic` already apply: yq resolves it against the length,
+/// jq keeps it as written.
+fn owned_index_component<S: EvalSemantics>(target: &OwnedValue, key: OwnedValue) -> OwnedValue {
+    if S::TAG == EvalTag::Yq {
+        if let (Some(items), OwnedValue::Int(i)) = (target.as_array(), &key) {
+            let resolved = items.len() as i64 + *i;
+            if *i < 0 && resolved >= 0 {
+                return OwnedValue::Int(resolved);
+            }
+        }
+    }
+    key
+}
+
+/// `getpath(p)` as a navigational stage (#2471): every component of `p` is
+/// taken, so the output stands where that chain lands.
+///
+/// jq's own model, captured from jq 1.7.1: `path(getpath(["a","b"]))` is
+/// `["a","b"]` and `path(getpath(["zz"]))` is `["zz"]` -- an absent
+/// component still counts. Real yq's lexer rejects `getpath` outright, so in
+/// yq mode this is a succinctly extension behind `--jq-extensions` (#1512)
+/// and jq's model is the only one there is.
+fn owned_identity_getpath_step<S: EvalSemantics, V: DocumentValue>(
+    path_expr: &Expr,
+    value: &OwnedValue,
+    id: &OwnedIdentity<V>,
+    optional: bool,
+    out: &mut Vec<(OwnedValue, OwnedIdentity<V>)>,
+) -> Result<(), EvalError> {
+    let path_expr = owned_identity_resolve_component(path_expr, id)?;
+    let paths = owned_identity_values::<S>(&path_expr, value, optional)?;
+    let values = owned_identity_values::<S>(
+        &Expr::Builtin(Builtin::GetPath(Box::new(path_expr))),
+        value,
+        optional,
+    )?;
+    // Zipped for the same reason the `Expr::IndexExpr` arm above is: a
+    // non-array argument raises in the owned evaluator, which is where that
+    // error text lives, and the surplus components are then unused.
+    for (v, p) in values.into_iter().zip(paths) {
+        let Some(components) = p.as_array() else {
+            continue;
+        };
+        let mut current = value.clone();
+        let mut current_id = id.clone();
+        for component in components {
+            let parent = Rc::new(current.clone());
+            current = owned_child_at(&current, component);
+            current_id = current_id.child(&parent, component.clone());
+        }
+        out.push((v, current_id));
+    }
+    Ok(())
+}
+
+/// The value at one path component of an owned container, or `null` -- the
+/// ancestor chain [`owned_identity_getpath_step`] records for `parent`,
+/// which is `getpath`'s own "missing is null" rule applied one step at a
+/// time.
+fn owned_child_at(value: &OwnedValue, component: &OwnedValue) -> OwnedValue {
+    match (value, component) {
+        (OwnedValue::Object(map), OwnedValue::String(k)) => {
+            map.get(k.as_str()).cloned().unwrap_or(OwnedValue::Null)
+        }
+        (OwnedValue::Array(items), OwnedValue::Int(i)) => usize::try_from(*i)
+            .ok()
+            .and_then(|i| items.get(i).cloned())
+            .unwrap_or(OwnedValue::Null),
+        _ => OwnedValue::Null,
     }
 }
 
@@ -24050,6 +24309,19 @@ mod tests {
         // real yq's own `downcase`/`upcase` spellings answer `key`/`path`
         // through the same rule -- no longer the "no identity rule" example.
         assert!(!eager(".a | ascii_downcase | key"));
+        // #2471 sub-item 1: a *computed* index/slice is navigation in the
+        // owned domain too, `?` over it included, so it no longer ends the
+        // owned identity pipe.
+        assert!(!eager(".a | to_entries | .[(0,1)] | key"));
+        assert!(!eager(".a | to_entries | .[(0,1)]? | path"));
+        assert!(!eager(".a | to_entries | .[(0):(1)] | key"));
+        assert!(!eager(".a | to_entries | .[(0):(1)]? | key"));
+        assert!(!eager(".a | to_entries | .[.[0].key | length] | key"));
+        // #2471 sub-item 2: `getpath(p)` is navigation by a chain of
+        // components.
+        assert!(!eager(".a | to_entries | getpath([0]) | key"));
+        assert!(!eager(".a | to_entries | getpath([0, \"key\"]) | path"));
+        assert!(!eager(".a | tostring | getpath([]) | path"));
         // ...and stays eager where it has no rule, where path context is
         // read after `key`/`path` already replaced the value, where the
         // stage itself reads path context, or where a later stage does so

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -13082,6 +13082,16 @@ fn path_context_resolve_constants(
             left: boxed(left),
             right: boxed(right),
         },
+        // #2471 sub-item 5: the owned identity pipe resolves a read inside
+        // an arithmetic operand (`key + 1`). The *absent* route's own gate
+        // ([`path_context_absent_resolvable`]) still refuses arithmetic, so
+        // adding the arm here widens what can be rewritten without widening
+        // what is routed there.
+        Expr::Arithmetic { op, left, right } => Expr::Arithmetic {
+            op: *op,
+            left: boxed(left),
+            right: boxed(right),
+        },
         Expr::And(left, right) => Expr::And(boxed(left), boxed(right)),
         Expr::Or(left, right) => Expr::Or(boxed(left), boxed(right)),
         other => other.clone(),
@@ -14689,7 +14699,7 @@ enum OwnedIdentityRule {
 
 fn owned_identity_rule(stage: &Expr) -> Option<OwnedIdentityRule> {
     use OwnedIdentityRule::{
-        Alternative, Detaches, DetachesContainer, Extremum, KeyNode, Keeps, LeftOperand, Slice,
+        Alternative, Detaches, DetachesContainer, Extremum, Keeps, KeyNode, LeftOperand, Slice,
     };
     Some(match strip_parens(stage) {
         Expr::Slice { .. } => Slice,
@@ -14780,14 +14790,14 @@ fn owned_identity_nav_supported(expr: &Expr) -> bool {
                 && start
                     .as_deref()
                     .map_or(true, owned_identity_component_supported)
-                && end.as_deref().map_or(true, owned_identity_component_supported)
+                && end
+                    .as_deref()
+                    .map_or(true, owned_identity_component_supported)
         }
         // #2471: `getpath(p)` is navigation by a computed *chain* of
         // components; jq's own `path(getpath(["a","b"]))` is `["a","b"]`
         // (captured from jq 1.7.1), i.e. every component is taken.
-        Expr::Builtin(Builtin::GetPath(path_expr)) => {
-            owned_identity_component_supported(path_expr)
-        }
+        Expr::Builtin(Builtin::GetPath(path_expr)) => owned_identity_component_supported(path_expr),
         Expr::Optional(inner) | Expr::Paren(inner) => owned_identity_nav_supported(inner),
         Expr::Pipe(exprs) => exprs.iter().all(owned_identity_nav_supported),
         _ => false,
@@ -14819,6 +14829,16 @@ fn owned_identity_operand_supported(expr: &Expr) -> bool {
     }
 }
 
+/// An operand of a ruled arithmetic/comparison/negation stage whose own
+/// path-context reads (if any) can be rewritten to the constants the
+/// identity answers (#2471 sub-item 5). An operand that reads nothing is
+/// admitted whatever its shape -- the ordinary owned evaluator computes it,
+/// and only the *left* one needs a nameable position, which
+/// [`OwnedIdentityRule::LeftOperand`] answers or declines on its own.
+fn owned_identity_operand_resolvable(expr: &Expr) -> bool {
+    !needs_path_context(expr) || path_context_absent_resolvable(expr)
+}
+
 /// The static gate for the owned identity pipe: every stage of `stages` is
 /// navigation, a path-context builtin answered from the identity, or a stage
 /// with an [`owned_identity_rule`] whose own path-context builtins (if any)
@@ -14839,8 +14859,29 @@ fn owned_identity_pipe_supported(stages: &[Expr]) -> bool {
             Expr::Builtin(Builtin::Key | Builtin::PathNoArg | Builtin::FileIndex) => {}
             Expr::Builtin(Builtin::Parent) => {}
             Expr::Builtin(Builtin::ParentN(n)) if matches!(**n, Expr::Literal(_)) => {}
-            Expr::Arithmetic { left, .. } | Expr::Compare { left, .. } | Expr::Negate(left) => {
-                if needs_path_context(stage) || !owned_identity_operand_supported(left) {
+            // #2471 sub-item 5: a read inside an operand is a constant for
+            // a fixed identity -- the same rewrite the ruled `_` arm below
+            // already applies -- so the stage is admitted when every operand
+            // resolves. `OwnedIdentityRule::LeftOperand` then places the
+            // output: a bare `key` operand leaves it detached, a bare
+            // `path`/`file_index` one leaves it where the node stood.
+            Expr::Arithmetic { left, right, .. } | Expr::Compare { left, right, .. } => {
+                if needs_path_context(stage) {
+                    if !owned_identity_operand_resolvable(left)
+                        || !owned_identity_operand_resolvable(right)
+                    {
+                        return false;
+                    }
+                } else if !owned_identity_operand_supported(left) {
+                    return false;
+                }
+            }
+            Expr::Negate(inner) => {
+                if needs_path_context(stage) {
+                    if !owned_identity_operand_resolvable(inner) {
+                        return false;
+                    }
+                } else if !owned_identity_operand_supported(inner) {
                     return false;
                 }
             }
@@ -15330,6 +15371,37 @@ fn owned_identity_placed_by<S: EvalSemantics, V: DocumentValue>(
             else {
                 unreachable!("LeftOperand is assigned to arithmetic, comparison and negation only")
             };
+            let left = strip_parens(left);
+            // #2471 sub-item 5: a *bare* path-context read as the left
+            // operand. Captured from yq v4.53.3 on `a: {b: [1,2,3], c: x}`:
+            //
+            // ```text
+            // .a | to_entries | .[0] | key + 1 | key         (nothing)
+            // .a | to_entries | .[0] | (key + 1) | path      []
+            // .a | to_entries | .[0] | (path + []) | key     0
+            // .a | to_entries | .[0] | (file_index + 0) | key  0
+            // ```
+            //
+            // `path`/`file_index` build an ordinary node at the position, so
+            // the output stands where the input stood; `key`'s own output is
+            // a key node, and yq's key node for an entry of a value it
+            // synthesized carries no parent, so arithmetic over it is
+            // detached. (The one shape succinctly does not follow is yq's
+            // `.a.c | tostring | (key + "x") | path` => `["a","cx"]`, a path
+            // naming a node that does not exist -- an artifact of yq
+            // mutating the key node in place. succinctly answers `[]`.)
+            if owned_identity_emits_position(left) {
+                return Ok(if matches!(left, Expr::Builtin(Builtin::Key)) {
+                    None
+                } else {
+                    Some(id.clone())
+                });
+            }
+            // A resolved read the rule cannot name (`[key] + 1`, `empty` at
+            // the document root) has no position either.
+            if !owned_identity_operand_supported(left) {
+                return Ok(None);
+            }
             owned_identity_operand::<S, V>(left, value, id, optional)?.map(|(_, oid)| oid)
         }
         OwnedIdentityRule::Extremum => {
@@ -15424,24 +15496,16 @@ fn eval_owned_identity_pipe<S: EvalSemantics, V: DocumentValue>(
         // second `key` emits nothing -- `id.key()` answers `None` for a key
         // node, which is exactly yq's own `.a.b | key | key`.
         Expr::Builtin(Builtin::Key) => match id.key() {
-            Ok(Some(key)) => eval_owned_identity_pipe::<S, V>(
-                rest,
-                key,
-                id.with_key_node(true),
-                optional,
-                sink,
-            ),
+            Ok(Some(key)) => {
+                eval_owned_identity_pipe::<S, V>(rest, key, id.with_key_node(true), optional, sink)
+            }
             Ok(None) => Flow::Exhausted,
             Err(e) => Flow::Escaped(Control::Error(e)),
         },
         Expr::Builtin(Builtin::PathNoArg) => match id.path() {
-            Ok(path) => eval_owned_identity_pipe::<S, V>(
-                rest,
-                OwnedValue::Array(path),
-                id,
-                optional,
-                sink,
-            ),
+            Ok(path) => {
+                eval_owned_identity_pipe::<S, V>(rest, OwnedValue::Array(path), id, optional, sink)
+            }
             Err(e) => Flow::Escaped(Control::Error(e)),
         },
         // Same measured status as `path_context_resolve_constants`'s own
@@ -24412,9 +24476,19 @@ mod tests {
             eager(".a | [key] | .[0] | path"),
             "the stage reads path context"
         );
+        // #2471 sub-item 5: a read *inside* an arithmetic or comparison
+        // operand is a constant for a fixed identity, so the stage is
+        // admitted now that #2460's empty-operand rule and #2470's
+        // read-only operands settled what it evaluates to.
+        assert!(!eager(".a | to_entries | .[0] | key + 1"));
+        assert!(!eager(".a | to_entries | .[0] | key == 0"));
+        assert!(!eager(".a | to_entries | .[0] | path + []"));
+        assert!(!eager(".a | tostring | key + \"x\""));
+        // ...but an operand whose own read the constants cannot express
+        // still hands the pipe over.
         assert!(
-            eager(".a | to_entries | .[0] | key + 1"),
-            "path context under arithmetic"
+            eager(".a | to_entries | .[0] | parent + {}"),
+            "parent is not a constant"
         );
         // #2416 step 2: a head that can reach an absent node is no longer a
         // reason on its own -- `path_context_absent_split` walks the head as

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -7816,7 +7816,7 @@ fn eval_each_pipe_generic<S: EvalSemantics, V: DocumentValue>(
         rest.iter().any(needs_path_context)
             && !path_context_is_navigational(first)
             && !path_context_stage_preserves_node(first)
-            && !needs_path_context(first)
+            && (!needs_path_context(first) || owned_identity_emits_position(first))
             && owned_identity_rule(first).is_some()
             && owned_identity_pipe_supported(rest)
     });
@@ -14530,6 +14530,13 @@ fn eval_builtin<S: EvalSemantics, V: DocumentValue>(
 struct OwnedIdentity<V: DocumentValue> {
     base: Option<V::Cursor>,
     ancestors: Vec<(Rc<OwnedValue>, OwnedValue)>,
+    /// This value *is* the key `key` emitted (#2471). It stands at the same
+    /// position -- `path`/`parent` answer exactly as they did for the node
+    /// `key` was asked of -- but a key has no key of its own, so a second
+    /// `key` emits nothing (`.a.b | key | key` prints nothing in yq
+    /// v4.53.3, where `.a.b | key | path` is still `["a","b"]` and
+    /// `.a.b | key | tostring | key` is `"b"` again).
+    key_node: bool,
 }
 
 impl<V: DocumentValue> Clone for OwnedIdentity<V> {
@@ -14537,6 +14544,7 @@ impl<V: DocumentValue> Clone for OwnedIdentity<V> {
         Self {
             base: self.base,
             ancestors: self.ancestors.clone(),
+            key_node: self.key_node,
         }
     }
 }
@@ -14554,6 +14562,7 @@ impl<V: DocumentValue> OwnedIdentity<V> {
         Self {
             base: Some(base),
             ancestors: Vec::new(),
+            key_node: false,
         }
     }
 
@@ -14562,7 +14571,15 @@ impl<V: DocumentValue> OwnedIdentity<V> {
         Self {
             base: None,
             ancestors: Vec::new(),
+            key_node: false,
         }
+    }
+
+    /// The same position, flagged as (or no longer as) the key `key`
+    /// emitted -- see [`OwnedIdentity::key_node`].
+    fn with_key_node(mut self, key_node: bool) -> Self {
+        self.key_node = key_node;
+        self
     }
 
     /// The identity of `component` inside `parent`, whose identity is `self`.
@@ -14572,12 +14589,17 @@ impl<V: DocumentValue> OwnedIdentity<V> {
         Self {
             base: self.base,
             ancestors,
+            // A child of a key node is an ordinary node again.
+            key_node: false,
         }
     }
 
     /// `key`: the last component taken, else the base node's own key, else
     /// nothing (a detached root, or the document root -- #2421).
     fn key(&self) -> Result<Option<OwnedValue>, EvalError> {
+        if self.key_node {
+            return Ok(None);
+        }
         match self.ancestors.last() {
             Some((_, component)) => Ok(Some(component.clone())),
             None => match self.base {
@@ -14605,6 +14627,8 @@ impl<V: DocumentValue> OwnedIdentity<V> {
     /// node above the base (nothing above a detached root or the document
     /// root).
     fn parent(mut self) -> Option<OwnedParent<V>> {
+        // Climbing out of a key node lands on an ordinary node.
+        self.key_node = false;
         match self.ancestors.pop() {
             Some((value, _)) => Some(OwnedParent::Owned((*value).clone(), self)),
             None => self
@@ -14653,11 +14677,19 @@ enum OwnedIdentityRule {
     /// `path(.a[0:3])` and takes the `{"start":s,"end":e}` component, the
     /// model #2215 pinned for the extension builtins there.
     Slice,
+    /// `key` (#2471): the emitted key stands where the node it was asked of
+    /// stood -- `path`/`parent` are unchanged -- but is flagged as a key
+    /// node, so a *second* `key` emits nothing. Captured from yq v4.53.3 on
+    /// `a: {b: 1}`: `.a.b | key | path` is `["a","b"]`, `.a.b | key |
+    /// parent | key` is `"a"`, `.a.b | key | key` prints nothing, and
+    /// `.a.b | key | tostring | key` is `"b"` again (any other rule builds
+    /// an ordinary node at the same position, which clears the flag).
+    KeyNode,
 }
 
 fn owned_identity_rule(stage: &Expr) -> Option<OwnedIdentityRule> {
     use OwnedIdentityRule::{
-        Alternative, Detaches, DetachesContainer, Extremum, Keeps, LeftOperand, Slice,
+        Alternative, Detaches, DetachesContainer, Extremum, KeyNode, Keeps, LeftOperand, Slice,
     };
     Some(match strip_parens(stage) {
         Expr::Slice { .. } => Slice,
@@ -14700,6 +14732,13 @@ fn owned_identity_rule(stage: &Expr) -> Option<OwnedIdentityRule> {
             | Builtin::Del(_)
             | Builtin::Select(_) => Keeps,
             Builtin::Keys | Builtin::KeysUnsorted | Builtin::WithEntries(_) => Detaches,
+            // #2471: `key`/`path`/`file_index` replace the value with a
+            // fresh scalar that keeps the node's position, so a later
+            // path-context read is answered from the identity instead of
+            // sending the whole pipe to the eager evaluator. `key` alone
+            // carries the key-node flag; see `OwnedIdentityRule::KeyNode`.
+            Builtin::Key => KeyNode,
+            Builtin::PathNoArg | Builtin::FileIndex => Keeps,
             Builtin::Map(_) => DetachesContainer,
             Builtin::Min | Builtin::Max => Extremum,
             _ => return None,
@@ -14784,17 +14823,20 @@ fn owned_identity_operand_supported(expr: &Expr) -> bool {
 /// navigation, a path-context builtin answered from the identity, or a stage
 /// with an [`owned_identity_rule`] whose own path-context builtins (if any)
 /// resolve to constants. `key`/`path`/`file_index` turn the value into a
-/// fresh scalar, so nothing after one of them may read path context.
+/// fresh scalar that keeps the node's position (#2471), so a later stage may
+/// still read it -- `key` alone flags its output as a key node, which
+/// answers a second `key` with nothing.
 fn owned_identity_pipe_supported(stages: &[Expr]) -> bool {
-    for (i, stage) in stages.iter().enumerate() {
-        let rest = &stages[i + 1..];
+    for stage in stages {
         if owned_identity_nav_supported(stage) {
             continue;
         }
         match strip_parens(stage) {
-            Expr::Builtin(Builtin::Key | Builtin::PathNoArg | Builtin::FileIndex) => {
-                return !rest.iter().any(needs_path_context);
-            }
+            // #2471: `key`/`path`/`file_index` replace the value with a
+            // fresh scalar that stands where the node stood, so a later
+            // path-context read is answered from the identity rather than
+            // ending the pipe here.
+            Expr::Builtin(Builtin::Key | Builtin::PathNoArg | Builtin::FileIndex) => {}
             Expr::Builtin(Builtin::Parent) => {}
             Expr::Builtin(Builtin::ParentN(n)) if matches!(**n, Expr::Literal(_)) => {}
             Expr::Arithmetic { left, .. } | Expr::Compare { left, .. } | Expr::Negate(left) => {
@@ -14836,11 +14878,23 @@ fn owned_identity_pipe_applies(exprs: &[Expr]) -> bool {
         }
         let rest = &exprs[i + 1..];
         return rest.iter().any(needs_path_context)
-            && !needs_path_context(stage)
+            && (!needs_path_context(stage) || owned_identity_emits_position(stage))
             && owned_identity_rule(stage).is_some()
             && owned_identity_pipe_supported(rest);
     }
     false
+}
+
+/// Whether a stage *is* a bare path-context read (#2471). Such a stage reads
+/// the position of the node it is given -- which the cursor route has already
+/// answered by the time the value reaches the owned identity pipe -- so it
+/// can be the stage a pipe leaves the cursor domain at, unlike a stage that
+/// merely *contains* a read.
+fn owned_identity_emits_position(stage: &Expr) -> bool {
+    matches!(
+        strip_parens(stage),
+        Expr::Builtin(Builtin::Key | Builtin::PathNoArg | Builtin::FileIndex)
+    )
 }
 
 /// One navigation step over an owned value, naming the component taken.
@@ -15225,8 +15279,24 @@ fn owned_identity_after_stage<S: EvalSemantics, V: DocumentValue>(
     output: &OwnedValue,
     optional: bool,
 ) -> Result<Option<OwnedIdentity<V>>, EvalError> {
+    // Every rule but `KeyNode` builds an ordinary node, so the key-node flag
+    // an input `key` left behind is cleared here -- `.a.b | key | tostring |
+    // key` is `"b"` again in yq v4.53.3.
+    let placed = owned_identity_placed_by::<S, V>(stage, rule, value, id, output, optional)?;
+    Ok(placed.map(|id| id.with_key_node(rule == OwnedIdentityRule::KeyNode)))
+}
+
+/// [`owned_identity_after_stage`] before the key-node flag is applied.
+fn owned_identity_placed_by<S: EvalSemantics, V: DocumentValue>(
+    stage: &Expr,
+    rule: OwnedIdentityRule,
+    value: &OwnedValue,
+    id: &OwnedIdentity<V>,
+    output: &OwnedValue,
+    optional: bool,
+) -> Result<Option<OwnedIdentity<V>>, EvalError> {
     Ok(match rule {
-        OwnedIdentityRule::Keeps => Some(id.clone()),
+        OwnedIdentityRule::Keeps | OwnedIdentityRule::KeyNode => Some(id.clone()),
         OwnedIdentityRule::Slice => {
             let Expr::Slice {
                 start,
@@ -15284,22 +15354,6 @@ fn owned_identity_after_stage<S: EvalSemantics, V: DocumentValue>(
         OwnedIdentityRule::Alternative => {
             unreachable!("Alternative is evaluated by eval_owned_identity_alternative")
         }
-    })
-}
-
-/// Hand a value with no further identity to the rest of the pipe: the
-/// ordinary owned evaluator, or the sink when nothing is left.
-fn continue_owned_identity_plain<S: EvalSemantics, V: DocumentValue>(
-    rest: &[Expr],
-    value: OwnedValue,
-    optional: bool,
-    sink: &mut dyn FnMut(GenericItem<V>) -> Demand,
-) -> Flow {
-    if rest.is_empty() {
-        return push_one_generic(GenericItem::Owned(value), sink);
-    }
-    eval_each_owned::<S>(&Expr::Pipe(rest.to_vec()), &value, optional, &mut |o| {
-        sink(GenericItem::Owned(o))
     })
 }
 
@@ -15366,24 +15420,38 @@ fn eval_owned_identity_pipe<S: EvalSemantics, V: DocumentValue>(
         return continue_owned_identity_items::<S, V>(rest, out, optional, sink);
     }
     match strip_parens(stage) {
+        // #2471: the emitted key keeps the node's position, flagged so a
+        // second `key` emits nothing -- `id.key()` answers `None` for a key
+        // node, which is exactly yq's own `.a.b | key | key`.
         Expr::Builtin(Builtin::Key) => match id.key() {
-            Ok(Some(key)) => continue_owned_identity_plain::<S, V>(rest, key, optional, sink),
+            Ok(Some(key)) => eval_owned_identity_pipe::<S, V>(
+                rest,
+                key,
+                id.with_key_node(true),
+                optional,
+                sink,
+            ),
             Ok(None) => Flow::Exhausted,
             Err(e) => Flow::Escaped(Control::Error(e)),
         },
         Expr::Builtin(Builtin::PathNoArg) => match id.path() {
-            Ok(path) => {
-                continue_owned_identity_plain::<S, V>(rest, OwnedValue::Array(path), optional, sink)
-            }
+            Ok(path) => eval_owned_identity_pipe::<S, V>(
+                rest,
+                OwnedValue::Array(path),
+                id,
+                optional,
+                sink,
+            ),
             Err(e) => Flow::Escaped(Control::Error(e)),
         },
         // Same measured status as `path_context_resolve_constants`'s own
         // `FileIndex` arm (see its comment): the table exists now, this route
         // is not reached with one installed, and `id.path()` is what to feed
         // `file_index_for_path` when it is.
-        Expr::Builtin(Builtin::FileIndex) => continue_owned_identity_plain::<S, V>(
+        Expr::Builtin(Builtin::FileIndex) => eval_owned_identity_pipe::<S, V>(
             rest,
             OwnedValue::Int(ambient_file_index().unwrap_or(0)),
+            id,
             optional,
             sink,
         ),
@@ -15531,6 +15599,9 @@ fn owned_identity_leaving_cursor<S: EvalSemantics, V: DocumentValue>(
     let id = OwnedIdentity::kept(cursor);
     match rule {
         OwnedIdentityRule::Keeps => Ok(Some(id)),
+        // #2471: `key` at the cursor boundary -- the emitted key stands
+        // where the node stood, flagged so a second `key` emits nothing.
+        OwnedIdentityRule::KeyNode => Ok(Some(id.with_key_node(true))),
         OwnedIdentityRule::Detaches => Ok(Some(OwnedIdentity::detached())),
         OwnedIdentityRule::DetachesContainer => Ok(Some(if cursor.is_container() {
             OwnedIdentity::detached()
@@ -24322,12 +24393,21 @@ mod tests {
         assert!(!eager(".a | to_entries | getpath([0]) | key"));
         assert!(!eager(".a | to_entries | getpath([0, \"key\"]) | path"));
         assert!(!eager(".a | tostring | getpath([]) | path"));
-        // ...and stays eager where it has no rule, where path context is
-        // read after `key`/`path` already replaced the value, where the
-        // stage itself reads path context, or where a later stage does so
-        // in a shape the constants cannot express.
+        // #2471 sub-item 3: a path-context read *after* `key`/`path`/
+        // `file_index` replaced the value is answered from the identity
+        // too. The fresh scalar stands where the node stood, and `key`'s
+        // own output is flagged as a key node so a second `key` emits
+        // nothing (yq v4.53.3).
+        assert!(!eager(".a | tostring | key | key"));
+        assert!(!eager(".a | tostring | key | path"));
+        assert!(!eager(".a | tostring | key | tostring | key"));
+        assert!(!eager(".a.b | path | length | key"));
+        assert!(!eager(".a.b | file_index | key"));
+        assert!(!eager(".a.b | key | parent | key"));
+        // ...and stays eager where it has no rule, where the stage itself
+        // reads path context, or where a later stage does so in a shape the
+        // constants cannot express.
         assert!(eager(".a | explode | key"), "no identity rule");
-        assert!(eager(".a | tostring | key | key"), "key after key");
         assert!(
             eager(".a | [key] | .[0] | path"),
             "the stage reads path context"
@@ -24395,10 +24475,10 @@ mod tests {
         // `DefCall` is a runtime node the parser never produces, so its
         // argument gate is pinned by the CLI (`f(key + 10)` in
         // `test_shared_keeps_path_context_2416`) rather than here.
-        // An emitted `key`/`path` is a computed value: a later builtin no
-        // longer stands on a node.
-        assert!(eager(".[] | key | key"));
-        assert!(eager(".[] | (key) | length | path"));
+        // An emitted `key`/`path` keeps the node's position since #2471, so
+        // a later builtin reads it from the identity instead of bridging.
+        assert!(!eager(".[] | key | key"));
+        assert!(!eager(".[] | (key) | length | path"));
         // ...but `select`/`parent` keep the node, so a later builtin is fine.
         assert!(!eager(".[] | select(key == \"a\") | parent | key"));
         assert!(!eager(".a[] | select(key != \"c\") | parent"));

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -7549,17 +7549,14 @@ fn test_computed_navigation_keeps_path_context_2471() -> Result<()> {
     let doc = r#"{"a":{"b":[1,2,3],"c":"x","d":{"e":5}},"z":9}"#;
     for (filter, want) in [
         (".a | to_entries | .[(0,1)] | key", "0\n1"),
-        (
-            ".a | to_entries | .[(0,1)] | path",
-            "[\"a\",0]\n[\"a\",1]",
-        ),
+        (".a | to_entries | .[(0,1)] | path", "[\"a\",0]\n[\"a\",1]"),
         (".a | to_entries | .[(0,1)]? | key", "0\n1"),
-        (".a.b | sort | .[(0,1)] | path", "[\"a\",\"b\",0]\n[\"a\",\"b\",1]"),
-        (".a.b | sort | .[(-1)] | path", "[\"a\",\"b\",-1]"),
         (
-            ".a.b | sort | .[(1):(3)] | key",
-            "{\"start\":1,\"end\":3}",
+            ".a.b | sort | .[(0,1)] | path",
+            "[\"a\",\"b\",0]\n[\"a\",\"b\",1]",
         ),
+        (".a.b | sort | .[(-1)] | path", "[\"a\",\"b\",-1]"),
+        (".a.b | sort | .[(1):(3)] | key", "{\"start\":1,\"end\":3}"),
         (
             ".a.b | sort | .[(1):(3)] | path",
             "[\"a\",\"b\",{\"start\":1,\"end\":3}]",
@@ -7592,7 +7589,10 @@ fn test_computed_navigation_keeps_path_context_2471() -> Result<()> {
         Some(doc),
     )?;
     assert_eq!(code, 5, "{err:?}");
-    assert!(err.contains("Path must be specified as an array"), "{err:?}");
+    assert!(
+        err.contains("Path must be specified as an array"),
+        "{err:?}"
+    );
     Ok(())
 }
 

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -7596,6 +7596,47 @@ fn test_computed_navigation_keeps_path_context_2471() -> Result<()> {
     Ok(())
 }
 
+/// #2471 (gate reason 1 of spine 2416): a path-context read *after*
+/// `key`/`path`/`file_index` already replaced the value.
+///
+/// The fresh scalar stands where the node stood, and `key`'s own output is a
+/// *key node* -- a key has no key, so a second `key` emits nothing, while any
+/// other stage rebuilds an ordinary node at the same position and `key`
+/// answers again. Captured from yq v4.53.3 (`-o=json -I0`) on the YAML
+/// equivalent of this document; `key`/`path` with no argument are succinctly
+/// extensions in jq mode (real jq rejects `path/0 is not defined`), so yq's
+/// model is the only oracle there is and jq mode follows it:
+///
+/// ```text
+/// $ yq '.a.b | key | key'              (nothing)
+/// $ yq '.a.b | key | path'             ["a","b"]
+/// $ yq '.a.b | key | parent | key'     "a"
+/// $ yq '.a.b | key | tostring | key'   "b"
+/// $ yq '.a.b | path | length | key'    "b"
+/// $ yq '.a.b | file_index | key'       "b"
+/// ```
+#[test]
+fn test_path_context_after_key_or_path_2471() -> Result<()> {
+    let doc = r#"{"a":{"b":1,"a":7}}"#;
+    for (filter, want) in [
+        (".a.b | key | key", ""),
+        (".a.b | key | path", "[\"a\",\"b\"]"),
+        (".a.b | key | parent | key", "\"a\""),
+        (".a.b | key | tostring | key", "\"b\""),
+        (".a.b | key | length | key", "\"b\""),
+        (".a.b | tostring | key | key", ""),
+        (".a.b | tostring | key | path", "[\"a\",\"b\"]"),
+        (".a.b | path | key", "\"b\""),
+        (".a.b | path | length | key", "\"b\""),
+        (".a.b | file_index | key", "\"b\""),
+    ] {
+        let (out, _, code) = run_jq_full(&["-c", filter], Some(doc))?;
+        assert_eq!(code, 0, "`{filter}`: {out:?}");
+        assert_eq!(out.trim(), want, "`{filter}`");
+    }
+    Ok(())
+}
+
 /// Documents the one remaining deliberate, narrow gap #1663/#1765 leave
 /// open rather than silently missing: a `?//`-chained `AsPattern` (2+
 /// alternatives) still has no dedicated evaluation arm, so a path-context

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -7522,6 +7522,80 @@ fn test_shared_keeps_path_context_2416() -> Result<()> {
     Ok(())
 }
 
+/// #2471 (gate reason 1 of spine 2416): a *computed* index or slice, and
+/// `getpath(p)`, are navigation inside the owned domain too, so a pipe that
+/// left the cursor domain earlier keeps its position through them instead of
+/// falling to the eager evaluator.
+///
+/// jq mode keeps jq's own `path(.[expr])` model, captured from
+/// `/usr/bin/jq` 1.7.1 on this document:
+///
+/// ```text
+/// $ jq -c '[path(.a.b[(0,1)])]'   [["a","b",0],["a","b",1]]
+/// $ jq -c 'path(.a.b[(1):(3)])'   ["a","b",{"start":1,"end":3}]
+/// $ jq -c 'path(.a.b[(-1)])'      ["a","b",-1]
+/// $ jq -c 'path(getpath(["a","b",0]))'   ["a","b",0]
+/// $ jq -c 'path(getpath(["zz"]))'        ["zz"]
+/// ```
+///
+/// `key`/`path` with no argument are succinctly extensions in jq mode (real
+/// jq rejects `path/0 is not defined`), so the rows below pin succinctly's
+/// answers against that captured *component* model rather than against a
+/// whole-filter jq capture. yq mode's own rows -- where a slice keeps the
+/// container's position instead (#2215/#2463) -- are in
+/// `test_owned_identity_rules_match_yq_2416`.
+#[test]
+fn test_computed_navigation_keeps_path_context_2471() -> Result<()> {
+    let doc = r#"{"a":{"b":[1,2,3],"c":"x","d":{"e":5}},"z":9}"#;
+    for (filter, want) in [
+        (".a | to_entries | .[(0,1)] | key", "0\n1"),
+        (
+            ".a | to_entries | .[(0,1)] | path",
+            "[\"a\",0]\n[\"a\",1]",
+        ),
+        (".a | to_entries | .[(0,1)]? | key", "0\n1"),
+        (".a.b | sort | .[(0,1)] | path", "[\"a\",\"b\",0]\n[\"a\",\"b\",1]"),
+        (".a.b | sort | .[(-1)] | path", "[\"a\",\"b\",-1]"),
+        (
+            ".a.b | sort | .[(1):(3)] | key",
+            "{\"start\":1,\"end\":3}",
+        ),
+        (
+            ".a.b | sort | .[(1):(3)] | path",
+            "[\"a\",\"b\",{\"start\":1,\"end\":3}]",
+        ),
+        (
+            ".a.b | sort | .[(1):(3)] | .[0] | path",
+            "[\"a\",\"b\",{\"start\":1,\"end\":3},0]",
+        ),
+        (".a | to_entries | getpath([0]) | key", "0"),
+        (
+            ".a | to_entries | getpath([0, \"key\"]) | path",
+            "[\"a\",0,\"key\"]",
+        ),
+        (
+            ".a | to_entries | getpath([0, \"zz\"]) | path",
+            "[\"a\",0,\"zz\"]",
+        ),
+        (".a | tostring | getpath([]) | path", "[\"a\"]"),
+        (".a.b | sort | getpath([1]) | key", "1"),
+    ] {
+        let (out, _, code) = run_jq_full(&["-c", filter], Some(doc))?;
+        assert_eq!(code, 0, "`{filter}`: {out:?}");
+        assert_eq!(out.trim(), want, "`{filter}`");
+    }
+    // A non-array argument still raises the owned evaluator's own message:
+    // the values every row above reports come from that one evaluator, so
+    // only the path component is derived by the identity pipe.
+    let (_, err, code) = run_jq_full(
+        &["-c", ".a | to_entries | getpath(\"x\") | path"],
+        Some(doc),
+    )?;
+    assert_eq!(code, 5, "{err:?}");
+    assert!(err.contains("Path must be specified as an array"), "{err:?}");
+    Ok(())
+}
+
 /// Documents the one remaining deliberate, narrow gap #1663/#1765 leave
 /// open rather than silently missing: a `?//`-chained `AsPattern` (2+
 /// alternatives) still has no dedicated evaluation arm, so a path-context

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -32425,6 +32425,21 @@ const OWNED_IDENTITY_ROWS_2416: &[(&str, &str)] = &[
     (".a.c | path | parent | key", r#""a""#),
     (".a.c | file_index | key", r#""c""#),
     (".a.b | to_entries | .[0].value | key | key", ""),
+    // #2471 sub-item 5: a path-context read under arithmetic or comparison
+    // inside a ruled stage. `path`/`file_index` build an ordinary node at
+    // the position, so the result stands where the input stood; `key`'s own
+    // output is a key node with no parent of its own, so arithmetic over it
+    // is detached.
+    (".a | to_entries | .[0] | key + 1", "1"),
+    (".a | to_entries | .[0] | key + 1 | key", ""),
+    (".a | to_entries | .[0] | (key + 1) | path", "[]"),
+    (".a | to_entries | .[0] | (key == 0)", "true"),
+    (".a | to_entries | .[0] | (key == 0) | key", ""),
+    (".a | to_entries | .[0] | (path + []) | key", "0"),
+    (".a | to_entries | .[0] | (path + []) | path", r#"["a",0]"#),
+    (".a | to_entries | .[0] | (file_index + 0) | key", "0"),
+    (r#".a.c | tostring | key + "x""#, r#""cx""#),
+    (r#".a.c | tostring | (key + "x") | key"#, ""),
 ];
 
 /// #2460: real yq's binary operators when one operand produces **zero

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -32407,6 +32407,24 @@ const OWNED_IDENTITY_ROWS_2416: &[(&str, &str)] = &[
     (".a.b | sort | .[(-1)] | key", "2"),
     (".a.b | sort | .[(-1)] | path", r#"["a","b",2]"#),
     (".a.d | to_entries | .[(0)] | key", "0"),
+    // #2471 sub-item 3: `key`/`path`/`file_index` replace the value with a
+    // fresh scalar that keeps the node's position, and `key`'s own output
+    // is a *key node* -- a second `key` emits nothing, while any other
+    // stage rebuilds an ordinary node at the same position and `key`
+    // answers again.
+    (".a.c | key | key", ""),
+    (".a.c | key | path", r#"["a","c"]"#),
+    (".a.c | key | parent | key", r#""a""#),
+    (".a.c | key | length | key", r#""c""#),
+    (".a.c | key | tostring | key", r#""c""#),
+    (".a.c | tostring | key | key", ""),
+    (".a.c | tostring | key | path", r#"["a","c"]"#),
+    (".a.c | tostring | key | tostring | key", r#""c""#),
+    (".a.c | path | key", r#""c""#),
+    (".a.c | path | length | key", r#""c""#),
+    (".a.c | path | parent | key", r#""a""#),
+    (".a.c | file_index | key", r#""c""#),
+    (".a.b | to_entries | .[0].value | key | key", ""),
 ];
 
 /// #2460: real yq's binary operators when one operand produces **zero

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -32372,6 +32372,41 @@ const OWNED_IDENTITY_ROWS_2416: &[(&str, &str)] = &[
     (".a.b | map(. + 1) | .[0] | parent | parent | path", ""),
     (".a.b | sort | .[0] | parent | path", r#"["a","b"]"#),
     (".a.b | sort | .[0] | parent | parent | key", r#""a""#),
+    // #2471 sub-item 1: a *computed* index or slice inside the owned domain
+    // is navigation like its literal sibling, `?` over it included. Real
+    // yq keeps the container's position for a slice, exactly as it does for
+    // the literal `.[1:]` rows above.
+    (
+        ".a | to_entries | .[(0,1)] | key",
+        "0
+1",
+    ),
+    (
+        ".a | to_entries | .[(0,1)] | path",
+        r#"["a",0]
+["a",1]"#,
+    ),
+    (
+        ".a | to_entries | .[(0,1)]? | key",
+        "0
+1",
+    ),
+    (
+        ".a | to_entries | .[(0,1)] | parent | key",
+        r#""a"
+"a""#,
+    ),
+    (
+        ".a.b | sort | .[(0,1)] | key",
+        "0
+1",
+    ),
+    (".a.b | sort | .[(1):(3)] | key", r#""b""#),
+    (".a.b | sort | .[(1):(3)] | .[0] | path", r#"["a","b",0]"#),
+    (".a.b | sort | .[(1):(3)]? | key", r#""b""#),
+    (".a.b | sort | .[(-1)] | key", "2"),
+    (".a.b | sort | .[(-1)] | path", r#"["a","b",2]"#),
+    (".a.d | to_entries | .[(0)] | key", "0"),
 ];
 
 /// #2460: real yq's binary operators when one operand produces **zero


### PR DESCRIPTION
## Summary

Three of #2471's five sub-items, each its own commit, with a docs commit recording the rules and the arm re-audit.

1. **Computed `IndexExpr`/`SliceExpr` (and `?` over them) and `getpath(p)` navigate the owned identity pipe.** Components are derived by the resolver the absent route already uses; every value still comes from the ordinary owned evaluator, so error text and mode-specific indexing keep one definition. Mode decides the slice component: yq keeps the container's position, jq takes `{"start","end"}` (#2215, #2463). Rows captured from yq v4.53.3 and `/usr/bin/jq` 1.7.1.
2. **A read after `key`/`path`/`file_index` keeps the node's position.** The issue's premise (a detached identity) was wrong against the oracle: yq keeps the position and only refuses a second `key`, so `.a.b | key | key` is nothing and `.a.b | key | path` is `["a","b"]`; a `key_node` flag on the identity expresses that.
3. **Path context under arithmetic inside a ruled owned stage** resolves through the constant resolver's new arithmetic arm, placed by the left-operand rule (a bare `path`/`file_index` operand keeps the position, a bare `key` operand is detached): `to_entries | .[0] | key + 1 | key` is nothing. One row pinned as divergent with its reason: `.a.c | tostring | (key + "x") | path` is `["a","cx"]` in yq, a path naming a node that does not exist.

## Left open on #2471

- **`with_entries`/`map_values` bodies and an assignment's right-hand side** (`.a | with_entries(.value = key)` is `{"b":0,"e":1}` in yq). Two blockers: `needs_path_context` does not descend into those bodies or into an assignment RHS, and real yq evaluates a map-family body at each member's own position, which needs cursor-threading `map_values`/`with_entries` arms in the generic evaluator rather than new eager arms. `map(f)` itself is already exact.
- **A computed bracket or `getpath` at the head of a pipe** still takes the eager route: nothing has left the cursor domain yet, and the cursor walk cannot evaluate a component uniformly because an absent position carries no cursor. This is why the five reason-1 arms still fire their proof queries; the pin stays at 43 with the re-audit recorded in `docs/plan/path-context-arm-reachability.md`.
- Residual captures: yq stringifies an array-index key node (`.[] | key | path` is `["0"]`) and reports `[]` for the key node of a synthesized element.

## Verification

fmt; clippy on all CI legs with `-D warnings`; `cargo test` in the three configurations plus `simd,scalar-yaml`; `cargo doc -D warnings`; yq goldens 113 and jq goldens 633; oracle sweep 3168 cases, 0 unexpected, manifest unchanged.

Part of #2471 (spine 2416, gate reason 1), which stays open for the map-family bodies and the head-of-pipe bracket.
