### PR TITLE
fix(jq): name the missing resolve_func_calls precondition on an unresolved builtin_fallback

### DIFF
--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -49965,15 +49965,21 @@ fn eval_func_call<'a, W: Clone + AsRef<[u64]>>(
     // (the field's own invariant), so without this check the message below
     // reads as an ordinary "no such builtin" typo report -- indistinguishable
     // from a genuine bug in the caller's filter, when the real cause is a
-    // missing resolve call before evaluating a jq-mode-parsed `Expr`
-    // directly. No extra tree walk: this only enriches the message on a
-    // node that was already about to error either way.
+    // missing resolve call before evaluating this `Expr` directly. No extra
+    // tree walk: this only enriches the message on a node that was already
+    // about to error either way.
+    //
+    // Deliberately not "jq-mode-parsed": `wrap_shadowable_call`
+    // (`parser.rs`) isn't gated on `ParserMode::Jq`, so a yq-mode-parsed
+    // `Expr` using a jq-extension special form (`until`/`while`/`repeat`/
+    // `error`/`first`/`last` under `--jq-extensions`) can carry an
+    // unresolved `builtin_fallback` too (review finding).
     let message = if unresolved_builtin_fallback {
         format!(
             "undefined function: {name}/{}: a `def {name}` elsewhere in this \
              program means the parser deferred resolving this call site -- \
              call `resolve_func_calls`/`resolve_func_calls_all` before \
-             evaluating a jq-mode-parsed `Expr` directly (see \
+             evaluating this `Expr` directly (see \
              `Expr::FuncCall::builtin_fallback`'s doc comment)",
             args.len()
         )
@@ -50067,6 +50073,40 @@ mod tests {
                 assert!(
                     e.message.contains("resolve_func_calls"),
                     "expected the message to name the missing precondition, got: {}",
+                    e.message
+                );
+            }
+            other => panic!("expected an Error, got {other:?}"),
+        }
+    }
+
+    /// #2402 review finding: `wrap_shadowable_call` (`parser.rs`) isn't
+    /// gated on `ParserMode::Jq`, so a yq-mode-parsed `Expr` using a
+    /// jq-extension special form under `--jq-extensions` can carry an
+    /// unresolved `builtin_fallback` too -- the message must not claim
+    /// "jq-mode-parsed" (an earlier revision of this fix did).
+    #[test]
+    fn test_eval_without_resolve_names_missing_precondition_yq_mode_2402() {
+        use crate::json::JsonIndex;
+
+        let json: &[u8] = b"[1,2,3]";
+        let index = JsonIndex::build(json);
+        // `def until(x): x;` shadows a different arity than the bare
+        // 2-argument `until(cond; update)` special form, so this call site
+        // never actually shadows -- but resolving is skipped here.
+        let expr =
+            parse_with_mode_and_extensions("def until(x): x; until(true; .)", ParserMode::Yq, true)
+                .unwrap();
+        match eval::<Vec<u64>, YqSemantics>(&expr, index.root(json)) {
+            QueryResult::Error(e) => {
+                assert!(
+                    e.message.contains("resolve_func_calls"),
+                    "expected the message to name the missing precondition, got: {}",
+                    e.message
+                );
+                assert!(
+                    !e.message.contains("jq-mode"),
+                    "message must not claim a parser mode that doesn't hold in general, got: {}",
                     e.message
                 );
             }

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -2450,7 +2450,11 @@ fn eval_single<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
             then,
             bound,
         } => eval_func_def::<W, S>(name, params, body, then, bound, value, optional),
-        Expr::FuncCall { name, args, .. } => eval_func_call::<W>(name, args, value, optional),
+        Expr::FuncCall {
+            name,
+            args,
+            builtin_fallback,
+        } => eval_func_call::<W>(name, args, builtin_fallback.is_some(), value, optional),
 
         // #1371: a call already bound to its definition. Unlike `FuncCall`
         // above (which only ever errors, since an unbound call is a compile
@@ -49950,13 +49954,33 @@ fn substitute_func_param_in_builtin(
 fn eval_func_call<'a, W: Clone + AsRef<[u64]>>(
     name: &str,
     args: &[Expr],
+    unresolved_builtin_fallback: bool,
     _value: StandardJson<'a, W>,
     _optional: bool,
 ) -> QueryResult<'a, W> {
-    QueryResult::Error(EvalError::new(format!(
-        "undefined function: {name}/{}",
-        args.len()
-    )))
+    // #2402: a `builtin_fallback`-carrying node reaching evaluation at all
+    // means the caller skipped `resolve_func_calls`/`resolve_func_calls_all`
+    // -- see `Expr::FuncCall::builtin_fallback`'s own doc comment for the
+    // documented precondition. `args` is deliberately empty on such a node
+    // (the field's own invariant), so without this check the message below
+    // reads as an ordinary "no such builtin" typo report -- indistinguishable
+    // from a genuine bug in the caller's filter, when the real cause is a
+    // missing resolve call before evaluating a jq-mode-parsed `Expr`
+    // directly. No extra tree walk: this only enriches the message on a
+    // node that was already about to error either way.
+    let message = if unresolved_builtin_fallback {
+        format!(
+            "undefined function: {name}/{}: a `def {name}` elsewhere in this \
+             program means the parser deferred resolving this call site -- \
+             call `resolve_func_calls`/`resolve_func_calls_all` before \
+             evaluating a jq-mode-parsed `Expr` directly (see \
+             `Expr::FuncCall::builtin_fallback`'s doc comment)",
+            args.len()
+        )
+    } else {
+        format!("undefined function: {name}/{}", args.len())
+    };
+    QueryResult::Error(EvalError::new(message))
 }
 
 #[cfg(test)]
@@ -50000,6 +50024,54 @@ mod tests {
             Some(Control::Halt(c)) => format!("halt:{c}"),
         };
         (out, tag)
+    }
+
+    /// #2402: `eval`/`eval_lenient` (the public library API) skip
+    /// `resolve.rs`'s scope-tracking pass, so a `builtin_fallback`-carrying
+    /// `Expr::FuncCall` node -- built by the parser whenever a lexical
+    /// prescan flags a call site's name as possibly `def`'d elsewhere in the
+    /// program (#2036) -- reaches `eval_func_call` still unresolved. Before
+    /// this fix, that produced a plain "undefined function" message
+    /// indistinguishable from a genuine typo in the caller's filter; the
+    /// caller has no way to tell "you forgot to call `resolve_func_calls`
+    /// first" from "this name is really undefined". Confirms both halves:
+    /// resolving first recovers the real builtin (arity mismatch means the
+    /// `def` doesn't shadow this call site), and skipping it now names the
+    /// missing precondition explicitly instead of leaving the caller to
+    /// guess.
+    #[test]
+    fn test_eval_without_resolve_names_missing_precondition_2402() {
+        use crate::jq::resolve_func_calls_all;
+        use crate::json::JsonIndex;
+
+        let json: &[u8] = b"[1,2,3]";
+        let index = JsonIndex::build(json);
+
+        // Resolved first, per the documented precondition: the bare
+        // `length` call keeps its builtin meaning (`def length(x)` is a
+        // different arity, so it never shadows this call site) and
+        // evaluates the real array length.
+        let mut resolved = parse("def length(x): x; length").unwrap();
+        resolve_func_calls_all(&mut resolved);
+        match eval::<Vec<u64>, JqSemantics>(&resolved, index.root(json)) {
+            QueryResult::Owned(OwnedValue::Int(3)) => {}
+            other => panic!("expected Owned(Int(3)), got {other:?}"),
+        }
+
+        // Same source, evaluated directly without resolving first: the
+        // node's `builtin_fallback` is still `Some`, so this must name the
+        // actual cause instead of reporting a bare arity/name mismatch.
+        let unresolved = parse("def length(x): x; length").unwrap();
+        match eval::<Vec<u64>, JqSemantics>(&unresolved, index.root(json)) {
+            QueryResult::Error(e) => {
+                assert!(
+                    e.message.contains("resolve_func_calls"),
+                    "expected the message to name the missing precondition, got: {}",
+                    e.message
+                );
+            }
+            other => panic!("expected an Error, got {other:?}"),
+        }
     }
 
     /// #1888: `catch_error_under_optional`'s full truth table, exercised


### PR DESCRIPTION
## Summary

- #2036 (a user `def` can shadow a builtin of the same name) added `Expr::FuncCall::builtin_fallback`, populated by the parser whenever a lexical prescan flags a call site's name as possibly `def`'d somewhere in the program. While this field is `Some`, the node's own `args` is deliberately left empty — `resolve.rs`'s `check` pass is the sole intended consumer, resolving it one way or the other before any evaluation happens.
- Both CLI runners (`jq_runner.rs`, `yq_runner.rs`) already call `resolve_func_calls`/`resolve_func_calls_all` before evaluating, so this is unreachable from the `succinctly` binary. But `succinctly::jq::{eval, eval_lenient}` are public library API, and evaluating a jq-mode-parsed `Expr` directly — skipping the resolve step — reaches `eval_func_call` with `builtin_fallback` still `Some` for any program containing a `def` of a builtin's name at an unrelated arity elsewhere. Before this fix, that surfaced as a plain `"undefined function: name/0"`, indistinguishable from a genuine typo in the caller's own filter — the caller had no way to tell "you forgot to call `resolve_func_calls` first" from "this name is really undefined."
- Threads `builtin_fallback.is_some()` into `eval_func_call` (the sole call site, in `eval_single`'s `Expr::FuncCall` arm) and enriches the error message when it's set, naming the actual cause and the exact functions to call (`resolve_func_calls`/`resolve_func_calls_all`) instead of a confusing arity/name mismatch. No additional tree walk: this only changes the message on a call site that was already about to error either way, so it costs nothing on the hot path — the issue's own analysis flagged this as the deciding factor between the three candidate fixes (making `eval_func_call` itself builtin-fallback-aware would need to duplicate `resolve.rs`'s scope-tracking machinery on the hottest evaluation path; a whole-tree precondition scan would add a walk to a path that currently has none).

Fixes #2402.

## Test plan

- [x] `cargo build --features cli`
- [x] `cargo test --features cli,simd,regex,serde` (full suite, including `tests/*.rs`) — 62/62 binaries green
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings`
- [x] Live-verified via a direct call to the public `eval` API: resolving first recovers the real builtin (`def length(x): x; length` on `[1,2,3]` still evaluates to `3`, since the `def`'s arity never shadows the bare call); skipping the resolve step now reports the missing precondition by name instead of a bare `"undefined function: length/0"`
- [x] `cargo llvm-cov` + `omni-dev coverage diff` — patch coverage 92% (23/25 new lines); the 2 remaining lines are `panic!` arms inside the new test's own assertion match statements (by design never hit on a passing run)
- [x] 1 new regression test covering both halves (resolved vs. unresolved) directly against the public library API