### PR TITLE
feat(jq): evaluate an update filter at its target's position (#2522)

### DIFF
--- a/docs/compliance/yq/limitations.md
+++ b/docs/compliance/yq/limitations.md
@@ -2102,6 +2102,65 @@ Two consequences worth naming:
   `x: 1`). Pinned in both shapes in
   `test_yq_assign_rhs_reading_its_own_target_lacks_node_identity_2481`.
 
+### An update filter's evaluation position — resolved (#2522); one `parent` row still diverges
+
+Real yq's `assignUpdateOperator` runs `|=`'s filter through
+`context.SingleChildContext(candidate)`, per matched node with `.` bound to that node — so
+`key`/`path`/`parent` inside the filter are the **target's**, not the assignment's input's.
+(A compound assignment is the other case: it evaluates its right side once, against the
+input, which is the `=` rule #2481 above records.) succinctly had no route that named the
+target's position, so every read in an update filter answered from nowhere: `key` produced
+nothing at all and the target was left untouched, `path` was `[]`.
+[#2522](https://github.com/rust-works/succinctly/issues/2522) closed that, and every row
+below now agrees with yq v4.53.3 (`-o=json -I0`, on `a: {b: 1, e: 2}` unless noted):
+
+| filter                                     | real yq (and now succinctly)         | succinctly before #2522 |
+|--------------------------------------------|--------------------------------------|--------------------------|
+| `.a \| .b \|= key`                           | `{"b":"b","e":2}`                    | `{"b":1,"e":2}`          |
+| `.a \| .b \|= path`                          | `{"b":["a","b"],"e":2}`              | `{"b":[],"e":2}`         |
+| `.a \| .b \|= (path\|join("/"))`              | `{"b":"a/b","e":2}`                  | `{"b":"","e":2}`         |
+| `.a.b \|= (path\|length)`                    | `{"a":{"b":2,"e":2}}`                | `{"a":{"b":0,"e":2}}`    |
+| `.a \| to_entries \| .[0] \| .value \|= path`  | `{"key":"b","value":["a",0,"value"]}` | `{"key":"b","value":[]}` |
+| `.a \| .zzz \|= key`                         | `{"b":1,"e":2,"zzz":"zzz"}`          | `{"b":1,"e":2,"zzz":null}` |
+| `.a \| (.b,.e) \|= key`                      | `{"b":"b","e":"e"}`                  | `{"b":1,"e":2}`          |
+| `.a \| .b \|= (parent\|keys)`                | `{"b":["b","e"],"e":2}`              | `{"b":1,"e":2}`          |
+| `.a \| .zzz \|= (parent\|keys)`              | `{"b":1,"e":2,"zzz":["b","e","zzz"]}` | `{"b":1,"e":2,"zzz":null}` |
+| `.a \| .b += key`                           | `{"b":"1a","e":2}`                   | `{"b":1,"e":2}`          |
+| `.a \| .b -= (key\|length)`                  | `{"b":0,"e":2}`                      | `{"b":1,"e":2}`          |
+| `.n[] \|= key` (on `n: [1, 2]`)             | `{"n":[0,1]}`                        | `{"n":[1,2]}`            |
+| `.n[] \|= path` (on `n: [1, 2]`)            | `{"n":[["n",0],["n",1]]}`            | `{"n":[[],[]]}`          |
+| `.n[] \|= (key + 10)` (on `n: [1, 2]`)      | `{"n":[10,11]}`                      | `{"n":[10,10]}`          |
+
+`.a | .zzz |= (parent|keys)` is the row that shows `parent` climbs a snapshot with the
+whole left side already auto-created: real yq resolves and vivifies its targets before any
+filter runs (#2481 above), so the key the write is about to fill is already in the parent
+the filter is handed.
+
+Implemented as `jq::eval::UpdatePos`, threaded through `update_path`/`update_path_steps` so
+the components the walk takes name the target, plus an ambient prefix
+(`jq::eval_generic::path_base`) for where the assignment's *input* itself sits — a
+mid-pipe `.a | .b |= path` has to answer `["a","b"]`, not `["b"]`. The rewrite is
+`path_context_resolve_constants`, the same one the owned identity pipe applies, so a
+position named here means what a position named anywhere else does.
+
+**The one row still divergent** is a bare `parent` written straight into its own target:
+
+| filter                | real yq                        | succinctly                     |
+|-----------------------|--------------------------------|--------------------------------|
+| `.a \| .b \|= parent`  | `{"b":{"b":{},"e":2},"e":2}`   | `{"b":{"b":1,"e":2},"e":2}`    |
+
+Real yq's `parent` is a *pointer* to the node it is in the middle of mutating, so assigning
+it into that node's own child makes the document self-referential and its printer emits the
+cycle truncated (`{}` at the second level). succinctly has no node identity (the same
+limitation the anchor/alias section above records), so it writes the parent's pre-write
+value. Every `parent` row that *reads* the node rather than embedding it — `parent|keys`,
+`parent|type`, `parent|length` — matches. Pinned in
+`test_yq_update_filter_reads_the_target_position_2522`.
+
+`line`/`column` inside an update filter are **not** covered: they are answered from a
+cursor, not from a path, and no cursor reaches the filter. `.a | .b |= line` is `2` in real
+yq and `0` in succinctly — a separate, pre-existing gap, not one #2522 touches.
+
 ### An `and`/`or` operand's evaluation context -- open (captured under [#2473](https://github.com/rust-works/succinctly/issues/2473))
 
 Real yq v4.53.3 does not evaluate an `and`/`or`'s **right** operand against the node the

--- a/docs/plan/path-context-arm-reachability.md
+++ b/docs/plan/path-context-arm-reachability.md
@@ -1,15 +1,17 @@
 # Per-arm reachability of the eager path-context evaluator (spine 2416, steps 4-5)
 
 `eval_stage_with_path_context` (`src/jq/eval.rs`) is the eager, materialising
-path-context evaluator ADR-0021 is retiring. It handles 43 expression shapes by
-name -- 5 pre-match `if` handlers plus 38 arms of its top-level `match first`
+path-context evaluator ADR-0021 is retiring. It handles 44 expression shapes by
+name -- 5 pre-match `if` handlers plus 39 arms of its top-level `match first`
 (the split `tests/jq_path_context_arm_guard.rs` pins) -- and each one was added
 to fix a shape the generic evaluator could not answer.
 
-Step 4 asks, of every one of those 43: is there still a query that reaches it?
+Step 4 asks, of every one of those: is there still a query that reaches it?
 
-**Answer: all 43 are reachable.** None was deleted; `PINNED_ARM_COUNT` stays at
-43. The rest of this page is the evidence.
+**Answer: all of them are reachable.** None was deleted. `PINNED_ARM_COUNT` sat
+at 43 through step 5 and moved to 44 with #2522, which *added* an arm rather
+than migrating one (see its section below). The rest of this page is the
+evidence.
 
 ## Method
 
@@ -120,7 +122,7 @@ R3 and onto the generic route, which is what an admission to
 now. Re-derive this paragraph's examples after any further admission rather than
 trusting them.
 
-## The 43 handlers
+## The 44 handlers
 
 | #   | Handler (site in `eval_stage_with_path_context`)                   | Verdict   | Proof query (jq mode, document `D`)                   | Gate |
 |-----|--------------------------------------------------------------------|-----------|-------------------------------------------------------|------|
@@ -167,6 +169,7 @@ trusting them.
 | A36 | `Expr::Try { .. }`                                                 | REACHABLE | `.a.b \| try (key + "x") catch "e"`                   | R2   |
 | A37 | `Expr::Label { name, body }`                                       | REACHABLE | `.a.b \| label $out \| (key + "x", break $out)`       | R2   |
 | A38 | `Expr::Break(name)`                                                | REACHABLE | `.a.b \| label $out \| (key + "x", break $out)`       | R2   |
+| A39 | `Expr::Update \| CompoundAssign \| AlternativeAssign`               | REACHABLE | `.a \| .b \|= key`                                    | R2   |
 
 ## Step 1b: `Expr::Arithmetic` admitted, and the pin holds at 43
 
@@ -445,17 +448,98 @@ with no path context anywhere in the filter:
   `.a | with_entries(.key = key)`, which yq answers `{"0":1,"1":2}`. A separate yq
   fidelity gap in `from_entries`, deliberately not fixed here.
 
+## #2522: an assignment arm added, and the pin moves to 44
+
+`|=` evaluates its filter at the **target's** position, not at the assignment's
+input (yq v4.53.3, on `a: {b: 1, e: 2}`: `.a | .b |= key` is `{"b":"b","e":2}`,
+where `.a | .b = key` is `{"b":"a","e":2}`). `eval::update_path` is the only
+place that knows the components walked to reach a target, but not where the
+value it was handed sits in the document -- so `.a | .b |= path` had to answer
+`["a","b"]` with only `["b"]` in hand.
+
+`needs_path_context` therefore gained `Expr::Update`/`Expr::CompoundAssign`/
+`Expr::AlternativeAssign` arms (gated on their right side, so an ordinary
+`.a |= . + 1` routes exactly as before), and `eval_stage_with_path_context`
+gained `A39`, which supplies the two positions involved:
+
+- for a compound assignment, whose right side is evaluated **once against this
+  stage's input**, the reads in it are constants for `current_path` and are
+  rewritten there -- the same rewrite the owned identity pipe already applies to
+  `=`'s right side (#2471);
+- for `|=`, the stage's `current_path` becomes an ambient prefix
+  (`eval_generic::path_base`) that `update_path` extends with the components it
+  walks.
+
+**This is an addition, not a migration.** Nothing moved off the cursor walk, and
+no shape that used to reach another arm now reaches `A39`: before it, an
+assignment stage fell to the `_` fallback, which evaluates it with no position
+at all. `PINNED_ARM_COUNT` goes 43 -> 44 for that reason, which is the "raise it
+only in a PR that says why" case rule 2 of "Hygiene going forward" allows.
+
+### Reachability of `A39`, and of the other 43
+
+`A39` instrumented and run against `D`:
+
+| Proof query           | Marker | Gate            | Output      |
+|-----------------------|--------|-----------------|-------------|
+| `.a \| .b \|= key`      | fired  | `R2` (and `R3`) | `{"b":"b"}` |
+| `.a \| .b += key`      | fired  | `R2` (and `R3`) | error (`number (1) and string ("a") cannot be added`) |
+| `.c[] \| .x //= key`   | fired  | `R3`            | error (`Cannot index number with string "x"`) |
+
+The listed query for `A39` is the first row. `R3` also holds for it (an
+assignment stage is not in `path_context_single_native`), so the row is `R2`
+only in the sense every other `R2` row is: that is the disjunct that would fire
+on its own.
+
+No other row is starved: none of the 43 proof queries above contains an
+assignment operator, so none of them can have moved onto `A39`.
+
+### What the change is measured against
+
+A differential over 4,896 assignment queries (eight heads x four operators x nine
+targets x seventeen bodies) on `a: {b: 1, e: 2}`, `n: [1, 2]`,
+`d: {x: {y: 3}, z: [4, 5]}`, `s: hi`, `u: null`, comparing the pre-change binary,
+the post-change binary and yq v4.53.3: **1,859 answers changed, 1,460 of them
+from disagreeing with yq to agreeing with it, and none the other way**
+(agreement 2,449 -> 3,909 of 4,896). The 399 that changed without reaching
+agreement break down as:
+
+- **228** where both sides raise and only succinctly's own wording moved,
+  because the resolved value now appears in it: `.a | .b += path` reports
+  `number (1) and array (["a"]) cannot be added` where it used to say
+  `array ([])`. yq's wording (`!!seq (a) cannot be added to a !!int (a.b)`) is a
+  separate, pre-existing gap.
+- **110** where yq's own **lexer** rejects the filter (`{k: key}`, a bare `if`
+  inside an update filter), so there is no yq answer to agree with; succinctly
+  answers as a superset, exactly as it did for those spellings before.
+- **42** where both answer and the values differ. All are `parent` reached
+  somewhere succinctly cannot follow: through an auto-vivified chain
+  (`.a | .x.y |= (parent|type)` is `""` in yq, `!!map` here -- yq vivifies the
+  intermediate node as an untagged null, #2435's gap), or above a value a
+  previous stage rebuilt (`.a | to_entries | .[0] | .b += (parent|type)` is
+  `!!seq` in yq, `!!map` here -- the eager evaluator climbs the *original*
+  document at `current_path`, which `to_entries` has since replaced). Both were
+  `null` before the change, so none of the 42 is worse than it was.
+- **19** where yq errors and succinctly answers, unchanged in that respect
+  before and after.
+
+The jq-mode half of the same method -- 4,900 queries built only from filters real
+jq defines (`path(.)`, `[paths]`, `del(...)`, arithmetic), across seven
+operators including `/=`/`%=`/`//=` -- reports **0 changed** and 4,900/4,900
+agreement with jq 1.7.1 before and after.
+
 ## Result
 
 | Metric                                            | Before | After                 |
 |---------------------------------------------------|--------|-----------------------|
-| Named handlers in `eval_stage_with_path_context`  | 43     | 43                    |
-| ... proven REACHABLE by a live query               | --     | 43                    |
+| Named handlers in `eval_stage_with_path_context`  | 43     | 44 (`A39`, #2522)     |
+| ... proven REACHABLE by a live query               | --     | 44                    |
 | ... proven UNREACHABLE                             | --     | 0                     |
 | ... neither                                        | --     | 0                     |
 | ... whose listed proof query moved off the gate    | --     | 1 (#2473); 14 (#2472) |
 | ... starved by #2471's remainder                   | --     | 0 (`A16`/`A18` re-run) |
-| `PINNED_ARM_COUNT`                                 | 43     | 43                    |
+| ... starved by #2522                               | --     | 0 (no row's query assigns) |
+| `PINNED_ARM_COUNT`                                 | 43     | 44                    |
 
 Nothing is deletable at this point in the spine. Doors 2 and 3 are closed as
 of step 5, which is a precondition rather than a deletion: the eager evaluator

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -1902,14 +1902,29 @@ pub(crate) fn needs_path_context(expr: &Expr) -> bool {
         // therefore left where it was -- unrouted, and answered exactly as
         // before -- rather than routed to a resolver that would refuse it.
         //
-        // `Expr::Update`/`CompoundAssign`/`AlternativeAssign` are excluded for
-        // a different reason: their right side is evaluated against the value
-        // *at the path*, not against the stage's input, so it stands somewhere
-        // else entirely (yq v4.53.3: `.a | .b |= key` is `{"b":"b","e":2}`,
-        // where `.a | .b = key` is `{"b":"a","e":2}`). Admitting them here
-        // without a route that knows the target's position would resolve their
-        // reads against the wrong node.
         Expr::Assign { value, .. } => needs_path_context(value),
+        // `.b |= key` (#2522). `|=` is the one operator whose right side
+        // stands *at the target*, not at the stage's input (yq v4.53.3:
+        // `.a | .b |= key` is `{"b":"b","e":2}`, where `.a | .b = key` is
+        // `{"b":"a","e":2}`), so admitting it here is not enough on its own:
+        // `update_path` resolves the filter against the target's own
+        // position, and this arm exists so the *prefix* of that position --
+        // where the assignment's input itself sits -- reaches it, via
+        // `eval_stage_with_path_context`'s own arm below. Without it,
+        // `.a | .b |= path` answers `["b"]` instead of `["a","b"]`.
+        Expr::Update { filter, .. } => needs_path_context(filter),
+        // `.b += key` (#2522). A compound assignment evaluates its right side
+        // *once, against the assignment's input* -- `eval_compound_assign`
+        // splices the resulting value into the `. op v` filter it builds --
+        // so this is `Expr::Assign`'s case exactly, not `Expr::Update`'s
+        // (yq v4.53.3: `.a | .b += key` is `{"b":"1a","e":2}`, the input's
+        // `"a"` concatenated onto `1`, and `.a | .b -= (key|length)` is
+        // `{"b":0,"e":2}`). `//=` is not real yq syntax at all, and is
+        // admitted for internal consistency with the `|=` it desugars to,
+        // the same judgement `eval_alternative_assign` already records.
+        Expr::CompoundAssign { value, .. } | Expr::AlternativeAssign { value, .. } => {
+            needs_path_context(value)
+        }
         Expr::Pipe(exprs) => exprs.iter().any(needs_path_context),
         Expr::Paren(inner) => needs_path_context(inner),
         Expr::Optional(inner) => needs_path_context(inner),
@@ -20869,9 +20884,60 @@ fn eval_update<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     // this flag.
     let scalar_noop = scalar_slice_noop && S::TAG == EvalTag::Yq;
 
+    // #2522: the position every target of this update stands at, assembled
+    // from the ambient prefix the routes above named (`eval_generic::
+    // path_base`) plus the components `update_path` walks. Both the snapshot
+    // and the gate are paid only for a filter that actually reads a position
+    // -- an ordinary `.a |= . + 1` clones nothing and resolves nothing.
+    let positioned = needs_path_context(filter_expr)
+        && super::eval_generic::path_context_at_resolvable(filter_expr);
+    let base = if positioned {
+        super::eval_generic::current_path_base()
+    } else {
+        Vec::new()
+    };
+    // `parent`'s source, and only built for a filter that actually climbs:
+    // every target auto-created, none of them written yet. `Expr::Identity`
+    // as the filter is exactly `yq_prepare_assign_targets`' own vivification
+    // pass -- it always produces one output, so no arm can delete anything,
+    // and what it leaves behind is the shape a `parent` inside the real
+    // filter is about to be handed. Named apart from `pre` above
+    // (`alias_identity`'s own snapshot, taken for a different reason and
+    // consumed after the loop).
+    let pre_update = (positioned && reads_parent(filter_expr)).then(|| {
+        let mut vivified = result.clone();
+        for path in &paths {
+            // A path that cannot even be walked contributes no vivification;
+            // the real write below raises for it in a moment either way, and
+            // reporting it from here would raise it before the filter that
+            // yq runs first has had its chance to escape.
+            let _ = update_path::<S>(
+                &mut vivified,
+                path,
+                &Expr::Identity,
+                false,
+                scalar_noop,
+                None,
+            );
+        }
+        vivified
+    });
+
     // Get current value at path, apply filter, and set back
     for path in &paths {
-        if let Err(escape) = update_path::<S>(&mut result, path, filter_expr, false, scalar_noop) {
+        let pos = positioned.then(|| UpdatePos {
+            path: base.clone(),
+            base_len: base.len(),
+            pre: pre_update.as_ref(),
+        });
+        if let Err(escape) = update_path::<S>(
+            &mut result,
+            path,
+            filter_expr,
+            false,
+            scalar_noop,
+            pos.as_ref(),
+        ) {
             return match escape {
                 EvalEscape::Error(_) if optional => QueryResult::None,
                 other => other.into(),
@@ -21148,9 +21214,16 @@ fn yq_prepare_assign_targets<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     let pre_creation = alias_identity::active().then(|| pristine.clone());
     let mut doc = pristine;
     for path in &paths {
-        if let Err(escape) =
-            update_path::<S>(&mut doc, path, &Expr::Identity, false, scalar_slice_noop)
-        {
+        if let Err(escape) = update_path::<S>(
+            &mut doc,
+            path,
+            &Expr::Identity,
+            false,
+            scalar_slice_noop,
+            // `Expr::Identity` is the filter: it holds no path-context read,
+            // so there is no position for #2522 to resolve against here.
+            None,
+        ) {
             return Err(match escape {
                 EvalEscape::Error(_) if optional => QueryResult::None,
                 other => other.into(),
@@ -21319,7 +21392,15 @@ fn eval_update_multi<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
         optional,
         build_filter,
         move |result, path, filter, _is_last_path| {
-            update_path::<S>(result, path, filter, false, scalar_noop).map(|_wrote| ())
+            // `None`: `filter` here is always `. op <value>` (or `. //
+            // <value>`) with the right side already evaluated into a literal
+            // by `collect_rhs_outputs` -- a compound assignment reads its
+            // right side at the *input's* position, not the target's (yq
+            // v4.53.3: `.a | .b += key` is `{"b":"1a","e":2}`, the input's
+            // `"a"`), and `eval_stage_with_path_context` resolves that before
+            // the value is ever collected. Nothing is left in `filter` for a
+            // target position to answer.
+            update_path::<S>(result, path, filter, false, scalar_noop, None).map(|_wrote| ())
         },
     )
 }
@@ -21623,9 +21704,26 @@ fn for_each_container_slot<E>(
     root: &mut OwnedValue,
     mut edit: impl FnMut(&mut OwnedValue) -> Result<(), E>,
 ) -> Option<Result<(), E>> {
+    for_each_container_entry(root, |_, slot| edit(slot))
+}
+
+/// [`for_each_container_slot`] with each slot's own path component -- an
+/// array index or an object key (#2522), which is what names the position an
+/// update filter fanned out by `.[]` stands at.
+fn for_each_container_entry<E>(
+    root: &mut OwnedValue,
+    mut edit: impl FnMut(OwnedValue, &mut OwnedValue) -> Result<(), E>,
+) -> Option<Result<(), E>> {
     match root {
-        OwnedValue::Array(arr) => Some(arr.iter_mut().try_for_each(&mut edit)),
-        OwnedValue::Object(map) => Some(map.values_mut().try_for_each(&mut edit)),
+        OwnedValue::Array(arr) => Some(
+            arr.iter_mut()
+                .enumerate()
+                .try_for_each(|(index, slot)| edit(OwnedValue::Int(index as i64), slot)),
+        ),
+        OwnedValue::Object(map) => Some(
+            map.iter_mut()
+                .try_for_each(|(key, slot)| edit(OwnedValue::String(key.clone()), slot)),
+        ),
         _ => None,
     }
 }
@@ -22660,6 +22758,173 @@ fn flatten_path_components(exprs: &[Expr]) -> Vec<Expr> {
     flat
 }
 
+/// Where the filter of a `|=` (or a desugared `op=`) stands (#2522).
+///
+/// Real yq evaluates an update filter at the *target's* position, not at the
+/// assignment's input: on `a: {b: 1, e: 2}`, `.a | .b |= key` is
+/// `{"b":"b","e":2}` and `.a | .b |= path` is `{"b":["a","b"],"e":2}`
+/// (captured from yq v4.53.3), where the same reads on the input side
+/// (`.a | .b = key`) answer `"a"`/`["a"]`. `update_path` is the one place
+/// that knows every component it walked to reach the target, so the position
+/// is assembled here and handed to
+/// [`resolve_path_context_at`](crate::jq::eval_generic::resolve_path_context_at)
+/// -- the same rewrite the owned identity pipe applies, so the two cannot
+/// disagree about what `key`/`path`/`parent` mean at a named position.
+///
+/// `path` is absolute: `base_len` marks where the update's *input* sits, a
+/// prefix that only the routes above `eval_update` know (see
+/// `eval_generic::path_base`). `pre` is what `parent`/`parent(n)` climb: the
+/// input with every target of this assignment auto-created but not yet
+/// written, which is the node a real yq `parent` is handed. Real yq resolves
+/// and vivifies its whole left side before any filter runs (#1412/#2481), so
+/// `.a | .zzz |= (parent|keys)` on `a: {b: 1, e: 2}` is
+/// `["b","e","zzz"]` there -- the key the write is about to fill is already
+/// in the parent. `None` where the filter reads no `parent` at all, which is
+/// what keeps an ordinary `.a |= key` from cloning the input.
+#[derive(Clone)]
+struct UpdatePos<'a> {
+    path: Vec<OwnedValue>,
+    base_len: usize,
+    pre: Option<&'a OwnedValue>,
+}
+
+impl<'a> UpdatePos<'a> {
+    /// The position of `component` inside the value this one describes.
+    fn child(&self, component: OwnedValue) -> Self {
+        let mut path = vec_with_capacity(self.path.len() + 1);
+        path.extend_from_slice(&self.path);
+        path.push(component);
+        Self {
+            path,
+            base_len: self.base_len,
+            pre: self.pre,
+        }
+    }
+
+    /// The whole run of `components` at once, for a chain walked without a
+    /// frame per level ([`update_path_steps`]'s fresh runs).
+    fn descend(&self, components: Vec<OwnedValue>) -> Self {
+        let mut path = vec_with_capacity(self.path.len() + components.len());
+        path.extend_from_slice(&self.path);
+        path.extend(components);
+        Self {
+            path,
+            base_len: self.base_len,
+            pre: self.pre,
+        }
+    }
+
+    /// `key`: the last component taken. `None` only at the update input's own
+    /// position (`. |= key`), where the component that named it belongs to
+    /// whatever produced that input and this walk never saw it.
+    fn key(&self) -> Option<&OwnedValue> {
+        (self.path.len() > self.base_len).then(|| self.path.last().expect("len checked"))
+    }
+
+    /// `parent(n)`: `n` levels up, read out of [`pre`](Self::pre).
+    ///
+    /// `None` above the update's input -- that node is outside the value
+    /// `update_path` was handed, and no route hands it one. `None` too for a
+    /// component that does not exist in `pre`: an ancestor reached only by
+    /// autovivification did not exist when the filter's position was named,
+    /// the same "nothing there" answer `parent` gives above the document root
+    /// (real yq vivifies instead, the pre-existing divergence #2435 records).
+    fn ancestor(&self, n: usize) -> Option<&'a OwnedValue> {
+        let depth = self.path.len() - self.base_len;
+        let keep = depth.checked_sub(n)?;
+        let mut cur = self.pre?;
+        for component in &self.path[self.base_len..self.base_len + keep] {
+            cur = owned_component(cur, component)?;
+        }
+        Some(cur)
+    }
+}
+
+/// One step into an owned container by a path component, or `None` where
+/// there is nothing there. [`UpdatePos::ancestor`]'s walk.
+fn owned_component<'a>(value: &'a OwnedValue, component: &OwnedValue) -> Option<&'a OwnedValue> {
+    match (value, component) {
+        (OwnedValue::Object(map), OwnedValue::String(name)) => map.get(name),
+        (OwnedValue::Array(arr), OwnedValue::Int(i)) => {
+            usize::try_from(*i).ok().and_then(|i| arr.get(i))
+        }
+        _ => None,
+    }
+}
+
+/// The position of `idx` inside an array of `len` elements, resolving a
+/// negative index the way `write_index` itself does.
+///
+/// `None` where no component names the slot: a negative index reaching past
+/// the front is an error `write_index` raises anyway, and no path component
+/// spells it in the meantime.
+fn index_child_pos<'a>(pos: Option<&UpdatePos<'a>>, idx: i64, len: usize) -> Option<UpdatePos<'a>> {
+    let pos = pos?;
+    let resolved = if idx < 0 {
+        i64::try_from(len)
+            .ok()?
+            .checked_add(idx)
+            .filter(|i| *i >= 0)?
+    } else {
+        idx
+    };
+    Some(pos.child(OwnedValue::Int(resolved)))
+}
+
+/// The position at the far end of a fresh `Field`/`Index` run
+/// ([`update_path_steps`]'s frame-free autovivification), which walks every
+/// component of `fresh` in one step.
+///
+/// Every container in a fresh run is created empty, so an `Index` there lands
+/// at `idx` itself -- `write_index` pads up to it. A negative one drops the
+/// position, exactly as [`index_child_pos`] does.
+fn fresh_run_pos<'a>(pos: Option<&UpdatePos<'a>>, fresh: &[Expr]) -> Option<UpdatePos<'a>> {
+    let pos = pos?;
+    let mut components = vec_with_capacity(fresh.len());
+    for step in fresh {
+        match unwrap_path_component(step).0 {
+            Expr::Field(name) => components.push(OwnedValue::String(name.clone())),
+            Expr::Index { idx, .. } if *idx >= 0 => components.push(OwnedValue::Int(*idx)),
+            _ => return None,
+        }
+    }
+    Some(pos.descend(components))
+}
+
+/// Whether `expr` climbs to an ancestor node -- the one path-context read
+/// [`UpdatePos`] needs a materialized snapshot for (#2522). `key` and `path`
+/// are functions of the position alone and cost nothing.
+fn reads_parent(expr: &Expr) -> bool {
+    any_subexpr(expr, &mut |e| {
+        matches!(e, Expr::Builtin(Builtin::Parent | Builtin::ParentN(_)))
+    })
+}
+
+/// [`UpdatePos`] rewritten into the filter it positions, or the filter
+/// unchanged where there is no position to rewrite against (#2522).
+///
+/// `Ok(None)` means "evaluate `filter_expr` as before": either it holds no
+/// path-context read at all, or no route named a position for this update.
+/// The resolvability gate is the caller's
+/// ([`eval_generic::path_context_at_resolvable`]) rather than a silent
+/// fallback here, so a shape the rewriter cannot express keeps exactly the
+/// answer it had.
+fn position_update_filter<S: EvalSemantics>(
+    filter_expr: &Expr,
+    pos: Option<&UpdatePos<'_>>,
+) -> Result<Option<Expr>, EvalError> {
+    let Some(pos) = pos else {
+        return Ok(None);
+    };
+    if !needs_path_context(filter_expr) {
+        return Ok(None);
+    }
+    let parent_of =
+        |n: usize| -> Result<Option<OwnedValue>, EvalError> { Ok(pos.ancestor(n).cloned()) };
+    super::eval_generic::resolve_path_context_at::<S>(filter_expr, pos.key(), &pos.path, &parent_of)
+        .map(Some)
+}
+
 /// Update a value at a path by applying a filter.
 ///
 /// Returns whether a real value reached `root` (#1877/#1894): `false` only
@@ -22682,6 +22947,7 @@ fn update_path<S: EvalSemantics>(
     filter_expr: &Expr,
     optional: bool,
     scalar_noop: bool,
+    pos: Option<&UpdatePos<'_>>,
 ) -> Result<bool, EvalEscape> {
     // yq's slice-write container no-op (#1142) is unconditional on the
     // operator, unlike `scalar_noop` (a caller-gated parameter, `false` for
@@ -22747,7 +23013,21 @@ fn update_path<S: EvalSemantics>(
             // autovivifies/pads *before* reaching here) -- so simply
             // skipping the assignment is exactly "leave it as it was", no
             // separate before/after snapshot needed.
-            let outputs = eval_owned_multi_first::<S>(filter_expr, root)?;
+            // #2522: the filter's own position, resolved into it before it
+            // runs. `with_absolute_path_base` then names that position for a
+            // nested assignment inside the filter (`.a | .b |= (.c |= path)`),
+            // which reaches `eval_update` through the ordinary dispatch with
+            // no parameter to ride on.
+            let positioned = position_update_filter::<S>(filter_expr, pos)?;
+            let filter_expr = positioned.as_ref().unwrap_or(filter_expr);
+            let outputs = match pos {
+                Some(pos) => {
+                    super::eval_generic::with_absolute_path_base(pos.path.clone(), || {
+                        eval_owned_multi_first::<S>(filter_expr, root)
+                    })?
+                }
+                None => eval_owned_multi_first::<S>(filter_expr, root)?,
+            };
             let wrote = !outputs.is_empty();
             if wrote || S::TAG != EvalTag::Yq {
                 *root = outputs.into_iter().next().unwrap_or(OwnedValue::Null);
@@ -22758,9 +23038,16 @@ fn update_path<S: EvalSemantics>(
             let root_was_null = matches!(root, OwnedValue::Null);
             autovivify_object(root);
             if let OwnedValue::Object(map) = root {
+                let child = pos.map(|pos| pos.child(OwnedValue::String(name.clone())));
                 let current = map.entry(name.clone()).or_insert(OwnedValue::Null);
-                let wrote =
-                    update_path::<S>(current, &Expr::Identity, filter_expr, optional, scalar_noop)?;
+                let wrote = update_path::<S>(
+                    current,
+                    &Expr::Identity,
+                    filter_expr,
+                    optional,
+                    scalar_noop,
+                    child.as_ref(),
+                )?;
                 // #1916 is jq-mode only. An update filter that produced no
                 // output at all (`.a |= empty`) deletes the key instead of
                 // leaving it `null` -- jq's `_modify` falls back to
@@ -22828,12 +23115,14 @@ fn update_path<S: EvalSemantics>(
                     // `.[10] |= select(false)` still pads all the way to
                     // index 10. Keep the original eager `write_index`
                     // call, unconditional on the filter's outcome.
+                    let child = index_child_pos(pos, *idx, arr.len());
                     update_path::<S>(
                         write_index(arr, *idx)?,
                         &Expr::Identity,
                         filter_expr,
                         optional,
                         scalar_noop,
+                        child.as_ref(),
                     )
                 } else {
                     // #1916: bounds-checking is deferred behind the
@@ -22852,12 +23141,15 @@ fn update_path<S: EvalSemantics>(
                     // empty update filter takes instead.
                     let wrote = match resolve_read_index(&OwnedValue::Int(*idx), arr.len()) {
                         Some(actual_idx) => {
+                            let child =
+                                pos.map(|pos| pos.child(OwnedValue::Int(actual_idx as i64)));
                             let wrote = update_path::<S>(
                                 &mut arr[actual_idx],
                                 &Expr::Identity,
                                 filter_expr,
                                 optional,
                                 scalar_noop,
+                                child.as_ref(),
                             )?;
                             if !wrote {
                                 arr.remove(actual_idx);
@@ -22875,12 +23167,14 @@ fn update_path<S: EvalSemantics>(
                             // matching `delpaths` silently skipping an
                             // out-of-range index either direction.
                             let mut scratch = OwnedValue::Null;
+                            let child = index_child_pos(pos, *idx, arr.len());
                             let wrote = update_path::<S>(
                                 &mut scratch,
                                 &Expr::Identity,
                                 filter_expr,
                                 optional,
                                 scalar_noop,
+                                child.as_ref(),
                             )?;
                             if wrote {
                                 *write_index(arr, *idx)? = scratch;
@@ -22914,13 +23208,15 @@ fn update_path<S: EvalSemantics>(
                     if S::TAG == EvalTag::Yq {
                         // #1916 is jq-mode only -- see the `Field` arm's
                         // comment above.
-                        for elem in arr.iter_mut() {
+                        for (index, elem) in arr.iter_mut().enumerate() {
+                            let child = pos.map(|pos| pos.child(OwnedValue::Int(index as i64)));
                             update_path::<S>(
                                 elem,
                                 &Expr::Identity,
                                 filter_expr,
                                 optional,
                                 scalar_noop,
+                                child.as_ref(),
                             )?;
                         }
                     } else {
@@ -22936,13 +23232,15 @@ fn update_path<S: EvalSemantics>(
                         // in place, since a `Vec::remove` per dropped
                         // element would be quadratic.
                         let mut retained = vec_with_capacity(arr.len());
-                        for mut elem in core::mem::take(arr) {
+                        for (index, mut elem) in core::mem::take(arr).into_iter().enumerate() {
+                            let child = pos.map(|pos| pos.child(OwnedValue::Int(index as i64)));
                             if update_path::<S>(
                                 &mut elem,
                                 &Expr::Identity,
                                 filter_expr,
                                 optional,
                                 scalar_noop,
+                                child.as_ref(),
                             )? {
                                 retained.push(elem);
                             }
@@ -22953,24 +23251,28 @@ fn update_path<S: EvalSemantics>(
                 }
                 OwnedValue::Object(map) => {
                     if S::TAG == EvalTag::Yq {
-                        for value in map.values_mut() {
+                        for (key, value) in map.iter_mut() {
+                            let child = pos.map(|pos| pos.child(OwnedValue::String(key.clone())));
                             update_path::<S>(
                                 value,
                                 &Expr::Identity,
                                 filter_expr,
                                 optional,
                                 scalar_noop,
+                                child.as_ref(),
                             )?;
                         }
                     } else {
                         let mut retained = IndexMap::with_capacity(map.len());
                         for (key, mut value) in core::mem::take(map) {
+                            let child = pos.map(|pos| pos.child(OwnedValue::String(key.clone())));
                             if update_path::<S>(
                                 &mut value,
                                 &Expr::Identity,
                                 filter_expr,
                                 optional,
                                 scalar_noop,
+                                child.as_ref(),
                             )? {
                                 retained.insert(key, value);
                             }
@@ -22984,13 +23286,15 @@ fn update_path<S: EvalSemantics>(
             }
         }
         Expr::Pipe(exprs) if !exprs.is_empty() => {
-            update_path_steps::<S>(root, exprs, filter_expr, optional, scalar_noop)
+            update_path_steps::<S>(root, exprs, filter_expr, optional, scalar_noop, pos)
         }
-        Expr::Optional(inner) => update_path::<S>(root, inner, filter_expr, true, scalar_noop),
+        Expr::Optional(inner) => update_path::<S>(root, inner, filter_expr, true, scalar_noop, pos),
         // `(EXPR)` at the top of a resolved path (e.g. `(.[0:1]) |= 99`) —
         // see `set_path`'s matching `Expr::Paren` arm for why this was
         // never needed before #1116.
-        Expr::Paren(inner) => update_path::<S>(root, inner, filter_expr, optional, scalar_noop),
+        Expr::Paren(inner) => {
+            update_path::<S>(root, inner, filter_expr, optional, scalar_noop, pos)
+        }
         // `.[a:b] |= f` runs `f` on the sub-array — not on each element — and
         // splices the answer back, so `[1,2,3] | .[1:2] |= . + ["q"]` is
         // `[1,2,"q",3]`. `f` may return an array of any length, but it has to
@@ -23009,7 +23313,23 @@ fn update_path<S: EvalSemantics>(
                 container_noop,
                 terminal_write: true,
             },
-            |sub| update_path::<S>(sub, &Expr::Identity, filter_expr, optional, scalar_noop),
+            // `None`: a slice has no path component to name it (real yq
+            // keeps the *container's* position for a slice, jq reports a
+            // `{"start":s,"end":e}` component -- see `OwnedIdentityRule::
+            // Slice`), and neither is the position of the sub-array this
+            // filter is handed. Left unpositioned rather than positioned
+            // wrongly; `.a[0:1] |= key` answers exactly as it did before
+            // #2522.
+            |sub| {
+                update_path::<S>(
+                    sub,
+                    &Expr::Identity,
+                    filter_expr,
+                    optional,
+                    scalar_noop,
+                    None,
+                )
+            },
         ),
         // Unreachable: `resolve_dynamic_indexes` rewrites every computed key
         // into a static component before this runs. Explicit rather than left
@@ -23074,6 +23394,7 @@ fn update_path_steps<S: EvalSemantics>(
     filter_expr: &Expr,
     optional: bool,
     scalar_noop: bool,
+    pos: Option<&UpdatePos<'_>>,
 ) -> Result<bool, EvalEscape> {
     // `undo_stranded`: #1428 is a jq-mode divergence, and deliberately stays
     // one -- real yq *wants* the chain a suppressed write leaves behind
@@ -23093,6 +23414,10 @@ fn update_path_steps<S: EvalSemantics>(
 
     let mut root = root;
     let mut steps = steps;
+    // #2522: extended in place as the loop peels components, so the
+    // frame-free walk this function exists to perform still names every
+    // position it passes through.
+    let mut pos = pos.cloned();
     loop {
         let (first, rest) = match steps {
             // Only ever reached via the fresh-run shortcut below, standing in
@@ -23103,9 +23428,25 @@ fn update_path_steps<S: EvalSemantics>(
             // between the two the way CLAUDE.md's "duplicated predicates
             // diverge silently" warns about.
             [] => {
-                return update_path::<S>(root, &Expr::Identity, filter_expr, optional, scalar_noop);
+                return update_path::<S>(
+                    root,
+                    &Expr::Identity,
+                    filter_expr,
+                    optional,
+                    scalar_noop,
+                    pos.as_ref(),
+                );
             }
-            [last] => return update_path::<S>(root, last, filter_expr, optional, scalar_noop),
+            [last] => {
+                return update_path::<S>(
+                    root,
+                    last,
+                    filter_expr,
+                    optional,
+                    scalar_noop,
+                    pos.as_ref(),
+                )
+            }
             [first, rest @ ..] => (first, rest),
         };
 
@@ -23151,6 +23492,7 @@ fn update_path_steps<S: EvalSemantics>(
                         unreachable!("already_exists only set true for an Object root")
                     };
                     root = map.entry(name.clone()).or_insert(OwnedValue::Null);
+                    pos = pos.map(|pos| pos.child(OwnedValue::String(name.clone())));
                     steps = rest;
                     continue;
                 }
@@ -23162,12 +23504,14 @@ fn update_path_steps<S: EvalSemantics>(
                 let run_len = 1 + fresh_run_len(rest);
                 let (fresh, remainder) = steps.split_at(run_len);
                 let mut scratch = OwnedValue::Null;
+                let inner = fresh_run_pos(pos.as_ref(), fresh);
                 let wrote = update_path_steps::<S>(
                     &mut scratch,
                     remainder,
                     filter_expr,
                     optional,
                     scalar_noop,
+                    inner.as_ref(),
                 )?;
                 if !wrote && undo_stranded {
                     // Nothing was ever really written -- leave the object
@@ -23226,6 +23570,7 @@ fn update_path_steps<S: EvalSemantics>(
                             unreachable!("actual_idx was only resolved for an Array root")
                         };
                         root = &mut arr[actual_idx];
+                        pos = pos.map(|pos| pos.child(OwnedValue::Int(actual_idx as i64)));
                         steps = rest;
                         continue;
                     }
@@ -23233,12 +23578,14 @@ fn update_path_steps<S: EvalSemantics>(
                 let run_len = 1 + fresh_run_len(rest);
                 let (fresh, remainder) = steps.split_at(run_len);
                 let mut scratch = OwnedValue::Null;
+                let inner = fresh_run_pos(pos.as_ref(), fresh);
                 let wrote = update_path_steps::<S>(
                     &mut scratch,
                     remainder,
                     filter_expr,
                     optional,
                     scalar_noop,
+                    inner.as_ref(),
                 )?;
                 if !wrote && undo_stranded {
                     // See the `Field` arm's matching comment above:
@@ -23265,9 +23612,18 @@ fn update_path_steps<S: EvalSemantics>(
                 if S::TAG == EvalTag::Yq {
                     autovivify_array(root);
                 }
-                let fanned = for_each_container_slot(root, |slot| {
-                    update_path_steps::<S>(slot, rest, filter_expr, optional, scalar_noop)
-                        .map(|_| ())
+                let outer = pos.clone();
+                let fanned = for_each_container_entry(root, |component, slot| {
+                    let child = outer.as_ref().map(|pos| pos.child(component));
+                    update_path_steps::<S>(
+                        slot,
+                        rest,
+                        filter_expr,
+                        optional,
+                        scalar_noop,
+                        child.as_ref(),
+                    )
+                    .map(|_| ())
                 });
                 return match fanned {
                     Some(result) => result.map(|()| true),
@@ -23280,7 +23636,14 @@ fn update_path_steps<S: EvalSemantics>(
             // rather than recursing on it alone, which would strand `rest`.
             Expr::Pipe(inner) => {
                 let spliced = splice_optional_group(inner, rest, here);
-                return update_path_steps::<S>(root, &spliced, filter_expr, optional, scalar_noop);
+                return update_path_steps::<S>(
+                    root,
+                    &spliced,
+                    filter_expr,
+                    optional,
+                    scalar_noop,
+                    pos.as_ref(),
+                );
             }
             Expr::Slice { start, end, .. } => {
                 return through_slice(
@@ -23297,7 +23660,11 @@ fn update_path_steps<S: EvalSemantics>(
                         // no need to allocate the `Pipe` just to check it.
                         terminal_write: rest.iter().all(is_effectively_identity),
                     },
-                    |sub| update_path_steps::<S>(sub, rest, filter_expr, optional, scalar_noop),
+                    // `None` for the same reason `update_path`'s own
+                    // `Expr::Slice` arm drops the position -- see its comment.
+                    |sub| {
+                        update_path_steps::<S>(sub, rest, filter_expr, optional, scalar_noop, None)
+                    },
                 );
             }
             // #2241: a *mid-chain* bare `.` (`.a | . | .b`) is a transparent
@@ -23317,7 +23684,9 @@ fn update_path_steps<S: EvalSemantics>(
                 steps = rest;
                 continue;
             }
-            _ => return update_path::<S>(root, first, filter_expr, here, scalar_noop),
+            _ => {
+                return update_path::<S>(root, first, filter_expr, here, scalar_noop, pos.as_ref())
+            }
         }
     }
 }
@@ -35066,6 +35435,56 @@ fn eval_and_continue_with_context<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>
     }
 }
 
+/// An assignment's right-hand side, rewritten to the constants the position
+/// `current_path` answers (#2522), or `None` where there is nothing to
+/// rewrite.
+///
+/// `=`'s own right side is deliberately not handled here: the generic
+/// evaluator's owned identity pipe already positions it (#2471), and moving a
+/// correct answer to a second route is risk with nothing to buy. `|=`'s
+/// filter is not handled here either, and cannot be -- it stands at the
+/// *target*, a position only `update_path` can name; this function's caller
+/// makes `current_path` ambient for that instead.
+fn resolve_assign_rhs_at<S: EvalSemantics>(
+    expr: &Expr,
+    root: &OwnedValue,
+    current_path: &[OwnedValue],
+) -> Result<Option<Expr>, EvalError> {
+    let (op, path, value) = match expr {
+        Expr::CompoundAssign { op, path, value } => (Some(*op), path, value),
+        Expr::AlternativeAssign { path, value } => (None, path, value),
+        _ => return Ok(None),
+    };
+    if !needs_path_context(value) || !super::eval_generic::path_context_at_resolvable(value) {
+        return Ok(None);
+    }
+    let parent_of = |n: usize| -> Result<Option<OwnedValue>, EvalError> {
+        let Some(keep) = current_path.len().checked_sub(n) else {
+            return Ok(None);
+        };
+        let mut cur = root;
+        for component in &current_path[..keep] {
+            let Some(next) = owned_component(cur, component) else {
+                return Ok(None);
+            };
+            cur = next;
+        }
+        Ok(Some(cur.clone()))
+    };
+    let resolved = super::eval_generic::resolve_path_context_at::<S>(
+        value,
+        current_path.last(),
+        current_path,
+        &parent_of,
+    )?;
+    let value = Box::new(resolved);
+    let path = path.clone();
+    Ok(Some(match op {
+        Some(op) => Expr::CompoundAssign { op, path, value },
+        None => Expr::AlternativeAssign { path, value },
+    }))
+}
+
 /// Evaluate `expr` against `value`, routing through the eager path-context
 /// evaluator only when `expr` itself needs it (#1978 code review) -- used by
 /// `Expr::Reduce`/`Expr::Foreach`'s own dispatch arms below, whose `input`
@@ -38512,6 +38931,41 @@ fn eval_stage_with_path_context<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
         // re-verified as redundant -- a direct `QueryResult::Break` here is
         // clearer than routing through the generic fallback's `Ok`/`Err`
         // dance regardless.
+        // #2522: an assignment whose right side reads a position. Two
+        // different positions are involved, and this arm supplies both:
+        //
+        // * a compound assignment (`+=`/`-=`/`*=`, and `//=`) evaluates its
+        //   right side once against *this* stage's input, so a read in it is
+        //   a constant for `current_path` and is resolved right here -- the
+        //   same rewrite the generic evaluator's owned identity pipe already
+        //   applies to `=`'s right side (#2471);
+        // * `|=` evaluates its filter at the *target*, a position only
+        //   `update_path` can name. What this arm supplies there is the
+        //   prefix -- `current_path` -- made ambient for the assignment's
+        //   dynamic extent, which `update_path` then extends with the
+        //   components it walks.
+        //
+        // Everything else about the assignment stays in the ordinary
+        // dispatch (`eval_and_continue_with_context`, the `_` arm's own
+        // call): only the position is added here.
+        Expr::Update { .. } | Expr::CompoundAssign { .. } | Expr::AlternativeAssign { .. } => {
+            let resolved = match resolve_assign_rhs_at::<S>(first, root, current_path) {
+                Ok(resolved) => resolved,
+                Err(e) => return QueryResult::Error(e),
+            };
+            let stage = resolved.as_ref().unwrap_or(first);
+            super::eval_generic::with_path_base(current_path, || {
+                eval_and_continue_with_context::<W, S>(
+                    stage,
+                    value,
+                    rest,
+                    root,
+                    file_origin,
+                    current_path,
+                    optional,
+                )
+            })
+        }
         Expr::Break(name) => QueryResult::Break(name.clone()),
         _ => {
             // For other expressions, evaluate normally and continue
@@ -79575,9 +80029,15 @@ mod tests {
         #[test]
         fn test_update_path_refuses_an_unresolved_key() {
             let mut root = OwnedValue::Null;
-            let err =
-                update_path::<JqSemantics>(&mut root, &unresolved(), &Expr::Identity, false, false)
-                    .unwrap_err();
+            let err = update_path::<JqSemantics>(
+                &mut root,
+                &unresolved(),
+                &Expr::Identity,
+                false,
+                false,
+                None,
+            )
+            .unwrap_err();
             let EvalEscape::Error(err) = err else {
                 panic!("expected EvalEscape::Error, got {err:?}");
             };
@@ -79692,9 +80152,15 @@ mod tests {
         #[test]
         fn test_update_path_refuses_an_unresolved_slice() {
             let mut root = OwnedValue::Null;
-            let err =
-                update_path::<JqSemantics>(&mut root, &unresolved(), &Expr::Identity, false, false)
-                    .unwrap_err();
+            let err = update_path::<JqSemantics>(
+                &mut root,
+                &unresolved(),
+                &Expr::Identity,
+                false,
+                false,
+                None,
+            )
+            .unwrap_err();
             let EvalEscape::Error(err) = err else {
                 panic!("expected EvalEscape::Error, got {err:?}");
             };
@@ -80816,6 +81282,7 @@ mod tests {
             &Expr::Identity,
             false,
             false,
+            None,
         );
         assert!(matches!(result, Err(EvalEscape::Error(_))));
     }

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -4189,6 +4189,133 @@ pub(crate) fn with_file_origin<R>(table: &[usize], f: impl FnOnce() -> R) -> R {
     file_origin::with(table, f)
 }
 
+/// The absolute path of the value an assignment is being evaluated over
+/// (#2522), for the current thread.
+///
+/// `|=` and the compound assignments evaluate their right-hand side at the
+/// *target's* position, not at the assignment's input (yq v4.53.3: `.a | .b
+/// |= key` is `{"b":"b","e":2}`, where `.a | .b = key` is
+/// `{"b":"a","e":2}`). `eval::update_path` knows the components it walked to
+/// reach the target, but not where the value it was handed sits in the
+/// document -- an assignment reached mid-pipe (`.a | .b |= path`) has to
+/// answer `["a","b"]`, not `["b"]`.
+///
+/// That prefix is ambient for the same reason [`path_context_route`] and
+/// [`file_origin`] are: the assignment evaluators are several recursion
+/// levels below every entry point, reached through `eval_expr`'s ordinary
+/// dispatch from routes that do not share a single environment parameter.
+/// It composes, rather than overwriting: a bridge into the eager
+/// path-context evaluator restarts `current_path` at `[]` relative to the
+/// value it was handed, so `eval::eval_stage_with_path_context` installs
+/// *this* prefix followed by its own `current_path`, and `update_path`
+/// installs the target's own absolute path around the filter so a nested
+/// `|=` inside one continues from there.
+///
+/// `#[cfg(feature = "std")]` only, same rationale as its two siblings: a
+/// `no_std` embedding has no `thread_local!`, and there the prefix is always
+/// empty -- which is exactly the pre-#2522 answer, so the degradation is the
+/// old behaviour for a mid-pipe assignment rather than a wrong one.
+#[cfg(feature = "std")]
+mod path_base {
+    use super::OwnedValue;
+    use alloc::rc::Rc;
+    use alloc::vec::Vec;
+    use std::cell::RefCell;
+
+    thread_local! {
+        static CURRENT: RefCell<Option<Rc<Vec<OwnedValue>>>> = const { RefCell::new(None) };
+    }
+
+    pub(crate) fn current() -> Option<Rc<Vec<OwnedValue>>> {
+        CURRENT.with(|c| c.borrow().clone())
+    }
+
+    /// Installs `base` for `f`'s dynamic extent, restoring the previous
+    /// value on the way out -- including when `f` escapes with a control.
+    pub(crate) fn with<R>(base: Rc<Vec<OwnedValue>>, f: impl FnOnce() -> R) -> R {
+        struct Restore(Option<Rc<Vec<OwnedValue>>>);
+        impl Drop for Restore {
+            fn drop(&mut self) {
+                CURRENT.with(|c| *c.borrow_mut() = self.0.take());
+            }
+        }
+        let _restore = Restore(CURRENT.with(|c| c.borrow_mut().replace(base)));
+        f()
+    }
+}
+
+#[cfg(not(feature = "std"))]
+mod path_base {
+    use super::OwnedValue;
+    use alloc::rc::Rc;
+    use alloc::vec::Vec;
+
+    pub(crate) fn current() -> Option<Rc<Vec<OwnedValue>>> {
+        None
+    }
+
+    pub(crate) fn with<R>(_base: Rc<Vec<OwnedValue>>, f: impl FnOnce() -> R) -> R {
+        f()
+    }
+}
+
+/// The ambient assignment position prefix, or `[]` where none is installed
+/// (every top-level evaluation, and every `no_std` build). See [`path_base`].
+pub(crate) fn current_path_base() -> Vec<OwnedValue> {
+    path_base::current().map_or_else(Vec::new, |base| (*base).clone())
+}
+
+/// Install `base` as the ambient assignment position prefix for `f` (#2522).
+///
+/// `prefix ++ base`, not `base`: see [`path_base`] for why the two compose.
+pub(crate) fn with_path_base<R>(base: &[OwnedValue], f: impl FnOnce() -> R) -> R {
+    let mut full = current_path_base();
+    full.extend_from_slice(base);
+    path_base::with(Rc::new(full), f)
+}
+
+/// Install `base` as the ambient assignment position prefix for `f`, without
+/// composing it with whatever prefix is already installed (#2522).
+///
+/// `eval::update_path` uses this for the filter's own evaluation: the path it
+/// installs is already absolute, having been built from the prefix it read.
+pub(crate) fn with_absolute_path_base<R>(base: Vec<OwnedValue>, f: impl FnOnce() -> R) -> R {
+    path_base::with(Rc::new(base), f)
+}
+
+/// Whether every path-context read in `expr` can be rewritten to the constant
+/// the position `expr` stands at answers, `parent`/`parent(n)` included
+/// (#2522). The gate `eval::update_path` gets its answer from, so the two
+/// evaluators share one definition of what an assignment filter can be
+/// positioned at.
+pub(crate) fn path_context_at_resolvable(expr: &Expr) -> bool {
+    path_context_resolvable(expr, ResolveAdmits::UPDATE_TARGET)
+}
+
+/// Rewrite every path-context read in `expr` to the constant the position
+/// `(key, path)` answers, with `parent_of` climbing `n` levels for
+/// `parent`/`parent(n)` (#2522).
+///
+/// `eval::update_path`'s entry into [`path_context_resolve_constants`] -- one
+/// definition of the rewrite, so an assignment filter positioned at its
+/// target answers `key`/`path`/`parent` exactly as a stage positioned by the
+/// owned identity pipe does.
+pub(crate) fn resolve_path_context_at<S: EvalSemantics>(
+    expr: &Expr,
+    key: Option<&OwnedValue>,
+    path: &[OwnedValue],
+    parent_of: &dyn Fn(usize) -> Result<Option<OwnedValue>, EvalError>,
+) -> Result<Expr, EvalError> {
+    path_context_resolve_constants::<S>(
+        expr,
+        &PathContextAt {
+            key,
+            path,
+            parent_of: Some(parent_of),
+        },
+    )
+}
+
 /// The ambient `--eval-all` file-origin table, if one is installed --
 /// `eval::eval_pipe_with_path_context`'s bridge into the eager evaluator's
 /// own `file_origin` parameter.
@@ -13158,7 +13285,7 @@ fn try_path_context_cursor_walk<S: EvalSemantics, V: DocumentValue>(
 /// therefore a refusal, not a fallback -- reached only with
 /// `needs_path_context` already true.
 fn path_context_absent_resolvable(expr: &Expr) -> bool {
-    path_context_resolvable(expr, false)
+    path_context_resolvable(expr, ResolveAdmits::CONSTANTS)
 }
 
 /// [`path_context_absent_resolvable`] with `parent`/`parent(n)` admitted
@@ -13167,35 +13294,78 @@ fn path_context_absent_resolvable(expr: &Expr) -> bool {
 /// -- `Expr::TrackedVar`, the one node that spells an arbitrary
 /// `OwnedValue`. See [`path_context_resolve_constants`]'s `Parent` arm.
 fn owned_identity_stage_resolvable(expr: &Expr) -> bool {
-    path_context_resolvable(expr, true)
+    path_context_resolvable(expr, ResolveAdmits::IDENTITY)
+}
+
+/// What [`path_context_resolvable`] admits, per caller.
+///
+/// Every consumer shares one recursion and one rewriter
+/// ([`path_context_resolve_constants`]); these are the two shapes a *caller*
+/// decides for itself, because admitting them changes which route a pipe
+/// takes rather than whether the rewrite is correct.
+#[derive(Clone, Copy)]
+struct ResolveAdmits {
+    /// `parent`/`parent(n)`: a document *node*, which no literal spells.
+    /// Only a caller carrying the ancestors can answer it.
+    parent: bool,
+    /// A read inside an arithmetic operand (`key + 10`). The rewriter has
+    /// handled this since #2471, but the absent and owned-identity gates
+    /// keep refusing it: `owned_identity_pipe_supported` has its own
+    /// `Expr::Arithmetic` arm, and widening the absent gate would move
+    /// pipes off the eager route with nothing to buy.
+    arithmetic: bool,
+}
+
+impl ResolveAdmits {
+    /// The absent route: constants only.
+    const CONSTANTS: Self = Self {
+        parent: false,
+        arithmetic: false,
+    };
+    /// The owned identity pipe, which carries the ancestors `parent` needs.
+    const IDENTITY: Self = Self {
+        parent: true,
+        arithmetic: false,
+    };
+    /// `eval::update_path`'s filter (#2522): the position is a named point in
+    /// a value the caller holds, so `parent` is answerable, and the filter is
+    /// rewritten in place rather than routed anywhere -- there is no route
+    /// for an arithmetic operand to be moved off.
+    const UPDATE_TARGET: Self = Self {
+        parent: true,
+        arithmetic: true,
+    };
 }
 
 /// The shared body of the two predicates above. `with_parent` is the *only*
 /// difference between them, so a construct admitted for one is admitted for
 /// the other and the rewriter's arms cover both call sites.
-fn path_context_resolvable(expr: &Expr, with_parent: bool) -> bool {
+fn path_context_resolvable(expr: &Expr, admits: ResolveAdmits) -> bool {
     if !needs_path_context(expr) {
         // Nothing to resolve. Whatever this is, it evaluates against the
         // `null` an absent position holds and answers exactly as it does on
         // the eager route, which navigated into the same `null`.
         return true;
     }
-    let sub = |e: &Expr| path_context_resolvable(e, with_parent);
+    let sub = |e: &Expr| path_context_resolvable(e, admits);
     match expr {
         Expr::Builtin(Builtin::Key | Builtin::PathNoArg | Builtin::FileIndex) => true,
         // #2472: a node, not a constant -- resolvable only where the caller
         // carries the identity to climb.
-        Expr::Builtin(Builtin::Parent) => with_parent,
+        Expr::Builtin(Builtin::Parent) => admits.parent,
         // `parent(n)` climbs `n` levels, and `n` has to be knowable without
         // evaluating a stream against a position that may not exist: the
         // same literal-only restriction `owned_identity_pipe_supported`
         // already places on a bare `parent(n)` stage.
-        Expr::Builtin(Builtin::ParentN(n)) => with_parent && matches!(**n, Expr::Literal(_)),
+        Expr::Builtin(Builtin::ParentN(n)) => admits.parent && matches!(**n, Expr::Literal(_)),
+        // #2522: `key + 10` inside a `|=` filter, admitted only where the
+        // rewrite happens in place -- see [`ResolveAdmits::arithmetic`].
+        Expr::Arithmetic { left, right, .. } => admits.arithmetic && sub(left) && sub(right),
         Expr::Paren(inner) | Expr::Array(inner) | Expr::Optional(inner) => sub(inner),
         Expr::FirstExpr(inner) | Expr::LastExpr(inner) => sub(inner),
         Expr::Builtin(Builtin::FirstStream(inner) | Builtin::LastStream(inner)) => sub(inner),
         Expr::Comma(exprs) => exprs.iter().all(sub),
-        Expr::Pipe(exprs) => path_context_stages_resolvable(exprs, with_parent),
+        Expr::Pipe(exprs) => path_context_stages_resolvable(exprs, admits),
         Expr::Builtin(Builtin::Select(cond)) => sub(cond),
         Expr::Limit { n, expr } => sub(n) && sub(expr),
         Expr::Try { expr, catch } => sub(expr) && catch.as_deref().map_or(true, sub),
@@ -13236,15 +13406,15 @@ fn path_context_resolvable(expr: &Expr, with_parent: bool) -> bool {
 /// the position only while the position has not moved, because the resolved
 /// constants describe one position and nothing carries a second one.
 fn path_context_absent_stages_resolvable(stages: &[Expr]) -> bool {
-    path_context_stages_resolvable(stages, false)
+    path_context_stages_resolvable(stages, ResolveAdmits::CONSTANTS)
 }
 
-/// [`path_context_absent_stages_resolvable`] with the `with_parent` knob
+/// [`path_context_absent_stages_resolvable`] with the [`ResolveAdmits`] knobs
 /// [`path_context_resolvable`] documents.
-fn path_context_stages_resolvable(stages: &[Expr], with_parent: bool) -> bool {
+fn path_context_stages_resolvable(stages: &[Expr], admits: ResolveAdmits) -> bool {
     let mut moved = false;
     for stage in stages {
-        if needs_path_context(stage) && (moved || !path_context_resolvable(stage, with_parent)) {
+        if needs_path_context(stage) && (moved || !path_context_resolvable(stage, admits)) {
             return false;
         }
         moved = moved || !path_context_absent_keeps_position(stage);
@@ -13455,27 +13625,31 @@ fn path_context_resolve_absent<S: EvalSemantics, V: DocumentValue>(
     // An absent position always has at least one component -- it took a
     // `.a`/`[i]` step to become absent -- so its key is the walk's own
     // `path.last()`.
-    path_context_resolve_constants::<S, V>(
+    path_context_resolve_constants::<S>(
         expr,
         &PathContextAt {
             key: pos.path.last(),
             path: &pos.path,
-            parent_from: None,
+            parent_of: None,
         },
     )
 }
 
 /// The position [`path_context_resolve_constants`] rewrites against.
 ///
-/// `key`/`path` are the constants the position answers. `parent_from` is
-/// the value and identity `parent`/`parent(n)` climb, carried only by the
-/// owned identity pipe -- the constant-only route leaves it `None`, and
-/// [`path_context_absent_resolvable`] refuses `parent` there, so the
+/// `key`/`path` are the constants the position answers. `parent_of` answers
+/// `parent`/`parent(n)`: `n` levels up, or `None` where there is nothing
+/// there. It is a callback rather than the climbing structure itself
+/// because two unrelated structures can answer it -- the owned identity
+/// pipe's [`OwnedIdentity`] (#2472) and `eval::update_path`'s pre-update
+/// snapshot of the value being written (#2522) -- and neither is a shape
+/// the other's route can build. The constant-only route leaves it `None`,
+/// and [`path_context_absent_resolvable`] refuses `parent` there, so the
 /// rewriter's `Parent` arms are unreachable with it unset.
-struct PathContextAt<'a, V: DocumentValue> {
+struct PathContextAt<'a> {
     key: Option<&'a OwnedValue>,
     path: &'a [OwnedValue],
-    parent_from: Option<(&'a OwnedValue, &'a OwnedIdentity<V>)>,
+    parent_of: Option<&'a dyn Fn(usize) -> Result<Option<OwnedValue>, EvalError>>,
 }
 
 /// [`path_context_resolve_absent`]'s worker, over the constants themselves:
@@ -13483,16 +13657,16 @@ struct PathContextAt<'a, V: DocumentValue> {
 /// detached owned root, #2416 step 3), and `path` is the full path. Shared
 /// with the owned identity pipe, whose `key`/`path` inside a `select`/`[..]`
 /// are constants for the same reason.
-fn path_context_resolve_constants<S: EvalSemantics, V: DocumentValue>(
+fn path_context_resolve_constants<S: EvalSemantics>(
     expr: &Expr,
-    at: &PathContextAt<'_, V>,
+    at: &PathContextAt<'_>,
 ) -> Result<Expr, EvalError> {
     if !needs_path_context(expr) {
         return Ok(expr.clone());
     }
     let (key, path) = (at.key, at.path);
     let boxed = |e: &Expr| -> Result<Box<Expr>, EvalError> {
-        Ok(Box::new(path_context_resolve_constants::<S, V>(e, at)?))
+        Ok(Box::new(path_context_resolve_constants::<S>(e, at)?))
     };
     Ok(match expr {
         Expr::Builtin(Builtin::Key) => match key {
@@ -13556,13 +13730,13 @@ fn path_context_resolve_constants<S: EvalSemantics, V: DocumentValue>(
         Expr::Comma(exprs) => Expr::Comma(
             exprs
                 .iter()
-                .map(|e| path_context_resolve_constants::<S, V>(e, at))
+                .map(|e| path_context_resolve_constants::<S>(e, at))
                 .collect::<Result<Vec<_>, _>>()?,
         ),
         Expr::Pipe(exprs) => Expr::Pipe(
             exprs
                 .iter()
-                .map(|e| path_context_resolve_constants::<S, V>(e, at))
+                .map(|e| path_context_resolve_constants::<S>(e, at))
                 .collect::<Result<Vec<_>, _>>()?,
         ),
         Expr::Limit { n, expr } => Expr::Limit {
@@ -13635,21 +13809,17 @@ fn path_context_resolve_constants<S: EvalSemantics, V: DocumentValue>(
 /// root, or a caller with no identity -- a shape
 /// [`path_context_absent_resolvable`] refuses, asserted rather than
 /// silently answered with `null`).
-fn path_context_resolve_parent<V: DocumentValue>(
-    at: &PathContextAt<'_, V>,
-    n: usize,
-) -> Result<Expr, EvalError> {
-    let Some((value, id)) = at.parent_from else {
+fn path_context_resolve_parent(at: &PathContextAt<'_>, n: usize) -> Result<Expr, EvalError> {
+    let Some(parent_of) = at.parent_of else {
         debug_assert!(
             false,
-            "path_context_absent_resolvable refuses parent without an identity"
+            "path_context_absent_resolvable refuses parent without an ancestor source"
         );
         return Ok(Expr::Builtin(Builtin::Empty));
     };
-    Ok(match owned_identity_ancestor(value, id, n) {
-        OwnedAncestor::Owned(v, _) => Expr::TrackedVar(Rc::new(v)),
-        OwnedAncestor::Node(c) => Expr::TrackedVar(Rc::new(to_owned_cursor(&c)?)),
-        OwnedAncestor::None => Expr::Builtin(Builtin::Empty),
+    Ok(match parent_of(n)? {
+        Some(v) => Expr::TrackedVar(Rc::new(v)),
+        None => Expr::Builtin(Builtin::Empty),
     })
 }
 
@@ -15778,7 +15948,7 @@ fn owned_identity_resolve_component<S: EvalSemantics, V: DocumentValue>(
     }
     let key = id.key()?;
     let path = id.path()?;
-    path_context_resolve_constants::<S, V>(
+    path_context_resolve_constants::<S>(
         expr,
         &PathContextAt {
             key: key.as_ref(),
@@ -15786,7 +15956,7 @@ fn owned_identity_resolve_component<S: EvalSemantics, V: DocumentValue>(
             // A computed component keeps the constant-only gate
             // ([`owned_identity_component_supported`]), so no `parent` can
             // appear in one.
-            parent_from: None,
+            parent_of: None,
         },
     )
 }
@@ -16445,7 +16615,7 @@ fn map_family_members(
 ///
 /// `None` means the input is not a container (see [`map_family_members`]) and
 /// the caller should evaluate the stage the ordinary way.
-fn eval_map_family_positioned<S: EvalSemantics, V: DocumentValue>(
+fn eval_map_family_positioned<S: EvalSemantics>(
     family: MapFamily,
     f: &Expr,
     container: &OwnedValue,
@@ -16465,12 +16635,12 @@ fn eval_map_family_positioned<S: EvalSemantics, V: DocumentValue>(
         let mut path = vec_with_capacity(container_path.len() + 1);
         path.extend_from_slice(container_path);
         path.push(component.clone());
-        let resolved = match path_context_resolve_constants::<S, V>(
+        let resolved = match path_context_resolve_constants::<S>(
             f,
             &PathContextAt {
                 key: Some(&component),
                 path: &path,
-                parent_from: None,
+                parent_of: None,
             },
         ) {
             Ok(expr) => expr,
@@ -16535,7 +16705,7 @@ fn eval_map_family_positioned_result<S: EvalSemantics, V: DocumentValue>(
     optional: bool,
 ) -> Option<GenericResult<V>> {
     let mut collected: Vec<OwnedValue> = Vec::new();
-    let flow = eval_map_family_positioned::<S, V>(
+    let flow = eval_map_family_positioned::<S>(
         family,
         f,
         container,
@@ -16656,12 +16826,28 @@ fn eval_owned_identity_pipe<S: EvalSemantics, V: DocumentValue>(
                     (Ok(key), Ok(path)) => (key, path),
                     (Err(e), _) | (_, Err(e)) => return Flow::Escaped(Control::Error(e)),
                 };
-                resolved = match path_context_resolve_constants::<S, V>(
+                let parent_of = |n: usize| -> Result<Option<OwnedValue>, EvalError> {
+                    Ok(match owned_identity_ancestor(&value, &id, n) {
+                        OwnedAncestor::Owned(v, _) => Some(v),
+                        // STYLE-0012: a decode failure while materializing
+                        // the ancestor `parent` answers with raises whatever
+                        // `optional` says, exactly as it did when this same
+                        // call lived in `path_context_resolve_parent` (which
+                        // has no `optional` to consult). The rewrite has to
+                        // produce *some* literal for the `parent` it is
+                        // replacing; suppressing here would leave the read
+                        // unresolved and answer `null`, the silent fallback
+                        // ADR-0021 exists to end.
+                        OwnedAncestor::Node(c) => Some(to_owned_cursor(&c)?),
+                        OwnedAncestor::None => None,
+                    })
+                };
+                resolved = match path_context_resolve_constants::<S>(
                     stage,
                     &PathContextAt {
                         key: key.as_ref(),
                         path: &path,
-                        parent_from: Some((&value, &id)),
+                        parent_of: Some(&parent_of),
                     },
                 ) {
                     Ok(e) => e,
@@ -16715,7 +16901,7 @@ fn eval_owned_identity_pipe<S: EvalSemantics, V: DocumentValue>(
                     Ok(path) => path,
                     Err(e) => return Some(Flow::Escaped(Control::Error(e))),
                 };
-                eval_map_family_positioned::<S, V>(family, f, &value, &path, optional, &mut emit)
+                eval_map_family_positioned::<S>(family, f, &value, &path, optional, &mut emit)
             });
             let upstream = match positioned {
                 Some(flow) => flow,
@@ -25602,6 +25788,36 @@ mod tests {
         // the eager evaluator for `.a.b | .c = key` (arm re-audit, #2471).
         assert!(eager(".a.b | .c = key"));
         assert!(path_context_absent_resolvable(&parse(".c = key").unwrap()));
+        // #2522: `|=` and the compound assignments are *not* in that class.
+        // Their right side stands at the target, which no constant known at
+        // this stage's position describes, so both gates refuse them and the
+        // pipe reaches `eval::eval_stage_with_path_context`'s own assignment
+        // arm -- where the stage's position becomes the prefix `update_path`
+        // extends. Live-verified with the arm instrumented: `.a | .b |= key`
+        // and `.a | .b += key` both fire it.
+        assert!(eager(".a | .b |= key"));
+        assert!(eager(".a | .b += key"));
+        assert!(eager(".c[] | .x //= key"));
+        assert!(!path_context_absent_resolvable(
+            &parse(".c |= key").unwrap()
+        ));
+        assert!(!owned_identity_stage_resolvable(
+            &parse(".c |= key").unwrap()
+        ));
+        assert!(!path_context_absent_resolvable(
+            &parse(".c += key").unwrap()
+        ));
+        // ...but the filter itself resolves at a position `update_path` can
+        // name, which is what `path_context_at_resolvable` answers -- and it
+        // is the one gate that admits a read inside an arithmetic operand,
+        // because the rewrite happens in place with no route to move.
+        assert!(path_context_at_resolvable(&parse("key").unwrap()));
+        assert!(path_context_at_resolvable(&parse("parent | keys").unwrap()));
+        assert!(path_context_at_resolvable(&parse("key + 10").unwrap()));
+        assert!(!path_context_absent_resolvable(&parse("key + 10").unwrap()));
+        assert!(!owned_identity_stage_resolvable(
+            &parse("key + 10").unwrap()
+        ));
         // ...but a body whose reads cannot be resolved at a member position
         // (`parent`, which real yq answers from a container it is halfway
         // through rewriting) stays exactly where it was.
@@ -25898,6 +26114,65 @@ mod tests {
         assert!(!owned_identity_stage_resolvable(
             &parse("parent(1 + 0)").unwrap()
         ));
+    }
+
+    /// The same gate-and-rewriter agreement for `eval::update_path`'s own
+    /// admits set (#2522), which widens the shared gate twice -- `parent`
+    /// (it holds the ancestors) and an arithmetic operand (it rewrites in
+    /// place, with no route the operand could be moved off).
+    ///
+    /// The property is the one CLAUDE.md's "one definition, plus a test that
+    /// the call sites agree" asks for: a shape
+    /// [`path_context_at_resolvable`] admits must come out of
+    /// [`resolve_path_context_at`] with no path context left in it. A shape
+    /// admitted and not rewritten would answer `key` from nowhere, which is
+    /// exactly the pre-#2522 bug.
+    #[test]
+    fn update_target_resolution_clears_path_context_2522() {
+        let key = OwnedValue::String("b".to_string());
+        let path = vec![OwnedValue::String("a".to_string()), key.clone()];
+        let ancestor = OwnedValue::Int(7);
+        let parent_of = |n: usize| -> Result<Option<OwnedValue>, EvalError> {
+            Ok((n <= path.len()).then(|| ancestor.clone()))
+        };
+        for filter in [
+            "key",
+            "path",
+            "parent",
+            "parent(1)",
+            "(path|length)",
+            "[key, path]",
+            "(key, path)",
+            "select(key == \"b\")",
+            "if key == \"b\" then 1 else 2 end",
+            "key + 10",
+            "(key + 1) * 2",
+            "{k: key}",
+            "parent | keys",
+            "try (key) catch \"e\"",
+        ] {
+            let expr = parse(filter).unwrap();
+            assert!(
+                path_context_at_resolvable(&expr),
+                "gate refuses `{filter}`; drop the row or widen the gate"
+            );
+            let resolved =
+                resolve_path_context_at::<JqSemantics>(&expr, Some(&key), &path, &parent_of)
+                    .expect("the update-target rewrite cannot fail here");
+            assert!(
+                !needs_path_context(&resolved),
+                "`{filter}` resolved to `{resolved:?}`, which still needs path context"
+            );
+        }
+        // Still refused: a stage that moves the position before reading it,
+        // and a `parent(n)` whose hop count is not a literal.
+        for filter in [".x | key", "parent(1 + 0)", "map(key)"] {
+            let expr = parse(filter).unwrap();
+            assert!(
+                !path_context_at_resolvable(&expr),
+                "`{filter}` must stay unresolved, and so unpositioned"
+            );
+        }
     }
 
     /// The split's four static conditions, each pinned by a shape that trips

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -38872,3 +38872,68 @@ fn test_owned_identity_pipe_carries_control_and_prefix_2495() -> Result<()> {
 
     Ok(())
 }
+
+/// jq mode's half of #2522: everything real jq defines is untouched, and the
+/// succinctly-only reads answer the target's position there too.
+///
+/// jq 1.7.1 has no `key`, no bare `path` and no `parent` -- all three are
+/// succinctly extensions, and it rejects them outright:
+///
+/// ```console
+/// $ jq '.a | .b |= key'      jq: error: key/0 is not defined at <top-level>, line 1:
+/// $ jq '.a | .b |= path'     jq: error: path/0 is not defined at <top-level>, line 1:
+/// $ jq '.a | .b |= parent'   jq: error: parent/0 is not defined at <top-level>, line 1:
+/// ```
+///
+/// So there is no oracle to match for those, and ADR-0018's rule 5 leaves the
+/// answer to internal consistency: one definition of "the position an update
+/// filter stands at", shared by both modes.
+///
+/// What jq *does* define is pinned unchanged, captured from jq 1.7.1 on
+/// `{"a":{"b":1,"e":2}}`:
+///
+/// ```console
+/// $ jq -c '.a | .b |= path(.)'   {"b":[],"e":2}
+/// $ jq -c '.a | .b |= [paths]'   {"b":[],"e":2}
+/// $ jq -c '.a | .b |= .'         {"b":1,"e":2}
+/// $ jq -c '.a | .b += 1'         {"b":2,"e":2}
+/// ```
+///
+/// `path(.)` being `[]` is the point of the control: jq's `_modify` binds the
+/// filter's `.` to the target as a *fresh root*, so its own path tracking
+/// restarts there. That is a different builtin from the bare `path` this
+/// change positions (`Builtin::Path` with an argument, not
+/// `Builtin::PathNoArg`), and it must stay `[]`.
+#[test]
+fn test_jq_update_filter_position_is_a_succinctly_extension_2522() -> Result<()> {
+    let doc = r#"{"a":{"b":1,"e":2}}"#;
+
+    // Real jq's own shapes: unchanged by #2522.
+    for (filter, expected) in [
+        (".a | .b |= path(.)", r#"{"b":[],"e":2}"#),
+        (".a | .b |= [paths]", r#"{"b":[],"e":2}"#),
+        (".a | .b |= .", r#"{"b":1,"e":2}"#),
+        (".a | .b += 1", r#"{"b":2,"e":2}"#),
+    ] {
+        let (output, code) = run_jq_stdin(filter, doc, &["-c"])?;
+        assert_eq!(code, 0, "`{filter}`: {output:?}");
+        assert_eq!(output.trim(), expected, "`{filter}`");
+    }
+
+    // The extensions, answered at the target's position like yq mode.
+    for (filter, expected) in [
+        (".a | .b |= key", r#"{"b":"b","e":2}"#),
+        (".a | .b |= path", r#"{"b":["a","b"],"e":2}"#),
+        (".a | .b |= (path|length)", r#"{"b":2,"e":2}"#),
+    ] {
+        let (output, code) = run_jq_stdin(filter, doc, &["-c"])?;
+        assert_eq!(code, 0, "`{filter}`: {output:?}");
+        assert_eq!(output.trim(), expected, "`{filter}`");
+    }
+
+    let (output, code) = run_jq_stdin(".n[] |= key", r#"{"n":[1,2]}"#, &["-c"])?;
+    assert_eq!(code, 0, "{output:?}");
+    assert_eq!(output.trim(), r#"{"n":[0,1]}"#);
+
+    Ok(())
+}

--- a/tests/jq_path_context_arm_guard.rs
+++ b/tests/jq_path_context_arm_guard.rs
@@ -51,7 +51,17 @@ use syn::visit::{self, Visit};
 /// arm -- `tests/jq_path_context_single_door_guard.rs` keeps it that way.
 /// Closing them removed no arm's only route, so the pin did not move. Read
 /// that page before assuming an arm is deletable.
-const PINNED_ARM_COUNT: usize = 43;
+///
+/// 43 -> 44 (#2522): a new arm for `Expr::Update`/`CompoundAssign`/
+/// `AlternativeAssign`, which is not a migration -- nothing moved off the
+/// cursor walk, and no shape that used to reach another arm now reaches this
+/// one. Before it, an assignment stage fell to the `_` fallback, which
+/// evaluates it with no position at all; the arm supplies the two the
+/// assignment operators need (`current_path` as an ambient prefix for `|=`'s
+/// target, and the same position resolved into a compound assignment's right
+/// side). `docs/plan/path-context-arm-reachability.md` records its own live
+/// proof query and gate reason alongside the other 43.
+const PINNED_ARM_COUNT: usize = 44;
 
 const TARGET_FN: &str = "eval_stage_with_path_context";
 const EVAL_RS: &str = include_str!("../src/jq/eval.rs");
@@ -195,7 +205,7 @@ fn test_eval_stage_with_path_context_arm_split_is_pinned() {
     let count = count_in_source(EVAL_RS, TARGET_FN);
     assert_eq!(
         (count.pre_match_handlers, count.match_arms),
-        (5, 38),
+        (5, 39),
         "pre-match handlers / match arms moved: {count:?}"
     );
 }

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -36782,3 +36782,127 @@ fn test_yq_type_answers_the_yaml_tag_2516() -> Result<()> {
 
     Ok(())
 }
+
+/// `|=` and the compound assignments evaluate their right side at the
+/// *target's* position, not at the assignment's own input (#2522).
+///
+/// `=` reads the input's position (#2471): on `a: {b: 1, e: 2}`,
+/// `.a | .b = key` is `{"b":"a","e":2}` -- `"a"` is where `.a` stands. `|=`
+/// runs its filter with `.` bound to the *target*, and `key`/`path`/`parent`
+/// there are the target's. Succinctly had no route that named that position,
+/// so every read in an update filter answered from nowhere: `key` produced
+/// nothing and the target was left untouched, `path` was `[]`.
+///
+/// A compound assignment is the `=` case, not the `|=` one: it evaluates its
+/// right side once against the assignment's *input* and splices the resulting
+/// value into the `. op v` filter it builds.
+///
+/// Captured from yq v4.53.3 (`-o=json -I0`) on `a: {b: 1, e: 2}`:
+///
+/// ```console
+/// $ yq '.a | .b |= key'                            {"b":"b","e":2}
+/// $ yq '.a | .b |= path'                           {"b":["a","b"],"e":2}
+/// $ yq '.a | .b |= (path|length)'                  {"b":2,"e":2}
+/// $ yq '.a.b |= (path|length)'                     {"a":{"b":2,"e":2}}
+/// $ yq '.a | to_entries | .[0] | .value |= path'   {"key":"b","value":["a",0,"value"]}
+/// $ yq '.a | .b |= (path|join("/"))'               {"b":"a/b","e":2}
+/// $ yq '.a | .zzz |= key'                          {"b":1,"e":2,"zzz":"zzz"}
+/// $ yq '.a | (.b,.e) |= key'                       {"b":"b","e":"e"}
+/// $ yq '.a | .b |= (key,path)'                     {"b":"b","e":2}
+/// $ yq '.a | .b |= select(key == "b")'             {"b":1,"e":2}
+/// $ yq '.a | .b |= select(key == "zz")'            {"b":1,"e":2}
+/// $ yq '.a | .b |= (parent|keys)'                  {"b":["b","e"],"e":2}
+/// $ yq '.a | .b |= (parent|type)'                  {"b":"!!map","e":2}
+/// $ yq '.a | .zzz |= (parent|keys)'                {"b":1,"e":2,"zzz":["b","e","zzz"]}
+/// $ yq '.a | .b += key'                            {"b":"1a","e":2}
+/// $ yq '.a | .b -= (key|length)'                   {"b":0,"e":2}
+/// $ yq '.a | .b *= key'                            {"b":"a","e":2}
+/// $ yq '.a | .b = key'                             {"b":"a","e":2}    (control, #2471)
+/// ```
+///
+/// and on `n: [1, 2]`:
+///
+/// ```console
+/// $ yq '.n[] |= key'          {"n":[0,1]}
+/// $ yq '.n[] |= path'         {"n":[["n",0],["n",1]]}
+/// $ yq '.n[0] |= key'         {"n":[0,2]}
+/// $ yq '.n |= key'            {"n":"n"}
+/// $ yq '.n[] |= (key + 10)'   {"n":[10,11]}
+/// $ yq '.n[] |= (parent|length)'  {"n":[2,2]}
+/// ```
+///
+/// `.a | .zzz |= (parent|keys)` is why `parent` climbs a snapshot with the
+/// assignment's whole left side already auto-created: real yq resolves and
+/// vivifies its targets before any filter runs (#1412/#2481), so the key the
+/// write is about to fill is already in the parent it hands the filter.
+///
+/// `//=` is deliberately absent: it is not real yq syntax at all (v4.53.3
+/// answers `'|' expects 2 args but there is 1` for `.a | .b //= 5`), so its
+/// yq-mode behaviour here is judged by internal consistency with the `|=` it
+/// desugars to, the same way `eval_alternative_assign` already judges it.
+///
+/// The one row that still diverges is `.a | .b |= parent`, recorded in
+/// `docs/compliance/yq/limitations.md`: real yq writes the very node it is
+/// mutating into itself and prints the cycle truncated
+/// (`{"b":{"b":{},"e":2},"e":2}`), where succinctly writes the parent's
+/// pre-write value (`{"b":{"b":1,"e":2},"e":2}`). Every `parent` row that
+/// *reads* the node rather than embedding it (`parent|keys`, `parent|type`,
+/// `parent|length`) matches.
+#[test]
+fn test_yq_update_filter_reads_the_target_position_2522() -> Result<()> {
+    let args = &["-o", "json", "-I0"];
+    let map = "a:\n  b: 1\n  e: 2\n";
+    let seq = "n: [1, 2]\n";
+
+    for (filter, expected) in [
+        (".a | .b |= key", r#"{"b":"b","e":2}"#),
+        (".a | .b |= path", r#"{"b":["a","b"],"e":2}"#),
+        (".a | .b |= (path|length)", r#"{"b":2,"e":2}"#),
+        (".a.b |= (path|length)", r#"{"a":{"b":2,"e":2}}"#),
+        (
+            ".a | to_entries | .[0] | .value |= path",
+            r#"{"key":"b","value":["a",0,"value"]}"#,
+        ),
+        (".a | .b |= (path|join(\"/\"))", r#"{"b":"a/b","e":2}"#),
+        (".a | .zzz |= key", r#"{"b":1,"e":2,"zzz":"zzz"}"#),
+        (".a | (.b,.e) |= key", r#"{"b":"b","e":"e"}"#),
+        (".a | .b |= (key,path)", r#"{"b":"b","e":2}"#),
+        (".a | .b |= select(key == \"b\")", r#"{"b":1,"e":2}"#),
+        (".a | .b |= select(key == \"zz\")", r#"{"b":1,"e":2}"#),
+        (".a | .b |= (parent|keys)", r#"{"b":["b","e"],"e":2}"#),
+        (".a | .b |= (parent|type)", r#"{"b":"!!map","e":2}"#),
+        (
+            ".a | .zzz |= (parent|keys)",
+            r#"{"b":1,"e":2,"zzz":["b","e","zzz"]}"#,
+        ),
+        (".a | .b += key", r#"{"b":"1a","e":2}"#),
+        (".a | .b -= (key|length)", r#"{"b":0,"e":2}"#),
+        (".a | .b *= key", r#"{"b":"a","e":2}"#),
+        // Control: `=`'s right side still reads the *input's* position.
+        (".a | .b = key", r#"{"b":"a","e":2}"#),
+    ] {
+        let (output, code) = run_yq_stdin(filter, map, args)?;
+        assert_eq!(code, 0, "`{filter}`: {output:?}");
+        assert_eq!(output.trim(), expected, "`{filter}`");
+    }
+
+    for (filter, expected) in [
+        (".n[] |= key", r#"{"n":[0,1]}"#),
+        (".n[] |= path", r#"{"n":[["n",0],["n",1]]}"#),
+        (".n[0] |= key", r#"{"n":[0,2]}"#),
+        (".n |= key", r#"{"n":"n"}"#),
+        (".n[] |= (key + 10)", r#"{"n":[10,11]}"#),
+        (".n[] |= (parent|length)", r#"{"n":[2,2]}"#),
+    ] {
+        let (output, code) = run_yq_stdin(filter, seq, args)?;
+        assert_eq!(code, 0, "`{filter}`: {output:?}");
+        assert_eq!(output.trim(), expected, "`{filter}`");
+    }
+
+    // The recorded divergence, pinned so a change to it is deliberate.
+    let (output, code) = run_yq_stdin(".a | .b |= parent", map, args)?;
+    assert_eq!(code, 0, "{output:?}");
+    assert_eq!(output.trim(), r#"{"b":{"b":1,"e":2},"e":2}"#);
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary

In yq mode `|=` and the compound assignments run their right-hand side with `.` bound to the target, so `key`, `path` and `parent` there are the target's: `.a | .b |= key` is `{"b":"b","e":2}`, `.n[] |= path` is `[["n",0],["n",1]]`, `.a | .zzz |= key` vivifies to `"zzz"`. `update_path` now names the target's position from the components it walked plus an ambient prefix for where the assignment's input sits, and the filter is rewritten by the same constant resolver the owned identity pipe and the map-family bodies use, so there is one definition. `//=` is not yq syntax and is kept consistent with its siblings.

Captures from yq v4.53.3 are in the tests. Over 4,896 yq-mode assignment queries against the previous binary and yq: 1,460 moved from disagreeing to agreeing, none moved away (the rest of the changes are error wording that now names the resolved value, yq lexer rejections, and `parent` through vivified chains that were all `null` before). Over 4,900 jq-mode queries built only from filters jq 1.7.1 defines: no change.

## The pin rises from 43 to 44, and why that is not a migration

`needs_path_context` gains gated arms for the three assignment operators, and `eval_stage_with_path_context` gains one arm for them. Before this, an assignment with a path-context RHS that reached the eager route fell to the positionless `_` fallback, so this is a new capability the eager evaluator has to carry as long as it is still the route for the remaining gate reasons (a `.a? |` head, a fan-out head, the head-of-pipe computed bracket). The arm is proven reachable by instrumentation, no existing proof query was starved, and the audit doc records it as the newest arm to retire with the others. ADR-0021 decision 8 asks for exactly this argument when the pin rises.

## Left open, recorded in the limitations doc

- `.a | .b |= parent`: yq writes the live node into its own child and prints a truncated cycle; succinctly has no node identity and writes the parent's pre-write value. Pinned as divergent; every `parent` row that reads rather than embeds matches.
- `line`/`column` inside an update filter are cursor properties and no cursor reaches the filter (pre-existing).
- A slice target has no path component naming it; unchanged.
- `.a | .[0] |= key` on a mapping: yq creates a `"0"` key, succinctly errors; pre-existing (#2459's write side).

## Verification

fmt; clippy on both CI legs with `-D warnings`; `cargo test` in the three configurations; `cargo doc -D warnings`; yq goldens 113 and jq goldens 633; oracle sweep 3168 cases, 0 unexpected, manifest unchanged. Rebased onto main after the batch PRs.

Behaviour change in yq mode; ships in its own release. Closes #2522.
