### PR TITLE
fix(yq): stop reconcile_presentation misattributing style across a position-shifting write

### DIFF
--- a/src/bin/succinctly/yq_runner.rs
+++ b/src/bin/succinctly/yq_runner.rs
@@ -6,6 +6,9 @@
 use anyhow::{Context, Result};
 use indexmap::IndexMap;
 use std::cell::Cell;
+use std::collections::hash_map::DefaultHasher;
+use std::collections::{HashMap, VecDeque};
+use std::hash::{Hash, Hasher};
 use std::io::{BufWriter, IsTerminal, Read, Write};
 use std::path::Path;
 
@@ -21,7 +24,8 @@ use succinctly::jq::eval_generic::{
 use succinctly::jq::stream::StreamFailure;
 use succinctly::jq::{
     self, assert_value_tree_depth, nesting_depth_exceeded_message, nonfinite_display_string,
-    sync_aliased_paths, Builtin, EvalError, Expr, NumberRepr, OwnedValue, QueryResult, YqSemantics,
+    sync_aliased_paths, Builtin, EvalError, Expr, NumberRepr, ObjectKey, OwnedValue, QueryResult,
+    YqSemantics,
 };
 use succinctly::json::light::JsonCursor;
 use succinctly::json::JsonIndex;
@@ -1873,6 +1877,11 @@ enum WriteKind {
 struct WriteTarget {
     path: Vec<PathStep>,
     kind: WriteKind,
+    /// The written value is a closed literal — it reads nothing from the
+    /// document, so every node it produces is freshly constructed and can
+    /// have inherited no presentation from anything. See
+    /// [`is_closed_literal`].
+    fresh: bool,
 }
 
 /// Collect the [`PathStep`]s of a *static* navigation chain, returning
@@ -1908,6 +1917,37 @@ fn static_path_steps(expr: &Expr, out: &mut Vec<PathStep>) -> bool {
     }
 }
 
+/// Whether `expr` produces a value that reads nothing from the document, so
+/// every node in it is freshly constructed (#870).
+///
+/// Real yq carries presentation on node identity: `.o = {"a": "1"}` drops
+/// `a`'s old comment because the `"1"` in the filter is a *new* scalar node,
+/// while `.o = {"a": .o.a}` keeps it because that one is the original node
+/// arriving by a different route (both verified against yq v4.53.3).
+/// Provable closedness is the half of that distinction reachable without a
+/// shared-node value model (#1351).
+///
+/// Deliberately one-directional: `true` means "certainly constructed", and
+/// anything not on this list answers `false` even when it happens to be
+/// closed. A false `true` would *discard* presentation the document really
+/// owns, so the burden of proof sits on the destructive answer.
+fn is_closed_literal(expr: &Expr) -> bool {
+    match expr {
+        Expr::Literal(_) => true,
+        Expr::Array(inner) | Expr::Paren(inner) | Expr::Negate(inner) => is_closed_literal(inner),
+        Expr::Comma(parts) => parts.iter().all(is_closed_literal),
+        Expr::Arithmetic { left, right, .. } => is_closed_literal(left) && is_closed_literal(right),
+        Expr::Object(entries) => entries.iter().all(|e| {
+            let key_closed = match &e.key {
+                ObjectKey::Literal(_) => true,
+                ObjectKey::Expr(k) => is_closed_literal(k),
+            };
+            key_closed && is_closed_literal(&e.value)
+        }),
+        _ => false,
+    }
+}
+
 /// Resolve which paths `expr` writes to, or `None` when any write stage's
 /// left-hand side is not a static navigation chain (#870).
 ///
@@ -1929,22 +1969,22 @@ fn static_path_steps(expr: &Expr, out: &mut Vec<PathStep>) -> bool {
 /// rejected by [`static_path_steps`] instead of being resolved against a
 /// document that may already be stale.
 fn collect_write_targets(expr: &Expr) -> Option<Vec<WriteTarget>> {
-    fn push(lhs: &Expr, kind: WriteKind, out: &mut Vec<WriteTarget>) -> bool {
+    fn push(lhs: &Expr, kind: WriteKind, fresh: bool, out: &mut Vec<WriteTarget>) -> bool {
         match lhs {
-            Expr::Paren(inner) => push(inner, kind, out),
+            Expr::Paren(inner) => push(inner, kind, fresh, out),
             // `del(.arr[0], .arr[2])` removes both, and each branch is a
             // path of its own — a generator is only valid on a `del`'s
             // left, never an assignment's, so this arm is gated on `Del`
             // rather than accepting `.a, .b = 1`.
             Expr::Comma(branches) if kind == WriteKind::Del => {
-                branches.iter().all(|b| push(b, kind, out))
+                branches.iter().all(|b| push(b, kind, fresh, out))
             }
             _ => {
                 let mut path = Vec::new();
                 if !static_path_steps(lhs, &mut path) {
                     return false;
                 }
-                out.push(WriteTarget { path, kind });
+                out.push(WriteTarget { path, kind, fresh });
                 true
             }
         }
@@ -1952,11 +1992,16 @@ fn collect_write_targets(expr: &Expr) -> Option<Vec<WriteTarget>> {
 
     fn walk(expr: &Expr, out: &mut Vec<WriteTarget>) -> bool {
         match expr {
-            Expr::Assign { path, .. }
-            | Expr::Update { path, .. }
+            // Only a plain `=` can be proved to write a constructed value:
+            // `|=`'s filter and a compound assign's operator both read the
+            // node already there, so their result is never wholly fresh.
+            Expr::Assign { path, value } => {
+                push(path, WriteKind::Set, is_closed_literal(value), out)
+            }
+            Expr::Update { path, .. }
             | Expr::CompoundAssign { path, .. }
-            | Expr::AlternativeAssign { path, .. } => push(path, WriteKind::Set, out),
-            Expr::Builtin(Builtin::Del(inner)) => push(inner, WriteKind::Del, out),
+            | Expr::AlternativeAssign { path, .. } => push(path, WriteKind::Set, false, out),
+            Expr::Builtin(Builtin::Del(inner)) => push(inner, WriteKind::Del, false, out),
             Expr::Identity
             | Expr::Builtin(
                 Builtin::Select(_) | Builtin::Empty | Builtin::Debug | Builtin::DebugMsg(_),
@@ -1968,12 +2013,42 @@ fn collect_write_targets(expr: &Expr) -> Option<Vec<WriteTarget>> {
     }
 
     let mut out = Vec::new();
-    walk(expr, &mut out).then_some(out)
+    if !walk(expr, &mut out) {
+        return None;
+    }
+
+    // Stage order is invisible here, and a `del` at an array index makes it
+    // matter: it renumbers every later slot, so a static index from another
+    // stage means one node before the `del` and a different one after.
+    // `.arr[1] = ... | del(.arr[0])` and `del(.arr[0]) | .arr[0] = ...` are
+    // the same two writes in this list and different documents on the page.
+    //
+    // Deletions from the *same* array are exempt — `array_sources` removes
+    // them as one set, which is what `del(.arr[0], .arr[2])` means anyway —
+    // and so is any path that never enters the array at all (`.z = 1 |
+    // del(.arr[0])`). Anything else gives up the whole expression rather
+    // than reconcile against an order it cannot see.
+    let ambiguous = out.iter().enumerate().any(|(di, d)| {
+        if d.kind != WriteKind::Del {
+            return false;
+        }
+        let Some((PathStep::Index(_), parent)) = d.path.split_last() else {
+            return false;
+        };
+        out.iter().enumerate().any(|(ti, t)| {
+            ti != di
+                && t.path.len() > parent.len()
+                && t.path[..parent.len()] == *parent
+                && !(t.kind == WriteKind::Del && t.path.len() == parent.len() + 1)
+        })
+    });
+    (!ambiguous).then_some(out)
 }
 
 /// A write path, relative to the node currently being reconciled, paired
-/// with what the write did there (#870).
-type RelTarget<'t> = (&'t [PathStep], WriteKind);
+/// with what the write did there and whether its value was constructed
+/// outright (#870).
+type RelTarget<'t> = (&'t [PathStep], WriteKind, bool);
 
 /// Turn a jq index (possibly negative) into a slot of a `len`-element
 /// container, matching `numeric_key_to_index`'s from-the-end convention.
@@ -1991,8 +2066,8 @@ fn resolve_index(idx: i64, len: usize) -> Option<usize> {
 fn descend_key<'t>(targets: &[RelTarget<'t>], key: &str) -> Vec<RelTarget<'t>> {
     targets
         .iter()
-        .filter_map(|(steps, kind)| match steps.split_first() {
-            Some((PathStep::Key(k), rest)) if k == key => Some((rest, *kind)),
+        .filter_map(|(steps, kind, fresh)| match steps.split_first() {
+            Some((PathStep::Key(k), rest)) if k == key => Some((rest, *kind, *fresh)),
             _ => None,
         })
         .collect()
@@ -2003,9 +2078,9 @@ fn descend_key<'t>(targets: &[RelTarget<'t>], key: &str) -> Vec<RelTarget<'t>> {
 fn descend_index<'t>(targets: &[RelTarget<'t>], index: usize, len: usize) -> Vec<RelTarget<'t>> {
     targets
         .iter()
-        .filter_map(|(steps, kind)| match steps.split_first() {
+        .filter_map(|(steps, kind, fresh)| match steps.split_first() {
             Some((PathStep::Index(n), rest)) if resolve_index(*n, len) == Some(index) => {
-                Some((rest, *kind))
+                Some((rest, *kind, *fresh))
             }
             _ => None,
         })
@@ -2027,43 +2102,54 @@ fn array_sources(
     r_items: &[OwnedValue],
     targets: &[RelTarget<'_>],
 ) -> Vec<Option<usize>> {
-    // A wholesale write at this array (`.arr = <expr>`, `|=`, `+=`)
-    // replaces its contents outright, so slot `i` of the result is not slot
-    // `i` of the pristine in any meaningful sense — a prepend shifts
-    // everything down one, a reverse turns the order around.
-    //
-    // Real yq carries presentation on *node identity*: an element the
-    // expression referenced keeps its own comment and style, one it
-    // constructed gets none. Matching each result element to the first
-    // still-unclaimed pristine element holding an equal value, in order,
-    // approximates that without a shared-node value model (#1351) — and
-    // reproduces yq exactly for the prepend and reverse that motivated this
-    // issue. Where it still differs is a constructed literal that happens
-    // to equal an old element; see [`reconcile_presentation`]'s own doc
-    // comment.
-    //
-    // Checked before the `del` remap below: once the array has been
-    // rewritten wholesale, pristine *positions* mean nothing, so a `del`
-    // in the same pipe has no positional model left to remap against.
-    if targets
+    let wholesale = targets
         .iter()
-        .any(|(steps, kind)| steps.is_empty() && *kind == WriteKind::Set)
-    {
-        let mut claimed = vec![false; p_items.len()];
-        return r_items
+        .find(|(steps, kind, _)| steps.is_empty() && *kind == WriteKind::Set);
+
+    if let Some((_, _, fresh)) = wholesale {
+        // A closed literal built every element here, so none of them can
+        // have inherited anything: `.arr = ["p","q"]` prints two bare
+        // scalars in real yq even where the old slots were quoted and
+        // commented.
+        if *fresh {
+            return vec![None; r_items.len()];
+        }
+
+        // Otherwise the expression read the document, so some of these
+        // elements may be nodes that were already here, arriving at a new
+        // slot: a prepend shifts everything down one, a reverse turns the
+        // order around. Match each result element to a pristine element
+        // holding an equal value.
+        let aligned = align_by_value(p_items, r_items);
+
+        // Only *use* that alignment where it is actually evidence of
+        // movement, because equal values are circumstantial: `.arr |= [.[]
+        // + 1]` turns `[1, 2]` into `[2, 3]`, which reads as "the 2 moved
+        // down a slot and the 3 is new" and is really "each element was
+        // incremented where it stood". Real yq keeps each node's own
+        // comment there, exactly as the positional walk always did, and
+        // reading the coincidence as movement would take that away — a step
+        // backwards, not the gap this issue is about.
+        //
+        // Two things make it real rather than circumstantial:
+        //
+        // 1. something has to have moved at all (`p != i` somewhere), which
+        //    rules out a self-assign and an append; and
+        // 2. at equal lengths, every element has to be accounted for. A
+        //    genuine permutation — a reverse, a sort, a rotation — is a
+        //    bijection; a coincidental overlap leaves some result element
+        //    unmatched, as `[1, 2] -> [2, 3]` leaves the 3.
+        //
+        // A length change is movement on its own: inserting or removing an
+        // element shifts its neighbours whatever the values say.
+        let moved = aligned
             .iter()
-            .map(|r_v| {
-                let found = p_items
-                    .iter()
-                    .enumerate()
-                    .find(|(p, p_v)| !claimed[*p] && *p_v == r_v)
-                    .map(|(p, _)| p);
-                if let Some(p) = found {
-                    claimed[p] = true;
-                }
-                found
-            })
-            .collect();
+            .enumerate()
+            .any(|(i, src)| src.is_some_and(|p| p != i));
+        let accounted = p_items.len() != r_items.len() || aligned.iter().all(Option::is_some);
+        if moved && accounted {
+            return aligned;
+        }
     }
 
     // `del(.arr[k])` shifts every later element down one slot, so slot `i`
@@ -2072,7 +2158,7 @@ fn array_sources(
     // of index 1's. The removed set is known exactly, so the remap is too.
     let mut removed: Vec<usize> = targets
         .iter()
-        .filter_map(|(steps, kind)| match (steps, kind) {
+        .filter_map(|(steps, kind, _)| match (steps, kind) {
             ([PathStep::Index(n)], WriteKind::Del) => resolve_index(*n, p_items.len()),
             _ => None,
         })
@@ -2094,6 +2180,102 @@ fn array_sources(
     }
 
     (0..r_items.len()).map(Some).collect()
+}
+
+/// Pair each element of `r_items` with a distinct element of `p_items`
+/// holding an equal value, in order (#870).
+///
+/// Indexes the pristine elements by [`owned_value_align_hash`] first, so a
+/// long sequence costs one pass rather than a scan per element — a 100k
+/// `.arr |= reverse` was quadratic when this matched by rescanning.
+///
+/// Ties are broken by document order, which is right for an insertion or a
+/// deletion but arbitrary for a permutation of *equal* elements: reversing
+/// `[a # c0, a # c1]` pairs `c0` with the first `a` where real yq, which
+/// tracks node identity, pairs `c1`. Values alone cannot tell those apart;
+/// see [`reconcile_presentation`]'s own doc comment.
+fn align_by_value(p_items: &[OwnedValue], r_items: &[OwnedValue]) -> Vec<Option<usize>> {
+    let mut buckets: HashMap<u64, VecDeque<usize>> = HashMap::new();
+    for (i, v) in p_items.iter().enumerate() {
+        buckets
+            .entry(owned_value_align_hash(v))
+            .or_default()
+            .push_back(i);
+    }
+    r_items
+        .iter()
+        .map(|r_v| {
+            let candidates = buckets.get_mut(&owned_value_align_hash(r_v))?;
+            // The hash only narrows: equal values always share a bucket,
+            // but a bucket can hold unequal ones (two i64 that round to the
+            // same f64), and a NaN element equals nothing at all — so the
+            // match is still decided by `==`.
+            let pos = candidates.iter().position(|&p| p_items[p] == *r_v)?;
+            candidates.remove(pos)
+        })
+        .collect()
+}
+
+/// Hash an [`OwnedValue`] consistently with its own `PartialEq`, for
+/// [`align_by_value`]'s bucketing (#870).
+///
+/// `OwnedValue`'s equality is *jq value equality*, not structural, so this
+/// has to agree with it on three points or equal values land in different
+/// buckets and the alignment silently misses them:
+///
+/// 1. `Int`, `Float` and `NumberLiteral` compare across variants by `f64`
+///    value, so all three hash through one canonical `f64`.
+/// 2. `-0.0 == 0.0`, whose bit patterns differ — zero is normalized first.
+/// 3. `Object` equality is order-independent (it mirrors `IndexMap`'s), so
+///    fields are combined with a commutative fold rather than in order.
+///
+/// The converse is not required: unequal values may collide freely, since
+/// [`align_by_value`] confirms every candidate with `==` anyway. NaN, which
+/// equals nothing, therefore needs no special case here.
+fn owned_value_align_hash(value: &OwnedValue) -> u64 {
+    fn number_bits(n: f64) -> u64 {
+        // `+0.0` and `-0.0` are equal but differently encoded.
+        if n == 0.0 { 0.0_f64 } else { n }.to_bits()
+    }
+
+    fn hash_at_depth(value: &OwnedValue, depth: usize) -> u64 {
+        assert_value_tree_depth(depth);
+        let mut h = DefaultHasher::new();
+        match value {
+            OwnedValue::Null => 0_u8.hash(&mut h),
+            OwnedValue::Bool(b) => (1_u8, b).hash(&mut h),
+            OwnedValue::Int(i) => (2_u8, number_bits(*i as f64)).hash(&mut h),
+            OwnedValue::Float(f) => (2_u8, number_bits(*f)).hash(&mut h),
+            OwnedValue::NumberLiteral(repr, _) => {
+                let n = match repr {
+                    NumberRepr::Int(i) => *i as f64,
+                    NumberRepr::Float(f) => *f,
+                };
+                (2_u8, number_bits(n)).hash(&mut h);
+            }
+            OwnedValue::String(s) => (3_u8, s).hash(&mut h),
+            OwnedValue::Array(items) => {
+                (4_u8, items.len()).hash(&mut h);
+                for item in items {
+                    hash_at_depth(item, depth + 1).hash(&mut h);
+                }
+            }
+            OwnedValue::Object(fields) => {
+                (5_u8, fields.len()).hash(&mut h);
+                // Commutative: `{a: 1, b: 2}` and `{b: 2, a: 1}` are equal.
+                let combined = fields.iter().fold(0_u64, |acc, (k, v)| {
+                    let mut fh = DefaultHasher::new();
+                    k.hash(&mut fh);
+                    hash_at_depth(v, depth + 1).hash(&mut fh);
+                    acc ^ fh.finish()
+                });
+                combined.hash(&mut h);
+            }
+        }
+        h.finish()
+    }
+
+    hash_at_depth(value, 0)
 }
 
 /// Reconcile a pristine (pre-write) presentation tree against a post-write
@@ -2121,32 +2303,45 @@ fn array_sources(
 /// the YAML documents this rewrites are config-file-sized, not
 /// data-file-sized.
 ///
-/// `targets` closes most of what #870 filed against the lockstep walk. A
-/// pure before/after value diff cannot tell "recursing into an untouched
-/// sibling subtree" apart from "recursing into a subtree the write
-/// reshuffled" — both look identical — so a write that moves an `Array`'s
-/// elements used to hand each new element whichever old element now
-/// happens to sit at its index. [`collect_write_targets`] resolves the
-/// paths a write actually touched straight from the AST (no
-/// `resolve_dynamic_indexes` plumbing needed, and no dependence on the
-/// document), and [`array_sources`] uses them to map each result slot back
-/// to the pristine slot it really came from: an exact remap across a
-/// `del()`, and a value-identity alignment across a wholesale write. An
-/// empty `targets` — a write whose path isn't static, e.g.
+/// `targets` closes what #870 filed against the lockstep walk. A pure
+/// before/after value diff cannot tell "recursing into an untouched sibling
+/// subtree" apart from "recursing into a subtree the write reshuffled" —
+/// both look identical — so a write that moves an `Array`'s elements used
+/// to hand each new element whichever old element now sits at its index.
+/// [`collect_write_targets`] resolves the paths a write actually touched
+/// straight from the AST (no `resolve_dynamic_indexes` plumbing needed, and
+/// no dependence on the document), and the arms below use them to decide
+/// what each result node may inherit:
+///
+/// - a `del()` gets an exact index remap ([`array_sources`]);
+/// - a wholesale write of a **closed literal** ([`is_closed_literal`])
+///   inherits nothing at all, matching yq's fresh construction;
+/// - any other wholesale write of an array aligns by value
+///   ([`align_by_value`]), but only where the alignment is real evidence of
+///   movement rather than a coincidence of equal values;
+/// - everything else stays positional, exactly as before #870.
+///
+/// An empty `targets` — a write whose path isn't static, e.g.
 /// `.arr[(.i)] = 1` — falls back to the pre-#870 lockstep walk unchanged.
 ///
-/// **Remaining gap**: real `yq` carries presentation on *node identity*,
-/// so a freshly constructed literal never inherits anything even when its
-/// value happens to equal an old node's. `.arr = ["b","a","a"]` over
-/// `[a # c0, a # c1, b # c2]` prints three bare scalars in `yq`; the
-/// value-identity alignment here matches them up and keeps the comments.
-/// Object fields have the same gap (`.o = {"a": "1"}` keeps `a`'s old
-/// comment where `yq` drops it) and are deliberately left on key matching:
-/// aligning object children by *value* would let one key inherit a
-/// different key's comment, which is the very misattribution #870 is
-/// about. Closing either needs the shared-node value model tracked by
-/// #1351 and #865. Purely cosmetic throughout (no data loss, no incorrect
-/// *values*).
+/// **Remaining gaps.** All three predate #870 and none is a wrong *value*:
+///
+/// 1. Real `yq` carries presentation on *node identity*, which values can
+///    only approximate. Under a genuine permutation of **equal** elements
+///    the pairing is arbitrary: reversing `[a # c0, a # c1]` pairs `c0`
+///    with the first `a` where `yq`, which knows the nodes, pairs `c1`.
+/// 2. Stage order is invisible in `targets`, and a `del` at an array index
+///    renumbers slots, so `.arr[1] = ... | del(.arr[0])` and its reverse
+///    are the same target list and different documents.
+///    [`collect_write_targets`] detects that shape and declines the whole
+///    expression rather than guess, leaving it on the positional walk.
+/// 3. Object fields are matched by key, never aligned by value: a key names
+///    the same node however the map is reordered, and aligning object
+///    children by value would let one key inherit a *different* key's
+///    comment — the very misattribution #870 is about.
+///
+/// Closing (1) and (2) properly needs the shared-node value model tracked
+/// by #1351 and #865.
 fn reconcile_presentation(
     pristine_value: &OwnedValue,
     pristine_tree: &CommentTree,
@@ -2155,7 +2350,7 @@ fn reconcile_presentation(
 ) -> CommentTree {
     let relative: Vec<RelTarget<'_>> = targets
         .iter()
-        .map(|t| (t.path.as_slice(), t.kind))
+        .map(|t| (t.path.as_slice(), t.kind, t.fresh))
         .collect();
     reconcile_presentation_at_depth(pristine_value, pristine_tree, result_value, &relative, 0)
 }
@@ -2177,15 +2372,21 @@ fn reconcile_presentation_at_depth(
             let own_meta = pristine_tree.meta().clone();
             let mut fields = IndexMap::new();
             let mut key_comments = IndexMap::new();
+            // A closed literal built every field here, so none of them can
+            // have inherited anything: real yq prints `.o = {"a": "1"}` with
+            // no comment on `a`, even where the value is unchanged.
+            let fresh_write = targets
+                .iter()
+                .any(|(steps, kind, fresh)| steps.is_empty() && *kind == WriteKind::Set && *fresh);
             for (k, r_v) in r_fields {
-                // Object children stay matched by key: a key names the same
-                // node before and after a write however the map is
+                // Object children are otherwise matched by key: a key names
+                // the same node before and after a write however the map is
                 // reordered, so there is no position to misattribute across
                 // (verified: `yq '.o = {"b": .o.b, "a": .o.a}'` keeps each
                 // field's own comment with its own key). See this function's
                 // doc comment for the object-side gap this leaves open.
                 let child_targets = descend_key(targets, k);
-                let child = match p_fields.get(k) {
+                let child = match p_fields.get(k).filter(|_| !fresh_write) {
                     Some(p_v) => reconcile_presentation_at_depth(
                         p_v,
                         pristine_tree.field(k),
@@ -2209,7 +2410,7 @@ fn reconcile_presentation_at_depth(
                 // key and comment, silently dropping the write's value
                 // entirely (found in review).
                 if let CommentTree::Object(_, _, pristine_key_comments) = pristine_tree {
-                    if let Some((kc, _)) = pristine_key_comments.get(k) {
+                    if let Some((kc, _)) = pristine_key_comments.get(k).filter(|_| !fresh_write) {
                         let value_absent = matches!(r_v, OwnedValue::Null);
                         key_comments.insert(k.clone(), (kc.clone(), value_absent));
                     }
@@ -7847,10 +8048,169 @@ mod tests {
         let pristine = [OwnedValue::Int(1), OwnedValue::Int(2), OwnedValue::Int(3)];
         let result = [OwnedValue::Int(2), OwnedValue::Int(3), OwnedValue::Int(9)];
         let steps = [PathStep::Index(0)];
-        let targets = [(&steps[..], WriteKind::Del)];
+        let targets = [(&steps[..], WriteKind::Del, false)];
         assert_eq!(
             array_sources(&pristine, &result, &targets),
             vec![Some(0), Some(1), Some(2)]
         );
+    }
+
+    /// The alignment hash has to agree with `OwnedValue`'s own *jq value*
+    /// equality, not with structural equality: any pair that compares equal
+    /// must land in the same bucket, or [`align_by_value`] silently fails
+    /// to match them. These are the three ways that can go wrong.
+    #[test]
+    fn owned_value_align_hash_agrees_with_value_equality_870() {
+        let equal_pairs = [
+            // Numbers compare across all three variants by f64 value.
+            (OwnedValue::Int(1), OwnedValue::Float(1.0)),
+            (
+                OwnedValue::Int(1),
+                OwnedValue::NumberLiteral(NumberRepr::Int(1), "1".into()),
+            ),
+            (
+                OwnedValue::Float(1.0),
+                OwnedValue::NumberLiteral(NumberRepr::Float(1.0), "1.0".into()),
+            ),
+            // `-0.0 == 0.0`, with different bit patterns.
+            (OwnedValue::Float(-0.0), OwnedValue::Float(0.0)),
+            (OwnedValue::Int(0), OwnedValue::Float(-0.0)),
+            // Object equality is order-independent.
+            (
+                OwnedValue::Object(IndexMap::from_iter([
+                    ("a".to_string(), OwnedValue::Int(1)),
+                    ("b".to_string(), OwnedValue::Int(2)),
+                ])),
+                OwnedValue::Object(IndexMap::from_iter([
+                    ("b".to_string(), OwnedValue::Int(2)),
+                    ("a".to_string(), OwnedValue::Int(1)),
+                ])),
+            ),
+            // ...including nested, and mixing the number rule in.
+            (
+                OwnedValue::Array(vec![OwnedValue::Object(IndexMap::from_iter([(
+                    "n".to_string(),
+                    OwnedValue::Int(2),
+                )]))]),
+                OwnedValue::Array(vec![OwnedValue::Object(IndexMap::from_iter([(
+                    "n".to_string(),
+                    OwnedValue::Float(2.0),
+                )]))]),
+            ),
+        ];
+        for (a, b) in equal_pairs {
+            assert_eq!(a, b, "test premise: {a:?} should equal {b:?}");
+            assert_eq!(
+                owned_value_align_hash(&a),
+                owned_value_align_hash(&b),
+                "equal values must hash equal: {a:?} vs {b:?}"
+            );
+        }
+    }
+
+    /// Values that differ only by *position* inside a container must not
+    /// collide, or the alignment stops distinguishing arrays it should.
+    /// (Unequal values are allowed to collide — `align_by_value` confirms
+    /// every candidate with `==` — this just checks the hash is not
+    /// uselessly coarse.)
+    #[test]
+    fn owned_value_align_hash_distinguishes_array_order_870() {
+        let a = OwnedValue::Array(vec![OwnedValue::Int(1), OwnedValue::Int(2)]);
+        let b = OwnedValue::Array(vec![OwnedValue::Int(2), OwnedValue::Int(1)]);
+        assert_ne!(a, b);
+        assert_ne!(owned_value_align_hash(&a), owned_value_align_hash(&b));
+    }
+
+    /// NaN equals nothing, itself included, so it can never be matched —
+    /// whatever it hashes to, the `==` confirmation rejects it.
+    #[test]
+    fn align_by_value_never_matches_nan_870() {
+        let nan = [OwnedValue::Float(f64::NAN)];
+        assert_eq!(align_by_value(&nan, &nan), vec![None]);
+    }
+
+    /// Each pristine element is claimed at most once, so a result with more
+    /// copies of a value than the document had leaves the extras unmatched.
+    #[test]
+    fn align_by_value_claims_each_element_once_870() {
+        let pristine = [OwnedValue::Int(7), OwnedValue::Int(8)];
+        let result = [
+            OwnedValue::Int(8),
+            OwnedValue::Int(7),
+            OwnedValue::Int(7),
+            OwnedValue::Int(9),
+        ];
+        assert_eq!(
+            align_by_value(&pristine, &result),
+            vec![Some(1), Some(0), None, None]
+        );
+    }
+
+    /// Only a plain `=` can carry a provably constructed value. `|=` and the
+    /// compound assigns always read the node already there.
+    #[test]
+    fn collect_write_targets_marks_closed_literal_writes_fresh_870() {
+        let lit = || Expr::Literal(succinctly::jq::Literal::Int(1));
+        let fresh_of = |e: &Expr| collect_write_targets(e).map(|ts| ts[0].fresh);
+
+        assert_eq!(
+            fresh_of(&Expr::Assign {
+                path: Box::new(Expr::Field("a".into())),
+                value: Box::new(Expr::Array(Box::new(lit()))),
+            }),
+            Some(true)
+        );
+        // References the document, so nothing about it is provably fresh.
+        assert_eq!(
+            fresh_of(&Expr::Assign {
+                path: Box::new(Expr::Field("a".into())),
+                value: Box::new(Expr::Field("b".into())),
+            }),
+            Some(false)
+        );
+        assert_eq!(
+            fresh_of(&Expr::Update {
+                path: Box::new(Expr::Field("a".into())),
+                filter: Box::new(Expr::Array(Box::new(lit()))),
+            }),
+            Some(false)
+        );
+    }
+
+    /// A `del` at an array index renumbers slots for every other write that
+    /// reaches into the same array, and the target list records no stage
+    /// order — so that combination is declined whole. Deletions from the
+    /// same array are exempt (they are removed as one set), and so is a
+    /// write that never enters the array.
+    #[test]
+    fn collect_write_targets_declines_del_that_renumbers_another_write_870() {
+        let del = |e: Expr| Expr::Builtin(Builtin::Del(Box::new(e)));
+        let arr_idx = |i: i64| {
+            Expr::Pipe(vec![
+                Expr::Field("arr".into()),
+                Expr::Index { idx: i, key: None },
+            ])
+        };
+        let set = |p: Expr| Expr::Assign {
+            path: Box::new(p),
+            value: Box::new(Expr::Literal(succinctly::jq::Literal::Int(1))),
+        };
+
+        // A write into the same array, after a del that renumbers it.
+        assert!(
+            collect_write_targets(&Expr::Pipe(vec![set(arr_idx(1)), del(arr_idx(0))])).is_none()
+        );
+        // Same two writes, other order — equally undecidable from this list.
+        assert!(
+            collect_write_targets(&Expr::Pipe(vec![del(arr_idx(0)), set(arr_idx(1))])).is_none()
+        );
+        // Two deletions from one array are handled together, not declined.
+        assert!(collect_write_targets(&del(Expr::Comma(vec![arr_idx(0), arr_idx(2)]))).is_some());
+        // A write elsewhere is unaffected by the renumbering.
+        assert!(collect_write_targets(&Expr::Pipe(vec![
+            del(arr_idx(0)),
+            set(Expr::Field("n".into()))
+        ]))
+        .is_some());
     }
 }

--- a/src/bin/succinctly/yq_runner.rs
+++ b/src/bin/succinctly/yq_runner.rs
@@ -8075,6 +8075,10 @@ mod tests {
             // `-0.0 == 0.0`, with different bit patterns.
             (OwnedValue::Float(-0.0), OwnedValue::Float(0.0)),
             (OwnedValue::Int(0), OwnedValue::Float(-0.0)),
+            // Null and Bool, whose only requirement is that they hash as
+            // themselves.
+            (OwnedValue::Null, OwnedValue::Null),
+            (OwnedValue::Bool(true), OwnedValue::Bool(true)),
             // Object equality is order-independent.
             (
                 OwnedValue::Object(IndexMap::from_iter([
@@ -8119,6 +8123,26 @@ mod tests {
         let b = OwnedValue::Array(vec![OwnedValue::Int(2), OwnedValue::Int(1)]);
         assert_ne!(a, b);
         assert_ne!(owned_value_align_hash(&a), owned_value_align_hash(&b));
+
+        // `null`, `false` and `0` are three different values, and a hash
+        // that ran them together would make the alignment pair them up.
+        let distinct = [
+            OwnedValue::Null,
+            OwnedValue::Bool(false),
+            OwnedValue::Bool(true),
+            OwnedValue::Int(0),
+            OwnedValue::String(String::new()),
+        ];
+        let hashes: Vec<u64> = distinct.iter().map(owned_value_align_hash).collect();
+        for i in 0..hashes.len() {
+            for j in (i + 1)..hashes.len() {
+                assert_ne!(
+                    hashes[i], hashes[j],
+                    "{:?} and {:?} must not share a bucket",
+                    distinct[i], distinct[j]
+                );
+            }
+        }
     }
 
     /// NaN equals nothing, itself included, so it can never be matched —
@@ -8173,6 +8197,21 @@ mod tests {
                 path: Box::new(Expr::Field("a".into())),
                 filter: Box::new(Expr::Array(Box::new(lit()))),
             }),
+            Some(false)
+        );
+
+        // A computed object key is closed only when the key expression is:
+        // `{(1): 2}` builds everything itself, `{(.k): 2}` does not.
+        let object_with_key = |key: Expr| Expr::Assign {
+            path: Box::new(Expr::Field("a".into())),
+            value: Box::new(Expr::Object(vec![succinctly::jq::ObjectEntry {
+                key: ObjectKey::Expr(Box::new(key)),
+                value: lit(),
+            }])),
+        };
+        assert_eq!(fresh_of(&object_with_key(lit())), Some(true));
+        assert_eq!(
+            fresh_of(&object_with_key(Expr::Field("k".into()))),
             Some(false)
         );
     }

--- a/src/bin/succinctly/yq_runner.rs
+++ b/src/bin/succinctly/yq_runner.rs
@@ -2027,6 +2027,45 @@ fn array_sources(
     r_items: &[OwnedValue],
     targets: &[RelTarget<'_>],
 ) -> Vec<Option<usize>> {
+    // A wholesale write at this array (`.arr = <expr>`, `|=`, `+=`)
+    // replaces its contents outright, so slot `i` of the result is not slot
+    // `i` of the pristine in any meaningful sense — a prepend shifts
+    // everything down one, a reverse turns the order around.
+    //
+    // Real yq carries presentation on *node identity*: an element the
+    // expression referenced keeps its own comment and style, one it
+    // constructed gets none. Matching each result element to the first
+    // still-unclaimed pristine element holding an equal value, in order,
+    // approximates that without a shared-node value model (#1351) — and
+    // reproduces yq exactly for the prepend and reverse that motivated this
+    // issue. Where it still differs is a constructed literal that happens
+    // to equal an old element; see [`reconcile_presentation`]'s own doc
+    // comment.
+    //
+    // Checked before the `del` remap below: once the array has been
+    // rewritten wholesale, pristine *positions* mean nothing, so a `del`
+    // in the same pipe has no positional model left to remap against.
+    if targets
+        .iter()
+        .any(|(steps, kind)| steps.is_empty() && *kind == WriteKind::Set)
+    {
+        let mut claimed = vec![false; p_items.len()];
+        return r_items
+            .iter()
+            .map(|r_v| {
+                let found = p_items
+                    .iter()
+                    .enumerate()
+                    .find(|(p, p_v)| !claimed[*p] && *p_v == r_v)
+                    .map(|(p, _)| p);
+                if let Some(p) = found {
+                    claimed[p] = true;
+                }
+                found
+            })
+            .collect();
+    }
+
     // `del(.arr[k])` shifts every later element down one slot, so slot `i`
     // of the result is a *different* pristine node than slot `i` was — the
     // exact case that made `del(.arr[0])` inherit index 0's comment instead

--- a/src/bin/succinctly/yq_runner.rs
+++ b/src/bin/succinctly/yq_runner.rs
@@ -7691,4 +7691,166 @@ mod tests {
             "serde_json_to_owned should panic at MAX_VALUE_TREE_DEPTH"
         );
     }
+
+    // -- #870: write-path resolution -------------------------------------
+    //
+    // `collect_write_targets` is only ever *called* behind
+    // `is_alias_sensitive_assign`, so several of its arms cannot be reached
+    // from a CLI filter string even though every one of them is load-bearing
+    // if that gate ever widens. Exercised directly here, in the same spirit
+    // as the `emit_yaml_value` flow-style test above.
+
+    fn assign(path: Expr) -> Expr {
+        Expr::Assign {
+            path: Box::new(path),
+            value: Box::new(Expr::Identity),
+        }
+    }
+
+    fn targets_of(expr: &Expr) -> Option<Vec<(Vec<PathStep>, WriteKind)>> {
+        collect_write_targets(expr).map(|ts| ts.into_iter().map(|t| (t.path, t.kind)).collect())
+    }
+
+    /// A leading `.` contributes no step: `.` is the node you are already
+    /// at, so `. = x` targets the root and `.a` is one step, not two.
+    #[test]
+    fn collect_write_targets_identity_path_is_the_root_870() {
+        assert_eq!(
+            targets_of(&assign(Expr::Identity)),
+            Some(vec![(vec![], WriteKind::Set)])
+        );
+        assert_eq!(
+            targets_of(&assign(Expr::Pipe(vec![
+                Expr::Identity,
+                Expr::Field("a".into()),
+            ]))),
+            Some(vec![(vec![PathStep::Key("a".into())], WriteKind::Set)])
+        );
+    }
+
+    /// `Paren`/`Optional` are transparent on both sides: around the whole
+    /// write (`(.a = 1)?`) and around the path itself (`(.a)? = 1`).
+    #[test]
+    fn collect_write_targets_unwraps_paren_and_optional_870() {
+        let a = || PathStep::Key("a".into());
+        for path in [
+            Expr::Paren(Box::new(Expr::Field("a".into()))),
+            Expr::Optional(Box::new(Expr::Field("a".into()))),
+        ] {
+            assert_eq!(
+                targets_of(&assign(path)),
+                Some(vec![(vec![a()], WriteKind::Set)])
+            );
+        }
+        for wrap in [
+            Expr::Paren(Box::new(assign(Expr::Field("a".into())))),
+            Expr::Optional(Box::new(assign(Expr::Field("a".into())))),
+        ] {
+            assert_eq!(targets_of(&wrap), Some(vec![(vec![a()], WriteKind::Set)]));
+        }
+        // ...including a parenthesised `del` path, which reaches `push`'s
+        // own `Paren` arm rather than `static_path_steps`'.
+        assert_eq!(
+            targets_of(&Expr::Builtin(Builtin::Del(Box::new(Expr::Paren(
+                Box::new(Expr::Field("a".into()))
+            ))))),
+            Some(vec![(vec![a()], WriteKind::Del)])
+        );
+    }
+
+    /// The pass-through stages `is_alias_sensitive_assign` allows alongside
+    /// a write contribute no target of their own, and must not make the
+    /// whole pipe unresolvable.
+    #[test]
+    fn collect_write_targets_pass_through_stages_contribute_nothing_870() {
+        for stage in [
+            Expr::Identity,
+            Expr::Builtin(Builtin::Empty),
+            Expr::Builtin(Builtin::Debug),
+            Expr::Builtin(Builtin::Select(Box::new(Expr::Identity))),
+        ] {
+            assert_eq!(
+                targets_of(&Expr::Pipe(vec![assign(Expr::Field("a".into())), stage])),
+                Some(vec![(vec![PathStep::Key("a".into())], WriteKind::Set)])
+            );
+        }
+    }
+
+    /// A generator is accepted on a `del`'s left, where it means "remove
+    /// each of these", and rejected on an assignment's, where it is not
+    /// valid syntax to begin with — accepting it there would invent a write
+    /// the evaluator never performs.
+    #[test]
+    fn collect_write_targets_comma_is_del_only_870() {
+        let branches = vec![
+            Expr::Index { idx: 0, key: None },
+            Expr::Index { idx: 2, key: None },
+        ];
+        assert_eq!(
+            targets_of(&Expr::Builtin(Builtin::Del(Box::new(Expr::Comma(
+                branches.clone()
+            ))))),
+            Some(vec![
+                (vec![PathStep::Index(0)], WriteKind::Del),
+                (vec![PathStep::Index(2)], WriteKind::Del),
+            ])
+        );
+        assert_eq!(targets_of(&assign(Expr::Comma(branches))), None);
+    }
+
+    /// Anything whose resolved path depends on the document — a computed
+    /// key, an iterate, a slice — makes the whole expression unresolvable,
+    /// so reconciliation falls back to the positional walk rather than
+    /// acting on a path it only guessed at.
+    #[test]
+    fn collect_write_targets_rejects_non_static_paths_870() {
+        for path in [
+            Expr::IndexExpr {
+                target: Box::new(Expr::Field("arr".into())),
+                key: Box::new(Expr::Field("i".into())),
+            },
+            Expr::Iterate,
+            Expr::Slice {
+                start: None,
+                end: None,
+                start_key: None,
+                end_key: None,
+            },
+        ] {
+            assert_eq!(targets_of(&assign(path)), None);
+        }
+        // A stage that is neither a write nor a pass-through is rejected
+        // whole, even though `is_alias_sensitive_assign` would not let one
+        // reach here today.
+        assert_eq!(targets_of(&Expr::Field("a".into())), None);
+    }
+
+    /// A negative index resolves from the end, and an out-of-range one
+    /// resolves to nothing rather than wrapping or clamping.
+    #[test]
+    fn resolve_index_handles_negatives_and_bounds_870() {
+        assert_eq!(resolve_index(0, 3), Some(0));
+        assert_eq!(resolve_index(2, 3), Some(2));
+        assert_eq!(resolve_index(3, 3), None);
+        assert_eq!(resolve_index(-1, 3), Some(2));
+        assert_eq!(resolve_index(-3, 3), Some(0));
+        assert_eq!(resolve_index(-4, 3), None);
+        assert_eq!(resolve_index(0, 0), None);
+    }
+
+    /// The `del` remap only applies when the array that actually came out is
+    /// the shape it predicts. Here it is not — one element was removed but
+    /// two arrived — so `array_sources` falls back to positional rather than
+    /// remapping against a model already shown wrong.
+    #[test]
+    fn array_sources_del_remap_falls_back_on_unexpected_length_870() {
+        let pristine = [OwnedValue::Int(1), OwnedValue::Int(2), OwnedValue::Int(3)];
+        let result = [OwnedValue::Int(2), OwnedValue::Int(3), OwnedValue::Int(9)];
+        let steps = [PathStep::Index(0)];
+        let targets = [(&steps[..], WriteKind::Del)];
+        assert_eq!(
+            array_sources(&pristine, &result, &targets),
+            vec![Some(0), Some(1), Some(2)]
+        );
+    }
 }

--- a/src/bin/succinctly/yq_runner.rs
+++ b/src/bin/succinctly/yq_runner.rs
@@ -1845,6 +1845,218 @@ fn walk_alias_groups<W: AsRef<[u64]> + Clone>(
     }
 }
 
+/// One step of a *statically resolvable* write path (#870).
+///
+/// A negative index is kept exactly as written: `-1` only means anything
+/// relative to the container it lands in, so
+/// [`reconcile_presentation_at_depth`] resolves it once it has that
+/// container in hand.
+#[derive(Clone, Debug, PartialEq)]
+enum PathStep {
+    Key(String),
+    Index(i64),
+}
+
+/// What a write did at the path it resolved to (#870).
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum WriteKind {
+    /// `=`, `|=`, a compound assign or `//=`: the node **at** the path was
+    /// rewritten in place.
+    Set,
+    /// `del(...)`: the node at the path was removed from its parent, so the
+    /// parent's later children all shifted down one slot.
+    Del,
+}
+
+/// A path a write actually touched, plus what it did there (#870).
+#[derive(Clone, Debug)]
+struct WriteTarget {
+    path: Vec<PathStep>,
+    kind: WriteKind,
+}
+
+/// Collect the [`PathStep`]s of a *static* navigation chain, returning
+/// `false` for anything whose resolved path is not a single, document-
+/// independent sequence known from the AST alone.
+///
+/// Accepts exactly `Identity`/`Field`/`Index` chained through `Pipe`, plus
+/// the `Paren`/`Optional` wrappers [`is_alias_sensitive_assign`] already
+/// unwraps. Everything else — `Iterate` (`.[]`), a computed key
+/// (`IndexExpr`), a slice, a `Comma`, a function call — is rejected, and
+/// its caller falls back to the pre-#870 lockstep walk.
+///
+/// Constant keys never need special handling here: the parser folds
+/// `.["a"]` into [`Expr::Field`] and `.[0]` into [`Expr::Index`] (see
+/// [`Expr::IndexExpr`]'s own doc comment), so a static chain is always
+/// spelled with those two variants. [`Expr::Index`]'s `key` slot only
+/// carries a *spelling* for `path()` output; `idx` is what navigation —
+/// and therefore reconciliation — actually uses.
+fn static_path_steps(expr: &Expr, out: &mut Vec<PathStep>) -> bool {
+    match expr {
+        Expr::Identity => true,
+        Expr::Field(name) => {
+            out.push(PathStep::Key(name.clone()));
+            true
+        }
+        Expr::Index { idx, .. } => {
+            out.push(PathStep::Index(*idx));
+            true
+        }
+        Expr::Paren(inner) | Expr::Optional(inner) => static_path_steps(inner, out),
+        Expr::Pipe(stages) => stages.iter().all(|s| static_path_steps(s, out)),
+        _ => false,
+    }
+}
+
+/// Resolve which paths `expr` writes to, or `None` when any write stage's
+/// left-hand side is not a static navigation chain (#870).
+///
+/// `None` is not an error — it means "reconcile the way it did before
+/// #870", which is still correct for every write that doesn't reshuffle
+/// positions, and no worse than before for one that does.
+///
+/// Only expressions [`is_alias_sensitive_assign`] already accepts reach
+/// here, so the pass-through arms below mirror its own allow-list exactly:
+/// `.`, `select(...)`, `empty`, `debug`/`debug(msg)` rewrite nothing and
+/// therefore contribute no target.
+///
+/// Resolving each stage's left-hand side independently — rather than
+/// re-evaluating the pipe against a running document, as an earlier plan
+/// for this issue proposed — is exact precisely *because* every accepted
+/// path is static: `.arr[0]` denotes `["arr", 0]` whatever the document
+/// holds, so no stage's resolution can depend on an earlier stage's write.
+/// A path that *would* depend on the document (`.arr[(.i)] = 1`) is
+/// rejected by [`static_path_steps`] instead of being resolved against a
+/// document that may already be stale.
+fn collect_write_targets(expr: &Expr) -> Option<Vec<WriteTarget>> {
+    fn push(lhs: &Expr, kind: WriteKind, out: &mut Vec<WriteTarget>) -> bool {
+        match lhs {
+            Expr::Paren(inner) => push(inner, kind, out),
+            // `del(.arr[0], .arr[2])` removes both, and each branch is a
+            // path of its own — a generator is only valid on a `del`'s
+            // left, never an assignment's, so this arm is gated on `Del`
+            // rather than accepting `.a, .b = 1`.
+            Expr::Comma(branches) if kind == WriteKind::Del => {
+                branches.iter().all(|b| push(b, kind, out))
+            }
+            _ => {
+                let mut path = Vec::new();
+                if !static_path_steps(lhs, &mut path) {
+                    return false;
+                }
+                out.push(WriteTarget { path, kind });
+                true
+            }
+        }
+    }
+
+    fn walk(expr: &Expr, out: &mut Vec<WriteTarget>) -> bool {
+        match expr {
+            Expr::Assign { path, .. }
+            | Expr::Update { path, .. }
+            | Expr::CompoundAssign { path, .. }
+            | Expr::AlternativeAssign { path, .. } => push(path, WriteKind::Set, out),
+            Expr::Builtin(Builtin::Del(inner)) => push(inner, WriteKind::Del, out),
+            Expr::Identity
+            | Expr::Builtin(
+                Builtin::Select(_) | Builtin::Empty | Builtin::Debug | Builtin::DebugMsg(_),
+            ) => true,
+            Expr::Paren(inner) | Expr::Optional(inner) => walk(inner, out),
+            Expr::Pipe(stages) => stages.iter().all(|s| walk(s, out)),
+            _ => false,
+        }
+    }
+
+    let mut out = Vec::new();
+    walk(expr, &mut out).then_some(out)
+}
+
+/// A write path, relative to the node currently being reconciled, paired
+/// with what the write did there (#870).
+type RelTarget<'t> = (&'t [PathStep], WriteKind);
+
+/// Turn a jq index (possibly negative) into a slot of a `len`-element
+/// container, matching `numeric_key_to_index`'s from-the-end convention.
+fn resolve_index(idx: i64, len: usize) -> Option<usize> {
+    let resolved = if idx < 0 {
+        len.checked_sub(idx.unsigned_abs() as usize)?
+    } else {
+        idx as usize
+    };
+    (resolved < len).then_some(resolved)
+}
+
+/// Narrow `targets` to those descending through object key `key`, dropping
+/// that step (#870).
+fn descend_key<'t>(targets: &[RelTarget<'t>], key: &str) -> Vec<RelTarget<'t>> {
+    targets
+        .iter()
+        .filter_map(|(steps, kind)| match steps.split_first() {
+            Some((PathStep::Key(k), rest)) if k == key => Some((rest, *kind)),
+            _ => None,
+        })
+        .collect()
+}
+
+/// Narrow `targets` to those descending through array slot `index` of a
+/// `len`-element array, dropping that step (#870).
+fn descend_index<'t>(targets: &[RelTarget<'t>], index: usize, len: usize) -> Vec<RelTarget<'t>> {
+    targets
+        .iter()
+        .filter_map(|(steps, kind)| match steps.split_first() {
+            Some((PathStep::Index(n), rest)) if resolve_index(*n, len) == Some(index) => {
+                Some((rest, *kind))
+            }
+            _ => None,
+        })
+        .collect()
+}
+
+/// Decide which pristine slot each result slot of an array actually came
+/// from (#870), given the writes that landed on this array.
+///
+/// `None` at a slot means "no pristine counterpart" — the slot gets fresh,
+/// empty metadata, which is what real `yq` gives a node the write created.
+///
+/// Positional identity (`i -> i`) is the pre-#870 behaviour and stays the
+/// answer for every write that doesn't move anything: `.arr[0] = "z"`
+/// rewrites one slot in place, and real `yq` keeps that slot's own style
+/// (`- "z"`, verified against the pinned binary).
+fn array_sources(
+    p_items: &[OwnedValue],
+    r_items: &[OwnedValue],
+    targets: &[RelTarget<'_>],
+) -> Vec<Option<usize>> {
+    // `del(.arr[k])` shifts every later element down one slot, so slot `i`
+    // of the result is a *different* pristine node than slot `i` was — the
+    // exact case that made `del(.arr[0])` inherit index 0's comment instead
+    // of index 1's. The removed set is known exactly, so the remap is too.
+    let mut removed: Vec<usize> = targets
+        .iter()
+        .filter_map(|(steps, kind)| match (steps, kind) {
+            ([PathStep::Index(n)], WriteKind::Del) => resolve_index(*n, p_items.len()),
+            _ => None,
+        })
+        .collect();
+    if !removed.is_empty() {
+        removed.sort_unstable();
+        removed.dedup();
+        let survivors: Vec<usize> = (0..p_items.len())
+            .filter(|i| !removed.contains(i))
+            .collect();
+        // Only trust the remap when the array that actually came out is the
+        // shape it predicts. A pipe that deleted *and* appended, or a `del`
+        // whose path didn't resolve the way it reads, falls through to
+        // positional rather than misattributing against a model that has
+        // already been shown wrong.
+        if survivors.len() == r_items.len() {
+            return survivors.into_iter().map(Some).collect();
+        }
+    }
+
+    (0..r_items.len()).map(Some).collect()
+}
+
 /// Reconcile a pristine (pre-write) presentation tree against a post-write
 /// value (issue #739, ADR-0017's mechanism 1, applied to path-mutation
 /// queries: `=`, `|=`, `+=`, `del()`, ...).
@@ -1870,33 +2082,43 @@ fn walk_alias_groups<W: AsRef<[u64]> + Clone>(
 /// the YAML documents this rewrites are config-file-sized, not
 /// data-file-sized.
 ///
-/// **Known gap, filed as #870**: this function matches a child to
-/// its pristine counterpart purely by key/index, so any write that
-/// reshuffles an `Array`'s or `Object`'s *positions* - not just a
-/// wholesale replacement like `.a = [4, 5, 6]` on `a: ['x', 'y', 'z']`,
-/// but an everyday `.arr = ["new"] + .arr` prepend or a `del()` that
-/// shifts later indices down - misattributes old elements' style/comments
-/// to whichever new element now sits at the same key/index, instead of
-/// giving every element under the write fresh (empty) metadata the way
-/// real `yq`'s node-mutation model does (confirmed against the pinned
-/// binary: prepending to `arr:\n  - "x"\n  - y` should drop the new
-/// element's style entirely and leave `"x"`'s own quotes exactly where
-/// they were; this function instead lets the new element inherit `"x"`'s
-/// old quote style and leaves `"x"` unquoted). This function has no way
-/// to tell "recursing into an untouched sibling subtree" apart from
-/// "recursing into a reshuffled subtree that happens to share
-/// positions/keys with the old one" - both look identical from a pure
-/// before/after value diff; only a path-based approach (the
-/// `resolve_dynamic_indexes` alternative above) could distinguish them.
-/// Purely cosmetic (no data loss, no incorrect *values*, still strictly
-/// better than every write losing all style/comments unconditionally,
-/// which was the pre-#739 baseline).
+/// `targets` closes most of what #870 filed against the lockstep walk. A
+/// pure before/after value diff cannot tell "recursing into an untouched
+/// sibling subtree" apart from "recursing into a subtree the write
+/// reshuffled" — both look identical — so a write that moves an `Array`'s
+/// elements used to hand each new element whichever old element now
+/// happens to sit at its index. [`collect_write_targets`] resolves the
+/// paths a write actually touched straight from the AST (no
+/// `resolve_dynamic_indexes` plumbing needed, and no dependence on the
+/// document), and [`array_sources`] uses them to map each result slot back
+/// to the pristine slot it really came from: an exact remap across a
+/// `del()`, and a value-identity alignment across a wholesale write. An
+/// empty `targets` — a write whose path isn't static, e.g.
+/// `.arr[(.i)] = 1` — falls back to the pre-#870 lockstep walk unchanged.
+///
+/// **Remaining gap**: real `yq` carries presentation on *node identity*,
+/// so a freshly constructed literal never inherits anything even when its
+/// value happens to equal an old node's. `.arr = ["b","a","a"]` over
+/// `[a # c0, a # c1, b # c2]` prints three bare scalars in `yq`; the
+/// value-identity alignment here matches them up and keeps the comments.
+/// Object fields have the same gap (`.o = {"a": "1"}` keeps `a`'s old
+/// comment where `yq` drops it) and are deliberately left on key matching:
+/// aligning object children by *value* would let one key inherit a
+/// different key's comment, which is the very misattribution #870 is
+/// about. Closing either needs the shared-node value model tracked by
+/// #1351 and #865. Purely cosmetic throughout (no data loss, no incorrect
+/// *values*).
 fn reconcile_presentation(
     pristine_value: &OwnedValue,
     pristine_tree: &CommentTree,
     result_value: &OwnedValue,
+    targets: &[WriteTarget],
 ) -> CommentTree {
-    reconcile_presentation_at_depth(pristine_value, pristine_tree, result_value, 0)
+    let relative: Vec<RelTarget<'_>> = targets
+        .iter()
+        .map(|t| (t.path.as_slice(), t.kind))
+        .collect();
+    reconcile_presentation_at_depth(pristine_value, pristine_tree, result_value, &relative, 0)
 }
 
 /// Panics past `succinctly::jq::MAX_VALUE_TREE_DEPTH` levels of nesting
@@ -1907,6 +2129,7 @@ fn reconcile_presentation_at_depth(
     pristine_value: &OwnedValue,
     pristine_tree: &CommentTree,
     result_value: &OwnedValue,
+    targets: &[RelTarget<'_>],
     depth: usize,
 ) -> CommentTree {
     assert_value_tree_depth(depth);
@@ -1916,10 +2139,21 @@ fn reconcile_presentation_at_depth(
             let mut fields = IndexMap::new();
             let mut key_comments = IndexMap::new();
             for (k, r_v) in r_fields {
+                // Object children stay matched by key: a key names the same
+                // node before and after a write however the map is
+                // reordered, so there is no position to misattribute across
+                // (verified: `yq '.o = {"b": .o.b, "a": .o.a}'` keeps each
+                // field's own comment with its own key). See this function's
+                // doc comment for the object-side gap this leaves open.
+                let child_targets = descend_key(targets, k);
                 let child = match p_fields.get(k) {
-                    Some(p_v) => {
-                        reconcile_presentation_at_depth(p_v, pristine_tree.field(k), r_v, depth + 1)
-                    }
+                    Some(p_v) => reconcile_presentation_at_depth(
+                        p_v,
+                        pristine_tree.field(k),
+                        r_v,
+                        &child_targets,
+                        depth + 1,
+                    ),
                     None => CommentTree::empty(),
                 };
                 fields.insert(k.clone(), child);
@@ -1946,17 +2180,24 @@ fn reconcile_presentation_at_depth(
         }
         (OwnedValue::Array(p_items), OwnedValue::Array(r_items)) => {
             let own_meta = pristine_tree.meta().clone();
+            // #870: which pristine slot each result slot really came from —
+            // identity unless a write at this node moved things.
+            let sources = array_sources(p_items, r_items, targets);
             let items = r_items
                 .iter()
                 .enumerate()
-                .map(|(i, r_v)| match p_items.get(i) {
-                    Some(p_v) => reconcile_presentation_at_depth(
-                        p_v,
-                        pristine_tree.at_index(i),
-                        r_v,
-                        depth + 1,
-                    ),
-                    None => CommentTree::empty(),
+                .map(|(i, r_v)| {
+                    let child_targets = descend_index(targets, i, r_items.len());
+                    match sources[i].and_then(|p| p_items.get(p).map(|p_v| (p, p_v))) {
+                        Some((p, p_v)) => reconcile_presentation_at_depth(
+                            p_v,
+                            pristine_tree.at_index(p),
+                            r_v,
+                            &child_targets,
+                            depth + 1,
+                        ),
+                        None => CommentTree::empty(),
+                    }
                 })
                 .collect();
             CommentTree::Array(own_meta, items)
@@ -2307,6 +2548,15 @@ fn evaluate_yaml_cursor<W: AsRef<[u64]> + Clone>(
         None => None,
     };
 
+    // Which paths this write actually touches (#870), resolved from the
+    // AST alone. Computed only when there is a pristine tree to reconcile
+    // against at all, so a plain read pays nothing; `None` (a non-static
+    // path) reconciles exactly as it did before #870.
+    let write_targets = presentation_sync_ctx
+        .as_ref()
+        .and_then(|_| collect_write_targets(expr))
+        .unwrap_or_default();
+
     let result = eval_with_cursor_using::<YqSemantics, _>(expr, cursor);
     // A value with no live cursor of its own (an assignment/`del()`
     // result, a computed value, ...) has no comment/style to read directly
@@ -2317,7 +2567,7 @@ fn evaluate_yaml_cursor<W: AsRef<[u64]> + Clone>(
         let comments = presentation_sync_ctx
             .as_ref()
             .map_or_else(CommentTree::empty, |(pristine, tree)| {
-                reconcile_presentation(pristine, tree, &v)
+                reconcile_presentation(pristine, tree, &v, &write_targets)
             });
         (v, comments)
     };
@@ -7017,11 +7267,11 @@ mod tests {
         use succinctly::jq::MAX_VALUE_TREE_DEPTH;
 
         let under = linear_array_nest(MAX_VALUE_TREE_DEPTH - 1);
-        let _ = reconcile_presentation(&under, &CommentTree::empty(), &under);
+        let _ = reconcile_presentation(&under, &CommentTree::empty(), &under, &[]);
 
         let over = linear_array_nest(MAX_VALUE_TREE_DEPTH);
         let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-            reconcile_presentation(&over, &CommentTree::empty(), &over)
+            reconcile_presentation(&over, &CommentTree::empty(), &over, &[])
         }));
         assert!(
             result.is_err(),

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -34068,4 +34068,135 @@ mod issue_870_position_shifting_writes {
         assert_eq!(output, "arr:\n  - \"z\"\n  - y\nn: 1\n");
         Ok(())
     }
+
+    /// The issue's own repro. A prepend shifts every old element down one
+    /// slot: the new element must get fresh metadata, and `"x"` must keep
+    /// its own quotes rather than inheriting index 1's plain style.
+    ///
+    /// $ yq '.arr = ["new"] + .arr | .n = 2'
+    ///   arr:\n  - new\n  - "x"\n  - y\nn: 2
+    #[test]
+    fn test_yaml_prepend_does_not_shift_style_onto_new_element_870() -> Result<()> {
+        let input = "arr:\n  - \"x\"\n  - y\nn: 1\n";
+        let (output, exit_code) = run_yq_stdin(".arr = [\"new\"] + .arr | .n = 2", input, &[])?;
+        assert_eq!(exit_code, 0);
+        assert_eq!(output, "arr:\n  - new\n  - \"x\"\n  - y\nn: 2\n");
+        Ok(())
+    }
+
+    /// A reverse keeps both elements but swaps their slots, so each must
+    /// carry its own style to its new position.
+    ///
+    /// $ yq '.arr = (.arr|reverse)'  =>  arr:\n  - y\n  - "x"
+    #[test]
+    fn test_yaml_reverse_carries_style_to_new_positions_870() -> Result<()> {
+        let input = "arr:\n  - \"x\"\n  - y\nn: 1\n";
+        let (output, exit_code) = run_yq_stdin(".arr = (.arr|reverse)", input, &[])?;
+        assert_eq!(exit_code, 0);
+        assert_eq!(output, "arr:\n  - y\n  - \"x\"\nn: 1\n");
+        Ok(())
+    }
+
+    /// `|=` reaches the same write path as `=` and must reorder identically.
+    ///
+    /// $ yq '.arr |= reverse'  =>  arr:\n  - y\n  - "x"
+    #[test]
+    fn test_yaml_update_assign_reverse_carries_style_870() -> Result<()> {
+        let input = "arr:\n  - \"x\"\n  - y\n";
+        let (output, exit_code) = run_yq_stdin(".arr |= reverse", input, &[])?;
+        assert_eq!(exit_code, 0);
+        assert_eq!(output, "arr:\n  - y\n  - \"x\"\n");
+        Ok(())
+    }
+
+    /// A wholesale replacement whose elements match nothing in the pristine
+    /// array gets no metadata at all — before #870 both new elements
+    /// inherited the old slots' comments and style.
+    ///
+    /// $ yq '.arr = ["p","q"]'  =>  arr:\n  - p\n  - q
+    #[test]
+    fn test_yaml_wholesale_replacement_drops_old_metadata_870() -> Result<()> {
+        let input = "arr:\n  - \"x\" # cx\n  - y # cy\n";
+        let (output, exit_code) = run_yq_stdin(".arr = [\"p\",\"q\"]", input, &[])?;
+        assert_eq!(exit_code, 0);
+        assert_eq!(output, "arr:\n  - p\n  - q\n");
+        Ok(())
+    }
+
+    /// `+=` appends: the existing elements keep their own slots and the
+    /// appended one gets nothing.
+    ///
+    /// $ yq '.arr += ["z"]'  =>  arr:\n  - "x"\n  - y\n  - z
+    #[test]
+    fn test_yaml_append_keeps_existing_and_leaves_new_bare_870() -> Result<()> {
+        let input = "arr:\n  - \"x\"\n  - y\n";
+        let (output, exit_code) = run_yq_stdin(".arr += [\"z\"]", input, &[])?;
+        assert_eq!(exit_code, 0);
+        assert_eq!(output, "arr:\n  - \"x\"\n  - y\n  - z\n");
+        Ok(())
+    }
+
+    /// Writing the array to itself changes nothing, so every element keeps
+    /// exactly what it had — the alignment must be stable, not merely
+    /// "different from before".
+    ///
+    /// $ yq '.arr = .arr'  =>  arr:\n  - "x" # cx\n  - y # cy
+    #[test]
+    fn test_yaml_self_assign_preserves_everything_870() -> Result<()> {
+        let input = "arr:\n  - \"x\" # cx\n  - y # cy\n";
+        let (output, exit_code) = run_yq_stdin(".arr = .arr", input, &[])?;
+        assert_eq!(exit_code, 0);
+        assert_eq!(output, "arr:\n  - \"x\" # cx\n  - y # cy\n");
+        Ok(())
+    }
+
+    /// Object fields stay matched by key across a wholesale write: a
+    /// reordering constructor must carry each field's own comment with its
+    /// own key, never align them by value across different keys.
+    ///
+    /// $ yq '.o = {"b": .o.b, "a": .o.a}'  =>  o:\n  b: 2 # cb\n  a: "1" # ca
+    #[test]
+    fn test_yaml_object_reorder_keeps_comments_with_their_keys_870() -> Result<()> {
+        let input = "o:\n  a: \"1\" # ca\n  b: 2 # cb\nn: 0\n";
+        let (output, exit_code) = run_yq_stdin(".o = {\"b\": .o.b, \"a\": .o.a}", input, &[])?;
+        assert_eq!(exit_code, 0);
+        assert_eq!(output, "o:\n  b: 2 # cb\n  a: \"1\" # ca\nn: 0\n");
+        Ok(())
+    }
+
+    /// A computed index is not statically resolvable, so `collect_write_targets`
+    /// declines it and reconciliation falls back to the pre-#870 lockstep
+    /// walk. The write itself must still land, and untouched siblings must
+    /// keep their metadata — "falls back" has to mean "unchanged", not
+    /// "loses everything". Nothing moved here, so the fallback happens to
+    /// agree with real yq exactly: slot 1 keeps its own plain style and its
+    /// own comment while taking the new value.
+    ///
+    /// $ yq '.arr[(.i)] = "z"'  =>  i: 1 / arr:\n  - "x" # cx\n  - z # cy / n: 1 # cn
+    #[test]
+    fn test_yaml_computed_index_write_falls_back_cleanly_870() -> Result<()> {
+        let input = "i: 1\narr:\n  - \"x\" # cx\n  - y # cy\nn: 1 # cn\n";
+        let (output, exit_code) = run_yq_stdin(".arr[(.i)] = \"z\"", input, &[])?;
+        assert_eq!(exit_code, 0);
+        assert_eq!(
+            output,
+            "i: 1\narr:\n  - \"x\" # cx\n  - z # cy\nn: 1 # cn\n"
+        );
+        Ok(())
+    }
+
+    /// An untouched sibling of a reshuffled array keeps its own comment and
+    /// style: threading write paths must narrow what gets reset, not widen
+    /// it.
+    #[test]
+    fn test_yaml_untouched_siblings_survive_a_reshuffle_870() -> Result<()> {
+        let input = "keep: \"q\" # ck\narr:\n  - \"x\" # cx\n  - y # cy\n";
+        let (output, exit_code) = run_yq_stdin(".arr = (.arr|reverse)", input, &[])?;
+        assert_eq!(exit_code, 0);
+        assert_eq!(
+            output,
+            "keep: \"q\" # ck\narr:\n  - y # cy\n  - \"x\" # cx\n"
+        );
+        Ok(())
+    }
 }

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -34199,4 +34199,168 @@ mod issue_870_position_shifting_writes {
         );
         Ok(())
     }
+
+    // -- review round: value alignment must not fire on coincidence -------
+
+    /// A `|=` that rewrites each element **in place** moves nothing, so
+    /// every element keeps its own comment. An earlier cut of this fix read
+    /// "no element matched by value" as "every element is new" and wiped
+    /// all four comments — worse than the positional walk it replaced.
+    ///
+    /// $ yq '.arr |= [.[] | .port = 9]'
+    ///   arr:\n  - name: a # ca\n    port: 9 # cp\n  - name: b # cb\n    port: 9 # cq
+    #[test]
+    fn test_yaml_in_place_transform_keeps_every_comment_870() -> Result<()> {
+        let input =
+            "arr:\n  - name: a # ca\n    port: 1 # cp\n  - name: b # cb\n    port: 2 # cq\n";
+        let (output, exit_code) = run_yq_stdin(".arr |= [.[] | .port = 9]", input, &[])?;
+        assert_eq!(exit_code, 0);
+        assert_eq!(
+            output,
+            "arr:\n  - name: a # ca\n    port: 9 # cp\n  - name: b # cb\n    port: 9 # cq\n"
+        );
+        Ok(())
+    }
+
+    /// The same, where the transform also changes each element's style.
+    ///
+    /// $ yq '.arr |= [.[] | . + "!"]'  =>  arr:\n  - "x!" # cx\n  - y! # cy
+    #[test]
+    fn test_yaml_in_place_transform_keeps_style_and_comment_870() -> Result<()> {
+        let input = "arr:\n  - \"x\" # cx\n  - y # cy\n";
+        let (output, exit_code) = run_yq_stdin(".arr |= [.[] | . + \"!\"]", input, &[])?;
+        assert_eq!(exit_code, 0);
+        assert_eq!(output, "arr:\n  - \"x!\" # cx\n  - y! # cy\n");
+        Ok(())
+    }
+
+    /// The hard case for a value-based rule: incrementing `[1, 2]` gives
+    /// `[2, 3]`, which *reads* as "the 2 slid down a slot and the 3 is new".
+    /// It is not — each element was rewritten where it stood — and the
+    /// giveaway is that the result is not a permutation: the 3 matches
+    /// nothing. Both comments must stay on their own slots.
+    ///
+    /// $ yq '.arr |= [.[] + 1]'  =>  arr:\n  - 2 # c0\n  - 3 # c1
+    #[test]
+    fn test_yaml_coincidental_value_overlap_is_not_movement_870() -> Result<()> {
+        let input = "arr:\n  - 1 # c0\n  - 2 # c1\n";
+        let (output, exit_code) = run_yq_stdin(".arr |= [.[] + 1]", input, &[])?;
+        assert_eq!(exit_code, 0);
+        assert_eq!(output, "arr:\n  - 2 # c0\n  - 3 # c1\n");
+        Ok(())
+    }
+
+    // -- closed literals inherit nothing ----------------------------------
+
+    /// A constructed literal is a new node in real yq, so it carries no
+    /// comment even when its value equals the element that was there — the
+    /// case value alignment alone cannot see.
+    ///
+    /// $ yq '.arr = ["b","a","a"]'  =>  arr:\n  - b\n  - a\n  - a
+    #[test]
+    fn test_yaml_closed_literal_array_inherits_nothing_870() -> Result<()> {
+        let input = "arr:\n  - a # c0\n  - a # c1\n  - b # c2\n";
+        let (output, exit_code) = run_yq_stdin(".arr = [\"b\",\"a\",\"a\"]", input, &[])?;
+        assert_eq!(exit_code, 0);
+        assert_eq!(output, "arr:\n  - b\n  - a\n  - a\n");
+        Ok(())
+    }
+
+    /// The object half of the same rule, including the case where every
+    /// value is unchanged: yq still drops both comments, because both
+    /// values are literals in the filter rather than the document's nodes.
+    ///
+    /// $ yq '.o = {"a": "1", "b": 2}'  =>  o:\n  a: "1"\n  b: 2
+    #[test]
+    fn test_yaml_closed_literal_object_inherits_nothing_870() -> Result<()> {
+        let input = "o:\n  a: \"1\" # ca\n  b: 2 # cb\n";
+        let (output, code) = run_yq_stdin(".o = {\"a\": \"1\", \"b\": 2}", input, &[])?;
+        assert_eq!(code, 0);
+        assert_eq!(output, "o:\n  a: \"1\"\n  b: 2\n");
+
+        // $ yq '.o = {"a": "9"}'  =>  o:\n  a: "9"
+        let (output, code) = run_yq_stdin(".o = {\"a\": \"9\"}", input, &[])?;
+        assert_eq!(code, 0);
+        assert_eq!(output, "o:\n  a: \"9\"\n");
+        Ok(())
+    }
+
+    /// The converse: a constructor that *references* the document is not
+    /// closed, so those fields keep what their own keys had.
+    ///
+    /// $ yq '.o = {"b": .o.b, "a": .o.a}'  =>  o:\n  b: 2 # cb\n  a: "1" # ca
+    #[test]
+    fn test_yaml_referencing_constructor_is_not_a_closed_literal_870() -> Result<()> {
+        let input = "o:\n  a: \"1\" # ca\n  b: 2 # cb\n";
+        let (output, code) = run_yq_stdin(".o = {\"b\": .o.b, \"a\": .o.a}", input, &[])?;
+        assert_eq!(code, 0);
+        assert_eq!(output, "o:\n  b: 2 # cb\n  a: \"1\" # ca\n");
+        Ok(())
+    }
+
+    /// `|=` and `+=` always read the node already there, so neither can be
+    /// a closed literal however literal its right-hand side looks — the
+    /// appended element is new, the existing ones keep everything.
+    ///
+    /// $ yq '.arr += ["z"]'  =>  arr:\n  - "x" # cx\n  - y # cy\n  - z
+    #[test]
+    fn test_yaml_compound_assign_is_never_a_closed_literal_870() -> Result<()> {
+        let input = "arr:\n  - \"x\" # cx\n  - y # cy\n";
+        let (output, exit_code) = run_yq_stdin(".arr += [\"z\"]", input, &[])?;
+        assert_eq!(exit_code, 0);
+        assert_eq!(output, "arr:\n  - \"x\" # cx\n  - y # cy\n  - z\n");
+        Ok(())
+    }
+
+    // -- documented residuals ---------------------------------------------
+
+    /// **Known divergence** (gap 1 on `reconcile_presentation`): under a
+    /// permutation of *equal* elements, values cannot say which node went
+    /// where. Real yq, which tracks node identity, reverses the comments
+    /// (`c2, c1, c0`); matching by value pairs each `a` with the first
+    /// unclaimed `a` instead. Pinned so a future node-identity model
+    /// (#1351) has to update it deliberately.
+    #[test]
+    fn test_yaml_permutation_of_equal_elements_is_arbitrary_870() -> Result<()> {
+        let input = "arr:\n  - a # c0\n  - a # c1\n  - b # c2\n";
+        let (output, exit_code) = run_yq_stdin(".arr |= reverse", input, &[])?;
+        assert_eq!(exit_code, 0);
+        // yq: `- b # c2`, `- a # c1`, `- a # c0`.
+        assert_eq!(output, "arr:\n  - b # c2\n  - a # c0\n  - a # c1\n");
+        Ok(())
+    }
+
+    /// **Known divergence** (gap 2): a `del` at an array index renumbers
+    /// every later slot, so a static index from another stage means one
+    /// node before it and another after — and the target list records no
+    /// order. `collect_write_targets` declines the expression instead of
+    /// guessing, which leaves it on the positional walk; both orderings
+    /// then give the same answer, where yq's differ from it.
+    ///
+    /// yq prints `- - new` / `  - b0 # b0` for both.
+    #[test]
+    fn test_yaml_del_renumbering_another_stages_index_falls_back_870() -> Result<()> {
+        let input = "arr:\n  - - a0 # a0\n  - - b0 # b0\n";
+        for filter in [
+            ".arr[1] = ([\"new\"] + .arr[1]) | del(.arr[0])",
+            "del(.arr[0]) | .arr[0] = ([\"new\"] + .arr[0])",
+        ] {
+            let (output, exit_code) = run_yq_stdin(filter, input, &[])?;
+            assert_eq!(exit_code, 0, "{filter}");
+            assert_eq!(output, "arr:\n  - - new # a0\n    - b0\n", "{filter}");
+        }
+        Ok(())
+    }
+
+    /// The bail-out above must stay narrow: a `del` alongside a write that
+    /// never enters the same array is unambiguous, and both fixes still
+    /// apply.
+    #[test]
+    fn test_yaml_del_beside_an_unrelated_write_still_remaps_870() -> Result<()> {
+        let input = "arr:\n  - \"x\" # cx\n  - y # cy\nn: 1\n";
+        let (output, exit_code) = run_yq_stdin("del(.arr[0]) | .n = 2", input, &[])?;
+        assert_eq!(exit_code, 0);
+        assert_eq!(output, "arr:\n  - y # cy\nn: 2\n");
+        Ok(())
+    }
 }

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -33932,3 +33932,140 @@ fn test_yq_update_zero_output_filter_leaves_target_untouched_2484() -> Result<()
     );
     Ok(())
 }
+
+// =============================================================================
+// #870: `reconcile_presentation` misattributes style/comments across a write
+// that shifts an array's positions.
+//
+// Wrapped in a module of its own rather than appended at bare file end: two
+// branches each adding a `-> Result<()>` test here otherwise present git with
+// identical trailing `    Ok(())\n}\n` context on both sides, which it happily
+// merges into one function short a closing brace.
+//
+// Every expectation below is the pinned real `yq` (v4.53.3) output for the
+// same input and filter, captured live.
+// =============================================================================
+mod issue_870_position_shifting_writes {
+    use super::*;
+
+    /// `del` at index 0 shifts index 1 down into its slot, so the survivor
+    /// must keep *its own* comment, not the deleted element's.
+    ///
+    /// $ yq 'del(.arr[0])'  =>  arr:\n  - y # cy
+    #[test]
+    fn test_yaml_del_array_element_remaps_later_comments_870() -> Result<()> {
+        let input = "arr:\n  - \"x\" # cx\n  - y # cy\n";
+        let (output, exit_code) = run_yq_stdin("del(.arr[0])", input, &[])?;
+        assert_eq!(exit_code, 0);
+        assert_eq!(output, "arr:\n  - y # cy\n");
+        Ok(())
+    }
+
+    /// Deleting from the middle: everything before the removed index keeps
+    /// its own slot, everything after shifts down exactly one.
+    ///
+    /// $ yq 'del(.arr[1])'  =>  arr:\n  - "x" # cx\n  - z # cz
+    #[test]
+    fn test_yaml_del_middle_element_keeps_prefix_and_shifts_suffix_870() -> Result<()> {
+        let input = "arr:\n  - \"x\" # cx\n  - y # cy\n  - z # cz\n";
+        let (output, exit_code) = run_yq_stdin("del(.arr[1])", input, &[])?;
+        assert_eq!(exit_code, 0);
+        assert_eq!(output, "arr:\n  - \"x\" # cx\n  - z # cz\n");
+        Ok(())
+    }
+
+    /// A negative index resolves from the end before the remap, like every
+    /// other navigation step.
+    ///
+    /// $ yq 'del(.arr[-1])'  =>  arr:\n  - a # c0\n  - b # c1
+    #[test]
+    fn test_yaml_del_negative_index_remaps_870() -> Result<()> {
+        let input = "arr:\n  - a # c0\n  - b # c1\n  - c # c2\n";
+        let (output, exit_code) = run_yq_stdin("del(.arr[-1])", input, &[])?;
+        assert_eq!(exit_code, 0);
+        assert_eq!(output, "arr:\n  - a # c0\n  - b # c1\n");
+        Ok(())
+    }
+
+    /// `del(.arr[0], .arr[2])` is a generator on `del`'s left: both branches
+    /// are paths, and the single survivor keeps its own comment.
+    ///
+    /// $ yq 'del(.arr[0], .arr[2])'  =>  arr:\n  - b # c1
+    #[test]
+    fn test_yaml_del_multiple_indices_remaps_870() -> Result<()> {
+        let input = "arr:\n  - a # c0\n  - b # c1\n  - c # c2\n";
+        let (output, exit_code) = run_yq_stdin("del(.arr[0], .arr[2])", input, &[])?;
+        assert_eq!(exit_code, 0);
+        assert_eq!(output, "arr:\n  - b # c1\n");
+        Ok(())
+    }
+
+    /// The remap must not fabricate an anchor *declaration*. Deleting the
+    /// `&x` element leaves the surviving `*x` with nothing to resolve
+    /// against, so `enforce_anchor_soundness` drops the mark and prints the
+    /// value — deliberately unlike real yq, which emits a dangling `- *x`
+    /// it then cannot read back (#763's documented divergence).
+    ///
+    /// Before #870 the survivor inherited index 0's `Declares` mark and
+    /// printed `- &x a`: an anchor declaration that was never in the input.
+    #[test]
+    fn test_yaml_del_anchor_element_does_not_fabricate_declaration_870() -> Result<()> {
+        let input = "l:\n  - &x a\n  - *x\n  - z\n";
+        let (output, exit_code) = run_yq_stdin("del(.l[0])", input, &[])?;
+        assert_eq!(exit_code, 0);
+        assert_eq!(output, "l:\n  - a\n  - z\n");
+        Ok(())
+    }
+
+    /// The mirror case, where the remap keeps a mark that really is sound:
+    /// `&x` stays at index 0 and the alias shifts down into index 1.
+    ///
+    /// $ yq 'del(.l[1])'  =>  l:\n  - &x a\n  - *x
+    #[test]
+    fn test_yaml_del_keeps_sound_alias_after_shift_870() -> Result<()> {
+        let input = "l:\n  - &x a\n  - q\n  - *x\n";
+        let (output, exit_code) = run_yq_stdin("del(.l[1])", input, &[])?;
+        assert_eq!(exit_code, 0);
+        assert_eq!(output, "l:\n  - &x a\n  - *x\n");
+        Ok(())
+    }
+
+    /// Object fields are matched by key, so deleting one has never shifted
+    /// anything — a control that the new path-threading left it alone.
+    ///
+    /// $ yq 'del(.o.a)'  =>  o:\n  b: 2 # cb
+    #[test]
+    fn test_yaml_del_object_key_unaffected_870() -> Result<()> {
+        let input = "o:\n  a: 1 # ca\n  b: 2 # cb\n";
+        let (output, exit_code) = run_yq_stdin("del(.o.a)", input, &[])?;
+        assert_eq!(exit_code, 0);
+        assert_eq!(output, "o:\n  b: 2 # cb\n");
+        Ok(())
+    }
+
+    /// A pipe of writes: each stage's path is resolved independently, and
+    /// the `del` still remaps.
+    ///
+    /// $ yq '.z = 1 | del(.arr[0])'  =>  a: 1 # ca / arr:\n  - y # cy / z: 1
+    #[test]
+    fn test_yaml_pipe_of_writes_remaps_del_870() -> Result<()> {
+        let input = "a: 1 # ca\narr:\n  - \"x\" # cx\n  - y # cy\n";
+        let (output, exit_code) = run_yq_stdin(".z = 1 | del(.arr[0])", input, &[])?;
+        assert_eq!(exit_code, 0);
+        assert_eq!(output, "a: 1 # ca\narr:\n  - y # cy\nz: 1\n");
+        Ok(())
+    }
+
+    /// An in-place write at an index moves nothing, so that slot keeps its
+    /// own style — real yq prints `- "z"`, not `- z`, because the write
+    /// overwrites the node's value and not its identity. This is the case
+    /// the remap must *not* disturb.
+    #[test]
+    fn test_yaml_index_write_keeps_slot_style_870() -> Result<()> {
+        let input = "arr:\n  - \"x\"\n  - y\nn: 1\n";
+        let (output, exit_code) = run_yq_stdin(".arr[0] = \"z\"", input, &[])?;
+        assert_eq!(exit_code, 0);
+        assert_eq!(output, "arr:\n  - \"z\"\n  - y\nn: 1\n");
+        Ok(())
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #870. `reconcile_presentation` matched a result child to its pristine
counterpart purely by key/index, so any write that **moves** an array's
elements gave each new element whichever old element now sits at its slot.

```console
$ printf 'arr:\n  - "x"\n  - y\nn: 1\n' | yq '.arr = ["new"] + .arr | .n = 2'
arr:
  - new          # before: - "new"   <- inherited "x"'s quotes
  - "x"          # before: - x       <- lost its own
  - y
n: 2
```

`collect_write_targets` resolves the paths a write actually touched from the
AST, and the reconcile arms use them to decide what each result node may
inherit:

| write | rule |
|---|---|
| `del()` | exact index remap — removing slot `k` shifts later slots down one |
| wholesale write of a **closed literal** (`.arr = ["p","q"]`) | inherits nothing; every node is freshly constructed |
| any other wholesale array write | align by value, **only where that is evidence of movement** |
| anything else | positional, exactly as before |

### Not purely cosmetic in one case

Filed as **Severity: Low, cosmetic only**. One shape is worse. Deleting an
anchor-*declaring* element let the survivor inherit its `&x` mark, printing
an anchor declaration never present in the input:

```console
$ printf 'l:\n  - &x a\n  - *x\n  - z\n' | succinctly yq 'del(.l[0])'
l:
  - &x a         # <- fabricated; `&x` was on the element just deleted
  - z
```

`enforce_anchor_soundness` could not catch it: it only strips `Aliases`
marks, never `Declares`. With the remap the survivor keeps its own `Aliases`
mark, correctly fails the soundness gate, and prints `- a`.

## Three-way oracle results

26 shapes, each run against pinned `yq` v4.53.3, a `main` baseline binary
(`a353c85ba`), and this branch. **Zero regressions, 12 fixed.**

The three remaining divergences fail on `main` too, are pre-existing, and are
each pinned by a test:

| divergence | why |
|---|---|
| permutation of *equal* elements (`[a #c0, a #c1] \| reverse`) | values cannot say which node went where — node identity (#1351) |
| `del` renumbering another stage's static index | stage order is not recoverable from the target list; declined outright, left on the positional walk |
| `del(.l[0])` on `[&x a, *x, z]` | **intentional** — real yq emits a dangling `*x` it cannot re-read; #763's documented soundness divergence |

## What the review round changed

The first cut of the alignment had a regression and a perf cliff. Both are
fixed; recording them because the reasoning is the interesting part.

**It fired on coincidence, not movement.** Alignment ran on every wholesale
write, so `.arr |= [.[] | .port = 9]` — which rewrites elements *where they
stand* — matched nothing by value and handed every element empty metadata,
dropping comments that `main` and yq both keep. Now alignment is used only
when something actually moved (`p != i`) **and** the result is accounted
for: at equal lengths, a complete bijection. That second clause is what
catches the subtle one — `.arr |= [.[] + 1]` turns `[1, 2]` into `[2, 3]`,
which reads as "the 2 slid down a slot and the 3 is new" but is an in-place
increment. The `3` matching nothing is the tell.

**It was quadratic.** Alignment rescanned the pristine array per element:
`.arr |= reverse` on 100k elements took 14.65 s. Now bucketed by hash —
0.11 s against `main`'s 0.09 s, output byte-identical to yq.

Writing that hash is the one genuinely delicate part of this PR.
`OwnedValue`'s equality is hand-written *jq value* equality, not structural,
so the hash has to agree with it in three specific places or equal values
land in different buckets and the match silently misses:

1. `Int`/`Float`/`NumberLiteral` compare across variants by `f64` value;
2. `-0.0 == 0.0`, with different bit patterns;
3. `Object` equality is order-independent.

Each has its own test. The converse is not required — unequal values may
collide freely, since every candidate is confirmed with `==` anyway, which
is also why NaN needs no special case.

**Stage order.** A `del` at an array index renumbers slots, so
`.arr[1] = ... | del(.arr[0])` and its reverse are one target list and two
documents. That shape is now declined rather than guessed at.

**The closed-literal rule** came out of the same review's node-identity
discussion and closed what the earlier commit had recorded as unfixable:
`.arr = ["b","a","a"]`, `.o = {"a": "1", "b": 2}` and `.o = {"a": "9"}` now
all match yq. It is deliberately one-directional — `true` means "certainly
constructed", and the burden of proof sits on the destructive answer, since
a false positive would discard presentation the document really owns.

## Two deviations from the issue's triage comment

**1. Paths come from the AST, not from evaluating `path(lhs)`.** The triage
proposed `Expr::Builtin(Builtin::Path(lhs))` through `evaluate_input`. Its
actual decision — don't plumb `resolve_dynamic_indexes` out of
`src/jq/eval.rs` — is respected; only the mechanism differs. Every accepted
path is a static navigation chain, so resolution is a pure function of the
AST: the whole-document JSON re-serialize + reindex per write buys nothing,
and it avoids needing a throwaway `ErrorSink` to keep `path(.arr[-1])`'s own
diagnostic out of the user's output. The triage's note that this helper is
shared with #798-PR1 still holds; it is just smaller than planned.

**2. Alignment is arrays-only; objects stay key-matched.** The triage said
"`=`-family, container result". Aligning object children by *value* would
let one key inherit a different key's comment — the very misattribution this
issue is about — and yq keeps object comments with their own keys across a
reordering constructor (verified). Objects get the closed-literal rule
instead, which is the part that was actually diverging.

## Test plan

- [x] `cargo build --features cli`
- [x] `cargo test --features cli,simd,regex,serde` — 7629 passed, 0 failed
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings`
      (this second leg matters — `--all-features` alone enables `scalar-yaml`
      and compiles out the YAML SIMD backends)
- [x] `cargo check --no-default-features` (`no_std`) — warning set identical to `main`'s
- [x] `cargo fmt --all -- --check`
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps`
- [x] 28 CLI tests + 13 helper unit tests, every expectation captured live
      from pinned `yq` v4.53.3
- [x] Three-way A/B vs a `main` baseline binary over 26 shapes; interleaved
      timing runs for the perf claim, gated on output identity first
- [x] `reconcile_presentation_panics_past_nesting_depth_limit_1005` still green

New CLI tests live in their own `mod issue_870_position_shifting_writes`
block rather than at bare file end: two branches each appending a
`-> Result<()>` test otherwise present git with identical trailing
`    Ok(())\n}\n` context on both sides, which it merges into one function
short a closing brace. That conflict did in fact occur on rebase and the
module is what made it a clean, purely-additive resolution.
