### PR TITLE
fix(yq): rank and/or below pipe, assignment and alternative in yq mode, matching yq's table (#2506)

### DIFF
--- a/docs/compliance/yq/limitations.md
+++ b/docs/compliance/yq/limitations.md
@@ -2162,49 +2162,49 @@ value. Every `parent` row that *reads* the node rather than embedding it — `pa
 cursor, not from a path, and no cursor reaches the filter. `.a | .b |= line` is `2` in real
 yq and `0` in succinctly — a separate, pre-existing gap, not one #2522 touches.
 
-### An `and`/`or` operand's evaluation context -- open (captured under [#2473](https://github.com/rust-works/succinctly/issues/2473))
+### An `and`/`or` operand's evaluation context -- resolved as precedence ([#2506](https://github.com/rust-works/succinctly/issues/2506)); a literal against an empty context remains a residual gap
 
-Real yq v4.53.3 does not evaluate an `and`/`or`'s **right** operand against the node the
-operator stands on -- it resolves it from the **document root** -- and it answers `false`
-for the whole expression whenever the operator's own input came from an absent
-navigation. succinctly evaluates both operands at the current node, in both modes.
+Captured under [#2473](https://github.com/rust-works/succinctly/issues/2473) as "real yq
+resolves an `and`/`or`'s right operand from the document root". That premise was wrong.
+The oracle capture for #2506 settled it with one probe:
 
-The divergence is not about path context: the first four rows contain no path-context
-builtin at all. It was found while making `and`/`or` with a path-context operand native
-(#2473, gate reason 3 of spine 2416), because a `key`/`parent` in the right operand makes
-it visible -- and it predates that change, which is why the rows are pinned as
-succinctly's own answers in `test_and_or_keep_path_context_2473`
-(`tests/yq_cli_tests.rs`) rather than encoded.
+```console
+$ yq -o=json -I0 '.a | (true and .b)' d.yaml     # true
+$ jq -c            '.a | (true and .b)' d.json   # true    <- identical
+$ yq -o=json -I0 '(.a | true) and .b'   d.yaml   # false
+$ jq -c            '(.a | true) and .b' d.json   # false   <- identical
+```
 
-Captured live (`-o=json -I0`) on `a: {b: 1}\nc: [10, 20]\n`:
+Once the grouping is written out, the two tools agree on every row. The divergence was
+**parser precedence**: `pkg/yqlib/operation.go` (v4.53.3) gives `and`/`or` `Precedence: 20`
+and `|` `Precedence: 30`, so `.a | true and .b` is `(.a | true) and .b` in yq and
+`.a | (true and .b)` in jq -- the right operand reaches the document root only because the
+pipe was consumed into the *left* operand. `=`/`==` (40) and `//` (42) also outrank
+`and`/`or` in yq where jq ranks them looser, and `and`/`or` share one precedence and chain
+right-associatively (yq's shunting yard pops only on strictly greater precedence).
 
-| filter                     | real yq | succinctly |
-|----------------------------|---------|------------|
-| `.a \| .b and true`         | `true`  | `true`     |
-| `.a \| true and .b`         | `false` | `true`     |
-| `.a \| true and .a.b`       | `true`  | `false`    |
-| `.c \| true and .[0]`       | `false` | `true`     |
-| `.a \| 0 + .b`              | `1`     | `1`        |
-| `.a \| (key) and true`      | `true`  | `true`     |
-| `.a \| true and (key)`      | `false` | `true`     |
-| `.a \| key and parent`      | `false` | `true`     |
+`succinctly yq` now implements that ladder (`parse_yq_boolean_expr`, `src/jq/parser.rs`);
+the rows are pinned in `test_and_or_keep_path_context_2473` and
+`test_yq_and_or_precedence_2506` (`tests/yq_cli_tests.rs`). No evaluator rule changed --
+#2460's empty-operand rule and #2470's read-only scope are what make the reparsed operands
+answer as they do, and both were already correct.
 
-Row 3 is the one that names the rule: `.a.b` resolved *at* `.a` is nothing, resolved at
-the root it is `1`. Row 5 shows arithmetic is not affected -- this is specific to
-`and`/`or`, and it is a different mechanism from the read-only rule the previous section
-describes (which is about a *missing key* inside an operand, not about which node the
-operand starts from).
+**Residual gap** ([#2540](https://github.com/rust-works/succinctly/issues/2540)). One row in the
+#2506 sweep is a different mechanism and still diverges:
 
-And on `a:\n  b: 1\n`, where the operator's input is an absent position:
+| filter                       | real yq | succinctly |
+|------------------------------|---------|------------|
+| `(.a.zz \| true) and true`   | `true`  | `false`    |
+| `(.a.zz \| 5) and true`      | `true`  | `false`    |
+| `(.a.zz \| [.]) and true`    | `true`  | `false`    |
+| `(.a.zz \| .) and true`      | `false` | `false`    |
+| `(.a.zz \| length) and true` | `false` | `false`    |
 
-| filter                              | real yq | succinctly |
-|-------------------------------------|---------|------------|
-| `.a.zz \| key == "zz"`               | `true`  | `true`     |
-| `.a.zz \| (key == "zz") and true`    | `false` | `true`     |
-| `.a.zz \| key and true`              | `false` | `true`     |
-
-The same comparison is `true` on its own and `false` as an `and` operand, so the operand
-is not being evaluated at the position the pipe reached.
+Inside `and`'s read-only scope `.a.zz` yields nothing, and yq's `valueOperator`
+(`operator_value.go:11-14`) special-cases an **empty** context by emitting the literal once
+anyway -- as do the `[...]` and `{...}` constructors. succinctly propagates the empty, so
+the left operand is empty and #2460's rule short-circuits to `false`. `.` and `length` loop
+the context and so stay empty in both tools.
 
 ### Ordering comparisons against a real `null` -- resolved for scalars ([#2483](https://github.com/rust-works/succinctly/issues/2483)); containers remain a residual gap
 

--- a/docs/reference/yq-language.md
+++ b/docs/reference/yq-language.md
@@ -63,15 +63,22 @@ All features from the [jq Language Reference](jq-language.md) work with yq, incl
 - Format strings (`@json`, `@csv`, `@base64`, etc.)
 - Module system (`import`, `include`)
 
-### Operator precedence differs on `|` vs `,`
+### Operator precedence differs on `|`, `,` and `and`/`or`
 
 The [jq operator-precedence table](jq-language.md#operator-precedence) applies in
-yq mode **except for its two loosest levels, which are swapped** (#2420). Real
-yq's parser is a shunting-yard operator-precedence parser and its own table
-(`pkg/yqlib/operation.go`, v4.53.3) gives `pipeOpType` precedence 30 and
-`unionOpType` (`,`) precedence 10 — pipe binds *tighter* than comma, the
-opposite of jq's `parser.y`. `succinctly yq` follows yq, `succinctly jq`
-follows jq (ADR-0018 rule 2: the mode decides, not the input format):
+yq mode **except at its loosest levels, which yq orders differently** (#2420,
+#2506). Real yq's parser is a shunting-yard operator-precedence parser, and its
+own table (`pkg/yqlib/operation.go`, v4.53.3) reads, loosest first:
+
+```text
+,(10)  <  and/or(20)  <  |(30)  <  = == < (40)  <  + - * / // (42)  <  select map(52)
+```
+
+where jq's `parser.y` reads `|  <  ,  <  //  <  =  <  or  <  and  <  ==  <  + -  <  * /`.
+`succinctly yq` follows yq, `succinctly jq` follows jq (ADR-0018 rule 2: the
+mode decides, not the input format).
+
+#### `|` binds tighter than `,`
 
 | Filter               | `succinctly yq` / `yq` | `succinctly jq` / `jq` |
 |----------------------|------------------------|------------------------|
@@ -85,6 +92,36 @@ every nesting depth. Explicit parentheses restore jq's grouping, on either side
 of the comma, because they are a boundary the shunting yard cannot see across;
 construction brackets do not, since `[...]` scopes evaluation rather than
 precedence.
+
+#### `and`/`or` bind looser than `|`, `=` and `//`, and chain to the right
+
+yq ranks `and` and `or` at the *same* precedence (20), below `|` (30) and below
+`=`/`==` (40) and `//` (42) — all three the opposite way round from jq, where
+`|`, `,`, `//` and `=` are all looser than `or`/`and`. And because yq's
+shunting yard pops a stacked operator only on *strictly* greater precedence, an
+equal-precedence `and`/`or` chain nests to the **right**, where jq ranks `and`
+above `or` and chains to the left (#2506):
+
+| Filter                    | `succinctly yq` / `yq` | `succinctly jq` / `jq` |
+|---------------------------|------------------------|------------------------|
+| `.a \| true and .b`       | `false`                | `true`                 |
+| `.a \| true and .a.b`     | `true`                 | `false`                |
+| `.a \| .c or .b`          | `false`                | `true`                 |
+| `.x and .a \| .b`         | `true`                 | *(error)*              |
+| `.a.b // .a.zz or false`  | `true`                 | `1`                    |
+| `false and true or true`  | `false`                | `true`                 |
+
+(on `a: {b: 1, c: false}`/`x: true`.) `.a | true and .b` groups as
+`(.a | true) and .b`, so the right operand's `.b` is read at the *document
+root*, where it is absent — not at `.a`, where it is `1`. Writing the grouping
+out with parentheses gives the same answer in both tools: `.a | (true and .b)`
+is `true` everywhere, `(.a | true) and .b` is `false` everywhere. Nothing about
+how an operand is *evaluated* differs between the modes.
+
+A parenthesised argument is a boundary the shunting yard cannot see across, so
+the level reappears inside one and the common `select(.x and .y)` idiom is
+unaffected: `.items[] | select(.name and .value)` filters per element in both
+modes, exactly as in jq.
 
 ---
 

--- a/src/jq/parser.rs
+++ b/src/jq/parser.rs
@@ -1218,7 +1218,10 @@ impl<'a> Parser<'a> {
                 // jq's `ExpD`, not `Exp`: the `,` here separates entries, so a
                 // value must stop at it or `{a: 1, b: 2}` reads `1, b` as one
                 // value. Use `(...)` to fan a value out: `{a: (1,2)}`.
-                self.parse_pipe_no_comma()?
+                // In yq mode this position also carries the `and`/`or` level,
+                // which yq ranks above `:` and `,` -- see
+                // `parse_pipe_no_comma_with_booleans` (#2506).
+                self.parse_pipe_no_comma_with_booleans()?
             } else {
                 // Shorthand: key must be literal identifier
                 match &key {
@@ -1995,7 +1998,7 @@ impl<'a> Parser<'a> {
         // comma-valued `n` re-invokes the whole builtin once per output.
         // That fanout isn't implemented here, so accepting a comma would
         // parse but silently misbehave — worse than today's parse error.
-        let n = self.parse_pipe_no_comma()?;
+        let n = self.parse_pipe_no_comma_with_booleans()?;
         self.skip_ws();
         // #2237 review: only `)` here is unambiguously a missing-2nd-arg
         // wrong-arity call -- rewinding on *any* non-`;` character (as an
@@ -4515,7 +4518,7 @@ impl<'a> Parser<'a> {
             // `n` deliberately stays restricted to non-comma — same rationale
             // as `parse_limit_expr`'s own `n`: real jq's `$n` parameter
             // convention isn't implemented here.
-            let n = self.parse_pipe_no_comma()?;
+            let n = self.parse_pipe_no_comma_with_booleans()?;
             self.skip_ws();
             self.expect(';')?;
             self.skip_ws();
@@ -4536,7 +4539,7 @@ impl<'a> Parser<'a> {
             // `n` deliberately stays restricted to non-comma — same rationale
             // as `parse_limit_expr`'s own `n` above: real jq's `$n` parameter
             // convention (per-output fanout) isn't implemented here.
-            let n = self.parse_pipe_no_comma()?;
+            let n = self.parse_pipe_no_comma_with_booleans()?;
             self.skip_ws();
             if self.peek() == Some(';') {
                 self.next();
@@ -4961,8 +4964,17 @@ impl<'a> Parser<'a> {
     }
 
     /// Parse `and` expressions: `expr and expr`
+    ///
+    /// **jq mode only.** Real yq ranks `and`/`or` (`operation.go`'s
+    /// `Precedence: 20`, v4.53.3) *below* `|` (30), so in `Yq` mode the level
+    /// sits above the pipe chain in [`Self::parse_yq_boolean_expr`] instead
+    /// and this one must leave the keyword alone -- otherwise the inner level
+    /// would swallow it first and the outer one would never see it (#2506).
     fn parse_and(&mut self) -> Result<Expr, ParseError> {
         let mut left = self.parse_comparison()?;
+        if self.mode == ParserMode::Yq {
+            return Ok(left);
+        }
         // Each iteration wraps `left` in another node, so this chain's own
         // length is AST depth even though the loop never recurses (#1156).
         let mut chain_depth = 0usize;
@@ -4984,8 +4996,14 @@ impl<'a> Parser<'a> {
     }
 
     /// Parse `or` expressions: `expr or expr`
+    ///
+    /// **jq mode only**, for the reason [`Self::parse_and`] documents: yq puts
+    /// `or` at the same precedence as `and`, both below `|` (#2506).
     fn parse_or(&mut self) -> Result<Expr, ParseError> {
         let mut left = self.parse_and()?;
+        if self.mode == ParserMode::Yq {
+            return Ok(left);
+        }
         // Each iteration wraps `left` in another node, so this chain's own
         // length is AST depth even though the loop never recurses (#1156).
         let mut chain_depth = 0usize;
@@ -5184,7 +5202,7 @@ impl<'a> Parser<'a> {
     /// [`Self::parse_expr`] under [`ParserMode::Yq`]. See that method's doc for
     /// the precedence numbers this encodes.
     fn parse_yq_comma_expr(&mut self) -> Result<Expr, ParseError> {
-        let first = self.parse_pipe_no_comma()?;
+        let first = self.parse_yq_boolean_expr()?;
         self.skip_ws();
 
         if self.peek() != Some(',') {
@@ -5196,7 +5214,7 @@ impl<'a> Parser<'a> {
         while self.peek() == Some(',') {
             self.next();
             self.skip_ws();
-            exprs.push(self.parse_pipe_no_comma()?);
+            exprs.push(self.parse_yq_boolean_expr()?);
             self.skip_ws();
         }
 
@@ -5239,6 +5257,102 @@ impl<'a> Parser<'a> {
         }
 
         Ok(Expr::comma(exprs))
+    }
+
+    /// Parse a yq-mode `and`/`or` chain: `chain and chain or chain ...`, where
+    /// each operand is a whole pipe chain.
+    ///
+    /// **yq mode only**, and the level [`Self::parse_and`]/[`Self::parse_or`]
+    /// step aside for. Real yq's precedence table
+    /// (`pkg/yqlib/operation.go`, v4.53.3) reads, loosest first,
+    ///
+    /// ```text
+    /// ,(10)  <  and/or(20)  <  |(30)  <  = == < (40)  <  + * // (42)  <  select(52)
+    /// ```
+    ///
+    /// where jq's `parser.y` reads `|  <  ,  <  //  <  =  <  or  <  and  <  ==`.
+    /// Two consequences, and between them they are the whole of #2506:
+    ///
+    /// 1. `|` binds *tighter* than `and`/`or` here, so `A | B and C` is
+    ///    `(A | B) and C`, not jq's `A | (B and C)`. `=` and `//` bind tighter
+    ///    too, so `X = Y and Z` is `(X = Y) and Z` and `X // Y or Z` is
+    ///    `(X // Y) or Z` -- both the opposite of jq. Captured live on
+    ///    `a: {b: 1, c: false}` / `x: true`: `yq '.a | true and .b'` is `false`
+    ///    (the right operand is `.b` *at the root*, absent) where jq's
+    ///    `.a | (true and .b)` is `true`, and `yq '.a.b // .a.zz or false'` is
+    ///    `true` where jq gives `1`.
+    ///
+    /// 2. `and` and `or` share one precedence, and yq's shunting yard
+    ///    (`expression_postfix.go`) pops only on *strictly* greater precedence,
+    ///    so an equal-precedence chain stays on the stack and nests to the
+    ///    **right**: `A and B or C` is `A and (B or C)`, where jq ranks `and`
+    ///    above `or` and gives `(A and B) or C`. Captured live:
+    ///    `yq 'false and true or true'` is `false`, jq's is `true`.
+    ///
+    /// The operands themselves are evaluated exactly as before -- this is a
+    /// grouping change only. Writing yq's grouping out with parentheses already
+    /// reproduced its answers here before this level existed (`(.a | true) and
+    /// .b` was `false` in both tools), which is what identified the divergence
+    /// as precedence rather than an operand-context rule (#2506; #2460's
+    /// empty-operand rule and #2470's read-only scope are unchanged).
+    ///
+    /// The fold is built iteratively rather than by recursing on the right, so
+    /// a long `a and b and c ...` chain costs stack depth only through
+    /// [`Self::check_expr_nesting`]'s own accounting, as
+    /// [`Self::parse_and`]'s loop already did (#1156).
+    fn parse_yq_boolean_expr(&mut self) -> Result<Expr, ParseError> {
+        let mut operands = vec![self.parse_pipe_no_comma()?];
+        let mut ops: Vec<bool> = Vec::new();
+
+        loop {
+            self.skip_ws();
+            let is_and = if self.matches_keyword("and") {
+                true
+            } else if self.matches_keyword("or") {
+                false
+            } else {
+                break;
+            };
+            self.consume_keyword(if is_and { "and" } else { "or" });
+            self.skip_ws();
+            ops.push(is_and);
+            self.check_expr_nesting(ops.len())?;
+            operands.push(self.parse_pipe_no_comma()?);
+        }
+
+        // Right-associative fold: the last operand is the innermost right-hand
+        // side, and each operator wraps the operand to its left around it.
+        let mut expr = operands
+            .pop()
+            .expect("parse_yq_boolean_expr always pushes a first operand");
+        while let Some(is_and) = ops.pop() {
+            let left = operands
+                .pop()
+                .expect("one operand more than operators by construction");
+            expr = if is_and {
+                Expr::And(Box::new(left), Box::new(expr))
+            } else {
+                Expr::Or(Box::new(left), Box::new(expr))
+            };
+        }
+        Ok(expr)
+    }
+
+    /// jq's `ExpD` production -- a pipe chain that stops at a comma -- plus
+    /// yq's own `and`/`or` level on top of it in `Yq` mode.
+    ///
+    /// The operand positions that parse at "pipe but not comma" precedence
+    /// (an object value, and `limit`/`skip`/`nth`'s leading count) sit *below*
+    /// a comma and so, in yq, below `and`/`or` as well: yq's `createMapOpType`
+    /// is precedence 15 and `,` is 10, both under `and`/`or`'s 20. Captured
+    /// live: `yq '{"k": .a | .b and .c}'` is `{"k":false}`, i.e.
+    /// `k: ((.a | .b) and .c)` (#2506). In jq mode this is exactly
+    /// [`Self::parse_pipe_no_comma`], unchanged.
+    fn parse_pipe_no_comma_with_booleans(&mut self) -> Result<Expr, ParseError> {
+        match self.mode {
+            ParserMode::Jq => self.parse_pipe_no_comma(),
+            ParserMode::Yq => self.parse_yq_boolean_expr(),
+        }
     }
 
     /// Parse a pipe expression: `stage | stage | ...`, where each stage is a
@@ -6227,6 +6341,78 @@ mod tests {
 
         // jq mode is untouched: `parse_comma_expr` has no collapse at all.
         assert_eq!(parse("., .").unwrap(), Expr::Comma(vec![id.clone(), id]));
+    }
+
+    #[test]
+    fn test_yq_mode_and_or_bind_looser_than_pipe_2506() {
+        let int = |i: i64| Expr::Literal(Literal::number_literal(i.to_string()));
+        let yq = |s: &str| parse_with_mode(s, ParserMode::Yq).unwrap();
+        let f = |n: &str| Expr::Field(n.into());
+        let and = |l: Expr, r: Expr| Expr::And(Box::new(l), Box::new(r));
+        let or = |l: Expr, r: Expr| Expr::Or(Box::new(l), Box::new(r));
+
+        // yq: `and`/`or` are precedence 20, `|` is 30 -- the pipe is consumed
+        // into the *left* operand. jq ranks `|` loosest, so the pipe wins.
+        assert_eq!(
+            yq(".a | 1 and .b"),
+            and(Expr::Pipe(vec![f("a"), int(1)]), f("b"))
+        );
+        assert_eq!(
+            parse(".a | 1 and .b").unwrap(),
+            Expr::Pipe(vec![f("a"), and(int(1), f("b"))])
+        );
+
+        // One precedence for both, popped only on strictly greater, so an
+        // `and`/`or` chain nests to the right in yq and to the left in jq.
+        assert_eq!(yq("1 and 2 or 3"), and(int(1), or(int(2), int(3))));
+        assert_eq!(
+            parse("1 and 2 or 3").unwrap(),
+            or(and(int(1), int(2)), int(3))
+        );
+        assert_eq!(yq("1 and 2 and 3"), and(int(1), and(int(2), int(3))));
+        assert_eq!(
+            parse("1 and 2 and 3").unwrap(),
+            and(and(int(1), int(2)), int(3))
+        );
+
+        // `,` (10) is still looser than `and`/`or` (20), in both modes, so a
+        // comma operand is a whole boolean chain.
+        assert_eq!(
+            yq("1 and 2, 3"),
+            Expr::Comma(vec![and(int(1), int(2)), int(3)])
+        );
+
+        // `//` (42) and `=` (40) outrank `and`/`or` in yq; in jq they are
+        // looser than `or`, so the two modes bracket these the other way.
+        assert_eq!(
+            yq(".a // .b or 1"),
+            or(
+                Expr::Alternative(Box::new(f("a")), Box::new(f("b"))),
+                int(1)
+            )
+        );
+        assert_eq!(
+            parse(".a // .b or 1").unwrap(),
+            Expr::Alternative(Box::new(f("a")), Box::new(or(f("b"), int(1))))
+        );
+
+        // Parentheses are a boundary the shunting yard cannot see across, so
+        // they restore jq's grouping -- which is what leaves `select(.x and
+        // .y)`, `[...]` contents and object values parsing per operand.
+        assert_eq!(
+            yq(".a | (1 and .b)"),
+            Expr::Pipe(vec![f("a"), Expr::Paren(Box::new(and(int(1), f("b")))),])
+        );
+
+        // An object value carries the level too (yq's `:` is precedence 15,
+        // under `and`/`or`'s 20), and still stops at the entry-separating `,`.
+        assert_eq!(
+            yq(r#"{"k": .a | .b and .c}"#),
+            Expr::Object(vec![ObjectEntry {
+                key: ObjectKey::Literal("k".into()),
+                value: and(Expr::Pipe(vec![f("a"), f("b")]), f("c")),
+            }])
+        );
     }
 
     #[test]

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -32965,30 +32965,18 @@ fn test_object_construction_keeps_path_context_2473() -> Result<()> {
 /// unchanged by this arm because both routes read it from
 /// `yq_empty_operand_output`.
 ///
-/// **One divergence stays, and it is not this arm's:** real yq evaluates an
-/// `and`/`or`'s *right* operand against the document **root**, not against the
-/// node the pipe stands on, and answers `false` outright when the operator's
-/// input came from an absent navigation. Captured on
-/// `a: {b: 1}\nc: [10, 20]\n` (and `a:\n  b: 1\n` for the last two):
-///
-/// ```text
-/// $ yq '.a | true and .b'                false   (`.b` resolved at the root)
-/// $ yq '.a | true and .a.b'              true
-/// $ yq '.c | true and .[0]'              false
-/// $ yq '.a | true and (key)'             false   (`key` at the root is nothing)
-/// $ yq '.a | key and parent'             false   (ditto for `parent`)
-/// $ yq '.a | .b and true'                true    (the *left* operand is not re-rooted)
-/// $ yq '.a | 0 + .b'                     1       (arithmetic is not re-rooted either)
-/// $ yq '.a.zz | key == "zz"'             true
-/// $ yq '.a.zz | (key == "zz") and true'  false   (same comparison, as an operand)
-/// ```
-///
-/// succinctly evaluates both operands at the current node in both modes, so
-/// it answers `true` for `.a | key and parent`. That predates this arm (the
-/// eager route answered `true` too) and is orthogonal to path context --
-/// `.a | true and .b` diverges with no path-context builtin anywhere -- so it
-/// is recorded in `docs/compliance/yq/limitations.md` ("An `and`/`or`
-/// operand's evaluation context") and pinned below rather than encoded.
+/// The rows below `a: {b: 1}\nc: [10, 20]\n` and `a:\n  b: 1\n` were pinned
+/// here as succinctly's *own* answers when this arm landed, under the reading
+/// that "real yq evaluates an `and`/`or`'s right operand against the document
+/// root". That reading was wrong, and #2506's capture replaced it: yq ranks
+/// `and`/`or` (`operation.go`'s `Precedence: 20`) **below** `|` (30), so
+/// `.a | true and .b` is `(.a | true) and .b` there and `.a | (true and .b)`
+/// in jq -- the right operand reaches the root only because the pipe was
+/// consumed into the left operand. Written out with parentheses the two tools
+/// already agreed, here included. `parse_yq_boolean_expr` (`src/jq/parser.rs`)
+/// now encodes that ladder, so every row matches real yq and they are asserted
+/// as such below; `test_yq_and_or_precedence_2506` covers the rest of the
+/// grouping shape (`=`, `//`, right-associative chaining).
 #[test]
 fn test_and_or_keep_path_context_2473() -> Result<()> {
     let args = &["-o=json", "-I=0"];
@@ -33014,34 +33002,163 @@ fn test_and_or_keep_path_context_2473() -> Result<()> {
         assert_eq!(code, 0, "`{filter}`: {output:?}");
         assert_eq!(output.trim(), expected, "`{filter}`");
     }
-    // The re-rooted-operand divergence above, pinned as succinctly's own
-    // answers so a future fix has to move these rows deliberately
-    // (`docs/compliance/yq/limitations.md`, "An `and`/`or` operand's
-    // evaluation context").
+    // Formerly the "re-rooted operand" divergence, now matching real yq via
+    // the #2506 precedence level. Every row re-captured live from yq v4.53.3.
     for (filter, expected) in [
         (".a | .b and true", "true"),
-        (".a | true and .b", "true"),
-        (".a | true and .a.b", "false"),
-        (".c | true and .[0]", "true"),
+        (".a | true and .b", "false"),
+        (".a | true and .a.b", "true"),
+        (".c | true and .[0]", "false"),
         (".a | 0 + .b", "1"),
         (".a | (key) and true", "true"),
-        (".a | true and (key)", "true"),
-        (".a | key and parent", "true"),
+        (".a | true and (key)", "false"),
+        (".a | key and parent", "false"),
     ] {
         let (output, code) = run_yq_stdin(filter, "a: {b: 1}\nc: [10, 20]\n", args)?;
         assert_eq!(code, 0, "`{filter}`: {output:?}");
         assert_eq!(output.trim(), expected, "`{filter}`");
     }
-    // The same divergence with the *input* coming from an absent navigation:
-    // real yq answers `false` for all three, succinctly `true`.
+    // The same rows with the operator's input coming from an absent
+    // navigation. `key == "zz"` on its own still answers `true`: only inside
+    // an `and`/`or` operand does #2470's read-only scope make `.a.zz` empty.
     for (filter, expected) in [
         (".a.zz | key == \"zz\"", "true"),
-        (".a.zz | (key == \"zz\") and true", "true"),
-        (".a.zz | key and true", "true"),
+        (".a.zz | (key == \"zz\") and true", "false"),
+        (".a.zz | key and true", "false"),
     ] {
         let (output, code) = run_yq_stdin(filter, "a:\n  b: 1\n", args)?;
         assert_eq!(code, 0, "`{filter}`: {output:?}");
         assert_eq!(output.trim(), expected, "`{filter}`");
+    }
+    Ok(())
+}
+
+/// yq ranks `and`/`or` below `|`, `=` and `//`, and chains them to the right
+/// (#2506).
+///
+/// `pkg/yqlib/operation.go` (v4.53.3) gives `and`/`or` `Precedence: 20`, `|`
+/// `30`, `=`/`==` `40` and `//` `42`; jq's `parser.y` ranks `|`, `,`, `//` and
+/// `=` *looser* than `or`/`and` and ranks `and` above `or`. yq's shunting yard
+/// pops a stacked operator only on strictly greater precedence, so an
+/// equal-precedence `and`/`or` chain nests right where jq's nests left.
+///
+/// The probe that identified this as precedence rather than an operand-context
+/// rule, and the reason no evaluator change was needed: with the grouping
+/// written out, both tools already agreed.
+///
+/// ```console
+/// $ yq '.a | (true and .b)'   # true      $ jq '.a | (true and .b)'   # true
+/// $ yq '(.a | true) and .b'   # false     $ jq '(.a | true) and .b'   # false
+/// ```
+///
+/// Every yq row below was captured live from Homebrew `yq` v4.53.3
+/// (`-o=json -I=0`) and every jq row from `/usr/bin/jq` 1.7.1 (`-c`).
+#[test]
+fn test_yq_and_or_precedence_2506() -> Result<()> {
+    let yq_args = &["-o=json", "-I=0"];
+    let doc = "a: {b: 1, c: false}\nx: true\n";
+    let json = r#"{"a": {"b": 1, "c": false}, "x": true}"#;
+
+    // `succinctly yq` == real yq.
+    for (filter, expected) in [
+        // `|` binds tighter, so the right operand is read at the root.
+        (".a | true and .b", "false"),
+        (".a | true and .a.b", "true"),
+        (".a | .b and true", "true"),
+        (".a | .b and .c", "false"),
+        (".a | .c or .b", "false"),
+        (".a | (.b == 1) and (.c == false)", "false"),
+        (".a | true and (. | .b)", "false"),
+        (".a | true and (.b | not)", "false"),
+        (".a | [.b, .c] | .[0] and .[1]", "false"),
+        (".[] | .b and .c", "false"),
+        (".x and .a | .b", "true"),
+        (".a.zz | (. == null) and true", "false"),
+        // Parentheses are a boundary the shunting yard cannot see across, so
+        // the level reappears inside one -- and `select`/`map` arguments,
+        // object values and `[...]` contents are all such boundaries. These
+        // are the rows the decision to implement turned on: the common
+        // `select(.x and .y)` idiom filters per element, exactly as in jq.
+        (".a | (.b and .c)", "false"),
+        (".a | (true and .b)", "true"),
+        ("(.a | true) and .b", "false"),
+        (".a | select(.b and .c)", ""),
+        (".a | select(.b)", r#"{"b":1,"c":false}"#),
+        ("select(.a.b and .a.c)", ""),
+        (".a | map(.b) and true", "true"),
+        (r#"{"k": .a.b and .a.c}"#, r#"{"k":false}"#),
+        (r#"{"k": .a | .b and .c}"#, r#"{"k":false}"#),
+        ("[.a.b and .a.c]", "[false]"),
+        // `=` (40) and `//` (42) outrank `and`/`or` (20) in yq; in jq both are
+        // looser than `or`, which is why these two rows move.
+        (".a.b // .a.zz or false", "true"),
+        (".a.zz = 1 and true", "true"),
+        // One precedence for both, popped only on strictly greater, so the
+        // chain nests right: `false and (true or true)`, not jq's
+        // `(false and true) or true`.
+        ("false and true or true", "false"),
+        ("true or false and false", "true"),
+        ("false or true and false", "false"),
+        ("true and false and true", "false"),
+        ("false or false or true", "true"),
+        // A binding's body is still a whole expression, unchanged by the level.
+        (".a as $x | $x.b and $x.c", "false"),
+    ] {
+        let (output, code) = run_yq_stdin(filter, doc, yq_args)?;
+        assert_eq!(code, 0, "yq `{filter}`: {output:?}");
+        assert_eq!(output.trim(), expected, "yq `{filter}`");
+    }
+
+    // `succinctly jq` keeps jq's ladder: `and` above `or`, both above `|`,
+    // `,`, `//` and `=`. Nothing below moves.
+    for (filter, expected) in [
+        (".a | true and .b", "true"),
+        (".a | true and .a.b", "false"),
+        (".a | .b and true", "true"),
+        (".a | .c or .b", "true"),
+        (".a | (.b == 1) and (.c == false)", "true"),
+        (".a | true and (. | .b)", "true"),
+        (".a | (true and .b)", "true"),
+        ("(.a | true) and .b", "false"),
+        (".a | select(.b and .c)", ""),
+        ("false and true or true", "true"),
+        ("true or false and false", "true"),
+        (".a.b // .a.zz or false", "1"),
+        (
+            ".a.zz = 1 and true",
+            r#"{"a":{"b":1,"c":false,"zz":true},"x":true}"#,
+        ),
+    ] {
+        let (output, code) = run_jq_stdin(filter, json, &["-c"])?;
+        assert_eq!(code, 0, "jq `{filter}`: {output:?}");
+        assert_eq!(output.trim(), expected, "jq `{filter}`");
+    }
+
+    // The idiom the decision hung on, over records: identical in both modes
+    // and identical to real jq/yq.
+    let recs_yaml =
+        "items:\n  - {name: alice, value: 1}\n  - {name: bob, value: null}\n  - {name: null, value: 3}\n";
+    let recs_json = r#"{"items":[{"name":"alice","value":1},{"name":"bob","value":null},{"name":null,"value":3}]}"#;
+    for (filter, expected) in [
+        (
+            ".items[] | select(.name and .value)",
+            r#"{"name":"alice","value":1}"#,
+        ),
+        (
+            ".items | map(select(.name and .value))",
+            r#"[{"name":"alice","value":1}]"#,
+        ),
+        (
+            ".items[] | select(.name or .value)",
+            "{\"name\":\"alice\",\"value\":1}\n{\"name\":\"bob\",\"value\":null}\n{\"name\":null,\"value\":3}",
+        ),
+    ] {
+        let (output, code) = run_yq_stdin(filter, recs_yaml, yq_args)?;
+        assert_eq!(code, 0, "yq `{filter}`: {output:?}");
+        assert_eq!(output.trim(), expected, "yq `{filter}`");
+        let (output, code) = run_jq_stdin(filter, recs_json, &["-c"])?;
+        assert_eq!(code, 0, "jq `{filter}`: {output:?}");
+        assert_eq!(output.trim(), expected, "jq `{filter}`");
     }
     Ok(())
 }


### PR DESCRIPTION
## Summary

#2506's premise was wrong, and the capture shows why: the divergence is parser precedence, not operand context. With the grouping explicit, yq, jq 1.7.1 and succinctly agree (`.a | (true and .b)` is `true` everywhere, `(.a | true) and .b` is `false` everywhere). yq's operator table (`operation.go`, v4.53.3) ranks `and`/`or` at 20 below `|` at 30, so `.a | true and .b` is `(.a | true) and .b` there and the right operand reaches the root only because the pipe was consumed into the left operand; `=` and `//` also outrank `and`/`or` where jq ranks them looser, and `and`/`or` share one precedence and chain right where jq ranks `and` above `or` and chains left.

Parser only, yq mode only: a right-associative boolean level between `,` and `|` (an iterative fold, no added stack depth), carried into object values and `limit`/`skip`/`nth` counts; jq mode is identical and pinned. No evaluator arm changed: #2460's empty-operand rule and #2470's read-only scope were already right, and the eager-arm pin is untouched. The decision gate held: `select(.x and .y)` evaluates its parenthesised argument per element (`selectOpType` binds tighter, at 52), so the common idiom is byte-identical before and after in all three tools.

All 29 rows previously pinned as succinctly's own answers in the #2473 test now match yq (re-captured live); two new tests pin 47 rows in both modes and the AST grouping.

## Left open

- #2540 (new): yq's value operator emits a literal once even over an empty context, so `(.a.zz | true) and true` is `true` there and `false` here; a different mechanism, recorded in the limitations doc.
- `--eval-all` rows differ in cardinality only, through the multi-document context list #2427 still owns.

## Verification

fmt; clippy on both CI legs with `-D warnings`; `cargo test` in the three configurations; `cargo doc -D warnings`; yq goldens 113 and jq goldens 633; oracle sweep 3168 cases, 0 unexpected, manifest unchanged.

Behaviour change in yq mode (grouping of unparenthesised `and`/`or` around `|`, `=`, `//`); ships in its own release, like #2454. Closes #2506.
