### PR TITLE
refactor(jq): spell out 8 Result-enum catch-all unreachable!() arms

### DIFF
--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -2668,6 +2668,29 @@ fn eval_array_construction<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     QueryResult::Owned(OwnedValue::Array(items))
 }
 
+/// The `QueryResult` variants [`eval_array_construction`] never returns,
+/// for a catch-all match arm at one of its call sites.
+///
+/// #2182 (review): 6 call sites each spelled out this identical variant
+/// list by hand after the fix that added it, one per site -- a future
+/// correction to the list (e.g. if `eval_array_construction` ever starts
+/// returning a variant it doesn't today) needed all 6 kept in lockstep by
+/// hand. Sharing the pattern here means there is exactly one place to
+/// correct; each call site still writes its own `match` (their surrounding
+/// control flow -- what happens to `Owned`'s value, how `Error`/`Break`/
+/// `Halt` propagate -- differs enough between them that unifying the whole
+/// match into one function/macro would obscure more than it saves).
+macro_rules! eval_array_construction_impossible_variants {
+    () => {
+        QueryResult::One(_)
+            | QueryResult::OneCursor(_)
+            | QueryResult::Many(_)
+            | QueryResult::None
+            | QueryResult::ManyOwned(_)
+            | QueryResult::Partial(..)
+    };
+}
+
 /// Non-local exit out of the object-construction recursion.
 ///
 /// `Error` and `Break` are the two `QueryResult` variants that must abandon the
@@ -9946,19 +9969,10 @@ fn map_bracketed_over_object_fields<'a, W: Clone + AsRef<[u64]>, S: EvalSemantic
             QueryResult::Error(e) => return Err(QueryResult::Error(e)),
             QueryResult::Break(label) => return Err(QueryResult::Break(label)),
             QueryResult::Halt(code) => return Err(QueryResult::Halt(code)),
-            // #2182: was a wildcard `_ =>` -- verified by reading
-            // `eval_array_construction`'s own body exhaustively: every path
-            // through it returns `Owned`, or early-returns `Error`/`Break`/
-            // `Halt`, so this is a provably closed set today. Spelled out
-            // per-variant so a future `QueryResult` variant it starts
-            // returning is a compile error at every one of its call sites,
-            // not a silent absorption into a catch-all.
-            QueryResult::One(_)
-            | QueryResult::OneCursor(_)
-            | QueryResult::Many(_)
-            | QueryResult::None
-            | QueryResult::ManyOwned(_)
-            | QueryResult::Partial(..) => {
+            // #2182: was a wildcard `_ =>` -- see
+            // `eval_array_construction_impossible_variants!`'s own doc
+            // comment for the verification and why this is shared.
+            eval_array_construction_impossible_variants!() => {
                 unreachable!("eval_array_construction only returns Owned/Error/Break/Halt")
             }
         }
@@ -10033,20 +10047,11 @@ fn builtin_min_by<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
                     QueryResult::Error(e) => return QueryResult::Error(e),
                     QueryResult::Break(label) => return QueryResult::Break(label),
                     QueryResult::Halt(code) => return QueryResult::Halt(code),
-                    // #2182: was a wildcard `_ =>` -- verified by reading
-                    // `eval_array_construction`'s own body exhaustively:
-                    // every path through it returns `Owned`, or
-                    // early-returns `Error`/`Break`/`Halt`, so this is a
-                    // provably closed set today. Spelled out per-variant so
-                    // a future `QueryResult` variant it starts returning is
-                    // a compile error at every one of its call sites, not a
-                    // silent absorption into a catch-all.
-                    QueryResult::One(_)
-                    | QueryResult::OneCursor(_)
-                    | QueryResult::Many(_)
-                    | QueryResult::None
-                    | QueryResult::ManyOwned(_)
-                    | QueryResult::Partial(..) => {
+                    // #2182: was a wildcard `_ =>` -- see
+                    // `eval_array_construction_impossible_variants!`'s own
+                    // doc comment for the verification and why this is
+                    // shared.
+                    eval_array_construction_impossible_variants!() => {
                         unreachable!("eval_array_construction only returns Owned/Error/Break/Halt")
                     }
                 }
@@ -10110,20 +10115,11 @@ fn builtin_max_by<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
                     QueryResult::Error(e) => return QueryResult::Error(e),
                     QueryResult::Break(label) => return QueryResult::Break(label),
                     QueryResult::Halt(code) => return QueryResult::Halt(code),
-                    // #2182: was a wildcard `_ =>` -- verified by reading
-                    // `eval_array_construction`'s own body exhaustively:
-                    // every path through it returns `Owned`, or
-                    // early-returns `Error`/`Break`/`Halt`, so this is a
-                    // provably closed set today. Spelled out per-variant so
-                    // a future `QueryResult` variant it starts returning is
-                    // a compile error at every one of its call sites, not a
-                    // silent absorption into a catch-all.
-                    QueryResult::One(_)
-                    | QueryResult::OneCursor(_)
-                    | QueryResult::Many(_)
-                    | QueryResult::None
-                    | QueryResult::ManyOwned(_)
-                    | QueryResult::Partial(..) => {
+                    // #2182: was a wildcard `_ =>` -- see
+                    // `eval_array_construction_impossible_variants!`'s own
+                    // doc comment for the verification and why this is
+                    // shared.
+                    eval_array_construction_impossible_variants!() => {
                         unreachable!("eval_array_construction only returns Owned/Error/Break/Halt")
                     }
                 }
@@ -11301,20 +11297,11 @@ fn builtin_group_by<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
                     QueryResult::Error(e) => return QueryResult::Error(e),
                     QueryResult::Break(label) => return QueryResult::Break(label),
                     QueryResult::Halt(code) => return QueryResult::Halt(code),
-                    // #2182: was a wildcard `_ =>` -- verified by reading
-                    // `eval_array_construction`'s own body exhaustively:
-                    // every path through it returns `Owned`, or
-                    // early-returns `Error`/`Break`/`Halt`, so this is a
-                    // provably closed set today. Spelled out per-variant so
-                    // a future `QueryResult` variant it starts returning is
-                    // a compile error at every one of its call sites, not a
-                    // silent absorption into a catch-all.
-                    QueryResult::One(_)
-                    | QueryResult::OneCursor(_)
-                    | QueryResult::Many(_)
-                    | QueryResult::None
-                    | QueryResult::ManyOwned(_)
-                    | QueryResult::Partial(..) => {
+                    // #2182: was a wildcard `_ =>` -- see
+                    // `eval_array_construction_impossible_variants!`'s own
+                    // doc comment for the verification and why this is
+                    // shared.
+                    eval_array_construction_impossible_variants!() => {
                         unreachable!("eval_array_construction only returns Owned/Error/Break/Halt")
                     }
                 };
@@ -11484,20 +11471,11 @@ fn builtin_unique_by<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
                     QueryResult::Error(e) => return QueryResult::Error(e),
                     QueryResult::Break(label) => return QueryResult::Break(label),
                     QueryResult::Halt(code) => return QueryResult::Halt(code),
-                    // #2182: was a wildcard `_ =>` -- verified by reading
-                    // `eval_array_construction`'s own body exhaustively:
-                    // every path through it returns `Owned`, or
-                    // early-returns `Error`/`Break`/`Halt`, so this is a
-                    // provably closed set today. Spelled out per-variant so
-                    // a future `QueryResult` variant it starts returning is
-                    // a compile error at every one of its call sites, not a
-                    // silent absorption into a catch-all.
-                    QueryResult::One(_)
-                    | QueryResult::OneCursor(_)
-                    | QueryResult::Many(_)
-                    | QueryResult::None
-                    | QueryResult::ManyOwned(_)
-                    | QueryResult::Partial(..) => {
+                    // #2182: was a wildcard `_ =>` -- see
+                    // `eval_array_construction_impossible_variants!`'s own
+                    // doc comment for the verification and why this is
+                    // shared.
+                    eval_array_construction_impossible_variants!() => {
                         unreachable!("eval_array_construction only returns Owned/Error/Break/Halt")
                     }
                 };
@@ -11598,20 +11576,11 @@ fn builtin_sort_by<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
                     QueryResult::Error(e) => return QueryResult::Error(e),
                     QueryResult::Break(label) => return QueryResult::Break(label),
                     QueryResult::Halt(code) => return QueryResult::Halt(code),
-                    // #2182: was a wildcard `_ =>` -- verified by reading
-                    // `eval_array_construction`'s own body exhaustively:
-                    // every path through it returns `Owned`, or
-                    // early-returns `Error`/`Break`/`Halt`, so this is a
-                    // provably closed set today. Spelled out per-variant so
-                    // a future `QueryResult` variant it starts returning is
-                    // a compile error at every one of its call sites, not a
-                    // silent absorption into a catch-all.
-                    QueryResult::One(_)
-                    | QueryResult::OneCursor(_)
-                    | QueryResult::Many(_)
-                    | QueryResult::None
-                    | QueryResult::ManyOwned(_)
-                    | QueryResult::Partial(..) => {
+                    // #2182: was a wildcard `_ =>` -- see
+                    // `eval_array_construction_impossible_variants!`'s own
+                    // doc comment for the verification and why this is
+                    // shared.
+                    eval_array_construction_impossible_variants!() => {
                         unreachable!("eval_array_construction only returns Owned/Error/Break/Halt")
                     }
                 };

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -9946,7 +9946,21 @@ fn map_bracketed_over_object_fields<'a, W: Clone + AsRef<[u64]>, S: EvalSemantic
             QueryResult::Error(e) => return Err(QueryResult::Error(e)),
             QueryResult::Break(label) => return Err(QueryResult::Break(label)),
             QueryResult::Halt(code) => return Err(QueryResult::Halt(code)),
-            _ => unreachable!("eval_array_construction only returns Owned/Error/Break/Halt"),
+            // #2182: was a wildcard `_ =>` -- verified by reading
+            // `eval_array_construction`'s own body exhaustively: every path
+            // through it returns `Owned`, or early-returns `Error`/`Break`/
+            // `Halt`, so this is a provably closed set today. Spelled out
+            // per-variant so a future `QueryResult` variant it starts
+            // returning is a compile error at every one of its call sites,
+            // not a silent absorption into a catch-all.
+            QueryResult::One(_)
+            | QueryResult::OneCursor(_)
+            | QueryResult::Many(_)
+            | QueryResult::None
+            | QueryResult::ManyOwned(_)
+            | QueryResult::Partial(..) => {
+                unreachable!("eval_array_construction only returns Owned/Error/Break/Halt")
+            }
         }
     }
     Ok(computed)
@@ -10019,7 +10033,20 @@ fn builtin_min_by<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
                     QueryResult::Error(e) => return QueryResult::Error(e),
                     QueryResult::Break(label) => return QueryResult::Break(label),
                     QueryResult::Halt(code) => return QueryResult::Halt(code),
-                    _ => {
+                    // #2182: was a wildcard `_ =>` -- verified by reading
+                    // `eval_array_construction`'s own body exhaustively:
+                    // every path through it returns `Owned`, or
+                    // early-returns `Error`/`Break`/`Halt`, so this is a
+                    // provably closed set today. Spelled out per-variant so
+                    // a future `QueryResult` variant it starts returning is
+                    // a compile error at every one of its call sites, not a
+                    // silent absorption into a catch-all.
+                    QueryResult::One(_)
+                    | QueryResult::OneCursor(_)
+                    | QueryResult::Many(_)
+                    | QueryResult::None
+                    | QueryResult::ManyOwned(_)
+                    | QueryResult::Partial(..) => {
                         unreachable!("eval_array_construction only returns Owned/Error/Break/Halt")
                     }
                 }
@@ -10083,7 +10110,20 @@ fn builtin_max_by<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
                     QueryResult::Error(e) => return QueryResult::Error(e),
                     QueryResult::Break(label) => return QueryResult::Break(label),
                     QueryResult::Halt(code) => return QueryResult::Halt(code),
-                    _ => {
+                    // #2182: was a wildcard `_ =>` -- verified by reading
+                    // `eval_array_construction`'s own body exhaustively:
+                    // every path through it returns `Owned`, or
+                    // early-returns `Error`/`Break`/`Halt`, so this is a
+                    // provably closed set today. Spelled out per-variant so
+                    // a future `QueryResult` variant it starts returning is
+                    // a compile error at every one of its call sites, not a
+                    // silent absorption into a catch-all.
+                    QueryResult::One(_)
+                    | QueryResult::OneCursor(_)
+                    | QueryResult::Many(_)
+                    | QueryResult::None
+                    | QueryResult::ManyOwned(_)
+                    | QueryResult::Partial(..) => {
                         unreachable!("eval_array_construction only returns Owned/Error/Break/Halt")
                     }
                 }
@@ -11261,7 +11301,20 @@ fn builtin_group_by<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
                     QueryResult::Error(e) => return QueryResult::Error(e),
                     QueryResult::Break(label) => return QueryResult::Break(label),
                     QueryResult::Halt(code) => return QueryResult::Halt(code),
-                    _ => {
+                    // #2182: was a wildcard `_ =>` -- verified by reading
+                    // `eval_array_construction`'s own body exhaustively:
+                    // every path through it returns `Owned`, or
+                    // early-returns `Error`/`Break`/`Halt`, so this is a
+                    // provably closed set today. Spelled out per-variant so
+                    // a future `QueryResult` variant it starts returning is
+                    // a compile error at every one of its call sites, not a
+                    // silent absorption into a catch-all.
+                    QueryResult::One(_)
+                    | QueryResult::OneCursor(_)
+                    | QueryResult::Many(_)
+                    | QueryResult::None
+                    | QueryResult::ManyOwned(_)
+                    | QueryResult::Partial(..) => {
                         unreachable!("eval_array_construction only returns Owned/Error/Break/Halt")
                     }
                 };
@@ -11431,7 +11484,20 @@ fn builtin_unique_by<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
                     QueryResult::Error(e) => return QueryResult::Error(e),
                     QueryResult::Break(label) => return QueryResult::Break(label),
                     QueryResult::Halt(code) => return QueryResult::Halt(code),
-                    _ => {
+                    // #2182: was a wildcard `_ =>` -- verified by reading
+                    // `eval_array_construction`'s own body exhaustively:
+                    // every path through it returns `Owned`, or
+                    // early-returns `Error`/`Break`/`Halt`, so this is a
+                    // provably closed set today. Spelled out per-variant so
+                    // a future `QueryResult` variant it starts returning is
+                    // a compile error at every one of its call sites, not a
+                    // silent absorption into a catch-all.
+                    QueryResult::One(_)
+                    | QueryResult::OneCursor(_)
+                    | QueryResult::Many(_)
+                    | QueryResult::None
+                    | QueryResult::ManyOwned(_)
+                    | QueryResult::Partial(..) => {
                         unreachable!("eval_array_construction only returns Owned/Error/Break/Halt")
                     }
                 };
@@ -11532,7 +11598,20 @@ fn builtin_sort_by<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
                     QueryResult::Error(e) => return QueryResult::Error(e),
                     QueryResult::Break(label) => return QueryResult::Break(label),
                     QueryResult::Halt(code) => return QueryResult::Halt(code),
-                    _ => {
+                    // #2182: was a wildcard `_ =>` -- verified by reading
+                    // `eval_array_construction`'s own body exhaustively:
+                    // every path through it returns `Owned`, or
+                    // early-returns `Error`/`Break`/`Halt`, so this is a
+                    // provably closed set today. Spelled out per-variant so
+                    // a future `QueryResult` variant it starts returning is
+                    // a compile error at every one of its call sites, not a
+                    // silent absorption into a catch-all.
+                    QueryResult::One(_)
+                    | QueryResult::OneCursor(_)
+                    | QueryResult::Many(_)
+                    | QueryResult::None
+                    | QueryResult::ManyOwned(_)
+                    | QueryResult::Partial(..) => {
                         unreachable!("eval_array_construction only returns Owned/Error/Break/Halt")
                     }
                 };
@@ -17653,7 +17732,20 @@ fn eval_pipe<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
                 QueryResult::Break(label) => QueryResult::Break(label),
                 QueryResult::Halt(code) => QueryResult::Halt(code),
                 QueryResult::Partial(vs, control) => QueryResult::Partial(vs, control),
-                _ => unreachable!("eval_owned_pipe only returns Owned-family variants"),
+                // #2182: was a wildcard `_ =>` -- verified by tracing
+                // `eval_owned_pipe`'s full call chain (`eval_owned_input` ->
+                // `eval_owned_fast_path`/`eval_owned_input_reindexed` ->
+                // `detach_from_temp_document`, the last already an
+                // exhaustive per-variant match): every path resolves to
+                // `Owned`/`None`/`Error`/`ManyOwned`/`Break`/`Halt`/
+                // `Partial`, never `One`/`OneCursor`/`Many`, so this is a
+                // provably closed set today. Spelled out per-variant so a
+                // future `QueryResult` variant this chain starts returning
+                // is a compile error here, not a silent absorption into a
+                // catch-all.
+                QueryResult::One(_) | QueryResult::OneCursor(_) | QueryResult::Many(_) => {
+                    unreachable!("eval_owned_pipe only returns Owned-family variants")
+                }
             }
         }
         QueryResult::ManyOwned(vs) => pipe_owned_prefix::<S, W>(rest, vs, None, optional),
@@ -18722,7 +18814,23 @@ fn eval_index_expr<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
                         // still survive as `Partial`, matching real jq's
                         // output instead of vanishing.
                         QueryResult::Error(e) => escape_with_prefix!(Control::Error(e)),
-                        _ => unreachable!("index_one yields only One/None/Error"),
+                        // #2182: was a wildcard `_ =>` -- verified by tracing
+                        // both of `index_one`'s callees (`index_object_by_name`,
+                        // `index_array_by_position`) exhaustively: every arm in
+                        // both resolves to `One`/`None`/`Error`, so this is a
+                        // provably closed set today. Spelled out per-variant so
+                        // a future `QueryResult` variant this callee starts
+                        // returning is a compile error here, not a silent
+                        // absorption into a catch-all.
+                        QueryResult::OneCursor(_)
+                        | QueryResult::Many(_)
+                        | QueryResult::Owned(_)
+                        | QueryResult::ManyOwned(_)
+                        | QueryResult::Break(_)
+                        | QueryResult::Halt(_)
+                        | QueryResult::Partial(..) => {
+                            unreachable!("index_one yields only One/None/Error")
+                        }
                     }
                 }
             }
@@ -19145,7 +19253,23 @@ fn eval_slice_expr<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
                             // target-evaluation fix above making the same
                             // claim.
                             QueryResult::Error(e) => escape!(Control::Error(e)),
-                            _ => unreachable!("Expr::Slice yields only One/Owned/None/Error"),
+                            // #2182: was a wildcard `_ =>` -- verified by
+                            // tracing `eval_single`'s own `Expr::Slice` arm
+                            // exhaustively (every branch, including its
+                            // `suppress_or_raise` calls, resolves to
+                            // `One`/`Owned`/`None`/`Error`), so this is a
+                            // provably closed set today. Spelled out
+                            // per-variant so a future `QueryResult` variant
+                            // that arm starts returning is a compile error
+                            // here, not a silent absorption into a catch-all.
+                            QueryResult::OneCursor(_)
+                            | QueryResult::Many(_)
+                            | QueryResult::ManyOwned(_)
+                            | QueryResult::Break(_)
+                            | QueryResult::Halt(_)
+                            | QueryResult::Partial(..) => {
+                                unreachable!("Expr::Slice yields only One/Owned/None/Error")
+                            }
                         }
                     }
                 }
@@ -36212,7 +36336,22 @@ fn eval_getpath_with_path_context<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>
             QueryResult::Error(e) => {
                 return partial(core::mem::take(&mut results), Control::Error(e));
             }
-            _ => unreachable!("getpath_walk_owned only ever produces Owned/None/Error"),
+            // #2182: was a wildcard `_ =>` -- verified by reading
+            // `getpath_walk_owned`'s own body exhaustively (every return
+            // path, including its `e.into()` calls, resolves to
+            // `Owned`/`None`/`Error`), so this is a provably closed set
+            // today. Spelled out per-variant so a future `QueryResult`
+            // variant it starts returning is a compile error here, not a
+            // silent absorption into a catch-all.
+            QueryResult::One(_)
+            | QueryResult::OneCursor(_)
+            | QueryResult::Many(_)
+            | QueryResult::ManyOwned(_)
+            | QueryResult::Break(_)
+            | QueryResult::Halt(_)
+            | QueryResult::Partial(..) => {
+                unreachable!("getpath_walk_owned only ever produces Owned/None/Error")
+            }
         }
     }
 

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -10555,7 +10555,26 @@ fn eval_index_expr<S: EvalSemantics, V: DocumentValue>(
                         // already-indexed prefix must still survive as
                         // `Partial`, not vanish with it.
                         GenericResult::Error(e) => escape_generic!(Control::Error(e)),
-                        _ => unreachable!("index_one_generic yields OneCursor/Owned/None/Error"),
+                        // #2182: was a wildcard `_ =>` -- verified by
+                        // reading `index_one_generic`'s own body
+                        // exhaustively: every branch resolves to
+                        // `OneCursor`/`Owned`/`None`/`Error`, so this is a
+                        // provably closed set today. Spelled out
+                        // per-variant so a future `GenericResult` variant
+                        // it starts returning is a compile error here, not
+                        // a silent absorption into a catch-all.
+                        GenericResult::One(_)
+                        | GenericResult::Many(_)
+                        | GenericResult::ManyCursor(_)
+                        | GenericResult::LazyKeys { .. }
+                        | GenericResult::LazyIndexRange(_)
+                        | GenericResult::LazySeq(_)
+                        | GenericResult::ManyOwned(_)
+                        | GenericResult::Break(_)
+                        | GenericResult::Halt(_)
+                        | GenericResult::Partial(..) => {
+                            unreachable!("index_one_generic yields OneCursor/Owned/None/Error")
+                        }
                     }
                 }
             }
@@ -10965,7 +10984,27 @@ fn eval_slice_expr<S: EvalSemantics, V: DocumentValue>(
                             // target-evaluation fix above making the same
                             // claim.
                             GenericResult::Error(e) => escape!(Control::Error(e)),
-                            _ => unreachable!("slice_one_generic yields Owned/None/Error"),
+                            // #2182: was a wildcard `_ =>` -- verified by
+                            // reading `slice_one_generic`'s own body
+                            // exhaustively: every return path resolves to
+                            // `Owned`/`None`/`Error`, so this is a provably
+                            // closed set today. Spelled out per-variant so
+                            // a future `GenericResult` variant it starts
+                            // returning is a compile error here, not a
+                            // silent absorption into a catch-all.
+                            GenericResult::One(_)
+                            | GenericResult::OneCursor(_)
+                            | GenericResult::Many(_)
+                            | GenericResult::ManyCursor(_)
+                            | GenericResult::LazyKeys { .. }
+                            | GenericResult::LazyIndexRange(_)
+                            | GenericResult::LazySeq(_)
+                            | GenericResult::ManyOwned(_)
+                            | GenericResult::Break(_)
+                            | GenericResult::Halt(_)
+                            | GenericResult::Partial(..) => {
+                                unreachable!("slice_one_generic yields Owned/None/Error")
+                            }
                         }
                     }
                 }
@@ -16956,10 +16995,25 @@ fn owned_identity_materialize<V: DocumentValue>(
         GenericResult::Error(e) => Err(Control::Error(e)),
         GenericResult::Break(label) => Err(Control::Break(label)),
         GenericResult::Halt(code) => Err(Control::Halt(code)),
-        // `generic_item_to_result` maps one item to `One`/`OneCursor`/
-        // `Owned` or a lazy variant, and `materialize_lazy` maps those to
-        // `Owned` or an escape.
-        _ => unreachable!("a single pipe item never materializes to a stream"),
+        // #2182: was a wildcard `_ =>` -- `generic_item_to_result` maps one
+        // item to `One`/`OneCursor`/`Owned` or a lazy variant
+        // (`LazyKeys`/`LazyIndexRange`/`LazySeq`), and `materialize_lazy`
+        // maps those lazy variants to `Owned` or an escape
+        // (`Error`/`Break`/`Halt`) -- so the combined range is exactly the
+        // six variants already handled above, verified by reading both
+        // functions' bodies. Spelled out per-variant so a future
+        // `GenericResult`/`GenericItem` variant is a compile error here,
+        // not a silent absorption into a catch-all.
+        GenericResult::Many(_)
+        | GenericResult::ManyCursor(_)
+        | GenericResult::LazyKeys { .. }
+        | GenericResult::LazyIndexRange(_)
+        | GenericResult::LazySeq(_)
+        | GenericResult::None
+        | GenericResult::ManyOwned(_)
+        | GenericResult::Partial(..) => {
+            unreachable!("a single pipe item never materializes to a stream")
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

Option 3 of #1401's fold (split out as #2182 once #1401 closed): a wildcard `_ =>`/catch-all arm inside a `QueryResult`/`GenericResult` match is a drift hazard #1401's own `Expr`-dispatch fold didn't cover — it breaks silently (no compile error) if the matched callee's return enum ever gains a variant, or starts returning one it previously didn't.

For each of the 8 sites, verified by reading the callee's full body (every return path, including any conversions it delegates to) that the claimed variant set is genuinely exhaustive today, then replaced the wildcard with an explicit multi-variant arm covering every remaining `QueryResult`/`GenericResult` variant, still calling `unreachable!()` with the same message. A future variant the callee starts returning is now a compile error at every one of these sites, not a silent absorption into a catch-all.

Sites (`eval.rs`): `index_one`, `Expr::Slice`'s literal-bounds arm, `eval_array_construction` (6 call sites), `eval_owned_pipe`, `getpath_walk_owned`.
Sites (`eval_generic.rs`): `index_one_generic`, `slice_one_generic`, `owned_identity_materialize`.

Left alone, per #2182's own methodology:
- Group (b) (arithmetic/length catch-alls, locally provable from a guard a few lines up — the issue's own example) — low value in touching these.
- Group (c) (`Expr`-dispatch catch-alls) — turned out to have grown substantially since #2182 was filed (6 more sites than the issue's own "effectively 2, essentially closed" count). Re-auditing and fixing that group is a different kind of verification work (an `Expr`'s variant list is much larger than `QueryResult`/`GenericResult`'s, so the same "spell out every remaining variant" pattern may not be the right shape there) — filed separately as #2549 rather than folded into this PR.

Fixes #2182.

## Test plan

- [x] `cargo build --features cli`
- [x] `cargo test --features cli,simd,regex,serde` (full suite, including `tests/*.rs`) — 62/62 binaries green
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings`
- [x] `cargo llvm-cov` + `omni-dev coverage diff` — patch coverage is 0% (0/6 new lines) by construction: every new line is inside a provably-unreachable match arm that cannot be exercised by any input, the whole point of this change. Could not use this codebase's usual `// omni-dev: coverage tolerate-line` annotation on these specific lines — each `unreachable!("...")` call is already 77–99 characters at its own indentation depth, leaving 5–23 characters of the 100-character line-length budget, nowhere near enough room for the annotation's own `// omni-dev: coverage tolerate-line reason="..."` prefix. The verification reasoning that annotation would carry is instead in the doc comment directly above each arm (identical in spirit, just not machine-readable by the coverage tool). No test suite change was needed or possible: nothing about program *behavior* changed, only which code paths are statically provable as dead.