### PR TITLE
perf(jq): reduce/foreach's fold accumulator by value, fixing #2086's residual O(n^2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1904,28 +1904,47 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   fix at all (measured *worse* than the string case, ~36s at just 25,000
   elements) — tracked separately as #2152.
 
-- **`reduce`/`foreach`'s bare-accumulator UPDATE body is now genuinely
-  O(n), not just a smaller O(n²) constant** (#2157): `try_reduce_step_alternatives`/
-  `try_foreach_step_alternatives`'s own fold loops hold their accumulator
-  `state: OwnedValue` fully unaliased (confirmed: unconditionally
-  overwritten immediately after this call, no live borrow of the old value
-  survives), so a new `try_owned_accumulator_step` recognizes the same
-  `. + <literal>`-shaped body #2086 already matches but, unlike
-  `eval_owned_fast_path`'s `&OwnedValue` signature, moves `state` *by
-  value* straight into `arith_combine` — letting `arith_add`'s existing
-  in-place `push_str`/`extend`/object-merge reuse the accumulator's own
-  spare capacity instead of being handed a fresh exact-capacity clone every
-  step. `eval_owned_fast_path` itself (and its other 3 call sites) is
-  unchanged and still clones — this is a fold-loop-scoped fix, not a
-  signature change. Measured (`reduce range(N) as $x (""; . + "x") |
-  length`): N=6,250 → 6ms, 12,500 → 7ms, 25,000 → 10ms, 50,000 → 16ms,
-  99,999 → 29ms (was 6/9/18/38/135ms) — growth is now close to linear
-  instead of the previous ~2x-per-doubling signature. Bonus: since the new
-  helper reuses #2152's own `literal_shaped_expr_to_owned`, the
-  array/object-accumulator idioms it covers get the same by-value treatment
-  for free — `reduce range(25000) as $x ([]; . + [$x]) | length` dropped
-  from ~1.25s to ~0.013s (~96x), confirmed with matching output at every
-  size measured.
+- **`reduce`'s bare-accumulator UPDATE body is now genuinely O(n), not
+  just a smaller O(n²) constant** (#2157): `try_reduce_step_alternatives`'s
+  own fold loop holds its accumulator `state: OwnedValue` fully unaliased
+  (confirmed: unconditionally overwritten immediately after this call, no
+  live borrow of the old value survives), so a new
+  `try_owned_accumulator_step` recognizes the same `. + <literal>`-shaped
+  body #2086 already matches but, unlike `eval_owned_fast_path`'s
+  `&OwnedValue` signature, moves `state` *by value* straight into
+  `arith_combine` — letting `arith_add`'s existing in-place
+  `push_str`/`extend`/object-merge reuse the accumulator's own spare
+  capacity instead of being handed a fresh exact-capacity clone every step.
+  `eval_owned_fast_path` itself (and its other 3 call sites) is unchanged
+  and still clones — this is a fold-loop-scoped fix, not a signature
+  change. Measured (`reduce range(N) as $x (""; . + "x") | length`):
+  N=6,250 → 6ms, 12,500 → 7ms, 25,000 → 10ms, 50,000 → 16ms, 99,999 →
+  29ms (was 6/9/18/38/135ms) — growth is now close to linear instead of
+  the previous ~2x-per-doubling signature. Bonus: since the new helper
+  reuses #2152's own `literal_shaped_expr_to_owned`, the array/object-
+  accumulator idioms it covers get the same by-value treatment for free
+  — `reduce range(25000) as $x ([]; . + [$x]) | length` dropped from
+  ~1.25s to ~0.013s (~96x), confirmed with matching output at every size
+  measured.
+  **`foreach` shares the same `try_owned_accumulator_step` call (same
+  `try_reduce_step_alternatives`-mirrored reasoning applies to its own
+  `state`), but does *not* reach the same O(n) result**: unlike `reduce`,
+  every `foreach` step also has to hand `state` to EXTRACT (or push it to
+  `outputs` directly when EXTRACT is omitted) *before* the next step can
+  consume it — a second, structurally unavoidable read of the same value
+  that a bare by-value move can't eliminate. `try_foreach_step_alternatives`
+  moved from two full clones per step (one for that EXTRACT/output read,
+  one for the next `state`) down to one (review caught a first version of
+  this fix that still did `update_vals.last().cloned()` for `state` *after*
+  the EXTRACT loop needed to borrow it, paying both clones anyway and
+  getting no benefit at all) — a real but modest win (~7%, measured over 5
+  interleaved reps at N=99,999 with output discarded via `| empty`), not
+  an asymptotic one. `foreach`'s own EXTRACT evaluation is entirely
+  untouched by this issue and still round-trips through the reindex bridge
+  for any shape beyond `eval_owned_fast_path`'s narrow coverage (plain
+  `.`/field/index/`tostring`/this same arithmetic arm) — genuinely fixing
+  `foreach`'s own asymptotic behavior would need that bridge closed too,
+  out of scope here.
 
 - **A decode failure (invalid UTF-8, or a structurally malformed value) now
   raises instead of silently materializing as `null`, `""`, or a dropped

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1904,6 +1904,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   fix at all (measured *worse* than the string case, ~36s at just 25,000
   elements) — tracked separately as #2152.
 
+- **`reduce`/`foreach`'s bare-accumulator UPDATE body is now genuinely
+  O(n), not just a smaller O(n²) constant** (#2157): `try_reduce_step_alternatives`/
+  `try_foreach_step_alternatives`'s own fold loops hold their accumulator
+  `state: OwnedValue` fully unaliased (confirmed: unconditionally
+  overwritten immediately after this call, no live borrow of the old value
+  survives), so a new `try_owned_accumulator_step` recognizes the same
+  `. + <literal>`-shaped body #2086 already matches but, unlike
+  `eval_owned_fast_path`'s `&OwnedValue` signature, moves `state` *by
+  value* straight into `arith_combine` — letting `arith_add`'s existing
+  in-place `push_str`/`extend`/object-merge reuse the accumulator's own
+  spare capacity instead of being handed a fresh exact-capacity clone every
+  step. `eval_owned_fast_path` itself (and its other 3 call sites) is
+  unchanged and still clones — this is a fold-loop-scoped fix, not a
+  signature change. Measured (`reduce range(N) as $x (""; . + "x") |
+  length`): N=6,250 → 6ms, 12,500 → 7ms, 25,000 → 10ms, 50,000 → 16ms,
+  99,999 → 29ms (was 6/9/18/38/135ms) — growth is now close to linear
+  instead of the previous ~2x-per-doubling signature. Bonus: since the new
+  helper reuses #2152's own `literal_shaped_expr_to_owned`, the
+  array/object-accumulator idioms it covers get the same by-value treatment
+  for free — `reduce range(25000) as $x ([]; . + [$x]) | length` dropped
+  from ~1.25s to ~0.013s (~96x), confirmed with matching output at every
+  size measured.
+
 - **A decode failure (invalid UTF-8, or a structurally malformed value) now
   raises instead of silently materializing as `null`, `""`, or a dropped
   field**, on nearly every route that turns lazily-indexed JSON/YAML into an

--- a/docs/compliance/jq/limitations.md
+++ b/docs/compliance/jq/limitations.md
@@ -3263,65 +3263,64 @@ to answer it directly against the `OwnedValue` tree, reusing the same
 measured directly at `REDUCE_FOREACH_MAX_STEPS` (`100000`) after that fix:
 ~0.17s, down from ~7.8s, a ~45x constant-factor win.
 
-**This is not an asymptotic fix -- the fold remains O(n²) after #2086,
-just with a much smaller constant.** The new arm still calls `input.clone()`
-on the whole accumulator every step before handing it to `arith_combine`
-(`eval_owned_fast_path`'s `&OwnedValue` signature leaves no other option),
-and `String`/`Vec::clone()` allocates at exact capacity with no spare
-headroom, so the very next `push_str`/`extend` inside `arith_add`
-reallocates a second time regardless -- two O(current-size) copies per
-step either way, just memcpy instead of serialize/parse. Measured post-fix
-scaling curve (interleaved runs, net of process-startup floor,
-`reduce range(N) as $x (""; . + "x") | length`):
+**#2086 was not an asymptotic fix -- the fold remained O(n²), just with a
+much smaller constant** (the new arm still called `input.clone()` on the
+whole accumulator every step before handing it to `arith_combine`, since
+`eval_owned_fast_path`'s `&OwnedValue` signature left no other option, and
+`String`/`Vec::clone()` allocates at exact capacity with no spare headroom,
+so the very next `push_str`/`extend` inside `arith_add` reallocated a
+second time regardless -- two O(current-size) copies per step either way,
+just memcpy instead of serialize/parse).
 
-| N | net time | time/N |
+[#2157](https://github.com/rust-works/succinctly/issues/2157) fixed the
+remaining O(n²) shape for the two call sites that actually matter --
+`try_reduce_step_alternatives`/`try_foreach_step_alternatives`'s own fold
+loops, where the accumulator `state: OwnedValue` is confirmed unaliased
+(unconditionally overwritten immediately after this call, with no live
+borrow of the old value surviving) -- via a new `try_owned_accumulator_step`
+that recognizes the same `. + <literal>`-shaped UPDATE body
+(`owned_arith_accumulator_shape`) but, unlike `eval_owned_fast_path`, takes
+`state` *by value* and moves it straight into `arith_combine`, so
+`arith_add`'s in-place `push_str`/`extend`/`Object` merge can reuse the
+accumulator's own spare capacity instead of being handed a fresh
+exact-capacity clone every step. `eval_owned_fast_path`'s own arm (and its
+other 3 call sites -- `eval_each_owned`, `eval_owned_expr_full`,
+`eval_owned_input`, none of which hold state this unaliased) is deliberately
+left unchanged and still clones; the fix is scoped to the fold loop, not a
+signature change to the shared function.
+
+Measured post-fix scaling curve (`reduce range(N) as $x (""; . + "x") |
+length`, wall-clock via bash's `time` builtin, output verified identical to
+pre-fix at every N):
+
+| N | pre-#2157 | post-#2157 |
 |---|---|---|
-| 6,250 | 1.89ms | 0.30µs |
-| 12,500 | 4.74ms | 0.38µs |
-| 25,000 | 13.53ms | 0.54µs |
-| 50,000 | 35.24ms | 0.71µs |
-| 99,999 | 133.58ms | 1.34µs |
+| 6,250 | 6ms | 6ms |
+| 12,500 | 9ms | 7ms |
+| 25,000 | 18ms | 10ms |
+| 50,000 | 38ms | 16ms |
+| 99,999 | 135ms | 29ms |
 
-Per-step cost keeps rising (0.30µs -> 1.34µs, a 4.4x increase over a 16x
-range of N) and the last doubling (50,000 -> 99,999) costs ~3.8x -- both
-the signature of O(n²), not O(n) (which would show flat per-step cost and a
-~2x doubling ratio). Pushing further past `REDUCE_FOREACH_MAX_STEPS` (via
-array input rather than `range()`, which has its own separate cap) confirms
-the trend continues: 100,000 -> 200,000 -> 300,000 -> 400,000 elements
-measured 0.15s -> 0.47s -> 1.07s -> 2.9s, a ~19x wall-clock increase for a
-4x increase in N. A true O(n) fix needs the fold's already-fully-owned
-accumulator state (confirmed unaliased at the one call site that matters,
-`try_reduce_step_alternatives`) passed *by value* into arithmetic so
-`arith_add`'s existing in-place `push_str`/`extend` can reuse capacity
-instead of being handed a fresh clone every step -- out of scope for #2086
-since `eval_owned_fast_path` is shared by 3 call sites (`eval_each_owned`,
-`eval_owned_expr_full`, `eval_owned_input`) that all need `input` back on
-the fallback branch, not just the one new arm; tracked as
-[#2157](https://github.com/rust-works/succinctly/issues/2157).
+Pre-fix time roughly doubles-plus per doubling of N throughout (the O(n²)
+signature); post-fix growth is close to linear once the ~5-6ms
+process-startup floor is netted out (net time 6,250->99,999: ~1ms->~24ms,
+a 16x range of N for a ~24x time increase, vs. pre-fix's ~1ms->~130ms net,
+a ~130x increase over the same range).
 
-Array/object-accumulating shapes (`reduce ... as $x ([]; . + [$x])`) were
-**not** covered by #2086's fix at all -- after substitution the right-hand
-side is an `Expr::Array`/`Expr::Object` construction wrapping a `Literal`,
-not a bare `Literal` itself, so it fell through to the same slow path, and
-measured *worse* than the string case ever did (~36s at just 25,000
-elements). Closed by [#2152](https://github.com/rust-works/succinctly/issues/2152)'s
-`literal_shaped_expr_to_owned` (`eval.rs`), which extends the same
-`eval_owned_fast_path` arm to recognize an `Expr::Array`/`Expr::Object`
-right-hand side whose every leaf is itself a `Literal` (or, for a dynamic
-object key, resolves to one), converting it to an `OwnedValue` directly the
-same way `literal_to_owned` already does for the scalar case, then reusing
-`arith_combine` exactly as #2086's own arm does -- no new arithmetic
-semantics, only a new way to build the operand. Same "constant factor, not
-asymptotic" caveat as #2086's own fix above applies here too (still calls
-`input.clone()` per step, #2157's own residual is unchanged) -- measured
-directly: 25,000-element array accumulation dropped from ~38.8s to ~6.0-6.6s
-(~6x), and the analogous object-accumulator idiom
-(`reduce ... as $x ({}; . + {($x): v})`) went from *not completing inside
-60s* to ~6.3s at the same N. Interleaved A/B at two sizes confirms the same
-quadratic shape survives at a smaller constant, matching #2157's own
-finding for the string case (5,000: ~1.36s -> ~0.25s, 10,000: ~5.77s ->
-~0.91s -- before roughly quadruples per doubling of N, after roughly
-triples).
+**Bonus, not part of #2157's own stated scope**: `owned_arith_accumulator_shape`
+calls the same `literal_shaped_expr_to_owned` [#2152](https://github.com/rust-works/succinctly/issues/2152)
+already extended to recognize literal-shaped `Expr::Array`/`Expr::Object`
+right-hand sides, so the array/object-accumulator idioms #2152 closed at
+the *constant-factor* level (still cloning via `eval_owned_fast_path`) get
+the same by-value treatment at these two fold-loop call sites, for free --
+confirmed live: `reduce range(25000) as $x ([]; . + [$x]) | length` dropped
+from ~1.25s to ~0.013s (~96x), and `reduce (range(5000) | tostring) as $x
+({}; . + {($x): $x}) | length` dropped from ~0.42s to ~0.010s (~42x), both
+with output verified identical pre/post-fix. A dynamic object key that
+itself isn't literal-shaped after substitution (e.g. `($x | tostring)`
+evaluated *inside* the fold body rather than on the outer generator) still
+falls through to the slow general path in both builds -- `literal_shaped_expr_to_owned`
+was, and remains, unchanged by #2157.
 
 **One correction to the AST shape this issue's own text guessed, confirmed
 live via a debug probe against the real repro rather than assumed**: a
@@ -3394,10 +3393,12 @@ shape `eval_owned_fast_path` doesn't cover): `[0,""] | until(.[0] >= N;
 [.[0]+1, .[1] + "x"]) | .[1] | length` measures ~15-16s at N approaching the
 new `100000` ceiling in this build, against real jq's own apparently-linear
 ~0.1-0.2s at the same N (confirmed live). #2086's fix (see the previous
-section -- a constant-factor win, not an asymptotic one; #2157 tracks the
-remaining O(n²) shape) brought that analogous `reduce` figure down from
-~7.8s to ~0.17s for `reduce`/`foreach`'s *bare* accumulator shape
-(`. + <literal>`) -- but this `until`/`while` repro's own state is
+section -- a constant-factor win, not an asymptotic one; #2157 fixed the
+remaining O(n²) shape, but only at `reduce`/`foreach`'s own fold-loop call
+sites, not `eval_owned_fast_path` itself, so `until`/`while`'s separate
+step mechanism below is unaffected by it either way) brought that analogous
+`reduce` figure down from ~7.8s to ~0.17s for `reduce`/`foreach`'s *bare*
+accumulator shape (`. + <literal>`) -- but this `until`/`while` repro's own state is
 array-wrapped (`[.[0]+1, .[1] + "x"]`, since a loop needs a counter *and* an
 accumulator, unlike `reduce`/`foreach`'s cleanly separate INIT-vs-`$x`
 shape), so neither inner arithmetic's left operand is the bare `.`

--- a/docs/compliance/jq/limitations.md
+++ b/docs/compliance/jq/limitations.md
@@ -3273,9 +3273,8 @@ second time regardless -- two O(current-size) copies per step either way,
 just memcpy instead of serialize/parse).
 
 [#2157](https://github.com/rust-works/succinctly/issues/2157) fixed the
-remaining O(n²) shape for the two call sites that actually matter --
-`try_reduce_step_alternatives`/`try_foreach_step_alternatives`'s own fold
-loops, where the accumulator `state: OwnedValue` is confirmed unaliased
+remaining O(n²) shape for `try_reduce_step_alternatives`'s own fold loop,
+where the accumulator `state: OwnedValue` is confirmed unaliased
 (unconditionally overwritten immediately after this call, with no live
 borrow of the old value surviving) -- via a new `try_owned_accumulator_step`
 that recognizes the same `. + <literal>`-shaped UPDATE body
@@ -3293,13 +3292,13 @@ Measured post-fix scaling curve (`reduce range(N) as $x (""; . + "x") |
 length`, wall-clock via bash's `time` builtin, output verified identical to
 pre-fix at every N):
 
-| N | pre-#2157 | post-#2157 |
-|---|---|---|
-| 6,250 | 6ms | 6ms |
-| 12,500 | 9ms | 7ms |
-| 25,000 | 18ms | 10ms |
-| 50,000 | 38ms | 16ms |
-| 99,999 | 135ms | 29ms |
+| N      | pre-#2157 | post-#2157 |
+|--------|-----------|------------|
+| 6,250  | 6ms       | 6ms        |
+| 12,500 | 9ms       | 7ms        |
+| 25,000 | 18ms      | 10ms       |
+| 50,000 | 38ms      | 16ms       |
+| 99,999 | 135ms     | 29ms       |
 
 Pre-fix time roughly doubles-plus per doubling of N throughout (the O(n²)
 signature); post-fix growth is close to linear once the ~5-6ms
@@ -3307,12 +3306,43 @@ process-startup floor is netted out (net time 6,250->99,999: ~1ms->~24ms,
 a 16x range of N for a ~24x time increase, vs. pre-fix's ~1ms->~130ms net,
 a ~130x increase over the same range).
 
+**`try_foreach_step_alternatives` shares the identical `try_owned_accumulator_step`
+call (the same unaliased-`state` reasoning applies equally to its own fold
+loop) but does not reach the same O(n) result, and this doc originally
+claimed otherwise -- corrected here per review.** `reduce` only ever reads
+its accumulator once per step (as the next step's input); `foreach` reads
+it *twice* -- once to hand to EXTRACT (or push directly to `outputs` when
+EXTRACT is omitted, `foreach`'s default per-step-emit behavior), and again
+as the next step's `state` -- and a plain by-value move can eliminate only
+one of the two reads, not both, since each needs its own owned copy. A
+first version of this fix moved `state` into `try_owned_accumulator_step`
+but then still cloned `update_vals.last()` for the next `state` *after* the
+EXTRACT loop had already needed to borrow `update_vals` -- paying both
+clones anyway (review caught this: interleaved benchmarking of that version
+against the pre-fix baseline showed no measurable difference, confirming
+zero benefit had actually landed). The corrected version defers taking
+`state` from `update_vals` until after the EXTRACT loop no longer needs to
+borrow it, so that one read becomes a real move -- landing one clone per
+step instead of two, not zero. Measured (`foreach range(99999) as $x (""; .
++ "x") | empty`, wall-clock, 5 interleaved reps): pre-fix ~6.48s average,
+post-fix ~6.05s average, a real but modest **~7%** improvement -- nowhere
+near `reduce`'s near-linear result, because the EXTRACT/output-emit clone
+is structurally unavoidable here and dominates the total cost regardless.
+Emitting a growing accumulator once per step is itself O(n²) in total
+output size no matter how efficiently `state` is threaded internally (the
+same "quadratic by output shape" property noted elsewhere in this
+codebase's own benchmarking discipline) -- genuinely fixing `foreach`'s own
+asymptotic behavior would need `eval_owned_fast_path` extended to cover
+common EXTRACT shapes too (starting with `empty`, currently absent from its
+match and so still round-tripping through the reindex bridge per step
+regardless of this fix), which is out of scope here.
+
 **Bonus, not part of #2157's own stated scope**: `owned_arith_accumulator_shape`
 calls the same `literal_shaped_expr_to_owned` [#2152](https://github.com/rust-works/succinctly/issues/2152)
 already extended to recognize literal-shaped `Expr::Array`/`Expr::Object`
 right-hand sides, so the array/object-accumulator idioms #2152 closed at
 the *constant-factor* level (still cloning via `eval_owned_fast_path`) get
-the same by-value treatment at these two fold-loop call sites, for free --
+the same by-value treatment `reduce`'s own fold loop gets above, for free --
 confirmed live: `reduce range(25000) as $x ([]; . + [$x]) | length` dropped
 from ~1.25s to ~0.013s (~96x), and `reduce (range(5000) | tostring) as $x
 ({}; . + {($x): $x}) | length` dropped from ~0.42s to ~0.010s (~42x), both
@@ -3394,11 +3424,13 @@ shape `eval_owned_fast_path` doesn't cover): `[0,""] | until(.[0] >= N;
 new `100000` ceiling in this build, against real jq's own apparently-linear
 ~0.1-0.2s at the same N (confirmed live). #2086's fix (see the previous
 section -- a constant-factor win, not an asymptotic one; #2157 fixed the
-remaining O(n²) shape, but only at `reduce`/`foreach`'s own fold-loop call
-sites, not `eval_owned_fast_path` itself, so `until`/`while`'s separate
-step mechanism below is unaffected by it either way) brought that analogous
-`reduce` figure down from ~7.8s to ~0.17s for `reduce`/`foreach`'s *bare*
-accumulator shape (`. + <literal>`) -- but this `until`/`while` repro's own state is
+remaining O(n²) shape for `reduce`'s own fold loop specifically (see the
+previous section's own correction for why `foreach`'s otherwise-identical
+call site doesn't reach the same result), not `eval_owned_fast_path`
+itself, so `until`/`while`'s separate step mechanism below is unaffected by
+it either way) brought that analogous `reduce` figure down from ~7.8s to
+~0.17s for `reduce`/`foreach`'s *bare* accumulator shape (`. + <literal>`)
+-- but this `until`/`while` repro's own state is
 array-wrapped (`[.[0]+1, .[1] + "x"]`, since a loop needs a counter *and* an
 accumulator, unlike `reduce`/`foreach`'s cleanly separate INIT-vs-`$x`
 shape), so neither inner arithmetic's left operand is the bare `.`

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -31362,14 +31362,11 @@ fn try_reduce_step_alternatives<S: EvalSemantics>(
         // #2157: `state` is unconditionally overwritten by the very next
         // statement regardless of which branch runs, so there is no live
         // borrow of its old value to preserve -- the one call site where
-        // `try_owned_accumulator_step` can move `state` straight into
-        // `arith_combine` instead of `eval_owned_expr_fork`'s own
+        // `fold_step_via_accumulator_or_fork` can move `state` straight
+        // into `arith_combine` instead of `eval_owned_expr_fork`'s own
         // `&OwnedValue`-forced clone.
         let (update_vals, update_control) =
-            match try_owned_accumulator_step::<S>(substituted, state, optional) {
-                Ok(result) => result,
-                Err(state) => eval_owned_expr_fork::<S>(substituted, &state, optional),
-            };
+            fold_step_via_accumulator_or_fork::<S>(substituted, state, optional);
         // Unconditional, mirroring the pre-#1365 single-pattern fold's own
         // "acc = update_vals.into_iter().last()" -- run even when
         // `update_control` is `Some(..)`, since a retried alternative
@@ -31786,8 +31783,8 @@ fn eval_owned_fast_path<S: EvalSemantics>(
         // (the `&OwnedValue` signature below leaves no other option), so
         // it only shrinks the constant factor -- the fold itself remains
         // O(n^2) over a growing accumulator here; see #2157, whose own
-        // fix is [`try_owned_accumulator_step`] below, for the genuinely
-        // owned sibling `reduce`/`foreach`'s own fold loop calls instead
+        // fix is [`fold_step_via_accumulator_or_fork`] below, for the
+        // genuinely owned sibling `reduce`'s own fold loop calls instead
         // of this borrowed one.
         //
         // #2152: extended from a bare `Expr::Literal` `right` to any shape
@@ -31814,7 +31811,7 @@ fn eval_owned_fast_path<S: EvalSemantics>(
 /// a literal-shaped right operand `to_owned`-able with no input access) --
 /// the common `reduce`/`foreach`/`until`/`while` UPDATE-body accumulator
 /// idiom both [`eval_owned_fast_path`]'s own arm and #2157's genuinely
-/// owned [`try_owned_accumulator_step`] fast-path. `None` for any other
+/// owned [`fold_step_via_accumulator_or_fork`] fast-path. `None` for any other
 /// shape, including a syntactically-`Arithmetic` one whose right operand
 /// isn't [`literal_shaped_expr_to_owned`]-recognizable.
 fn owned_arith_accumulator_shape(expr: &Expr) -> Option<(ArithOp, OwnedValue)> {
@@ -31827,51 +31824,62 @@ fn owned_arith_accumulator_shape(expr: &Expr) -> Option<(ArithOp, OwnedValue)> {
     Some((*op, literal_shaped_expr_to_owned(right.as_ref(), 0)?))
 }
 
-/// #2157: the genuinely-owned sibling of [`eval_owned_fast_path`]'s own
-/// `. + <literal>` arm, for a caller that -- unlike that function's
-/// `&OwnedValue` signature -- already holds full ownership of `state` and
-/// is about to unconditionally overwrite it regardless of this call's
-/// outcome (`reduce`/`foreach`'s own fold loop, confirmed via
-/// `try_reduce_step_alternatives`: `state` is reassigned from
-/// `update_vals.into_iter().last()` immediately after, with no live borrow
-/// of the old value surviving that reassignment).
+/// #2157: `reduce`/`foreach`'s own fold-loop UPDATE dispatch -- shared by
+/// [`try_reduce_step_alternatives`] and [`try_foreach_step_alternatives`]
+/// (review flagged an earlier version of this fix as duplicating this
+/// exact dispatch verbatim at both call sites, byte-for-byte down to the
+/// comment). Both hold `state` fully unaliased at this call (unconditionally
+/// overwritten immediately after, no live borrow of the old value
+/// surviving), unlike [`eval_owned_fast_path`]'s own `&OwnedValue`-bound
+/// `. + <literal>` arm -- so when `expr` is that same shape
+/// (`owned_arith_accumulator_shape`), `state` moves *by value* straight
+/// into [`arith_combine`] instead of being cloned first, letting
+/// `arith_add`'s in-place `push_str`/`extend` reuse the accumulator's own
+/// spare capacity. `owned_arith_accumulator_shape` only inspects `&expr`,
+/// never `state`, so the shape check happens *before* `state` is touched
+/// at all -- an earlier version of this function instead moved `state` in
+/// unconditionally and handed it back via `Err(state)` on a shape
+/// mismatch, a `Result`-as-"try this, or hand it back" convention review
+/// called out as solely a byproduct of that ordering, easy to misread as
+/// "the operation failed" rather than "shape didn't match." Checking the
+/// shape first removes the need for it entirely: the `None` arm below
+/// simply borrows `state` for the existing [`eval_owned_expr_fork`] path
+/// rather than ever needing it back.
 ///
-/// Moving `state` straight into [`arith_combine`] (which already takes its
-/// `left` operand by value) instead of cloning it first is the actual O(n)
-/// fix #2086/#2152's own `&OwnedValue`-bound fast path couldn't make:
-/// `arith_add`'s in-place `push_str`/`extend` can then reuse the
-/// accumulator's own spare capacity instead of being handed a fresh
-/// exact-capacity clone every step, the same way it already does for any
-/// other genuinely-owned caller.
+/// For `reduce`, this is the actual O(n) fix #2086/#2152's own
+/// `&OwnedValue`-bound fast path couldn't make. For `foreach`, it is not:
+/// every `foreach` step also hands `state` to EXTRACT (or pushes it
+/// straight to `outputs` when EXTRACT is omitted) before the next step can
+/// consume it, a second read this by-value move alone can't eliminate --
+/// see `try_foreach_step_alternatives`'s own doc comment and
+/// `docs/compliance/jq/limitations.md`'s #2157 section for the measured
+/// (modest, non-asymptotic) result there.
 ///
-/// Returns `Ok((vec![new_state], None))` on a successful combine and
-/// `Ok((Vec::new(), Some(Control::Error(e))))`/`Ok((Vec::new(), None))`
-/// (the latter when `optional` suppresses the error) on failure -- the
-/// exact shape [`eval_owned_expr_fork`] itself returns for this same
-/// expression, so the caller's own `update_vals`/`update_control` handling
-/// downstream (retry-on-`?//`-alternative included) needs no changes.
-/// `Err(state)` when `expr` isn't this shape at all -- checked before
-/// `state` is touched at all, so it comes back completely unconsumed for
-/// the caller to fall through to its existing [`eval_owned_expr_fork`]
-/// call with -- deliberately narrow: replicating that call's own
-/// `?//`-retry/decode-failure semantics here for the rare failing-combine
-/// case would be new surface for exactly the kind of subtle regression
-/// #2237's own review already caught twice in a similarly "looks like a
-/// safe mechanical copy" refactor (#2389), for a case that isn't the
-/// O(n^2) driver this fix targets in the first place.
-fn try_owned_accumulator_step<S: EvalSemantics>(
+/// On a match, returns the exact `(Vec<OwnedValue>, Option<Control>)`
+/// shape [`eval_owned_expr_fork`] itself returns for this same expression
+/// (`(vec![v], None)` on success, `(Vec::new(), Some(Control::Error(e)))`
+/// or `(Vec::new(), None)` when `optional` suppresses the error) -- so the
+/// caller's own `update_vals`/`update_control` handling downstream
+/// (retry-on-`?//`-alternative included) needs no changes either way.
+/// Deliberately doesn't replicate `eval_owned_expr_fork`'s own
+/// `?//`-retry/decode-failure semantics for the failing-combine case --
+/// new surface for exactly the kind of subtle regression #2237's own
+/// review already caught twice in a similarly "looks like a safe
+/// mechanical copy" refactor (#2389), for a case that isn't the O(n^2)
+/// driver this fix targets in the first place.
+fn fold_step_via_accumulator_or_fork<S: EvalSemantics>(
     expr: &Expr,
     state: OwnedValue,
     optional: bool,
-) -> Result<(Vec<OwnedValue>, Option<Control>), OwnedValue> {
-    let Some((op, rhs)) = owned_arith_accumulator_shape(expr) else {
-        return Err(state);
-    };
-    Ok(match arith_combine::<S>(op, state, rhs) {
-        Ok(v) => (vec![v], None),
-        Err(_) if optional => (Vec::new(), None),
-        Err(e) => (Vec::new(), Some(Control::Error(e))),
-    })
+) -> (Vec<OwnedValue>, Option<Control>) {
+    match owned_arith_accumulator_shape(expr) {
+        Some((op, rhs)) => match arith_combine::<S>(op, state, rhs) {
+            Ok(v) => (vec![v], None),
+            Err(_) if optional => (Vec::new(), None),
+            Err(e) => (Vec::new(), Some(Control::Error(e))),
+        },
+        None => eval_owned_expr_fork::<S>(expr, &state, optional),
+    }
 }
 
 /// The `Identity`/`Field`/`Index` arms of [`eval_owned_fast_path`], factored
@@ -32688,17 +32696,26 @@ fn try_foreach_step_alternatives<S: EvalSemantics>(
             return (state, Some(control));
         }
 
-        // #2157: same reasoning as `try_reduce_step_alternatives`'s own
-        // identical call site -- `state` is unconditionally overwritten
-        // immediately below regardless of which branch runs.
+        // #2157: `state` is fed into `fold_step_via_accumulator_or_fork` by
+        // value (see `try_reduce_step_alternatives`'s own identical call
+        // site), but unlike that sibling, the resulting `update_vals`
+        // can't be consumed right away here -- the EXTRACT loop just below
+        // still needs to borrow it. Setting the *next* `state` from
+        // `update_vals` is therefore deferred past that loop (see the
+        // `into_iter().last()` after it) instead of happening right here;
+        // review found an earlier version of this fix set `state` via
+        // `.last().cloned()` at this exact point, which clones the whole
+        // accumulator every step on top of the EXTRACT loop's own read of
+        // it -- paying both clones and confirmed (interleaved benchmark)
+        // to land zero measurable improvement. Deferring to `into_iter()`
+        // below removes one of those two clones, a real but modest win
+        // (~7%, measured) -- not `reduce`'s O(n) result, since the
+        // EXTRACT/output read is a second, structurally unavoidable read
+        // of `state` this fix was never going to eliminate on its own; see
+        // `fold_step_via_accumulator_or_fork`'s own doc comment and
+        // `docs/compliance/jq/limitations.md`'s #2157 section.
         let (update_vals, update_control) =
-            match try_owned_accumulator_step::<S>(substituted_update, state, optional) {
-                Ok(result) => result,
-                Err(state) => eval_owned_expr_fork::<S>(substituted_update, &state, optional),
-            };
-        // Unconditional, mirroring `try_reduce_step_alternatives`'s own
-        // rule -- a retried alternative resumes from exactly this value.
-        state = update_vals.last().cloned().unwrap_or(OwnedValue::Null);
+            fold_step_via_accumulator_or_fork::<S>(substituted_update, state, optional);
 
         // EXTRACT (or the implicit identity when omitted) runs once per
         // UPDATE output THIS alternative actually produced -- unconditionally,
@@ -32717,7 +32734,15 @@ fn try_foreach_step_alternatives<S: EvalSemantics>(
                 // there are source elements (#695), and that width needs
                 // its own accounting.
                 if let Some(control) = charge_budget(budget, "foreach") {
-                    return (state, Some(control));
+                    // `state` was already moved into `fold_step_via_accumulator_or_fork`
+                    // above and not yet reassigned (that happens after this
+                    // loop) -- `Null` stands in for it here since the caller
+                    // discards whatever `state` a `Some(control)` return
+                    // carries once it aborts the fold (confirmed at this
+                    // function's own call site: `state = new_state;` runs,
+                    // but `state` is never read again once `step_control`
+                    // is `Some`, the fork just `break`s).
+                    return (OwnedValue::Null, Some(control));
                 }
                 let (ext_vals, ext_control) =
                     eval_owned_expr_fork::<S>(ext_expr, update_val, optional);
@@ -32743,12 +32768,23 @@ fn try_foreach_step_alternatives<S: EvalSemantics>(
                         state = update_val.clone();
                         continue 'alternatives;
                     }
-                    Some(control) => return (state, Some(control)),
+                    // Same moved-`state`/discarded-on-abort reasoning as the
+                    // budget-check return above.
+                    Some(control) => return (OwnedValue::Null, Some(control)),
                 }
             } else {
                 outputs.push(update_val.clone());
             }
         }
+
+        // Only reached once the EXTRACT loop above has run to completion
+        // without retrying (a retry already set `state` itself and jumped
+        // straight to the next `'alternatives` iteration, skipping this).
+        // `update_vals` is no longer borrowed by anything past this point,
+        // so this is the one place its last element can move into `state`
+        // instead of being cloned out of it -- mirroring
+        // `try_reduce_step_alternatives`'s own `into_iter().last()`.
+        state = update_vals.into_iter().last().unwrap_or(OwnedValue::Null);
 
         match update_control {
             None => return (state, None),
@@ -68651,7 +68687,7 @@ mod tests {
 
     #[test]
     fn test_2157_owned_arith_accumulator_shape_recognizes_and_rejects_correctly() {
-        // Direct unit coverage of the shape-check `try_owned_accumulator_step`
+        // Direct unit coverage of the shape-check `fold_step_via_accumulator_or_fork`
         // gates on: `Some` only for a bare `Identity`-left `Arithmetic` whose
         // right side `literal_shaped_expr_to_owned` can convert with no
         // input access, `None` for everything else (including a
@@ -68690,40 +68726,44 @@ mod tests {
     }
 
     #[test]
-    fn test_2157_try_owned_accumulator_step_returns_state_unconsumed_on_shape_mismatch() {
-        // The `Err(state)` path must hand `state` back completely
-        // unconsumed -- the whole point of checking the shape *before*
-        // touching `state` is so the caller's fallback to
-        // `eval_owned_expr_fork` sees the original, un-mutated accumulator.
-        let state = OwnedValue::String("untouched".to_string());
-        match try_owned_accumulator_step::<JqSemantics>(&Expr::Identity, state, false) {
-            Err(OwnedValue::String(s)) => assert_eq!(s, "untouched"),
-            // `Expr::Identity` never matches `owned_arith_accumulator_shape`'s
-            // `Arithmetic` pattern, so `Err(state)` unchanged is the only
-            // possible outcome here.
-            other => unreachable!("Expr::Identity never matches the Arithmetic shape: {other:?}"), // omni-dev: coverage tolerate-line reason="Expr::Identity never matches owned_arith_accumulator_shape (#2157)"
-        }
+    fn test_2157_fold_step_via_accumulator_or_fork_borrows_state_on_shape_mismatch() {
+        // On a shape mismatch, `owned_arith_accumulator_shape` (which only
+        // ever inspects `&expr`) has already decided `None` before `state`
+        // is touched at all, so the `None` arm borrows it for
+        // `eval_owned_expr_fork` rather than needing it handed back --
+        // pinned here via a value `eval_owned_expr_fork` itself would
+        // reject if it received anything other than the original,
+        // unmodified accumulator -- confirmed live against jq 1.7.1:
+        // `reduce (1) as $x (5; .foo)` raises "Cannot index number with
+        // string \"foo\"", naming `5`, the untouched original `state`, not
+        // some corrupted intermediate.
+        query!(b"null", r"reduce (1) as $x (5; .foo)",
+            QueryResult::Error(e) => {
+                assert!(e.message.contains("Cannot index number with string"));
+            }
+        );
     }
 
     #[test]
-    fn test_2157_try_owned_accumulator_step_suppresses_error_when_optional() {
-        // `try_owned_accumulator_step`'s `Err(_) if optional` arm mirrors
-        // `eval_owned_fast_path`'s own identical convention for this same
-        // `. + <literal>` shape (#2086) -- exercised directly here since no
-        // ordinary jq syntax reaches it *through* `reduce`/`foreach`'s own
-        // callers: `Expr::Try`/`Expr::Optional` never force `optional =
-        // true` into the expression they wrap (#693 -- see the `scalar_noop`
-        // binding's doc comment in `update_path` for the established
-        // precedent), so `(reduce ...)?` catches a per-step error via its
-        // own outer `eval_try`, not by setting this flag. Unit-level-only
-        // coverage, not jq-oracle-verifiable through any surface syntax.
+    fn test_2157_fold_step_via_accumulator_or_fork_suppresses_error_when_optional() {
+        // `fold_step_via_accumulator_or_fork`'s `Err(_) if optional` arm
+        // mirrors `eval_owned_fast_path`'s own identical convention for
+        // this same `. + <literal>` shape (#2086) -- exercised directly
+        // here since no ordinary jq syntax reaches it *through*
+        // `reduce`/`foreach`'s own callers: `Expr::Try`/`Expr::Optional`
+        // never force `optional = true` into the expression they wrap
+        // (#693 -- see the `scalar_noop` binding's doc comment in
+        // `update_path` for the established precedent), so `(reduce ...)?`
+        // catches a per-step error via its own outer `eval_try`, not by
+        // setting this flag. Unit-level-only coverage, not
+        // jq-oracle-verifiable through any surface syntax.
         let expr = Expr::Arithmetic {
             op: ArithOp::Add,
             left: Box::new(Expr::Identity),
             right: Box::new(Expr::Literal(Literal::String("a".to_string()))),
         };
         let (vals, control) =
-            try_owned_accumulator_step::<JqSemantics>(&expr, OwnedValue::Int(1), true).unwrap();
+            fold_step_via_accumulator_or_fork::<JqSemantics>(&expr, OwnedValue::Int(1), true);
         assert!(vals.is_empty());
         assert!(control.is_none());
     }
@@ -68732,7 +68772,7 @@ mod tests {
     fn test_2157_fold_accumulator_by_value_move_matches_general_evaluator() {
         // #2157: `try_reduce_step_alternatives`/`try_foreach_step_alternatives`
         // now move `state` by value into `arith_combine` via
-        // `try_owned_accumulator_step` instead of cloning through
+        // `fold_step_via_accumulator_or_fork` instead of cloning through
         // `eval_owned_fast_path`. Every case here is confirmed live against
         // jq 1.7.1 to still agree byte-for-byte -- this is the same
         // input/output contract #2086/#2152's own tests already pin, run
@@ -68760,6 +68800,25 @@ mod tests {
                 r"reduce (range(500) | tostring) as $x ({}; . + {($x): true}) | length"
             ),
             ["500"]
+        );
+        // `foreach`'s own analogue of the reduce cases above -- a growing
+        // String/Array accumulator, not the O(1)-sized Int case already
+        // covered (which can't distinguish a correct move from a subtly
+        // broken one, since cloning an Int is free either way). Confirmed
+        // live against jq 1.7.1.
+        assert_eq!(
+            outputs(
+                b"null",
+                r#"foreach range(50) as $x (""; . + "x") | select(length == 50)"#
+            ),
+            [r#""xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx""#]
+        );
+        assert_eq!(
+            outputs(
+                b"null",
+                r"foreach range(50) as $x ([]; . + [$x]) | select(length == 50)"
+            ),
+            ["[0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49]"]
         );
     }
 

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -31359,8 +31359,17 @@ fn try_reduce_step_alternatives<S: EvalSemantics>(
             return (state, Some(control));
         }
 
+        // #2157: `state` is unconditionally overwritten by the very next
+        // statement regardless of which branch runs, so there is no live
+        // borrow of its old value to preserve -- the one call site where
+        // `try_owned_accumulator_step` can move `state` straight into
+        // `arith_combine` instead of `eval_owned_expr_fork`'s own
+        // `&OwnedValue`-forced clone.
         let (update_vals, update_control) =
-            eval_owned_expr_fork::<S>(substituted, &state, optional);
+            match try_owned_accumulator_step::<S>(substituted, state, optional) {
+                Ok(result) => result,
+                Err(state) => eval_owned_expr_fork::<S>(substituted, &state, optional),
+            };
         // Unconditional, mirroring the pre-#1365 single-pattern fold's own
         // "acc = update_vals.into_iter().last()" -- run even when
         // `update_control` is `Some(..)`, since a retried alternative
@@ -31775,17 +31784,19 @@ fn eval_owned_fast_path<S: EvalSemantics>(
         // through `to_json_for_reindex` + `JsonIndex::build` every single
         // step. This arm skips that round-trip, but still clones `input`
         // (the `&OwnedValue` signature below leaves no other option), so
-        // it only shrinks the constant factor -- the fold remains O(n^2)
-        // over a growing accumulator; see #2157 and
-        // docs/compliance/jq/limitations.md.
+        // it only shrinks the constant factor -- the fold itself remains
+        // O(n^2) over a growing accumulator here; see #2157, whose own
+        // fix is [`try_owned_accumulator_step`] below, for the genuinely
+        // owned sibling `reduce`/`foreach`'s own fold loop calls instead
+        // of this borrowed one.
         //
         // #2152: extended from a bare `Expr::Literal` `right` to any shape
         // [`literal_shaped_expr_to_owned`] recognizes -- the array/object
         // accumulator idioms (`. + [$x]`, `. + {($x): true}`) that #2086's
         // own body flagged as unmeasured and out of scope at the time.
-        Expr::Arithmetic { op, left, right } if matches!(left.as_ref(), Expr::Identity) => {
-            let rhs = literal_shaped_expr_to_owned(right.as_ref(), 0)?;
-            match arith_combine::<S>(*op, input.clone(), rhs) {
+        Expr::Arithmetic { .. } => {
+            let (op, rhs) = owned_arith_accumulator_shape(expr)?;
+            match arith_combine::<S>(op, input.clone(), rhs) {
                 Ok(v) => Some(Ok(Some(v))),
                 // Mirrors the `Field`/`Index` arms' own `_ if optional`
                 // convention below, so a caller that ever does reach this
@@ -31797,6 +31808,70 @@ fn eval_owned_fast_path<S: EvalSemantics>(
         }
         _ => None,
     }
+}
+
+/// Whether `expr` is `. + <literal>`-shaped (bare `Identity` left operand,
+/// a literal-shaped right operand `to_owned`-able with no input access) --
+/// the common `reduce`/`foreach`/`until`/`while` UPDATE-body accumulator
+/// idiom both [`eval_owned_fast_path`]'s own arm and #2157's genuinely
+/// owned [`try_owned_accumulator_step`] fast-path. `None` for any other
+/// shape, including a syntactically-`Arithmetic` one whose right operand
+/// isn't [`literal_shaped_expr_to_owned`]-recognizable.
+fn owned_arith_accumulator_shape(expr: &Expr) -> Option<(ArithOp, OwnedValue)> {
+    let Expr::Arithmetic { op, left, right } = expr else {
+        return None;
+    };
+    if !matches!(left.as_ref(), Expr::Identity) {
+        return None;
+    }
+    Some((*op, literal_shaped_expr_to_owned(right.as_ref(), 0)?))
+}
+
+/// #2157: the genuinely-owned sibling of [`eval_owned_fast_path`]'s own
+/// `. + <literal>` arm, for a caller that -- unlike that function's
+/// `&OwnedValue` signature -- already holds full ownership of `state` and
+/// is about to unconditionally overwrite it regardless of this call's
+/// outcome (`reduce`/`foreach`'s own fold loop, confirmed via
+/// `try_reduce_step_alternatives`: `state` is reassigned from
+/// `update_vals.into_iter().last()` immediately after, with no live borrow
+/// of the old value surviving that reassignment).
+///
+/// Moving `state` straight into [`arith_combine`] (which already takes its
+/// `left` operand by value) instead of cloning it first is the actual O(n)
+/// fix #2086/#2152's own `&OwnedValue`-bound fast path couldn't make:
+/// `arith_add`'s in-place `push_str`/`extend` can then reuse the
+/// accumulator's own spare capacity instead of being handed a fresh
+/// exact-capacity clone every step, the same way it already does for any
+/// other genuinely-owned caller.
+///
+/// Returns `Ok((vec![new_state], None))` on a successful combine and
+/// `Ok((Vec::new(), Some(Control::Error(e))))`/`Ok((Vec::new(), None))`
+/// (the latter when `optional` suppresses the error) on failure -- the
+/// exact shape [`eval_owned_expr_fork`] itself returns for this same
+/// expression, so the caller's own `update_vals`/`update_control` handling
+/// downstream (retry-on-`?//`-alternative included) needs no changes.
+/// `Err(state)` when `expr` isn't this shape at all -- checked before
+/// `state` is touched at all, so it comes back completely unconsumed for
+/// the caller to fall through to its existing [`eval_owned_expr_fork`]
+/// call with -- deliberately narrow: replicating that call's own
+/// `?//`-retry/decode-failure semantics here for the rare failing-combine
+/// case would be new surface for exactly the kind of subtle regression
+/// #2237's own review already caught twice in a similarly "looks like a
+/// safe mechanical copy" refactor (#2389), for a case that isn't the
+/// O(n^2) driver this fix targets in the first place.
+fn try_owned_accumulator_step<S: EvalSemantics>(
+    expr: &Expr,
+    state: OwnedValue,
+    optional: bool,
+) -> Result<(Vec<OwnedValue>, Option<Control>), OwnedValue> {
+    let Some((op, rhs)) = owned_arith_accumulator_shape(expr) else {
+        return Err(state);
+    };
+    Ok(match arith_combine::<S>(op, state, rhs) {
+        Ok(v) => (vec![v], None),
+        Err(_) if optional => (Vec::new(), None),
+        Err(e) => (Vec::new(), Some(Control::Error(e))),
+    })
 }
 
 /// The `Identity`/`Field`/`Index` arms of [`eval_owned_fast_path`], factored
@@ -32613,8 +32688,14 @@ fn try_foreach_step_alternatives<S: EvalSemantics>(
             return (state, Some(control));
         }
 
+        // #2157: same reasoning as `try_reduce_step_alternatives`'s own
+        // identical call site -- `state` is unconditionally overwritten
+        // immediately below regardless of which branch runs.
         let (update_vals, update_control) =
-            eval_owned_expr_fork::<S>(substituted_update, &state, optional);
+            match try_owned_accumulator_step::<S>(substituted_update, state, optional) {
+                Ok(result) => result,
+                Err(state) => eval_owned_expr_fork::<S>(substituted_update, &state, optional),
+            };
         // Unconditional, mirroring `try_reduce_step_alternatives`'s own
         // rule -- a retried alternative resumes from exactly this value.
         state = update_vals.last().cloned().unwrap_or(OwnedValue::Null);
@@ -68565,6 +68646,120 @@ mod tests {
         assert!(
             result.is_err(),
             "literal_shaped_expr_to_owned should panic at MAX_VALUE_TREE_DEPTH"
+        );
+    }
+
+    #[test]
+    fn test_2157_owned_arith_accumulator_shape_recognizes_and_rejects_correctly() {
+        // Direct unit coverage of the shape-check `try_owned_accumulator_step`
+        // gates on: `Some` only for a bare `Identity`-left `Arithmetic` whose
+        // right side `literal_shaped_expr_to_owned` can convert with no
+        // input access, `None` for everything else (including a
+        // syntactically-`Arithmetic` node whose right side isn't literal
+        // enough) -- the fold loop's fallback correctness depends on this
+        // never mis-classifying a shape it can't actually answer.
+        assert_eq!(
+            owned_arith_accumulator_shape(&Expr::Arithmetic {
+                op: ArithOp::Add,
+                left: Box::new(Expr::Identity),
+                right: Box::new(Expr::Literal(Literal::Int(1))),
+            }),
+            Some((ArithOp::Add, OwnedValue::Int(1)))
+        );
+        // Non-`Identity` left (e.g. `.foo + 1`) is out of scope here --
+        // `eval_owned_expr_fork`'s general path handles it.
+        assert_eq!(
+            owned_arith_accumulator_shape(&Expr::Arithmetic {
+                op: ArithOp::Add,
+                left: Box::new(Expr::Field("foo".to_string())),
+                right: Box::new(Expr::Literal(Literal::Int(1))),
+            }),
+            None
+        );
+        // Right side isn't literal-shaped (a field access, not a constant).
+        assert_eq!(
+            owned_arith_accumulator_shape(&Expr::Arithmetic {
+                op: ArithOp::Add,
+                left: Box::new(Expr::Identity),
+                right: Box::new(Expr::Field("foo".to_string())),
+            }),
+            None
+        );
+        // Not an `Arithmetic` node at all.
+        assert_eq!(owned_arith_accumulator_shape(&Expr::Identity), None);
+    }
+
+    #[test]
+    fn test_2157_try_owned_accumulator_step_returns_state_unconsumed_on_shape_mismatch() {
+        // The `Err(state)` path must hand `state` back completely
+        // unconsumed -- the whole point of checking the shape *before*
+        // touching `state` is so the caller's fallback to
+        // `eval_owned_expr_fork` sees the original, un-mutated accumulator.
+        let state = OwnedValue::String("untouched".to_string());
+        match try_owned_accumulator_step::<JqSemantics>(&Expr::Identity, state, false) {
+            Err(OwnedValue::String(s)) => assert_eq!(s, "untouched"),
+            other => panic!("expected Err(original state) unchanged, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_2157_fold_accumulator_by_value_move_matches_general_evaluator() {
+        // #2157: `try_reduce_step_alternatives`/`try_foreach_step_alternatives`
+        // now move `state` by value into `arith_combine` via
+        // `try_owned_accumulator_step` instead of cloning through
+        // `eval_owned_fast_path`. Every case here is confirmed live against
+        // jq 1.7.1 to still agree byte-for-byte -- this is the same
+        // input/output contract #2086/#2152's own tests already pin, run
+        // again through the by-value call site specifically so a future
+        // change to the ownership plumbing (not just the arithmetic
+        // semantics) is caught here too.
+        assert_eq!(
+            outputs(b"null", r#"reduce range(500) as $x (""; . + "x") | length"#),
+            ["500"]
+        );
+        assert_eq!(
+            outputs(
+                b"null",
+                r"foreach range(500) as $x (0; . + $x) | select(. == 124750)"
+            ),
+            ["124750"]
+        );
+        assert_eq!(
+            outputs(b"null", r"reduce range(500) as $x ([]; . + [$x]) | length"),
+            ["500"]
+        );
+        assert_eq!(
+            outputs(
+                b"null",
+                r"reduce (range(500) | tostring) as $x ({}; . + {($x): true}) | length"
+            ),
+            ["500"]
+        );
+    }
+
+    #[test]
+    fn test_2157_fold_retry_alternative_resumes_from_failed_attempts_output_not_original_state() {
+        // #2157 review: the by-value move must not disturb
+        // `try_reduce_step_alternatives`'s own documented `?//` retry
+        // contract (see that function's doc comment) -- a failed
+        // alternative's own zero-output state (`null`, not the pre-attempt
+        // accumulator) is what the next alternative resumes from, even
+        // though the failing attempt's UPDATE body is exactly the
+        // `. + <literal>`-shaped arm this issue's fast path now answers.
+        // Per that doc comment's own worked example: element 1 (`{"a":1}`)
+        // errors on alt1 (state resets to `null`), alt2 then computes
+        // `null+null+1` = `1` (jq's `null + n` = `n`), not `100+null+1` =
+        // `101` -- so element 2 (`{"a":2}`) continues from `1`, giving
+        // `1+2+null` (alt1 matches; `$y` null-filled) = `3`. `reduce` only
+        // ever emits this single final accumulator, not the intermediate
+        // per-element values the doc comment describes -- confirmed live
+        // against jq 1.7.1: `3`.
+        assert_eq!(
+            outputs(
+                b"[{\"a\":1},{\"a\":2}]",
+                r#"reduce .[] as {a:$x} ?// {a:$y} (100; if $x==1 then error("boom") else .+$x+$y end)"#
+            ),
+            ["3"]
         );
     }
 

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -68698,8 +68698,34 @@ mod tests {
         let state = OwnedValue::String("untouched".to_string());
         match try_owned_accumulator_step::<JqSemantics>(&Expr::Identity, state, false) {
             Err(OwnedValue::String(s)) => assert_eq!(s, "untouched"),
-            other => panic!("expected Err(original state) unchanged, got {other:?}"),
+            // `Expr::Identity` never matches `owned_arith_accumulator_shape`'s
+            // `Arithmetic` pattern, so `Err(state)` unchanged is the only
+            // possible outcome here.
+            other => unreachable!("Expr::Identity never matches the Arithmetic shape: {other:?}"), // omni-dev: coverage tolerate-line reason="Expr::Identity never matches owned_arith_accumulator_shape (#2157)"
         }
+    }
+
+    #[test]
+    fn test_2157_try_owned_accumulator_step_suppresses_error_when_optional() {
+        // `try_owned_accumulator_step`'s `Err(_) if optional` arm mirrors
+        // `eval_owned_fast_path`'s own identical convention for this same
+        // `. + <literal>` shape (#2086) -- exercised directly here since no
+        // ordinary jq syntax reaches it *through* `reduce`/`foreach`'s own
+        // callers: `Expr::Try`/`Expr::Optional` never force `optional =
+        // true` into the expression they wrap (#693 -- see the `scalar_noop`
+        // binding's doc comment in `update_path` for the established
+        // precedent), so `(reduce ...)?` catches a per-step error via its
+        // own outer `eval_try`, not by setting this flag. Unit-level-only
+        // coverage, not jq-oracle-verifiable through any surface syntax.
+        let expr = Expr::Arithmetic {
+            op: ArithOp::Add,
+            left: Box::new(Expr::Identity),
+            right: Box::new(Expr::Literal(Literal::String("a".to_string()))),
+        };
+        let (vals, control) =
+            try_owned_accumulator_step::<JqSemantics>(&expr, OwnedValue::Int(1), true).unwrap();
+        assert!(vals.is_empty());
+        assert!(control.is_none());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- `try_reduce_step_alternatives`'s own fold-loop `state: OwnedValue` is confirmed fully unaliased at the one call site that matters (unconditionally overwritten immediately after, no live borrow of the old value survives) — a new `fold_step_via_accumulator_or_fork` moves it *by value* straight into `arith_combine` instead of cloning through `eval_owned_fast_path`'s `&OwnedValue`-bound arm, letting `arith_add`'s existing in-place `push_str`/`extend`/object-merge reuse the accumulator's own spare capacity instead of paying for a fresh exact-capacity clone every step.
- Measured (`reduce range(N) as $x (""; . + "x") | length`, wall-clock, output identical pre/post-fix at every N): N=6,250 → 6ms, 12,500 → 7ms, 25,000 → 10ms, 50,000 → 16ms, 99,999 → 29ms (was 6/9/18/38/135ms) — growth is now close to linear instead of the prior ~2x-per-doubling (O(n²)) signature.
- **Bonus, outside #2157's own stated scope**: since the new helper reuses #2152's own `literal_shaped_expr_to_owned`, the array/object-accumulator idioms it already covers get the same by-value treatment for free — `reduce range(25000) as $x ([]; . + [$x]) | length` dropped from ~1.25s to ~0.013s (~96x).
- **`foreach` shares the same call, but does not reach the same O(n) result** — every `foreach` step also reads `state` for EXTRACT/output-emit before the next step can consume it, a second, structurally unavoidable read a by-value move alone can't eliminate. It still gets a real, modest (~7%, measured) improvement from removing one of two redundant clones. This is called out explicitly in the code/docs to avoid overclaiming.
- Updated `docs/compliance/jq/limitations.md` and `CHANGELOG.md` to reflect the fix precisely for both `reduce` and `foreach`.

Fixes #2157

## Review history

An internal 8-agent code review caught two real issues in the first version of this PR, both now fixed:

1. **Critical: the `foreach` fix was a no-op.** The first version reordered `try_foreach_step_alternatives` but still cloned `state` from `update_vals.last().cloned()` at a point where it had to, defeating the by-value move entirely (confirmed via interleaved A/B: zero measurable difference from `main`). Fixed by deferring the `state` extraction until after the EXTRACT loop's own borrow of `update_vals` is no longer needed, using `into_iter().last()` (a move) instead — landing a real, if modest, ~7% win. Documentation was corrected to stop claiming `foreach` reaches the same O(n) result as `reduce`.
2. **Duplication**, independently flagged by three separate review passes: the try/fallback dispatch glue was byte-identical across both fold loops, and the `Result<_, OwnedValue>` "give it back on shape mismatch" convention was flagged as confusing (easy to misread `Err` as failure rather than "shape didn't match"). Collapsed into one shared `fold_step_via_accumulator_or_fork` that checks the shape *before* touching `state` at all, removing the need for the `Result`-as-signal convention entirely.

Also fixed: a non-fixed-width markdown table (STYLE-0009), and added a `foreach`-with-growing-accumulator regression test (the original only exercised a free-to-clone `Int` accumulator, which couldn't have caught the clone regression above).

A larger idea surfaced during review — generalizing `eval_owned_fast_path`'s `&OwnedValue` signature to `Cow<'_, OwnedValue>` so any owned caller (not just `reduce`/`foreach`'s fold loops) could benefit — is out of scope for this issue and not implemented here.

## Test plan

- [x] `cargo build --features cli` — clean
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings` — clean
- [x] `cargo test --features cli,simd,regex,serde` — full suite, 0 failed, run repeatedly through each fix iteration
- [x] 7 unit tests: shape-recognition, shape-mismatch fallback, optional-suppression, output-identity vs. general evaluator (string/foreach-int/array/object, plus new foreach-string/foreach-array growing-accumulator cases), and a `?//`-retry-semantics regression — all confirmed live against jq 1.7.1 where oracle-reachable
- [x] Interleaved A/B scaling-curve benchmarks (baseline vs. fix) for both `reduce` (near-linear) and `foreach` (modest, non-asymptotic, ~7%) — output identity gated
- [x] `cargo llvm-cov` + `omni-dev coverage diff` — **100% patch coverage** (92/92 new lines)
- [x] Rebased onto latest `origin/main`
