### PR TITLE
fix(jq): make yq length's owned number arm match the cursor arm's rule (#2453)

### DIFF
--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -8501,8 +8501,9 @@ fn builtin_length<W: Clone + AsRef<[u64]>, S: EvalSemantics>(
             }
         }
         StandardJson::Number(n) => {
-            // Length of a number is its absolute value.
-            // checked_abs: i64::MIN has no i64 absolute value; use f64
+            // Length of a number: jq's absolute-value rule, or the width
+            // of yq's own rendering -- see `numeric_length_owned`'s doc
+            // comment (#2453).
             if is_nan_sentinel(n.raw_bytes()) {
                 QueryResult::Owned(OwnedValue::Float(f64::NAN))
             } else if is_infinity_sentinel(n.raw_bytes()).is_some() {
@@ -8510,12 +8511,9 @@ fn builtin_length<W: Clone + AsRef<[u64]>, S: EvalSemantics>(
                 // same positive infinity (#1083/#1087).
                 QueryResult::Owned(OwnedValue::Float(f64::INFINITY))
             } else if let Ok(i) = n.as_i64() {
-                QueryResult::Owned(match i.checked_abs() {
-                    Some(a) => OwnedValue::Int(a),
-                    None => OwnedValue::Float(-(i as f64)),
-                })
+                QueryResult::Owned(numeric_length_owned::<S>(OwnedValue::Int(i)))
             } else if let Ok(f) = n.as_f64() {
-                QueryResult::Owned(OwnedValue::Float(f.abs()))
+                QueryResult::Owned(numeric_length_owned::<S>(OwnedValue::Float(f)))
             } else {
                 QueryResult::Owned(OwnedValue::Int(0))
             }
@@ -12134,6 +12132,50 @@ pub(crate) fn owned_to_string<S: EvalSemantics>(value: &OwnedValue) -> String {
         // `@csv`/`@tsv`/string interpolation on an array containing a
         // scientific-notation element all preserve it.
         OwnedValue::Array(_) | OwnedValue::Object(_) => owned_value_to_json::<S>(value),
+    }
+}
+
+/// `Builtin::Length` of a materialized (cursor-less) number: jq's own
+/// absolute-value rule, or the width of yq's own rendering (#2453) --
+/// consulted by both `builtin_length` (this file, the owned `StandardJson`
+/// path) and `eval_generic.rs`'s cursor-arm fallback (reached once
+/// `as_str()`/`as_array()`/`as_object()` have all declined), so the rule
+/// is one definition rather than two hand-copies that can drift apart
+/// (CLAUDE.md's "duplicated predicates diverge silently" case, and this
+/// exact issue's own root cause: the two sites already had drifted).
+///
+/// yq's cursor-backed path gets its own rule "for free" without ever
+/// calling this: a YAML scalar's raw source text is a `String` in that
+/// representation regardless of its resolved type, so `Length`'s
+/// `as_str()` check fires before either arm's numeric fallback runs, and
+/// the string arm's plain `chars().count()` already answers with the
+/// source spelling's width (confirmed live: `1e3`/`!!float 2` both answer
+/// with their raw text's width, not a re-rendering of the parsed value).
+/// This function is the *owned* counterpart for a value with no source
+/// text left to read -- computed via arithmetic, or threaded through an
+/// array/object literal, `to_entries`, a comma fan-out, ... (all of which
+/// call `numeric_display_string` for the same job in `tostring`/`@text`,
+/// so reusing it here keeps `length` and `tostring` from disagreeing on
+/// what a computed number renders as).
+///
+/// `value` must be `OwnedValue::Int` or `OwnedValue::Float`; any other
+/// variant is returned unchanged (both call sites only ever pass one of
+/// the two, and NaN/Infinity sentinels are intercepted before either call
+/// site reaches this, so `numeric_display_string`'s own non-finite
+/// handling is never exercised from here in practice).
+pub(crate) fn numeric_length_owned<S: EvalSemantics>(value: OwnedValue) -> OwnedValue {
+    if S::TAG == EvalTag::Yq {
+        let rendered = numeric_display_string::<S>(&value);
+        OwnedValue::Int(rendered.chars().count() as i64)
+    } else {
+        match value {
+            OwnedValue::Int(i) => match i.checked_abs() {
+                Some(a) => OwnedValue::Int(a),
+                None => OwnedValue::Float(-(i as f64)),
+            },
+            OwnedValue::Float(f) => OwnedValue::Float(f.abs()),
+            other => other,
+        }
     }
 }
 

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -43,14 +43,14 @@ use super::eval::{
     extract_pattern_bindings, fold_escaped_generator_prefix, format_owned,
     has_type_mismatch_is_permissive, index_component_value, index_in_array_bounds,
     index_one_owned as index_owned_by_key, is_pure_chain_link, is_retryable_stop, literal_to_owned,
-    needs_path_context, numeric_key_to_array_index, numeric_key_to_index, owned_bound_to_i64,
-    owned_to_string, prefer_pending_control, slice_component_value, slice_object_as_yq_children,
-    slice_owned_value_read, streams_escaped_generator_prefix, substitute_bound_var,
-    substitute_vars, suppress_or_raise, suppresses, tonumber_from_str, vec_with_capacity,
-    yq_absent_key_read_is_empty, yq_empty_operand_output, yq_negative_index_check,
-    yq_numeric_index_on_object_is_null, yq_read_only_context, BinaryFanoutRules, Control, Demand,
-    EmptyOperandOp, EvalError, EvalSemantics, EvalTag, Flow, JqSemantics, LimitN, PathTrail,
-    QueryResult, YqSemantics,
+    needs_path_context, numeric_key_to_array_index, numeric_key_to_index, numeric_length_owned,
+    owned_bound_to_i64, owned_to_string, prefer_pending_control, slice_component_value,
+    slice_object_as_yq_children, slice_owned_value_read, streams_escaped_generator_prefix,
+    substitute_bound_var, substitute_vars, suppress_or_raise, suppresses, tonumber_from_str,
+    vec_with_capacity, yq_absent_key_read_is_empty, yq_empty_operand_output,
+    yq_negative_index_check, yq_numeric_index_on_object_is_null, yq_read_only_context,
+    BinaryFanoutRules, Control, Demand, EmptyOperandOp, EvalError, EvalSemantics, EvalTag, Flow,
+    JqSemantics, LimitN, PathTrail, QueryResult, YqSemantics,
 };
 #[cfg(test)]
 use super::expr::FuncDefBound;
@@ -13981,13 +13981,14 @@ fn eval_builtin<S: EvalSemantics, V: DocumentValue>(
                     Err(err) => GenericResult::Error(err),
                 }
             } else if let Some(i) = value.as_i64() {
-                // checked_abs: i64::MIN has no i64 absolute value; use f64
-                GenericResult::Owned(match i.checked_abs() {
-                    Some(a) => OwnedValue::Int(a),
-                    None => OwnedValue::Float(-(i as f64)),
-                })
+                // Reached only for a value with no source text of its own
+                // to answer from (`as_str()` above already declined) --
+                // `numeric_length_owned`'s doc comment (`eval.rs`) has the
+                // full jq-vs-yq rule and why it's one shared definition
+                // (#2453).
+                GenericResult::Owned(numeric_length_owned::<S>(OwnedValue::Int(i)))
             } else if let Some(f) = value.as_f64() {
-                GenericResult::Owned(OwnedValue::Float(f.abs()))
+                GenericResult::Owned(numeric_length_owned::<S>(OwnedValue::Float(f)))
             } else {
                 decode_failure_or(&value, optional, || {
                     GenericResult::Error(EvalError::has_no_length(&to_owned_for_diagnostic(

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -38744,3 +38744,61 @@ fn test_assignment_rhs_sees_the_input_position_2471() -> Result<()> {
     }
     Ok(())
 }
+
+/// #2453: the jq-mode counterpart of
+/// `yq_cli_tests::test_yq_length_of_a_number_is_its_rendered_width_2453` --
+/// jq's absolute-value rule for `length` of a number is unaffected by that
+/// fix (it only changed yq mode's rule, gated on `S::TAG == EvalTag::Yq` in
+/// the shared `numeric_length_owned`), and both the plain-navigation and
+/// materialized paths already agreed with each other before this fix, so
+/// there is no "was" value to contrast here the way the yq test has.
+///
+/// Every row live-captured against `/usr/bin/jq` 1.7.1 on
+/// `{"a":1,"b":22,"neg":-5,"negd":-22,"flt":0.5,"zero":0}`:
+///
+/// ```console
+/// $ jq '.a | length'                              # 1
+/// $ jq '.b | length'                               # 22   (absolute value, not rendered width)
+/// $ jq '.neg | length'                             # 5    (abs(-5))
+/// $ jq '.negd | length'                            # 22   (abs(-22))
+/// $ jq '.flt | length'                             # 0.5  (abs(0.5))
+/// $ jq -c '[.a, .b] | .[] | length'                # 1 / 22
+/// $ jq -c '(.a, .b) | [.] | .[0] | length'         # 1 / 22
+/// $ jq '.a + 0 | length'                           # 1
+/// $ jq '.b + 0 | length'                           # 22
+/// $ jq -c 'to_entries | .[].value | length'        # 1 / 22
+/// $ jq '(0 - .b) | length'                         # 22   (abs(-22))
+/// ```
+#[test]
+fn test_jq_length_of_a_number_is_unaffected_2453() -> Result<()> {
+    let doc = r#"{"a":1,"b":22,"neg":-5,"negd":-22,"flt":0.5,"zero":0}"#;
+
+    for (filter, expected) in [
+        (".a | length", "1"),
+        (".b | length", "22"),
+        (".neg | length", "5"),
+        (".negd | length", "22"),
+        (".flt | length", "0.5"),
+        (".zero | length", "0"),
+    ] {
+        let (out, code) = run_jq_stdin(filter, doc, &[])?;
+        assert_eq!(code, 0, "`{filter}`: {out:?}");
+        assert_eq!(out.trim(), expected, "`{filter}`");
+    }
+
+    let ab_doc = r#"{"a":1,"b":22}"#;
+    for (filter, expected) in [
+        ("[.a, .b] | .[] | length", "1\n22"),
+        ("(.a, .b) | [.] | .[0] | length", "1\n22"),
+        (".a + 0 | length", "1"),
+        (".b + 0 | length", "22"),
+        ("to_entries | .[].value | length", "1\n22"),
+        ("(0 - .b) | length", "22"),
+    ] {
+        let (out, code) = run_jq_stdin(filter, ab_doc, &["-c"])?;
+        assert_eq!(code, 0, "`{filter}`: {out:?}");
+        assert_eq!(out.trim(), expected, "`{filter}`");
+    }
+
+    Ok(())
+}

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -35882,6 +35882,88 @@ fn test_assignment_rhs_sees_the_input_position_2471() -> Result<()> {
     Ok(())
 }
 
+/// #2453: `length` of a number disagreed between the plain-navigation path
+/// and any path that forces materialization first (a comma fan-out, an
+/// array/object literal, `to_entries`, arithmetic) -- the plain path used
+/// yq's own rule (the width of the number's rendering), the materialized
+/// path fell back to jq's absolute-value rule. Both now consult one
+/// definition (`numeric_length_owned` in `src/jq/eval.rs`): jq's
+/// absolute-value rule in jq mode, the character width of yq's own
+/// rendering in yq mode. A YAML scalar's raw source text answers directly
+/// when a cursor is still live (`22`'s own bytes are already `"22"`), so
+/// this rule only has work to do once that source text is gone.
+///
+/// Every row live-captured against yq v4.53.3 on
+/// `LENGTH_NUMBER_DOC_2453` (`a: 1`, `b: 22`, `neg: -5`, `negd: -22`,
+/// `flt: 0.5`, `exp: 1e3`, `ftag: !!float 2`, `qstr: "22"`, `zero: 0`):
+///
+/// ```text
+/// $ yq '.a | length'      => 1     $ yq '.b | length'    => 2
+/// $ yq '.neg | length'    => 2     $ yq '.negd | length' => 3
+/// $ yq '.flt | length'    => 3     $ yq '.exp | length'  => 3   (raw "1e3", not "1000")
+/// $ yq '.ftag | length'   => 1     $ yq '.qstr | length' => 2   (already a string, unaffected)
+/// $ yq '.zero | length'   => 1
+/// ```
+///
+/// And the shapes that force materialization before `length` runs, on
+/// `a: 1` / `b: 22`:
+///
+/// ```console
+/// $ yq -o=json -I0 '[.a, .b] | .[] | length'          # 1 / 2   (was 1 / 22 before this fix)
+/// $ yq -o=json -I0 '(.a, .b) | [.] | .[0] | length'    # 1 / 2   (was 1 / 22)
+/// $ yq '.a + 0 | length'                               # 1
+/// $ yq '.b + 0 | length'                               # 2       (was 22)
+/// $ yq -o=json -I0 'to_entries | .[].value | length'   # 1 / 2   (was 1 / 22)
+/// $ yq '(0 - .b) | length'                             # 3       (a computed negative: "-22")
+/// $ yq '(.b * 1.0) | length'                           # 2       (a computed float rendering as "22", not "22.0")
+/// $ yq '(1.5 + 1.5) | length'                          # 1       (a computed float rendering as "3", not "3.0")
+/// ```
+///
+/// jq mode is unchanged and pinned separately in `jq_cli_tests.rs`
+/// (`test_jq_length_of_a_number_is_unaffected_2453`) -- jq's absolute-value
+/// rule already agreed across both paths before this fix.
+const LENGTH_NUMBER_DOC_2453: &str =
+    "a: 1\nb: 22\nneg: -5\nnegd: -22\nflt: 0.5\nexp: 1e3\nftag: !!float 2\nqstr: \"22\"\nzero: 0\n";
+
+#[test]
+fn test_yq_length_of_a_number_is_its_rendered_width_2453() -> Result<()> {
+    let args = &["-o", "json", "-I0"];
+
+    for (filter, expected) in [
+        (".a | length", "1"),
+        (".b | length", "2"),
+        (".neg | length", "2"),
+        (".negd | length", "3"),
+        (".flt | length", "3"),
+        (".exp | length", "3"),
+        (".ftag | length", "1"),
+        (".qstr | length", "2"),
+        (".zero | length", "1"),
+    ] {
+        let (out, code) = run_yq_stdin(filter, LENGTH_NUMBER_DOC_2453, args)?;
+        assert_eq!(code, 0, "`{filter}`: {out:?}");
+        assert_eq!(out.trim(), expected, "`{filter}`");
+    }
+
+    let ab_doc = "a: 1\nb: 22\n";
+    for (filter, expected) in [
+        ("[.a, .b] | .[] | length", "1\n2"),
+        ("(.a, .b) | [.] | .[0] | length", "1\n2"),
+        (".a + 0 | length", "1"),
+        (".b + 0 | length", "2"),
+        ("to_entries | .[].value | length", "1\n2"),
+        ("(0 - .b) | length", "3"),
+        ("(.b * 1.0) | length", "2"),
+        ("(1.5 + 1.5) | length", "1"),
+    ] {
+        let (out, code) = run_yq_stdin(filter, ab_doc, args)?;
+        assert_eq!(code, 0, "`{filter}`: {out:?}");
+        assert_eq!(out.trim(), expected, "`{filter}`");
+    }
+
+    Ok(())
+}
+
 /// #2471 (gate reason 1 of spine 2416): a map-family body stands at its own
 /// **member's** position, not at its container's.
 ///


### PR DESCRIPTION
## Summary

In yq mode a number's `length` is the width of its rendering; the cursor arm already read the scalar's source text, but the owned arm fell to jq's absolute value, so `[.a, .b] | .[] | length` on `a: 1` / `b: 22` printed `1 22`. One shared `numeric_length_owned` (rendering through the same function `tostring` uses) is consulted by both evaluators' owned arms; jq mode keeps the absolute-value rule, pinned from `/usr/bin/jq` 1.7.1.

Captures from yq v4.53.3 in the tests: `1`, `22`, `-5`, `-22`, `0.5`, `1e3` (width of the raw text, 3), `!!float 2` (1), a quoted `"22"`, `0`; the fan-out shapes `[.a,.b] | .[] | length`, `(.a,.b) | [.] | .[0] | length`, `.a + 0 | length`, `to_entries | .[].value | length` all now match the plain path.

## Verification

fmt; clippy `-D warnings`; `cargo test --features cli,simd,regex,serde`; yq goldens 113; jq goldens 633; oracle sweep 0 unexpected. Rebased over the #2471 map-family work.

Closes #2453.