### PR TITLE
fix(jq): yq creates an assignment's target before evaluating its rhs (#2481)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`succinctly yq` now creates an assignment's target *before* evaluating its
+  right side, so the right side sees the mutated document** (#2481). Real yq's
+  `assignUpdateOperator` traverses the left side with auto-creation on and only
+  then evaluates the right side against the already-mutated document. Confirmed
+  live against yq v4.53.3 on `a: 1`: `.x = (keys)` is `{"a":1,"x":["a","x"]}`
+  and `.x = (length)` is `x: 2` (both listed/counted the target that did not
+  exist a moment earlier), `.zzz.q = (.zzz | key)` is `{"zzz":{"q":"zzz"}}`,
+  and `(.x, .y) = (keys)` gives both keys `["a","x","y"]`; on `[]`,
+  `.[2] = (length)` is `[null,null,3]` because the padding happens first. The
+  same applies to the compound forms real yq accepts (`+=`, `-=`, `*=`) and,
+  for internal consistency, to succinctly's own `/=`/`%=`/`//=` extensions;
+  `|=` is unchanged, since real yq evaluates its filter per matched node
+  instead. jq mode is unaffected and still evaluates its right side against
+  the pristine input (`.x = (keys)` is `{"a":1,"x":["a"]}` in jq 1.7.1).
+  Two knock-on effects: a *dynamic* left side is now resolved before the right
+  side in yq mode too — real yq's own order (#1412) — so a left-side walk that
+  raises where yq's does not now reports its own error rather than the right
+  side's; and a right side reading the assignment's own target
+  (`.x = (1, .x)`) still diverges, because succinctly has no node identity.
+  Both are recorded in `docs/compliance/yq/limitations.md`.
+
+### Fixed
+
 - **`succinctly yq`'s `|=` with a zero-output update filter now leaves an
   already-existing target completely untouched** (#2484). Confirmed live
   against yq v4.53.3: `.a |= (1 | select(false))` on `a: 1` stays `{"a":1}`,

--- a/docs/compliance/yq/limitations.md
+++ b/docs/compliance/yq/limitations.md
@@ -1847,7 +1847,7 @@ a value that isn't a snapshot of anything in the document -- a different kind of
 #2213's path-threading fix, which only ever continues with a value already known to be
 correct (`Null`, jq's own answer for what the missing/OOB read itself evaluates to).
 
-### An absent key read inside a read-only context — resolved (#2470); four neighbouring shapes remain
+### An absent key read inside a read-only context — resolved (#2470); two neighbouring shapes remain
 
 [#2460](https://github.com/rust-works/succinctly/issues/2460) gave yq mode real yq's rule
 for a binary operator whose operand produces **zero outputs**, and left two matrix cells
@@ -1880,24 +1880,28 @@ which inherits the ordinary auto-creating setting.
 
 Implemented once as `jq::eval::yq_read_only_context` (the ambient scope) plus
 `jq::eval::yq_absent_key_read_is_empty` (the mode gate), consulted by every navigation
-site in both evaluators, and `jq::eval::yq_empty_rhs_document` for the other half of the
-assignment rule: a zero-output right side still emits one document, with the target path
-auto-created and never written, so a new target survives as an explicit `null` while an
-existing one keeps its old value. Only **key** lookups are covered — real yq auto-creates
-through arrays even read-only (`.x = (.n[9] | key)` on `n: [1, 2]` is `x: 9`), so an
-out-of-range array index stays the ordinary `null` read.
+site in both evaluators, and `jq::eval::yq_prepare_assign_targets` for the other half of
+the assignment rule: a zero-output right side still emits one document, with the target
+path auto-created and never written, so a new target survives as an explicit `null` while
+an existing one keeps its old value. Only **key** lookups are covered — real yq
+auto-creates through arrays even read-only (`.x = (.n[9] | key)` on `n: [1, 2]` is
+`x: 9`), so an out-of-range array index stays the ordinary `null` read. succinctly
+answers `x: 9` there but does **not** write yq's padding back into `.n` (`{"n":[1,2],
+"x":9}` against yq's ten-element `n`) — a separate, pre-existing read-side gap, unchanged
+by #2470 and #2481 alike.
 
-Three neighbouring shapes were captured alongside and are **not** part of this rule;
-each is a separate divergence (two more, ordering comparisons against a real `null` and
-`|=` with a zero-output filter, were captured here too but are now resolved -- see
-[#2483](https://github.com/rust-works/succinctly/issues/2483) and
-[#2484](https://github.com/rust-works/succinctly/issues/2484) below):
+Two neighbouring shapes were captured alongside and are **not** part of this rule; each
+is a separate divergence (three more — ordering comparisons against a real `null`, `|=`
+with a zero-output filter, and the evaluation *order* of an assignment's two sides — were
+captured here too but are now resolved: see
+[#2483](https://github.com/rust-works/succinctly/issues/2483),
+[#2484](https://github.com/rust-works/succinctly/issues/2484) below, and the section
+immediately after this one):
 
 | filter                                    | input             | real yq        | succinctly                             |
 |-------------------------------------------|-------------------|----------------|----------------------------------------|
 | `.s.zzz`                                  | `s: x`            | *(nothing)*    | `Error: Cannot index string with string "zzz"` |
 | `.a \| with_entries(.value = key)`        | `a: {b: 1, e: 2}` | `{"b":0,"e":1}`| `{"b":1,"e":2}`                        |
-| `.x = (keys)`                             | `a: 1`            | `{"a":1,"x":["a","x"]}` | `{"a":1,"x":["a"]}`           |
 
 Row 1 is yq indexing a *scalar* with a key, which yields nothing everywhere, not only in
 a read-only context — it is what makes `.s.zzz + 1` also `1`. Row 2 is what `key` reports
@@ -1905,29 +1909,70 @@ for an element of a constructed array: real yq answers the index, succinctly has
 context for a value it built itself, so the `=` right side is empty and the write is
 skipped.
 
-Row 3 is an evaluation-*order* divergence that predates all of this and is unrelated to
-absent reads: real yq's `assignUpdateOperator` resolves (and auto-creates) the **left**
-side first, then evaluates the right side against the document that traversal has already
-mutated, so the right side can see the node the assignment is about to write into.
-succinctly evaluates the right side against the pristine input. `.x = (length)` on `a: 1`
-is `x: 2` in real yq and `x: 1` here for the same reason.
+### An assignment's target is created before its right side runs — resolved (#2481)
 
-That order is why four shapes that used to agree by coincidence now do not. `.zzz.q =
-(.zzz | key)` on `a: 1` is `zzz: {q: "zzz"}` in real yq because `.zzz` genuinely *exists*
-by the time the right side runs; succinctly's old answer matched only because its absent
-read fabricated a `null` node whose key happened to be spelled the same. With the read
-now correctly empty, the underlying order difference is what shows:
+Real yq's `assignUpdateOperator` (`pkg/yqlib/operator_assign.go`, v4.53.3) resolves and
+auto-creates the **left** side first, then evaluates the right side — through
+`ReadOnlyClone`, whose own half of the rule is #2470 above — against the document that
+traversal has already mutated. So the right side sees the node the assignment is about to
+write into. succinctly used to evaluate the right side against the pristine input;
+[#2481](https://github.com/rust-works/succinctly/issues/2481) closed that, and every row
+below now agrees with yq v4.53.3:
 
-| filter                    | input  | real yq              | succinctly          |
-|---------------------------|--------|----------------------|---------------------|
-| `.zzz.q = (.zzz \| key)`   | `a: 1` | `{"zzz":{"q":"zzz"}}`| `{"zzz":{"q":null}}`|
-| `.zzz.q += (.zzz \| key)`  | `a: 1` | `{"zzz":{"q":"zzz"}}`| `{"zzz":{"q":null}}`|
-| `.zzz.q -= (.zzz \| key)`  | `a: 1` | `{"zzz":{"q":"zzz"}}`| `{"zzz":{"q":null}}`|
-| `.zzz.q *= (.zzz \| key)`  | `a: 1` | *(error, exit 1)*    | `{"zzz":{"q":null}}`|
+| filter                    | input  | real yq (and now succinctly) | succinctly before #2481 |
+|---------------------------|--------|------------------------------|-------------------------|
+| `.x = (keys)`             | `a: 1` | `{"a":1,"x":["a","x"]}`      | `{"a":1,"x":["a"]}`     |
+| `.x = (length)`           | `a: 1` | `{"a":1,"x":2}`              | `{"a":1,"x":1}`         |
+| `.zzz.q = (.zzz \| key)`   | `a: 1` | `{"a":1,"zzz":{"q":"zzz"}}`  | `{"a":1,"zzz":{"q":null}}` |
+| `.zzz.q += (.zzz \| key)`  | `a: 1` | `{"a":1,"zzz":{"q":"zzz"}}`  | `{"a":1,"zzz":{"q":null}}` |
+| `.zzz.q -= (.zzz \| key)`  | `a: 1` | `{"a":1,"zzz":{"q":"zzz"}}`  | `{"a":1,"zzz":{"q":null}}` |
+| `(.x, .y) = (keys)`       | `a: 1` | both `["a","x","y"]`         | both `["a"]`            |
+| `.[2] = (length)`         | `[]`   | `[null,null,3]`              | `[null,null,0]`         |
 
-(the `a: 1` prefix elided). Closing these needs the right side evaluated against the
-left-vivified document, which is a change to the assignment model rather than to this
-rule -- and would move `.x = (keys)`/`.x = (length)` at the same time.
+`.zzz.q = (.zzz | key)` is the row that shows why this had to follow #2470 rather than
+precede it: succinctly's old answer matched yq only because its absent read fabricated a
+`null` node whose key happened to be spelled the same. Once that read was correctly
+empty, the underlying order difference was the only thing left holding the row up.
+
+`|=` is deliberately excluded: its filter runs through
+`context.SingleChildContext(candidate)`, per matched node with `.` bound to that node,
+not against the document — the same split #2470's table records.
+
+Implemented as `jq::eval::yq_prepare_assign_targets`, one definition shared by
+`eval_assign`, `eval_compound_assign` and `eval_alternative_assign`, which also carries
+#2470's zero-output-right-side document. Auto-creation is `path |= .` through the
+existing `update_path` walk rather than a second hand-written one, so yq's scalar-target
+no-op comes along for free (`.a.b = 1` on `a: 1` creates nothing and writes nothing,
+matching yq).
+
+Two consequences worth naming:
+
+- yq mode now resolves a **dynamic** left side before the right side too, which is real
+  yq's own order (`.[error("p")] = error("r")` reports `"p"`, where jq reports `"r"` —
+  the open half of [#1412](https://github.com/rust-works/succinctly/issues/1412)). Where
+  succinctly's left-side walk raises and real yq's does not, that error now surfaces
+  instead of the right side's: `(.a.x, .b.x) = error("boom")` on `a: 5\nb: {}` reports
+  `Cannot index number with string "x"`, where yq reports `boom`. The underlying gap is
+  pre-existing — a plain `(.a.x, .b.x) = 9` raises identically before and after — and is
+  #1412's comma-LHS half, not a new one.
+- A right side that reads the assignment's **own target** still diverges, because
+  succinctly has no node identity (the same limitation the anchor/alias section above
+  records). Real yq's right-side candidates are pointers into the document, so writing
+  through one and then assigning it to itself is a no-op; succinctly collects values and
+  applies the last. Live on `x: 5` (v4.53.3):
+
+  | filter                | real yq   | succinctly |
+  |-----------------------|-----------|------------|
+  | `.x = (1, .x)`        | `{"x":1}` | `{"x":5}`  |
+  | `.x = (1, .x, 2, .x)` | `{"x":2}` | `{"x":5}`  |
+  | `.x = (.x, 1)`        | `{"x":1}` | `{"x":1}`  |
+
+  Pre-existing on an existing target, and #2481 extends it to a *vivified* one, where
+  succinctly used to agree by coincidence: `.x = (1, .x)` on `a: 1` was `x: 1` only
+  because the absent `.x` read contributed nothing at all. Now that the target exists,
+  the read yields the vivified `null` and last-wins stores it (`x: null`, against yq's
+  `x: 1`). Pinned in both shapes in
+  `test_yq_assign_rhs_reading_its_own_target_lacks_node_identity_2481`.
 
 ### An `and`/`or` operand's evaluation context -- open (captured under [#2473](https://github.com/rust-works/succinctly/issues/2473))
 

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -19886,10 +19886,32 @@ fn eval_assign<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
         return QueryResult::Owned(unchanged);
     }
 
+    // #2481 (yq mode): create the target path(s) on a working copy *before*
+    // the right side runs, so the right side reads yq's already-mutated
+    // document. jq mode gets `None` here and keeps evaluating its RHS
+    // against the untouched input, exactly as before -- see
+    // [`yq_prepare_assign_targets`].
+    let resolved = match yq_noop_check {
+        YqAssignNoopCheck::Continue { pristine, paths } => Some((pristine, paths)),
+        YqAssignNoopCheck::Skip(_) => unreachable!("handled by the early return above"),
+        YqAssignNoopCheck::NotChecked => None,
+    };
+    let yq_targets = match yq_prepare_assign_targets::<W, S>(
+        path_expr, value_expr, &input, resolved, optional, true,
+    ) {
+        Ok(targets) => targets,
+        Err(early_return) => return early_return,
+    };
+
     // Evaluate the RHS once, keeping every output instead of collapsing to
     // the first (#392) -- shared with `eval_compound_assign`/
     // `eval_alternative_assign` (#1778/#1844).
-    let (rhs_values, terminal) = match collect_rhs_outputs::<W, S>(value_expr, &input, optional) {
+    let (rhs_values, terminal) = match collect_rhs_outputs::<W, S>(
+        value_expr,
+        &input,
+        yq_targets.as_ref().and_then(YqAssignTargets::rhs_document),
+        optional,
+    ) {
         Ok(v) => v,
         Err(early_return) => return early_return,
     };
@@ -19898,7 +19920,10 @@ fn eval_assign<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     // (#1844). See `normalize_rhs_values_for_fork`'s own doc comment for
     // the full rationale of both rules.
     let (rhs_values, terminal) = match normalize_rhs_values_for_fork::<W, S>(
-        rhs_values, terminal, optional, path_expr, &input,
+        rhs_values,
+        terminal,
+        optional,
+        yq_targets.as_ref().map(|targets| &targets.doc),
     ) {
         Ok(v) => v,
         Err(early_return) => return early_return,
@@ -19924,14 +19949,18 @@ fn eval_assign<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     // inside the path.
     // #1233 (code review): reuse `yq_noop_check`'s own resolution instead
     // of redoing an identical `to_owned_lossy` + `resolve_dynamic_indexes` pass
-    // -- see `YqAssignNoopCheck::Continue`'s doc comment. Only the
-    // `NotChecked` case (jq mode, or a genuinely dynamic path) still needs
-    // to resolve here from scratch, exactly as this function always did
-    // before that check existed.
-    let (pristine, paths) = match yq_noop_check {
-        YqAssignNoopCheck::Continue { pristine, paths } => (pristine, paths),
-        YqAssignNoopCheck::Skip(_) => unreachable!("handled by the early return above"),
-        YqAssignNoopCheck::NotChecked => {
+    // -- see `YqAssignNoopCheck::Continue`'s doc comment. Since #2481 that
+    // reuse rides through `yq_prepare_assign_targets`, which also owns the
+    // dynamic-path resolution in yq mode (real yq resolves its left side
+    // first, #1412); only jq mode still resolves here from scratch, exactly
+    // as this function always did before either check existed.
+    let (pristine, paths) = match yq_targets {
+        // yq mode: `yq_prepare_assign_targets` already resolved the paths
+        // and vivified them; its working copy *is* yq's document, so the
+        // writes below splice into that rather than into the untouched
+        // input (#2481).
+        Some(YqAssignTargets { doc, paths, .. }) => (doc, paths),
+        None => {
             // #1953: a non-decode-failure to_owned error (a #1194
             // malformed-member error -- a #1642 collision error is itself
             // tagged as a decode failure and so is unaffected by this)
@@ -20079,9 +20108,15 @@ fn eval_update<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
 /// combinator here uses (#400, #494), so the zero-prefix case (a bare
 /// `Error`/`Break`) and the nonzero-prefix case (`Partial`) share one code
 /// path in [`normalize_rhs_values_for_fork`] below instead of two.
+///
+/// `vivified` is [`YqAssignTargets::rhs_document`]'s answer (#2481): the
+/// working copy the left side was already auto-created on, whenever creating
+/// it actually changed the document. The right side then reads *that*, not
+/// the input, which is what makes `.x = (keys)` on `a: 1` include `"x"`.
 fn collect_rhs_outputs<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     value_expr: &Expr,
     input: &StandardJson<'a, W>,
+    vivified: Option<&OwnedValue>,
     optional: bool,
 ) -> Result<(Vec<OwnedValue>, Option<Control>), QueryResult<'a, W>> {
     // #2470 (yq mode): `assignUpdateOperator` runs a plain `=`'s right side
@@ -20096,7 +20131,19 @@ fn collect_rhs_outputs<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     // `update_path` instead, matching yq's own `SingleChildContext`, which
     // leaves `DontAutoCreate` alone. See `yq_read_only_context`.
     let _scope = S::READ_ONLY_ABSENT_KEY_IS_EMPTY.then(yq_read_only_context::enter);
-    match eval_single::<W, S>(value_expr, input.clone(), optional).materialize_cursor() {
+    // #2481: `eval_owned_input` round-trips the working copy through a
+    // throwaway document, so a node's own *position* (`line`/`column`/
+    // `style`) is not preserved across it -- which is why `rhs_document`
+    // hands this `None` whenever auto-creating the target changed nothing,
+    // keeping the far more common case on the input cursor. (Those three
+    // builtins already read `0`/`""` from an assignment's right side on the
+    // cursor route too, so nothing regresses either way; see
+    // `docs/compliance/yq/limitations.md`.)
+    let evaluated = match vivified {
+        Some(doc) => eval_owned_input::<W, S>(value_expr, doc, optional),
+        None => eval_single::<W, S>(value_expr, input.clone(), optional),
+    };
+    match evaluated.materialize_cursor() {
         QueryResult::One(v) => match to_owned(&v) {
             Ok(owned) => Ok((vec![owned], None)),
             Err(e) => Err(suppress_or_raise(e, optional)),
@@ -20126,7 +20173,8 @@ fn collect_rhs_outputs<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
 ///   short-circuits the caller directly with that result) -- not
 ///   `eval_rhs_once`'s old "collapse empty to `Null`" behavior. In **yq**
 ///   mode it produces exactly one document instead, with the target path
-///   auto-created but never written -- [`yq_empty_rhs_document`], #2470.
+///   auto-created but never written -- that document is `yq_target_doc`,
+///   built up front by [`yq_prepare_assign_targets`] (#2470/#2481).
 /// - Real yq never forks over a multi-output RHS the way jq's does (#392):
 ///   it applies only the *last* output, once, to every resolved path --
 ///   confirmed live (v4.53.3): `.x = (1,2,3)` on `{"x":0}` is `{"x":3}`,
@@ -20143,15 +20191,15 @@ fn normalize_rhs_values_for_fork<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     mut rhs_values: Vec<OwnedValue>,
     terminal: Option<Control>,
     optional: bool,
-    path_expr: &Expr,
-    input: &StandardJson<'a, W>,
+    yq_target_doc: Option<&OwnedValue>,
 ) -> Result<(Vec<OwnedValue>, Option<Control>), QueryResult<'a, W>> {
     if rhs_values.is_empty() {
         return Err(match terminal {
-            None if S::READ_ONLY_ABSENT_KEY_IS_EMPTY => {
-                yq_empty_rhs_document::<W, S>(path_expr, input, optional)
-            }
-            None => QueryResult::None,
+            // `Some` exactly in yq mode (every assignment entry point
+            // prepares its targets there, #2481) -- that working copy is
+            // already the document real yq would emit after running its
+            // write loop zero times, so there is nothing left to compute.
+            None => yq_target_doc.map_or(QueryResult::None, |doc| QueryResult::Owned(doc.clone())),
             Some(Control::Error(_)) if optional => QueryResult::None,
             Some(control) => partial(Vec::new(), control), // normalizes to bare Error/Break
         });
@@ -20164,19 +20212,73 @@ fn normalize_rhs_values_for_fork<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     Ok((rhs_values, terminal))
 }
 
-/// The one document a yq-mode assignment with a **zero-output** right side
-/// still emits (#2470): the target path auto-created, and nothing written
-/// into it.
+/// yq's assignment target, resolved and auto-created **before** the right
+/// side is evaluated (#2481) -- [`yq_prepare_assign_targets`]'s result.
+struct YqAssignTargets {
+    /// The working copy with every target path created. This is yq's own
+    /// mutated document: the right side reads it, and every write is
+    /// spliced into it rather than into the untouched input.
+    doc: OwnedValue,
+    /// `path_expr` resolved against the input, once, up front -- reused as
+    /// the write loop's path list so it is never resolved twice.
+    paths: Vec<Expr>,
+    /// Whether auto-creating the targets actually changed the document.
+    /// The single gate on [`Self::rhs_document`].
+    created: bool,
+}
+
+impl YqAssignTargets {
+    /// The document the right side must be evaluated against, or `None` to
+    /// leave it on the input cursor.
+    ///
+    /// `Some` only when auto-creating the target really changed something:
+    /// an unchanged working copy is by definition indistinguishable from
+    /// the input for any *value* the right side can read, so routing it
+    /// through [`eval_owned_input`]'s reindex bridge would buy nothing and
+    /// cost a whole serialize/reparse round trip -- one that also drops the
+    /// node positions `line`/`column`/`style` are read from.
+    fn rhs_document(&self) -> Option<&OwnedValue> {
+        self.created.then_some(&self.doc)
+    }
+}
+
+/// Resolve and auto-create a yq-mode assignment's target path(s) on an owned
+/// working copy, before its right side runs. `None` in jq mode, which
+/// evaluates its right side against the untouched input as it always has.
 ///
-/// Real yq's `assignUpdateOperator` navigates the left side with
-/// auto-creation on before it ever looks at the right side's candidates, and
-/// then simply runs its write loop zero times. So a *new* target survives as
-/// an explicit `null` while an *existing* one keeps its old value, and the
-/// document is emitted either way -- where jq mode produces no document at
-/// all (`jq '.x = empty'` is empty output, pinned in jq mode). Live-captured
-/// against yq v4.53.3 with a right side that is empty for reasons of its own
-/// (`1 | select(false)`), so the rule is keyed on "the right side produced
-/// nothing" and not on why:
+/// Real yq's `assignUpdateOperator` traverses the left side with
+/// auto-creation *on* and only then evaluates the right side, against the
+/// already-mutated document (through `ReadOnlyClone`, whose own half of the
+/// rule is [`yq_read_only_context`], #2470). So the right side genuinely
+/// sees the node the assignment is about to write. Captured on `a: 1`
+/// (v4.53.3, `-o=json -I0`), succinctly's pre-#2481 answer alongside:
+///
+/// | filter                  | yq v4.53.3                  | was          |
+/// |-------------------------|-----------------------------|--------------|
+/// | `.x = (keys)`           | `{"a":1,"x":["a","x"]}`     | `["a"]`      |
+/// | `.x = (length)`         | `{"a":1,"x":2}`             | `1`          |
+/// | `.zzz.q = (.zzz \| key)` | `{"a":1,"zzz":{"q":"zzz"}}` | `{"q":null}` |
+/// | `.zzz.q += (.zzz \| key)`| `{"a":1,"zzz":{"q":"zzz"}}` | `{"q":null}` |
+/// | `(.x,.y) = (keys)`      | `x`/`y` both `["a","x","y"]`| both `["a"]` |
+/// | `.x.y = (.x \| keys)`   | `{"a":1,"x":{"y":["y"]}}`   | `{"y":null}` |
+///
+/// and on `[]`: `.[2] = (length)` is `[null,null,3]` (the padding happens
+/// first), where it used to be `[null,null,0]`.
+///
+/// `.x = (.x | type)` moves the same way but does not reach parity: the
+/// vivified `null` is now read back (it used to contribute nothing at all,
+/// leaving the target at the auto-created `null`), so this answers
+/// `x: "null"` where real yq says `x: "!!null"` -- `type`'s yq-tag spelling
+/// is a separate, pre-existing gap this change neither touches nor causes.
+///
+/// The same up-front walk is what a **zero-output** right side then emits
+/// unchanged (#2470): yq runs its write loop zero times, so a *new* target
+/// survives as an explicit `null` while an *existing* one keeps its old
+/// value, and the document is emitted either way -- where jq mode produces
+/// no document at all (`jq '.x = empty'` is empty output, pinned in jq
+/// mode). Live-captured with a right side that is empty for reasons of its
+/// own (`1 | select(false)`), so the rule is keyed on "the right side
+/// produced nothing" and not on why:
 ///
 /// | filter                     | input        | yq v4.53.3               |
 /// |----------------------------|--------------|--------------------------|
@@ -20187,40 +20289,87 @@ fn normalize_rhs_values_for_fork<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
 /// | `.a[] = (1 \| select(false))` | `a: [1,2]` | `{"a":[1,2]}`            |
 /// | `(.a,.b) = (1 \| select(false))` | `a: 1`  | `{"a":1,"b":null}`       |
 ///
-/// Implemented as `path |= .` rather than a bespoke "vivify but skip the
-/// write" walk: `update_path` already creates every missing step on the way
-/// down and then writes back whatever the filter returned, so an
+/// Auto-creation is `path |= .` rather than a bespoke "vivify but skip the
+/// write" walk: [`update_path`] already creates every missing step on the
+/// way down and then writes back whatever the filter returned, so an
 /// `Expr::Identity` filter is exactly "create the path, change nothing" --
-/// including the `Iterate`-autovivifies-`Null`-to-`[]` and slice cases,
-/// which a second hand-written walk would have had to re-derive (and could
-/// then drift from, the #106 failure this file keeps one definition to
-/// avoid).
-fn yq_empty_rhs_document<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
+/// including the `Iterate`-autovivifies-`Null`-to-`[]` and slice cases, and
+/// including the scalar-target no-op that makes `.a.b = 1` on `a: 1` create
+/// nothing at all (`{"a":1}`, matching yq). A second hand-written walk would
+/// have had to re-derive all of that, and could then drift from it -- the
+/// #106 failure this file keeps one definition to avoid.
+///
+/// `scalar_slice_noop` is the caller's own [`eval_update_multi`] flag,
+/// passed straight through so this walk creates exactly what that operator's
+/// write would have created and no more -- `-=`/`*=` keep #1340's
+/// deliberate exclusion from the slice no-op mechanism (real yq's own no-op
+/// for those two is not "run the filter and discard", and is not implemented
+/// here), instead of silently gaining it through the pre-pass.
+///
+/// `resolved` is [`YqAssignNoopCheck::Continue`]'s already-computed
+/// `(pristine, paths)` pair when the caller had one; otherwise the pair is
+/// derived here. Deriving it here is what moves *dynamic* path resolution
+/// ahead of the right side in yq mode, which is the order real yq itself
+/// uses (`.[error("p")] = error("r")` reports `"p"`, where jq reports
+/// `"r"` -- #1412); jq mode is untouched, since this returns `None` there
+/// before resolving anything.
+fn yq_prepare_assign_targets<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     path_expr: &Expr,
+    value_expr: &Expr,
     input: &StandardJson<'a, W>,
+    resolved: Option<(OwnedValue, Vec<Expr>)>,
     optional: bool,
-) -> QueryResult<'a, W> {
+    scalar_slice_noop: bool,
+) -> Result<Option<YqAssignTargets>, QueryResult<'a, W>> {
+    if S::TAG != EvalTag::Yq {
+        return Ok(None);
+    }
     // Same `optional` policy, in the same order, as `eval_assign`'s own
-    // `NotChecked` arm: a non-decode-failure `to_owned` error and a path
+    // jq-mode arm: a non-decode-failure `to_owned` error and a path
     // resolution error are both swallowed by an outer `?`, a halt never is.
-    let mut result = match to_owned(input) {
-        Ok(result) => result,
-        Err(e) => return suppress_or_raise(e, optional),
+    let (pristine, paths) = match resolved {
+        Some(pair) => pair,
+        None => {
+            let pristine = match to_owned(input) {
+                Ok(pristine) => pristine,
+                Err(e) => return Err(suppress_or_raise(e, optional)),
+            };
+            let paths = match resolve_dynamic_indexes::<S>(path_expr, &pristine, false) {
+                Ok(paths) => paths,
+                Err((_, EvalEscape::Error(_))) if optional => return Err(QueryResult::None),
+                Err((_, escape)) => return Err(escape.into()),
+            };
+            (pristine, paths)
+        }
     };
-    let paths = match resolve_dynamic_indexes::<S>(path_expr, &result, false) {
-        Ok(paths) => paths,
-        Err((_, EvalEscape::Error(_))) if optional => return QueryResult::None,
-        Err((_, escape)) => return escape.into(),
-    };
+    // Change detection costs a second copy of the whole document, and only
+    // ever buys something for a right side that can read one. A bare
+    // literal (`.a = 5`, the overwhelmingly common shape) cannot, so it
+    // skips the copy outright and reports `created: false` -- correct by
+    // construction, since `rhs_document`'s only consumer is the right side
+    // that literal has already been proved independent of.
+    let before = (!matches!(
+        super::eval_generic::strip_parens(value_expr),
+        Expr::Literal(_)
+    ))
+    .then(|| pristine.clone());
+    let mut doc = pristine;
     for path in &paths {
-        if let Err(escape) = update_path::<S>(&mut result, path, &Expr::Identity, false, true) {
-            return match escape {
+        if let Err(escape) =
+            update_path::<S>(&mut doc, path, &Expr::Identity, false, scalar_slice_noop)
+        {
+            return Err(match escape {
                 EvalEscape::Error(_) if optional => QueryResult::None,
                 other => other.into(),
-            };
+            });
         }
     }
-    QueryResult::Owned(result)
+    let created = before.is_some_and(|before| doc != before);
+    Ok(Some(YqAssignTargets {
+        doc,
+        paths,
+        created,
+    }))
 }
 
 /// Shared RHS-fork loop for `eval_assign`/`eval_compound_assign`/
@@ -20301,6 +20450,10 @@ fn fork_rhs_over_paths<'a, W: Clone + AsRef<[u64]>, State>(
 /// value` for compound assignment, `. // value` for alternative
 /// assignment) fresh per output, so `update_path`'s per-path `Identity`
 /// resolves to that output's own spliced value, not a shared one.
+#[allow(clippy::too_many_arguments)] // STYLE-0004: `yq_targets` (#2481) joins the
+                                     // `path_expr`/`input` pair it *replaces* in yq mode -- both are still needed for jq
+                                     // mode's own resolve, so bundling them would mean a struct whose two halves are never
+                                     // live at the same time.
 fn eval_update_multi<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     path_expr: &Expr,
     input: StandardJson<'a, W>,
@@ -20308,28 +20461,41 @@ fn eval_update_multi<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     scalar_slice_noop: bool,
     rhs_values: Vec<OwnedValue>,
     terminal: Option<Control>,
+    yq_targets: Option<YqAssignTargets>,
     build_filter: impl FnMut(OwnedValue) -> Expr,
 ) -> QueryResult<'a, W> {
     let (rhs_values, terminal) = match normalize_rhs_values_for_fork::<W, S>(
-        rhs_values, terminal, optional, path_expr, &input,
+        rhs_values,
+        terminal,
+        optional,
+        yq_targets.as_ref().map(|targets| &targets.doc),
     ) {
         Ok(v) => v,
         Err(early_return) => return early_return,
     };
 
-    // #1953: a non-decode-failure to_owned error respects `optional`
-    // like the sibling `resolve_dynamic_indexes` arm just below (and
-    // `eval_assign`/`eval_update`'s matching sites) -- only a genuine
-    // decode failure is unconditional.
-    let pristine = match to_owned(&input) {
-        Ok(v) => v,
-        Err(e) => return suppress_or_raise(e, optional),
-    };
-    let paths = match resolve_dynamic_indexes::<S>(path_expr, &pristine, false) {
-        Ok(paths) => paths,
-        // `?` swallows only a genuine error; a halt always escapes (#791).
-        Err((_, EvalEscape::Error(_))) if optional => return QueryResult::None,
-        Err((_, escape)) => return escape.into(),
+    let (pristine, paths) = match yq_targets {
+        // yq mode: already resolved and auto-created before the right side
+        // ran (#2481), and that working copy is the document every write
+        // splices into.
+        Some(YqAssignTargets { doc, paths, .. }) => (doc, paths),
+        None => {
+            // #1953: a non-decode-failure to_owned error respects `optional`
+            // like the sibling `resolve_dynamic_indexes` arm just below (and
+            // `eval_assign`/`eval_update`'s matching sites) -- only a genuine
+            // decode failure is unconditional.
+            let pristine = match to_owned(&input) {
+                Ok(v) => v,
+                Err(e) => return suppress_or_raise(e, optional),
+            };
+            let paths = match resolve_dynamic_indexes::<S>(path_expr, &pristine, false) {
+                Ok(paths) => paths,
+                // `?` swallows only a genuine error; a halt always escapes (#791).
+                Err((_, EvalEscape::Error(_))) if optional => return QueryResult::None,
+                Err((_, escape)) => return escape.into(),
+            };
+            (pristine, paths)
+        }
     };
     let scalar_noop = scalar_slice_noop && S::TAG == EvalTag::Yq;
 
@@ -20389,7 +20555,31 @@ fn eval_compound_assign<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     // old behavior) -- jq forks once per output, yq keeps only the last;
     // see `eval_update_multi`'s own doc comment for the full rationale and
     // oracle verification.
-    let (rhs_values, terminal) = match collect_rhs_outputs::<W, S>(value_expr, &input, optional) {
+    // #2481: create the target path(s) on a working copy before the right
+    // side runs, so it reads yq's already-mutated document -- one
+    // definition, shared with `eval_assign`. `None` (the `resolved`
+    // argument) rather than a reused `YqAssignNoopCheck::Continue` payload:
+    // this caller went through the `yq_assign_skip_rhs` wrapper, which
+    // discards it, so the pair is re-derived here exactly as it was before
+    // (#1414).
+    let yq_targets = match yq_prepare_assign_targets::<W, S>(
+        path_expr,
+        value_expr,
+        &input,
+        None,
+        optional,
+        matches!(op, AssignOp::Add),
+    ) {
+        Ok(targets) => targets,
+        Err(early_return) => return early_return,
+    };
+
+    let (rhs_values, terminal) = match collect_rhs_outputs::<W, S>(
+        value_expr,
+        &input,
+        yq_targets.as_ref().and_then(YqAssignTargets::rhs_document),
+        optional,
+    ) {
         Ok(v) => v,
         Err(early_return) => return early_return,
     };
@@ -20420,6 +20610,7 @@ fn eval_compound_assign<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
         matches!(op, AssignOp::Add),
         rhs_values,
         terminal,
+        yq_targets,
         move |rhs_value| Expr::Arithmetic {
             op: arith_op,
             left: Box::new(Expr::Identity),
@@ -20455,7 +20646,26 @@ fn eval_alternative_assign<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     //
     // #1778: every output is kept, not just the first; see
     // `eval_update_multi`'s own doc comment.
-    let (rhs_values, terminal) = match collect_rhs_outputs::<W, S>(value_expr, &input, optional) {
+    // #2481: create the target path(s) on a working copy before the right
+    // side runs, so it reads yq's already-mutated document -- one
+    // definition, shared with `eval_assign`. `None` (the `resolved`
+    // argument) rather than a reused `YqAssignNoopCheck::Continue` payload:
+    // this caller went through the `yq_assign_skip_rhs` wrapper, which
+    // discards it, so the pair is re-derived here exactly as it was before
+    // (#1414).
+    let yq_targets = match yq_prepare_assign_targets::<W, S>(
+        path_expr, value_expr, &input, None, optional, true,
+    ) {
+        Ok(targets) => targets,
+        Err(early_return) => return early_return,
+    };
+
+    let (rhs_values, terminal) = match collect_rhs_outputs::<W, S>(
+        value_expr,
+        &input,
+        yq_targets.as_ref().and_then(YqAssignTargets::rhs_document),
+        optional,
+    ) {
         Ok(v) => v,
         Err(early_return) => return early_return,
     };
@@ -20479,6 +20689,7 @@ fn eval_alternative_assign<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
         true,
         rhs_values,
         terminal,
+        yq_targets,
         |rhs_value| {
             Expr::Alternative(
                 Box::new(Expr::Identity),
@@ -53387,7 +53598,7 @@ mod tests {
         let index = JsonIndex::build(json_bytes);
         let cursor = index.root(json_bytes);
         let expr = parse(".").unwrap();
-        match collect_rhs_outputs::<Vec<u64>, JqSemantics>(&expr, &cursor.value(), false) {
+        match collect_rhs_outputs::<Vec<u64>, JqSemantics>(&expr, &cursor.value(), None, false) {
             Err(QueryResult::Error(e)) => assert!(e.is_decode_failure(), "{e:?}"),
             other => panic!("unexpected result: {other:?}"),
         }
@@ -53400,7 +53611,7 @@ mod tests {
         let index = JsonIndex::build(json_bytes);
         let cursor = index.root(json_bytes);
         let expr = parse(".[]").unwrap();
-        match collect_rhs_outputs::<Vec<u64>, JqSemantics>(&expr, &cursor.value(), false) {
+        match collect_rhs_outputs::<Vec<u64>, JqSemantics>(&expr, &cursor.value(), None, false) {
             Err(QueryResult::Error(e)) => assert!(e.is_decode_failure(), "{e:?}"),
             other => panic!("unexpected result: {other:?}"),
         }

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -15158,7 +15158,12 @@ fn owned_identity_rule(stage: &Expr) -> Option<OwnedIdentityRule> {
 }
 
 /// `((e))` positions its output exactly as `e` does.
-fn strip_parens(mut expr: &Expr) -> &Expr {
+///
+/// `pub(super)` since #2481: `eval::yq_prepare_assign_targets` asks the same
+/// "what is this expression really" question of an assignment's right side,
+/// and a second copy of this two-line loop is exactly the duplicated-predicate
+/// shape (#106) this crate keeps one definition to avoid.
+pub(super) fn strip_parens(mut expr: &Expr) -> &Expr {
     while let Expr::Paren(inner) = expr {
         expr = inner;
     }

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -20234,20 +20234,41 @@ fn test_yq_slice_assign_scalar_noop_still_propagates_rhs_error_unaffected_by_123
 }
 
 /// #1233 (deliberate non-goal, filed as #1412): a comma-grouped LHS where
-/// one branch is a genuine write must still evaluate (and propagate an
-/// error from) the RHS -- `yq_assign_is_total_noop`'s own gate
-/// (`!needs_path_prepass`) excludes every `Comma`-containing path from the
-/// fast path entirely, so this is really a regression guard on the
-/// *unchanged* existing flow, not new behavior.
+/// one branch is a genuine write skips `yq_assign_is_total_noop`'s fast
+/// path entirely -- its gate (`!needs_path_prepass`) excludes every
+/// `Comma`-containing path -- so the scalar branch (`.a.x` on `a: 5`)
+/// reaches the write and raises where real yq silently no-ops it.
+///
+/// That divergence is pre-existing and unchanged: a plain `(.a.x, .b.x) =
+/// 9` on the same input raises here both before and after #2481, while yq
+/// answers `{"a":5,"b":{"x":9}}` (v4.53.3). What #2481 did change is
+/// *which* error a failing RHS reports alongside it: the left side is now
+/// walked first, so its own failure surfaces instead of `boom`. Pinned as
+/// the observable consequence of that ordering, not as parity -- yq
+/// reports `boom` here, because its own left-side walk doesn't fail.
 #[test]
-fn test_yq_comma_lhs_mixed_noop_and_real_write_still_evaluates_rhs_1233() -> Result<()> {
+fn test_yq_comma_lhs_mixed_noop_and_real_write_raises_lhs_error_1233() -> Result<()> {
     let (_out, err, code) = run_yq_stdin_with_stderr(
         "(.a.x, .b.x) = error(\"boom\")",
         "a: 5\nb: {}\n",
         &["-o", "json"],
     )?;
     assert_ne!(code, 0);
-    assert!(err.contains("boom"), "err={err}");
+    assert!(
+        err.contains(r#"Cannot index number with string "x""#),
+        "err={err}"
+    );
+
+    // The same shape with a harmless RHS raises identically -- proof the
+    // error above is the pre-existing write-path gap surfacing earlier,
+    // not a new failure #2481 introduced.
+    let (_out, err, code) =
+        run_yq_stdin_with_stderr("(.a.x, .b.x) = 9", "a: 5\nb: {}\n", &["-o", "json"])?;
+    assert_ne!(code, 0);
+    assert!(
+        err.contains(r#"Cannot index number with string "x""#),
+        "err={err}"
+    );
     Ok(())
 }
 
@@ -25378,8 +25399,11 @@ fn test_yq_nonterminal_iterate_container_fanout_noop_1432() -> Result<()> {
 /// diverge from succinctly's in ways well outside #1432's own RHS-discard
 /// scope (live-verified against v4.53.3) --
 /// - a `Field` step hitting a real `Array` raises yq's own structural
-///   "cannot index array" error *before* the RHS ever evaluates, where
-///   succinctly evaluates the RHS first (`boom`);
+///   "cannot index array" error *before* the RHS ever evaluates. Since
+///   #2481 succinctly agrees on the ordering (the left side is resolved and
+///   auto-created before the right side runs), differing only in the
+///   message text -- so that shape asserts the structural error below,
+///   where it used to assert `boom`;
 /// - a genuinely out-of-range `Index` step *autovivifies* the array out
 ///   to that length in real yq (writing `null` padding, then fanning the
 ///   `Iterate` into the newly-created empty tail -- no error, no RHS
@@ -25387,10 +25411,14 @@ fn test_yq_nonterminal_iterate_container_fanout_noop_1432() -> Result<()> {
 ///   evaluates the RHS instead;
 /// - an `Index` step hitting a real `Object` coerces the index to a
 ///   string key and inserts it in real yq (`{"0": []}`), where
-///   succinctly has no such coercion and evaluates the RHS instead.
+///   succinctly has no such coercion and raises. Since #2481 it raises
+///   from the left-side walk (before the RHS), so that shape asserts the
+///   structural error below too -- it used to report `boom`. A harmless
+///   RHS raises the same error both before and after, which is what makes
+///   this an ordering change rather than a new failure.
 ///
-/// All three are pre-existing, unrelated write-path gaps (this exact
-/// catch-all replaces `navigate_read_only`'s own pre-existing `_ =>
+/// The remaining two are pre-existing, unrelated write-path gaps (this
+/// exact catch-all replaces `navigate_read_only`'s own pre-existing `_ =>
 /// Absent` for the identical shapes) -- out of scope here, not
 /// introduced or worsened by this fix. The fourth shape (`Index` hitting
 /// a genuine scalar) is the one case that *does* already match yq: a
@@ -25399,14 +25427,21 @@ fn test_yq_nonterminal_iterate_container_fanout_noop_1432() -> Result<()> {
 #[test]
 fn test_yq_assign_all_noop_mismatched_element_type_1432() -> Result<()> {
     // `Field` mid-prefix hits a real `Array` (wrong container type),
-    // with a `Field` still ahead of it in the prefix.
+    // with a `Field` still ahead of it in the prefix. #2481: the left
+    // side is walked before the right side, so its structural failure is
+    // what surfaces -- the same ordering real yq uses here (`cannot index
+    // array with 'b' (strconv.ParseInt: parsing "b": invalid syntax)`,
+    // v4.53.3), where this used to report `boom` instead.
     let (_out, err, code) = run_yq_stdin_with_stderr(
         ".a.b[].c = error(\"boom\")",
         "a:\n  - 1\n  - 2\n",
         &["-o", "json"],
     )?;
     assert_ne!(code, 0);
-    assert!(err.contains("boom"), "err={err}");
+    assert!(
+        err.contains(r#"Cannot index array with string "b""#),
+        "err={err}"
+    );
 
     // `Index` mid-prefix is out of range on a real `Array`, with an
     // `Index` still ahead of it in the prefix.
@@ -25429,7 +25464,14 @@ fn test_yq_assign_all_noop_mismatched_element_type_1432() -> Result<()> {
     let (_out, err, code) =
         run_yq_stdin_with_stderr(".a[0][].b = error(\"boom\")", "a: {}\n", &["-o", "json"])?;
     assert_ne!(code, 0);
-    assert!(err.contains("boom"), "err={err}");
+    assert!(err.contains("Cannot index object with number"), "err={err}");
+
+    // Same shape, harmless RHS: the identical error, before and after
+    // #2481 -- the write-path gap is pre-existing, only its ordering
+    // relative to the RHS moved.
+    let (_out, err, code) = run_yq_stdin_with_stderr(".a[0][].b = 9", "a: {}\n", &["-o", "json"])?;
+    assert_ne!(code, 0);
+    assert!(err.contains("Cannot index object with number"), "err={err}");
 
     Ok(())
 }
@@ -33278,7 +33320,8 @@ fn test_yq_absent_key_in_assign_rhs_yields_no_node_2470() -> Result<()> {
 /// unchanged row an assignment that skipped the write on an *existing*
 /// target. Captured with `1 | select(false)` -- a right side that is empty
 /// for reasons of its own -- so the rule is keyed on "produced nothing" and
-/// not on why. `jq::eval::yq_empty_rhs_document` implements it; jq mode is
+/// not on why. `jq::eval::yq_prepare_assign_targets` implements it (#2481
+/// moved the same walk ahead of the right side); jq mode is
 /// pinned to jq's own opposite answer (no document at all) in
 /// `test_jq_absent_key_and_empty_rhs_keep_jqs_own_answers_2470`.
 #[test]
@@ -33485,6 +33528,215 @@ fn test_jq_absent_key_and_empty_rhs_keep_jqs_own_answers_2470() -> Result<()> {
         (r".a.e -= (.zzz)", r"", 5),
     ] {
         let (out, stderr, code) = run_jq_stdin_with_stderr(filter, ABSENT_RHS_JSON_2470, &["-c"])?;
+        assert_eq!(
+            (out.trim(), code),
+            (want, want_code),
+            "`{filter}` -- stderr: {stderr}"
+        );
+    }
+    Ok(())
+}
+
+// =============================================================================
+// #2481: yq resolves and auto-creates the assignment target before the RHS
+// =============================================================================
+
+/// The document every #2481 row runs against: one scalar key, so a `keys`
+/// or `length` in the right side changes its answer the moment the target
+/// is created. `yq -o=json -I0 FILTER` on this YAML, `/usr/bin/jq 1.7.1 -c
+/// FILTER` on `{"a":1}`.
+const VIVIFY_DOC_2481: &str = "a: 1\n";
+
+/// The same document as JSON, for the jq-mode control below.
+const VIVIFY_JSON_2481: &str = r#"{"a":1}"#;
+
+/// #2481: real yq's `assignUpdateOperator` (`pkg/yqlib/operator_assign.go`,
+/// v4.53.3) traverses the **left** side with auto-creation on and only then
+/// evaluates the right side, against the document that traversal already
+/// mutated. So `.x = (keys)` on `a: 1` lists `"x"` too, and `.x = (length)`
+/// counts it.
+///
+/// Every row is a live capture from yq v4.53.3 (`-o=json -I0`); jq's own
+/// opposite answers are pinned in
+/// `test_jq_assign_rhs_still_sees_the_pristine_input_2481` below.
+///
+/// This is what makes #2470's read-only rule observable rather than
+/// coincidental: `.zzz.q = (.zzz | key)` used to match yq only because an
+/// absent read fabricated a `null` node spelled `zzz`. With that read now
+/// correctly empty, the target genuinely existing by the time the right
+/// side runs is the only thing that can produce `"zzz"`.
+#[test]
+fn test_yq_assign_vivifies_target_before_rhs_2481() -> Result<()> {
+    for (filter, want) in [
+        (r".x = (keys)", r#"{"a":1,"x":["a","x"]}"#),
+        (r".x = (length)", r#"{"a":1,"x":2}"#),
+        // The vivified node is a real `null` the right side can read back,
+        // ask the key of, and ask the path of.
+        (r".x = (.x)", r#"{"a":1,"x":null}"#),
+        (r".x = (.x | key)", r#"{"a":1,"x":"x"}"#),
+        (r".x = (.x | path)", r#"{"a":1,"x":["x"]}"#),
+        // A whole missing chain is created, not just the leaf.
+        (r".zzz.q = (.zzz | key)", r#"{"a":1,"zzz":{"q":"zzz"}}"#),
+        (r".x.y = (.x | keys)", r#"{"a":1,"x":{"y":["y"]}}"#),
+        (r".x.y = ([..] | length)", r#"{"a":1,"x":{"y":4}}"#),
+        // ...but never *through* a scalar: yq's own field/index no-op
+        // (#1232) means nothing is created and nothing is written.
+        (r".a.b.c = (.a | keys)", r#"{"a":1}"#),
+        (r".a.b = 1", r#"{"a":1}"#),
+        // Every branch of a comma-grouped left side is created first, so
+        // both see both.
+        (
+            r"(.x, .y) = (keys)",
+            r#"{"a":1,"x":["a","x","y"],"y":["a","x","y"]}"#,
+        ),
+        (r"(.x, .y) = (length)", r#"{"a":1,"x":3,"y":3}"#),
+        // The compound operators real yq accepts share the rule.
+        (r".x += (keys)", r#"{"a":1,"x":["a","x"]}"#),
+        (r".x += (length)", r#"{"a":1,"x":2}"#),
+        (r".zzz.q += (.zzz | key)", r#"{"a":1,"zzz":{"q":"zzz"}}"#),
+        (r".zzz.q -= (.zzz | key)", r#"{"a":1,"zzz":{"q":"zzz"}}"#),
+    ] {
+        let (out, stderr, code) =
+            run_yq_stdin_with_stderr(filter, VIVIFY_DOC_2481, &["-o", "json", "-I", "0"])?;
+        assert_eq!(
+            (out.trim(), code),
+            (want, 0),
+            "`{filter}` -- stderr: {stderr}"
+        );
+    }
+    Ok(())
+}
+
+/// #2481, the array half: an out-of-range index target is **padded** before
+/// the right side runs, so `length` counts the padding it just created.
+/// Captured on `[]` (yq v4.53.3, `-o=json -I0`); jq answers `[0]` and
+/// `[null,null,0]` for the first two, pinned below.
+#[test]
+fn test_yq_assign_vivify_pads_an_array_target_before_rhs_2481() -> Result<()> {
+    for (filter, want) in [
+        (r".[0] = (length)", r"[1]"),
+        (r".[2] = (length)", r"[null,null,3]"),
+    ] {
+        let (out, stderr, code) =
+            run_yq_stdin_with_stderr(filter, "[]\n", &["-o", "json", "-I", "0"])?;
+        assert_eq!(
+            (out.trim(), code),
+            (want, 0),
+            "`{filter}` -- stderr: {stderr}"
+        );
+    }
+    Ok(())
+}
+
+/// #2481's write-side ordering, captured before it was encoded.
+///
+/// Real yq applies a multi-output right side **in sequence to one
+/// document** rather than forking one document per output (#1430's
+/// collapse-to-last, which #2481 leaves exactly as it was) -- so the value
+/// that survives is the last one. Every row here is a live capture from yq
+/// v4.53.3, and each is only interesting *because* the target is vivified:
+/// `keys`/`length` in the middle of the stream answer for the mutated
+/// document.
+///
+/// `|=` is the deliberate exception, and is unchanged: its filter runs
+/// through `context.SingleChildContext(candidate)`, i.e. per matched node
+/// with `.` bound to that node, so nothing about the document-level rule
+/// applies to it (#2470's own table row).
+#[test]
+fn test_yq_assign_vivify_multi_output_rhs_and_per_node_update_2481() -> Result<()> {
+    for (filter, want) in [
+        // Last output wins, once, one document -- not two.
+        (r".x = (keys, length)", r#"{"a":1,"x":2}"#),
+        (r".x = (keys, length, .a)", r#"{"a":1,"x":1}"#),
+        // An output *after* the first still reads the vivified document.
+        (r".y = (1, keys)", r#"{"a":1,"y":["a","y"]}"#),
+        // `|=` binds `.` to the (freshly created) node, not the document.
+        (r#".x |= (. // "d")"#, r#"{"a":1,"x":"d"}"#),
+    ] {
+        let (out, stderr, code) =
+            run_yq_stdin_with_stderr(filter, VIVIFY_DOC_2481, &["-o", "json", "-I", "0"])?;
+        assert_eq!(
+            (out.trim(), code),
+            (want, 0),
+            "`{filter}` -- stderr: {stderr}"
+        );
+    }
+    Ok(())
+}
+
+/// #2481's remaining gap, pinned as succinctly's own answer rather than as
+/// parity: real yq's right-side candidates are *pointers into the document*,
+/// so a right side that reads the assignment's own target aliases the node
+/// the write is about to change, and assigning that node to itself is a
+/// no-op rather than a re-read of the pre-write value.
+///
+/// Live on `x: 5` (v4.53.3): `.x = (1, .x)` is `{"x":1}` -- the write of `1`
+/// mutates the very node the second candidate points at, so the second
+/// write stores `1` again. succinctly has no node identity (the same
+/// limitation the anchor/alias section of `docs/compliance/yq/limitations.md`
+/// records), so its collected right side is `[1, 5]` and the last value
+/// wins: `{"x":5}`.
+///
+/// That divergence is **pre-existing** -- `x: 5` is unchanged by #2481 -- but
+/// #2481 does extend it to a *vivified* target, where succinctly used to
+/// agree by coincidence: `.x = (1, .x)` on `a: 1` was `x: 1` only because
+/// the absent `.x` read contributed nothing at all, leaving `[1]`. Now that
+/// the target exists, the read yields the vivified `null` and the last-wins
+/// rule stores it. Pinned in both shapes so the gap cannot close silently.
+#[test]
+fn test_yq_assign_rhs_reading_its_own_target_lacks_node_identity_2481() -> Result<()> {
+    for (doc, filter, want) in [
+        // Pre-existing: yq `{"x":1}`.
+        ("x: 5\n", r".x = (1, .x)", r#"{"x":5}"#),
+        // Pre-existing: yq `{"x":2}`.
+        ("x: 5\n", r".x = (1, .x, 2, .x)", r#"{"x":5}"#),
+        // Agrees with yq: the last output is not a self-reference.
+        ("x: 5\n", r".x = (.x, 1)", r#"{"x":1}"#),
+        // Extended by #2481: yq `{"a":1,"x":1}`.
+        ("a: 1\n", r".x = (1, .x)", r#"{"a":1,"x":null}"#),
+    ] {
+        let (out, stderr, code) =
+            run_yq_stdin_with_stderr(filter, doc, &["-o", "json", "-I", "0"])?;
+        assert_eq!(
+            (out.trim(), code),
+            (want, 0),
+            "`{filter}` on `{doc}` -- stderr: {stderr}"
+        );
+    }
+    Ok(())
+}
+
+/// #2481's jq-mode control: none of it applies there. jq's `_modify`
+/// evaluates `.x = f` as `f as $v | setpath(...)`, with `$v` bound against
+/// the **pristine** input, so `.x = (keys)` never lists `x` and a
+/// multi-output right side forks one document per output. Captured live
+/// from `/usr/bin/jq` 1.7.1 (the pinned oracle -- Homebrew's is 1.8.2).
+#[test]
+fn test_jq_assign_rhs_still_sees_the_pristine_input_2481() -> Result<()> {
+    for (filter, want, want_code) in [
+        (r".x = (keys)", r#"{"a":1,"x":["a"]}"#, 0),
+        (r".x = (length)", r#"{"a":1,"x":1}"#, 0),
+        (r".x = (.x | type)", r#"{"a":1,"x":"null"}"#, 0),
+        (r".x = ([paths])", r#"{"a":1,"x":[["a"]]}"#, 0),
+        (r".x += (keys)", r#"{"a":1,"x":["a"]}"#, 0),
+        (r"(.x,.y) = (length)", r#"{"a":1,"x":1,"y":1}"#, 0),
+        // Forks a whole document per output, where yq keeps only the last.
+        (
+            r".x = (keys, length)",
+            "{\"a\":1,\"x\":[\"a\"]}\n{\"a\":1,\"x\":1}",
+            0,
+        ),
+        // No node identity question to answer: `$v` is a value, and the
+        // second output is the pristine (absent) `.x`.
+        (
+            r".x = (1, .x)",
+            "{\"a\":1,\"x\":1}\n{\"a\":1,\"x\":null}",
+            0,
+        ),
+        // jq raises where yq creates: no auto-creation before the RHS.
+        (r".a.b.c = (.a | keys)", r"", 5),
+    ] {
+        let (out, stderr, code) = run_jq_stdin_with_stderr(filter, VIVIFY_JSON_2481, &["-c"])?;
         assert_eq!(
             (out.trim(), code),
             (want, want_code),


### PR DESCRIPTION
## Summary

In yq mode an assignment resolves and auto-creates its target before evaluating the right-hand side, so the RHS sees the mutated document (`.x = (keys)` on `a: 1` is `{"a":1,"x":["a","x"]}`, `.x = (length)` is 2, `.zzz.q = (.zzz | key)` is `{"q":"zzz"}`). One definition, `yq_prepare_assign_targets`, resolves the targets and creates them on an owned working copy through the existing `update_path` walk (so the scalar-target no-op, array padding and iterate-to-empty rules all come from one place), then hands that copy to the RHS collection and the write loop. It subsumes #2470's vivify-only walk, which is removed rather than duplicated, and is shared by `=`, the compound forms and `//=`. The generic evaluator has no assignment arm of its own, so both routes consult it.

Captures from yq v4.53.3 are in the tests, including rows the capture added: a multi-output RHS applies to one document, last wins (already #1430's rule, now pinned); `|=` is per node and unchanged; array padding happens before the RHS; a scalar target silently no-ops. One premise on the issue was wrong and is corrected in the test comments: `+=` through an absent target does not error in yq, only `*=` does.

Cost: the RHS takes the reindex bridge only when vivification actually changed the document, and change detection skips the clone for a literal RHS. Interleaved A/B on a 7 MB document: no regression.

## Left open, recorded in the limitations doc

Node identity in a self-referential RHS (`.x = (1, .x)` is `{"x":1}` in yq, whose candidates are pointers), pinned as divergent; read-side array padding inside a read-only RHS; `type` spelling yq's tags (#2516, pre-existing and unrelated); `line`/`column`/`style` read from an RHS (pre-existing). Two pinned tests now report the left-side structural error before the RHS, which matches yq's ordering and closes a gap those tests documented.

## Verification

fmt; clippy on all CI legs with `-D warnings`; `cargo test --features cli`, default, `--no-default-features`; `cargo doc -D warnings`; yq goldens 113 and jq goldens 633; the assignment-path oracle sweep byte-identical over 20,496 cases; the path-context sweep 3168 cases, 0 unexpected, manifest unchanged.

Behaviour change in yq mode; CHANGELOG entry included; ships in its own release. Closes #2481.
