### PR TITLE
fix(yq): extend --sort-keys alias-soundness fallback to every M2 filter

### DIFF
--- a/docs/compliance/yq/limitations.md
+++ b/docs/compliance/yq/limitations.md
@@ -230,6 +230,11 @@ $ printf 'a: &x 1\nb: *x\n' | succinctly yq '.b'
 1
 ```
 
+[#2486](https://github.com/rust-works/succinctly/issues/2486) extended the same fallback to
+every M2-streamable filter, not just identity (`--sort-keys '.outer'`, `--sort-keys '.[]'`,
+...) — the fallback now evaluates the real filter expression instead of always assuming `.`,
+so any shape that can reach the M2 fast path gets the same soundness check.
+
 Related open items in the same family, still unresolved:
 [#1359](https://github.com/rust-works/succinctly/issues/1359) (a write that changes a node's
 kind drops its `&anchor`, where real yq keeps it),

--- a/src/bin/succinctly/yq_runner.rs
+++ b/src/bin/succinctly/yq_runner.rs
@@ -1539,17 +1539,17 @@ fn evaluate_yaml_direct_filtered(
     }
 }
 
-/// #1350: `--sort-keys` on the M2 streaming fast path has no soundness
-/// pass -- `enforce_anchor_soundness` only runs on the DOM path
+/// #1350/#2486: `--sort-keys` on the M2 streaming fast path has no
+/// soundness pass -- `enforce_anchor_soundness` only runs on the DOM path
 /// (`evaluate_yaml_direct_filtered` + [`output_value`] below), so a sort
 /// that inverts an anchor's declaration order relative to its alias
 /// produces YAML succinctly itself cannot read back. Routes one file's (or
-/// stdin's) identity output through the DOM evaluator instead of the M2
-/// streamers, reusing `bytes` already in hand -- a second parse, not a
-/// second read. Callers gate this on `sort_keys && index.has_aliases()`
-/// (an index they already built to decide the M2 path in the first place),
-/// so the cost is paid only under `--sort-keys` on alias-bearing documents;
-/// every other invocation is unaffected.
+/// stdin's) output through the DOM evaluator instead of the M2 streamers,
+/// reusing `bytes` already in hand -- a second parse, not a second read.
+/// Callers gate this on `sort_keys && index.has_aliases()` (an index they
+/// already built to decide the M2 path in the first place), so the cost is
+/// paid only under `--sort-keys` on alias-bearing documents; every other
+/// invocation is unaffected.
 ///
 /// Deliberately whole-*file* granularity, not per-document within a
 /// multi-document file, matching the fix locus named in #1350's own
@@ -1558,17 +1558,27 @@ fn evaluate_yaml_direct_filtered(
 /// route alongside its siblings, rather than adding a second axis of
 /// per-document routing on top of the existing per-file M2-vs-DOM switch.
 ///
-/// Identity only (`&Expr::Identity`, not a general filter): callers must
-/// gate this on `is_identity` too, not just `sort_keys && has_aliases()` --
-/// a non-identity M2-streamable filter (`.foo`) still needs its own real
-/// evaluation, which this function does not perform (#1350 code review: an
-/// earlier version without the `is_identity` gate silently replaced such a
-/// filter's result with the whole identity-evaluated document).
+/// #2486: takes the real `expr`, not a hardcoded `&Expr::Identity` -- an
+/// earlier version (#1350) only handled identity output and gated callers
+/// on `is_identity` for exactly that reason (#1350 code review: without
+/// that gate, a non-identity M2-streamable filter's result was silently
+/// replaced by the whole identity-evaluated document). Passing the real
+/// expression through removes the need for that gate: `.outer`, `.[]`,
+/// `select(...)`, and every other M2-streamable shape now get their own
+/// correct evaluation here too, not just `.`. Confirmed live that
+/// `evaluate_yaml_direct_filtered` + [`output_value`] already reproduce the
+/// M2 fast path's own output byte-for-byte on alias-free input across
+/// field access, iteration, indexing, `keys_unsorted`, `select`, and
+/// `first` -- the DOM route this falls back to is not a special case, it's
+/// the same evaluator every non-M2-eligible filter already goes through.
 ///
-/// `doc_streamed`/`any_truthy` grouped into one struct rather than two more
-/// `&mut bool` parameters (clippy's `too_many_arguments`, matching this
-/// file's own [`DirectEvalOptions`] precedent for the identical reason).
+/// `strip_style`/`doc_streamed`/`any_truthy` grouped into one struct rather
+/// than three more scalar parameters (clippy's `too_many_arguments`,
+/// matching this file's own [`DirectEvalOptions`] precedent for the
+/// identical reason -- adding `expr` for #2486 pushed this back over the
+/// limit `FallbackStreamState` alone had already been introduced to clear).
 struct FallbackStreamState<'a> {
+    strip_style: bool,
     doc_streamed: &'a mut bool,
     any_truthy: &'a mut bool,
 }
@@ -1576,13 +1586,14 @@ struct FallbackStreamState<'a> {
 fn stream_yaml_sort_keys_alias_fallback<W: Write>(
     writer: &mut W,
     bytes: &[u8],
+    expr: &Expr,
     doc_filter: Option<(usize, usize)>,
     sink: &mut ErrorSink,
     output_config: &OutputConfig,
-    strip_style: bool,
     state: FallbackStreamState<'_>,
 ) -> Result<usize> {
     let FallbackStreamState {
+        strip_style,
         doc_streamed,
         any_truthy,
     } = state;
@@ -1594,7 +1605,7 @@ fn stream_yaml_sort_keys_alias_fallback<W: Write>(
     // signature returns `Result` for its *own*, more general callers.
     let eval_result = evaluate_yaml_direct_filtered(
         bytes,
-        &Expr::Identity,
+        expr,
         doc_filter,
         sink,
         DirectEvalOptions {
@@ -1606,14 +1617,24 @@ fn stream_yaml_sort_keys_alias_fallback<W: Write>(
     );
     let (doc_results, num_docs) = eval_result?; // omni-dev: coverage tolerate-line reason="unreachable: bytes already parsed successfully by every caller (#1350)"
     for results in doc_results {
+        // #2486: `---` only ever separates distinct *documents*, never two
+        // results produced from evaluating the same document (e.g. `.[]`
+        // yielding several outputs) -- the DOM `else` branch's own loop
+        // gives every result in `results` the same treatment, and `-P`
+        // confirms it live: multiple results from one document print back
+        // to back with no separator between them. Only the first result in
+        // each `results` group gets a chance at `doc_streamed`'s marker;
+        // every later result in the same group gets none.
+        let mut first_result_in_doc = true;
         for (result, comments) in results {
             // Mirrors the DOM `else` branch's own identical truthiness
             // accumulation for `--exit-status` (#178).
             *any_truthy |= !matches!(&result, OwnedValue::Null | OwnedValue::Bool(false));
-            let separator = Some(DocSeparatorArgs {
-                doc_streamed,
+            let separator = first_result_in_doc.then_some(DocSeparatorArgs {
+                doc_streamed: &mut *doc_streamed,
                 no_doc: output_config.no_doc,
             });
+            first_result_in_doc = false;
             output_value(writer, &result, &comments, output_config, separator)?;
         }
     }
@@ -5629,22 +5650,14 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
                 index.mark_json_sourced();
             }
 
-            // #1350: `--sort-keys` has no soundness pass on the M2 fast
-            // path below -- fall back to the DOM evaluator for this whole
+            // #1350/#2486: `--sort-keys` has no soundness pass on the M2
+            // fast path below -- fall back to the DOM evaluator (via
+            // `program.expr`, so any M2-streamable filter gets its own
+            // correct evaluation here, not just identity) for this whole
             // input, which already gets it right. `index` is already built
             // (this check costs nothing extra); the fallback itself is a
             // second parse of `yaml_bytes`, paid only here.
-            //
-            // `is_identity` is load-bearing, not incidental:
-            // `stream_yaml_sort_keys_alias_fallback` always evaluates
-            // `&Expr::Identity`, not `program.expr` -- a non-identity
-            // M2-streamable filter (e.g. `.foo`) combined with `--sort-keys`
-            // on an alias-bearing document must keep evaluating that real
-            // filter on the fast path below, not silently ignore it here.
-            if is_identity
-                && sort_keys
-                && output_config.output_format == OutputFormat::Yaml
-                && index.has_aliases()
+            if sort_keys && output_config.output_format == OutputFormat::Yaml && index.has_aliases()
             {
                 let doc_filter = args.document.map(|target| (target, global_doc_index));
                 // Single stdin input, no further reads to filter -- unlike
@@ -5653,11 +5666,12 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
                 let _num_docs = stream_yaml_sort_keys_alias_fallback(
                     &mut writer,
                     &yaml_bytes,
+                    &program.expr,
                     doc_filter,
                     &mut sink,
                     &output_config,
-                    args.pretty_print,
                     FallbackStreamState {
+                        strip_style: args.pretty_print,
                         doc_streamed: &mut yaml_doc_streamed,
                         any_truthy: &mut any_truthy,
                     },
@@ -5821,11 +5835,9 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
                     index.mark_json_sourced();
                 }
 
-                // #1350: see the stdin branch's identical check above for
-                // the full rationale, including why `is_identity` is
-                // load-bearing here.
-                if is_identity
-                    && sort_keys
+                // #1350/#2486: see the stdin branch's identical check above
+                // for the full rationale.
+                if sort_keys
                     && output_config.output_format == OutputFormat::Yaml
                     && index.has_aliases()
                 {
@@ -5833,11 +5845,12 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
                     let num_docs = stream_yaml_sort_keys_alias_fallback(
                         &mut writer,
                         &yaml_bytes,
+                        &program.expr,
                         doc_filter,
                         &mut sink,
                         &output_config,
-                        args.pretty_print,
                         FallbackStreamState {
+                            strip_style: args.pretty_print,
                             doc_streamed: &mut yaml_doc_streamed,
                             any_truthy: &mut any_truthy,
                         },

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -24966,18 +24966,17 @@ fn test_yaml_root_alias_container_target_no_spurious_anchor_1350() -> Result<()>
 
 /// Code review on #1350's fix: an earlier version gated the DOM fallback on
 /// `sort_keys && index.has_aliases()` alone, with no `is_identity` check --
-/// but `stream_yaml_sort_keys_alias_fallback` always evaluates
+/// but `stream_yaml_sort_keys_alias_fallback` always evaluated
 /// `&Expr::Identity`, not the real filter. A non-identity M2-streamable
 /// filter (`.outer`) combined with `--sort-keys` on an alias-bearing
 /// document would have silently ignored `.outer` and streamed the *whole*
 /// identity-evaluated document instead -- caught before merge by exactly
 /// this test failing under the broad gate.
 ///
-/// This does not close the soundness gap for non-identity filters (`.outer`
-/// here can still emit an alias above its anchor -- confirmed live, still
-/// unreadable by `succinctly yq` itself); it only pins that the *value*
-/// returned is correct, not silently replaced by the whole document. The
-/// non-identity soundness gap is real and separate, filed as a follow-up.
+/// #2486 later generalized the fallback to take the real `expr` instead of
+/// a hardcoded identity, which also closed the soundness gap this test's
+/// own comment used to describe as open -- see
+/// `test_yaml_sort_keys_non_identity_filter_takes_dom_path_2486` for that.
 #[test]
 fn test_yaml_sort_keys_non_identity_filter_still_applies_1350() -> Result<()> {
     let input = "outer:\n  b: &x 1\n  a: *x\nunrelated: 99\n";
@@ -24991,6 +24990,56 @@ fn test_yaml_sort_keys_non_identity_filter_still_applies_1350() -> Result<()> {
         output.contains('1'),
         "must contain .outer's own content: {output:?}"
     );
+    Ok(())
+}
+
+/// #2486: `stream_yaml_sort_keys_alias_fallback` now takes the real `expr`
+/// instead of a hardcoded `Expr::Identity` (#1350 only covered identity
+/// output), so a non-identity M2-streamable filter combined with
+/// `--sort-keys` over an alias-bearing document takes the same sound DOM
+/// route identity output already did -- matches `-P`, and re-parses.
+#[test]
+fn test_yaml_sort_keys_non_identity_filter_takes_dom_path_2486() -> Result<()> {
+    let input = "outer:\n  b: &x 1\n  a: *x\nunrelated: 99\n";
+
+    let (streamed, code) = run_yq_stdin(".outer", input, &["--sort-keys"])?;
+    assert_eq!(code, 0);
+    let (dom_forced, code) = run_yq_stdin(".outer", input, &["--sort-keys", "-P"])?;
+    assert_eq!(code, 0);
+    assert_eq!(
+        streamed, dom_forced,
+        "streaming and DOM-forced (-P) output must agree"
+    );
+
+    let (_, reread_code) = run_yq_stdin(".", &streamed, &[])?;
+    assert_eq!(
+        reread_code, 0,
+        ".outer's sorted output must be readable by succinctly yq itself, output: {streamed}"
+    );
+    Ok(())
+}
+
+/// #2486: the same fix must hold for a filter that walks *into* a document
+/// with aliases in more than one place, and for a filter that fans a
+/// single input out into multiple documents (`.[]`), not just a single
+/// field access.
+#[test]
+fn test_yaml_sort_keys_non_identity_filter_multi_output_2486() -> Result<()> {
+    let input = "outer:\n  b: &x 1\n  a: *x\nlist:\n  - m: &y 1\n    n: *y\n";
+
+    let (streamed, code) = run_yq_stdin(".[]", input, &["--sort-keys"])?;
+    assert_eq!(code, 0);
+    let (dom_forced, code) = run_yq_stdin(".[]", input, &["--sort-keys", "-P"])?;
+    assert_eq!(code, 0);
+    assert_eq!(streamed, dom_forced);
+
+    for doc in streamed.split("---\n") {
+        if doc.trim().is_empty() {
+            continue;
+        }
+        let (_, reread_code) = run_yq_stdin(".", doc, &[])?;
+        assert_eq!(reread_code, 0, "each document must re-parse: {doc:?}");
+    }
     Ok(())
 }
 


### PR DESCRIPTION
## Summary

- #1350's DOM fallback for `--sort-keys` + aliased documents only covered identity output (`succinctly yq --sort-keys '.'`): it hardcoded `&Expr::Identity` and gated callers on `is_identity` for exactly that reason. A non-identity M2-streamable filter (`.outer`, `.[]`, `select(...)`, ...) combined with `--sort-keys` over an alias-bearing document still emitted unreadable YAML:
  ```bash
  $ printf 'outer:\n  b: &x 1\n  a: *x\nunrelated: 99\n' | succinctly yq --sort-keys '.outer'
  a: *x
  b: &x 1
  $ ... | succinctly yq --sort-keys '.outer' | succinctly yq '.'
  Error: YAML parse error: unknown anchor 'x' referenced at offset 3
  ```
- `stream_yaml_sort_keys_alias_fallback` now takes the real `expr` and evaluates it via the same `evaluate_yaml_direct_filtered` the DOM `else` branch already uses for every non-M2-eligible filter — so `is_identity` is no longer needed as a gate; the fallback correctly evaluates whatever filter reached it. Confirmed live that this DOM route reproduces the M2 fast path's own output byte-for-byte on alias-free input across field access, iteration, indexing, `keys_unsorted`, `select`, and `first`.
- **Found and fixed a real bug while generalizing**: the fallback gave every individual *result* its own `---` document separator, when `---` only ever separates distinct *documents* — never multiple results from evaluating one document (e.g. `.[]`'s several outputs). `.[]` on a single aliased document was wrongly inserting a spurious `---` between its own outputs where `-P` shows none. Caught by testing a multi-output filter before merge.

## Test plan

- [x] `cargo build --features cli`
- [x] `cargo test --features cli,simd,regex,serde` (full workspace, 0 failures)
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings` (non-`scalar-yaml` leg)
- [x] `cargo fmt --check`
- [x] New tests in `tests/yq_cli_tests.rs`:
  - `test_yaml_sort_keys_non_identity_filter_takes_dom_path_2486`: `.outer` matches `-P`, re-parses
  - `test_yaml_sort_keys_non_identity_filter_multi_output_2486`: `.[]` (multiple results from one document) matches `-P` exactly, including the corrected separator behavior, and every produced document re-parses
  - Updated the stale doc comment on `test_yaml_sort_keys_non_identity_filter_still_applies_1350` (its own "the non-identity gap is real and separate" claim is what this PR closes)
- [x] 100% patch coverage (`omni-dev coverage diff`)
- [x] `docs/compliance/yq/limitations.md` updated to note the fallback now covers every M2-streamable filter, not just identity

Fixes #2486.