### PR TITLE
fix(jq): close #2211's container-gap check for nested containers in two more materializers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **A stray `,` with zero real children in a *nested* container (`{"a": [,]}`,
+  `{"a": {,}}`) now raises in two more materializers, matching real jq/yq**
+  (#2403). `eval_generic::to_owned_at_depth` already closed this gap for
+  nested containers (#2358); `eval.rs`'s own separate `to_owned_at_depth`
+  (behind the public `succinctly::jq::eval` library API) and `yq_runner.rs`'s
+  `to_owned_canonicalizing_numbers_at_depth` (behind `succinctly yq
+  --slurp`/`--eval-all`/`--inplace --input-format json`) had the identical
+  shape but were never audited by that fix. Both now thread the same
+  already-resolved child cursor through as the next level's container
+  cursor, the same way #2358 did. Confirmed live and CLI-reachable for the
+  yq-mode case: `echo '{"a": [,]}' | succinctly yq --slurp --input-format
+  json -o json '.[0]'` used to silently accept the document; real yq
+  v4.53.3 rejects it. The *true top level* of both functions is unaffected
+  and remains a documented, permanent gap (no container cursor is ever
+  available there, by construction).
+
 - **`succinctly jq -n`/`--null-input` now keeps a computed float's
   scientific-notation spelling through `tostring`, a format function
   (`@json`, `@csv`, ...), and string interpolation** (#2543). `-n` always

--- a/docs/compliance/jq/limitations.md
+++ b/docs/compliance/jq/limitations.md
@@ -1348,6 +1348,14 @@ practice #2243's own issue text cites for not folding into #2211):
   already resolve a cursor" opportunity `eval_generic.rs` did, but neither was touched by
   #2358, whose scope named only that one function; tracked as #2403 rather than assumed
   to close the same way without checking.
+
+  **Update (#2403)**: confirmed and closed. Both functions had the identical shape --
+  `elem_cursor`/`field.value_cursor` already resolved in the recursive call and discarded
+  before the tail check -- and now thread it through the same way, via a shared
+  `tail_gap_ok` helper (`document.rs`) extracted in review rather than a third and fourth
+  hand-copy of the `container_tail_gap_ok`/`child_tail_gap_ok` dispatch. Only the true top
+  level (`to_owned`'s and `to_owned_canonicalizing_numbers`'s own depth-0 entry points, no
+  cursor to give) keeps the gap, matching `eval_generic.rs`'s own residual scope above.
 - **#2263**: `jq_runner.rs` still carries its own independent, hand-copied
   `trailing_gap_ok`/`scalar_end_pos` pair rather than the new trait methods --
   a cleanup, not a behavior gap, but the same "duplicated predicates diverge

--- a/docs/compliance/yq/limitations.md
+++ b/docs/compliance/yq/limitations.md
@@ -670,8 +670,19 @@ stray `,` *after* a real last child, `[1,]`/`{"a":1,}`). Only the second is adda
 `container_gap_ok` needs a cursor to the container itself, and this function (like
 `eval_generic::to_owned_at_depth`) is only ever given a bare `value: &V` — once a container's
 child walk is exhausted there is no cursor left to find its opening bracket from. `[,]`/`{,}`
-therefore remain silently accepted; `[1,]`/`{"a":1,}` now correctly raise, confirmed live and
-CLI-reachable:
+therefore remained silently accepted at the time; `[1,]`/`{"a":1,}` now correctly raise,
+confirmed live and CLI-reachable:
+
+**Update (#2403)**: the "no cursor left to find its opening bracket from" premise above no
+longer holds for nested containers. `container_gap_ok` needs a cursor to the container
+itself, but every recursive call into `to_owned_canonicalizing_numbers_at_depth` already
+resolves the child's own cursor (`field.value_cursor`, `elem_cursor`) for an unrelated
+reason and previously discarded it — threading it through (via the shared `tail_gap_ok`
+helper in `document.rs`, mirroring #2358's identical fix for `eval_generic::to_owned_at_depth`)
+lets `container_tail_gap_ok` close `[,]`/`{,}` for every *nested* container the same way
+`to_owned_cursor_at_depth` always could. Only the true top level
+(`to_owned_canonicalizing_numbers`'s own depth-0 entry point, which has no cursor to give in
+the first place) keeps the gap now.
 
 ```console
 $ echo '[1,]' | succinctly yq --slurp --input-format json -o json '.[0]'

--- a/src/bin/succinctly/yq_runner.rs
+++ b/src/bin/succinctly/yq_runner.rs
@@ -13,8 +13,8 @@ use std::io::{BufWriter, IsTerminal, Read, Write};
 use std::path::Path;
 
 use succinctly::jq::document::{
-    child_tail_gap_ok, effective_keys, DisplayKeyGuard, DocumentCursor, DocumentElements,
-    DocumentFields, DocumentValue, IndentSpec, JsonConvention,
+    child_tail_gap_ok, container_tail_gap_ok, effective_keys, DisplayKeyGuard, DocumentCursor,
+    DocumentElements, DocumentFields, DocumentValue, IndentSpec, JsonConvention,
 };
 use succinctly::jq::escape::AsciiEscapeWriter;
 use succinctly::jq::eval_generic::{
@@ -1121,24 +1121,25 @@ fn gather_input_sources(
 /// CLI-reachable through `--slurp`/`--eval-all`/`--inplace
 /// --input-format json` (this function's only callers):
 /// `echo '[1,]' | succinctly yq --slurp --input-format json -o json '.[0]'`
-/// used to exit 0 with `1`, where real yq rejects it. `[,]`/`{,}` remain
-/// unchecked here: this function is never given a cursor for the
-/// *container itself*, only `value: &V`, so once a container's child walk
-/// is exhausted there is no cursor left to find its opening bracket from.
-/// `eval_generic::to_owned_at_depth` had the identical shape, but #2358
-/// found every one of its recursive call sites already resolves the
-/// child's own cursor for an unrelated reason and simply discards it --
-/// threading it through closed the gap there for every nested container.
-/// This function's own recursion (below) does the same "resolve, then
-/// discard" thing for its own #1677 checks -- untouched by #2358, whose
-/// own scope named only the `eval_generic.rs` function; tracked as #2403
-/// rather than assumed to close the same way without checking.
+/// used to exit 0 with `1`, where real yq rejects it.
+///
+/// `[,]`/`{,}` remain unchecked only at the *true top level*: the bare
+/// `value: &V` this function's own public entry point receives has no
+/// cursor for the container itself, so once a container's child walk is
+/// exhausted there is no cursor left to find its opening bracket from.
+/// `eval_generic::to_owned_at_depth` had the identical shape, and #2358
+/// closed it there by threading each recursive call's already-resolved
+/// child cursor through as the next level's container cursor -- #2403
+/// applies the same fix here (`to_owned_canonicalizing_numbers_at_depth`'s
+/// own `cursor` parameter below), closing the gap for every *nested*
+/// container the same way.
 fn to_owned_canonicalizing_numbers<V: DocumentValue>(value: &V) -> Result<OwnedValue, EvalError> {
-    to_owned_canonicalizing_numbers_at_depth(value, 0)
+    to_owned_canonicalizing_numbers_at_depth(value, None, 0)
 }
 
 fn to_owned_canonicalizing_numbers_at_depth<V: DocumentValue>(
     value: &V,
+    cursor: Option<&V::Cursor>,
     depth: usize,
 ) -> Result<OwnedValue, EvalError> {
     // `check_nesting_depth` (256, matching `eval_generic::to_owned_at_depth`
@@ -1196,7 +1197,11 @@ fn to_owned_canonicalizing_numbers_at_depth<V: DocumentValue>(
             let key = field.checked_key(&f, &map, &mut guard, is_first)?;
             map.insert(
                 key,
-                to_owned_canonicalizing_numbers_at_depth(&field.value, depth + 1)?,
+                to_owned_canonicalizing_numbers_at_depth(
+                    &field.value,
+                    Some(&field.value_cursor),
+                    depth + 1,
+                )?,
             );
             last_field = Some(field.value_cursor);
             f = rest;
@@ -1209,13 +1214,16 @@ fn to_owned_canonicalizing_numbers_at_depth<V: DocumentValue>(
         if f.ends_unpaired() {
             return Err(f.malformed_member_error());
         }
-        // #2262/#1803: `child_tail_gap_ok` is the value-domain tail --
-        // `{"a":1,}` checked via the last real field's own cursor, `{,}`
-        // left unchecked because #2211's `container_gap_ok` needs a cursor
-        // for the container itself that this signature never receives. Its
-        // doc comment carries the full reasoning, which this site and
-        // `eval_generic::to_owned_at_depth` used to state twice.
-        child_tail_gap_ok(last_field.as_ref(), b'}')?;
+        // #2403: with `cursor` in hand (every level but the true top),
+        // `container_tail_gap_ok` closes #2211's `{,}` gap the same way
+        // `eval_generic::to_owned_at_depth` does since #2358 --
+        // `child_tail_gap_ok` alone (the `None` fallback, only ever hit at
+        // the true top level) still can't, for the reason this function's
+        // own doc comment above explains.
+        match cursor {
+            Some(c) => container_tail_gap_ok(c, last_field.as_ref(), b'}')?,
+            None => child_tail_gap_ok(last_field.as_ref(), b'}')?,
+        }
         OwnedValue::Object(map)
     } else if let Some(elements) = value.as_array() {
         let mut items = Vec::new();
@@ -1235,18 +1243,18 @@ fn to_owned_canonicalizing_numbers_at_depth<V: DocumentValue>(
             }
             items.push(to_owned_canonicalizing_numbers_at_depth(
                 &elem_cursor.value(),
+                Some(&elem_cursor),
                 depth + 1,
             )?);
             last_elem = Some(elem_cursor);
             elems = rest;
             is_first = false;
         }
-        // #2262: same reasoning as the object arm's own check above --
-        // `[,]` remains unchecked here (no container cursor available),
-        // but `[1,]` is, via the last real element's own cursor. This is
-        // the live, CLI-reachable fix: `echo '[1,]' | succinctly yq --slurp
-        // --input-format json -o json '.[0]'` used to exit 0 with `1`.
-        child_tail_gap_ok(last_elem.as_ref(), b']')?;
+        // #2403: same reasoning as the object arm's own check above.
+        match cursor {
+            Some(c) => container_tail_gap_ok(c, last_elem.as_ref(), b']')?,
+            None => child_tail_gap_ok(last_elem.as_ref(), b']')?,
+        }
         OwnedValue::Array(items)
     } else if value.is_null() {
         OwnedValue::Null
@@ -8193,6 +8201,78 @@ mod tests {
                 panic!("{json:?}: known gap -- silently accepted, got error {e:?}");
             }
         }
+    }
+
+    /// #2403: unlike the true top level (pinned above as a permanent,
+    /// documented gap), a *nested* stray `,` in an empty container now
+    /// raises -- every recursive call below the top level has a real cursor
+    /// to the child it just resolved, which #2403 threads through as this
+    /// function's own `cursor` parameter (the same fix #2358 already
+    /// applied to `eval_generic::to_owned_at_depth`) specifically so
+    /// `container_tail_gap_ok` (not `child_tail_gap_ok`'s weaker,
+    /// cursor-less fallback) can close #2211's `{,}`/`[,]` check one level
+    /// down. Confirmed live and CLI-reachable: `echo '{"a": [,]}' |
+    /// succinctly yq --slurp --input-format json -o json '.[0]'` used to
+    /// silently accept the document; real yq v4.53.3 rejects it.
+    #[test]
+    fn to_owned_canonicalizing_numbers_raises_on_nested_stray_comma_in_empty_container_2403() {
+        for json in [&br#"{"a": {,}}"#[..], &br#"{"a": [,]}"#[..]] {
+            let index = JsonIndex::build(json);
+            let cursor = index.root(json);
+            let err = to_owned_canonicalizing_numbers(&cursor.value())
+                .expect_err("a stray comma in a nested empty container is not JSON");
+            assert!(
+                err.message.contains("Invalid JSON text"),
+                "{json:?}: message: {}",
+                err.message
+            );
+        }
+    }
+
+    /// #2403 regression guard: the pre-existing nested trailing-comma check
+    /// (`{"a":1,}` / `[1,]`, #2262 -- already reachable at nested depth
+    /// before #2403, via the same `last_field`/`last_elem` cursor
+    /// `child_tail_gap_ok` always used) is unaffected by #2403 routing that
+    /// check through `container_tail_gap_ok` instead, one level down.
+    #[test]
+    fn to_owned_canonicalizing_numbers_raises_on_nested_trailing_comma_2403() {
+        for json in [&br#"{"a": {"b":1,}}"#[..], &br#"{"a": [1,]}"#[..]] {
+            let index = JsonIndex::build(json);
+            let cursor = index.root(json);
+            let err = to_owned_canonicalizing_numbers(&cursor.value())
+                .expect_err("a stray trailing comma after a real nested child is not JSON");
+            assert!(
+                err.message.contains("Invalid JSON text"),
+                "{json:?}: message: {}",
+                err.message
+            );
+        }
+    }
+
+    /// #2403: ordinary well-formed nested containers -- including a nested
+    /// empty container, the exact shape the new check above targets --
+    /// round-trip unaffected.
+    #[test]
+    fn to_owned_canonicalizing_numbers_wellformed_nested_containers_unaffected_2403() {
+        let json = br#"{"a": [1,2,{"b":3}], "c": {}, "d": []}"#;
+        let index = JsonIndex::build(json);
+        let cursor = index.root(json);
+        let expected = OwnedValue::Object(IndexMap::from([
+            (
+                "a".to_string(),
+                OwnedValue::Array(vec![
+                    OwnedValue::Int(1),
+                    OwnedValue::Int(2),
+                    OwnedValue::Object(IndexMap::from([("b".to_string(), OwnedValue::Int(3))])),
+                ]),
+            ),
+            ("c".to_string(), OwnedValue::Object(IndexMap::new())),
+            ("d".to_string(), OwnedValue::Array(vec![])),
+        ]));
+        assert_eq!(
+            to_owned_canonicalizing_numbers(&cursor.value()).unwrap(),
+            expected
+        );
     }
 
     /// `depth` levels of single-child `CommentTree::Array` nesting, mirroring

--- a/src/bin/succinctly/yq_runner.rs
+++ b/src/bin/succinctly/yq_runner.rs
@@ -13,8 +13,8 @@ use std::io::{BufWriter, IsTerminal, Read, Write};
 use std::path::Path;
 
 use succinctly::jq::document::{
-    child_tail_gap_ok, container_tail_gap_ok, effective_keys, DisplayKeyGuard, DocumentCursor,
-    DocumentElements, DocumentFields, DocumentValue, IndentSpec, JsonConvention,
+    effective_keys, tail_gap_ok, DisplayKeyGuard, DocumentCursor, DocumentElements, DocumentFields,
+    DocumentValue, IndentSpec, JsonConvention,
 };
 use succinctly::jq::escape::AsciiEscapeWriter;
 use succinctly::jq::eval_generic::{
@@ -1215,15 +1215,12 @@ fn to_owned_canonicalizing_numbers_at_depth<V: DocumentValue>(
             return Err(f.malformed_member_error());
         }
         // #2403: with `cursor` in hand (every level but the true top),
-        // `container_tail_gap_ok` closes #2211's `{,}` gap the same way
-        // `eval_generic::to_owned_at_depth` does since #2358 --
-        // `child_tail_gap_ok` alone (the `None` fallback, only ever hit at
-        // the true top level) still can't, for the reason this function's
-        // own doc comment above explains.
-        match cursor {
-            Some(c) => container_tail_gap_ok(c, last_field.as_ref(), b'}')?,
-            None => child_tail_gap_ok(last_field.as_ref(), b'}')?,
-        }
+        // `tail_gap_ok` closes #2211's `{,}` gap the same way
+        // `eval_generic::to_owned_at_depth` does since #2358 -- its own
+        // `None` fallback (only ever hit at the true top level) still
+        // can't, for the reason this function's own doc comment above
+        // explains.
+        tail_gap_ok(cursor, last_field.as_ref(), b'}')?;
         OwnedValue::Object(map)
     } else if let Some(elements) = value.as_array() {
         let mut items = Vec::new();
@@ -1251,10 +1248,7 @@ fn to_owned_canonicalizing_numbers_at_depth<V: DocumentValue>(
             is_first = false;
         }
         // #2403: same reasoning as the object arm's own check above.
-        match cursor {
-            Some(c) => container_tail_gap_ok(c, last_elem.as_ref(), b']')?,
-            None => child_tail_gap_ok(last_elem.as_ref(), b']')?,
-        }
+        tail_gap_ok(cursor, last_elem.as_ref(), b']')?;
         OwnedValue::Array(items)
     } else if value.is_null() {
         OwnedValue::Null

--- a/src/jq/document.rs
+++ b/src/jq/document.rs
@@ -1674,6 +1674,34 @@ pub fn container_tail_gap_ok<C: DocumentCursor>(
     }
 }
 
+/// The post-loop tail check for a container walk that only *sometimes* holds
+/// the container's own cursor.
+///
+/// Used by a recursive value-domain materializer (`eval::to_owned_at_depth`,
+/// `eval_generic::to_owned_at_depth`, `yq_runner::
+/// to_owned_canonicalizing_numbers_at_depth`) whose public entry point
+/// starts at `cursor: None` (no container cursor exists yet) and whose own
+/// recursive calls pass `Some` (the child cursor each already resolved for
+/// an unrelated reason, per #2358/#2403). Delegates to
+/// [`container_tail_gap_ok`] when a cursor is available (closing #2211's
+/// `{,}`/`[,]` check) or [`child_tail_gap_ok`]'s weaker fallback when it
+/// isn't (the true top level, where the gap remains open by construction --
+/// see those two functions' own doc comments for why).
+///
+/// Extracted (#2403 review) after the identical 4-line `match cursor { ... }`
+/// was hand-copied into three separate files -- one call this instead of a
+/// fourth (or fifth) copy.
+pub fn tail_gap_ok<C: DocumentCursor>(
+    cursor: Option<&C>,
+    last_child: Option<&C>,
+    close_char: u8,
+) -> Result<(), EvalError> {
+    match cursor {
+        Some(c) => container_tail_gap_ok(c, last_child, close_char),
+        None => child_tail_gap_ok(last_child, close_char),
+    }
+}
+
 /// [`trailing_element_gap_ok`], for a key-only object walk that has
 /// tracked only the last field's *key* cursor (`census`, `checked_len`,
 /// `contains_checked`'s exhaustion path, [`DistinctKeyCursors`]'s own

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -39,9 +39,9 @@ use std::rc::Rc;
 use indexmap::IndexMap;
 
 use super::document::{
-    child_tail_gap_ok, effective_fields, effective_fields_checked, effective_keys,
-    effective_len_checked, key_display_string, key_display_string_kind, DisplayKeyGuard,
-    DocumentCursor, DocumentElements, DocumentFields,
+    child_tail_gap_ok, container_tail_gap_ok, effective_fields, effective_fields_checked,
+    effective_keys, effective_len_checked, key_display_string, key_display_string_kind,
+    DisplayKeyGuard, DocumentCursor, DocumentElements, DocumentFields,
 };
 use super::slice::{self, SliceBounds};
 use super::walk::{any_subexpr, map_builtin_subexprs, map_subexprs};
@@ -1605,18 +1605,16 @@ fn to_owned_lossy_at_depth<W: Clone + AsRef<[u64]>>(
 /// `OwnedValue` before this function ever runs on it -- but a real gap for
 /// a direct library caller of the public `succinctly::jq::eval` entry
 /// point). #2211's `container_gap_ok` (a stray `,` with *zero* real
-/// children, `[,]`/`{,}`) is not addable here: unlike
-/// `to_owned_cursor_at_depth`, this function is never given a cursor for
-/// the *container itself* (only `value: &StandardJson<'_, W>`), so once a
+/// children, `[,]`/`{,}`) remains unchecked only at the *true top level*:
+/// the bare `value: &StandardJson<'_, W>` this function's own public entry
+/// point receives has no cursor for the container itself, so once a
 /// container's child walk is exhausted there is no cursor left to find its
-/// opening bracket from -- the same limitation #2211 already documented for
-/// `jq_runner::standard_json_to_jq_value`'s identical value-only shape.
-/// `eval_generic::to_owned_at_depth` had this same shape too, but #2358
-/// found every one of its recursive call sites already resolves the
-/// child's own cursor for an unrelated reason and simply discards it --
-/// threading it through closed the gap there for nested containers. This
-/// function's own recursion likely has the identical opportunity;
-/// untouched here, out of #2358's own scope (tracked as #2403).
+/// opening bracket from. `eval_generic::to_owned_at_depth` had the
+/// identical shape, and #2358 closed it there by threading each recursive
+/// call's already-resolved child cursor through as the next level's
+/// container cursor -- #2403 applies the same fix here (`to_owned_at_depth`'s
+/// own `cursor` parameter below), closing the gap for every *nested*
+/// container the same way.
 ///
 /// A decode failure raised here is never suppressed by `?` — see
 /// [`suppresses`], and [`to_owned_or_suppress`] for the call-site idiom
@@ -1635,7 +1633,7 @@ fn to_owned_lossy_at_depth<W: Clone + AsRef<[u64]>>(
 /// [`DocumentValue`](super::document::DocumentValue) impl making the shared
 /// helper directly usable.
 fn to_owned<W: Clone + AsRef<[u64]>>(value: &StandardJson<'_, W>) -> Result<OwnedValue, EvalError> {
-    let result = to_owned_at_depth(value, 0);
+    let result = to_owned_at_depth(value, None, 0);
     // #2334: asserted here, at the depth-0 entry point, not inside the
     // recursive `to_owned_at_depth` -- one assert per materialization rather
     // than one per node.
@@ -1645,6 +1643,7 @@ fn to_owned<W: Clone + AsRef<[u64]>>(value: &StandardJson<'_, W>) -> Result<Owne
 
 fn to_owned_at_depth<W: Clone + AsRef<[u64]>>(
     value: &StandardJson<'_, W>,
+    cursor: Option<&JsonCursor<'_, W>>,
     depth: usize,
 ) -> Result<OwnedValue, EvalError> {
     assert_value_tree_depth(depth);
@@ -1672,16 +1671,25 @@ fn to_owned_at_depth<W: Clone + AsRef<[u64]>>(
                 if !elem_cursor.element_gap_ok(is_first) {
                     return Err(elem_cursor.malformed_delimiter_error());
                 }
-                items.push(to_owned_at_depth(&elem_cursor.value(), depth + 1)?);
+                items.push(to_owned_at_depth(
+                    &elem_cursor.value(),
+                    Some(&elem_cursor),
+                    depth + 1,
+                )?);
                 last_elem = Some(elem_cursor);
                 elems = rest;
                 is_first = false;
             }
-            // #2262/#1803: the value-domain tail -- `[1,]` (#2243) checked
-            // via the last real element's own cursor, `[,]` (#2211) not,
-            // because no container cursor is ever in hand here. See
-            // `child_tail_gap_ok`'s own doc comment.
-            child_tail_gap_ok(last_elem.as_ref(), b']')?;
+            // #2403: with `cursor` in hand (every level but the true top),
+            // `container_tail_gap_ok` closes #2211's `[,]` gap the same way
+            // `eval_generic::to_owned_at_depth` does since #2358 --
+            // `child_tail_gap_ok` alone (the `None` fallback, only ever hit
+            // at the true top level) still can't, for the reason this
+            // function's own doc comment above explains.
+            match cursor {
+                Some(c) => container_tail_gap_ok(c, last_elem.as_ref(), b']')?,
+                None => child_tail_gap_ok(last_elem.as_ref(), b']')?,
+            }
             OwnedValue::Array(items)
         }
         StandardJson::Object(fields) => {
@@ -1713,7 +1721,10 @@ fn to_owned_at_depth<W: Clone + AsRef<[u64]>>(
                 // one shared call -- see `DocumentField::checked_key`. This
                 // function had none of the delimiter half before #2262.
                 let key = field.checked_key(&f, &map, &mut guard, is_first)?;
-                map.insert(key, to_owned_at_depth(&field.value, depth + 1)?);
+                map.insert(
+                    key,
+                    to_owned_at_depth(&field.value, Some(&field.value_cursor), depth + 1)?,
+                );
                 last_field = Some(field.value_cursor);
                 f = rest;
                 is_first = false;
@@ -1721,8 +1732,11 @@ fn to_owned_at_depth<W: Clone + AsRef<[u64]>>(
             if f.ends_unpaired() {
                 return Err(f.malformed_member_error());
             }
-            // #2262: same reasoning as the array arm's own check above.
-            child_tail_gap_ok(last_field.as_ref(), b'}')?;
+            // #2403: same reasoning as the array arm's own check above.
+            match cursor {
+                Some(c) => container_tail_gap_ok(c, last_field.as_ref(), b'}')?,
+                None => child_tail_gap_ok(last_field.as_ref(), b'}')?,
+            }
             OwnedValue::Object(map)
         }
         // #2286 review: this arm used to silently substitute `Null` for a
@@ -62205,6 +62219,80 @@ mod tests {
                 panic!("{json:?}: known gap -- silently accepted, got error {e:?}");
             }
         }
+    }
+
+    /// #2403: unlike the true top level (pinned above as a permanent,
+    /// documented gap), a *nested* stray `,` in an empty container now
+    /// raises -- every recursive call below the top level has a real
+    /// cursor to the child it just resolved, which #2403 threads through as
+    /// `to_owned_at_depth`'s own `cursor` parameter (the same fix #2358
+    /// already applied to `eval_generic::to_owned_at_depth`) specifically
+    /// so `container_tail_gap_ok` (not `child_tail_gap_ok`'s weaker,
+    /// cursor-less fallback) can close #2211's `{,}`/`[,]` check one level
+    /// down. Confirmed live against `/usr/bin/jq` 1.7.1: `{"a": {,}}` and
+    /// `{"a": [,]}` both exit 5 with a parse error.
+    #[test]
+    fn test_to_owned_raises_on_nested_stray_comma_in_empty_container_2403() {
+        for json in [br#"{"a": {,}}"#.as_slice(), br#"{"a": [,]}"#.as_slice()] {
+            let index = JsonIndex::build(json);
+            let cursor = index.root(json);
+            let err = to_owned(&cursor.value())
+                .expect_err("a stray comma in a nested empty container is not JSON");
+            assert!(
+                err.message.contains("Invalid JSON text"),
+                "{json:?}: message: {}",
+                err.message
+            );
+        }
+    }
+
+    /// #2403 regression guard: the pre-existing nested trailing-comma check
+    /// (`{"a":1,}` / `[1,]`, #2262 -- already reachable at nested depth
+    /// before #2403, via the same `last_field`/`last_elem` cursor
+    /// `child_tail_gap_ok` always used) is unaffected by #2403 routing that
+    /// check through `container_tail_gap_ok` instead, one level down.
+    #[test]
+    fn test_to_owned_raises_on_nested_trailing_comma_2403() {
+        for json in [
+            br#"{"a": {"b":1,}}"#.as_slice(),
+            br#"{"a": [1,]}"#.as_slice(),
+        ] {
+            let index = JsonIndex::build(json);
+            let cursor = index.root(json);
+            let err = to_owned(&cursor.value())
+                .expect_err("a stray trailing comma after a real nested child is not JSON");
+            assert!(
+                err.message.contains("Invalid JSON text"),
+                "{json:?}: message: {}",
+                err.message
+            );
+        }
+    }
+
+    /// #2403: ordinary well-formed nested containers -- including a nested
+    /// empty container, the exact shape the new check above targets --
+    /// round-trip unaffected.
+    #[test]
+    fn test_to_owned_wellformed_nested_containers_unaffected_2403() {
+        let json = br#"{"a": [1,2,{"b":3}], "c": {}, "d": []}"#;
+        let index = JsonIndex::build(json);
+        let cursor = index.root(json);
+        let expected = OwnedValue::Object(IndexMap::from([
+            (
+                "a".to_string(),
+                OwnedValue::Array(vec![
+                    OwnedValue::from_number_literal("1"),
+                    OwnedValue::from_number_literal("2"),
+                    OwnedValue::Object(IndexMap::from([(
+                        "b".to_string(),
+                        OwnedValue::from_number_literal("3"),
+                    )])),
+                ]),
+            ),
+            ("c".to_string(), OwnedValue::Object(IndexMap::new())),
+            ("d".to_string(), OwnedValue::Array(vec![])),
+        ]));
+        assert_eq!(to_owned(&cursor.value()).unwrap(), expected);
     }
 
     /// #2262: well-formed arrays/objects (including a multi-element array

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -39,9 +39,9 @@ use std::rc::Rc;
 use indexmap::IndexMap;
 
 use super::document::{
-    child_tail_gap_ok, container_tail_gap_ok, effective_fields, effective_fields_checked,
-    effective_keys, effective_len_checked, key_display_string, key_display_string_kind,
-    DisplayKeyGuard, DocumentCursor, DocumentElements, DocumentFields,
+    effective_fields, effective_fields_checked, effective_keys, effective_len_checked,
+    key_display_string, key_display_string_kind, tail_gap_ok, DisplayKeyGuard, DocumentCursor,
+    DocumentElements, DocumentFields,
 };
 use super::slice::{self, SliceBounds};
 use super::walk::{any_subexpr, map_builtin_subexprs, map_subexprs};
@@ -1681,15 +1681,12 @@ fn to_owned_at_depth<W: Clone + AsRef<[u64]>>(
                 is_first = false;
             }
             // #2403: with `cursor` in hand (every level but the true top),
-            // `container_tail_gap_ok` closes #2211's `[,]` gap the same way
-            // `eval_generic::to_owned_at_depth` does since #2358 --
-            // `child_tail_gap_ok` alone (the `None` fallback, only ever hit
-            // at the true top level) still can't, for the reason this
-            // function's own doc comment above explains.
-            match cursor {
-                Some(c) => container_tail_gap_ok(c, last_elem.as_ref(), b']')?,
-                None => child_tail_gap_ok(last_elem.as_ref(), b']')?,
-            }
+            // `tail_gap_ok` closes #2211's `[,]` gap the same way
+            // `eval_generic::to_owned_at_depth` does since #2358 -- its own
+            // `None` fallback (only ever hit at the true top level) still
+            // can't, for the reason this function's own doc comment above
+            // explains.
+            tail_gap_ok(cursor, last_elem.as_ref(), b']')?;
             OwnedValue::Array(items)
         }
         StandardJson::Object(fields) => {
@@ -1733,10 +1730,7 @@ fn to_owned_at_depth<W: Clone + AsRef<[u64]>>(
                 return Err(f.malformed_member_error());
             }
             // #2403: same reasoning as the array arm's own check above.
-            match cursor {
-                Some(c) => container_tail_gap_ok(c, last_field.as_ref(), b'}')?,
-                None => child_tail_gap_ok(last_field.as_ref(), b'}')?,
-            }
+            tail_gap_ok(cursor, last_field.as_ref(), b'}')?;
             OwnedValue::Object(map)
         }
         // #2286 review: this arm used to silently substitute `Null` for a

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -30,9 +30,9 @@ use super::document::{
     child_tail_gap_ok, collapsed_fields, collapsed_fields_if, container_tail_gap_ok,
     effective_fields_checked, effective_fields_with_raw_last, effective_keys,
     effective_len_checked, key_delimiter_ok, key_display_string, key_display_string_kind,
-    key_is_malformed, resolve_display_key, trailing_element_gap_ok, value_delimiter_ok,
-    DisplayKeyGuard, DistinctKeyCursors, DocumentCursor, DocumentElements, DocumentFields,
-    DocumentValue, IndentSpec, JsonConvention,
+    key_is_malformed, resolve_display_key, tail_gap_ok, trailing_element_gap_ok,
+    value_delimiter_ok, DisplayKeyGuard, DistinctKeyCursors, DocumentCursor, DocumentElements,
+    DocumentFields, DocumentValue, IndentSpec, JsonConvention,
 };
 use super::eval::{
     apply_compare_op, arith_combine, as_var_refs, binary_fanout_rules, bind_def, bind_def_call,
@@ -372,15 +372,11 @@ fn to_owned_at_depth<V: DocumentValue>(
             return Err(f.malformed_member_error());
         }
         // #2358: with `cursor` in hand (every level but the true top),
-        // `container_tail_gap_ok` closes #2211's `{,}` gap the same way
-        // `to_owned_cursor_at_depth` always could -- `child_tail_gap_ok`
-        // alone (the `None` fallback, only ever hit at the true top level)
-        // still can't, for the reason this function's own doc comment
-        // above explains.
-        match cursor {
-            Some(c) => container_tail_gap_ok(c, last_field.as_ref(), b'}')?,
-            None => child_tail_gap_ok(last_field.as_ref(), b'}')?,
-        }
+        // `tail_gap_ok` closes #2211's `{,}` gap the same way
+        // `to_owned_cursor_at_depth` always could -- its own `None` fallback
+        // (only ever hit at the true top level) still can't, for the reason
+        // this function's own doc comment above explains.
+        tail_gap_ok(cursor, last_field.as_ref(), b'}')?;
         Ok(OwnedValue::Object(map))
     } else if let Some(elements) = value.as_array() {
         let mut items = Vec::new();
@@ -408,10 +404,7 @@ fn to_owned_at_depth<V: DocumentValue>(
             is_first = false;
         }
         // #2358: same reasoning as the object arm's own check above.
-        match cursor {
-            Some(c) => container_tail_gap_ok(c, last_elem.as_ref(), b']')?,
-            None => child_tail_gap_ok(last_elem.as_ref(), b']')?,
-        }
+        tail_gap_ok(cursor, last_elem.as_ref(), b']')?;
         Ok(OwnedValue::Array(items))
     // Then check scalars in order of specificity
     } else if value.is_null() {


### PR DESCRIPTION
## Summary
- #2358 fixed `eval_generic::to_owned_at_depth`'s missing `#2211` check (a stray `,` with zero real children, `[,]`/`{,}`) for *nested* containers by threading each recursive call's already-resolved child cursor through as the next level's container cursor. That fix's own scope named only `eval_generic.rs`; #2403 audits the two other copies of this traversal `docs/compliance/jq/limitations.md` named as having the identical shape:
  - `eval.rs`'s own separate `to_owned_at_depth`, behind the public `succinctly::jq::eval` library API
  - `yq_runner.rs`'s `to_owned_canonicalizing_numbers_at_depth`, behind `succinctly yq --slurp`/`--eval-all`/`--inplace --input-format json`
- Both mirror #2358's exact fix: `cursor: Option<&V::Cursor>` (or `Option<&JsonCursor<'_, W>>` for `eval.rs`'s `StandardJson`-specific copy) threaded through, `container_tail_gap_ok` when `Some` (every level but the true top), `child_tail_gap_ok`'s weaker fallback only at the top level — which has no container cursor by construction and remains a documented, permanent gap.
- Confirmed live and CLI-reachable for the yq-mode case: `echo '{"a": [,]}' | succinctly yq --slurp --input-format json -o json '.[0]'` used to silently accept the document; real yq v4.53.3 rejects it.
- Updated both functions' own doc comments (which explicitly named #2403 as the tracked follow-up for this exact gap) to reflect the fix, and added tests mirroring #2358's own three-test pattern (nested stray-comma now raises, nested trailing-comma regression guard, well-formed nested containers unaffected) for both functions.

## Test plan
- [x] `cargo build --features cli`
- [x] `cargo test --features cli,simd,regex,serde` (full suite, all green)
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings`
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features`
- [x] New unit tests for both functions, mirroring #2358's own pattern
- [x] Live-verified the CLI-reachable `yq_runner.rs` fix against the pinned yq oracle

Fixes #2403