### PR TITLE
fix(yq): keep the alias mark when assigning an alias-valued node to a new key

### DIFF
--- a/docs/compliance/yq/limitations.md
+++ b/docs/compliance/yq/limitations.md
@@ -148,10 +148,28 @@ a: 1
 b: 1
 ```
 
-This is not a bug in the propagation pass — it is rule 4(a) applying to a second write shape
-that reaches the same unsound state `del(.a)` above does, discovered mechanically rather than
-special-cased: `enforce_anchor_soundness` runs unchanged afterwards and simply finds no
-`Declares` mark left for `x` to resolve either alias against.
+Discovered mechanically rather than special-cased: `enforce_anchor_soundness` runs
+unchanged afterwards and simply finds no `Declares` mark left for `x` to resolve either
+alias against.
+
+**Rule 4(b)**, on the same `propagate_assign_alias_marks` pass: a computed `value` side
+(`.c = (.b + 1)`) is not a static read of `.b`, so the pass leaves `.c` a plain scalar
+rather than aliasing it. Real yq does alias it, and the result is data loss — it prints
+`c: *x` but the value underneath is still `.b`'s own `1`, not the computed `2`:
+
+```bash
+$ printf 'a: &x 1\nb: *x\n' | yq '.c = (.b + 1)'
+a: &x 1
+b: *x
+c: *x
+$ printf 'a: &x 1\nb: *x\n' | yq '.c = (.b + 1)' | yq '.c'
+*x
+
+$ printf 'a: &x 1\nb: *x\n' | succinctly yq '.c = (.b + 1)'
+a: &x 1
+b: *x
+c: 2
+```
 
 A related, narrower gap sits in `select`/`if`'s condition-truthiness check
 (`push_generic_truthiness_cursor_error`, [src/jq/eval_generic.rs](../../../src/jq/eval_generic.rs)):

--- a/docs/compliance/yq/limitations.md
+++ b/docs/compliance/yq/limitations.md
@@ -96,8 +96,9 @@ still holds the anchor's value, so a position rebound earlier in the pipe (`.b =
 9`) is written positionally, as yq treats a rebound position. The gate's one false positive
 is a rebind to a value *equal* to the anchor's: `.b = .a | .a.p = 9` (or `.b = {"p": 1, "q":
 2} | .a.p = 9`) detaches `b` in yq (`b: {p: 1, q: 2}`), while succinctly cannot tell the
-rebound copy from an untouched one and keeps it in step (`b: *x`, value `{p: 9, q: 2}`). The
-written value is never affected, only which other positions follow it. Two further
+rebound copy from an untouched one and keeps its value in step (`b: {p: 9, q: 2}`; the `*x`
+mark itself is cleared by the plain `=`, see the assignment rule below). The written value is
+never affected, only which other positions follow it. Two further
 consequences are recorded divergences/limitations rather than matches:
 
 - **A value-producing update at an alias node is not discarded — rule 4(b).** Real yq

--- a/docs/compliance/yq/limitations.md
+++ b/docs/compliance/yq/limitations.md
@@ -128,6 +128,31 @@ positionally and drops the marks. A multi-document stream applies the redirect a
 anchor marks to the last document only
 ([#2520](https://github.com/rust-works/succinctly/issues/2520), pre-existing).
 
+The same soundness gate also governs `.c = .b`-style plain assignments
+(split out of #1351 as [#2497](https://github.com/rust-works/succinctly/issues/2497)):
+`propagate_assign_alias_marks` copies an alias mark onto the assignment's target whenever the
+value side is a static read of an aliased node, then leaves `enforce_anchor_soundness` to
+decide whether that mark actually survives. Writing an alias *onto* the very node that
+declares its own anchor destroys the only remaining declaration, so both marks come out
+unresolvable and both are dropped:
+
+```bash
+$ printf 'a: &x 1\nb: *x\n' | yq '.a = .b'
+a: *x
+b: *x
+$ printf 'a: &x 1\nb: *x\n' | yq '.a = .b' | yq '.'
+Error: bad file '-': yaml: line 1, column 5: unknown anchor 'x' referenced
+
+$ printf 'a: &x 1\nb: *x\n' | succinctly yq '.a = .b'
+a: 1
+b: 1
+```
+
+This is not a bug in the propagation pass — it is rule 4(a) applying to a second write shape
+that reaches the same unsound state `del(.a)` above does, discovered mechanically rather than
+special-cased: `enforce_anchor_soundness` runs unchanged afterwards and simply finds no
+`Declares` mark left for `x` to resolve either alias against.
+
 A related, narrower gap sits in `select`/`if`'s condition-truthiness check
 (`push_generic_truthiness_cursor_error`, [src/jq/eval_generic.rs](../../../src/jq/eval_generic.rs)):
 it does not walk into a *container* reached through an alias, so a decode failure reachable

--- a/src/bin/succinctly/yq_runner.rs
+++ b/src/bin/succinctly/yq_runner.rs
@@ -2806,6 +2806,152 @@ fn comment_tree_at_path_mut<'t>(
     Some(node)
 }
 
+/// Read-only counterpart of [`comment_tree_at_path_mut`] used by
+/// [`propagate_assign_alias_marks`] (#2497) to look up a `value` operand's
+/// current mark before copying it onto the assignment's target. Built on
+/// [`CommentTree::field`]/[`CommentTree::at_index`], which already fall back
+/// to [`CommentTree::empty`] for a missing key/index or a shape mismatch, so
+/// unlike its mutable counterpart this never needs to fail — an
+/// out-of-bounds or wrong-kind step along the way just means "no mark here",
+/// which is exactly the answer that should make the caller do nothing.
+fn nav_comment_tree<'t>(tree: &'t CommentTree, steps: &[TreeStep<'_>]) -> &'t CommentTree {
+    let mut node = tree;
+    for step in steps {
+        node = match step {
+            TreeStep::Key(k) => node.field(k),
+            TreeStep::Index(i) => node.at_index(*i),
+        };
+    }
+    node
+}
+
+/// Whether `expr` is *static navigation* — a chain of `Expr::Field`/
+/// `Expr::Index` steps through `Expr::Paren`/`Expr::Optional`, e.g. `.b`,
+/// `.a.b`, `.b?`, `(.b)` — and if so, the [`TreeStep`] path it names.
+///
+/// `.["b"]` needs no case of its own: the parser already folds a
+/// constant-string index to [`Expr::Field`] (see that variant's own doc
+/// comment), so it reaches the `Expr::Field` arm below like `.b` would.
+/// A negative [`Expr::Index`] is deliberately excluded (`None`) — resolving
+/// `.[-1]` needs the target array's length, which a purely syntactic path
+/// can't supply, and this function only ever runs against a path/value pair
+/// that must be statically knowable from the AST alone.
+///
+/// Used by [`propagate_assign_alias_marks`] (#2497) to recognise both an
+/// assignment's `path` and its `value` operand as "just navigation", the
+/// narrow class where copying a mark from one path to another is safe: an
+/// arithmetic or other computed `value` (`.c = (.b + 1)`) returns `None`
+/// here and the pass leaves that assignment alone, matching real yq's own
+/// data-loss bug on that shape rather than "fixing" it (see the limitations
+/// doc entry this issue adds).
+fn static_nav_steps(expr: &Expr) -> Option<Vec<TreeStep<'_>>> {
+    match expr {
+        Expr::Identity => Some(Vec::new()),
+        Expr::Field(name) => Some(vec![TreeStep::Key(name.as_str())]),
+        Expr::Index { idx, .. } if *idx >= 0 => Some(vec![TreeStep::Index(*idx as usize)]),
+        Expr::Paren(inner) | Expr::Optional(inner) => static_nav_steps(inner),
+        Expr::Pipe(stages) => {
+            let mut steps = Vec::new();
+            for stage in stages {
+                steps.extend(static_nav_steps(stage)?);
+            }
+            Some(steps)
+        }
+        _ => None,
+    }
+}
+
+/// Extract `expr`'s `(path, value)` pairs when its shape is a plain
+/// [`Expr::Assign`] (`=`) or a [`Expr::Pipe`] of such assigns applied in
+/// order (`.c = .b | .d = .c`), unwrapping `Expr::Paren`/`Expr::Optional`
+/// around the whole expression or any one stage.
+///
+/// Deliberately narrower than [`is_alias_sensitive_assign`]'s own
+/// `is_shape_preserving`, which also admits `Update`/`CompoundAssign`/
+/// `AlternativeAssign`/`del`/`select`/... — [`propagate_assign_alias_marks`]
+/// only knows how to reason about plain `=`, whose right-hand side is a
+/// value expression to copy rather than a filter applied to the existing
+/// one, so `.a |= .b`, `.a += .b`, etc. all correctly fall outside this and
+/// are left for `enforce_anchor_soundness` alone to settle (#2497's own
+/// scope note excludes `|=`).
+fn collect_assign_chain(expr: &Expr) -> Option<Vec<(&Expr, &Expr)>> {
+    match expr {
+        Expr::Assign { path, value } => Some(vec![(path.as_ref(), value.as_ref())]),
+        Expr::Paren(inner) | Expr::Optional(inner) => collect_assign_chain(inner),
+        Expr::Pipe(stages) => {
+            let mut pairs = Vec::new();
+            for stage in stages {
+                pairs.extend(collect_assign_chain(stage)?);
+            }
+            Some(pairs)
+        }
+        _ => None,
+    }
+}
+
+/// Propagate an alias mark through a plain assignment whose value is a
+/// static read of an aliased node (#2497, split from #1351's "case 2"):
+/// real `yq` prints `c: *x` for `.c = .b` when the source has `b: *x`,
+/// because go-yaml's `Set` copies the RHS node's `Kind`/`Tag`/`Value`
+/// wholesale, and an alias node's `Kind` says "I am an alias" — so the
+/// destination becomes an alias node too. `reconcile_presentation_at_depth`
+/// has no notion of a write's *source* path (it only diffs pristine vs.
+/// result value shape at matching keys/indices), so a key that's brand new
+/// in the result — `.c` did not exist before this write — gets
+/// `CommentTree::empty()` and never had a chance to pick up `.b`'s mark on
+/// its own.
+///
+/// Walks `expr`'s assignment stages in order, mutating `tree` — the
+/// already-[`reconcile_presentation`]d tree for one result document — as it
+/// goes, rather than reading a separate pristine snapshot: for every path
+/// this pass hasn't touched yet, `tree` already agrees with the pristine
+/// tree exactly (`reconcile_presentation_at_depth`'s "both scalars: mark
+/// survives" rule), and for a path an *earlier* stage in this same chain
+/// just wrote to (`.c` in `.c = .b | .d = .c`), `tree` holds the fresher
+/// answer pristine never had at all. Reading `tree` uniformly is therefore
+/// both simpler and gives the chain case exactly the "second stage sees the
+/// first stage's mark" behaviour it needs, with no separate fallback logic.
+///
+/// Only ever *adds* an `Aliases` mark, and only when both `path` and
+/// `value` are [`static_nav_steps`] — never for `Declares(_)` or an absent
+/// mark on the value side (`.c = .a`, an anchor's own declaration, stays
+/// plain: `c: 1`), and never for a non-navigation value (`.c = (.b + 1)`
+/// stays plain too, matching real yq's own data-loss bug on that shape
+/// rather than reproducing it). The write fully replaces the target's
+/// `CommentTree` node with a fresh alias-only leaf — dropping any comment/
+/// style the target previously carried — since a plain assignment is, in
+/// go-yaml's model, a wholesale node replacement, not an in-place value
+/// edit; a brand-new key (`.c`) had no comment/style to lose anyway, and an
+/// existing key overwritten this way (`.a = .b` on `a: &x 1`) trades its old
+/// `Declares` mark for the new `Aliases` one, which is exactly what lets
+/// [`enforce_anchor_soundness`] — running after this pass — discover no
+/// declaration for `x` survives and drop both marks (rule 4(a): `.a = .b`
+/// prints `a: 1` / `b: 1`, recorded in `docs/compliance/yq/limitations.md`
+/// next to the `del(.a)` example).
+fn propagate_assign_alias_marks(expr: &Expr, tree: &mut CommentTree) {
+    let Some(stages) = collect_assign_chain(expr) else {
+        return;
+    };
+    for (path_expr, value_expr) in stages {
+        let (Some(path_steps), Some(value_steps)) =
+            (static_nav_steps(path_expr), static_nav_steps(value_expr))
+        else {
+            continue;
+        };
+        let Some(AnchorMark::Aliases(name)) = nav_comment_tree(tree, &value_steps).anchor_mark()
+        else {
+            continue;
+        };
+        let name = name.clone();
+        if let Some(node) = comment_tree_at_path_mut(tree, &path_steps) {
+            *node = CommentTree::Leaf(NodeMeta {
+                anchor: Some(AnchorMark::Aliases(name)),
+                ..NodeMeta::empty()
+            });
+        }
+    }
+}
+
 /// Evaluate a jq expression directly on a YAML cursor.
 ///
 /// This uses the generic evaluator to preserve position metadata (line/column).
@@ -3055,6 +3201,24 @@ fn evaluate_yaml_cursor<W: AsRef<[u64]> + Clone>(
         if let Ok(docs) = &mut docs {
             for (value, _comments) in docs.iter_mut() {
                 sync_aliased_paths(value, pristine, groups);
+            }
+        }
+    }
+
+    // Propagate an alias mark through a plain assignment whose value is a
+    // static read of an aliased node (#2497): see
+    // `propagate_assign_alias_marks`'s own doc comment for the full
+    // rationale. Gated on `presentation_sync_ctx` rather than re-deriving
+    // its own condition: that's exactly "there is a reconciled `CommentTree`
+    // here worth revisiting", which this pass needs and nothing else does.
+    // Must run after `reconcile_presentation` has produced each result
+    // document's tree (via `no_comments`/`owned_with_comments` above) and
+    // before `enforce_anchor_soundness` below, which is what actually
+    // decides whether the mark this pass adds is safe to keep.
+    if presentation_sync_ctx.is_some() {
+        if let Ok(docs) = &mut docs {
+            for (_value, comments) in docs.iter_mut() {
+                propagate_assign_alias_marks(expr, comments);
             }
         }
     }

--- a/src/bin/succinctly/yq_runner.rs
+++ b/src/bin/succinctly/yq_runner.rs
@@ -2806,25 +2806,6 @@ fn comment_tree_at_path_mut<'t>(
     Some(node)
 }
 
-/// Read-only counterpart of [`comment_tree_at_path_mut`] used by
-/// [`propagate_assign_alias_marks`] (#2497) to look up a `value` operand's
-/// current mark before copying it onto the assignment's target. Built on
-/// [`CommentTree::field`]/[`CommentTree::at_index`], which already fall back
-/// to [`CommentTree::empty`] for a missing key/index or a shape mismatch, so
-/// unlike its mutable counterpart this never needs to fail — an
-/// out-of-bounds or wrong-kind step along the way just means "no mark here",
-/// which is exactly the answer that should make the caller do nothing.
-fn nav_comment_tree<'t>(tree: &'t CommentTree, steps: &[TreeStep<'_>]) -> &'t CommentTree {
-    let mut node = tree;
-    for step in steps {
-        node = match step {
-            TreeStep::Key(k) => node.field(k),
-            TreeStep::Index(i) => node.at_index(*i),
-        };
-    }
-    node
-}
-
 /// Whether `expr` is *static navigation* — a chain of `Expr::Field`/
 /// `Expr::Index` steps through `Expr::Paren`/`Expr::Optional`, e.g. `.b`,
 /// `.a.b`, `.b?`, `(.b)` — and if so, the [`TreeStep`] path it names.
@@ -2837,16 +2818,22 @@ fn nav_comment_tree<'t>(tree: &'t CommentTree, steps: &[TreeStep<'_>]) -> &'t Co
 /// can't supply, and this function only ever runs against a path/value pair
 /// that must be statically knowable from the AST alone.
 ///
+/// No `Expr::Identity` arm: the root node can never itself carry an
+/// `Aliases` mark that survives to the emitter (a root `*name` result is
+/// always resolved to its value — see `output_value`'s own note on why),
+/// so treating bare `.` as an empty static path would only complicate this
+/// function's callers for a case whose answer is always "no mark" anyway.
+///
 /// Used by [`propagate_assign_alias_marks`] (#2497) to recognise both an
 /// assignment's `path` and its `value` operand as "just navigation", the
 /// narrow class where copying a mark from one path to another is safe: an
 /// arithmetic or other computed `value` (`.c = (.b + 1)`) returns `None`
-/// here and the pass leaves that assignment alone, matching real yq's own
-/// data-loss bug on that shape rather than "fixing" it (see the limitations
-/// doc entry this issue adds).
+/// here, so the pass leaves that assignment's target un-aliased — refusing
+/// real yq's own data-loss bug on that shape rather than reproducing it
+/// (rule 4(b), see the entry this issue adds to
+/// `docs/compliance/yq/limitations.md`).
 fn static_nav_steps(expr: &Expr) -> Option<Vec<TreeStep<'_>>> {
     match expr {
-        Expr::Identity => Some(Vec::new()),
         Expr::Field(name) => Some(vec![TreeStep::Key(name.as_str())]),
         Expr::Index { idx, .. } if *idx >= 0 => Some(vec![TreeStep::Index(*idx as usize)]),
         Expr::Paren(inner) | Expr::Optional(inner) => static_nav_steps(inner),
@@ -2862,18 +2849,30 @@ fn static_nav_steps(expr: &Expr) -> Option<Vec<TreeStep<'_>>> {
 }
 
 /// Extract `expr`'s `(path, value)` pairs when its shape is a plain
-/// [`Expr::Assign`] (`=`) or a [`Expr::Pipe`] of such assigns applied in
-/// order (`.c = .b | .d = .c`), unwrapping `Expr::Paren`/`Expr::Optional`
-/// around the whole expression or any one stage.
+/// [`Expr::Assign`] (`=`), or a [`Expr::Pipe`] containing one or more such
+/// assigns applied in order (`.c = .b | .d = .c`), unwrapping
+/// `Expr::Paren`/`Expr::Optional` around the whole expression or any one
+/// stage.
 ///
-/// Deliberately narrower than [`is_alias_sensitive_assign`]'s own
-/// `is_shape_preserving`, which also admits `Update`/`CompoundAssign`/
-/// `AlternativeAssign`/`del`/`select`/... — [`propagate_assign_alias_marks`]
-/// only knows how to reason about plain `=`, whose right-hand side is a
-/// value expression to copy rather than a filter applied to the existing
-/// one, so `.a |= .b`, `.a += .b`, etc. all correctly fall outside this and
-/// are left for `enforce_anchor_soundness` alone to settle (#2497's own
-/// scope note excludes `|=`).
+/// A `Pipe` stage that is not itself a plain `=` (`Identity`, `select`,
+/// `del`, `debug`, `|=`, a compound assign, ...) is skipped rather than
+/// aborting the whole scan — [`propagate_assign_alias_marks`] is only ever
+/// called once [`is_alias_sensitive_assign`] has already vetted `expr`'s
+/// *overall* shape as path-preserving, so a pass-through stage sitting
+/// between two `=` stages (`del(.z) | .c = .b`, `.c = .b | select(true)`,
+/// `. | .c = .b`) is already known not to disturb any path this scan
+/// cares about; only the stages this function doesn't know how to reason
+/// about (a filter applied to the existing value, rather than a value
+/// expression to copy) are left out. `.a |= .b`, `.a += .b`, etc. always
+/// fall into that skipped category and are left for
+/// `enforce_anchor_soundness` alone to settle (#2497's own scope note
+/// excludes `|=`).
+///
+/// Returns `None` only when the *top-level* shape isn't one of
+/// `Assign`/`Paren`/`Optional`/`Pipe` at all — a lone `select(...)` or
+/// `del(...)` with no `=` anywhere reaches here only via a `Pipe`, since a
+/// bare non-assign expression never satisfies `is_alias_sensitive_assign`'s
+/// own `contains_assign` check on its own.
 fn collect_assign_chain(expr: &Expr) -> Option<Vec<(&Expr, &Expr)>> {
     match expr {
         Expr::Assign { path, value } => Some(vec![(path.as_ref(), value.as_ref())]),
@@ -2881,7 +2880,9 @@ fn collect_assign_chain(expr: &Expr) -> Option<Vec<(&Expr, &Expr)>> {
         Expr::Pipe(stages) => {
             let mut pairs = Vec::new();
             for stage in stages {
-                pairs.extend(collect_assign_chain(stage)?);
+                if let Some(stage_pairs) = collect_assign_chain(stage) {
+                    pairs.extend(stage_pairs);
+                }
             }
             Some(pairs)
         }
@@ -2912,42 +2913,64 @@ fn collect_assign_chain(expr: &Expr) -> Option<Vec<(&Expr, &Expr)>> {
 /// both simpler and gives the chain case exactly the "second stage sees the
 /// first stage's mark" behaviour it needs, with no separate fallback logic.
 ///
-/// Only ever *adds* an `Aliases` mark, and only when both `path` and
-/// `value` are [`static_nav_steps`] — never for `Declares(_)` or an absent
-/// mark on the value side (`.c = .a`, an anchor's own declaration, stays
-/// plain: `c: 1`), and never for a non-navigation value (`.c = (.b + 1)`
-/// stays plain too, matching real yq's own data-loss bug on that shape
-/// rather than reproducing it). The write fully replaces the target's
-/// `CommentTree` node with a fresh alias-only leaf — dropping any comment/
-/// style the target previously carried — since a plain assignment is, in
-/// go-yaml's model, a wholesale node replacement, not an in-place value
-/// edit; a brand-new key (`.c`) had no comment/style to lose anyway, and an
-/// existing key overwritten this way (`.a = .b` on `a: &x 1`) trades its old
-/// `Declares` mark for the new `Aliases` one, which is exactly what lets
-/// [`enforce_anchor_soundness`] — running after this pass — discover no
-/// declaration for `x` survives and drop both marks (rule 4(a): `.a = .b`
-/// prints `a: 1` / `b: 1`, recorded in `docs/compliance/yq/limitations.md`
-/// next to the `del(.a)` example).
+/// Each target node is updated **in place** (`meta_mut().anchor = ...`),
+/// never replaced wholesale — a plain assignment overwrites a go-yaml
+/// node's `Value`/`Kind`/`Tag`, but its comment and style live in
+/// succinctly's own side-tree, not on that node, and real yq keeps a
+/// target's trailing comment across a write that turns it into an alias
+/// (`c: 2 # keep` + `.c = .b` -> `c: *x # keep`, verified against the
+/// pinned binary) exactly as it does for any other scalar overwrite.
+///
+/// The mark only ever moves the two ways a plain `=` can actually leave it:
+///
+/// - **Set to `Aliases(name)`** when `value` is [`static_nav_steps`] and its
+///   current mark is `Aliases(name)` — copying `.b`'s alias onto `.c`.
+/// - **Cleared to `None`**, but *only* if the target already carried an
+///   `Aliases` mark, whenever `value` is anything else: not static
+///   navigation at all (`.c = (.b + 1)`, rule 4(b) — see the entry this
+///   issue adds to `docs/compliance/yq/limitations.md`), or static
+///   navigation to a plain value or an anchor *declaration*
+///   (`.c = .a`). A plain `=` always replaces the target's node wholesale,
+///   so a stale `Aliases` mark left over from an earlier stage in the same
+///   chain (`.c = .b | .c = 1`) or from the target's own pristine value
+///   (`.b = 1` on `b: *x`) must not survive just because the write happens
+///   to leave the value looking unchanged. A `Declares` mark is never
+///   touched by this arm — `.a = 5` on `a: &x 1` keeps `&x` (the
+///   declaration's own identity persists across a value-only overwrite,
+///   matching real yq) — only `Aliases` is ever this pass's to clear.
+///
+/// [`enforce_anchor_soundness`], run after this pass, is what decides
+/// whether a surviving `Aliases` mark is actually safe to keep: writing an
+/// alias *onto* the very node that declares its own anchor destroys the
+/// only remaining declaration, so `.a = .b` on `a: &x 1\nb: *x` comes out
+/// of this pass with both `.a` and `.b` marked `Aliases(x)` and no
+/// `Declares` left anywhere — `enforce_anchor_soundness` then drops both
+/// (rule 4(a), `a: 1` / `b: 1`, recorded in
+/// `docs/compliance/yq/limitations.md` next to the `del(.a)` example).
 fn propagate_assign_alias_marks(expr: &Expr, tree: &mut CommentTree) {
     let Some(stages) = collect_assign_chain(expr) else {
         return;
     };
     for (path_expr, value_expr) in stages {
-        let (Some(path_steps), Some(value_steps)) =
-            (static_nav_steps(path_expr), static_nav_steps(value_expr))
-        else {
+        let Some(path_steps) = static_nav_steps(path_expr) else {
             continue;
         };
-        let Some(AnchorMark::Aliases(name)) = nav_comment_tree(tree, &value_steps).anchor_mark()
-        else {
+        let source_mark = match static_nav_steps(value_expr) {
+            Some(value_steps) => comment_tree_at_path_mut(tree, &value_steps)
+                .and_then(|node| node.anchor_mark().cloned()),
+            None => None,
+        };
+        let Some(node) = comment_tree_at_path_mut(tree, &path_steps) else {
             continue;
         };
-        let name = name.clone();
-        if let Some(node) = comment_tree_at_path_mut(tree, &path_steps) {
-            *node = CommentTree::Leaf(NodeMeta {
-                anchor: Some(AnchorMark::Aliases(name)),
-                ..NodeMeta::empty()
-            });
+        match source_mark {
+            Some(AnchorMark::Aliases(name)) => {
+                node.meta_mut().anchor = Some(AnchorMark::Aliases(name));
+            }
+            _ if matches!(node.anchor_mark(), Some(AnchorMark::Aliases(_))) => {
+                node.meta_mut().anchor = None;
+            }
+            _ => {}
         }
     }
 }
@@ -3208,14 +3231,17 @@ fn evaluate_yaml_cursor<W: AsRef<[u64]> + Clone>(
     // Propagate an alias mark through a plain assignment whose value is a
     // static read of an aliased node (#2497): see
     // `propagate_assign_alias_marks`'s own doc comment for the full
-    // rationale. Gated on `presentation_sync_ctx` rather than re-deriving
-    // its own condition: that's exactly "there is a reconciled `CommentTree`
-    // here worth revisiting", which this pass needs and nothing else does.
-    // Must run after `reconcile_presentation` has produced each result
-    // document's tree (via `no_comments`/`owned_with_comments` above) and
-    // before `enforce_anchor_soundness` below, which is what actually
-    // decides whether the mark this pass adds is safe to keep.
-    if presentation_sync_ctx.is_some() {
+    // rationale. Gated on `presentation_sync_ctx` (exactly "there is a
+    // reconciled `CommentTree` here worth revisiting") and `has_aliases`
+    // (mirroring the gate below on `enforce_anchor_soundness`, the only
+    // thing that can act on a mark this pass sets or clears): an
+    // alias-free document has no `Aliases` mark anywhere to copy or drop,
+    // so there is nothing for this pass to do. Must run after
+    // `reconcile_presentation` has produced each result document's tree
+    // (via `no_comments`/`owned_with_comments` above) and before
+    // `enforce_anchor_soundness` below, which is what actually decides
+    // whether the mark this pass adds is safe to keep.
+    if has_aliases && presentation_sync_ctx.is_some() {
         if let Ok(docs) = &mut docs {
             for (_value, comments) in docs.iter_mut() {
                 propagate_assign_alias_marks(expr, comments);

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -35721,12 +35721,14 @@ fn test_yaml_rebind_to_equal_value_is_indistinguishable_from_the_anchor_1351() -
     // DELIBERATE DIVERGENCE (docs/compliance/yq/limitations.md): the equality
     // gate's one false positive. Real yq detaches `b` here (`b: {p: 1, q: 2}`);
     // succinctly cannot tell a copy rebound to an equal value from an untouched
-    // one, so `b` follows the anchor.
+    // one, so `b`'s *value* follows the anchor. Since #2497 the plain `=`
+    // clears the stale `*x` mark (its right-hand side is not an alias read),
+    // so the followed value prints expanded rather than as `b: *x`.
     for filter in [".b = .a | .a.p = 9", r#".b = {"p": 1, "q": 2} | .a.p = 9"#] {
         assert_yq_1351(
             filter,
             "a: &x {p: 1, q: 2}\nb: *x\n",
-            "a: &x {p: 9, q: 2}\nb: *x\n",
+            "a: &x {p: 9, q: 2}\nb:\n  p: 9\n  q: 2\n",
             r#"{"a":{"p":9,"q":2},"b":{"p":9,"q":2}}"#,
         )?;
     }

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -25085,6 +25085,133 @@ fn test_yaml_nested_write_through_alias_keeps_the_mark_763_1351() -> Result<()> 
     Ok(())
 }
 
+// =============================================================================
+// #2497 (split from #1351's "case 2") - a plain assignment (`.c = .b`) whose
+// value is a static read of an aliased node must itself alias, matching real
+// yq's node-copy semantics: `propagate_assign_alias_marks` in
+// `yq_runner.rs` looks up the source path's mark in the already-reconciled
+// `CommentTree` and copies an `Aliases` mark onto the target when found.
+// Every expected string below is pinned against mikefarah/yq v4.53.3, run
+// directly against that binary.
+// =============================================================================
+
+#[test]
+fn test_yaml_assign_from_alias_keeps_alias_mark_2497() -> Result<()> {
+    // Scalar source: `yq '.c = .b'` on `b: *x` prints `c: *x`.
+    let input = "a: &x 1\nb: *x\n";
+    let (output, exit_code) = run_yq_stdin(".c = .b", input, &[])?;
+    assert_eq!(exit_code, 0);
+    assert_eq!(output, "a: &x 1\nb: *x\nc: *x\n");
+
+    let (json, exit_code) = run_yq_stdin(".c = .b", input, &["-o=json", "-I=0"])?;
+    assert_eq!(exit_code, 0);
+    assert_eq!(json.trim(), r#"{"a":1,"b":1,"c":1}"#, "values unchanged");
+
+    // Container source: same rule, `.a` is a mapping rather than a scalar.
+    let input = "a: &x {p: 1}\nb: *x\n";
+    let (output, exit_code) = run_yq_stdin(".c = .b", input, &[])?;
+    assert_eq!(exit_code, 0);
+    assert_eq!(output, "a: &x {p: 1}\nb: *x\nc: *x\n");
+
+    let (json, exit_code) = run_yq_stdin(".c = .b", input, &["-o=json", "-I=0"])?;
+    assert_eq!(exit_code, 0);
+    assert_eq!(json.trim(), r#"{"a":{"p":1},"b":{"p":1},"c":{"p":1}}"#);
+    Ok(())
+}
+
+#[test]
+fn test_yaml_assign_from_alias_paren_optional_bracket_forms_2497() -> Result<()> {
+    // `(.b)`, `.b?`, and `.["b"]` are all still static navigation to `.b` and
+    // must propagate the mark exactly like the bare `.b` case above.
+    let input = "a: &x 1\nb: *x\n";
+    for filter in [".c = (.b)", ".c = .b?", r#".c = .["b"]"#] {
+        let (output, exit_code) = run_yq_stdin(filter, input, &[])?;
+        assert_eq!(exit_code, 0, "filter: {filter}");
+        assert_eq!(output, "a: &x 1\nb: *x\nc: *x\n", "filter: {filter}");
+
+        let (json, exit_code) = run_yq_stdin(filter, input, &["-o=json", "-I=0"])?;
+        assert_eq!(exit_code, 0, "filter: {filter}");
+        assert_eq!(
+            json.trim(),
+            r#"{"a":1,"b":1,"c":1}"#,
+            "values unchanged, filter: {filter}"
+        );
+    }
+    Ok(())
+}
+
+#[test]
+fn test_yaml_assign_from_anchor_is_plain_2497() -> Result<()> {
+    // `.a` is the anchor's own declaration, not an alias -- `yq '.c = .a'`
+    // prints a plain `c: 1`, never `&x`/`*x`.
+    let input = "a: &x 1\nb: *x\n";
+    let (output, exit_code) = run_yq_stdin(".c = .a", input, &[])?;
+    assert_eq!(exit_code, 0);
+    assert_eq!(output, "a: &x 1\nb: *x\nc: 1\n");
+    Ok(())
+}
+
+#[test]
+fn test_yaml_assign_from_alias_chain_2497() -> Result<()> {
+    // `.c = .b | .d = .c`: the second stage must see the mark the first
+    // stage just set on `.c`, which did not exist in the pristine document
+    // at all.
+    let input = "a: &x 1\nb: *x\n";
+    let (output, exit_code) = run_yq_stdin(".c = .b | .d = .c", input, &[])?;
+    assert_eq!(exit_code, 0);
+    assert_eq!(output, "a: &x 1\nb: *x\nc: *x\nd: *x\n");
+
+    let (json, exit_code) = run_yq_stdin(".c = .b | .d = .c", input, &["-o=json", "-I=0"])?;
+    assert_eq!(exit_code, 0);
+    assert_eq!(json.trim(), r#"{"a":1,"b":1,"c":1,"d":1}"#);
+    Ok(())
+}
+
+#[test]
+fn test_yaml_assign_arithmetic_rhs_is_plain_2497() -> Result<()> {
+    // DELIBERATE NON-DIVERGENCE: real yq has a data-loss bug here --
+    // `.c = (.b + 1)` prints `c: *x` while silently keeping the *old* value
+    // (1, not 2) underneath. succinctly does not reproduce that: the RHS
+    // isn't static navigation, so this pass leaves it alone and the actual
+    // computed value (2) prints as a plain scalar.
+    let input = "a: &x 1\nb: *x\n";
+    let (output, exit_code) = run_yq_stdin(".c = (.b + 1)", input, &[])?;
+    assert_eq!(exit_code, 0);
+    assert_eq!(output, "a: &x 1\nb: *x\nc: 2\n");
+
+    let (json, exit_code) = run_yq_stdin(".c = (.b + 1)", input, &["-o=json", "-I=0"])?;
+    assert_eq!(exit_code, 0);
+    assert_eq!(json.trim(), r#"{"a":1,"b":1,"c":2}"#);
+    Ok(())
+}
+
+#[test]
+fn test_yaml_assign_alias_onto_anchor_drops_both_2497() -> Result<()> {
+    // DELIBERATE DIVERGENCE, rule 4(a) (see
+    // `docs/compliance/yq/limitations.md`). Real yq prints `a: *x\nb: *x\n`
+    // here -- overwriting the anchor's own declaration with an alias to
+    // itself, so no `&x` is left anywhere and yq then refuses to re-read its
+    // own output (`unknown anchor 'x' referenced`, verified against the
+    // pinned binary). `enforce_anchor_soundness` runs after this pass finds
+    // no surviving declaration and drops both marks.
+    let input = "a: &x 1\nb: *x\n";
+    let (output, exit_code) = run_yq_stdin(".a = .b", input, &[])?;
+    assert_eq!(exit_code, 0);
+    assert_eq!(output, "a: 1\nb: 1\n");
+
+    let (round_tripped, exit_code) = run_yq_stdin(".", &output, &[])?;
+    assert_eq!(
+        exit_code, 0,
+        "succinctly must be able to re-read its own output"
+    );
+    assert_eq!(round_tripped, output);
+
+    let (json, exit_code) = run_yq_stdin(".a = .b", input, &["-o=json", "-I=0"])?;
+    assert_eq!(exit_code, 0);
+    assert_eq!(json.trim(), r#"{"a":1,"b":1}"#, "values unchanged");
+    Ok(())
+}
+
 /// #1201: `reduce`/`foreach`'s binding clause is parsed by the shared
 /// `parse_pattern`, which both `ParserMode`s reach, so full destructuring
 /// patterns land in yq mode too. There is no oracle to match here -- real yq

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -25209,6 +25209,122 @@ fn test_yaml_assign_alias_onto_anchor_drops_both_2497() -> Result<()> {
     let (json, exit_code) = run_yq_stdin(".a = .b", input, &["-o=json", "-I=0"])?;
     assert_eq!(exit_code, 0);
     assert_eq!(json.trim(), r#"{"a":1,"b":1}"#, "values unchanged");
+
+    // Container variant: real yq's node-copy bug is identical here -- it
+    // prints `a: *x\nb: *x\n`, an alias with no `&x` anywhere (verified
+    // against the pinned binary), not the flow-style object either name
+    // ever held. succinctly drops both marks the same way as the scalar
+    // case, but because it never replaces `.a`'s own `CommentTree` node
+    // wholesale (only its `anchor` field), `.a` keeps the flow style its
+    // *own* pristine node carried (`{p: 1}`); `.b` was always an alias
+    // syntactically and never had a container style of its own to keep, so
+    // it falls back to the emitter's default block style once its mark is
+    // gone.
+    let input = "a: &x {p: 1}\nb: *x\n";
+    let (output, exit_code) = run_yq_stdin(".a = .b", input, &[])?;
+    assert_eq!(exit_code, 0);
+    assert_eq!(output, "a: {p: 1}\nb:\n  p: 1\n");
+
+    let (round_tripped, exit_code) = run_yq_stdin(".", &output, &[])?;
+    assert_eq!(
+        exit_code, 0,
+        "succinctly must be able to re-read its own output"
+    );
+    assert_eq!(round_tripped, output);
+
+    let (json, exit_code) = run_yq_stdin(".a = .b", input, &["-o=json", "-I=0"])?;
+    assert_eq!(exit_code, 0);
+    assert_eq!(
+        json.trim(),
+        r#"{"a":{"p":1},"b":{"p":1}}"#,
+        "values unchanged"
+    );
+    Ok(())
+}
+
+#[test]
+fn test_yaml_assign_from_alias_keeps_target_comment_2497() -> Result<()> {
+    // A plain `=` overwrites a go-yaml node's value in place, never the
+    // node itself -- so a target's own trailing comment survives an
+    // assignment that turns it into an alias, exactly as it survives any
+    // other scalar overwrite (`test_yaml_assign_to_anchor_keeps_anchor_
+    // and_alias_763` above). Verified against the pinned binary:
+    // `.c = .b` on `c: 2 # keep` prints `c: *x # keep`, not a bare `c: *x`.
+    let input = "a: &x 1\nb: *x\nc: 2 # keep\n";
+    let (output, exit_code) = run_yq_stdin(".c = .b", input, &[])?;
+    assert_eq!(exit_code, 0);
+    assert_eq!(output, "a: &x 1\nb: *x\nc: *x # keep\n");
+
+    let (json, exit_code) = run_yq_stdin(".c = .b", input, &["-o=json", "-I=0"])?;
+    assert_eq!(exit_code, 0);
+    assert_eq!(json.trim(), r#"{"a":1,"b":1,"c":1}"#, "values unchanged");
+    Ok(())
+}
+
+#[test]
+fn test_yaml_assign_from_alias_through_passthrough_stages_2497() -> Result<()> {
+    // A pass-through stage (`.`, `select(true)`, `del(.z)`, a leading `.`)
+    // sitting next to a `.c = .b` assign in the same pipe must not block
+    // the mark propagation -- `collect_assign_chain` skips stages that
+    // aren't a plain `=` rather than bailing out of the whole pipe.
+    let input = "a: &x 1\nb: *x\nz: 9\n";
+    for (filter, expected) in [
+        (".c = .b | .", "a: &x 1\nb: *x\nz: 9\nc: *x\n"),
+        (".c = .b | select(true)", "a: &x 1\nb: *x\nz: 9\nc: *x\n"),
+        ("del(.z) | .c = .b", "a: &x 1\nb: *x\nc: *x\n"),
+        (". | .c = .b", "a: &x 1\nb: *x\nz: 9\nc: *x\n"),
+    ] {
+        let (output, exit_code) = run_yq_stdin(filter, input, &[])?;
+        assert_eq!(exit_code, 0, "filter: {filter}");
+        assert_eq!(output, expected, "filter: {filter}");
+    }
+    Ok(())
+}
+
+#[test]
+fn test_yaml_later_plain_assign_clears_alias_mark_2497() -> Result<()> {
+    // A plain `=` always replaces the target's node wholesale, so a stale
+    // `Aliases` mark must not survive a later overwrite just because the
+    // new value happens to render the same -- whether the mark came from
+    // an earlier stage in the same chain (`.c = .b | .c = 1`, `.c = .b |
+    // .c = .a`) or from the target's own pristine value (`.b = 1`, `.b =
+    // .a` on `b: *x`, where the literal/anchor-read RHS both happen to
+    // equal the value `.b` already aliased to). All four print a plain
+    // scalar in real yq.
+    let input = "a: &x 1\nb: *x\n";
+    for (filter, expected, expected_json) in [
+        (
+            ".c = .b | .c = 1",
+            "a: &x 1\nb: *x\nc: 1\n",
+            r#"{"a":1,"b":1,"c":1}"#,
+        ),
+        (
+            ".c = .b | .c = .a",
+            "a: &x 1\nb: *x\nc: 1\n",
+            r#"{"a":1,"b":1,"c":1}"#,
+        ),
+        (".b = 1", "a: &x 1\nb: 1\n", r#"{"a":1,"b":1}"#),
+        (".b = .a", "a: &x 1\nb: 1\n", r#"{"a":1,"b":1}"#),
+    ] {
+        let (output, exit_code) = run_yq_stdin(filter, input, &[])?;
+        assert_eq!(exit_code, 0, "filter: {filter}");
+        assert_eq!(output, expected, "filter: {filter}");
+
+        let (json, exit_code) = run_yq_stdin(filter, input, &["-o=json", "-I=0"])?;
+        assert_eq!(exit_code, 0, "filter: {filter}");
+        assert_eq!(
+            json.trim(),
+            expected_json,
+            "values unchanged, filter: {filter}"
+        );
+    }
+
+    // `.a = 5`: a `Declares` mark, unlike `Aliases`, is never cleared by
+    // this pass -- the anchor's own identity survives a value-only
+    // overwrite, matching real yq.
+    let (output, exit_code) = run_yq_stdin(".a = 5", input, &[])?;
+    assert_eq!(exit_code, 0);
+    assert_eq!(output, "a: &x 5\nb: *x\n");
     Ok(())
 }
 


### PR DESCRIPTION
## Summary

Split out of issue 1351 as its "case 2". Assigning an alias-valued node to a new key
(`.c = .b` where `b: *x`) printed the plain value instead of another alias to the
same anchor, because `reconcile_presentation_at_depth` has no notion of a write's
*source* path — a brand-new key gets `CommentTree::empty()` no matter what the RHS
resolved through.

Adds a post-pass, `propagate_assign_alias_marks` in `src/bin/succinctly/yq_runner.rs`,
that runs after `reconcile_presentation` and before `enforce_anchor_soundness`: when
the top-level expression is a plain `Expr::Assign` (or a `Pipe` containing one or more
such assigns, applied in order, skipping any pass-through stage in between) and both
`path` and `value` are static navigation (`Field`/`Index` chains through
`Paren`/`Optional`), it copies an `Aliases` mark from `value`'s current node onto
`path`'s node — updating the target's `NodeMeta` in place rather than replacing the
node, so an existing comment/style survives. When the RHS is *not* a static alias
read, a stale `Aliases` mark already on the target is cleared instead (a `Declares`
mark is never touched). `enforce_anchor_soundness` then decides whether a surviving
mark is actually safe to keep (declaration must still be emitted, and earlier), which
is what makes `.a = .b` (writing an alias onto the very node that anchors it) fall out
correctly to dropping both marks with no special-casing.

**Update:** review of the first version of this PR found a regression (target's own
comment/style was being dropped) and several in-scope gaps (pass-through pipe stages
losing the mark; a stale mark surviving a later plain overwrite). All were fixed in a
second commit on this branch — see the oracle table below for the full, current
picture.

Oracle table (Homebrew `yq` v4.53.3, live-verified):

| Filter | yq | succinctly yq |
|---|---|---|
| `.c = .b` (scalar/container source) | `c: *x` | `c: *x` (matches) |
| `.c = (.b)`, `.c = .b?`, `.c = .["b"]` | `c: *x` | `c: *x` (matches) |
| `.c = .b \| .d = .c` (chain) | `d: *x` | `d: *x` (matches) |
| `.c = .a` (anchor source) | `c: 1` | `c: 1` (matches) |
| `c: 2 # keep` + `.c = .b` | `c: *x # keep` | `c: *x # keep` (matches) |
| `.c = .b \| .`, `.c = .b \| select(true)`, `del(.z) \| .c = .b`, `. \| .c = .b` | `c: *x` | `c: *x` (matches) |
| `.c = .b \| .c = 1`, `.c = .b \| .c = .a` | `c: 1` | `c: 1` (matches) |
| `.b = 1`, `.b = .a` (on `b: *x`) | `b: 1` | `b: 1` (matches) |
| `.a = 5` (on `a: &x 1`, `Declares` survives) | `a: &x 5` | `a: &x 5` (matches) |
| `.a = .b` (onto its own anchor, scalar) | `a: *x` / `b: *x` (unreadable) | `a: 1` / `b: 1` — rule 4(a) divergence |
| `.a = .b` (onto its own anchor, flow container) | `a: *x` / `b: *x` (unreadable) | `a: {p: 1}` / `b:\n  p: 1` — rule 4(a) divergence |
| `.c = (.b + 1)` | `c: *x` with stale value `1` (yq data-loss bug) | `c: 2` — rule 4(b), not reproduced |

The last three rows are deliberate divergences under ADR-0018 rule 4(a)/4(b), documented
in `docs/compliance/yq/limitations.md` next to the existing `del(.a)` example.

## Known gaps (follow-up)

Out of scope for this PR — filing a follow-up issue to track:

- `.c.d = .b` writing under a brand-new parent
- `.c = .b[-1]` (negative index on the value side)
- `(.c, .d) = .b` (comma-valued path)
- `.c = [.b]` (construction arms carry no `CommentTree`, same blocker as #1361/#865)
- `.c = (.b // 0)`
- `.c += .b` (compound assign)
- `.c = .b | .a = 5` (the copy doesn't join the alias group, so a later write to the
  anchor doesn't propagate to the copy)

## Test plan

- [x] `cargo build --release --features cli` then live-diffed every oracle row above against the pinned `yq` binary
- [x] `cargo test --features cli,simd,regex,serde` — full suite green (62 test binaries, 0 failed), including 9 `_2497`-suffixed tests in `tests/yq_cli_tests.rs`
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings` — clean
- [x] `cargo fmt -- --check` — clean

Fixes #2497
