### PR TITLE
fix(yq): gate path(f) behind --jq-extensions in yq mode

### DIFF
--- a/docs/compliance/yq/limitations.md
+++ b/docs/compliance/yq/limitations.md
@@ -949,8 +949,8 @@ same shared `path_step_generic`, but pass it different duplicate-key collapse fl
 call sites sit ~500 lines apart and the mismatch reads as an oversight without this:
 
 ```bash
-$ printf '{"a":1,"a":2}' | succinctly yq -o=json -I=0 '[path(.[])]'   # [["a"],["a"]]
-$ printf '{"a":1,"a":2}' | succinctly yq -o=json -I=0 '[.[] | key]'   # ["a"]
+$ printf '{"a":1,"a":2}' | succinctly yq --jq-extensions -o=json -I=0 '[path(.[])]'   # [["a"],["a"]]
+$ printf '{"a":1,"a":2}' | succinctly yq -o=json -I=0 '[.[] | key]'                   # ["a"]
 ```
 
 `key`/`path`/`parent` pass `true` unconditionally because they replace a bridge that used to
@@ -958,7 +958,8 @@ materialize into an `IndexMap` (which collapses structurally in both modes) — 
 (`["a"]` in v4.53.3). `path(f)` passes `S::COLLAPSE_DUPLICATE_KEYS` (the mode's own rule)
 instead, because it isn't replacing a materialization and has **no yq oracle at all**: real
 yq's `path` is the no-argument form only, so `path(f)` is a jq builtin succinctly exposes as
-an extension in yq mode, exempt from ADR-0018's divergence rule. In jq mode both walks agree
+an extension in yq mode (gated behind `--jq-extensions`, #2430), exempt from ADR-0018's
+divergence rule. In jq mode both walks agree
 with real jq 1.7.1 (`[["a"]]`). So the two flags are a recorded choice, not a bug — this
 entry (plus the cross-referencing doc comments on both functions) is what keeps a future
 reader from "fixing" the mismatch into a real divergence.

--- a/docs/reference/yq-language.md
+++ b/docs/reference/yq-language.md
@@ -421,6 +421,7 @@ surface (#1512):
 | Builtin                                              | Description                                   |
 |------------------------------------------------------|-----------------------------------------------|
 | `paths`, `paths(f)`, `leaf_paths`                    | Paths to every node / every leaf node         |
+| `path(f)`                                            | Path to values selected by `f` (#2430)        |
 | `getpath(path)`                                      | Value at a path array                         |
 | `tostream`, `fromstream(f)`, `truncate_stream(f)`    | Streaming event representation                |
 | `IN(s)`, `IN(src; s)`                                | Membership test                               |

--- a/src/jq/parser.rs
+++ b/src/jq/parser.rs
@@ -434,13 +434,24 @@ impl<'a> Parser<'a> {
     /// before consuming the keyword, so a rejected keyword's position is
     /// still where the caller expects.
     fn reject_unless_jq_extensions(&self, name: &str) -> Result<(), ParseError> {
+        self.reject_unless_jq_extensions_at(name, self.pos)
+    }
+
+    /// Same as [`reject_unless_jq_extensions`], but reports the rejection at
+    /// an explicit position instead of the parser's current one. For a
+    /// keyword whose gated/ungated form can only be told apart by looking
+    /// past it (`path` vs. `path(f)`, #2430), the keyword must already be
+    /// consumed before that lookahead runs -- this lets the error still
+    /// point at the keyword's own start, matching every other gated name's
+    /// convention, instead of wherever the lookahead left `self.pos`.
+    fn reject_unless_jq_extensions_at(&self, name: &str, pos: usize) -> Result<(), ParseError> {
         if self.mode == ParserMode::Yq && !self.jq_extensions {
             return Err(ParseError::new(
                 format!(
                     "\"{name}\" is not part of yq's syntax; pass --jq-extensions to enable \
                      succinctly's jq-compatible builtin surface"
                 ),
-                self.pos,
+                pos,
             ));
         }
         Ok(())
@@ -3917,12 +3928,15 @@ impl<'a> Parser<'a> {
         // path(expr) - return the path to values selected by expr
         // path (no-arg, yq) - return the current traversal path
         if self.matches_keyword("path") {
+            let keyword_start = self.pos;
             self.consume_keyword("path");
             self.skip_ws();
             if self.peek() == Some('(') {
                 // path(expr) - jq style; real yq's `path` is nullary, so this
-                // form is jq-only surface in yq mode (#2430).
-                self.reject_unless_jq_extensions("path(f)")?;
+                // form is jq-only surface in yq mode (#2430). The gate/no-gate
+                // split can only be told apart by looking past the keyword,
+                // so report it at the keyword's own start rather than here.
+                self.reject_unless_jq_extensions_at("path(f)", keyword_start)?;
                 self.next();
                 self.skip_ws();
                 let expr = self.parse_expr()?;

--- a/src/jq/parser.rs
+++ b/src/jq/parser.rs
@@ -3920,7 +3920,9 @@ impl<'a> Parser<'a> {
             self.consume_keyword("path");
             self.skip_ws();
             if self.peek() == Some('(') {
-                // path(expr) - jq style
+                // path(expr) - jq style; real yq's `path` is nullary, so this
+                // form is jq-only surface in yq mode (#2430).
+                self.reject_unless_jq_extensions("path(f)")?;
                 self.next();
                 self.skip_ws();
                 let expr = self.parse_expr()?;

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -29971,7 +29971,7 @@ fn test_path_context_bypass_keeps_yq_float_fidelity_1909() -> Result<()> {
     // `10000000000000000000.0` materializes as a bare `Float` (not a
     // `NumberLiteral` — it is past what `is_preservable_float_literal`
     // keeps), which is exactly what `reindex_bridge_is_identity` refuses.
-    let (out, code) = run_yq_stdin("[path(..)]", doc, &["-o", "json", "-I0"])?;
+    let (out, code) = run_yq_stdin("[path(..)]", doc, &["--jq-extensions", "-o", "json", "-I0"])?;
     assert_eq!(code, 0, "out: {out:?}");
     assert_eq!(
         out.trim(),
@@ -30084,7 +30084,7 @@ fn test_path_context_cursor_walk_composite_stages_2061() -> Result<()> {
         (".a|.|.b|key", AB, r#""b""#),
         (".a.b|.|parent|key", AB, r#""a""#),
     ] {
-        let (out, code) = run_yq_stdin(filter, input, &["-o", "json", "-I0"])?;
+        let (out, code) = run_yq_stdin(filter, input, &["--jq-extensions", "-o", "json", "-I0"])?;
         assert_eq!(code, 0, "`{filter}` on `{input}`: {out:?}");
         assert_eq!(out.trim(), want, "`{filter}` on `{input}`");
     }
@@ -30561,7 +30561,7 @@ fn fold_source_value_reuse_is_jq_mode_only_1872() -> Result<()> {
     let (_out, stderr, code) = run_yq_stdin_with_stderr(
         "path(foreach (.a.b) as $k (.; .))",
         "a: [1, 2]\n",
-        &["-o", "json"],
+        &["--jq-extensions", "-o", "json"],
     )?;
     assert_ne!(code, 0);
     assert!(
@@ -30574,7 +30574,7 @@ fn fold_source_value_reuse_is_jq_mode_only_1872() -> Result<()> {
     let (_out, stderr, code) = run_yq_stdin_with_stderr(
         "path(foreach (1,2,keys[]) as $k (.; .))",
         "a: 1\n",
-        &["-o", "json"],
+        &["--jq-extensions", "-o", "json"],
     )?;
     assert_ne!(code, 0);
     assert!(
@@ -30583,7 +30583,11 @@ fn fold_source_value_reuse_is_jq_mode_only_1872() -> Result<()> {
     );
 
     // A navigating source that resolves cleanly is unaffected either way.
-    let (out, code) = run_yq_stdin("path(reduce (.[]) as $k (.; .))", "a: 1\n", &["-o", "json"])?;
+    let (out, code) = run_yq_stdin(
+        "path(reduce (.[]) as $k (.; .))",
+        "a: 1\n",
+        &["--jq-extensions", "-o", "json"],
+    )?;
     assert_eq!(code, 0);
     assert_eq!(out.trim(), "[]");
 
@@ -30593,7 +30597,7 @@ fn fold_source_value_reuse_is_jq_mode_only_1872() -> Result<()> {
     let (_out, stderr, code) = run_yq_stdin_with_stderr(
         "path(foreach (1,2,(.a|tostring|halt_error(3))) as $k (.; .))",
         "a: 1\n",
-        &["-o", "json"],
+        &["--jq-extensions", "-o", "json"],
     )?;
     assert_eq!(code, 3, "stderr: {stderr}");
     assert_eq!(stderr, "1");
@@ -32129,12 +32133,11 @@ fn test_yq_iterate_path_context_non_container_is_noop_2346() -> Result<()> {
 
 /// #2346, `path_step_generic`: a distinct third `Expr::Iterate` site from
 /// the two above, backing `path(expr)`'s own cursor-native path-computation
-/// walk. `path` is a jq-only builtin succinctly does not gate behind
-/// `--jq-extensions` in yq mode (a separate, pre-existing gap, unrelated to
-/// this fix) -- reachable here without any extension flag.
+/// walk. `path(expr)` is jq-only surface, gated behind `--jq-extensions` in
+/// yq mode since #2430.
 #[test]
 fn test_yq_path_step_generic_non_container_is_noop_2346() -> Result<()> {
-    let (out, code) = run_yq_stdin("[path(.a[])]", "a: 5\n", &["-o", "json"])?;
+    let (out, code) = run_yq_stdin("[path(.a[])]", "a: 5\n", &["--jq-extensions", "-o", "json"])?;
     assert_eq!(code, 0, "out: {out:?}");
     assert_eq!(out.trim(), "[]");
     Ok(())

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -1425,6 +1425,10 @@ fn test_yq_default_rejects_jq_only_builtins_1512() -> Result<()> {
         // test_yq_downcase_upcase_builtins_2462).
         "ascii_downcase",
         "ascii_upcase",
+        // #2430: real yq's `path` is nullary; `path(f)` is jq's. Bare
+        // `path` (not in this list) stays ungated -- see
+        // test_yq_bare_path_ungated_2430.
+        "path(.a)",
     ] {
         let (_out, stderr, code) = run_yq_stdin_with_stderr(filter, "a: 1\n", &[])?;
         assert_ne!(code, 0, "filter {filter:?} should be rejected by default");
@@ -1579,6 +1583,7 @@ fn test_yq_jq_extensions_flag_enables_jq_only_builtins_1512() -> Result<()> {
         "nan",
         "\"ABC\" | ascii_downcase",
         "\"abc\" | ascii_upcase",
+        "path(.a)",
     ] {
         let (_out, stderr, code) =
             run_yq_stdin_with_stderr(filter, "a: 1\n", &["--jq-extensions"])?;
@@ -1587,6 +1592,28 @@ fn test_yq_jq_extensions_flag_enables_jq_only_builtins_1512() -> Result<()> {
             "filter {filter:?} should succeed with --jq-extensions, stderr: {stderr}"
         );
     }
+    Ok(())
+}
+
+/// #2430: real yq's `path` is nullary (the current traversal path); `path(f)`
+/// is jq's own construct and has no yq oracle at all -- unlike `path`, it's
+/// gated behind `--jq-extensions` above. Pins the error position at the
+/// keyword's own start (matching every other `reject_unless_jq_extensions`
+/// site), not at the `(` that disambiguates the two forms, and confirms bare
+/// `path` keeps working with no flag either way.
+#[test]
+fn test_yq_bare_path_ungated_2430() -> Result<()> {
+    let (out, code) = run_yq_stdin(".a | path", "a: 1\n", &["-o=json", "-I=0"])?;
+    assert_eq!(code, 0);
+    assert_eq!(out.trim(), r#"["a"]"#);
+
+    let (_out, stderr, code) = run_yq_stdin_with_stderr("path(.a)", "a: 1\n", &[])?;
+    assert_ne!(code, 0);
+    assert!(
+        stderr.contains("parse error at position 0"),
+        "stderr: {stderr}"
+    );
+    assert!(stderr.contains("--jq-extensions"), "stderr: {stderr}");
     Ok(())
 }
 


### PR DESCRIPTION
## Summary
- Real yq's `path` is nullary (returns the current traversal path); `path(f)` is jq's own construct and has no yq oracle at all. It escaped the #1512 `--jq-extensions` gate that already covers `paths`/`getpath`/etc.
- Gate `path(f)` (the paren-arg jq-style form) the same way, with the same error shape as the other gated builtins. Bare `path` (yq's real, ungated syntax) is untouched.
- Updated 6 pre-existing test call sites (in `tests/yq_cli_tests.rs`) that exercised `path(f)` in yq mode without the flag — none of them were actually testing the gate itself, so they just needed `--jq-extensions` added to keep working. `--jq-extensions`-parsed unit tests via the `yq_query!` macro already hardcode the flag on, so they were unaffected.
- Added `path(f)` to the gated-builtins table in `docs/reference/yq-language.md`.

## Test plan
- [x] `cargo build --features cli`
- [x] `cargo test --features cli,simd,regex,serde` (full suite, 1605/1605 pass in `yq_cli_tests`)
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings`
- [x] Diffed against real yq v4.53.3: `path(.a)` now errors the same way (`bad expression...` in real yq vs. succinctly's own gate message); bare `path` and `--jq-extensions path(.a)` both still work; jq mode unaffected

Fixes #2430