### PR TITLE
test(jq): close #1351's remaining patch-coverage gaps

### DIFF
--- a/src/bin/succinctly/yq_runner.rs
+++ b/src/bin/succinctly/yq_runner.rs
@@ -8185,6 +8185,106 @@ mod tests {
         assert_eq!(targets_of(&Expr::Field("a".into())), None);
     }
 
+    fn setpath(path: Expr, value: Expr) -> Expr {
+        Expr::Builtin(Builtin::SetPath(Box::new(path), Box::new(value)))
+    }
+
+    fn delpaths(paths: Expr) -> Expr {
+        Expr::Builtin(Builtin::DelPaths(Box::new(paths)))
+    }
+
+    fn array_of(items: Vec<Expr>) -> Expr {
+        match <[Expr; 1]>::try_from(items) {
+            Ok([single]) => Expr::Array(Box::new(single)),
+            Err(items) => Expr::Array(Box::new(Expr::Comma(items))),
+        }
+    }
+
+    fn str_lit(s: &str) -> Expr {
+        Expr::Literal(Literal::String(s.into()))
+    }
+
+    /// `setpath`/`delpaths` name their path as an array literal of string
+    /// and integer keys (`literal_path_steps`); anything else -- a path
+    /// that isn't an array literal at all, a `delpaths` list that doesn't
+    /// hold exactly one path, or a path array containing something other
+    /// than a string/integer key -- makes the whole write unresolvable,
+    /// same as a computed bracket key does for `static_path_steps`.
+    #[test]
+    fn literal_path_steps_rejects_non_array_and_odd_items_870() {
+        // Not an array literal at all.
+        assert_eq!(targets_of(&setpath(Expr::Identity, Expr::Identity)), None);
+        assert_eq!(targets_of(&delpaths(Expr::Identity)), None);
+        // `delpaths`' own list holds a path that isn't an array literal.
+        assert_eq!(targets_of(&delpaths(array_of(vec![Expr::Identity]))), None);
+        // `delpaths` accepts only exactly one path per call.
+        assert_eq!(
+            targets_of(&delpaths(array_of(vec![
+                array_of(vec![str_lit("a")]),
+                array_of(vec![str_lit("b")]),
+            ]))),
+            None
+        );
+        // A path item that is neither a string nor an integer key.
+        assert_eq!(
+            targets_of(&setpath(
+                array_of(vec![str_lit("a"), Expr::Literal(Literal::Bool(true))]),
+                Expr::Identity,
+            )),
+            None
+        );
+    }
+
+    /// A plain `Literal::Int` path item -- reachable from a leading-zero
+    /// negative integer like `-01`, which fails JSON's number grammar and
+    /// so bypasses `NumberLiteral` (see `parse_number_literal`) -- names an
+    /// index exactly like the ordinary `NumberLiteral` spelling does.
+    #[test]
+    fn literal_path_steps_accepts_bare_int_literal_870() {
+        assert_eq!(
+            targets_of(&setpath(
+                array_of(vec![str_lit("a"), Expr::Literal(Literal::Int(-1))]),
+                Expr::Identity,
+            )),
+            Some(vec![(
+                vec![PathStep::Key("a".into()), PathStep::Index(-1)],
+                WriteKind::Set
+            )])
+        );
+    }
+
+    /// A `NumberLiteral` path item names an index only when its spelling
+    /// parses as a plain integer; a fractional spelling (`["a", 1.5]`, the
+    /// form a `setpath` path array can hold even though it never denotes a
+    /// real array slot) makes the whole path non-static instead of
+    /// truncating or otherwise guessing at an index.
+    #[test]
+    fn literal_path_steps_number_literal_int_ok_and_float_err_870() {
+        assert_eq!(
+            targets_of(&setpath(
+                array_of(vec![
+                    str_lit("a"),
+                    Expr::Literal(Literal::NumberLiteral(NumberRepr::Int(5), "5".into())),
+                ]),
+                Expr::Identity,
+            )),
+            Some(vec![(
+                vec![PathStep::Key("a".into()), PathStep::Index(5)],
+                WriteKind::Set
+            )])
+        );
+        assert_eq!(
+            targets_of(&setpath(
+                array_of(vec![
+                    str_lit("a"),
+                    Expr::Literal(Literal::NumberLiteral(NumberRepr::Float(1.5), "1.5".into())),
+                ]),
+                Expr::Identity,
+            )),
+            None
+        );
+    }
+
     /// A negative index resolves from the end, and an out-of-range one
     /// resolves to nothing rather than wrapping or clamping.
     #[test]

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -911,7 +911,7 @@ pub mod alias_identity {
                             redirected.extend(components[i..].iter().cloned());
                             redirect_components(redirected, doc, table, opts, hops + 1, out);
                             return;
-                        }
+                        } // omni-dev: coverage tolerate-line reason="unreachable: def is always a collect_alias_groups anchor path, which step_to_expr never fails on (#1351)"
                     }
                 }
             }
@@ -932,7 +932,7 @@ pub mod alias_identity {
         let mut paths = vec![rebuild(components)];
         redirect_paths(&mut paths, doc, Redirect::SINGLE);
         let Some(redirected) = paths.pop() else {
-            return;
+            return; // omni-dev: coverage tolerate-line reason="unreachable: redirect_paths with Redirect::SINGLE always contributes exactly one output per input, so a 1-element paths always pops Some (#1351)"
         };
         let mut flat = Vec::new();
         push_path_components(&mut flat, &redirected);
@@ -941,11 +941,11 @@ pub mod alias_identity {
             .map(|c| match unwrap_path_component(c).0 {
                 Expr::Field(name) => Some(OwnedValue::String(name.clone())),
                 Expr::Index { idx, .. } => Some(OwnedValue::Int(*idx)),
-                _ => None,
+                _ => None, // omni-dev: coverage tolerate-line reason="unreachable: a concrete setpath/delpaths path's components are always Field/Index -- step_to_expr never produces another shape (#1351)"
             })
             .collect::<Option<Vec<OwnedValue>>>()
         else {
-            return;
+            return; // omni-dev: coverage tolerate-line reason="unreachable: the map above never yields None, since it only ever matches Field/Index (#1351)"
         };
         *path = concrete;
     }
@@ -85099,6 +85099,24 @@ mod tests {
             let mut with_slice = vec![OwnedValue::String("b".into()), slice.clone()];
             alias_identity::redirect_concrete_path(&mut with_slice, &doc);
             assert_eq!(with_slice, vec![OwnedValue::String("b".into()), slice]);
+        }
+
+        /// A concrete path's redirected components can land on an array
+        /// index, not just an object key -- `setpath`/`delpaths` addressing
+        /// a sequence alias (`l: [&s {p: 1}, *s]`) exercises the `Index` arm
+        /// of `redirect_concrete_path`'s own component-to-`OwnedValue` map,
+        /// same as an object key exercises the `Field` arm above.
+        #[test]
+        fn concrete_path_redirect_normalises_an_index_component_1351() {
+            let table = alias_identity::AliasTable::from_groups(vec![(
+                path(&["l", "0"]),
+                vec![path(&["l", "1"])],
+            )]);
+            let _guard = alias_identity::enter(table);
+            let doc = json(r#"{"l":[{"p":1},{"p":1}]}"#);
+            let mut p = path(&["l", "1", "p"]);
+            alias_identity::redirect_concrete_path(&mut p, &doc);
+            assert_eq!(p, path(&["l", "0", "p"]));
         }
 
         #[test]


### PR DESCRIPTION
## Summary

Follow-up to #2510: closes the patch-coverage gaps its coverage comment flagged (19 uncovered new lines across `yq_runner.rs`'s `setpath`/`delpaths` literal-path handling and `eval.rs`'s `alias_identity` module).

- `yq_runner.rs`: direct unit tests for `literal_path_steps`/`collect_write_targets` — a non-array `setpath`/`delpaths` path, a `delpaths` list with other than one path, a non-string/int path item, a bare `Literal::Int` item (the leading-zero `-01` spelling), and both arms of the `NumberLiteral` integer parse.
- `eval.rs`: a test for `redirect_concrete_path`'s `Expr::Index` arm via an alias reached through an array index.
- `eval.rs`: four branches that are unreachable by construction (`step_to_expr` and `Redirect::SINGLE`'s one-output-per-input invariant rule them out, per the module's doc comments) are marked `omni-dev: coverage tolerate-line`, matching the existing `yq_runner.rs`/`yaml/light.rs` precedent.

Test-only plus coverage annotations; no behaviour change.

## Test plan

- [x] `cargo test --features cli --lib alias_identity` (11 passed)
- [x] `cargo test --features cli --bin succinctly` for the new `yq_runner` unit tests
- [x] `cargo clippy --all-targets --all-features -- -D warnings` and the CI feature set
- [x] `RUSTDOCFLAGS=-D warnings cargo doc --no-deps --all-features`
- [x] `cargo fmt -- --check`

Refs #1351 (already closed by #2510).
