### PR TITLE
feat(jq): walk an optional head so the absent split takes it (#2558)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   inherited a walk that accepted `{"a" 1}`. Confirmed the YAML side doesn't
   move: the full comment/anchor/style corpus is byte-identical, since every
   new check is a no-op there by construction.
+- **An optional head (`.a? | key`, `.c[-1]? | path`) now reads path context
+  from the document node it stands on, instead of sending the whole pipe to
+  the eager path-context evaluator** (#2558, spine 2416).
+  `path_context_is_navigational` excluded `?`, so the absent split found an
+  empty head and declined, and `path_context_needs_eager` handed over whatever
+  followed. `?` over navigation moves the position exactly as the bare
+  navigation does and produces *no* position for the step it suppresses --
+  captured on a flow document and its block spelling from both pinned
+  oracles, which agree (`jq -c 'path(.s.b?)'` and `yq '.s.b? | key'` are both
+  empty; `yq '.[0]? | key'` on a mapping is `0` where jq suppresses the raise
+  to nothing). Two answers change and both move *towards* yq v4.53.3:
+  `.c[-1]? | key` on `c: [10, 20]` is `1`, the resolved index, where it used
+  to be `-1` (the index as written, which is jq mode's rule, not yq's), and
+  `.a? | .b = key` is `{"b":"a"}` where it used to be `{"b":1}` (the
+  assignment's right side had no position to read). `.c[-5]? | key` still
+  raises: a yq-mode negative index still negative after resolving, and a
+  string-decode failure, are the two errors `?` does not swallow.
 
 - **A stray `,` with zero real children in a *nested* container (`{"a": [,]}`,
   `{"a": {,}}`) now raises in two more materializers, matching real jq/yq**

--- a/docs/adrs/adr-0021.md
+++ b/docs/adrs/adr-0021.md
@@ -73,7 +73,12 @@ in-place transforms *inside owned values*, which have no node to stand on.
    head that can reach an absent node followed by a computed stage, or a construct the
    generic evaluator has no cursor-threading arm for (`path_context_single_native` is a
    closed list). Node-preserving stages — `select`, `parent`, `first`, `.a?` — carry the
-   node, and its possible absence, forward. **The gate is the only entry.**
+   node, and its possible absence, forward; `.a?` is *navigation* as well since #2558
+   (`path_context_is_navigational`), so the walk and the absent split take a `?` head
+   like any other — the step is suppressed and produces no position, which is what both
+   references do (`jq -c 'path(.s.b?)'` and `yq '.s.b? | key'` are both empty), and only
+   `EvalError::is_uncatchable_at_value_position` survives the `?`. **The gate is the only
+   entry.**
    `--eval-all` (`eval_owned_with_file_index`, #715) and `eval::eval_pipe`'s own
    diversion each reached the eager evaluator without consulting it; both route
    through it now, and `tests/jq_path_context_single_door_guard.rs` fails on a new
@@ -160,7 +165,8 @@ in-place transforms *inside owned values*, which have no node to stand on.
 
    **The residue is a fan-out head.** `.[] | .k | select(key == "k")` is one position per
    element, the memory cost `path_context_fans_out` exists to refuse and the same guard
-   `path_context_walk_split` applies. It stays eager by design, and it is what decision 8's
+   `path_context_walk_split` applies (and `.[]?` counts, since #2558 gave that predicate
+   its own `Expr::Optional` arm). It stays eager by design, and it is what decision 8's
    exit condition has to survive: this route is not what will remove it.
 
 8. **No regrowth.** `tests/jq_path_context_arm_guard.rs` pins the eager evaluator's named
@@ -195,9 +201,10 @@ in-place transforms *inside owned values*, which have no node to stand on.
   asserting the exit code and diagnostic, not an empty stdout.
 - **What remains on the eager route** is bounded by three reasons, each with a known
   next step: the owned-domain stages decision 7's list does not cover; a fan-out head with
-  a computed tail, plus a `?` head the walk does not step, which is all #2472 and #2473
-  left of the absent reason (its other two shapes, `parent` from a possibly-absent
-  position and navigation after a non-navigational stage, are decision 7's route now);
+  a computed tail, plus a stage with no `owned_identity_rule` behind a head that can miss,
+  which is all #2472, #2473 and #2558 left of the absent reason (its other three shapes,
+  `parent` from a possibly-absent position, navigation after a non-navigational stage,
+  and a `?` head, are decision 7's route or the walk's now);
   and the reason-3 residue. #2473 closed most of that third one -- `and`/`or` and
   `reduce`/`foreach` have native `eval_single` arms now, and `needs_path_context`
   descends into `Expr::Object` (#1332's other half), so an object literal's slots are

--- a/docs/plan/path-context-arm-reachability.md
+++ b/docs/plan/path-context-arm-reachability.md
@@ -105,8 +105,10 @@ order; the `Gate` column names the first that fired for that query.
 R2 still dominates the table, but for a narrower reason since #2472 (below): a
 `.field` step can always miss, and a *head that can miss* is only handed over
 now when neither the constant route nor the owned identity pipe can take the
-stages after it. The probe shape that trips it is `.a?` (which
-`path_context_is_navigational` excludes, so no position is walked) or a bare
+stages after it. The probe shape that trips it was `.a?` until #2558 (below)
+made `?` over navigation navigational; what is left is a stage with no
+`owned_identity_rule` after a head that can miss (`.a.b | . as $x | ...`,
+`map`, `reduce`/`foreach`, `label`/`def`) or a bare
 `parent` operand (which no route can name a position for). The same shapes with
 a head that cannot miss trip R3 instead -- e.g. `.a[] | (key | tostring)`,
 `.a[] | (key | length)`, `.a[] | {"k": (key | tostring)}` and
@@ -126,9 +128,9 @@ trusting them.
 
 | #   | Handler (site in `eval_stage_with_path_context`)                   | Verdict   | Proof query (jq mode, document `D`)                   | Gate |
 |-----|--------------------------------------------------------------------|-----------|-------------------------------------------------------|------|
-| H1  | pre-match `if matches!(first, Expr::Builtin(Builtin::PathNoArg))`  | REACHABLE | `.a? \| path + []`                                    | R2   |
-| H2  | pre-match `if matches!(first, Expr::Builtin(Builtin::Key))`        | REACHABLE | `.a? \| key + "x"`                                    | R2   |
-| H3  | pre-match `if matches!(first, Expr::Builtin(Builtin::FileIndex))`  | REACHABLE | `.a? \| file_index + 1`                               | R2   |
+| H1  | pre-match `if matches!(first, Expr::Builtin(Builtin::PathNoArg))`  | REACHABLE | `.a.b \| . as $x \| path + []`                         | R2   |
+| H2  | pre-match `if matches!(first, Expr::Builtin(Builtin::Key))`        | REACHABLE | `.a.b \| . as $x \| key + "x"`                         | R2   |
+| H3  | pre-match `if matches!(first, Expr::Builtin(Builtin::FileIndex))`  | REACHABLE | `.a.b \| . as $x \| file_index + 1`                    | R2   |
 | H4  | pre-match `if matches!(first, Expr::Builtin(Builtin::Parent))`     | REACHABLE | `.a.b \| parent + {}`                                 | R2   |
 | H5  | pre-match `if let Expr::Builtin(Builtin::ParentN(n_expr)) = first` | REACHABLE | `.a.b \| parent(0+1) + {}`                            | R2   |
 | A01 | `Expr::Identity`                                                   | REACHABLE | `.a.b \| . \| parent + {}`                            | R2   |
@@ -138,20 +140,20 @@ trusting them.
 | A05 | `Expr::Iterate`                                                    | REACHABLE | `.a[] \| (key \| tostring)`                            | R3   |
 | A06 | `Expr::Paren(inner)`                                               | REACHABLE | `.a.b \| (parent) + {}`                               | R2   |
 | A07 | `Expr::Optional(inner) if IndexExpr/SliceExpr`                     | REACHABLE | `.c[.n]? \| key + 1`                                  | R1   |
-| A08 | `Expr::Optional(inner)`                                            | REACHABLE | `.a? \| key + "x"`                                    | R2   |
+| A08 | `Expr::Optional(inner)`                                            | REACHABLE | `.a? \| . as $x \| key`                                | R2   |
 | A09 | `Expr::Pipe(inner) if rest.is_empty()`                             | REACHABLE | `.a.b \| -(key\|length)`                              | R2   |
 | A10 | `Expr::Pipe(inner)`                                                | REACHABLE | `.a.b \| parent + {}`                                 | R2   |
 | A11 | `Expr::Arithmetic { .. }`                                          | REACHABLE | `.a.b \| parent + {}`                                 | R2   |
-| A12 | `Expr::And(..) \| Expr::Or(..)`                                    | REACHABLE | `.a? \| key == "a" and true`                          | R2   |
+| A12 | `Expr::And(..) \| Expr::Or(..)`                                    | REACHABLE | `.a.b \| . as $x \| (key and parent)`                  | R2   |
 | A13 | `Expr::Negate(operand)`                                            | REACHABLE | `.a.b \| -(key\|length)`                              | R2   |
-| A14 | `Expr::Compare { .. }`                                             | REACHABLE | `.a? \| (key + "x") \| . == "bx"`                     | R2   |
+| A14 | `Expr::Compare { .. }`                                             | REACHABLE | `.a.b \| . as $x \| (key + "x") \| . == "bx"`          | R2   |
 | A15 | `Expr::Builtin(Builtin::Select(cond))`                             | REACHABLE | `.a.b \| select(key == "b") \| parent + {}`           | R2   |
 | A16 | `Expr::Builtin(Builtin::Map(f))`                                   | REACHABLE | `.a \| map(key + "x")`                                | R2   |
 | A17 | `Expr::Builtin(Builtin::GetPath(path_expr))`                       | REACHABLE | `.a \| getpath(["b"]) \| . as $x \| key`              | R1   |
 | A18 | `Expr::Builtin(_)`                                                 | REACHABLE | `.a[] \| (key \| length)`                             | R3   |
 | A19 | `Expr::IndexExpr { target, key }`                                  | REACHABLE | `.c[.n] \| key + 1`                                   | R1   |
 | A20 | `Expr::SliceExpr { target, start, end }`                           | REACHABLE | `.c[.n:.m] \| .[0] \| key + 1`                        | R1   |
-| A21 | `Expr::Array(inner) if needs_path_context(inner)`                  | REACHABLE | `.a? \| [key] + ["x"]`                                | R2   |
+| A21 | `Expr::Array(inner) if needs_path_context(inner)`                  | REACHABLE | `.a.b \| . as $x \| [key] + ["x"]`                     | R2   |
 | A22 | `Expr::StringInterpolation(parts) if ..`                           | REACHABLE | `.a.b \| ("\(key)") \| . + "x"`                       | R2   |
 | A23 | `Expr::DefCall { .. }`                                             | REACHABLE | `def f: key; .a.b \| f + "x"`                         | R2   |
 | A24 | `Expr::Shared(inner)`                                              | REACHABLE | `def f(x): x; .a.b \| f(key) + "z"`                   | R2   |
@@ -163,7 +165,7 @@ trusting them.
 | A30 | `Expr::LastExpr(expr) if ..`                                       | REACHABLE | `.a.b \| last(key + "x")`                             | R2   |
 | A31 | `Expr::Reduce { .. } if ..`                                        | REACHABLE | `.a.b \| reduce (key) as $k (""; . + $k) \| . + "x"`  | R2   |
 | A32 | `Expr::Foreach { .. } if ..`                                       | REACHABLE | `.a.b \| foreach (key) as $k (""; . + $k) \| . + "x"` | R2   |
-| A33 | `Expr::Object(_) \| Expr::Array(_) \| Expr::Literal(_)`            | REACHABLE | `.a? \| (key + "x") \| {z: .}`                        | R2   |
+| A33 | `Expr::Object(_) \| Expr::Array(_) \| Expr::Literal(_)`            | REACHABLE | `.a.b \| . as $x \| (key + "x") \| {z: .}`             | R2   |
 | A34 | `Expr::If { .. }`                                                  | REACHABLE | `.a.b \| if key == "b" then key + "x" else "y" end`   | R2   |
 | A35 | `Expr::Comma(exprs)`                                               | REACHABLE | `.a.b \| (key + "x"), key`                            | R2   |
 | A36 | `Expr::Try { .. }`                                                 | REACHABLE | `.a.b \| try (key + "x") catch "e"`                   | R2   |
@@ -528,6 +530,105 @@ jq defines (`path(.)`, `[paths]`, `del(...)`, arithmetic), across seven
 operators including `/=`/`%=`/`//=` -- reports **0 changed** and 4,900/4,900
 agreement with jq 1.7.1 before and after.
 
+## #2558: `?` at the head admitted, and the pin still holds at 44
+
+[#2558](https://github.com/rust-works/succinctly/issues/2558) removed what the
+"Notes for the next migration" section below had measured as reason `R2`'s
+single biggest source: `path_context_is_navigational` excluded
+`Expr::Optional`, so `path_context_absent_split` found an *empty* navigational
+head, declined, and `path_context_needs_eager` handed the whole pipe over
+whatever followed the `?`.
+
+`?` over navigation is now navigational. The step is one arm in
+`path_context_step_generic` -- run the inner step, keep the positions it
+reached, drop the error it raised -- which is `path_step_generic`'s own
+`Expr::Optional` arm one level up, not a second set of semantics. Two errors
+are exempt, the same two the eager evaluator's `Expr::Optional` arm exempts
+(`EvalError::is_uncatchable_at_value_position`): a yq-mode negative index still
+negative after resolving, and a string-decode failure.
+`path_context_fans_out` gained a matching `Expr::Optional` arm, so `.[]?` still
+counts as the fan-out it is.
+
+Every row was captured first from Homebrew yq v4.53.3 and `/usr/bin/jq` 1.7.1,
+on a flow document and its block spelling, which yq answers identically; the
+captures are in the doc comments of `test_optional_head_is_walkable_2558`
+(`tests/yq_cli_tests.rs` and `tests/jq_cli_tests.rs`). Of the 128 probed
+answers, **four changed and all four moved from disagreeing with yq to
+agreeing with it**, none the other way:
+
+| query | before | after | yq v4.53.3 |
+|---|---|---|---|
+| `.c[-1]? \| key` (flow) | `-1` | `1` | `1` |
+| `.c[-1]? \| key` (block) | `-1` | `1` | `1` |
+| `.a? \| .b = key` (flow) | `{"b":1}` | `{"b":"a"}` | `{"b":"a"}` |
+| `.a? \| .b = key` (block) | `{"b":1}` | `{"b":"a"}` | `{"b":"a"}` |
+
+The first pair is the row
+`test_negative_index_out_of_range_survives_path_context_2254` had pinned as
+`-1` with the note "this row flips when the eager evaluator retires"; the
+second is ADR-0021 decision 7's assignment rule reaching a `?` head for the
+first time. `.c[-5]? | key` still raises, which is the row that says the `?`
+does not swallow everything.
+
+**`PINNED_ARM_COUNT` stays at 44.** Nine of the table's rows had a `?` head in
+their listed proof query (`H1`, `H2`, `H3`, `A07`, `A08`, `A12`, `A14`, `A21`,
+`A33`), so each was re-derived with the method above (instrument, run, revert;
+instrumentation applied to those nine handlers and to
+`path_context_needs_eager`'s three disjuncts, and reverted before this document
+was committed). Document `D`:
+
+| Id  | Listed query before            | Re-derived query                            | Gate | Marker | Output       |
+|-----|--------------------------------|---------------------------------------------|------|--------|--------------|
+| H1  | `.a? \| path + []`             | `.a.b \| . as $x \| path + []`               | R2   | fired  | `["a","b"]`  |
+| H2  | `.a? \| key + "x"`             | `.a.b \| . as $x \| key + "x"`               | R2   | fired  | `"bx"`       |
+| H3  | `.a? \| file_index + 1`        | `.a.b \| . as $x \| file_index + 1`          | R2   | fired  | `1`          |
+| A07 | `.c[.n]? \| key + 1`           | unchanged                                   | R1   | fired  | `1`          |
+| A08 | `.a? \| key + "x"`             | `.a? \| . as $x \| key`                      | R2   | fired  | `"a"`        |
+| A12 | `.a? \| key == "a" and true`   | `.a.b \| . as $x \| (key and parent)`        | R2   | fired  | `true`       |
+| A14 | `.a? \| (key + "x") \| . == "bx"` | `.a.b \| . as $x \| (key + "x") \| . == "bx"` | R2 | fired | `true`      |
+| A21 | `.a? \| [key] + ["x"]`         | `.a.b \| . as $x \| [key] + ["x"]`           | R2   | fired  | `["b","x"]`  |
+| A33 | `.a? \| (key + "x") \| {z: .}` | `.a.b \| . as $x \| (key + "x") \| {z: .}`   | R2   | fired  | `{"z":"bx"}` |
+
+Both spellings are pinned in
+`test_arm_audit_proof_queries_are_unmoved_by_the_gate_2416`, which is what
+makes the move readable as "same outputs, different route".
+
+Three things are worth recording about the re-run:
+
+- **`A07` is unaffected on purpose.** Its head is `.c[.n]?` -- `?` over a
+  *computed* bracket, which `path_context_is_navigational` still does not admit
+  (an absent `PathNode` carries no cursor to evaluate the component against).
+  That is #2471's own "next step for this cluster" and is not what #2558
+  changed; its gate is `R1`, not `R2`, and both are unmoved.
+- **`A08` is still reachable, and by a `?` head.** `?` over navigation being
+  *walkable* does not make a pipe routable: `.a? | . as $x | key` still hands
+  over, because `as` has no `owned_identity_rule`, and the eager evaluator's
+  own `Expr::Optional` arm is what steps the `?` once it does. The arm dies
+  with the `R2` stage cluster, not with this change.
+- **`H1`/`H2`/`A21` fire as a side effect whenever `A08` does.** The eager
+  `Expr::Optional` arm appends `path_probe_stage`'s `[path, .]` to isolate the
+  inner pipe (#1409), and that probe is an `Expr::Array` containing `path`. The
+  re-derived rows above avoid the artefact by using an `as` stage rather than
+  a `?` one, so each marker is the handler the row is claiming.
+
+**Nothing became unreachable, so nothing was deleted**, and the reason is
+structural rather than a matter of finding another query: `path_context_is_
+navigational`, `path_context_fans_out` and `path_context_step_generic` are the
+only three functions this change touches, and each gained an `Expr::Optional`
+arm and nothing else. A pipe with no `Expr::Optional` anywhere in it is
+therefore routed *identically* before and after, which is why the 35 rows
+whose listed query has no `?` need no re-derivation and none was done.
+
+### A caveat about the gate instrumentation
+
+`path_context_needs_eager` is consulted in two unrelated places: at the routing
+decision, and from `path_context_single_native`'s own `Expr::Pipe` arm, which
+asks it of a *nested* pipe. An `eprintln!` per disjunct therefore fires for
+filters that never reach the eager evaluator at all -- `.a? | [key] | .[0] |
+path` prints `R1` and `R2` and hits no arm. The `ARMHIT` markers, not the
+`GATE` ones, are what says a handler ran; the `Gate` column records the
+disjunct that fired for a query the markers confirm got there.
+
 ## Result
 
 | Metric                                            | Before | After                 |
@@ -536,9 +637,10 @@ agreement with jq 1.7.1 before and after.
 | ... proven REACHABLE by a live query               | --     | 44                    |
 | ... proven UNREACHABLE                             | --     | 0                     |
 | ... neither                                        | --     | 0                     |
-| ... whose listed proof query moved off the gate    | --     | 1 (#2473); 14 (#2472) |
+| ... whose listed proof query moved off the gate    | --     | 1 (#2473); 14 (#2472); 8 (#2558) |
 | ... starved by #2471's remainder                   | --     | 0 (`A16`/`A18` re-run) |
 | ... starved by #2522                               | --     | 0 (no row's query assigns) |
+| ... starved by #2558                               | --     | 0 (9 `?`-headed rows re-derived) |
 | `PINNED_ARM_COUNT`                                 | 43     | 44                    |
 
 Nothing is deletable at this point in the spine. Doors 2 and 3 are closed as
@@ -578,12 +680,13 @@ evaluator, with no second route to check.
   the remaining move for this reason; widening the absent route again buys
   nothing, because it already accepts every `rest` those stages are missing
   from.
-- **`?` at the head is now the single biggest source of `R2`.** It is excluded
-  from `path_context_is_navigational` on purpose (`?` in path context is not
-  `?` in a path expression), so `path_context_absent_split` finds an empty head
-  and declines, and the pipe goes eager whatever follows. Teaching the walk to
-  step `.a?` -- which means deciding what it does on a *scalar* input, where
-  `.a` errors and `.a?` yields nothing -- is what would empty that cluster.
+- **`?` at the head was the single biggest source of `R2`; #2558 closed it.**
+  It is admitted to `path_context_is_navigational` now, and what it does on a
+  *scalar* input is the question that had to be answered: the step is
+  suppressed and produces no position at all, which is what both oracles do
+  (`jq -c 'path(.s.b?)'` and `yq '.s.b? | key'` both print nothing). What is
+  left of the `R2` cluster is the bullet above -- the stage shapes with no
+  `owned_identity_rule` -- plus the fan-out head, which is by design.
 - The step-5 closure did *not* change what the sweep
   (`scripts/jq-path-context-oracle-sweep.sh`) sees for `file_index`. Its
   yq-mode cases run `succinctly yq FILTER one.yaml two.yaml` with no

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -12268,16 +12268,17 @@ fn path_step_pipe_generic<S: EvalSemantics, V: DocumentValue>(
 ///   semantics (#1449) that the walk does not model, so such a pipe is
 ///   refused here rather than discovered mid-walk.
 ///
-/// Two deliberate exclusions, both narrower than the `path()` predicate:
+/// One deliberate exclusion, narrower than the `path()` predicate:
+/// `parent(n)` with a computed `n`. `n` is evaluated against the *current*
+/// value, which the walk would have to materialize to do -- exactly the cost
+/// being removed. A literal covers the real uses.
 ///
-/// * `Expr::Optional`. `?` in path context is not the same rule as `?` in a
-///   path expression -- `eval_pipe_with_path_context_internal` gives it three
-///   separate arms, one of them a bracket carve-out shared with the plain
-///   evaluator. Reproducing that here would be re-deriving semantics rather
-///   than reusing them, so `?` defers.
-/// * `parent(n)` with a computed `n`. `n` is evaluated against the *current*
-///   value, which the walk would have to materialize to do -- exactly the
-///   cost being removed. A literal covers the real uses.
+/// `?` over navigation is **not** an exclusion since #2558 (spine 2416): a
+/// suppressed step is one the walk simply does not take, which is the same
+/// answer the eager evaluator's own `Expr::Optional` arm produces by
+/// catching. It is `path_context_is_navigational` that admits it, so the
+/// absent split's head takes it too -- and `?` at the head was the single
+/// biggest source of the gate's reason 2.
 ///
 /// `Expr::Array` is included so `[.[] | key]` -- whose outputs are one
 /// bounded array, not one per element -- stays on the walk too.
@@ -12310,6 +12311,14 @@ fn path_context_pipe_is_walkable(stages: &[Expr]) -> bool {
 fn path_context_is_navigational(expr: &Expr) -> bool {
     match expr {
         Expr::Identity | Expr::Iterate | Expr::Field(_) | Expr::Index { .. } => true,
+        // #2558: `?` over navigation moves the position exactly as the bare
+        // navigation does, and suppresses the step that raised instead of
+        // producing a position for it. `key`/`path` never see a `?` at all,
+        // so there is no second rule to re-derive -- the step's own arm in
+        // [`path_context_step_generic`] is the whole of it. `?` over
+        // anything else (`key?`, `(.a | tostring)?`) is not navigation and
+        // is not admitted here.
+        Expr::Optional(inner) => path_context_is_navigational(inner),
         Expr::Paren(inner) => path_context_is_navigational(inner),
         Expr::Pipe(exprs) | Expr::Comma(exprs) => exprs.iter().all(path_context_is_navigational),
         Expr::Builtin(Builtin::Parent) => true,
@@ -12337,7 +12346,12 @@ fn path_context_fans_out(expr: &Expr) -> bool {
         Expr::Iterate => true,
         Expr::Comma(exprs) => exprs.len() > 1 || exprs.iter().any(path_context_fans_out),
         Expr::Pipe(exprs) => exprs.iter().any(path_context_fans_out),
-        Expr::Paren(inner) | Expr::Array(inner) => path_context_fans_out(inner),
+        // `Expr::Optional` since #2558: `.[]?` became navigational there, so
+        // without this arm a suppressed iterate would hide the very fan-out
+        // this guard exists to refuse.
+        Expr::Paren(inner) | Expr::Array(inner) | Expr::Optional(inner) => {
+            path_context_fans_out(inner)
+        }
         _ => false,
     }
 }
@@ -12585,6 +12599,33 @@ fn path_context_step_generic<S: EvalSemantics, V: DocumentValue>(
             let n = classify_parent_n::<S>(&literal_to_owned(lit), pos.path.len())?;
             out.extend(path_context_hop(pos, n));
             Ok(())
+        }
+        // #2558: the same rule as `path_step_generic`'s own `Expr::Optional`
+        // arm, one level up so a whole *position* (path plus ancestors)
+        // survives -- the error is swallowed, the positions already reached
+        // are not. A suppressed step produces no position, which is what
+        // makes `.a? | key` on a scalar-valued `.a`'s child empty rather
+        // than absent: captured live on `{"a":{"b":1},"s":"hi"}`, jq 1.7.1's
+        // `path(.s.b?)` prints nothing and yq v4.53.3's `.s.b? | key` prints
+        // nothing, where the *unsuppressed* `.s.b` raises in jq mode.
+        //
+        // Two errors are not this `?`'s to swallow, and they are exactly the
+        // two the eager evaluator's own `Expr::Optional` arm exempts
+        // (`EvalError::is_uncatchable_at_value_position`, whose doc comment
+        // has the rationale): a yq-mode negative index still negative after
+        // resolving against the length (#2254) and a string-decode failure
+        // (#1620). `.c[-5]? | key` on `c: [10, 20]` is
+        // `Error: index [-5] out of range, array size is 2` in yq v4.53.3,
+        // and swallowing it here would have made this migration change the
+        // answer instead of the route.
+        Expr::Optional(inner) => {
+            let mut branch = Vec::new();
+            let stepped = path_context_step_generic::<S, V>(inner, pos, &mut branch);
+            out.append(&mut branch);
+            match stepped {
+                Err(e) if e.is_uncatchable_at_value_position() => Err(e),
+                _ => Ok(()),
+            }
         }
         other => unreachable!(
             "path_context_is_navigational admitted a stage the walk cannot step: {other:?}"
@@ -26099,8 +26140,16 @@ mod tests {
         assert!(!walkable("(.a | key) | .x"));
         assert!(!walkable("(key, .b) | .c"));
         assert!(!walkable("[.[] | key] | .[0]"));
+        // #2558: `?` over navigation is walkable -- the step it wraps is
+        // taken, or suppressed and no position produced.
+        assert!(walkable(".a? | key"));
+        assert!(walkable(".a?.b | path"));
+        assert!(walkable(".a | .b? | parent"));
+        assert!(walkable(".[]? | key"));
+        // ...but `?` over something that is not navigation still is not.
+        assert!(!walkable("key? | tostring"));
+        assert!(!walkable("(.a | tostring)? | key"));
         // Shapes the walk does not model at all.
-        assert!(!walkable(".a? | key"));
         assert!(!walkable(".a | parent(1 + 1)"));
         assert!(!walkable(".a | select(true) | key"));
         assert!(!walkable(".a | key | tostring"));
@@ -26129,6 +26178,15 @@ mod tests {
         assert_eq!(split(".[] | .k | parent"), None);
         assert_eq!(split(".[] | .k | parent | key"), Some((4, 0)));
         assert_eq!(split("(.a.x, .b.y) | parent"), None);
+        // #2558: `?` over navigation is navigational, so a `?` head is taken
+        // whole exactly as its bare spelling is -- and `.[]?` still counts as
+        // a fan-out, which is what `path_context_fans_out`'s own `Optional`
+        // arm is for.
+        assert_eq!(split(".a? | key"), Some((2, 0)));
+        assert_eq!(split(".a?.b | path"), Some((2, 0)));
+        assert_eq!(split(".a | .b? | parent | key"), Some((4, 0)));
+        assert_eq!(split(".[]? | .k | parent"), None);
+        assert_eq!(split(".[]? | .k | parent | key"), Some((4, 0)));
     }
 
     /// What the M2 gate asks: cursors end to end, never a computed tail.
@@ -26163,6 +26221,15 @@ mod tests {
             };
             path_context_needs_eager(&stages)
         };
+        // #2558: some rows below have to say *which* route answers, not only
+        // what the gate reports, because the gate is asked after the walk
+        // and the absent split have each had their turn.
+        fn pipe_stages(f: &str) -> Vec<Expr> {
+            let Expr::Pipe(stages) = parse(f).unwrap() else {
+                panic!("not a pipe: {f}")
+            };
+            stages
+        }
         // No path context at all: never the eager evaluator's business.
         assert!(!eager(".a | tostring"));
         // Generic: a navigational head that cannot miss, then a native stage.
@@ -26425,12 +26492,48 @@ mod tests {
             "`.x` can be absent"
         );
         assert!(!eager(".x[] | first(.a | parent | parent)"));
-        // Node-preserving stages carry the absent possibility along, but
-        // `?` is not one the absent split can walk: `path_context_is_
-        // navigational` excludes it (the walk's own documented exclusion --
-        // `?` in path context is not `?` in a path expression), so the head
-        // stops before it and there is no position to resolve against.
+        // #2558: `?` over navigation is navigational now, so a head that
+        // ends in one is routed like any other -- `docs/plan/path-context-
+        // arm-reachability.md`'s "`?` at the head is now the single biggest
+        // source of `R2`" no longer holds. Every one of these hands over
+        // before the change and does not after.
+        assert!(!eager(".a? | key + \"x\""));
+        assert!(!eager(".a? | [key] + [\"x\"]"));
+        assert!(!eager(".a? | select(key == \"a\")"));
+        assert!(!eager(".a? | [path, parent]"));
+        assert!(!eager(".a? | {\"k\": key}"));
+        assert!(!eager(".a? | key == \"a\" and true"));
+        assert!(!eager(".a? | if key == \"a\" then 1 else 2 end"));
+        assert!(!eager(".a? | first(key)"));
+        assert!(!eager(".a? | limit(1; key)"));
+        assert!(!eager(".a? | try key catch \"e\""));
+        assert!(!eager(".a? | tostring | key"));
+        assert!(!eager(".a? | to_entries | .[0] | key"));
+        assert!(!eager(".a? | file_index + 1"));
+        // A whole-pipe walk reports `true` here for the same reason
+        // `.a.b | key` does -- `path_context_absent_split` steps aside for a
+        // pipe the walk already takes, so `absent_routed` is `false` and the
+        // gate is never the route that answers. `path_context_walk_split`
+        // is where that is pinned (`..._takes_whole_head_or_nothing_2416`).
+        assert!(eager(".a? | key"));
+        assert!(path_context_walk_split(&pipe_stages(".a? | key")).is_some());
         assert!(eager(".a[5]? | key"));
+        assert!(path_context_walk_split(&pipe_stages(".a[5]? | key")).is_some());
+        // An assignment's right side is the `.a.b | .c = key` row above with
+        // a `?` head: the absent route answers it first, so the gate's own
+        // `true` is not the route taken.
+        assert!(eager(".a? | .b = key"));
+        assert!(path_context_absent_split(&pipe_stages(".a? | .b = key")).is_some());
+        // ...but only `?` over *navigation*: `?` over anything else is not a
+        // head the walk can step, so the pipe hands over exactly as before.
+        assert!(eager(".a | (key | tostring)? | key"));
+        // A `?` head does not rescue a stage no route can name a position
+        // for, nor a fan-out head -- the residue ADR-0021 records.
+        assert!(eager(".a? | .b |= key"));
+        assert!(eager(".a? | explode | key"));
+        assert!(eager(".a? | map(key + \"x\")"));
+        assert!(eager(".a? | . as $x | key"));
+        assert!(eager(".[]? | .k | select(key == \"k\")"));
         assert!(!eager(".a[] | select(true) | key"));
     }
 
@@ -26647,6 +26750,14 @@ mod tests {
         // Neither route: `explode` has no identity rule, so there is
         // nothing to carry the position through it.
         assert_eq!(split(".a.b | explode | key"), None);
+        // #2558: a `?` head is part of the navigational head now, so the
+        // split finds one instead of stopping before it and declining.
+        assert_eq!(split(".a? | select(key == \"a\")"), Some((1, 1, Constants)));
+        assert_eq!(split(".a? | [path, parent]"), Some((1, 1, OwnedIdentity)));
+        assert_eq!(split(".a.b? | tostring | key"), Some((1, 2, OwnedIdentity)));
+        // ...but a `?` head that fans out is refused by the same guard every
+        // other fan-out head is.
+        assert_eq!(split(".[]? | .k | select(key == \"k\")"), None);
     }
 
     /// The absent-reachability fold behind reason 2.
@@ -26668,6 +26779,12 @@ mod tests {
         assert!(can("(.a, .[])"), "either branch");
         assert!(can(".[] | .a"));
         assert!(!can("."), "the pipe's input is a real node");
+        // #2558: `?` forwards its inner step's answer, which is what makes a
+        // `?` head routable at all.
+        assert!(can(".a?"));
+        assert!(can(".a?.b"));
+        assert!(!can(".a?[]"));
+        assert!(!can(".[]?"));
     }
 
     /// `key`/`parent`/`path` as cursor properties, straight from the tree,

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -39129,3 +39129,83 @@ fn test_jq_update_filter_position_is_a_succinctly_extension_2522() -> Result<()>
 
     Ok(())
 }
+
+/// #2558 (spine 2416, gate reason 2): an optional head (`.a? | ...`) is
+/// walkable, in jq mode too.
+///
+/// jq 1.7.1 has no `key`/`path`-with-no-argument, so its half of the oracle
+/// is the *component* model `path(...)` reports -- which is what the walk's
+/// `Expr::Optional` step has to reproduce. Captured 2026-09-07 from
+/// `/usr/bin/jq` 1.7.1 on `{"a": {"b": 1}, "c": [10, 20], "s": "hi"}`:
+///
+/// ```text
+/// $ jq -c 'path(.a?)'        ["a"]
+/// $ jq -c 'path(.a.x?)'      ["a","x"]
+/// $ jq -c 'path(.[0]?)'      (nothing -- `.[0]` on an object raises, `?` suppresses)
+/// $ jq -c 'path(.s.b?)'      (nothing -- `.s.b` on a string raises, `?` suppresses)
+/// $ jq -c 'path(.c[0]?)'     ["c",0]
+/// $ jq -c 'path(.c[5]?)'     ["c",5]
+/// $ jq -c 'path(.c[-5]?)'    ["c",-5]
+/// $ jq -c 'path(.a?.b)'      ["a","b"]
+/// $ jq -c 'path((.a?))'      ["a"]
+/// $ jq -c '[path(.[0]?)]'    []
+/// $ jq -c '[path(.s.b?)]'    []
+/// $ jq -c '.a?'              {"b":1}
+/// $ jq -c '.s.b?'            (nothing)
+/// ```
+///
+/// The `key`/`path`/`parent` rows below are succinctly's jq-mode extension
+/// (`jq: error: key/0 is not defined` in real jq), so they follow yq's model
+/// for the *builtin* and jq's model for the *component* -- which is why
+/// `.c[-5]? | key` is `-5` here where yq mode raises: a negative index stays
+/// as written in jq mode (ADR-0021 decision 5), and the yq-only raise is what
+/// `EvalError::is_uncatchable_at_value_position` exempts from the `?`.
+#[test]
+fn test_optional_head_is_walkable_2558() -> Result<()> {
+    let doc = r#"{"a": {"b": 1}, "c": [10, 20], "s": "hi"}"#;
+    for (filter, want) in [
+        // The jq-captured half.
+        ("path(.a?)", "[\"a\"]"),
+        ("path(.a.x?)", "[\"a\",\"x\"]"),
+        ("path(.[0]?)", ""),
+        ("path(.s.b?)", ""),
+        ("path(.c[0]?)", "[\"c\",0]"),
+        ("path(.c[5]?)", "[\"c\",5]"),
+        ("path(.c[-5]?)", "[\"c\",-5]"),
+        ("path(.a?.b)", "[\"a\",\"b\"]"),
+        ("path((.a?))", "[\"a\"]"),
+        ("[path(.[0]?)]", "[]"),
+        ("[path(.s.b?)]", "[]"),
+        (".a?", "{\"b\":1}"),
+        (".s.b?", ""),
+        // The same positions, read through the extension builtins the walk
+        // now answers from a `?` head.
+        (".a? | key", "\"a\""),
+        (".a? | path", "[\"a\"]"),
+        (".a.x? | key", "\"x\""),
+        (".a.x? | path", "[\"a\",\"x\"]"),
+        (".[0]? | key", ""),
+        (".[0]? | path", ""),
+        (".s.b? | key", ""),
+        (".c[0]? | key", "0"),
+        (".c[5]? | key", "5"),
+        (".c[-5]? | key", "-5"),
+        (".a?.b | key", "\"b\""),
+        ("(.a?) | key", "\"a\""),
+        (".a? | select(key == \"a\")", "{\"b\":1}"),
+        (
+            ".a? | [path, parent]",
+            "[[\"a\"],{\"a\":{\"b\":1},\"c\":[10,20],\"s\":\"hi\"}]",
+        ),
+        (".a? | parent(2)", ""),
+        (".a? | .b = key", "{\"b\":\"a\"}"),
+        (".a?[] | key", "\"b\""),
+        (".a? | key + \"x\"", "\"ax\""),
+        (".[]? | key", "\"a\"\n\"c\"\n\"s\""),
+    ] {
+        let (out, err, code) = run_jq_full(&["-c", filter], Some(doc))?;
+        assert_eq!(code, 0, "`{filter}`: {out:?} {err}");
+        assert_eq!(out.trim_end(), want, "`{filter}`");
+    }
+    Ok(())
+}

--- a/tests/jq_evaluator_parity_tests.rs
+++ b/tests/jq_evaluator_parity_tests.rs
@@ -1739,6 +1739,31 @@ fn test_walk_vs_bridge_path_context_parity_2416() {
             ".a.zz | first(key)",
             ".a.zz | try (key) catch \"e\"",
             ".a.zz.yy | [path, parent]",
+            // #2558: `?` over navigation is a walkable head now, so the
+            // walk takes shapes that used to reach the bridge only. Both
+            // routes still have to answer them identically -- including the
+            // ones where the `?` actually suppresses (`.[0]?` on a mapping
+            // in jq mode, `.a?` on the array document).
+            ".a? | key",
+            ".a? | path",
+            ".a? | parent",
+            ".a?.b | key",
+            "(.a?) | key",
+            ".a? | [key, path]",
+            ".a? | (key, path)",
+            ".a?[] | key",
+            ".a[]? | key",
+            "[.a?[] | key]",
+            ".a? | select(key == \"a\")",
+            ".a? | select(true) | key",
+            ".a.zz? | key",
+            ".a.zz? | path",
+            ".a.zz? | [path, parent]",
+            ".d[9]? | key",
+            ".[0]? | key",
+            ".a? | key | tostring",
+            ".a? | first(key)",
+            ".a? | try (key) catch \"e\"",
         ] {
             assert_walk_bridge_parity(doc, filter);
         }
@@ -2091,9 +2116,12 @@ fn test_arm_audit_proof_queries_are_unmoved_by_the_gate_2416() {
         // fourteen rows' listed queries off the eager evaluator, so the
         // audit re-derived one apiece. Both spellings stay pinned, which is
         // what makes the move readable as "same outputs, different route".
-        // `?` is the reliable R2 head now: `path_context_is_navigational`
-        // excludes it, so the absent split's head stops before it and there
-        // is no position to route.
+        // `?` was the reliable R2 head when these were derived, because
+        // `path_context_is_navigational` excluded it. #2558 admitted it, so
+        // these rows now run on the walk, the absent route or the owned
+        // identity pipe -- their *outputs* are unchanged, which is the whole
+        // point of keeping them pinned, and the re-derived spellings that
+        // still reach each arm are at the end of this list.
         (r".a? | path + []", &[r#"["a"]"#]),
         (".a? | file_index + 1", &["1"]),
         (".a.b | (file_index | tostring)", &[r#""0""#]),
@@ -2115,6 +2143,32 @@ fn test_arm_audit_proof_queries_are_unmoved_by_the_gate_2416() {
         // eager `Expr::And(..) | Expr::Or(..)` arm -- a `?` head, which no
         // route can walk. Both spellings stay pinned.
         (r#".a? | key == "a" and true"#, &["true"]),
+        // #2558's re-derived proof queries, same precedent once more:
+        // `path_context_is_navigational` admits `?` over navigation now, so
+        // the nine rows whose listed query used a `?` head are routed rather
+        // than handed over -- the eight `?`-headed spellings just above and
+        // `.a? | key + "x"` further up all report no gate at all. The
+        // re-derivations keep the same *reason* (`R2`: a head that can miss
+        // and a stage no route can name a position for) with an `as` stage
+        // supplying the unroutable half instead of the `?`. Verified with
+        // the arms instrumented (2026-09-07, method in
+        // `docs/plan/path-context-arm-reachability.md`): `H1`, `H3`, `A12`,
+        // `A14`, `A21` and `A33` each fire on their row below, `H2` on the
+        // `.a.b | . as $x | key + "x"` row already present above, `A07` on
+        // its unchanged `.c[.n]? | key + 1`, and `A08` on the one `?` row
+        // here -- `?` over navigation is walkable, but a `?` head in front
+        // of a stage with no `owned_identity_rule` still lands on the eager
+        // evaluator's own `Expr::Optional` arm.
+        (r".a.b | . as $x | path + []", &[r#"["a","b"]"#]),
+        (r".a.b | . as $x | file_index + 1", &["1"]),
+        (r".a.b | . as $x | (key and parent)", &["true"]),
+        (r#".a.b | . as $x | (key + "x") | . == "bx""#, &["true"]),
+        (r#".a.b | . as $x | [key] + ["x"]"#, &[r#"["b","x"]"#]),
+        (
+            r#".a.b | . as $x | (key + "x") | {z: .}"#,
+            &[r#"{"z":"bx"}"#],
+        ),
+        (r".a? | . as $x | key", &[r#""a""#]),
     ];
     for (filter, expected) in rows {
         // `path + []` is the audit's H1 row spelled against `.a.b`.

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -30939,16 +30939,16 @@ fn test_negative_index_out_of_range_survives_path_context_2254() -> Result<()> {
     // unaffected by the fix -- `?` is still a true no-op for either, not
     // just for the error case. Real yq v4.53.3 answers `1` -- the
     // *resolved* index -- for `.a[-1]? | key` on a two-element sequence
-    // (captured live); the `-1` pinned here is the eager path-context
-    // evaluator's own path component, which this `?` spelling still
-    // reaches (spine 2416: `?` over an index can hit an absent node, whose
-    // path only that evaluator carries). The un-`?` spelling already
-    // answers `1` through the cursor walk -- see
-    // `test_negative_index_path_component_is_resolved_in_yq_mode_2416` --
-    // and this row flips when the eager evaluator retires.
+    // (captured live, re-confirmed 2026-09-07). This row used to pin `-1`,
+    // the eager path-context evaluator's own path component, with the note
+    // that it "flips when the eager evaluator retires": #2558 is that flip.
+    // `?` over navigation is walkable now (`path_context_is_navigational`),
+    // so this spelling reaches the same cursor walk the un-`?` spelling
+    // already did (`test_negative_index_path_component_is_resolved_in_yq_
+    // mode_2416`), and both answer `1`.
     let (out, code) = run_yq_stdin(".a[-1]? | key", "a: [1, 2]\n", &["-o", "json"])?;
     assert_eq!(code, 0);
-    assert_eq!(out.trim(), "-1");
+    assert_eq!(out.trim(), "1");
     let (out, code) = run_yq_stdin(".a[5]? | key", "a: [1, 2]\n", &["-o", "json"])?;
     assert_eq!(code, 0);
     assert_eq!(out.trim(), "5");
@@ -37083,5 +37083,129 @@ fn test_yq_update_filter_reads_the_target_position_2522() -> Result<()> {
     assert_eq!(code, 0, "{output:?}");
     assert_eq!(output.trim(), r#"{"b":{"b":1,"e":2},"e":2}"#);
 
+    Ok(())
+}
+
+/// The flow-style document `test_optional_head_is_walkable_2558` captures on.
+const OPTIONAL_HEAD_FLOW_2558: &str = "{\"a\": {\"b\": 1}, \"c\": [10, 20], \"s\": \"hi\"}\n";
+
+/// The block-style spelling of [`OPTIONAL_HEAD_FLOW_2558`]. Every row below
+/// was captured on both, and yq v4.53.3 answers them identically -- style is
+/// not part of this rule, and asserting on both is what says so.
+const OPTIONAL_HEAD_BLOCK_2558: &str = "a:\n  b: 1\nc:\n  - 10\n  - 20\ns: hi\n";
+
+/// #2558 (spine 2416, gate reason 2): an optional head (`.a? | ...`) is
+/// walkable.
+///
+/// `path_context_is_navigational` used to exclude `Expr::Optional`, so
+/// `path_context_absent_split` found an empty head, declined, and
+/// `path_context_needs_eager` handed the whole pipe to the eager evaluator --
+/// which `docs/plan/path-context-arm-reachability.md` had measured as reason
+/// 2's single biggest source. `?` over navigation reaches the same positions
+/// the bare navigation does and produces *no* position for the step it
+/// suppresses, which is one arm in `path_context_step_generic`, not a second
+/// set of semantics.
+///
+/// Captured 2026-09-07 from Homebrew yq v4.53.3 (`yq -o=json -I=0`), on both
+/// documents above, byte-identical between the two:
+///
+/// ```text
+/// $ yq '.a? | key'                  "a"
+/// $ yq '.a? | path'                 ["a"]
+/// $ yq '.a.x? | key'                "x"
+/// $ yq '.a.x? | path'               ["a","x"]
+/// $ yq '.[0]? | key'                0
+/// $ yq '.[0]? | path'               [0]
+/// $ yq '.a? | select(key == "a")'   {"b":1}
+/// $ yq '.a? | [path, parent]'       [["a"],{"a":{"b":1},"c":[10,20],"s":"hi"}]
+/// $ yq '.a?.b | key'                "b"
+/// $ yq '(.a?) | key'                "a"
+/// $ yq '.a? | parent(2)'            (nothing)
+/// $ yq '.a? | parent'               {"a":{"b":1},"c":[10,20],"s":"hi"}
+/// $ yq '.s? | key'                  "s"
+/// $ yq '.s.b? | key'                (nothing)
+/// $ yq '.s.b? | path'               (nothing)
+/// $ yq '.c[0]? | key'               0
+/// $ yq '.c[5]? | key'               5
+/// $ yq '.c[-1]? | key'              1
+/// $ yq '.c[-5]? | key'              Error: index [-5] out of range, array size is 2   (exit 1)
+/// $ yq '.a? | .b = key'             {"b":"a"}
+/// $ yq '.a?[] | key'                "b"
+/// $ yq '.a? | .x? | key'            "x"
+/// $ yq '.a? | key + "x"'            "ax"
+/// $ yq '.a? | [key] + ["x"]'        ["a","x"]
+/// $ yq '.a? | key == "a" and true'  true
+/// $ yq '.a? | file_index + 1'       1
+/// $ yq '.a? | path + []'            ["a"]
+/// $ yq '.a? | {"k": key}'           {"k":"a"}
+/// $ yq '.a? | [path, parent(2)]'    [["a"]]
+/// $ yq '.[]? | key'                 "a" "c" "s"
+/// $ yq '.a?[]? | key'               "b"
+/// ```
+///
+/// Two of these were wrong before the migration and are the reason it is a
+/// fidelity fix as well as a routing one: `.c[-1]? | key` answered `-1` (the
+/// eager evaluator reports the index as written; the walk resolves it against
+/// the length, ADR-0021 decision 5) and `.a? | .b = key` answered `{"b":1}`
+/// (the assignment's right side had no position to read, ADR-0021 decision 7
+/// via the absent route). Both agree with yq now.
+///
+/// `.c[-5]? | key` is the row that says the `?` does not swallow everything:
+/// a yq-mode negative index still negative after resolving is
+/// `EvalError::is_uncatchable_at_value_position`, exactly as the eager
+/// evaluator's own `Expr::Optional` arm has it (#2254).
+#[test]
+fn test_optional_head_is_walkable_2558() -> Result<()> {
+    let args = &["-o", "json", "-I0"];
+    for doc in [OPTIONAL_HEAD_FLOW_2558, OPTIONAL_HEAD_BLOCK_2558] {
+        for (filter, expected) in [
+            (".a? | key", "\"a\""),
+            (".a? | path", "[\"a\"]"),
+            (".a.x? | key", "\"x\""),
+            (".a.x? | path", "[\"a\",\"x\"]"),
+            (".[0]? | key", "0"),
+            (".[0]? | path", "[0]"),
+            (".a? | select(key == \"a\")", "{\"b\":1}"),
+            (
+                ".a? | [path, parent]",
+                "[[\"a\"],{\"a\":{\"b\":1},\"c\":[10,20],\"s\":\"hi\"}]",
+            ),
+            (".a?.b | key", "\"b\""),
+            ("(.a?) | key", "\"a\""),
+            (".a? | parent(2)", ""),
+            (
+                ".a? | parent",
+                "{\"a\":{\"b\":1},\"c\":[10,20],\"s\":\"hi\"}",
+            ),
+            (".s? | key", "\"s\""),
+            (".s.b? | key", ""),
+            (".s.b? | path", ""),
+            (".c[0]? | key", "0"),
+            (".c[5]? | key", "5"),
+            (".c[-1]? | key", "1"),
+            (".a? | .b = key", "{\"b\":\"a\"}"),
+            (".a?[] | key", "\"b\""),
+            (".a? | .x? | key", "\"x\""),
+            (".a? | key + \"x\"", "\"ax\""),
+            (".a? | [key] + [\"x\"]", "[\"a\",\"x\"]"),
+            (".a? | key == \"a\" and true", "true"),
+            (".a? | file_index + 1", "1"),
+            (".a? | path + []", "[\"a\"]"),
+            (".a? | {\"k\": key}", "{\"k\":\"a\"}"),
+            (".a? | [path, parent(2)]", "[[\"a\"]]"),
+            (".[]? | key", "\"a\"\n\"c\"\n\"s\""),
+            (".a?[]? | key", "\"b\""),
+        ] {
+            let (output, code) = run_yq_stdin(filter, doc, args)?;
+            assert_eq!(code, 0, "`{filter}` on `{doc}`: {output:?}");
+            assert_eq!(output.trim_end(), expected, "`{filter}` on `{doc}`");
+        }
+        let (output, stderr, code) = run_yq_stdin_with_stderr(".c[-5]? | key", doc, args)?;
+        assert_eq!(code, 1, "`{doc}`: {output:?} {stderr:?}");
+        assert!(
+            stderr.contains("index [-5] out of range, array size is 2"),
+            "`{doc}`: {stderr:?}"
+        );
+    }
     Ok(())
 }


### PR DESCRIPTION
## Summary

An optional head (`.a? | ...`) was not navigational to the path-context predicates, so the absent split saw an empty head, declined, and the pipe went to the eager evaluator; the #2472 and #2473 re-audits found it the largest single source of gate reason 2. Three predicates gain an `Optional` arm: the navigational predicate, the walk step (keep the positions reached, drop the error, except the errors that must raise at a value position: a yq negative index still negative after resolving, and a decode failure, the same exemption the eager arm has), and the fan-out predicate so `.[]?` still counts as a fan-out. The owned identity pipe already admitted `Optional`.

Captures from yq v4.53.3 and `/usr/bin/jq` 1.7.1 on both flow and block spellings are in the tests, with the mode split pinned (`.[0]?` on a mapping reads null in yq and suppresses to nothing in jq). Differential over 128 probed answers: 4 changed, all from disagreeing with yq to agreeing (`.c[-1]? | key` is `1`, the row #2254's test had pinned as flipping when the eager route retires; `.a? | .b = key` reaches decision 7's assignment rule for the first time). Twenty `?`-headed filters join the walk-versus-bridge parity test across all five documents; all rows equal.

## Pin

Stays at 44. Nine proof queries used a `?` head; all nine arms still fire through a re-derived query, and the reason is now exact: walkable is not routable, since `.a? | . as $x | key` still hands over because `as` has no identity rule. Both spellings are pinned. Two methodological caveats are recorded in the audit doc: three arms fire as a side effect whenever the `Optional` arm's probe runs, and gate-disjunct prints are not proof of routing (the gate is consulted a second time from the nested-pipe arm); the arm markers are ground truth.

## Left open

`?` over a computed bracket (`.c[.n]?`) is #2471's head-of-pipe item; `path(f)`'s own `Optional` arm still swallows a yq negative-index raise (a succinctly extension in yq mode, #2430, no oracle), flagged as a follow-up.

## Verification

fmt; clippy on both CI legs with `-D warnings`; `cargo test` in the three configurations; `cargo doc -D warnings`; yq goldens 113, jq goldens 633, jq error messages 223; oracle sweep 3168 cases, 0 unexpected, manifest unchanged.

Behaviour change in yq mode on two rows; CHANGELOG entry included. Closes #2558 (spine 2416).
