### PR TITLE
fix(jq): nth's skipped-item decode failure no longer loses to a ?// retry

### DIFF
--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -10010,17 +10010,38 @@ fn nth_with_n_generic<S: EvalSemantics, V: DocumentValue>(
         }
         Demand::Continue
     });
-    // Mirrors `each_take_nth` + its caller's own priority exactly: a
-    // captured item at index `n` always wins, even over a trailing escape
-    // from beyond that point (and, by construction, over `skipped_err` too
-    // -- once `wanted` is set the sink returns `Demand::Stop` immediately,
-    // so no later item, and no `skipped_err`, can still be pending);
-    // short of reaching index `n` at all, whatever ended the pull
-    // (exhaustion, a skipped item's own forced failure, or the generator's
-    // own escape before index `n`) decides. The *wanted* item alone is
-    // kept cursor-backed ([`generic_item_to_result`], #607's own
+    // #2199: `skipped_err` is checked *before* `wanted`, reversing this
+    // function's own prior order -- the comment that used to sit here
+    // claimed "by construction, over `skipped_err` too -- once `wanted` is
+    // set the sink returns `Demand::Stop` immediately, so no later item,
+    // and no `skipped_err`, can still be pending". True for a single,
+    // non-retried pull (the sink is never re-entered after its own
+    // `Demand::Stop`), but false the moment `expr` contains a `?//`: a
+    // *retryable*-looking `Demand::Stop` (`Demand` carries no payload
+    // distinguishing "consumer satisfied" from "this skipped item's forced
+    // decode genuinely failed") lets `each_pattern_alternatives_generic`
+    // retry the next alternative through this exact same sink closure,
+    // which can then populate `wanted` from that (illegitimate) retry --
+    // leaving `skipped_err` still `Some` from the first alternative's own
+    // unrelated failure, silently discarded by the old `!wanted.is_empty()`
+    // check firing first. Confirmed live: `nth(1; [.p] as $x ?// [$x] |
+    // (if ($x|type)=="array" then .a else 100 end), 9)` over
+    // `{"a": <undecodable>, "p": 1}` used to answer `Ok([100])` (alt2's
+    // own value, wanted populated); it must raise the decode failure
+    // instead, since jq's own rule (`is_decode_failure()`, never
+    // retryable, `is_last` or not) means alt2 should never have run at
+    // all. This only reorders the *check*, not the pull itself -- a fuller
+    // fix would need `Demand` to carry the failure so the retry itself
+    // never happens (tracked as a follow-up; the illegitimate retry's own
+    // side effects, if any, still run today, they just can no longer win).
+    // A captured item at index `n` still wins over a *trailing* escape
+    // from beyond that point (`take_stopping_items_to_generic_result`,
+    // #1519) -- kept cursor-backed ([`generic_item_to_result`], #607's own
     // conversion) rather than forced through `OwnedValue`, so a duplicate
     // key *inside* it survives too, not just across the walk to reach it.
+    if let Some(control) = skipped_err {
+        return partial_generic(Vec::new(), control);
+    }
     if !wanted.is_empty() {
         // #1519: a later `?//` alternative's own error is genuinely reached by
         // jq after an earlier one answered, so it raises rather than being
@@ -10028,13 +10049,9 @@ fn nth_with_n_generic<S: EvalSemantics, V: DocumentValue>(
         // `first` and `nth` share.
         return take_stopping_items_to_generic_result(wanted, flow);
     }
-    if let Some(control) = skipped_err {
-        partial_generic(Vec::new(), control)
-    } else {
-        match flow {
-            Flow::Stopped { .. } | Flow::Exhausted => GenericResult::None,
-            Flow::Escaped(control) => partial_generic(Vec::new(), control),
-        }
+    match flow {
+        Flow::Stopped { .. } | Flow::Exhausted => GenericResult::None,
+        Flow::Escaped(control) => partial_generic(Vec::new(), control),
     }
 }
 

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -27471,6 +27471,38 @@ fn test_jq_nth_still_evaluates_a_skipped_output_that_would_error_1607() -> Resul
     Ok(())
 }
 
+/// #2199: the sibling of #1607 above, but in the *generic* evaluator's
+/// `nth_with_n_generic` (reached here via the `?//` alternative operator,
+/// which forces the eager `eval.rs` path to hand off) rather than the
+/// native fast path. `nth`'s own force-decode of a *skipped* item (`.a`,
+/// structurally a string token but holding `\x` -- not a valid JSON escape,
+/// matching `test_select_raises_on_decode_failure_instead_of_silently_truthy_1645`'s
+/// trigger shape) used to fail via a bare `Demand::Stop`, indistinguishable
+/// from an ordinary "consumer got what it wanted" signal. `?//`'s own
+/// retry-decision code read that `Stop` as license to retry the next
+/// alternative, whose own (trivially successful) output then inherited the
+/// `seen` counter's progress from the first, wrongly-aborted attempt and was
+/// mistaken for the wanted index -- silently answering `100` (jq's own
+/// `nth($n;f) == last(limit($n+1;f))` desugaring instead requires this
+/// skipped output's own failure to surface, exactly as the non-generic path
+/// already guarantees above).
+#[test]
+fn test_jq_nth_generic_still_surfaces_a_skipped_decode_failure_through_a_retry_2199() -> Result<()>
+{
+    let (stdout, stderr, code) = run_jq_full(
+        &["nth(1; [.p] as $x ?// [$x] | (if ($x|type)==\"array\" then .a else 100 end), 9)"],
+        Some(r#"{"a": "\x", "p": 1}"#),
+    )
+    .expect("nth generic-evaluator skipped-decode-failure repro runs");
+    assert_eq!(code, 5, "stdout: {stdout}\nstderr: {stderr}");
+    assert_eq!(stdout, "");
+    assert!(
+        stderr.contains("invalid escape sequence"),
+        "stderr: {stderr}"
+    );
+    Ok(())
+}
+
 /// The carve-out keys off the `line`/`at_offset`/... *builtins*, so a field
 /// or key that merely spells one of their names must not trip it -- that
 /// would quietly switch a filter back to the eager path and undo #1504's own


### PR DESCRIPTION
## Summary
- `nth_with_n_generic` (the generic evaluator's `nth(n; f)`) forces the decode of any *skipped* output (index < n) for jq-fidelity, per `nth($n;f) == last(limit($n+1;f))`.
- When that forced decode failed, the sink returned a bare `Demand::Stop` — indistinguishable from an ordinary "consumer satisfied" signal. `each_pattern_alternatives_generic` read that as license to retry the next `?//` alternative through the same sink closure, whose own (trivially successful) output then inherited the `seen` counter's progress from the first, wrongly-aborted attempt and was mistaken for the wanted index.
- Confirmed live: `nth(1; [.p] as $x ?// [$x] | (if ($x|type)=="array" then .a else 100 end), 9)` over `{"a": "\x", "p": 1}` (an invalid JSON escape, structurally a string token but undecodable) used to silently answer `100` instead of raising the decode failure.
- Fix: `nth_with_n_generic` now checks `skipped_err` *before* `wanted`, so a genuinely-failed skipped item always wins over anything a subsequent (illegitimate) retry produced.
- Scope note left in the code: this reorders the *check*, not the pull itself — the illegitimate retry still actually runs today (any of its own side effects still happen), it just can no longer win the final answer. A fuller fix would need `Demand` to carry the failure so the retry itself never starts.

Fixes #2199

## Test plan
- [x] New regression test `test_jq_nth_generic_still_surfaces_a_skipped_decode_failure_through_a_retry_2199`, confirmed to fail pre-fix (wrongly answers `100`, exit 0) and pass post-fix (exit 5, "invalid escape sequence").
- [x] `cargo clippy --all-targets --all-features -- -D warnings` (and the other two CI clippy feature-set legs) — clean.
- [x] `cargo test --features cli,simd,regex,serde` — full suite green, verified by real process exit code (not text grep).
- [x] `no_std` build + test (`--no-default-features --features portable-popcount`) — clean.
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --all-features` — clean.
- [x] `omni-dev coverage diff` — 100% patch coverage on the changed lines.