### PR TITLE
feat(jq): and/or, object slots, and fold sources read path context natively (#2473)

### DIFF
--- a/docs/adrs/adr-0021.md
+++ b/docs/adrs/adr-0021.md
@@ -23,7 +23,10 @@ and three defects compounded (#2416):
   it; every laziness and side-effect-ordering issue on the spine (#2129, #2259) was
   unfixable arm by arm.
 - **Silent fallback.** `.a | {"x": key}` printed `{"x": null}` for a year (#1332) because
-  `Expr::Object` had no arm and nothing noticed.
+  `Expr::Object` had no arm and nothing noticed. (Closed in two halves: #2439 gave the
+  generic evaluator a cursor-threading `Expr::Object` arm, and #2473 gave
+  `needs_path_context` one, so the shapes that need a *route* -- an absent position, a
+  value already out of the cursor domain -- are routed rather than answered from none.)
 
 The oracle-backed differential built as the spine's phase 0 (`scripts/jq-path-context-
 oracle-sweep.sh`, the `path_ctx_*` goldens in both corpora, the walk-vs-bridge axis in
@@ -166,10 +169,15 @@ in-place transforms *inside owned values*, which have no node to stand on.
   asserting the exit code and diagnostic, not an empty stdout.
 - **What remains on the eager route** is bounded by three reasons, each with a known
   next step: the owned-domain stages decision 7's list does not cover; a fan-out head with
-  a computed tail, which is all #2472 left of the absent reason (its other two shapes,
-  `parent` from a possibly-absent position and navigation after a non-navigational stage,
-  are decision 7's route now); and native `eval_single` arms for the constructs that still
-  bridge (`and`/`or`, `reduce`/`foreach`). #2471 closed four of
+  a computed tail, plus a `?` head the walk does not step, which is all #2472 and #2473
+  left of the absent reason (its other two shapes, `parent` from a possibly-absent
+  position and navigation after a non-navigational stage, are decision 7's route now);
+  and the reason-3 residue. #2473 closed most of that third one -- `and`/`or` and
+  `reduce`/`foreach` have native `eval_single` arms now, and `needs_path_context`
+  descends into `Expr::Object` (#1332's other half), so an object literal's slots are
+  routed instead of being invisible to routing -- leaving `range`/`repeat`/`while`/
+  `until`, which neither reference can express and which are therefore pinned as
+  extensions rather than migrated. #2471 closed four of
   reason 1's shapes -- a computed `IndexExpr`/`SliceExpr` (and `?` over one) and
   `getpath(p)` as navigation, a read after `key`/`path`/`file_index` replaced the value,
   and a read under arithmetic inside a ruled stage -- so `key` gained a rule of its own

--- a/docs/compliance/yq/limitations.md
+++ b/docs/compliance/yq/limitations.md
@@ -1929,6 +1929,50 @@ now correctly empty, the underlying order difference is what shows:
 left-vivified document, which is a change to the assignment model rather than to this
 rule -- and would move `.x = (keys)`/`.x = (length)` at the same time.
 
+### An `and`/`or` operand's evaluation context -- open (captured under [#2473](https://github.com/rust-works/succinctly/issues/2473))
+
+Real yq v4.53.3 does not evaluate an `and`/`or`'s **right** operand against the node the
+operator stands on -- it resolves it from the **document root** -- and it answers `false`
+for the whole expression whenever the operator's own input came from an absent
+navigation. succinctly evaluates both operands at the current node, in both modes.
+
+The divergence is not about path context: the first four rows contain no path-context
+builtin at all. It was found while making `and`/`or` with a path-context operand native
+(#2473, gate reason 3 of spine 2416), because a `key`/`parent` in the right operand makes
+it visible -- and it predates that change, which is why the rows are pinned as
+succinctly's own answers in `test_and_or_keep_path_context_2473`
+(`tests/yq_cli_tests.rs`) rather than encoded.
+
+Captured live (`-o=json -I0`) on `a: {b: 1}\nc: [10, 20]\n`:
+
+| filter                     | real yq | succinctly |
+|----------------------------|---------|------------|
+| `.a \| .b and true`         | `true`  | `true`     |
+| `.a \| true and .b`         | `false` | `true`     |
+| `.a \| true and .a.b`       | `true`  | `false`    |
+| `.c \| true and .[0]`       | `false` | `true`     |
+| `.a \| 0 + .b`              | `1`     | `1`        |
+| `.a \| (key) and true`      | `true`  | `true`     |
+| `.a \| true and (key)`      | `false` | `true`     |
+| `.a \| key and parent`      | `false` | `true`     |
+
+Row 3 is the one that names the rule: `.a.b` resolved *at* `.a` is nothing, resolved at
+the root it is `1`. Row 5 shows arithmetic is not affected -- this is specific to
+`and`/`or`, and it is a different mechanism from the read-only rule the previous section
+describes (which is about a *missing key* inside an operand, not about which node the
+operand starts from).
+
+And on `a:\n  b: 1\n`, where the operator's input is an absent position:
+
+| filter                              | real yq | succinctly |
+|-------------------------------------|---------|------------|
+| `.a.zz \| key == "zz"`               | `true`  | `true`     |
+| `.a.zz \| (key == "zz") and true`    | `false` | `true`     |
+| `.a.zz \| key and true`              | `false` | `true`     |
+
+The same comparison is `true` on its own and `false` as an `and` operand, so the operand
+is not being evaluated at the position the pipe reached.
+
 ### Ordering comparisons against a real `null` -- resolved for scalars ([#2483](https://github.com/rust-works/succinctly/issues/2483)); containers remain a residual gap
 
 Real yq v4.53.3's ordering comparators (`<`/`<=`/`>`/`>=`) treat a real `null` operand as

--- a/docs/plan/path-context-arm-reachability.md
+++ b/docs/plan/path-context-arm-reachability.md
@@ -106,15 +106,19 @@ now when neither the constant route nor the owned identity pipe can take the
 stages after it. The probe shape that trips it is `.a?` (which
 `path_context_is_navigational` excludes, so no position is walked) or a bare
 `parent` operand (which no route can name a position for). The same shapes with
-a head that cannot miss trip R3 instead -- e.g. `.a[] | (key | tostring)`, `.a[] | reduce (key) as $k (""; . +
-$k) | . + "x"` and `.a[] | select(key == "b" and true)` all report R3. This is an
-ordering artefact, not a claim that R3 is rare.
+a head that cannot miss trip R3 instead -- e.g. `.a[] | (key | tostring)`,
+`.a[] | (key | length)`, `.a[] | {"k": (key | tostring)}` and
+`.a[] | ((key | tostring) and true)` all report R3 (re-derived after #2473,
+below). This is an ordering artefact, not a claim that R3 is rare.
 
 Step 1b (below) moved two of the three shapes this paragraph used to name --
 `.a[] | key + "x"` and `.a[] | if key == "b" then key + "x" else "y" end` -- off
 R3 and onto the generic route, which is what an admission to
-`path_context_single_native` is *for*. Re-derive this paragraph's examples after
-any further admission rather than trusting them.
+`path_context_single_native` is *for*, and #2473 moved two more:
+`.a[] | select(key == "b" and true)` and
+`.a[] | reduce (key) as $k (""; . + $k) | . + "x"` both report no gate at all
+now. Re-derive this paragraph's examples after any further admission rather than
+trusting them.
 
 ## The 43 handlers
 
@@ -136,7 +140,7 @@ any further admission rather than trusting them.
 | A09 | `Expr::Pipe(inner) if rest.is_empty()`                             | REACHABLE | `.a.b \| -(key\|length)`                              | R2   |
 | A10 | `Expr::Pipe(inner)`                                                | REACHABLE | `.a.b \| parent + {}`                                 | R2   |
 | A11 | `Expr::Arithmetic { .. }`                                          | REACHABLE | `.a.b \| parent + {}`                                 | R2   |
-| A12 | `Expr::And(..) \| Expr::Or(..)`                                    | REACHABLE | `.a.b \| key == "b" and true`                         | R2   |
+| A12 | `Expr::And(..) \| Expr::Or(..)`                                    | REACHABLE | `.a? \| key == "a" and true`                          | R2   |
 | A13 | `Expr::Negate(operand)`                                            | REACHABLE | `.a.b \| -(key\|length)`                              | R2   |
 | A14 | `Expr::Compare { .. }`                                             | REACHABLE | `.a? \| (key + "x") \| . == "bx"`                     | R2   |
 | A15 | `Expr::Builtin(Builtin::Select(cond))`                             | REACHABLE | `.a.b \| select(key == "b") \| parent + {}`           | R2   |
@@ -288,16 +292,99 @@ containing one still hands over -- and once it does, the generic structural
 arms (`A01`, `A02`, `A06`, `A10`, `A11`) run inside it. Deleting an arm needs
 those *stage* shapes migrated, not this route widened.
 
+## #2473: gate reason 3 narrowed, and the pin still holds at 43
+
+[#2473](https://github.com/rust-works/succinctly/issues/2473) is the gate's
+third disjunct: a stage built from a construct the generic evaluator has no
+cursor-threading arm for. Four constructs were on the list; three moved and one
+did not.
+
+- **`and`/`or`** got `eval_single` arms of their own (`eval_boolean_generic`
+  over `eval::boolean_fanout_bools`, shared with the eager route so #2460's
+  zero-output-operand rule and #2470's read-only operand scope keep one
+  definition), and joined `path_context_single_native`. Gated on
+  `needs_path_context`, exactly as `Expr::Arithmetic` is, so an `and`/`or` that
+  reads no path context still pays the bridge's ambient decode on a malformed
+  document.
+- **`Expr::Object` inside `needs_path_context`** -- #1332's other half. This is
+  not an admission (`path_context_single_native` has had an `Expr::Object` arm
+  since #2439) but a *routing* fix: an object literal's key and value slots
+  were invisible to `needs_path_context`, so a pipe containing one was never
+  recognised as a path-context pipe and no route was ever asked. The generic
+  evaluator's own arm reads the cursor, which is why a live-node shape happened
+  to be right; every shape that needs a route -- an absent position, a value
+  that had left the cursor domain -- answered `null` (jq mode) or nothing (yq
+  mode). `path_context_resolvable` and `path_context_resolve_constants` gained
+  matching `Expr::Object` arms, and the eager evaluator's existing
+  value-construction arm now evaluates the slots at the position it was given
+  instead of resetting the context first (the same split `Expr::Array(inner) if
+  needs_path_context(inner)` has made since #1302). That last change is a
+  pluggable slot evaluator on `build_object_entries`, **not** a new handler, so
+  the arm count is unmoved.
+- **`reduce`/`foreach`** joined `path_context_single_native`: the generic arms
+  already evaluate INPUT and INIT through `stream_owned_outputs_generic` with
+  the cursor, so the admission is the same "the arm already exists, say so"
+  shape `Expr::As`/`Expr::Label` had. UPDATE and EXTRACT are not part of the
+  gate -- they evaluate against the accumulator, a value with no document
+  position, which is why `needs_path_context` does not descend into them
+  either.
+- **`range`/`repeat`/`while`/`until` got no arm.** Real yq's lexer rejects all
+  four (v4.53.3), and jq 1.7.1 has no path-context builtin to put inside one,
+  so there is no captured behaviour to migrate toward -- only succinctly's own
+  extension surface. Their current answers are pinned instead
+  (`test_range_repeat_while_until_stay_extension_only_2473`).
+
+**`PINNED_ARM_COUNT` stays at 43.** Re-run of the method above on the
+post-#2473 tree, in two passes.
+
+Pass 1 instrumented `path_context_needs_eager` alone (one `eprintln!` per
+disjunct) and ran all 43 listed proof queries: **42 still enter the gate, 1
+does not.** The one is `A12` (`Expr::And(..) | Expr::Or(..)`), whose listed
+query `.a.b | key == "b" and true` is exactly the shape the first bullet
+migrated. Every other row reports the same disjunct it reported before, and
+every output is unchanged (`test_arm_audit_proof_queries_are_unmoved_by_the_gate_2416`).
+
+Pass 2 instrumented `A12` and swept candidates. **It still fires**, on several
+shapes and through all three disjuncts:
+
+| Candidate                                       | Gate | Marker | Output      |
+|-------------------------------------------------|------|--------|-------------|
+| `.a? \| key == "a" and true`                     | R2   | fired  | `true`      |
+| `.a? \| (key and parent)`                        | R2   | fired  | `true`      |
+| `.[] \| ((key \| tostring) and true)`             | R3   | fired  | `true` (x4) |
+| `.a \| to_entries \| .[0] \| key == 0 and true`    | R1   | fired  | `true`      |
+| `.[] \| .k \| (key == "k" and true)`              | R2   | fired  | `true`      |
+
+The table above carries the first of those as `A12`'s query now; the old
+spelling stays pinned alongside it, which is what makes the move readable as
+"same outputs, different route" rather than as a silent change.
+
+The three arms this change could plausibly have starved were checked
+explicitly and all still fire: `A21` (`Expr::Array(inner) if
+needs_path_context(inner)`) and `A33` (`Expr::Object(_) | Expr::Array(_) |
+Expr::Literal(_)`) on `.a? | {"k": key}` and `.a? | [key] + ["x"]`, and
+`A31`/`A32` (`reduce`/`foreach`) on their own listed queries, which still enter
+at `R2` because a `.a.b` head can miss.
+
+**Nothing became unreachable, so nothing was deleted.** The reason is the same
+structural one #2472 recorded, seen from the other side: an admission to
+`path_context_single_native` removes a *reason* for one stage shape, not the
+arm. `.a?` remains a head no route can walk, so any construct placed after one
+still reaches its arm -- and the eager evaluator's structural arms
+(`Expr::Field`, `Expr::Pipe`, `Expr::Paren`, ...) run inside whatever does.
+Deleting an arm needs the `?` head and the fan-out head routed, not this list
+widened further.
+
 ## Result
 
-| Metric                                            | Before | After |
-|---------------------------------------------------|--------|-------|
-| Named handlers in `eval_stage_with_path_context`  | 43     | 43    |
-| ... proven REACHABLE by a live query               | --     | 43    |
-| ... proven UNREACHABLE                             | --     | 0     |
-| ... neither                                        | --     | 0     |
-| ... whose listed proof query moved off the gate    | --     | 14    |
-| `PINNED_ARM_COUNT`                                 | 43     | 43    |
+| Metric                                            | Before | After                 |
+|---------------------------------------------------|--------|-----------------------|
+| Named handlers in `eval_stage_with_path_context`  | 43     | 43                    |
+| ... proven REACHABLE by a live query               | --     | 43                    |
+| ... proven UNREACHABLE                             | --     | 0                     |
+| ... neither                                        | --     | 0                     |
+| ... whose listed proof query moved off the gate    | --     | 1 (#2473); 14 (#2472) |
+| `PINNED_ARM_COUNT`                                 | 43     | 43                    |
 
 Nothing is deletable at this point in the spine. Doors 2 and 3 are closed as
 of step 5, which is a precondition rather than a deletion: the eager evaluator
@@ -327,9 +414,19 @@ evaluator, with no second route to check.
   read without re-running would have claimed 14 deletable arms.
 - The `R2` cluster is now the *stage* shapes with no `owned_identity_rule`
   (`and`/`or`, `map`, `reduce`/`foreach`, `as`/`label`/`def`, the bounded
-  consumers) plus a bare `parent` operand. Those are what to migrate next for
-  this reason; widening the absent route again buys nothing, because it already
-  accepts every `rest` those stages are missing from.
+  consumers) plus a bare `parent` operand. #2473 gave `and`/`or` and
+  `reduce`/`foreach` native `eval_single` arms, which removes `R3` for them but
+  **not** `R2`: a native stage still hands over when the head can miss and no
+  route can name the position. Giving those stages an `owned_identity_rule` is
+  the remaining move for this reason; widening the absent route again buys
+  nothing, because it already accepts every `rest` those stages are missing
+  from.
+- **`?` at the head is now the single biggest source of `R2`.** It is excluded
+  from `path_context_is_navigational` on purpose (`?` in path context is not
+  `?` in a path expression), so `path_context_absent_split` finds an empty head
+  and declines, and the pipe goes eager whatever follows. Teaching the walk to
+  step `.a?` -- which means deciding what it does on a *scalar* input, where
+  `.a` errors and `.a?` yields nothing -- is what would empty that cluster.
 - The step-5 closure did *not* change what the sweep
   (`scripts/jq-path-context-oracle-sweep.sh`) sees for `file_index`. Its
   yq-mode cases run `succinctly yq FILTER one.yaml two.yaml` with no

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -1319,12 +1319,32 @@ pub(crate) fn needs_path_context(expr: &Expr) -> bool {
         // `[key]`/`[parent]`/`[file_index]` (#1302): an array literal is
         // still just "collect this inner expression's outputs", the same
         // reasoning as `Comma` above -- whatever the wrapped expression
-        // needs, the `[...]` wrapper needs too. `Expr::Object` isn't
-        // included here yet: it has the identical gap (`{"x": key}` also
-        // stubs to `null`, confirmed live), but its multi-entry/generator-key
-        // shape needs more design work than a single recursive call, so it's
-        // tracked separately rather than folded into this fix.
+        // needs, the `[...]` wrapper needs too.
         Expr::Array(inner) => needs_path_context(inner),
+        // `{"x": key}` / `{(key): 1}` (#1332's other half, closed by #2473 --
+        // gate reason 3 of spine 2416): object construction is the same
+        // "evaluate these expressions at my own position" shape as `Array`
+        // above, one per key and per value. It was left out of this function
+        // when #1302 added `Array`, and that omission is what made the whole
+        // class invisible to routing: `.a.x | {"k": key}` was never seen as a
+        // path-context pipe at all, so no route (walk, absent, owned
+        // identity, eager) was ever asked, and `key` answered `null` -- the
+        // silent fallback ADR-0021 exists to end. The generic evaluator's own
+        // `Expr::Object` arm (`build_object_entries_generic`, #2439) already
+        // reads the cursor, so a *live-node* shape answered correctly by
+        // accident; only the shapes that need a route -- an absent position,
+        // and a value that already left the cursor domain -- were wrong.
+        //
+        // `path_context_resolvable`/`path_context_resolve_constants`
+        // (`eval_generic.rs`) gained matching arms in the same change, so the
+        // absent and owned-identity routes accept what this now sends them.
+        Expr::Object(entries) => entries.iter().any(|entry| {
+            needs_path_context(&entry.value)
+                || match &entry.key {
+                    ObjectKey::Literal(_) => false,
+                    ObjectKey::Expr(key) => needs_path_context(key),
+                }
+        }),
         // `getpath([key])` (#2253): same reasoning as `IndexExpr`'s `key`
         // below -- without this arm, a `key`/`parent`/`file_index` reachable
         // only through `getpath`'s own path argument (not downstream of it)
@@ -2141,6 +2161,12 @@ impl From<Control> for ObjectEscape {
     }
 }
 
+/// How [`build_object_entries`] evaluates one key or value slot of an object
+/// literal: every output the slot produced, plus a deferred escape if its own
+/// generator terminated in an error, a break or a halt --
+/// [`stream_outputs_checked`]'s pair, which both strategies wrap (#2473).
+type ObjectSlotEvaluator<'a> = dyn FnMut(&Expr) -> (Vec<OwnedValue>, Option<Control>) + 'a;
+
 /// Emit one object per combination of the remaining entries' key/value outputs.
 ///
 /// Object construction is a generator in jq: an entry whose key or value yields
@@ -2173,9 +2199,29 @@ impl From<Control> for ObjectEscape {
 /// the accumulated values into the object instead of cloning them, keeping the
 /// common path allocation-for-allocation identical to the pre-#354 code. Without
 /// it, `{a: .big}` would deep-clone `.big` on the way out.
-fn build_object_entries<W: Clone + AsRef<[u64]>, S: EvalSemantics>(
+///
+/// The *operand evaluator* is a parameter (#2473, gate reason 3 of spine
+/// 2416), so the key/value slots can be evaluated somewhere other than
+/// [`eval_single`].
+///
+/// The second strategy is `eval_stage_with_path_context`'s own
+/// value-construction arm, which evaluates each slot through
+/// [`eval_pipe_with_path_context_internal`] so a `key`/`parent`/`path` inside
+/// `{"k": key}` still stands where the input node stood. That arm used to
+/// call the plain evaluator for the whole construction, which is what made
+/// `.a | {"x": key}` print `{"x": null}` for a year (#1332) -- but only the
+/// *inputs* of a construction read the enclosing position; the constructed
+/// value itself is still a fresh root, which is why the arm's own
+/// "reset the path context" handling of the result is untouched. Exactly the
+/// split `Expr::Array(inner) if needs_path_context(inner)` (#1302) already
+/// makes for array construction.
+///
+/// One definition, two strategies -- the shape [`boolean_fanout_core`] and
+/// [`binary_fanout_core`] already use, and for the same reason: a second copy
+/// of jq's keys-vary-slowest fan-out would drift from this one.
+fn build_object_entries(
     entries: &[super::expr::ObjectEntry],
-    value: &StandardJson<'_, W>,
+    eval_operand: &mut ObjectSlotEvaluator<'_>,
     optional: bool,
     sole: bool,
     acc: &mut Vec<(String, OwnedValue)>,
@@ -2196,18 +2242,16 @@ fn build_object_entries<W: Clone + AsRef<[u64]>, S: EvalSemantics>(
 
     let (keys, key_trailing) = match &entry.key {
         ObjectKey::Literal(s) => (vec![OwnedValue::String(s.clone())], None),
-        ObjectKey::Expr(key_expr) => {
-            // #2022: checked, not `stream_outputs` -- an undecodable computed
-            // key must raise, not silently materialize as `""`.
-            stream_outputs_checked(eval_single::<W, S>(key_expr, value.clone(), optional))
-        }
+        // #2022: the strategies are `stream_outputs_checked`-wrapped, not
+        // `stream_outputs` -- an undecodable computed key must raise, not
+        // silently materialize as `""`.
+        ObjectKey::Expr(key_expr) => eval_operand(key_expr),
     };
     let sole = sole && keys.len() == 1;
 
     for key in keys {
         // #2022: same fix as the key slot above, for the value slot.
-        let (vals, val_trailing) =
-            stream_outputs_checked(eval_single::<W, S>(&entry.value, value.clone(), optional));
+        let (vals, val_trailing) = eval_operand(&entry.value);
         let sole = sole && vals.len() == 1;
 
         for val in vals {
@@ -2225,7 +2269,7 @@ fn build_object_entries<W: Clone + AsRef<[u64]>, S: EvalSemantics>(
             };
 
             acc.push((key_str.clone(), val));
-            let result = build_object_entries::<W, S>(rest, value, optional, sole, acc, out);
+            let result = build_object_entries(rest, eval_operand, optional, sole, acc, out);
             acc.pop();
             result?;
         }
@@ -2253,6 +2297,23 @@ fn eval_object_construction<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     value: StandardJson<'a, W>,
     optional: bool,
 ) -> QueryResult<'a, W> {
+    eval_object_construction_with(
+        entries,
+        &mut |expr| stream_outputs_checked(eval_single::<W, S>(expr, value.clone(), optional)),
+        optional,
+    )
+}
+
+/// [`eval_object_construction`] over [`build_object_entries`]'s
+/// pluggable operand evaluator -- see that function for why there are two
+/// strategies (#2473). Only the fan-out's inputs change; the escape-to-result
+/// conversion below is shared, so `try {("a",1):2}` streams its prefix the
+/// same way on both.
+fn eval_object_construction_with<'a, W: Clone + AsRef<[u64]>>(
+    entries: &[super::expr::ObjectEntry],
+    eval_operand: &mut ObjectSlotEvaluator<'_>,
+    optional: bool,
+) -> QueryResult<'a, W> {
     let mut objects = Vec::new();
     let mut acc = Vec::new();
 
@@ -2261,7 +2322,14 @@ fn eval_object_construction<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     // objects already pushed to `out` by the time `build_object_entries`
     // returns `Err` travel onward as `QueryResult::Partial`'s prefix, the same
     // carrier `eval_comma` uses for `(1,error("x"))` (#400/#494).
-    match build_object_entries::<W, S>(entries, &value, optional, true, &mut acc, &mut objects) {
+    match build_object_entries(
+        entries,
+        eval_operand,
+        optional,
+        true,
+        &mut acc,
+        &mut objects,
+    ) {
         Ok(()) => {}
         Err(ObjectEscape::None) => return QueryResult::None,
         Err(ObjectEscape::Break(label)) => {
@@ -36898,7 +36966,44 @@ fn eval_stage_with_path_context<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
             // where *each* constructed value must become its own root --
             // so a multi-output result loops by hand below instead,
             // mirroring how `Expr::Comma` accumulates its own branches.
-            match eval_owned_input::<W, S>(first, value, optional) {
+            // #2473 (#1332's other half): only the *result* of a
+            // construction is a fresh root -- its key and value slots are
+            // evaluated at the position this stage was given, exactly like
+            // `Expr::Array(inner) if needs_path_context(inner)` (#1302, A21)
+            // a few arms above. `eval_owned_input` evaluates them with no
+            // position at all, which is what made `.a | {"x": key}` print
+            // `{"x": null}`. Routing them through this same function keeps
+            // the position; everything below -- each constructed value
+            // becoming its own root, the fan-out, the escape handling -- is
+            // unchanged and shared. Not a new handler: this is the same
+            // `Expr::Object(_) | Expr::Array(_) | Expr::Literal(_)` arm, so
+            // `tests/jq_path_context_arm_guard.rs`'s count is unmoved.
+            //
+            // The inner evaluation forces `optional` to `false` for the same
+            // reason A21 documents: `Expr::Optional` broadcasts `true` into
+            // whatever it wraps with no catch of its own, so a genuine error
+            // inside the construction must surface here and be caught by
+            // *this* arm's own `optional` below, atomically.
+            let constructed = match first {
+                Expr::Object(entries) if needs_path_context(first) => {
+                    eval_object_construction_with::<W>(
+                        entries,
+                        &mut |expr| {
+                            stream_outputs_checked(eval_pipe_with_path_context_internal::<W, S>(
+                                core::slice::from_ref(expr),
+                                value,
+                                root,
+                                file_origin,
+                                current_path,
+                                false,
+                            ))
+                        },
+                        optional,
+                    )
+                }
+                _ => eval_owned_input::<W, S>(first, value, optional),
+            };
+            match constructed {
                 // #1280: a zero-output generator inside the construction
                 // (`{(empty): 1}`, `[empty]` behaves differently -- this is
                 // specifically the object-key-generator case) means the

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -6090,20 +6090,54 @@ fn boolean_fanout_core<'a, W: Clone + AsRef<[u64]>>(
     short_circuit: bool,
     rules: BinaryFanoutRules,
 ) -> QueryResult<'a, W> {
+    let (out, control) = boolean_fanout_bools(
+        |expr, bools| push_truthiness(eval_operand(expr), bools),
+        left,
+        right,
+        short_circuit,
+        rules,
+    );
+    match control {
+        Some(control) => partial(out.into_iter().map(OwnedValue::Bool).collect(), control),
+        None => bools_to_result(out),
+    }
+}
+
+/// [`boolean_fanout_core`]'s algorithm with the result type factored out:
+/// the loop only ever needs one truthiness bit per operand output, so the
+/// operand strategy pushes bits and this returns bits, leaving each caller
+/// to build its own result from them.
+///
+/// The generic evaluator's `and`/`or` arm (`eval_generic::eval_boolean_generic`,
+/// spine 2416 gate reason 3) is the second caller. It threads a cursor into
+/// both operands, which `QueryResult` cannot carry, so sharing the *body*
+/// rather than copying it is what keeps #2460's empty-operand rule and
+/// #2470's read-only scope from drifting between the two routes -- the same
+/// "one definition, plus a test that the call sites agree" rule
+/// [`binary_fanout_core`] and `eval_generic::binary_fanout_each_generic`
+/// already follow for arithmetic and comparison.
+pub(crate) fn boolean_fanout_bools(
+    mut push_operand: impl FnMut(&Expr, &mut Vec<bool>) -> Option<Control>,
+    left: &Expr,
+    right: &Expr,
+    short_circuit: bool,
+    rules: BinaryFanoutRules,
+) -> (Vec<bool>, Option<Control>) {
     // #2470 (yq mode): `and`/`or` evaluate both operands read-only, exactly
     // like arithmetic -- `(.zzz | key) and true` is `false` in real yq while
-    // `"zzz" and true` is `true`. This operand strategy is eager (a whole
-    // `QueryResult` per call, not a sink), so there is nothing to suspend:
-    // the scope covers only the call itself.
-    let mut eval_operand = move |expr: &Expr| {
+    // `"zzz" and true` is `true`. Both operand strategies are eager (a whole
+    // result per call, not a sink), so there is nothing to suspend: the scope
+    // covers only the call itself, and the truthiness push inside it does no
+    // key lookup for `yq_absent_key_read_is_empty` to answer.
+    let mut push_operand = move |expr: &Expr, bools: &mut Vec<bool>| {
         if !rules.read_only {
-            return eval_operand(expr);
+            return push_operand(expr, bools);
         }
         let _scope = yq_read_only_context::enter();
-        eval_operand(expr)
+        push_operand(expr, bools)
     };
     let mut left_bools = Vec::new();
-    let left_control = push_truthiness(eval_operand(left), &mut left_bools);
+    let left_control = push_operand(left, &mut left_bools);
     // #2460 (yq mode only): an operand that produced *zero* outputs
     // contributes one `false` truthiness value, which is the whole of yq's
     // captured `and`/`or` behaviour -- `and` then short-circuits to `false`
@@ -6122,18 +6156,15 @@ fn boolean_fanout_core<'a, W: Clone + AsRef<[u64]>>(
             continue;
         }
         let before = out.len();
-        if let Some(control) = push_truthiness(eval_operand(right), &mut out) {
-            return partial(out.into_iter().map(OwnedValue::Bool).collect(), control);
+        if let Some(control) = push_operand(right, &mut out) {
+            return (out, Some(control));
         }
         if out.len() == before {
             out.extend(empty_boolean_operand(rules.empty));
         }
     }
 
-    match left_control {
-        Some(control) => partial(out.into_iter().map(OwnedValue::Bool).collect(), control),
-        None => bools_to_result(out),
-    }
+    (out, left_control)
 }
 
 /// Backs `eval_arithmetic`/`eval_compare`. Operands are evaluated through

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -12944,6 +12944,19 @@ fn path_context_resolvable(expr: &Expr, with_parent: bool) -> bool {
         Expr::Compare { left, right, .. } => sub(left) && sub(right),
         Expr::And(left, right) | Expr::Or(left, right) => sub(left) && sub(right),
         Expr::Negate(inner) => sub(inner),
+        // #2473 (gate reason 3 of spine 2416): every key and value expression
+        // of an object literal is evaluated at the stage's own input, exactly
+        // like `Expr::Array`'s inner expression above, so a read inside one
+        // resolves against this position. Reachable only since
+        // `needs_path_context` learned to descend into `Expr::Object`
+        // (#1332's other half) -- before that no route was ever asked.
+        Expr::Object(entries) => entries.iter().all(|entry| {
+            sub(&entry.value)
+                && match &entry.key {
+                    ObjectKey::Literal(_) => true,
+                    ObjectKey::Expr(key) => sub(key),
+                }
+        }),
         _ => false,
     }
 }
@@ -13345,6 +13358,25 @@ fn path_context_resolve_constants<S: EvalSemantics, V: DocumentValue>(
         },
         Expr::And(left, right) => Expr::And(boxed(left)?, boxed(right)?),
         Expr::Or(left, right) => Expr::Or(boxed(left)?, boxed(right)?),
+        // #2473: the rewriter's half of `path_context_resolvable`'s own
+        // `Expr::Object` arm -- one rewrite per key and per value, so a
+        // `{"k": key}` at an absent position comes out with no path context
+        // left in it (`path_context_absent_resolution_clears_path_context_2416`
+        // is the test that holds the two halves equal).
+        Expr::Object(entries) => Expr::Object(
+            entries
+                .iter()
+                .map(|entry| {
+                    Ok(ObjectEntry {
+                        key: match &entry.key {
+                            ObjectKey::Literal(name) => ObjectKey::Literal(name.clone()),
+                            ObjectKey::Expr(key) => ObjectKey::Expr(boxed(key)?),
+                        },
+                        value: *boxed(&entry.value)?,
+                    })
+                })
+                .collect::<Result<Vec<_>, EvalError>>()?,
+        ),
         other => other.clone(),
     })
 }
@@ -24931,13 +24963,21 @@ mod tests {
         // ...but `select`/`parent` keep the node, so a later builtin is fine.
         assert!(!eager(".[] | select(key == \"a\") | parent | key"));
         assert!(!eager(".a[] | select(key != \"c\") | parent"));
-        // A stage built from something that bridges mid-expression. (Bare
-        // `{k: key}` never reaches the gate at all: `needs_path_context` does
-        // not descend into `Expr::Object`, #1332, so that pipe is not seen as
-        // a path-context pipe in the first place; and object construction is
-        // native now, so `(key | {k: .})` is admitted.)
+        // A stage built from something that bridges mid-expression. Object
+        // construction is native, so `(key | {k: .})` is admitted -- and
+        // since #2473 gave `needs_path_context` its own `Expr::Object` arm
+        // (#1332's other half), a bare `{k: key}` reaches this gate at all
+        // for the first time, and is admitted for the same reason.
         assert!(eager(".[] | (key | tostring)"));
         assert!(!eager(".[] | (key | {k: .})"));
+        assert!(!eager(".[] | {\"k\": key}"));
+        assert!(!eager(".[] | {(key): 1}"));
+        assert!(!eager(".[] | {\"k\": key, \"p\": path}"));
+        assert!(!eager(".[] | {\"k\": (key + \"x\")}"));
+        // ...but a value expression that is not itself single-native keeps
+        // the construction on the eager route, the same closed-list rule
+        // every other arm follows.
+        assert!(eager(".[] | {\"k\": (key | tostring)}"));
         assert!(!eager(".[] | if key == \"a\" then . else empty end"));
         assert!(!eager(".[] | limit(1; .[] | key)"));
         assert!(eager(".[] | limit(1 + 0; key)"), "computed n");

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -12737,6 +12737,27 @@ fn path_context_single_native(expr: &Expr) -> bool {
         Expr::FuncDef { body, then, .. } => {
             path_context_single_native(body) && path_context_single_native(then)
         }
+        // Native since spine 2416 gate reason 3 (#2473): `eval_single`'s own
+        // `Expr::Reduce`/`Expr::Foreach` arms evaluate INIT and the source
+        // generator through `stream_owned_outputs_generic` *with the cursor*,
+        // so `.a[] | reduce (key) as $k (""; . + $k)` folds the per-element
+        // keys instead of bridging the whole fold to the eager evaluator.
+        // Guarded exactly as those arms are: a `repeat` anywhere in INPUT or
+        // INIT sends the construct to the wildcard bridge instead, where
+        // there is no cursor.
+        //
+        // UPDATE and EXTRACT are deliberately not checked. Both evaluate
+        // against the *accumulator* -- a value the fold built, with no
+        // document position -- which is why `needs_path_context` does not
+        // descend into them either (see its own `Expr::Reduce`/`Expr::Foreach`
+        // arms). A `key` there answers from no position on this route and on
+        // the eager one alike, so admitting the construct cannot move it.
+        Expr::Reduce { input, init, .. } | Expr::Foreach { input, init, .. } => {
+            !streams_unbounded(input)
+                && !streams_unbounded(init)
+                && path_context_single_native(input)
+                && path_context_single_native(init)
+        }
         // Native since #2416 phase 3: transparent to evaluation, so whatever
         // `inner` is decides.
         Expr::Shared(inner) => path_context_single_native(inner),
@@ -24969,6 +24990,24 @@ mod tests {
         // (#1332's other half), a bare `{k: key}` reaches this gate at all
         // for the first time, and is admitted for the same reason.
         assert!(eager(".[] | (key | tostring)"));
+        // Native since spine 2416 gate reason 3 (#2473): the generic
+        // `Expr::Reduce`/`Expr::Foreach` arms evaluate INPUT and INIT with
+        // the cursor, so a fold whose *source* reads the position no longer
+        // drags the pipe to the eager evaluator. UPDATE/EXTRACT run against
+        // the accumulator on either route, so they are not part of the gate.
+        assert!(!eager(".a[] | reduce (key) as $k (\"\"; . + $k)"));
+        assert!(!eager(".a[] | foreach (key) as $k (\"\"; . + $k; [$k, .])"));
+        assert!(!eager(".a[] | reduce (1,2) as $x (key; [., $x])"));
+        assert!(!eager(".a[] | [reduce (key) as $k (\"\"; . + $k)]"));
+        // `repeat` in INPUT or INIT sends the construct to the wildcard
+        // bridge instead of the native arm, so the gate refuses it too.
+        // (`repeat` in INPUT is not a row here: `needs_path_context` has no
+        // `Expr::Repeat` arm, so `reduce (repeat(key)) as ...` is not seen as
+        // a path-context stage at all and the gate is never asked -- the
+        // extension-only shape #2473 deliberately left alone, see
+        // `docs/plan/path-context-arm-reachability.md`.)
+        assert!(eager(".a[] | reduce (key) as $k (repeat(1); .)"));
+        assert!(eager(".a[] | foreach (key) as $k (repeat(1); .; .)"));
         assert!(!eager(".[] | (key | {k: .})"));
         assert!(!eager(".[] | {\"k\": key}"));
         assert!(!eager(".[] | {(key): 1}"));

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -36,10 +36,11 @@ use super::document::{
 };
 use super::eval::{
     apply_compare_op, arith_combine, as_var_refs, binary_fanout_rules, bind_def, bind_def_call,
-    cannot_reserve_cross_product, classify_limit_n, classify_nth_n, classify_parent_n,
-    collapse_vec, collect_pattern_var_names, compare_values, debug_assert_materialization_error,
-    enter_def_call_frame, eval_each_owned, eval_foreach_with_values, eval_full as full_eval,
-    eval_reduce_with_values, extract_pattern_bindings, fold_escaped_generator_prefix, format_owned,
+    boolean_fanout_bools, cannot_reserve_cross_product, classify_limit_n, classify_nth_n,
+    classify_parent_n, collapse_vec, collect_pattern_var_names, compare_values,
+    debug_assert_materialization_error, enter_def_call_frame, eval_each_owned,
+    eval_foreach_with_values, eval_full as full_eval, eval_reduce_with_values,
+    extract_pattern_bindings, fold_escaped_generator_prefix, format_owned,
     has_type_mismatch_is_permissive, index_component_value, index_in_array_bounds,
     index_one_owned as index_owned_by_key, is_pure_chain_link, is_retryable_stop, literal_to_owned,
     needs_path_context, numeric_key_to_array_index, numeric_key_to_index, owned_bound_to_i64,
@@ -6226,6 +6227,28 @@ fn eval_single<S: EvalSemantics, V: DocumentValue>(
             collect_each_generic::<S, V>(expr, value, optional, cursor)
         }
 
+        // Spine 2416 gate reason 3 (#2473): `and`/`or` with a path-context
+        // operand, through `eval_boolean_generic` -- `eval::boolean_fanout_bools`
+        // with `eval_single` *plus the cursor* as the operand strategy. Without
+        // this arm `.[] | key == "a" and true` fell to the wildcard bridge
+        // below, which materializes the ambient value and hands the eager
+        // evaluator a document re-rooted at this stage's input.
+        //
+        // **Gated on `needs_path_context`, for the same reason the
+        // `Expr::Arithmetic` arm above is** (and the `Expr::Compare` arm is
+        // not): the bridge's ambient materialization is what makes
+        // `try (1+1) catch "x"` fail on a #1194-malformed document, and
+        // `test_try_catch_contains_a_genuinely_catchable_malformed_key_error_1812`
+        // pins that. An `and`/`or` that reads no path context stays on the
+        // bridge and keeps paying the decode; one that does could not have
+        // stood on a malformed document's root and survived the walk anyway.
+        Expr::And(left, right) if needs_path_context(left) || needs_path_context(right) => {
+            eval_boolean_generic::<S, V>(left, right, false, value, optional, cursor)
+        }
+        Expr::Or(left, right) if needs_path_context(left) || needs_path_context(right) => {
+            eval_boolean_generic::<S, V>(left, right, true, value, optional, cursor)
+        }
+
         // Array construction: collect every output of the inner expression
         // into one array. Handled natively (mirrors `eval::eval_array_construction`)
         // so a builtin with its own cursor-native, duplicate-key-preserving fix
@@ -8908,6 +8931,51 @@ fn eval_compare_generic<S: EvalSemantics, V: DocumentValue>(
         Flow::Escaped(control) => Some(control),
     };
     finish_fork_generic(out, control.or(stray), optional)
+}
+
+/// `and`/`or` with the cursor threaded into both operands (spine 2416 gate
+/// reason 3, #2473) -- the boolean twin of [`eval_compare_generic`] above.
+///
+/// The loop itself is `eval::boolean_fanout_bools`, shared with the eager
+/// route rather than copied, so #2460's zero-output-operand rule and #2470's
+/// read-only operand scope have one definition across both. What this adds is
+/// the operand strategy: `eval_single` *with* `cursor`, so `.[] | key == "a"
+/// and true` reads each element's own key instead of being handed a `null`
+/// by the eager bridge.
+///
+/// `short_circuit` is the truth value that ends the pairing -- `false` for
+/// `and`, `true` for `or` -- exactly as `eval::eval_and`/`eval::eval_or`
+/// pass it.
+fn eval_boolean_generic<S: EvalSemantics, V: DocumentValue>(
+    left: &Expr,
+    right: &Expr,
+    short_circuit: bool,
+    value: V,
+    optional: bool,
+    cursor: Option<V::Cursor>,
+) -> GenericResult<V> {
+    let (bools, control) = boolean_fanout_bools(
+        |operand, out| {
+            push_generic_truthiness(
+                eval_single::<S, V>(operand, value.clone(), optional, cursor),
+                out,
+            )
+        },
+        left,
+        right,
+        short_circuit,
+        binary_fanout_rules::<S>(EmptyOperandOp::Boolean),
+    );
+    let outputs: Vec<OwnedValue> = bools.into_iter().map(OwnedValue::Bool).collect();
+    // `partial_generic`/`owned_vec_to_generic_result`, not
+    // `finish_fork_generic`: `eval::boolean_fanout_core` never consults
+    // `optional` for its own trailing control either (an ambient `?` catches
+    // the aggregate once, at `Expr::Optional`'s arm), and the two routes have
+    // to agree on that as much as on the loop.
+    match control {
+        Some(control) => partial_generic(outputs, control),
+        None => owned_vec_to_generic_result(outputs),
+    }
 }
 
 /// Shared resolution of [`each_take_first_generic`]'s and
@@ -12580,6 +12648,16 @@ fn path_context_single_native(expr: &Expr) -> bool {
         // ambient decode `try (1+1) catch "x"` depends on for a malformed
         // document, which the arm's own `needs_path_context` gate preserves.
         Expr::Arithmetic { left, right, .. } => {
+            path_context_single_native(left) && path_context_single_native(right)
+        }
+        // Native since spine 2416 gate reason 3 (#2473): `eval_single`'s own
+        // `Expr::And`/`Expr::Or` arms, above, over `eval_boolean_generic`.
+        // Same `needs_path_context` gate and same reason as `Expr::Arithmetic`
+        // just above, and the loop those arms run is `eval::boolean_fanout_bools`,
+        // so #2460's rule for an operand that produces zero outputs -- `key and
+        // true` at the document root is `false` in real yq, not nothing -- is
+        // the same definition on this route as on the eager one.
+        Expr::And(left, right) | Expr::Or(left, right) => {
             path_context_single_native(left) && path_context_single_native(right)
         }
         Expr::Try { expr, catch } => {
@@ -24863,7 +24941,19 @@ mod tests {
         assert!(!eager(".[] | if key == \"a\" then . else empty end"));
         assert!(!eager(".[] | limit(1; .[] | key)"));
         assert!(eager(".[] | limit(1 + 0; key)"), "computed n");
-        assert!(eager(".[] | select(key == \"a\" and true)"));
+        // Native since spine 2416 gate reason 3 (#2473): `and`/`or` have
+        // `eval_single` arms of their own now, so a path-context operand
+        // reads the cursor on the non-sink route too. `select(...)`'s own
+        // condition is single-evaluated, so it follows.
+        assert!(!eager(".[] | select(key == \"a\" and true)"));
+        assert!(!eager(".[] | key == \"a\" and true"));
+        assert!(!eager(".[] | (key == \"a\") or false"));
+        assert!(!eager(".[] | key and parent"));
+        assert!(!eager(".[] | {\"k\": (key and true)}"));
+        // ...and an operand that is not itself single-native still keeps the
+        // whole pipe on the eager route, the same closed-list discipline
+        // every other arm follows.
+        assert!(eager(".[] | (key | tostring) and true"));
         assert!(eager(".[] | parent(1 + 0)"));
         // A nested pipe that would itself fall to the eager evaluator from a
         // re-rooted input keeps the outer pipe eager too.

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -7522,6 +7522,88 @@ fn test_shared_keeps_path_context_2416() -> Result<()> {
     Ok(())
 }
 
+/// Spine 2416 gate reason 3 (#2473): `and`/`or` with a path-context operand
+/// are native in `eval_single` (`eval_boolean_generic` over
+/// `eval::boolean_fanout_bools`), so the non-sink route threads the cursor
+/// into both operands instead of handing the eager bridge a `null`.
+///
+/// No jq oracle: `key`/`parent`/`path` are succinctly extensions jq 1.7.1
+/// rejects at compile time (`key/0 is not defined`). Every row below is the
+/// yq-captured answer where yq has one (see the yq-mode twin,
+/// `test_and_or_keep_path_context_2473` in `tests/yq_cli_tests.rs`) and the
+/// pinned extension answer otherwise.
+///
+/// **Two rows moved**, both toward jq's own generator semantics. `key` at the
+/// document root emits *nothing* (ADR-0021 decision 2), and jq's `empty and
+/// true` is nothing, not `false` (verified live against jq 1.7.1). The eager
+/// bridge used to answer `false` for `key and true` and `true` for
+/// `parent and true` there, from a stub with no position; the native arm
+/// answers with jq's own zero-output rule. yq mode keeps `false` for both,
+/// which is what real yq prints -- #2460's empty-operand rule, consulted from
+/// the one definition both routes share.
+#[test]
+fn test_and_or_keep_path_context_2473() -> Result<()> {
+    let doc = r#"{"a":1,"b":2}"#;
+    for (filter, want) in [
+        (".[] | key == \"a\" and true", "true\nfalse"),
+        (".[] | (key == \"b\") or false", "false\ntrue"),
+        (".[] | key and true", "true\ntrue"),
+        (".[] | select(key == \"a\" and . == 1)", "1"),
+        // #1332's object gap seen through `and`: the value expression is
+        // single-evaluated, so the native arm reaches it with the cursor.
+        // The eager bridge answered `{"k":false}` twice.
+        (
+            ".[] | {\"k\": (key and true)}",
+            "{\"k\":true}\n{\"k\":true}",
+        ),
+        (
+            ".[] | [key, (key == \"a\" and true)]",
+            "[\"a\",true]\n[\"b\",false]",
+        ),
+        (".a | key and parent", "true"),
+        // A `key` at the root produces no outputs, and jq's `and`/`or` have
+        // no empty-operand rule, so the whole expression produces none.
+        ("key and true", ""),
+        ("key or false", ""),
+        ("parent and true", ""),
+    ] {
+        let (out, _, code) = run_jq_full(&["-c", filter], Some(doc))?;
+        assert_eq!(code, 0, "`{filter}`: {out:?}");
+        assert_eq!(out.trim(), want, "`{filter}`");
+    }
+    Ok(())
+}
+
+/// Spine 2416 gate reason 3 (#2473) companion: the `and`/`or` arms are gated
+/// on `needs_path_context`, exactly like `Expr::Arithmetic`'s (#2475), so an
+/// `and`/`or` that reads no path context still takes the eager bridge and
+/// still pays its ambient decode on a #1194-malformed document.
+///
+/// `try (key and true) catch "x"` exits 0 with no output on the native route,
+/// which is not a regression this arm introduces: `try (key + 1) catch "x"`
+/// and `try (key == 1) catch "x"` already did, from the `Expr::Arithmetic`
+/// and `Expr::Compare` arms. It is pinned here so the *difference* between a
+/// gated and an ungated arm stays visible, alongside
+/// `test_try_catch_contains_a_genuinely_catchable_malformed_key_error_1812`.
+#[test]
+fn test_and_or_without_path_context_still_pays_the_ambient_decode_2473() -> Result<()> {
+    let doc = "{123: 1}";
+    for filter in ["true and true", r#"try (true and true) catch "x""#] {
+        let (stdout, stderr, code) = run_jq_full(&["-c", filter], Some(doc))?;
+        assert_eq!(code, 5, "`{filter}` stdout: {stdout:?} stderr: {stderr}");
+        assert!(stdout.trim().is_empty(), "`{filter}` stdout: {stdout:?}");
+        assert!(
+            stderr.contains("Invalid JSON text"),
+            "`{filter}` stderr: {stderr}"
+        );
+    }
+    let (stdout, stderr, code) =
+        run_jq_full(&["-c", r#"try (key and true) catch "x""#], Some(doc))?;
+    assert_eq!(code, 0, "stdout: {stdout:?} stderr: {stderr}");
+    assert!(stdout.trim().is_empty(), "stdout: {stdout:?}");
+    Ok(())
+}
+
 /// #2471 (gate reason 1 of spine 2416): a *computed* index or slice, and
 /// `getpath(p)`, are navigation inside the owned domain too, so a pipe that
 /// left the cursor domain earlier keeps its position through them instead of

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -7522,6 +7522,104 @@ fn test_shared_keeps_path_context_2416() -> Result<()> {
     Ok(())
 }
 
+/// Spine 2416 gate reason 3 (#2473): a `reduce`/`foreach` whose *source* or
+/// INIT reads path context is native in `eval_single` -- those two slots are
+/// already evaluated through `stream_owned_outputs_generic` with the cursor,
+/// so admitting `Expr::Reduce`/`Expr::Foreach` to `path_context_single_native`
+/// takes the whole fold off the eager route.
+///
+/// UPDATE and EXTRACT are deliberately *not* part of that: both evaluate
+/// against the accumulator, a value the fold built with no document position,
+/// which is why `needs_path_context` does not descend into them either. A
+/// `key` there answers from no position on both routes -- the last two rows
+/// pin exactly that, unchanged.
+///
+/// No oracle in either direction: real yq's lexer rejects `reduce`/`foreach`
+/// outright (`1:1: lexer: invalid input text "reduce ..."`, v4.53.3, so
+/// succinctly's are documented extensions -- `docs/reference/yq-language.md`),
+/// and jq 1.7.1 has no `key`/`path`. Every row was captured on this PR's own
+/// pre-change build and is unchanged by the admission, which is what a route
+/// migration should look like.
+#[test]
+fn test_reduce_and_foreach_source_keeps_path_context_2473() -> Result<()> {
+    let doc = r#"{"a":{"b":1,"c":2},"d":[10,20]}"#;
+    for (filter, want) in [
+        (".a[] | reduce (key) as $k (\"\"; . + $k)", "\"b\"\n\"c\""),
+        (
+            ".a | reduce (.[] | key) as $k ([]; . + [$k])",
+            "[\"b\",\"c\"]",
+        ),
+        (
+            ".a[] | foreach (key) as $k (\"\"; . + $k; [$k, .])",
+            "[\"b\",\"b\"]\n[\"c\",\"c\"]",
+        ),
+        (
+            ".a[] | reduce (key, path[0]) as $k ([]; . + [$k])",
+            "[\"b\",\"a\"]\n[\"c\",\"a\"]",
+        ),
+        // INIT reads the position too.
+        (".a | reduce (1,2) as $x (key; [., $x])", "[[\"a\",1],2]"),
+        // `key` at the document root emits nothing, so the source is empty
+        // and `reduce` answers with INIT alone while `foreach` answers with
+        // nothing at all -- jq's own rule for an empty source.
+        ("reduce (key) as $k (\"\"; . + $k)", "\"\""),
+        ("foreach (key) as $k (\"\"; . + $k)", ""),
+        // UPDATE/EXTRACT read the accumulator, which has no position: `key`
+        // there is `null`, on this route and on the eager one alike.
+        ("reduce .d[] as $x (.a; [.[] | key])", "[0,1]"),
+        (
+            "foreach .[] as $x (0; . + 1; [$x, key])",
+            "[{\"b\":1,\"c\":2},null]\n[[10,20],null]",
+        ),
+    ] {
+        let (out, _, code) = run_jq_full(&["-c", filter], Some(doc))?;
+        assert_eq!(code, 0, "`{filter}`: {out:?}");
+        assert_eq!(out.trim(), want, "`{filter}`");
+    }
+    Ok(())
+}
+
+/// Spine 2416 gate reason 3 (#2473), the constructs deliberately left alone:
+/// `range`, `repeat`, `while` and `until` with a path-context builtin in the
+/// body.
+///
+/// Neither reference can express these. Real yq's lexer rejects all four
+/// (v4.53.3: `1:7: lexer: invalid input text "range(2) | key]"`, and the same
+/// for `limit`, `while`, `until`), and jq 1.7.1 has no `key`/`path` to put in
+/// them -- so there is no captured behaviour to migrate toward, only
+/// succinctly's own extension surface. They get no `path_context_single_native`
+/// arm; these rows pin what they answer today so a later change to the gate
+/// has to move them deliberately.
+///
+/// `range` and `limit` are additionally gated behind `--jq-extensions` in yq
+/// mode (#1512); `while`/`until` are not, which is a pre-existing gap in that
+/// gate rather than anything this change touches.
+#[test]
+fn test_range_repeat_while_until_stay_extension_only_2473() -> Result<()> {
+    let doc = r#"{"a":{"b":1,"c":2},"d":[10,20]}"#;
+    for (filter, want) in [
+        (".a | [range(2) | key]", "[\"a\",\"a\"]"),
+        (".a[] | [range(2) | key]", "[\"b\",\"b\"]\n[\"c\",\"c\"]"),
+        (".a | [range(2) | path]", "[[\"a\"],[\"a\"]]"),
+        // `repeat`'s body re-enters from its own previous output, which has
+        // no position -- hence `null`, not `"a"`.
+        (".a | [limit(2; repeat(key))]", "[null,null]"),
+        // `while`/`until` fold from a seed value, so `key` inside the update
+        // stands on that seed and answers nothing; the loops therefore stop
+        // on their first test.
+        (".a | [1 | while(. < 3; . + (key|length))]", "[1]"),
+        (".a | [1 | until(. > 2; . + (key|length))]", "[]"),
+        // A `range` that only *feeds* a later `key` still resolves against
+        // the constructed array, not the input node.
+        (".a | [range(2)] | map(key)", "[0,1]"),
+    ] {
+        let (out, _, code) = run_jq_full(&["-c", filter], Some(doc))?;
+        assert_eq!(code, 0, "`{filter}`: {out:?}");
+        assert_eq!(out.trim(), want, "`{filter}`");
+    }
+    Ok(())
+}
+
 /// #1332's other half, closed by #2473 (gate reason 3 of spine 2416), in jq
 /// mode. `needs_path_context` descends into `Expr::Object` now, so an object
 /// literal's key and value slots are routed like any other path-context read.

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -7522,6 +7522,53 @@ fn test_shared_keeps_path_context_2416() -> Result<()> {
     Ok(())
 }
 
+/// #1332's other half, closed by #2473 (gate reason 3 of spine 2416), in jq
+/// mode. `needs_path_context` descends into `Expr::Object` now, so an object
+/// literal's key and value slots are routed like any other path-context read.
+///
+/// No jq oracle -- `key`/`parent`/`path` are succinctly extensions jq 1.7.1
+/// rejects at compile time -- so these pin the extension answers, which are
+/// byte-identical to the yq-captured rows in
+/// `test_object_construction_keeps_path_context_2473`
+/// (`tests/yq_cli_tests.rs`) except for the `parent`-on-absent one #2435
+/// already records. The four "was `{"x":null}`" rows below are the bug #1332
+/// reported: the value slot answered with no position at all.
+#[test]
+fn test_object_construction_keeps_path_context_2473() -> Result<()> {
+    let doc = r#"{"a":{"b":1},"c":[10,20]}"#;
+    for (filter, want) in [
+        (".a | {\"k\": key}", "{\"k\":\"a\"}"),
+        (
+            ".[] | {\"k\": key, \"p\": path}",
+            "{\"k\":\"a\",\"p\":[\"a\"]}\n{\"k\":\"c\",\"p\":[\"c\"]}",
+        ),
+        // Was `{"k":null}`: an absent position.
+        (".zz | {\"k\": key}", "{\"k\":\"zz\"}"),
+        (".a.zz | {\"k\": key}", "{\"k\":\"zz\"}"),
+        // Was `{"k":null}`: a value that has left the cursor domain.
+        (".a | tostring | {\"k\": key}", "{\"k\":\"a\"}"),
+        (".c | to_entries | .[0] | {\"k\": key}", "{\"k\":0}"),
+        (".a? | {\"k\": key}", "{\"k\":\"a\"}"),
+        (".a | {\"k\": key} as $o | $o", "{\"k\":\"a\"}"),
+        // Was a `Cannot use null (null) as object key` error.
+        (".a.zz | {(key): 1}", "{\"zz\":1}"),
+        (
+            ".a.b | {\"k\": key, \"p\": parent}",
+            "{\"k\":\"b\",\"p\":{\"b\":1}}",
+        ),
+        (".a | {\"k\": (key + \"!\")}", "{\"k\":\"a!\"}"),
+        (
+            ".a.zz | {\"p\": parent, \"k\": key}",
+            "{\"p\":{\"b\":1},\"k\":\"zz\"}",
+        ),
+    ] {
+        let (out, _, code) = run_jq_full(&["-c", filter], Some(doc))?;
+        assert_eq!(code, 0, "`{filter}`: {out:?}");
+        assert_eq!(out.trim(), want, "`{filter}`");
+    }
+    Ok(())
+}
+
 /// Spine 2416 gate reason 3 (#2473): `and`/`or` with a path-context operand
 /// are native in `eval_single` (`eval_boolean_generic` over
 /// `eval::boolean_fanout_bools`), so the non-sink route threads the cursor

--- a/tests/jq_evaluator_parity_tests.rs
+++ b/tests/jq_evaluator_parity_tests.rs
@@ -2108,6 +2108,13 @@ fn test_arm_audit_proof_queries_are_unmoved_by_the_gate_2416() {
         (r".a[] | (key | length)", &["1"]),
         (r#".a? | [key] + ["x"]"#, &[r#"["a","x"]"#]),
         (r#".a? | (key + "x") | {z: .}"#, &[r#"{"z":"ax"}"#]),
+        // #2473's re-derived proof query, same precedent again: admitting
+        // `Expr::And`/`Expr::Or` to `path_context_single_native` moved A12's
+        // listed query (`.a.b | key == "b" and true`, just above) onto the
+        // generic route, so the audit re-derived one that still reaches the
+        // eager `Expr::And(..) | Expr::Or(..)` arm -- a `?` head, which no
+        // route can walk. Both spellings stay pinned.
+        (r#".a? | key == "a" and true"#, &["true"]),
     ];
     for (filter, expected) in rows {
         // `path + []` is the audit's H1 row spelled against `.a.b`.
@@ -2134,10 +2141,13 @@ fn test_arm_audit_proof_queries_are_unmoved_by_the_gate_2416() {
 ///
 /// Measured, not guessed: with the diversion instrumented, exactly these
 /// constructs got there, because `needs_path_context` deliberately does not
-/// recurse into `reduce`/`foreach`'s UPDATE and EXTRACT, into an assignment's
-/// right-hand side, or into `Expr::Object`'s entries -- so the enclosing
-/// program answers `false` and the inner pipe arrives with no routing
-/// decision made for it. The first four are `path_context_needs_eager ==
+/// recurse into `reduce`/`foreach`'s UPDATE and EXTRACT or into an
+/// assignment's right-hand side -- so the enclosing program answers `false`
+/// and the inner pipe arrives with no routing decision made for it.
+/// (`Expr::Object`'s entries were a third such construct when this was
+/// captured; #2473 gave `needs_path_context` an `Expr::Object` arm, so an
+/// object literal is routed like any other stage now and no longer arrives
+/// here undecided.) The first four are `path_context_needs_eager ==
 /// false` rows, i.e. the ones the door closure actually moves onto the
 /// generic evaluator.
 ///

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -32427,24 +32427,29 @@ fn test_object_construction_keeps_path_context_2473() -> Result<()> {
 /// `yq_empty_operand_output`.
 ///
 /// **One divergence stays, and it is not this arm's:** real yq evaluates an
-/// `and`/`or` *operand* against the document **root**, not against the node
-/// the pipe stands on. Captured on `a: {b: 1}\nc: [10, 20]\n`:
+/// `and`/`or`'s *right* operand against the document **root**, not against the
+/// node the pipe stands on, and answers `false` outright when the operator's
+/// input came from an absent navigation. Captured on
+/// `a: {b: 1}\nc: [10, 20]\n` (and `a:\n  b: 1\n` for the last two):
 ///
 /// ```text
-/// $ yq '.a | true and .b'        false   (`.b` resolved at the root)
-/// $ yq '.a | true and .a.b'      true
-/// $ yq '.c | true and .[0]'      false
-/// $ yq '.a | true and (key)'     false   (`key` at the root is nothing)
-/// $ yq '.a | key and parent'     false   (ditto for `parent`)
-/// $ yq '.a | .b and true'        true    (the *left* operand is not re-rooted)
-/// $ yq '.a | 0 + .b'             1       (arithmetic is not re-rooted either)
+/// $ yq '.a | true and .b'                false   (`.b` resolved at the root)
+/// $ yq '.a | true and .a.b'              true
+/// $ yq '.c | true and .[0]'              false
+/// $ yq '.a | true and (key)'             false   (`key` at the root is nothing)
+/// $ yq '.a | key and parent'             false   (ditto for `parent`)
+/// $ yq '.a | .b and true'                true    (the *left* operand is not re-rooted)
+/// $ yq '.a | 0 + .b'                     1       (arithmetic is not re-rooted either)
+/// $ yq '.a.zz | key == "zz"'             true
+/// $ yq '.a.zz | (key == "zz") and true'  false   (same comparison, as an operand)
 /// ```
 ///
 /// succinctly evaluates both operands at the current node in both modes, so
 /// it answers `true` for `.a | key and parent`. That predates this arm (the
 /// eager route answered `true` too) and is orthogonal to path context --
 /// `.a | true and .b` diverges with no path-context builtin anywhere -- so it
-/// is recorded here rather than encoded.
+/// is recorded in `docs/compliance/yq/limitations.md` ("An `and`/`or`
+/// operand's evaluation context") and pinned below rather than encoded.
 #[test]
 fn test_and_or_keep_path_context_2473() -> Result<()> {
     let args = &["-o=json", "-I=0"];
@@ -32471,12 +32476,31 @@ fn test_and_or_keep_path_context_2473() -> Result<()> {
         assert_eq!(output.trim(), expected, "`{filter}`");
     }
     // The re-rooted-operand divergence above, pinned as succinctly's own
-    // answer so a future fix has to move this row deliberately.
+    // answers so a future fix has to move these rows deliberately
+    // (`docs/compliance/yq/limitations.md`, "An `and`/`or` operand's
+    // evaluation context").
     for (filter, expected) in [
-        (".a | key and parent", "true"),
+        (".a | .b and true", "true"),
         (".a | true and .b", "true"),
+        (".a | true and .a.b", "false"),
+        (".c | true and .[0]", "true"),
+        (".a | 0 + .b", "1"),
+        (".a | (key) and true", "true"),
+        (".a | true and (key)", "true"),
+        (".a | key and parent", "true"),
     ] {
         let (output, code) = run_yq_stdin(filter, "a: {b: 1}\nc: [10, 20]\n", args)?;
+        assert_eq!(code, 0, "`{filter}`: {output:?}");
+        assert_eq!(output.trim(), expected, "`{filter}`");
+    }
+    // The same divergence with the *input* coming from an absent navigation:
+    // real yq answers `false` for all three, succinctly `true`.
+    for (filter, expected) in [
+        (".a.zz | key == \"zz\"", "true"),
+        (".a.zz | (key == \"zz\") and true", "true"),
+        (".a.zz | key and true", "true"),
+    ] {
+        let (output, code) = run_yq_stdin(filter, "a:\n  b: 1\n", args)?;
         assert_eq!(code, 0, "`{filter}`: {output:?}");
         assert_eq!(output.trim(), expected, "`{filter}`");
     }

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -32115,11 +32115,12 @@ fn test_absent_position_keeps_path_context_2416() -> Result<()> {
 /// `parent(0)` row is a straight fidelity gain, since the vivification
 /// never applies to the value itself.
 ///
-/// `{"p": parent, "k": key}` prints nothing here, in yq mode and jq mode
-/// alike: `needs_path_context` does not descend into `Expr::Object`
-/// (#1332), so that pipe is never seen as a path-context pipe by any route
-/// and `parent` is answered with no position at all. It is pinned as the
-/// pre-existing gap it is, unmoved by this change.
+/// `{"p": parent, "k": key}` printed nothing here when this test was written,
+/// in yq mode and jq mode alike, because `needs_path_context` did not descend
+/// into `Expr::Object` (#1332) and no route was ever asked. #2473 closed that
+/// half, so the row below is now resolved at the absent position like every
+/// other one -- with the same #2435 divergence on `parent` (succinctly prints
+/// the deepest real ancestor, `{"b":1}`; yq vivifies, `{"b":1,"x":null}`).
 #[test]
 fn test_absent_position_owned_identity_2472() -> Result<()> {
     let args = &["-o=json", "-I=0"];
@@ -32161,8 +32162,16 @@ fn test_absent_position_owned_identity_2472() -> Result<()> {
         (".a.x | tostring | parent | key", "\"a\""),
         (".a.x | length | key", "\"x\""),
         (".a.x.y | tostring | parent(2) | key", "\"a\""),
-        // #1332's object-construction gap, unmoved.
-        (".a.x | {\"p\": parent, \"k\": key}", ""),
+        // #1332's object-construction gap, closed by #2473: `needs_path_context`
+        // descends into `Expr::Object` now, so this pipe is seen as a
+        // path-context pipe and the absent position is resolved inside the
+        // construction. `parent` is the deepest real ancestor, the same
+        // #2435 divergence from yq's vivified `{"b":1,"x":null}` that the
+        // `[path, parent]` rows above already record.
+        (
+            ".a.x | {\"p\": parent, \"k\": key}",
+            "{\"p\":{\"b\":1},\"k\":\"x\"}",
+        ),
     ] {
         let (output, code) = run_yq_stdin(filter, doc, args)?;
         assert_eq!(code, 0, "`{filter}`: {output:?}");
@@ -32252,6 +32261,83 @@ fn test_owned_identity_rules_match_yq_2416() -> Result<()> {
         let (output, code) = run_yq_stdin(filter, doc, args)?;
         assert_eq!(code, 0, "{filter}");
         assert_eq!(output.trim_end(), expected, "{filter}");
+    }
+    Ok(())
+}
+
+/// #1332's other half, closed by #2473 (gate reason 3 of spine 2416):
+/// `needs_path_context` now descends into `Expr::Object`, so a
+/// `key`/`parent`/`path` inside an object literal is *routed* like any other
+/// path-context read instead of being invisible to routing entirely.
+///
+/// Before this, `{"x": key}` was never seen as a path-context read at all, so
+/// no route was ever asked. The generic evaluator's own `Expr::Object` arm
+/// (`build_object_entries_generic`, #2439) reads the cursor, so a *live-node*
+/// shape happened to be right; every shape that needs a route -- an absent
+/// position, or a value that has already left the cursor domain -- answered
+/// `null` (jq mode) or nothing (yq mode). All of them are captured rows now.
+///
+/// Captured 2026-09-06 from yq v4.53.3 on `a:\n  b: 1\nc:\n  - 10\n  - 20\n`,
+/// `-o=json -I=0`:
+///
+/// ```text
+/// $ yq '.a | {"k": key}'                        {"k":"a"}
+/// $ yq '.[] | {"k": key, "p": path}'            {"k":"a","p":["a"]} / {"k":"c","p":["c"]}
+/// $ yq '.zz | {"k": key}'                       {"k":"zz"}
+/// $ yq '.a.zz | {"k": key}'                     {"k":"zz"}
+/// $ yq '.a | tostring | {"k": key}'             {"k":"a"}
+/// $ yq '.c | to_entries | .[0] | {"k": key}'    {"k":0}
+/// $ yq '.a? | {"k": key}'                       {"k":"a"}
+/// $ yq '.a | {"k": key} as $o | $o'             {"k":"a"}
+/// $ yq '.a | {(key): 1}'                        {"a":1}
+/// $ yq '.a.b | {"k": key, "p": parent}'         {"k":"b","p":{"b":1}}
+/// $ yq '.a | {"k": (key + "!")}'                {"k":"a!"}
+/// $ yq '.a.zz | {"p": parent, "k": key}'        {"p":{"b":1,"zz":null},"k":"zz"}
+/// ```
+///
+/// Every row matches byte for byte except the last, which is the #2435
+/// vivification divergence `test_absent_position_owned_identity_2472` already
+/// records: succinctly prints the deepest real ancestor for an absent
+/// `parent`, yq materializes the missing key into it.
+#[test]
+fn test_object_construction_keeps_path_context_2473() -> Result<()> {
+    let args = &["-o=json", "-I=0"];
+    let doc = "a:\n  b: 1\nc:\n  - 10\n  - 20\n";
+    for (filter, expected) in [
+        (".a | {\"k\": key}", "{\"k\":\"a\"}"),
+        (
+            ".[] | {\"k\": key, \"p\": path}",
+            "{\"k\":\"a\",\"p\":[\"a\"]}\n{\"k\":\"c\",\"p\":[\"c\"]}",
+        ),
+        // An absent position: the constant route resolves `key` inside the
+        // construction now that the pipe is routed at all.
+        (".zz | {\"k\": key}", "{\"k\":\"zz\"}"),
+        (".a.zz | {\"k\": key}", "{\"k\":\"zz\"}"),
+        // A value that has left the cursor domain: the owned identity pipe.
+        (".a | tostring | {\"k\": key}", "{\"k\":\"a\"}"),
+        (".c | to_entries | .[0] | {\"k\": key}", "{\"k\":0}"),
+        // `?` is the head no route can walk, so this one reaches the eager
+        // evaluator -- whose value-construction arm evaluates the key/value
+        // slots at the stage's own position since #2473, instead of resetting
+        // the context before they run.
+        (".a? | {\"k\": key}", "{\"k\":\"a\"}"),
+        (".a | {\"k\": key} as $o | $o", "{\"k\":\"a\"}"),
+        (".a | {(key): 1}", "{\"a\":1}"),
+        (
+            ".a.b | {\"k\": key, \"p\": parent}",
+            "{\"k\":\"b\",\"p\":{\"b\":1}}",
+        ),
+        (".a | {\"k\": (key + \"!\")}", "{\"k\":\"a!\"}"),
+        // #2435: yq vivifies the missing key into the parent it returns
+        // (`{"b":1,"zz":null}`); succinctly prints the deepest real ancestor.
+        (
+            ".a.zz | {\"p\": parent, \"k\": key}",
+            "{\"p\":{\"b\":1},\"k\":\"zz\"}",
+        ),
+    ] {
+        let (output, code) = run_yq_stdin(filter, doc, args)?;
+        assert_eq!(code, 0, "`{filter}`: {output:?}");
+        assert_eq!(output.trim(), expected, "`{filter}`");
     }
     Ok(())
 }

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -32265,6 +32265,65 @@ fn test_owned_identity_rules_match_yq_2416() -> Result<()> {
     Ok(())
 }
 
+/// Spine 2416 gate reason 3 (#2473) in yq mode: a `reduce`/`foreach` whose
+/// source or INIT reads path context, and the `range`/`repeat`/`while`/`until`
+/// family that stays extension-only.
+///
+/// **Real yq has none of this syntax.** Captured 2026-09-06 from v4.53.3 on
+/// `a:\n  b: 1\n  c: 2\nd:\n  - 10\n  - 20\n`:
+///
+/// ```text
+/// $ yq '.a[] | reduce (key) as $k (""; . + $k)'   Error: 1:8: lexer: invalid input text "reduce (key) as ..."
+/// $ yq '.a | [range(2) | key]'                    Error: 1:7: lexer: invalid input text "range(2) | key]"
+/// $ yq '.a | [limit(2; repeat(key))]'             Error: 1:7: lexer: invalid input text "limit(2; repeat(..."
+/// $ yq '.a | [1 | while(. < 3; . + 1)]'           Error: 1:11: lexer: invalid input text "while(. < 3; . +..."
+/// $ yq '.a | [1 | until(. > 2; . + 1)]'           Error: 1:11: lexer: invalid input text "until(. > 2; . +..."
+/// ```
+///
+/// So these are succinctly extensions in yq mode (ADR-0018 rule 5), and the
+/// rows below pin succinctly's own answers. `reduce`/`foreach` are documented
+/// extensions accepted without a flag (`docs/reference/yq-language.md`);
+/// `range`/`limit` are gated behind `--jq-extensions` (#1512), and the gating
+/// error is pinned here too. `while`/`until` are *not* gated, a pre-existing
+/// gap in that gate rather than anything #2473 touches.
+#[test]
+fn test_fold_and_loop_path_context_2473() -> Result<()> {
+    let args = &["-o=json", "-I=0"];
+    let doc = "a:\n  b: 1\n  c: 2\nd:\n  - 10\n  - 20\n";
+    for (filter, expected) in [
+        (".a[] | reduce (key) as $k (\"\"; . + $k)", "\"b\"\n\"c\""),
+        (
+            ".a | reduce (.[] | key) as $k ([]; . + [$k])",
+            "[\"b\",\"c\"]",
+        ),
+        (
+            ".a[] | foreach (key) as $k (\"\"; . + $k; [$k, .])",
+            "[\"b\",\"b\"]\n[\"c\",\"c\"]",
+        ),
+        (".a | reduce (1,2) as $x (key; [., $x])", "[[\"a\",1],2]"),
+        // UPDATE reads the accumulator, which has no position.
+        ("reduce .d[] as $x (.a; [.[] | key])", "[0,1]"),
+    ] {
+        let (output, code) = run_yq_stdin(filter, doc, args)?;
+        assert_eq!(code, 0, "`{filter}`: {output:?}");
+        assert_eq!(output.trim(), expected, "`{filter}`");
+    }
+    // `range`/`limit` need `--jq-extensions`; the loops do not.
+    let (output, code) = run_yq_stdin(".a | [range(2) | key]", doc, args)?;
+    assert_ne!(code, 0, "{output:?}");
+    let ext = &["-o=json", "-I=0", "--jq-extensions"];
+    for (filter, expected) in [
+        (".a | [range(2) | key]", "[\"a\",\"a\"]"),
+        (".a[] | [range(2) | key]", "[\"b\",\"b\"]\n[\"c\",\"c\"]"),
+        (".a | [limit(2; repeat(key))]", "[]"),
+    ] {
+        let (output, code) = run_yq_stdin(filter, doc, ext)?;
+        assert_eq!(code, 0, "`{filter}`: {output:?}");
+        assert_eq!(output.trim(), expected, "`{filter}`");
+    }
+    Ok(())
+}
+
 /// #1332's other half, closed by #2473 (gate reason 3 of spine 2416):
 /// `needs_path_context` now descends into `Expr::Object`, so a
 /// `key`/`parent`/`path` inside an object literal is *routed* like any other

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -32256,6 +32256,88 @@ fn test_owned_identity_rules_match_yq_2416() -> Result<()> {
     Ok(())
 }
 
+/// Spine 2416 gate reason 3 (#2473): `and`/`or` with a path-context operand,
+/// against yq v4.53.3.
+///
+/// Captured 2026-09-06 on `a: 1\nb: 2\n`, `-o=json -I=0`:
+///
+/// ```text
+/// $ yq '.[] | key == "a" and true'          true / false
+/// $ yq '.[] | (key == "b") or false'        false / true
+/// $ yq '.[] | key and true'                 true / true
+/// $ yq '.[] | select(key == "a" and . == 1)' 1
+/// $ yq '.[] | {"k": (key and true)}'        {"k":true} / {"k":true}
+/// $ yq '.[] | [key, (key == "a" and true)]' ["a",true] / ["b",false]
+/// $ yq 'key and true'                       false
+/// $ yq 'key or false'                       false
+/// $ yq 'parent and true'                    false
+/// ```
+///
+/// `{"k": (key and true)}` was `{"k":false}` before this arm and is the row
+/// the migration is *for*: the object's value expression is single-evaluated,
+/// so an `and` inside it had no cursor until `eval_single` gained an arm.
+/// The three root rows are #2460's empty-operand rule (`key`/`parent` at the
+/// root emit nothing, and a zero-output operand contributes one `false`),
+/// unchanged by this arm because both routes read it from
+/// `yq_empty_operand_output`.
+///
+/// **One divergence stays, and it is not this arm's:** real yq evaluates an
+/// `and`/`or` *operand* against the document **root**, not against the node
+/// the pipe stands on. Captured on `a: {b: 1}\nc: [10, 20]\n`:
+///
+/// ```text
+/// $ yq '.a | true and .b'        false   (`.b` resolved at the root)
+/// $ yq '.a | true and .a.b'      true
+/// $ yq '.c | true and .[0]'      false
+/// $ yq '.a | true and (key)'     false   (`key` at the root is nothing)
+/// $ yq '.a | key and parent'     false   (ditto for `parent`)
+/// $ yq '.a | .b and true'        true    (the *left* operand is not re-rooted)
+/// $ yq '.a | 0 + .b'             1       (arithmetic is not re-rooted either)
+/// ```
+///
+/// succinctly evaluates both operands at the current node in both modes, so
+/// it answers `true` for `.a | key and parent`. That predates this arm (the
+/// eager route answered `true` too) and is orthogonal to path context --
+/// `.a | true and .b` diverges with no path-context builtin anywhere -- so it
+/// is recorded here rather than encoded.
+#[test]
+fn test_and_or_keep_path_context_2473() -> Result<()> {
+    let args = &["-o=json", "-I=0"];
+    let doc = "a: 1\nb: 2\n";
+    for (filter, expected) in [
+        (".[] | key == \"a\" and true", "true\nfalse"),
+        (".[] | (key == \"b\") or false", "false\ntrue"),
+        (".[] | key and true", "true\ntrue"),
+        (".[] | select(key == \"a\" and . == 1)", "1"),
+        (
+            ".[] | {\"k\": (key and true)}",
+            "{\"k\":true}\n{\"k\":true}",
+        ),
+        (
+            ".[] | [key, (key == \"a\" and true)]",
+            "[\"a\",true]\n[\"b\",false]",
+        ),
+        ("key and true", "false"),
+        ("key or false", "false"),
+        ("parent and true", "false"),
+    ] {
+        let (output, code) = run_yq_stdin(filter, doc, args)?;
+        assert_eq!(code, 0, "`{filter}`: {output:?}");
+        assert_eq!(output.trim(), expected, "`{filter}`");
+    }
+    // The re-rooted-operand divergence above, pinned as succinctly's own
+    // answer so a future fix has to move this row deliberately.
+    for (filter, expected) in [
+        (".a | key and parent", "true"),
+        (".a | true and .b", "true"),
+    ] {
+        let (output, code) = run_yq_stdin(filter, "a: {b: 1}\nc: [10, 20]\n", args)?;
+        assert_eq!(code, 0, "`{filter}`: {output:?}");
+        assert_eq!(output.trim(), expected, "`{filter}`");
+    }
+    Ok(())
+}
+
 const OWNED_IDENTITY_DOC_2416: &str = "a:\n  b: [1, 2, 3]\n  c: x\n  d: {e: 5}\nz: 9\n";
 
 /// `(filter, expected stdout)`, captured from yq v4.53.3; an empty expected


### PR DESCRIPTION
## Summary

Gate reason 3 of spine 2416: the constructs `path_context_stage_native` refused. One commit per construct plus two docs commits.

1. **`and`/`or` with a path-context operand run natively.** `eval_boolean_generic` over a refactored `boolean_fanout_bools`, so the loop, #2460's zero-output rule and #2470's read-only scope keep one definition and only the operand strategy varies; `eval_single` arms gated on `needs_path_context` so the ambient decode failure on a malformed document is kept. `.[] | {"k": (key and true)}` is `{"k":true}` as in yq (was `{"k":false}`).
2. **Object construction's slots go through path context** (#1332's other half). Adding `Expr::Object` to `needs_path_context` alone regressed 68 shapes, because pipes that were invisible to routing started going eager where the value-construction arm reset the context; fixed at the source with a pluggable slot evaluator, so the eager arm evaluates slots through the path-context pipe the way arrays have since #1302. Over a 1092-filter corpus classified against yq: 184 fixes, 0 regressions, 65 changed-but-both-wrong, each a pre-existing divergence made reachable by `key` now resolving (filed as #2507, #2508, plus #2377 and #2435 already on record). No new handler.
3. **`reduce`/`foreach` source and init read path context natively**; update and extract run against the accumulator, which has no position, identically on both routes. Pure route move, byte-identical off the root.
4. **`range`/`repeat`/`while`/`until`** are extension-only (yq's lexer rejects all four, jq has no path-context builtin), so no arms are added and current answers are pinned.

## Arm re-audit

Pin stays at 43: one proof query no longer enters the gate (the `and`/`or` arm's), but the arm still fires through all three gate reasons with re-derived queries, pinned in the parity test. The audit doc records that `.a? | ...` is now the largest reason-2 source, since the navigational predicate excludes `Optional` and the absent split therefore sees an empty head; that is the next migration.

## Found, not fixed

Real yq resolves an `and`/`or` right operand from the document root and answers `false` when the operator's input came from an absent navigation (`.a | true and .b` is `false`, `.a | true and .a.b` is `true`); pre-existing, recorded in the limitations doc and filed as #2506.

## Verification

fmt; clippy on both CI legs with `-D warnings`; `cargo test` in the three configurations; `cargo doc -D warnings`; yq goldens 113 and jq goldens 633; oracle sweep 3168 cases, 0 unexpected, manifest unchanged.

Closes #2473 (spine 2416, gate reason 3).
