### PR TITLE
fix(jq): redirect through aliases before yq creates an assignment's targets

### DIFF
--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -20894,7 +20894,7 @@ fn yq_prepare_assign_targets<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     // Same `optional` policy, in the same order, as `eval_assign`'s own
     // jq-mode arm: a non-decode-failure `to_owned` error and a path
     // resolution error are both swallowed by an outer `?`, a halt never is.
-    let (pristine, paths) = match resolved {
+    let (pristine, mut paths) = match resolved {
         Some(pair) => pair,
         None => {
             let pristine = match to_owned(input) {
@@ -20915,11 +20915,19 @@ fn yq_prepare_assign_targets<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     // skips the copy outright and reports `created: false` -- correct by
     // construction, since `rhs_document`'s only consumer is the right side
     // that literal has already been proved independent of.
+    // #2530: redirect through aliases *before* the targets are created, so a
+    // new key under `b: *x` is created on the anchor's node, not on the
+    // copy -- otherwise the copy no longer equals the anchor and the write's
+    // own redirect (rule 3's equality gate) rightly refuses. Idempotent for
+    // paths `yq_assign_noop_check` already redirected, and a no-op in jq
+    // mode, where no table is ever installed.
+    alias_identity::redirect_paths(&mut paths, &pristine, alias_identity::Redirect::THROUGH);
     let before = (!matches!(
         super::eval_generic::strip_parens(value_expr),
         Expr::Literal(_)
     ))
     .then(|| pristine.clone());
+    let pre_creation = alias_identity::active().then(|| pristine.clone());
     let mut doc = pristine;
     for path in &paths {
         if let Err(escape) =
@@ -20932,6 +20940,12 @@ fn yq_prepare_assign_targets<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
         }
     }
     let created = before.is_some_and(|before| doc != before);
+    // #2530: the created slot is part of the shared node, so every alias copy
+    // gets it too -- keeping the copies equal to the anchor for the write
+    // that follows and for later pipe stages.
+    if let Some(pre) = &pre_creation {
+        alias_identity::mirror_after_write(pre, &mut doc);
+    }
     Ok(Some(YqAssignTargets {
         doc,
         paths,

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -35911,6 +35911,47 @@ fn test_yaml_nested_groups_sync_to_a_fixpoint_1351() -> Result<()> {
 }
 
 #[test]
+fn test_yaml_new_key_compound_and_comma_writes_through_alias_2530() -> Result<()> {
+    // #2530: #2481 creates an assignment's targets before its right-hand side
+    // runs; the redirect has to happen before that creation or the new key
+    // lands on the alias copy and the copy no longer equals the anchor.
+    // Every expected string captured from yq v4.53.3.
+    assert_yq_1351(
+        ".b.p += 1",
+        "a: &x {s: [1, 2]}\nb: *x\n",
+        "a: &x {s: [1, 2], p: 1}\nb: *x\n",
+        r#"{"a":{"s":[1,2],"p":1},"b":{"s":[1,2],"p":1}}"#,
+    )?;
+    assert_yq_1351(
+        "(.b, .c).p = 2",
+        ALIAS_MAP_DOC_1351,
+        "a: &x {p: 2, q: 2}\nb: *x\nc: *x\n",
+        r#"{"a":{"p":2,"q":2},"b":{"p":2,"q":2},"c":{"p":2,"q":2}}"#,
+    )?;
+    assert_yq_1351(
+        "(.b, .c).r = 3",
+        ALIAS_MAP_DOC_1351,
+        "a: &x {p: 1, q: 2, r: 3}\nb: *x\nc: *x\n",
+        r#"{"a":{"p":1,"q":2,"r":3},"b":{"p":1,"q":2,"r":3},"c":{"p":1,"q":2,"r":3}}"#,
+    )?;
+    // A new key written through the alias, then an anchor write: both slots
+    // stay in step because the created key was mirrored into the copy.
+    assert_yq_1351(
+        ".a.p = 9 | .b.p = 9 | .a.q = 7",
+        "a: &x {s: [1, 2]}\nb: *x\n",
+        "a: &x {s: [1, 2], p: 9, q: 7}\nb: *x\n",
+        r#"{"a":{"s":[1,2],"p":9,"q":7},"b":{"s":[1,2],"p":9,"q":7}}"#,
+    )?;
+    // Multi-hop with a new key on every position.
+    assert_yq_1351(
+        ".[] .p += 1",
+        "x: &y {z: 0}\na: &x {q: *y}\nb: *x\n",
+        "x: &y {z: 0, p: 1}\na: &x {q: *y, p: 2}\nb: *x\n",
+        r#"{"x":{"z":0,"p":1},"a":{"q":{"z":0,"p":1},"p":2},"b":{"q":{"z":0,"p":1},"p":2}}"#,
+    )
+}
+
+#[test]
 fn test_yaml_deleted_declaration_writes_positionally_1351() -> Result<()> {
     // Rule 7, a recorded limitation: with the anchor deleted earlier in the
     // pipe there is no declaration to redirect to, so `.b.p = 9` is


### PR DESCRIPTION
## Summary

Regression found by re-running `scripts/yq-alias-oracle-sweep.sh` against main after #2510 landed: a write through an alias that creates a **new key** via a compound assign (`.b.p += 1` on `a: &x {s: [1, 2]}` / `b: *x`), or any comma-path write (`(.b, .c).p = 2`), landed on the alias copy instead of the shared node.

Cause: #2481's `yq_prepare_assign_targets` resolves the paths and creates the targets before the right-hand side runs. In yq mode it always returns `Some`, so the redirect #2510 placed in `eval_assign`'s fallback arm was unreachable for comma paths; for compound assigns the redirect in `eval_update_multi` ran only after the new key had been created on the copy, so the copy no longer equalled the anchor and the equality gate (correctly) refused.

Fix: redirect inside `yq_prepare_assign_targets` right after resolution (idempotent for paths already redirected by `yq_assign_noop_check`, no-op in jq mode where no table is installed), and mirror the created slot into the alias copies so they stay equal to the anchor for the write itself and for later pipe stages.

Sweep on this branch: the `values-differ` rows return to exactly the recorded set — the rule 4(b) `.c = (.b + 1)` shape, the equality gate's rebind-to-equal-value false positive, the numeric-index-on-mapping write (issue 2514) and the comma-grouped scalar no-op (issue 1419).

## Test plan

- [x] Live-diffed `.b.p += 1`, `(.b, .c).p = 2`, `.a.p = 9 | .b.p = 9 | .a.q = 7` (new key) and the multi-hop `.[] .p += 1` against yq v4.53.3 — identical
- [x] `scripts/yq-alias-oracle-sweep.sh --summary` — no regression rows
- [x] New CLI test `test_yaml_new_key_compound_and_comma_writes_through_alias_2530`; the `_1351`/`_2497`/`_2500`/`_763`/`_711`/`_870`/`_2481` groups pass
- [x] `cargo test --no-fail-fast --features cli,simd,regex,serde`
- [x] `cargo clippy --all-targets --all-features -- -D warnings` and the CI feature set
- [x] `cargo test --no-default-features`
- [x] `RUSTDOCFLAGS=-D warnings cargo doc --no-deps --all-features`
- [x] `cargo fmt -- --check`

Fixes #2530
