### PR TITLE
fix(yq): follow binders and no-arg defs when gating alias/comment preservation

### DIFF
--- a/src/bin/succinctly/yq_runner.rs
+++ b/src/bin/succinctly/yq_runner.rs
@@ -26,7 +26,8 @@ use succinctly::jq::stream::StreamFailure;
 use succinctly::jq::{
     self, alias_identity, assert_value_tree_depth, is_alias_sensitive_assign,
     nesting_depth_exceeded_message, nonfinite_display_string, sync_aliased_paths, Builtin,
-    EvalError, Expr, Literal, NumberRepr, ObjectKey, OwnedValue, QueryResult, YqSemantics,
+    DefScope, EvalError, Expr, Literal, NumberRepr, ObjectKey, OwnedValue, QueryResult,
+    YqSemantics,
 };
 use succinctly::json::light::JsonCursor;
 use succinctly::json::JsonIndex;
@@ -2050,7 +2051,7 @@ fn collect_write_targets(expr: &Expr) -> Option<Vec<WriteTarget>> {
         }
     }
 
-    fn walk(expr: &Expr, out: &mut Vec<WriteTarget>) -> bool {
+    fn walk<'e>(expr: &'e Expr, scope: &mut DefScope<'e>, out: &mut Vec<WriteTarget>) -> bool {
         match expr {
             // Only a plain `=` can be proved to write a constructed value:
             // `|=`'s filter and a compound assign's operator both read the
@@ -2107,14 +2108,54 @@ fn collect_write_targets(expr: &Expr) -> Option<Vec<WriteTarget>> {
             | Expr::Builtin(
                 Builtin::Select(_) | Builtin::Empty | Builtin::Debug | Builtin::DebugMsg(_),
             ) => true,
-            Expr::Paren(inner) | Expr::Optional(inner) => walk(inner, out),
-            Expr::Pipe(stages) => stages.iter().all(|s| walk(s, out)),
+            Expr::Paren(inner) | Expr::Optional(inner) => walk(inner, scope, out),
+            Expr::Shared(inner) => walk(inner, scope, out),
+            Expr::Pipe(stages) => stages.iter().all(|s| walk(s, scope, out)),
+            // #2091: exactly the wrappers `is_alias_sensitive_assign`
+            // follows. When the gate accepted a wrapped write and this walk
+            // did not, `write_targets` came back empty and
+            // `reconcile_presentation` silently fell back to the positional
+            // lockstep -- turning "no comments on a wrapped write" into "the
+            // *wrong* comments", which `-i` then writes to disk.
+            // `1 as $v | del(.arr[0])` is real yq syntax and printed
+            // `- 2 # one` where yq prints `- 2 # two`.
+            Expr::As { body, .. } | Expr::AsPattern { body, .. } => walk(body, scope, out),
+            Expr::FuncDef {
+                name,
+                params,
+                body,
+                then,
+                ..
+            } => {
+                let def = jq::VisibleDef {
+                    name,
+                    arity: params.len(),
+                    body,
+                    outer: scope.depth(),
+                };
+                scope.with_def(def, |scope| walk(then, scope, out))
+            }
+            // `memoize: false` -- unlike the two boolean predicates, this
+            // walk's answer is not only its `bool` but the targets it
+            // appended, and a cached `true` would skip appending them the
+            // second time.
+            Expr::FuncCall { name, args, .. } => {
+                scope.resolve(name, args.len()).is_some_and(|def| {
+                    scope.in_def_body(def, false, |scope| walk(def.body, scope, out))
+                })
+            }
+            Expr::DefCall { def, args, .. } => {
+                args.is_empty() && {
+                    let bound = jq::bound_def(def, scope.depth());
+                    scope.in_def_body(bound, false, |scope| walk(&def.body, scope, out))
+                }
+            }
             _ => false,
         }
     }
 
     let mut out = Vec::new();
-    if !walk(expr, &mut out) {
+    if !walk(expr, &mut DefScope::default(), &mut out) {
         return None;
     }
 
@@ -8852,5 +8893,104 @@ mod tests {
             set(Expr::Field("n".into()))
         ]))
         .is_some());
+    }
+
+    /// `collect_write_targets` must follow exactly the wrappers
+    /// `jq::is_alias_sensitive_assign` follows (#2091). When the gate
+    /// accepted a wrapped write while this walk declined it,
+    /// `write_targets` came back empty and `reconcile_presentation` silently
+    /// fell back to the positional lockstep -- attributing #870's comments to
+    /// the wrong nodes, which `-i` then wrote to disk.
+    ///
+    /// The two live in different crates now (#1351 moved the gate into the
+    /// library), which is exactly why this agreement needs a test rather than
+    /// proximity.
+    #[test]
+    fn collect_write_targets_follows_the_same_wrappers_2091() {
+        let del_arr0 = || {
+            Expr::Builtin(Builtin::Del(Box::new(Expr::Pipe(vec![
+                Expr::Field("arr".into()),
+                Expr::Index { idx: 0, key: None },
+            ]))))
+        };
+        let expected = Some(vec![(
+            vec![PathStep::Key("arr".into()), PathStep::Index(0)],
+            WriteKind::Del,
+        )]);
+        let of = |e: &Expr| {
+            collect_write_targets(e)
+                .map(|ts| ts.into_iter().map(|t| (t.path, t.kind)).collect::<Vec<_>>())
+        };
+        let bound_call = |body: Expr, args: Vec<Expr>| Expr::DefCall {
+            def: std::rc::Rc::new(succinctly::jq::FuncDefData {
+                name: "f".into(),
+                params: if args.is_empty() {
+                    Vec::new()
+                } else {
+                    vec!["v".into()]
+                },
+                body,
+            }),
+            args,
+            frames: 0,
+            bound: succinctly::jq::BoundBody::default(),
+        };
+
+        for wrapped in [
+            del_arr0(),
+            Expr::Shared(std::rc::Rc::new(del_arr0())),
+            Expr::As {
+                expr: Box::new(Expr::Literal(succinctly::jq::Literal::Int(1))),
+                var: "v".into(),
+                body: Box::new(del_arr0()),
+            },
+            bound_call(del_arr0(), Vec::new()),
+            Expr::FuncDef {
+                name: "f".into(),
+                params: Vec::new(),
+                body: Box::new(del_arr0()),
+                then: Box::new(Expr::FuncCall {
+                    name: "f".into(),
+                    args: Vec::new(),
+                    builtin_fallback: None,
+                }),
+                bound: succinctly::jq::FuncDefBound::default(),
+            },
+        ] {
+            assert_eq!(of(&wrapped), expected, "{wrapped:?}");
+            // ...and the gate must accept every one of them, or the two have
+            // drifted in the other direction.
+            assert!(
+                succinctly::jq::is_alias_sensitive_assign(&wrapped),
+                "gate declined what the target walk accepted: {wrapped:?}"
+            );
+        }
+
+        // Both must also *refuse* the same expressions, not merely accept the
+        // same ones.
+        for refused in [
+            bound_call(
+                del_arr0(),
+                vec![Expr::Literal(succinctly::jq::Literal::Int(1))],
+            ),
+            Expr::FuncDef {
+                name: "f".into(),
+                params: Vec::new(),
+                body: Box::new(Expr::FuncCall {
+                    name: "f".into(),
+                    args: Vec::new(),
+                    builtin_fallback: None,
+                }),
+                then: Box::new(Expr::FuncCall {
+                    name: "f".into(),
+                    args: Vec::new(),
+                    builtin_fallback: None,
+                }),
+                bound: succinctly::jq::FuncDefBound::default(),
+            },
+        ] {
+            assert_eq!(of(&refused), None, "{refused:?}");
+            assert!(!succinctly::jq::is_alias_sensitive_assign(&refused));
+        }
     }
 }

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -86102,4 +86102,41 @@ mod tests {
         assert!(!contains_assign(&expr));
         assert!(!is_alias_sensitive_assign(&expr));
     }
+
+    /// **The walk must not be exponential.** `def f1: f0|f0; def f2: f1|f1;
+    /// …` doubles the number of expansions per level, so without memoizing a
+    /// body's answer the gate is `O(2^n)` in the nesting depth: 24 levels
+    /// took 5.1s before the memo, and each further level doubled that.
+    ///
+    /// Memoizing is sound only *because* a body's scope is fixed at its
+    /// definition site, which makes the answer a function of the body alone.
+    ///
+    /// Calls the predicate **directly**, with no evaluation: `f0|f0` also
+    /// doubles the evaluator's own output count, so a CLI-level version of
+    /// this test measures that pre-existing cost rather than the gate's, and
+    /// its wall-clock bound then fails under `cargo llvm-cov`'s
+    /// instrumentation for reasons that have nothing to do with the gate.
+    /// 40 levels is ~10^12 expansions unmemoized — this test does not need a
+    /// timing assertion to fail, it simply would not finish.
+    #[test]
+    fn write_shape_gate_is_not_exponential_in_def_nesting_2091() {
+        let mut filter = String::from("def f0: .a = 1;");
+        let mut prev = String::from("f0");
+        for i in 1..=40 {
+            filter.push_str(&format!(" def f{i}: {prev}|{prev};"));
+            prev = format!("f{i}");
+        }
+        filter.push(' ');
+        filter.push_str(&prev);
+
+        let expr = parse(&filter).expect("filter should parse");
+        // Every level is a pipe of writes, so the whole thing is one.
+        assert!(is_alias_sensitive_assign(&expr));
+
+        // The same shape with a reshaping leaf must be refused, and just as
+        // cheaply -- a `false` answer walks the same tree.
+        let reshaping = filter.replacen("def f0: .a = 1;", "def f0: map(.);", 1);
+        let expr = parse(&reshaping).expect("filter should parse");
+        assert!(!is_alias_sensitive_assign(&expr));
+    }
 }

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -1109,6 +1109,172 @@ pub mod alias_identity {
     pub(crate) fn mirror_after_write(_pre: &OwnedValue, _post: &mut OwnedValue) {}
 }
 
+/// A user-defined function visible at some point of a scoped walk (#2091).
+///
+/// `pub` so the CLI's own `collect_write_targets` (`yq_runner.rs`) walks the
+/// same wrappers this module's predicates do. When those two disagreed, the
+/// gate accepted a wrapped write while the target walk declined it, leaving
+/// `reconcile_presentation` on its positional fallback and attributing
+/// comments to the wrong nodes -- one definition of "which wrappers a write
+/// can hide behind" is the point, the same reason #1351 moved the predicates
+/// here in the first place.
+#[derive(Clone, Copy)]
+pub struct VisibleDef<'e> {
+    /// The definition's name.
+    pub name: &'e str,
+    /// How many parameters it takes.
+    pub arity: usize,
+    /// Its body.
+    pub body: &'e Expr,
+    /// How many definitions were already in scope where *this* one was
+    /// written. Walking into its body restores exactly that set (plus this
+    /// definition itself, so a self-recursive call still resolves) — jq
+    /// scopes a name at its definition site, not at the call site.
+    pub outer: usize,
+}
+
+/// The definitions in scope while a write-shape walk descends an expression,
+/// plus the guards that keep it terminating and cheap (#2091).
+///
+/// `contains_assign`, [`is_alias_sensitive_assign`] and the CLI's
+/// `collect_write_targets` all carry one, rather than treating "contains a
+/// `FuncDef`" as an answer in itself. A false *positive* on shape-preservation
+/// is not merely a wasted snapshot: `sync_aliased_paths` diffs the same path
+/// across a *reshaped* document and can clobber values, which
+/// `def f: map(.); f` would do.
+#[derive(Default)]
+pub struct DefScope<'e> {
+    defs: Vec<VisibleDef<'e>>,
+    /// Bodies currently being expanded, by address. A definition that calls
+    /// itself (`def f: f; f`) would otherwise resolve forever.
+    expanding: Vec<usize>,
+    /// How many resolutions were refused because the body was already being
+    /// expanded. A result computed while this never moved does not depend on
+    /// the surrounding `expanding` set and is safe to memoize; one computed
+    /// across a cut is not.
+    cuts: u32,
+    /// Completed answers by body address. Without it the walk is exponential:
+    /// `def f1: f0|f0; def f2: f1|f1; …` doubles per level, and 24 levels of
+    /// that in a 421-byte filter took 5.1s against a two-line document.
+    ///
+    /// `BTreeMap`, not `HashMap`: this crate is `no_std` + `alloc`.
+    memo: BTreeMap<usize, bool>,
+}
+
+/// The address of an expression node, a cheap identity for the
+/// expanding-set and the memo.
+///
+/// A plain cast, not `core::ptr::from_ref`: that is stable only since 1.76
+/// and this crate's MSRV is 1.73 (`clippy::incompatible_msrv` is the only
+/// thing that catches the difference — it builds either way).
+#[must_use]
+pub fn expr_key(expr: &Expr) -> usize {
+    expr as *const Expr as usize
+}
+
+/// A [`VisibleDef`] for an already-bound [`Expr::DefCall`] (#1371), whose
+/// definition carries no recorded definition site.
+///
+/// `outer` is "keep whatever is visible here", the closest available
+/// approximation — and costs nothing in practice, since that arm is
+/// unreachable from any CLI filter string today: `DefCall` is installed when
+/// an enclosing `FuncDef` is *evaluated*, strictly after these predicates
+/// have run. Routing it through the same [`DefScope::in_def_body`] as an
+/// ordinary call keeps one recursion guard and one memo.
+#[must_use]
+pub fn bound_def(def: &FuncDefData, visible: usize) -> VisibleDef<'_> {
+    VisibleDef {
+        name: &def.name,
+        arity: 0,
+        body: &def.body,
+        outer: visible,
+    }
+}
+
+impl<'e> DefScope<'e> {
+    /// How many definitions are visible right now — the `outer` a definition
+    /// written at this point should record.
+    #[must_use]
+    pub fn depth(&self) -> usize {
+        self.defs.len()
+    }
+
+    /// The innermost definition of `name` taking `arity` arguments that is
+    /// visible here, if it is one a walk can follow.
+    ///
+    /// **Arity 0 only.** A parameterised definition's body refers to
+    /// parameters whose call-site expressions these walks do not substitute,
+    /// so `def f(v): .a = v; f(99)` cannot be judged from the body alone and
+    /// is excluded rather than guessed at.
+    #[must_use]
+    pub fn resolve(&self, name: &str, arity: usize) -> Option<VisibleDef<'e>> {
+        if arity != 0 {
+            return None;
+        }
+        self.defs
+            .iter()
+            .rev()
+            .find(|d| d.name == name && d.arity == 0)
+            .copied()
+    }
+
+    /// Run `f` with `def` in scope.
+    pub fn with_def(&mut self, def: VisibleDef<'e>, f: impl FnOnce(&mut Self) -> bool) -> bool {
+        self.defs.push(def);
+        let result = f(self);
+        self.defs.pop();
+        result
+    }
+
+    /// Walk into `def`'s body under *its own* scope: the definitions that
+    /// existed where it was written, plus itself.
+    ///
+    /// Resolving at the call site instead let a name inside a body bind to a
+    /// **later** definition. Not a cosmetic scoping nicety: on
+    /// `a: &x 1 / b: *x / c: 2`, `def f: {a: .c, b: .a, c: .b}; def g: f;
+    /// def f: .a = 99; g` mis-classified a reshaping filter as a
+    /// shape-preserving write, and the alias sync then rewrote `b` from 1 to
+    /// 2 — the exact clobber [`DefScope`]'s own doc comment warns about.
+    ///
+    /// `memoize` is false for a walk whose answer is not only its `bool` (the
+    /// CLI's target collection also appends output, which a cached `true`
+    /// would skip).
+    pub fn in_def_body(
+        &mut self,
+        def: VisibleDef<'e>,
+        memoize: bool,
+        f: impl FnOnce(&mut Self) -> bool,
+    ) -> bool {
+        let key = expr_key(def.body);
+        if memoize {
+            if let Some(&cached) = self.memo.get(&key) {
+                return cached;
+            }
+        }
+        if self.expanding.contains(&key) {
+            self.cuts += 1;
+            return false;
+        }
+        // Restore the definition's own scope: everything visible where it was
+        // written, plus the definition itself so recursion still resolves.
+        // Clamped because [`bound_def`] synthesizes `outer` as "keep whatever
+        // is visible here", which is one past the last real index.
+        let tail = self.defs.split_off((def.outer + 1).min(self.defs.len()));
+        self.expanding.push(key);
+        let cuts_before = self.cuts;
+        let result = f(self);
+        self.expanding.pop();
+        self.defs.extend(tail);
+        // Memoizing is sound *because* the scope is fixed at the definition
+        // site: the answer for a body is a function of that body alone. A
+        // result computed across a recursion cut is not.
+        if memoize && self.cuts == cuts_before {
+            self.memo.insert(key, result);
+        }
+        result
+    }
+}
+
 /// Whether `expr` is itself an assignment-family write: `.path = value`,
 /// `|=`, a compound assign, `//=`, `del(...)`, `setpath(...)` or
 /// `delpaths(...)` (the last two added by #1351: they write at a path exactly
@@ -1122,14 +1288,50 @@ pub mod alias_identity {
 /// pay for alias-sync snapshotting -- only a pipe that both preserves shape
 /// *and* actually writes somewhere needs the pristine-vs-result diff.
 fn contains_assign(expr: &Expr) -> bool {
+    contains_assign_scoped(expr, &mut DefScope::default())
+}
+
+fn contains_assign_scoped<'e>(expr: &'e Expr, scope: &mut DefScope<'e>) -> bool {
     match expr {
         Expr::Assign { .. }
         | Expr::Update { .. }
         | Expr::CompoundAssign { .. }
         | Expr::AlternativeAssign { .. }
         | Expr::Builtin(Builtin::Del(_) | Builtin::SetPath(..) | Builtin::DelPaths(_)) => true,
-        Expr::Paren(inner) | Expr::Optional(inner) => contains_assign(inner),
-        Expr::Pipe(stages) => stages.iter().any(contains_assign),
+        Expr::Paren(inner) | Expr::Optional(inner) => contains_assign_scoped(inner, scope),
+        Expr::Shared(inner) => contains_assign_scoped(inner, scope),
+        Expr::Pipe(stages) => stages
+            .iter()
+            .any(|stage| contains_assign_scoped(stage, scope)),
+        // Only the body reaches the output; the bound expression never does.
+        Expr::As { body, .. } | Expr::AsPattern { body, .. } => contains_assign_scoped(body, scope),
+        Expr::FuncDef {
+            name,
+            params,
+            body,
+            then,
+            ..
+        } => {
+            let def = VisibleDef {
+                name,
+                arity: params.len(),
+                body,
+                outer: scope.depth(),
+            };
+            scope.with_def(def, |scope| contains_assign_scoped(then, scope))
+        }
+        Expr::FuncCall { name, args, .. } => scope.resolve(name, args.len()).is_some_and(|def| {
+            scope.in_def_body(def, true, |scope| contains_assign_scoped(def.body, scope))
+        }),
+        // Already bound to its definition (#1371); same rule as `FuncCall`.
+        Expr::DefCall { def, args, .. } => {
+            args.is_empty() && {
+                let bound = bound_def(def, scope.depth());
+                scope.in_def_body(bound, true, |scope| {
+                    contains_assign_scoped(&def.body, scope)
+                })
+            }
+        }
         _ => false,
     }
 }
@@ -1165,7 +1367,7 @@ fn contains_assign(expr: &Expr) -> bool {
 /// CLI so the two consumers cannot drift (#2091 tracks `def`-wrapped writes,
 /// which this predicate does not yet see through).
 pub fn is_alias_sensitive_assign(expr: &Expr) -> bool {
-    fn is_shape_preserving(expr: &Expr) -> bool {
+    fn is_shape_preserving<'e>(expr: &'e Expr, scope: &mut DefScope<'e>) -> bool {
         match expr {
             Expr::Assign { .. }
             | Expr::Update { .. }
@@ -1181,13 +1383,43 @@ pub fn is_alias_sensitive_assign(expr: &Expr) -> bool {
                 | Builtin::Debug
                 | Builtin::DebugMsg(_),
             ) => true,
-            Expr::Paren(inner) | Expr::Optional(inner) => is_shape_preserving(inner),
-            Expr::Pipe(stages) => stages.iter().all(is_shape_preserving),
+            Expr::Paren(inner) | Expr::Optional(inner) => is_shape_preserving(inner, scope),
+            Expr::Shared(inner) => is_shape_preserving(inner, scope),
+            Expr::Pipe(stages) => stages.iter().all(|stage| is_shape_preserving(stage, scope)),
+            Expr::As { body, .. } | Expr::AsPattern { body, .. } => {
+                is_shape_preserving(body, scope)
+            }
+            Expr::FuncDef {
+                name,
+                params,
+                body,
+                then,
+                ..
+            } => {
+                let def = VisibleDef {
+                    name,
+                    arity: params.len(),
+                    body,
+                    outer: scope.depth(),
+                };
+                scope.with_def(def, |scope| is_shape_preserving(then, scope))
+            }
+            Expr::FuncCall { name, args, .. } => {
+                scope.resolve(name, args.len()).is_some_and(|def| {
+                    scope.in_def_body(def, true, |scope| is_shape_preserving(def.body, scope))
+                })
+            }
+            Expr::DefCall { def, args, .. } => {
+                args.is_empty() && {
+                    let bound = bound_def(def, scope.depth());
+                    scope.in_def_body(bound, true, |scope| is_shape_preserving(&def.body, scope))
+                }
+            }
             _ => false,
         }
     }
 
-    is_shape_preserving(expr) && contains_assign(expr)
+    is_shape_preserving(expr, &mut DefScope::default()) && contains_assign(expr)
 }
 
 /// Whether a key lookup that found nothing must yield **no output** here,
@@ -85707,5 +85939,167 @@ mod tests {
             }
             assert!(!alias_identity::active());
         }
+    }
+
+    // -- #2091: the write-shape gate's wrapper following ------------------
+
+    fn assign_a_2091() -> Expr {
+        Expr::Assign {
+            path: Box::new(Expr::Field("a".into())),
+            value: Box::new(Expr::Literal(Literal::Int(99))),
+        }
+    }
+
+    /// A reshaping body, which must stay excluded through every wrapper: a
+    /// false positive here is not a wasted snapshot but an alias sync that
+    /// diffs two differently-shaped documents.
+    fn map_identity_2091() -> Expr {
+        Expr::Builtin(Builtin::Map(Box::new(Expr::Identity)))
+    }
+
+    fn def_call_2091(body: Expr, args: Vec<Expr>) -> Expr {
+        Expr::DefCall {
+            def: Rc::new(FuncDefData {
+                name: "f".into(),
+                params: if args.is_empty() {
+                    Vec::new()
+                } else {
+                    vec!["v".into()]
+                },
+                body,
+            }),
+            args,
+            frames: 0,
+            bound: BoundBody::default(),
+        }
+    }
+
+    /// `Expr::DefCall` (#1371's already-bound call) and `Expr::Shared` are
+    /// installed at *evaluation* time, strictly after this predicate has run,
+    /// so no filter string reaches these arms today. They are kept because
+    /// the ordering that makes them unreachable is not something this
+    /// predicate controls, and answering `false` there would silently drop
+    /// preservation rather than fail. Driven directly.
+    #[test]
+    fn def_call_is_judged_by_its_body_2091() {
+        let write = def_call_2091(assign_a_2091(), Vec::new());
+        assert!(contains_assign(&write));
+        assert!(is_alias_sensitive_assign(&write));
+
+        let reshape = def_call_2091(map_identity_2091(), Vec::new());
+        assert!(!contains_assign(&reshape));
+        assert!(!is_alias_sensitive_assign(&reshape));
+    }
+
+    /// A bound call *with* arguments is excluded for the same reason its
+    /// unbound form is: the body refers to parameters this walk does not
+    /// substitute.
+    #[test]
+    fn def_call_with_arguments_is_excluded_2091() {
+        let call = def_call_2091(assign_a_2091(), vec![Expr::Literal(Literal::Int(1))]);
+        assert!(!contains_assign(&call));
+        assert!(!is_alias_sensitive_assign(&call));
+    }
+
+    /// `Expr::Shared` is transparent: it must not change either answer, in
+    /// either direction.
+    #[test]
+    fn shared_wrapper_is_transparent_2091() {
+        let write = Expr::Shared(Rc::new(assign_a_2091()));
+        assert!(contains_assign(&write));
+        assert!(is_alias_sensitive_assign(&write));
+
+        let reshape = Expr::Shared(Rc::new(map_identity_2091()));
+        assert!(!contains_assign(&reshape));
+        assert!(!is_alias_sensitive_assign(&reshape));
+    }
+
+    /// Both halves must follow the *same* wrappers, since
+    /// `is_alias_sensitive_assign` is `is_shape_preserving && contains_assign`
+    /// -- a wrapper only one of them follows would make the pair answer
+    /// correctly for the wrong reason, and stop doing so the moment the other
+    /// side changed.
+    #[test]
+    fn both_predicate_halves_follow_the_same_wrappers_2091() {
+        for expr in [
+            Expr::Paren(Box::new(assign_a_2091())),
+            Expr::Optional(Box::new(assign_a_2091())),
+            Expr::Shared(Rc::new(assign_a_2091())),
+            Expr::As {
+                expr: Box::new(Expr::Literal(Literal::Int(99))),
+                var: "v".into(),
+                body: Box::new(assign_a_2091()),
+            },
+            def_call_2091(assign_a_2091(), Vec::new()),
+            Expr::FuncDef {
+                name: "f".into(),
+                params: Vec::new(),
+                body: Box::new(assign_a_2091()),
+                then: Box::new(Expr::FuncCall {
+                    name: "f".into(),
+                    args: Vec::new(),
+                    builtin_fallback: None,
+                }),
+                bound: FuncDefBound::default(),
+            },
+        ] {
+            assert!(contains_assign(&expr), "contains_assign: {expr:?}");
+            assert!(
+                is_alias_sensitive_assign(&expr),
+                "is_alias_sensitive_assign: {expr:?}"
+            );
+        }
+    }
+
+    /// A definition's body is scoped where it was *written*, not where it is
+    /// called, so `g`'s `f` is the reshaping one even though a write-shaped
+    /// `f` is defined later. Resolving at the call site instead classified a
+    /// reshaping filter as a shape-preserving write, and the alias sync then
+    /// clobbered a value (see the CLI-level `..._binds_at_definition_site_2091`).
+    #[test]
+    fn def_body_binds_at_its_definition_site_2091() {
+        let call = |name: &str| Expr::FuncCall {
+            name: name.into(),
+            args: Vec::new(),
+            builtin_fallback: None,
+        };
+        let def = |name: &str, body: Expr, then: Expr| Expr::FuncDef {
+            name: name.into(),
+            params: Vec::new(),
+            body: Box::new(body),
+            then: Box::new(then),
+            bound: FuncDefBound::default(),
+        };
+        // def f: map(.); def g: f; def f: .a = 99; g
+        let expr = def(
+            "f",
+            map_identity_2091(),
+            def("g", call("f"), def("f", assign_a_2091(), call("g"))),
+        );
+        assert!(
+            !is_alias_sensitive_assign(&expr),
+            "`g` must resolve `f` to the reshaping definition visible where \
+             `g` was written, not the later write-shaped one"
+        );
+    }
+
+    /// A self-recursive definition terminates the walk rather than resolving
+    /// forever.
+    #[test]
+    fn self_recursive_def_terminates_the_walk_2091() {
+        let call_f = || Expr::FuncCall {
+            name: "f".into(),
+            args: Vec::new(),
+            builtin_fallback: None,
+        };
+        let expr = Expr::FuncDef {
+            name: "f".into(),
+            params: Vec::new(),
+            body: Box::new(call_f()),
+            then: Box::new(call_f()),
+            bound: FuncDefBound::default(),
+        };
+        assert!(!contains_assign(&expr));
+        assert!(!is_alias_sensitive_assign(&expr));
     }
 }

--- a/src/jq/mod.rs
+++ b/src/jq/mod.rs
@@ -87,10 +87,10 @@ pub mod walk;
 
 pub use error::{BinOp, Control, ErrorKind, EvalError, EvalErrorPayload};
 pub use eval::{
-    alias_identity, enter_file_index_scope, eval, eval_documents_together, eval_lenient,
-    eval_owned_with_file_index, is_alias_sensitive_assign, nonfinite_display_string,
-    substitute_vars, sync_aliased_paths, EvalSemantics, FileIndexScope, JqSemantics, QueryResult,
-    YqSemantics,
+    alias_identity, bound_def, enter_file_index_scope, eval, eval_documents_together, eval_lenient,
+    eval_owned_with_file_index, expr_key, is_alias_sensitive_assign, nonfinite_display_string,
+    substitute_vars, sync_aliased_paths, DefScope, EvalSemantics, FileIndexScope, JqSemantics,
+    QueryResult, VisibleDef, YqSemantics,
 };
 // `input`/`inputs`/`input_line_number`'s CLI-facing seam (#723) -- only
 // exists under `eval.rs`'s own `#[cfg(feature = "std")]` gate (a `thread_local!`

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -40061,39 +40061,4 @@ mod issue_2091_def_and_binder_wrapped_writes {
         }
         Ok(())
     }
-
-    /// **The walk must not be exponential.** `def f1: f0|f0; def f2: f1|f1;
-    /// …` doubles the number of expansions per level; without memoizing a
-    /// body's answer, 24 levels of it in a 421-byte filter spent 5.1s on a
-    /// two-line document, and each further level doubled that.
-    ///
-    /// Memoizing is sound only *because* a body's scope is now fixed at its
-    /// definition site, which makes the answer a function of the body alone.
-    ///
-    /// The bound here is deliberately loose -- it is guarding against
-    /// exponential blowup, not measuring the machine. Pre-fix this filter
-    /// took over 5s; the evaluator's own (pre-existing, semantic) cost for it
-    /// is well under a second.
-    #[test]
-    fn test_yaml_def_gate_is_not_exponential_2091() -> Result<()> {
-        let mut filter = String::from("def f0: empty;");
-        let mut prev = String::from("f0");
-        for i in 1..=24 {
-            filter.push_str(&format!(" def f{i}: {prev}|{prev};"));
-            prev = format!("f{i}");
-        }
-        filter.push(' ');
-        filter.push_str(&prev);
-
-        let start = std::time::Instant::now();
-        let (_output, code) = run_yq_stdin(&filter, DOC, &[])?;
-        let elapsed = start.elapsed();
-        assert_eq!(code, 0);
-        assert!(
-            elapsed < std::time::Duration::from_secs(5),
-            "24 nested doubling defs took {elapsed:?}; the gate is expanding \
-             each body more than once"
-        );
-        Ok(())
-    }
 }

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -39839,3 +39839,261 @@ fn test_yq_map_scalar_passthrough_feeds_one_item_arms_2103() -> Result<()> {
 
     Ok(())
 }
+
+// =============================================================================
+// #2091: anchor/alias/comment preservation and #711's alias value sync were
+// invisible to any write wrapped in a binder or a user definition.
+// `contains_assign`/`is_shape_preserving` matched a small fixed set of AST
+// shapes, so `99 as $v | .a = $v` -- real yq syntax -- silently lost the
+// anchor, the comment *and* the alias's value.
+//
+// Own module rather than bare file end: the identical-trailing-`Ok(())`
+// merge hazard that actually bit #870 on rebase.
+//
+// Every `as` expectation is pinned real `yq` v4.53.3 output. `def` is not
+// yq syntax at all (its lexer rejects it), so those are pinned against the
+// bare equivalent the def wraps -- the invariant that actually matters.
+// =============================================================================
+mod issue_2091_def_and_binder_wrapped_writes {
+    use super::*;
+
+    /// `a: &x 1 # c` / `b: *x` — an anchor, a comment, and an alias whose
+    /// value must track the anchor's.
+    const DOC: &str = "a: &x 1 # c\nb: *x\n";
+
+    /// Real yq syntax, and the case that makes this a data bug rather than a
+    /// presentation one: before the fix `b` printed `1`, the stale pre-write
+    /// value, instead of tracking the anchor.
+    ///
+    /// $ yq '99 as $v | .a = $v'  =>  a: &x 99 # c / b: *x
+    #[test]
+    fn test_yaml_as_binding_assign_syncs_alias_2091() -> Result<()> {
+        for filter in ["99 as $v | .a = $v", ".a as $v | .a = 99"] {
+            let (output, code) = run_yq_stdin(filter, DOC, &[])?;
+            assert_eq!(code, 0, "{filter}");
+            assert_eq!(output, "a: &x 99 # c\nb: *x\n", "{filter}");
+        }
+        Ok(())
+    }
+
+    /// The same through a `def`. Not yq syntax, so the reference is the bare
+    /// write it wraps: wrapping must change nothing.
+    #[test]
+    fn test_yaml_def_wrapped_assign_syncs_alias_2091() -> Result<()> {
+        for (wrapped, bare) in [
+            ("def f: .a = 99; f", ".a = 99"),
+            ("def f: .b = 5; f", ".b = 5"),
+            ("def f: del(.b); f", "del(.b)"),
+        ] {
+            let (wrapped_out, wrapped_code) = run_yq_stdin(wrapped, DOC, &[])?;
+            let (bare_out, bare_code) = run_yq_stdin(bare, DOC, &[])?;
+            assert_eq!(wrapped_code, 0, "{wrapped}");
+            assert_eq!(bare_code, 0, "{bare}");
+            assert_eq!(wrapped_out, bare_out, "`{wrapped}` must equal `{bare}`");
+        }
+        // Concretely, for the first pair: anchor, comment and alias all kept.
+        let (output, _) = run_yq_stdin("def f: .a = 99; f", DOC, &[])?;
+        assert_eq!(output, "a: &x 99 # c\nb: *x\n");
+        Ok(())
+    }
+
+    /// A definition calling another definition resolves through both.
+    #[test]
+    fn test_yaml_def_calling_def_2091() -> Result<()> {
+        let (output, code) = run_yq_stdin("def g: .a = 99; def f: g; f", DOC, &[])?;
+        assert_eq!(code, 0);
+        assert_eq!(output, "a: &x 99 # c\nb: *x\n");
+        Ok(())
+    }
+
+    /// The innermost definition of a shadowed name wins, so the walk must
+    /// resolve to `.b = 5`, not to the outer `.a = 99`.
+    #[test]
+    fn test_yaml_shadowed_def_resolves_innermost_2091() -> Result<()> {
+        let (shadowed, code) = run_yq_stdin("def f: .a = 99; def f: .b = 5; f", DOC, &[])?;
+        assert_eq!(code, 0);
+        let (bare, _) = run_yq_stdin(".b = 5", DOC, &[])?;
+        assert_eq!(shadowed, bare);
+        Ok(())
+    }
+
+    /// The negative case, and the reason "contains a `FuncDef`" cannot be the
+    /// rule: a def whose body *reshapes* the document must stay excluded.
+    /// `sync_aliased_paths` on a reshaped result diffs the same path across
+    /// two differently-shaped documents and can clobber values -- a false
+    /// positive here is data loss, not a wasted snapshot.
+    #[test]
+    fn test_yaml_def_map_body_is_not_treated_as_assign_2091() -> Result<()> {
+        for (filter, expected) in [
+            ("def f: map(.); f", "- 1\n- 1\n"),
+            ("def f: [.]; f", "- a: 1\n  b: 1\n"),
+        ] {
+            let (output, code) = run_yq_stdin(filter, DOC, &[])?;
+            assert_eq!(code, 0, "{filter}");
+            assert_eq!(output, expected, "{filter}");
+        }
+        Ok(())
+    }
+
+    /// A parameterised definition is excluded deliberately: its body refers
+    /// to parameters this walk does not substitute, so it cannot be judged
+    /// from the body alone. Pinned so the exclusion is a decision, not an
+    /// accident -- `b` staying `1` here is the pre-#2091 behaviour.
+    #[test]
+    fn test_yaml_def_with_params_is_excluded_2091() -> Result<()> {
+        let (output, code) = run_yq_stdin("def f(v): .a = v; f(99)", DOC, &[])?;
+        assert_eq!(code, 0);
+        assert_eq!(output, "a: 99\nb: 1\n");
+        Ok(())
+    }
+
+    /// A self-recursive definition must terminate the *walk*, whatever the
+    /// evaluator then does with it. Without the expanding-set guard the
+    /// predicate would follow `f` into itself forever and hang before
+    /// evaluation ever started.
+    #[test]
+    fn test_yaml_self_recursive_def_gate_terminates_2091() -> Result<()> {
+        let (_output, _stderr, code) = run_yq_stdin_with_stderr("def f: f; f", DOC, &[])?;
+        // The evaluator's own recursion limit reports the error; the point is
+        // that we get here at all rather than hanging in the gate.
+        assert_eq!(code, 1);
+        Ok(())
+    }
+
+    /// `--jq-extensions` does not change any of this. The flag decides parse
+    /// acceptance; these predicates run after parsing, so a gated `def`
+    /// reaches them either way (#1887's triage flags `def` for gating).
+    #[test]
+    fn test_yaml_def_gate_is_independent_of_jq_extensions_2091() -> Result<()> {
+        for filter in [
+            "def f: .a = 99; f",
+            "99 as $v | .a = $v",
+            "def f: map(.); f",
+        ] {
+            let (plain, plain_code) = run_yq_stdin(filter, DOC, &[])?;
+            let (gated, gated_code) = run_yq_stdin(filter, DOC, &["--jq-extensions"])?;
+            assert_eq!(plain_code, gated_code, "{filter}");
+            assert_eq!(plain, gated, "{filter}");
+        }
+        Ok(())
+    }
+
+    // -- review round: the three ways widening the gate went wrong ---------
+
+    /// **`collect_write_targets` must follow the same wrappers as the gate.**
+    /// When the gate accepted a wrapped write but that walk did not,
+    /// `write_targets` came back empty and `reconcile_presentation` fell back
+    /// to the positional lockstep -- so #870's `del` remap stopped applying
+    /// and each survivor inherited the *deleted* element's comment. That
+    /// turns "no comments on a wrapped write" into "the wrong comments",
+    /// which `yq -i` then writes to disk.
+    ///
+    /// `1 as $v | del(.arr[0])` is real yq syntax:
+    /// $ yq '1 as $v | del(.arr[0])'  =>  arr:\n  - 2 # two\n  - 3 # three
+    #[test]
+    fn test_yaml_wrapped_del_keeps_870_remap_2091() -> Result<()> {
+        let doc = "arr:\n  - 1 # one\n  - 2 # two\n  - 3 # three\n";
+        let expected = "arr:\n  - 2 # two\n  - 3 # three\n";
+        for filter in [
+            "del(.arr[0])",
+            "def f: del(.arr[0]); f",
+            "1 as $v | del(.arr[0])",
+        ] {
+            let (output, code) = run_yq_stdin(filter, doc, &[])?;
+            assert_eq!(code, 0, "{filter}");
+            assert_eq!(output, expected, "{filter}");
+        }
+        Ok(())
+    }
+
+    /// The same for #870's closed-literal rule: a constructed literal
+    /// inherits nothing, wrapper or not.
+    ///
+    /// $ yq '.o = {"a": "1"}'  =>  o:\n  a: "1"     (no comment)
+    #[test]
+    fn test_yaml_wrapped_write_keeps_870_fresh_literal_rule_2091() -> Result<()> {
+        let doc = "o:\n  a: \"1\" # ca\n";
+        for filter in [".o = {\"a\": \"1\"}", "def f: .o = {\"a\": \"1\"}; f"] {
+            let (output, code) = run_yq_stdin(filter, doc, &[])?;
+            assert_eq!(code, 0, "{filter}");
+            assert_eq!(output, "o:\n  a: \"1\"\n", "{filter}");
+        }
+        Ok(())
+    }
+
+    /// **A name in a definition's body binds at the definition site**, not at
+    /// the call site. Resolving at the call site let `f` inside `g` bind to a
+    /// *later* `def f`, so a reshaping filter was classified as a
+    /// shape-preserving write and `sync_aliased_paths` clobbered a value:
+    /// `b` came out 2 where the filter computes 1.
+    ///
+    /// Not a scoping nicety -- a wrong *value* in the output.
+    #[test]
+    fn test_yaml_def_body_binds_at_definition_site_2091() -> Result<()> {
+        let doc = "a: &x 1\nb: *x\nc: 2\n";
+        let (wrapped, code) = run_yq_stdin(
+            "def f: {a: .c, b: .a, c: .b}; def g: f; def f: .a = 99; g",
+            doc,
+            &[],
+        )?;
+        assert_eq!(code, 0);
+        // `g` calls the `f` visible where `g` was written -- the reshaping
+        // one -- so the result is that filter's own output, unsynced.
+        let (direct, _) = run_yq_stdin("{a: .c, b: .a, c: .b}", doc, &[])?;
+        assert_eq!(wrapped, direct);
+        assert_eq!(wrapped, "a: 2\nb: 1\nc: 1\n");
+        Ok(())
+    }
+
+    /// Definition-site scoping must not break ordinary shadowing: a call
+    /// still resolves to the innermost definition visible *at the call*.
+    #[test]
+    fn test_yaml_shadowing_still_resolves_innermost_at_the_call_2091() -> Result<()> {
+        for (wrapped, bare) in [
+            ("def f: .a = 99; def f: .b = 5; f", ".b = 5"),
+            ("def g: .a = 99; def f: g; f", ".a = 99"),
+        ] {
+            let (w, wc) = run_yq_stdin(wrapped, DOC, &[])?;
+            let (b, bc) = run_yq_stdin(bare, DOC, &[])?;
+            assert_eq!(wc, 0, "{wrapped}");
+            assert_eq!(bc, 0, "{bare}");
+            assert_eq!(w, b, "`{wrapped}` must equal `{bare}`");
+        }
+        Ok(())
+    }
+
+    /// **The walk must not be exponential.** `def f1: f0|f0; def f2: f1|f1;
+    /// …` doubles the number of expansions per level; without memoizing a
+    /// body's answer, 24 levels of it in a 421-byte filter spent 5.1s on a
+    /// two-line document, and each further level doubled that.
+    ///
+    /// Memoizing is sound only *because* a body's scope is now fixed at its
+    /// definition site, which makes the answer a function of the body alone.
+    ///
+    /// The bound here is deliberately loose -- it is guarding against
+    /// exponential blowup, not measuring the machine. Pre-fix this filter
+    /// took over 5s; the evaluator's own (pre-existing, semantic) cost for it
+    /// is well under a second.
+    #[test]
+    fn test_yaml_def_gate_is_not_exponential_2091() -> Result<()> {
+        let mut filter = String::from("def f0: empty;");
+        let mut prev = String::from("f0");
+        for i in 1..=24 {
+            filter.push_str(&format!(" def f{i}: {prev}|{prev};"));
+            prev = format!("f{i}");
+        }
+        filter.push(' ');
+        filter.push_str(&prev);
+
+        let start = std::time::Instant::now();
+        let (_output, code) = run_yq_stdin(&filter, DOC, &[])?;
+        let elapsed = start.elapsed();
+        assert_eq!(code, 0);
+        assert!(
+            elapsed < std::time::Duration::from_secs(5),
+            "24 nested doubling defs took {elapsed:?}; the gate is expanding \
+             each body more than once"
+        );
+        Ok(())
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #2091. `contains_assign` and `is_alias_sensitive_assign::is_shape_preserving`
matched a fixed set of AST shapes, so **any write wrapped in a binder or a
user definition was invisible** to ADR-0017 mechanism 2's presentation
snapshot and to #711's alias value sync.

`99 as $v | .a = $v` is real yq syntax, and it lost the anchor, the comment
**and** the alias's value:

```console
$ printf 'a: &x 1 # c\nb: *x\n' | yq            '99 as $v | .a = $v'
a: &x 99 # c
b: *x

$ printf 'a: &x 1 # c\nb: *x\n' | succinctly yq '99 as $v | .a = $v'
a: 99
b: 1              # <- stale pre-write value
```

Both predicates now carry a `DefScope` and walk into `As`/`AsPattern` bodies
and into no-argument user definitions, resolving a call to the innermost
matching definition.

### Where the fix lives

**In the library** (`src/jq/eval.rs`), not the CLI. #1351 landed mid-flight
and moved `is_alias_sensitive_assign`/`contains_assign` there so their
consumers cannot drift — and its doc comment already named this issue as the
gap: *"#2091 tracks `def`-wrapped writes, which this predicate does not yet
see through."* This branch was re-ported onto that location rather than
resolving a conflict against a moved function.

That puts the widened gate on a **third** consumer: #1351's `|=` terminal
alias redirect. Verified against yq before widening — a binder-wrapped filter
behaves exactly as the unwrapped one:

```console
$ printf 'a: &x {p: 1}\nb: *x\n' | yq '.b |= (99 as $v | .p = $v)'
a: &x {p: 99}          # mutates the shared node, as `.b |= (.p = 9)` does
b: *x
$ printf 'a: &x {p: 1}\nb: *x\n' | yq '.b |= (5 as $v | $v)'
a: &x {p: 1}           # rebinds, as `.b |= 5` does
b: 5
```

`collect_write_targets` (the CLI's own write-path walk from #870) follows the
same wrappers. The two now live in **different crates**, so their agreement
is asserted by a test in both directions — every wrapper one accepts the
other accepts, every one it refuses the other refuses — rather than relying
on proximity. That drift is exactly what review finding 1 below was.

## What is deliberately *not* followed

**Not a blanket "contains a `FuncDef` ⇒ assign-shaped".** A false positive
here is not a wasted snapshot: `sync_aliased_paths` on a *reshaped* result
diffs the same path across two differently-shaped documents and can clobber
values. `def f: map(.); f` is the live example and stays excluded — pinned,
along with `def f: [.]; f`.

**Arity 0 only.** A parameterised definition's body refers to parameters this
walk does not substitute, so `def f(v): .a = v; f(99)` cannot be judged from
the body alone and stays excluded. Pinned so it reads as a decision.

**`if`/`try`/`reduce`/`foreach`/`label` stay out.** None is yq syntax, and
`reduce`/`foreach` preserve shape only when the init is `.` and the update is
itself shape-preserving — a separate analysis, as the triage specified.

**Self-recursion is guarded** by an expanding-set keyed on body address, so
the gate terminates before the evaluator's own recursion limit is reached.

## Oracle results

The two `as` forms are real yq syntax and are pinned against yq v4.53.3
directly. `def` is not yq syntax at all (its lexer rejects it), so those are
pinned against **the bare write each def wraps** — the invariant that
actually matters:

| filter | before | after |
|---|---|---|
| `99 as $v \| .a = $v` | ✗ `a: 99` / `b: 1` | ✓ `a: &x 99 # c` / `b: *x` |
| `.a as $v \| .a = 99` | ✗ | ✓ |
| `def f: .a = 99; f` | ✗ | ✓ = `.a = 99` |
| `def f: .b = 5; f` | ✗ | ✓ = `.b = 5` |
| `def f: del(.b); f` | ✗ | ✓ = `del(.b)` |
| `def g: .a = 99; def f: g; f` | ✗ | ✓ = `.a = 99` |
| `def f: .a = 99; def f: .b = 5; f` | ✗ | ✓ = `.b = 5` (innermost wins) |
| `def f: map(.); f` | ✓ excluded | ✓ still excluded |
| `def f(v): .a = v; f(99)` | ✓ excluded | ✓ still excluded |
| `def f: f; f` | — | ✓ gate terminates |

`--jq-extensions` changes none of it, and a test pins that: the flag decides
parse acceptance, and these predicates run after parsing, so a gated `def`
reaches them either way (#1887's triage flags `def` for gating).

## Review round: three problems, all confirmed against the binary

**1. `collect_write_targets` was not widened alongside the gate.** The most
serious. #870's write-target walk still declined `as`/`def`, so an expression
the gate accepted came back with no targets and `reconcile_presentation`
silently dropped to the positional lockstep — turning "no comments on a
wrapped write" into **the wrong comments**, which `-i` writes to disk. On
real yq syntax:

```console
$ printf 'arr:\n  - 1 # one\n  - 2 # two\n' | yq '1 as $v | del(.arr[0])'
arr:
  - 2 # two
$ ...                                        | succinctly yq   # before
arr:
  - 2 # one
```

Both walks now follow identical wrappers. #870's closed-literal rule was
lost the same way and is restored with it.

**2. A name in a def body bound at the call site, not the definition site.**
`def f: {a: .c, b: .a, c: .b}; def g: f; def f: .a = 99; g` resolved `f`
inside `g` to the *later* definition, classified a reshaping filter as
shape-preserving, and `sync_aliased_paths` rewrote `b` from 1 to 2 — a wrong
**value**, reached through the scoping rule rather than a wrapper. Shadowing
at the *call* is unchanged and separately pinned.

**3. The walk was exponential.** Memoized on body address — sound *because*
of fix 2: with scope fixed at the definition site, a body's answer is a
function of that body alone. Results computed across a recursion cut are not,
and are deliberately not cached.

Attributed rather than assumed, per `docs/guides/benchmarking.md`. The
predicate's cost is now indistinguishable from a binary containing none of
this code:

| levels | `main` (no #2091 walk) | branch | branch pre-memo |
|---|---:|---:|---:|
| 22 | 0.10s | 0.11s | 1.20s |
| 24 | 0.36s | 0.37s | 5.15s |
| 26 | 1.38s | 1.42s | — |

The residual exponential at 30+ levels is the **evaluator's own** and
predates this work (`f0|f0` genuinely doubles the outputs), so the new test
guards the gate's contribution with a loose bound rather than measuring the
machine.

The round also folded `in_bound_body`/`walk_bound_body` into the def-body
helpers. They differed only in keeping the currently-visible scope, and their
recursion-cut branches were *unconstructible* — an `Rc<FuncDefData>` is built
before anything can reference it, so a `DefCall` body cannot be cyclic. One
recursion guard and one memo, rather than a second copy that could drift;
drift between these walks is exactly what finding 1 was.

## Two things found while finishing

**An MSRV violation only clippy sees.** `core::ptr::from_ref`, used to key
the expanding-set on a body's address, is stable since 1.76 while this crate
declares 1.73. It *builds* fine — only `clippy::incompatible_msrv` catches
it. Replaced with a plain cast.

**Reachability settled before writing tests.** Coverage flagged the
`Expr::Shared` and `Expr::DefCall` arms. Rather than invent a repro, I
instrumented them and probed every route that could plausibly hand the gate a
mutated `program.expr` — multi-file, `--eval-all`, `--inplace`, nested and
chained defs. **Zero entries into either arm**: #1371 installs `DefCall` when
it *evaluates* an enclosing `FuncDef`, strictly after these predicates run.

They stay because the ordering that makes them unreachable is not something
these predicates control — a `program.expr` shared across files is one
refactor away from arriving pre-bound, and answering `false` there would
silently drop preservation rather than fail loudly. Covered by direct unit
tests instead, following this module's own precedent.

One of those tests pins what the triage explicitly warned about: both
predicates must follow the **same** wrappers, since
`is_alias_sensitive_assign` is their conjunction — a wrapper only one of them
follows would make the pair answer correctly for the wrong reason.

## Test plan

- [x] `cargo test --features cli,simd,regex,serde` — 7731 passed, 0 failed
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings`
- [x] `cargo check --no-default-features` (`no_std`)
- [x] `cargo fmt --all -- --check`
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps`
- [x] 13 CLI tests + 7 unit tests (6 in the library, 1 in the CLI)
- [x] **100% patch coverage** on added `src/` lines (314/314, both crates)

CLI tests live in their own `mod issue_2091_def_and_binder_wrapped_writes`
block rather than at bare file end — the identical-trailing-`Ok(())`-context
merge hazard, which bit this branch for real on rebase against #1349.
