### PR TITLE
feat(jq): walk a computed bracket at the head of a pipe (#2471)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,37 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   inherited a walk that accepted `{"a" 1}`. Confirmed the YAML side doesn't
   move: the full comment/anchor/style corpus is byte-identical, since every
   new check is a no-op there by construction.
+- **A computed bracket at the head of a pipe (`.c[.n] | key`, `.a[.k] | path`,
+  `.c[.n]? | key`) now reads path context from the document node it stands on,
+  instead of sending the whole pipe to the eager path-context evaluator**
+  (#2471, spine 2416). `path_context_is_navigational` admitted only a
+  *literal* `Expr::Index`, so a computed bracket was a detaching stage with no
+  identity rule and `path_context_needs_eager` handed the pipe over -- gate
+  reason 1's last lever. The component is evaluated at the walked position
+  (against the node's cursor, or against the `null` an absent position holds)
+  following jq's own `K as $k | E | .[$k]` model, and each component is then
+  taken by the *literal* `Expr::Field`/`Expr::Index` step that spells it, so
+  every mode-specific indexing rule keeps one definition. Rows captured from
+  Homebrew yq v4.53.3 and `/usr/bin/jq` 1.7.1 on a flow document and its block
+  spelling, which yq answers identically.
+
+  Five yq-mode answers change and every one moves *towards* yq v4.53.3:
+  `.c[-1 as a computed index] | key` (`.c[.neg] | key` on `c: [10, 20]`) is
+  `1`, the resolved index, where it used to be `-1` -- the literal `.c[-1] |
+  key` already answered `1`, so the two spellings had disagreed with each
+  other; `.s[.n] | key` and `.c[.n][.n] | key` on a scalar target print
+  nothing where they used to raise `Cannot index string/number with number`;
+  `(.a[("z"+"z")] | key) + "!"` is `"!"` where it used to be `"zz!"` (an
+  absent key read inside an operand produces nothing); and `.c[.n] | key |
+  key` prints nothing where it used to print `0`. jq mode is unchanged on
+  every `path(...)` row -- a negative index stays as written, a numeric index
+  on an object still raises, and a string index on a scalar still raises.
+
+  A slice (`.c[.n:.m]`) and `getpath(p)` at the head are deliberately *not*
+  walkable: both can stand on a value that is not a document node, which the
+  walk's `PathNode` cannot carry. Nor is a component that can `halt`/`break`,
+  nor one that fans out.
+
 - **An optional head (`.a? | key`, `.c[-1]? | path`) now reads path context
   from the document node it stands on, instead of sending the whole pipe to
   the eager path-context evaluator** (#2558, spine 2416).

--- a/docs/adrs/adr-0021.md
+++ b/docs/adrs/adr-0021.md
@@ -210,16 +210,25 @@ in-place transforms *inside owned values*, which have no node to stand on.
   descends into `Expr::Object` (#1332's other half), so an object literal's slots are
   routed instead of being invisible to routing -- leaving `range`/`repeat`/`while`/
   `until`, which neither reference can express and which are therefore pinned as
-  extensions rather than migrated. #2471 closed four of
+  extensions rather than migrated. #2471 closed five of
   reason 1's shapes -- a computed `IndexExpr`/`SliceExpr` (and `?` over one) and
-  `getpath(p)` as navigation, a read after `key`/`path`/`file_index` replaced the value,
-  and a read under arithmetic inside a ruled stage -- so `key` gained a rule of its own
-  (`OwnedIdentityRule::KeyNode`: the emitted key stands where the node stood, and a
-  *second* `key` emits nothing) and `path`/`file_index` gained `Keeps`. What is left of
-  reason 1 is a builtin with no captured rule, and the map family (`map_values`,
-  `with_entries`), whose bodies real yq evaluates at each member's own position and which
-  succinctly answers from no position at all -- those need a cursor-threading
-  implementation in the generic evaluator, not a rule.
+  `getpath(p)` as navigation in the owned domain, a read after `key`/`path`/`file_index`
+  replaced the value, a read under arithmetic inside a ruled stage, the map family's
+  bodies and an assignment's right side, and finally a computed bracket at the *head* of
+  a pipe -- so `key` gained a rule of its own (`OwnedIdentityRule::KeyNode`: the emitted
+  key stands where the node stood, and a *second* `key` emits nothing),
+  `path`/`file_index` gained `Keeps`, and `path_context_is_navigational` gained an
+  `Expr::IndexExpr` arm whose component is evaluated at the walked position and taken by
+  the *literal* `Expr::Field`/`Expr::Index` step that spells it, so every mode-specific
+  indexing rule keeps one definition. What is left of reason 1 is a builtin with no
+  captured rule, and the three head shapes that admission refuses on purpose: a slice or
+  a `getpath` (both can stand on a value that is not a document node, which `PathNode`
+  cannot carry), a component that can `halt`/`break` (the walk's step returns
+  `Result<(), EvalError>`, with no room for a `Control`), and a component that fans out
+  (a fan-out head over *absent* positions loses its position once the pipe leaves the
+  walk -- pre-existing, and demonstrable as `(.c[0], .c[1]) | key` on `c: []`). The first
+  of those needs a third `PathNode` variant carrying an owned value; the others need
+  work outside this decision.
 - **The owned domain was where fidelity was worst.** Of 96 multi-stage owned-domain
   shapes captured from yq for decision 7, the eager evaluator answered 47 differently:
   `null` for the `key` of a detached value where yq prints nothing, `["a","b"]` for

--- a/docs/plan/path-context-arm-reachability.md
+++ b/docs/plan/path-context-arm-reachability.md
@@ -139,7 +139,7 @@ trusting them.
 | A04 | `Expr::Slice { .. }`                                               | REACHABLE | `.c[0:1] \| .[0] \| key + 1`                          | R1   |
 | A05 | `Expr::Iterate`                                                    | REACHABLE | `.a[] \| (key \| tostring)`                            | R3   |
 | A06 | `Expr::Paren(inner)`                                               | REACHABLE | `.a.b \| (parent) + {}`                               | R2   |
-| A07 | `Expr::Optional(inner) if IndexExpr/SliceExpr`                     | REACHABLE | `.c[.n]? \| key + 1`                                  | R1   |
+| A07 | `Expr::Optional(inner) if IndexExpr/SliceExpr`                     | REACHABLE | `.c[.n]? \| . as $x \| key`                            | R2   |
 | A08 | `Expr::Optional(inner)`                                            | REACHABLE | `.a? \| . as $x \| key`                                | R2   |
 | A09 | `Expr::Pipe(inner) if rest.is_empty()`                             | REACHABLE | `.a.b \| -(key\|length)`                              | R2   |
 | A10 | `Expr::Pipe(inner)`                                                | REACHABLE | `.a.b \| parent + {}`                                 | R2   |
@@ -151,7 +151,7 @@ trusting them.
 | A16 | `Expr::Builtin(Builtin::Map(f))`                                   | REACHABLE | `.a \| map(key + "x")`                                | R2   |
 | A17 | `Expr::Builtin(Builtin::GetPath(path_expr))`                       | REACHABLE | `.a \| getpath(["b"]) \| . as $x \| key`              | R1   |
 | A18 | `Expr::Builtin(_)`                                                 | REACHABLE | `.a[] \| (key \| length)`                             | R3   |
-| A19 | `Expr::IndexExpr { target, key }`                                  | REACHABLE | `.c[.n] \| key + 1`                                   | R1   |
+| A19 | `Expr::IndexExpr { target, key }`                                  | REACHABLE | `.c[.n] \| . as $x \| key`                             | R2   |
 | A20 | `Expr::SliceExpr { target, start, end }`                           | REACHABLE | `.c[.n:.m] \| .[0] \| key + 1`                        | R1   |
 | A21 | `Expr::Array(inner) if needs_path_context(inner)`                  | REACHABLE | `.a.b \| . as $x \| [key] + ["x"]`                     | R2   |
 | A22 | `Expr::StringInterpolation(parts) if ..`                           | REACHABLE | `.a.b \| ("\(key)") \| . + "x"`                       | R2   |
@@ -242,6 +242,14 @@ component -- which it cannot do uniformly, because an *absent* position
 (`PathNode::Absent`) carries no cursor to evaluate the component against. That
 is the next step for this cluster, and it is what would make the five `R1` rows
 unreachable.
+
+*(Superseded by "#2471 remainder: a computed bracket at the head" below. The
+absent position is not the obstacle it looks like here -- the component is
+evaluated against the `null` such a position holds, exactly as the owned
+identity pipe does -- and the walk took `Expr::IndexExpr` on those terms. Two
+of the five rows still fire and three of them never could: a slice and a
+`getpath` can stand on a value that is not a document node at all, which is the
+real obstacle and is `PathNode`'s, not the component's.)*
 
 ## #2472: gate reason 2 narrowed, and the pin still holds at 43
 
@@ -599,7 +607,9 @@ Three things are worth recording about the re-run:
   *computed* bracket, which `path_context_is_navigational` still does not admit
   (an absent `PathNode` carries no cursor to evaluate the component against).
   That is #2471's own "next step for this cluster" and is not what #2558
-  changed; its gate is `R1`, not `R2`, and both are unmoved.
+  changed; its gate is `R1`, not `R2`, and both are unmoved. *(That step landed:
+  see "#2471 remainder: a computed bracket at the head" below, where `A07`'s
+  query is re-derived to `.c[.n]? | . as $x | key` and its gate moves to `R2`.)*
 - **`A08` is still reachable, and by a `?` head.** `?` over navigation being
   *walkable* does not make a pipe routable: `.a? | . as $x | key` still hands
   over, because `as` has no `owned_identity_rule`, and the eager evaluator's
@@ -629,6 +639,109 @@ path` prints `R1` and `R2` and hits no arm. The `ARMHIT` markers, not the
 `GATE` ones, are what says a handler ran; the `Gate` column records the
 disjunct that fired for a query the markers confirm got there.
 
+## #2471 remainder: a computed bracket at the head, and the pin still holds at 44
+
+The last of [#2471](https://github.com/rust-works/succinctly/issues/2471)'s list, and
+the lever every one of the five `R1` rows above named: a *computed* bracket standing at
+the **head** of a pipe. `path_context_is_navigational` admitted only a literal
+`Expr::Index`, so `.c[.n] | key` left the cursor domain at a stage with no
+`owned_identity_rule` and the gate handed the whole pipe over.
+
+`Expr::IndexExpr` is navigation there now. The component is one more value to evaluate
+-- against the stage's *own* input, jq's `K as $k | E | .[$k]` model (`.a[.a.b]` reads
+`.a.b` from the position the bracket stands at, not from `.a`) -- and each component it
+produces is then taken by the walk's **literal** `Expr::Field`/`Expr::Index` step, spelled
+as the node that carries it (`path_component_step_expr`). That is the whole of the
+change's fidelity argument: every mode-specific indexing rule -- yq's negative-index
+resolution (#2254), its numeric index on a mapping (#2459), its scalar target (#2482),
+its absent key inside a read-only operand (#2470), and jq's raises for the same three --
+stays one definition instead of being re-derived for the computed spelling.
+
+Three shapes are deliberately **not** admitted, each for a reason the walk's own data
+model gives:
+
+- **`Expr::SliceExpr` and `getpath(p)`.** Both can land on a value that is not a document
+  node: a slice builds a fresh container, and a `getpath` segment may be jq's own
+  `{"start":s,"end":e}` descriptor (`eval::getpath_walk_owned`'s `Object`-segment arms).
+  A walked stage may have to *emit* the node it stands on (`path_context_emit_node`), and
+  `PathNode` carries only a cursor or an absence -- `.a.b | parent | .[0:1]` would emit
+  the container instead of the slice. They stay on the owned identity pipe (#2493) and
+  the eager evaluator, which carry an owned value.
+- **A component that can escape** (`.c[halt] | key`). The walk's step returns
+  `Result<(), EvalError>`, which has no room for `Control::Halt`/`Control::Break`;
+  #2495's `Control` plumbing lives on the eager route, so a component containing
+  `halt`/`halt_error`/`break` stays there and `.c[halt] | key` still exits silently.
+- **A component that fans out** (`.c[(0,1)] | tostring | key`). A comma inside the
+  component makes the bracket a fan-out head, and a fan-out head standing on *absent*
+  positions loses its position once the pipe leaves the walk. That is pre-existing and
+  demonstrable with no computed bracket anywhere in the filter: on `c: []`,
+  `(.c[0], .c[1]) | key` prints nothing here where yq v4.53.3 answers `0` and `1`.
+  Admitting one would have moved `.c[(0,1)] | tostring | key` -- which the eager
+  evaluator answers correctly -- onto that gap, so it is refused instead. Measured: the
+  admission cost four rows that moved *away* from yq, and refusing it costs nothing (the
+  same shapes keep their pre-change answers).
+
+**`PINNED_ARM_COUNT` stays at 44.** Re-run of the method above on the post-change tree,
+with the five `R1` arms and the gate's three disjuncts instrumented, each arm fed its
+listed proof query (document `D`):
+
+| Id  | Listed query before          | Re-derived query               | Gate | Marker | Output |
+|-----|------------------------------|--------------------------------|------|--------|--------|
+| A04 | `.c[0:1] \| .[0] \| key + 1`    | unchanged                      | R1   | fired  | `1`    |
+| A07 | `.c[.n]? \| key + 1`          | `.c[.n]? \| . as $x \| key`       | R2   | fired  | `0`    |
+| A17 | `.a \| getpath(["b"]) \| . as $x \| key` | unchanged           | R1   | fired  | `"b"`  |
+| A19 | `.c[.n] \| key + 1`           | `.c[.n] \| . as $x \| key`        | R2   | fired  | `0`    |
+| A20 | `.c[.n:.m] \| .[0] \| key + 1`  | unchanged                      | R1   | fired  | `1`    |
+
+`A04`, `A17` and `A20` are unaffected because their heads are the three shapes the
+admission refuses. `A07` and `A19` needed re-derivation for the reason every earlier
+re-derivation in this document needed one: their listed queries now report **no gate at
+all** -- `.c[.n] | key + 1` and `.c[.n]? | key + 1` are answered by the absent route,
+because a computed bracket is a navigational head the absent split can take. The
+re-derivations keep the same head and put an `as` stage -- which has no
+`owned_identity_rule` -- where the arithmetic was, so the reason moves from `R1` to `R2`
+while the arm is unchanged. Both spellings are pinned in
+`test_arm_audit_proof_queries_are_unmoved_by_the_gate_2416`.
+
+Two more `R1` proof queries were confirmed alongside, both still firing their arm on the
+post-change tree: `.c[(0,1)] | key + 1` fires `A19` at `R1` and `.c[(0,1)]? | key + 1`
+fires `A07` at `R1` -- the refused fan-out component keeping the original reason intact.
+
+**Nothing became unreachable, so nothing was deleted**, and the reason is structural: the
+change adds an `Expr::IndexExpr` arm to `path_context_is_navigational`,
+`path_context_fans_out` and `path_context_step_generic` and nothing else, so a pipe with
+no `Expr::IndexExpr` anywhere in it is routed *identically* before and after. That is why
+the 39 rows whose listed query has no computed bracket need no re-derivation and none was
+done. The instrumentation was reverted before this document was committed.
+
+### What the change is measured against
+
+A differential over 2,070 queries (nineteen computed-bracket heads x eighteen tails plus
+a tail of assignment, `path()` and nested-bracket shapes) on
+`{"a":{"b":1,"e":2},"c":[10,20,30],"n":0,"m":2,"s":"hi","u":null,"d":{...},"k":"b",
+"neg":-1}` and on `{"c":[],"a":{},"n":0}`, in both modes and in both YAML and JSON
+spellings: **154 answers changed** before the fan-out component was refused, **57 after**.
+Classified three-way against yq v4.53.3 on the yq-mode half: **42 moved from disagreeing
+with yq to agreeing with it, 11 changed without reaching agreement, and 4 read as moving
+away** -- of which two are filters yq's own lexer rejects (`try ... catch`, `{k: key}`),
+so there is no yq answer to move away from, and the other two are the *literal*
+spelling's own pre-existing gap, reached by the computed spelling for the first time:
+on `c: []`, `.c[0] | parent | key | path` and `.c[0] | parent | tostring | key` print
+nothing here (and `["c"]` / `"c"` in yq) before this change as much as after it.
+
+The five yq-mode rows the change *fixes* are pinned in
+`test_computed_bracket_head_is_walkable_2471` (`tests/yq_cli_tests.rs`), with the capture
+for each; the jq-mode half of the same test pins the ten `path(...)` rows real jq 1.7.1
+answers, all unchanged.
+
+One walk-versus-bridge divergence is left open rather than pinned, and is recorded in
+`test_walk_vs_bridge_path_context_parity_2416`'s own comment: `[.a[("b"+"")] | key]` on a
+scalar-valued `.a` is `[]` on the walk (matching yq v4.53.3, and matching succinctly's own
+*value* route, which already answers `[]` for `[.a[("b"+"")]]`) and raises `Cannot index
+number with string "b"` on the eager route, whose `Expr::IndexExpr` arm never got #2482's
+scalar rule. The walk is the side that matches the oracle, so the row is not asserted as
+"the routes agree"; the eager arm's missing rule is a separate fix.
+
 ## Result
 
 | Metric                                            | Before | After                 |
@@ -641,6 +754,7 @@ disjunct that fired for a query the markers confirm got there.
 | ... starved by #2471's remainder                   | --     | 0 (`A16`/`A18` re-run) |
 | ... starved by #2522                               | --     | 0 (no row's query assigns) |
 | ... starved by #2558                               | --     | 0 (9 `?`-headed rows re-derived) |
+| ... starved by #2471's head-of-pipe half           | --     | 0 (`A07`/`A19` re-derived)       |
 | `PINNED_ARM_COUNT`                                 | 43     | 44                    |
 
 Nothing is deletable at this point in the spine. Doors 2 and 3 are closed as
@@ -654,14 +768,16 @@ evaluator, with no second route to check.
 ### Notes for the next migration
 
 - The five `R1` rows (`A04`, `A07`, `A17`, `A19`, `A20`) are the detached-value
-  reason and are the cheapest cluster to attack: `Expr::Slice`, `Expr::IndexExpr`
-  and `Expr::SliceExpr` are missing from `path_context_single_native` even though
-  their literal-bound siblings (`Expr::Index`, `Expr::Slice` with folded bounds)
-  are navigational. #2471 (section above) took the *owned-domain* half of that
-  cluster and left all five arms reachable: what remains is the head-of-pipe
-  half, which needs the cursor walk to evaluate a computed component. #2471's
-  *remainder* (section above) closed the map-family and assignment-right-side
-  shapes and left all five reachable for the same reason.
+  reason. #2471 took it in three passes -- the owned-domain half, the map-family
+  and assignment-right-side shapes, and the head-of-pipe computed bracket
+  (sections above) -- and all five arms are still reachable after all three.
+  What is left of the cluster is the two head shapes the walk's `PathNode`
+  cannot carry: `Expr::Slice`/`Expr::SliceExpr` (`A04`, `A20`) and `getpath(p)`
+  (`A17`), both of which can stand on a value that is not a document node.
+  Giving the walk a third `PathNode` variant for an owned value is what would
+  make those reachable by the walk; `A07`/`A19` need the *stage* shapes behind
+  a computed head (`as`, and a fan-out component) migrated, not this head
+  admission widened.
 - `A24` (`Expr::Shared`) is only ever produced by `substitute_func_param`
   (`src/jq/eval.rs`), so it dies with `A23`/`A25` and not before.
 - `A38` (`Expr::Break`) cannot be reached without `A37` (`Expr::Label`): the

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -55,7 +55,9 @@ use super::eval::{
 };
 #[cfg(test)]
 use super::expr::FuncDefBound;
-use super::expr::{Builtin, CompareOp, Expr, FormatType, Literal, ObjectEntry, ObjectKey, Pattern};
+use super::expr::{
+    Builtin, CompareOp, Expr, FormatType, Literal, NumberKey, ObjectEntry, ObjectKey, Pattern,
+};
 use super::slice::{literal_component_from_values, slice_str, SliceBounds};
 use super::value::{owned_value_eq, NumberRepr, OwnedValue};
 use crate::json::JsonIndex;
@@ -12319,12 +12321,73 @@ fn path_context_is_navigational(expr: &Expr) -> bool {
         // anything else (`key?`, `(.a | tostring)?`) is not navigation and
         // is not admitted here.
         Expr::Optional(inner) => path_context_is_navigational(inner),
+        // #2471 (gate reason 1 of spine 2416): a *computed* bracket moves the
+        // position exactly as a literal `Expr::Index` does -- the component
+        // is one more value to evaluate, not a different kind of step. The
+        // target has to be navigation the walk can take first, and the
+        // component has to be something the walk can evaluate at a position
+        // ([`path_context_component_walkable`]).
+        //
+        // `Expr::SliceExpr` and `getpath(p)` are deliberately *not* admitted
+        // here. Both can land on a value that is not a document node at all
+        // -- a slice builds a fresh container, and a `getpath` segment may be
+        // jq's own `{"start":s,"end":e}` slice descriptor
+        // (`eval::getpath_walk_owned`'s `Object`-segment arms) -- and a
+        // walked stage may have to *emit* the node it stands on
+        // (`path_context_emit_node`), which `PathNode` can only do for a
+        // cursor or an absent position. They stay on the routes that carry an
+        // owned value: the owned identity pipe (#2493) and the eager
+        // evaluator.
+        Expr::IndexExpr { target, key } => {
+            path_context_is_navigational(target)
+                && path_context_component_walkable(key)
+                // The component must also be single-branch. A comma inside
+                // one makes the bracket a *fan-out* head, and a fan-out head
+                // standing on **absent** positions already loses its position
+                // once the pipe leaves the walk: `(.c[0], .c[1]) | key` on
+                // `c: []` prints nothing here where yq v4.53.3 answers `0`
+                // and `1`, with no computed bracket anywhere in it. Admitting
+                // one would route `.c[(0,1)] | tostring | key` -- which the
+                // eager evaluator answers correctly -- onto that gap, so it
+                // stays where it is.
+                && !path_context_fans_out(key)
+        }
         Expr::Paren(inner) => path_context_is_navigational(inner),
         Expr::Pipe(exprs) | Expr::Comma(exprs) => exprs.iter().all(path_context_is_navigational),
         Expr::Builtin(Builtin::Parent) => true,
         Expr::Builtin(Builtin::ParentN(n)) => matches!(**n, Expr::Literal(_)),
         _ => false,
     }
+}
+
+/// A computed navigation component (`.[K]`) the *walk* can evaluate at a
+/// position (#2471).
+///
+/// Two conditions. The first is [`owned_identity_component_supported`], the
+/// same predicate the owned identity pipe asks of the same component: a read
+/// inside it resolves to the constants the position answers with, and
+/// anything that reads nothing is evaluated as written.
+///
+/// The second is that evaluating it cannot *escape*. The walk's step returns
+/// `Result<(), EvalError>`, which has no room for `Control::Halt` or
+/// `Control::Break`, so a component that can raise one stays on the eager
+/// route -- where #2495's `Control` plumbing already adjudicates it, and
+/// where `.c[halt] | key` still exits silently rather than turning a halt
+/// into an error.
+fn path_context_component_walkable(expr: &Expr) -> bool {
+    owned_identity_component_supported(expr) && !path_context_component_can_escape(expr)
+}
+
+/// Whether evaluating `expr` can end the program or jump to a label -- see
+/// [`path_context_component_walkable`] for why the walk refuses one.
+fn path_context_component_can_escape(expr: &Expr) -> bool {
+    crate::jq::walk::any_subexpr(expr, &mut |e| {
+        matches!(
+            e,
+            Expr::Break(_)
+                | Expr::Builtin(Builtin::Halt | Builtin::HaltError | Builtin::HaltErrorCode(_))
+        )
+    })
 }
 
 /// Whether a walked expression can emit more than one *materialized* value.
@@ -12352,6 +12415,11 @@ fn path_context_fans_out(expr: &Expr) -> bool {
         Expr::Paren(inner) | Expr::Array(inner) | Expr::Optional(inner) => {
             path_context_fans_out(inner)
         }
+        // #2471: a computed bracket fans out exactly when its *target*
+        // does. Its component cannot: `path_context_is_navigational` admits
+        // one only when `path_context_fans_out` already answers `false` for
+        // it, which is what keeps this arm about the target alone.
+        Expr::IndexExpr { target, .. } => path_context_fans_out(target),
         _ => false,
     }
 }
@@ -12600,6 +12668,24 @@ fn path_context_step_generic<S: EvalSemantics, V: DocumentValue>(
             out.extend(path_context_hop(pos, n));
             Ok(())
         }
+        // #2471: `E[K]` and its `?`-guarded spelling. The `?` covers the
+        // *indexing* step alone, never the component's or the target's own
+        // evaluation -- the same split `owned_identity_step` draws for the
+        // owned domain, and the same one the eager evaluator's own
+        // `Expr::Optional(IndexExpr)` arm draws (`bracket_optional: true`
+        // with the key and target still at `optional: false`). So this arm
+        // has to sit ahead of the generic `Expr::Optional` one below, which
+        // would otherwise swallow a component's own error:
+        // `.c[error("x")]? | key` raises in both modes.
+        Expr::Optional(inner) if matches!(&**inner, Expr::IndexExpr { .. }) => {
+            let Expr::IndexExpr { target, key } = &**inner else {
+                unreachable!("the guard above restricts inner to IndexExpr")
+            };
+            path_context_step_computed_index::<S, V>(target, key, true, pos, out)
+        }
+        Expr::IndexExpr { target, key } => {
+            path_context_step_computed_index::<S, V>(target, key, false, pos, out)
+        }
         // #2558: the same rule as `path_step_generic`'s own `Expr::Optional`
         // arm, one level up so a whole *position* (path plus ancestors)
         // survives -- the error is swallowed, the positions already reached
@@ -12631,6 +12717,129 @@ fn path_context_step_generic<S: EvalSemantics, V: DocumentValue>(
             "path_context_is_navigational admitted a stage the walk cannot step: {other:?}"
         ),
     }
+}
+
+/// One computed-bracket step (`E[K]`, or `E[K]?` with `bracket_optional`),
+/// from `pos` (#2471).
+///
+/// jq compiles `E[K]` as `K as $k | E | .[$k]`: the component stream is
+/// evaluated against *this stage's own input*, outer, and the target is
+/// stepped inner. `.a[.a.b]` therefore reads `.a.b` from the position the
+/// bracket stands at, not from `.a`.
+///
+/// Each component is then taken by the walk's *literal* navigation arms, via
+/// the `Expr::Field`/`Expr::Index` node that spells it
+/// ([`path_component_step_expr`]). That is what keeps every mode-specific
+/// rule -- yq's negative-index resolution (#2254), its numeric index on a
+/// mapping (#2459), its scalar target (#2482) and its absent key in a
+/// read-only context (#2470) -- one definition rather than a second copy
+/// that could drift from the literal spelling's.
+fn path_context_step_computed_index<S: EvalSemantics, V: DocumentValue>(
+    target: &Expr,
+    key: &Expr,
+    bracket_optional: bool,
+    pos: &PathContextPos<V>,
+    out: &mut Vec<PathContextPos<V>>,
+) -> Result<(), EvalError> {
+    let components = path_context_component_values::<S, V>(key, pos)?;
+    let mut targets = Vec::new();
+    let stepped = path_context_step_generic::<S, V>(target, pos, &mut targets);
+    for component in &components {
+        for tpos in &targets {
+            match path_component_step_expr(component) {
+                Some(step) => {
+                    let step = if bracket_optional {
+                        Expr::Optional(Box::new(step))
+                    } else {
+                        step
+                    };
+                    path_context_step_generic::<S, V>(&step, tpos, out)?;
+                }
+                // A component no navigation can take (`null`, a boolean, a
+                // container): the same error the value route raises, from
+                // the same constructor, and suppressed by this bracket's own
+                // `?` exactly as an indexing error is -- `.c[null]? | key`
+                // is empty, `.c[null] | key` raises.
+                None if bracket_optional => {}
+                None => {
+                    return Err(EvalError::cannot_index(
+                        path_node_type_name::<V>(&tpos.node),
+                        component,
+                    ))
+                }
+            }
+        }
+    }
+    stepped
+}
+
+/// Every value a computed component takes at `pos` (#2471).
+///
+/// A `key`/`path` inside the component is a constant for this position, and
+/// is rewritten by the same [`path_context_resolve_constants`] the absent
+/// route and the owned identity pipe use. A live position evaluates the
+/// component against its own cursor; an absent one evaluates it against the
+/// `null` it holds, which is what the owned identity pipe does with the same
+/// component.
+fn path_context_component_values<S: EvalSemantics, V: DocumentValue>(
+    expr: &Expr,
+    pos: &PathContextPos<V>,
+) -> Result<Vec<OwnedValue>, EvalError> {
+    let resolved;
+    let expr = if needs_path_context(expr) {
+        resolved = path_context_resolve_constants::<S>(
+            expr,
+            &PathContextAt {
+                key: pos.path.last(),
+                path: &pos.path,
+                // `path_context_component_walkable` keeps the constant-only
+                // gate, so no `parent` can appear in a component.
+                parent_of: None,
+            },
+        )?;
+        &resolved
+    } else {
+        expr
+    };
+    let (values, control) = match &pos.node {
+        PathNode::At(c) => stream_owned_outputs_generic::<S, V>(expr, c.value(), false, Some(*c)),
+        PathNode::Absent => owned_identity_values::<S>(expr, &OwnedValue::Null, false),
+    };
+    match control {
+        None => Ok(values),
+        Some(Control::Error(e)) => Err(e),
+        // `path_context_component_walkable` refuses a component that can
+        // halt or break, which is the whole of what is left.
+        Some(other) => unreachable!("a walkable component cannot escape: {other:?}"),
+    }
+}
+
+/// The literal navigation step that takes `component`, or `None` for a value
+/// no navigation can take (#2471).
+///
+/// The spelling matters: a float component keeps its own rendering in the
+/// path (`path(.c[(1.0)])` is `["c",1.0]` in jq 1.7.1), which is exactly
+/// what [`NumberKey`] carries for a literal float bracket, so the synthesized
+/// node reuses it rather than re-deriving a second rendering rule.
+fn path_component_step_expr(component: &OwnedValue) -> Option<Expr> {
+    Some(match component {
+        OwnedValue::String(s) => Expr::Field(s.clone()),
+        OwnedValue::Int(i) => Expr::Index { idx: *i, key: None },
+        OwnedValue::Float(f) => Expr::Index {
+            idx: *f as i64,
+            key: Some(NumberKey::Float(*f)),
+        },
+        // An integer-spelled literal renders identically to its own `i64`,
+        // which is why `NumberKey` has no `Int` arm -- see its doc comment.
+        OwnedValue::NumberLiteral(NumberRepr::Int(i), _) => Expr::Index { idx: *i, key: None },
+        OwnedValue::NumberLiteral(NumberRepr::Float(f), text) => Expr::Index {
+            idx: *f as i64,
+            key: Some(NumberKey::Literal(*f, text.to_string().into_boxed_str())),
+        },
+        OwnedValue::Null | OwnedValue::Bool(_) | OwnedValue::Array(_) | OwnedValue::Object(_) => {
+            return None
+        }
+    })
 }
 
 /// Walk one emitting expression from `pos`, delivering each output to `sink`
@@ -26535,6 +26744,54 @@ mod tests {
         assert!(eager(".a? | . as $x | key"));
         assert!(eager(".[]? | .k | select(key == \"k\")"));
         assert!(!eager(".a[] | select(true) | key"));
+        // #2471 (gate reason 1 of spine 2416), the head-of-pipe half: a
+        // *computed* bracket is navigation the walk takes now, so a pipe
+        // headed by one is routed exactly like `.c[0] | ...`. The whole-pipe
+        // rows report `true` here for the same reason `.a? | key` does above
+        // -- the walk already took them, so the gate is never the route that
+        // answers.
+        assert!(eager(".c[.n] | key"));
+        assert!(path_context_walk_split(&pipe_stages(".c[.n] | key")).is_some());
+        assert!(eager(".c[.n] | path"));
+        assert!(path_context_walk_split(&pipe_stages(".c[.n] | path")).is_some());
+        assert!(eager(".c[.n]? | key"));
+        assert!(path_context_walk_split(&pipe_stages(".c[.n]? | key")).is_some());
+        assert!(eager(".c[.n] | [key, path]"));
+        assert!(path_context_walk_split(&pipe_stages(".c[.n] | [key, path]")).is_some());
+        assert!(eager(".c[.n] | parent | key"));
+        assert!(path_context_walk_split(&pipe_stages(".c[.n] | parent | key")).is_some());
+        // ...and a rest the walk does not model is answered by the absent
+        // route or the owned identity pipe, not by the eager evaluator --
+        // which is what takes `.c[.n] | key + 1` (`A19`'s listed proof query
+        // until this change) and `.c[.n]? | key + 1` (`A07`'s) off it.
+        assert!(!eager(".c[.n] | key + 1"));
+        assert!(!eager(".c[.n]? | key + 1"));
+        assert!(!eager(".c[.n] | key | key"));
+        assert!(!eager(".c[.n] | tostring | key"));
+        assert!(!eager(".c[.n] | select(key == 0)"));
+        assert!(!eager(".c[.n] | {k: key}"));
+        // Three shapes stay exactly where they were, each for its own
+        // reason. A component that can *escape* has no room in the walk's
+        // `Result<(), EvalError>` step ...
+        assert!(eager(".c[halt] | key"));
+        // ... a component that *fans out* would make the bracket a fan-out
+        // head, and a fan-out head over absent positions loses its position
+        // once the pipe leaves the walk (`(.c[0], .c[1]) | key` on `c: []`
+        // is empty with no computed bracket in it at all) ...
+        assert!(eager(".c[(0,1)] | key"));
+        assert!(eager(".c[(0,1)] | tostring | key"));
+        // ... and a slice or a `getpath` can land on a value that is not a
+        // document node at all, which `PathNode` cannot carry.
+        assert!(eager(".c[.n:.m] | key"));
+        assert!(eager(".c[.n:.m] | .[0] | key"));
+        assert!(eager(".c[0:1] | .[0] | key + 1"));
+        assert!(eager("getpath([\"a\",\"b\"]) | key"));
+        assert!(!path_context_is_navigational(&parse(".c[.n:.m]").unwrap()));
+        assert!(!path_context_is_navigational(
+            &parse("getpath([\"a\"])").unwrap()
+        ));
+        assert!(path_context_is_navigational(&parse(".c[.n]").unwrap()));
+        assert!(path_context_is_navigational(&parse(".c[.n]?").unwrap()));
     }
 
     /// The absent route's gate and its rewriter are two descriptions of one

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -39196,6 +39196,105 @@ fn test_jq_update_filter_position_is_a_succinctly_extension_2522() -> Result<()>
     Ok(())
 }
 
+/// #2471 (spine 2416, gate reason 1): a *computed* bracket at the head of a
+/// pipe (`.c[.n] | ...`) is walkable, in jq mode too.
+///
+/// jq 1.7.1 has no `key`/`path`-with-no-argument, so its half of the oracle
+/// is the *component* model `path(...)` reports -- which is what the walk's
+/// computed-bracket step has to reproduce, component for component. Captured
+/// 2026-09-07 from `/usr/bin/jq` 1.7.1 on
+/// `{"a":{"b":1},"c":[10,20],"n":0,"m":1,"s":"hi","k":"b","neg":-1}`:
+///
+/// ```text
+/// $ jq -c 'path(.c[.n])'            ["c",0]
+/// $ jq -c '[path(.c[(0,1)])]'       [["c",0],["c",1]]
+/// $ jq -c 'path(.c[.n]?)'           ["c",0]
+/// $ jq -c '[path(.zz[.n])]'         [["zz",0]]
+/// $ jq -c 'path(.c[9])'             ["c",9]
+/// $ jq -c 'path(.a[.k])'            ["a","b"]
+/// $ jq -c 'path(.a[("z"+"z")])'     ["a","zz"]
+/// $ jq -c 'path(.c[.neg])'          ["c",-1]
+/// $ jq -c 'path(.a[.a.b])'          Cannot index object with number  (exit 5)
+/// $ jq -c '[path(.s[.n])]'          Cannot index string with number  (exit 5)
+/// $ jq -c '[path(.c[.n] | .x?)]'    []
+/// $ jq -c '.c[.n]'                  10
+/// $ jq -c '.a[.k]'                  1
+/// ```
+///
+/// The two rows jq raises on are the mode split this migration must not blur:
+/// a negative index stays as written in jq mode (`["c",-1]`, where yq resolves
+/// it to `["c",1]`), a numeric index on an object raises here (where yq reads
+/// it as an absent position), and a string index on a scalar raises here
+/// (where yq produces no position at all). The walk gets all three by
+/// spelling each component as the *literal* `Expr::Field`/`Expr::Index` step
+/// that carries the mode rule already, rather than re-deriving one.
+///
+/// The `key`/`path`/`parent` rows are succinctly's jq-mode extension
+/// (`jq: error: key/0 is not defined` in real jq), so they follow yq's model
+/// for the builtin and jq's for the component.
+#[test]
+fn test_computed_bracket_head_is_walkable_2471() -> anyhow::Result<()> {
+    let doc = r#"{"a":{"b":1},"c":[10,20],"n":0,"m":1,"s":"hi","k":"b","neg":-1}"#;
+    for (filter, want) in [
+        // The jq-captured half.
+        ("path(.c[.n])", "[\"c\",0]"),
+        ("[path(.c[(0,1)])]", "[[\"c\",0],[\"c\",1]]"),
+        ("path(.c[.n]?)", "[\"c\",0]"),
+        ("[path(.zz[.n])]", "[[\"zz\",0]]"),
+        ("path(.c[9])", "[\"c\",9]"),
+        ("path(.a[.k])", "[\"a\",\"b\"]"),
+        ("path(.a[(\"z\"+\"z\")])", "[\"a\",\"zz\"]"),
+        ("path(.c[.neg])", "[\"c\",-1]"),
+        ("[path(.c[.n] | .x?)]", "[]"),
+        (".c[.n]", "10"),
+        (".a[.k]", "1"),
+        // The same positions through the extension builtins the walk now
+        // answers from a computed head.
+        (".c[.n] | key", "0"),
+        (".c[.n] | path", "[\"c\",0]"),
+        (".c[.n]? | key", "0"),
+        (".c[.n]? | path", "[\"c\",0]"),
+        (".a[.k] | key", "\"b\""),
+        (".a[.k] | path", "[\"a\",\"b\"]"),
+        (".c[(0,1)] | key", "0\n1"),
+        (".zz[.n] | key", "0"),
+        (".zz[.n] | path", "[\"zz\",0]"),
+        (".c[9] | key", "9"),
+        (".c[.neg] | key", "-1"),
+        (".c[.neg] | path", "[\"c\",-1]"),
+        (".c[.n] | .x? | key", ""),
+        (".c[.n] | parent | key", "\"c\""),
+        (".c[.n] | [key, path]", "[0,[\"c\",0]]"),
+        (".c[.n] | key + 1", "1"),
+        (".c[.n] | tostring | key", "0"),
+        (".c[.n] | . as $x | key", "0"),
+        (".c[.n] | select(key == 0)", "10"),
+        (".c[.n] | file_index + 1", "1"),
+        // #2471 sub-item 3's `KeyNode` rule, reached from a computed head for
+        // the first time: `key` keeps the position but a *second* `key` emits
+        // nothing (yq v4.53.3: `.c[.n] | key | key` prints nothing).
+        (".c[.n] | key | key", ""),
+        (".c[.n] | key | path", "[\"c\",0]"),
+    ] {
+        let (out, err, code) = run_jq_full(&["-c", filter], Some(doc))?;
+        assert_eq!(code, 0, "`{filter}`: {out:?} {err}");
+        assert_eq!(out.trim_end(), want, "`{filter}`");
+    }
+    // The three rows real jq raises on, which the walk must keep raising in
+    // jq mode.
+    for (filter, message) in [
+        ("path(.a[.a.b])", "Cannot index object with number"),
+        (".a[.a.b] | key", "Cannot index object with number"),
+        ("[path(.s[.n])]", "Cannot index string with number"),
+        (".s[.n] | key", "Cannot index string with number"),
+    ] {
+        let (_out, err, code) = run_jq_full(&["-c", filter], Some(doc))?;
+        assert_eq!(code, 5, "`{filter}`: {err}");
+        assert!(err.contains(message), "`{filter}`: {err}");
+    }
+    Ok(())
+}
+
 /// #2558 (spine 2416, gate reason 2): an optional head (`.a? | ...`) is
 /// walkable, in jq mode too.
 ///

--- a/tests/jq_evaluator_parity_tests.rs
+++ b/tests/jq_evaluator_parity_tests.rs
@@ -1764,6 +1764,58 @@ fn test_walk_vs_bridge_path_context_parity_2416() {
             ".a? | key | tostring",
             ".a? | first(key)",
             ".a? | try (key) catch \"e\"",
+            // #2471: a computed bracket is a walkable head now, so the walk
+            // takes these where only the bridge used to. The components are
+            // spelled so the parser cannot fold them back to a literal
+            // `Expr::Index`/`Expr::Field` (`.d[(0)]` and `.a[("b")]` both
+            // fold, `.d[(0+0)]` and `.a[("b"+"")]` do not), which is what
+            // makes them exercise the new arm rather than the old one.
+            ".d[(0+0)] | key",
+            ".d[(0+0)] | path",
+            ".d[(0+0)] | parent",
+            ".d[(0+0)] | file_index",
+            ".d[(0+1)]? | key",
+            ".d[(9+0)] | key",
+            ".d[(9+0)] | path",
+            ".d[(0+0)] | parent | key",
+            ".d[(0+0)][(0+0)] | key",
+            ".d[(0+0)] | [key, path]",
+            ".d[(0+0)] | (key, path)",
+            ".a[(\"b\"+\"\")] | key",
+            ".a[(\"b\"+\"\")] | path",
+            ".a[(\"b\"+\"\")] | parent",
+            ".a[(\"b\"+\"\")]? | key",
+            ".a[(\"z\"+\"z\")] | key",
+            ".a[(\"z\"+\"z\")] | path",
+            ".a[(\"z\"+\"z\")] | [key, path]",
+            ".a[(\"b\"+\"\")] | key | tostring",
+            ".a[(\"b\"+\"\")] | select(true) | key",
+            ".a[(\"b\"+\"\")] | first(key)",
+            ".a[(\"b\"+\"\")] | try (key) catch \"e\"",
+            // `[.a[("b"+"")] | key]` is deliberately *not* here. On the
+            // scalar-valued `{"a":1,"a":2,...}` document below, yq mode's
+            // #2482 rule (a scalar has no fields, so the step produces no
+            // position at all) is applied by the walk -- through the literal
+            // `Expr::Field` step the component is spelled as -- and not by
+            // the eager `Expr::IndexExpr` arm, which still raises `Cannot
+            // index number with string "b"`. The walk is the side that
+            // matches the oracle (`yq -o=json -I0 '[.a["b"] | key]'` on
+            // `a: 1` is `[]` in v4.53.3, and succinctly's own *value* route
+            // already answers `[]` for `[.a[("b"+"")]]`), so this is an
+            // eager-route gap the migration exposes rather than a walk bug;
+            // pinning it as "the routes agree" would pin the wrong answer.
+            // The bare `.a[("b"+"")] | key` spelling above does agree,
+            // because there the eager route yields no output either.
+            ".zz[(0+0)] | key",
+            ".zz[(0+0)] | path",
+            ".a[(0+0)] | key",
+            // The three shapes the head admission refuses, kept here so the
+            // routes are asserted to agree on them too: a component that can
+            // escape, one that fans out, and a slice or `getpath` head.
+            ".d[(0,1)] | key",
+            ".d[(0,1)] | path",
+            ".d[(0+0):(0+1)] | key",
+            "getpath([\"a\"]) | key",
         ] {
             assert_walk_bridge_parity(doc, filter);
         }
@@ -2169,6 +2221,19 @@ fn test_arm_audit_proof_queries_are_unmoved_by_the_gate_2416() {
             &[r#"{"z":"bx"}"#],
         ),
         (r".a? | . as $x | key", &[r#""a""#]),
+        // #2471's head-of-pipe half, same precedent once more: a *computed*
+        // bracket is navigation the walk takes now, so `A19`'s listed query
+        // (`.c[.n] | key + 1`) and `A07`'s (`.c[.n]? | key + 1`) are answered
+        // by the absent route and report no arm at all. Both re-derivations
+        // keep the same head and put an `as` stage -- which has no
+        // `owned_identity_rule` -- where the arithmetic was, so the reason
+        // moves from `R1` to `R2` while the arm is unchanged. Verified with
+        // the arms instrumented (2026-09-07, method in
+        // `docs/plan/path-context-arm-reachability.md`): `A19` fires on the
+        // first row, `A07` on the second, and `A04`/`A17`/`A20` still fire on
+        // their unchanged listed queries above.
+        (r".c[.n] | . as $x | key", &["0"]),
+        (r".c[.n]? | . as $x | key", &["0"]),
     ];
     for (filter, expected) in rows {
         // `path + []` is the audit's H1 row spelled against `.a.b`.

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -37094,6 +37094,135 @@ const OPTIONAL_HEAD_FLOW_2558: &str = "{\"a\": {\"b\": 1}, \"c\": [10, 20], \"s\
 /// not part of this rule, and asserting on both is what says so.
 const OPTIONAL_HEAD_BLOCK_2558: &str = "a:\n  b: 1\nc:\n  - 10\n  - 20\ns: hi\n";
 
+/// The flow-style document #2471's computed-bracket rows were captured on.
+const COMPUTED_HEAD_FLOW_2471: &str =
+    "{\"a\": {\"b\": 1}, \"c\": [10, 20], \"n\": 0, \"m\": 1, \"s\": \"hi\", \"k\": \"b\", \"neg\": -1}\n";
+
+/// The block-style spelling of [`COMPUTED_HEAD_FLOW_2471`]. Every row below
+/// was captured on both and yq v4.53.3 answers them identically.
+const COMPUTED_HEAD_BLOCK_2471: &str =
+    "a:\n  b: 1\nc:\n  - 10\n  - 20\nn: 0\nm: 1\ns: hi\nk: b\nneg: -1\n";
+
+/// #2471 (spine 2416, gate reason 1): a *computed* bracket at the head of a
+/// pipe (`.c[.n] | ...`) is walkable.
+///
+/// `path_context_is_navigational` used to admit only a *literal*
+/// `Expr::Index`, so a pipe headed by `.c[.n]` left the cursor domain at a
+/// stage with no `owned_identity_rule`, `owned_identity_pipe_applies`
+/// declined, and `path_context_needs_eager` handed the whole pipe over --
+/// gate reason 1, the disjunct `docs/plan/path-context-arm-reachability.md`
+/// attributes all five of its `R1` rows to. A computed bracket moves the
+/// position exactly as a literal one does; what is new is that the component
+/// is a value to evaluate first, against the stage's own input (jq's
+/// `K as $k | E | .[$k]` model). Each component is then taken by the walk's
+/// *literal* `Expr::Field`/`Expr::Index` step, which is what keeps every
+/// mode-specific rule -- negative-index resolution (#2254), a numeric index
+/// on a mapping (#2459), a scalar target (#2482), an absent key in a
+/// read-only context (#2470) -- one definition rather than a second copy.
+///
+/// Captured 2026-09-07 from Homebrew yq v4.53.3 (`yq -o=json -I0`), on both
+/// documents above, byte-identical between the two:
+///
+/// ```text
+/// $ yq '.c[.n] | key'                    0
+/// $ yq '.c[.n] | path'                   ["c",0]
+/// $ yq '.c[.n] | key + 1'                1
+/// $ yq '.c[.n]? | key'                   0
+/// $ yq '.c[.n]? | path'                  ["c",0]
+/// $ yq '.a[.k] | key'                    "b"
+/// $ yq '.a[.k] | path'                   ["a","b"]
+/// $ yq '.c[(0,1)] | key'                 0 1
+/// $ yq '.c[.n] | .x? | key'              (nothing)
+/// $ yq '.zz[.n] | key'                   0
+/// $ yq '.zz[.n] | path'                  ["zz",0]
+/// $ yq '.c[9] | key'                     9
+/// $ yq '.a[.a.b] | key'                  1
+/// $ yq '.a[.a.b] | path'                 ["a",1]
+/// $ yq '.c[.neg] | key'                  1
+/// $ yq '.c[.neg] | path'                 ["c",1]
+/// $ yq '.c[.n] | key | key'              (nothing)
+/// $ yq '.c[.n] | parent | key'           "c"
+/// $ yq '.s[.n] | key'                    (nothing)
+/// $ yq '.c[.n] | [key, path]'            [0,["c",0]]
+/// $ yq '.c[.n] | {"k": key}'             {"k":0}
+/// $ yq '.a[("z"+"z")] | key'             "zz"
+/// $ yq '(.a[("z"+"z")] | key) + "!"'     "!"
+/// $ yq '.c[.n] | tostring | key'         0
+/// $ yq '.c[.n] | select(key == 0)'       10
+/// $ yq '.c[.n] | . as $x | key'          0
+/// $ yq '.c[.n] | file_index + 1'         1
+/// $ yq '.c[.n] | path + []'              ["c",0]
+/// $ yq '.c[.n] | key == 0 and true'      true
+/// $ yq '.c[.m] | parent | key'           "c"
+/// $ yq '.c[.n][.n] | key'                (nothing)
+/// ```
+///
+/// Five of these were wrong before the migration, which is why it is a
+/// fidelity fix as well as a routing one -- and every one is a yq-mode rule
+/// the walk gets by spelling the component as a literal step:
+///
+/// * `.c[.neg] | key` answered `-1` (the eager evaluator reports a computed
+///   index as written; `.c[-1] | key` already answered `1`, so the two
+///   spellings disagreed with each other as well as with yq);
+/// * `.s[.n] | key` and `.c[.n][.n] | key` raised `Cannot index string/number
+///   with number` (#2482: a scalar has no fields in yq's model, so the step
+///   produces no position at all);
+/// * `(.a[("z"+"z")] | key) + "!"` answered `"zz!"` (#2470: an absent key
+///   read inside an operand produces nothing, so yq's zero-output-operand
+///   rule leaves `"!"`);
+/// * `.c[.n] | key | key` answered `0` (#2471's own `KeyNode` rule, reached
+///   from a computed head for the first time).
+///
+/// `.c[.n:.m]` has no row here on purpose: real yq cannot parse a slice with
+/// computed bounds at all (`Error: cannot index array with 'n'
+/// (strconv.ParseInt: parsing "n": invalid syntax)`), so there is no oracle
+/// for it, and it is deliberately not walkable -- a slice builds a fresh
+/// container, which `PathNode` has no cursor for.
+#[test]
+fn test_computed_bracket_head_is_walkable_2471() -> Result<()> {
+    let args = &["-o", "json", "-I0"];
+    for doc in [COMPUTED_HEAD_FLOW_2471, COMPUTED_HEAD_BLOCK_2471] {
+        for (filter, expected) in [
+            (".c[.n] | key", "0"),
+            (".c[.n] | path", "[\"c\",0]"),
+            (".c[.n] | key + 1", "1"),
+            (".c[.n]? | key", "0"),
+            (".c[.n]? | path", "[\"c\",0]"),
+            (".a[.k] | key", "\"b\""),
+            (".a[.k] | path", "[\"a\",\"b\"]"),
+            (".c[(0,1)] | key", "0\n1"),
+            (".c[.n] | .x? | key", ""),
+            (".zz[.n] | key", "0"),
+            (".zz[.n] | path", "[\"zz\",0]"),
+            (".c[9] | key", "9"),
+            (".a[.a.b] | key", "1"),
+            (".a[.a.b] | path", "[\"a\",1]"),
+            (".c[.neg] | key", "1"),
+            (".c[.neg] | path", "[\"c\",1]"),
+            (".c[.n] | key | key", ""),
+            (".c[.n] | parent | key", "\"c\""),
+            (".s[.n] | key", ""),
+            (".c[.n] | [key, path]", "[0,[\"c\",0]]"),
+            (".c[.n] | {\"k\": key}", "{\"k\":0}"),
+            (".a[(\"z\"+\"z\")] | key", "\"zz\""),
+            ("(.a[(\"z\"+\"z\")] | key) + \"!\"", "\"!\""),
+            (".c[.n] | tostring | key", "0"),
+            (".c[.n] | select(key == 0)", "10"),
+            (".c[.n] | . as $x | key", "0"),
+            (".c[.n] | file_index + 1", "1"),
+            (".c[.n] | path + []", "[\"c\",0]"),
+            (".c[.n] | key == 0 and true", "true"),
+            (".c[.m] | parent | key", "\"c\""),
+            (".c[.n][.n] | key", ""),
+        ] {
+            let (output, code) = run_yq_stdin(filter, doc, args)?;
+            assert_eq!(code, 0, "`{filter}` on `{doc}`: {output:?}");
+            assert_eq!(output.trim_end(), expected, "`{filter}` on `{doc}`");
+        }
+    }
+    Ok(())
+}
+
 /// #2558 (spine 2416, gate reason 2): an optional head (`.a? | ...`) is
 /// walkable.
 ///


### PR DESCRIPTION
## Summary

The last item of #2471 (spine 2416, gate reason 1): a computed bracket at the head of a pipe is now a walkable navigation step. `Expr::IndexExpr` joins the navigational predicate with a matching walk step and fan-out entry; the component is evaluated at the walked position (against the node's cursor, or against `null` for an absent position, with `key`/`path` inside it resolved by the shared constant resolver), and the component is then taken by the walk's literal field or index step. `Optional` over a computed bracket gets its own arm so `?` covers the indexing step alone. No eager arm added; `path(f)` is untouched.

Three head shapes are refused with the reason in code, ADR-0021 and the audit doc: a slice or `getpath` (both can stand on a value that is not a document node, and a walked stage may have to emit its node), a component that can `halt`/`break` (the step carries no control signal), and a component that fans out (admitting it moved rows away from yq because a fan-out head on absent positions loses its position off the walk; the same gap exists today for the literal spelling).

## Captures and differential

31 rows captured from yq v4.53.3 on flow and block spellings, all now byte-identical (`.c[.neg] | key` is `1`, `.s[.n] | key` and `.c[.n][.n] | key` are nothing, `(.a[("z"+"z")] | key) + "!"` is `"!"`); yq cannot parse a computed slice, so there is no row for it. Thirteen jq 1.7.1 rows for `path(.c[.n])`, `path(.a[.k])`, `path(.c[.neg])` and friends are unchanged in jq mode. Over 2070 queries in two modes on four documents, 57 answers changed: 42 toward yq, 11 with no oracle either way, and 4 nominally away, two of which yq's lexer rejects and two of which are the literal spelling's pre-existing gap now reached by the computed one; none moved away with an oracle behind it. 32 computed-head rows join the walk-versus-bridge parity test.

## Pin

Stays at 44. Two reason-1 proof queries now fire no gate at all (the absent route takes them) and were re-derived with an `as` stage, moving their reason to 2 with the arm unchanged (#2563 is that lever); the other three keep their refused heads. One walk-versus-bridge divergence is deliberately recorded rather than pinned equal: `[.a[("b"+"")] | key]` on a scalar `a` is `[]` on the walk (yq's answer) and raises on the eager route, whose computed-index arm never received #2482's scalar rule; a follow-up on the retiring route.

## Verification

fmt; clippy on both CI legs with `-D warnings`; `cargo test` in the three configurations; `cargo doc -D warnings`; yq goldens 113 and jq goldens 633; oracle sweep 3168 cases, 0 unexpected, manifest unchanged; parity 55 tests green.

Behaviour change in yq mode on the rows above; CHANGELOG entry included. Part of #2471 (spine 2416), which can close once the slice and `getpath` heads are decided.
