### PR TITLE
fix(jq): concatenate a string with a number or boolean in yq's + (#2507)

### DIFF
--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -526,6 +526,52 @@ pub(crate) fn yq_object_key_stringify<S: EvalSemantics>(key: &OwnedValue) -> Opt
     }
 }
 
+/// yq mode only (#2507): whether `+` mixing a string with a number or
+/// boolean, in either order, concatenates instead of raising jq's `<type>
+/// and <type> cannot be added`.
+///
+/// Real yq's `+` has no notion of "wrong type" for this pairing at all --
+/// the non-string side is converted to its string spelling and appended.
+/// Captured live against yq v4.53.3 (`-o=json -I0`, `-n`):
+///
+/// | filter              | real yq   | filter              | real yq   |
+/// |---------------------|-----------|----------------------|-----------|
+/// | `0 + "x"`            | `"0x"`    | `"x" + 0`            | `"x0"`    |
+/// | `1.5 + "x"`          | `"1.5x"`  | `"x" + 1.5`          | `"x1.5"`  |
+/// | `1.0 + "x"`          | `"1.0x"`  | `"x" + 1.0`          | `"x1.0"`  |
+/// | `1e100 + "x"`        | `"1e100x"`| `"x" + 1e100`        | `"x1e100"`|
+/// | `(0-5) + "x"`        | `"-5x"`   | `"x" + (0-5)`        | `"x-5"`   |
+/// | `true + "x"`         | `"truex"` | `"x" + true`         | `"xtrue"` |
+/// | `false + "x"`        | `"falsex"`| `"x" + false`        | `"xfalse"`|
+///
+/// The `1.0`/`1e100` rows are why this reuses [`owned_to_string`] (the same
+/// conversion `tostring`/string interpolation already use) rather than a
+/// fresh `format!("{}", ...)`: a `NumberLiteral`'s exact source spelling
+/// must survive into the concatenation, the same way it survives into
+/// `tostring`.
+///
+/// **Scoped to non-container scalars only** -- confirmed live that `"x" +
+/// [1,2]`/`{} + "x"`/`"x" + {}` all still raise (`!!seq () cannot be added
+/// to a !!str ()`, and the object-arm's own mirrored wording), and `[1,2] +
+/// "x"` is a *different*, already-implemented rule (`arith_add`'s
+/// `S::ARRAY_PLUS_APPENDS` arm, #1119) that appends the string as a single
+/// new array element rather than concatenating text. `-`/`*` were captured
+/// alongside for completeness and need no fix: every scalar/string mismatch
+/// for those two still raises in real yq too (`0 - "x"`, `"x" - 0`, `true -
+/// "x"`, `true * "x"`, ... all error live), so `arith_sub`/`arith_mul`'s
+/// existing catch-all error arms already agree with the oracle. jq 1.7.1
+/// raises unconditionally for every row in the table above, which is what
+/// succinctly reproduced in both modes before this fix.
+///
+/// One definition consulted by [`arith_add`], the single function both
+/// evaluators' arithmetic fan-outs already route through (`eval_generic`'s
+/// own arithmetic arms import and call `arith_combine` directly rather than
+/// hand-rolling a second `+`/`-`/`*`/`/`/`%` implementation) -- CLAUDE.md's
+/// "duplicated predicates diverge silently" (#106).
+pub(crate) fn yq_scalar_string_concat_is_ok<S: EvalSemantics>() -> bool {
+    S::TAG == EvalTag::Yq
+}
+
 /// yq mode only (#2483): an ordering comparison (`<`/`<=`/`>`/`>=`) against a
 /// **real** `null` operand -- as opposed to [`yq_empty_operand_output`]'s
 /// zero-*output* operand, a distinct "null-ish" category per that function's
@@ -6967,6 +7013,27 @@ fn arith_add<S: EvalSemantics>(
                 (OwnedValue::Float(a), OwnedValue::Float(b)) => Ok(OwnedValue::Float(a + b)),
                 _ => unreachable!("both operands already confirmed numeric by the guard above"),
             }
+        }
+        // #2507 (yq mode only): a string mixed with a number or boolean, in
+        // either order, concatenates by converting the scalar to its string
+        // spelling -- see `yq_scalar_string_concat_is_ok`'s own doc comment
+        // for the full captured matrix and why `owned_to_string` (not a bare
+        // `format!`) is the right conversion here. Placed ahead of the
+        // final type-mismatch arm below, after every array/object/numeric
+        // arm above -- none of those match a `(String, scalar)`/`(scalar,
+        // String)` pairing, so ordering only matters against the catch-all.
+        (OwnedValue::String(mut s), other)
+            if yq_scalar_string_concat_is_ok::<S>() && other.is_number_or_bool() =>
+        {
+            s.push_str(&owned_to_string::<S>(&other));
+            Ok(OwnedValue::String(s))
+        }
+        (other, OwnedValue::String(s))
+            if yq_scalar_string_concat_is_ok::<S>() && other.is_number_or_bool() =>
+        {
+            let mut result = owned_to_string::<S>(&other);
+            result.push_str(&s);
+            Ok(OwnedValue::String(result))
         }
         // Type mismatch -- `left`/`right` are still the *original*,
         // uncollapsed operands here (the guard above never fires, so

--- a/src/jq/value.rs
+++ b/src/jq/value.rs
@@ -1691,6 +1691,15 @@ impl OwnedValue {
         self.number_repr().is_some()
     }
 
+    /// Whether this value is a number (any of [`Self::is_number`]'s three
+    /// representations) or a [`Self::Bool`] -- the two scalar kinds
+    /// `arith_add`'s yq-mode string-concatenation arm accepts on the
+    /// non-`String` side (#2507: `0 + "x"`/`true + "x"` both concatenate in
+    /// real yq, `[1,2] + "x"`/`{} + "x"` do not).
+    pub(crate) fn is_number_or_bool(&self) -> bool {
+        self.is_number() || matches!(self, Self::Bool(_))
+    }
+
     /// Get the type name of this value.
     pub fn type_name(&self) -> &'static str {
         match self {

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -13190,7 +13190,11 @@ fn test_top_level_map_lazy_seq_dom_fallback_725() -> Result<()> {
     assert_eq!(code, 0);
     assert_eq!(output.trim(), "[2,3,4]");
 
-    let (output, stderr, code) = run_yq_stdin_with_stderr("map(. + 1)", "a: 1\nb: two\n", &[])?;
+    // #2507: a string element (`b: two`) no longer errors here -- `"two" +
+    // 1` concatenates to `"two1"` in real yq now that succinctly matches --
+    // so this uses an object element instead, which still raises (a
+    // number/object mismatch has no such rule).
+    let (output, stderr, code) = run_yq_stdin_with_stderr("map(. + 1)", "a: 1\nb: {}\n", &[])?;
     assert_eq!(code, 1);
     assert_eq!(output, "");
     assert!(stderr.contains("cannot be added"), "{stderr}");
@@ -36537,6 +36541,100 @@ fn test_yq_index_scalar_with_key_is_empty_2482() -> Result<()> {
     let (output, code) = run_yq_stdin(".s.zzz = 1", doc, &[])?;
     assert_eq!(code, 0);
     assert!(output.contains("s: x"), "got: {output:?}");
+
+    Ok(())
+}
+
+/// #2507: `+` mixing a string with a number or boolean, in either order,
+/// concatenates in real yq -- the non-string side is converted to its
+/// string spelling, the same conversion `tostring` uses (so a
+/// scientific-notation or trailing-`.0` literal survives verbatim). Captured
+/// live from yq v4.53.3 (`-o=json -I0`, `-n`):
+///
+/// ```text
+/// $ yq -n '0 + "x"'          "0x"        $ yq -n '"x" + 0'          "x0"
+/// $ yq -n '1.5 + "x"'        "1.5x"      $ yq -n '"x" + 1.5'        "x1.5"
+/// $ yq -n '1.0 + "x"'        "1.0x"      $ yq -n '"x" + 1.0'        "x1.0"
+/// $ yq -n '1e100 + "x"'      "1e100x"    $ yq -n '"x" + 1e100'      "x1e100"
+/// $ yq -n '(0-5) + "x"'      "-5x"       $ yq -n '"x" + (0-5)'      "x-5"
+/// $ yq -n 'true + "x"'       "truex"     $ yq -n '"x" + true'       "xtrue"
+/// $ yq -n 'false + "x"'      "falsex"    $ yq -n '"x" + false'      "xfalse"
+/// $ succinctly yq -n '0 + "x"'   Error: number (0) and string ("x") cannot be added  (was, exit 1)
+/// ```
+///
+/// `-`/`*` were captured alongside for completeness and need no fix: every
+/// scalar/string mismatch for those two still raises in real yq too (`0 -
+/// "x"`, `"x" - 0`, `true - "x"`, `true * "x"`, ... all error live), and a
+/// container (array/object) mixed with a string is unaffected either way --
+/// `"x" + [1,2]`/`{} + "x"`/`"x" + {}` all still raise, and `[1,2] + "x"` is
+/// the *different*, already-implemented array-append rule (#1119), not this
+/// one. jq 1.7.1 raises unconditionally for every row above, so jq mode is
+/// untouched.
+///
+/// Fixed as `eval::yq_scalar_string_concat_is_ok`, consulted by `arith_add`
+/// -- the single function both evaluators' arithmetic fan-outs already
+/// route through, so this is one definition, not two.
+#[test]
+fn test_yq_scalar_string_concat_matrix_2507() -> Result<()> {
+    let args = &["-o", "json", "-I0", "-n"];
+    for (filter, expected) in [
+        (r#"0 + "x""#, r#""0x""#),
+        (r#""x" + 0"#, r#""x0""#),
+        (r#"1.5 + "x""#, r#""1.5x""#),
+        (r#""x" + 1.5"#, r#""x1.5""#),
+        (r#"1.0 + "x""#, r#""1.0x""#),
+        (r#""x" + 1.0"#, r#""x1.0""#),
+        (r#"1e100 + "x""#, r#""1e100x""#),
+        (r#""x" + 1e100"#, r#""x1e100""#),
+        (r#"(0-5) + "x""#, r#""-5x""#),
+        (r#""x" + (0-5)"#, r#""x-5""#),
+        (r#"true + "x""#, r#""truex""#),
+        (r#""x" + true"#, r#""xtrue""#),
+        (r#"false + "x""#, r#""falsex""#),
+        (r#""x" + false"#, r#""xfalse""#),
+    ] {
+        let (output, code) = run_yq_stdin(filter, "", args)?;
+        assert_eq!(code, 0, "`{filter}`: {output:?}");
+        assert_eq!(output.trim(), expected, "`{filter}`");
+    }
+
+    // Containers are unaffected -- still raise on either side, and array +
+    // string is the separate, already-implemented append rule (#1119).
+    let (output, code) = run_yq_stdin(r#"[1,2] + "x""#, "", args)?;
+    assert_eq!(code, 0);
+    assert_eq!(output.trim(), r#"[1,2,"x"]"#);
+
+    for filter in [r#""x" + [1,2]"#, r#"{} + "x""#, r#""x" + {}"#] {
+        let (_out, stderr, code) = run_yq_stdin_with_stderr(filter, "", args)?;
+        assert_ne!(code, 0, "`{filter}` should still error");
+        assert!(stderr.contains("cannot be added"), "`{filter}`: {stderr}");
+    }
+
+    // `-`/`*` are unaffected -- still raise on a scalar/string mismatch.
+    for filter in [
+        r#"0 - "x""#,
+        r#""x" - 0"#,
+        r#"true - "x""#,
+        r#""x" - true"#,
+        r#"true * "x""#,
+        r#""x" * true"#,
+    ] {
+        let (_out, stderr, code) = run_yq_stdin_with_stderr(filter, "", args)?;
+        assert_ne!(code, 0, "`{filter}` should still error");
+        assert!(
+            stderr.contains("cannot be subtracted") || stderr.contains("cannot be multiplied"),
+            "`{filter}`: {stderr}"
+        );
+    }
+
+    // `*` between a number and a string already repeats the string (a
+    // pre-existing, jq-compatible rule unrelated to this fix) -- pinned
+    // here so a future edit can't accidentally couple the two.
+    for (filter, expected) in [(r#"2 * "x""#, r#""xx""#), (r#""x" * 2"#, r#""xx""#)] {
+        let (output, code) = run_yq_stdin(filter, "", args)?;
+        assert_eq!(code, 0, "`{filter}`: {output:?}");
+        assert_eq!(output.trim(), expected, "`{filter}`");
+    }
 
     Ok(())
 }


### PR DESCRIPTION
## Summary

In real yq `+` between a string and a number or boolean concatenates through string conversion (`0 + "x"` is `"0x"`), where jq 1.7.1 raises. One predicate, `yq_scalar_string_concat_is_ok`, in `arith_add`, the function both evaluators already share; number literals keep their spelling (`1.0`, `1e100`). `-` and `*` were captured for completeness and already matched. jq mode unchanged and pinned.

## Verification

fmt; clippy `-D warnings`; `cargo test --features cli,simd,regex,serde`; yq goldens 113; jq goldens 633; oracle sweep 0 unexpected.

Closes #2507.
