### PR TITLE
fix(yq): compare by structural identity, not jq equality, in the alias gates

### DIFF
--- a/docs/compliance/yq/limitations.md
+++ b/docs/compliance/yq/limitations.md
@@ -65,15 +65,19 @@ Error: bad file '-': yaml: line 1, column 5: unknown anchor 'x' referenced
 succinctly refuses to produce that output. `enforce_anchor_soundness`
 ([src/bin/succinctly/yq_runner.rs](../../../src/bin/succinctly/yq_runner.rs), from
 [#763](https://github.com/rust-works/succinctly/issues/763)) emits a `*name` only when a
-matching `&name` exists, is emitted **earlier**, and holds an **equal** value; otherwise the
-mark is dropped and the value printed:
+matching `&name` exists, is emitted **earlier**, and holds an **identical** value —
+structural identity, not jq value equality, so `NaN` counts as identical to itself even
+though `NaN != NaN` under jq's own `==`
+([#1360](https://github.com/rust-works/succinctly/issues/1360): under jq equality an
+anchored `.nan` looked diverged from itself for no real reason, and lost its mark); otherwise
+the mark is dropped and the value printed:
 
 ```bash
 $ printf 'a: &x 1\nb: *x\n' | succinctly yq 'del(.a)'
 b: 1
 ```
 
-The equal-value clause is also the backstop for alias *node identity*
+The identical-value clause is also the backstop for alias *node identity*
 ([#1351](https://github.com/rust-works/succinctly/issues/1351)). Real yq treats `&x`/`*x` as
 one node: a write whose path passes *through* an alias and continues (`.b.p = 9` on `b: *x`)
 mutates the anchor's node and every position follows, while a path that ends exactly at the
@@ -91,10 +95,10 @@ $ printf 'a: &x {p: 1}\nb: *x\nc: *x\n' | succinctly yq -o=json -I=0 '.[] .p += 
 {"a":{"p":4},"b":{"p":4},"c":{"p":4}}        # three positions, one node: matches yq
 ```
 
-The redirect is gated on *identity by equality*: it applies only while the alias position
+The redirect is gated on structural identity: it applies only while the alias position
 still holds the anchor's value, so a position rebound earlier in the pipe (`.b = 5 | .b.p =
 9`) is written positionally, as yq treats a rebound position. The gate's one false positive
-is a rebind to a value *equal* to the anchor's: `.b = .a | .a.p = 9` (or `.b = {"p": 1, "q":
+is a rebind to a value *identical* to the anchor's: `.b = .a | .a.p = 9` (or `.b = {"p": 1, "q":
 2} | .a.p = 9`) detaches `b` in yq (`b: {p: 1, q: 2}`), while succinctly cannot tell the
 rebound copy from an untouched one and keeps its value in step (`b: {p: 9, q: 2}`; the `*x`
 mark itself is cleared by the plain `=`, see the assignment rule below). The written value is
@@ -117,8 +121,8 @@ consequences are recorded divergences/limitations rather than matches:
   ([#2501](https://github.com/rust-works/succinctly/issues/2501), the value-level twin of
   #870).
 
-Wherever the redirect declines, the values differ and the equal-value clause drops the mark
-and prints the computed value, rather than emitting `*x` and discarding the write.
+Wherever the redirect declines, the values differ and the identical-value clause drops the
+mark and prints the computed value, rather than emitting `*x` and discarding the write.
 
 The redirect runs wherever a write goes through `evaluate_yaml_cursor` — stdout,
 `--split-exp`, `--front-matter`, and since
@@ -260,8 +264,7 @@ so any shape that can reach the M2 fast path gets the same soundness check.
 Related open items in the same family, still unresolved:
 [#1359](https://github.com/rust-works/succinctly/issues/1359) (a write that changes a node's
 kind drops its `&anchor`, where real yq keeps it),
-[#1360](https://github.com/rust-works/succinctly/issues/1360) (NaN false-positives the
-equal-value rule), [#1352](https://github.com/rust-works/succinctly/issues/1352) and
+[#1352](https://github.com/rust-works/succinctly/issues/1352) and
 [#1353](https://github.com/rust-works/succinctly/issues/1353).
 
 ### `-0`/`--nul-output` multi-document separator — rule 4(a)

--- a/src/bin/succinctly/yq_runner.rs
+++ b/src/bin/succinctly/yq_runner.rs
@@ -2844,7 +2844,12 @@ fn scan_anchor_soundness<'v, 'c>(
         // Spelled as a negated `matches!` rather than clippy's suggested
         // `is_none_or`, which is stable only since 1.82 and this crate's
         // MSRV is 1.73.
-        Some(AnchorMark::Aliases(name)) if !matches!(declared.get(name.as_str()), Some(d) if *d == value) =>
+        // `identical`, not `==` (#1360): jq value equality says `NaN` differs
+        // from itself, so an anchored `.nan` reported a divergence that never
+        // happened and lost its alias mark. It is also too loose in the other
+        // direction -- `Int(1) == Float(1.0)` -- and this gate is asking
+        // "would these render the same", not "are these jq-equal".
+        Some(AnchorMark::Aliases(name)) if !matches!(declared.get(name.as_str()), Some(d) if d.identical(value)) =>
         {
             unresolvable.push(path.clone());
         }

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -38720,7 +38720,14 @@ fn propagate_anchor_writes(
             let def_pre = get_value_at_path(pre, def);
             aliases
                 .iter()
-                .map(|alias| get_value_at_path(pre, alias).filter(|v| Some(v) == def_pre.as_ref()))
+                .map(|alias| {
+                    // `identical`, not `==` (#1360): with jq equality an
+                    // anchored `.nan` never looks like a copy of itself, so
+                    // the slot is never propagated to and #763's gate then
+                    // drops its mark as diverged.
+                    get_value_at_path(pre, alias)
+                        .filter(|v| def_pre.as_ref().is_some_and(|d| v.identical(d)))
+                })
                 .collect()
         })
         .collect();
@@ -38734,10 +38741,14 @@ fn propagate_anchor_writes(
                 let Some(want) = expected[g][a].as_ref() else {
                     continue;
                 };
-                if *want == new {
+                if want.identical(&new) {
                     continue;
                 }
-                if get_value_at_path(post, alias).as_ref() != Some(want) {
+                // Same rule for "was this slot rebound by an earlier stage"
+                // (#2499): all three comparisons in this loop have to agree
+                // on what "unchanged" means, or a NaN slot is judged a copy
+                // by one and a divergence by another.
+                if !get_value_at_path(post, alias).is_some_and(|v| v.identical(want)) {
                     continue;
                 }
                 if let Ok(updated) = set_value_at_path(post.clone(), alias, new.clone()) {

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -877,11 +877,24 @@ pub mod alias_identity {
         }
     }
 
-    /// Both positions resolve and hold equal values right now.
+    /// Both positions resolve and hold *identical* values right now — i.e.
+    /// this alias slot is still the untouched copy of its anchor, not one an
+    /// earlier stage rebound.
+    ///
+    /// `identical`, not `==` (#1360). Jq value equality gets this wrong in
+    /// both directions, and this gate decides whether a write is redirected
+    /// onto the shared node, so either way is a wrong *value* on the page:
+    ///
+    /// - `NaN` differs from itself under `==`, so `.b.p = 9` on
+    ///   `a: &x {p: .nan} / b: *x` failed to redirect and wrote only the
+    ///   copy, where real yq mutates the anchor;
+    /// - `{p: 1}` and `{p: 1.0}` are `==` but do not render alike, so
+    ///   `.b = {"p": 1.0} | .b.p = 9` redirected onto the anchor a slot the
+    ///   first stage had already rebound.
     fn same_node(doc: &OwnedValue, a: &[OwnedValue], b: &[OwnedValue]) -> bool {
         matches!(
             (get_value_at_path(doc, a), get_value_at_path(doc, b)),
-            (Some(x), Some(y)) if x == y
+            (Some(x), Some(y)) if x.identical(&y)
         )
     }
 

--- a/src/jq/value.rs
+++ b/src/jq/value.rs
@@ -2720,6 +2720,89 @@ pub(crate) fn numeric_repr_cmp(a: NumberRepr, b: NumberRepr) -> core::cmp::Order
     }
 }
 
+impl OwnedValue {
+    /// Structural identity: would these two render *identically*?
+    ///
+    /// Deliberately stricter than [`PartialEq`], which is **jq value
+    /// equality** — `Int(1) == Float(1.0)`, `-0.0 == 0.0`, and `NaN` equal to
+    /// nothing at all, itself included. That is the right rule for jq's `==`
+    /// and the wrong one for asking "has this node changed?", which is what
+    /// #763's anchor-soundness gate and #711's alias propagation both need.
+    ///
+    /// The NaN case is the one that shows why (#1360). An anchored `.nan`
+    /// reports a divergence that never happened, so the alias is never
+    /// propagated to and its `*x` mark is then dropped as unresolvable:
+    ///
+    /// ```text
+    /// $ printf 'a: &x .nan\nb: *x\n' | yq            '.c = 1'   # b: *x
+    /// $ printf 'a: &x .nan\nb: *x\n' | succinctly yq '.c = 1'   # b: .nan
+    /// ```
+    ///
+    /// `.inf` is the control: it compares equal to itself and was already
+    /// correct, which is what pins the cause to NaN rather than to floats in
+    /// general.
+    ///
+    /// Floats compare by [`f64::to_bits`], not `total_cmp`: the same answers
+    /// on every case here, but it states the intent ("would render
+    /// identically") and sidesteps a `-0.0`/NaN-sign discussion. A number
+    /// keeps its own spelling, so `Int(1)` is not identical to `Float(1.0)`
+    /// nor to a `NumberLiteral` of either — a write that changes only the
+    /// spelling is a real change, and treating it as one is what stops it
+    /// being silently discarded.
+    ///
+    /// Objects compare by key **order** as well as content: `emit_yaml_value`
+    /// writes fields in order, so two orderings do not render identically
+    /// even though jq considers them equal.
+    ///
+    /// Panics past [`MAX_VALUE_TREE_DEPTH`] levels of nesting (#1005), like
+    /// the `PartialEq` beside it.
+    #[must_use]
+    pub fn identical(&self, other: &Self) -> bool {
+        owned_value_identical_at_depth(self, other, 0)
+    }
+}
+
+/// The recursion behind [`OwnedValue::identical`], carrying the depth guard
+/// its trait-shaped sibling cannot.
+fn owned_value_identical_at_depth(a: &OwnedValue, b: &OwnedValue, depth: usize) -> bool {
+    assert_value_tree_depth(depth);
+    /// Two number representations that would render identically.
+    fn repr_identical(a: NumberRepr, b: NumberRepr) -> bool {
+        match (a, b) {
+            (NumberRepr::Int(a), NumberRepr::Int(b)) => a == b,
+            (NumberRepr::Float(a), NumberRepr::Float(b)) => a.to_bits() == b.to_bits(),
+            // A number that reached `Int` and one that reached `Float` do not
+            // render the same way, whatever their values.
+            _ => false,
+        }
+    }
+    match (a, b) {
+        (OwnedValue::Null, OwnedValue::Null) => true,
+        (OwnedValue::Bool(a), OwnedValue::Bool(b)) => a == b,
+        (OwnedValue::Int(a), OwnedValue::Int(b)) => a == b,
+        (OwnedValue::Float(a), OwnedValue::Float(b)) => a.to_bits() == b.to_bits(),
+        (OwnedValue::NumberLiteral(ra, ta), OwnedValue::NumberLiteral(rb, tb)) => {
+            repr_identical(*ra, *rb) && ta == tb
+        }
+        (OwnedValue::String(a), OwnedValue::String(b)) => a == b,
+        (OwnedValue::Array(a), OwnedValue::Array(b)) => {
+            a.len() == b.len()
+                && a.iter()
+                    .zip(b.iter())
+                    .all(|(x, y)| owned_value_identical_at_depth(x, y, depth + 1))
+        }
+        (OwnedValue::Object(a), OwnedValue::Object(b)) => {
+            a.len() == b.len()
+                && a.iter().zip(b.iter()).all(|((ka, va), (kb, vb))| {
+                    ka == kb && owned_value_identical_at_depth(va, vb, depth + 1)
+                })
+        }
+        // Every cross-variant pair, the number ones included: `Int(1)` and
+        // `Float(1.0)` are jq-equal and do not render the same.
+        _ => false,
+    }
+}
+
 impl PartialEq for OwnedValue {
     fn eq(&self, other: &Self) -> bool {
         owned_value_eq_at_depth(self, other, 0)
@@ -5037,6 +5120,110 @@ mod tests {
                 !is_jq_canonical_number(raw.as_bytes()),
                 "{raw:?} is reformatted by jq and must not take the fast path"
             );
+        }
+    }
+
+    // -- #1360: structural identity vs jq value equality ------------------
+
+    /// The four places `identical` must be *stricter* than `==`, which is
+    /// the whole reason it exists: each of these pairs is jq-equal and does
+    /// not render the same way.
+    #[test]
+    fn identical_is_stricter_than_jq_equality_1360() {
+        let looser = [
+            // NaN is the case that motivated this: `==` says it differs from
+            // itself, so an anchored `.nan` reported a divergence that never
+            // happened.
+            (
+                OwnedValue::Float(f64::NAN),
+                OwnedValue::Float(f64::NAN),
+                true,
+            ),
+            // ...and these are jq-equal but render differently.
+            (OwnedValue::Float(-0.0), OwnedValue::Float(0.0), false),
+            (OwnedValue::Int(1), OwnedValue::Float(1.0), false),
+            (
+                OwnedValue::Int(1),
+                OwnedValue::NumberLiteral(NumberRepr::Int(1), "1".into()),
+                false,
+            ),
+        ];
+        for (a, b, want) in looser {
+            assert_eq!(
+                a.identical(&b),
+                want,
+                "identical({a:?}, {b:?}) should be {want}"
+            );
+        }
+
+        // The `==` answers these differ from, stated explicitly so a change
+        // to either rule shows up here.
+        assert_ne!(OwnedValue::Float(f64::NAN), OwnedValue::Float(f64::NAN));
+        assert_eq!(OwnedValue::Float(-0.0), OwnedValue::Float(0.0));
+        assert_eq!(OwnedValue::Int(1), OwnedValue::Float(1.0));
+    }
+
+    /// A `NumberLiteral` keeps its own source spelling, so two that parse to
+    /// the same number are not identical unless the text matches too.
+    #[test]
+    fn identical_compares_number_literal_spelling_1360() {
+        let lit = |r, t: &str| OwnedValue::NumberLiteral(r, t.into());
+        assert!(lit(NumberRepr::Float(1.0), "1.0").identical(&lit(NumberRepr::Float(1.0), "1.0")));
+        assert!(!lit(NumberRepr::Float(1.0), "1.0").identical(&lit(NumberRepr::Float(1.0), "1.00")));
+        assert!(!lit(NumberRepr::Int(1), "1").identical(&lit(NumberRepr::Float(1.0), "1.0")));
+        // NaN inside a literal repr is still reflexive under bit equality.
+        assert!(lit(NumberRepr::Float(f64::NAN), ".nan")
+            .identical(&lit(NumberRepr::Float(f64::NAN), ".nan")));
+    }
+
+    /// Containers recurse, and objects compare key **order** too: the emitter
+    /// writes fields in order, so two orderings do not render identically
+    /// even though jq considers them equal.
+    #[test]
+    fn identical_recurses_and_respects_key_order_1360() {
+        let nan_arr = || OwnedValue::Array(vec![OwnedValue::Float(f64::NAN)]);
+        assert!(nan_arr().identical(&nan_arr()));
+        assert_ne!(nan_arr(), nan_arr(), "jq equality still says otherwise");
+
+        let obj = |pairs: &[(&str, i64)]| {
+            OwnedValue::Object(
+                pairs
+                    .iter()
+                    .map(|(k, v)| ((*k).to_string(), OwnedValue::Int(*v)))
+                    .collect(),
+            )
+        };
+        assert!(obj(&[("a", 1), ("b", 2)]).identical(&obj(&[("a", 1), ("b", 2)])));
+        assert!(!obj(&[("a", 1), ("b", 2)]).identical(&obj(&[("b", 2), ("a", 1)])));
+        // IndexMap equality is order-independent, so `==` disagrees here.
+        assert_eq!(obj(&[("a", 1), ("b", 2)]), obj(&[("b", 2), ("a", 1)]));
+        // Length and key names still matter.
+        assert!(!obj(&[("a", 1)]).identical(&obj(&[("a", 1), ("b", 2)])));
+        assert!(!obj(&[("a", 1)]).identical(&obj(&[("z", 1)])));
+    }
+
+    /// Every ordinary value is identical to itself -- the property the gate
+    /// actually relies on, and the one `==` broke for NaN.
+    #[test]
+    fn identical_is_reflexive_for_every_variant_1360() {
+        for v in [
+            OwnedValue::Null,
+            OwnedValue::Bool(true),
+            OwnedValue::Bool(false),
+            OwnedValue::Int(0),
+            OwnedValue::Int(-7),
+            OwnedValue::Float(0.0),
+            OwnedValue::Float(-0.0),
+            OwnedValue::Float(f64::INFINITY),
+            OwnedValue::Float(f64::NEG_INFINITY),
+            OwnedValue::Float(f64::NAN),
+            OwnedValue::NumberLiteral(NumberRepr::Float(f64::NAN), ".nan".into()),
+            OwnedValue::String(String::new()),
+            OwnedValue::String("s".into()),
+            OwnedValue::Array(Vec::new()),
+            OwnedValue::Object(indexmap::IndexMap::new()),
+        ] {
+            assert!(v.identical(&v), "not reflexive: {v:?}");
         }
     }
 }

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -40062,3 +40062,156 @@ mod issue_2091_def_and_binder_wrapped_writes {
         Ok(())
     }
 }
+
+// #1360: #763's soundness gate and #711's alias propagation both compared
+// values with `OwnedValue`'s **jq value equality**, under which `NaN` differs
+// from itself. An anchored `.nan` therefore reported a divergence that never
+// happened: the alias was never propagated to, and the gate then dropped its
+// `*x` mark as unresolvable.
+//
+// Own module rather than bare file end: the identical-trailing-`Ok(())`
+// context merge hazard that has bitten this repo for real (#2500).
+//
+// Every expectation is pinned real `yq` v4.53.3 output.
+// =============================================================================
+mod issue_1360_identity_not_jq_equality {
+    use super::*;
+
+    /// The issue's own repro.
+    ///
+    /// $ yq '.c = 1'  =>  a: &x .nan / b: *x / c: 1
+    #[test]
+    fn test_yaml_nan_anchor_alias_survives_unrelated_write_1360() -> Result<()> {
+        let (output, code) = run_yq_stdin(".c = 1", "a: &x .nan\nb: *x\n", &[])?;
+        assert_eq!(code, 0);
+        assert_eq!(output, "a: &x .nan\nb: *x\nc: 1\n");
+        Ok(())
+    }
+
+    /// A `NaN` *anywhere inside* an anchored container cost the whole subtree
+    /// its mark, not just the scalar holding it.
+    #[test]
+    fn test_yaml_nan_anchor_alias_survives_nested_1360() -> Result<()> {
+        for (input, expected) in [
+            (
+                "a: &x {p: .nan, q: 1}\nb: *x\n",
+                "a: &x {p: .nan, q: 1}\nb: *x\nc: 1\n",
+            ),
+            (
+                "a: &x [1.0, .nan, .inf]\nb: *x\n",
+                "a: &x [1.0, .nan, .inf]\nb: *x\nc: 1\n",
+            ),
+        ] {
+            let (output, code) = run_yq_stdin(".c = 1", input, &[])?;
+            assert_eq!(code, 0, "{input}");
+            assert_eq!(output, expected, "{input}");
+        }
+        Ok(())
+    }
+
+    /// The control that pins the cause to `NaN` rather than to floats in
+    /// general: `.inf` compares equal to itself and was always correct.
+    #[test]
+    fn test_yaml_inf_anchor_alias_control_1360() -> Result<()> {
+        for input in ["a: &x .inf\nb: *x\n", "a: &x -.inf\nb: *x\n"] {
+            let (output, code) = run_yq_stdin(".c = 1", input, &[])?;
+            assert_eq!(code, 0, "{input}");
+            assert!(output.ends_with("b: *x\nc: 1\n"), "{input}: {output}");
+        }
+        Ok(())
+    }
+
+    /// `-0.0` is jq-equal to `0.0` but does not render the same, so the
+    /// stricter rule must not mistake an anchored `-0.0` for a divergence
+    /// either.
+    #[test]
+    fn test_yaml_negative_zero_anchor_alias_unrelated_write_1360() -> Result<()> {
+        let (output, code) = run_yq_stdin(".c = 1", "a: &x -0.0\nb: *x\n", &[])?;
+        assert_eq!(code, 0);
+        assert_eq!(output, "a: &x -0.0\nb: *x\nc: 1\n");
+        Ok(())
+    }
+
+    /// **The regression guard for the propagation half.** `.a = 1.0` on
+    /// `a: &x 1` changes only the number's spelling. If the gate is strict
+    /// but the propagation still uses jq equality, the sync skips the alias
+    /// (`1 == 1.0`), the gate then sees `1.0` against `1`, and the mark is
+    /// dropped. Both must use the same rule.
+    ///
+    /// $ yq '.a = 1.0'  =>  a: &x 1.0 / b: *x
+    #[test]
+    fn test_yaml_assign_float_spelling_to_anchor_syncs_alias_1360() -> Result<()> {
+        let (output, code) = run_yq_stdin(".a = 1.0", "a: &x 1\nb: *x\n", &[])?;
+        assert_eq!(code, 0);
+        assert_eq!(output, "a: &x 1.0\nb: *x\n");
+        Ok(())
+    }
+
+    /// A write landing *on* the alias must not be discarded because the new
+    /// value happens to be jq-equal to the anchor's.
+    ///
+    /// These two pass by way of #1351's alias-identity rebinding rather than
+    /// the equality rule — a path ending exactly at an alias rebinds that
+    /// position — so they guard that interaction rather than this fix. Pinned
+    /// because the issue's own triage predicted them failing, and they are
+    /// the shape that would break first if either rule moved.
+    ///
+    /// $ yq '.b = -0.0'  =>  a: &x 0.0 / b: -0.0
+    /// $ yq '.b = 1.0'   =>  a: &x 1   / b: 1.0
+    #[test]
+    fn test_yaml_write_through_alias_spelling_not_discarded_1360() -> Result<()> {
+        for (input, filter, expected) in [
+            ("a: &x 0.0\nb: *x\n", ".b = -0.0", "a: &x 0.0\nb: -0.0\n"),
+            ("a: &x 1\nb: *x\n", ".b = 1.0", "a: &x 1\nb: 1.0\n"),
+        ] {
+            let (output, code) = run_yq_stdin(filter, input, &[])?;
+            assert_eq!(code, 0, "{filter}");
+            assert_eq!(output, expected, "{filter}");
+        }
+        Ok(())
+    }
+
+    /// A stricter rule must not start reporting divergences for numbers that
+    /// merely *round-trip* through the reindex bridge. The issue's triage
+    /// flagged this as the way the fix could backfire: if the bridge
+    /// collapsed an untouched `NumberLiteral` to a plain `Int`/`Float`,
+    /// strict identity would call every untouched number changed and drop its
+    /// mark.
+    #[test]
+    fn test_yaml_number_spellings_round_trip_under_strict_identity_1360() -> Result<()> {
+        for spelling in [
+            "1", "1.0", "0", "0.10", "3.140", "1e10", "1E+10", "-0.0", ".inf", "-.inf", ".nan",
+        ] {
+            let input = format!("a: &x {spelling}\nb: *x\n");
+            let (output, code) = run_yq_stdin(".c = 1", &input, &[])?;
+            assert_eq!(code, 0, "{spelling}");
+            assert_eq!(
+                output,
+                format!("a: &x {spelling}\nb: *x\nc: 1\n"),
+                "spelling {spelling} must survive untouched, mark included"
+            );
+        }
+        Ok(())
+    }
+
+    /// Ordinary values are unaffected: the change is about *which* comparison
+    /// the gate uses, not about which documents it accepts.
+    #[test]
+    fn test_yaml_ordinary_anchor_alias_unaffected_1360() -> Result<()> {
+        for (input, filter, expected) in [
+            ("a: &x 1\nb: *x\n", ".a = 99", "a: &x 99\nb: *x\n"),
+            ("a: &x 1\nb: *x\n", ".c = 3", "a: &x 1\nb: *x\nc: 3\n"),
+            ("a: &x {p: 1}\nb: *x\n", ".a.p = 9", "a: &x {p: 9}\nb: *x\n"),
+            (
+                "a: &x \"s\"\nb: *x\n",
+                ".c = 1",
+                "a: &x \"s\"\nb: *x\nc: 1\n",
+            ),
+        ] {
+            let (output, code) = run_yq_stdin(filter, input, &[])?;
+            assert_eq!(code, 0, "{filter}");
+            assert_eq!(output, expected, "{filter} on {input:?}");
+        }
+        Ok(())
+    }
+}

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -40214,4 +40214,56 @@ mod issue_1360_identity_not_jq_equality {
         }
         Ok(())
     }
+
+    /// The **fourth** comparison, found in review: #1351's redirect gate
+    /// (`alias_identity::same_node`) decides whether a write through an alias
+    /// lands on the shared node, and it was still using jq equality. That is
+    /// a wrong *value* on the page, in both directions.
+    ///
+    /// NaN made the redirect fail, so the write hit only the copy:
+    /// $ yq '.b.p = 9' on `a: &x {p: .nan} / b: *x`  =>  a: &x {p: 9} / b: *x
+    #[test]
+    fn test_yaml_write_through_alias_redirects_past_nan_1360() -> Result<()> {
+        for (input, filter, expected) in [
+            (
+                "a: &x {p: .nan}\nb: *x\n",
+                ".b.p = 9",
+                "a: &x {p: 9}\nb: *x\n",
+            ),
+            (
+                "a: &x {p: .nan, q: 1}\nb: *x\n",
+                "del(.b.p)",
+                "a: &x {q: 1}\nb: *x\n",
+            ),
+            // The non-NaN control, which always worked -- it is what pins the
+            // cause to the comparison rather than to the redirect itself.
+            ("a: &x {p: 1}\nb: *x\n", ".b.p = 9", "a: &x {p: 9}\nb: *x\n"),
+        ] {
+            let (output, code) = run_yq_stdin(filter, input, &[])?;
+            assert_eq!(code, 0, "{filter}");
+            assert_eq!(output, expected, "{filter} on {input:?}");
+        }
+        Ok(())
+    }
+
+    /// The other direction of the same gate: `{p: 1}` and `{p: 1.0}` are
+    /// jq-equal but do not render alike, so a slot an earlier stage had
+    /// already rebound still looked like the anchor's own copy and the second
+    /// write was redirected onto the anchor.
+    ///
+    /// $ yq '.b = {"p": 1.0} | .b.p = 9'  =>  a: &x {p: 1} / b: {p: 9}
+    #[test]
+    fn test_yaml_rebound_alias_slot_is_not_redirected_1360() -> Result<()> {
+        let (output, code) =
+            run_yq_stdin(".b = {\"p\": 1.0} | .b.p = 9", "a: &x {p: 1}\nb: *x\n", &[])?;
+        assert_eq!(code, 0);
+        assert_eq!(output, "a: &x {p: 1}\nb:\n  p: 9\n");
+
+        // #2499's own control: a slot rebound to something plainly different
+        // was never redirected, and still is not.
+        let (output, code) = run_yq_stdin(".b = null | .a.p = 9", "a: &x {p: 1}\nb: *x\n", &[])?;
+        assert_eq!(code, 0);
+        assert_eq!(output, "a: &x {p: 9}\nb: null\n");
+        Ok(())
+    }
 }


### PR DESCRIPTION
## Summary

Fixes #1360. #763's anchor-soundness gate and #711's alias propagation both
ask *"has this node changed?"* using `OwnedValue`'s `PartialEq` — which is
**jq value equality**. Under that rule `NaN` differs from itself, so an
anchored `.nan` reports a divergence that never happened: the alias is never
propagated to, and the gate then drops its `*x` mark as unresolvable.

```console
$ printf 'a: &x .nan\nb: *x\n' | yq            '.c = 1'
a: &x .nan
b: *x
c: 1

$ printf 'a: &x .nan\nb: *x\n' | succinctly yq '.c = 1'
a: &x .nan
b: .nan            # <- mark lost; nothing about the document changed
c: 1
```

A `NaN` *anywhere inside* an anchored container costs the whole subtree its
mark. `.inf` is the control that pins the cause to NaN specifically rather
than to floats in general — it compares equal to itself and was always
correct.

## The fix

`OwnedValue::identical`, added beside the hand-written `PartialEq` without
touching it. It answers *"would these render identically?"*, which is the
question both call sites are actually asking:

| | `==` (jq equality) | `identical` |
|---|---|---|
| `NaN` vs `NaN` | ✗ differ | ✓ same |
| `-0.0` vs `0.0` | ✓ same | ✗ differ |
| `Int(1)` vs `Float(1.0)` | ✓ same | ✗ differ |
| `1.0` vs `1.00` (literal text) | ✓ same | ✗ differ |
| `{a,b}` vs `{b,a}` | ✓ same | ✗ differ |

Floats compare by `to_bits`, not `total_cmp`: same answers on every case
here, but it states the intent and sidesteps a `-0.0`/NaN-sign discussion.
Objects compare by key **order** too, since `emit_yaml_value` writes fields
in order.

### Both sites must move together

`.a = 1.0` on `a: &x 1` changes only the number's spelling. With a strict
gate but loose propagation, the sync skips the alias (`1 == 1.0`), the gate
then sees `1.0` against `1`, and the mark dies. Pinned by
`test_yaml_assign_float_spelling_to_anchor_syncs_alias_1360`.

The issue's triage named `sync_aliased_paths` as the second site. It is now a
thin wrapper over `propagate_anchor_writes`, which has **three** comparisons
— is this slot still a copy of the anchor's pre-value, did the anchor change,
was the slot rebound by an earlier stage (#2499). All three move together, or
a NaN slot is judged a copy by one and a divergence by another.

## Two corrections to the triage, both verified against the oracle first

**1. Its "worse than filed" half is already fixed.** The triage (2026-09-04)
reported that loose equality also *discards writes* — `.b = -0.0` and
`.b = 1.0` printing `b: *x`. Both now pass on `main`: #1351's alias-identity
work landed since, and a path ending exactly at an alias rebinds that
position rather than consulting this gate. Kept as tests, documented as
guarding that interaction rather than this fix.

I still implemented the triage's `identical` rather than a narrow
NaN-reflexivity patch, because its reasoning holds independently: the gate is
asking "would these render the same", and `Int(1) == Float(1.0)` is the wrong
answer to that whichever way the write arrives.

**2. Its pitfall does not bite.** It warned that if the JSON reindex bridge
collapsed an untouched `NumberLiteral` to a plain `Int`/`Float`, strict
identity would flag every untouched number as changed and drop its mark. All
eleven spellings round-trip with the mark intact:

`1`, `1.0`, `0`, `0.10`, `3.140`, `1e10`, `1E+10`, `-0.0`, `.inf`, `-.inf`,
`.nan` — plus nested (`{p: 1.0, q: [2.50, .nan]}`, `[1.0, .nan, .inf]`).

Pinned by `test_yaml_number_spellings_round_trip_under_strict_identity_1360`.

## Unblocks

#1359's own triage says "#1359's kind-change fix and #1353's group fix both
lean on this gate; land this first."

## Test plan

- [x] `cargo test --features cli,simd,regex,serde` — 7724 passed, 0 failed
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings`
- [x] `cargo check --no-default-features` (`no_std`)
- [x] `cargo fmt --all -- --check`
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps`
- [x] 8 CLI tests + 4 unit tests on `identical` itself
- [x] **100% patch coverage** on added `src/` lines (108/108)

Every CLI expectation is pinned real `yq` v4.53.3 output. New tests live in
their own `mod issue_1360_identity_not_jq_equality` block rather than at bare
file end — the identical-trailing-`Ok(())` merge hazard that hit #2500.
