### PR TITLE
fix(yq): route --inplace's DOM fallback through the cursor-native evaluator

### DIFF
--- a/docs/adrs/adr-0017.md
+++ b/docs/adrs/adr-0017.md
@@ -151,11 +151,16 @@ still owes, the explicit source tag the DOM path drops (#1132/#747), a home with
 further pass over every construction site: grouping the loose `(comment, style)` tuple
 fields into `NodeMeta` is the one refactor, not the first of three.
 
-The one output route that inherits *nothing* from this is `--inplace`, which never builds
-a `CommentTree` at all — it evaluates through `evaluate_input` with
-`CommentTree::empty()`, so it drops comments, style and anchors alike, and skips #711's
-alias value sync too. That is #1349: a gap in that route's own wiring, not something the
-side-tree choice can reach.
+One output route used to inherit *nothing* from this: `--inplace`'s DOM fallback never
+built a `CommentTree` at all, evaluating through `evaluate_input` with
+`CommentTree::empty()`, so it dropped comments, style and anchors alike and skipped
+#711's alias value sync. That was #1349 — a gap in that route's own wiring, not
+something the side-tree choice could reach — and it is closed: a YAML-sourced `-i` file
+now goes through `evaluate_yaml_direct_filtered`, the same cursor-native evaluator
+stdout uses, so the same filter no longer produces a different document depending on
+whether it edited the file or printed it. JSON-sourced `-i` files stay on the
+materializing route on purpose (see #2276): a `YamlIndex` accepts `[1,]` as a flow
+sequence, and JSON has no comments, anchors or block style to lose.
 
 Two further findings from implementing it, both worth recording because they contradict
 what this ADR assumed:

--- a/docs/compliance/yq/limitations.md
+++ b/docs/compliance/yq/limitations.md
@@ -1213,23 +1213,33 @@ $ echo '"a{}c"' | yq            'sub({};"X";"g")'   # "ac" (coerces to "{}", als
 $ echo '"a{}c"' | succinctly yq 'sub({};"X";"g")'   # Error: object ({}) is not a string -- unchanged, known gap
 ```
 
-### Presentation metadata lost on two whole output routes
+### Presentation metadata lost on one whole output route
 
-Neither route builds a `CommentTree`, so both drop comments, style **and** anchors together:
-`--inplace` never builds one ([#1349](https://github.com/rust-works/succinctly/issues/1349)),
-and any filter yielding multiple results — anything containing a comma — loses its cursor
-before one can be captured
-([#1361](https://github.com/rust-works/succinctly/issues/1361)). Both predate
-[ADR-0017](../../adrs/adr-0017.md)'s mechanism and neither is anchor-specific.
+A filter yielding multiple results — anything containing a comma — loses its cursor before a
+`CommentTree` can be captured, so it drops comments, style **and** anchors together
+([#1361](https://github.com/rust-works/succinctly/issues/1361)). It predates
+[ADR-0017](../../adrs/adr-0017.md)'s mechanism and is not anchor-specific.
 
-There used to be a third: `map(...)`, which lost all three the same way for the same reason —
-it took the DOM route, which carries none of them.
+Two others have been closed. `map(...)` lost all three the same way for the same reason — it
+took the DOM route, which carried none of them;
 [#757](https://github.com/rust-works/succinctly/issues/757) closed it by streaming `map`'s
-elements from their own cursors (see the duplicate-key section above for the full list of
-what that one route was dropping). `--inplace` is *not* an exception here despite #1349:
-its M2 fast path shares `stream_cursor!` with stdout, so an M2-eligible `map` keeps comments
-and style through `-i` too — #1349 is about the `--inplace` **DOM fallback**, which a
-non-M2-eligible filter still reaches.
+elements from their own cursors (see the duplicate-key section above for the full list of what
+that one route was dropping). And `--inplace`'s DOM fallback, which never built a
+`CommentTree` at all, was closed by
+[#1349](https://github.com/rust-works/succinctly/issues/1349): a YAML-sourced `-i` file now
+goes through the same cursor-native evaluator stdout uses, so `-i '.a = 99'` on
+`a: &x 1\nb: *x` writes `b: *x` rather than the `b: 1` it used to — the same filter no longer
+produces a different *value* depending on whether it edited the file or printed it. `-i`'s M2
+fast path already shared `stream_cursor!` with stdout, so this only ever concerned the
+fallback a non-M2-eligible filter reaches.
+
+A JSON-sourced `-i` file stays on the materializing route deliberately: a `YamlIndex` accepts
+`[1,]` as a flow sequence, so rerouting it would reopen the hole
+[#2276](https://github.com/rust-works/succinctly/issues/2276) closed, and JSON has no
+comments, anchors or block style to lose either way. The duplicate-key cost noted above is
+also unchanged by #1349 — `evaluate_yaml_cursor` still materializes each result into an
+`IndexMap`-backed `OwnedValue` before `output_value` writes it, so the cursor-native route
+preserves *presentation* but not duplicate keys.
 
 ### An untracked terminal path branch — resolved for `path()`/`=`/`|=`/compound-assigns, still open for `del()` and for trailing navigation
 

--- a/docs/compliance/yq/limitations.md
+++ b/docs/compliance/yq/limitations.md
@@ -1233,6 +1233,18 @@ produces a different *value* depending on whether it edited the file or printed 
 fast path already shared `stream_cursor!` with stdout, so this only ever concerned the
 fallback a non-M2-eligible filter reaches.
 
+**One fork remains between `-i` and stdout**, and it is deliberate. A document with two
+*complex* mapping keys whose display spellings collide (`? [1]\n: v1\n? [2]\n: v2`, both
+`""` per [#222](https://github.com/rust-works/succinctly/issues/222)) makes `-i` raise
+`object key "" is ambiguous` and leave the file untouched
+([#1749](https://github.com/rust-works/succinctly/issues/1749)'s guard), where stdout prints
+`'': v2` and drops the first entry silently. Real yq keeps *both* keys, so both routes
+diverge from it; `-i` diverges in the safe direction, since the alternative is destroying a
+key in the user's own file. Closing the stdout half needs `YamlValue::key_string_kind`'s
+classification on the `DocumentValue` trait — `resolve_display_key`'s generic
+`key_display_string_kind` flags only keys whose *decode* failed, and a complex key decodes
+cleanly to `""`.
+
 A JSON-sourced `-i` file stays on the materializing route deliberately: a `YamlIndex` accepts
 `[1,]` as a flow sequence, so rerouting it would reopen the hole
 [#2276](https://github.com/rust-works/succinctly/issues/2276) closed, and JSON has no

--- a/src/bin/succinctly/yq_runner.rs
+++ b/src/bin/succinctly/yq_runner.rs
@@ -6439,21 +6439,122 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
                 // already reflects whether any real output happened.
                 !output_buffer.is_empty()
             } else {
-                // #2276: `parse_input_m2_parity`, not plain `parse_input` --
-                // this is `--inplace`'s own DOM fallback, reached exactly
-                // when its M2 fast path declines JSON-sourced input.
-                let inputs = parse_input_m2_parity(&input_bytes, format)?;
+                // Two routes to the same `Vec<Vec<ResultWithComments>>`,
+                // picked by the file's *resolved* format (#1349).
+                //
+                // A YAML-sourced file goes through
+                // `evaluate_yaml_direct_filtered`, the cursor-native
+                // evaluator the stdout path has always used, so `--inplace`
+                // finally preserves what every other route does: comments,
+                // flow style, anchor marks, and #711's alias value sync.
+                // Before this, `-i '.a = 99'` on `a: &x 1\nb: *x` wrote
+                // `b: 1` where the identical query on stdout wrote `b: *x` --
+                // the same filter silently producing a different *value*
+                // depending on whether it edited the file or printed it.
+                //
+                // JSON-sourced files deliberately stay on the materializing
+                // `parse_input_m2_parity` route. `evaluate_yaml_direct_filtered`
+                // builds a `YamlIndex`, which accepts `[1,]` as a YAML flow
+                // sequence, so rerouting them would reopen exactly the hole
+                // #2276 closed (see
+                // `test_yq_inplace_fast_path_rejects_trailing_comma_leaves_file_untouched_2276`).
+                // JSON carries no comments, anchors or block style, so it
+                // gives up nothing by staying put.
+                let (doc_results, is_multi_doc) = if format == InputFormat::Json {
+                    // #2276: `parse_input_m2_parity`, not plain `parse_input`
+                    // -- this is `--inplace`'s own DOM fallback, reached
+                    // exactly when its M2 fast path declines JSON-sourced
+                    // input.
+                    let inputs = parse_input_m2_parity(&input_bytes, format)?;
+                    // Count matching docs for multi-doc separator logic
+                    let matching_docs: usize = if let Some(target_doc) = args.document {
+                        usize::from(
+                            (global_doc_index..global_doc_index + inputs.len())
+                                .contains(&target_doc),
+                        )
+                    } else {
+                        inputs.len()
+                    };
+                    let mut collected = Vec::new();
+                    for (local_idx, input) in inputs.iter().enumerate() {
+                        let current_doc_index = global_doc_index + local_idx;
+                        // Apply --doc filter if specified
+                        if let Some(target_doc) = args.document {
+                            if current_doc_index != target_doc {
+                                continue;
+                            }
+                        }
+                        let results = evaluate_input(input, &program.expr, &mut sink)?;
+                        // A JSON-sourced result has no presentation to carry:
+                        // the empty tree is exactly what `output_value`
+                        // received here before #1349.
+                        collected.push(
+                            results
+                                .into_iter()
+                                .map(|v| (v, CommentTree::empty()))
+                                .collect::<Vec<ResultWithComments>>(),
+                        );
+                        // halt/halt_error (#791): evaluate no further
+                        // documents in this file. `evaluate_yaml_direct_filtered`
+                        // makes the same check internally for the YAML arm.
+                        if sink.halted().is_some() {
+                            break;
+                        }
+                    }
+                    global_doc_index += inputs.len();
+                    (collected, matching_docs > 1)
+                } else {
+                    // Validation gate, result discarded (#1349). This is the
+                    // *same* call this route already made before rerouting,
+                    // kept for everything it rejects that the cursor-native
+                    // evaluator does not: #1749's colliding complex/
+                    // undecodable mapping keys (two different sequence keys
+                    // both stringify to `""`, and `OwnedValue::Object`'s
+                    // `IndexMap` would silently drop one), and #2276's M2
+                    // nesting-depth parity check.
+                    //
+                    // The collision check cannot simply move to the
+                    // cursor-native walk: `resolve_display_key`'s generic
+                    // `key_display_string_kind` only flags a key whose
+                    // *decode* failed, while a YAML complex key decodes
+                    // cleanly to `""`. Classifying it needs `YamlValue`'s own
+                    // `key_string_kind` (#1749), which is not on the
+                    // `DocumentValue` trait -- so the cursor-native route
+                    // silently drops one of the two, which is exactly what
+                    // this gate exists to prevent. Re-deriving that
+                    // classification here instead would duplicate a
+                    // predicate that must not drift.
+                    //
+                    // Costs no more than before: this route already
+                    // materialized every document to evaluate it, and now
+                    // materializes them to validate instead.
+                    let _validated = parse_input_m2_parity(&input_bytes, format)?;
+
+                    let (collected, num_docs) = evaluate_yaml_direct_filtered(
+                        &input_bytes,
+                        &program.expr,
+                        // `doc_filter`'s `(target, global_offset)` is exactly
+                        // the `--doc` arithmetic the JSON arm above does by
+                        // hand.
+                        args.document.map(|target| (target, global_doc_index)),
+                        &mut sink,
+                        DirectEvalOptions {
+                            need_comments: output_config.output_format == OutputFormat::Yaml,
+                            strip_style: args.pretty_print,
+                            sort_keys: output_config.sort_keys,
+                            mark_json_sourced: false,
+                        },
+                    )?;
+                    global_doc_index += num_docs;
+                    // Documents that produced no results are dropped by
+                    // `evaluate_yaml_direct_filtered`, so this counts
+                    // documents that will actually emit -- the same measure
+                    // the stdout DOM path uses for its own separators.
+                    let is_multi_doc = collected.len() > 1;
+                    (collected, is_multi_doc)
+                };
 
                 let mut buf_writer = BufWriter::new(&mut output_buffer);
-                // Count matching docs for multi-doc separator logic
-                let matching_docs: usize = if let Some(target_doc) = args.document {
-                    usize::from(
-                        (global_doc_index..global_doc_index + inputs.len()).contains(&target_doc),
-                    )
-                } else {
-                    inputs.len()
-                };
-                let is_multi_doc = matching_docs > 1;
 
                 // `--front-matter=process` opens its own leading `---` fence
                 // here; the body's closing fence + body text are appended
@@ -6481,21 +6582,15 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
                 // too" bug in the DOM branch went unreachable until this
                 // fix made `Auto` resolve to `Yaml` for real.
                 let mut any_doc_output_this_file = false;
-                for (local_idx, input) in inputs.iter().enumerate() {
-                    let current_doc_index = global_doc_index + local_idx;
-                    // Apply --doc filter if specified
-                    if let Some(target_doc) = args.document {
-                        if current_doc_index != target_doc {
-                            continue;
-                        }
-                    }
-
-                    let results = evaluate_input(input, &program.expr, &mut sink)?;
+                // `--doc` filtering and halt-checking both happened while
+                // `doc_results` was built (#1349), in whichever arm produced
+                // it -- this loop only writes.
+                for results in &doc_results {
                     // `output_config` was already shadowed to `use_color:
                     // false` above — reused here rather than building a
                     // second, parallel no-color config.
                     let mut doc_had_output = false;
-                    for result in results {
+                    for (result, comments) in results {
                         // For regular multi-doc (without split_doc), add ---
                         // before each doc's first real output — not
                         // unconditionally before the doc is even evaluated.
@@ -6539,36 +6634,21 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
                         // --eval-all arm above).
                         let split_separator =
                             split_doc_state.write_separator(&mut buf_writer, &output_config)?;
-                        any_truthy |=
-                            !matches!(&result, OwnedValue::Null | OwnedValue::Bool(false));
+                        any_truthy |= !matches!(result, OwnedValue::Null | OwnedValue::Bool(false));
                         let separator = split_separator.or_else(|| {
                             defer_to_nul_check.then_some(DocSeparatorArgs {
                                 doc_streamed: &mut any_doc_output_this_file,
                                 no_doc: output_config.no_doc,
                             })
                         });
-                        output_value(
-                            &mut buf_writer,
-                            &result,
-                            &CommentTree::empty(),
-                            &output_config,
-                            separator,
-                        )?;
+                        output_value(&mut buf_writer, result, comments, &output_config, separator)?;
                         if defer_to_nul_check {
                             doc_had_output = true;
                         }
                         any_real_output = true;
                     }
-                    // halt/halt_error (#791): still write this file's buffer
-                    // so far (below, matching the "prefix already output
-                    // survives" rule elsewhere), but evaluate no further
-                    // documents in this file or any other.
-                    if sink.halted().is_some() {
-                        break;
-                    }
                 }
                 buf_writer.flush()?;
-                global_doc_index += inputs.len();
                 any_real_output
             };
 

--- a/src/bin/succinctly/yq_runner.rs
+++ b/src/bin/succinctly/yq_runner.rs
@@ -708,6 +708,66 @@ impl OutputConfig {
     }
 }
 
+/// Raise if any mapping in `bytes` holds two keys whose *display* spellings
+/// collide in a way an `IndexMap<String, _>` cannot represent (#1749),
+/// without materializing a single value (#1349).
+///
+/// [`yaml_to_owned_value`] performs this same check as it builds its map,
+/// and every route that goes through it is already covered. The
+/// cursor-native evaluator is not: it reaches `OwnedValue` through
+/// `to_owned_with_comments`, whose generic `resolve_display_key` classifies
+/// only *decode-failure* keys as fallback spellings, and a YAML complex key
+/// (`? [1,2]`) decodes cleanly to `""`. Telling those apart needs
+/// [`YamlValue::key_string_kind`], which is not on the `DocumentValue`
+/// trait — the same reason `yaml_to_owned_value` drives [`DisplayKeyGuard`]
+/// by hand rather than going through the generic path.
+///
+/// **This shares its classification with [`yaml_to_owned_value`] and must
+/// keep doing so**: both call `key_string_kind` and `DisplayKeyGuard::check`
+/// rather than restating the rule, so only the traversal is written twice.
+/// `validate_yaml_display_keys_agrees_with_yaml_to_owned_value_1349` pins
+/// that the two answer identically.
+fn validate_yaml_display_keys(bytes: &[u8]) -> Result<()> {
+    fn walk<W: AsRef<[u64]>>(cursor: YamlCursor<'_, W>, depth: usize) -> Result<()> {
+        // The same limit `yaml_to_owned_value` recurses under; a document
+        // deeper than this is refused there rather than overflowing here.
+        check_nesting_depth(depth).map_err(|e| anyhow::anyhow!("{e}"))?;
+        match cursor.value() {
+            YamlValue::Mapping(fields) => {
+                let mut seen: IndexMap<String, ()> = IndexMap::new();
+                let mut guard = DisplayKeyGuard::default();
+                for field in fields {
+                    let (key, is_fallback) = field.key().key_string_kind();
+                    let key = key.into_owned();
+                    if !guard.check(&seen, &key, is_fallback) {
+                        return Err(anyhow::anyhow!(
+                            "{}",
+                            EvalError::colliding_display_key(&key)
+                        ));
+                    }
+                    seen.insert(key, ());
+                    walk(field.value_cursor(), depth + 1)?;
+                }
+                Ok(())
+            }
+            YamlValue::Sequence(elements) => {
+                let mut rest = elements;
+                // `uncons_resolved_cursor`, matching `yaml_to_owned_value`'s
+                // own sequence arm and its #835 note.
+                while let Some((elem_cursor, next)) = rest.uncons_resolved_cursor() {
+                    walk(elem_cursor, depth + 1)?;
+                    rest = next;
+                }
+                Ok(())
+            }
+            _ => Ok(()),
+        }
+    }
+
+    let index = YamlIndex::build(bytes).map_err(|e| anyhow::anyhow!("YAML parse error: {e}"))?;
+    walk(index.root(bytes), 0)
+}
+
 /// Convert a YAML value to an OwnedValue for jq evaluation.
 ///
 /// Takes a cursor rather than a bare `YamlValue`: an explicit tag
@@ -6504,31 +6564,23 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
                     global_doc_index += inputs.len();
                     (collected, matching_docs > 1)
                 } else {
-                    // Validation gate, result discarded (#1349). This is the
-                    // *same* call this route already made before rerouting,
-                    // kept for everything it rejects that the cursor-native
-                    // evaluator does not: #1749's colliding complex/
-                    // undecodable mapping keys (two different sequence keys
-                    // both stringify to `""`, and `OwnedValue::Object`'s
-                    // `IndexMap` would silently drop one), and #2276's M2
-                    // nesting-depth parity check.
-                    //
-                    // The collision check cannot simply move to the
-                    // cursor-native walk: `resolve_display_key`'s generic
+                    // #1749's colliding-key guard, which the cursor-native
+                    // evaluator does not apply for itself (#1349 review):
+                    // `resolve_display_key`'s generic
                     // `key_display_string_kind` only flags a key whose
                     // *decode* failed, while a YAML complex key decodes
-                    // cleanly to `""`. Classifying it needs `YamlValue`'s own
-                    // `key_string_kind` (#1749), which is not on the
-                    // `DocumentValue` trait -- so the cursor-native route
-                    // silently drops one of the two, which is exactly what
-                    // this gate exists to prevent. Re-deriving that
-                    // classification here instead would duplicate a
-                    // predicate that must not drift.
+                    // cleanly to `""`, so two different sequence keys both
+                    // land on `""` and `OwnedValue::Object`'s `IndexMap`
+                    // silently drops one of them.
                     //
-                    // Costs no more than before: this route already
-                    // materialized every document to evaluate it, and now
-                    // materializes them to validate instead.
-                    let _validated = parse_input_m2_parity(&input_bytes, format)?;
+                    // Keys only, no values: the cursor-native route
+                    // materializes each result itself and raises any
+                    // value-level decode error on its own, so this walk has
+                    // nothing to add there. An earlier cut reused
+                    // `parse_input_m2_parity` for this instead and paid a
+                    // second full materialization of the document for it --
+                    // 2.1x slower and 2.9x peak RSS on a 5 MB file.
+                    validate_yaml_display_keys(&input_bytes)?;
 
                     let (collected, num_docs) = evaluate_yaml_direct_filtered(
                         &input_bytes,

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -14741,9 +14741,16 @@ fn test_front_matter_process_inplace_rewrites_file() -> Result<()> {
     assert!(output.status.success());
 
     let rewritten = std::fs::read_to_string(input_file.path())?;
+    // #1349: `tags: [a, b]` keeps its flow style, exactly as the stdout
+    // twin of this test above already asserted. Until `--inplace` was
+    // routed through the cursor-native evaluator, this test pinned the very
+    // divergence #1349 reports -- the same filter losing presentation only
+    // because it edited the file instead of printing it. Verified against
+    // the pinned real `yq` binary: `yq --front-matter process -i` leaves
+    // the flow sequence alone.
     assert_eq!(
         rewritten,
-        "---\ntitle: New\ntags:\n  - a\n  - b\n---\n# Body\n\nSome text.\n"
+        "---\ntitle: New\ntags: [a, b]\n---\n# Body\n\nSome text.\n"
     );
     Ok(())
 }
@@ -34612,6 +34619,178 @@ mod issue_870_position_shifting_writes {
         let (output, exit_code) = run_yq_stdin("del(.arr[0]) | .n = 2", input, &[])?;
         assert_eq!(exit_code, 0);
         assert_eq!(output, "arr:\n  - y # cy\nn: 2\n");
+        Ok(())
+    }
+}
+
+// =============================================================================
+// #1349: `--inplace`'s DOM fallback dropped comments, style and anchors, and
+// skipped #711's alias value sync — so the same filter produced a different
+// document, and in the alias case a different *value*, depending only on
+// whether it edited the file or printed it.
+//
+// In its own module rather than appended at bare file end: two branches each
+// adding a `-> Result<()>` test here otherwise present git with identical
+// trailing `    Ok(())\n}\n` context on both sides, which it merges into one
+// function short a closing brace (this happened for real on #870).
+//
+// Every expectation is the pinned real `yq` (v4.53.3) output for the same
+// input and filter, captured live via `yq -i`.
+// =============================================================================
+mod issue_1349_inplace_presentation {
+    use super::*;
+
+    /// Run `filter` over `contents` with `-i` plus `extra_args`, and return
+    /// what the file holds afterwards.
+    fn inplace(contents: &str, filter: &str, extra_args: &[&str]) -> Result<String> {
+        let mut file = NamedTempFile::new()?;
+        write!(file, "{contents}")?;
+        let output = Command::new(env!("CARGO_BIN_EXE_succinctly"))
+            .arg("yq")
+            .arg("-i")
+            .args(extra_args)
+            .arg(filter)
+            .arg(file.path())
+            .stdin(Stdio::null())
+            .output()?;
+        assert!(
+            output.status.success(),
+            "stderr: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        Ok(std::fs::read_to_string(file.path())?)
+    }
+
+    /// The headline case, and the reason this is "silent wrong data" rather
+    /// than a presentation gap: `-i` used to write `b: 1` where the same
+    /// filter on stdout wrote `b: *x`. The alias was resolved to a stale
+    /// copy of the *pre-write* value, so the file disagreed with the query.
+    ///
+    /// $ yq -i '.a = 99'  =>  a: &x 99 / b: *x
+    #[test]
+    fn test_yq_inplace_dom_path_syncs_alias_value_1349() -> Result<()> {
+        assert_eq!(
+            inplace("a: &x 1\nb: *x\n", ".a = 99", &[])?,
+            "a: &x 99\nb: *x\n"
+        );
+        Ok(())
+    }
+
+    /// The same document under `-o=json`, where the marks are expanded and
+    /// only the *value* is observable: `b` must be 9, not the stale 1.
+    ///
+    /// $ yq -i -o=json '.a = 9'  =>  {"a": 9, "b": 9}
+    #[test]
+    fn test_yq_inplace_dom_path_json_output_syncs_alias_1349() -> Result<()> {
+        let out = inplace("a: &x 1\nb: *x\n", ".a = 9", &["-o=json"])?;
+        assert_eq!(out.replace([' ', '\n'], ""), "{\"a\":9,\"b\":9}");
+        Ok(())
+    }
+
+    /// A trailing comment on an untouched sibling survives the write.
+    ///
+    /// $ yq -i '.a = 99'  =>  a: 99 # ca / b: 2 # cb
+    #[test]
+    fn test_yq_inplace_dom_path_keeps_comments_1349() -> Result<()> {
+        assert_eq!(
+            inplace("a: 1 # ca\nb: 2 # cb\n", ".a = 99", &[])?,
+            "a: 99 # ca\nb: 2 # cb\n"
+        );
+        Ok(())
+    }
+
+    /// Flow style on an untouched sibling survives; before #1349 `-i`
+    /// expanded it to block style.
+    ///
+    /// $ yq -i '.b = 9'  =>  a: {p: 1, q: 2} / b: 9
+    #[test]
+    fn test_yq_inplace_dom_path_keeps_flow_style_1349() -> Result<()> {
+        assert_eq!(
+            inplace("a: {p: 1, q: 2}\nb: 3\n", ".b = 9", &[])?,
+            "a: {p: 1, q: 2}\nb: 9\n"
+        );
+        Ok(())
+    }
+
+    /// Multi-document files keep each document's own comments, and the `---`
+    /// separator bookkeeping still works off the rerouted results.
+    ///
+    /// The trailing `a: 9` is not a duplicated document: `.a = 9` *creates*
+    /// `a` in the second document, which has none. Real yq prints exactly
+    /// this, and so does succinctly's own stdout path.
+    ///
+    /// $ yq -i '.a = 9'  =>  a: 9 # c1 / --- / b: 2 # c2 / a: 9
+    #[test]
+    fn test_yq_inplace_dom_path_multi_doc_1349() -> Result<()> {
+        assert_eq!(
+            inplace("a: 1 # c1\n---\nb: 2 # c2\n", ".a = 9", &[])?,
+            "a: 9 # c1\n---\nb: 2 # c2\na: 9\n"
+        );
+        // `|=` behaves the same way: the second document's absent `.a`
+        // updates from null, so it gains `a: 1`, and its own comment is
+        // untouched either way.
+        //
+        // $ yq -i '.a |= . + 1'  =>  a: 2 # c1 / --- / b: 2 # c2 / a: 1
+        assert_eq!(
+            inplace("a: 1 # c1\n---\nb: 2 # c2\n", ".a |= . + 1", &[])?,
+            "a: 2 # c1\n---\nb: 2 # c2\na: 1\n"
+        );
+        Ok(())
+    }
+
+    /// `del()` reaches the same rerouted path, and the anchor soundness pass
+    /// runs on it: `&x` is deleted, so `b`'s mark cannot resolve and the
+    /// value is printed instead (#763's documented divergence from yq, which
+    /// emits a dangling `*x` it cannot re-read).
+    #[test]
+    fn test_yq_inplace_dom_path_del_runs_anchor_soundness_1349() -> Result<()> {
+        assert_eq!(inplace("a: &x 1\nb: *x\n", "del(.a)", &[])?, "b: 1\n");
+        Ok(())
+    }
+
+    /// The whole point of the fix stated as an invariant: for a YAML file,
+    /// `-i` must write exactly what the same filter prints to stdout.
+    #[test]
+    fn test_yq_inplace_matches_stdout_for_the_same_filter_1349() -> Result<()> {
+        let cases = [
+            ("a: &x 1\nb: *x\n", ".a = 99"),
+            ("a: 1 # ca\nb: 2 # cb\n", ".a = 99"),
+            ("a: {p: 1, q: 2}\nb: 3\n", ".b = 9"),
+            ("a: &x 1\nb: *x\nc: 3\n", "del(.c)"),
+            ("list:\n  - x # cx\n  - y\n", ".list[1] = \"z\""),
+        ];
+        for (input, filter) in cases {
+            let (stdout, code) = run_yq_stdin(filter, input, &[])?;
+            assert_eq!(code, 0, "{filter}");
+            assert_eq!(
+                inplace(input, filter, &[])?,
+                stdout,
+                "-i and stdout must agree for `{filter}` on {input:?}"
+            );
+        }
+        Ok(())
+    }
+
+    /// The JSON carve-out: a JSON-sourced `-i` file stays on the
+    /// materializing route, so #2276's trailing-comma rejection still holds.
+    /// Rerouting it through a `YamlIndex` would accept `[1,]` as a flow
+    /// sequence and silently rewrite the file.
+    #[test]
+    fn test_yq_inplace_json_source_still_rejects_trailing_comma_1349() -> Result<()> {
+        let mut file = NamedTempFile::new()?;
+        write!(file, "[1,]")?;
+        let output = Command::new(env!("CARGO_BIN_EXE_succinctly"))
+            .arg("yq")
+            .args(["-i", "-p=json", "."])
+            .arg(file.path())
+            .stdin(Stdio::null())
+            .output()?;
+        assert!(!output.status.success(), "must not accept `[1,]` as JSON");
+        assert_eq!(
+            std::fs::read_to_string(file.path())?,
+            "[1,]",
+            "the file must be left byte-identical"
+        );
         Ok(())
     }
 }

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -34749,7 +34749,14 @@ mod issue_1349_inplace_presentation {
     }
 
     /// The whole point of the fix stated as an invariant: for a YAML file,
-    /// `-i` must write exactly what the same filter prints to stdout.
+    /// `-i` writes exactly what the same filter prints to stdout.
+    ///
+    /// One deliberate exception, not covered here: two *complex* mapping
+    /// keys whose display spellings collide make `-i` raise and leave the
+    /// file alone (#1749's guard), where stdout silently drops one. Real yq
+    /// keeps both, so both routes diverge from it — `-i` in the safe
+    /// direction. Recorded in `compliance/yq/limitations.md`; pinned by
+    /// `test_yaml_native_dom_raises_on_colliding_complex_key_1749`.
     #[test]
     fn test_yq_inplace_matches_stdout_for_the_same_filter_1349() -> Result<()> {
         let cases = [
@@ -34791,6 +34798,129 @@ mod issue_1349_inplace_presentation {
             "[1,]",
             "the file must be left byte-identical"
         );
+        Ok(())
+    }
+
+    /// The walker `-i` uses to apply #1749's guard shares its
+    /// *classification* with `yaml_to_owned_value` (both call
+    /// `key_string_kind` + `DisplayKeyGuard::check`) but writes its own
+    /// *traversal*. Pins that the two agree, so the copy cannot drift:
+    /// `--slurp` drives `yaml_to_owned_value`, `-i` drives the walker, and
+    /// they must accept and reject exactly the same documents.
+    #[test]
+    fn validate_yaml_display_keys_agrees_with_yaml_to_owned_value_1349() -> Result<()> {
+        // (document, must_raise)
+        let cases = [
+            // Two complex keys, both displaying as "".
+            ("? [1,2]\n: a\n? [3,4]\n: b\n", true),
+            // Three of them: the guard fires at the second, not "eventually".
+            ("? [1,2]\n: a\n? [3,4]\n: b\n? [5,6]\n: c\n", true),
+            // Nested one level down inside a sequence.
+            ("outer:\n  - ? [1,2]\n    : a\n    ? [3,4]\n    : b\n", true),
+            // Nested inside another mapping.
+            (
+                "outer:\n  inner:\n    ? [1,2]\n    : a\n    ? [3,4]\n    : b\n",
+                true,
+            ),
+            // A genuine key colliding with a complex key's fallback spelling.
+            ("\"\": g\n? [1,2]\n: a\n", true),
+            // An *ordinary* repeated key still wins last, no raise.
+            ("a: 1\na: 2\n", false),
+            // A lone complex key has nothing to collide with.
+            ("? [1,2]\n: a\nb: 2\n", false),
+            // Two complex keys in *different* mappings do not collide.
+            ("x:\n  ? [1,2]\n  : a\ny:\n  ? [3,4]\n  : b\n", false),
+            ("plain: 1\nnested:\n  - 1\n  - two\n", false),
+        ];
+        for (doc, must_raise) in cases {
+            // `--slurp` with `.[0]`, not `.`: bare `.` under `--slurp`
+            // streams without ever materializing, so it never reaches
+            // `yaml_to_owned_value` at all. `.[0]` forces the DOM route --
+            // the same driver `test_yaml_native_dom_raises_on_colliding_complex_key_1749`
+            // uses, and for the same reason.
+            let (_out, slurp_err, slurp_code) =
+                run_yq_stdin_with_stderr(".[0]", doc, &["--slurp"])?;
+            // `-i -P` routes through the #1349 validation walker.
+            let mut file = NamedTempFile::new()?;
+            write!(file, "{doc}")?;
+            let out = Command::new(env!("CARGO_BIN_EXE_succinctly"))
+                .arg("yq")
+                .args(["-i", "-P", "."])
+                .arg(file.path())
+                .stdin(Stdio::null())
+                .output()?;
+            let inplace_raised = !out.status.success();
+            let inplace_err = String::from_utf8_lossy(&out.stderr).to_string();
+
+            assert_eq!(
+                slurp_code == 1,
+                must_raise,
+                "--slurp on {doc:?}: stderr {slurp_err}"
+            );
+            assert_eq!(
+                inplace_raised, must_raise,
+                "-i on {doc:?}: stderr {inplace_err}"
+            );
+            if must_raise {
+                assert!(
+                    inplace_err.contains("ambiguous"),
+                    "-i on {doc:?} must name the ambiguity, got: {inplace_err}"
+                );
+                // A raise must never touch the file.
+                assert_eq!(std::fs::read_to_string(file.path())?, doc);
+            }
+        }
+        Ok(())
+    }
+
+    /// The JSON arm keeps its own `--doc` filtering and halt handling, which
+    /// #1349 moved rather than changed. Pinned because the move made them
+    /// newly-added lines with no coverage of their own, and because a JSON
+    /// `-i` file is exactly what must *not* drift onto the YAML route.
+    ///
+    /// All three answers are byte-identical to the pre-#1349 binary.
+    #[test]
+    fn test_yq_inplace_json_arm_keeps_doc_filter_and_halt_1349() -> Result<()> {
+        let json = "{\"a\":1,\"b\":2}";
+
+        // `--doc 0` selects the single JSON document; the write lands.
+        let mut file = NamedTempFile::new()?;
+        write!(file, "{json}")?;
+        let out = Command::new(env!("CARGO_BIN_EXE_succinctly"))
+            .arg("yq")
+            .args(["-i", "-p", "json", "--doc", "0", ".a = 9"])
+            .arg(file.path())
+            .stdin(Stdio::null())
+            .output()?;
+        assert!(out.status.success());
+        assert_eq!(std::fs::read_to_string(file.path())?, "a: 9\nb: 2\n");
+
+        // `--doc 1` selects nothing -- `parse_input` yields exactly one
+        // document for JSON -- so the filter's `continue` fires and the file
+        // is truncated, the same way any legitimately-empty `-i` output is.
+        let mut file = NamedTempFile::new()?;
+        write!(file, "{json}")?;
+        let out = Command::new(env!("CARGO_BIN_EXE_succinctly"))
+            .arg("yq")
+            .args(["-i", "-p", "json", "--doc", "1", ".a = 9"])
+            .arg(file.path())
+            .stdin(Stdio::null())
+            .output()?;
+        assert!(out.status.success());
+        assert_eq!(std::fs::read_to_string(file.path())?, "");
+
+        // A halt leaves the file byte-identical (#791), unlike an ordinary
+        // empty result above.
+        let mut file = NamedTempFile::new()?;
+        write!(file, "{json}")?;
+        let out = Command::new(env!("CARGO_BIN_EXE_succinctly"))
+            .arg("yq")
+            .args(["-i", "-p", "json", "(.a = 9) | halt"])
+            .arg(file.path())
+            .stdin(Stdio::null())
+            .output()?;
+        assert!(out.status.success());
+        assert_eq!(std::fs::read_to_string(file.path())?, json);
         Ok(())
     }
 }


### PR DESCRIPTION
## Summary

Fixes #1349. `--inplace`'s DOM fallback evaluated through `evaluate_input`
and handed `output_value` a `CommentTree::empty()`, so it dropped comments,
flow style and anchor marks, and never ran #711's alias value sync.

That last one is not a presentation gap — it is **silent wrong data**:

```console
$ printf 'a: &x 1\nb: *x\n' > f.yaml && succinctly yq -i '.a = 99' f.yaml && cat f.yaml
a: 99
b: 1              # <- stale copy of the pre-write value

$ printf 'a: &x 1\nb: *x\n' | succinctly yq '.a = 99'
a: &x 99
b: *x
```

The same filter produced a different **value** depending only on whether it
edited the file or printed it. Real yq writes `b: *x` for both.

A YAML-sourced `-i` file now goes through `evaluate_yaml_direct_filtered` —
the cursor-native evaluator stdout has always used — so `-i` and stdout agree
by construction, which is what `test_yq_inplace_matches_stdout_for_the_same_filter_1349`
asserts directly.

### The JSON carve-out

JSON-sourced files stay on the materializing route deliberately.
`evaluate_yaml_direct_filtered` builds a `YamlIndex`, which accepts `[1,]` as
a YAML flow sequence, so rerouting them would reopen exactly the hole #2276
closed. JSON carries no comments, anchors or block style, so it gives up
nothing by staying put. Pinned by
`test_yq_inplace_json_source_still_rejects_trailing_comma_1349`.

## Oracle results

Every case captured live from pinned `yq` v4.53.3 via `yq -i`:

| case | before | after |
|---|---|---|
| alias value sync (`-i '.a = 99'` on `a: &x 1 / b: *x`) | ✗ wrote `b: 1` | ✓ `b: *x` |
| alias value under `-i -o=json` | ✗ `"b": 1` | ✓ `"b": 9` |
| trailing comments | ✗ dropped | ✓ |
| flow style | ✗ expanded to block | ✓ |
| multi-document | ✗ comments dropped | ✓ |
| `del()` + anchor soundness | ✗ | ✓ |
| `--front-matter=process` flow style | ✗ expanded | ✓ |

## Review round: the reroute bypassed #1749's guard

The first cut regressed a data-loss guard, caught by the full suite:

```console
$ printf '? [1,2]\n: a\n? [3,4]\n: b\n' | succinctly yq -i -P '.' f.yaml
'': b            # exit 0 — one entry silently gone
```

`main` raises `object key "" is ambiguous: ...` and leaves the file
untouched. Two different complex keys both stringify to `""` per #222, and
`OwnedValue::Object`'s `IndexMap` cannot hold both.

**Why the check could not simply move onto the cursor-native walk**:
`resolve_display_key`'s generic `key_display_string_kind` only flags a key
whose *decode* failed, while a YAML complex key decodes cleanly to `""`.
Classifying it needs `YamlValue::key_string_kind` (#1749), which is not on
the `DocumentValue` trait — which is exactly why `yaml_to_owned_value` drives
`DisplayKeyGuard` itself rather than going through the generic path.

The first fix reused `parse_input_m2_parity` as a validation gate and claimed
it was free. **That claim was wrong** — it materialized the whole document a
second time. `validate_yaml_display_keys` now walks keys only and builds no
values, sharing its *classification* with `yaml_to_owned_value` (both call
`key_string_kind` + `DisplayKeyGuard::check`) so only the traversal is
written twice.

`validate_yaml_display_keys_agrees_with_yaml_to_owned_value_1349` drives both
routes over nine documents to pin that they never diverge. It earned its
place immediately: written with `--slurp '.'` it failed, because bare `.`
under `--slurp` streams without materializing and never reaches
`yaml_to_owned_value` at all — which is why the existing #1749 test uses
`.[0]`.

### Cost

Attributed by building again with the validation walk disabled, per
`docs/guides/benchmarking.md`. The walk itself is free (248 → 253 MB, time
within noise); the cost is `evaluate_yaml_direct_filtered`, and it is what
the fix buys. 5 MB YAML, `-i '.items[0].value = 99'`, interleaved:

| binary | route | time | peak RSS |
|---|---|---:|---:|
| `main` | `-i` | 0.19 s | 96 MB |
| `main` | **stdout** | 0.36 s | 247 MB |
| branch | `-i` | 0.40 s | 246 MB |

`-i` now costs what stdout has always cost for the same filter. The old `-i`
was cheaper precisely because it was doing less — not building the
`CommentTree` carrying the comments, style and anchors it was dropping.

## Two things the issue's triage got wrong

**1. `test_yq_inplace_mixed_yaml_json_files_collapses_yaml_duplicate_keys_too_2276`
does not need updating.** The triage predicted the YAML file would start
keeping `a: 1\na: 2`. It does not, and the test still passes untouched:
`evaluate_yaml_cursor` still materializes each result into an
`IndexMap`-backed `OwnedValue` before `output_value` writes it, so the
cursor-native route preserves *presentation* but not duplicate keys. Verified
live rather than edited to match the prediction; the distinction is now
recorded in `compliance/yq/limitations.md`.

**2. One existing test was pinning the bug.**
`test_front_matter_process_inplace_rewrites_file` asserted
`tags:\n  - a\n  - b` while the stdout twin two functions above it asserted
`tags: [a, b]` as yq-verified — i.e. it pinned the very `-i`-vs-stdout
divergence this issue reports. Updated, after confirming against
`yq --front-matter process -i` live.

## Out of scope, filed separately

Two pre-existing bugs found while verifying, both reproducing on merged
`main` and neither introduced here:

- the leading document head-comment (`# head`) is dropped on the **stdout**
  DOM path too;
- stdout `-P` has the same colliding-complex-key data loss this PR restores
  the guard for on `-i` (`'': b`, exit 0), because it goes through the
  generic classifier. Fixing it needs the `DocumentValue` trait-surface
  change described above, with a much wider blast radius.

This leaves **one deliberate fork** between `-i` and stdout: a document with
two complex keys whose display spellings collide makes `-i` raise and leave
the file untouched, where stdout prints `'': v2` and drops an entry. Real yq
keeps both keys, so both routes diverge from it — `-i` in the safe
direction, since the alternative is destroying a key in the user's own file.
Recorded in `limitations.md` and on the invariant test's own doc comment.

## Docs

`docs/adrs/adr-0017.md` and `docs/compliance/yq/limitations.md` both listed
`--inplace` as a route that inherits nothing from ADR-0017's mechanism 2.
That section is now "one whole output route" — only a multi-result filter
(#1361) remains.

## Test plan

- [x] `cargo test --features cli,simd,regex,serde` — 7639 passed, 0 failed
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings`
- [x] `cargo check --no-default-features` (`no_std`)
- [x] `cargo fmt --all -- --check`
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps`
- [x] 11 new tests in `tests/yq_cli_tests.rs`, every expectation captured live from pinned `yq` v4.53.3
- [x] all six `_1749` guard tests still green (the regression this round caught)
- [x] `_2276` JSON-source tests still green

New tests live in their own `mod issue_1349_inplace_presentation` block
rather than at bare file end — the identical-trailing-`Ok(())`-context merge
hazard that actually bit #870 on rebase.
