### PR TITLE
feat(jq): map-family bodies and an assignment rhs read their member's position (#2471)

### DIFF
--- a/docs/adrs/adr-0021.md
+++ b/docs/adrs/adr-0021.md
@@ -132,6 +132,32 @@ in-place transforms *inside owned values*, which have no node to stand on.
    (#2435), and the only change is that the eager route's `{}` for a one-level absent
    ancestor is now the walk's `null`, the same answer for the same position.
 
+   **A map-family body stands at its member, not at its container** (#2471 remainder).
+   Decision 7's table places a builtin's *output*; `map`, `map_values` and `with_entries`
+   also run a body once per member, and real yq evaluates that body at the member's own
+   position — `.a | map_values(key)` on `a: {b: 1, e: 2}` is `{"b":"b","e":"e"}` in
+   v4.53.3, and `.a | with_entries(.value = key)` is `{"b":0,"e":1}`, the member there
+   being an entry of the array `to_entries` built, so its key is the index. That is one
+   position per member, so it cannot be a single stage-wide rewrite:
+   `eval_map_family_positioned` derives each member's `key`/`path` from the container's
+   own position plus the component, rewrites the body against it with the same
+   `path_context_resolve_constants` every other route uses, and hands the result to the
+   ordinary owned evaluator. Both entries into it are gated on the body reading path
+   context at all, so an ordinary `map_values(. + 1)` never sees this route: what it takes
+   over is exactly the set of shapes that were answering with no position. A body whose
+   reads cannot be resolved at a member position — `parent`, which real yq answers from a
+   container it is halfway through rewriting — is refused and left where it was.
+
+   **An assignment's right-hand side stands at the assignment's own input.** `.a | .b =
+   key` is `{"b":"a","e":2}` in yq v4.53.3, not `{"b":"b",...}`: `eval_assign` hands the
+   right side the same value the whole stage received, so the read is an ordinary
+   stage-wide constant and `path_context_resolvable`/`path_context_resolve_constants`
+   answer it like any other slot. The *left* side is excluded: it is a path expression,
+   and the rewriter's `parent` arm spells its answer as an `Expr::TrackedVar` holding a
+   materialized value, which no path walker can take. `|=` and the compound operators are
+   excluded for a different reason — their right side is evaluated against the value *at
+   the path* (`.a | .b |= key` is `{"b":"b","e":2}`), a position no route names yet.
+
    **The residue is a fan-out head.** `.[] | .k | select(key == "k")` is one position per
    element, the memory cost `path_context_fans_out` exists to refuse and the same guard
    `path_context_walk_split` applies. It stays eager by design, and it is what decision 8's

--- a/docs/plan/path-context-arm-reachability.md
+++ b/docs/plan/path-context-arm-reachability.md
@@ -375,6 +375,76 @@ still reaches its arm -- and the eager evaluator's structural arms
 Deleting an arm needs the `?` head and the fan-out head routed, not this list
 widened further.
 
+## #2471 remainder: map-family bodies and an assignment's right side, and the pin still holds at 43
+
+The rest of [#2471](https://github.com/rust-works/succinctly/issues/2471) closed two
+shapes that were invisible to routing altogether, not merely handed to the eager
+evaluator: `needs_path_context` did not descend into a `map_values`/`with_entries`
+body, nor into an assignment's right-hand side, so no route was ever asked and
+`key`/`path` answered with nothing. Both now descend, and both have somewhere to go
+(ADR-0021 decision 7): an assignment's right side is a stage-wide constant, answered
+by the existing constant/identity rewrite; a map-family body is one position *per
+member*, answered by `eval_map_family_positioned` from the container's position plus
+the component.
+
+**`PINNED_ARM_COUNT` stays at 43,** and the argument is the same shape as #2471's own
+above. Re-run of the method with the five `R1` arms instrumented, each fed its proof
+query from the table (document `D`):
+
+| Id  | Proof query                                | Marker  | Output  |
+|-----|--------------------------------------------|---------|---------|
+| A04 | `.c[0:1] \| .[0] \| key + 1`                | fired   | `1`     |
+| A07 | `.c[.n]? \| key + 1`                        | fired   | `1`     |
+| A17 | `.a \| getpath(["b"]) \| . as $x \| key`    | fired   | `"b"`   |
+| A19 | `.c[.n] \| key + 1`                         | fired   | `1`     |
+| A20 | `.c[.n:.m] \| .[0] \| key + 1`              | fired   | `1`     |
+
+All five still fire with their pinned outputs, for the reason #2471's own section
+already gives: a computed bracket or a `getpath` at the *head* of a pipe is still a
+detaching stage with no `owned_identity_rule`, which this change does not touch.
+
+The two arms the change could plausibly have starved were instrumented in the same
+run, since the map-family stages used to reach the eager evaluator through them:
+
+| Id  | Proof query                | Marker  | Output    |
+|-----|----------------------------|---------|-----------|
+| A16 | `.a \| map(key + "x")`      | fired   | `["bx"]`  |
+| A18 | `.a[] \| (key \| length)`   | fired   | `1`       |
+
+`A16` (`Builtin::Map`) is deliberately kept reachable: a `map` over a *live* cursor is
+already exact on the eager route, so `path_context_needs_eager` admits only
+`map_values`/`with_entries` for a live head, and `map` reaches the positioned route
+only once its input has already left the cursor domain (`.a | to_entries | map(.value =
+key)`). Moving a correct answer to a new route buys nothing and risks something.
+
+The migration is real rather than nominal even so — with the same instrumentation,
+`.a | map_values(key)`, `.a | with_entries(.value = key)`, `.a | to_entries | map(.value
+= key)`, `.a | to_entries | map(key)`, `.a | map(key)` and `.a | .b = key` all fire *no*
+marker at all: none of them enters the eager evaluator any more. The instrumentation was
+reverted before this document was committed.
+
+### What the change is measured against
+
+A differential over 531 map-family and assignment queries (nine heads x three families
+x seventeen bodies, plus the assignment rows) on `a: {b: 1, e: 2}`, `n: [1, 2]`,
+`d: {x: {y: 3}, z: [4, 5]}`, `s: hi`, `u: null`, comparing the pre-change binary, the
+post-change binary and yq v4.53.3: **142 answers changed, 102 of them from disagreeing
+with yq to agreeing with it, and none the other way.** The remaining 40 are three
+pre-existing gaps this change makes *reachable* rather than causes, each demonstrable
+with no path context anywhere in the filter:
+
+- `map_values(select(...))` — real yq keeps a member whose filter produced nothing (its
+  zero-output update rule, #2484), succinctly drops it. `.a | map_values(select(. == 1))`
+  diverges identically. The new answer is strictly closer (`{"b":1}` where it was `{}`).
+- `with_entries(<body that is not an entry>)` — the body now produces a value where it
+  used to produce nothing, so `from_entries` refuses it. Real yq refuses too, with its own
+  wording, so the exit code now agrees where it previously did not.
+- `from_entries` on a non-string key — real yq stringifies (`.n | to_entries |
+  from_entries` is `{"0":1,"1":2}` in v4.53.3), succinctly raises `Cannot use number (0)
+  as object key` in both modes, matching jq 1.7.1. That refusal is now reachable from
+  `.a | with_entries(.key = key)`, which yq answers `{"0":1,"1":2}`. A separate yq
+  fidelity gap in `from_entries`, deliberately not fixed here.
+
 ## Result
 
 | Metric                                            | Before | After                 |
@@ -384,6 +454,7 @@ widened further.
 | ... proven UNREACHABLE                             | --     | 0                     |
 | ... neither                                        | --     | 0                     |
 | ... whose listed proof query moved off the gate    | --     | 1 (#2473); 14 (#2472) |
+| ... starved by #2471's remainder                   | --     | 0 (`A16`/`A18` re-run) |
 | `PINNED_ARM_COUNT`                                 | 43     | 43                    |
 
 Nothing is deletable at this point in the spine. Doors 2 and 3 are closed as
@@ -402,7 +473,9 @@ evaluator, with no second route to check.
   their literal-bound siblings (`Expr::Index`, `Expr::Slice` with folded bounds)
   are navigational. #2471 (section above) took the *owned-domain* half of that
   cluster and left all five arms reachable: what remains is the head-of-pipe
-  half, which needs the cursor walk to evaluate a computed component.
+  half, which needs the cursor walk to evaluate a computed component. #2471's
+  *remainder* (section above) closed the map-family and assignment-right-side
+  shapes and left all five reachable for the same reason.
 - `A24` (`Expr::Shared`) is only ever produced by `substitute_func_param`
   (`src/jq/eval.rs`), so it dies with `A23`/`A25` and not before.
 - `A38` (`Expr::Break`) cannot be reached without `A37` (`Expr::Label`): the

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -1765,6 +1765,31 @@ pub(crate) fn needs_path_context(expr: &Expr) -> bool {
         // for every element instead of resolving or erroring (#715
         // follow-up).
         Expr::Builtin(Builtin::Map(f)) => needs_path_context(f),
+        // `.b = key` (#2471, gate reason 1 of spine 2416): an assignment's
+        // right-hand side is evaluated against the assignment's own input --
+        // `eval_assign` hands it the same `value` the whole stage received --
+        // so a `key`/`path`/`file_index` in it needs the ambient position, the
+        // same reasoning `Expr::As` gives above. Captured from yq v4.53.3 on
+        // `a: {b: 1, e: 2}`: `.a | .b = key` is `{"b":"a","e":2}` and
+        // `.a | to_entries | .[0] | .value = key` is `{"key":"b","value":0}`,
+        // where succinctly left both untouched.
+        //
+        // The *left* side is deliberately excluded. It is a path expression,
+        // not a value one: `path_context_resolve_constants` rewrites a
+        // `parent` into an `Expr::TrackedVar` holding a whole materialized
+        // value, which is not a shape the assignment's path walker can take.
+        // A read reachable only through the left side (`.[key] = 1`) is
+        // therefore left where it was -- unrouted, and answered exactly as
+        // before -- rather than routed to a resolver that would refuse it.
+        //
+        // `Expr::Update`/`CompoundAssign`/`AlternativeAssign` are excluded for
+        // a different reason: their right side is evaluated against the value
+        // *at the path*, not against the stage's input, so it stands somewhere
+        // else entirely (yq v4.53.3: `.a | .b |= key` is `{"b":"b","e":2}`,
+        // where `.a | .b = key` is `{"b":"a","e":2}`). Admitting them here
+        // without a route that knows the target's position would resolve their
+        // reads against the wrong node.
+        Expr::Assign { value, .. } => needs_path_context(value),
         Expr::Pipe(exprs) => exprs.iter().any(needs_path_context),
         Expr::Paren(inner) => needs_path_context(inner),
         Expr::Optional(inner) => needs_path_context(inner),

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -1765,6 +1765,19 @@ pub(crate) fn needs_path_context(expr: &Expr) -> bool {
         // for every element instead of resolving or erroring (#715
         // follow-up).
         Expr::Builtin(Builtin::Map(f)) => needs_path_context(f),
+        // `map_values(f)`/`with_entries(f)` (#2471, gate reason 1 of spine
+        // 2416): the same recursion as `Builtin::Map` above, and the same
+        // omission it had before #715 -- `.a | map_values(key)` was never
+        // seen as a path-context pipe at all, so no route was ever asked and
+        // `key` answered with nothing (yq v4.53.3 answers `{"b":"b","e":"e"}`
+        // on `a: {b: 1, e: 2}`). Real yq evaluates a map-family body at each
+        // *member's* own position, not at the container's, which is why
+        // `path_context_resolvable` deliberately does **not** gain a matching
+        // arm: the constant-resolving routes would rewrite the body's `key`
+        // to the container's key. `map_family_body`/
+        // `eval_map_family_positioned` (`eval_generic.rs`) are what answer
+        // these instead.
+        Expr::Builtin(Builtin::MapValues(f) | Builtin::WithEntries(f)) => needs_path_context(f),
         // `.b = key` (#2471, gate reason 1 of spine 2416): an assignment's
         // right-hand side is evaluated against the assignment's own input --
         // `eval_assign` hands it the same `value` the whole stage received --
@@ -11579,7 +11592,7 @@ fn entry_key_and_value(entry: &OwnedValue) -> Result<(OwnedValue, OwnedValue), E
 /// to look up `value`. Re-inserting a key keeps its original position and
 /// replaces its value, which is what jq's `add` over the mapped singletons
 /// does.
-fn entries_to_object<I: IntoIterator<Item = OwnedValue>>(
+pub(crate) fn entries_to_object<I: IntoIterator<Item = OwnedValue>>(
     entries: I,
 ) -> Result<IndexMap<String, OwnedValue>, EvalError> {
     let mut result = IndexMap::new();

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -38,7 +38,7 @@ use super::eval::{
     apply_compare_op, arith_combine, as_var_refs, binary_fanout_rules, bind_def, bind_def_call,
     boolean_fanout_bools, cannot_reserve_cross_product, classify_limit_n, classify_nth_n,
     classify_parent_n, collapse_vec, collect_pattern_var_names, compare_values,
-    debug_assert_materialization_error, enter_def_call_frame, eval_each_owned,
+    debug_assert_materialization_error, enter_def_call_frame, entries_to_object, eval_each_owned,
     eval_foreach_with_values, eval_full as full_eval, eval_reduce_with_values,
     extract_pattern_bindings, fold_escaped_generator_prefix, format_owned,
     has_type_mismatch_is_permissive, index_component_value, index_in_array_bounds,
@@ -12511,7 +12511,25 @@ pub(crate) fn path_context_needs_eager(exprs: &[Expr]) -> bool {
     let absent_routed = path_context_absent_split(exprs).is_some();
     for stage in exprs {
         if needs_path_context(stage) {
-            if !is_node || (can_absent && !absent_routed) || !path_context_stage_native(stage) {
+            // #2416 gate reason 1 (#2471): a `map_values`/`with_entries`
+            // whose *body* is what reads path context reads nothing at its
+            // own position -- `eval_builtin`'s own positioned arm evaluates
+            // that body once per member instead. So `can_absent` does not
+            // apply (an absent input has no members, and the body never
+            // runs), and `path_context_stage_native` is answered by that arm
+            // rather than by `path_context_single_native`'s closed list.
+            // What the stage still needs is a *live* input: the member
+            // positions come from the container's cursor. `map` is
+            // deliberately not admitted here -- its cursor-input shapes are
+            // already exact on the eager route (#2493), and moving a correct
+            // answer to a new route is risk with nothing to buy.
+            if !matches!(
+                map_family_positioned(stage),
+                Some((MapFamily::MapValues | MapFamily::WithEntries, _))
+            ) && (!is_node
+                || (can_absent && !absent_routed)
+                || !path_context_stage_native(stage))
+            {
                 return true;
             }
             is_node = path_context_stage_preserves_node(stage);
@@ -13586,6 +13604,37 @@ fn eval_builtin<S: EvalSemantics, V: DocumentValue>(
     optional: bool,
     cursor: Option<V::Cursor>,
 ) -> GenericResult<V> {
+    // #2471 (gate reason 1 of spine 2416): a map-family body that reads path
+    // context is evaluated once per member, at the member's own position.
+    // Gated on `needs_path_context` so an ordinary `map_values(.+1)` never
+    // sees this route at all -- the shapes it takes over are exactly the ones
+    // that were answering with no position before it existed.
+    //
+    // A cursor is what makes the container's path knowable here; without one
+    // (the library's owned entry points) the stage falls through to the
+    // evaluation it already had. `to_owned_cursor` materializes the container
+    // the same way the fallback below would, so a decode failure surfaces
+    // from that fallback rather than being re-reported here.
+    if let Some((family, f)) = map_family_body(builtin) {
+        if needs_path_context(f) && path_context_absent_resolvable(f) {
+            if let Some(c) = cursor {
+                // STYLE-0012: neither raises nor suppresses -- a failure to
+                // materialize the container here hands the stage back to the
+                // ordinary evaluation below, which materializes the same
+                // container itself and reports (or suppresses, per its own
+                // `optional`) the identical failure. Answering it twice is
+                // what would change behaviour.
+                let container = to_owned_cursor(&c);
+                if let (Ok(container), Ok((path, _))) = (container, cursor_path_and_ancestors(&c)) {
+                    if let Some(result) = eval_map_family_positioned_result::<S, V>(
+                        family, f, &container, &path, optional,
+                    ) {
+                        return result;
+                    }
+                }
+            }
+        }
+    }
     match builtin {
         Builtin::Line => {
             let line = cursor.map_or(0, |c| c.line());
@@ -15315,7 +15364,16 @@ fn owned_identity_pipe_supported(stages: &[Expr]) -> bool {
             }
             _ => match owned_identity_rule(stage) {
                 Some(_) => {
-                    if needs_path_context(stage) && !owned_identity_stage_resolvable(stage) {
+                    // #2471: a map-family stage's body stands at each
+                    // *member's* position, which this pipe can name (the
+                    // identity plus the component), so it is admitted here
+                    // instead of being asked to resolve against the
+                    // container's own position -- see
+                    // `eval_map_family_positioned`.
+                    if needs_path_context(stage)
+                        && map_family_positioned(stage).is_none()
+                        && !owned_identity_stage_resolvable(stage)
+                    {
                         return false;
                     }
                 }
@@ -15917,6 +15975,235 @@ fn eval_owned_identity_alternative<S: EvalSemantics, V: DocumentValue>(
     owned_identity_operand::<S, V>(right, value, id, optional)
 }
 
+/// Which map-family builtin a stage is (#2471, gate reason 1 of spine 2416).
+///
+/// All three evaluate their body once per *member* of their input, so the
+/// position a `key`/`path`/`file_index` inside one reads is the member's, not
+/// the container's -- which is why they are answered here rather than by
+/// [`path_context_resolve_constants`]'s ordinary stage rewrite. Captured from
+/// yq v4.53.3 on `a: {b: 1, e: 2}`:
+///
+/// ```text
+/// .a | map_values(key)                {"b":"b","e":"e"}
+/// .a | map_values(path)               {"b":["a","b"],"e":["a","e"]}
+/// .a | with_entries(.value = key)     {"b":0,"e":1}
+/// .a | with_entries(.value = path)    {"b":["a",0],"e":["a",1]}
+/// .a | to_entries | map(.value = key) [{"key":"b","value":0},{"key":"e","value":1}]
+/// ```
+///
+/// `with_entries`'s member is an *entry* of the array `to_entries` built, so
+/// its key is the index; `map_values`'s is the object member itself, so its
+/// key is the field name.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+enum MapFamily {
+    /// `map(f)`: every output of `f`, over the members, in one fresh array.
+    Map,
+    /// `map_values(f)`: `f`'s *first* output replaces each member, and a
+    /// member whose `f` produced nothing is dropped -- exactly
+    /// `eval::builtin_map_values`'s own rule, which this route reproduces
+    /// rather than re-decides.
+    MapValues,
+    /// `with_entries(f)`: `to_entries | map(f) | from_entries`, the same
+    /// composition `eval::builtin_with_entries` is.
+    WithEntries,
+}
+
+/// The map-family builtin `builtin` is, with its body.
+fn map_family_body(builtin: &Builtin) -> Option<(MapFamily, &Expr)> {
+    Some(match builtin {
+        Builtin::Map(f) => (MapFamily::Map, f),
+        Builtin::MapValues(f) => (MapFamily::MapValues, f),
+        Builtin::WithEntries(f) => (MapFamily::WithEntries, f),
+        _ => return None,
+    })
+}
+
+/// Whether `stage` is a map-family stage whose body reads path context and
+/// whose reads can be resolved at each member's own position.
+///
+/// The body is gated by [`path_context_absent_resolvable`] -- the constants-
+/// only predicate -- deliberately, not by its `with_parent` sibling: a
+/// `parent` inside a map-family body is one of the shapes where real yq
+/// re-reads a container it is halfway through rewriting and prints a
+/// self-referential tree (`.a | map_values(parent)` on `a: {b: 1, e: 2}` is
+/// `{"b":{"b":{},"e":{"b":1,"e":{"b":1}}},...}` in v4.53.3). Refusing it here
+/// leaves those stages exactly where they already were, on the eager
+/// evaluator, rather than encoding a rewrite-order artefact as a rule.
+fn map_family_positioned(stage: &Expr) -> Option<(MapFamily, &Expr)> {
+    let Expr::Builtin(builtin) = strip_parens(stage) else {
+        return None;
+    };
+    let (family, f) = map_family_body(builtin)?;
+    (needs_path_context(f) && path_context_absent_resolvable(f)).then_some((family, f))
+}
+
+/// One `{"key": k, "value": v}` entry, as `to_entries` builds it.
+fn map_family_entry(key: OwnedValue, value: OwnedValue) -> OwnedValue {
+    let mut entry = IndexMap::with_capacity(2);
+    entry.insert("key".to_string(), key);
+    entry.insert("value".to_string(), value);
+    OwnedValue::Object(entry)
+}
+
+/// The `(component, member)` pairs a map-family stage's body runs over, or
+/// `None` where the input has no members at all.
+///
+/// `None` is not a refusal of the *value* -- it means the body never runs, so
+/// the position it would have read cannot be observed and the ordinary
+/// (unpositioned) evaluation of the whole builtin answers identically. Every
+/// mode-specific rule for a scalar input (`eval::builtin_map`'s yq no-op,
+/// #1907; `to_entries`'s "has no keys") therefore stays in exactly one place.
+fn map_family_members(
+    family: MapFamily,
+    container: &OwnedValue,
+) -> Option<Vec<(OwnedValue, OwnedValue)>> {
+    let members = match container {
+        OwnedValue::Object(fields) => fields
+            .iter()
+            .enumerate()
+            .map(|(i, (k, v))| match family {
+                MapFamily::WithEntries => (
+                    OwnedValue::Int(i as i64),
+                    map_family_entry(OwnedValue::String(k.clone()), v.clone()),
+                ),
+                _ => (OwnedValue::String(k.clone()), v.clone()),
+            })
+            .collect(),
+        OwnedValue::Array(elements) => elements
+            .iter()
+            .enumerate()
+            .map(|(i, v)| {
+                let index = OwnedValue::Int(i as i64);
+                match family {
+                    MapFamily::WithEntries => (index.clone(), map_family_entry(index, v.clone())),
+                    _ => (index, v.clone()),
+                }
+            })
+            .collect(),
+        _ => return None,
+    };
+    Some(members)
+}
+
+/// Evaluate a map-family stage with its body positioned at each member
+/// (#2471, gate reason 1 of spine 2416).
+///
+/// `container_path` is the path of the input container, so member *i*'s own
+/// position is `container_path ++ [component]` and its `key` is `component`
+/// -- the two constants [`path_context_resolve_constants`] needs. The body is
+/// rewritten once per member and then handed to the ordinary owned evaluator,
+/// so every construct inside it keeps one definition; only the position is
+/// supplied here.
+///
+/// `None` means the input is not a container (see [`map_family_members`]) and
+/// the caller should evaluate the stage the ordinary way.
+fn eval_map_family_positioned<S: EvalSemantics, V: DocumentValue>(
+    family: MapFamily,
+    f: &Expr,
+    container: &OwnedValue,
+    container_path: &[OwnedValue],
+    optional: bool,
+    sink: &mut dyn FnMut(OwnedValue) -> Demand,
+) -> Option<Flow> {
+    let members = map_family_members(family, container)?;
+    // `map`/`with_entries` are array construction and `map_values` is object
+    // construction: all three are atomic in jq, so a control escaping any
+    // member's body discards the whole partly-built result rather than
+    // surfacing a prefix -- the same rule `eval::map_over`,
+    // `eval::builtin_map_values` and `eval::builtin_with_entries` each state.
+    let mut array: Vec<OwnedValue> = Vec::new();
+    let mut object = IndexMap::with_capacity(members.len());
+    for (component, member) in members {
+        let mut path = vec_with_capacity(container_path.len() + 1);
+        path.extend_from_slice(container_path);
+        path.push(component.clone());
+        let resolved = match path_context_resolve_constants::<S, V>(
+            f,
+            &PathContextAt {
+                key: Some(&component),
+                path: &path,
+                parent_from: None,
+            },
+        ) {
+            Ok(expr) => expr,
+            Err(e) => return Some(Flow::Escaped(Control::Error(e))),
+        };
+        let mut outputs: Vec<OwnedValue> = Vec::new();
+        if let Flow::Escaped(control) =
+            eval_each_owned::<S>(&resolved, &member, optional, &mut |v| {
+                outputs.push(v);
+                Demand::Continue
+            })
+        {
+            return Some(Flow::Escaped(control));
+        }
+        match family {
+            MapFamily::Map | MapFamily::WithEntries => array.extend(outputs),
+            MapFamily::MapValues => {
+                let Some(value) = outputs.into_iter().next() else {
+                    continue;
+                };
+                match &component {
+                    // An array input keeps its shape: the components are
+                    // indices, and a dropped member closes the gap, exactly
+                    // as `eval::builtin_map_values`' own array arm does.
+                    OwnedValue::Int(_) => array.push(value),
+                    _ => {
+                        object.insert(owned_to_string::<S>(&component), value);
+                    }
+                }
+            }
+        }
+    }
+    let result = match family {
+        MapFamily::Map => OwnedValue::Array(array),
+        MapFamily::MapValues => match container {
+            OwnedValue::Array(_) => OwnedValue::Array(array),
+            _ => OwnedValue::Object(object),
+        },
+        // `from_entries`, the one definition `eval::builtin_with_entries`
+        // also ends in -- including its refusal of a key that is not a
+        // string, and `?`'s suppression of that refusal.
+        MapFamily::WithEntries => match entries_to_object(array) {
+            Ok(fields) => OwnedValue::Object(fields),
+            Err(_) if optional => return Some(Flow::Exhausted),
+            Err(e) => return Some(Flow::Escaped(Control::Error(e))),
+        },
+    };
+    Some(match sink(result) {
+        Demand::Continue => Flow::Exhausted,
+        Demand::Stop => Flow::Stopped { pending: None },
+    })
+}
+
+/// [`eval_map_family_positioned`] for a caller that wants a `GenericResult`
+/// -- `eval_builtin`'s own entry, where the map-family stage is the one
+/// leaving the cursor domain and nothing follows it.
+fn eval_map_family_positioned_result<S: EvalSemantics, V: DocumentValue>(
+    family: MapFamily,
+    f: &Expr,
+    container: &OwnedValue,
+    container_path: &[OwnedValue],
+    optional: bool,
+) -> Option<GenericResult<V>> {
+    let mut collected: Vec<OwnedValue> = Vec::new();
+    let flow = eval_map_family_positioned::<S, V>(
+        family,
+        f,
+        container,
+        container_path,
+        optional,
+        &mut |v| {
+            collected.push(v);
+            Demand::Continue
+        },
+    )?;
+    Some(match flow {
+        Flow::Exhausted | Flow::Stopped { .. } => owned_vec_to_generic_result(collected),
+        Flow::Escaped(control) => partial_generic(collected, control),
+    })
+}
+
 /// The owned identity pipe (#2416 step 3): evaluate `stages` from an owned
 /// `value` whose position is `id`, answering `key`/`path`/`parent`/
 /// `parent(n)`/`file_index` from the identity and threading it through
@@ -16026,7 +16313,7 @@ fn eval_owned_identity_pipe<S: EvalSemantics, V: DocumentValue>(
                 stage
             };
             let mut downstream: Option<Flow> = None;
-            let upstream = eval_each_owned::<S>(stage_expr, &value, optional, &mut |output| {
+            let mut emit = |output: OwnedValue| -> Demand {
                 let flow = match owned_identity_after_stage::<S, V>(
                     stage, rule, &value, &id, &output, optional,
                 ) {
@@ -16053,7 +16340,28 @@ fn eval_owned_identity_pipe<S: EvalSemantics, V: DocumentValue>(
                         Demand::Stop
                     }
                 }
+            };
+            // #2471 (gate reason 1 of spine 2416): a map-family stage whose
+            // body reads path context runs that body once per *member*, at
+            // the member's own position -- `stage_expr`'s stage-wide rewrite
+            // above would have resolved those reads to the container's key
+            // instead, which is why `owned_identity_pipe_supported` admits
+            // such a stage without asking `owned_identity_stage_resolvable`.
+            // The output is placed by the stage's ordinary
+            // `owned_identity_rule` (`map` detaches, `map_values` keeps,
+            // `with_entries` detaches), so `rest` continues identically
+            // either way.
+            let positioned = map_family_positioned(stage).and_then(|(family, f)| {
+                let path = match id.path() {
+                    Ok(path) => path,
+                    Err(e) => return Some(Flow::Escaped(Control::Error(e))),
+                };
+                eval_map_family_positioned::<S, V>(family, f, &value, &path, optional, &mut emit)
             });
+            let upstream = match positioned {
+                Some(flow) => flow,
+                None => eval_each_owned::<S>(stage_expr, &value, optional, &mut emit),
+            };
             match downstream {
                 Some(flow) => flow,
                 None => upstream,
@@ -24887,6 +25195,14 @@ mod tests {
         // owned identity pipe.
         assert!(!eager(".a | to_entries | .[(0,1)] | key"));
         assert!(!eager(".a | to_entries | .[(0,1)]? | path"));
+        // #2471 remainder: a `map_values`/`with_entries` whose body is what
+        // reads path context is answered per member by `eval_builtin`'s own
+        // positioned arm, so a live head no longer sends it here -- not even
+        // one that can miss, since an absent input has no members and the
+        // body never runs.
+        assert!(!eager(".a | map_values(key)"));
+        assert!(!eager(".a | with_entries(.value = key)"));
+        assert!(!eager(".a | to_entries | map(.value = key)"));
         // An assignment's right-hand side is a *constant* for a fixed
         // position, so the pipe is answered before this gate is asked at
         // all: `try_path_context_absent_sink` runs first and takes it, which
@@ -24894,6 +25210,14 @@ mod tests {
         // the eager evaluator for `.a.b | .c = key` (arm re-audit, #2471).
         assert!(eager(".a.b | .c = key"));
         assert!(path_context_absent_resolvable(&parse(".c = key").unwrap()));
+        // ...but a body whose reads cannot be resolved at a member position
+        // (`parent`, which real yq answers from a container it is halfway
+        // through rewriting) stays exactly where it was.
+        assert!(eager(".a | map_values(parent)"));
+        assert!(eager(".a | with_entries(.value = parent)"));
+        // `map` is deliberately not admitted for a *live* head: its cursor
+        // shapes are already exact on the eager route (#2493).
+        assert!(eager(".a | map(key + \"x\")"));
         assert!(!eager(".a | to_entries | .[(0):(1)] | key"));
         assert!(!eager(".a | to_entries | .[(0):(1)]? | key"));
         assert!(!eager(".a | to_entries | .[.[0].key | length] | key"));

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -12978,6 +12978,14 @@ fn path_context_resolvable(expr: &Expr, with_parent: bool) -> bool {
                     ObjectKey::Expr(key) => sub(key),
                 }
         }),
+        // #2471 (gate reason 1 of spine 2416): `eval_assign` evaluates an
+        // assignment's right-hand side against the same input the whole stage
+        // received, so a read inside it resolves against this position --
+        // exactly like `Expr::Object`'s value slots above. The left side is
+        // a *path* expression and is refused rather than rewritten, matching
+        // `needs_path_context`'s own arm (see its comment for why a
+        // `TrackedVar` cannot stand in a path).
+        Expr::Assign { path, value } => !needs_path_context(path) && sub(value),
         _ => false,
     }
 }
@@ -13398,6 +13406,13 @@ fn path_context_resolve_constants<S: EvalSemantics, V: DocumentValue>(
                 })
                 .collect::<Result<Vec<_>, EvalError>>()?,
         ),
+        // #2471: the rewriter's half of `path_context_resolvable`'s own
+        // `Expr::Assign` arm -- the right side only, the left one being
+        // refused there rather than rewritten.
+        Expr::Assign { path, value } => Expr::Assign {
+            path: path.clone(),
+            value: boxed(value)?,
+        },
         other => other.clone(),
     })
 }
@@ -24872,6 +24887,13 @@ mod tests {
         // owned identity pipe.
         assert!(!eager(".a | to_entries | .[(0,1)] | key"));
         assert!(!eager(".a | to_entries | .[(0,1)]? | path"));
+        // An assignment's right-hand side is a *constant* for a fixed
+        // position, so the pipe is answered before this gate is asked at
+        // all: `try_path_context_absent_sink` runs first and takes it, which
+        // is why the gate still reports `true` here and no marker fires in
+        // the eager evaluator for `.a.b | .c = key` (arm re-audit, #2471).
+        assert!(eager(".a.b | .c = key"));
+        assert!(path_context_absent_resolvable(&parse(".c = key").unwrap()));
         assert!(!eager(".a | to_entries | .[(0):(1)] | key"));
         assert!(!eager(".a | to_entries | .[(0):(1)]? | key"));
         assert!(!eager(".a | to_entries | .[.[0].key | length] | key"));
@@ -25099,6 +25121,14 @@ mod tests {
             "key | tostring",
             "select(true) | key",
             "(key)?",
+            // #2471 remainder: an assignment's right-hand side stands where
+            // the assignment's own input stands, so it resolves here like
+            // any other slot evaluated against the stage's input. The *left*
+            // side is refused rather than rewritten (a `TrackedVar` cannot
+            // stand in a path expression), which the third loop below pins.
+            ".c = key",
+            ".c = [key, path]",
+            ".c = file_index",
         ] {
             let expr = parse(filter).unwrap();
             assert!(
@@ -25119,6 +25149,22 @@ mod tests {
         // spell them -- as an `Expr::TrackedVar` around the ancestor's
         // value, not a literal -- so the second loop pins that the two
         // gates differ by `parent` and nothing else.
+        // #2471 remainder: a read reachable only through an assignment's
+        // *left* side is not routed at all -- `needs_path_context` stops at
+        // the right side, because there is no rewrite for a path expression
+        // (a `TrackedVar` holding a materialized ancestor is not a shape the
+        // assignment's path walker can take). The two gates above answer
+        // `true` for these trivially, having nothing to resolve, so
+        // `needs_path_context` is the assertion that carries the exclusion:
+        // pinned here so widening it to the left side without also giving
+        // the rewriter a story for that side fails loudly.
+        for filter in [".[key] = 1", ".[path[0]] = 1"] {
+            let expr = parse(filter).unwrap();
+            assert!(
+                !needs_path_context(&expr),
+                "`{filter}` reads only through a path expression; it must stay unrouted"
+            );
+        }
         for filter in ["parent", "parent(1)", "[path, parent]", "select(parent)"] {
             let expr = parse(filter).unwrap();
             assert!(

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -38684,3 +38684,24 @@ fn test_jq_mode_update_zero_output_filter_still_deletes_2484() -> Result<()> {
     }
     Ok(())
 }
+
+/// #2471 (gate reason 1 of spine 2416): the jq-mode half of
+/// `yq_cli_tests::test_assignment_rhs_sees_the_input_position_2471` -- same
+/// extension caveat as the test above.
+#[test]
+fn test_assignment_rhs_sees_the_input_position_2471() -> Result<()> {
+    let input = r#"{"a":{"b":1,"e":2},"n":[1,2]}"#;
+    for (filter, expected) in [
+        (".a | .b = key", r#"{"b":"a","e":2}"#),
+        (".a | .b = path", r#"{"b":["a"],"e":2}"#),
+        (
+            ".a | to_entries | .[0] | .value = key",
+            r#"{"key":"b","value":0}"#,
+        ),
+    ] {
+        let (output, code) = run_jq_stdin(filter, input, &["-c"])?;
+        assert_eq!(code, 0, "`{filter}`: {output:?}");
+        assert_eq!(output.trim_end(), expected, "`{filter}`");
+    }
+    Ok(())
+}

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -38686,6 +38686,45 @@ fn test_jq_mode_update_zero_output_filter_still_deletes_2484() -> Result<()> {
 }
 
 /// #2471 (gate reason 1 of spine 2416): the jq-mode half of
+/// `yq_cli_tests::test_map_family_bodies_see_their_members_position_2471`.
+///
+/// `key`/`path`-with-no-argument are succinctly extensions in jq mode (real jq
+/// 1.7.1 refuses both: `key/0 is not defined`, `path/0 is not defined`), so
+/// there is no jq oracle for these rows -- what they pin is that the mode that
+/// *does* have an oracle and the mode that does not answer the same position,
+/// rather than the extension quietly drifting into a second model.
+/// `map_values(select(...))` is deliberately included as the one row where the
+/// two modes must **not** agree: jq's `map_values` drops a member whose filter
+/// produced nothing, which is jq's own documented rule and unrelated to the
+/// position the filter read.
+#[test]
+fn test_map_family_bodies_see_their_members_position_2471() -> Result<()> {
+    let input = r#"{"a":{"b":1,"e":2},"n":[1,2]}"#;
+    for (filter, expected) in [
+        (".a | map_values(key)", r#"{"b":"b","e":"e"}"#),
+        (".a | map_values(path)", r#"{"b":["a","b"],"e":["a","e"]}"#),
+        (".n | map_values(key)", "[0,1]"),
+        (".a | with_entries(.value = key)", r#"{"b":0,"e":1}"#),
+        (
+            ".a | with_entries(.value = path)",
+            r#"{"b":["a",0],"e":["a",1]}"#,
+        ),
+        (
+            ".a | to_entries | map(.value = key)",
+            r#"[{"key":"b","value":0},{"key":"e","value":1}]"#,
+        ),
+        // jq's own `map_values` rule, not a position: a member whose filter
+        // yields nothing is dropped.
+        (".a | map_values(select(key == \"b\"))", r#"{"b":1}"#),
+    ] {
+        let (output, code) = run_jq_stdin(filter, input, &["-c"])?;
+        assert_eq!(code, 0, "`{filter}`: {output:?}");
+        assert_eq!(output.trim_end(), expected, "`{filter}`");
+    }
+    Ok(())
+}
+
+/// #2471 (gate reason 1 of spine 2416): the jq-mode half of
 /// `yq_cli_tests::test_assignment_rhs_sees_the_input_position_2471` -- same
 /// extension caveat as the test above.
 #[test]

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -35595,3 +35595,44 @@ fn test_yaml_write_through_alias_leaves_json_input_alone_1351() -> Result<()> {
     assert_eq!(output.trim(), r#"{"a":{"p":1},"b":{"p":9}}"#);
     Ok(())
 }
+
+/// #2471 (gate reason 1 of spine 2416): an assignment's right-hand side stands
+/// where the **assignment's own input** stands.
+///
+/// `eval_assign` hands the right side the same value the whole stage received,
+/// so `.a | .b = key` writes `"a"` -- the key of `.a` -- and not `"b"`. Every
+/// row was captured from yq v4.53.3 (`-o=json -I0`) on
+/// `ASSIGN_RHS_DOC_2471`; before this change `needs_path_context` did not
+/// descend into an assignment's right side, so every one of them left the
+/// target untouched.
+const ASSIGN_RHS_DOC_2471: &str = "a: {b: 1, e: 2}\nn: [1, 2]\n";
+
+const ASSIGN_RHS_ROWS_2471: &[(&str, &str)] = &[
+    (".a | .b = key", r#"{"b":"a","e":2}"#),
+    (".a | .b = path", r#"{"b":["a"],"e":2}"#),
+    (".a.b | . = key", r#""b""#),
+    (".a.b | . = path", r#"["a","b"]"#),
+    (
+        ".a | to_entries | .[0] | .value = key",
+        r#"{"key":"b","value":0}"#,
+    ),
+    (
+        ".a | to_entries | .[0] | .value = path",
+        r#"{"key":"b","value":["a",0]}"#,
+    ),
+    (
+        ".a | to_entries | .[0] | .key = key",
+        r#"{"key":0,"value":1}"#,
+    ),
+];
+
+#[test]
+fn test_assignment_rhs_sees_the_input_position_2471() -> Result<()> {
+    let args = &["-o", "json", "-I0"];
+    for (filter, expected) in ASSIGN_RHS_ROWS_2471 {
+        let (output, code) = run_yq_stdin(filter, ASSIGN_RHS_DOC_2471, args)?;
+        assert_eq!(code, 0, "`{filter}`: {output:?}");
+        assert_eq!(output.trim_end(), *expected, "`{filter}`");
+    }
+    Ok(())
+}

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -35636,3 +35636,56 @@ fn test_assignment_rhs_sees_the_input_position_2471() -> Result<()> {
     }
     Ok(())
 }
+
+/// #2471 (gate reason 1 of spine 2416): a map-family body stands at its own
+/// **member's** position, not at its container's.
+///
+/// `with_entries`'s member is an entry of the array `to_entries` built (so its
+/// key is the index), `map_values`'s is the object member itself (so its key is
+/// the field name). Every row was captured from yq v4.53.3 (`-o=json -I0`) on
+/// `MAP_FAMILY_DOC_2471`. Before this change `needs_path_context` did not
+/// descend into a map-family body at all, so no route was ever asked and every
+/// one of these answered with no position.
+const MAP_FAMILY_DOC_2471: &str = "a: {b: 1, e: 2}\nn: [1, 2]\n";
+
+const MAP_FAMILY_ROWS_2471: &[(&str, &str)] = &[
+    // The body sees the member.
+    (".a | map_values(key)", r#"{"b":"b","e":"e"}"#),
+    (".a | map_values(path)", r#"{"b":["a","b"],"e":["a","e"]}"#),
+    (".a | map_values(path | length)", r#"{"b":2,"e":2}"#),
+    (".a | map_values(file_index)", r#"{"b":0,"e":0}"#),
+    (".n | map_values(key)", "[0,1]"),
+    (".a | with_entries(.value = key)", r#"{"b":0,"e":1}"#),
+    (
+        ".a | with_entries(.value = path)",
+        r#"{"b":["a",0],"e":["a",1]}"#,
+    ),
+    (".a | with_entries(.value = file_index)", r#"{"b":0,"e":0}"#),
+    // ...including once the container has already left the cursor domain,
+    // where the member's position is the owned identity plus its component.
+    (
+        ".a | to_entries | map(.value = key)",
+        r#"[{"key":"b","value":0},{"key":"e","value":1}]"#,
+    ),
+    (".a | to_entries | map(key)", "[0,1]"),
+    (".a | to_entries | map(path)", r#"[["a",0],["a",1]]"#),
+    (".a | to_entries | map_values(key)", "[0,1]"),
+    // A body that reads nothing is unmoved: the stage never reaches the
+    // positioned route at all.
+    (
+        ".a | with_entries(.value = (.key | length))",
+        r#"{"b":1,"e":1}"#,
+    ),
+    (".a | map_values(.)", r#"{"b":1,"e":2}"#),
+];
+
+#[test]
+fn test_map_family_bodies_see_their_members_position_2471() -> Result<()> {
+    let args = &["-o", "json", "-I0"];
+    for (filter, expected) in MAP_FAMILY_ROWS_2471 {
+        let (output, code) = run_yq_stdin(filter, MAP_FAMILY_DOC_2471, args)?;
+        assert_eq!(code, 0, "`{filter}`: {output:?}");
+        assert_eq!(output.trim_end(), *expected, "`{filter}`");
+    }
+    Ok(())
+}


### PR DESCRIPTION
## Summary

The remainder of #2471 (spine 2416, gate reason 1): map-family bodies and an assignment's right-hand side now see their member's position.

1. **An assignment's RHS reads the input's position.** `needs_path_context` descends into `Expr::Assign`'s value, and the constant and owned-identity routes answer it, so `.a | .b = key` is `{"b":"a",...}` and `.a | to_entries | .[0] | .value = key` is `{"key":"b","value":0}`, as in yq. The LHS is excluded (a path expression cannot take a rewritten value); `|=` and the compound forms run their RHS at the target's position and are filed as #2522.
2. **`map_values`/`with_entries` bodies evaluate at their member's position.** `eval_map_family_positioned` derives each member's `key`/`path` from the container's position plus the component, rewrites the body with the shared constant resolver, and hands it to the ordinary owned evaluator, so `from_entries`, atomicity and every construct keep one definition. Reached from `eval_builtin` when the container is a cursor and from the owned identity pipe when it is already owned; `map` over a live cursor stays on the eager route where it is already exact. No eager arm added.

Captures from yq v4.53.3 are in the tests (`.a | with_entries(.value = key)` is `{"b":0,"e":1}`, `.a | map_values(path)` is `{"b":["a","b"],"e":["a","e"]}`, `.n | map_values(key)` is `[0,1]`). Differential against the base binary over 531 map-family and assignment queries: 142 answers changed, 102 moved from disagreeing with yq to agreeing, none moved away.

## Left open, recorded in ADR-0021 and the audit doc

- `from_entries` stringifying a non-string key (yq only): #2521, now reachable from `with_entries(.key = key)`.
- `|=`/compound RHS at the target's position: #2522.
- `map_values` with a zero-output body follows #2484's rule in yq; pre-existing, strictly closer than before.
- `parent` inside a map-family body: yq prints a self-referential tree from a container mid-rewrite; refused by the gate rather than encoding a rewrite-order artefact.

## Pin

Stays at 43. The five reason-1 arms still fire their proof queries because a computed bracket or `getpath` at the head of a pipe is still a detaching stage with no identity rule; the two arms this change could have starved (`map`, the builtin fallback) also still fire. Six shapes that used to hit the eager evaluator now fire no marker at all.

## Verification

fmt; clippy on all CI legs with `-D warnings`; `cargo test` in the three configurations plus `simd` and `simd,scalar-yaml`; `cargo doc -D warnings`; yq goldens 113 and jq goldens 633; oracle sweep 3168 cases, 0 unexpected, manifest unchanged; clippy and tests rerun after a package clean. Rebased over the `--inplace` work that landed on main meanwhile.

Part of #2471, which stays open for the head-of-pipe computed bracket, the last reason-1 lever.
