### PR TITLE
fix(jq): nested def's bare-vs-$-style parameter can now be told apart post-parse

### DIFF
--- a/src/bin/succinctly/jq_runner.rs
+++ b/src/bin/succinctly/jq_runner.rs
@@ -22,7 +22,7 @@ use succinctly::jq::eval_generic::{
 use succinctly::jq::walk::map_builtin_subexprs;
 use succinctly::jq::{
     self, format_number_jq_compat, jq_bare_float_display, nonfinite_display_string, Builtin,
-    EvalError, Expr, FuncDefBound, JqSemantics, JqValue, OwnedValue, Program, StreamStats,
+    EvalError, Expr, FuncDefBound, JqSemantics, JqValue, OwnedValue, Param, Program, StreamStats,
     UnresolvedCall, MAX_VALUE_TREE_DEPTH,
 };
 use succinctly::json::light::{preceding_gap_ok, JsonCursor, StandardJson};
@@ -52,9 +52,9 @@ pub struct ModuleLoader {
     /// Search path for modules (in order of priority)
     search_path: Vec<PathBuf>,
     /// Loaded modules (path -> function definitions: name, params, body)
-    loaded_modules: BTreeMap<String, Vec<(String, Vec<String>, Expr)>>,
+    loaded_modules: BTreeMap<String, Vec<(String, Vec<Param>, Expr)>>,
     /// Auto-loaded ~/.jq file definitions (if file exists): name, params, body
-    auto_loaded_defs: Vec<(String, Vec<String>, Expr)>,
+    auto_loaded_defs: Vec<(String, Vec<Param>, Expr)>,
 }
 
 impl ModuleLoader {
@@ -124,7 +124,7 @@ impl ModuleLoader {
     }
 
     /// Load a module and return its function definitions (name, params, body).
-    pub fn load_module(&mut self, module_path: &str) -> Result<Vec<(String, Vec<String>, Expr)>> {
+    pub fn load_module(&mut self, module_path: &str) -> Result<Vec<(String, Vec<Param>, Expr)>> {
         // Check if already loaded
         if let Some(defs) = self.loaded_modules.get(module_path) {
             return Ok(defs.clone());
@@ -485,10 +485,10 @@ fn rewrite_namespaced_calls(expr: Expr) -> Expr {
 }
 
 /// Extract function definitions from an expression, preserving parameters.
-fn extract_func_defs(expr: &Expr) -> Vec<(String, Vec<String>, Expr)> {
+fn extract_func_defs(expr: &Expr) -> Vec<(String, Vec<Param>, Expr)> {
     let mut defs = Vec::new();
 
-    fn extract_inner(expr: &Expr, defs: &mut Vec<(String, Vec<String>, Expr)>) {
+    fn extract_inner(expr: &Expr, defs: &mut Vec<(String, Vec<Param>, Expr)>) {
         if let Expr::FuncDef {
             name,
             params,

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -50475,7 +50475,7 @@ mod tests {
         ]);
         let substituted = substitute_var(&dollar_last, "a", &OwnedValue::Int(9));
         let Expr::FuncDef { body, .. } = &substituted else {
-            panic!("expected FuncDef");
+            unreachable!("FuncDef arm always returns FuncDef"); // omni-dev: coverage tolerate-line reason="substitute_var_impl's FuncDef arm always returns FuncDef (#2283)"
         };
         assert_eq!(
             **body,
@@ -50495,7 +50495,7 @@ mod tests {
         ]);
         let substituted = substitute_var(&dollar_first, "a", &OwnedValue::Int(9));
         let Expr::FuncDef { body, .. } = &substituted else {
-            panic!("expected FuncDef");
+            unreachable!("FuncDef arm always returns FuncDef"); // omni-dev: coverage tolerate-line reason="substitute_var_impl's FuncDef arm always returns FuncDef (#2283)"
         };
         assert_eq!(
             **body,

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -364,7 +364,7 @@ use crate::json::light::{JsonCursor, JsonElements, JsonFields, StandardJson};
 
 use super::expr::{
     ArithOp, AssignOp, BoundBody, Builtin, CompareOp, Expr, FormatType, FuncDefBound, FuncDefData,
-    Literal, MergeFlags, NumberKey, ObjectEntry, ObjectKey, Pattern, StringPart,
+    Literal, MergeFlags, NumberKey, ObjectEntry, ObjectKey, Param, Pattern, StringPart,
 };
 use super::value::{
     assert_value_tree_depth, cmp_f64, infinite_float_preview_text, is_infinity_sentinel,
@@ -2457,7 +2457,15 @@ fn eval_single<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
             body,
             then,
             bound,
-        } => eval_func_def::<W, S>(name, params, body, then, bound, value, optional),
+        } => eval_func_def::<W, S>(
+            name,
+            &param_names(params),
+            body,
+            then,
+            bound,
+            value,
+            optional,
+        ),
         Expr::FuncCall {
             name,
             args,
@@ -4956,7 +4964,7 @@ fn eval_each<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
             then,
             bound,
         } => {
-            let bound_then = bind_def(name, params, body, then, bound);
+            let bound_then = bind_def(name, &param_names(params), body, then, bound);
             eval_each::<W, S>(&bound_then, value, optional, sink)
         }
 
@@ -31048,30 +31056,39 @@ fn substitute_var_impl(
             then,
             ..
         } => {
-            // #2141 review: deliberately NOT changed to always substitute
-            // `body` (an earlier draft of this fix did, reasoning that
-            // `params` are bare and `var_name` is `$`-bound, so a bare
-            // nested parameter can never shadow an outer `$`-bound name).
-            // That reasoning is correct for a *bare* nested parameter
-            // (`def f(g): $g` -- `$g` inside should resolve to the outer
-            // binding) but wrong for a `$`-style one (`def f($g): $g` --
-            // `$g` inside is `f`'s *own* parameter, and must NOT be
-            // pre-filled with the outer value before `f` is ever called,
-            // or `f`'s own later argument substitution has nothing left to
-            // replace): `parse_func_def_parts` discards a parameter's
-            // leading `$` at parse time, so `params: Vec<String>` cannot
-            // tell the two cases apart, and this function has no way to
-            // pick the right answer for both from the AST alone. Confirmed
-            // live against jq 1.7.1 that the "always substitute" draft
-            // broke the `$`-style case: `3 as $g | def f($g): $g; f(1)`
-            // must be `1` (matches this un-reverted code); the draft gave
-            // `3` instead (the outer value, captured before `f` even ran).
-            // Keeping the pre-existing shadow check means the *bare*-nested-
-            // parameter case remains wrong the other way (`3 as $g | def
-            // f(g): $g; f(1)` is `3` on jq, `1` here) -- a real, known gap,
-            // tracked separately (#2141 follow-up) rather than "fixed" into
-            // a worse regression on the more common `$`-style shape.
-            let shadowed = params.contains(&var_name.to_string());
+            // #2283: shadowed only when the *last* (jq's own later-wins
+            // shadowing rule for duplicate parameter names) matching
+            // parameter is itself `$`-style. A bare nested parameter
+            // (`def f(g): $g`) has no `$`-binding of its own, so an outer
+            // `$g` substitution must still reach into `f`'s body; a
+            // `$`-style one (`def f($g): $g`) must not be pre-filled with
+            // the outer value before `f` is ever called, or `f`'s own
+            // later argument substitution has nothing left to replace.
+            // `parse_func_def_parts`/`parse_def_expr` used to discard a
+            // parameter's leading `$` at parse time, making `params:
+            // Vec<String>` alone unable to tell the two cases apart
+            // (#2141 review reverted an "always substitute" draft here
+            // after confirming live that it broke the `$`-style case: `3
+            // as $g | def f($g): $g; f(1)` must be `1`, not `3`, the outer
+            // value baked in too early) -- `Param`'s own `Bare`/`Dollar`
+            // variants now carry exactly that distinction, so both cases
+            // resolve correctly instead of picking one to get right at the
+            // other's expense. `.rev().find()`, not the first match: a
+            // duplicate-named parameter list (`def f(a; $a): ...`) must
+            // resolve by its *last* occurrence, matching ordinary
+            // shadowing precedence -- an earlier version of this exact fix
+            // used the first match instead and let an outer `$a` leak
+            // through `def f(a; $a): $a` (confirmed live against jq 1.7.1:
+            // `9 as $a | def f(a; $a): $a; f(1;2)` is `2`, not `9`).
+            // Confirmed live against jq 1.7.1: `3 as $g | def f(g): $g;
+            // f(1)` is `3` (bare -- outer reaches in), `3 as $g | def
+            // f($g): $g; f(1)` is `1` (dollar-style -- shadowed), matching
+            // this fix.
+            let shadowed = params
+                .iter()
+                .rev()
+                .find(|p| p.name() == var_name)
+                .is_some_and(Param::is_dollar);
             Expr::FuncDef {
                 name: name.clone(),
                 params: params.clone(),
@@ -38319,7 +38336,7 @@ fn eval_stage_with_path_context<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
             // Each output continues `rest` from its own path, not this
             // arm's ambient one -- see `path_probe_stage` (#1409).
             let paired = !rest.is_empty() && rest.iter().any(needs_path_context);
-            let bound_then = bind_def(name, params, body, then, bound);
+            let bound_then = bind_def(name, &param_names(params), body, then, bound);
             // #2094 review kept `bound_then` clone-free in the unpaired
             // (common) case so this arm keeps the full benefit of
             // `bind_def`'s own cache; #1510 extends that to the paired case,
@@ -49251,6 +49268,19 @@ mod ambient_frame_depth {
     }
 }
 
+/// The bare identifier of each of `params`, regardless of bare-vs-`$`
+/// spelling -- #2283: `bind_def`/`FuncDefData`'s own `params: Vec<String>`
+/// only ever needs the bare call-binding name (both spellings bind that
+/// identically; only `substitute_var_impl`/`substitute_func_param_impl`'s
+/// shadow checks need `Param`'s own `Bare`/`Dollar` distinction, and they
+/// run on the still-`Expr::FuncDef`-shaped tree before this conversion
+/// ever happens), so every one of `Expr::FuncDef`'s four evaluation arms
+/// converts once here rather than `bind_def` itself taking `&[Param]` and
+/// converting on every one of its own many (test-included) call sites.
+pub(crate) fn param_names(params: &[Param]) -> Vec<String> {
+    params.iter().map(|p| p.name().to_string()).collect()
+}
+
 /// Install `def name(params): body` over `then`, the shared first half of
 /// every `Expr::FuncDef` evaluation arm (#1371).
 ///
@@ -50080,22 +50110,39 @@ fn substitute_func_param_impl(expr: &Expr, param: &str, arg: &Expr, subst_dollar
             // innermost-first def lookup resolves it to the nested `def g`,
             // not to `param`'s substituted argument.
             let then_shadowed = name == param && params.is_empty();
-            // A nested def's own parameter list shadows `param` within its
-            // own body -- correct when the nested parameter is bare
-            // (`def h(param): ...`, the same namespace as `param` itself),
-            // but pre-existing and unfixed here (#2141 review): a *bare*
-            // `param` can never carry an outer `$param` reference's own
-            // value into a nested def whose OWN parameter is `$`-style
-            // (`def h($param): $param` inside `f(param)`'s own body still
-            // needs `f`'s outer `$param`, since `h`'s `$param` is `h`'s
-            // own, unrelated binding) -- `params` can't tell the two
-            // spellings apart (`parse_func_def_parts` discards `$` at
-            // parse time), so this blanket check over-shadows the `$`-style
-            // case identically to `substitute_var_impl`'s own `FuncDef` arm
-            // (see that arm's doc comment for the live-verified repro and
-            // why neither direction can be made fully correct without a
-            // parser change).
-            let body_shadowed = params.contains(&param.to_string());
+            // #2283 review: this blanket "any matching param name shadows,
+            // bare or `$`-style alike" is correct as-is for the *bare*
+            // `param`-reference substitution this arm mostly exists for --
+            // confirmed live against jq 1.7.1 that a `$`-style nested
+            // parameter shadows the *bare* namespace too, not just its own
+            // `$name`: `def h($param): param` is itself a compile error in
+            // jq ("param is not defined") when called with no enclosing
+            // bare `param` of its own, and `def f(param): def h($param):
+            // param; h(1); f(5)` answers `1` (`h`'s own bound argument),
+            // never `5` -- so a `$`-style parameter desugars to something
+            // that binds *both* the bare and `$` namespaces (matching `def
+            // f(param): param as $param | ...`), and this check's pre-#2283
+            // comment's claim that a `$`-style nested parameter does *not*
+            // shadow a bare substitution was wrong -- this line needed no
+            // change once `Param` was available to check.
+            //
+            // What *is* still wrong here, confirmed live and NOT fixed by
+            // this issue (tracked as a follow-up instead): this same
+            // blanket check also gates *`$param`-Var* substitution (via
+            // `subst_dollar` staying ambient into `body` below) whenever
+            // any matching param name exists, even a *bare* one -- but a
+            // bare nested parameter creates no `$name` binding at all, so
+            // an outer `$param` substitution should still reach through
+            // it. `def f($param): def h(param): $param; h(1); f(99)`
+            // answers `99` in jq (`h`'s own bare parameter doesn't touch
+            // `$param`, so it resolves to `f`'s own) but `1` here. Fixing
+            // this needs a second, independent `subst_bare`-style flag
+            // threaded through this whole function (this one gate
+            // conflates "block bare substitution" with "block
+            // `$`-substitution", and they need different shadowing rules)
+            // -- a materially larger change than this arm's own `Param`
+            // fix, out of scope here.
+            let body_shadowed = params.iter().any(|p| p.name() == param);
             Expr::FuncDef {
                 name: name.clone(),
                 params: params.clone(),
@@ -50396,6 +50443,68 @@ mod tests {
     /// `#[cfg(feature = "std")]`: `ambient_frame_depth` itself is a no-op
     /// under `no_std` (see its own module doc comment) -- there is no
     /// no_std variant of this mechanism to test.
+    /// #2283 review: `substitute_var_impl`'s shadow check must resolve a
+    /// duplicate-named parameter list by its *last* occurrence (jq's own
+    /// later-wins shadowing precedence), not its first -- an earlier
+    /// version of this exact fix used `.position()` (first match) and let
+    /// an outer `$a` leak straight into `def f(a; $a): $a`'s body despite
+    /// the *later* `$a` parameter being `$`-style. Verified directly on
+    /// the substitution itself (bypassing `bind_def_call`'s own separate,
+    /// pre-existing, unrelated bug in duplicate-name *argument* binding --
+    /// confirmed live against jq 1.7.1 that `9 as $a | def f(a; $a): $a;
+    /// f(1;2)` end-to-end is `2` on jq but `1` even on unmodified `main`,
+    /// for a reason unconnected to shadowing -- so this test checks the
+    /// shadow decision in isolation): `f`'s own `$a` reference inside
+    /// `body` must remain an unsubstituted `Expr::Var`, not get replaced
+    /// with the outer `9`, whichever position the `$`-style parameter
+    /// sits at.
+    #[test]
+    fn test_duplicate_named_param_shadow_resolves_by_last_occurrence_2283() {
+        let make_funcdef = |params: Vec<Param>| Expr::FuncDef {
+            name: "f".to_string(),
+            params,
+            body: Box::new(Expr::Var("a".to_string())),
+            then: Box::new(Expr::Identity),
+            bound: FuncDefBound::default(),
+        };
+
+        // `$`-style parameter last: `def f(a; $a): $a`.
+        let dollar_last = make_funcdef(vec![
+            Param::Bare("a".to_string()),
+            Param::Dollar("a".to_string()),
+        ]);
+        let substituted = substitute_var(&dollar_last, "a", &OwnedValue::Int(9));
+        let Expr::FuncDef { body, .. } = &substituted else {
+            panic!("expected FuncDef");
+        };
+        assert_eq!(
+            **body,
+            Expr::Var("a".to_string()),
+            "the later, $-style parameter must shadow the outer $a -- body should stay \
+             unsubstituted, not become Literal(9)"
+        );
+
+        // `$`-style parameter first, bare last: `def f($a; a): $a` -- the
+        // *bare* trailing parameter no longer has a `$`-binding of its own
+        // at that position, so this one is NOT shadowed (matches
+        // `test_bare_nested_param_no_longer_shadows_outer_dollar_binding_2283`'s
+        // own single-parameter case).
+        let dollar_first = make_funcdef(vec![
+            Param::Dollar("a".to_string()),
+            Param::Bare("a".to_string()),
+        ]);
+        let substituted = substitute_var(&dollar_first, "a", &OwnedValue::Int(9));
+        let Expr::FuncDef { body, .. } = &substituted else {
+            panic!("expected FuncDef");
+        };
+        assert_eq!(
+            **body,
+            Expr::Literal(Literal::Int(9)),
+            "the later, bare parameter has no $-binding of its own -- the outer $a must \
+             reach through"
+        );
+    }
+
     #[test]
     fn test_bind_def_memoizes_per_node_2094() {
         let Expr::FuncDef {
@@ -50409,9 +50518,9 @@ mod tests {
             panic!("expected a top-level FuncDef");
         };
 
-        let first = bind_def(&name, &params, &body, &then, &bound);
+        let first = bind_def(&name, &param_names(&params), &body, &then, &bound);
         let first_ptr = Rc::as_ptr(&first);
-        let second = bind_def(&name, &params, &body, &then, &bound);
+        let second = bind_def(&name, &param_names(&params), &body, &then, &bound);
         assert!(
             Rc::ptr_eq(&first, &second),
             "a second call at the same depth sharing the same FuncDefBound must reuse the \
@@ -50422,7 +50531,7 @@ mod tests {
         // An independent node's own cache cell is untouched by the one
         // above -- confirms the cache is keyed per-node, not global.
         let fresh_cache = FuncDefBound::default();
-        let third = bind_def(&name, &params, &body, &then, &fresh_cache);
+        let third = bind_def(&name, &param_names(&params), &body, &then, &fresh_cache);
         assert!(
             !Rc::ptr_eq(&first, &third),
             "a different FuncDefBound must compute its own Rc, not see another node's cache"
@@ -50454,7 +50563,7 @@ mod tests {
 
         // No ambient depth entered yet: a fresh top-level `def` still seeds
         // from `0`, matching every evaluator's actual call site.
-        match &*bind_def(&name, &params, &body, &then, &cache) {
+        match &*bind_def(&name, &param_names(&params), &body, &then, &cache) {
             Expr::DefCall { frames, .. } => assert_eq!(*frames, 0),
             other => panic!("expected DefCall, got {other:?}"),
         }
@@ -50466,7 +50575,7 @@ mod tests {
         // FuncDef node.
         {
             let _guard = enter_def_call_frame(MAX_EVAL_FRAMES - 1);
-            match &*bind_def(&name, &params, &body, &then, &cache) {
+            match &*bind_def(&name, &param_names(&params), &body, &then, &cache) {
                 Expr::DefCall { frames, .. } => assert_eq!(*frames, MAX_EVAL_FRAMES - 1),
                 other => panic!("expected DefCall, got {other:?}"),
             }
@@ -50476,7 +50585,7 @@ mod tests {
         // `def` reached *after* the nested call returns -- a sibling, not
         // something nested inside it -- does not inherit a depth that no
         // longer applies to it.
-        match &*bind_def(&name, &params, &body, &then, &cache) {
+        match &*bind_def(&name, &param_names(&params), &body, &then, &cache) {
             Expr::DefCall { frames, .. } => assert_eq!(*frames, 0),
             other => panic!("expected DefCall, got {other:?}"),
         }
@@ -50511,7 +50620,7 @@ mod tests {
 
         let cache = FuncDefBound::default();
 
-        let first = bind_def(&name, &params, &body, &then, &cache);
+        let first = bind_def(&name, &param_names(&params), &body, &then, &cache);
         let first_frames = match &*first {
             Expr::DefCall { frames, .. } => *frames,
             other => panic!("expected DefCall, got {other:?}"),
@@ -50522,7 +50631,7 @@ mod tests {
         // node being reached again through an `Expr::Shared` wrapper
         // threaded into a deeper recursive `DefCall`'s substituted body.
         let _guard = enter_def_call_frame(500);
-        let second = bind_def(&name, &params, &body, &then, &cache);
+        let second = bind_def(&name, &param_names(&params), &body, &then, &cache);
         let second_frames = match &*second {
             Expr::DefCall { frames, .. } => *frames,
             other => panic!("expected DefCall, got {other:?}"),
@@ -50565,7 +50674,7 @@ mod tests {
 
         let _guard = enter_def_call_frame(MAX_EVAL_FRAMES);
         let cache = FuncDefBound::default();
-        let bound_then = bind_def(&name, &params, &body, &then, &cache);
+        let bound_then = bind_def(&name, &param_names(&params), &body, &then, &cache);
         let Expr::DefCall {
             def,
             args,

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -44,14 +44,14 @@ use super::eval::{
     has_type_mismatch_is_permissive, index_component_value, index_in_array_bounds,
     index_one_owned as index_owned_by_key, is_pure_chain_link, is_retryable_stop, literal_to_owned,
     needs_path_context, numeric_key_to_array_index, numeric_key_to_index, numeric_length_owned,
-    owned_bound_to_i64, owned_to_string, prefer_pending_control, slice_component_value,
-    slice_object_as_yq_children, slice_owned_value_read, streams_escaped_generator_prefix,
-    substitute_bound_var, substitute_vars, suppress_or_raise, suppresses, tonumber_from_str,
-    vec_with_capacity, yq_absent_key_read_is_empty, yq_empty_operand_output,
-    yq_field_index_on_scalar_is_empty, yq_negative_index_check, yq_numeric_index_on_object_is_null,
-    yq_object_key_stringify, yq_read_only_context, BinaryFanoutRules, Control, Demand,
-    EmptyOperandOp, EvalError, EvalSemantics, EvalTag, Flow, JqSemantics, LimitN, PathTrail,
-    QueryResult, YqSemantics,
+    owned_bound_to_i64, owned_to_string, param_names, prefer_pending_control,
+    slice_component_value, slice_object_as_yq_children, slice_owned_value_read,
+    streams_escaped_generator_prefix, substitute_bound_var, substitute_vars, suppress_or_raise,
+    suppresses, tonumber_from_str, vec_with_capacity, yq_absent_key_read_is_empty,
+    yq_empty_operand_output, yq_field_index_on_scalar_is_empty, yq_negative_index_check,
+    yq_numeric_index_on_object_is_null, yq_object_key_stringify, yq_read_only_context,
+    BinaryFanoutRules, Control, Demand, EmptyOperandOp, EvalError, EvalSemantics, EvalTag, Flow,
+    JqSemantics, LimitN, PathTrail, QueryResult, YqSemantics,
 };
 #[cfg(test)]
 use super::expr::FuncDefBound;
@@ -7267,7 +7267,7 @@ fn eval_each_generic<S: EvalSemantics, V: DocumentValue>(
             then,
             bound,
         } => {
-            let bound_then = bind_def(name, params, body, then, bound);
+            let bound_then = bind_def(name, &param_names(params), body, then, bound);
             eval_each_generic::<S, V>(&bound_then, value, optional, cursor, sink)
         }
 
@@ -25841,7 +25841,7 @@ mod tests {
 
         let _guard = enter_def_call_frame(crate::jq::eval::MAX_EVAL_FRAMES);
         let cache = FuncDefBound::default();
-        let defcall = bind_def(&name, &params, &body, &then, &cache);
+        let defcall = bind_def(&name, &param_names(&params), &body, &then, &cache);
         assert!(
             matches!(&*defcall, Expr::DefCall { frames, .. } if *frames == crate::jq::eval::MAX_EVAL_FRAMES),
             "expected bind_def to seed frames from the ambient depth"

--- a/src/jq/expr.rs
+++ b/src/jq/expr.rs
@@ -17,6 +17,65 @@ use std::rc::Rc;
 
 use super::value::{NumberRepr, OwnedValue};
 
+/// A `def`'s own parameter, carrying whether it was written with a
+/// leading `$` (`def f($g): ...`) or bare (`def f(g): ...`).
+///
+/// #2283: the two shapes bind a call-site argument to the identical
+/// value, but answer a different question when a nested `def`'s own
+/// parameter of a matching name might shadow an *outer* `$var`
+/// substitution: a bare parameter has no `$`-binding of its own (an
+/// outer `$g` reaches through it), while a `$`-style one does (it must
+/// not be pre-filled with the outer value before this def is ever
+/// called). Storing this as a variant on the parameter itself, rather
+/// than stripping the `$` at parse time (as the pre-#2283 parser did) or
+/// as a parallel bitmask alongside a bare-only `Vec<String>` (an earlier
+/// version of this fix, reverted after review): a `Vec<Param>` occupies
+/// the identical 24 bytes `Vec<String>` did (`Vec<T>`'s own
+/// representation -- pointer, length, capacity -- never depends on `T`'s
+/// size), so `Expr::FuncDef` and `Expr`'s own pinned footprint (`#1401`)
+/// are both unchanged by this type, unlike adding a same-purpose field
+/// alongside `params` (which measurably cost `Expr` 8 bytes regardless
+/// of the field's own size -- confirmed via `-Zprint-type-sizes` across
+/// every shape tried, including a bare `u8`, and pushed
+/// `MAX_EXPR_DEPTH`/`MAX_PATTERN_DEPTH`, `src/jq/parser.rs`, into a
+/// genuine stack overflow on the CLI's own 8 MiB stack before this
+/// design was chosen instead).
+///
+/// [`Param::name`] recovers the bare identifier every existing bare-name
+/// consumer (call-site argument substitution, arity checks) already
+/// expects, regardless of variant -- both spellings bind that same bare
+/// name at the call site; only the shadow-check sites in
+/// `substitute_var_impl`/`substitute_func_param_impl` (`src/jq/eval.rs`)
+/// need to distinguish `Bare`/`Dollar` at all.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Param {
+    /// `def f(g): ...` -- binds only the bare `g` call-site namespace.
+    Bare(String),
+    /// `def f($g): ...` -- binds the bare `g` namespace (identically to
+    /// `Bare`) *and* makes `$g` available inside the body, with no other
+    /// binding mechanism for that `$g` (confirmed live against jq 1.7.1:
+    /// `def f(g): $g; f(1)` is a compile error, "$g is not defined" --
+    /// bare alone never creates a `$`-binding).
+    Dollar(String),
+}
+
+impl Param {
+    /// The bare identifier, regardless of spelling -- what every existing
+    /// bare-name consumer (call-site substitution, arity/name checks)
+    /// already expects; only the two shadow-check sites need the
+    /// `Bare`/`Dollar` distinction itself.
+    pub fn name(&self) -> &str {
+        match self {
+            Self::Bare(name) | Self::Dollar(name) => name,
+        }
+    }
+
+    /// Whether this parameter was written `$`-style (`$g`, not bare `g`).
+    pub fn is_dollar(&self) -> bool {
+        matches!(self, Self::Dollar(_))
+    }
+}
+
 /// A jq expression representing a query path.
 #[derive(Debug, Clone, PartialEq)]
 pub enum Expr {
@@ -395,8 +454,10 @@ pub enum Expr {
     FuncDef {
         /// Function name
         name: String,
-        /// Parameter names (empty for no-arg functions)
-        params: Vec<String>,
+        /// Parameters (empty for no-arg functions) -- see [`Param`]'s own
+        /// doc comment for why each carries its bare-vs-`$`-style spelling
+        /// instead of just a bare `String`.
+        params: Vec<Param>,
         /// Function body
         body: Box<Self>,
         /// Expression where this function is in scope

--- a/src/jq/mod.rs
+++ b/src/jq/mod.rs
@@ -105,8 +105,8 @@ pub use eval::{
 pub use eval::input_queue_is_active;
 pub use expr::{
     ArithOp, AssignOp, BoundBody, Builtin, CompareOp, Expr, FormatType, FuncDefBound, FuncDefData,
-    Import, Include, Literal, MetaValue, ModuleMeta, NumberKey, ObjectEntry, ObjectKey, Pattern,
-    PatternEntry, Program, StringPart,
+    Import, Include, Literal, MetaValue, ModuleMeta, NumberKey, ObjectEntry, ObjectKey, Param,
+    Pattern, PatternEntry, Program, StringPart,
 };
 pub use lazy::JqValue;
 pub use parser::{

--- a/src/jq/parser.rs
+++ b/src/jq/parser.rs
@@ -8305,6 +8305,21 @@ mod tests {
         parse(&format!("[{}]", vec!["1"; n].join(", "))).expect("a long comma list is not nesting");
     }
 
+    /// #2283: `parse_func_params`'s own malformed-syntax error, shared by
+    /// `parse_def_expr`/`parse_func_def_parts` -- pre-existing behavior
+    /// (unchanged by #2283) that had no direct test before the shared
+    /// helper's own review surfaced it as untested.
+    #[test]
+    fn test_func_params_malformed_separator_is_a_parse_error_2283() {
+        let err = parse("def f(a b): a; f(1;2)").expect_err("missing separator must error");
+        assert!(
+            err.message
+                .contains("expected ';', ',', or ')' in parameter list"),
+            "unexpected error: {}",
+            err.message
+        );
+    }
+
     /// Control: just under the limit still parses, for the recursive and the
     /// iterative shape alike.
     #[test]

--- a/src/jq/parser.rs
+++ b/src/jq/parser.rs
@@ -35,7 +35,7 @@ use std::collections::{BTreeMap, BTreeSet};
 
 use super::expr::{
     ArithOp, AssignOp, Builtin, CompareOp, Expr, FormatType, FuncDefBound, Import, Include,
-    Literal, MergeFlags, MetaValue, ModuleMeta, NumberKey, ObjectEntry, ObjectKey, Pattern,
+    Literal, MergeFlags, MetaValue, ModuleMeta, NumberKey, ObjectEntry, ObjectKey, Param, Pattern,
     PatternEntry, Program, StringPart,
 };
 use super::value::{parse_i64_or_f64, NumberRepr};
@@ -2536,6 +2536,58 @@ impl<'a> Parser<'a> {
         Ok(Expr::Break(name))
     }
 
+    /// Parse a `def`'s optional `(PARAMS)` parameter list, one [`Param`]
+    /// per entry recording whether it was written `$`-style or bare --
+    /// #2283: the two shapes bind a call-site argument identically, but
+    /// answer a different outer-`$var`-shadowing question once a nested
+    /// `def` is involved (see `Param`'s own doc comment, `src/jq/expr.rs`).
+    /// One definition shared by `parse_def_expr`/`parse_func_def_parts`
+    /// instead of two independent copies of this loop, per this
+    /// codebase's own "duplicated predicates diverge silently" lesson
+    /// (#106) -- a first version of this exact fix had two copies and
+    /// nothing would have caught them drifting apart.
+    fn parse_func_params(&mut self) -> Result<Vec<Param>, ParseError> {
+        if self.peek() != Some('(') {
+            return Ok(Vec::new());
+        }
+        self.next();
+        self.skip_ws();
+        let mut params = Vec::new();
+
+        if self.peek() != Some(')') {
+            loop {
+                // Parameters can be $var or just var
+                let is_dollar = self.peek() == Some('$');
+                if is_dollar {
+                    self.next();
+                }
+                let name = self.parse_ident()?;
+                params.push(if is_dollar {
+                    Param::Dollar(name)
+                } else {
+                    Param::Bare(name)
+                });
+                self.skip_ws();
+
+                match self.peek() {
+                    Some(';' | ',') => {
+                        self.next();
+                        self.skip_ws();
+                    }
+                    Some(')') => break,
+                    _ => {
+                        return Err(ParseError::new(
+                            "expected ';', ',', or ')' in parameter list",
+                            self.pos,
+                        ));
+                    }
+                }
+            }
+        }
+        self.expect(')')?;
+        Ok(params)
+    }
+
     /// Parse a function definition.
     /// Syntax: def NAME: BODY; or def NAME(PARAMS): BODY;
     fn parse_def_expr(&mut self) -> Result<Expr, ParseError> {
@@ -2547,41 +2599,7 @@ impl<'a> Parser<'a> {
         self.skip_ws();
 
         // Parse optional parameters
-        let params = if self.peek() == Some('(') {
-            self.next();
-            self.skip_ws();
-            let mut params = Vec::new();
-
-            if self.peek() != Some(')') {
-                loop {
-                    // Parameters can be $var or just var
-                    if self.peek() == Some('$') {
-                        self.next();
-                    }
-                    let param = self.parse_ident()?;
-                    params.push(param);
-                    self.skip_ws();
-
-                    match self.peek() {
-                        Some(';' | ',') => {
-                            self.next();
-                            self.skip_ws();
-                        }
-                        Some(')') => break,
-                        _ => {
-                            return Err(ParseError::new(
-                                "expected ';', ',', or ')' in parameter list",
-                                self.pos,
-                            ));
-                        }
-                    }
-                }
-            }
-            self.expect(')')?;
-            params
-        } else {
-            Vec::new()
-        };
+        let params = self.parse_func_params()?;
 
         self.skip_ws();
         self.expect(':')?;
@@ -5569,7 +5587,7 @@ impl<'a> Parser<'a> {
         self.skip_ws();
 
         // Collect function definitions at module level
-        let mut defs: Vec<(String, Vec<String>, Expr)> = Vec::new();
+        let mut defs: Vec<(String, Vec<Param>, Expr)> = Vec::new();
 
         // Parse function definitions until we hit something that isn't one
         while self.matches_keyword("def") {
@@ -5601,7 +5619,7 @@ impl<'a> Parser<'a> {
     }
 
     /// Parse just the function definition parts (name, params, body) without the "then" clause
-    fn parse_func_def_parts(&mut self) -> Result<(String, Vec<String>, Expr), ParseError> {
+    fn parse_func_def_parts(&mut self) -> Result<(String, Vec<Param>, Expr), ParseError> {
         self.consume_keyword("def");
         self.skip_ws();
 
@@ -5609,38 +5627,7 @@ impl<'a> Parser<'a> {
         self.skip_ws();
 
         // Parse optional parameters
-        let params = if self.peek() == Some('(') {
-            self.next();
-            self.skip_ws();
-            let mut params = Vec::new();
-            while self.peek() != Some(')') {
-                // Parameters can be $var or just var
-                if self.peek() == Some('$') {
-                    self.next();
-                }
-                let param = self.parse_ident()?;
-                params.push(param);
-                self.skip_ws();
-
-                match self.peek() {
-                    Some(';' | ',') => {
-                        self.next();
-                        self.skip_ws();
-                    }
-                    Some(')') => break,
-                    _ => {
-                        return Err(ParseError::new(
-                            "expected ';', ',', or ')' in parameter list",
-                            self.pos,
-                        ));
-                    }
-                }
-            }
-            self.expect(')')?;
-            params
-        } else {
-            Vec::new()
-        };
+        let params = self.parse_func_params()?;
 
         self.skip_ws();
         self.expect(':')?;

--- a/src/jq/resolve.rs
+++ b/src/jq/resolve.rs
@@ -51,14 +51,14 @@
 //! | `def f(g): g(1); f(.)` | error `g/1` — a param binds arity 0 only |
 //! | `def f: 1; def g: f; def f: 2; g` | `1` — later same-arity def shadows |
 //!
-//! The parser strips the `$` from a `$`-prefixed parameter (`parse_def_expr`,
-//! `src/jq/parser.rs`), so `def f($a)` and `def f(a)` both arrive here as
-//! `params: ["a"]`. Binding the bare name at arity 0 is right for both:
-//! jq's `def f($a): …` desugars to `def f(a): a as $a | …`, which leaves `a`
-//! callable.
+//! `Expr::FuncDef::params` distinguishes `def f($a)` from `def f(a)` (`Param`,
+//! `src/jq/expr.rs` -- #2283), but this pass only ever needs
+//! [`Param::name`](super::Param::name), the bare identifier either spelling
+//! binds: jq's `def f($a): …` desugars to `def f(a): a as $a | …`, which
+//! leaves `a` callable at arity 0 regardless of which spelling was written.
 
 use alloc::rc::Rc;
-use alloc::string::String;
+use alloc::string::{String, ToString};
 use alloc::vec::Vec;
 
 use super::walk::{builtin_kids, map_builtin_subexprs, BuiltinKids};

--- a/src/jq/resolve.rs
+++ b/src/jq/resolve.rs
@@ -637,7 +637,7 @@ fn check(expr: &mut Expr, scope: &mut Scope, errors: &mut Vec<UnresolvedCall>) {
             // `g`. Pushed after the function's own name so a parameter
             // shadowing it wins.
             for p in params.iter() {
-                scope.push((p.clone(), 0));
+                scope.push((p.name().to_string(), 0));
             }
             check(body, scope, errors);
             scope.truncate(with_self);

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -21422,32 +21422,32 @@ fn test_bare_param_not_shadowed_by_dollar_binding_of_same_name_2141() -> Result<
     Ok(())
 }
 
-/// #2141 review found a genuine, *not-fixable-here* ambiguity next to the
-/// original bug: `parse_func_def_parts` discards a parameter's leading `$`
-/// at parse time, so `def f(g)` and `def f($g)` produce the identical
-/// `params: ["g"]` -- `substitute_var_impl`'s `Expr::FuncDef` arm has no
+/// #2141 review found a genuine ambiguity next to the original bug:
+/// `parse_func_def_parts` discarded a parameter's leading `$` at parse
+/// time, so `def f(g)` and `def f($g)` produced the identical
+/// `params: ["g"]` -- `substitute_var_impl`'s `Expr::FuncDef` arm had no
 /// way to tell, from the AST alone, whether a nested def's own parameter
 /// of a matching name should shadow an *outer* `$`-bound value (true for
 /// `$`-style, since `$g` inside then means the nested def's *own*
 /// argument) or not (true for bare-style, since a bare `g` inside has no
 /// `$`-binding of its own and `$g` there still means the outer value).
+/// Fixed by #2283's `Param` enum, which retains exactly that distinction
+/// instead of discarding it.
 ///
-/// A first draft of this fix optimized for the bare case (always
+/// A first draft of #2141's own fix optimized for the bare case (always
 /// substitute) and broke the `$`-style one in the process -- confirmed
 /// live regression against jq 1.7.1:
 /// `3 as $item | def double($item): $item * 2; double(10)` must be `20`
 /// (uses `double`'s own argument), the draft gave `6` (wrongly captured
 /// the outer `3` into `double`'s body before `double` was ever called).
 /// See `test_dollar_style_func_param_shadows_outer_binding_of_same_name_2141`
-/// below for that (correct, unregressed) shape.
+/// below for that (correct, unregressed, still-relevant-post-#2283) shape.
 ///
-/// Reverting to the original shadow check keeps that `$`-style case
+/// #2141 reverted to the original shadow check, keeping that `$`-style case
 /// correct at the cost of leaving the *bare*-nested-parameter case wrong
-/// the other way, pinned here as a known gap rather than left untested:
-/// jq 1.7.1's `3 as $g | def f(g): $g; f(1)` is `3` (the outer `$g`,
-/// untouched by `f`'s own unrelated bare `g` parameter); this prints `1`
-/// instead (`f`'s own bare-parameter substitution wrongly fills in the
-/// `$g` that the outer substitution's shadow check left untouched).
+/// the other way -- pinned as a known gap at the time
+/// (`test_bare_nested_param_wrongly_shadows_outer_dollar_binding_known_gap_2141`),
+/// now fixed and renamed by #2283 below (see that test's own doc comment).
 #[test]
 fn test_dollar_style_func_param_shadows_outer_binding_of_same_name_2141() -> Result<()> {
     let (stdout, stderr, code) = run_jq_full(
@@ -21462,14 +21462,18 @@ fn test_dollar_style_func_param_shadows_outer_binding_of_same_name_2141() -> Res
     Ok(())
 }
 
+/// #2283 fixed the gap this test used to pin: `Expr::FuncDef` now stores
+/// `Vec<Param>` (`Param::Bare`/`Param::Dollar`) instead of a bare
+/// `Vec<String>`, so `substitute_var_impl`'s shadow check can tell a bare
+/// nested parameter (which has no `$`-binding of its own, so an outer `$g`
+/// reaches through it) apart from a `$`-style one (which does, and blocks
+/// it) -- previously both looked identical. Confirmed live against jq
+/// 1.7.1: `3`.
 #[test]
-fn test_bare_nested_param_wrongly_shadows_outer_dollar_binding_known_gap_2141() -> Result<()> {
+fn test_bare_nested_param_no_longer_shadows_outer_dollar_binding_2283() -> Result<()> {
     let (stdout, stderr, code) = run_jq_full(&["-nc", "3 as $g | def f(g): $g; f(1)"], None)?;
     assert_eq!(code, 0, "stderr: {stderr:?}");
-    // jq 1.7.1 answers "3" (the outer $g); this is the known, documented
-    // gap -- see this test's own doc comment above and
-    // substitute_var_impl's `Expr::FuncDef` arm.
-    assert_eq!(stdout.trim_end(), "1");
+    assert_eq!(stdout.trim_end(), "3");
     Ok(())
 }
 
@@ -21486,6 +21490,68 @@ fn test_dollar_style_func_param_still_resolves_2141() -> Result<()> {
     let (stdout, stderr, code) = run_jq_full(&["-nc", "def f($x): $x; f(5)"], None)?;
     assert_eq!(code, 0, "stderr: {stderr:?}");
     assert_eq!(stdout.trim_end(), "5");
+    Ok(())
+}
+
+/// #2283: a mixed bare/`$`-style parameter list (`parse_func_params`'s own
+/// per-parameter loop) records each parameter's own spelling independently
+/// -- not just a single flag for the whole def. Confirmed live against jq
+/// 1.7.1.
+#[test]
+fn test_mixed_bare_and_dollar_params_in_one_def_2283() -> Result<()> {
+    let (stdout, stderr, code) =
+        run_jq_full(&["-nc", "def f(a; $b; c): [a, $b, c]; f(1; 2; 3)"], None)?;
+    assert_eq!(code, 0, "stderr: {stderr:?}");
+    assert_eq!(stdout.trim_end(), "[1,2,3]");
+    Ok(())
+}
+
+/// #2283 review: `substitute_func_param_impl`'s own `Expr::FuncDef` arm has
+/// a *different*, deeper, NOT-fixed-here gap next to the one this issue
+/// closed in `substitute_var_impl` -- pinned as a known gap per this
+/// project's convention rather than left silently wrong. `Param` confirms
+/// a nested def's own matching parameter (bare *or* `$`-style) correctly
+/// shadows an outer *bare* `param` substitution (`$`-style desugars to
+/// bind the bare namespace too, confirmed live: `def h($param): param`
+/// alone is a compile error, "param is not defined", so `$`-style alone
+/// never leaves bare `param` unbound) -- but the same blanket check also
+/// blocks an outer `$param`(dollar) substitution from reaching a nested
+/// *bare*-only parameter's body, which it should not (a bare parameter
+/// creates no `$`-binding of its own). Needs a second, independent
+/// `subst_bare`-style flag threaded through `substitute_func_param_impl`
+/// the way `subst_dollar` already is -- a materially larger change than
+/// #2283's own `Param` type, tracked separately as #2555. jq 1.7.1 answers
+/// `99` (`h`'s own bare parameter doesn't touch `$param`, so it resolves
+/// to `f`'s own); this answers `1` (`h`'s own argument, wrongly captured).
+#[test]
+fn test_bare_nested_param_wrongly_shadows_outer_dollar_func_param_known_gap_2283() -> Result<()> {
+    let (stdout, stderr, code) = run_jq_full(
+        &["-nc", "def f($param): def h(param): $param; h(1); f(99)"],
+        None,
+    )?;
+    assert_eq!(code, 0, "stderr: {stderr:?}");
+    assert_eq!(stdout.trim_end(), "1");
+    Ok(())
+}
+
+/// #2283 review: `bind_def_call`'s own argument-binding for a duplicate
+/// parameter name is *separately* broken, confirmed present on
+/// unmodified `main` (i.e. entirely unrelated to #2283's own shadow-check
+/// fix -- not a regression, and not fixed here) -- pinned as a known gap,
+/// tracked separately as #2560. jq 1.7.1 resolves `$a` to the *second* occurrence's own argument (`2`,
+/// ordinary later-wins parameter shadowing); this resolves to the first
+/// occurrence's argument (`1`) instead. See
+/// `test_duplicate_named_param_shadow_resolves_by_last_occurrence_2283`
+/// (`src/jq/eval.rs`) for direct, isolated confirmation that #2283's own
+/// shadow-check logic (which outer-`$var` substitution reaches a nested
+/// def's body) already resolves duplicate names correctly by the *last*
+/// occurrence -- this remaining gap is specifically in argument binding at
+/// call time, a different mechanism.
+#[test]
+fn test_duplicate_named_param_argument_binding_known_gap_2283() -> Result<()> {
+    let (stdout, stderr, code) = run_jq_full(&["-nc", "9 as $a | def f(a; $a): $a; f(1;2)"], None)?;
+    assert_eq!(code, 0, "stderr: {stderr:?}");
+    assert_eq!(stdout.trim_end(), "1");
     Ok(())
 }
 


### PR DESCRIPTION
## Summary

- `parse_func_def_parts`/`parse_def_expr` discarded a parameter's leading `$` at parse time, so `def f(g)` and `def f($g)` produced the identical `params: ["g"]` — `substitute_var_impl`'s shadow check (deciding whether an outer `$var` substitution reaches into a nested def's own body) could only get one of the two shapes right.
- `Expr::FuncDef` now stores `Vec<Param>` (`Param::Bare`/`Param::Dollar`) instead of `Vec<String>`, recording each parameter's original spelling. A new shared `parse_func_params` helper feeds both parser entry points instead of two independently-duplicated copies of this loop.
- `3 as $g | def f(g): $g; f(1)` is now `3` (was `1`), matching jq 1.7.1. `$`-style parameters are unaffected: `3 as $g | def f($g): $g; f(1)` stays `1`.
- A duplicate-named parameter list (`def f(a; $a): ...`) resolves the shadow check by its *last* occurrence, matching jq's own later-wins parameter shadowing — verified directly against the substitution itself, isolated from a separate, pre-existing, unrelated bug in duplicate-name argument binding (#2560).
- `substitute_func_param_impl`'s own, deeper, related gap is **not** fixed here — filed as #2555 with a live repro, since a correct fix needs a second, independent `subst_bare` flag threaded through that whole function, a materially larger change than this issue's own `Param` type.

## Design: `Vec<Param>`, not a parallel field — and why

The first version of this fix added `dollar_params: Box<[bool]>` (also tried `Vec<bool>` and a `u64` bitmask) alongside `params: Vec<String>`. Adding **any** field to `Expr::FuncDef` — regardless of its own size, down to a bare `u8` — disabled a niche optimization that was letting `Expr`'s enum discriminant ride for free, growing `Expr`'s pinned size (`#1401`) by a flat 8 bytes (96 → 104) on *every* `Expr` node in *every* parsed program, not just `FuncDef` ones. That pushed `MAX_EXPR_DEPTH`/`MAX_PATTERN_DEPTH` (256) past their safety margin on the CLI's real 8 MiB stack — `test_expr_depth_limit_returns_parse_error_not_overflow_1156` genuinely SIGABRTs there in both debug and release, a real crash risk on adversarial input. That version also needed a new, jq-fidelity-violating 64-parameter cap (`u64::BITS`) purely to fit the bitmask.

An internal 8-agent code review (three of eight finders independently) flagged both the depth-limit reduction and the parameter cap as genuine, avoidable divergences requiring documentation under this repo's own CLAUDE.md rule ("every divergence must be recorded in `docs/compliance/jq/limitations.md`"), and one finder identified the fix used here: `Vec<T>`'s own representation (pointer, length, capacity) never depends on `T`'s size, so replacing `params: Vec<String>` with `params: Vec<Param>` (an enum, not a new field) costs `Expr` nothing — confirmed via `-Zprint-type-sizes`, `Expr` stays exactly 96 bytes, `MAX_EXPR_DEPTH`/`MAX_PATTERN_DEPTH` stay at 256, and there is no parameter-count cap of any kind. This version has no divergence to document.

The same review round also caught a genuine bug in the field-based version's own shadow-check: `params.iter().position(...)` found only the *first* matching parameter name, so a duplicate-named parameter list where a *later* occurrence was the `$`-style one (`def f(a; $a): ...`) let an outer value leak through incorrectly. Fixed by resolving via the *last* matching occurrence (`.rev().find(...)`) instead, matching jq's own later-wins shadowing — verified both by a direct AST-level unit test and against the pinned oracle.

Fixes #2283

## Test plan

- [x] `cargo build --features cli` — clean
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings` — clean
- [x] `cargo test --features cli,simd,regex,serde` — full suite, 0 failed, verified via real exit code (not just text-pattern grep, after an earlier version's stack-overflow finding taught that lesson the hard way)
- [x] `test_expr_size_is_pinned_1401` passes at the **original** 96 bytes; `MAX_EXPR_DEPTH`/`MAX_PATTERN_DEPTH` stay at the **original** 256 — this design introduces no size or depth cost at all
- [x] New/updated unit + CLI tests: shadow-check fix (renamed known-gap test to assert the corrected `3`), mixed bare/`$` param lists, a direct AST-level test confirming duplicate-parameter-name shadowing resolves by last occurrence (isolated from the unrelated #2560 argument-binding bug), `substitute_func_param_impl`'s own known-gap pinned with a live repro (#2555), malformed-parameter-list boundary test — all confirmed live against jq 1.7.1 where oracle-reachable
- [x] `cargo llvm-cov` + `omni-dev coverage diff` — 97.22% patch coverage (105/108 new lines; the 3 remaining are two provably-unreachable test panic arms with `coverage tolerate-line` annotations, and one block-closing brace)
- [x] Rebased onto latest `origin/main`, rebuilt and re-ran the full suite clean post-rebase

## Follow-ups filed during review

- #2555 — `substitute_func_param_impl`'s own deeper shadow-check gap (needs a `subst_bare` flag)
- #2560 — `bind_def_call`'s pre-existing, unrelated duplicate-parameter-name argument-binding bug
