### PR TITLE
fix(jq): stop copying the anchor's marks under an alias position's CommentTree

### DIFF
--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -983,13 +983,29 @@ pub fn to_owned_with_comments<V: DocumentValue>(
     value: &V,
     cursor: Option<&V::Cursor>,
 ) -> Result<(OwnedValue, CommentTree), EvalError> {
-    to_owned_with_comments_at_depth(value, cursor, 0)
+    to_owned_with_comments_at_depth(value, cursor, 0, false)
 }
 
+/// `under_alias`: whether some ancestor on the path from the root is itself
+/// an alias node -- i.e. whether the node currently being converted was
+/// only reached by resolving through a `YamlValue::Alias` to its target's
+/// own fields, rather than by walking the document's real tree shape.
+///
+/// Exists for #2500: `value.as_object()`/`as_array()` resolve straight
+/// through an alias to its target, so converting an alias node walks the
+/// *target*'s cursors for its children -- including any `&name` the target
+/// declares. Recording that declaration here would duplicate the one
+/// already recorded when the target's own (non-alias) position was
+/// converted, so a `Declares` mark found `under_alias` is dropped below.
+/// An `Aliases` mark found the same way is kept -- it's a genuine
+/// reference this document's writer still needs to resolve or drop on its
+/// own merits, e.g. `cfg: *base` nested inside an expanded `env: *env`
+/// copy must still round-trip as `*base`, not inline `base`'s value.
 fn to_owned_with_comments_at_depth<V: DocumentValue>(
     value: &V,
     cursor: Option<&V::Cursor>,
     depth: usize,
+    under_alias: bool,
 ) -> Result<(OwnedValue, CommentTree), EvalError> {
     assert_nesting_depth(depth);
     // The raw (`#`-prefixed) form, not the stripped `line_comment` builtin
@@ -1007,12 +1023,27 @@ fn to_owned_with_comments_at_depth<V: DocumentValue>(
                 DocumentCursor::anchor(c).map(|name| AnchorMark::Declares(name.to_string()))
             })
     });
+    // Children (if any) are themselves `under_alias` when this node is --
+    // computed from `own_anchor` before #2500's `Declares` suppression
+    // below touches it, since suppression never changes whether *this*
+    // node is an alias.
+    let child_under_alias = under_alias || matches!(own_anchor, Some(AnchorMark::Aliases(_)));
+    // #2500: see this function's own doc comment above for why a
+    // `Declares` mark reached `under_alias` is not a source declaration --
+    // it's the anchor target's own mark, copied onto this alias-expanded
+    // position, and the document already carries the genuine one at the
+    // target's real (non-alias) position.
+    let own_anchor = if under_alias && matches!(own_anchor, Some(AnchorMark::Declares(_))) {
+        None
+    } else {
+        own_anchor
+    };
     let own_meta = NodeMeta {
         comment: own_comment,
         style: own_style,
         anchor: own_anchor,
     };
-    let (owned, tree) = if let Some(fields) = value.as_object() {
+    if let Some(fields) = value.as_object() {
         let mut map = IndexMap::new();
         let mut comment_map = IndexMap::new();
         let mut key_comment_map = IndexMap::new();
@@ -1046,6 +1077,7 @@ fn to_owned_with_comments_at_depth<V: DocumentValue>(
                 &field.value,
                 Some(&field.value_cursor),
                 depth + 1,
+                child_under_alias,
             )?;
             map.insert(key.clone(), v);
             comment_map.insert(key.clone(), c);
@@ -1071,10 +1103,10 @@ fn to_owned_with_comments_at_depth<V: DocumentValue>(
         if f.ends_unpaired() {
             return Err(f.malformed_member_error());
         }
-        (
+        Ok((
             OwnedValue::Object(map),
-            CommentTree::Object(own_meta.clone(), comment_map, key_comment_map),
-        )
+            CommentTree::Object(own_meta, comment_map, key_comment_map),
+        ))
     } else if let Some(elements) = value.as_array() {
         let mut items = Vec::new();
         let mut comment_items = Vec::new();
@@ -1083,51 +1115,30 @@ fn to_owned_with_comments_at_depth<V: DocumentValue>(
         let mut elems = elements;
         while let Some((elem_cursor, rest)) = elems.uncons_cursor() {
             let elem_value = elem_cursor.value();
-            let (v, c) =
-                to_owned_with_comments_at_depth(&elem_value, Some(&elem_cursor), depth + 1)?;
+            let (v, c) = to_owned_with_comments_at_depth(
+                &elem_value,
+                Some(&elem_cursor),
+                depth + 1,
+                child_under_alias,
+            )?;
             items.push(v);
             comment_items.push(c);
             elems = rest;
         }
-        (
+        Ok((
             OwnedValue::Array(items),
-            CommentTree::Array(own_meta.clone(), comment_items),
-        )
+            CommentTree::Array(own_meta, comment_items),
+        ))
     } else {
         // #2358: `value` is scalar here (the object/array arms above
         // return first), so `to_owned_at_depth`'s `cursor` parameter is
         // never consulted on this path either -- passed through from this
         // function's own parameter purely because it's already in scope,
         // not because it matters.
-        (
+        Ok((
             to_owned_at_depth(value, cursor, depth)?,
-            CommentTree::Leaf(own_meta.clone()),
-        )
-    };
-    // #2500: `value.as_object()`/`as_array()` resolve straight through a
-    // `YamlValue::Alias` to the anchor *target*'s fields, so the loops
-    // above -- when `value` is itself an alias node -- just walked the
-    // target's own cursors and built a full child `CommentTree` out of
-    // them, marks included. That copies the anchor's own `&name`
-    // declarations onto this alias position's subtree, where they sit
-    // dormant as long as the alias mark itself survives (the emitter
-    // checks `comments.alias_name()` before any value-shape dispatch and
-    // never descends into an aliased node's children at all) but
-    // resurface as a second, spurious declaration the moment a later
-    // write makes this position diverge from its anchor and
-    // `enforce_anchor_soundness` drops the `*name` mark, falling through
-    // to the ordinary container render.
-    //
-    // `owned` (the fully expanded value, needed everywhere downstream) is
-    // built above and left untouched; only the parallel comment tree is
-    // collapsed to a childless `Leaf` here, so a diverged alias renders
-    // its expanded copy with default style/no marks like any other
-    // computed subtree -- `CommentTree::field`/`at_index` already answer
-    // the empty tree for a `Leaf`'s "children".
-    if matches!(own_meta.anchor, Some(AnchorMark::Aliases(_))) {
-        Ok((owned, CommentTree::Leaf(own_meta)))
-    } else {
-        Ok((owned, tree))
+            CommentTree::Leaf(own_meta),
+        ))
     }
 }
 
@@ -23488,17 +23499,10 @@ mod tests {
         assert!(err.message.contains("Invalid JSON text"), "{err:?}");
     }
 
-    /// #2500: `value.as_object()`/`as_array()` resolve straight through a
-    /// `YamlValue::Alias` to the anchor target's own fields, so
-    /// `to_owned_with_comments_at_depth` used to recurse into those target
-    /// cursors and build a full child `CommentTree` for an alias position --
-    /// copying the anchor's own nested `&mark`s (here, `p`'s `&y`) onto the
-    /// alias node's subtree. The fix collapses an alias position's tree to a
-    /// childless `Leaf` carrying only its own `Aliases` mark: this asserts
-    /// that shape directly, independent of the write/render path the CLI
-    /// tests exercise end-to-end.
+    /// #2500: see `to_owned_with_comments_at_depth`'s own doc comment for
+    /// the `under_alias` mechanism this asserts directly.
     #[test]
-    fn test_to_owned_with_comments_alias_position_is_leaf_2500() {
+    fn test_to_owned_with_comments_alias_subtree_drops_copied_declares_2500() {
         use crate::yaml::YamlIndex;
 
         let yaml = b"a: &x\n  p: &y 1\n  q: *y\nb: *x\n";
@@ -23511,20 +23515,21 @@ mod tests {
 
         let (_owned, comments) = to_owned_with_comments(&value, Some(&mapping_cursor)).unwrap();
 
-        let b_tree = comments.field("b");
-        assert!(
-            matches!(
-                b_tree,
-                CommentTree::Leaf(NodeMeta {
-                    anchor: Some(AnchorMark::Aliases(name)),
-                    ..
-                }) if name == "x"
-            ),
-            "expected a childless Leaf carrying Aliases(\"x\"), got {b_tree:?}"
-        );
-        // A `Leaf`'s `field`/`at_index` fall back to the empty tree for any
-        // child -- confirming no nested `&y` mark survived underneath.
-        assert!(b_tree.field("p").anchor_mark().is_none());
+        // `.b` is an alias (`*x`) -- its own mark is kept...
+        assert!(matches!(
+            comments.field("b").anchor_mark(),
+            Some(AnchorMark::Aliases(name)) if name == "x"
+        ));
+        // ...but the `&y` declaration reached only by walking through `.b`'s
+        // expanded copy (`.b.p`) is the anchor target's own mark, already
+        // recorded at `.a.p`'s real position, so it must not survive here.
+        assert!(comments.field("b").field("p").declared_anchor().is_none());
+        // A nested *alias* found the same way is a genuine reference, not a
+        // copied declaration, so it is kept: `.b.q` still resolves to `*y`.
+        assert!(matches!(
+            comments.field("b").field("q").anchor_mark(),
+            Some(AnchorMark::Aliases(name)) if name == "y"
+        ));
     }
 
     /// `to_owned_key_shape`'s array/object branches (#626/#670/#903) are a

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -1012,7 +1012,7 @@ fn to_owned_with_comments_at_depth<V: DocumentValue>(
         style: own_style,
         anchor: own_anchor,
     };
-    if let Some(fields) = value.as_object() {
+    let (owned, tree) = if let Some(fields) = value.as_object() {
         let mut map = IndexMap::new();
         let mut comment_map = IndexMap::new();
         let mut key_comment_map = IndexMap::new();
@@ -1071,10 +1071,10 @@ fn to_owned_with_comments_at_depth<V: DocumentValue>(
         if f.ends_unpaired() {
             return Err(f.malformed_member_error());
         }
-        Ok((
+        (
             OwnedValue::Object(map),
-            CommentTree::Object(own_meta, comment_map, key_comment_map),
-        ))
+            CommentTree::Object(own_meta.clone(), comment_map, key_comment_map),
+        )
     } else if let Some(elements) = value.as_array() {
         let mut items = Vec::new();
         let mut comment_items = Vec::new();
@@ -1089,20 +1089,45 @@ fn to_owned_with_comments_at_depth<V: DocumentValue>(
             comment_items.push(c);
             elems = rest;
         }
-        Ok((
+        (
             OwnedValue::Array(items),
-            CommentTree::Array(own_meta, comment_items),
-        ))
+            CommentTree::Array(own_meta.clone(), comment_items),
+        )
     } else {
         // #2358: `value` is scalar here (the object/array arms above
         // return first), so `to_owned_at_depth`'s `cursor` parameter is
         // never consulted on this path either -- passed through from this
         // function's own parameter purely because it's already in scope,
         // not because it matters.
-        Ok((
+        (
             to_owned_at_depth(value, cursor, depth)?,
-            CommentTree::Leaf(own_meta),
-        ))
+            CommentTree::Leaf(own_meta.clone()),
+        )
+    };
+    // #2500: `value.as_object()`/`as_array()` resolve straight through a
+    // `YamlValue::Alias` to the anchor *target*'s fields, so the loops
+    // above -- when `value` is itself an alias node -- just walked the
+    // target's own cursors and built a full child `CommentTree` out of
+    // them, marks included. That copies the anchor's own `&name`
+    // declarations onto this alias position's subtree, where they sit
+    // dormant as long as the alias mark itself survives (the emitter
+    // checks `comments.alias_name()` before any value-shape dispatch and
+    // never descends into an aliased node's children at all) but
+    // resurface as a second, spurious declaration the moment a later
+    // write makes this position diverge from its anchor and
+    // `enforce_anchor_soundness` drops the `*name` mark, falling through
+    // to the ordinary container render.
+    //
+    // `owned` (the fully expanded value, needed everywhere downstream) is
+    // built above and left untouched; only the parallel comment tree is
+    // collapsed to a childless `Leaf` here, so a diverged alias renders
+    // its expanded copy with default style/no marks like any other
+    // computed subtree -- `CommentTree::field`/`at_index` already answer
+    // the empty tree for a `Leaf`'s "children".
+    if matches!(own_meta.anchor, Some(AnchorMark::Aliases(_))) {
+        Ok((owned, CommentTree::Leaf(own_meta)))
+    } else {
+        Ok((owned, tree))
     }
 }
 
@@ -23461,6 +23486,45 @@ mod tests {
         let err = to_owned_with_comments(&value, Some(&cursor))
             .expect_err("an unpaired member is not JSON");
         assert!(err.message.contains("Invalid JSON text"), "{err:?}");
+    }
+
+    /// #2500: `value.as_object()`/`as_array()` resolve straight through a
+    /// `YamlValue::Alias` to the anchor target's own fields, so
+    /// `to_owned_with_comments_at_depth` used to recurse into those target
+    /// cursors and build a full child `CommentTree` for an alias position --
+    /// copying the anchor's own nested `&mark`s (here, `p`'s `&y`) onto the
+    /// alias node's subtree. The fix collapses an alias position's tree to a
+    /// childless `Leaf` carrying only its own `Aliases` mark: this asserts
+    /// that shape directly, independent of the write/render path the CLI
+    /// tests exercise end-to-end.
+    #[test]
+    fn test_to_owned_with_comments_alias_position_is_leaf_2500() {
+        use crate::yaml::YamlIndex;
+
+        let yaml = b"a: &x\n  p: &y 1\n  q: *y\nb: *x\n";
+        let index = YamlIndex::build(yaml).unwrap();
+        let cursor = index.root(yaml);
+        let mapping_cursor = cursor
+            .first_child()
+            .expect("YAML document should have content");
+        let value = mapping_cursor.value();
+
+        let (_owned, comments) = to_owned_with_comments(&value, Some(&mapping_cursor)).unwrap();
+
+        let b_tree = comments.field("b");
+        assert!(
+            matches!(
+                b_tree,
+                CommentTree::Leaf(NodeMeta {
+                    anchor: Some(AnchorMark::Aliases(name)),
+                    ..
+                }) if name == "x"
+            ),
+            "expected a childless Leaf carrying Aliases(\"x\"), got {b_tree:?}"
+        );
+        // A `Leaf`'s `field`/`at_index` fall back to the empty tree for any
+        // child -- confirming no nested `&y` mark survived underneath.
+        assert!(b_tree.field("p").anchor_mark().is_none());
     }
 
     /// `to_owned_key_shape`'s array/object branches (#626/#670/#903) are a

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -25370,12 +25370,11 @@ fn test_yaml_diverged_alias_in_sequence_prints_no_duplicate_anchor_2500() -> Res
 /// #2500: a nested *alias reference* reached through a diverged alias's
 /// expanded copy is not a copied declaration and must survive as `*base`,
 /// not inline the target's value -- see `to_owned_with_comments_at_depth`'s
-/// own doc comment for why only a `Declares` mark is dropped. `.prod.name`
-/// writes through the `prod` alias on this branch, diverging its expanded
-/// copy (issue 1351 will later redirect this particular write onto `.env`
-/// instead, at which point `.prod` would stay `*env` and never reach the
-/// expanded-copy path at all) -- named for the mechanism rather than this
-/// specific write shape so it keeps meaning either way.
+/// own doc comment for why only a `Declares` mark is dropped. With #1351's
+/// redirect a write through `.prod` lands on `.env`, so the copy is diverged
+/// here by deleting the declaration first (`del(.env)`): the later
+/// `.prod.name` write has nothing to redirect to and stays positional, and
+/// real yq prints the unreadable `prod: *env` for this shape.
 #[test]
 fn test_yaml_alias_subtree_keeps_nested_alias_marks_2500() -> Result<()> {
     let input = concat!(
@@ -25387,7 +25386,7 @@ fn test_yaml_alias_subtree_keeps_nested_alias_marks_2500() -> Result<()> {
         "  name: dev\n",
         "prod: *env\n",
     );
-    let (output, exit_code) = run_yq_stdin(r#".prod.name = "prod""#, input, &[])?;
+    let (output, exit_code) = run_yq_stdin(r#"del(.env) | .prod.name = "prod""#, input, &[])?;
     assert_eq!(exit_code, 0, "output: {output:?}");
     assert_eq!(
         output,
@@ -25395,9 +25394,6 @@ fn test_yaml_alias_subtree_keeps_nested_alias_marks_2500() -> Result<()> {
             "base: &base\n",
             "  host: h\n",
             "  port: 1\n",
-            "env: &env\n",
-            "  cfg: *base\n",
-            "  name: dev\n",
             "prod:\n",
             "  cfg: *base\n",
             "  name: prod\n",

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -25255,7 +25255,8 @@ fn test_yaml_assign_alias_onto_anchor_drops_both_2497() -> Result<()> {
 /// (`.b.q = ...`) so the repro keeps diverging `.b` regardless of whether
 /// this branch or issue 1351's write-through-the-anchor fix is applying the
 /// write; real yq writes through the alias either way and would print
-/// `a: &x {p: &y 1, q: 7}` / `b: *x` here, out of scope for this fix.#[test]
+/// `a: &x {p: &y 1, q: 7}` / `b: *x` here, out of scope for this fix.
+#[test]
 fn test_yaml_diverged_alias_prints_no_duplicate_anchor_2500() -> Result<()> {
     let input = "a: &x\n  p: &y 1\n  q: *y\nb: *x\n";
     let (output, exit_code) = run_yq_stdin(r#".b = {"p": 1, "q": 7}"#, input, &[])?;

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -25242,6 +25242,39 @@ fn test_yaml_assign_alias_onto_anchor_drops_both_2497() -> Result<()> {
     Ok(())
 }
 
+/// #2500: the alias position's `CommentTree` used to be built by recursing
+/// through the anchor *target*'s own cursors (`value.as_object()` resolves
+/// straight through a `YamlValue::Alias`), so it carried a copy of every
+/// mark the target declared -- here, `p`'s own `&y`. As long as the alias
+/// mark itself survives that copy sits dormant (the emitter never descends
+/// into an aliased node), but the write below makes `.b` diverge from `.a`,
+/// so `enforce_anchor_soundness` drops `.b`'s `*x` mark and the expanded
+/// copy renders through the ordinary object arm instead -- which used to
+/// resurface the copied `&y`, re-declaring it a second time in document
+/// order. Fixed by collapsing an alias position's tree to a childless
+/// `Leaf`, so the diverged expansion prints with no inherited marks at all.
+///
+/// Real yq writes *through* the alias here (issue 1351, out of scope for
+/// this fix) and would print `a: &x {p: &y 1, q: 5}` / `b: *x` -- but even
+/// under succinctly's copy-on-divergence model, the expected output has
+/// exactly one `&y`, never two.
+#[test]
+fn test_yaml_diverged_alias_prints_no_duplicate_anchor_2500() -> Result<()> {
+    let input = "a: &x\n  p: &y 1\n  q: *y\nb: *x\n";
+    let (output, exit_code) = run_yq_stdin(".b.q = 5", input, &[])?;
+    assert_eq!(exit_code, 0, "output: {output:?}");
+    assert_eq!(
+        output, "a: &x\n  p: &y 1\n  q: *y\nb:\n  p: 1\n  q: 5\n",
+        "output: {output:?}"
+    );
+    assert_eq!(
+        output.matches("&y").count(),
+        1,
+        "expected exactly one &y declaration, output: {output:?}"
+    );
+    Ok(())
+}
+
 #[test]
 fn test_yaml_assign_from_alias_keeps_target_comment_2497() -> Result<()> {
     // A plain `=` overwrites a go-yaml node's value in place, never the
@@ -25325,6 +25358,45 @@ fn test_yaml_later_plain_assign_clears_alias_mark_2497() -> Result<()> {
     let (output, exit_code) = run_yq_stdin(".a = 5", input, &[])?;
     assert_eq!(exit_code, 0);
     assert_eq!(output, "a: &x 5\nb: *x\n");
+    Ok(())
+}
+
+/// #2500's sibling repro: the alias sits inside a sequence item rather than
+/// a mapping field, exercising the array arm of the same recursion.
+#[test]
+fn test_yaml_diverged_alias_in_sequence_prints_no_duplicate_anchor_2500() -> Result<()> {
+    let input = "items:\n  - &t {n: &m 1, o: *m}\n  - *t\n";
+    let (output, exit_code) = run_yq_stdin(".items[1].o = 5", input, &[])?;
+    assert_eq!(exit_code, 0, "output: {output:?}");
+    assert_eq!(
+        output, "items:\n  - &t {n: &m 1, o: *m}\n  - n: 1\n    o: 5\n",
+        "output: {output:?}"
+    );
+    assert_eq!(
+        output.matches("&m").count(),
+        1,
+        "expected exactly one &m declaration, output: {output:?}"
+    );
+    Ok(())
+}
+
+/// #2500: the fix only changes the *side-tree* built for an alias position,
+/// never the value the writer/emitter renders when the alias mark itself
+/// survives -- `emit_yaml_value_at_depth` checks `comments.alias_name()`
+/// before any value-shape dispatch and never touches the (now-`Leaf`)
+/// children in that case, so a plain identity query over a document whose
+/// aliases never diverge must be byte-for-byte unaffected.
+#[test]
+fn test_yaml_alias_identity_output_unchanged_2500() -> Result<()> {
+    let input = "a: &x\n  p: &y 1\n  q: *y\nb: *x\n";
+    let (output, exit_code) = run_yq_stdin(".", input, &[])?;
+    assert_eq!(exit_code, 0, "output: {output:?}");
+    assert_eq!(output, input);
+
+    let input = "items:\n  - &t {n: &m 1, o: *m}\n  - *t\n";
+    let (output, exit_code) = run_yq_stdin(".", input, &[])?;
+    assert_eq!(exit_code, 0, "output: {output:?}");
+    assert_eq!(output, input);
     Ok(())
 }
 

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -24784,6 +24784,13 @@ fn test_yaml_dom_output_matches_streaming_output_over_an_anchor_corpus_763() -> 
         "e: &w\n",
         "  m: 1\n",
         "f: *w\n",
+        // #2500: `h`'s expanded copy (built on the DOM path) reaches `g`'s
+        // own nested `&u` declaration and `*u` reference through the alias
+        // -- the exact shape `to_owned_with_comments_at_depth`'s
+        // `under_alias` mechanism has to get right without changing a byte
+        // of this undiverged identity output.
+        "g: &v {r: &u 1, s: *u}\n",
+        "h: *v\n",
     );
     let (streamed, exit_code) = run_yq_stdin(".", input, &[])?;
     assert_eq!(exit_code, 0);
@@ -25242,35 +25249,20 @@ fn test_yaml_assign_alias_onto_anchor_drops_both_2497() -> Result<()> {
     Ok(())
 }
 
-/// #2500: the alias position's `CommentTree` used to be built by recursing
-/// through the anchor *target*'s own cursors (`value.as_object()` resolves
-/// straight through a `YamlValue::Alias`), so it carried a copy of every
-/// mark the target declared -- here, `p`'s own `&y`. As long as the alias
-/// mark itself survives that copy sits dormant (the emitter never descends
-/// into an aliased node), but the write below makes `.b` diverge from `.a`,
-/// so `enforce_anchor_soundness` drops `.b`'s `*x` mark and the expanded
-/// copy renders through the ordinary object arm instead -- which used to
-/// resurface the copied `&y`, re-declaring it a second time in document
-/// order. Fixed by collapsing an alias position's tree to a childless
-/// `Leaf`, so the diverged expansion prints with no inherited marks at all.
-///
-/// Real yq writes *through* the alias here (issue 1351, out of scope for
-/// this fix) and would print `a: &x {p: &y 1, q: 5}` / `b: *x` -- but even
-/// under succinctly's copy-on-divergence model, the expected output has
-/// exactly one `&y`, never two.
-#[test]
+/// #2500: see `to_owned_with_comments_at_depth`'s own doc comment for the
+/// mechanism -- this pins the original duplicate-`&y` repro end-to-end.
+/// Uses a whole-value replace (`.b = {...}`) rather than a through-write
+/// (`.b.q = ...`) so the repro keeps diverging `.b` regardless of whether
+/// this branch or issue 1351's write-through-the-anchor fix is applying the
+/// write; real yq writes through the alias either way and would print
+/// `a: &x {p: &y 1, q: 7}` / `b: *x` here, out of scope for this fix.#[test]
 fn test_yaml_diverged_alias_prints_no_duplicate_anchor_2500() -> Result<()> {
     let input = "a: &x\n  p: &y 1\n  q: *y\nb: *x\n";
-    let (output, exit_code) = run_yq_stdin(".b.q = 5", input, &[])?;
+    let (output, exit_code) = run_yq_stdin(r#".b = {"p": 1, "q": 7}"#, input, &[])?;
     assert_eq!(exit_code, 0, "output: {output:?}");
     assert_eq!(
-        output, "a: &x\n  p: &y 1\n  q: *y\nb:\n  p: 1\n  q: 5\n",
+        output, "a: &x\n  p: &y 1\n  q: *y\nb:\n  p: 1\n  q: 7\n",
         "output: {output:?}"
-    );
-    assert_eq!(
-        output.matches("&y").count(),
-        1,
-        "expected exactly one &y declaration, output: {output:?}"
     );
     Ok(())
 }
@@ -25362,41 +25354,75 @@ fn test_yaml_later_plain_assign_clears_alias_mark_2497() -> Result<()> {
 }
 
 /// #2500's sibling repro: the alias sits inside a sequence item rather than
-/// a mapping field, exercising the array arm of the same recursion.
+/// a mapping field, exercising the array arm of the same mechanism.
 #[test]
 fn test_yaml_diverged_alias_in_sequence_prints_no_duplicate_anchor_2500() -> Result<()> {
     let input = "items:\n  - &t {n: &m 1, o: *m}\n  - *t\n";
-    let (output, exit_code) = run_yq_stdin(".items[1].o = 5", input, &[])?;
+    let (output, exit_code) = run_yq_stdin(r#".items[1] = {"n": 1, "o": 5}"#, input, &[])?;
     assert_eq!(exit_code, 0, "output: {output:?}");
     assert_eq!(
         output, "items:\n  - &t {n: &m 1, o: *m}\n  - n: 1\n    o: 5\n",
         "output: {output:?}"
     );
+    Ok(())
+}
+
+/// #2500: a nested *alias reference* reached through a diverged alias's
+/// expanded copy is not a copied declaration and must survive as `*base`,
+/// not inline the target's value -- see `to_owned_with_comments_at_depth`'s
+/// own doc comment for why only a `Declares` mark is dropped. `.prod.name`
+/// writes through the `prod` alias on this branch, diverging its expanded
+/// copy (issue 1351 will later redirect this particular write onto `.env`
+/// instead, at which point `.prod` would stay `*env` and never reach the
+/// expanded-copy path at all) -- named for the mechanism rather than this
+/// specific write shape so it keeps meaning either way.
+#[test]
+fn test_yaml_alias_subtree_keeps_nested_alias_marks_2500() -> Result<()> {
+    let input = concat!(
+        "base: &base\n",
+        "  host: h\n",
+        "  port: 1\n",
+        "env: &env\n",
+        "  cfg: *base\n",
+        "  name: dev\n",
+        "prod: *env\n",
+    );
+    let (output, exit_code) = run_yq_stdin(r#".prod.name = "prod""#, input, &[])?;
+    assert_eq!(exit_code, 0, "output: {output:?}");
     assert_eq!(
-        output.matches("&m").count(),
-        1,
-        "expected exactly one &m declaration, output: {output:?}"
+        output,
+        concat!(
+            "base: &base\n",
+            "  host: h\n",
+            "  port: 1\n",
+            "env: &env\n",
+            "  cfg: *base\n",
+            "  name: dev\n",
+            "prod:\n",
+            "  cfg: *base\n",
+            "  name: prod\n",
+        ),
+        "output: {output:?}"
     );
     Ok(())
 }
 
-/// #2500: the fix only changes the *side-tree* built for an alias position,
-/// never the value the writer/emitter renders when the alias mark itself
-/// survives -- `emit_yaml_value_at_depth` checks `comments.alias_name()`
-/// before any value-shape dispatch and never touches the (now-`Leaf`)
-/// children in that case, so a plain identity query over a document whose
-/// aliases never diverge must be byte-for-byte unaffected.
+/// #2500: a diverged alias's expanded copy keeps ordinary presentation data
+/// (comments, style, nested marks) the same as any other computed subtree
+/// would -- see `to_owned_with_comments_at_depth`'s own doc comment; only a
+/// copied anchor *declaration* is special-cased and dropped. No oracle to
+/// match: real yq prints an unreadable `b: *x` here (no `&x` anywhere,
+/// since `.a` was deleted -- confirmed live against v4.53.3), so this pins
+/// succinctly's own behavior only.
 #[test]
-fn test_yaml_alias_identity_output_unchanged_2500() -> Result<()> {
-    let input = "a: &x\n  p: &y 1\n  q: *y\nb: *x\n";
-    let (output, exit_code) = run_yq_stdin(".", input, &[])?;
+fn test_yaml_alias_subtree_keeps_comments_and_style_2500() -> Result<()> {
+    let input = "a: &x\n  p: 1 # note\n  l: [1, 2]\nb: *x\n";
+    let (output, exit_code) = run_yq_stdin("del(.a) | .b.p = 2", input, &[])?;
     assert_eq!(exit_code, 0, "output: {output:?}");
-    assert_eq!(output, input);
-
-    let input = "items:\n  - &t {n: &m 1, o: *m}\n  - *t\n";
-    let (output, exit_code) = run_yq_stdin(".", input, &[])?;
-    assert_eq!(exit_code, 0, "output: {output:?}");
-    assert_eq!(output, input);
+    assert_eq!(
+        output, "b:\n  p: 2 # note\n  l: [1, 2]\n",
+        "output: {output:?}"
+    );
     Ok(())
 }
 


### PR DESCRIPTION
## Summary

- `to_owned_with_comments_at_depth`'s `own_anchor` correctly records `AnchorMark::Aliases(name)` for an alias node, but the function then fell into the `value.as_object()`/`as_array()` arms — which `YamlValue::Alias` resolves straight through to the anchor *target*'s own fields — and built a full child `CommentTree` from the target's cursors, marks included. That copied the anchor's own `&name` declarations onto the alias position's subtree.
- The copy sat dormant as long as the alias's own `*name` mark survived (the emitter checks `comments.alias_name()` before any value-shape dispatch and never descends into an aliased node's children), but resurfaced as a spurious, duplicate anchor declaration the moment a later write diverged the alias from its anchor and `enforce_anchor_soundness` dropped the now-unresolvable `*name` mark, falling through to the ordinary container render.
- Fixed with a narrower mechanism than the tree originally proposed: `to_owned_with_comments_at_depth` now threads an `under_alias: bool` (the public `to_owned_with_comments` passes `false`). A `&name` declaration (`AnchorMark::Declares`) reached only by walking through an alias's expanded copy is not a source declaration at all — it's the anchor target's own mark, already recorded once at the target's real (non-alias) position — so it is suppressed to `None`. A nested `*name` reference (`AnchorMark::Aliases`) found the same way is a genuine reference this document's writer still needs to resolve or drop on its own merits, so it is kept as-is. The object/array arms are otherwise unchanged from before this issue (early `return`s, no cloning).
- Real yq writes *through* the alias in this repro (issue 1351, out of scope here) and would print `a: &x {p: &y 1, q: 7}` / `b: *x`. This fix only ensures succinctly's own copy-on-divergence model prints the inner anchor exactly once instead of twice.

```console
$ printf 'a: &x\n  p: &y 1\n  q: *y\nb: *x\n' | succinctly yq '.b = {"p": 1, "q": 7}'
a: &x
  p: &y 1
  q: *y
b:
  p: 1
  q: 7
```

### Known consequence

A diverged alias position's expanded copy now prints with all of its own comments, style, and nested `&`/`*` marks intact — none of that is an anchor declaration, so none of it is suppressed. Only a copied *declaration* (`&name`) is ever dropped; everything else about the copy renders exactly like any other computed subtree. This is intended: real yq never actually prints an expanded copy at this position at all — it either writes through the alias (issue 1351) or, when that's not possible, emits an unreadable `*x` with no matching `&x` anywhere in the document. succinctly's copy-on-divergence model is the divergence from real yq that makes an expanded copy observable in the first place; this fix only ensures that copy is internally consistent (no duplicate declarations) rather than also stripping presentation data that has nothing to do with the bug.

## Test plan

- [x] `cargo build --release --features cli` then live-checked all repros (mapping-field duplicate-anchor, sequence-item duplicate-anchor, nested-alias-under-diverged-copy, comments/style-under-diverged-copy) against real `yq` v4.53.3 — fix matches expected output; `-o=json -I=0` values unchanged; identity (`.`) output byte-identical.
- [x] `cargo test --features cli,simd,regex,serde` — 3504+ / 1518 / etc. tests passed across all suites, 0 failed (1 pre-existing ignored).
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean.
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings` — clean.
- [x] `cargo fmt -- --check` — clean.
- [x] Added `test_yaml_diverged_alias_prints_no_duplicate_anchor_2500`, `test_yaml_diverged_alias_in_sequence_prints_no_duplicate_anchor_2500`, `test_yaml_alias_subtree_keeps_nested_alias_marks_2500`, `test_yaml_alias_subtree_keeps_comments_and_style_2500`, and a DOM-path corpus addition to `test_yaml_dom_output_matches_streaming_output_over_an_anchor_corpus_763` (`tests/yq_cli_tests.rs`), plus `test_to_owned_with_comments_alias_subtree_drops_copied_declares_2500` (`src/jq/eval_generic.rs` unit test module) — all pass.

Fixes #2500
