### PR TITLE
fix(jq): yq alias sync skips rebound slots and iterates nested groups to a fixpoint

### DIFF
--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -38488,7 +38488,7 @@ fn set_value_at_path(
 /// by the caller from the pre-mutation document. For each group, if the
 /// value at the definition path differs between `pristine` (before the
 /// write) and `result` (after), every alias path is overwritten with a clone
-/// of the new value.
+/// of the new value -- subject to the rule below.
 ///
 /// A group whose definition path no longer resolves in `result` (e.g. the
 /// anchored key was deleted) is left untouched, so its aliases keep their
@@ -38496,12 +38496,41 @@ fn set_value_at_path(
 /// yq. Likewise, a write that lands on an alias path directly rather than
 /// the anchor's own path leaves every other member of the group alone, since
 /// the anchor's own value never changed.
+///
+/// **Rule A -- rebound-slot gate (#2499).** An alias slot is only a
+/// candidate for overwriting while it still holds the value this function
+/// itself last put there (or, before any pass has touched it, the pristine
+/// value the alias originally resolved to). Per alias path, an `expected`
+/// value tracks that: it starts as the value at that path in `pristine`, and
+/// is updated to whatever this function writes there. A slot is only
+/// overwritten while its *current* value in `result` still equals its
+/// `expected` value; a slot that some earlier stage of the same pipe already
+/// rebound, deleted, or moved no longer matches and is left alone (`.b =
+/// null | .a.p = 9` keeps `b: null` rather than clobbering it with the
+/// anchor's new value). A slot whose path no longer resolves in `result` at
+/// all (`get_value_at_path` returns `None`, e.g. `del(.b)` ran first) is
+/// skipped outright -- never autovivified or array-padded by
+/// `set_value_at_path`.
 pub fn sync_aliased_paths(
     result: &mut OwnedValue,
     pristine: &OwnedValue,
     groups: &[(Vec<OwnedValue>, Vec<Vec<OwnedValue>>)],
 ) {
-    for (def_path, alias_paths) in groups {
+    // Per-slot expected value (Rule A), indexed the same way as `groups`:
+    // `expected[i][j]` tracks alias `groups[i].1[j]`. Seeded from `pristine`
+    // since a fresh, never-yet-synced alias slot holds exactly the value it
+    // originally resolved to there.
+    let mut expected: Vec<Vec<Option<OwnedValue>>> = groups
+        .iter()
+        .map(|(_, alias_paths)| {
+            alias_paths
+                .iter()
+                .map(|alias_path| get_value_at_path(pristine, alias_path))
+                .collect()
+        })
+        .collect();
+
+    for (group_idx, (def_path, alias_paths)) in groups.iter().enumerate() {
         let (Some(old), Some(new)) = (
             get_value_at_path(pristine, def_path),
             get_value_at_path(result, def_path),
@@ -38511,9 +38540,25 @@ pub fn sync_aliased_paths(
         if old == new {
             continue;
         }
-        for alias_path in alias_paths {
+        for (alias_idx, alias_path) in alias_paths.iter().enumerate() {
+            // Never autovivify or array-pad a slot that no longer resolves
+            // (e.g. `del(.b)` ran earlier in the pipe).
+            let Some(current) = get_value_at_path(result, alias_path) else {
+                continue;
+            };
+            // Rule A: only overwrite a slot that's still the untouched copy
+            // this function (or the initial pristine snapshot) last left
+            // there.
+            if expected[group_idx][alias_idx].as_ref() != Some(&current) {
+                continue;
+            }
+            if current == new {
+                // Already in sync; nothing to write or re-track.
+                continue;
+            }
             if let Ok(updated) = set_value_at_path(result.clone(), alias_path, new.clone()) {
                 *result = updated;
+                expected[group_idx][alias_idx] = Some(new.clone());
             }
         }
     }
@@ -68040,6 +68085,128 @@ mod tests {
                 Err(r#"Cannot index string with string "b""#),
             ),
         ]);
+    }
+
+    /// #2499: `sync_aliased_paths`'s rebound-slot gate. An alias slot that
+    /// an earlier stage of the same pipe already rebound to a different
+    /// value (`b`) must be left alone by the def-path sync, while a slot
+    /// that's still the untouched copy (`c`) still gets updated. Mirrors
+    /// the live oracle repro (`.b = null | .a.p = 9` on `a: &x {p:1,q:2}`,
+    /// `b: *x`, `c: *x`) at the `OwnedValue` level, one step below the CLI.
+    #[test]
+    fn test_sync_aliased_paths_skips_rebound_slot_2499() {
+        let pristine = OwnedValue::Object(IndexMap::from([
+            (
+                "a".to_string(),
+                OwnedValue::Object(IndexMap::from([
+                    ("p".to_string(), OwnedValue::Int(1)),
+                    ("q".to_string(), OwnedValue::Int(2)),
+                ])),
+            ),
+            (
+                "b".to_string(),
+                OwnedValue::Object(IndexMap::from([
+                    ("p".to_string(), OwnedValue::Int(1)),
+                    ("q".to_string(), OwnedValue::Int(2)),
+                ])),
+            ),
+            (
+                "c".to_string(),
+                OwnedValue::Object(IndexMap::from([
+                    ("p".to_string(), OwnedValue::Int(1)),
+                    ("q".to_string(), OwnedValue::Int(2)),
+                ])),
+            ),
+        ]));
+
+        // Simulate the pipe's own two writes, as if `.b = null | .a.p = 9`
+        // already ran: `b` is rebound to `null`, `a.p` becomes `9`, `c` is
+        // still whatever the pristine copy was.
+        let mut result = pristine.clone();
+        result = set_value_at_path(
+            result,
+            &[OwnedValue::String("b".to_string())],
+            OwnedValue::Null,
+        )
+        .unwrap();
+        result = set_value_at_path(
+            result,
+            &[
+                OwnedValue::String("a".to_string()),
+                OwnedValue::String("p".to_string()),
+            ],
+            OwnedValue::Int(9),
+        )
+        .unwrap();
+
+        let groups = vec![(
+            vec![OwnedValue::String("a".to_string())],
+            vec![
+                vec![OwnedValue::String("b".to_string())],
+                vec![OwnedValue::String("c".to_string())],
+            ],
+        )];
+
+        sync_aliased_paths(&mut result, &pristine, &groups);
+
+        let OwnedValue::Object(entries) = &result else {
+            panic!("expected object");
+        };
+        // `b` was rebound earlier in the pipe -- the sync must leave it null.
+        assert_eq!(entries.get("b"), Some(&OwnedValue::Null));
+        // `c` was never touched -- it still gets synced to the new anchor value.
+        assert_eq!(
+            entries.get("c"),
+            Some(&OwnedValue::Object(IndexMap::from([
+                ("p".to_string(), OwnedValue::Int(9)),
+                ("q".to_string(), OwnedValue::Int(2)),
+            ])))
+        );
+    }
+
+    /// #2499: a slot whose path no longer resolves at all (`del(.b)` ran
+    /// earlier) must be skipped outright, never autovivified or
+    /// array-padded back into existence by the sync.
+    #[test]
+    fn test_sync_aliased_paths_skips_deleted_slot_2499() {
+        let pristine = OwnedValue::Object(IndexMap::from([
+            (
+                "a".to_string(),
+                OwnedValue::Object(IndexMap::from([("p".to_string(), OwnedValue::Int(1))])),
+            ),
+            (
+                "b".to_string(),
+                OwnedValue::Object(IndexMap::from([("p".to_string(), OwnedValue::Int(1))])),
+            ),
+        ]));
+
+        // Simulate `del(.b) | .a.p = 9`.
+        let OwnedValue::Object(mut entries) = pristine.clone() else {
+            unreachable!()
+        };
+        entries.shift_remove("b");
+        let mut result = OwnedValue::Object(entries);
+        result = set_value_at_path(
+            result,
+            &[
+                OwnedValue::String("a".to_string()),
+                OwnedValue::String("p".to_string()),
+            ],
+            OwnedValue::Int(9),
+        )
+        .unwrap();
+
+        let groups = vec![(
+            vec![OwnedValue::String("a".to_string())],
+            vec![vec![OwnedValue::String("b".to_string())]],
+        )];
+
+        sync_aliased_paths(&mut result, &pristine, &groups);
+
+        let OwnedValue::Object(entries) = &result else {
+            panic!("expected object");
+        };
+        assert!(!entries.contains_key("b"), "del(.b) must not be undone");
     }
 
     /// `null` is the one value jq auto-vivifies, and it becomes whichever

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -38488,7 +38488,7 @@ fn set_value_at_path(
 /// by the caller from the pre-mutation document. For each group, if the
 /// value at the definition path differs between `pristine` (before the
 /// write) and `result` (after), every alias path is overwritten with a clone
-/// of the new value -- subject to the rule below.
+/// of the new value -- subject to the two rules below.
 ///
 /// A group whose definition path no longer resolves in `result` (e.g. the
 /// anchored key was deleted) is left untouched, so its aliases keep their
@@ -38502,8 +38502,8 @@ fn set_value_at_path(
 /// itself last put there (or, before any pass has touched it, the pristine
 /// value the alias originally resolved to). Per alias path, an `expected`
 /// value tracks that: it starts as the value at that path in `pristine`, and
-/// is updated to whatever this function writes there. A slot is only
-/// overwritten while its *current* value in `result` still equals its
+/// is updated to whatever this function writes there. A pass only
+/// overwrites a slot whose *current* value in `result` still equals its
 /// `expected` value; a slot that some earlier stage of the same pipe already
 /// rebound, deleted, or moved no longer matches and is left alone (`.b =
 /// null | .a.p = 9` keeps `b: null` rather than clobbering it with the
@@ -38511,6 +38511,25 @@ fn set_value_at_path(
 /// all (`get_value_at_path` returns `None`, e.g. `del(.b)` ran first) is
 /// skipped outright -- never autovivified or array-padded by
 /// `set_value_at_path`.
+///
+/// **Rule B -- fixpoint over nested groups (#2498).** A single pass over
+/// `groups` in `collect_alias_groups` order can leave an inner alias stale:
+/// if an anchored node contains another anchor/alias pair, the outer
+/// group's def-path value may only pick up the inner sync's write partway
+/// through (or not at all) depending on processing order, and the inner
+/// def can equally sit *outside* the node the outer alias copies into. So
+/// the whole group loop repeats to a fixpoint -- until a full pass writes
+/// nothing -- capped at `groups.len()` passes, which is exact because each
+/// pass can only add writes (so the value at any def path can change at
+/// most `groups.len()` times: once per group whose sync could possibly
+/// touch it) and a pass that changes nothing proves the rest would too.
+/// Rule A's per-slot `expected` value is exactly what makes a second pass
+/// correct here rather than re-triggering Rule A's own gate: once pass 1
+/// copies the outer anchor's value into its alias, that alias slot's
+/// `expected` is updated to the copied value, so pass 2 -- after the inner
+/// group changes the outer anchor's value again -- still recognizes the
+/// slot as an untouched copy and updates it, rather than mistaking the
+/// first pass's own write for an external rebind.
 pub fn sync_aliased_paths(
     result: &mut OwnedValue,
     pristine: &OwnedValue,
@@ -38530,36 +38549,45 @@ pub fn sync_aliased_paths(
         })
         .collect();
 
-    for (group_idx, (def_path, alias_paths)) in groups.iter().enumerate() {
-        let (Some(old), Some(new)) = (
-            get_value_at_path(pristine, def_path),
-            get_value_at_path(result, def_path),
-        ) else {
-            continue;
-        };
-        if old == new {
-            continue;
-        }
-        for (alias_idx, alias_path) in alias_paths.iter().enumerate() {
-            // Never autovivify or array-pad a slot that no longer resolves
-            // (e.g. `del(.b)` ran earlier in the pipe).
-            let Some(current) = get_value_at_path(result, alias_path) else {
+    // Rule B: repeat the group loop to a fixpoint, capped at `groups.len()`
+    // passes -- see the doc comment above for why that bound is exact.
+    for _ in 0..groups.len() {
+        let mut changed = false;
+        for (group_idx, (def_path, alias_paths)) in groups.iter().enumerate() {
+            let (Some(old), Some(new)) = (
+                get_value_at_path(pristine, def_path),
+                get_value_at_path(result, def_path),
+            ) else {
                 continue;
             };
-            // Rule A: only overwrite a slot that's still the untouched copy
-            // this function (or the initial pristine snapshot) last left
-            // there.
-            if expected[group_idx][alias_idx].as_ref() != Some(&current) {
+            if old == new {
                 continue;
             }
-            if current == new {
-                // Already in sync; nothing to write or re-track.
-                continue;
+            for (alias_idx, alias_path) in alias_paths.iter().enumerate() {
+                // Never autovivify or array-pad a slot that no longer
+                // resolves (e.g. `del(.b)` ran earlier in the pipe).
+                let Some(current) = get_value_at_path(result, alias_path) else {
+                    continue;
+                };
+                // Rule A: only overwrite a slot that's still the untouched
+                // copy this function (or the initial pristine snapshot)
+                // last left there.
+                if expected[group_idx][alias_idx].as_ref() != Some(&current) {
+                    continue;
+                }
+                if current == new {
+                    // Already in sync; nothing to write or re-track.
+                    continue;
+                }
+                if let Ok(updated) = set_value_at_path(result.clone(), alias_path, new.clone()) {
+                    *result = updated;
+                    expected[group_idx][alias_idx] = Some(new.clone());
+                    changed = true;
+                }
             }
-            if let Ok(updated) = set_value_at_path(result.clone(), alias_path, new.clone()) {
-                *result = updated;
-                expected[group_idx][alias_idx] = Some(new.clone());
-            }
+        }
+        if !changed {
+            break;
         }
     }
 }
@@ -68207,6 +68235,89 @@ mod tests {
             panic!("expected object");
         };
         assert!(!entries.contains_key("b"), "del(.b) must not be undone");
+    }
+
+    /// #2498: `sync_aliased_paths` must iterate nested groups to a
+    /// fixpoint. Mirrors the live oracle repro (`.a.p = 5` on
+    /// `a: &x {p: &y 1, q: *y}`, `b: *x`): the outer group (`x` -> `b`) is
+    /// processed before the inner one (`y` -> `a.q`) resolves, so a single
+    /// pass would copy `a`'s stale `q` into `b`. A second pass, made
+    /// possible by Rule A's per-slot `expected` tracking, must pick up the
+    /// inner group's own update and re-sync `b`.
+    #[test]
+    fn test_sync_aliased_paths_iterates_nested_groups_to_fixpoint_2498() {
+        let pristine = OwnedValue::Object(IndexMap::from([
+            (
+                "a".to_string(),
+                OwnedValue::Object(IndexMap::from([
+                    ("p".to_string(), OwnedValue::Int(1)),
+                    ("q".to_string(), OwnedValue::Int(1)),
+                ])),
+            ),
+            (
+                "b".to_string(),
+                OwnedValue::Object(IndexMap::from([
+                    ("p".to_string(), OwnedValue::Int(1)),
+                    ("q".to_string(), OwnedValue::Int(1)),
+                ])),
+            ),
+        ]));
+
+        // Simulate `.a.p = 5`: only `a.p` changes; `a.q` (the inner alias)
+        // and `b` (the outer alias) are both still their pristine copies.
+        let mut result = pristine.clone();
+        result = set_value_at_path(
+            result,
+            &[
+                OwnedValue::String("a".to_string()),
+                OwnedValue::String("p".to_string()),
+            ],
+            OwnedValue::Int(5),
+        )
+        .unwrap();
+
+        // Outer group (anchor `x`, def `a`, alias `b`) is listed before the
+        // inner group (anchor `y`, def `a.p`, alias `a.q`) -- the same
+        // document-order `collect_alias_groups` produces for this shape,
+        // and the ordering a single, non-fixpoint pass gets wrong.
+        let groups = vec![
+            (
+                vec![OwnedValue::String("a".to_string())],
+                vec![vec![OwnedValue::String("b".to_string())]],
+            ),
+            (
+                vec![
+                    OwnedValue::String("a".to_string()),
+                    OwnedValue::String("p".to_string()),
+                ],
+                vec![vec![
+                    OwnedValue::String("a".to_string()),
+                    OwnedValue::String("q".to_string()),
+                ]],
+            ),
+        ];
+
+        sync_aliased_paths(&mut result, &pristine, &groups);
+
+        assert_eq!(
+            result,
+            OwnedValue::Object(IndexMap::from([
+                (
+                    "a".to_string(),
+                    OwnedValue::Object(IndexMap::from([
+                        ("p".to_string(), OwnedValue::Int(5)),
+                        ("q".to_string(), OwnedValue::Int(5)),
+                    ])),
+                ),
+                (
+                    "b".to_string(),
+                    OwnedValue::Object(IndexMap::from([
+                        ("p".to_string(), OwnedValue::Int(5)),
+                        ("q".to_string(), OwnedValue::Int(5)),
+                    ])),
+                ),
+            ]))
+        );
     }
 
     /// `null` is the one value jq auto-vivifies, and it becomes whichever

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -25105,6 +25105,53 @@ fn test_yaml_sync_skips_deleted_alias_2499() -> Result<()> {
     Ok(())
 }
 
+// =============================================================================
+// #2498: `sync_aliased_paths`'s nested-group fixpoint -- an anchor whose
+// subtree contains another anchor/alias pair must have that inner sync's
+// own write picked up before the outer group's copy is finalized, however
+// many passes that takes. See issue 1351's design-plan case 3. Verified
+// live against Homebrew `yq` v4.53.3.
+// =============================================================================
+
+/// #2498: an anchor nested inside another anchor's subtree -- the inner
+/// alias must follow the outer sync to a fixpoint rather than freezing at
+/// whatever value the inner group held when the outer group's single pass
+/// ran. Live oracle: `.a.p = 5` on `a: &x {p: &y 1, q: *y}\nb: *x\n` gives
+/// `{"a":{"p":5,"q":5},"b":{"p":5,"q":5}}` -- `b`'s copy of `q` must be `5`,
+/// not the stale `1` a single, non-fixpoint pass would leave it at.
+#[test]
+fn test_yaml_sync_nested_anchor_inner_alias_follows_2498() -> Result<()> {
+    let input = "a: &x\n  p: &y 1\n  q: *y\nb: *x\n";
+
+    let (output, exit_code) = run_yq_stdin(".a.p = 5", input, &[])?;
+    assert_eq!(exit_code, 0);
+    assert_eq!(output, "a: &x\n  p: &y 5\n  q: *y\nb: *x\n");
+
+    let (output, exit_code) = run_yq_stdin(".a.p = 5", input, &["-o=json", "-I=0"])?;
+    assert_eq!(exit_code, 0);
+    assert_eq!(output.trim(), r#"{"a":{"p":5,"q":5},"b":{"p":5,"q":5}}"#);
+    Ok(())
+}
+
+/// #2498: the inner def can also sit *outside* the outer anchor while its
+/// alias sits inside it, so depth-sorting the groups would not be enough --
+/// only a real fixpoint over the group loop handles this. Live oracle:
+/// `.x = 5` on `x: &y 1\na: &x {q: *y}\nb: *x\n` gives
+/// `{"x":5,"a":{"q":5},"b":{"q":5}}`.
+#[test]
+fn test_yaml_sync_inner_def_outside_outer_anchor_2498() -> Result<()> {
+    let input = "x: &y 1\na: &x {q: *y}\nb: *x\n";
+
+    let (output, exit_code) = run_yq_stdin(".x = 5", input, &[])?;
+    assert_eq!(exit_code, 0);
+    assert_eq!(output, "x: &y 5\na: &x {q: *y}\nb: *x\n");
+
+    let (output, exit_code) = run_yq_stdin(".x = 5", input, &["-o=json", "-I=0"])?;
+    assert_eq!(exit_code, 0);
+    assert_eq!(output.trim(), r#"{"x":5,"a":{"q":5},"b":{"q":5}}"#);
+    Ok(())
+}
+
 /// #1201: `reduce`/`foreach`'s binding clause is parsed by the shared
 /// `parse_pattern`, which both `ParserMode`s reach, so full destructuring
 /// patterns land in yq mode too. There is no oracle to match here -- real yq

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -25039,6 +25039,72 @@ fn test_yaml_nested_alias_mark_is_dropped_at_its_own_path_763() -> Result<()> {
     Ok(())
 }
 
+// =============================================================================
+// #2499: `sync_aliased_paths`'s rebound-slot gate -- an alias slot an
+// earlier stage of the same pipe already rebound, deleted, or moved must be
+// left alone by a later def-path sync. See issue 1351's design-plan finding
+// B1. Verified live against Homebrew `yq` v4.53.3.
+// =============================================================================
+
+/// #2499: an alias slot that an earlier stage of the same pipe already
+/// rebound to `null` must be left alone by a later def-path sync -- the
+/// write is not silently discarded. Live oracle: `.b = null | .a.p = 9` on
+/// `a: &x {p: 1, q: 2}\nb: *x\nc: *x\n` gives `a: &x {p: 9, q: 2}\nb:
+/// null\nc: *x\n` (`c`, never rebound, still syncs and keeps its `*x` mark).
+#[test]
+fn test_yaml_sync_skips_rebound_alias_null_2499() -> Result<()> {
+    let input = "a: &x {p: 1, q: 2}\nb: *x\nc: *x\n";
+
+    let (output, exit_code) = run_yq_stdin(".b = null | .a.p = 9", input, &[])?;
+    assert_eq!(exit_code, 0);
+    assert_eq!(output, "a: &x {p: 9, q: 2}\nb: null\nc: *x\n");
+
+    let (output, exit_code) = run_yq_stdin(".b = null | .a.p = 9", input, &["-o=json", "-I=0"])?;
+    assert_eq!(exit_code, 0);
+    assert_eq!(
+        output.trim(),
+        r#"{"a":{"p":9,"q":2},"b":null,"c":{"p":9,"q":2}}"#
+    );
+    Ok(())
+}
+
+/// #2499: same rebound-slot gate, this time rebinding to a plain scalar
+/// rather than `null`. Live oracle: `.b = 5 | .a.p = 9` keeps `b: 5`.
+#[test]
+fn test_yaml_sync_skips_rebound_alias_scalar_2499() -> Result<()> {
+    let input = "a: &x {p: 1, q: 2}\nb: *x\nc: *x\n";
+
+    let (output, exit_code) = run_yq_stdin(".b = 5 | .a.p = 9", input, &[])?;
+    assert_eq!(exit_code, 0);
+    assert_eq!(output, "a: &x {p: 9, q: 2}\nb: 5\nc: *x\n");
+
+    let (output, exit_code) = run_yq_stdin(".b = 5 | .a.p = 9", input, &["-o=json", "-I=0"])?;
+    assert_eq!(exit_code, 0);
+    assert_eq!(
+        output.trim(),
+        r#"{"a":{"p":9,"q":2},"b":5,"c":{"p":9,"q":2}}"#
+    );
+    Ok(())
+}
+
+/// #2499: a slot whose path no longer resolves at all (`del(.b)` ran
+/// earlier in the pipe) must be skipped outright, never autovivified or
+/// array-padded back into existence by a later def-path sync. Live oracle:
+/// `del(.b) | .a.p = 9` does not recreate `b`.
+#[test]
+fn test_yaml_sync_skips_deleted_alias_2499() -> Result<()> {
+    let input = "a: &x {p: 1, q: 2}\nb: *x\nc: *x\n";
+
+    let (output, exit_code) = run_yq_stdin("del(.b) | .a.p = 9", input, &[])?;
+    assert_eq!(exit_code, 0);
+    assert_eq!(output, "a: &x {p: 9, q: 2}\nc: *x\n");
+
+    let (output, exit_code) = run_yq_stdin("del(.b) | .a.p = 9", input, &["-o=json", "-I=0"])?;
+    assert_eq!(exit_code, 0);
+    assert_eq!(output.trim(), r#"{"a":{"p":9,"q":2},"c":{"p":9,"q":2}}"#);
+    Ok(())
+}
+
 /// #1201: `reduce`/`foreach`'s binding clause is parsed by the shared
 /// `parse_pattern`, which both `ParserMode`s reach, so full destructuring
 /// patterns land in yq mode too. There is no oracle to match here -- real yq


### PR DESCRIPTION
## Summary

Two bugs in `sync_aliased_paths` (`src/jq/eval.rs`, #711), found while probing for issue 1351's design plan, bundled here because they change the same function's loop body.

- **#2499 (High, severity: a write is silently discarded).** `sync_aliased_paths` unconditionally overwrote *every* pristine alias path once the anchor's value changed, including an alias position an earlier stage of the same filter had already rebound to something else. Fix: track a per-slot "expected" value, seeded from the pristine document and updated on every write this function makes; a slot is only overwritten while its current value in `result` still equals its expected value. A slot whose path no longer resolves (`get_value_at_path` is `None`, e.g. after `del(...)`) is skipped outright, never autovivified or array-padded.

- **#2498 (Medium, silent wrong value).** `sync_aliased_paths` processed alias groups in `collect_alias_groups` order in a single pass. When an anchored node contains another anchor whose alias is also inside it (nested either way -- the inner def can sit inside *or outside* the outer anchor), the outer group could clone the parent into its aliases before the inner group's own write landed, leaving the inner alias stale in the outer copies. Fix: repeat the whole group loop until a pass writes nothing, capped at `groups.len()` passes (each pass can only add writes, so that bound is exact). #2499's per-slot expected-value tracking is exactly what makes a second pass correct instead of re-triggering its own rebound gate.

### Oracle repros (Homebrew `yq` v4.53.3, live-verified; succinctly now matches all of them)

```console
$ printf 'a: &x {p: 1, q: 2}\nb: *x\nc: *x\n' | yq '.b = null | .a.p = 9'
a: &x {p: 9, q: 2}
b: null
c: *x

$ printf 'a: &x\n  p: &y 1\n  q: *y\nb: *x\n' | yq -o=json -I=0 '.a.p = 5'
{"a":{"p":5,"q":5},"b":{"p":5,"q":5}}

$ printf 'x: &y 1\na: &x {q: *y}\nb: *x\n' | yq -o=json -I=0 '.x = 5'
{"x":5,"a":{"q":5},"b":{"q":5}}
```

succinctly's release build produces byte-identical output for all three (and for `.b = 5 | .a.p = 9`, `del(.b) | .a.p = 9`, and the pre-existing `.a.p = 9` / `.[] .p = 1` cases), including the re-emitted `&anchor`/`*alias` marks on the YAML output path.

## Test plan

- [x] `cargo build --release --features cli` then live-diffed every repro above against Homebrew `yq` v4.53.3 -- byte-identical
- [x] `cargo test --features cli,simd,regex,serde` (via `cargo-guard.sh`) -- all binaries pass, 0 failed
- [x] `cargo clippy --all-targets --all-features -- -D warnings` -- clean
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings` -- clean
- [x] `cargo fmt -- --check` -- clean
- [x] New unit tests in `src/jq/eval.rs` exercising `sync_aliased_paths` directly (rebound gate, deleted-slot skip, nested-group fixpoint)
- [x] New CLI tests in `tests/yq_cli_tests.rs` (YAML + `-o=json -I=0` twins) for both issues

Fixes #2499
Fixes #2498