### PR TITLE
feat(jq): answer an absent position from an owned identity (#2472)

### DIFF
--- a/docs/adrs/adr-0021.md
+++ b/docs/adrs/adr-0021.md
@@ -94,10 +94,11 @@ in-place transforms *inside owned values*, which have no node to stand on.
    positions and, for an absent one, rewrites those builtins in the rest of the pipe to
    the literals they answer (`path_context_resolve_absent`), then runs what is left over
    `null` in the ordinary owned evaluator — so `select`, `if`, comparison and `limit` keep
-   their one definition. `parent`/`parent(n)` answer with a node no literal spells and stay
-   on the eager route from a possibly-absent position, as does a stage that moves the
-   position after the constants were fixed. The gate is static
-   (`path_context_absent_split`) and the rewrite is held equal to the gate by a test.
+   their one definition. `parent`/`parent(n)` answer with a node no literal spells, and a
+   stage that moves the position after the constants were fixed leaves them stale; those
+   two shapes go to decision 7's route instead (#2472, below), and a *fan-out* head is the
+   one that still stays eager. The gate is static (`path_context_absent_split`, which also
+   picks between the two routes) and the rewrite is held equal to the gate by a test.
    (Step 2.)
 
 7. **An owned value carries its position.** Real yq's nodes carry parent pointers, and a
@@ -112,6 +113,26 @@ in-place transforms *inside owned values*, which have no node to stand on.
    site where an owned value leaves the cursor domain. `parent` climbs the chain and then
    continues into the document. A stage with no rule keeps its pipe on the eager
    evaluator, so an unlisted builtin costs the migration, never an answer. (Step 3.)
+
+   **An absent position is an owned identity too** (#2472). Decision 6 describes an absent
+   position by its path; the same position is described *completely* by the deepest real
+   ancestor it hangs under plus the components taken past it, which is an `OwnedIdentity`
+   with value `null`, `base` that ancestor's cursor, and one chain link per component. That
+   gives `parent` a node to answer with and lets the position move, so the two shapes
+   decision 6 declines are answered here instead of on the eager route, and
+   `path_context_resolve_constants` gained a `parent`/`parent(n)` arm that spells the
+   ancestor as an `Expr::TrackedVar` rather than as a literal it has no syntax for.
+   `path_context_absent_split` picks the route and prefers the constant one, which
+   materializes nothing; the identity route pays one `to_owned_cursor` of the deepest real
+   ancestor per absent position. The divergence this makes visible is not new: succinctly
+   prints the deepest real ancestor chain for `parent` where yq vivifies the missing key
+   (#2435), and the only change is that the eager route's `{}` for a one-level absent
+   ancestor is now the walk's `null`, the same answer for the same position.
+
+   **The residue is a fan-out head.** `.[] | .k | select(key == "k")` is one position per
+   element, the memory cost `path_context_fans_out` exists to refuse and the same guard
+   `path_context_walk_split` applies. It stays eager by design, and it is what decision 8's
+   exit condition has to survive: this route is not what will remove it.
 
 8. **No regrowth.** `tests/jq_path_context_arm_guard.rs` pins the eager evaluator's named
    handlers at their exact count (43 at the time of writing); a migration lowers the pin,
@@ -144,10 +165,11 @@ in-place transforms *inside owned values*, which have no node to stand on.
   becomes native inherits it, and a test guarding that construct's *rejection* keeps
   asserting the exit code and diagnostic, not an empty stdout.
 - **What remains on the eager route** is bounded by three reasons, each with a known
-  next step: the owned-domain stages decision 7's list does not cover; the absent shapes
-  decision 6 leaves behind (`parent` from a possibly-absent position, navigation after a
-  non-navigational stage, a fan-out head); and native `eval_single` arms for the
-  constructs that still bridge (`and`/`or`, `reduce`/`foreach`). #2471 closed four of
+  next step: the owned-domain stages decision 7's list does not cover; a fan-out head with
+  a computed tail, which is all #2472 left of the absent reason (its other two shapes,
+  `parent` from a possibly-absent position and navigation after a non-navigational stage,
+  are decision 7's route now); and native `eval_single` arms for the constructs that still
+  bridge (`and`/`or`, `reduce`/`foreach`). #2471 closed four of
   reason 1's shapes -- a computed `IndexExpr`/`SliceExpr` (and `?` over one) and
   `getpath(p)` as navigation, a read after `key`/`path`/`file_index` replaced the value,
   and a read under arithmetic inside a ruled stage -- so `key` gained a rule of its own
@@ -165,7 +187,11 @@ in-place transforms *inside owned values*, which have no node to stand on.
   match (`test_owned_identity_rules_match_yq_2416`), and jq mode's relative `path(f)` is
   unaffected. The pin cannot be lowered honestly until a reason is removed,
   because `path_context_needs_eager` hands whole pipes to the eager evaluator, where any
-  arm can run.
+  arm can run. #2472 measured exactly that: narrowing reason 2 moved *fourteen* of the 43
+  arms' listed proof queries off the gate and made not one arm unreachable, because the
+  stage shapes that still hand over (`and`/`or`, `map`, `reduce`/`foreach`, `as`/`label`/
+  `def`, the bounded consumers, a bare `parent` operand) run the generic structural arms
+  inside themselves (`docs/plan/path-context-arm-reachability.md`).
 
 ## Alternatives Considered
 

--- a/docs/plan/path-context-arm-reachability.md
+++ b/docs/plan/path-context-arm-reachability.md
@@ -100,9 +100,13 @@ order; the `Gate` column names the first that fired for that query.
 | R2  | `can_absent && !absent_routed`       | the navigational head can miss, and `path_context_absent_split` declined the pipe     |
 | R3  | `!path_context_stage_native(stage)`  | the stage is built from a construct with no native cursor-threading arm               |
 
-R2 dominates the table because the natural probe shape starts `.a.b`, and a
-`.field` step can always miss. The same shapes with a head that cannot miss trip
-R3 instead -- e.g. `.a[] | (key | tostring)`, `.a[] | reduce (key) as $k (""; . +
+R2 still dominates the table, but for a narrower reason since #2472 (below): a
+`.field` step can always miss, and a *head that can miss* is only handed over
+now when neither the constant route nor the owned identity pipe can take the
+stages after it. The probe shape that trips it is `.a?` (which
+`path_context_is_navigational` excludes, so no position is walked) or a bare
+`parent` operand (which no route can name a position for). The same shapes with
+a head that cannot miss trip R3 instead -- e.g. `.a[] | (key | tostring)`, `.a[] | reduce (key) as $k (""; . +
 $k) | . + "x"` and `.a[] | select(key == "b" and true)` all report R3. This is an
 ordering artefact, not a claim that R3 is rare.
 
@@ -116,32 +120,32 @@ any further admission rather than trusting them.
 
 | #   | Handler (site in `eval_stage_with_path_context`)                   | Verdict   | Proof query (jq mode, document `D`)                   | Gate |
 |-----|--------------------------------------------------------------------|-----------|-------------------------------------------------------|------|
-| H1  | pre-match `if matches!(first, Expr::Builtin(Builtin::PathNoArg))`  | REACHABLE | `.a.b \| path + []`                                   | R2   |
-| H2  | pre-match `if matches!(first, Expr::Builtin(Builtin::Key))`        | REACHABLE | `.a.b \| key + "x"`                                   | R2   |
-| H3  | pre-match `if matches!(first, Expr::Builtin(Builtin::FileIndex))`  | REACHABLE | `.a.b \| file_index + 1`                              | R2   |
+| H1  | pre-match `if matches!(first, Expr::Builtin(Builtin::PathNoArg))`  | REACHABLE | `.a? \| path + []`                                    | R2   |
+| H2  | pre-match `if matches!(first, Expr::Builtin(Builtin::Key))`        | REACHABLE | `.a? \| key + "x"`                                    | R2   |
+| H3  | pre-match `if matches!(first, Expr::Builtin(Builtin::FileIndex))`  | REACHABLE | `.a? \| file_index + 1`                               | R2   |
 | H4  | pre-match `if matches!(first, Expr::Builtin(Builtin::Parent))`     | REACHABLE | `.a.b \| parent + {}`                                 | R2   |
 | H5  | pre-match `if let Expr::Builtin(Builtin::ParentN(n_expr)) = first` | REACHABLE | `.a.b \| parent(0+1) + {}`                            | R2   |
-| A01 | `Expr::Identity`                                                   | REACHABLE | `.a.b \| . \| key + "x"`                              | R2   |
-| A02 | `Expr::Field(name)`                                                | REACHABLE | `.a.b \| key + "x"`                                   | R2   |
-| A03 | `Expr::Index { idx, key }`                                         | REACHABLE | `.c[0] \| key + 1`                                    | R2   |
+| A01 | `Expr::Identity`                                                   | REACHABLE | `.a.b \| . \| parent + {}`                            | R2   |
+| A02 | `Expr::Field(name)`                                                | REACHABLE | `.a.b \| parent + {}`                                 | R2   |
+| A03 | `Expr::Index { idx, key }`                                         | REACHABLE | `.c[0] \| parent + []`                                | R2   |
 | A04 | `Expr::Slice { .. }`                                               | REACHABLE | `.c[0:1] \| .[0] \| key + 1`                          | R1   |
 | A05 | `Expr::Iterate`                                                    | REACHABLE | `.a[] \| (key \| tostring)`                            | R3   |
-| A06 | `Expr::Paren(inner)`                                               | REACHABLE | `(.a.b) \| key + "x"`                                 | R2   |
+| A06 | `Expr::Paren(inner)`                                               | REACHABLE | `.a.b \| (parent) + {}`                               | R2   |
 | A07 | `Expr::Optional(inner) if IndexExpr/SliceExpr`                     | REACHABLE | `.c[.n]? \| key + 1`                                  | R1   |
 | A08 | `Expr::Optional(inner)`                                            | REACHABLE | `.a? \| key + "x"`                                    | R2   |
 | A09 | `Expr::Pipe(inner) if rest.is_empty()`                             | REACHABLE | `.a.b \| -(key\|length)`                              | R2   |
-| A10 | `Expr::Pipe(inner)`                                                | REACHABLE | `.a.b \| key + "x"`                                   | R2   |
-| A11 | `Expr::Arithmetic { .. }`                                          | REACHABLE | `.a.b \| key + "x"`                                   | R2   |
+| A10 | `Expr::Pipe(inner)`                                                | REACHABLE | `.a.b \| parent + {}`                                 | R2   |
+| A11 | `Expr::Arithmetic { .. }`                                          | REACHABLE | `.a.b \| parent + {}`                                 | R2   |
 | A12 | `Expr::And(..) \| Expr::Or(..)`                                    | REACHABLE | `.a.b \| key == "b" and true`                         | R2   |
 | A13 | `Expr::Negate(operand)`                                            | REACHABLE | `.a.b \| -(key\|length)`                              | R2   |
-| A14 | `Expr::Compare { .. }`                                             | REACHABLE | `.a.b \| (key + "x") \| . == "bx"`                    | R2   |
-| A15 | `Expr::Builtin(Builtin::Select(cond))`                             | REACHABLE | `.a.b \| select(key == "b") \| key + "x"`             | R2   |
+| A14 | `Expr::Compare { .. }`                                             | REACHABLE | `.a? \| (key + "x") \| . == "bx"`                     | R2   |
+| A15 | `Expr::Builtin(Builtin::Select(cond))`                             | REACHABLE | `.a.b \| select(key == "b") \| parent + {}`           | R2   |
 | A16 | `Expr::Builtin(Builtin::Map(f))`                                   | REACHABLE | `.a \| map(key + "x")`                                | R2   |
 | A17 | `Expr::Builtin(Builtin::GetPath(path_expr))`                       | REACHABLE | `.a \| getpath(["b"]) \| . as $x \| key`              | R1   |
-| A18 | `Expr::Builtin(_)`                                                 | REACHABLE | `.a.b \| (key + "x") \| length`                       | R2   |
+| A18 | `Expr::Builtin(_)`                                                 | REACHABLE | `.a[] \| (key \| length)`                             | R3   |
 | A19 | `Expr::IndexExpr { target, key }`                                  | REACHABLE | `.c[.n] \| key + 1`                                   | R1   |
 | A20 | `Expr::SliceExpr { target, start, end }`                           | REACHABLE | `.c[.n:.m] \| .[0] \| key + 1`                        | R1   |
-| A21 | `Expr::Array(inner) if needs_path_context(inner)`                  | REACHABLE | `.a.b \| [key] + ["x"]`                               | R2   |
+| A21 | `Expr::Array(inner) if needs_path_context(inner)`                  | REACHABLE | `.a? \| [key] + ["x"]`                                | R2   |
 | A22 | `Expr::StringInterpolation(parts) if ..`                           | REACHABLE | `.a.b \| ("\(key)") \| . + "x"`                       | R2   |
 | A23 | `Expr::DefCall { .. }`                                             | REACHABLE | `def f: key; .a.b \| f + "x"`                         | R2   |
 | A24 | `Expr::Shared(inner)`                                              | REACHABLE | `def f(x): x; .a.b \| f(key) + "z"`                   | R2   |
@@ -153,7 +157,7 @@ any further admission rather than trusting them.
 | A30 | `Expr::LastExpr(expr) if ..`                                       | REACHABLE | `.a.b \| last(key + "x")`                             | R2   |
 | A31 | `Expr::Reduce { .. } if ..`                                        | REACHABLE | `.a.b \| reduce (key) as $k (""; . + $k) \| . + "x"`  | R2   |
 | A32 | `Expr::Foreach { .. } if ..`                                       | REACHABLE | `.a.b \| foreach (key) as $k (""; . + $k) \| . + "x"` | R2   |
-| A33 | `Expr::Object(_) \| Expr::Array(_) \| Expr::Literal(_)`            | REACHABLE | `.a.b \| (key + "x") \| {z: .}`                       | R2   |
+| A33 | `Expr::Object(_) \| Expr::Array(_) \| Expr::Literal(_)`            | REACHABLE | `.a? \| (key + "x") \| {z: .}`                        | R2   |
 | A34 | `Expr::If { .. }`                                                  | REACHABLE | `.a.b \| if key == "b" then key + "x" else "y" end`   | R2   |
 | A35 | `Expr::Comma(exprs)`                                               | REACHABLE | `.a.b \| (key + "x"), key`                            | R2   |
 | A36 | `Expr::Try { .. }`                                                 | REACHABLE | `.a.b \| try (key + "x") catch "e"`                   | R2   |
@@ -230,6 +234,60 @@ component -- which it cannot do uniformly, because an *absent* position
 is the next step for this cluster, and it is what would make the five `R1` rows
 unreachable.
 
+## #2472: gate reason 2 narrowed, and the pin still holds at 43
+
+[#2472](https://github.com/rust-works/succinctly/issues/2472) took two of the
+three shapes gate reason `R2` still hands over -- a `parent`/`parent(n)` read
+from a possibly-absent position inside a non-navigational stage, and navigation
+*after* a non-navigational stage -- and moved them onto the owned identity pipe
+(ADR-0021 decision 7). An absent position is the deepest real ancestor it hangs
+under plus the components taken past it, which is exactly an `OwnedIdentity`, so
+`parent` has a node to answer with and the position may move. The third shape, a
+fan-out head, stays eager by design: one position per element is the memory cost
+`path_context_fans_out` exists to refuse, and ADR-0021 records it as the exit
+condition's residue.
+
+**`PINNED_ARM_COUNT` stays at 43.** Re-run of the method above on the post-#2472
+tree, in two passes. Pass 1 instrumented `path_context_needs_eager` alone
+(one `eprintln!` per disjunct) and ran all 43 listed proof queries: **29 still
+enter the gate, 14 no longer do.** The 14 are `H1`, `H2`, `H3`, `A01`, `A02`,
+`A03`, `A06`, `A10`, `A11`, `A14`, `A15`, `A18`, `A21` and `A33` -- every one
+of them a `.a.b`-headed `key`/`path`/`file_index` shape, which is precisely the
+class the identity route now answers.
+
+Pass 2 instrumented those 14 handlers and swept the 29 surviving queries plus
+candidates. **All 14 still fire**, and the table above now carries the
+re-derived query for each (outputs pinned in
+`test_arm_audit_proof_queries_are_unmoved_by_the_gate_2416`, alongside the old
+spellings). Two shapes do the work:
+
+- **`?` is the reliable `R2` head now.** `path_context_is_navigational`
+  deliberately excludes `Expr::Optional` (the walk's own documented exclusion:
+  `?` in path context is not `?` in a path expression), so the absent split's
+  head stops before it, there is no position to walk, and the pipe still trips
+  `can_absent && !absent_routed`. `.a? | key + "x"` fires `H1`, `H2`, `A01`,
+  `A02`, `A11` and `A21` in one query.
+- **`parent` outside a ruled stage is still not routable.** A bare
+  `parent + {}` has `parent` as an arithmetic *operand*, and
+  `owned_identity_operand_resolvable` refuses a read it cannot name a position
+  for -- #2471's own pinned row. So `.a.b | parent + {}` still enters at `R2`
+  and reaches `A02`, `A10` and `A11`.
+
+The 29 unmoved rows need no re-derivation and none was done: this change does
+not touch `eval_stage_with_path_context` at all, only which pipes reach it, so a
+query that still enters the gate fires exactly the arms it fired before.
+
+**Nothing became unreachable, so nothing was deleted.** The reason is
+structural, not incidental: every arm listed here is reached by *some* stage
+shape, and the identity route accepts a `rest` only when every stage of it has
+an `owned_identity_rule` or is navigation the pipe can name a component for.
+`and`/`or` (`A12`), unary minus outside a ruled stage (`A13`), `map` (`A16`),
+`reduce`/`foreach` (`A31`/`A32`), `as`/`label`/`def` (`A23`-`A27`, `A37`,
+`A38`) and the bounded consumers (`A28`-`A30`) have no rule, so a pipe
+containing one still hands over -- and once it does, the generic structural
+arms (`A01`, `A02`, `A06`, `A10`, `A11`) run inside it. Deleting an arm needs
+those *stage* shapes migrated, not this route widened.
+
 ## Result
 
 | Metric                                            | Before | After |
@@ -238,6 +296,7 @@ unreachable.
 | ... proven REACHABLE by a live query               | --     | 43    |
 | ... proven UNREACHABLE                             | --     | 0     |
 | ... neither                                        | --     | 0     |
+| ... whose listed proof query moved off the gate    | --     | 14    |
 | `PINNED_ARM_COUNT`                                 | 43     | 43    |
 
 Nothing is deletable at this point in the spine. Doors 2 and 3 are closed as
@@ -263,7 +322,14 @@ evaluator, with no second route to check.
   proof query is the same one.
 - Reachability here is a property of the current tree. Re-run the method above
   (instrument, run, revert) rather than trusting this table after the gate or
-  `path_context_single_native` moves.
+  `path_context_single_native` moves. #2472 is the worked example: 14 of the 43
+  rows needed a re-derived query and *none* of them was unreachable, so a table
+  read without re-running would have claimed 14 deletable arms.
+- The `R2` cluster is now the *stage* shapes with no `owned_identity_rule`
+  (`and`/`or`, `map`, `reduce`/`foreach`, `as`/`label`/`def`, the bounded
+  consumers) plus a bare `parent` operand. Those are what to migrate next for
+  this reason; widening the absent route again buys nothing, because it already
+  accepts every `rest` those stages are missing from.
 - The step-5 closure did *not* change what the sweep
   (`scripts/jq-path-context-oracle-sweep.sh`) sees for `file_index`. Its
   yq-mode cases run `succinctly yq FILTER one.yaml two.yaml` with no

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -12817,49 +12817,55 @@ fn try_path_context_cursor_walk<S: EvalSemantics, V: DocumentValue>(
 /// therefore a refusal, not a fallback -- reached only with
 /// `needs_path_context` already true.
 fn path_context_absent_resolvable(expr: &Expr) -> bool {
+    path_context_resolvable(expr, false)
+}
+
+/// [`path_context_absent_resolvable`] with `parent`/`parent(n)` admitted
+/// too (#2472): the owned identity pipe *does* hold the node they answer
+/// with, so a read the constant-only route has to refuse is a literal there
+/// -- `Expr::TrackedVar`, the one node that spells an arbitrary
+/// `OwnedValue`. See [`path_context_resolve_constants`]'s `Parent` arm.
+fn owned_identity_stage_resolvable(expr: &Expr) -> bool {
+    path_context_resolvable(expr, true)
+}
+
+/// The shared body of the two predicates above. `with_parent` is the *only*
+/// difference between them, so a construct admitted for one is admitted for
+/// the other and the rewriter's arms cover both call sites.
+fn path_context_resolvable(expr: &Expr, with_parent: bool) -> bool {
     if !needs_path_context(expr) {
         // Nothing to resolve. Whatever this is, it evaluates against the
         // `null` an absent position holds and answers exactly as it does on
         // the eager route, which navigated into the same `null`.
         return true;
     }
+    let sub = |e: &Expr| path_context_resolvable(e, with_parent);
     match expr {
         Expr::Builtin(Builtin::Key | Builtin::PathNoArg | Builtin::FileIndex) => true,
-        Expr::Paren(inner) | Expr::Array(inner) | Expr::Optional(inner) => {
-            path_context_absent_resolvable(inner)
-        }
-        Expr::FirstExpr(inner) | Expr::LastExpr(inner) => path_context_absent_resolvable(inner),
-        Expr::Builtin(Builtin::FirstStream(inner) | Builtin::LastStream(inner)) => {
-            path_context_absent_resolvable(inner)
-        }
-        Expr::Comma(exprs) => exprs.iter().all(path_context_absent_resolvable),
-        Expr::Pipe(exprs) => path_context_absent_stages_resolvable(exprs),
-        Expr::Builtin(Builtin::Select(cond)) => path_context_absent_resolvable(cond),
-        Expr::Limit { n, expr } => {
-            path_context_absent_resolvable(n) && path_context_absent_resolvable(expr)
-        }
-        Expr::Try { expr, catch } => {
-            path_context_absent_resolvable(expr)
-                && catch
-                    .as_deref()
-                    .map_or(true, path_context_absent_resolvable)
-        }
+        // #2472: a node, not a constant -- resolvable only where the caller
+        // carries the identity to climb.
+        Expr::Builtin(Builtin::Parent) => with_parent,
+        // `parent(n)` climbs `n` levels, and `n` has to be knowable without
+        // evaluating a stream against a position that may not exist: the
+        // same literal-only restriction `owned_identity_pipe_supported`
+        // already places on a bare `parent(n)` stage.
+        Expr::Builtin(Builtin::ParentN(n)) => with_parent && matches!(**n, Expr::Literal(_)),
+        Expr::Paren(inner) | Expr::Array(inner) | Expr::Optional(inner) => sub(inner),
+        Expr::FirstExpr(inner) | Expr::LastExpr(inner) => sub(inner),
+        Expr::Builtin(Builtin::FirstStream(inner) | Builtin::LastStream(inner)) => sub(inner),
+        Expr::Comma(exprs) => exprs.iter().all(sub),
+        Expr::Pipe(exprs) => path_context_stages_resolvable(exprs, with_parent),
+        Expr::Builtin(Builtin::Select(cond)) => sub(cond),
+        Expr::Limit { n, expr } => sub(n) && sub(expr),
+        Expr::Try { expr, catch } => sub(expr) && catch.as_deref().map_or(true, sub),
         Expr::If {
             cond,
             then_branch,
             else_branch,
-        } => {
-            path_context_absent_resolvable(cond)
-                && path_context_absent_resolvable(then_branch)
-                && path_context_absent_resolvable(else_branch)
-        }
-        Expr::Compare { left, right, .. } => {
-            path_context_absent_resolvable(left) && path_context_absent_resolvable(right)
-        }
-        Expr::And(left, right) | Expr::Or(left, right) => {
-            path_context_absent_resolvable(left) && path_context_absent_resolvable(right)
-        }
-        Expr::Negate(inner) => path_context_absent_resolvable(inner),
+        } => sub(cond) && sub(then_branch) && sub(else_branch),
+        Expr::Compare { left, right, .. } => sub(left) && sub(right),
+        Expr::And(left, right) | Expr::Or(left, right) => sub(left) && sub(right),
+        Expr::Negate(inner) => sub(inner),
         _ => false,
     }
 }
@@ -12868,9 +12874,15 @@ fn path_context_absent_resolvable(expr: &Expr) -> bool {
 /// the position only while the position has not moved, because the resolved
 /// constants describe one position and nothing carries a second one.
 fn path_context_absent_stages_resolvable(stages: &[Expr]) -> bool {
+    path_context_stages_resolvable(stages, false)
+}
+
+/// [`path_context_absent_stages_resolvable`] with the `with_parent` knob
+/// [`path_context_resolvable`] documents.
+fn path_context_stages_resolvable(stages: &[Expr], with_parent: bool) -> bool {
     let mut moved = false;
     for stage in stages {
-        if needs_path_context(stage) && (moved || !path_context_absent_resolvable(stage)) {
+        if needs_path_context(stage) && (moved || !path_context_resolvable(stage, with_parent)) {
             return false;
         }
         moved = moved || !path_context_absent_keeps_position(stage);
@@ -12936,7 +12948,7 @@ fn path_context_absent_keeps_position(expr: &Expr) -> bool {
 /// deduplication: it keeps `PathContextRoute::BridgeOnly` meaning what
 /// `tests/jq_evaluator_parity_tests.rs` needs it to mean for those pipes --
 /// walk off, bridge on -- instead of quietly substituting a third route.
-fn path_context_absent_split(exprs: &[Expr]) -> Option<(&[Expr], &[Expr])> {
+fn path_context_absent_split(exprs: &[Expr]) -> Option<(&[Expr], &[Expr], AbsentRestRoute)> {
     if path_context_walk_split(exprs).is_some() {
         return None;
     }
@@ -12951,10 +12963,129 @@ fn path_context_absent_split(exprs: &[Expr]) -> Option<(&[Expr], &[Expr])> {
     if !head_can_yield_absent(head) || head.iter().any(path_context_fans_out) {
         return None;
     }
-    if !path_context_absent_stages_resolvable(rest) || path_context_needs_eager(rest) {
-        return None;
+    let route = path_context_absent_rest_route(rest)?;
+    Some((head, rest, route))
+}
+
+/// How the stages after an absent-route head are evaluated at a position.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+enum AbsentRestRoute {
+    /// ADR-0021 decision 6: `key`/`path`/`file_index` become literals and
+    /// what is left runs over `null` in the ordinary owned evaluator. No
+    /// materialization at all, so it is preferred wherever it applies.
+    Constants,
+    /// ADR-0021 decision 7 (#2472): the position becomes an
+    /// [`OwnedIdentity`] and the rest runs in [`eval_owned_identity_pipe`],
+    /// which answers `parent` with a real node and lets the position move.
+    OwnedIdentity,
+}
+
+/// Which route [`path_context_absent_split`]'s `rest` takes, or `None` to
+/// leave the pipe on the eager evaluator.
+///
+/// The constant route is tried first because it answers a position without
+/// materializing anything; the identity route pays one `to_owned_cursor` of
+/// the deepest real ancestor per position (see
+/// [`path_context_absent_identity`]).
+///
+/// The constant route additionally requires that `rest` not need the eager
+/// evaluator itself: `rest` is evaluated from the walked *node*, so an eager
+/// evaluation of it would materialize a document re-rooted there and answer
+/// `key`/`path` against the wrong root. The identity route has no such
+/// requirement -- it evaluates `rest` itself, from a position it carries --
+/// which is exactly why it reaches the shapes decision 6 declines.
+fn path_context_absent_rest_route(rest: &[Expr]) -> Option<AbsentRestRoute> {
+    if path_context_absent_stages_resolvable(rest) && !path_context_needs_eager(rest) {
+        return Some(AbsentRestRoute::Constants);
     }
-    Some((head, rest))
+    if owned_identity_pipe_supported(rest) && owned_identity_escapes_are_carried(rest) {
+        return Some(AbsentRestRoute::OwnedIdentity);
+    }
+    None
+}
+
+/// Whether every *navigation* stage of `rest` carries an escape, and an
+/// already-emitted prefix, out of the owned identity pipe the way the eager
+/// route this replaces does.
+///
+/// Two gaps say no for a computed bracket or `getpath`, and only for those:
+/// [`owned_identity_values`] folds every non-error escape into "no more
+/// values" (so `[.a | .[halt_error] | key]` would exit 0 instead of 5), and
+/// [`eval_owned_identity_pipe`]'s navigation arm drops the outputs a step
+/// produced before it failed (so `.arr | .[(0,"a")] | key` would lose the
+/// `0` the first component answered). Every other navigation stage -- `.c`,
+/// `.[0]`, `.[]`, a literal slice -- has no sub-expression to escape from,
+/// and a computed bracket *inside* a ruled stage (`[.[halt]]`,
+/// `select(.[halt])`) is evaluated by `eval_each_owned`, which returns a
+/// `Flow` and carries both.
+///
+/// This is a refusal, not a fix: the same two gaps are live on the owned
+/// identity pipe's own route (`owned_identity_pipe_applies`), where they
+/// predate this one. Widening the absent route is not the place to close
+/// them, so a pipe that would newly meet them stays exactly where it was.
+///
+/// The recursion mirrors [`owned_identity_nav_supported`]'s -- `?`, `(..)`
+/// and a nested pipe are the only wrappers a navigation stage has -- so a
+/// shape admitted there is inspected here.
+fn owned_identity_escapes_are_carried(stages: &[Expr]) -> bool {
+    stages.iter().all(owned_identity_stage_escapes_are_carried)
+}
+
+/// [`owned_identity_escapes_are_carried`] for one stage.
+fn owned_identity_stage_escapes_are_carried(expr: &Expr) -> bool {
+    match strip_parens(expr) {
+        Expr::IndexExpr { .. } | Expr::SliceExpr { .. } | Expr::Builtin(Builtin::GetPath(_)) => {
+            false
+        }
+        Expr::Optional(inner) => owned_identity_stage_escapes_are_carried(inner),
+        Expr::Pipe(exprs) => exprs.iter().all(owned_identity_stage_escapes_are_carried),
+        _ => true,
+    }
+}
+
+/// The [`OwnedIdentity`] of an absent position (#2472).
+///
+/// An absent position is completely described by the deepest real ancestor
+/// it hangs under plus the components taken past it, which is exactly what
+/// an `OwnedIdentity` records: `base` is that ancestor's cursor, and the
+/// chain holds one link per component. Only the first link has a value to
+/// carry -- everything below the ancestor is absent, which is `null` -- so
+/// this pays exactly one `to_owned_cursor` per absent position.
+///
+/// `parent` then pops the chain, which is what the walk's own answers
+/// already are: on `a: {b: 1}`, `.a.x.y | parent` is `null` (the absent
+/// `.a.x`) and `parent(2)` is the real `.a`. Real yq *vivifies* the missing
+/// keys and prints `{"y":null}` / `{"b":1,"x":{"y":null}}` there; that
+/// divergence is #2435's, recorded in `docs/compliance/yq/limitations.md`,
+/// and this route reproduces succinctly's side of it rather than changing
+/// it.
+fn path_context_absent_identity<V: DocumentValue>(
+    pos: &PathContextPos<V>,
+) -> Result<OwnedIdentity<V>, EvalError> {
+    // A position becomes absent by stepping off a real node, and the walk
+    // roots itself at one (`path_context_root`), so the ancestor chain
+    // always holds at least one live cursor -- and, since a step from an
+    // absent node is absent too, every entry after the last live one is
+    // absent.
+    let Some(base_index) = pos
+        .ancestors
+        .iter()
+        .rposition(|node| matches!(node, PathNode::At(_)))
+    else {
+        debug_assert!(false, "an absent position hangs under a real ancestor");
+        return Ok(OwnedIdentity::detached());
+    };
+    let PathNode::At(base) = pos.ancestors[base_index] else {
+        unreachable!("rposition matched a live cursor")
+    };
+    let base_value = Rc::new(to_owned_cursor(&base)?);
+    let absent = Rc::new(OwnedValue::Null);
+    let mut id = OwnedIdentity::kept(base);
+    for (i, component) in pos.path[base_index..].iter().enumerate() {
+        let parent = if i == 0 { &base_value } else { &absent };
+        id = id.child(parent, component.clone());
+    }
+    Ok(id)
 }
 
 /// The `Expr` one resolved path component spells.
@@ -12985,11 +13116,34 @@ fn path_component_literal(component: &OwnedValue) -> Expr {
 /// here would evaluate its `key` against no position and answer `null`,
 /// which is the silent-fallback failure ADR-0021 was written to end. The
 /// `_` arm is reached only for a subtree with no path-context builtin in it.
-fn path_context_resolve_absent<V: DocumentValue>(expr: &Expr, pos: &PathContextPos<V>) -> Expr {
+fn path_context_resolve_absent<S: EvalSemantics, V: DocumentValue>(
+    expr: &Expr,
+    pos: &PathContextPos<V>,
+) -> Result<Expr, EvalError> {
     // An absent position always has at least one component -- it took a
     // `.a`/`[i]` step to become absent -- so its key is the walk's own
     // `path.last()`.
-    path_context_resolve_constants(expr, pos.path.last(), &pos.path)
+    path_context_resolve_constants::<S, V>(
+        expr,
+        &PathContextAt {
+            key: pos.path.last(),
+            path: &pos.path,
+            parent_from: None,
+        },
+    )
+}
+
+/// The position [`path_context_resolve_constants`] rewrites against.
+///
+/// `key`/`path` are the constants the position answers. `parent_from` is
+/// the value and identity `parent`/`parent(n)` climb, carried only by the
+/// owned identity pipe -- the constant-only route leaves it `None`, and
+/// [`path_context_absent_resolvable`] refuses `parent` there, so the
+/// rewriter's `Parent` arms are unreachable with it unset.
+struct PathContextAt<'a, V: DocumentValue> {
+    key: Option<&'a OwnedValue>,
+    path: &'a [OwnedValue],
+    parent_from: Option<(&'a OwnedValue, &'a OwnedIdentity<V>)>,
 }
 
 /// [`path_context_resolve_absent`]'s worker, over the constants themselves:
@@ -12997,16 +13151,18 @@ fn path_context_resolve_absent<V: DocumentValue>(expr: &Expr, pos: &PathContextP
 /// detached owned root, #2416 step 3), and `path` is the full path. Shared
 /// with the owned identity pipe, whose `key`/`path` inside a `select`/`[..]`
 /// are constants for the same reason.
-fn path_context_resolve_constants(
+fn path_context_resolve_constants<S: EvalSemantics, V: DocumentValue>(
     expr: &Expr,
-    key: Option<&OwnedValue>,
-    path: &[OwnedValue],
-) -> Expr {
+    at: &PathContextAt<'_, V>,
+) -> Result<Expr, EvalError> {
     if !needs_path_context(expr) {
-        return expr.clone();
+        return Ok(expr.clone());
     }
-    let boxed = |e: &Expr| Box::new(path_context_resolve_constants(e, key, path));
-    match expr {
+    let (key, path) = (at.key, at.path);
+    let boxed = |e: &Expr| -> Result<Box<Expr>, EvalError> {
+        Ok(Box::new(path_context_resolve_constants::<S, V>(e, at)?))
+    };
+    Ok(match expr {
         Expr::Builtin(Builtin::Key) => match key {
             Some(component) => path_component_literal(component),
             None => Expr::Builtin(Builtin::Empty),
@@ -13035,52 +13191,69 @@ fn path_context_resolve_constants(
         Expr::Builtin(Builtin::FileIndex) => {
             Expr::Literal(Literal::Int(ambient_file_index().unwrap_or(0)))
         }
-        Expr::Paren(inner) => Expr::Paren(boxed(inner)),
-        Expr::Array(inner) => Expr::Array(boxed(inner)),
-        Expr::Optional(inner) => Expr::Optional(boxed(inner)),
-        Expr::FirstExpr(inner) => Expr::FirstExpr(boxed(inner)),
-        Expr::LastExpr(inner) => Expr::LastExpr(boxed(inner)),
-        Expr::Negate(inner) => Expr::Negate(boxed(inner)),
+        // #2472: `parent`/`parent(n)` inside a stage the owned identity
+        // pipe evaluates as a whole (`[path, parent]`, `select(parent !=
+        // null)`). The node they answer with is not a constant -- no
+        // `Literal` spells an object -- but the identity holds it, and
+        // `Expr::TrackedVar` is the node that carries an arbitrary
+        // `OwnedValue` through the ordinary evaluator (it is what `$x`
+        // becomes once bound). Nothing above the document root is `empty`,
+        // the same answer `eval_owned_identity_pipe`'s own bare `parent`
+        // arm gives (#2421).
+        Expr::Builtin(Builtin::Parent) => path_context_resolve_parent(at, 1)?,
+        Expr::Builtin(Builtin::ParentN(n_expr)) => {
+            let Expr::Literal(lit) = &**n_expr else {
+                unreachable!("path_context_resolvable admits a literal n only")
+            };
+            let n = classify_parent_n::<S>(&literal_to_owned(lit), path.len())?;
+            path_context_resolve_parent(at, n)?
+        }
+        Expr::Paren(inner) => Expr::Paren(boxed(inner)?),
+        Expr::Array(inner) => Expr::Array(boxed(inner)?),
+        Expr::Optional(inner) => Expr::Optional(boxed(inner)?),
+        Expr::FirstExpr(inner) => Expr::FirstExpr(boxed(inner)?),
+        Expr::LastExpr(inner) => Expr::LastExpr(boxed(inner)?),
+        Expr::Negate(inner) => Expr::Negate(boxed(inner)?),
         Expr::Builtin(Builtin::FirstStream(inner)) => {
-            Expr::Builtin(Builtin::FirstStream(boxed(inner)))
+            Expr::Builtin(Builtin::FirstStream(boxed(inner)?))
         }
         Expr::Builtin(Builtin::LastStream(inner)) => {
-            Expr::Builtin(Builtin::LastStream(boxed(inner)))
+            Expr::Builtin(Builtin::LastStream(boxed(inner)?))
         }
-        Expr::Builtin(Builtin::Select(cond)) => Expr::Builtin(Builtin::Select(boxed(cond))),
+        Expr::Builtin(Builtin::Select(cond)) => Expr::Builtin(Builtin::Select(boxed(cond)?)),
         Expr::Comma(exprs) => Expr::Comma(
             exprs
                 .iter()
-                .map(|e| path_context_resolve_constants(e, key, path))
-                .collect(),
+                .map(|e| path_context_resolve_constants::<S, V>(e, at))
+                .collect::<Result<Vec<_>, _>>()?,
         ),
         Expr::Pipe(exprs) => Expr::Pipe(
             exprs
                 .iter()
-                .map(|e| path_context_resolve_constants(e, key, path))
-                .collect(),
+                .map(|e| path_context_resolve_constants::<S, V>(e, at))
+                .collect::<Result<Vec<_>, _>>()?,
         ),
         Expr::Limit { n, expr } => Expr::Limit {
-            n: boxed(n),
-            expr: boxed(expr),
+            n: boxed(n)?,
+            expr: boxed(expr)?,
         },
         Expr::Try { expr, catch } => Expr::Try {
-            expr: boxed(expr),
-            catch: catch.as_deref().map(boxed),
+            expr: boxed(expr)?,
+            catch: catch.as_deref().map(boxed).transpose()?,
         },
         Expr::If {
             cond,
             then_branch,
             else_branch,
         } => Expr::If {
-            cond: boxed(cond),
-            then_branch: boxed(then_branch),
-            else_branch: boxed(else_branch),
+            cond: boxed(cond)?,
+            then_branch: boxed(then_branch)?,
+            else_branch: boxed(else_branch)?,
         },
         Expr::Compare { op, left, right } => Expr::Compare {
             op: *op,
-            left: boxed(left),
-            right: boxed(right),
+            left: boxed(left)?,
+            right: boxed(right)?,
         },
         // #2471 sub-item 5: the owned identity pipe resolves a read inside
         // an arithmetic operand (`key + 1`). The *absent* route's own gate
@@ -13089,13 +13262,37 @@ fn path_context_resolve_constants(
         // what is routed there.
         Expr::Arithmetic { op, left, right } => Expr::Arithmetic {
             op: *op,
-            left: boxed(left),
-            right: boxed(right),
+            left: boxed(left)?,
+            right: boxed(right)?,
         },
-        Expr::And(left, right) => Expr::And(boxed(left), boxed(right)),
-        Expr::Or(left, right) => Expr::Or(boxed(left), boxed(right)),
+        Expr::And(left, right) => Expr::And(boxed(left)?, boxed(right)?),
+        Expr::Or(left, right) => Expr::Or(boxed(left)?, boxed(right)?),
         other => other.clone(),
-    }
+    })
+}
+
+/// The literal `parent(n)` answers with at `at`, for
+/// [`path_context_resolve_constants`]: the ancestor's value carried in an
+/// `Expr::TrackedVar`, or `empty` where there is none (above the document
+/// root, or a caller with no identity -- a shape
+/// [`path_context_absent_resolvable`] refuses, asserted rather than
+/// silently answered with `null`).
+fn path_context_resolve_parent<V: DocumentValue>(
+    at: &PathContextAt<'_, V>,
+    n: usize,
+) -> Result<Expr, EvalError> {
+    let Some((value, id)) = at.parent_from else {
+        debug_assert!(
+            false,
+            "path_context_absent_resolvable refuses parent without an identity"
+        );
+        return Ok(Expr::Builtin(Builtin::Empty));
+    };
+    Ok(match owned_identity_ancestor(value, id, n) {
+        OwnedAncestor::Owned(v, _) => Expr::TrackedVar(Rc::new(v)),
+        OwnedAncestor::Node(c) => Expr::TrackedVar(Rc::new(to_owned_cursor(&c)?)),
+        OwnedAncestor::None => Expr::Builtin(Builtin::Empty),
+    })
 }
 
 /// The absent route (#2416 step 2): walk the navigational head as positions,
@@ -13119,7 +13316,7 @@ fn try_path_context_absent_sink<S: EvalSemantics, V: DocumentValue>(
     root: V::Cursor,
     sink: &mut dyn FnMut(GenericItem<V>) -> Demand,
 ) -> Option<Flow> {
-    let (head, rest) = path_context_absent_split(exprs)?;
+    let (head, rest, route) = path_context_absent_split(exprs)?;
     let root_pos = match path_context_root::<V>(root) {
         Ok(pos) => pos,
         Err(control) => return Some(Flow::Escaped(control)),
@@ -13130,25 +13327,44 @@ fn try_path_context_absent_sink<S: EvalSemantics, V: DocumentValue>(
     // error follows them, the same rule `path_context_step_generic` states.
     let stepped =
         path_context_step_generic::<S, V>(&Expr::Pipe(head.to_vec()), &root_pos, &mut positions);
+    // A live node keeps its cursor wherever `rest` can be evaluated from
+    // one; the identity route's own real positions are the shapes where it
+    // cannot (`.c | key` moves the position `rest` reads), and those
+    // materialize the node instead of re-rooting the document eagerly.
+    let rest_is_cursor_native = !path_context_needs_eager(rest);
     for pos in &positions {
         let flow = match &pos.node {
-            PathNode::At(c) => {
+            PathNode::At(c) if rest_is_cursor_native => {
                 eval_each_pipe_generic::<S, V>(rest, c.value(), false, Some(*c), sink)
             }
-            PathNode::Absent => {
-                let resolved = Expr::Pipe(
-                    rest.iter()
-                        .map(|stage| path_context_resolve_absent::<V>(stage, pos))
-                        .collect(),
-                );
-                debug_assert!(
-                    !needs_path_context(&resolved),
-                    "path_context_absent_split admitted a stage the resolver leaves unresolved"
-                );
-                eval_each_owned::<S>(&resolved, &OwnedValue::Null, false, &mut |v| {
-                    sink(GenericItem::Owned(v))
-                })
-            }
+            PathNode::At(c) => match to_owned_cursor(c) {
+                Ok(value) => eval_owned_identity_pipe::<S, V>(
+                    rest,
+                    value,
+                    OwnedIdentity::kept(*c),
+                    false,
+                    sink,
+                ),
+                Err(e) => Flow::Escaped(Control::Error(e)),
+            },
+            PathNode::Absent => match route {
+                AbsentRestRoute::Constants => {
+                    match path_context_resolve_absent_stages::<S, V>(rest, pos) {
+                        Ok(resolved) => {
+                            eval_each_owned::<S>(&resolved, &OwnedValue::Null, false, &mut |v| {
+                                sink(GenericItem::Owned(v))
+                            })
+                        }
+                        Err(e) => Flow::Escaped(Control::Error(e)),
+                    }
+                }
+                AbsentRestRoute::OwnedIdentity => match path_context_absent_identity::<V>(pos) {
+                    Ok(id) => {
+                        eval_owned_identity_pipe::<S, V>(rest, OwnedValue::Null, id, false, sink)
+                    }
+                    Err(e) => Flow::Escaped(Control::Error(e)),
+                },
+            },
         };
         match flow {
             Flow::Exhausted => {}
@@ -13159,6 +13375,24 @@ fn try_path_context_absent_sink<S: EvalSemantics, V: DocumentValue>(
         Ok(()) => Flow::Exhausted,
         Err(e) => Flow::Escaped(Control::Error(e)),
     })
+}
+
+/// [`path_context_resolve_absent`] over every stage of `rest`, as the one
+/// pipe the ordinary owned evaluator then runs over `null`.
+fn path_context_resolve_absent_stages<S: EvalSemantics, V: DocumentValue>(
+    rest: &[Expr],
+    pos: &PathContextPos<V>,
+) -> Result<Expr, EvalError> {
+    let mut stages = vec_with_capacity(rest.len());
+    for stage in rest {
+        stages.push(path_context_resolve_absent::<S, V>(stage, pos)?);
+    }
+    let resolved = Expr::Pipe(stages);
+    debug_assert!(
+        !needs_path_context(&resolved),
+        "path_context_absent_split admitted a stage the resolver leaves unresolved"
+    );
+    Ok(resolved)
 }
 
 /// The non-sink half of [`try_path_context_absent_sink`], for
@@ -14649,6 +14883,41 @@ impl<V: DocumentValue> OwnedIdentity<V> {
     }
 }
 
+/// Where `parent(n)` from an owned value with identity lands: inside the
+/// owned tree (or at its root), on a document node above that root, or
+/// nowhere at all. One definition of the climb, so
+/// [`eval_owned_identity_pipe`]'s `parent`/`parent(n)` stages and
+/// [`path_context_resolve_constants`]'s rewrite of a `parent` *inside* a
+/// stage cannot disagree about where `n` levels up is.
+enum OwnedAncestor<V: DocumentValue> {
+    Owned(OwnedValue, OwnedIdentity<V>),
+    Node(V::Cursor),
+    None,
+}
+
+/// `n` levels up from `value`, whose position is `id`. `n == 0` is the
+/// value itself, matching `parent(0)`.
+fn owned_identity_ancestor<V: DocumentValue>(
+    value: &OwnedValue,
+    id: &OwnedIdentity<V>,
+    n: usize,
+) -> OwnedAncestor<V> {
+    let mut current = (value.clone(), id.clone());
+    for climbed in 0..n {
+        match current.1.parent() {
+            Some(OwnedParent::Owned(v, vid)) => current = (v, vid),
+            Some(OwnedParent::Node(c)) => {
+                return match cursor_ancestor(&c, n - climbed - 1) {
+                    Some(a) => OwnedAncestor::Node(a),
+                    None => OwnedAncestor::None,
+                };
+            }
+            None => return OwnedAncestor::None,
+        }
+    }
+    OwnedAncestor::Owned(current.0, current.1)
+}
+
 /// How a stage that leaves the cursor domain positions its output (#2416
 /// step 3). A closed list: a stage with no rule keeps the pipe on the eager
 /// evaluator, exactly as before, so an unlisted builtin can only cost the
@@ -14895,7 +15164,7 @@ fn owned_identity_pipe_supported(stages: &[Expr]) -> bool {
             }
             _ => match owned_identity_rule(stage) {
                 Some(_) => {
-                    if needs_path_context(stage) && !path_context_absent_resolvable(stage) {
+                    if needs_path_context(stage) && !owned_identity_stage_resolvable(stage) {
                         return false;
                     }
                 }
@@ -15070,7 +15339,7 @@ fn owned_identity_step<S: EvalSemantics, V: DocumentValue>(
 /// position `id` describes, so the rewrite is the same one
 /// [`eval_owned_identity_pipe`]'s ruled-stage arm applies -- one definition
 /// ([`path_context_resolve_constants`]), consulted from both.
-fn owned_identity_resolve_component<V: DocumentValue>(
+fn owned_identity_resolve_component<S: EvalSemantics, V: DocumentValue>(
     expr: &Expr,
     id: &OwnedIdentity<V>,
 ) -> Result<Expr, EvalError> {
@@ -15079,7 +15348,17 @@ fn owned_identity_resolve_component<V: DocumentValue>(
     }
     let key = id.key()?;
     let path = id.path()?;
-    Ok(path_context_resolve_constants(expr, key.as_ref(), &path))
+    path_context_resolve_constants::<S, V>(
+        expr,
+        &PathContextAt {
+            key: key.as_ref(),
+            path: &path,
+            // A computed component keeps the constant-only gate
+            // ([`owned_identity_component_supported`]), so no `parent` can
+            // appear in one.
+            parent_from: None,
+        },
+    )
 }
 
 /// `.[K]` / `.[S:T]` / `E[K]` / `E[S:T]` over an owned value, naming the
@@ -15118,7 +15397,7 @@ fn owned_identity_computed_step<S: EvalSemantics, V: DocumentValue>(
     };
     match expr {
         Expr::IndexExpr { target, key } => {
-            let key_expr = owned_identity_resolve_component(key, id)?;
+            let key_expr = owned_identity_resolve_component::<S, V>(key, id)?;
             let keys = owned_identity_values::<S>(&key_expr, value, optional)?;
             let values = owned_identity_values::<S>(
                 &wrap(Expr::IndexExpr {
@@ -15146,11 +15425,11 @@ fn owned_identity_computed_step<S: EvalSemantics, V: DocumentValue>(
         }
         Expr::SliceExpr { target, start, end } => {
             let start_expr = match start {
-                Some(e) => Some(owned_identity_resolve_component(e, id)?),
+                Some(e) => Some(owned_identity_resolve_component::<S, V>(e, id)?),
                 None => None,
             };
             let end_expr = match end {
-                Some(e) => Some(owned_identity_resolve_component(e, id)?),
+                Some(e) => Some(owned_identity_resolve_component::<S, V>(e, id)?),
                 None => None,
             };
             let values = owned_identity_values::<S>(
@@ -15230,7 +15509,7 @@ fn owned_identity_getpath_step<S: EvalSemantics, V: DocumentValue>(
     optional: bool,
     out: &mut Vec<(OwnedValue, OwnedIdentity<V>)>,
 ) -> Result<(), EvalError> {
-    let path_expr = owned_identity_resolve_component(path_expr, id)?;
+    let path_expr = owned_identity_resolve_component::<S, V>(path_expr, id)?;
     let paths = owned_identity_values::<S>(&path_expr, value, optional)?;
     let values = owned_identity_values::<S>(
         &Expr::Builtin(Builtin::GetPath(Box::new(path_expr))),
@@ -15447,6 +15726,29 @@ fn continue_owned_identity_items<S: EvalSemantics, V: DocumentValue>(
     Flow::Exhausted
 }
 
+/// Continue a pipe `n` levels up from an owned value with identity. A climb
+/// that leaves the owned tree hands the rest of the pipe back to
+/// [`eval_each_pipe_generic`] with the document cursor it reached, which is
+/// what keeps `parent` from materializing the document.
+fn continue_owned_identity_ancestor<S: EvalSemantics, V: DocumentValue>(
+    rest: &[Expr],
+    value: &OwnedValue,
+    id: &OwnedIdentity<V>,
+    n: usize,
+    optional: bool,
+    sink: &mut dyn FnMut(GenericItem<V>) -> Demand,
+) -> Flow {
+    match owned_identity_ancestor(value, id, n) {
+        OwnedAncestor::Owned(v, vid) => {
+            eval_owned_identity_pipe::<S, V>(rest, v, vid, optional, sink)
+        }
+        OwnedAncestor::Node(c) => {
+            eval_each_pipe_generic::<S, V>(rest, c.value(), optional, Some(c), sink)
+        }
+        OwnedAncestor::None => Flow::Exhausted,
+    }
+}
+
 /// `a // b` over an owned value with identity: the left operand's value if
 /// it is truthy (errors in it suppressed, as `//` does), else the right's.
 fn eval_owned_identity_alternative<S: EvalSemantics, V: DocumentValue>(
@@ -15519,15 +15821,9 @@ fn eval_owned_identity_pipe<S: EvalSemantics, V: DocumentValue>(
             optional,
             sink,
         ),
-        Expr::Builtin(Builtin::Parent) => match id.parent() {
-            Some(OwnedParent::Owned(v, vid)) => {
-                eval_owned_identity_pipe::<S, V>(rest, v, vid, optional, sink)
-            }
-            Some(OwnedParent::Node(c)) => {
-                eval_each_pipe_generic::<S, V>(rest, c.value(), optional, Some(c), sink)
-            }
-            None => Flow::Exhausted,
-        },
+        Expr::Builtin(Builtin::Parent) => {
+            continue_owned_identity_ancestor::<S, V>(rest, &value, &id, 1, optional, sink)
+        }
         Expr::Builtin(Builtin::ParentN(n_expr)) => {
             let Expr::Literal(lit) = &**n_expr else {
                 unreachable!("owned_identity_pipe_supported admits a literal n only")
@@ -15539,26 +15835,7 @@ fn eval_owned_identity_pipe<S: EvalSemantics, V: DocumentValue>(
                 Ok(n) => n,
                 Err(e) => return Flow::Escaped(Control::Error(e)),
             };
-            let mut current = (value, id);
-            for climbed in 0..n {
-                match current.1.parent() {
-                    Some(OwnedParent::Owned(v, vid)) => current = (v, vid),
-                    Some(OwnedParent::Node(c)) => {
-                        return match cursor_ancestor(&c, n - climbed - 1) {
-                            Some(a) => eval_each_pipe_generic::<S, V>(
-                                rest,
-                                a.value(),
-                                optional,
-                                Some(a),
-                                sink,
-                            ),
-                            None => Flow::Exhausted,
-                        };
-                    }
-                    None => return Flow::Exhausted,
-                }
-            }
-            eval_owned_identity_pipe::<S, V>(rest, current.0, current.1, optional, sink)
+            continue_owned_identity_ancestor::<S, V>(rest, &value, &id, n, optional, sink)
         }
         Expr::Alternative(left, right) => {
             match eval_owned_identity_alternative::<S, V>(left, right, &value, &id, optional) {
@@ -15582,7 +15859,17 @@ fn eval_owned_identity_pipe<S: EvalSemantics, V: DocumentValue>(
                     (Ok(key), Ok(path)) => (key, path),
                     (Err(e), _) | (_, Err(e)) => return Flow::Escaped(Control::Error(e)),
                 };
-                resolved = path_context_resolve_constants(stage, key.as_ref(), &path);
+                resolved = match path_context_resolve_constants::<S, V>(
+                    stage,
+                    &PathContextAt {
+                        key: key.as_ref(),
+                        path: &path,
+                        parent_from: Some((&value, &id)),
+                    },
+                ) {
+                    Ok(e) => e,
+                    Err(e) => return Flow::Escaped(Control::Error(e)),
+                };
                 &resolved
             } else {
                 stage
@@ -24506,21 +24793,31 @@ mod tests {
             !eager(".a[] | select(true) | key"),
             "iterate cannot yield absent"
         );
-        // ...but three shapes of it still are, and each is a real limit of
-        // resolving the position to constants rather than an oversight:
-        // `parent` answers with a document *node* no literal can spell;
-        // navigation after a non-navigational stage moves the position the
-        // constants describe; and a fan-out head would collect one position
-        // per element, the guard `path_context_walk_split` already applies.
-        assert!(eager(".a.b | [path, parent]"), "parent is not a constant");
-        assert!(
-            eager(".a.b | select(true) | .c | key"),
-            "navigation after a non-navigational stage moves the position"
-        );
+        // #2472: two of the three shapes the constant route declined are
+        // the owned identity pipe's now. An absent position is the deepest
+        // real ancestor plus the components taken past it, which is exactly
+        // an `OwnedIdentity`, so `parent` answers with a real node again
+        // and the position may move after a non-navigational stage.
+        assert!(!eager(".a.b | [path, parent]"));
+        assert!(!eager(".a.b | [path, parent(2)]"));
+        assert!(!eager(".a.b | select(true) | .c | key"));
+        assert!(!eager(".a.b | select(parent != null) | key"));
+        assert!(!eager(".a.b | tostring | parent | key"));
+        // The third shape stays eager by design, and is the exit
+        // condition's residue ADR-0021 records: a fan-out head is one
+        // position per element, the memory guard `path_context_fans_out`
+        // documents and `path_context_walk_split` already applies.
         assert!(
             eager(".[] | .k | select(key == \"k\")"),
             "a fan-out head collects one position per element"
         );
+        // A stage with no identity rule still has nothing to carry the
+        // position through it, on either route.
+        assert!(eager(".a.b | explode | key"), "no identity rule");
+        // `parent(n)` with a computed `n` is refused by both routes: the
+        // hop count would have to be evaluated against a position that may
+        // not exist.
+        assert!(eager(".a.b | [path, parent(1 + 0)]"));
         // #2416 phase 3, this PR: `as` is now single-native
         // (`collect_each_generic` over `each_as_generic`), so a pipe with it
         // as the last stage runs generically -- same admission `if`/`limit`/
@@ -24634,20 +24931,37 @@ mod tests {
                 path_context_absent_resolvable(&expr),
                 "gate refuses `{filter}`; drop the row or widen the gate"
             );
-            let resolved = path_context_resolve_absent(&expr, &pos);
+            let resolved = path_context_resolve_absent::<JqSemantics, _>(&expr, &pos)
+                .expect("the constant route's rewrite cannot fail");
             assert!(
                 !needs_path_context(&resolved),
                 "`{filter}` resolved to `{resolved:?}`, which still needs path context"
             );
         }
-        // `parent` is the deliberate exclusion: it answers with a document
-        // node, which no literal spells.
+        // `parent` is the deliberate exclusion *on this route*: it answers
+        // with a document node, which no literal spells and this position
+        // carries no identity to climb. #2472 routes exactly these shapes
+        // to the owned identity pipe instead, where the same rewriter does
+        // spell them -- as an `Expr::TrackedVar` around the ancestor's
+        // value, not a literal -- so the second loop pins that the two
+        // gates differ by `parent` and nothing else.
         for filter in ["parent", "parent(1)", "[path, parent]", "select(parent)"] {
+            let expr = parse(filter).unwrap();
             assert!(
-                !path_context_absent_resolvable(&parse(filter).unwrap()),
-                "`{filter}` must stay on the eager route"
+                !path_context_absent_resolvable(&expr),
+                "`{filter}` must stay off the constant route"
+            );
+            assert!(
+                owned_identity_stage_resolvable(&expr),
+                "`{filter}` is the identity route's business (#2472)"
             );
         }
+        // A `parent(n)` whose `n` is not a literal is refused by both: the
+        // hop count would have to be evaluated against a position that may
+        // not exist.
+        assert!(!owned_identity_stage_resolvable(
+            &parse("parent(1 + 0)").unwrap()
+        ));
     }
 
     /// The split's four static conditions, each pinned by a shape that trips
@@ -24659,13 +24973,18 @@ mod tests {
                 Expr::Pipe(stages) => stages,
                 other => vec![other],
             };
-            path_context_absent_split(&stages).map(|(head, rest)| (head.len(), rest.len()))
+            path_context_absent_split(&stages)
+                .map(|(head, rest, route)| (head.len(), rest.len(), route))
         };
-        assert_eq!(split(".a.b | select(key == \"b\")"), Some((1, 1)));
-        assert_eq!(split(".a | select(true) | key"), Some((1, 2)));
+        use AbsentRestRoute::{Constants, OwnedIdentity};
+        assert_eq!(
+            split(".a.b | select(key == \"b\")"),
+            Some((1, 1, Constants))
+        );
+        assert_eq!(split(".a | select(true) | key"), Some((1, 2, Constants)));
         assert_eq!(
             split(".a.b.c | if key == \"c\" then 1 else 2 end"),
-            Some((1, 1))
+            Some((1, 1, Constants))
         );
         // The head cannot miss: already exact on the cursor route.
         assert_eq!(split(".[] | select(key == \"b\")"), None);
@@ -24673,16 +24992,26 @@ mod tests {
         // takes end to end: the walk's business, not this route's.
         assert_eq!(split(".a.b | key"), None);
         assert_eq!(split(".a.b | parent | key"), None);
-        // A fan-out head would collect one position per element.
+        // A fan-out head would collect one position per element -- the
+        // guard `path_context_walk_split` applies for the same memory
+        // reason, and the residue ADR-0021 records (#2472 shape 3).
         assert_eq!(split(".[] | .k | select(key == \"k\")"), None);
-        // `parent` is not a constant.
-        assert_eq!(split(".a.b | [path, parent]"), None);
-        // Navigation after a non-navigational stage moves the position the
-        // constants describe.
-        assert_eq!(split(".a.b | select(true) | .c | key"), None);
+        // #2472 shapes 1 and 2: `parent` is not a constant, and navigation
+        // after a non-navigational stage moves the position the constants
+        // describe -- both are the owned identity pipe's now.
+        assert_eq!(split(".a.b | [path, parent]"), Some((1, 1, OwnedIdentity)));
+        assert_eq!(
+            split(".a.b | select(true) | .c | key"),
+            Some((1, 3, OwnedIdentity))
+        );
         // `rest` would take the eager evaluator, which would materialize a
-        // document re-rooted at the walked node.
-        assert_eq!(split(".a.b | tostring | key"), None);
+        // document re-rooted at the walked node -- so the constant route
+        // refuses it and the identity route, which evaluates `rest` itself
+        // from a position it carries, takes it.
+        assert_eq!(split(".a.b | tostring | key"), Some((1, 2, OwnedIdentity)));
+        // Neither route: `explode` has no identity rule, so there is
+        // nothing to carry the position through it.
+        assert_eq!(split(".a.b | explode | key"), None);
     }
 
     /// The absent-reachability fold behind reason 2.

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -38166,10 +38166,25 @@ fn test_absent_position_keeps_path_context_2416() -> Result<()> {
         (".a.c[5] | select(key == 5)", "null"),
         (".a.x | limit(1; key)", "\"x\""),
         (".a.x | try (key) catch \"e\"", "\"x\""),
-        // Not the absent route: an absent `parent` is a node no constant can
-        // spell, so this stays on the eager evaluator (see the yq-mode
-        // sibling test for the divergence that leaves visible).
-        (".a.x.y | [path, parent]", "[[\"a\",\"x\",\"y\"],{}]"),
+        // #2472: an absent `parent` is a node no constant can spell, so
+        // these take the owned identity pipe instead -- the position is the
+        // deepest real ancestor plus the components past it, and `parent`
+        // pops that chain. jq has no `parent` at all (`parent/0 is not
+        // defined`, 1.7.1), so the yq-mode sibling test carries the oracle;
+        // these rows pin that jq mode answers from the same identity.
+        (".a.x.y | [path, parent]", "[[\"a\",\"x\",\"y\"],null]"),
+        (".a.x.y | [path, parent(0)]", "[[\"a\",\"x\",\"y\"],null]"),
+        (
+            ".a.x.y | [path, parent(2)]",
+            "[[\"a\",\"x\",\"y\"],{\"b\":1,\"c\":[1,2]}]",
+        ),
+        (".a.c[5] | [path, parent]", "[[\"a\",\"c\",5],[1,2]]"),
+        // Navigation after a non-navigational stage: the position moves, so
+        // the constants cannot describe it and the identity does.
+        (".a.x | select(true) | .z | key", "\"z\""),
+        (".a.x | select(true) | .z | path", "[\"a\",\"x\",\"z\"]"),
+        (".a.x | tostring | key", "\"x\""),
+        (".a.x | tostring | path", "[\"a\",\"x\"]"),
     ] {
         let (out, _, code) = run_jq_full(&["-c", filter], Some(doc))?;
         assert_eq!(code, 0, "`{filter}`: {out:?}");

--- a/tests/jq_evaluator_parity_tests.rs
+++ b/tests/jq_evaluator_parity_tests.rs
@@ -2086,6 +2086,28 @@ fn test_arm_audit_proof_queries_are_unmoved_by_the_gate_2416() {
             r#".a[] | reduce (key) as $k (""; . + $k) | . + "x""#,
             &[r#""bx""#],
         ),
+        // #2472's re-derived proof queries, same precedent as A05's above:
+        // routing the absent shapes to the owned identity pipe moved
+        // fourteen rows' listed queries off the eager evaluator, so the
+        // audit re-derived one apiece. Both spellings stay pinned, which is
+        // what makes the move readable as "same outputs, different route".
+        // `?` is the reliable R2 head now: `path_context_is_navigational`
+        // excludes it, so the absent split's head stops before it and there
+        // is no position to route.
+        (r".a? | path + []", &[r#"["a"]"#]),
+        (".a? | file_index + 1", &["1"]),
+        (".a.b | (file_index | tostring)", &[r#""0""#]),
+        (".a.b | . | parent + {}", &[r#"{"b":1}"#]),
+        (".c[0] | parent + []", &["[10,20]"]),
+        (".a.b | (parent) + {}", &[r#"{"b":1}"#]),
+        (r#".a? | (key + "x") | . == "bx""#, &["false"]),
+        (
+            r#".a.b | select(key == "b") | parent + {}"#,
+            &[r#"{"b":1}"#],
+        ),
+        (r".a[] | (key | length)", &["1"]),
+        (r#".a? | [key] + ["x"]"#, &[r#"["a","x"]"#]),
+        (r#".a? | (key + "x") | {z: .}"#, &[r#"{"z":"ax"}"#]),
     ];
     for (filter, expected) in rows {
         // `path + []` is the audit's H1 row spelled against `.a.b`.

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -32044,6 +32044,9 @@ fn test_block_sequence_item_key_path_parent_through_generic_route_2455() -> Resu
 /// $ yq -o=json -I=0 '.a.x.y | parent'        {"y":null}         succinctly: null
 /// $ yq -o=json -I=0 '.a.x.y | parent(2)'     {"b":1,"x":{"y":null}}  succinctly: {"b":1}
 /// ```
+///
+/// `test_absent_position_owned_identity_2472` carries the shapes this
+/// constant route declines and #2472 moved to the owned identity pipe.
 #[test]
 fn test_absent_position_keeps_path_context_2416() -> Result<()> {
     let args = &["-o=json", "-I=0"];
@@ -32074,31 +32077,118 @@ fn test_absent_position_keeps_path_context_2416() -> Result<()> {
     Ok(())
 }
 
-/// Spine 2416, step 2: the shapes the absent route deliberately does *not*
-/// take, pinned as still-correct output rather than as a route.
+/// #2472 (spine 2416 gate reason 2): the two absent shapes the constant
+/// resolver declines, now answered by the owned identity pipe.
 ///
-/// `parent` answers with a document node, which the resolver cannot spell as
-/// a constant, so a `parent` inside a non-navigational stage keeps the eager
-/// evaluator -- and with it the eager evaluator's own `{}` for the absent
-/// ancestor, where the walk emits `null` for the same position. Both are
-/// pinned here so the inconsistency is visible rather than latent; real yq
-/// prints its vivified `{"y":null}` for the second element (captured
-/// 2026-09-05, v4.53.3).
+/// An absent position *is* an `OwnedIdentity` (ADR-0021 decision 7): value
+/// `null`, `base` the deepest real ancestor's cursor, `ancestors` the chain
+/// of components taken past it. That gives `parent` a real node to answer
+/// with -- so a `parent` inside a construct no longer needs a literal that
+/// cannot be written -- and lets the position *move* after a
+/// non-navigational stage, which is what the resolved constants could not
+/// survive.
+///
+/// Captured 2026-09-06 from yq v4.53.3 on `a:\n  b: 1\n` (and, byte for
+/// byte, on the flow spelling `a: {b: 1}`), `-o=json -I=0`:
 ///
 /// ```text
-/// $ yq -o=json -I=0 '.a.x.y | [path, parent]'   [["a","x","y"],{"y":null}]
-/// $ yq -o=json -I=0 '.a.x.y | parent'           {"y":null}
+/// $ yq '.a.x.y | [path, parent]'          [["a","x","y"],{"y":null}]
+/// $ yq '.a.x.y | [path, parent(2)]'       [["a","x","y"],{"b":1,"x":{"y":null}}]
+/// $ yq '.a.x.y | [path, parent(0)]'       [["a","x","y"],null]
+/// $ yq '.a.x.y | parent | parent | key'   "a"
+/// $ yq '.a.x.y | parent | key'            "x"
+/// $ yq '.a.x | (parent | key), key'       "a"
+/// $ yq '.a.x | select(true) | .c | path'  ["a","x","c"]
+/// $ yq '.a.b | select(true) | .c | key'   (nothing)
+/// $ yq '.a.x | {"p": parent, "k": key}'   {"p":{"b":1,"x":null},"k":"x"}
+/// $ yq '.a[5] | parent'                   [1,null,null,null,null,null]   (on `a: [1]`)
+/// $ yq '.[] | .k | select(key == "k")'    1 / 2   (on `a: {k: 1}` / `b: {k: 2}`)
 /// ```
+///
+/// The `parent`-on-absent rows diverge, and deliberately: yq *vivifies* the
+/// missing key into the node it returns, succinctly prints the deepest real
+/// ancestor chain instead (ADR-0018 rule 4(b), #2146/#2435, recorded in
+/// `docs/compliance/yq/limitations.md`). This route does not change that
+/// answer -- it makes it *consistent*: the eager evaluator used to print
+/// `{}` for the one-level absent ancestor of `.a.x.y` where the walk prints
+/// `null` for the very same position, and both now print `null`. The
+/// `parent(0)` row is a straight fidelity gain, since the vivification
+/// never applies to the value itself.
+///
+/// `{"p": parent, "k": key}` prints nothing here, in yq mode and jq mode
+/// alike: `needs_path_context` does not descend into `Expr::Object`
+/// (#1332), so that pipe is never seen as a path-context pipe by any route
+/// and `parent` is answered with no position at all. It is pinned as the
+/// pre-existing gap it is, unmoved by this change.
 #[test]
-fn test_absent_position_parent_still_takes_the_eager_route_2416() -> Result<()> {
+fn test_absent_position_owned_identity_2472() -> Result<()> {
     let args = &["-o=json", "-I=0"];
     let doc = "a:\n  b: 1\n";
-    // The eager route's `{}` for an absent ancestor, next to the walk's
-    // `null` for the very same position one row above in
-    // `test_absent_position_keeps_path_context_2416`.
-    let (output, code) = run_yq_stdin(".a.x.y | [path, parent]", doc, args)?;
+    for (filter, expected) in [
+        // Shape 1: `parent`/`parent(n)` from a possibly-absent position
+        // inside a non-navigational stage.
+        (".a.x.y | [path, parent]", "[[\"a\",\"x\",\"y\"],null]"),
+        (".a.x.y | [path, parent(0)]", "[[\"a\",\"x\",\"y\"],null]"),
+        (
+            ".a.x.y | [path, parent(2)]",
+            "[[\"a\",\"x\",\"y\"],{\"b\":1}]",
+        ),
+        (
+            ".a.x.y | [path, parent(3)]",
+            "[[\"a\",\"x\",\"y\"],{\"a\":{\"b\":1}}]",
+        ),
+        // Above the document root is nothing at all, the same answer a bare
+        // `parent` gives there (#2421).
+        (".a.x.y | [path, parent(4)]", "[[\"a\",\"x\",\"y\"]]"),
+        (".a.x | [path, parent]", "[[\"a\",\"x\"],{\"b\":1}]"),
+        (".a.x | select(parent != null) | key", "\"x\""),
+        // succinctly's absent `parent` is `null` where yq's is `{"y":null}`,
+        // so this `select` passes here and fails there -- the same #2435
+        // divergence, seen through a predicate.
+        (
+            ".a.x.y | select(parent == null) | path",
+            "[\"a\",\"x\",\"y\"]",
+        ),
+        // Shape 2: navigation after a non-navigational stage.
+        (".a.x | select(true) | .c | key", "\"c\""),
+        (".a.x | select(true) | .c | path", "[\"a\",\"x\",\"c\"]"),
+        (".a | select(true) | .b | key", "\"b\""),
+        // Same route, from a stage that replaces the value rather than
+        // filtering it: the identity is what carries the position, so the
+        // absent side answers exactly as the live side does.
+        (".a.x | tostring | key", "\"x\""),
+        (".a.x | tostring | path", "[\"a\",\"x\"]"),
+        (".a.x | tostring | parent | key", "\"a\""),
+        (".a.x | length | key", "\"x\""),
+        (".a.x.y | tostring | parent(2) | key", "\"a\""),
+        // #1332's object-construction gap, unmoved.
+        (".a.x | {\"p\": parent, \"k\": key}", ""),
+    ] {
+        let (output, code) = run_yq_stdin(filter, doc, args)?;
+        assert_eq!(code, 0, "`{filter}`: {output:?}");
+        assert_eq!(output.trim(), expected, "`{filter}`");
+    }
+    // An absent *index* hangs under a real sequence, so the chain's deepest
+    // real ancestor is that sequence and `parent` is the sequence itself.
+    for (filter, expected) in [
+        (".a[5] | parent", "[1]"),
+        (".a[5] | [path, parent, key]", "[[\"a\",5],[1],5]"),
+        (".a[5] | [path, parent(2)]", "[[\"a\",5],{\"a\":[1]}]"),
+    ] {
+        let (output, code) = run_yq_stdin(filter, "a: [1]\n", args)?;
+        assert_eq!(code, 0, "`{filter}`: {output:?}");
+        assert_eq!(output.trim(), expected, "`{filter}`");
+    }
+    // Shape 3, the residue ADR-0021 records: a fan-out head would collect
+    // one position per element, so it stays on the eager evaluator by
+    // design. Pinned as output, not as a route -- the answer is yq's.
+    let (output, code) = run_yq_stdin(
+        ".[] | .k | select(key == \"k\")",
+        "a: {k: 1}\nb: {k: 2}\n",
+        args,
+    )?;
     assert_eq!(code, 0, "{output:?}");
-    assert_eq!(output.trim(), "[[\"a\",\"x\",\"y\"],{}]");
+    assert_eq!(output.trim(), "1\n2");
     Ok(())
 }
 


### PR DESCRIPTION
## Summary

Gate reason 2 of spine 2416: the absent shapes decision 6's constant resolver declined. An absent position is now also representable as an owned `null` whose identity is the deepest real ancestor's cursor plus the chain of components past it (the design on #2472), so `parent`/`parent(n)` from a possibly-absent position and navigation after a non-navigational stage run through the owned identity pipe instead of the eager evaluator. `path_context_absent_split` returns a route: the constant route is unchanged and preferred (it materialises nothing), the identity route costs one materialisation of the real ancestor per absent position. The constant resolver gains `parent`/`parent(n)` arms spelling the ancestor as a tracked value, and `owned_identity_ancestor` is the one climb definition both use.

The only behavioural change on a `parent`-of-absent row is the one-level ancestor: `{}` (the eager placeholder) becomes `null` (the walk's own answer for that position), so the two routes stop disagreeing; the #2435 divergence (yq vivifies, succinctly prints the real chain) is preserved and re-pinned through the new route, with `parent(0)`, `tostring | key`, `tostring | path`, `length | key` on an absent position now matching yq. Captures from yq v4.53.3 on both the flow and block spellings are in the tests; jq 1.7.1 has none of these builtins.

The fan-out head (`.[] | .k | select(key == "k")`) stays eager by design and is recorded in ADR-0021 as the exit condition's residue.

## Arm re-audit

Pin stays at 43. Fourteen proof queries no longer enter the gate (every `.a.b`-headed `key`/`path`/`file_index` shape, the class this route absorbs), but each of those fourteen handlers still fires through a re-derived query: `?` is a reliable reason-2 head because the navigational predicate excludes `Optional`, and a bare `parent` operand of arithmetic is refused by the operand resolver. The re-derived queries are pinned in the parity test next to the old spellings; the audit doc records the argument.

## Found, not fixed (filed as #2495)

Two pre-existing escape-handling bugs in the owned identity pipe: a `halt` inside a computed component is swallowed as "no more values", and a navigation step's already-produced outputs are dropped when a later component fails. The new route declines those shapes rather than reaching them.

## Verification

fmt; clippy on both CI legs with `-D warnings`; `cargo test` in the three configurations; `cargo doc -D warnings`; yq goldens 113 and jq goldens 633; oracle sweep 3168 cases, 0 unexpected, manifest unchanged; walk-versus-bridge parity rows equal.

Closes #2472 (spine 2416, gate reason 2; the fan-out residue is recorded in ADR-0021).
