### PR TITLE
fix(jq): yq writes through an alias reach the shared node

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -340,12 +340,23 @@ Real yq's `sort_keys` diverges the same way when sorting would move an alias abo
 declaration — and succinctly's own `--sort-keys` currently *reproduces* that unsound output,
 because the soundness pass doesn't reach the streaming path (#1350). That is a bug against
 the rule, not a second exception to it, so the "never" above is the intent and #1350 is the
-one place it does not hold. The equal-value rule also contains a real gap rather than
-papering over it:
-succinctly's alias sync is one-directional (anchor → aliases), so a write *through* an
-alias (`.b.p = 9`) updates only `.b`, where yq mutates the shared node. Emitting `b: *x`
-there would silently discard the write, so the mark is dropped and the computed value
-printed instead. True alias node identity remains unimplemented.
+one place it does not hold.
+
+**A write through an alias reaches the shared node (#1351).** yq decides by *path shape*: a
+path that ends exactly at an alias (`.b = 5`, `.b |= 5`, `del(.b)`) rebinds that position;
+one that passes through it and continues (`.b.p = 9`, `del(.b.p)`, `.b[0] = 9`,
+`setpath(["b","p"]; 9)`) mutates the anchor's node, and every position follows. succinctly
+keeps its copy model and recovers this in `jq::alias_identity`: for an alias-sensitive write
+on an alias-bearing document, the write entry points redirect any resolved path whose proper
+prefix is an alias position onto the anchor's path (transitively, and only while the alias
+position still holds the anchor's value — a slot rebound earlier in the pipe is written
+positionally), then mirror the anchor's new value back into every alias slot that was still
+an untouched copy. Shared positions accumulate (`.[] .p += 1` over three positions is 4, as
+in yq). Two recorded divergences: yq silently *discards* a value-producing update at an
+alias node (`.b += 1`, `.b |= . + {..}`), which succinctly rebinds instead (rule 4(b)); and
+with the anchor deleted earlier in the pipe there is nothing to redirect to, so the write
+stays positional. The equal-value rule above is then the backstop: wherever the redirect
+declines, the values differ and the mark is dropped rather than discarding the write.
 
 ### jq Position-Based Navigation (succinctly extension)
 

--- a/docs/adrs/adr-0017.md
+++ b/docs/adrs/adr-0017.md
@@ -181,6 +181,42 @@ what this ADR assumed:
   (`.b.p = 9`) updates only that position, so the values disagree, the mark is dropped,
   and the computed value is printed — rather than `*x` silently discarding the write.
 
+### Amendment (#1351, implemented): alias *identity* is a path redirect, not a shared node
+
+The one gap the #763 amendment left open — a write *through* an alias updating only that
+position — is closed without either of the alternatives this ADR rejects. The observation
+that made it tractable: real yq decides whether a write mutates the shared node or rebinds a
+position **by path shape alone** (`.b = {"p": 4}` rebinds; `.b.p = 4` mutates the node both
+`a` and `b` resolve to), never by value. So no value-level diff can recover the distinction,
+and a mutable shared-node document is not needed to honour it either — the resolved
+concrete path, which the write entry points already compute, carries the answer.
+
+`jq::alias_identity` (in `eval.rs`) is an ambient table of `(alias path → anchor path)`
+pairs derived from `collect_alias_groups`, installed by `evaluate_yaml_cursor` only for an
+alias-sensitive write against an alias-bearing document (the same gate as `sync_aliased_paths`),
+and consulted at every yq-mode write entry point (`=`, `|=`, compound and alternative
+assignment, `del()`, `setpath`, `delpaths`):
+
+- a resolved path whose *proper* prefix is an alias position is rewritten onto the anchor's
+  path, transitively; a path ending exactly at the alias is left alone (`.b = 5` rebinds);
+  `|=` also redirects its terminal position when its filter is itself a shape-preserving
+  write (`.b |= (.p = 9)`), matching yq;
+- the redirect is gated on *identity by equality* — the alias position must still hold the
+  anchor's value — which is what lets a positional model stand in for a graph: a position
+  rebound earlier in the pipe no longer matches and is written positionally, exactly as yq
+  treats a rebound position;
+- after each write expression the anchor's new value is mirrored into every alias slot that
+  was still an untouched copy of it before the write, iterating to a fixpoint over nested
+  groups, so later pipe stages see a consistent document and shared positions accumulate
+  (`.[] .p += 1` over three positions is 4, as in yq).
+
+`OwnedValue`'s shape and the JSON evaluator are untouched; jq mode never installs a table.
+Two behaviours are recorded in `compliance/yq/limitations.md` as divergences rather than
+matched: yq's silent discard of a value-producing update at an alias node (`.b += 1`) is
+refused under rule 4(b) and rebinds instead, and a declaration deleted earlier in the pipe
+leaves nothing to redirect to. The equal-value soundness rule from the #763 amendment
+remains the backstop for both.
+
 ## Consequences
 
 **Positive:**

--- a/docs/adrs/adr-0018.md
+++ b/docs/adrs/adr-0018.md
@@ -196,10 +196,12 @@ writing against one of them:
 - **(a) The reference emits output it cannot itself consume.** Anchor soundness
   ([#763](https://github.com/rust-works/succinctly/issues/763)) is the case: real `yq`
   prints `b: *x` with no `&x` anywhere and then rejects its own output.
-- **(b) Matching would corrupt a document or silently discard a write.** The remaining half
-  of the anchor rule is this: succinctly's alias sync is one-directional, so emitting `*x`
-  after a write *through* the alias would discard the write; it prints the computed value
-  instead.
+- **(b) Matching would corrupt a document or silently discard a write.** The anchor rule's
+  other half is this: real yq silently discards a value-producing update at an alias node
+  (`.b += 1` on `b: *x` prints the document unchanged), and succinctly rebinds the position
+  with the computed value instead; likewise wherever the alias redirect declines
+  ([#1351](https://github.com/rust-works/succinctly/issues/1351)) it prints the computed
+  value rather than a `*x` that would discard the write.
 - **(c) Matching would take the host process down.** succinctly is a library as well as a
   CLI, so a crash is a caller's crash. `null | setpath([1e30]; 9)` gets jq killed on the
   allocation; succinctly refuses with `Cannot grow array to <n> elements` — see

--- a/docs/compliance/yq/limitations.md
+++ b/docs/compliance/yq/limitations.md
@@ -93,8 +93,12 @@ $ printf 'a: &x {p: 1}\nb: *x\nc: *x\n' | succinctly yq -o=json -I=0 '.[] .p += 
 
 The redirect is gated on *identity by equality*: it applies only while the alias position
 still holds the anchor's value, so a position rebound earlier in the pipe (`.b = 5 | .b.p =
-9`) is written positionally, as yq treats a rebound position. Two consequences are recorded
-divergences/limitations rather than matches:
+9`) is written positionally, as yq treats a rebound position. The gate's one false positive
+is a rebind to a value *equal* to the anchor's: `.b = .a | .a.p = 9` (or `.b = {"p": 1, "q":
+2} | .a.p = 9`) detaches `b` in yq (`b: {p: 1, q: 2}`), while succinctly cannot tell the
+rebound copy from an untouched one and keeps it in step (`b: *x`, value `{p: 9, q: 2}`). The
+written value is never affected, only which other positions follow it. Two further
+consequences are recorded divergences/limitations rather than matches:
 
 - **A value-producing update at an alias node is not discarded — rule 4(b).** Real yq
   no-ops `.b |= . + 1`, `.b += 1`, `.b += [3]` and `.b |= . + {"r": 3}` at an alias node

--- a/docs/compliance/yq/limitations.md
+++ b/docs/compliance/yq/limitations.md
@@ -73,12 +73,46 @@ $ printf 'a: &x 1\nb: *x\n' | succinctly yq 'del(.a)'
 b: 1
 ```
 
-The equal-value clause also covers a genuine gap rather than papering over it: succinctly's
-alias sync is one-directional (anchor → aliases), so a write *through* an alias (`.b.p = 9`)
-updates only that position where real yq mutates the shared node. Emitting `*x` there would
-silently discard the write, so the mark is dropped and the computed value printed — rule
-4(b). True alias node identity remains unimplemented
-([#1351](https://github.com/rust-works/succinctly/issues/1351)).
+The equal-value clause is also the backstop for alias *node identity*
+([#1351](https://github.com/rust-works/succinctly/issues/1351)). Real yq treats `&x`/`*x` as
+one node: a write whose path passes *through* an alias and continues (`.b.p = 9` on `b: *x`)
+mutates the anchor's node and every position follows, while a path that ends exactly at the
+alias (`.b = 5`) rebinds that position only. succinctly's `jq::alias_identity` redirects such
+a through-path onto the anchor's own path before the write runs (transitively for an alias
+inside an anchored mapping that is itself aliased) and mirrors the result back into every
+alias slot that was still an untouched copy, so `b: *x` survives:
+
+```bash
+$ printf 'a: &x {p: 1, q: 2}\nb: *x\nc: *x\n' | succinctly yq '.b.p = 9'
+a: &x {p: 9, q: 2}
+b: *x
+c: *x
+$ printf 'a: &x {p: 1}\nb: *x\nc: *x\n' | succinctly yq -o=json -I=0 '.[] .p += 1'
+{"a":{"p":4},"b":{"p":4},"c":{"p":4}}        # three positions, one node: matches yq
+```
+
+The redirect is gated on *identity by equality*: it applies only while the alias position
+still holds the anchor's value, so a position rebound earlier in the pipe (`.b = 5 | .b.p =
+9`) is written positionally, as yq treats a rebound position. Two consequences are recorded
+divergences/limitations rather than matches:
+
+- **A value-producing update at an alias node is not discarded — rule 4(b).** Real yq
+  no-ops `.b |= . + 1`, `.b += 1`, `.b += [3]` and `.b |= . + {"r": 3}` at an alias node
+  (the document comes out unchanged) and errors on `.b |= reverse` / `.b |= keys` /
+  `.b *= {..}` (`node at path [b] is not an array (it's a )`). succinctly rebinds the
+  position with the computed value, consistent with `.b |= 5` (which yq also rebinds).
+  `.b |= (.p = 9)` and `.b |= del(.p)`, whose body is itself a write, mutate the shared node
+  in both tools.
+- **A declaration deleted earlier in the pipe leaves nothing to redirect to.**
+  `del(.a) | .b.p = 9` writes `b` positionally and `c` does not follow (yq prints `b: *x` /
+  `c: *x` with no `&x` anywhere — the unreadable-output case above). Likewise an alias
+  group's paths are recorded against the pristine document, so an array-shifting stage
+  ahead of the write (`del(.items[0]) | .items[0].n = 9`) leaves them one element off
+  ([#2501](https://github.com/rust-works/succinctly/issues/2501), the value-level twin of
+  #870).
+
+Wherever the redirect declines, the values differ and the equal-value clause drops the mark
+and prints the computed value, rather than emitting `*x` and discarding the write.
 
 A related, narrower gap sits in `select`/`if`'s condition-truthiness check
 (`push_generic_truthiness_cursor_error`, [src/jq/eval_generic.rs](../../../src/jq/eval_generic.rs)):

--- a/docs/compliance/yq/limitations.md
+++ b/docs/compliance/yq/limitations.md
@@ -119,11 +119,13 @@ consequences are recorded divergences/limitations rather than matches:
 Wherever the redirect declines, the values differ and the equal-value clause drops the mark
 and prints the computed value, rather than emitting `*x` and discarding the write.
 
-The redirect runs on the route that builds a `CommentTree` (stdout, `--split-exp`,
-`--front-matter`); `--inplace` and `--eval-all` evaluate without it, so `yq -i '.b.p = 9'`
-still writes `b` positionally and drops the marks — the value half of the
-[#1349](https://github.com/rust-works/succinctly/issues/1349) route gap. A multi-document
-stream applies the redirect and the anchor marks to the last document only
+The redirect runs wherever a write goes through `evaluate_yaml_cursor` — stdout,
+`--split-exp`, `--front-matter`, and since
+[#1349](https://github.com/rust-works/succinctly/issues/1349) `--inplace` too (`yq -i
+'.b.p = 9'` writes `a: &x {p: 9, q: 2}` / `b: *x` back to the file). `--eval-all`
+evaluates the collected documents without it, so `yq ea '.b.p = 9'` still writes `b`
+positionally and drops the marks. A multi-document stream applies the redirect and the
+anchor marks to the last document only
 ([#2520](https://github.com/rust-works/succinctly/issues/2520), pre-existing).
 
 A related, narrower gap sits in `select`/`if`'s condition-truthiness check

--- a/docs/compliance/yq/limitations.md
+++ b/docs/compliance/yq/limitations.md
@@ -102,8 +102,9 @@ consequences are recorded divergences/limitations rather than matches:
 
 - **A value-producing update at an alias node is not discarded — rule 4(b).** Real yq
   no-ops `.b |= . + 1`, `.b += 1`, `.b += [3]` and `.b |= . + {"r": 3}` at an alias node
-  (the document comes out unchanged) and errors on `.b |= reverse` / `.b |= keys` /
-  `.b *= {..}` (`node at path [b] is not an array (it's a )`). succinctly rebinds the
+  (the document comes out unchanged) and errors on `.b |= reverse` (`node at path [b] is
+  not an array (it's a )`), `.b |= keys` (`cannot get keys of , keys only works for maps
+  and arrays`) and `.b *= {..}` (`cannot multiply  with !!map`). succinctly rebinds the
   position with the computed value, consistent with `.b |= 5` (which yq also rebinds).
   `.b |= (.p = 9)` and `.b |= del(.p)`, whose body is itself a write, mutate the shared node
   in both tools.
@@ -117,6 +118,13 @@ consequences are recorded divergences/limitations rather than matches:
 
 Wherever the redirect declines, the values differ and the equal-value clause drops the mark
 and prints the computed value, rather than emitting `*x` and discarding the write.
+
+The redirect runs on the route that builds a `CommentTree` (stdout, `--split-exp`,
+`--front-matter`); `--inplace` and `--eval-all` evaluate without it, so `yq -i '.b.p = 9'`
+still writes `b` positionally and drops the marks — the value half of the
+[#1349](https://github.com/rust-works/succinctly/issues/1349) route gap. A multi-document
+stream applies the redirect and the anchor marks to the last document only
+([#2520](https://github.com/rust-works/succinctly/issues/2520), pre-existing).
 
 A related, narrower gap sits in `select`/`if`'s condition-truthiness check
 (`push_generic_truthiness_cursor_error`, [src/jq/eval_generic.rs](../../../src/jq/eval_generic.rs)):

--- a/scripts/yq-alias-oracle-sweep.sh
+++ b/scripts/yq-alias-oracle-sweep.sh
@@ -1,0 +1,142 @@
+#!/usr/bin/env bash
+#
+# Differential oracle sweep for yq-mode writes over alias-bearing YAML
+# (#1351 and its split-outs #2497/#2498/#2499/#2500).
+#
+# Cross-products a small alphabet of anchor/alias document shapes with a set
+# of write filters, runs each case through the built succinctly binary and
+# the pinned real yq (v4.53.3), and classifies every difference *by
+# direction* rather than reporting a bare mismatch count:
+#
+#   same              values and YAML text identical
+#   yq-unsound        real yq's output does not re-read as YAML at all (e.g. a
+#                     `*x` with no `&x` left) -- rule 4(a) territory, expected
+#   yq-discards       real yq's values equal its *input* although the filter
+#                     writes something -- yq silently dropped the write; rule
+#                     4(b) territory, expected
+#   presentation      values agree, YAML text differs (marks/style/comments)
+#   values-differ     values differ and neither yq-side excuse applies --
+#                     a succinctly bug until proven otherwise
+#
+# The alphabet deliberately includes the shapes yq itself gets wrong (see
+# docs/compliance/yq/limitations.md), so the sweep reports them as expected
+# divergences instead of hiding them -- a generator that cannot emit the
+# reference's own bugs cannot tell a refusal from a regression.
+#
+# Usage:
+#   cargo build --release --features cli
+#   ./scripts/yq-alias-oracle-sweep.sh [--summary] [--all] [binary]
+#
+# Without --summary the full TSV record is printed:
+#   class <TAB> doc <TAB> filter <TAB> yq_json <TAB> succ_json <TAB> yq_yaml <TAB> succ_yaml
+# (newlines escaped as \n). With --summary only the per-class counts and the
+# `values-differ`/`presentation` rows are shown. `--all` also lists the rows
+# in the two expected-divergence classes.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SUMMARY=0
+SHOW_ALL=0
+SUCC=""
+for arg in "$@"; do
+  case "$arg" in
+    --summary) SUMMARY=1 ;;
+    --all) SHOW_ALL=1 ;;
+    *) SUCC="$arg" ;;
+  esac
+done
+SUCC="${SUCC:-$REPO_ROOT/target/release/succinctly}"
+YQ="${YQ:-yq}"
+
+if [[ ! -x "$SUCC" ]]; then
+  echo "error: succinctly binary not found at $SUCC -- run: cargo build --release --features cli" >&2
+  exit 1
+fi
+if ! "$YQ" --version 2>/dev/null | grep -q 'v4\.53\.3'; then
+  echo "warning: $YQ is not the pinned v4.53.3: $("$YQ" --version 2>&1)" >&2
+fi
+
+# name|document (\n-escaped)
+DOCS=(
+  'map2|a: &x {p: 1, q: 2}\nb: *x\nc: *x\n'
+  'seq|a: &x [1, 2]\nb: *x\n'
+  'scalar|a: &x 1\nb: *x\n'
+  'nested|a: &x\n  p: &y 1\n  q: *y\nb: *x\n'
+  'multihop|x: &y {z: 0}\na: &x {q: *y}\nb: *x\n'
+  'items|items:\n  - &t {n: 1}\n  - *t\n  - *t\n'
+  'defout|x: &y 1\na: &x {q: *y}\nb: *x\n'
+  'cont|a: &x {s: [1, 2]}\nb: *x\n'
+)
+
+# Filters applied to every document whose paths resolve (a path that does not
+# apply to a shape is still run -- yq and succinctly should then agree on the
+# no-op or error too).
+FILTERS=(
+  '.b.p = 9' '.b.p |= . + 1' '.b.p += 1' 'del(.b.p)' '.b.r = 3'
+  '.b = 5' '.b |= 5' 'del(.b)' '.b = .c' '.c = .b' '.c = .a'
+  '.b |= (.p = 9)' '.b |= del(.p)' '.b |= . + {"r": 3}' '.b |= . + 1' '.b += 1'
+  '.[] .p += 1' '.[].p |= . + 1' '(.b, .c).p = 2'
+  '.b.p = 9 | .c.q = 8' '.b.p = 9 | .b = 5' '.b = 5 | .b.p = 9' '.b = null | .a.p = 9'
+  '.[].p = 9 | .a.q = 7' '.a.p = 9 | .b.p = 9 | .a.q = 7' '.b.p = 9 | .a.q = 7'
+  'del(.a) | .b.p = 9' 'del(.a) | .b.p = 9 | .c'
+  'setpath(["b","p"]; 9)' 'delpaths([["b","p"]])' 'del(.b.p, .c.q)'
+  '.b[0] = 9' '.b[-1] = 5' '.b[2] = 3' 'del(.b[0])' '.b += [3]'
+  '.b.s[0] = 9' '.b.q.z = 1' '.b.q = 5' '.b.p = 5' '.a.p = 5' '.x = 5'
+  '.items[].n += 1' '.items[1].n = 9' '.items[1] = {"n": 3}' 'del(.items[1])'
+  '.b = .a | .a.p = 9' '.c = .b | .d = .c' '.c = (.b + 1)' '.c = .b | .c = 1'
+)
+
+esc() { printf '%s' "$1" | awk 'BEGIN{ORS="\\n"} {print}' ; }
+
+declare -A COUNT
+ROWS=()
+for entry in "${DOCS[@]}"; do
+  name="${entry%%|*}"; doc="${entry#*|}"
+  input="$(printf "$doc")"
+  input_json="$(printf '%s' "$input" | "$YQ" -o=json -I=0 '.' 2>/dev/null || true)"
+  for f in "${FILTERS[@]}"; do
+    yq_json="$(printf '%s' "$input" | "$YQ" -o=json -I=0 "$f" 2>&1 || true)"
+    succ_json="$(printf '%s' "$input" | "$SUCC" yq -o=json -I=0 "$f" 2>&1 || true)"
+    yq_yaml="$(printf '%s' "$input" | "$YQ" "$f" 2>&1 || true)"
+    succ_yaml="$(printf '%s' "$input" | "$SUCC" yq "$f" 2>&1 || true)"
+    if [[ "$yq_json" == "$succ_json" && "$yq_yaml" == "$succ_yaml" ]]; then
+      class=same
+    elif ! printf '%s\n' "$yq_yaml" | "$YQ" '.' >/dev/null 2>&1; then
+      class=yq-unsound
+    elif [[ "$yq_json" == "$input_json" && "$succ_json" != "$input_json" ]]; then
+      class=yq-discards
+    elif [[ "$yq_json" == "$succ_json" ]]; then
+      class=presentation
+    else
+      class=values-differ
+    fi
+    COUNT[$class]=$(( ${COUNT[$class]:-0} + 1 ))
+    ROWS+=("$class	$name	$f	$(esc "$yq_json")	$(esc "$succ_json")	$(esc "$yq_yaml")	$(esc "$succ_yaml")")
+  done
+done
+
+if [[ $SUMMARY -eq 0 ]]; then
+  printf '%s\n' "${ROWS[@]}"
+  exit 0
+fi
+
+echo "cases: ${#ROWS[@]}"
+for c in same presentation values-differ yq-unsound yq-discards; do
+  echo "  $c: ${COUNT[$c]:-0}"
+done
+echo
+for row in "${ROWS[@]}"; do
+  class="${row%%	*}"
+  case "$class" in
+    values-differ|presentation) ;;
+    yq-unsound|yq-discards) [[ $SHOW_ALL -eq 1 ]] || continue ;;
+    *) continue ;;
+  esac
+  IFS=$'\t' read -r cls name f yj sj yy sy <<<"$row"
+  echo "[$cls] $name :: $f"
+  echo "    yq   json: $yj"
+  echo "    succ json: $sj"
+  echo "    yq   yaml: $yy"
+  echo "    succ yaml: $sy"
+done

--- a/src/bin/succinctly/yq_runner.rs
+++ b/src/bin/succinctly/yq_runner.rs
@@ -25,7 +25,7 @@ use succinctly::jq::stream::StreamFailure;
 use succinctly::jq::{
     self, alias_identity, assert_value_tree_depth, is_alias_sensitive_assign,
     nesting_depth_exceeded_message, nonfinite_display_string, sync_aliased_paths, Builtin,
-    EvalError, Expr, NumberRepr, ObjectKey, OwnedValue, QueryResult, YqSemantics,
+    EvalError, Expr, Literal, NumberRepr, ObjectKey, OwnedValue, QueryResult, YqSemantics,
 };
 use succinctly::json::light::JsonCursor;
 use succinctly::json::JsonIndex;
@@ -1895,6 +1895,43 @@ struct WriteTarget {
 /// spelled with those two variants. [`Expr::Index`]'s `key` slot only
 /// carries a *spelling* for `path()` output; `idx` is what navigation —
 /// and therefore reconciliation — actually uses.
+/// The elements of an array literal's body: the parser stores `[a, b]` as
+/// `Array(Comma([a, b]))` and a one-element `[a]` as `Array(a)`.
+fn array_literal_items(inner: &Expr) -> Vec<&Expr> {
+    match inner {
+        Expr::Comma(items) => items.iter().collect(),
+        single => vec![single],
+    }
+}
+
+/// [`static_path_steps`] for a path spelled as an array literal of string
+/// and integer literals (`["arr", 0]`), the form `setpath`/`delpaths` take.
+fn literal_path_steps(expr: &Expr, out: &mut Vec<PathStep>) -> bool {
+    let Expr::Array(inner) = expr else {
+        return false;
+    };
+    array_literal_items(inner).iter().all(|item| match item {
+        Expr::Literal(Literal::String(key)) => {
+            out.push(PathStep::Key(key.clone()));
+            true
+        }
+        Expr::Literal(Literal::Int(idx)) => {
+            out.push(PathStep::Index(*idx));
+            true
+        }
+        // The parser keeps an integer literal's spelling (`NumberLiteral`,
+        // #1008); only a plain integer spelling names an index.
+        Expr::Literal(Literal::NumberLiteral(_, text)) => match text.parse::<i64>() {
+            Ok(idx) => {
+                out.push(PathStep::Index(idx));
+                true
+            }
+            Err(_) => false,
+        },
+        _ => false,
+    })
+}
+
 fn static_path_steps(expr: &Expr, out: &mut Vec<PathStep>) -> bool {
     match expr {
         Expr::Identity => true,
@@ -1920,7 +1957,8 @@ fn static_path_steps(expr: &Expr, out: &mut Vec<PathStep>) -> bool {
 /// while `.o = {"a": .o.a}` keeps it because that one is the original node
 /// arriving by a different route (both verified against yq v4.53.3).
 /// Provable closedness is the half of that distinction reachable without a
-/// shared-node value model (#1351).
+/// shared-node value model (#1351 closed the alias half of that model with a
+/// path redirect, not a shared node, so this half still stands alone).
 ///
 /// Deliberately one-directional: `true` means "certainly constructed", and
 /// anything not on this list answers `false` even when it happens to be
@@ -1997,6 +2035,47 @@ fn collect_write_targets(expr: &Expr) -> Option<Vec<WriteTarget>> {
             | Expr::CompoundAssign { path, .. }
             | Expr::AlternativeAssign { path, .. } => push(path, WriteKind::Set, false, out),
             Expr::Builtin(Builtin::Del(inner)) => push(inner, WriteKind::Del, false, out),
+            // `setpath(["a", 0]; v)` / `delpaths([["a", 0]])` name their
+            // paths as array literals (#1351 made both alias-sensitive, so
+            // they reach this walk). Only a literal path list is static; a
+            // computed one gives up the whole expression, as a computed
+            // `.[(.i)]` does above.
+            Expr::Builtin(Builtin::SetPath(path, value)) => {
+                let mut steps = Vec::new();
+                if !literal_path_steps(path, &mut steps) {
+                    return false;
+                }
+                out.push(WriteTarget {
+                    path: steps,
+                    kind: WriteKind::Set,
+                    fresh: is_closed_literal(value),
+                });
+                true
+            }
+            // Only a one-path list: yq applies `delpaths` sequentially (a
+            // second index resolves against the already-shortened array, so
+            // `[["arr",0],["arr",2]]` on three elements deletes one, verified
+            // live), which is not the simultaneous set `array_sources` models
+            // for `del(.a, .b)`; a longer list gives up as a non-static write.
+            Expr::Builtin(Builtin::DelPaths(paths)) => {
+                let Expr::Array(inner) = paths.as_ref() else {
+                    return false;
+                };
+                let items = array_literal_items(inner);
+                let [single] = items.as_slice() else {
+                    return false;
+                };
+                let mut steps = Vec::new();
+                if !literal_path_steps(single, &mut steps) {
+                    return false;
+                }
+                out.push(WriteTarget {
+                    path: steps,
+                    kind: WriteKind::Del,
+                    fresh: false,
+                });
+                true
+            }
             Expr::Identity
             | Expr::Builtin(
                 Builtin::Select(_) | Builtin::Empty | Builtin::Debug | Builtin::DebugMsg(_),
@@ -2335,8 +2414,9 @@ fn owned_value_align_hash(value: &OwnedValue) -> u64 {
 ///    children by value would let one key inherit a *different* key's
 ///    comment — the very misattribution #870 is about.
 ///
-/// Closing (1) and (2) properly needs the shared-node value model tracked
-/// by #1351 and #865.
+/// Closing (1) and (2) properly needs a node-identity model for the values
+/// themselves (#865; #1351's alias redirect gives anchors and aliases that
+/// identity, not arbitrary reshaped nodes).
 fn reconcile_presentation(
     pristine_value: &OwnedValue,
     pristine_tree: &CommentTree,
@@ -2586,14 +2666,15 @@ enum TreeStep<'a> {
 /// three in practice: `yq 'del(.a)'` on `a: &x 1\nb: *x` prints `b: *x`
 /// with no anchor left anywhere, and `yq` then rejects its own output with
 /// `unknown anchor 'x' referenced` (verified against the pinned binary).
-/// Rule 3 is also the backstop for the alias *value* model: since #1351 a
-/// write *through* an alias (`.b.p = 9`) is redirected onto the anchor's
+/// The rules are also the backstop for the alias *value* model: since #1351
+/// a write *through* an alias (`.b.p = 9`) is redirected onto the anchor's
 /// node (`jq::alias_identity`) and every alias slot follows, so the two
-/// sides agree and `b: *x` survives; wherever that redirect declines (the
-/// anchor was deleted earlier in the pipe, or a position was rebound and
-/// then written through) the values differ and the mark is dropped —
-/// printing `b: {p: 9}` (the value succinctly computed) instead of `b: *x`
-/// (which would discard the write entirely).
+/// sides agree and `b: *x` survives. Wherever that redirect declines, one of
+/// the rules drops the mark instead of letting `*x` discard the write: a
+/// position rebound and then written through no longer equals its anchor
+/// (rule 3), and an anchor deleted earlier in the pipe leaves no declaration
+/// at all (rule 1) — printing `b: {p: 9}` (the value succinctly computed)
+/// either way.
 ///
 /// Anchor *declarations* are never dropped: an unreferenced `&x` is valid
 /// YAML and real `yq` keeps it (`yq 'del(.b)'` still prints `a: &x 1`).

--- a/src/bin/succinctly/yq_runner.rs
+++ b/src/bin/succinctly/yq_runner.rs
@@ -23,9 +23,9 @@ use succinctly::jq::eval_generic::{
 };
 use succinctly::jq::stream::StreamFailure;
 use succinctly::jq::{
-    self, assert_value_tree_depth, nesting_depth_exceeded_message, nonfinite_display_string,
-    sync_aliased_paths, Builtin, EvalError, Expr, NumberRepr, ObjectKey, OwnedValue, QueryResult,
-    YqSemantics,
+    self, alias_identity, assert_value_tree_depth, is_alias_sensitive_assign,
+    nesting_depth_exceeded_message, nonfinite_display_string, sync_aliased_paths, Builtin,
+    EvalError, Expr, NumberRepr, ObjectKey, OwnedValue, QueryResult, YqSemantics,
 };
 use succinctly::json::light::JsonCursor;
 use succinctly::json::JsonIndex;
@@ -1769,75 +1769,10 @@ fn query_result_to_owned_values(
     }
 }
 
-/// Whether `expr` is itself an assignment-family write: `.path = value`,
-/// `|=`, a compound assign, `//=`, or `del(...)`. Unwraps `Paren`/`Optional`
-/// so `(.a = 1)?` still counts, and recurses into `Pipe` so a chain counts
-/// as soon as *any* stage writes.
-///
-/// Split out from [`is_alias_sensitive_assign`] so a pipe made entirely of
-/// pass-through stages (`select(true) | debug`, no write at all) doesn't
-/// pay for alias-sync snapshotting -- only a pipe that both preserves shape
-/// *and* actually writes somewhere needs the pristine-vs-result diff.
-fn contains_assign(expr: &Expr) -> bool {
-    match expr {
-        Expr::Assign { .. }
-        | Expr::Update { .. }
-        | Expr::CompoundAssign { .. }
-        | Expr::AlternativeAssign { .. }
-        | Expr::Builtin(Builtin::Del(_)) => true,
-        Expr::Paren(inner) | Expr::Optional(inner) => contains_assign(inner),
-        Expr::Pipe(stages) => stages.iter().any(contains_assign),
-        _ => false,
-    }
-}
-
-/// Whether `expr`'s top-level shape is "rewrite the document at specific
-/// paths, leaving everything else identical" -- the class of expression for
-/// which comparing a path's value before and after the write is meaningful.
-/// Unwraps `Paren`/`Optional` so `(.a = 1)?` still matches, and recurses into
-/// `Pipe` so a chain matches when every stage does, whether the stage is a
-/// write (`.a = 1 | .b = 2`) or one of a small allow-list of pass-through
-/// stages that provably either emit the input document completely unchanged
-/// or emit nothing at all: `.` (`Identity`), `select(...)`, `empty`,
-/// `debug`/`debug(msg)`. Mixing one into an assignment pipe (`.a = 1 |
-/// select(.a > 0)`, the guard-style `yq -i` idiom from #764) still leaves
-/// "the same path means the same thing" true for every document that comes
-/// out the other end, since none of these four ever rewrite or reshape the
-/// value they pass through -- unlike `map`, `select`'s own predicate or
-/// `debug`'s own message expression never appear in the pipeline's output,
-/// only their pass/fail or side-effect result does, so `contains_assign`
-/// deliberately does not recurse into either.
-///
-/// Used to gate the alias-sync post-process (#711): outside this class (a
-/// bare `map`, `.a, .b`, ...) the result document doesn't necessarily share
-/// the input's shape at all, so diffing "the same path" in both would be
-/// meaningless at best and could clobber it at worst. A pipe with a stage
-/// outside both the write list and this pass-through allow-list is
-/// conservatively excluded for the same reason -- verifying more stages
-/// preserve paths is left for a future extension, not assumed here.
-fn is_alias_sensitive_assign(expr: &Expr) -> bool {
-    fn is_shape_preserving(expr: &Expr) -> bool {
-        match expr {
-            Expr::Assign { .. }
-            | Expr::Update { .. }
-            | Expr::CompoundAssign { .. }
-            | Expr::AlternativeAssign { .. }
-            | Expr::Identity
-            | Expr::Builtin(
-                Builtin::Del(_)
-                | Builtin::Select(_)
-                | Builtin::Empty
-                | Builtin::Debug
-                | Builtin::DebugMsg(_),
-            ) => true,
-            Expr::Paren(inner) | Expr::Optional(inner) => is_shape_preserving(inner),
-            Expr::Pipe(stages) => stages.iter().all(is_shape_preserving),
-            _ => false,
-        }
-    }
-
-    is_shape_preserving(expr) && contains_assign(expr)
-}
+// `is_alias_sensitive_assign` (and its `contains_assign` half) moved into the
+// library (`jq::is_alias_sensitive_assign`, #1351) so the alias-identity
+// redirect's `|=` terminal rule and this file's alias-sync/presentation gates
+// read one definition.
 
 /// Walk `cursor`'s document collecting, for every anchor with at least one
 /// alias, its definition path and the path of every alias that resolves to
@@ -2651,12 +2586,14 @@ enum TreeStep<'a> {
 /// three in practice: `yq 'del(.a)'` on `a: &x 1\nb: *x` prints `b: *x`
 /// with no anchor left anywhere, and `yq` then rejects its own output with
 /// `unknown anchor 'x' referenced` (verified against the pinned binary).
-/// Rule 3 is also what keeps the gap in succinctly's own alias *value*
-/// model safe rather than wrong: a write *through* an alias (`.b.p = 9`)
-/// updates only `.b`, where real `yq` mutates the shared node, so the two
-/// sides no longer agree and the mark is dropped — printing `b: {p: 9}`
-/// (the value succinctly computed) instead of `b: *x` (which would discard
-/// the write entirely).
+/// Rule 3 is also the backstop for the alias *value* model: since #1351 a
+/// write *through* an alias (`.b.p = 9`) is redirected onto the anchor's
+/// node (`jq::alias_identity`) and every alias slot follows, so the two
+/// sides agree and `b: *x` survives; wherever that redirect declines (the
+/// anchor was deleted earlier in the pipe, or a position was rebound and
+/// then written through) the values differ and the mark is dropped —
+/// printing `b: {p: 9}` (the value succinctly computed) instead of `b: *x`
+/// (which would discard the write entirely).
 ///
 /// Anchor *declarations* are never dropped: an unreferenced `&x` is valid
 /// YAML and real `yq` keeps it (`yq 'del(.b)'` still prints `a: &x 1`).
@@ -2857,7 +2794,16 @@ fn evaluate_yaml_cursor<W: AsRef<[u64]> + Clone>(
         .and_then(|_| collect_write_targets(expr))
         .unwrap_or_default();
 
+    // #1351: for the duration of the write, let the evaluator's write entry
+    // points see which positions share a node, so a path descending *through*
+    // an alias (`.b.p = 9` on `b: *x`) lands on the anchor's node and every
+    // alias slot follows -- see `jq::alias_identity`. Same gate as the sync
+    // context above: nothing is installed for a read or an alias-free document.
+    let alias_identity_guard = alias_sync_ctx.as_ref().map(|(_, groups)| {
+        alias_identity::enter(alias_identity::AliasTable::from_groups(groups.clone()))
+    });
     let result = eval_with_cursor_using::<YqSemantics, _>(expr, cursor);
+    drop(alias_identity_guard);
     // A value with no live cursor of its own (an assignment/`del()`
     // result, a computed value, ...) has no comment/style to read directly
     // - but if it came from a shape-preserving write, `presentation_sync_ctx`

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -665,7 +665,7 @@ pub(crate) mod yq_read_only_context {
 pub mod alias_identity {
     use super::{
         get_value_at_path, is_alias_sensitive_assign, push_path_components, set_value_at_path,
-        unwrap_path_component, Expr, OwnedValue,
+        unwrap_path_component, vec_with_capacity, Expr, OwnedValue,
     };
     use alloc::rc::Rc;
     use alloc::vec::Vec;
@@ -692,7 +692,7 @@ pub mod alias_identity {
                 aliases
                     .iter()
                     .any(|a| a.as_slice() == prefix)
-                    .then(|| def.as_slice())
+                    .then_some(def.as_slice())
             })
         }
 
@@ -789,7 +789,7 @@ pub mod alias_identity {
     /// every `=`/compound assign/`del()` whose path ends at the alias.
     pub(crate) fn redirect_paths(paths: &mut Vec<Expr>, doc: &OwnedValue, opts: Redirect) {
         with_table(|table| {
-            let mut out = Vec::with_capacity(paths.len());
+            let mut out = vec_with_capacity(paths.len());
             for path in paths.drain(..) {
                 let mut components = Vec::new();
                 push_path_components(&mut components, &path);
@@ -1059,9 +1059,11 @@ fn contains_assign(expr: &Expr) -> bool {
     }
 }
 
-/// Whether `expr`'s top-level shape is "rewrite the document at specific
-/// paths, leaving everything else identical" -- the class of expression for
-/// which comparing a path's value before and after the write is meaningful.
+/// Whether `expr` is a shape-preserving write: "rewrite the document at
+/// specific paths, leaving everything else identical".
+///
+/// That is the class of expression for which comparing a path's value before
+/// and after the write is meaningful.
 /// Unwraps `Paren`/`Optional` so `(.a = 1)?` still matches, and recurses into
 /// `Pipe` so a chain matches when every stage does, whether the stage is a
 /// write (`.a = 1 | .b = 2`) or one of a small allow-list of pass-through
@@ -45495,8 +45497,11 @@ fn delpaths_one<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     }
     // #1351: a path descending through an alias position deletes from the
     // shared node. The extra `to_owned` runs only while a table is installed.
+    // STYLE-0012: a probe, not the materialization -- a failure here just
+    // skips the redirect, and the `to_owned(value)` in `result` below (the
+    // site that decides) re-raises it exactly as before.
     let delpaths_pre = if alias_identity::active() {
-        to_owned(value).ok()
+        to_owned(value).ok() // STYLE-0012: probe only; the site below decides.
     } else {
         None
     };

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -664,8 +664,8 @@ pub(crate) mod yq_read_only_context {
 #[cfg(feature = "std")]
 pub mod alias_identity {
     use super::{
-        get_value_at_path, is_alias_sensitive_assign, push_path_components, set_value_at_path,
-        unwrap_path_component, vec_with_capacity, Expr, OwnedValue,
+        get_value_at_path, propagate_anchor_writes, push_path_components, unwrap_path_component,
+        vec_with_capacity, Expr, OwnedValue,
     };
     use alloc::rc::Rc;
     use alloc::vec::Vec;
@@ -680,8 +680,8 @@ pub mod alias_identity {
     }
 
     impl AliasTable {
-        /// Build from `collect_alias_groups`'s output. Paths are plain
-        /// `String`/`Int` key sequences addressing the `OwnedValue` tree.
+        /// Builds a table from `collect_alias_groups`'s output. Paths are
+        /// plain `String`/`Int` key sequences addressing the `OwnedValue` tree.
         pub fn from_groups(groups: Vec<(Vec<OwnedValue>, Vec<Vec<OwnedValue>>)>) -> Self {
             Self { groups }
         }
@@ -742,7 +742,7 @@ pub mod alias_identity {
         }
     }
 
-    /// Install `table` for the caller's scope.
+    /// Installs `table` for the caller's scope.
     pub fn enter(table: AliasTable) -> Guard {
         let previous = TABLE.with(|t| t.borrow_mut().replace(Rc::new(table)));
         Guard(previous)
@@ -814,6 +814,21 @@ pub mod alias_identity {
         /// `del()`, whose single-path walker must not receive several
         /// paths and whose effect does not accumulate anyway.
         pub fan_out_iterate: bool,
+    }
+
+    impl Redirect {
+        /// `=`, compound/alternative assign, and `|=` with a value-producing
+        /// filter: through-writes only, iterates fanned out.
+        pub(crate) const THROUGH: Self = Self {
+            through_terminal: false,
+            fan_out_iterate: true,
+        };
+        /// `del()`, `setpath`, `delpaths`: through-writes only, one path in,
+        /// one path out.
+        pub(crate) const SINGLE: Self = Self {
+            through_terminal: false,
+            fan_out_iterate: false,
+        };
     }
 
     fn redirect_components(
@@ -915,14 +930,7 @@ pub mod alias_identity {
             return;
         };
         let mut paths = vec![rebuild(components)];
-        redirect_paths(
-            &mut paths,
-            doc,
-            Redirect {
-                through_terminal: false,
-                fan_out_iterate: false,
-            },
-        );
+        redirect_paths(&mut paths, doc, Redirect::SINGLE);
         let Some(redirected) = paths.pop() else {
             return;
         };
@@ -944,75 +952,27 @@ pub mod alias_identity {
 
     /// After one write expression has run, copy every anchor's new value into
     /// each alias slot that was still an untouched copy of that anchor before
-    /// the write, iterating to a fixpoint (bounded by the group count) so a
-    /// nested anchor's change reaches the outer anchor's aliases too. A slot
-    /// that was rebound earlier (`.b = 5 | .a.p = 9` keeps `b: 5`) or that no
-    /// longer resolves is never written.
+    /// the write -- see [`propagate_anchor_writes`], which this shares with
+    /// the CLI's end-of-pipe [`sync_aliased_paths`] so there is exactly one
+    /// propagation rule.
     ///
-    /// `pre` is the document the write expression started from — not the
-    /// pristine input of the whole pipe — which is what makes the "was a copy
+    /// `pre` is the document the write expression started from -- not the
+    /// pristine input of the whole pipe -- which is what makes the "was a copy
     /// before this write" test exact mid-pipe.
     pub(crate) fn mirror_after_write(pre: &OwnedValue, post: &mut OwnedValue) {
-        with_table(|table| {
-            // Per alias slot, the value it must still hold to be written:
-            // its pre-write value if that was a copy of the anchor's
-            // pre-write value, updated to whatever this pass writes.
-            let mut expected: Vec<Vec<Option<OwnedValue>>> = table
-                .groups
-                .iter()
-                .map(|(def, aliases)| {
-                    let def_pre = get_value_at_path(pre, def);
-                    aliases
-                        .iter()
-                        .map(|alias| {
-                            get_value_at_path(pre, alias).filter(|v| Some(v) == def_pre.as_ref())
-                        })
-                        .collect()
-                })
-                .collect();
-            for _ in 0..table.groups.len() {
-                let mut changed = false;
-                for (g, (def, aliases)) in table.groups.iter().enumerate() {
-                    let Some(new) = get_value_at_path(post, def) else {
-                        continue;
-                    };
-                    for (a, alias) in aliases.iter().enumerate() {
-                        let Some(want) = expected[g][a].as_ref() else {
-                            continue;
-                        };
-                        if *want == new {
-                            continue;
-                        }
-                        if get_value_at_path(post, alias).as_ref() != Some(want) {
-                            continue;
-                        }
-                        if let Ok(updated) = set_value_at_path(post.clone(), alias, new.clone()) {
-                            *post = updated;
-                            expected[g][a] = Some(new.clone());
-                            changed = true;
-                        }
-                    }
-                }
-                if !changed {
-                    break;
-                }
-            }
-        });
-    }
-
-    /// `|=`'s terminal rule needs the same "is this filter a shape-preserving
-    /// write" answer the CLI's alias-sync gate uses; re-exported here so both
-    /// read one definition.
-    pub(crate) fn update_filter_writes_through(filter: &Expr) -> bool {
-        is_alias_sensitive_assign(filter)
+        with_table(|table| propagate_anchor_writes(pre, post, &table.groups));
     }
 }
 
+/// `no_std` stand-in for the ambient alias-identity table: there is no
+/// thread-local to install one in, so nothing is ever active and every hook
+/// is a no-op (same limitation as `yq_read_only_context`).
 #[cfg(not(feature = "std"))]
 pub mod alias_identity {
     use super::{Expr, OwnedValue};
     use alloc::vec::Vec;
 
+    /// Always `false`: no table can be installed without `std`.
     pub fn active() -> bool {
         false
     }
@@ -1023,15 +983,22 @@ pub mod alias_identity {
         pub fan_out_iterate: bool,
     }
 
+    impl Redirect {
+        pub(crate) const THROUGH: Self = Self {
+            through_terminal: false,
+            fan_out_iterate: true,
+        };
+        pub(crate) const SINGLE: Self = Self {
+            through_terminal: false,
+            fan_out_iterate: false,
+        };
+    }
+
     pub(crate) fn redirect_paths(_paths: &mut Vec<Expr>, _doc: &OwnedValue, _opts: Redirect) {}
 
     pub(crate) fn redirect_concrete_path(_path: &mut Vec<OwnedValue>, _doc: &OwnedValue) {}
 
     pub(crate) fn mirror_after_write(_pre: &OwnedValue, _post: &mut OwnedValue) {}
-
-    pub(crate) fn update_filter_writes_through(_filter: &Expr) -> bool {
-        false
-    }
 }
 
 /// Whether `expr` is itself an assignment-family write: `.path = value`,
@@ -20323,14 +20290,7 @@ fn yq_assign_noop_check<W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     // #1351: a path descending through an alias position is the anchor's
     // own path -- redirect before the no-op classification so the check
     // and the write below agree on where the write lands.
-    alias_identity::redirect_paths(
-        &mut paths,
-        &pristine,
-        alias_identity::Redirect {
-            through_terminal: false,
-            fan_out_iterate: true,
-        },
-    );
+    alias_identity::redirect_paths(&mut paths, &pristine, alias_identity::Redirect::THROUGH);
     // Classified once per path and reused for both the total-noop and
     // rhs-unused decisions below, instead of walking each path twice via
     // separately-called `yq_assign_is_total_noop`/`yq_assign_rhs_unused`
@@ -20488,10 +20448,7 @@ fn eval_assign<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
             alias_identity::redirect_paths(
                 &mut paths,
                 &pristine,
-                alias_identity::Redirect {
-                    through_terminal: false,
-                    fan_out_iterate: true,
-                },
+                alias_identity::Redirect::THROUGH,
             );
             (pristine, paths)
         }
@@ -20592,7 +20549,7 @@ fn eval_update<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
         &mut paths,
         &result,
         alias_identity::Redirect {
-            through_terminal: alias_identity::update_filter_writes_through(filter_expr),
+            through_terminal: is_alias_sensitive_assign(filter_expr),
             fan_out_iterate: true,
         },
     );
@@ -21040,14 +20997,7 @@ fn eval_update_multi<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     // data-loss bug succinctly does not reproduce, rule 4(b)); one whose path
     // passes through an alias lands on the shared node.
     let mut paths = paths;
-    alias_identity::redirect_paths(
-        &mut paths,
-        &pristine,
-        alias_identity::Redirect {
-            through_terminal: false,
-            fan_out_iterate: true,
-        },
-    );
+    alias_identity::redirect_paths(&mut paths, &pristine, alias_identity::Redirect::THROUGH);
 
     fork_rhs_over_paths::<W, _>(
         pristine,
@@ -39375,45 +39325,99 @@ fn set_value_at_path(
     }
 }
 
+/// Copy every anchor's post-write value into each alias slot that was still
+/// an untouched copy of that anchor before the write (#711, #1351, #2498,
+/// #2499).
+///
+/// `groups` is `(anchor definition path, [alias paths...])` as
+/// `collect_alias_groups` builds it from the pristine document; `pre` and
+/// `post` are the document before and after one write (a single write
+/// expression for [`alias_identity::mirror_after_write`], the whole pipe for
+/// [`sync_aliased_paths`]). For each group whose anchor changed, an alias slot
+/// is overwritten only while its current value equals the value it held in
+/// `pre` *and* that value was the anchor's own `pre` value -- i.e. it is
+/// still the unmodified copy the alias resolved to. A slot that some earlier
+/// stage rebound (`.b = null | .a.p = 9` keeps `b: null`, #2499), deleted, or
+/// that no longer resolves is never written or autovivified. The group loop
+/// repeats until a pass writes nothing, bounded by the group count, so a
+/// nested anchor's change reaches the outer anchor's aliases whatever order
+/// the groups were collected in (#2498); a slot this function has just
+/// written is tracked as the new expected value, which is what lets the next
+/// pass update it again.
+fn propagate_anchor_writes(
+    pre: &OwnedValue,
+    post: &mut OwnedValue,
+    groups: &[(Vec<OwnedValue>, Vec<Vec<OwnedValue>>)],
+) {
+    // Per alias slot, the value it must still hold to be written: its
+    // pre-write value if that was a copy of the anchor's pre-write value,
+    // updated to whatever a pass writes.
+    let mut expected: Vec<Vec<Option<OwnedValue>>> = groups
+        .iter()
+        .map(|(def, aliases)| {
+            let def_pre = get_value_at_path(pre, def);
+            aliases
+                .iter()
+                .map(|alias| get_value_at_path(pre, alias).filter(|v| Some(v) == def_pre.as_ref()))
+                .collect()
+        })
+        .collect();
+    for _ in 0..groups.len() {
+        let mut changed = false;
+        for (g, (def, aliases)) in groups.iter().enumerate() {
+            let Some(new) = get_value_at_path(post, def) else {
+                continue;
+            };
+            for (a, alias) in aliases.iter().enumerate() {
+                let Some(want) = expected[g][a].as_ref() else {
+                    continue;
+                };
+                if *want == new {
+                    continue;
+                }
+                if get_value_at_path(post, alias).as_ref() != Some(want) {
+                    continue;
+                }
+                if let Ok(updated) = set_value_at_path(post.clone(), alias, new.clone()) {
+                    *post = updated;
+                    expected[g][a] = Some(new.clone());
+                    changed = true;
+                }
+            }
+        }
+        if !changed {
+            break;
+        }
+    }
+}
+
 /// Propagate a write through a YAML anchor to every alias sharing it (#711).
 ///
 /// YAML anchor/alias pairs are the same node in the representation graph: a
 /// write through the anchor's own path must be visible through every alias
 /// that points to it, matching real `yq`. `OwnedValue` itself has no notion
-/// of shared identity, so this is applied as a post-process instead: `groups`
-/// is a list of `(anchor_definition_path, [alias_paths...])` pairs, computed
-/// by the caller from the pre-mutation document. For each group, if the
-/// value at the definition path differs between `pristine` (before the
-/// write) and `result` (after), every alias path is overwritten with a clone
-/// of the new value.
+/// of shared identity, so this is applied as a post-process over the whole
+/// pipe: `groups` is a list of `(anchor_definition_path, [alias_paths...])`
+/// pairs, computed by the caller from the pre-mutation document, and
+/// `pristine` is that document. The rule itself lives in
+/// [`propagate_anchor_writes`], shared with the per-write mirror the
+/// evaluator runs while an [`alias_identity`] table is installed (#1351) --
+/// after which this end-of-pipe pass finds nothing left to do. It stays as
+/// the one propagation step for callers that evaluate without the table.
 ///
 /// A group whose definition path no longer resolves in `result` (e.g. the
 /// anchored key was deleted) is left untouched, so its aliases keep their
 /// last-resolved value -- matching how a detached graph node behaves in real
-/// yq. Likewise, a write that lands on an alias path directly rather than
-/// the anchor's own path leaves every other member of the group alone, since
-/// the anchor's own value never changed.
+/// yq. A write that lands on an alias path directly rather than the anchor's
+/// own path leaves every other member of the group alone, since the anchor's
+/// own value never changed, and that rebound slot is itself never overwritten
+/// by a later anchor write (#2499).
 pub fn sync_aliased_paths(
     result: &mut OwnedValue,
     pristine: &OwnedValue,
     groups: &[(Vec<OwnedValue>, Vec<Vec<OwnedValue>>)],
 ) {
-    for (def_path, alias_paths) in groups {
-        let (Some(old), Some(new)) = (
-            get_value_at_path(pristine, def_path),
-            get_value_at_path(result, def_path),
-        ) else {
-            continue;
-        };
-        if old == new {
-            continue;
-        }
-        for alias_path in alias_paths {
-            if let Ok(updated) = set_value_at_path(result.clone(), alias_path, new.clone()) {
-                *result = updated;
-            }
-        }
-    }
+    propagate_anchor_writes(pristine, result, groups);
 }
 
 /// Builtin: setpath(path; value) - set value at path
@@ -41115,10 +41119,7 @@ fn builtin_del<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     // #1351: pre-write snapshot for the alias mirror, only while a table is
     // installed (never in jq mode).
     let del_pre = alias_identity::active().then(|| result.clone());
-    let del_redirect = alias_identity::Redirect {
-        through_terminal: false,
-        fan_out_iterate: false,
-    };
+    let del_redirect = alias_identity::Redirect::SINGLE;
 
     // yq's comma-grouped chained-slice del() pre-rewrite (#1223):
     // `resolve_dynamic_indexes`'s own generic navigation raises a hard type
@@ -84952,10 +84953,7 @@ mod tests {
             paths.iter().map(steps).collect()
         }
 
-        const THROUGH: alias_identity::Redirect = alias_identity::Redirect {
-            through_terminal: false,
-            fan_out_iterate: true,
-        };
+        const THROUGH: alias_identity::Redirect = alias_identity::Redirect::THROUGH;
 
         #[test]
         fn nothing_installed_is_a_no_op() {
@@ -85007,10 +85005,7 @@ mod tests {
                 redirected(".[].p", &doc, THROUGH),
                 vec![vec!["a", "p"], vec!["a", "p"], vec!["a", "p"]]
             );
-            let no_fan = alias_identity::Redirect {
-                through_terminal: false,
-                fan_out_iterate: false,
-            };
+            let no_fan = alias_identity::Redirect::SINGLE;
             assert_eq!(redirected(".[].p", &doc, no_fan), vec![vec!["[]", "p"]]);
             // No alias lives under `.a`, so its iterate is left to the walker.
             assert_eq!(
@@ -85046,6 +85041,47 @@ mod tests {
             assert_eq!(
                 redirected(".l[7].k", &doc, THROUGH),
                 vec![vec!["l", "7", "k"]]
+            );
+        }
+
+        #[test]
+        fn non_static_steps_stop_the_walk_and_odd_shapes_pass_through() {
+            let _guard = alias_identity::enter(table());
+            let doc = json(DOC);
+            // The root path has no components at all.
+            assert_eq!(redirected(".", &doc, THROUGH), vec![Vec::<String>::new()]);
+            // `.b` redirects first; the index step against the mapping at
+            // `.a` cannot be normalised, so the rest is left as written.
+            assert_eq!(
+                redirected(".b[0].p", &doc, THROUGH),
+                vec![vec!["a", "0", "p"]]
+            );
+            // A slice is never part of the static prefix.
+            assert_eq!(
+                steps(&{
+                    let mut paths = vec![parse(".b[0:1].p").unwrap()];
+                    alias_identity::redirect_paths(&mut paths, &doc, THROUGH);
+                    paths.pop().unwrap()
+                })
+                .len(),
+                3
+            );
+            // `.[]?` fans out like `.[]`, keeping the `?` on each element.
+            assert_eq!(
+                redirected(".[]?.p", &doc, THROUGH),
+                vec![vec!["a", "p"], vec!["a", "p"], vec!["a", "p"]]
+            );
+            // An alias recorded under a prefix that no longer holds a
+            // container: nothing to fan out over, the iterate is left alone.
+            let doc = json(r#"{"a":{"p":1,"q":2},"b":7,"c":{"p":1,"q":2}}"#);
+            let odd = alias_identity::AliasTable::from_groups(vec![(
+                path(&["a"]),
+                vec![path(&["b", "0"])],
+            )]);
+            let _inner = alias_identity::enter(odd);
+            assert_eq!(
+                redirected(".b[].p", &doc, THROUGH),
+                vec![vec!["b", "[]", "p"]]
             );
         }
 

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -39400,7 +39400,7 @@ fn propagate_anchor_writes(
 /// pipe: `groups` is a list of `(anchor_definition_path, [alias_paths...])`
 /// pairs, computed by the caller from the pre-mutation document, and
 /// `pristine` is that document. The rule itself lives in
-/// [`propagate_anchor_writes`], shared with the per-write mirror the
+/// `propagate_anchor_writes` (private), shared with the per-write mirror the
 /// evaluator runs while an [`alias_identity`] table is installed (#1351) --
 /// after which this end-of-pipe pass finds nothing left to do. It stays as
 /// the one propagation step for callers that evaluate without the table.

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -623,6 +623,496 @@ pub(crate) mod yq_read_only_context {
     }
 }
 
+/// Ambient alias-identity table for yq-mode writes (#1351 — the remaining half of
+/// ADR-0017's mechanism 2).
+///
+/// Real yq models `&x`/`*x` as **one node reachable from several positions**: a
+/// write whose path descends *through* an alias position and continues (`.b.p = 9`
+/// on `b: *x`) lands on the anchor's node and is visible at every position, while a
+/// write that *ends* at the alias (`.b = 5`) rebinds that one position. `OwnedValue`
+/// clones every alias independently, so the distinction is recovered here by path
+/// shape rather than by a shared node: the CLI installs, for the duration of one
+/// alias-sensitive write expression, the `(alias path -> anchor path)` table
+/// `collect_alias_groups` derived from the pristine document, and the write entry
+/// points consult it through two hooks — both no-ops when nothing is installed,
+/// which is every jq-mode evaluation and every yq read:
+///
+/// - `redirect_paths` rewrites each resolved write path whose **proper** prefix is
+///   an alias position onto the anchor's own path, transitively (an alias inside an
+///   anchored mapping that is itself aliased), and only while the alias position's
+///   current value still equals the anchor's — *identity by equality*, which is what
+///   lets a positional model stand in for a graph: a slot rebound earlier in the
+///   pipe (`.b = 5 | .b.p = 9`) no longer equals the anchor and is written
+///   positionally, exactly as yq treats a rebound position. A path that ends
+///   exactly at the alias is left alone (rule 1 of the plan on #1351).
+/// - `mirror_after_write` re-copies the anchor's post-write value into every
+///   alias slot that was still an untouched copy of the anchor *before* the write,
+///   so a later stage of the same pipe (`.b.p = 9 | .c.q = 8`) sees a consistent
+///   document. The CLI's end-of-pipe `sync_aliased_paths` then finds nothing left
+///   to do.
+///
+/// Verified live against yq v4.53.3 (see the plan on #1351 for the full matrix):
+/// `.b.p = 9`, `.b.p |= . + 1`, `del(.b.p)`, `.b.r = 3`, `.b[0] = 9` and
+/// `setpath(["b","p"]; 9)` all mutate the shared node; `.b = 5`, `.b |= 5`,
+/// `del(.b)` rebind/remove the position only; three positions sharing one node
+/// accumulate — `.[] .p += 1` over `a: &x {p: 1}` / `b: *x` / `c: *x` yields 4.
+///
+/// Same ambient shape (and `#[cfg(feature = "std")]` limitation) as
+/// `yq_read_only_context`: the sites that consult the table are many recursion
+/// levels below the site that installs it, and this codebase has no evaluation-
+/// environment parameter for it to ride on.
+#[cfg(feature = "std")]
+pub mod alias_identity {
+    use super::{
+        get_value_at_path, is_alias_sensitive_assign, push_path_components, set_value_at_path,
+        unwrap_path_component, Expr, OwnedValue,
+    };
+    use alloc::rc::Rc;
+    use alloc::vec::Vec;
+    use std::cell::RefCell;
+
+    /// One alias-sensitive write's view of which positions share a node.
+    #[derive(Debug, Clone)]
+    pub struct AliasTable {
+        /// `(anchor definition path, [alias paths...])`, one entry per anchor
+        /// that has at least one alias — the shape `sync_aliased_paths` takes.
+        groups: Vec<(Vec<OwnedValue>, Vec<Vec<OwnedValue>>)>,
+    }
+
+    impl AliasTable {
+        /// Build from `collect_alias_groups`'s output. Paths are plain
+        /// `String`/`Int` key sequences addressing the `OwnedValue` tree.
+        pub fn from_groups(groups: Vec<(Vec<OwnedValue>, Vec<Vec<OwnedValue>>)>) -> Self {
+            Self { groups }
+        }
+
+        /// The anchor path this exact alias position resolves to, if any.
+        fn anchor_for(&self, prefix: &[OwnedValue]) -> Option<&[OwnedValue]> {
+            self.groups.iter().find_map(|(def, aliases)| {
+                aliases
+                    .iter()
+                    .any(|a| a.as_slice() == prefix)
+                    .then(|| def.as_slice())
+            })
+        }
+
+        /// Whether any alias position lies strictly *below* `prefix` — the
+        /// only case in which fanning an `Iterate` out into per-element
+        /// paths can change what a write does.
+        fn has_alias_under(&self, prefix: &[OwnedValue]) -> bool {
+            self.groups.iter().any(|(_, aliases)| {
+                aliases
+                    .iter()
+                    .any(|a| a.len() > prefix.len() && a[..prefix.len()] == *prefix)
+            })
+        }
+
+        fn hop_bound(&self) -> usize {
+            self.groups
+                .iter()
+                .map(|(_, aliases)| aliases.len())
+                .sum::<usize>()
+                + 1
+        }
+    }
+
+    thread_local! {
+        static TABLE: RefCell<Option<Rc<AliasTable>>> = const { RefCell::new(None) };
+    }
+
+    /// Whether a table is installed for the current evaluation.
+    pub fn active() -> bool {
+        TABLE.with(|t| t.borrow().is_some())
+    }
+
+    fn with_table<R>(f: impl FnOnce(&AliasTable) -> R) -> Option<R> {
+        let table = TABLE.with(|t| t.borrow().clone())?;
+        Some(f(&table))
+    }
+
+    /// Restores the previous table on drop, so a nested or later evaluation
+    /// never inherits a table built for a different document.
+    #[must_use]
+    pub struct Guard(Option<Rc<AliasTable>>);
+
+    impl Drop for Guard {
+        fn drop(&mut self) {
+            let previous = self.0.take();
+            TABLE.with(|t| *t.borrow_mut() = previous);
+        }
+    }
+
+    /// Install `table` for the caller's scope.
+    pub fn enter(table: AliasTable) -> Guard {
+        let previous = TABLE.with(|t| t.borrow_mut().replace(Rc::new(table)));
+        Guard(previous)
+    }
+
+    /// One concrete path step as the `Expr` component the write walkers take.
+    /// `None` for a component shape `collect_alias_groups` never produces.
+    fn step_to_expr(step: &OwnedValue) -> Option<Expr> {
+        match step {
+            OwnedValue::String(key) => Some(Expr::Field(key.clone())),
+            OwnedValue::Int(idx) => Some(Expr::Index {
+                idx: *idx,
+                key: None,
+            }),
+            _ => None,
+        }
+    }
+
+    fn rebuild(mut components: Vec<Expr>) -> Expr {
+        match components.len() {
+            0 => Expr::Identity,
+            1 => components.pop().expect("len checked"),
+            _ => Expr::Pipe(components),
+        }
+    }
+
+    /// Both positions resolve and hold equal values right now.
+    fn same_node(doc: &OwnedValue, a: &[OwnedValue], b: &[OwnedValue]) -> bool {
+        matches!(
+            (get_value_at_path(doc, a), get_value_at_path(doc, b)),
+            (Some(x), Some(y)) if x == y
+        )
+    }
+
+    /// Rewrite every path in `paths` per the rules above, against `doc` (the
+    /// document the paths were resolved on, before any write). A path may
+    /// fan out into several when an `Iterate` over a container holding
+    /// aliases is enumerated so each element can be redirected on its own.
+    ///
+    /// `through_terminal`: also redirect a path that ends *exactly* at an
+    /// alias position. `|=` passes `true` when its filter is itself a
+    /// shape-preserving write (`.b |= (.p = 9)`, `.b |= del(.p)`: yq mutates
+    /// the shared node), `false` otherwise — `.b |= 5` rebinds, and so does
+    /// every `=`/compound assign/`del()` whose path ends at the alias.
+    pub(crate) fn redirect_paths(paths: &mut Vec<Expr>, doc: &OwnedValue, opts: Redirect) {
+        with_table(|table| {
+            let mut out = Vec::with_capacity(paths.len());
+            for path in paths.drain(..) {
+                let mut components = Vec::new();
+                push_path_components(&mut components, &path);
+                redirect_components(components, doc, table, opts, 0, &mut out);
+            }
+            *paths = out;
+        });
+    }
+
+    /// Per-entry-point options for [`redirect_paths`].
+    #[derive(Debug, Clone, Copy)]
+    pub(crate) struct Redirect {
+        /// Also redirect a path that ends *exactly* at an alias position.
+        /// Only `|=` with a shape-preserving write as its filter sets this
+        /// (`.b |= (.p = 9)`: yq mutates the shared node); `=`, compound
+        /// assigns, `.b |= 5` and `del(.b)` all rebind or remove the
+        /// position itself.
+        pub through_terminal: bool,
+        /// Fan an `Iterate` over a container holding aliases out into one
+        /// path per element, so each can be redirected on its own (rule 6:
+        /// `.[] .p += 1` over three shared positions is 4 in yq). Off for
+        /// `del()`, whose single-path walker must not receive several
+        /// paths and whose effect does not accumulate anyway.
+        pub fan_out_iterate: bool,
+    }
+
+    fn redirect_components(
+        components: Vec<Expr>,
+        doc: &OwnedValue,
+        table: &AliasTable,
+        opts: Redirect,
+        hops: usize,
+        out: &mut Vec<Expr>,
+    ) {
+        let mut prefix: Vec<OwnedValue> = Vec::new();
+        let mut i = 0;
+        while i < components.len() {
+            let (component, optional) = unwrap_path_component(&components[i]);
+            match component {
+                Expr::Field(name) => prefix.push(OwnedValue::String(name.clone())),
+                Expr::Index { idx, .. } => {
+                    // Normalise a negative index against the container it
+                    // indexes *now*, so `.b[-1]` and `.b[1]` name the same
+                    // slot in the table's non-negative coordinates.
+                    let Some(OwnedValue::Array(arr)) = get_value_at_path(doc, &prefix) else {
+                        break;
+                    };
+                    let len = arr.len() as i64;
+                    let norm = if *idx < 0 { *idx + len } else { *idx };
+                    if norm < 0 || norm >= len {
+                        break;
+                    }
+                    prefix.push(OwnedValue::Int(norm));
+                }
+                Expr::Iterate => {
+                    // Rule 6: several positions sharing one node accumulate
+                    // (`.[] .p += 1` over three shared positions is 4 in yq),
+                    // which needs each element to be a path of its own so it
+                    // can be redirected. Fan out only where it can matter —
+                    // an alias lives under this container — and only over a
+                    // container that exists now, leaving `null | .a[] = 1`-
+                    // style autovivification shapes to the walkers untouched.
+                    if opts.fan_out_iterate && table.has_alias_under(&prefix) {
+                        let wrap = |e: Expr| {
+                            if optional {
+                                Expr::Optional(Box::new(e))
+                            } else {
+                                e
+                            }
+                        };
+                        let elements: Vec<Expr> = match get_value_at_path(doc, &prefix) {
+                            Some(OwnedValue::Object(map)) => {
+                                map.keys().map(|k| wrap(Expr::Field(k.clone()))).collect()
+                            }
+                            Some(OwnedValue::Array(arr)) => (0..arr.len() as i64)
+                                .map(|idx| wrap(Expr::Index { idx, key: None }))
+                                .collect(),
+                            _ => Vec::new(),
+                        };
+                        if !elements.is_empty() {
+                            for element in elements {
+                                let mut fanned = components[..i].to_vec();
+                                fanned.push(element);
+                                fanned.extend(components[i + 1..].iter().cloned());
+                                redirect_components(fanned, doc, table, opts, hops, out);
+                            }
+                            return;
+                        }
+                    }
+                    break;
+                }
+                _ => break,
+            }
+            i += 1;
+            // Reaching here with `i == components.len()` means every component
+            // was static, so the whole path names one concrete position.
+            let is_proper_prefix = i < components.len();
+            if (is_proper_prefix || opts.through_terminal) && hops < table.hop_bound() {
+                if let Some(def) = table.anchor_for(&prefix) {
+                    if same_node(doc, &prefix, def) {
+                        if let Some(mut redirected) =
+                            def.iter().map(step_to_expr).collect::<Option<Vec<Expr>>>()
+                        {
+                            redirected.extend(components[i..].iter().cloned());
+                            redirect_components(redirected, doc, table, opts, hops + 1, out);
+                            return;
+                        }
+                    }
+                }
+            }
+        }
+        out.push(rebuild(components));
+    }
+
+    /// Redirect one concrete (`String`/`Int`) path, the form `setpath`/
+    /// `delpaths` take. A slice descriptor or any other component shape
+    /// leaves the path untouched.
+    pub(crate) fn redirect_concrete_path(path: &mut Vec<OwnedValue>, doc: &OwnedValue) {
+        if !active() {
+            return;
+        }
+        let Some(components) = path.iter().map(step_to_expr).collect::<Option<Vec<Expr>>>() else {
+            return;
+        };
+        let mut paths = vec![rebuild(components)];
+        redirect_paths(
+            &mut paths,
+            doc,
+            Redirect {
+                through_terminal: false,
+                fan_out_iterate: false,
+            },
+        );
+        let Some(redirected) = paths.pop() else {
+            return;
+        };
+        let mut flat = Vec::new();
+        push_path_components(&mut flat, &redirected);
+        let Some(concrete) = flat
+            .iter()
+            .map(|c| match unwrap_path_component(c).0 {
+                Expr::Field(name) => Some(OwnedValue::String(name.clone())),
+                Expr::Index { idx, .. } => Some(OwnedValue::Int(*idx)),
+                _ => None,
+            })
+            .collect::<Option<Vec<OwnedValue>>>()
+        else {
+            return;
+        };
+        *path = concrete;
+    }
+
+    /// After one write expression has run, copy every anchor's new value into
+    /// each alias slot that was still an untouched copy of that anchor before
+    /// the write, iterating to a fixpoint (bounded by the group count) so a
+    /// nested anchor's change reaches the outer anchor's aliases too. A slot
+    /// that was rebound earlier (`.b = 5 | .a.p = 9` keeps `b: 5`) or that no
+    /// longer resolves is never written.
+    ///
+    /// `pre` is the document the write expression started from — not the
+    /// pristine input of the whole pipe — which is what makes the "was a copy
+    /// before this write" test exact mid-pipe.
+    pub(crate) fn mirror_after_write(pre: &OwnedValue, post: &mut OwnedValue) {
+        with_table(|table| {
+            // Per alias slot, the value it must still hold to be written:
+            // its pre-write value if that was a copy of the anchor's
+            // pre-write value, updated to whatever this pass writes.
+            let mut expected: Vec<Vec<Option<OwnedValue>>> = table
+                .groups
+                .iter()
+                .map(|(def, aliases)| {
+                    let def_pre = get_value_at_path(pre, def);
+                    aliases
+                        .iter()
+                        .map(|alias| {
+                            get_value_at_path(pre, alias).filter(|v| Some(v) == def_pre.as_ref())
+                        })
+                        .collect()
+                })
+                .collect();
+            for _ in 0..table.groups.len() {
+                let mut changed = false;
+                for (g, (def, aliases)) in table.groups.iter().enumerate() {
+                    let Some(new) = get_value_at_path(post, def) else {
+                        continue;
+                    };
+                    for (a, alias) in aliases.iter().enumerate() {
+                        let Some(want) = expected[g][a].as_ref() else {
+                            continue;
+                        };
+                        if *want == new {
+                            continue;
+                        }
+                        if get_value_at_path(post, alias).as_ref() != Some(want) {
+                            continue;
+                        }
+                        if let Ok(updated) = set_value_at_path(post.clone(), alias, new.clone()) {
+                            *post = updated;
+                            expected[g][a] = Some(new.clone());
+                            changed = true;
+                        }
+                    }
+                }
+                if !changed {
+                    break;
+                }
+            }
+        });
+    }
+
+    /// `|=`'s terminal rule needs the same "is this filter a shape-preserving
+    /// write" answer the CLI's alias-sync gate uses; re-exported here so both
+    /// read one definition.
+    pub(crate) fn update_filter_writes_through(filter: &Expr) -> bool {
+        is_alias_sensitive_assign(filter)
+    }
+}
+
+#[cfg(not(feature = "std"))]
+pub mod alias_identity {
+    use super::{Expr, OwnedValue};
+    use alloc::vec::Vec;
+
+    pub fn active() -> bool {
+        false
+    }
+
+    #[derive(Debug, Clone, Copy)]
+    pub(crate) struct Redirect {
+        pub through_terminal: bool,
+        pub fan_out_iterate: bool,
+    }
+
+    pub(crate) fn redirect_paths(_paths: &mut Vec<Expr>, _doc: &OwnedValue, _opts: Redirect) {}
+
+    pub(crate) fn redirect_concrete_path(_path: &mut Vec<OwnedValue>, _doc: &OwnedValue) {}
+
+    pub(crate) fn mirror_after_write(_pre: &OwnedValue, _post: &mut OwnedValue) {}
+
+    pub(crate) fn update_filter_writes_through(_filter: &Expr) -> bool {
+        false
+    }
+}
+
+/// Whether `expr` is itself an assignment-family write: `.path = value`,
+/// `|=`, a compound assign, `//=`, `del(...)`, `setpath(...)` or
+/// `delpaths(...)` (the last two added by #1351: they write at a path exactly
+/// as `=`/`del()` do, so an alias-bearing document needs the same sync and
+/// redirect for them). Unwraps `Paren`/`Optional`
+/// so `(.a = 1)?` still counts, and recurses into `Pipe` so a chain counts
+/// as soon as *any* stage writes.
+///
+/// Split out from [`is_alias_sensitive_assign`] so a pipe made entirely of
+/// pass-through stages (`select(true) | debug`, no write at all) doesn't
+/// pay for alias-sync snapshotting -- only a pipe that both preserves shape
+/// *and* actually writes somewhere needs the pristine-vs-result diff.
+fn contains_assign(expr: &Expr) -> bool {
+    match expr {
+        Expr::Assign { .. }
+        | Expr::Update { .. }
+        | Expr::CompoundAssign { .. }
+        | Expr::AlternativeAssign { .. }
+        | Expr::Builtin(Builtin::Del(_) | Builtin::SetPath(..) | Builtin::DelPaths(_)) => true,
+        Expr::Paren(inner) | Expr::Optional(inner) => contains_assign(inner),
+        Expr::Pipe(stages) => stages.iter().any(contains_assign),
+        _ => false,
+    }
+}
+
+/// Whether `expr`'s top-level shape is "rewrite the document at specific
+/// paths, leaving everything else identical" -- the class of expression for
+/// which comparing a path's value before and after the write is meaningful.
+/// Unwraps `Paren`/`Optional` so `(.a = 1)?` still matches, and recurses into
+/// `Pipe` so a chain matches when every stage does, whether the stage is a
+/// write (`.a = 1 | .b = 2`) or one of a small allow-list of pass-through
+/// stages that provably either emit the input document completely unchanged
+/// or emit nothing at all: `.` (`Identity`), `select(...)`, `empty`,
+/// `debug`/`debug(msg)`. Mixing one into an assignment pipe (`.a = 1 |
+/// select(.a > 0)`, the guard-style `yq -i` idiom from #764) still leaves
+/// "the same path means the same thing" true for every document that comes
+/// out the other end, since none of these four ever rewrite or reshape the
+/// value they pass through -- unlike `map`, `select`'s own predicate or
+/// `debug`'s own message expression never appear in the pipeline's output,
+/// only their pass/fail or side-effect result does, so `contains_assign`
+/// deliberately does not recurse into either.
+///
+/// Used by the CLI (`yq_runner.rs`) to gate the alias-sync post-process
+/// (#711) and the presentation snapshot (#739), and by [`alias_identity`]
+/// for `|=`'s terminal rule (#1351): outside this class (a bare `map`,
+/// `.a, .b`, ...) the result document doesn't necessarily share the input's
+/// shape at all, so diffing "the same path" in both would be meaningless at
+/// best and could clobber it at worst. A pipe with a stage outside both the
+/// write list and this pass-through allow-list is conservatively excluded
+/// for the same reason -- verifying more stages preserve paths is left for a
+/// future extension, not assumed here. Lives in the library rather than the
+/// CLI so the two consumers cannot drift (#2091 tracks `def`-wrapped writes,
+/// which this predicate does not yet see through).
+pub fn is_alias_sensitive_assign(expr: &Expr) -> bool {
+    fn is_shape_preserving(expr: &Expr) -> bool {
+        match expr {
+            Expr::Assign { .. }
+            | Expr::Update { .. }
+            | Expr::CompoundAssign { .. }
+            | Expr::AlternativeAssign { .. }
+            | Expr::Identity
+            | Expr::Builtin(
+                Builtin::Del(_)
+                | Builtin::SetPath(..)
+                | Builtin::DelPaths(_)
+                | Builtin::Select(_)
+                | Builtin::Empty
+                | Builtin::Debug
+                | Builtin::DebugMsg(_),
+            ) => true,
+            Expr::Paren(inner) | Expr::Optional(inner) => is_shape_preserving(inner),
+            Expr::Pipe(stages) => stages.iter().all(is_shape_preserving),
+            _ => false,
+        }
+    }
+
+    is_shape_preserving(expr) && contains_assign(expr)
+}
+
 /// Whether a key lookup that found nothing must yield **no output** here,
 /// instead of the `null` node every other context reads back (#2470).
 ///
@@ -19824,10 +20314,21 @@ fn yq_assign_noop_check<W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     // fail in practice; falling back to `NotChecked` on the (unreachable)
     // `Err` arm just means the caller re-derives from scratch, same as
     // before this function existed.
-    let paths = match resolve_dynamic_indexes::<S>(path_expr, &pristine, false) {
+    let mut paths = match resolve_dynamic_indexes::<S>(path_expr, &pristine, false) {
         Ok(paths) => paths,
         Err(_) => return Ok(YqAssignNoopCheck::NotChecked),
     };
+    // #1351: a path descending through an alias position is the anchor's
+    // own path -- redirect before the no-op classification so the check
+    // and the write below agree on where the write lands.
+    alias_identity::redirect_paths(
+        &mut paths,
+        &pristine,
+        alias_identity::Redirect {
+            through_terminal: false,
+            fan_out_iterate: true,
+        },
+    );
     // Classified once per path and reused for both the total-noop and
     // rhs-unused decisions below, instead of walking each path twice via
     // separately-called `yq_assign_is_total_noop`/`yq_assign_rhs_unused`
@@ -19979,6 +20480,17 @@ fn eval_assign<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
                 Err((_, EvalEscape::Error(_))) if optional => return QueryResult::None,
                 Err((_, escape)) => return escape.into(),
             };
+            let mut paths = paths;
+            // #1351: same redirect `yq_assign_noop_check` applies on its
+            // own arm -- a no-op here in jq mode (no table is ever installed).
+            alias_identity::redirect_paths(
+                &mut paths,
+                &pristine,
+                alias_identity::Redirect {
+                    through_terminal: false,
+                    fan_out_iterate: true,
+                },
+            );
             (pristine, paths)
         }
     };
@@ -20063,13 +20575,26 @@ fn eval_update<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     // an outer `(.[-5] |= 9)?` needs exactly that swallowed. `update_path` is
     // always entered with `false` below; any `?` it still sees came from an
     // `Expr::Optional` node inside `path_expr` itself.
-    let paths = match resolve_dynamic_indexes::<S>(path_expr, &result, false) {
+    let mut paths = match resolve_dynamic_indexes::<S>(path_expr, &result, false) {
         Ok(paths) => paths,
         // `?` swallows only a genuine error; a halt always escapes — see the
         // matching comment in `eval_assign` (#791).
         Err((_, EvalEscape::Error(_))) if optional => return QueryResult::None,
         Err((_, escape)) => return escape.into(),
     };
+    // #1351: redirect through aliases. `|=` is the one operator whose
+    // *terminal* alias position is also redirected, and only when the filter
+    // is itself a shape-preserving write (`.b |= (.p = 9)` mutates the shared
+    // node in yq; `.b |= 5` rebinds the position) -- see `alias_identity`.
+    alias_identity::redirect_paths(
+        &mut paths,
+        &result,
+        alias_identity::Redirect {
+            through_terminal: alias_identity::update_filter_writes_through(filter_expr),
+            fan_out_iterate: true,
+        },
+    );
+    let pre = alias_identity::active().then(|| result.clone());
 
     // yq's slice-assignment no-op (#1101, generalized to any chain depth by
     // #1116) — `update_path` itself now no-ops the *write* whenever it
@@ -20095,6 +20620,9 @@ fn eval_update<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
                 other => other.into(),
             };
         }
+    }
+    if let Some(pre) = &pre {
+        alias_identity::mirror_after_write(pre, &mut result);
     }
 
     QueryResult::Owned(result)
@@ -20403,6 +20931,10 @@ fn fork_rhs_over_paths<'a, W: Clone + AsRef<[u64]>, State>(
     let rhs_last = rhs_values.len() - 1;
     let last_path = paths.len().saturating_sub(1);
     let mut docs: Vec<OwnedValue> = vec_with_capacity(rhs_values.len());
+    // #1351: the pre-write document, kept only while an alias table is
+    // installed, so each forked result can re-copy a written anchor into the
+    // alias slots that were still untouched copies of it.
+    let pre = alias_identity::active().then(|| pristine.clone());
     for (j, rhs_value) in rhs_values.into_iter().enumerate() {
         let mut result = if j == rhs_last {
             core::mem::replace(&mut pristine, OwnedValue::Null)
@@ -20421,6 +20953,9 @@ fn fork_rhs_over_paths<'a, W: Clone + AsRef<[u64]>, State>(
                     other => partial(docs, other.into()),
                 };
             }
+        }
+        if let Some(pre) = &pre {
+            alias_identity::mirror_after_write(pre, &mut result);
         }
         docs.push(result);
     }
@@ -20498,6 +21033,19 @@ fn eval_update_multi<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
         }
     };
     let scalar_noop = scalar_slice_noop && S::TAG == EvalTag::Yq;
+    // #1351: a compound/alternative assign whose path *ends* at an alias
+    // rebinds that position (real yq discards the write outright there -- a
+    // data-loss bug succinctly does not reproduce, rule 4(b)); one whose path
+    // passes through an alias lands on the shared node.
+    let mut paths = paths;
+    alias_identity::redirect_paths(
+        &mut paths,
+        &pristine,
+        alias_identity::Redirect {
+            through_terminal: false,
+            fan_out_iterate: true,
+        },
+    );
 
     fork_rhs_over_paths::<W, _>(
         pristine,
@@ -38914,8 +39462,18 @@ fn builtin_setpath<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
                 Ok(owned) => owned,
                 Err(e) => return suppress_or_raise(e, optional),
             };
+            // #1351: `setpath(["b","p"]; 9)` through an alias lands on the
+            // shared node, like `.b.p = 9`.
+            let mut path = path;
+            alias_identity::redirect_concrete_path(&mut path, &owned);
+            let pre = alias_identity::active().then(|| owned.clone());
             match set_value_at_path(owned, &path, new_val) {
-                Ok(result) => QueryResult::Owned(result),
+                Ok(mut result) => {
+                    if let Some(pre) = &pre {
+                        alias_identity::mirror_after_write(pre, &mut result);
+                    }
+                    QueryResult::Owned(result)
+                }
                 // An optional context swallows the refusal, as it does for
                 // every other builtin here.
                 Err(_) if optional => QueryResult::None,
@@ -40552,6 +41110,13 @@ fn builtin_del<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     // `Expr::Optional` node baked into `path_expr`, which the walkers still
     // honor on their own.
     let mut result = to_owned_or_suppress!(&value, optional);
+    // #1351: pre-write snapshot for the alias mirror, only while a table is
+    // installed (never in jq mode).
+    let del_pre = alias_identity::active().then(|| result.clone());
+    let del_redirect = alias_identity::Redirect {
+        through_terminal: false,
+        fan_out_iterate: false,
+    };
 
     // yq's comma-grouped chained-slice del() pre-rewrite (#1223):
     // `resolve_dynamic_indexes`'s own generic navigation raises a hard type
@@ -40681,6 +41246,15 @@ fn builtin_del<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
                 // `filter_map`'s dropped sibling and `DropParent`'s truncated
                 // one both stop existing once branches share nodes.
                 let inserted = match slice_paths.get(index).and_then(Option::as_ref) {
+                    // #1351: a branch descending through an alias position
+                    // deletes from the shared node. Assembling the branch to
+                    // a flat `Expr` costs the O(depth) #1690 avoided, but only
+                    // while an alias table is installed.
+                    None if alias_identity::active() => {
+                        let mut exprs = vec![assemble_one_branch(branch)];
+                        alias_identity::redirect_paths(&mut exprs, &result, del_redirect);
+                        exprs.iter().try_for_each(|e| builder.insert_expr(e))
+                    }
                     None => builder.insert_branch(&branch.path),
                     Some(path) => match yq_del_slice_outcome(path, &result, false) {
                         YqDelSliceOutcome::DropParent(rewritten) => builder.insert_expr(&rewritten),
@@ -40713,7 +41287,12 @@ fn builtin_del<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
         // walk below can take it by value.
         drop(resolved);
         return match delete_trie_apply(result, &trie, DELETE_TRIE_ROOT, S::TAG == EvalTag::Yq) {
-            Ok(result) => QueryResult::Owned(result),
+            Ok(mut result) => {
+                if let Some(pre) = &del_pre {
+                    alias_identity::mirror_after_write(pre, &mut result);
+                }
+                QueryResult::Owned(result)
+            }
             Err(_) if optional => QueryResult::None,
             Err(e) => e.into(),
         };
@@ -40729,6 +41308,10 @@ fn builtin_del<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
         DelPaths::Root => vec![Expr::Identity],
         DelPaths::Branches(branches) => assemble_path_branches(branches),
     };
+    // #1351: `del(.b.p)` on `b: *x` deletes from the anchor's node; `del(.b)`
+    // (a path ending at the alias) removes that position only.
+    let mut paths = paths;
+    alias_identity::redirect_paths(&mut paths, &result, del_redirect);
     debug_assert!(
         paths.len() <= 1,
         "a multi-path del() match set should have been merged into a DeleteTrie (#1690)"
@@ -40819,6 +41402,9 @@ fn builtin_del<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
                 QueryResult::Error(e)
             };
         }
+    }
+    if let Some(pre) = &del_pre {
+        alias_identity::mirror_after_write(pre, &mut result);
     }
     QueryResult::Owned(result)
 }
@@ -44907,6 +45493,20 @@ fn delpaths_one<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
             return QueryResult::Error(EvalError::path_must_be_array_not(path.type_name()));
         }
     }
+    // #1351: a path descending through an alias position deletes from the
+    // shared node. The extra `to_owned` runs only while a table is installed.
+    let delpaths_pre = if alias_identity::active() {
+        to_owned(value).ok()
+    } else {
+        None
+    };
+    if let Some(doc) = &delpaths_pre {
+        for path in &mut paths {
+            if let OwnedValue::Array(path) = path {
+                alias_identity::redirect_concrete_path(path, doc);
+            }
+        }
+    }
 
     // A NaN component is dropped with the path around it, because it names no
     // element at any depth — `resolve_read_index` refuses it, as jq's `jv_get`
@@ -45072,7 +45672,12 @@ fn delpaths_one<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     };
     match result {
         Ok(_) if root_deleted => QueryResult::None,
-        Ok(v) => QueryResult::Owned(v),
+        Ok(mut v) => {
+            if let Some(pre) = &delpaths_pre {
+                alias_identity::mirror_after_write(pre, &mut v);
+            }
+            QueryResult::Owned(v)
+        }
         // #1746 review: a decode failure from `to_owned` must bypass
         // `optional` the same way every other converted call site does
         // (`eval_assign`/`eval_update`/`builtin_path`/`builtin_setpath`/

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -84895,4 +84895,225 @@ mod tests {
         );
         query!(br"5", "(implode)?", QueryResult::None => {});
     }
+
+    /// #1351: `alias_identity`'s redirect and mirror, exercised directly on
+    /// hand-built tables so each gate is pinned independently of the CLI
+    /// tests that drive the same code end to end.
+    #[cfg(feature = "std")]
+    mod alias_identity_tests_1351 {
+        use super::*;
+
+        fn json(s: &str) -> OwnedValue {
+            parse_complete_json(s, false).unwrap()
+        }
+
+        fn path(keys: &[&str]) -> Vec<OwnedValue> {
+            keys.iter()
+                .map(|k| match k.parse::<i64>() {
+                    Ok(i) => OwnedValue::Int(i),
+                    Err(_) => OwnedValue::String((*k).to_string()),
+                })
+                .collect()
+        }
+
+        /// One `Field`/`Index`/`Iterate` component per entry, so a redirected
+        /// `Expr` can be compared without depending on how the parser nests
+        /// a `Pipe`.
+        fn steps(expr: &Expr) -> Vec<String> {
+            let mut flat = Vec::new();
+            push_path_components(&mut flat, expr);
+            flat.iter()
+                .map(|c| match unwrap_path_component(c).0 {
+                    Expr::Field(name) => name.clone(),
+                    Expr::Index { idx, .. } => idx.to_string(),
+                    Expr::Iterate => "[]".to_string(),
+                    other => format!("{other:?}"),
+                })
+                .collect()
+        }
+
+        fn table() -> alias_identity::AliasTable {
+            // a: &x {p: 1, q: 2} / b: *x / c: *x
+            alias_identity::AliasTable::from_groups(vec![(
+                path(&["a"]),
+                vec![path(&["b"]), path(&["c"])],
+            )])
+        }
+
+        const DOC: &str = r#"{"a":{"p":1,"q":2},"b":{"p":1,"q":2},"c":{"p":1,"q":2}}"#;
+
+        fn redirected(
+            filter: &str,
+            doc: &OwnedValue,
+            opts: alias_identity::Redirect,
+        ) -> Vec<Vec<String>> {
+            let mut paths = vec![parse(filter).unwrap()];
+            alias_identity::redirect_paths(&mut paths, doc, opts);
+            paths.iter().map(steps).collect()
+        }
+
+        const THROUGH: alias_identity::Redirect = alias_identity::Redirect {
+            through_terminal: false,
+            fan_out_iterate: true,
+        };
+
+        #[test]
+        fn nothing_installed_is_a_no_op() {
+            let doc = json(DOC);
+            assert!(!alias_identity::active());
+            assert_eq!(redirected(".b.p", &doc, THROUGH), vec![vec!["b", "p"]]);
+            let mut post = json(r#"{"a":{"p":9},"b":{"p":1}}"#);
+            alias_identity::mirror_after_write(&json(r#"{"a":{"p":1},"b":{"p":1}}"#), &mut post);
+            assert_eq!(post, json(r#"{"a":{"p":9},"b":{"p":1}}"#));
+        }
+
+        #[test]
+        fn proper_prefix_redirects_and_terminal_does_not() {
+            let _guard = alias_identity::enter(table());
+            let doc = json(DOC);
+            assert_eq!(redirected(".b.p", &doc, THROUGH), vec![vec!["a", "p"]]);
+            assert_eq!(redirected(".c.q", &doc, THROUGH), vec![vec!["a", "q"]]);
+            // Rule 1: a path ending exactly at the alias is left alone...
+            assert_eq!(redirected(".b", &doc, THROUGH), vec![vec!["b"]]);
+            // ...unless the caller asked for the terminal too (`|=` with a
+            // shape-preserving filter).
+            let terminal = alias_identity::Redirect {
+                through_terminal: true,
+                fan_out_iterate: true,
+            };
+            assert_eq!(redirected(".b", &doc, terminal), vec![vec!["a"]]);
+            // Paths off the alias positions are untouched.
+            assert_eq!(redirected(".a.p", &doc, THROUGH), vec![vec!["a", "p"]]);
+            assert_eq!(redirected(".zzz.p", &doc, THROUGH), vec![vec!["zzz", "p"]]);
+        }
+
+        #[test]
+        fn equality_gate_refuses_a_rebound_position() {
+            let _guard = alias_identity::enter(table());
+            // `b` was rebound to 5 earlier in the pipe: no longer the shared node.
+            let doc = json(r#"{"a":{"p":1,"q":2},"b":5,"c":{"p":1,"q":2}}"#);
+            assert_eq!(redirected(".b.p", &doc, THROUGH), vec![vec!["b", "p"]]);
+            assert_eq!(redirected(".c.p", &doc, THROUGH), vec![vec!["a", "p"]]);
+            // A deleted anchor leaves nothing to redirect to (rule 7).
+            let doc = json(r#"{"b":{"p":1,"q":2},"c":{"p":1,"q":2}}"#);
+            assert_eq!(redirected(".b.p", &doc, THROUGH), vec![vec!["b", "p"]]);
+        }
+
+        #[test]
+        fn iterate_fans_out_only_over_aliases_and_only_when_asked() {
+            let _guard = alias_identity::enter(table());
+            let doc = json(DOC);
+            assert_eq!(
+                redirected(".[].p", &doc, THROUGH),
+                vec![vec!["a", "p"], vec!["a", "p"], vec!["a", "p"]]
+            );
+            let no_fan = alias_identity::Redirect {
+                through_terminal: false,
+                fan_out_iterate: false,
+            };
+            assert_eq!(redirected(".[].p", &doc, no_fan), vec![vec!["[]", "p"]]);
+            // No alias lives under `.a`, so its iterate is left to the walker.
+            assert_eq!(
+                redirected(".a[].z", &doc, THROUGH),
+                vec![vec!["a", "[]", "z"]]
+            );
+        }
+
+        #[test]
+        fn multi_hop_and_negative_index_normalisation() {
+            // x: &y {z: 0} / a: &x {q: *y} / b: *x, and l: [&s {p: 1}, *s] --
+            // an alias reached through an array index.
+            let table = alias_identity::AliasTable::from_groups(vec![
+                (path(&["x"]), vec![path(&["a", "q"])]),
+                (path(&["a"]), vec![path(&["b"])]),
+                (path(&["l", "0"]), vec![path(&["l", "1"])]),
+            ]);
+            let _guard = alias_identity::enter(table);
+            let doc =
+                json(r#"{"x":{"z":0},"a":{"q":{"z":0}},"b":{"q":{"z":0}},"l":[{"p":1},{"p":1}]}"#);
+            assert_eq!(redirected(".b.q.z", &doc, THROUGH), vec![vec!["x", "z"]]);
+            // `.l[-1]` names the same slot as `.l[1]` for the table lookup; the
+            // components after a redirected prefix are kept as written.
+            assert_eq!(
+                redirected(".l[-1].p", &doc, THROUGH),
+                vec![vec!["l", "0", "p"]]
+            );
+            assert_eq!(
+                redirected(".l[1].p", &doc, THROUGH),
+                vec![vec!["l", "0", "p"]]
+            );
+            // Out of range: the static walk stops and the path is left as is.
+            assert_eq!(
+                redirected(".l[7].k", &doc, THROUGH),
+                vec![vec!["l", "7", "k"]]
+            );
+        }
+
+        #[test]
+        fn concrete_paths_redirect_and_slice_descriptors_bail() {
+            let _guard = alias_identity::enter(table());
+            let doc = json(DOC);
+            let mut p = path(&["b", "p"]);
+            alias_identity::redirect_concrete_path(&mut p, &doc);
+            assert_eq!(p, path(&["a", "p"]));
+            let mut terminal = path(&["b"]);
+            alias_identity::redirect_concrete_path(&mut terminal, &doc);
+            assert_eq!(terminal, path(&["b"]));
+            let slice = json(r#"{"start":0,"end":1}"#);
+            let mut with_slice = vec![OwnedValue::String("b".into()), slice.clone()];
+            alias_identity::redirect_concrete_path(&mut with_slice, &doc);
+            assert_eq!(with_slice, vec![OwnedValue::String("b".into()), slice]);
+        }
+
+        #[test]
+        fn mirror_copies_untouched_slots_and_skips_rebound_ones() {
+            let _guard = alias_identity::enter(table());
+            let pre = json(DOC);
+            // The write landed on the anchor; `b` is untouched, `c` was rebound.
+            let mut post = json(r#"{"a":{"p":9,"q":2},"b":{"p":1,"q":2},"c":null}"#);
+            alias_identity::mirror_after_write(&pre, &mut post);
+            assert_eq!(
+                post,
+                json(r#"{"a":{"p":9,"q":2},"b":{"p":9,"q":2},"c":null}"#)
+            );
+            // A slot that was not a copy of the anchor before the write is
+            // never written even if it still equals its own pre-write value.
+            let pre = json(r#"{"a":{"p":1,"q":2},"b":5,"c":{"p":1,"q":2}}"#);
+            let mut post = json(r#"{"a":{"p":9,"q":2},"b":5,"c":{"p":1,"q":2}}"#);
+            alias_identity::mirror_after_write(&pre, &mut post);
+            assert_eq!(post, json(r#"{"a":{"p":9,"q":2},"b":5,"c":{"p":9,"q":2}}"#));
+        }
+
+        #[test]
+        fn mirror_reaches_a_fixpoint_over_nested_groups() {
+            // a: &x {p: &y 1, q: *y} / b: *x -- group order puts the outer
+            // anchor first, so the inner alias's update must be picked up by a
+            // second pass.
+            let table = alias_identity::AliasTable::from_groups(vec![
+                (path(&["a"]), vec![path(&["b"])]),
+                (path(&["a", "p"]), vec![path(&["a", "q"])]),
+            ]);
+            let _guard = alias_identity::enter(table);
+            let pre = json(r#"{"a":{"p":1,"q":1},"b":{"p":1,"q":1}}"#);
+            let mut post = json(r#"{"a":{"p":5,"q":1},"b":{"p":1,"q":1}}"#);
+            alias_identity::mirror_after_write(&pre, &mut post);
+            assert_eq!(post, json(r#"{"a":{"p":5,"q":5},"b":{"p":5,"q":5}}"#));
+        }
+
+        #[test]
+        fn guard_restores_the_previous_table() {
+            assert!(!alias_identity::active());
+            {
+                let _outer = alias_identity::enter(table());
+                assert!(alias_identity::active());
+                {
+                    let _inner =
+                        alias_identity::enter(alias_identity::AliasTable::from_groups(vec![]));
+                    assert!(alias_identity::active());
+                }
+                assert!(alias_identity::active());
+            }
+            assert!(!alias_identity::active());
+        }
+    }
 }

--- a/src/jq/mod.rs
+++ b/src/jq/mod.rs
@@ -87,9 +87,10 @@ pub mod walk;
 
 pub use error::{BinOp, Control, ErrorKind, EvalError, EvalErrorPayload};
 pub use eval::{
-    enter_file_index_scope, eval, eval_documents_together, eval_lenient,
-    eval_owned_with_file_index, nonfinite_display_string, substitute_vars, sync_aliased_paths,
-    EvalSemantics, FileIndexScope, JqSemantics, QueryResult, YqSemantics,
+    alias_identity, enter_file_index_scope, eval, eval_documents_together, eval_lenient,
+    eval_owned_with_file_index, is_alias_sensitive_assign, nonfinite_display_string,
+    substitute_vars, sync_aliased_paths, EvalSemantics, FileIndexScope, JqSemantics, QueryResult,
+    YqSemantics,
 };
 // `input`/`inputs`/`input_line_number`'s CLI-facing seam (#723) -- only
 // exists under `eval.rs`'s own `#[cfg(feature = "std")]` gate (a `thread_local!`

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -35474,6 +35474,23 @@ fn test_yaml_rebound_alias_is_not_redirected_1351() -> Result<()> {
 }
 
 #[test]
+fn test_yaml_rebind_to_equal_value_is_indistinguishable_from_the_anchor_1351() -> Result<()> {
+    // DELIBERATE DIVERGENCE (docs/compliance/yq/limitations.md): the equality
+    // gate's one false positive. Real yq detaches `b` here (`b: {p: 1, q: 2}`);
+    // succinctly cannot tell a copy rebound to an equal value from an untouched
+    // one, so `b` follows the anchor.
+    for filter in [".b = .a | .a.p = 9", r#".b = {"p": 1, "q": 2} | .a.p = 9"#] {
+        assert_yq_1351(
+            filter,
+            "a: &x {p: 1, q: 2}\nb: *x\n",
+            "a: &x {p: 9, q: 2}\nb: *x\n",
+            r#"{"a":{"p":9,"q":2},"b":{"p":9,"q":2}}"#,
+        )?;
+    }
+    Ok(())
+}
+
+#[test]
 fn test_yaml_deleted_declaration_writes_positionally_1351() -> Result<()> {
     // Rule 7, a recorded limitation: with the anchor deleted earlier in the
     // pipe there is no declaration to redirect to, so `.b.p = 9` is

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -35176,3 +35176,307 @@ mod issue_1349_inplace_presentation {
         Ok(())
     }
 }
+
+// Issue #1351: a write *through* an alias reaches the shared node
+//
+// Real yq models `&x`/`*x` as one node reachable from several positions, and
+// decides by *path shape* whether a write mutates that node or rebinds one
+// position: a path that ends exactly at an alias (`.b = 5`) rebinds it; a
+// path that passes through the alias and continues (`.b.p = 9`) lands on
+// the anchor's node and every position follows. succinctly recovers that
+// distinction with `jq::alias_identity`'s path redirect (installed by
+// `evaluate_yaml_cursor` for alias-sensitive writes) plus a post-write
+// mirror. Every expected string below was captured live from yq v4.53.3.
+// =============================================================================
+
+const ALIAS_MAP_DOC_1351: &str = "a: &x {p: 1, q: 2}\nb: *x\nc: *x\n";
+const ALIAS_SEQ_DOC_1351: &str = "a: &x [1, 2]\nb: *x\n";
+
+fn assert_yq_1351(filter: &str, input: &str, yaml: &str, json: &str) -> Result<()> {
+    let (output, exit_code) = run_yq_stdin(filter, input, &[])?;
+    assert_eq!(exit_code, 0, "yaml run of {filter}");
+    assert_eq!(output, yaml, "yaml output of {filter}");
+    let (output, exit_code) = run_yq_stdin(filter, input, &["-o=json", "-I=0"])?;
+    assert_eq!(exit_code, 0, "json run of {filter}");
+    assert_eq!(output.trim(), json, "json output of {filter}");
+    Ok(())
+}
+
+#[test]
+fn test_yaml_write_through_alias_updates_shared_node_1351() -> Result<()> {
+    // The issue's own repro: yq mutates the anchor's node and keeps `b: *x`.
+    assert_yq_1351(
+        ".b.p = 9",
+        ALIAS_MAP_DOC_1351,
+        "a: &x {p: 9, q: 2}\nb: *x\nc: *x\n",
+        r#"{"a":{"p":9,"q":2},"b":{"p":9,"q":2},"c":{"p":9,"q":2}}"#,
+    )
+}
+
+#[test]
+fn test_yaml_write_through_alias_update_and_compound_1351() -> Result<()> {
+    for filter in [".b.p |= . + 1", ".b.p += 1"] {
+        assert_yq_1351(
+            filter,
+            ALIAS_MAP_DOC_1351,
+            "a: &x {p: 2, q: 2}\nb: *x\nc: *x\n",
+            r#"{"a":{"p":2,"q":2},"b":{"p":2,"q":2},"c":{"p":2,"q":2}}"#,
+        )?;
+    }
+    Ok(())
+}
+
+#[test]
+fn test_yaml_del_through_alias_deletes_from_shared_node_1351() -> Result<()> {
+    assert_yq_1351(
+        "del(.b.p)",
+        ALIAS_MAP_DOC_1351,
+        "a: &x {q: 2}\nb: *x\nc: *x\n",
+        r#"{"a":{"q":2},"b":{"q":2},"c":{"q":2}}"#,
+    )?;
+    // A comma-grouped `del()` goes through the delete trie, which redirects
+    // each branch on its own.
+    assert_yq_1351(
+        "del(.b.p, .c.q)",
+        ALIAS_MAP_DOC_1351,
+        "a: &x {}\nb: *x\nc: *x\n",
+        r#"{"a":{},"b":{},"c":{}}"#,
+    )
+}
+
+#[test]
+fn test_yaml_new_key_through_alias_lands_on_shared_node_1351() -> Result<()> {
+    assert_yq_1351(
+        ".b.r = 3",
+        ALIAS_MAP_DOC_1351,
+        "a: &x {p: 1, q: 2, r: 3}\nb: *x\nc: *x\n",
+        r#"{"a":{"p":1,"q":2,"r":3},"b":{"p":1,"q":2,"r":3},"c":{"p":1,"q":2,"r":3}}"#,
+    )
+}
+
+#[test]
+fn test_yaml_setpath_and_delpaths_through_alias_1351() -> Result<()> {
+    assert_yq_1351(
+        r#"setpath(["b","p"]; 9)"#,
+        ALIAS_MAP_DOC_1351,
+        "a: &x {p: 9, q: 2}\nb: *x\nc: *x\n",
+        r#"{"a":{"p":9,"q":2},"b":{"p":9,"q":2},"c":{"p":9,"q":2}}"#,
+    )?;
+    assert_yq_1351(
+        r#"delpaths([["b","p"]])"#,
+        ALIAS_MAP_DOC_1351,
+        "a: &x {q: 2}\nb: *x\nc: *x\n",
+        r#"{"a":{"q":2},"b":{"q":2},"c":{"q":2}}"#,
+    )
+}
+
+#[test]
+fn test_yaml_write_through_alias_sequence_index_1351() -> Result<()> {
+    assert_yq_1351(
+        ".b[0] = 9",
+        ALIAS_SEQ_DOC_1351,
+        "a: &x [9, 2]\nb: *x\n",
+        r#"{"a":[9,2],"b":[9,2]}"#,
+    )?;
+    // A negative index is normalised against the container before the
+    // table lookup, so `.b[-1]` names the same slot as `.b[1]`.
+    assert_yq_1351(
+        ".b[-1] = 5",
+        ALIAS_SEQ_DOC_1351,
+        "a: &x [1, 5]\nb: *x\n",
+        r#"{"a":[1,5],"b":[1,5]}"#,
+    )?;
+    assert_yq_1351(
+        ".b[2] = 3",
+        ALIAS_SEQ_DOC_1351,
+        "a: &x [1, 2, 3]\nb: *x\n",
+        r#"{"a":[1,2,3],"b":[1,2,3]}"#,
+    )?;
+    assert_yq_1351(
+        "del(.b[0])",
+        ALIAS_SEQ_DOC_1351,
+        "a: &x [2]\nb: *x\n",
+        r#"{"a":[2],"b":[2]}"#,
+    )?;
+    // A container nested inside the aliased mapping.
+    assert_yq_1351(
+        ".b.s[0] = 9",
+        "a: &x {s: [1, 2]}\nb: *x\n",
+        "a: &x {s: [9, 2]}\nb: *x\n",
+        r#"{"a":{"s":[9,2]},"b":{"s":[9,2]}}"#,
+    )
+}
+
+#[test]
+fn test_yaml_write_through_alias_multi_hop_1351() -> Result<()> {
+    // `.b` aliases `a`, whose `q` aliases `x`: the redirect follows both hops.
+    assert_yq_1351(
+        ".b.q.z = 1",
+        "x: &y {z: 0}\na: &x {q: *y}\nb: *x\n",
+        "x: &y {z: 1}\na: &x {q: *y}\nb: *x\n",
+        r#"{"x":{"z":1},"a":{"q":{"z":1}},"b":{"q":{"z":1}}}"#,
+    )
+}
+
+#[test]
+fn test_yaml_write_through_alias_nested_anchor_1351() -> Result<()> {
+    let doc = "a: &x\n  p: &y 1\n  q: *y\nb: *x\n";
+    // Through the outer alias onto the inner anchor: the inner alias follows
+    // too, and the outer alias sees both changes (the mirror iterates to a
+    // fixpoint over the nested groups).
+    assert_yq_1351(
+        ".b.p = 5",
+        doc,
+        "a: &x\n  p: &y 5\n  q: *y\nb: *x\n",
+        r#"{"a":{"p":5,"q":5},"b":{"p":5,"q":5}}"#,
+    )?;
+    // Through the outer alias onto the inner *alias*: that terminal position
+    // rebinds (drops `*y`), and the outer alias still follows.
+    assert_yq_1351(
+        ".b.q = 5",
+        doc,
+        "a: &x\n  p: &y 1\n  q: 5\nb: *x\n",
+        r#"{"a":{"p":1,"q":5},"b":{"p":1,"q":5}}"#,
+    )
+}
+
+#[test]
+fn test_yaml_write_ending_at_alias_rebinds_that_position_1351() -> Result<()> {
+    // Rule 1: a path that ends exactly at the alias never redirects.
+    for filter in [".b = 5", ".b |= 5"] {
+        assert_yq_1351(
+            filter,
+            ALIAS_MAP_DOC_1351,
+            "a: &x {p: 1, q: 2}\nb: 5\nc: *x\n",
+            r#"{"a":{"p":1,"q":2},"b":5,"c":{"p":1,"q":2}}"#,
+        )?;
+    }
+    assert_yq_1351(
+        "del(.b)",
+        ALIAS_MAP_DOC_1351,
+        "a: &x {p: 1, q: 2}\nc: *x\n",
+        r#"{"a":{"p":1,"q":2},"c":{"p":1,"q":2}}"#,
+    )
+}
+
+#[test]
+fn test_yaml_update_body_write_at_alias_redirects_1351() -> Result<()> {
+    // Rule 4: `|=` whose filter is itself a shape-preserving write mutates the
+    // shared node in yq, unlike `.b |= 5` above.
+    assert_yq_1351(
+        ".b |= (.p = 9 | .q = 8)",
+        ALIAS_MAP_DOC_1351,
+        "a: &x {p: 9, q: 8}\nb: *x\nc: *x\n",
+        r#"{"a":{"p":9,"q":8},"b":{"p":9,"q":8},"c":{"p":9,"q":8}}"#,
+    )?;
+    assert_yq_1351(
+        ".b |= del(.p)",
+        ALIAS_MAP_DOC_1351,
+        "a: &x {q: 2}\nb: *x\nc: *x\n",
+        r#"{"a":{"q":2},"b":{"q":2},"c":{"q":2}}"#,
+    )
+}
+
+#[test]
+fn test_yaml_value_update_at_alias_rebinds_not_discarded_1351() -> Result<()> {
+    // Rule 5, a recorded divergence (docs/compliance/yq/limitations.md): real
+    // yq silently *discards* `.b |= . + 1` / `.b += 1` / `.b += [3]` /
+    // `.b |= . + {..}` at an alias node (it prints the document unchanged).
+    // succinctly rebinds the position with the computed value instead, the
+    // same as `.b |= 5`, rather than lose the write (rule 4(b)).
+    for filter in [".b |= . + 1", ".b += 1"] {
+        assert_yq_1351(
+            filter,
+            "a: &x 1\nb: *x\n",
+            "a: &x 1\nb: 2\n",
+            r#"{"a":1,"b":2}"#,
+        )?;
+    }
+    assert_yq_1351(
+        ".b += [3]",
+        ALIAS_SEQ_DOC_1351,
+        "a: &x [1, 2]\nb:\n  - 1\n  - 2\n  - 3\n",
+        r#"{"a":[1,2],"b":[1,2,3]}"#,
+    )?;
+    assert_yq_1351(
+        r#".b |= . + {"r": 3}"#,
+        ALIAS_MAP_DOC_1351,
+        "a: &x {p: 1, q: 2}\nb:\n  p: 1\n  q: 2\n  r: 3\nc: *x\n",
+        r#"{"a":{"p":1,"q":2},"b":{"p":1,"q":2,"r":3},"c":{"p":1,"q":2}}"#,
+    )
+}
+
+#[test]
+fn test_yaml_writes_accumulate_over_shared_positions_1351() -> Result<()> {
+    // Rule 6: three positions sharing one node take three increments.
+    assert_yq_1351(
+        ".[] .p += 1",
+        ALIAS_MAP_DOC_1351,
+        "a: &x {p: 4, q: 2}\nb: *x\nc: *x\n",
+        r#"{"a":{"p":4,"q":2},"b":{"p":4,"q":2},"c":{"p":4,"q":2}}"#,
+    )?;
+    let seq = "items:\n  - &t {n: 1}\n  - *t\n  - *t\n";
+    assert_yq_1351(
+        ".items[].n += 1",
+        seq,
+        "items:\n  - &t {n: 4}\n  - *t\n  - *t\n",
+        r#"{"items":[{"n":4},{"n":4},{"n":4}]}"#,
+    )?;
+    assert_yq_1351(
+        ".items[1].n = 9",
+        seq,
+        "items:\n  - &t {n: 9}\n  - *t\n  - *t\n",
+        r#"{"items":[{"n":9},{"n":9},{"n":9}]}"#,
+    )
+}
+
+#[test]
+fn test_yaml_pipe_of_writes_through_two_aliases_1351() -> Result<()> {
+    // The mirror runs after each write expression, so the second stage sees
+    // `c` still equal to the anchor and redirects too.
+    assert_yq_1351(
+        ".b.p = 9 | .c.q = 8",
+        ALIAS_MAP_DOC_1351,
+        "a: &x {p: 9, q: 8}\nb: *x\nc: *x\n",
+        r#"{"a":{"p":9,"q":8},"b":{"p":9,"q":8},"c":{"p":9,"q":8}}"#,
+    )
+}
+
+#[test]
+fn test_yaml_rebound_alias_is_not_redirected_1351() -> Result<()> {
+    // Rule 3: once `.b` has been rebound its value no longer equals the
+    // anchor's, so `.b.p = 9` is positional -- a yq-mode field write on a
+    // scalar is a no-op, leaving `b: 5`.
+    assert_yq_1351(
+        ".b = 5 | .b.p = 9",
+        ALIAS_MAP_DOC_1351,
+        "a: &x {p: 1, q: 2}\nb: 5\nc: *x\n",
+        r#"{"a":{"p":1,"q":2},"b":5,"c":{"p":1,"q":2}}"#,
+    )
+}
+
+#[test]
+fn test_yaml_deleted_declaration_writes_positionally_1351() -> Result<()> {
+    // Rule 7, a recorded limitation: with the anchor deleted earlier in the
+    // pipe there is no declaration to redirect to, so `.b.p = 9` is
+    // positional and `c` does not follow. Real yq prints `b: *x` / `c: *x`
+    // with no `&x` anywhere (a document it cannot read back, rule 4(a)).
+    let (output, exit_code) = run_yq_stdin("del(.a) | .b.p = 9", ALIAS_MAP_DOC_1351, &[])?;
+    assert_eq!(exit_code, 0);
+    assert_eq!(output, "b:\n  p: 9\n  q: 2\nc:\n  p: 1\n  q: 2\n");
+    Ok(())
+}
+
+#[test]
+fn test_yaml_write_through_alias_leaves_json_input_alone_1351() -> Result<()> {
+    // JSON has no aliases: no table is installed and `.b.p = 9` writes `b`
+    // only, exactly as before.
+    let (output, exit_code) = run_yq_stdin(
+        ".b.p = 9",
+        r#"{"a": {"p": 1}, "b": {"p": 1}}"#,
+        &["-o=json", "-I=0"],
+    )?;
+    assert_eq!(exit_code, 0);
+    assert_eq!(output.trim(), r#"{"a":{"p":1},"b":{"p":9}}"#);
+    Ok(())
+}

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -35491,6 +35491,86 @@ fn test_yaml_rebind_to_equal_value_is_indistinguishable_from_the_anchor_1351() -
 }
 
 #[test]
+fn test_yaml_anchor_write_after_rebind_leaves_the_rebound_slot_alone_1351() -> Result<()> {
+    // #2499's shapes: an alias slot rebound earlier in the pipe is no longer a
+    // copy of the anchor, so a later anchor write must not resync it. The
+    // per-write mirror and the end-of-pipe sync share one rule
+    // (`propagate_anchor_writes`), so neither pass clobbers `b`.
+    assert_yq_1351(
+        ".b = null | .a.p = 9",
+        ALIAS_MAP_DOC_1351,
+        "a: &x {p: 9, q: 2}\nb: null\nc: *x\n",
+        r#"{"a":{"p":9,"q":2},"b":null,"c":{"p":9,"q":2}}"#,
+    )?;
+    assert_yq_1351(
+        ".b = 5 | .a.p = 9",
+        ALIAS_MAP_DOC_1351,
+        "a: &x {p: 9, q: 2}\nb: 5\nc: *x\n",
+        r#"{"a":{"p":9,"q":2},"b":5,"c":{"p":9,"q":2}}"#,
+    )?;
+    assert_yq_1351(
+        "del(.b) | .a.p = 9",
+        ALIAS_MAP_DOC_1351,
+        "a: &x {p: 9, q: 2}\nc: *x\n",
+        r#"{"a":{"p":9,"q":2},"c":{"p":9,"q":2}}"#,
+    )?;
+    // A through-write followed by a rebind of the same position.
+    assert_yq_1351(
+        ".b.p = 9 | .b = 5",
+        ALIAS_MAP_DOC_1351,
+        "a: &x {p: 9, q: 2}\nb: 5\nc: *x\n",
+        r#"{"a":{"p":9,"q":2},"b":5,"c":{"p":9,"q":2}}"#,
+    )
+}
+
+#[test]
+fn test_yaml_through_write_then_anchor_write_keeps_every_slot_in_step_1351() -> Result<()> {
+    // A write that touched both positions (via `.[]`, or explicitly) must not
+    // read as a rebind: the later anchor-only write still reaches every alias.
+    for filter in [".[].p = 9 | .a.q = 7", ".a.p = 9 | .b.p = 9 | .a.q = 7"] {
+        assert_yq_1351(
+            filter,
+            ALIAS_MAP_DOC_1351,
+            "a: &x {p: 9, q: 7}\nb: *x\nc: *x\n",
+            r#"{"a":{"p":9,"q":7},"b":{"p":9,"q":7},"c":{"p":9,"q":7}}"#,
+        )?;
+    }
+    assert_yq_1351(
+        ".a.p = 9 | .b.q = 3",
+        ALIAS_MAP_DOC_1351,
+        "a: &x {p: 9, q: 3}\nb: *x\nc: *x\n",
+        r#"{"a":{"p":9,"q":3},"b":{"p":9,"q":3},"c":{"p":9,"q":3}}"#,
+    )?;
+    // Nested groups: the inner alias `q` is rebound by the second stage while
+    // the outer alias `b` still follows the anchor.
+    assert_yq_1351(
+        ".[].p = 9 | .a.q = 7",
+        "a: &x\n  p: &y 1\n  q: *y\nb: *x\n",
+        "a: &x\n  p: &y 9\n  q: 7\nb: *x\n",
+        r#"{"a":{"p":9,"q":7},"b":{"p":9,"q":7}}"#,
+    )
+}
+
+#[test]
+fn test_yaml_nested_groups_sync_to_a_fixpoint_1351() -> Result<()> {
+    // #2498's shapes: a write through the anchor whose change must reach an
+    // inner alias and then the outer alias, whichever order the groups were
+    // collected in.
+    assert_yq_1351(
+        ".a.p = 5",
+        "a: &x\n  p: &y 1\n  q: *y\nb: *x\n",
+        "a: &x\n  p: &y 5\n  q: *y\nb: *x\n",
+        r#"{"a":{"p":5,"q":5},"b":{"p":5,"q":5}}"#,
+    )?;
+    assert_yq_1351(
+        ".x = 5",
+        "x: &y 1\na: &x {q: *y}\nb: *x\n",
+        "x: &y 5\na: &x {q: *y}\nb: *x\n",
+        r#"{"x":5,"a":{"q":5},"b":{"q":5}}"#,
+    )
+}
+
+#[test]
 fn test_yaml_deleted_declaration_writes_positionally_1351() -> Result<()> {
     // Rule 7, a recorded limitation: with the anchor deleted earlier in the
     // pipe there is no declaration to redirect to, so `.b.p = 9` is

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -24664,19 +24664,17 @@ fn test_yaml_write_inside_anchored_container_keeps_anchor_763() -> Result<()> {
 }
 
 #[test]
-fn test_yaml_write_through_alias_drops_the_mark_rather_than_the_write_763() -> Result<()> {
-    // DELIBERATE DIVERGENCE. Real yq models an alias as a shared node, so
-    // `.b.p = 9` mutates the anchor's own value and prints
-    // `a: &x {p: 9}\nb: *x\n`. succinctly's alias sync is one-directional
-    // (anchor -> aliases), so `.a` still holds `{p: 1}` here. Emitting
-    // `b: *x` on top of that would silently throw the write away and print
-    // `p: 1` back; the soundness gate sees the two values disagree and drops
-    // the mark instead, so the computed value survives. Tracked separately
-    // as the alias-identity follow-up.
+fn test_yaml_write_through_alias_reaches_the_shared_node_763_1351() -> Result<()> {
+    // Until #1351 this test pinned a DELIBERATE DIVERGENCE: succinctly's
+    // alias sync was one-directional, so `.b.p = 9` updated only `.b`, and
+    // the soundness gate dropped `b`'s mark rather than let `b: *x` discard
+    // the write (`a: &x {p: 1}\nb:\n  p: 9\n`). #1351's path redirect now
+    // lands the write on the anchor's node, as real yq does, and the mark
+    // survives because the values agree again.
     let input = "a: &x {p: 1}\nb: *x\n";
     let (output, exit_code) = run_yq_stdin(".b.p = 9", input, &[])?;
     assert_eq!(exit_code, 0);
-    assert_eq!(output, "a: &x {p: 1}\nb:\n  p: 9\n");
+    assert_eq!(output, "a: &x {p: 9}\nb: *x\n");
     Ok(())
 }
 
@@ -25056,14 +25054,34 @@ fn test_yaml_nested_alias_mark_is_dropped_at_its_own_path_763() -> Result<()> {
     // Exercises the soundness gate's path bookkeeping: the mark it clears
     // is two levels down, so it has to walk back to that exact node rather
     // than the root. Object and array steps both, since they take separate
-    // branches.
+    // branches. The write *ends* at the alias (a rebind to a different value
+    // of the same kind, so `reconcile_presentation` keeps the stale mark and
+    // only the gate can clear it); a write *through* the alias would instead
+    // be redirected onto the anchor since #1351 -- see the test below.
+    let (output, exit_code) =
+        run_yq_stdin(r#".o.b = {"p": 5}"#, "o:\n  a: &x {p: 1}\n  b: *x\n", &[])?;
+    assert_eq!(exit_code, 0);
+    assert_eq!(output, "o:\n  a: &x {p: 1}\n  b:\n    p: 5\n");
+
+    let (output, exit_code) =
+        run_yq_stdin(r#".l[1] = {"p": 5}"#, "l:\n  - &x {p: 1}\n  - *x\n", &[])?;
+    assert_eq!(exit_code, 0);
+    assert_eq!(output, "l:\n  - &x {p: 1}\n  - p: 5\n");
+    Ok(())
+}
+
+#[test]
+fn test_yaml_nested_write_through_alias_keeps_the_mark_763_1351() -> Result<()> {
+    // The same two nested shapes written *through* the alias: #1351 redirects
+    // each onto the anchor two levels down, so the mark survives (verified
+    // against yq v4.53.3).
     let (output, exit_code) = run_yq_stdin(".o.b.p = 9", "o:\n  a: &x {p: 1}\n  b: *x\n", &[])?;
     assert_eq!(exit_code, 0);
-    assert_eq!(output, "o:\n  a: &x {p: 1}\n  b:\n    p: 9\n");
+    assert_eq!(output, "o:\n  a: &x {p: 9}\n  b: *x\n");
 
     let (output, exit_code) = run_yq_stdin(".l[1].p = 9", "l:\n  - &x {p: 1}\n  - *x\n", &[])?;
     assert_eq!(exit_code, 0);
-    assert_eq!(output, "l:\n  - &x {p: 1}\n  - p: 9\n");
+    assert_eq!(output, "l:\n  - &x {p: 9}\n  - *x\n");
     Ok(())
 }
 


### PR DESCRIPTION
## Summary

Real yq treats `&x`/`*x` as one node reachable from several positions, and decides **by path shape** whether a write mutates it or rebinds a position: a path ending exactly at an alias (`.b = 5`, `.b |= 5`, `del(.b)`) rebinds it; a path passing through the alias (`.b.p = 9`, `del(.b.p)`, `.b[0] = 9`, `setpath(["b","p"]; 9)`) mutates the anchor's node so every position follows. succinctly cloned every alias, so `.b.p = 9` updated only `.b` and the soundness pass dropped the alias mark rather than discard the write.

This is case 1 of issue 1351, per the design plan posted there (phases 1–2). It keeps the copy model and `OwnedValue`'s shape (ADR-0017), and recovers the shared-node behaviour with a path redirect:

- **`jq::alias_identity`** (new, `eval.rs`): an ambient `(alias path → anchor path)` table, installed by `evaluate_yaml_cursor` only for an alias-sensitive write on an alias-bearing document (the same gate as the existing sync), consulted at every yq-mode write entry point — `=`, `|=`, compound and alternative assign, `del()` (single path and the delete trie), `setpath`, `delpaths`.
- **Redirect**: each resolved path whose *proper* prefix is an alias position is rewritten onto the anchor's path, transitively (`x: &y {z: 0}` / `a: &x {q: *y}` / `b: *x`, `.b.q.z = 1` writes `x.z`), and only while the alias position still equals the anchor — *identity by equality*, so a position rebound earlier in the pipe (`.b = 5 | .b.p = 9`) stays positional exactly as yq treats a rebound position. `|=` also redirects its terminal position when its filter is itself a shape-preserving write (`.b |= (.p = 9)`, `.b |= del(.p)`); `.b |= 5` rebinds.
- **Mirror**: after each write expression the anchor's new value is copied into every alias slot that was still an untouched copy before the write, to a fixpoint over nested groups, so later pipe stages see a consistent document and shared positions accumulate (`.[] .p += 1` over three positions is 4, as in yq).
- `is_alias_sensitive_assign` moves into the library so the CLI gates and the `|=` rule read one definition; it now also covers `setpath`/`delpaths`.

jq mode never installs a table; JSON input in yq mode has no aliases and is unaffected.

Every expected string was captured live from Homebrew yq v4.53.3 (full matrix in the plan comment on issue 1351). Recorded divergences (`docs/compliance/yq/limitations.md`, ADR-0017 second amendment, CLAUDE.md):

- yq silently **discards** a value-producing update at an alias node (`.b += 1`, `.b |= . + 1`, `.b += [3]`, `.b |= . + {..}`) and errors on `.b |= reverse`; succinctly rebinds with the computed value (rule 4(b)).
- A declaration deleted earlier in the pipe leaves nothing to redirect to (`del(.a) | .b.p = 9` stays positional).
- The equality gate's one false positive: a rebind to a value equal to the anchor's (`.b = .a | .a.p = 9`) is kept in step where yq detaches it.

Two #763 tests that deliberately pinned the old "drop the mark, write only `.b`" output now assert the yq-matching output; the nested soundness-gate test keeps its purpose through a same-kind rebind.

**One propagation rule.** Review found the per-write mirror and the pre-existing end-of-pipe `sync_aliased_paths` were two algorithms in sequence, the older unconditional one overriding the mirror (`.b = null | .a.p = 9` still clobbered `b`). Both now call `propagate_anchor_writes`: an alias slot is overwritten only while it still holds its pre-write value and that value was the anchor's (a rebound, deleted or moved slot is never written or autovivified), iterating to a fixpoint over nested groups. That closes issues 2498 and 2499 as well, so PR #2504 is superseded; its shapes are pinned here (`.b = null | .a.p = 9`, `del(.b) | .a.p = 9`, `.a.p = 5` on the nested doc, `.x = 5` with the inner declaration outside the outer anchor) together with the through-write-then-anchor-write shapes its own review flagged (`.[].p = 9 | .a.q = 7`, `.a.p = 9 | .b.p = 9 | .a.q = 7`).

**`setpath`/`delpaths`.** Making them alias-sensitive also switches on the #739/#870 presentation reconcile for them, so `collect_write_targets` learns their literal-path forms (`setpath(["arr",1]; 9)`, `delpaths([["arr",0]])`) — yq's `delpaths` with several paths is sequential, not a simultaneous set, so that form stays a non-static write.

Follow-ups filed from the review and the sweep: issue 2505 (remaining mark-propagation shapes), 2513 (merge-key duplicate declaration), 2514 (numeric index written on a mapping), 2520 (multi-document stream applies alias handling to the last document only, pre-existing).

## Test plan

- [x] `cargo build --release --features cli`; live-diffed the full oracle matrix (mapping, sequence, nested-anchor, multi-hop, scalar, index-shift documents; `=`, `|=`, `+=`, `del`, `setpath`, `delpaths`, `.[]`, pipes) against yq v4.53.3 — every row matches except the recorded divergences
- [x] `cargo test --no-fail-fast --features cli,simd,regex,serde` (all suites green after the two #763 test updates)
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings`
- [x] `cargo test --no-default-features` (no_std)
- [x] `cargo fmt -- --check`
- [x] 22 new CLI tests suffixed `_1351` plus 10 unit tests on `alias_identity` covering rules 1–7 with YAML and `-o=json` twins
- [x] `scripts/yq-alias-oracle-sweep.sh --summary` (400 cases, 8 documents × 50 filters): every `values-differ` row is one of (a) the rebind-then-sync clobber that PR #2504's gate closes (`.b.p = 9 | .b = 5`, `.b = null | .a.p = 9`, `.[].p = 9 | .a.q = 7` on the nested doc), (b) the recorded rule 4(b)/false-positive divergences, or (c) pre-existing, alias-unrelated gaps now filed as issue 2514 (numeric index written on a mapping) and already tracked as issue 1419 (comma-grouped assign on a scalar)

Fixes #1351
Fixes #2498
Fixes #2499
