### PR TITLE
fix(jq): switch a computed float to scientific notation past jq's threshold

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **`succinctly jq` now switches a computed float to scientific notation past
+  jq's own magnitude/digit-count threshold, instead of always printing a full
+  decimal expansion** (#2456). Confirmed live against jq 1.7.1: `.a * 1e100`
+  is `1e+100` (was a 101-digit decimal expansion); the threshold itself is
+  jq's own (`decpt <= -4 || decpt > ndigits + 15`, reading the shortest
+  round-tripping decimal's digit count and decimal-point position), distinct
+  from yq's fixed `>= 1e6`/`<= 1e-4` magnitude range (#953) — `1e10` is
+  already scientific in yq mode but stays a plain decimal in jq mode. Applies
+  to every jq-mode computed-float output path: plain identity/`-c` output,
+  array/object construction, `tostring`/`@json`/string interpolation, and the
+  M2 streaming writer, which now all agree (they previously disagreed with
+  each other, not just with the oracle). yq mode is unaffected.
+
 ### Changed
 
 - **`succinctly yq`'s `type` now answers the YAML tag (`!!str`, `!!int`,

--- a/src/bin/succinctly/jq_runner.rs
+++ b/src/bin/succinctly/jq_runner.rs
@@ -21,9 +21,9 @@ use succinctly::jq::eval_generic::{
 };
 use succinctly::jq::walk::map_builtin_subexprs;
 use succinctly::jq::{
-    self, format_number_jq_compat, nonfinite_display_string, Builtin, EvalError, Expr,
-    FuncDefBound, JqSemantics, JqValue, OwnedValue, Program, StreamStats, UnresolvedCall,
-    MAX_VALUE_TREE_DEPTH,
+    self, format_number_jq_compat, jq_bare_float_display, nonfinite_display_string, Builtin,
+    EvalError, Expr, FuncDefBound, JqSemantics, JqValue, OwnedValue, Program, StreamStats,
+    UnresolvedCall, MAX_VALUE_TREE_DEPTH,
 };
 use succinctly::json::light::{preceding_gap_ok, JsonCursor, StandardJson};
 use succinctly::json::validate::{self, ValidationError};
@@ -5737,9 +5737,12 @@ impl LiteralFormatter for JqCompatFormatter {
         // such fallback text in real jq either and stays `null`. Reuses
         // #1075's `nonfinite_display_string` (the same NaN-vs-Infinity split
         // already pinned for jq's *text*-format path) rather than a fourth
-        // hand-rolled copy of the same two branches.
+        // hand-rolled copy of the same two branches. #2456: the finite arm
+        // used to be a bare `format!("{f}")`, which never switches to
+        // scientific notation past jq's own threshold -- `jq_bare_float_display`
+        // is the same formatter `OwnedValue::to_json` uses.
         if f.is_finite() {
-            format!("{f}")
+            jq_bare_float_display(f)
         } else {
             nonfinite_display_string::<JqSemantics>(f).to_string()
         }
@@ -5764,12 +5767,12 @@ impl LiteralFormatter for PreserveFormatter {
     }
 
     fn format_float(&self, f: f64) -> String {
-        // Same split as `JqCompatFormatter::format_float` above (#1087): a
-        // computed Infinity has no source literal for preserve mode to keep
-        // either, so both formatters need the identical jq-real-output rule
-        // here, not just the jq_compat one.
+        // Same split as `JqCompatFormatter::format_float` above (#1087, and
+        // #2456's finite-arm fix): a computed Infinity has no source literal
+        // for preserve mode to keep either, so both formatters need the
+        // identical jq-real-output rule here, not just the jq_compat one.
         if f.is_finite() {
-            format!("{f}")
+            jq_bare_float_display(f)
         } else {
             nonfinite_display_string::<JqSemantics>(f).to_string()
         }

--- a/src/bin/succinctly/output.rs
+++ b/src/bin/succinctly/output.rs
@@ -13,8 +13,8 @@ use succinctly::jq::escape::{
     write_json_body_yq, write_json_body_yq_ascii,
 };
 use succinctly::jq::{
-    assert_value_tree_depth, format_number_jq_compat, nonfinite_display_string, EvalError,
-    JqSemantics, NumberRepr, OwnedValue, StreamError,
+    assert_value_tree_depth, format_number_jq_compat, jq_bare_float_display,
+    nonfinite_display_string, EvalError, JqSemantics, NumberRepr, OwnedValue, StreamError,
 };
 use succinctly::yaml::format_float_with_fraction;
 pub use succinctly::yaml::format_float_yq;
@@ -606,7 +606,12 @@ fn format_json_impl(value: &OwnedValue, opts: &JsonFormatOpts, level: usize) -> 
                 format_float_yq(*f)
             } else {
                 match opts.float_style {
-                    FloatStyle::Shortest => f.to_string(),
+                    // #2456: was a bare `f.to_string()`, which never switches
+                    // to scientific notation -- `jq_bare_float_display` is
+                    // the same formatter `OwnedValue::to_json` and the M2
+                    // streaming writer use, so this CLI print path stops
+                    // diverging from them past the threshold.
+                    FloatStyle::Shortest => jq_bare_float_display(*f),
                     // Whole floats keep their decimal point at any magnitude;
                     // the old `<= i64::MAX` guard silently dropped it above
                     // that, disagreeing with the YAML writers (issue #169).

--- a/src/jq/mod.rs
+++ b/src/jq/mod.rs
@@ -117,7 +117,8 @@ pub use resolve::{resolve_func_calls, resolve_func_calls_all, UnresolvedCall};
 pub use stream::{StreamError, StreamStats, StreamableValue};
 pub use value::{
     assert_value_tree_depth, format_number_jq_compat, jq_bare_float_display,
-    nesting_depth_exceeded_message, NumberRepr, OwnedValue, MAX_VALUE_TREE_DEPTH,
+    jq_float_is_scientific, nesting_depth_exceeded_message, NumberRepr, OwnedValue,
+    MAX_VALUE_TREE_DEPTH,
 };
 // `pub(crate)`, not `pub`: only `yaml::light`'s alias-chain resolvers (#1191
 // code review, #1193/PR #1314) need this from outside `jq::value` --

--- a/src/jq/mod.rs
+++ b/src/jq/mod.rs
@@ -116,8 +116,8 @@ pub use parser::{
 pub use resolve::{resolve_func_calls, resolve_func_calls_all, UnresolvedCall};
 pub use stream::{StreamError, StreamStats, StreamableValue};
 pub use value::{
-    assert_value_tree_depth, format_number_jq_compat, nesting_depth_exceeded_message, NumberRepr,
-    OwnedValue, MAX_VALUE_TREE_DEPTH,
+    assert_value_tree_depth, format_number_jq_compat, jq_bare_float_display,
+    nesting_depth_exceeded_message, NumberRepr, OwnedValue, MAX_VALUE_TREE_DEPTH,
 };
 // `pub(crate)`, not `pub`: only `yaml::light`'s alias-chain resolvers (#1191
 // code review, #1193/PR #1314) need this from outside `jq::value` --

--- a/src/jq/value.rs
+++ b/src/jq/value.rs
@@ -474,17 +474,74 @@ pub fn format_number_jq_compat(raw: &[u8]) -> String {
     assemble_scientific(sign, &mantissa_str, shifted_exp)
 }
 
-/// jq mode's bare `Float` display: no forced decimal point, matching real
-/// jq's own convention that a computed value (one with no preserved
-/// `NumberLiteral` source text) loses its literal formatting entirely
-/// (`1.0 + 4.0` prints `5`, not `5.0`). Named and shared, rather than a
-/// hand-copied `|f| f.to_string()` closure at each call site, per the #106
-/// "duplicated predicates diverge silently" lesson in `CLAUDE.md` --
+/// jq mode's bare `Float` display: no forced decimal point.
+///
+/// Matches real jq's own convention that a computed value (one with no
+/// preserved `NumberLiteral` source text) loses its literal formatting
+/// entirely (`1.0 + 4.0` prints `5`, not `5.0`). Named and shared, rather
+/// than a hand-copied `|f| f.to_string()` closure at each call site, per the
+/// #106 "duplicated predicates diverge silently" lesson in `CLAUDE.md` --
 /// [`to_json`](OwnedValue::to_json), [`to_json_for_reindex_at_depth`]'s
 /// jq-mode fallback, and [`stream::stream_owned_value_json_jq`](crate::jq::stream)
 /// all need this exact formatter.
-pub(crate) fn jq_bare_float_display(f: f64) -> String {
-    f.to_string()
+///
+/// #2456: a plain `f.to_string()` alone is wrong past
+/// [`jq_float_is_scientific`]'s threshold -- Rust's `Display` for `f64` never
+/// switches to exponential notation, so a computed value like `1e100` used to
+/// come out as a 101-digit decimal expansion where real jq 1.7.1 prints
+/// `1e+100`.
+#[must_use]
+pub fn jq_bare_float_display(f: f64) -> String {
+    if !jq_float_is_scientific(f) {
+        return f.to_string();
+    }
+    // Only the scientific branch needs the exponential rendering -- an
+    // everyday-magnitude value never pays for a string it would immediately
+    // discard, matching yq's own `format_float_yq_with` (`src/yaml/light.rs`).
+    let sci = format!("{f:e}");
+    let (mantissa, exp_str) = sci
+        .split_once('e')
+        .expect("Rust's exponential formatter always includes a lowercase 'e'");
+    let exp: i64 = exp_str
+        .parse()
+        .expect("exponent from Rust's exponential formatter is always a valid i64");
+    let sign = if exp < 0 { '-' } else { '+' };
+    format!("{mantissa}e{sign}{:02}", exp.unsigned_abs())
+}
+
+/// Whether real jq would spell a computed `f64` in scientific notation
+/// rather than decimally, when printing it bare ([`jq_bare_float_display`]).
+///
+/// Unlike yq's own threshold ([`crate::yaml::yq_float_is_scientific`], a
+/// fixed magnitude range), jq's C `dtoa`/`g_fmt`-derived formatter
+/// (`jv_dtoa.c`/`jv_print.c` in the reference implementation) decides by
+/// digit count: writing `f`'s shortest round-tripping decimal as
+/// `d.ddd...e{exp}` (`ndigits` significant digits, decimal point at position
+/// `decpt = exp + 1`), scientific notation is used exactly when
+/// `decpt <= -4` or `decpt > ndigits + 15`. Oracle-verified against jq 1.7.1
+/// across a matrix of magnitudes and digit counts straddling both boundaries
+/// (`1e15`/`1e16`, `1e-4`/`1e-5`, and multi-digit mantissas at each) --
+/// pinned by `jq_float_is_scientific_agrees_with_the_pinned_oracle`.
+///
+/// `f` must be finite; 0.0 always takes the ordinary branch (`{:e}` renders
+/// it `0e0`, `ndigits = 1`, `decpt = 1`, well inside the ordinary range).
+#[must_use]
+pub(crate) fn jq_float_is_scientific(f: f64) -> bool {
+    debug_assert!(
+        f.is_finite(),
+        "jq_float_is_scientific requires a finite value; NaN/Infinity have no \
+         JSON spelling here and must be special-cased by the caller"
+    );
+    let sci = format!("{f:e}");
+    let (mantissa, exp_str) = sci
+        .split_once('e')
+        .expect("Rust's exponential formatter always includes a lowercase 'e'");
+    let ndigits = mantissa.bytes().filter(u8::is_ascii_digit).count() as i64;
+    let exp: i64 = exp_str
+        .parse()
+        .expect("exponent from Rust's exponential formatter is always a valid i64");
+    let decpt = exp + 1;
+    decpt <= -4 || decpt > ndigits + 15
 }
 
 /// Join a sign, an already-normalized mantissa, a negative-exponent flag,
@@ -1631,7 +1688,11 @@ impl OwnedValue {
     pub fn number_str(&self) -> Option<Cow<'_, str>> {
         match self {
             Self::Int(n) => Some(Cow::Owned(n.to_string())),
-            Self::Float(f) => Some(Cow::Owned(f.to_string())),
+            // #2456: was a bare `f.to_string()`, matching `jq_bare_float_display`'s
+            // own pre-fix bug (this is jq mode's own rendering convention --
+            // `numeric_display_string`'s yq-mode arms always return before
+            // reaching here for a `Float`).
+            Self::Float(f) => Some(Cow::Owned(jq_bare_float_display(*f))),
             Self::NumberLiteral(_, literal) => {
                 Some(Cow::Owned(format_number_jq_compat(literal.as_bytes())))
             }
@@ -3160,11 +3221,14 @@ mod tests {
         }
     }
 
-    /// #2438: the bridge's yq fallback now spells a *computed* float by the
-    /// same threshold the emitters use, rather than forcing a decimal point
-    /// at every magnitude. jq mode's own fallback is untouched.
+    /// #2438: the bridge's yq fallback spells a *computed* float by yq's own
+    /// threshold, rather than forcing a decimal point at every magnitude.
+    /// #2456: jq mode's own fallback applies its own (different) threshold
+    /// too, rather than never reformatting a computed float at all -- this
+    /// used to pin the opposite (a full 21-digit decimal expansion) as
+    /// deliberately untouched by #2438, which #2456 fixes.
     #[test]
-    fn test_to_json_for_reindex_yq_float_uses_the_shared_threshold_2438() {
+    fn test_to_json_for_reindex_float_uses_each_modes_own_threshold_2438_2456() {
         assert_eq!(
             OwnedValue::Float(1e20).to_json_for_reindex::<YqSemantics>(),
             "1e+20"
@@ -3175,8 +3239,55 @@ mod tests {
         );
         assert_eq!(
             OwnedValue::Float(1e20).to_json_for_reindex::<JqSemantics>(),
-            "100000000000000000000"
+            "1e+20"
         );
+        // jq's own threshold sits at a different magnitude than yq's fixed
+        // `>= 1e6`/`<= 1e-4` (#953): 1e10 already clears yq's, but jq's own
+        // digit-count rule (`decpt = 11 <= ndigits(1) + 15 = 16`) keeps it
+        // decimal there.
+        assert_eq!(
+            OwnedValue::Float(1e10).to_json_for_reindex::<JqSemantics>(),
+            "10000000000"
+        );
+        assert_eq!(
+            OwnedValue::Float(1e10).to_json_for_reindex::<YqSemantics>(),
+            "1e+10"
+        );
+    }
+
+    /// #2456: `jq_bare_float_display`'s digit-count threshold
+    /// (`decpt <= -4 || decpt > ndigits + 15`), pinned directly against real
+    /// jq 1.7.1 (`echo null | jq -cn '1 * <value>'`) across both boundary
+    /// crossings and several multi-digit mantissas at each. `1e15`/`1e16`
+    /// and `1e-4`/`1e-5` are the exact boundary and its first crossing;
+    /// `9.99999999999999e15` (16-digit mantissa, one digit short of rounding
+    /// up to `1e16`) pins that the threshold reads the shortest-round-trip
+    /// digit count, not the source magnitude alone.
+    #[test]
+    fn test_jq_float_scientific_threshold_matches_pinned_oracle_2456() {
+        for (f, want) in [
+            (1e15, "1000000000000000"),
+            (1e16, "1e+16"),
+            (1e17, "1e+17"),
+            (1.5e15, "1500000000000000"),
+            (1.5e16, "15000000000000000"),
+            (1.5e17, "1.5e+17"),
+            (1.23456e17, "123456000000000000"),
+            (1.23456e18, "1234560000000000000"),
+            (9.99999999999999e15, "9999999999999990"),
+            (1e-4, "0.0001"),
+            (1e-5, "1e-05"),
+            (1e-6, "1e-06"),
+            (0.0, "0"),
+        ] {
+            assert_eq!(jq_bare_float_display(f), want, "for {f:e}");
+            assert_eq!(
+                jq_bare_float_display(-f),
+                format!("-{want}"),
+                "for {:e}",
+                -f
+            );
+        }
     }
 
     #[test]

--- a/src/jq/value.rs
+++ b/src/jq/value.rs
@@ -3310,11 +3310,11 @@ mod tests {
                 "jq_float_is_scientific for {f:e}"
             );
             assert_eq!(jq_bare_float_display(f), want, "for {f:e}");
+            let neg = -f;
             assert_eq!(
-                jq_bare_float_display(-f),
+                jq_bare_float_display(neg),
                 format!("-{want}"),
-                "for {:e}",
-                -f
+                "for {neg:e}"
             );
         }
     }

--- a/src/jq/value.rs
+++ b/src/jq/value.rs
@@ -481,7 +481,7 @@ pub fn format_number_jq_compat(raw: &[u8]) -> String {
 /// entirely (`1.0 + 4.0` prints `5`, not `5.0`). Named and shared, rather
 /// than a hand-copied `|f| f.to_string()` closure at each call site, per the
 /// #106 "duplicated predicates diverge silently" lesson in `CLAUDE.md` --
-/// [`to_json`](OwnedValue::to_json), [`to_json_for_reindex_at_depth`]'s
+/// [`to_json`](OwnedValue::to_json), `to_json_for_reindex_at_depth`'s
 /// jq-mode fallback, and [`stream::stream_owned_value_json_jq`](crate::jq::stream)
 /// all need this exact formatter.
 ///

--- a/src/jq/value.rs
+++ b/src/jq/value.rs
@@ -490,14 +490,39 @@ pub fn format_number_jq_compat(raw: &[u8]) -> String {
 /// switches to exponential notation, so a computed value like `1e100` used to
 /// come out as a 101-digit decimal expansion where real jq 1.7.1 prints
 /// `1e+100`.
+///
+/// `f` must be finite, like [`jq_float_is_scientific`] -- NaN/Infinity have
+/// no JSON spelling here and must be special-cased by the caller (every
+/// current call site already does, via `is_nan()`/`is_infinite()` upstream).
 #[must_use]
 pub fn jq_bare_float_display(f: f64) -> String {
-    if !jq_float_is_scientific(f) {
+    // Parsed once and reused for both the threshold decision and the
+    // eventual render -- `jq_float_is_scientific` alone would need this same
+    // `format!("{f:e}")` a second time on every value that actually takes
+    // the scientific branch.
+    let (mantissa, exp) = jq_float_digits(f);
+    if !jq_float_is_scientific_from_digits(&mantissa, exp) {
         return f.to_string();
     }
-    // Only the scientific branch needs the exponential rendering -- an
-    // everyday-magnitude value never pays for a string it would immediately
-    // discard, matching yq's own `format_float_yq_with` (`src/yaml/light.rs`).
+    let sign = if exp < 0 { '-' } else { '+' };
+    format!("{mantissa}e{sign}{:02}", exp.unsigned_abs())
+}
+
+/// Splits `f`'s shortest round-tripping decimal (via Rust's own exponential
+/// formatter) into its normalized mantissa text and base-10 exponent --
+/// shared by [`jq_bare_float_display`] and [`jq_float_is_scientific`] so
+/// they agree on the same underlying digits by construction, not by two
+/// independent implementations kept in sync by hand.
+///
+/// `f` must be finite -- NaN/Infinity render as `"NaN"`/`"inf"` here, which
+/// contain no `'e'` and would panic the `split_once` below regardless of
+/// build profile, not just under `debug_assert`.
+fn jq_float_digits(f: f64) -> (String, i64) {
+    debug_assert!(
+        f.is_finite(),
+        "jq_float_digits requires a finite value; NaN/Infinity have no JSON \
+         spelling here and must be special-cased by the caller"
+    );
     let sci = format!("{f:e}");
     let (mantissa, exp_str) = sci
         .split_once('e')
@@ -505,8 +530,7 @@ pub fn jq_bare_float_display(f: f64) -> String {
     let exp: i64 = exp_str
         .parse()
         .expect("exponent from Rust's exponential formatter is always a valid i64");
-    let sign = if exp < 0 { '-' } else { '+' };
-    format!("{mantissa}e{sign}{:02}", exp.unsigned_abs())
+    (mantissa.to_string(), exp)
 }
 
 /// Whether real jq would spell a computed `f64` in scientific notation
@@ -521,25 +545,24 @@ pub fn jq_bare_float_display(f: f64) -> String {
 /// `decpt <= -4` or `decpt > ndigits + 15`. Oracle-verified against jq 1.7.1
 /// across a matrix of magnitudes and digit counts straddling both boundaries
 /// (`1e15`/`1e16`, `1e-4`/`1e-5`, and multi-digit mantissas at each) --
-/// pinned by `jq_float_is_scientific_agrees_with_the_pinned_oracle`.
+/// pinned by `test_jq_float_scientific_threshold_matches_pinned_oracle_2456`
+/// (via [`jq_bare_float_display`], which shares this exact decision).
 ///
 /// `f` must be finite; 0.0 always takes the ordinary branch (`{:e}` renders
 /// it `0e0`, `ndigits = 1`, `decpt = 1`, well inside the ordinary range).
 #[must_use]
-pub(crate) fn jq_float_is_scientific(f: f64) -> bool {
-    debug_assert!(
-        f.is_finite(),
-        "jq_float_is_scientific requires a finite value; NaN/Infinity have no \
-         JSON spelling here and must be special-cased by the caller"
-    );
-    let sci = format!("{f:e}");
-    let (mantissa, exp_str) = sci
-        .split_once('e')
-        .expect("Rust's exponential formatter always includes a lowercase 'e'");
+pub fn jq_float_is_scientific(f: f64) -> bool {
+    let (mantissa, exp) = jq_float_digits(f);
+    jq_float_is_scientific_from_digits(&mantissa, exp)
+}
+
+/// The threshold decision itself, taking [`jq_float_digits`]'s own output
+/// directly -- split out so [`jq_bare_float_display`] can reuse one parse of
+/// `f` for both the decision and the render, while [`jq_float_is_scientific`]
+/// stays available as a standalone predicate for anything that only needs
+/// the bool.
+fn jq_float_is_scientific_from_digits(mantissa: &str, exp: i64) -> bool {
     let ndigits = mantissa.bytes().filter(u8::is_ascii_digit).count() as i64;
-    let exp: i64 = exp_str
-        .parse()
-        .expect("exponent from Rust's exponential formatter is always a valid i64");
     let decpt = exp + 1;
     decpt <= -4 || decpt > ndigits + 15
 }
@@ -3280,6 +3303,12 @@ mod tests {
             (1e-6, "1e-06"),
             (0.0, "0"),
         ] {
+            let expect_scientific = want.contains('e');
+            assert_eq!(
+                jq_float_is_scientific(f),
+                expect_scientific,
+                "jq_float_is_scientific for {f:e}"
+            );
             assert_eq!(jq_bare_float_display(f), want, "for {f:e}");
             assert_eq!(
                 jq_bare_float_display(-f),

--- a/src/yaml/light.rs
+++ b/src/yaml/light.rs
@@ -3531,9 +3531,10 @@ pub fn format_float_with_fraction(f: f64) -> String {
 ///
 /// The threshold and the `e+NN`/`e-NN` (lowercase, signed, exponent padded
 /// to at least 2 digits) spelling are both oracle-verified against real yq;
-/// this is yq's own threshold, distinct from jq mode's (which only
-/// reformats when the source literal itself already used exponent
-/// notation).
+/// this is yq's own fixed-magnitude threshold, distinct from jq mode's own
+/// digit-count threshold (`jq_float_is_scientific`/`jq_bare_float_display`,
+/// `src/jq/value.rs`, #2456) -- both reformat a genuinely computed float,
+/// just at different magnitudes and via a different rule shape.
 ///
 /// Lives here (not in the CLI binary) rather than only in
 /// `src/bin/succinctly/output.rs`, which now re-exports this under the

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -22147,6 +22147,65 @@ fn test_jq_reduce_accumulator_unaffected_by_yq_float_fraction_fix_953() -> Resul
     Ok(())
 }
 
+/// #2456: a computed float past jq's own digit-count threshold
+/// (`decpt <= -4 || decpt > ndigits + 15`, see `jq_float_is_scientific`'s doc
+/// comment) now switches to scientific notation, matching real jq 1.7.1,
+/// instead of a bare `f.to_string()`'s full decimal expansion. Every case
+/// here (including the exact boundary crossings and multi-digit mantissas)
+/// is confirmed live against the pinned oracle.
+#[test]
+fn test_jq_computed_float_scientific_notation_threshold_2456() -> Result<()> {
+    for (filter, want) in [
+        // The issue's own repro.
+        (".a * 1e100", "1e+100"),
+        ("[.a * 1e100]", "[1e+100]"),
+        // Positive-exponent boundary: 1e15 stays decimal, 1e16 switches.
+        (".a * 1e15", "1000000000000000"),
+        (".a * 1e16", "1e+16"),
+        (".a * 1e17", "1e+17"),
+        // Multi-digit mantissa at and past the same boundary.
+        (".a * 1.5e15", "1500000000000000"),
+        (".a * 1.5e16", "15000000000000000"),
+        (".a * 1.5e17", "1.5e+17"),
+        // Negative-exponent boundary: 1e-4 stays decimal, 1e-5 switches.
+        (".a / 10000", "0.0001"),
+        (".a / 100000", "1e-05"),
+        (".a / 1000000", "1e-06"),
+        // Sign is preserved on both sides of the threshold.
+        (".a * -1e17", "-1e+17"),
+        (".a * -1e-5", "-1e-05"),
+        // A whole-number result at ordinary magnitude keeps jq's own
+        // "computed value loses the decimal point" rule (#953) unaffected.
+        (".a * 1.0", "1"),
+    ] {
+        let (out, code) = run_jq_stdin(filter, "{\"a\":1}", &["-c"])?;
+        assert_eq!(code, 0, "for {filter:?}: {out:?}");
+        assert_eq!(out.trim_end(), want, "for {filter:?}");
+    }
+    Ok(())
+}
+
+/// #2456: the same threshold applies through `tostring`/`@json`/string
+/// interpolation (`OwnedValue::number_str`'s `Float` arm), not just the
+/// reindex-bridge/JSON-output path above -- these used to disagree (the
+/// bridge already routed through `jq_bare_float_display`'s sibling call
+/// sites, `number_str` didn't).
+#[test]
+fn test_jq_computed_float_scientific_notation_tostring_2456() -> Result<()> {
+    for (filter, want) in [
+        (".a * 1e100 | tostring", "1e+100"),
+        (".a * 1e100 | @json", "1e+100"),
+        (r#""\(.a * 1e100)""#, "1e+100"),
+        (".a * 1e16 | tostring", "1e+16"),
+        (".a * 1e15 | tostring", "1000000000000000"),
+    ] {
+        let (out, code) = run_jq_stdin(filter, "{\"a\":1}", &[])?;
+        assert_eq!(code, 0, "for {filter:?}: {out:?}");
+        assert_eq!(out.trim(), format!("\"{want}\""), "for {filter:?}");
+    }
+    Ok(())
+}
+
 /// #1051: `builtin_stderr` gained an `S: EvalSemantics` parameter so yq mode
 /// can echo a `NumberLiteral` verbatim; confirm jq mode's own container
 /// formatting (`format_number_jq_compat`'s uppercase-`E` reformatting) is

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -11732,22 +11732,23 @@ fn test_computed_float_threshold_agrees_inside_array_and_comma_2438() -> Result<
 /// `to_json_for_reindex` fallback (`jq_bare_float_display`) is `S`-gated
 /// away from `format_float_yq` and stays that way.
 ///
-/// This pins the *pre-existing* jq-mode divergence rather than a fix: real
-/// jq 1.7.1 prints `1e+100` here, succinctly prints the full expansion, and
-/// it does so identically for the bare filter and the array-wrapped one --
-/// i.e. the gap is jq mode's own number formatting, not the reindex bridge,
-/// so #2438 neither widens nor closes it. Captured live on `{"a":1}`:
+/// Renamed/updated by #2456: this used to pin jq mode's own pre-existing
+/// divergence (a full decimal expansion where real jq prints `1e+100`) as
+/// deliberately *unchanged* by #2438 -- #2456 is the fix for that divergence
+/// itself, so the "unchanged" framing no longer applies; what's pinned now is
+/// that jq mode's own threshold (distinct from yq's -- see
+/// `jq_float_is_scientific`'s doc comment) is what applies here, still
+/// independent of `format_float_yq`. Captured live on `{"a":1}`:
 ///
 /// ```console
 /// $ /usr/bin/jq -c '[.a * 1e100]' a.json   => [1e+100]
 /// $ /usr/bin/jq -c '.a * 1e100'   a.json   => 1e+100
 /// ```
 #[test]
-fn test_jq_mode_float_threshold_unchanged_by_2438() -> Result<()> {
-    let expansion = format!("1{}", "0".repeat(100));
+fn test_jq_mode_float_threshold_matches_oracle_2438_2456() -> Result<()> {
     for (filter, want) in [
-        ("[.a * 1e100]", format!("[{expansion}]")),
-        (".a * 1e100", expansion.clone()),
+        ("[.a * 1e100]", "[1e+100]".to_string()),
+        (".a * 1e100", "1e+100".to_string()),
     ] {
         let (out, code) = run_jq_stdin(filter, "{\"a\":1}\n", &["-c"])?;
         assert_eq!(code, 0, "for {filter:?}: {out:?}");


### PR DESCRIPTION
## Summary
- Real jq (1.7.1) switches a computed float from decimal to scientific notation via a `dtoa`/`g_fmt`-style digit-count rule (`decpt <= -4 || decpt > ndigits + 15`), distinct from yq's own fixed magnitude range (`>= 1e6`/`<= 1e-4`, #953). succinctly's jq mode had no such rule at all: `.a * 1e100` printed a 101-digit decimal expansion instead of `1e+100`.
- Fixed at the source (`jq_bare_float_display`, `src/jq/value.rs`) with a new `jq_float_is_scientific` predicate, oracle-verified against real jq across a 900-case randomized differential fuzz plus a hand-picked boundary matrix (both threshold crossings, multiple mantissa digit counts, signs).
- Testing every invocation path surfaced **two more duplicated formatters** that bypassed the shared function entirely (CLAUDE.md's "duplicated predicates diverge silently" pattern, #106): `OwnedValue::number_str`'s `Float` arm (reached by `tostring`/`@json`/string interpolation) and two CLI printers (`output.rs`'s `format_json_impl`, `jq_runner.rs`'s `JqCompatFormatter`/`PreserveFormatter`). All three now delegate to `jq_bare_float_display`.
- `jq_bare_float_display` is now `pub` (was `pub(crate)`) so the CLI binary crate can reach it; re-exported from `src/jq/mod.rs`.

## Follow-ups filed (out of scope here, cross-linked on #2456)
- #2542: a rare (1/900 fuzz cases) disagreement between Rust's and jq's own shortest-round-trip decimal formatter at *ordinary* magnitudes (not a threshold issue).
- #2543: `--null-input` mode's `tostring` reaches a different code path than every other invocation mode for a computed-float arithmetic result, giving jq's *literal*-reformatting convention (uppercase `E`) instead of its *computed*-value one (lowercase `e`).

## Test plan
- [x] `cargo build --features cli`
- [x] `cargo test --features cli,simd,regex,serde` (full suite, all green)
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings`
- [x] New unit tests (`src/jq/value.rs`): `jq_float_is_scientific`'s threshold pinned against the live oracle; both modes' distinct thresholds contrasted directly
- [x] New CLI tests (`tests/jq_cli_tests.rs`): boundary matrix across identity/array/tostring/@json/string-interpolation, oracle-verified
- [x] Updated 2 pre-existing tests that pinned the old buggy behavior as deliberately unchanged (`tests/yq_cli_tests.rs`'s `test_jq_mode_float_threshold_unchanged_by_2438` → `..._matches_oracle_2438_2456`; `src/jq/value.rs`'s `test_to_json_for_reindex_yq_float_uses_the_shared_threshold_2438` → `...each_modes_own_threshold_2438_2456`)
- [x] Diffed against real jq 1.7.1 directly throughout, not just golden fixtures

Fixes #2456