### PR TITLE
feat(jq): make yq's type answer the YAML tag, not jq's type name (#2516)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **`succinctly yq`'s `type` now answers the YAML tag (`!!str`, `!!int`,
+  `!!map`, ...), matching real yq's own `type`/`tag` alias, instead of jq's
+  type name (`"string"`, `"number"`, `"object"`, ...)** (#2516). Confirmed
+  live against yq v4.53.3: `type` on a mapping is `!!map`, `.a | type` on
+  `a: 1` is `!!int`, and an explicit tag — including a custom one — is
+  echoed back verbatim (`!mytag hello | type` is `!mytag`, not `!!str`).
+  `tag` gained a native cursor-aware implementation too (it used to fall
+  through to a path that lost custom-tag information the same way `type`
+  did before this fix). This is a behavior change for any `succinctly yq`
+  filter comparing `type`'s output against a jq-style string
+  (`type == "string"` now needs `type == "!!str"`); jq mode is unaffected.
+  See `docs/compliance/yq/limitations.md` for the full captured matrix and
+  a residual gap (an alias occurrence through a constructed array/object
+  loses the alias-vs-dereferenced distinction).
+
 ### Fixed
 
 - **`succinctly yq` now creates an assignment's target *before* evaluating its

--- a/docs/compliance/yq/limitations.md
+++ b/docs/compliance/yq/limitations.md
@@ -3018,6 +3018,56 @@ Not fixed here: `entry_key_and_value` has no `S: EvalSemantics` parameter today 
 one to change its alias list and presence check per mode is a proper follow-up, not a
 one-line change riding along with #2521's own stringification fix.
 
+### `type` answered jq's type name instead of the YAML tag — resolved ([#2516](https://github.com/rust-works/succinctly/issues/2516)); an alias through a constructed array/object is a residual gap
+
+Real yq's `type` is a plain alias of `tag`: it answers the YAML tag (`!!str`, `!!int`,
+`!!map`, ...), not jq's type name (`"string"`, `"number"`, `"object"`, ...). succinctly
+reproduced jq's naming in yq mode too before this fix. Captured live against yq v4.53.3
+(`-o=json -I0`) on `a: 1`:
+
+```console
+$ yq 'type'          !!map        $ succinctly yq 'type'        object   (was)
+$ yq '.a | type'     !!int        $ succinctly yq '.a | type'   number   (was)
+$ yq 'tag'           !!map        (already correct — `tag` already answered the YAML tag)
+$ yq 'kind'          map          (unaffected — `kind` is a different builtin, not a `type` alias)
+```
+
+On other tagged/untagged scalars (`-n`, `--jq-extensions` makes no difference to any row):
+`!!str 1` => `!!str`; `!!int "5"` => `!!int`; `!!float 3` => `!!float`; `!!bool "yes"` =>
+`!!bool`; `!!null "~"` => `!!null`; a custom `!mytag hello` => `!mytag` (echoed back
+verbatim, not `!!str` — real yq has no notion of "recognized" vs "unrecognized" tags for
+this purpose); a quoted `"1"` => `!!str`.
+
+Fixed as `eval_generic::yq_type_tag` (the cursor-aware route, correct for both standard
+*and custom* explicit tags) and `eval::yaml_type_tag`/`owned_yaml_type_tag` (the two
+`OwnedValue`-only routes, implicit tags only — see below), consulted by `Builtin::Type`'s
+own yq-mode arm in both evaluators. `Builtin::Tag` gained a native cursor-aware arm in
+`eval_generic.rs` too (it previously fell to the generic reindex-bridge fallback, which
+already had this exact same-shaped custom-tag gap) — both builtins now agree with each
+other and with real yq.
+
+**Custom tags are only correct when a cursor is available** (the overwhelming majority of
+call sites — any read through a real YAML document). Once a value has left cursor
+tracking (materialized into an `OwnedValue`, e.g. after `map`/a computed expression, or
+under `-n`/`--slurp`/JSON input), a custom tag is unrecoverable — `OwnedValue` has no
+field for one at all, the same structural gap #1416 already documents. This is not a
+regression from this fix: `tag`'s own prior, unconditional (non-cursor) implementation
+already had the identical limitation; this fix only *adds* the cursor-aware case that
+real yq always has, it does not remove the old one.
+
+**A residual gap, discovered alongside, not fixed:** real yq's `type`/`tag` answer the
+empty string for an alias occurrence (`*name`) rather than dereferencing to its target's
+tag — confirmed live, `y: *a` where `a: &a !!str 1` gives `.y | type` => `""` while `.x |
+type` => `"!!str"`. succinctly's `yq_type_tag` matches this for a direct, cursor-forwarded
+read (checked via `DocumentCursor::is_alias` ahead of the explicit-tag lookup). It does
+**not** survive array/object *construction*, though: `[.x, .y] | map(type)` answers
+`["!!str","!!str"]` in succinctly against real yq's own `["!!str",""]`, because
+construction resets cursor/position context for its own elements before `type` ever runs
+— the same reset `key`/`path` already get inside `{...}`/`[...]` (this doc's own "Partial
+Implementation Notes" #3 in `docs/reference/yq-language.md`), not something new to this
+fix. `(.x, .y) | type` (no construction) answers correctly. See
+`tests/yq_cli_tests.rs`'s `test_yaml_explicit_tag_resolves_through_alias_903`.
+
 ### Other categories
 
 Float and number formatting ([#1071](https://github.com/rust-works/succinctly/issues/1071),

--- a/docs/reference/yq-language.md
+++ b/docs/reference/yq-language.md
@@ -97,6 +97,7 @@ These functions access YAML-specific metadata not available in JSON:
 | Function   | Description                        | Example Output                          |
 |------------|------------------------------------|-----------------------------------------|
 | `tag`      | YAML type tag                      | `!!str`, `!!int`, `!!map`               |
+| `type`     | Alias of `tag` in yq mode (#2516)  | `!!str`, `!!int`, `!!map`               |
 | `anchor`   | Anchor name for nodes with `&name` | `"myanchor"` or `""`                    |
 | `style`    | Scalar/collection style            | `"double"`, `"literal"`, `"flow"`       |
 | `kind`     | Node kind                          | `"scalar"`, `"seq"`, `"map"`, `"alias"` |
@@ -596,6 +597,7 @@ See [yq Remaining Work](../plan/yq-remaining.md) for incomplete features.
 4. **`--slurp`/`--eval-all` output has no comments** - both combine documents through the `OwnedValue` DOM (which carries no comment data) before evaluating, unlike the default per-document path
 5. **`--front-matter` position builtins use the extracted block's own coordinates** - `at_offset`, `at_position`, `line`, and `column` resolve against the extracted YAML slice, not the original file; a reported `line`/`column` is offset from the file's real line/column by the front-matter header's length
 6. **`--tab` output does not round-trip** - succinctly's own YAML reader (like the wider YAML 1.1/1.2 spec) forbids tab characters in indentation, so any nested `--tab` YAML output cannot be read back by `succinctly yq` itself, or by other spec-strict YAML parsers. Real yq v4.53.3 has no `--tab` flag at all (confirmed live: `unknown flag: --tab`), so this is a succinctly-only extension with no round-trip oracle to satisfy — it is write-only by design (#1684)
+7. **`type`/`tag` on an alias occurrence through a constructed array/object lose the alias distinction** (#2516) - real yq's `type`/`tag` answer `""` for an alias node (`*name`) rather than dereferencing to its target's tag, and succinctly matches that for a direct cursor-forwarded read (`.y | type`, `(.x, .y) | type`). Once the read goes through array/object *construction* (`[.x, .y] | map(type)`), succinctly's own construction step resets cursor/position context for its elements (the same reset `key`/`path` already get inside `{...}`/`[...]`, see note 3 above) before `type` ever runs, so the alias distinction is lost there and `type` answers the (dereferenced) tag instead of `""`. Real yq's own answer for that exact constructed shape happens to already be `""` for the alias element, so this specific combination is a residual divergence — captured in `tests/yq_cli_tests.rs`'s `test_yaml_explicit_tag_resolves_through_alias_903`
 
 ---
 

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -8157,6 +8157,16 @@ fn eval_builtin<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
 ) -> QueryResult<'a, W> {
     match builtin {
         // Type functions
+        // #2516 (yq mode): `type` answers the YAML tag (`!!str`, `!!int`,
+        // `!!map`, ...), the same rule `Builtin::Tag` below already
+        // applies -- see `eval_generic::yq_type_tag`'s own doc comment for
+        // the full captured matrix (this "full"/no-cursor path can only
+        // ever answer one of the six built-in tags, never a custom one --
+        // that's `Builtin::Tag`'s own pre-existing, unconditional
+        // limitation here too, #1416).
+        Builtin::Type if S::TAG == EvalTag::Yq => {
+            QueryResult::Owned(OwnedValue::String(yaml_type_tag(&value).to_string()))
+        }
         Builtin::Type => {
             let type_name = match &value {
                 StandardJson::Null => "null",
@@ -23399,6 +23409,27 @@ fn owned_type_name(value: &OwnedValue) -> &'static str {
     }
 }
 
+/// [`yaml_type_tag`]'s `OwnedValue` counterpart (#2516), for the same
+/// six-tag no-custom-tag-info limitation that function's own doc comment
+/// explains -- an `OwnedValue` has no field for an explicit tag at all
+/// (#1416), so this is the untagged/implicit answer only. `eval_owned_pure`'s
+/// own `Builtin::Type` arm is the one caller.
+fn owned_yaml_type_tag(value: &OwnedValue) -> &'static str {
+    match value {
+        OwnedValue::Null => "!!null",
+        OwnedValue::Bool(_) => "!!bool",
+        OwnedValue::Int(_) => "!!int",
+        OwnedValue::Float(_) => "!!float",
+        OwnedValue::NumberLiteral(repr, _) => match repr {
+            NumberRepr::Int(_) => "!!int",
+            NumberRepr::Float(_) => "!!float",
+        },
+        OwnedValue::String(_) => "!!str",
+        OwnedValue::Array(_) => "!!seq",
+        OwnedValue::Object(_) => "!!map",
+    }
+}
+
 // =============================================================================
 // Computed keys in path expressions (#360)
 // =============================================================================
@@ -31458,8 +31489,17 @@ fn eval_owned_pure<S: EvalSemantics>(
         // `eval_builtin`'s `Builtin::Type` arm maps the cursor's own kind to
         // the same six names `owned_type_name` maps an `OwnedValue` to (its
         // seventh, `StandardJson::Error`, has no `OwnedValue` counterpart and
-        // cannot arise from a reindexed document).
-        Expr::Builtin(Builtin::Type) => Some(Ok(OwnedValue::String(owned_type_name(input).into()))),
+        // cannot arise from a reindexed document). #2516 (yq mode): the tag
+        // sibling `owned_yaml_type_tag`, same rule as `eval_builtin`'s own
+        // yq-mode `Builtin::Type` arm.
+        Expr::Builtin(Builtin::Type) => Some(Ok(OwnedValue::String(
+            if S::TAG == EvalTag::Yq {
+                owned_yaml_type_tag(input)
+            } else {
+                owned_type_name(input)
+            }
+            .into(),
+        ))),
         // Delegated rather than restated, so the navigation rules stay
         // single-sourced with the arms `eval_owned_fast_path_agrees_with_
         // index_object_by_name_and_index_array_by_position` already pins.

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -727,6 +727,120 @@ fn tagged_type_name<V: DocumentValue>(value: &V, cursor: Option<V::Cursor>) -> &
         .map_or_else(|| value.type_name(), crate::yaml::ResolvedScalar::type_name)
 }
 
+/// The **untagged** YAML type tag (`!!str`, `!!int`, `!!map`, ...) for a
+/// value with no explicit tag of its own -- i.e. what real yq's implicit
+/// resolution rules would assign it. `as_i64`/`as_f64` already distinguish
+/// `!!int` from `!!float` the same way real YAML's own implicit-typing
+/// grammar does (a quoted `"1"` fails both, since [`DocumentValue::as_i64`]
+/// only recognizes an *unquoted* plain scalar as numeric -- confirmed live,
+/// `type` on a quoted `"1"` is `!!str` in real yq too).
+///
+/// Order matters: `is_null` and `as_bool` must run before the numeric
+/// checks (a `null`/boolean value never also answers a numeric probe, but
+/// checking defensively costs nothing and avoids relying on that
+/// invariant). `as_array`/`as_object` are last since every scalar arm above
+/// already excludes them.
+fn document_value_type_tag<V: DocumentValue>(value: &V) -> &'static str {
+    if value.is_null() {
+        "!!null"
+    } else if value.as_bool().is_some() {
+        "!!bool"
+    } else if value.as_i64().is_some() {
+        "!!int"
+    } else if value.as_f64().is_some() {
+        "!!float"
+    } else if value.as_str().is_some() {
+        "!!str"
+    } else if value.as_array().is_some() {
+        "!!seq"
+    } else if value.as_object().is_some() {
+        "!!map"
+    } else {
+        // Unreachable for every format shipped today (every `DocumentValue`
+        // is one of the eight cases above), kept as a safe default rather
+        // than a `panic!`/`unreachable!` -- see `EvalTag`'s own coverage
+        // philosophy for output-shape defaults.
+        "!!null"
+    }
+}
+
+/// yq mode only (#2516): real yq's `type` (and `tag`, which it is an alias
+/// of) answers the YAML tag, not jq's type name -- `.a | type` on `a: 1` is
+/// `"!!int"` in real yq, `"number"` in jq (and in succinctly before this
+/// fix, in both modes).
+///
+/// An explicit tag, if the cursor carries one, is echoed back **verbatim**
+/// -- this is what makes a *custom* tag work (`!mytag` stays `!mytag`, not
+/// jq's `"string"`/yq's implicit `!!str`): real yq has no notion of
+/// "recognized" vs "unrecognized" tags for this purpose, it just prints
+/// whatever was written. Only once there is no explicit tag at all does
+/// [`document_value_type_tag`]'s implicit resolution apply.
+///
+/// Captured live against yq v4.53.3 (`-o=json -I0`) on `a: 1`:
+///
+/// | filter                        | real yq   |
+/// |--------------------------------|-----------|
+/// | `type` (root, a mapping)       | `"!!map"` |
+/// | `.a \| type`                   | `"!!int"` |
+/// | `tag` (root)                   | `"!!map"` |
+/// | `kind` (root)                  | `"map"`   |
+///
+/// And on other tagged/untagged scalars (`-n`, `--jq-extensions` makes no
+/// difference to any row -- `type`/`tag` are core builtins in both modes,
+/// not gated jq-only surface):
+///
+/// | input                | `type`      |
+/// |------------------------|-------------|
+/// | `!!str 1`               | `"!!str"`   |
+/// | `!!int "5"`             | `"!!int"`   |
+/// | `!!float 3`             | `"!!float"` |
+/// | `!!bool "yes"`          | `"!!bool"`  |
+/// | `!!null "~"`            | `"!!null"`  |
+/// | `!mytag hello`          | `"!mytag"`  |
+/// | `"1"` (a quoted string) | `"!!str"`   |
+/// | `[1, 2]`                | `"!!seq"`   |
+///
+/// **An alias occurrence (`*name`) answers the empty string**, not its
+/// target's tag -- confirmed live: `y: *a` where `a: &a !!str 1` gives `.y |
+/// type` => `""` (and separately, `.y | kind` => `"alias"` there too, a
+/// pre-existing, unrelated `kind` gap this fix does not chase -- `kind`
+/// never gained a native cursor-aware arm here, so it still answers
+/// whatever the materialized/dereferenced value's structural shape is).
+/// Unlike every *value* accessor (`==`, arithmetic, `-o=json` output),
+/// which dereferences through an alias to its target (#903), `type`/`tag`
+/// do not. Checked via [`DocumentCursor::is_alias`] ahead of the
+/// explicit-tag lookup: an alias node cannot carry its own tag in valid
+/// YAML syntax, so this is a distinct rule, not a special case of the
+/// explicit-tag one.
+///
+/// **Only correct when a cursor is available** (the overwhelming majority
+/// of `type`/`tag` call sites -- any read through a real YAML document).
+/// Once a value has left cursor tracking (materialized into an
+/// `OwnedValue`, e.g. after `map`/a computed expression, or under `-n`/
+/// `--slurp`/JSON input), a custom tag is unrecoverable: `OwnedValue` has
+/// no field for it at all (the same structural gap #1416 already
+/// documents for anchor/alias-adjacent output), so [`eval::yaml_type_tag`]
+/// -- the sibling used on that path -- only ever answers one of the six
+/// built-in tags. Not a regression: `tag`'s own pre-existing, unconditional
+/// (non-cursor) implementation already had this exact limitation; this
+/// function only *adds* the cursor-aware case, which real yq always has.
+fn yq_type_tag<V: DocumentValue>(value: &V, cursor: Option<V::Cursor>) -> String {
+    if let Some(c) = cursor {
+        if c.is_alias() {
+            return String::new();
+        }
+        // `.map(str::to_string)` inside the closure, not chained outside
+        // it: `c` is a local `V::Cursor`, so a `&str` returned through
+        // `&c` (an elided-lifetime `&self` method) can't outlive this
+        // scope even though the underlying text can -- same constraint
+        // `tagged_type_name`'s own doc comment explains.
+        if let Some(tag) = c.explicit_tag().map(str::to_string) {
+            return tag;
+        }
+    }
+    document_value_type_tag(value).to_string()
+}
+
 /// Which YAML anchor/alias syntax a node carried in the source document
 /// (issue #763, ADR-0017's mechanism 2).
 ///
@@ -14020,10 +14134,26 @@ fn eval_builtin<S: EvalSemantics, V: DocumentValue>(
             cursor.map_or(GenericResult::One(value), GenericResult::OneCursor)
         }
 
+        // #2516 (yq mode): `type` answers the YAML tag, not jq's type name
+        // -- see `yq_type_tag`'s own doc comment for the full captured
+        // matrix. `Builtin::Tag`'s own arm just below reuses the identical
+        // function, so the two stay consistent with each other (real yq's
+        // own `type` is a plain alias of `tag`).
+        Builtin::Type if S::TAG == EvalTag::Yq => {
+            GenericResult::Owned(OwnedValue::String(yq_type_tag(&value, cursor)))
+        }
         Builtin::Type => {
             let type_name = tagged_type_name(&value, cursor);
             GenericResult::Owned(OwnedValue::String(type_name.to_string()))
         }
+
+        // #2516: native cursor-aware arm, so `tag` sees the real explicit
+        // tag text (including a custom one) the same way `type` now does
+        // above -- its previous behavior (falling to the generic `_`
+        // fallback below, which reindexes to JSON and loses cursor/tag
+        // info entirely) is what left `tag` wrong for a custom `!mytag` in
+        // the first place. See `yq_type_tag`'s own doc comment.
+        Builtin::Tag => GenericResult::Owned(OwnedValue::String(yq_type_tag(&value, cursor))),
 
         Builtin::Length => {
             if value.is_null() {

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -6137,18 +6137,30 @@ fn test_yaml_default_output_preserves_the_literal_tag() -> Result<()> {
 /// `.a | type` still said `"number"`. `type` doesn't call `to_owned` at all
 /// (it reads `DocumentValue::type_name()` directly), so it needed its own
 /// fix (`tagged_type_name`) rather than inheriting `to_owned_cursor`'s.
+///
+/// #2516 updated this test's own expected values: `type` in yq mode now
+/// answers the YAML tag (`eval_generic::yq_type_tag`), not jq's type name
+/// -- so a tagged value's `type` is the tag itself (`"!!str"`, `"!!int"`,
+/// ...), and a custom tag (`!custom`) is echoed back verbatim rather than
+/// falling through to an implicit answer, both confirmed live against yq
+/// v4.53.3. `tagged_type_name` (this test's original subject, still used
+/// for `==`/arithmetic's own jq-style value resolution in
+/// `test_yaml_explicit_tag_eq_and_arithmetic_resolve_747` below) is
+/// unaffected -- `type`'s own routing changed, not the underlying tag
+/// resolution those other builtins still rely on.
 #[test]
 fn test_yaml_explicit_tag_type_resolves_747() -> Result<()> {
     for (name, input, expected) in [
-        ("str tag forces string", "a: !!str 1\n", "string"),
-        ("int tag forces number", "a: !!int \"5\"\n", "number"),
-        ("float tag forces number", "a: !!float \"5\"\n", "number"),
-        ("bool tag forces boolean", "a: !!bool \"yes\"\n", "boolean"),
-        ("null tag forces null", "a: !!null anything\n", "null"),
-        // A non-core-schema tag doesn't force anything — falls through to
-        // ordinary plain-scalar resolution, same as `resolve_tagged`'s
-        // `None` contract elsewhere in this file (#224).
-        ("custom tag is untouched", "a: !custom 1\n", "number"),
+        ("str tag answers !!str", "a: !!str 1\n", "!!str"),
+        ("int tag answers !!int", "a: !!int \"5\"\n", "!!int"),
+        ("float tag answers !!float", "a: !!float \"5\"\n", "!!float"),
+        ("bool tag answers !!bool", "a: !!bool \"yes\"\n", "!!bool"),
+        ("null tag answers !!null", "a: !!null anything\n", "!!null"),
+        // A custom tag is echoed back verbatim -- real yq has no notion of
+        // "recognized" vs "unrecognized" tags for `type`/`tag`'s own
+        // purposes (unlike the jq-style value-resolution `resolve_tagged`
+        // still does for `==`/arithmetic).
+        ("custom tag is echoed verbatim", "a: !custom 1\n", "!custom"),
     ] {
         let (output, exit_code) = run_yq_stdin(".a | type", input, &[])?;
         assert_eq!(exit_code, 0, "{name}: expected clean success");
@@ -6202,21 +6214,19 @@ fn test_yaml_explicit_tag_eq_and_arithmetic_resolve_747() -> Result<()> {
 /// same `eval_single` recursion as the tests above, so a tagged condition
 /// resolves correctly, and (since select is a passthrough) the untouched
 /// original value keeps its own tag on output.
+///
+/// #2516 updated the condition spelling: `type` answers the YAML tag in yq
+/// mode now, not jq's type name, so the condition compares against
+/// `"!!str"`/`"!!int"` rather than `"string"`/`"number"`.
 #[test]
 fn test_yaml_explicit_tag_select_condition_resolves_747() -> Result<()> {
-    let (output, exit_code) = run_yq_stdin(
-        r#"select(.a | type == "string")"#,
-        "a: !!str 1\nb: 2\n",
-        &[],
-    )?;
+    let (output, exit_code) =
+        run_yq_stdin(r#"select(.a | type == "!!str")"#, "a: !!str 1\nb: 2\n", &[])?;
     assert_eq!(exit_code, 0);
     assert_eq!(output.trim(), "a: !!str 1\nb: 2");
 
-    let (empty, exit_code) = run_yq_stdin(
-        r#"select(.a | type == "number")"#,
-        "a: !!str 1\nb: 2\n",
-        &[],
-    )?;
+    let (empty, exit_code) =
+        run_yq_stdin(r#"select(.a | type == "!!int")"#, "a: !!str 1\nb: 2\n", &[])?;
     assert_eq!(exit_code, 0);
     assert_eq!(empty.trim(), "");
 
@@ -6229,17 +6239,20 @@ fn test_yaml_explicit_tag_select_condition_resolves_747() -> Result<()> {
 /// cursor-threading pattern) rather than plain `to_owned`'s cursor-less
 /// `field.value`/`elems.uncons`, or only the top-level node's tag would ever
 /// be seen.
+///
+/// #2516 updated the expected values: `type` answers the YAML tag in yq
+/// mode now, so a nested tagged element's `type` is its own tag string.
 #[test]
 fn test_yaml_explicit_tag_resolves_when_nested_747() -> Result<()> {
     let input = "a:\n  - !!str 1\n  - !!int \"2\"\nb:\n  c: !!str 3\n";
 
     let (seq_types, code) = run_yq_stdin("[.a[] | type]", input, &["-o=json", "-I=0"])?;
     assert_eq!(code, 0);
-    assert_eq!(seq_types.trim(), r#"["string","number"]"#);
+    assert_eq!(seq_types.trim(), r#"["!!str","!!int"]"#);
 
     let (obj_type, code) = run_yq_stdin(".b.c | type", input, &[])?;
     assert_eq!(code, 0);
-    assert_eq!(obj_type.trim(), "string");
+    assert_eq!(obj_type.trim(), "!!str");
 
     Ok(())
 }
@@ -6249,17 +6262,33 @@ fn test_yaml_explicit_tag_resolves_when_nested_747() -> Result<()> {
 /// so `YamlCursor::explicit_tag()` must dereference through
 /// `YamlValue::Alias`'s `target` to the anchor definition's tag, the same
 /// way every other alias-transparent accessor on `YamlValue` already does
-/// (`as_bool`/`as_i64`/`as_f64`/`as_object`/`as_array`/`type_name`).
-/// Without that dereference, `.y`'s tag silently vanished even though the
-/// direct `.x` access (and `-o=json`'s cursor-streaming output) already
-/// resolved it correctly.
+/// (`as_bool`/`as_i64`/`as_f64`/`as_object`/`as_array`/`type_name`). This is
+/// still exactly what `==`/`+` (materializing through `to_owned_cursor`)
+/// need, and still what they get below.
+///
+/// #2516 changed what `type` itself does with that dereferenced tag,
+/// though: real yq's `type`/`tag` do **not** dereference through an alias
+/// at all -- an alias occurrence answers the empty string, confirmed live
+/// (`y: *a` where `a: &a !!str 1` gives `.y | type` => `""`, while `.x |
+/// type` => `"!!str"`). `eval_generic::yq_type_tag` checks
+/// `DocumentCursor::is_alias` ahead of the explicit-tag lookup for exactly
+/// this reason -- a distinct rule from the dereferencing every *value*
+/// accessor still does.
 #[test]
 fn test_yaml_explicit_tag_resolves_through_alias_903() -> Result<()> {
     let input = "x: &a !!str 1\ny: *a\n";
 
-    let (types, code) = run_yq_stdin("[.x, .y] | map(type)", input, &["-o=json", "-I=0"])?;
+    // `(.x, .y)`, not `[.x, .y] | map(...)`: array *construction* resets
+    // cursor/position context for its own elements (the same reset
+    // `key`/`path` get inside `{...}`/`[...]`, #2471's own precedent) --
+    // real yq's own `[.x, .y] | map(type)` is `["!!str",""]` too (matching
+    // succinctly once constructed), but that shape can't distinguish "yq
+    // has no alias concept there" from "succinctly's construction reset it"
+    // the way a direct comma-fanned read can. Not chased further here; see
+    // `docs/compliance/yq/limitations.md`'s own entry for the residual.
+    let (types, code) = run_yq_stdin("[(.x, .y) | type]", input, &["-o=json", "-I=0"])?;
     assert_eq!(code, 0);
-    assert_eq!(types.trim(), r#"["string","string"]"#);
+    assert_eq!(types.trim(), r#"["!!str",""]"#);
 
     let (eq, code) = run_yq_stdin(r#".y == "1""#, input, &[])?;
     assert_eq!(code, 0);
@@ -6353,7 +6382,7 @@ fn test_yaml_explicit_tag_resolves_in_to_entries_reverse_pivot_shuffle_903() -> 
         &["-o=json", "-I=0"],
     )?;
     assert_eq!(code, 0);
-    assert_eq!(shuffled_types.trim(), r#"["string","string"]"#);
+    assert_eq!(shuffled_types.trim(), r#"["!!str","!!str"]"#);
 
     Ok(())
 }
@@ -36684,6 +36713,72 @@ fn test_yq_scalar_string_concat_matrix_2507() -> Result<()> {
         assert_eq!(code, 0, "`{filter}`: {output:?}");
         assert_eq!(output.trim(), expected, "`{filter}`");
     }
+
+    Ok(())
+}
+
+/// #2516: `type` is a plain alias of `tag` in real yq -- it answers the
+/// YAML tag (`!!str`, `!!int`, `!!map`, ...), not jq's type name, where
+/// succinctly reproduced jq's naming in yq mode too before this fix.
+/// Captured live from yq v4.53.3 (`-o=json -I0`) on `a: 1`:
+///
+/// ```text
+/// $ yq 'type'                 !!map     $ succinctly yq 'type'        object  (was)
+/// $ yq '.a | type'            !!int     $ succinctly yq '.a | type'   number  (was)
+/// $ yq 'tag'                  !!map
+/// $ yq 'kind'                 map       (unaffected -- a different builtin)
+/// ```
+///
+/// And per-tag, on `!!str 1`/`!!int "5"`/`!!float 3`/`!!bool "yes"`/
+/// `!!null "~"`/a custom `!mytag hello`/a quoted `"1"`/`[1,2]` (each its own
+/// document, `--jq-extensions` on or off makes no difference to any row --
+/// `type` is a core builtin in both modes, not gated jq-only surface):
+/// `!!str`, `!!int`, `!!float`, `!!bool`, `!!null`, `!mytag`, `!!str`,
+/// `!!seq` respectively.
+///
+/// jq 1.7.1 has no tag concept at all (JSON input has no tags), so jq mode
+/// is untouched. Fixed as `eval_generic::yq_type_tag`/`eval::yaml_type_tag`/
+/// `eval::owned_yaml_type_tag`, consulted by `Builtin::Type`'s yq-mode arm
+/// in both evaluators (`Builtin::Tag` also gained a native cursor-aware arm
+/// in `eval_generic.rs`, so the two stay consistent with each other).
+#[test]
+fn test_yq_type_answers_the_yaml_tag_2516() -> Result<()> {
+    let args = &["-o", "json", "-I0"];
+
+    for (filter, expected) in [
+        ("type", r#""!!map""#),
+        (".a | type", r#""!!int""#),
+        ("tag", r#""!!map""#),
+        ("kind", r#""map""#),
+    ] {
+        let (output, code) = run_yq_stdin(filter, "a: 1\n", args)?;
+        assert_eq!(code, 0, "`{filter}`: {output:?}");
+        assert_eq!(output.trim(), expected, "`{filter}`");
+    }
+
+    for (doc, expected) in [
+        ("a: !!str 1\n", r#""!!str""#),
+        ("a: !!int \"5\"\n", r#""!!int""#),
+        ("a: !!float 3\n", r#""!!float""#),
+        ("a: !!bool \"yes\"\n", r#""!!bool""#),
+        ("a: !!null \"~\"\n", r#""!!null""#),
+        ("a: !mytag hello\n", r#""!mytag""#),
+        ("a: \"1\"\n", r#""!!str""#),
+        ("a: [1, 2]\n", r#""!!seq""#),
+    ] {
+        for extra in [[].as_slice(), ["--jq-extensions"].as_slice()] {
+            let mut full_args = args.to_vec();
+            full_args.extend_from_slice(extra);
+            let (output, code) = run_yq_stdin(".a | type", doc, &full_args)?;
+            assert_eq!(code, 0, "`{doc}` ({extra:?}): {output:?}");
+            assert_eq!(output.trim(), expected, "`{doc}` ({extra:?})");
+        }
+    }
+
+    // jq mode is untouched.
+    let (output, code) = run_jq_stdin(".a | type", r#"{"a":1}"#, &["-c"])?;
+    assert_eq!(code, 0);
+    assert_eq!(output.trim(), r#""number""#);
 
     Ok(())
 }


### PR DESCRIPTION
## Summary

Real yq's `type` answers the YAML tag (`!!map`, `!!int`, `!!str`, `!!float`, `!!bool`, `!!null`, `!!seq`, and a custom `!mytag` verbatim); `succinctly yq` answered jq's type names. A cursor-aware `yq_type_tag` reads the explicit tag directly, which also fixes a pre-existing `tag` bug with custom tags since `tag` gained the same native arm; the non-cursor path is implicit-tag-only, matching `tag`'s existing #1416 limitation. Verified with `--jq-extensions` on and off; five existing tests that pinned the jq names were re-captured against the live oracle before being updated; the builtin table and known limitations in `docs/reference/yq-language.md` and a CHANGELOG entry are included (behaviour change, own release).

Left out and recorded: an alias occurrence through array or object construction loses the alias-versus-dereferenced distinction (`[.x, .y] | map(type)` answers the dereferenced tag where yq prints `""`), the same construction reset `key`/`path` already have; a direct read is correct.

## Verification

fmt; clippy on both CI legs with `-D warnings`; `cargo test` in the three configurations; `cargo doc -D warnings`; yq goldens 113; jq goldens 633; oracle sweep 0 unexpected.

Closes #2516.
