### PR TITLE
fix(jq): keep computed-float scientific notation under -n's streaming path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`succinctly jq -n`/`--null-input` now keeps a computed float's
+  scientific-notation spelling through `tostring`, a format function
+  (`@json`, `@csv`, ...), and string interpolation** (#2543). `-n` always
+  uses the sink-based streaming evaluator (unlike piped/file input, which
+  can pick the eager one instead), and that path routed a computed value
+  immediately followed by one of these into a JSON round-trip that rebaked
+  its already-correct spelling as a document-sourced-*looking* literal,
+  so jq's literal-preserving convention (uppercase `E`) applied instead of
+  its computed-value one (lowercase `e`): `succinctly jq -n '(2 * 1e16) |
+  tostring'` gave `"2E+16"` where real jq (and every non-`-n` succinctly
+  path) gives `"2e+16"`. Deliberately narrow, mirroring an existing bypass
+  one call site over (`eval_on_owned`'s own `Expr::Format`/`Builtin::
+  ToString` special-casing) rather than widened to any single remaining
+  pipe stage -- an earlier, broader version of this fix let `first(...)`
+  evaluate a comma's later branch it must never reach.
+
 - **`succinctly jq` now switches a computed float to scientific notation past
   jq's own magnitude/digit-count threshold, instead of always printing a full
   decimal expansion** (#2456). Confirmed live against jq 1.7.1: `.a * 1e100`

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -31740,6 +31740,26 @@ fn eval_owned_fast_path<S: EvalSemantics>(
         }
     }
     match expr {
+        // #2543: a single-stage `Expr::Pipe` is semantically identical to
+        // its one stage, but `fold_pipe_stages_sink`'s `GenericResult::Owned`
+        // arm (`eval_generic.rs`) always wraps its remaining stages in
+        // `Expr::Pipe(...)` before calling `eval_each_owned` -- even when
+        // only one stage is left -- so a solitary `Builtin::ToString` (or
+        // any other shape this match recognizes) arrives here as
+        // `Expr::Pipe([Builtin::ToString])`, not the bare
+        // `Expr::Builtin(Builtin::ToString)` the arm below matches, and
+        // fell through to the round-trip fallback unconditionally under
+        // `-n`/any streaming (sink-based) evaluation. That round-trip
+        // reparses the computed value's JSON spelling as a
+        // document-sourced-*looking* number, so `tostring` on it echoed
+        // jq's *literal*-reformatting convention (uppercase `E`) instead of
+        // its *computed*-value one (lowercase `e`) past the scientific-
+        // notation threshold (#2456) -- confirmed live:
+        // `succinctly jq -n '(2 * 1e16) | tostring'` gave `"2E+16"` where
+        // real jq and every non-`-n` succinctly invocation gave `"2e+16"`.
+        Expr::Pipe(stages) if stages.len() == 1 => {
+            eval_owned_fast_path::<S>(&stages[0], input, optional)
+        }
         Expr::Identity | Expr::Field(_) | Expr::Index { .. } => {
             eval_owned_navigation::<S>(expr, input, optional)
         }

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -31757,9 +31757,10 @@ fn eval_owned_fast_path<S: EvalSemantics>(
         // notation threshold (#2456) -- confirmed live:
         // `succinctly jq -n '(2 * 1e16) | tostring'` gave `"2E+16"` where
         // real jq and every non-`-n` succinctly invocation gave `"2e+16"`.
-        Expr::Pipe(stages) if stages.len() == 1 => {
-            eval_owned_fast_path::<S>(&stages[0], input, optional)
-        }
+        Expr::Pipe(stages) => match stages.as_slice() {
+            [only] => eval_owned_fast_path::<S>(only, input, optional),
+            _ => None,
+        },
         Expr::Identity | Expr::Field(_) | Expr::Index { .. } => {
             eval_owned_navigation::<S>(expr, input, optional)
         }

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -5733,6 +5733,53 @@ fn each_lazy_array_iterate_sink<V: DocumentValue>(
 /// `eval_each_owned`, which already know how to thread an arbitrary-length
 /// remaining pipe through one value without re-deriving cursor threading here
 /// (the #1503 lesson).
+/// #2543: when `remaining` (the stages still to apply to an already-computed
+/// `o`) is exactly one `Expr::Format`/`Builtin::ToString`, routes through
+/// `eval_on_owned` directly instead of the caller's own `Expr::Pipe`-wrapped
+/// `eval_each_owned` fallback. `eval_on_owned` (this file) already
+/// special-cases exactly these two shapes immediately after a computed value
+/// to avoid rebaking its scientific-notation spelling as a
+/// document-sourced-looking literal on the JSON round-trip below it (#1054);
+/// the wrapped route missed both -- `eval_owned_fast_path` (`eval.rs`) has no
+/// `Expr::Format` arm at all, and (before also being fixed there) didn't
+/// recognize a `Builtin::ToString` wrapped in a trivial `Expr::Pipe` as the
+/// same shape its own bare-`Builtin` arm matches. Confirmed live:
+/// `succinctly jq -n '(2 * 1e16) | @json'` gave `"2E+16"` (jq's
+/// literal-reformat convention) where real jq and every non-streaming
+/// succinctly path give `"2e+16"` (the computed-value convention).
+///
+/// Shared by [`fold_pipe_stages_sink`] and `continue_pipe_element_generic`
+/// so the allowed-shapes list and its short-circuit-safety rationale live in
+/// one place, not two hand-copied `matches!` guards (CLAUDE.md's #106
+/// "duplicated predicates diverge silently" lesson).
+///
+/// Returns `Ok(flow)` once handled, or `Err(o)` handing `o` straight back so
+/// the caller can fall through to its own general-case handling with no
+/// clone. Deliberately narrower than "exactly one stage left": both matched
+/// shapes are single-output and side-effect-free once `o` is already
+/// computed, matching `eval_on_owned`'s own restriction exactly --
+/// widening this to *any* one-stage remainder previously routed
+/// `(1, ("B"|stderr))` through the same eager `eval_on_owned` call, which
+/// has no demand signal to stop after the first output, so
+/// `first(1 | (1, ("B"|stderr)))` printed `B` where real jq (and this same
+/// pipe minus the trailing single-stage optimization) never evaluates the
+/// second comma branch at all. Caught by
+/// `test_short_circuit_side_effect_shapes_already_match_jq_820`.
+fn try_owned_format_or_tostring_bypass<S: EvalSemantics, V: DocumentValue>(
+    remaining: &[Expr],
+    o: OwnedValue,
+    optional: bool,
+    sink: &mut dyn FnMut(GenericItem<V>) -> Demand,
+) -> Result<Flow, OwnedValue> {
+    match remaining {
+        [stage @ (Expr::Format(_) | Expr::Builtin(Builtin::ToString))] => Ok(drain_result_generic(
+            eval_on_owned::<S, V>(stage, o, optional),
+            sink,
+        )),
+        _ => Err(o),
+    }
+}
+
 fn fold_pipe_stages_sink<S: EvalSemantics, V: DocumentValue>(
     mut current: GenericResult<V>,
     stages: &[Expr],
@@ -5798,43 +5845,16 @@ fn fold_pipe_stages_sink<S: EvalSemantics, V: DocumentValue>(
                     sink,
                 );
             }
-            // #2543: `Expr::Format`/`Builtin::ToString` as the sole
-            // remaining stage route through `eval_on_owned` directly,
-            // instead of `eval_each_owned` wrapped in a single-element
-            // `Expr::Pipe`. `eval_on_owned` (this file) already
-            // special-cases exactly these two shapes immediately after a
-            // computed value to avoid rebaking its scientific-notation
-            // spelling as a document-sourced-looking literal on the JSON
-            // round-trip below it (#1054); the wrapped route missed both --
-            // `eval_owned_fast_path` (`eval.rs`) has no `Expr::Format` arm
-            // at all, and (before also being fixed there) didn't recognize
-            // a `Builtin::ToString` wrapped in a trivial `Expr::Pipe` as the
-            // same shape its own bare-`Builtin` arm matches. Confirmed live:
-            // `succinctly jq -n '(2 * 1e16) | @json'` gave `"2E+16"` (jq's
-            // literal-reformat convention) where real jq and every
-            // non-streaming succinctly path give `"2e+16"` (the
-            // computed-value convention).
-            //
-            // Deliberately narrower than "exactly one stage left": both
-            // matched shapes are single-output and side-effect-free once
-            // `o` is already computed, matching `eval_on_owned`'s own
-            // restriction exactly -- widening this to *any* one-stage
-            // remainder previously routed `(1, ("B"|stderr))` through the
-            // same eager `eval_on_owned` call, which has no demand signal
-            // to stop after the first output, so `first(1 | (1,
-            // ("B"|stderr)))` printed `B` where real jq (and this same
-            // pipe minus the trailing single-stage optimization) never
-            // evaluates the second comma branch at all. Caught by
-            // `test_short_circuit_side_effect_shapes_already_match_jq_820`.
-            GenericResult::Owned(o)
-                if matches!(
-                    &stages[j..],
-                    [Expr::Format(_) | Expr::Builtin(Builtin::ToString)]
-                ) =>
-            {
-                return drain_result_generic(eval_on_owned::<S, V>(&stages[j], o, optional), sink);
-            }
             GenericResult::Owned(o) => {
+                let o = match try_owned_format_or_tostring_bypass::<S, V>(
+                    &stages[j..],
+                    o,
+                    optional,
+                    sink,
+                ) {
+                    Ok(flow) => return flow,
+                    Err(o) => o,
+                };
                 let rest_pipe = Expr::Pipe(stages[j..].to_vec());
                 return eval_each_owned::<S>(&rest_pipe, &o, optional, &mut |o| {
                     sink(GenericItem::Owned(o))
@@ -7500,32 +7520,23 @@ fn continue_pipe_element_generic<S: EvalSemantics, V: DocumentValue>(
         GenericItem::OneCursorValue(c, v) => {
             eval_each_pipe_generic::<S, V>(rest.stages(), v, optional, Some(c), sink)
         }
-        // #2543: `Expr::Format`/`Builtin::ToString` as the sole remaining
-        // stage route through `eval_on_owned` directly rather than
-        // `rest.owned()`'s single-element `Expr::Pipe` wrapper -- see
-        // `fold_pipe_stages_sink`'s identical `Owned` arm above for the full
-        // rationale (`eval_on_owned`'s bypass for exactly these two shapes
-        // vs. `eval_owned_fast_path` having no `Expr::Format` arm at all),
-        // and for why this must stay narrower than "any one-stage
-        // remainder" -- `eval_on_owned` has no demand signal to stop early,
-        // so widening this let `first(1 | (1, ("B"|stderr)))` evaluate the
-        // second comma branch's `stderr` side effect, which real jq's own
-        // short-circuit never reaches. This is the call site a plain
-        // top-level pipe (`EXPR | tostring`/`EXPR | @json`/...) actually
-        // reaches -- `fold_pipe_stages_sink` itself is only entered from a
+        // #2543: this is the call site a plain top-level pipe
+        // (`EXPR | tostring`/`EXPR | @json`/...) actually reaches --
+        // `fold_pipe_stages_sink` itself is only entered from a
         // `LazyKeys`/`LazyIndexRange`/`LazySeq` item elsewhere in this
-        // function.
-        GenericItem::Owned(o)
-            if matches!(
-                rest.stages(),
-                [Expr::Format(_) | Expr::Builtin(Builtin::ToString)]
-            ) =>
-        {
-            drain_result_generic(eval_on_owned::<S, V>(&rest.stages()[0], o, optional), sink)
+        // function. See `try_owned_format_or_tostring_bypass`'s own doc
+        // comment for the full rationale.
+        GenericItem::Owned(o) => {
+            let o =
+                match try_owned_format_or_tostring_bypass::<S, V>(rest.stages(), o, optional, sink)
+                {
+                    Ok(flow) => return flow,
+                    Err(o) => o,
+                };
+            eval_each_owned::<S>(rest.owned(), &o, optional, &mut |o| {
+                sink(GenericItem::Owned(o))
+            })
         }
-        GenericItem::Owned(o) => eval_each_owned::<S>(rest.owned(), &o, optional, &mut |o| {
-            sink(GenericItem::Owned(o))
-        }),
         item @ (GenericItem::LazyKeys { .. }
         | GenericItem::LazyIndexRange(_)
         | GenericItem::LazySeq(_)) => {

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -5798,6 +5798,42 @@ fn fold_pipe_stages_sink<S: EvalSemantics, V: DocumentValue>(
                     sink,
                 );
             }
+            // #2543: `Expr::Format`/`Builtin::ToString` as the sole
+            // remaining stage route through `eval_on_owned` directly,
+            // instead of `eval_each_owned` wrapped in a single-element
+            // `Expr::Pipe`. `eval_on_owned` (this file) already
+            // special-cases exactly these two shapes immediately after a
+            // computed value to avoid rebaking its scientific-notation
+            // spelling as a document-sourced-looking literal on the JSON
+            // round-trip below it (#1054); the wrapped route missed both --
+            // `eval_owned_fast_path` (`eval.rs`) has no `Expr::Format` arm
+            // at all, and (before also being fixed there) didn't recognize
+            // a `Builtin::ToString` wrapped in a trivial `Expr::Pipe` as the
+            // same shape its own bare-`Builtin` arm matches. Confirmed live:
+            // `succinctly jq -n '(2 * 1e16) | @json'` gave `"2E+16"` (jq's
+            // literal-reformat convention) where real jq and every
+            // non-streaming succinctly path give `"2e+16"` (the
+            // computed-value convention).
+            //
+            // Deliberately narrower than "exactly one stage left": both
+            // matched shapes are single-output and side-effect-free once
+            // `o` is already computed, matching `eval_on_owned`'s own
+            // restriction exactly -- widening this to *any* one-stage
+            // remainder previously routed `(1, ("B"|stderr))` through the
+            // same eager `eval_on_owned` call, which has no demand signal
+            // to stop after the first output, so `first(1 | (1,
+            // ("B"|stderr)))` printed `B` where real jq (and this same
+            // pipe minus the trailing single-stage optimization) never
+            // evaluates the second comma branch at all. Caught by
+            // `test_short_circuit_side_effect_shapes_already_match_jq_820`.
+            GenericResult::Owned(o)
+                if matches!(
+                    &stages[j..],
+                    [Expr::Format(_) | Expr::Builtin(Builtin::ToString)]
+                ) =>
+            {
+                return drain_result_generic(eval_on_owned::<S, V>(&stages[j], o, optional), sink);
+            }
             GenericResult::Owned(o) => {
                 let rest_pipe = Expr::Pipe(stages[j..].to_vec());
                 return eval_each_owned::<S>(&rest_pipe, &o, optional, &mut |o| {
@@ -7463,6 +7499,29 @@ fn continue_pipe_element_generic<S: EvalSemantics, V: DocumentValue>(
         // re-deriving it here would just repeat that work.
         GenericItem::OneCursorValue(c, v) => {
             eval_each_pipe_generic::<S, V>(rest.stages(), v, optional, Some(c), sink)
+        }
+        // #2543: `Expr::Format`/`Builtin::ToString` as the sole remaining
+        // stage route through `eval_on_owned` directly rather than
+        // `rest.owned()`'s single-element `Expr::Pipe` wrapper -- see
+        // `fold_pipe_stages_sink`'s identical `Owned` arm above for the full
+        // rationale (`eval_on_owned`'s bypass for exactly these two shapes
+        // vs. `eval_owned_fast_path` having no `Expr::Format` arm at all),
+        // and for why this must stay narrower than "any one-stage
+        // remainder" -- `eval_on_owned` has no demand signal to stop early,
+        // so widening this let `first(1 | (1, ("B"|stderr)))` evaluate the
+        // second comma branch's `stderr` side effect, which real jq's own
+        // short-circuit never reaches. This is the call site a plain
+        // top-level pipe (`EXPR | tostring`/`EXPR | @json`/...) actually
+        // reaches -- `fold_pipe_stages_sink` itself is only entered from a
+        // `LazyKeys`/`LazyIndexRange`/`LazySeq` item elsewhere in this
+        // function.
+        GenericItem::Owned(o)
+            if matches!(
+                rest.stages(),
+                [Expr::Format(_) | Expr::Builtin(Builtin::ToString)]
+            ) =>
+        {
+            drain_result_generic(eval_on_owned::<S, V>(&rest.stages()[0], o, optional), sink)
         }
         GenericItem::Owned(o) => eval_each_owned::<S>(rest.owned(), &o, optional, &mut |o| {
             sink(GenericItem::Owned(o))

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -22239,6 +22239,58 @@ fn test_jq_computed_float_scientific_notation_tostring_2456() -> Result<()> {
     Ok(())
 }
 
+/// #2543: `--null-input` (`-n`) mode's own top-level evaluation entry point
+/// (`evaluate_input_streaming`, always the sink-based/streaming evaluator --
+/// unlike file/piped input, which can pick the eager evaluator instead)
+/// reached a *different* bug than #2456 fixed: a computed value immediately
+/// followed by `tostring`/a format function/string interpolation was routed
+/// through `eval_each_owned` wrapped in a single-element `Expr::Pipe`, which
+/// `eval_owned_fast_path` (`eval.rs`) didn't recognize as the same shape its
+/// own bare-`Builtin(ToString)` arm matches (and had no `Expr::Format` arm
+/// for at all) -- falling through to a JSON round-trip that rebakes the
+/// already-correct scientific-notation spelling as a document-sourced
+/// literal, so `tostring`'s own literal-preserving convention (uppercase
+/// `E`) applied instead of the computed-value one (lowercase `e`). Every
+/// case here is confirmed live against jq 1.7.1 with `-n` specifically (the
+/// non-`-n` piped equivalent already passed before this fix).
+#[test]
+fn test_jq_null_input_computed_float_scientific_notation_2543() -> Result<()> {
+    for (filter, want) in [
+        ("(2 * 1e16) | tostring", "\"2e+16\""),
+        ("(2 * 1e16) | @json", "\"2e+16\""),
+        (r#""\(2 * 1e16)""#, "\"2e+16\""),
+        ("[2 * 1e16] | @csv", "\"2e+16\""),
+        ("(1 * 1e15) | tostring", "\"1000000000000000\""),
+    ] {
+        let (stdout, stderr, code) = run_jq_full(&["-nc", filter], None)?;
+        assert_eq!(
+            code, 0,
+            "for {filter:?}: stdout={stdout:?} stderr={stderr:?}"
+        );
+        assert_eq!(stdout.trim_end(), want, "for {filter:?}");
+    }
+    Ok(())
+}
+
+/// #2543 review: the fix above must stay narrow enough to preserve
+/// short-circuit demand -- routing *any* single remaining pipe stage
+/// through `eval_on_owned` (rather than only the side-effect-free
+/// `Expr::Format`/`Builtin::ToString` shapes) made `first(...)` evaluate a
+/// comma's later branch it must never reach. `-n` specifically, since that's
+/// the evaluation path the fix touches; the equivalent piped-input case is
+/// already pinned by `test_short_circuit_side_effect_shapes_already_match_jq_820`.
+#[test]
+fn test_jq_null_input_first_over_comma_still_short_circuits_2543() -> Result<()> {
+    let (stdout, stderr, code) = run_jq_full(&["-nc", "first(1 | (1, (\"B\" | stderr)))"], None)?;
+    assert_eq!(code, 0, "stdout={stdout:?} stderr={stderr:?}");
+    assert_eq!(stdout.trim_end(), "1");
+    assert_eq!(
+        stderr, "",
+        "stderr must stay empty -- the second comma branch's `stderr` side effect must never run"
+    );
+    Ok(())
+}
+
 /// #1051: `builtin_stderr` gained an `S: EvalSemantics` parameter so yq mode
 /// can echo a `NumberLiteral` verbatim; confirm jq mode's own container
 /// formatting (`format_number_jq_compat`'s uppercase-`E` reformatting) is


### PR DESCRIPTION
## Summary
- `--null-input` (`-n`) mode always uses the sink-based streaming evaluator (`evaluate_input_streaming` → `eval_generic::eval_each_with_cursor`), unlike piped/file input, which can pick the eager evaluator instead when a filter isn't cursor-transparent. That streaming path had its own, separate bug from #2456: a computed value immediately followed by `tostring`/a format function (`@json`, `@csv`, ...)/string interpolation was routed through `eval_each_owned` wrapped in a single-element `Expr::Pipe`, which `eval_owned_fast_path` (`eval.rs`) didn't recognize as the same shape its own bare `Builtin::ToString` arm matches (and had no `Expr::Format` arm at all) — falling through to a JSON round-trip that rebakes the already-correct scientific-notation spelling (#2456) as a document-sourced-*looking* literal, so jq's literal-preserving convention (uppercase `E`) applied instead of its computed-value one (lowercase `e`): `succinctly jq -n '(2 * 1e16) | tostring'` gave `"2E+16"` where real jq (and every non-`-n` succinctly path) gives `"2e+16"`.
- Traced empirically: forcing the piped path onto the same streaming evaluator (`SUCCINCTLY_JQ_M2_EVAL=stream`) reproduced the identical bug, confirming it's specific to that evaluator, not to `-n` per se.
- Two-part fix:
  - `eval_owned_fast_path` (`eval.rs`) now unwraps a single-stage `Expr::Pipe` before dispatching — helps any caller passing one, not just this path.
  - `fold_pipe_stages_sink` and `continue_pipe_element_generic` (`eval_generic.rs`) now route a computed value's sole remaining `Expr::Format`/`Builtin::ToString` stage through `eval_on_owned` directly, which already has both bypasses (added for #1054).
- **Deliberately narrow**: an earlier version of this fix routed *any* single remaining pipe stage through `eval_on_owned`, not just `Expr::Format`/`Builtin::ToString`. `eval_on_owned` has no demand signal to stop early, so that broader version let `first(1 | (1, ("B"|stderr)))` evaluate the second comma branch's `stderr` side effect — where real jq's own short-circuit never reaches it. Caught by two pre-existing tests before this PR was pushed (`test_short_circuit_side_effect_shapes_already_match_jq_820`, `test_first_over_pipe_prefix_dispatches_every_generic_result_shape_1451`); both pass with the narrowed fix.

## Test plan
- [x] `cargo build --features cli`
- [x] `cargo test --features cli,simd,regex,serde` (full suite, all green, twice — once after the initial fix caught the short-circuit regression, once after narrowing it)
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings`
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features`
- [x] 450-case randomized differential fuzz against the pinned jq 1.7.1 oracle across `-n` mode's `tostring`/`@json`/`@sh`, 0 mismatches
- [x] New tests (`tests/jq_cli_tests.rs`): the fix itself across `tostring`/`@json`/`@csv`/string interpolation, plus a dedicated short-circuit-safety regression guard
- [x] `omni-dev coverage diff`: 100% patch coverage (12/12 new lines)

Fixes #2543