### PR TITLE
docs(jq): record unary minus's literal-preservation loss as ADR-0018 rule 4c

### DIFF
--- a/docs/compliance/jq/limitations.md
+++ b/docs/compliance/jq/limitations.md
@@ -3723,7 +3723,8 @@ jq 1.7.1 still answers empty here, but only because its own unary minus
 collapses a literal this large to a `double` before `range` ever sees it
 (confirmed live: `jq -nc '-9223372036854775758'` prints
 `-9223372036854776000`, already rounded) -- an unrelated, pre-existing
-divergence (see the "Widened divergence" discussion below), not something
+divergence (see "Unary minus in filter text destroys literal preservation"
+below, #2357), not something
 #2219 changed. The pre-#2219 empty answer matched jq's only by coincidence
 of that unrelated quirk; feeding the same magnitudes in as *data* instead of
 literals (`echo '[-9223372036854775758,-9223372036854775808,-100]' | jq -c
@@ -3886,6 +3887,54 @@ described:
   large-but-safe integers to `f64`, as the `±2^53` gate did, or reproducing
   jq's own hang, as ADR-0018 does not require — is the worse failure mode
   for the realistic inputs this magnitude range covers).
+
+### Unary minus in filter text destroys literal preservation — accepted divergence, ADR-0018 rule 4c (#2357)
+
+Real jq preserves a number literal's exact source spelling through to output (`jq -n
+'1.0'` → `1.0`, `1e10` → `1E+10`), but a *unary minus written in the filter text* breaks
+that: `-1.0` is `negate(1.0)`, a computed `double`, not a preserved literal, so jq's own
+answer at extreme magnitude no longer matches the value as written. succinctly keeps the
+exact value regardless of a leading `-` in the filter. Confirmed live against jq 1.7.1:
+
+```console
+$ jq  -nc -- '-9223372036854775758'      # -9223372036854776000
+$ sjq -nc -- '-9223372036854775758'      # -9223372036854775758
+$ jq  -nc -- '-9007199254740993'         # -9007199254740992
+$ sjq -nc -- '-9007199254740993'         # -9007199254740993
+$ jq  -nc -- '-1.10'                     # -1.1  (agrees -- magnitude-specific)
+$ sjq -nc -- '-1.10'                     # -1.1
+```
+
+Only reachable above `2^53` (where a `double` can no longer hold the literal exactly) — the
+same magnitude floor the `range` divergence above starts at. It is specifically the
+*filter-text* unary minus: the identical value arriving as **data** keeps its exact spelling
+in both tools (unrelated to this divergence, and not the general large-integer class it might
+first look like):
+
+```console
+$ echo '[-9223372036854775758]' | jq  -c '.[0]'   # -9223372036854775758
+$ echo '[-9223372036854775758]' | sjq -c '.[0]'   # -9223372036854775758
+```
+
+**Why this is worth stating explicitly rather than leaving as an obvious consequence of
+jq's own parser:** it silently changes the answer of anything downstream of a negative
+literal at that magnitude, and it produced a real analysis error in this repo before this
+was recorded — the `range` divergence above (`range(-9223372036854775758;
+-9223372036854775808; -100)`) used to read as evidence that succinctly's overflow handling
+agreed with jq's, when the agreement was actually two independent bugs' outputs coinciding:
+jq's `[]` came entirely from unary minus collapsing `from` to exactly `i64::MIN` before
+`range` ever ran, not from anything `range` itself computed. Feeding the identical
+magnitudes in as data (where jq keeps its literals) already showed the two tools
+disagreeing on `range` itself, underneath the unary-minus coincidence.
+
+**Accepted rather than matched (ADR-0018 rule 4c):** succinctly already diverges
+deliberately and wholesale from jq's `double`-based number model above `2^53` for this
+whole magnitude class (see the `range` divergence above, and #2131/#2089) — including cases
+where matching jq would mean reproducing a genuine hang. Making unary minus specifically
+collapse to `double`, while every other operation in the same class keeps the exact value,
+would make succinctly's own behavior *less* internally consistent, not more, for a single
+operator's worth of parity. Pinned by
+`test_unary_minus_destroys_literal_preservation_2357` (`tests/jq_cli_tests.rs`).
 
 ### `--argjson`/`--jsonargs` still reject a bare trailing decimal point with no exponent (`1.`) — accepted divergence, ADR-0018 rule 4c (#2240)
 

--- a/docs/compliance/jq/limitations.md
+++ b/docs/compliance/jq/limitations.md
@@ -3888,7 +3888,7 @@ described:
   jq's own hang, as ADR-0018 does not require — is the worse failure mode
   for the realistic inputs this magnitude range covers).
 
-### Unary minus in filter text destroys literal preservation — accepted divergence, ADR-0018 rule 4c (#2357)
+### Unary minus in filter text destroys literal preservation — inherits the `range` divergence's own rule 4(c) grant (#2357)
 
 Real jq preserves a number literal's exact source spelling through to output (`jq -n
 '1.0'` → `1.0`, `1e10` → `1E+10`), but a *unary minus written in the filter text* breaks
@@ -3927,13 +3927,23 @@ jq's `[]` came entirely from unary minus collapsing `from` to exactly `i64::MIN`
 magnitudes in as data (where jq keeps its literals) already showed the two tools
 disagreeing on `range` itself, underneath the unary-minus coincidence.
 
-**Accepted rather than matched (ADR-0018 rule 4c):** succinctly already diverges
-deliberately and wholesale from jq's `double`-based number model above `2^53` for this
-whole magnitude class (see the `range` divergence above, and #2131/#2089) — including cases
-where matching jq would mean reproducing a genuine hang. Making unary minus specifically
-collapse to `double`, while every other operation in the same class keeps the exact value,
-would make succinctly's own behavior *less* internally consistent, not more, for a single
-operator's worth of parity. Pinned by
+**Accepted rather than matched — not a fresh rule-4 exemption, the same one already
+granted above.** This is not an independent divergence needing its own justification: it is
+the necessary consequence of the `range` divergence's own accepted trade-off ("succinctly
+stays on the exact `i64` path where jq's own arithmetic would round, stall, or hang",
+above), which already covers this exact magnitude class under ADR-0018 rule 4(c) —
+avoiding **the same named failure mode** rule 4(c) rejected there: "silently degrading
+large-but-safe integers to `f64`". Making unary minus specifically force that same
+degradation, for the one syntactic shape "a literal token immediately preceded by `-`" and
+no other, would reintroduce precisely that failure mode for this operator alone — while
+`9223372036854775758` negated via `0 - 9223372036854775758`, or the identical magnitude
+arriving as data with its sign already attached, both keep the exact value today. A
+special case narrow enough to catch only the unary-minus spelling would need to specifically
+detect and degrade a literal it would otherwise preserve exactly, which is the regression
+the `range` fix's own rule-4(c) argument already ruled out for this magnitude class, not a
+new argument invented for this operator. ("The other operator does the same thing" is not
+itself a rule-4 condition — the condition being invoked here is 4(c), inherited from the
+`range` entry above, not re-derived from consistency alone.) Pinned by
 `test_unary_minus_destroys_literal_preservation_2357` (`tests/jq_cli_tests.rs`).
 
 ### `--argjson`/`--jsonargs` still reject a bare trailing decimal point with no exponent (`1.`) — accepted divergence, ADR-0018 rule 4c (#2240)

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -37455,7 +37455,7 @@ fn test_m2_lazyseq_halt_prints_nothing_1576() -> Result<()> {
 /// apart at `~2^63` magnitude round to the *same* `f64` once real jq parses
 /// them (its own unary minus collapses a literal this large to a `double`
 /// before `range` ever sees it -- an unrelated, already-documented
-/// divergence, `docs/compliance/jq/limitations.md`'s #2131 section), so
+/// divergence, `docs/compliance/jq/limitations.md`'s #2357 section), so
 /// real jq's `while(. > $upto; . + $by)` never even emits its own starting
 /// value -- confirmed live against the pinned jq 1.7.1 oracle (empty
 /// output, exit 0). succinctly no longer matches that by coincidence: since
@@ -37477,6 +37477,29 @@ fn test_range_i64_overflow_keeps_exact_prefix_diverging_from_jq_2219() -> Result
         stdout, "-9223372036854775758\n",
         "expected the exact from value, kept rather than discarded (#2219)"
     );
+    Ok(())
+}
+
+/// #2357: real jq's unary minus destroys literal preservation above `2^53`
+/// (the operand becomes a computed `double`, not a preserved literal),
+/// where succinctly keeps the exact value -- accepted as a deliberate
+/// divergence (ADR-0018 rule 4c, `docs/compliance/jq/limitations.md`'s
+/// "Unary minus in filter text destroys literal preservation" section), for
+/// the same reason succinctly stays exact everywhere else above `2^53`
+/// rather than matching jq's `double`/`decNumber` model one operator at a
+/// time. `-1.10` is the magnitude-specific control: below `2^53`, `double`
+/// holds the value exactly either way, so the two tools still agree.
+#[test]
+fn test_unary_minus_destroys_literal_preservation_2357() -> Result<()> {
+    for (filter, want) in [
+        ("-9223372036854775758", "-9223372036854775758"),
+        ("-9007199254740993", "-9007199254740993"),
+        ("-1.10", "-1.1"),
+    ] {
+        let (stdout, stderr, code) = run_jq_full(&["-nc", "--", filter], None)?;
+        assert_eq!(code, 0, "stdout: {stdout:?} stderr: {stderr:?}");
+        assert_eq!(stdout.trim_end(), want, "for filter {filter:?}");
+    }
     Ok(())
 }
 


### PR DESCRIPTION
## Summary
- Real jq's unary minus makes its operand a computed `double` rather than a preserved literal (`-1.0` is `negate(1.0)`), so above `2^53` (where `double` can no longer hold the value exactly) jq's own answer stops matching the value as written in the filter text. succinctly keeps the exact value regardless. Confirmed live against jq 1.7.1 (all three rows in the issue).
- This isn't just an aesthetic mismatch — it masked a real bug: #2131's headline `range()` repro (`range(-9223372036854775758; -9223372036854775808; -100)`, both closed since) agreed between jq and succinctly only because jq's unary minus had already collapsed `from` to exactly `i64::MIN` before `range()` ever ran — not because `range()` itself computed the same thing. Feeding the identical magnitudes in as *data* (where jq keeps its literals) already showed the two tools disagreeing on `range()` underneath that coincidence.
- Per the issue's own analysis, matching jq's collapse would make succinctly *less* internally consistent with the large-integer exactness it already commits to everywhere else above `2^53` (`docs/compliance/jq/limitations.md`'s `range` section, #2131/#2089) — so this documents the divergence as deliberate (ADR-0018 rule 4c) rather than fixing it.
- Added a dedicated `limitations.md` section (previously only mentioned in passing inside the unrelated `range` section, with a stale forward-reference to a "Widened divergence" discussion that didn't actually cover this), corrected that cross-reference, and added a test pinning all three example rows against the live oracle.

## Test plan
- [x] `cargo build --features cli`
- [x] `cargo test --features cli,simd,regex,serde` (full suite, all green)
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings`
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features`
- [x] New test (`tests/jq_cli_tests.rs`) pins all three rows against the live oracle
- [x] Doc-only change — no behavior change, so no CHANGELOG entry

Fixes #2357