### PR TITLE
fix(jq): index a scalar with any key as empty in yq mode (#2482)

### DIFF
--- a/docs/compliance/yq/limitations.md
+++ b/docs/compliance/yq/limitations.md
@@ -2004,24 +2004,33 @@ answers `x: 9` there but does **not** write yq's padding back into `.n` (`{"n":[
 "x":9}` against yq's ten-element `n`) — a separate, pre-existing read-side gap, unchanged
 by #2470 and #2481 alike.
 
-Two neighbouring shapes were captured alongside and are **not** part of this rule; each
-is a separate divergence (three more — ordering comparisons against a real `null`, `|=`
-with a zero-output filter, and the evaluation *order* of an assignment's two sides — were
-captured here too but are now resolved: see
+One neighbouring shape was captured alongside and is **not** part of this rule; it is a
+separate divergence (four more — ordering comparisons against a real `null`, `|=` with a
+zero-output filter, the evaluation *order* of an assignment's two sides, and indexing a
+*scalar* with a key — were captured here too but are now resolved: see
 [#2483](https://github.com/rust-works/succinctly/issues/2483),
-[#2484](https://github.com/rust-works/succinctly/issues/2484) below, and the section
-immediately after this one):
+[#2484](https://github.com/rust-works/succinctly/issues/2484) below, the section
+immediately after this one, and
+[#2482](https://github.com/rust-works/succinctly/issues/2482)):
 
 | filter                                    | input             | real yq        | succinctly                             |
 |-------------------------------------------|-------------------|----------------|----------------------------------------|
-| `.s.zzz`                                  | `s: x`            | *(nothing)*    | `Error: Cannot index string with string "zzz"` |
 | `.a \| with_entries(.value = key)`        | `a: {b: 1, e: 2}` | `{"b":0,"e":1}`| `{"b":1,"e":2}`                        |
 
-Row 1 is yq indexing a *scalar* with a key, which yields nothing everywhere, not only in
-a read-only context — it is what makes `.s.zzz + 1` also `1`. Row 2 is what `key` reports
-for an element of a constructed array: real yq answers the index, succinctly has no path
-context for a value it built itself, so the `=` right side is empty and the write is
-skipped.
+This row is what `key` reports for an element of a constructed array: real yq answers the
+index, succinctly has no path context for a value it built itself, so the `=` right side
+is empty and the write is skipped.
+
+**Resolved (#2482):** indexing a *scalar* (string/number/boolean) with any key -- a field
+name (`.s.zzz`), a numeric index (`.s[0]`), or a computed key of either kind -- yields
+nothing everywhere in real yq, not only in a read-only context (it is what makes
+`.s.zzz + 1` also `1`), where succinctly used to raise jq's own `Cannot index <type> with
+<key>` in yq mode too. Fixed as `jq::eval::yq_field_index_on_scalar_is_empty`, consulted
+by both evaluators at every scalar-target index site; see that predicate's own doc
+comment for the full call-site list and `tests/yq_cli_tests.rs`'s
+`test_yq_index_scalar_with_key_is_empty_2482` for the full captured matrix. `null` is
+unaffected (it keeps its own separate, unconditional-null rule), and a real container
+target keeps its own structural error.
 
 ### An assignment's target is created before its right side runs — resolved (#2481)
 
@@ -2205,13 +2214,16 @@ identical copy of the same three lines; it now calls into the `Expr::Identity` a
 of duplicating it, so this fix (and any future one) cannot drift between the two the way
 CLAUDE.md's "duplicated predicates diverge silently" warns about.
 
-**Not chased here:** `.a |= (.zzz | key)` on `a: 1` (also asked for in the issue) is not
-part of this fix. Real yq answers `{"a":1}` because `.zzz` on the number `1` -- `|=`'s
-right side runs against the *target's own value*, not the whole document -- yields
-nothing there (yq indexes a scalar with a key as "nothing everywhere", the "Row 2"
-divergence in the entry above); succinctly still raises `Cannot index number with string
-"zzz"` for that shape, so the update filter never gets the chance to become zero-output in
-the first place. That is the pre-existing scalar-indexing gap, not this one.
+**Not chased here, but since resolved by a different fix:** `.a |= (.zzz | key)` on `a: 1`
+(also asked for in the issue) was not part of this fix at the time. Real yq answers
+`{"a":1}` because `.zzz` on the number `1` -- `|=`'s right side runs against the *target's
+own value*, not the whole document -- yields nothing there (yq indexes a scalar with a key
+as "nothing everywhere" everywhere, not only read-only). succinctly used to raise `Cannot
+index number with string "zzz"` for that shape instead, so the update filter never got the
+chance to become zero-output in the first place -- that was the pre-existing
+scalar-indexing gap, not this one. [#2482](https://github.com/rust-works/succinctly/issues/2482)
+has since closed it directly (see the entry above), and succinctly now answers `{"a":1}`
+here too.
 
 ### A negative out-of-range array index (`.a[-N]`) raises -- resolved for ordinary reads, a few call sites remain
 

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -17711,6 +17711,14 @@ fn index_object_by_name<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
         // jq returns null for field access on null
         StandardJson::Null if absent_is_empty => QueryResult::None,
         StandardJson::Null => QueryResult::One(StandardJson::Null),
+        // #2482 (yq mode): a scalar (string/number/boolean) has no fields at
+        // all in real yq's model, but that reads as an *empty* result, not
+        // jq's structural error -- see `yq_field_index_on_scalar_is_empty`.
+        StandardJson::String(_) | StandardJson::Number(_) | StandardJson::Bool(_)
+            if yq_field_index_on_scalar_is_empty::<S>() =>
+        {
+            QueryResult::None
+        }
         _ if optional => QueryResult::None,
         _ => QueryResult::Error(EvalError::cannot_index_with_field(type_name(&value), name)),
     }
@@ -17759,6 +17767,14 @@ fn index_array_by_position<W: Clone + AsRef<[u64]>, S: EvalSemantics>(
         StandardJson::Null => QueryResult::One(StandardJson::Null),
         StandardJson::Object(_) if yq_numeric_index_on_object_is_null::<S>() => {
             QueryResult::One(StandardJson::Null)
+        }
+        // #2482 (yq mode): `.s[0]` on a scalar `s` -- same empty-not-error
+        // rule as the field-name sibling in `index_object_by_name`, see
+        // `yq_field_index_on_scalar_is_empty`.
+        StandardJson::String(_) | StandardJson::Number(_) | StandardJson::Bool(_)
+            if yq_field_index_on_scalar_is_empty::<S>() =>
+        {
+            QueryResult::None
         }
         _ if optional => QueryResult::None,
         _ => QueryResult::Error(EvalError::cannot_index_with_type(
@@ -17884,6 +17900,33 @@ pub(crate) fn yq_numeric_index_on_object_is_null<S: EvalSemantics>() -> bool {
     S::TAG == EvalTag::Yq
 }
 
+/// Whether indexing a *scalar* (string, number, or boolean -- **not** `null`,
+/// which already has its own unconditional-null rule) with any key -- a
+/// field name, a numeric index, or a computed key of either kind -- produces
+/// **no output** rather than jq's `Cannot index <type> with <key>`.
+///
+/// Real yq v4.53.3 (confirmed live, #2482) has no notion of "indexable" the
+/// way jq does: on `s: x`, `.s.zzz` and `.s[0]` both print nothing at all
+/// (exit 0), not even a `null` node -- but `.s.zzz + 1` is `1`, since the
+/// empty read still resolves to `null` once it reaches an arithmetic
+/// operand (`yq_empty_operand_output`'s own zero-output row). `.s | .zzz`
+/// and `.s.zzz | key`/`| path` are the same empty read through a pipe/path
+/// step. `-e` still reports "no matches found" (exit 1), same as any other
+/// empty read. jq raises unconditionally, which is what succinctly
+/// reproduced in both modes before this rule. The *write* side (`.s.zzz =
+/// 1`) is untouched by this predicate -- it already no-ops via
+/// `yq_assign_classify`'s total-noop classification, a separate mechanism.
+///
+/// `S: EvalSemantics`-generic so every scalar-target index site in both
+/// evaluators -- `index_object_by_name`/`index_array_by_position`/
+/// `index_one` here, and their `eval_generic` counterparts (`eval_single`'s
+/// `Expr::Field`/`Expr::Index` arms, `index_one_generic`, and
+/// `path_step_generic`'s `Expr::Field`/`Expr::Index` arms) -- consult one
+/// definition (CLAUDE.md's "duplicated predicates diverge silently", #106).
+pub(crate) fn yq_field_index_on_scalar_is_empty<S: EvalSemantics>() -> bool {
+    S::TAG == EvalTag::Yq
+}
+
 /// Apply one resolved key to one target value.
 ///
 /// The key kind is dispatched *before* the container is inspected, so the error
@@ -17914,6 +17957,16 @@ fn index_one<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
                 // no element. jq yields null rather than erroring.
                 None => QueryResult::One(StandardJson::Null),
             }
+        }
+        // #2482 (yq mode): a computed key (`.s[$k]`) on a scalar target is
+        // the same empty-not-error rule as the literal-field/literal-index
+        // siblings above -- see `yq_field_index_on_scalar_is_empty`.
+        _ if matches!(
+            target,
+            StandardJson::String(_) | StandardJson::Number(_) | StandardJson::Bool(_)
+        ) && yq_field_index_on_scalar_is_empty::<S>() =>
+        {
+            QueryResult::None
         }
         _ if optional => QueryResult::None,
         _ => QueryResult::Error(EvalError::cannot_index(type_name(&target), key)),
@@ -31116,6 +31169,19 @@ fn eval_owned_navigation<S: EvalSemantics>(
             }),
             OwnedValue::Null if yq_absent_key_read_is_empty::<S>() => Ok(None),
             OwnedValue::Null => Ok(Some(OwnedValue::Null)),
+            // #2482 (yq mode): a scalar has no fields at all in real yq's
+            // model, and that's an empty result, not jq's structural error
+            // -- same rule, same predicate as `index_object_by_name`'s own
+            // scalar arm.
+            OwnedValue::String(_)
+            | OwnedValue::Int(_)
+            | OwnedValue::Float(_)
+            | OwnedValue::NumberLiteral(..)
+            | OwnedValue::Bool(_)
+                if yq_field_index_on_scalar_is_empty::<S>() =>
+            {
+                Ok(None)
+            }
             _ if optional => Ok(None),
             _ => Err(EvalError::cannot_index_with_field(
                 owned_type_name(input),
@@ -31155,6 +31221,17 @@ fn eval_owned_navigation<S: EvalSemantics>(
             // own `Object` arm. See `yq_numeric_index_on_object_is_null`.
             OwnedValue::Object(_) if yq_numeric_index_on_object_is_null::<S>() => {
                 Ok(Some(OwnedValue::Null))
+            }
+            // #2482 (yq mode): `.s[0]` on a scalar `s` -- same empty rule as
+            // the sibling `Expr::Field` arm above.
+            OwnedValue::String(_)
+            | OwnedValue::Int(_)
+            | OwnedValue::Float(_)
+            | OwnedValue::NumberLiteral(..)
+            | OwnedValue::Bool(_)
+                if yq_field_index_on_scalar_is_empty::<S>() =>
+            {
+                Ok(None)
             }
             _ if optional => Ok(None),
             _ => Err(EvalError::cannot_index_with_type(
@@ -36064,6 +36141,17 @@ fn eval_stage_with_path_context<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
                     optional,
                 );
             }
+            // #2482 (yq mode): a scalar (string/number/boolean) has no
+            // fields at all in real yq's model -- an empty result, not jq's
+            // structural error. An array target still raises its own
+            // structural error (`.arr.zzz`), excluded here the same way the
+            // ordinary (non-path-context) `index_object_by_name` excludes
+            // it. `rest` never runs (there's no node to continue from), the
+            // same "no position produced" outcome the absent-key arm above
+            // returns.
+            if !matches!(value, OwnedValue::Array(_)) && yq_field_index_on_scalar_is_empty::<S>() {
+                return QueryResult::None;
+            }
             // Non-object/null: error (or None if optional). #2212/#2227:
             // currently unreachable with `optional == true` -- see this
             // function's own doc comment for the verification method.
@@ -36153,6 +36241,13 @@ fn eval_stage_with_path_context<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
                     &new_path,
                     optional,
                 );
+            }
+            // #2482 (yq mode): every yq-mode `Object` case was already
+            // absorbed by the branch above -- only a genuine scalar reaches
+            // here. `.s[0] | key` is empty in real yq, same as `Expr::
+            // Field`'s own scalar arm.
+            if yq_field_index_on_scalar_is_empty::<S>() {
+                return QueryResult::None;
             }
             // #2212/#2227: currently unreachable with `optional == true` --
             // same verification as `Expr::Field`'s sibling arm above.

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -48,9 +48,10 @@ use super::eval::{
     slice_object_as_yq_children, slice_owned_value_read, streams_escaped_generator_prefix,
     substitute_bound_var, substitute_vars, suppress_or_raise, suppresses, tonumber_from_str,
     vec_with_capacity, yq_absent_key_read_is_empty, yq_empty_operand_output,
-    yq_negative_index_check, yq_numeric_index_on_object_is_null, yq_object_key_stringify,
-    yq_read_only_context, BinaryFanoutRules, Control, Demand, EmptyOperandOp, EvalError,
-    EvalSemantics, EvalTag, Flow, JqSemantics, LimitN, PathTrail, QueryResult, YqSemantics,
+    yq_field_index_on_scalar_is_empty, yq_negative_index_check, yq_numeric_index_on_object_is_null,
+    yq_object_key_stringify, yq_read_only_context, BinaryFanoutRules, Control, Demand,
+    EmptyOperandOp, EvalError, EvalSemantics, EvalTag, Flow, JqSemantics, LimitN, PathTrail,
+    QueryResult, YqSemantics,
 };
 #[cfg(test)]
 use super::expr::FuncDefBound;
@@ -5824,6 +5825,17 @@ fn eval_single<S: EvalSemantics, V: DocumentValue>(
                 } else {
                     GenericResult::Owned(OwnedValue::Null)
                 }
+            } else if value.as_array().is_none() && yq_field_index_on_scalar_is_empty::<S>() {
+                // #2482 (yq mode, unconditional -- not gated on read-only
+                // context like `absent_is_empty` above): a genuine scalar
+                // (string/number/boolean) has no fields at all in real yq's
+                // model, and that reads as an *empty* result everywhere, not
+                // just inside a binary-op operand. An *array* target still
+                // raises its own structural error in real yq (`.arr.zzz` on
+                // `arr: [1, 2]`, confirmed live), so this is gated on "not a
+                // container" rather than "anything but object/null". See
+                // `eval::yq_field_index_on_scalar_is_empty`.
+                GenericResult::None
             } else if optional {
                 GenericResult::None
             } else {
@@ -5883,6 +5895,14 @@ fn eval_single<S: EvalSemantics, V: DocumentValue>(
                 // applies for the computed-key sibling `.a[$k]`. See
                 // `eval::yq_numeric_index_on_object_is_null`.
                 GenericResult::Owned(OwnedValue::Null)
+            } else if yq_field_index_on_scalar_is_empty::<S>() {
+                // #2482 (yq mode): every yq-mode `Object` case was already
+                // absorbed by the branch above (the predicate there is
+                // unconditionally true in yq mode), so only a genuine scalar
+                // (string/number/boolean) reaches here -- `.s[0]` on `s: x`
+                // is empty in real yq, not an error. See
+                // `eval::yq_field_index_on_scalar_is_empty`.
+                GenericResult::None
             } else {
                 // No `optional`-guarded arm here (unlike `index_one_generic`,
                 // the computed-key sibling this literal `.[N]` form doesn't
@@ -9809,6 +9829,14 @@ fn index_one_generic<S: EvalSemantics, V: DocumentValue>(
                 } else {
                     GenericResult::Owned(OwnedValue::Null)
                 }
+            } else if target.as_array().is_none() && yq_field_index_on_scalar_is_empty::<S>() {
+                // #2482 (yq mode): a computed string key (`.s[$k]`) on a
+                // scalar target is the same empty-not-error rule as the
+                // literal-field sibling in `eval_single`'s own `Expr::Field`
+                // arm -- see `eval::yq_field_index_on_scalar_is_empty`. An
+                // array target keeps its own structural error, excluded the
+                // same way that sibling arm excludes it.
+                GenericResult::None
             } else if optional {
                 GenericResult::None
             } else {
@@ -9865,11 +9893,29 @@ fn index_one_generic<S: EvalSemantics, V: DocumentValue>(
                 || (target.as_object().is_some() && yq_numeric_index_on_object_is_null::<S>())
             {
                 GenericResult::Owned(OwnedValue::Null)
+            } else if yq_field_index_on_scalar_is_empty::<S>() {
+                // #2482 (yq mode): every yq-mode `Object` case was already
+                // absorbed by the branch above -- only a genuine scalar
+                // reaches here. `.s[0]`/`0 as $k | .s[$k]` on `s: x` are
+                // both empty in real yq, not an error.
+                GenericResult::None
             } else if optional {
                 GenericResult::None
             } else {
                 GenericResult::Error(EvalError::cannot_index(target.type_name(), key))
             }
+        }
+        // #2482 (yq mode): any other key kind (bool/array/object/null) on a
+        // scalar target is the same empty-not-error rule -- real yq has no
+        // notion of "wrong key kind" for a target that has no children at
+        // all (confirmed live: `null as $k | .s[$k]`, `[1,2] as $k |
+        // .s[$k]`, and `{} as $k | .s[$k]` are all empty on `s: x`).
+        _ if target.as_array().is_none()
+            && target.as_object().is_none()
+            && !target.is_null()
+            && yq_field_index_on_scalar_is_empty::<S>() =>
+        {
+            GenericResult::None
         }
         _ if optional => GenericResult::None,
         _ => GenericResult::Error(EvalError::cannot_index(target.type_name(), key)),
@@ -11552,6 +11598,19 @@ fn path_step_generic<S: EvalSemantics, V: DocumentValue>(
                             Some(fc) => PathNode::At(fc),
                             None => PathNode::Absent,
                         }
+                    } else if v.as_array().is_none() && yq_field_index_on_scalar_is_empty::<S>() {
+                        // #2482 (yq mode, unconditional -- not gated on
+                        // read-only context like the absent-key rule below):
+                        // a scalar has no fields at all in real yq's model,
+                        // and the walk produces no position to continue
+                        // from at all, so `key`/`path` are never reached
+                        // either -- `.s.zzz | key` is empty in real yq,
+                        // same as the bare read. An array target still
+                        // raises its own structural error (`.arr.zzz`),
+                        // excluded here the same way `eval_single`'s own
+                        // `Expr::Field` arm excludes it. See
+                        // `eval::yq_field_index_on_scalar_is_empty`.
+                        return Ok(());
                     } else {
                         return Err(EvalError::cannot_index_with_field(
                             path_node_type_name::<V>(node),
@@ -11631,6 +11690,13 @@ fn path_step_generic<S: EvalSemantics, V: DocumentValue>(
                         // `.a[5] | key` is `5`, `.a[5] | path` is `["a",5]`.
                         // See `eval::yq_numeric_index_on_object_is_null`.
                         PathNode::Absent
+                    } else if yq_field_index_on_scalar_is_empty::<S>() {
+                        // #2482 (yq mode): every yq-mode `Object` case was
+                        // already absorbed by the branch above -- only a
+                        // genuine scalar reaches here. `.s[0] | key` is
+                        // empty in real yq, same as `Expr::Field`'s own
+                        // scalar arm above.
+                        return Ok(());
                     } else {
                         return Err(EvalError::cannot_index_with_type(
                             path_node_type_name::<V>(node),

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -6283,9 +6283,17 @@ fn test_yaml_explicit_tag_resolves_through_alias_903() -> Result<()> {
 fn test_yaml_explicit_tag_error_messages_agree_with_type_903() -> Result<()> {
     let input = "a: !!str 1\n";
 
-    let (_, err, code) = run_yq_stdin_with_stderr(".a.foo", input, &[])?;
-    assert_eq!(code, 1);
-    assert!(err.contains("Cannot index string with"), "{err}");
+    // #2482 closed this particular row's error off entirely: a scalar
+    // (tagged or not) indexed by a field name is now an empty read in yq
+    // mode, never `Cannot index string with...` -- so `tagged_type_name`'s
+    // divergent (explicit-tag) branch is no longer reachable through
+    // `Expr::Field`/`Expr::Index`'s own error arm at all (real yq has no
+    // such error to match). The other four rows below are unaffected --
+    // none of them navigate through `Expr::Field`/`Expr::Index`, so they
+    // still exercise `tagged_type_name` on this exact tagged value.
+    let (out, code) = run_yq_stdin(".a.foo", input, &[])?;
+    assert_eq!(code, 0);
+    assert_eq!(out.trim(), "");
 
     let (_, err, code) = run_yq_stdin_with_stderr(".a | last", input, &[])?;
     assert_eq!(code, 1);
@@ -28258,15 +28266,21 @@ fn test_map_preserves_presentation_inplace_757() -> Result<()> {
 /// byte-at-a-time writer could not avoid.
 #[test]
 fn test_map_error_writes_no_truncated_prefix_757() -> Result<()> {
-    // Element 1 converts fine; element 2 cannot be indexed.
+    // Element 1 converts fine; element 2 cannot be indexed. #2482: a
+    // *scalar* (number/string/boolean) target no longer errors here in yq
+    // mode (`.a.b` on `a: 5` is empty, not `Cannot index number...`), so
+    // this uses an *array* target instead -- real yq still raises its own
+    // structural error there (`.arr.zzz`, confirmed live), unaffected by
+    // that fix.
     let (stdout, stderr, code) =
-        run_yq_stdin_with_stderr("map(.a.b)", "- a: {b: 1}\n- a: 5\n", &[])?;
+        run_yq_stdin_with_stderr("map(.a.b)", "- a: {b: 1}\n- a: [1, 2]\n", &[])?;
     assert_eq!(stdout, "", "no partial array may reach stdout");
-    assert!(stderr.contains("Cannot index number"), "stderr: {stderr:?}");
+    assert!(stderr.contains("Cannot index array"), "stderr: {stderr:?}");
     assert_eq!(code, 1);
 
     // Same for a body that fails on the very first element.
-    let (stdout, _, code) = run_yq_stdin_with_stderr("map(.a.b)", "- a: 5\n- a: 6\n", &[])?;
+    let (stdout, _, code) =
+        run_yq_stdin_with_stderr("map(.a.b)", "- a: [1, 2]\n- a: [3, 4]\n", &[])?;
     assert_eq!(stdout, "");
     assert_eq!(code, 1);
     Ok(())
@@ -28331,19 +28345,22 @@ fn test_map_over_empty_container_757() -> Result<()> {
 /// rather than silently change output.
 #[test]
 fn test_map_multidoc_separator_matches_other_m2_expressions_757() -> Result<()> {
+    // #2482: an array target, not a scalar (`a: 5` no longer errors here in
+    // yq mode -- see `test_map_error_writes_no_truncated_prefix_757`'s own
+    // updated doc comment).
     let (map_out, _, code) =
-        run_yq_stdin_with_stderr("map(.a.b)", "- a: {b: 1}\n---\n- a: 5\n", &[])?;
+        run_yq_stdin_with_stderr("map(.a.b)", "- a: {b: 1}\n---\n- a: [1, 2]\n", &[])?;
     assert_eq!(map_out, "- 1\n---\n");
     assert_eq!(code, 1);
 
     // The pre-existing M2 expression, same shape, same trailing separator.
-    let (nav_out, _, code) = run_yq_stdin_with_stderr(".a.b", "a: {b: 1}\n---\na: 5\n", &[])?;
+    let (nav_out, _, code) = run_yq_stdin_with_stderr(".a.b", "a: {b: 1}\n---\na: [1, 2]\n", &[])?;
     assert_eq!(nav_out, "1\n---\n");
     assert_eq!(code, 1);
 
     // The DOM path suppresses it, for `map` and navigation alike.
     let (dom_out, _, code) =
-        run_yq_stdin_with_stderr("map(.a.b)", "- a: {b: 1}\n---\n- a: 5\n", &["-P"])?;
+        run_yq_stdin_with_stderr("map(.a.b)", "- a: {b: 1}\n---\n- a: [1, 2]\n", &["-P"])?;
     assert_eq!(dom_out, "- 1\n");
     assert_eq!(code, 1);
     Ok(())
@@ -30452,15 +30469,21 @@ fn test_runaway_recursion_errors_cleanly_in_yq_mode_1371() -> Result<()> {
 #[test]
 fn fold_source_value_reuse_is_jq_mode_only_1872() -> Result<()> {
     // The `scalar_noop` shape: still the evaluator's own type error, not
-    // the resolver's target-unchanged branch value.
+    // the resolver's target-unchanged branch value. #2482: an *array*
+    // target, not a scalar -- `.a.b` on a number/string/boolean `a` no
+    // longer errors in yq mode at all (it's an empty read there now), so
+    // this needs a shape the evaluator still genuinely raises on to keep
+    // testing what it always tested (real yq still raises its own
+    // structural error on a field-name index into an array, confirmed
+    // live).
     let (_out, stderr, code) = run_yq_stdin_with_stderr(
         "path(foreach (.a.b) as $k (.; .))",
-        "a: 1\n",
+        "a: [1, 2]\n",
         &["-o", "json"],
     )?;
     assert_ne!(code, 0);
     assert!(
-        stderr.contains(r#"Cannot index number with string "b""#),
+        stderr.contains(r#"Cannot index array with string "b""#),
         "stderr: {stderr}"
     );
 
@@ -32300,33 +32323,32 @@ fn test_yq_pipe_precedence_holds_at_every_depth_2420() -> Result<()> {
     Ok(())
 }
 
-/// #2420: a probe where succinctly's post-fix grouping is right but the
-/// *output* still differs from real yq, for reasons scoped elsewhere. Pinned
-/// so the residue is visible rather than mistaken for a precedence bug.
+/// #2420: a probe that used to carry two residual divergences where
+/// succinctly's post-fix *grouping* was right but the *output* still
+/// differed from real yq, for reasons scoped elsewhere. Both are now
+/// closed, so this pins the (now-matching) output instead of the residue.
 #[test]
 fn test_yq_pipe_precedence_residual_divergences_2420() -> Result<()> {
     let args = &["-o", "json", "-I0"];
 
     // Grouping is `(.a | .b), (.c | . + 1)`; `.a | .b` indexes the number 1
-    // and fails in both tools. Real yq *drops* the failing comma branch
-    // silently and prints only the second:
+    // with a field name. This used to look like real yq "dropping" a
+    // failing comma branch, but #2482 supplies the real mechanism: `.a | .b`
+    // was never an error in real yq to begin with (indexing a scalar with a
+    // key is an empty read there, not a structural error) -- there is no
+    // failing branch for a comma to drop. succinctly now agrees:
     // $ yq -o=json -I0 '.a | .b, .c | . + 1'  =>  4   (exit 0, empty stderr)
-    // succinctly is fail-loud here, as jq is:
+    // jq's own model has no such rule, so it still raises there:
     // $ jq -c '.a | .b, .c | . + 1'  =>  "Cannot index number with string
     //                                     \"b\"" (exit 5, no stdout)
-    // That silent-drop behaviour is a separate divergence from #2420's
-    // grouping, and is not what this change is about.
     let (stdout, stderr, code) =
         run_yq_stdin_with_stderr(".a | .b, .c | . + 1", PRECEDENCE_DOC_2420, args)?;
-    assert_eq!(code, 1);
-    assert_eq!(stdout, "");
-    assert!(
-        stderr.contains("Cannot index number with string \"b\""),
-        "stderr: {stderr:?}"
-    );
+    assert_eq!(code, 0, "stderr: {stderr:?}");
+    assert_eq!(stdout.trim(), "4");
+    assert_eq!(stderr, "");
 
     // The second residual this test used to carry -- `(.a, .b) | (.c, .d)`
-    // answering `3 4 5 6` where yq answers `3 5 4 6` -- is gone: that was
+    // answering `3 4 5 6` where yq answers `3 5 4 6` -- is gone too: that was
     // yq's context-list evaluation model, not its precedence table, and
     // #2451 implements it. See `test_yq_pipe_into_union_is_branch_major_2451`.
 
@@ -36403,6 +36425,118 @@ fn test_yq_from_entries_scalar_key_stringify_2521() -> Result<()> {
         stderr.contains("Cannot use number (0) as object key"),
         "{stderr}"
     );
+
+    Ok(())
+}
+
+/// #2482: indexing a *scalar* (string/number/boolean) with any key -- a
+/// field name (`.s.zzz`), a numeric index (`.s[0]`), or a computed key of
+/// either kind -- produces no output at all in real yq, not jq's `Cannot
+/// index <type> with <key>` structural error, which succinctly reproduced
+/// in both modes before this fix. Captured live from yq v4.53.3 on `s: x`
+/// (plain scalar output -- yq prints nothing for an empty stream, so
+/// `-o=json -I0`'s bracketing would only obscure that):
+///
+/// ```text
+/// $ yq '.s.zzz'          (nothing, exit 0)
+/// $ yq '.s.zzz + 1'      1
+/// $ yq '.s[0]'           (nothing, exit 0)
+/// $ yq '.s[]'            (nothing, exit 0)
+/// $ yq '.s | .zzz'       (nothing, exit 0)
+/// $ yq '.s.zzz?'         (nothing, exit 0)
+/// $ yq '.s.zzz | key'    (nothing, exit 0)
+/// $ yq '.s.zzz | path'   (nothing, exit 0)
+/// $ yq -e '.s.zzz'       Error: no matches found  (exit 1)
+/// $ yq '.s.zzz = 1'      s: x   (unchanged -- a pre-existing no-op via
+///                                `yq_assign_classify`'s total-noop
+///                                classification, untouched by this fix)
+/// $ succinctly yq '.s.zzz'   Error: Cannot index string with string "zzz"  (was, exit 1)
+/// ```
+///
+/// Same empty-not-error rule on a number/boolean target (`n: 5`, `b: true`):
+/// `.n.zzz`, `.b.zzz`, `.n.zzz + 1` and `.b.zzz + 1` (both `1`). `null` is
+/// unaffected -- `.z.zzz` on `z: null` is already `null` in both real and
+/// succinctly yq (indexing `null` keeps its own separate, unconditional-null
+/// rule; it is not treated as a "scalar" by this predicate). A real
+/// container target keeps its own structural error: `.arr.zzz` on `arr:
+/// [1, 2]` is `Error: cannot index array with 'zzz' (...)` in real yq (a
+/// different message, still an error, exit 1) -- unaffected, since this
+/// predicate is gated on "not a container", not merely "not an object".
+///
+/// jq 1.7.1 raises unconditionally (`Cannot index string with string
+/// "zzz"`), so jq mode is untouched -- not asserted against the oracle
+/// here, see `test_jq_mode_has_no_downcase_upcase_2462`'s own precedent
+/// (jq_cli_tests.rs) for why jq mode's own suite covers that side.
+///
+/// Fixed as `eval::yq_field_index_on_scalar_is_empty`, consulted by both
+/// evaluators at every scalar-target index site: `eval::
+/// index_object_by_name`/`index_array_by_position`/`index_one`/
+/// `eval_owned_navigation`/`eval_stage_with_path_context`'s `Expr::Field`/
+/// `Expr::Index` arms, and `eval_generic`'s `eval_single`'s `Expr::Field`/
+/// `Expr::Index` arms, `index_one_generic`, and `path_step_generic`'s
+/// `Expr::Field`/`Expr::Index` arms -- one definition, several call sites
+/// (CLAUDE.md's "duplicated predicates diverge silently", #106).
+#[test]
+fn test_yq_index_scalar_with_key_is_empty_2482() -> Result<()> {
+    let doc = "s: x\nn: 5\nb: true\nz: null\narr:\n  - 1\n  - 2\n";
+    for filter in [
+        ".s.zzz",
+        ".s[0]",
+        ".s[]",
+        ".s | .zzz",
+        ".s.zzz?",
+        ".s.zzz | key",
+        ".s.zzz | path",
+        ".n.zzz",
+        ".b.zzz",
+        "0 as $k | .s[$k]",
+        "\"zzz\" as $k | .s[$k]",
+        "null as $k | .s[$k]",
+    ] {
+        let (output, code) = run_yq_stdin(filter, doc, &[])?;
+        assert_eq!(code, 0, "`{filter}`: {output:?}");
+        assert_eq!(
+            output.trim(),
+            "",
+            "`{filter}` should print nothing, got {output:?}"
+        );
+    }
+
+    // Arithmetic operand context: the empty read still resolves to `null`.
+    for (filter, expected) in [
+        (".s.zzz + 1", "1"),
+        (".n.zzz + 1", "1"),
+        (".b.zzz + 1", "1"),
+    ] {
+        let (output, code) = run_yq_stdin(filter, doc, &[])?;
+        assert_eq!(code, 0, "`{filter}`: {output:?}");
+        assert_eq!(output.trim(), expected, "`{filter}`");
+    }
+
+    // `null` keeps its own separate, unconditional-null rule -- not "scalar".
+    let (output, code) = run_yq_stdin(".z.zzz", doc, &[])?;
+    assert_eq!(code, 0);
+    assert_eq!(output.trim(), "null");
+
+    // A real container keeps its own structural error -- a different
+    // message than the scalar case, but still an error -- this predicate is
+    // gated on "not a container".
+    let (_out, stderr, code) = run_yq_stdin_with_stderr(".arr.zzz", doc, &[])?;
+    assert_ne!(code, 0, "`.arr.zzz` should still error");
+    assert!(stderr.contains("Cannot index array"), "got: {stderr}");
+
+    // `-e`: an empty stream still reports "no matches found" (exit 1), same
+    // as any other empty read.
+    let (_out, stderr, code) = run_yq_stdin_with_stderr(".s.zzz", doc, &["-e"])?;
+    assert_ne!(code, 0, "`-e` over an empty stream should exit non-zero");
+    assert!(stderr.contains("no matches found"), "got: {stderr}");
+
+    // Write side is a pre-existing no-op (`yq_assign_classify`'s total-noop
+    // classification), untouched by this predicate -- captured here for
+    // completeness, not as new behavior.
+    let (output, code) = run_yq_stdin(".s.zzz = 1", doc, &[])?;
+    assert_eq!(code, 0);
+    assert!(output.contains("s: x"), "got: {output:?}");
 
     Ok(())
 }


### PR DESCRIPTION
## Summary

Indexing a scalar (string, number, boolean) with any key yields nothing in real yq, where jq 1.7.1 raises `Cannot index string with string "zzz"`; succinctly reproduced jq's error in both modes. One predicate, `yq_field_index_on_scalar_is_empty`, is now consulted at the seven navigation sites across both evaluators, so `.s.zzz`, `.s[0]`, `.s[]`, `.s | .zzz`, a computed key, and `.s.zzz | key`/`path` all match yq v4.53.3; `null` and container targets keep their own rules, and the write side was already a no-op. jq mode is unchanged and pinned. Two related entries in the limitations doc close.

## Verification

fmt; clippy `-D warnings`; `cargo test --features cli,simd,regex,serde`; yq goldens 113; jq goldens 633; oracle sweep 0 unexpected. Pre-existing tests that had pinned the error were re-verified against the live oracles before being updated.

Closes #2482.
