### PR TITLE
refactor(jq): collapse push_generic_truthiness_cursor_error's tail-gap dispatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **`eval_generic::push_generic_truthiness_cursor_error`'s object/array arms now call
+  `container_tail_gap_ok` instead of hand-inlining the `None`/`Some(last)`
+  container-vs-trailing-gap dispatch** (#2409). No behavior change: this was the last
+  hold-out of a dispatch shape that `to_owned_cursor_at_depth` (`eval_generic.rs`) and
+  `cursor_to_owned_at_depth` (`lazy.rs`) had already consolidated onto the same helper.
+  Also settles a minor, previously-inert inconsistency the two hand-inlined copies had —
+  both built their error from the container cursor even on the trailing-comma branch,
+  where `container_tail_gap_ok` (via `child_tail_gap_ok`) builds it from the last child
+  instead; byte-identical today (`JsonCursor`'s `malformed_delimiter_error()` override
+  reads the same whole-document `self.text` regardless of which node's cursor calls it,
+  and YAML never reaches either raise at all), but no longer a live divergence risk if a
+  future cursor type ever makes it position-sensitive.
+
 - **`succinctly yq`'s `type` now answers the YAML tag (`!!str`, `!!int`,
   `!!map`, ...), matching real yq's own `type`/`tag` alias, instead of jq's
   type name (`"string"`, `"number"`, `"object"`, ...)** (#2516). Confirmed

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -2808,18 +2808,12 @@ fn push_generic_truthiness_cursor_error<C: DocumentCursor>(c: &C, depth: usize) 
         // `to_owned_cursor_at_depth`'s own object arm runs after its loop
         // -- a stray `,` with no real field (`{,}`) or a trailing `,`
         // after the last real field (`{"a":1,}`) both passed silently
-        // here before this fix.
-        match last_field {
-            None => {
-                if !c.container_gap_ok(b'}') {
-                    return Some(Control::Error(c.malformed_delimiter_error()));
-                }
-            }
-            Some(value_cursor) => {
-                if !trailing_element_gap_ok(&value_cursor, b'}') {
-                    return Some(Control::Error(c.malformed_delimiter_error()));
-                }
-            }
+        // here before this fix. #2409: was a hand-inlined `match last_field`
+        // dispatch (the last hold-out of that duplicated shape); now the
+        // same `container_tail_gap_ok` its `to_owned_cursor_at_depth` sibling
+        // already calls.
+        if let Err(e) = container_tail_gap_ok(c, last_field.as_ref(), b'}') {
+            return Some(Control::Error(e));
         }
         None
     } else if let Some(elements) = value.as_array() {
@@ -2852,18 +2846,11 @@ fn push_generic_truthiness_cursor_error<C: DocumentCursor>(c: &C, depth: usize) 
         // #2349/#2211/#2243: same container/trailing-gap checks
         // `to_owned_cursor_at_depth`'s own array arm runs after its loop --
         // `[,]` (no real element) or `[1,]` (trailing `,`) both passed
-        // silently here before this fix.
-        match last_elem {
-            None => {
-                if !c.container_gap_ok(b']') {
-                    return Some(Control::Error(c.malformed_delimiter_error()));
-                }
-            }
-            Some(last) => {
-                if !trailing_element_gap_ok(&last, b']') {
-                    return Some(Control::Error(c.malformed_delimiter_error()));
-                }
-            }
+        // silently here before this fix. #2409: was a hand-inlined
+        // `match last_elem` dispatch; now the same `container_tail_gap_ok`
+        // its `to_owned_cursor_at_depth` sibling already calls.
+        if let Err(e) = container_tail_gap_ok(c, last_elem.as_ref(), b']') {
+            return Some(Control::Error(e));
         }
         None
     } else if let Some(reason) = value.string_decode_error() {


### PR DESCRIPTION
## Summary

- `push_generic_truthiness_cursor_error`'s object/array arms hand-inlined the `None`-vs-`Some(last)` container/trailing-gap dispatch that `to_owned_cursor_at_depth` (`eval_generic.rs`) and `cursor_to_owned_at_depth` (`lazy.rs`) had already consolidated onto `container_tail_gap_ok` — the last hold-out of that shape (#2409).
- Both arms now call `container_tail_gap_ok` directly instead.
- No behavior change beyond settling which cursor's `malformed_delimiter_error()` builds the trailing-comma error — byte-identical today for every cursor type this codebase ships (JSON's override reads the same whole-document `self.text` regardless of receiver; YAML never reaches either raise).

Fixes #2409

## Test plan

- [x] `cargo build --features cli`
- [x] `cargo test --features cli,simd,regex,serde` — all 62 binaries pass, 0 failures
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings`
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features`
- [x] Independent code review (verified behavior-preservation claim, receiver-identity, and error-equivalence claim against `malformed_delimiter_error()`'s actual default/override implementations)