### PR TITLE
fix(jq): yq from_entries stringifies a non-string key (#2521)

### DIFF
--- a/docs/compliance/yq/limitations.md
+++ b/docs/compliance/yq/limitations.md
@@ -2964,6 +2964,43 @@ Three related divergences are **not** covered and stay open:
   multi-valued shape the oracle sweep exercises has either an empty prefix or an iterating
   one (`.a[]`), neither of which can yield an absent node, so the sweep is clean.
 
+### `from_entries`/`with_entries` accept jq's alias set and truthy-fallback where real yq wants an exact, case-sensitive `key`/`value` field — not chased ([#2521](https://github.com/rust-works/succinctly/issues/2521) discovered it, not fixed)
+
+Found while implementing #2521's own numeric-key stringification fix (`entries_to_object`
+now stringifies a scalar key via `yq_object_key_stringify`, matching real yq's `[1,2] |
+to_entries | from_entries` => `{"0":1,"1":2}`). A second, separate divergence surfaced
+alongside it in the same function, live-verified against yq v4.53.3 and left unfixed:
+
+```console
+$ yq -n '[{"key":1,"value":1}] | from_entries'    # {"1":1}
+$ yq -n '[{"Key":1,"value":1}] | from_entries'    # expected to find one 'key' entry but found 0 in position 0
+$ yq -n '[{"name":1,"value":1}] | from_entries'   # same error -- "name"/"Name"/"k"/"K" all rejected too
+$ yq -n '[{"key":1,"Value":9}] | from_entries'    # expected to find one 'value' entry but found 0 in position 0
+$ succinctly yq -n '[{"Key":1,"value":1}] | from_entries'   # {"1":1} -- accepts the jq alias
+```
+
+Real yq's own key/value lookup wants the exact, lowercase field name and nothing else --
+none of jq's alias set (`key`/`Key`/`name`/`Name`/`k`/`K` for the key half, `value`/`Value`
+for the value half) survives past `"key"`/`"value"` themselves. succinctly's
+`entry_key_and_value` (`src/jq/eval.rs`) is shared, unconditional code implementing jq's
+own alias chain (`ENTRY_KEY_ALIASES`) in both modes -- gating it per mode is a real,
+separate fix, not part of this issue's "give `entries_to_object` the `S` parameter" scope.
+
+A second, smaller wrinkle in the same function: jq's own `from_entries` definition reads
+`.key // .k // .name // ...` (a truthy-fallback chain, per real jq's own `builtin.jq`), so
+a *falsy* `.key` (`false`, `0`, `""`) is treated as absent and falls through the whole
+alias chain -- both jq 1.7.1 and succinctly agree there (`[{"key":false,"value":1}] |
+from_entries` is `Cannot use null (null) as object key` in both). Real yq has no such
+fallback: `.key` is read directly, so `[{"key":false,"value":1}] | from_entries` is
+`{"false":1}` there, not a null-key refusal. Both wrinkles are visible together because
+they share the same lookup path (`entry_key_and_value`'s `is_truthy()`-filtered
+`find_map` over `ENTRY_KEY_ALIASES`), but are two independent behaviors: the alias set
+and the truthy-vs-presence check.
+
+Not fixed here: `entry_key_and_value` has no `S: EvalSemantics` parameter today and adding
+one to change its alias list and presence check per mode is a proper follow-up, not a
+one-line change riding along with #2521's own stringification fix.
+
 ### Other categories
 
 Float and number formatting ([#1071](https://github.com/rust-works/succinctly/issues/1071),

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -465,9 +465,10 @@ pub(crate) fn yq_empty_operand_output(
     }
 }
 
-/// yq mode only (#2508): a non-string *scalar* object-construction key
-/// (`{(0): 1}`) stringifies instead of raising jq's `Cannot use <type> as
-/// object key`.
+/// yq mode only (#2508/#2521): a non-string *scalar* key -- an
+/// object-construction key (`{(0): 1}`) or a `from_entries`/`with_entries`
+/// entry's own `key` field -- stringifies instead of raising jq's `Cannot
+/// use <type> as object key`.
 ///
 /// `None` means "keep the existing behavior" -- either jq mode, or a key
 /// this rule does not cover (a real `String` never reaches the caller's own
@@ -476,20 +477,24 @@ pub(crate) fn yq_empty_operand_output(
 ///
 /// Captured live against yq v4.53.3 (`-o=json -I0`, `-n`):
 ///
-/// | filter             | real yq        |
-/// |---------------------|----------------|
-/// | `{(0): 1}`           | `{"0":1}`      |
-/// | `{(1.5): 1}`         | `{"1.5":1}`    |
-/// | `{(1.0): 1}`         | `{"1.0":1}`    |
-/// | `{(1e10): 1}`        | `{"1e10":1}`   |
-/// | `{(true): 1}`        | `{"true":1}`   |
-/// | `{(false): 1}`       | `{"false":1}`  |
-/// | `{(null): 1}`        | `{"null":1}`   |
+/// | filter                                            | real yq        |
+/// |-----------------------------------------------------|----------------|
+/// | `{(0): 1}`                                           | `{"0":1}`      |
+/// | `{(1.5): 1}`                                         | `{"1.5":1}`    |
+/// | `{(1.0): 1}`                                         | `{"1.0":1}`    |
+/// | `{(1e10): 1}`                                        | `{"1e10":1}`   |
+/// | `{(true): 1}`                                        | `{"true":1}`   |
+/// | `{(false): 1}`                                       | `{"false":1}`  |
+/// | `{(null): 1}`                                        | `{"null":1}`   |
+/// | `[1,2] \| to_entries \| from_entries`                | `{"0":1,"1":2}`|
+/// | `{a:1,e:2} \| with_entries(.key = key)`              | `{"0":1,"1":2}`|
+/// | `[{"key":true,"value":1}] \| from_entries`           | `{"true":1}`   |
+/// | `[{"key":null,"value":1}] \| from_entries`           | `{"null":1}`   |
 ///
 /// The `1.0`/`1e10` rows are why this reuses [`owned_to_string`] (the same
-/// conversion `tostring`/[`yq_scalar_string_concat_is_ok`]-style `+` already
-/// use) rather than a fresh `format!`: a `NumberLiteral`'s exact source
-/// spelling survives here too.
+/// conversion `tostring`/`+`'s own string-concatenation rule already use)
+/// rather than a fresh `format!`: a `NumberLiteral`'s exact source spelling
+/// survives here too.
 ///
 /// **Deliberately excludes `Array`/`Object` keys.** Real yq's own
 /// stringification there is a much deeper, likely-unintentional Go-internal
@@ -498,15 +503,16 @@ pub(crate) fn yq_empty_operand_output(
 /// string (`{([1,2,3]): 1}` and `{({"a":1}): 1}` are both `{"":1}`), while
 /// an empty object key is the one exception (`{({}): 1}` is `{"{}":1}`) --
 /// not `owned_to_string`'s own JSON-shaped answer for either case. That is
-/// a separate, much odder divergence than this issue's scope (which only
-/// asked to capture float/bool/null keys), so it is left raising rather
-/// than guessed at.
+/// a separate, much odder divergence than these two issues' scope, so it is
+/// left raising rather than guessed at.
 ///
 /// jq 1.7.1 raises unconditionally for every row above, so jq mode is
 /// untouched. One definition consulted by [`build_object_entries`] (this
-/// file's native fan-out) and `eval_generic::build_object_entries_generic`
-/// (the generic fan-out, already `S`-generic) -- CLAUDE.md's "duplicated
-/// predicates diverge silently" (#106).
+/// file's native object-construction fan-out), `entries_to_object` (shared
+/// by `from_entries`/`with_entries`, both evaluators), and
+/// `eval_generic::build_object_entries_generic` (the generic
+/// object-construction fan-out) -- CLAUDE.md's "duplicated predicates
+/// diverge silently" (#106).
 pub(crate) fn yq_object_key_stringify<S: EvalSemantics>(key: &OwnedValue) -> Option<String> {
     if S::TAG != EvalTag::Yq {
         return None;
@@ -11659,14 +11665,27 @@ fn entry_key_and_value(entry: &OwnedValue) -> Result<(OwnedValue, OwnedValue), E
 /// to look up `value`. Re-inserting a key keeps its original position and
 /// replaces its value, which is what jq's `add` over the mapped singletons
 /// does.
-pub(crate) fn entries_to_object<I: IntoIterator<Item = OwnedValue>>(
+///
+/// `S: EvalSemantics`-generic (#2521) so a non-string *scalar* key
+/// stringifies in yq mode instead of raising -- `[1,2] | to_entries |
+/// from_entries` is `{"0":1,"1":2}` in real yq, and `with_entries` shares
+/// this function per the doc comment above, so `.a | with_entries(.key =
+/// key)` on a mapping is `{"0":1,"1":2}` too (an entry's `key` is its
+/// *position*, a number). See [`yq_object_key_stringify`]'s own doc comment
+/// for the full captured matrix, including why an `Array`/`Object` key is
+/// excluded.
+pub(crate) fn entries_to_object<S: EvalSemantics, I: IntoIterator<Item = OwnedValue>>(
     entries: I,
 ) -> Result<IndexMap<String, OwnedValue>, EvalError> {
     let mut result = IndexMap::new();
     for entry in entries {
         let (key, value) = entry_key_and_value(&entry)?;
-        let OwnedValue::String(k) = key else {
-            return Err(EvalError::cannot_use_as_object_key(&key));
+        let k = match key {
+            OwnedValue::String(s) => s,
+            _ => match yq_object_key_stringify::<S>(&key) {
+                Some(s) => s,
+                None => return Err(EvalError::cannot_use_as_object_key(&key)),
+            },
         };
         result.insert(k, value);
     }
@@ -11712,7 +11731,7 @@ fn builtin_from_entries<W: Clone + AsRef<[u64]>, S: EvalSemantics>(
         Ok(entries) => entries,
         Err(e) => return suppress_or_raise(e, optional),
     };
-    match entries_to_object(entries) {
+    match entries_to_object::<S, _>(entries) {
         Ok(result) => QueryResult::Owned(OwnedValue::Object(result)),
         // The `?` suffix swallows the refusal outright in jq, as the arm
         // above already does for a non-array/non-object input. See
@@ -11800,7 +11819,7 @@ fn builtin_with_entries<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     }
 
     // from_entries
-    match entries_to_object(transformed) {
+    match entries_to_object::<S, _>(transformed) {
         Ok(result) => QueryResult::Owned(OwnedValue::Object(result)),
         Err(_) if optional => QueryResult::None,
         Err(e) => e.into(),

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -16316,7 +16316,7 @@ fn eval_map_family_positioned<S: EvalSemantics, V: DocumentValue>(
         // `from_entries`, the one definition `eval::builtin_with_entries`
         // also ends in -- including its refusal of a key that is not a
         // string, and `?`'s suppression of that refusal.
-        MapFamily::WithEntries => match entries_to_object(array) {
+        MapFamily::WithEntries => match entries_to_object::<S, _>(array) {
             Ok(fields) => OwnedValue::Object(fields),
             Err(_) if optional => return Some(Flow::Exhausted),
             Err(e) => return Some(Flow::Escaped(Control::Error(e))),

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -36308,12 +36308,96 @@ fn test_yq_object_construction_scalar_key_stringify_2508() -> Result<()> {
         "{stderr}"
     );
 
-    // `from_entries` is a separate function (#2521), unaffected by this fix.
-    let (_out, stderr, code) = run_yq_stdin_with_stderr(
+    // `from_entries` is a separate function; #2521 gave it the same rule
+    // (`[{"key":0,"value":1}] | from_entries` is `{"0":1}` in real yq),
+    // pinned by its own test below.
+    let (output, code) = run_yq_stdin(
         r#"[{"key":0,"value":1}] | from_entries"#,
         "null",
-        &["-o", "json"],
+        &["-o", "json", "-I0"],
     )?;
+    assert_eq!(code, 0, "{output:?}");
+    assert_eq!(output.trim(), r#"{"0":1}"#);
+
+    Ok(())
+}
+
+/// #2521: `from_entries`/`with_entries` stringify a non-string *scalar* key
+/// instead of raising jq's `Cannot use <type> as object key` -- the same
+/// rule #2508 gave object construction, extended to `entries_to_object`
+/// (shared by both builtins, per its own doc comment: `with_entries(f)` is
+/// `from_entries(map(f))` in jq's own definition). Captured live from yq
+/// v4.53.3 (`-o=json -I0`) on `n: [1, 2]` and `a: {b: 1, e: 2}`:
+///
+/// ```text
+/// $ yq '.n | to_entries | from_entries'   {"0":1,"1":2}
+/// $ yq '.a | with_entries(.key = key)'    {"0":1,"1":2}
+/// $ yq '.n | with_entries(.value = key)'  {"0":0,"1":1}
+/// $ yq -n '[{"key":true,"value":1}] | from_entries'   {"true":1}
+/// $ yq -n '[{"key":null,"value":1}] | from_entries'   {"null":1}
+/// $ succinctly yq '.n | to_entries | from_entries'  Error: Cannot use number (0) as object key  (was, exit 1)
+/// ```
+///
+/// jq 1.7.1 also errors here (this is yq-only), so jq mode is untouched.
+///
+/// **Not fixed here, discovered alongside and documented instead:** real
+/// yq's own key/value lookup wants an exact, case-sensitive `"key"`/
+/// `"value"` field, rejecting every jq alias (`Key`/`name`/`Name`/`k`/`K`)
+/// succinctly still accepts in both modes, and has no truthy-fallback (a
+/// falsy `false`/`0`/`""` key is read directly, not treated as absent). See
+/// `docs/compliance/yq/limitations.md`'s own entry for the full matrix --
+/// a separate fix (`entry_key_and_value` needs its own `S` parameter),
+/// out of this issue's "give `entries_to_object` the `S` parameter" scope.
+///
+/// Fixed as `eval::entries_to_object` (now `S`-generic), consulted by
+/// `builtin_from_entries`/`builtin_with_entries` (this file) and
+/// `eval_generic`'s `MapFamily::WithEntries` arm.
+#[test]
+fn test_yq_from_entries_scalar_key_stringify_2521() -> Result<()> {
+    let args = &["-o", "json", "-I0"];
+    let doc = "n: [1, 2]\na: {b: 1, e: 2}\n";
+    for (filter, expected) in [
+        (".n | to_entries | from_entries", r#"{"0":1,"1":2}"#),
+        (".a | with_entries(.key = key)", r#"{"0":1,"1":2}"#),
+        (".n | with_entries(.value = key)", r#"{"0":0,"1":1}"#),
+    ] {
+        let (output, code) = run_yq_stdin(filter, doc, args)?;
+        assert_eq!(code, 0, "`{filter}`: {output:?}");
+        assert_eq!(output.trim(), expected, "`{filter}`");
+    }
+
+    // `false` deliberately excluded here: real yq answers `{"false":1}`, but
+    // succinctly's shared `entry_key_and_value` still applies jq's own
+    // truthy-fallback to the key lookup (a separate, documented, not-yet-fixed
+    // divergence -- see `docs/compliance/yq/limitations.md`), so `false`
+    // falls through to a null key there. `true`/`null`/a float all stay
+    // truthy, so they exercise only this issue's own stringification fix.
+    for (entry, expected) in [
+        (r#"{"key":true,"value":1}"#, r#"{"true":1}"#),
+        (r#"{"key":null,"value":1}"#, r#"{"null":1}"#),
+        (r#"{"key":1.5,"value":1}"#, r#"{"1.5":1}"#),
+    ] {
+        let filter = format!("[{entry}] | from_entries");
+        let (output, code) = run_yq_stdin(&filter, "", &["-o", "json", "-I0", "-n"])?;
+        assert_eq!(code, 0, "`{filter}`: {output:?}");
+        assert_eq!(output.trim(), expected, "`{filter}`");
+    }
+
+    // Array/object keys are out of scope (same #2508 exclusion) -- still raise.
+    let (_out, stderr, code) = run_yq_stdin_with_stderr(
+        r#"[{"key":[1,2],"value":1}] | from_entries"#,
+        "",
+        &["-o", "json", "-I0", "-n"],
+    )?;
+    assert_ne!(code, 0);
+    assert!(
+        stderr.contains("Cannot use") && stderr.contains("as object key"),
+        "{stderr}"
+    );
+
+    // jq mode is untouched.
+    let (_out, stderr, code) =
+        run_jq_stdin_with_stderr(r#"[{"key":0,"value":1}] | from_entries"#, "null", &["-n"])?;
     assert_ne!(code, 0);
     assert!(
         stderr.contains("Cannot use number (0) as object key"),


### PR DESCRIPTION
## Summary

`from_entries` and `with_entries` stringify a non-string key in real yq (`.n | to_entries | from_entries` on `n: [1, 2]` is `{"0":1,"1":2}`), where jq 1.7.1 raises. `entries_to_object` becomes generic over the semantics and reuses #2508's predicate, so `with_entries(.key = key)` now answers `{"0":1,"1":2}` as yq does.

Left out and recorded in the limitations doc: real yq's `key`/`value` entry-field lookup is an exact, case-sensitive match with no truthy fallback, while succinctly still accepts jq's alias set (`Key`, `name`, `Name`, `k`, `K`) and truthy-filters `false`/`0`/`""` in both modes; that needs `entry_key_and_value` to take the semantics parameter, outside this issue's scope.

## Verification

fmt; clippy `-D warnings`; `cargo test --features cli,simd,regex,serde`; yq goldens 113; jq goldens 633; oracle sweep 0 unexpected.

Closes #2521.
