### PR TITLE
feat(jq): give an as binding an owned identity rule (#2563)

### DIFF
--- a/docs/adrs/adr-0021.md
+++ b/docs/adrs/adr-0021.md
@@ -163,6 +163,20 @@ in-place transforms *inside owned values*, which have no node to stand on.
    excluded for a different reason — their right side is evaluated against the value *at
    the path* (`.a | .b |= key` is `{"b":"b","e":2}`), a position no route names yet.
 
+   **A binding keeps the input's identity for its body** (#2563). `E as $x | body`
+   stands where its input stood: the body's `.` is the same node, so
+   `key`/`path`/`parent` inside it answer exactly as they do without the binding
+   (`.a.b | . as $x | key` is `"b"` in yq v4.53.3, `.a.b | . as $x | parent | key`
+   is `"a"`), and the bound variable is a *value*. `eval_owned_identity_as`
+   evaluates the source at the stage's own position, substitutes each bound value
+   into the body with the `substitute_bound_var` the generic route already uses,
+   and splices the substituted body in front of the rest of the pipe through this
+   same route -- so every stage rule keeps one definition instead of gaining a
+   second evaluator for what follows a binding. `Expr::AsPattern` (destructuring,
+   `?//`) is excluded: its alternative-fallthrough rule has one definition in
+   `each_pattern_alternatives_generic` and no second one here, and real yq's lexer
+   rejects both spellings outright.
+
    **The residue is a fan-out head.** `.[] | .k | select(key == "k")` is one position per
    element, the memory cost `path_context_fans_out` exists to refuse and the same guard
    `path_context_walk_split` applies (and `.[]?` counts, since #2558 gave that predicate

--- a/docs/plan/path-context-arm-reachability.md
+++ b/docs/plan/path-context-arm-reachability.md
@@ -128,9 +128,9 @@ trusting them.
 
 | #   | Handler (site in `eval_stage_with_path_context`)                   | Verdict   | Proof query (jq mode, document `D`)                   | Gate |
 |-----|--------------------------------------------------------------------|-----------|-------------------------------------------------------|------|
-| H1  | pre-match `if matches!(first, Expr::Builtin(Builtin::PathNoArg))`  | REACHABLE | `.a.b \| . as $x \| path + []`                         | R2   |
-| H2  | pre-match `if matches!(first, Expr::Builtin(Builtin::Key))`        | REACHABLE | `.a.b \| . as $x \| key + "x"`                         | R2   |
-| H3  | pre-match `if matches!(first, Expr::Builtin(Builtin::FileIndex))`  | REACHABLE | `.a.b \| . as $x \| file_index + 1`                    | R2   |
+| H1  | pre-match `if matches!(first, Expr::Builtin(Builtin::PathNoArg))`  | REACHABLE | `.a.b \| reduce (path) as $p ([]; . + $p) \| . + ["x"]` | R2   |
+| H2  | pre-match `if matches!(first, Expr::Builtin(Builtin::Key))`        | REACHABLE | `.a.b \| reduce (key) as $k (""; . + $k) \| . + "x"`   | R2   |
+| H3  | pre-match `if matches!(first, Expr::Builtin(Builtin::FileIndex))`  | REACHABLE | `.a.b \| reduce (file_index) as $f (0; . + $f) \| . + 1` | R2 |
 | H4  | pre-match `if matches!(first, Expr::Builtin(Builtin::Parent))`     | REACHABLE | `.a.b \| parent + {}`                                 | R2   |
 | H5  | pre-match `if let Expr::Builtin(Builtin::ParentN(n_expr)) = first` | REACHABLE | `.a.b \| parent(0+1) + {}`                            | R2   |
 | A01 | `Expr::Identity`                                                   | REACHABLE | `.a.b \| . \| parent + {}`                            | R2   |
@@ -139,33 +139,33 @@ trusting them.
 | A04 | `Expr::Slice { .. }`                                               | REACHABLE | `.c[0:1] \| .[0] \| key + 1`                          | R1   |
 | A05 | `Expr::Iterate`                                                    | REACHABLE | `.a[] \| (key \| tostring)`                            | R3   |
 | A06 | `Expr::Paren(inner)`                                               | REACHABLE | `.a.b \| (parent) + {}`                               | R2   |
-| A07 | `Expr::Optional(inner) if IndexExpr/SliceExpr`                     | REACHABLE | `.c[.n]? \| . as $x \| key`                            | R2   |
-| A08 | `Expr::Optional(inner)`                                            | REACHABLE | `.a? \| . as $x \| key`                                | R2   |
-| A09 | `Expr::Pipe(inner) if rest.is_empty()`                             | REACHABLE | `.a.b \| -(key\|length)`                              | R2   |
+| A07 | `Expr::Optional(inner) if IndexExpr/SliceExpr`                     | REACHABLE | `.c[.n]? \| (key and parent)`                          | R2   |
+| A08 | `Expr::Optional(inner)`                                            | REACHABLE | `.a? \| (key and parent)`                              | R2   |
+| A09 | `Expr::Pipe(inner) if rest.is_empty()`                             | REACHABLE | `.a[] \| (key \| tostring)`                            | R3   |
 | A10 | `Expr::Pipe(inner)`                                                | REACHABLE | `.a.b \| parent + {}`                                 | R2   |
 | A11 | `Expr::Arithmetic { .. }`                                          | REACHABLE | `.a.b \| parent + {}`                                 | R2   |
 | A12 | `Expr::And(..) \| Expr::Or(..)`                                    | REACHABLE | `.a.b \| . as $x \| (key and parent)`                  | R2   |
-| A13 | `Expr::Negate(operand)`                                            | REACHABLE | `.a.b \| -(key\|length)`                              | R2   |
-| A14 | `Expr::Compare { .. }`                                             | REACHABLE | `.a.b \| . as $x \| (key + "x") \| . == "bx"`          | R2   |
+| A13 | `Expr::Negate(operand)`                                            | REACHABLE | `.a.b \| -(parent\|length)`                            | R2   |
+| A14 | `Expr::Compare { .. }`                                             | REACHABLE | `.a.b \| (parent \| length) == 1`                      | R2   |
 | A15 | `Expr::Builtin(Builtin::Select(cond))`                             | REACHABLE | `.a.b \| select(key == "b") \| parent + {}`           | R2   |
 | A16 | `Expr::Builtin(Builtin::Map(f))`                                   | REACHABLE | `.a \| map(key + "x")`                                | R2   |
-| A17 | `Expr::Builtin(Builtin::GetPath(path_expr))`                       | REACHABLE | `.a \| getpath(["b"]) \| . as $x \| key`              | R1   |
+| A17 | `Expr::Builtin(Builtin::GetPath(path_expr))`                       | REACHABLE | `.a \| getpath(["b"]) \| (key and parent)`            | R1   |
 | A18 | `Expr::Builtin(_)`                                                 | REACHABLE | `.a[] \| (key \| length)`                             | R3   |
-| A19 | `Expr::IndexExpr { target, key }`                                  | REACHABLE | `.c[.n] \| . as $x \| key`                             | R2   |
+| A19 | `Expr::IndexExpr { target, key }`                                  | REACHABLE | `.c[.n] \| (key and parent)`                           | R2   |
 | A20 | `Expr::SliceExpr { target, start, end }`                           | REACHABLE | `.c[.n:.m] \| .[0] \| key + 1`                        | R1   |
-| A21 | `Expr::Array(inner) if needs_path_context(inner)`                  | REACHABLE | `.a.b \| . as $x \| [key] + ["x"]`                     | R2   |
+| A21 | `Expr::Array(inner) if needs_path_context(inner)`                  | REACHABLE | `.a.b \| [(key and parent)] + ["x"]`                   | R2   |
 | A22 | `Expr::StringInterpolation(parts) if ..`                           | REACHABLE | `.a.b \| ("\(key)") \| . + "x"`                       | R2   |
 | A23 | `Expr::DefCall { .. }`                                             | REACHABLE | `def f: key; .a.b \| f + "x"`                         | R2   |
 | A24 | `Expr::Shared(inner)`                                              | REACHABLE | `def f(x): x; .a.b \| f(key) + "z"`                   | R2   |
 | A25 | `Expr::FuncDef { .. }`                                             | REACHABLE | `.a.b \| def f: key; f + "x"`                         | R2   |
-| A26 | `Expr::As { .. } if ..`                                            | REACHABLE | `.a.b \| . as $x \| key + "x"`                        | R2   |
+| A26 | `Expr::As { .. } if ..`                                            | REACHABLE | `.a.b \| . as $x \| (key and parent)`                  | R2   |
 | A27 | `Expr::AsPattern { .. } if ..`                                     | REACHABLE | `.c \| . as [$x] \| key + "x"`                        | R2   |
 | A28 | `Expr::Limit { n, expr } if ..`                                    | REACHABLE | `.a.b \| limit(1; key + "x")`                         | R2   |
 | A29 | `Expr::FirstExpr(expr) if ..`                                      | REACHABLE | `.a.b \| first(key + "x")`                            | R2   |
 | A30 | `Expr::LastExpr(expr) if ..`                                       | REACHABLE | `.a.b \| last(key + "x")`                             | R2   |
 | A31 | `Expr::Reduce { .. } if ..`                                        | REACHABLE | `.a.b \| reduce (key) as $k (""; . + $k) \| . + "x"`  | R2   |
 | A32 | `Expr::Foreach { .. } if ..`                                       | REACHABLE | `.a.b \| foreach (key) as $k (""; . + $k) \| . + "x"` | R2   |
-| A33 | `Expr::Object(_) \| Expr::Array(_) \| Expr::Literal(_)`            | REACHABLE | `.a.b \| . as $x \| (key + "x") \| {z: .}`             | R2   |
+| A33 | `Expr::Object(_) \| Expr::Array(_) \| Expr::Literal(_)`            | REACHABLE | `.a.b \| . as $x \| (key and parent) \| {z: .}`         | R2   |
 | A34 | `Expr::If { .. }`                                                  | REACHABLE | `.a.b \| if key == "b" then key + "x" else "y" end`   | R2   |
 | A35 | `Expr::Comma(exprs)`                                               | REACHABLE | `.a.b \| (key + "x"), key`                            | R2   |
 | A36 | `Expr::Try { .. }`                                                 | REACHABLE | `.a.b \| try (key + "x") catch "e"`                   | R2   |
@@ -742,6 +742,116 @@ number with string "b"` on the eager route, whose `Expr::IndexExpr` arm never go
 scalar rule. The walk is the side that matches the oracle, so the row is not asserted as
 "the routes agree"; the eager arm's missing rule is a separate fix.
 
+## #2563: an `as` binding gets an identity rule, and the pin still holds at 44
+
+[#2563](https://github.com/rust-works/succinctly/issues/2563) is the first of the
+`R2` cluster's *stage* shapes -- the ones with no `owned_identity_rule`, which the
+"Notes for the next migration" section below names as the remaining move for that
+reason. Every re-derived proof query the last three sections produced was spelled
+through the same shape (`.a.b | . as $x | key`), because `Expr::As` had no rule: a
+binding made `owned_identity_pipe_supported` decline, so `path_context_absent_split`
+found no route for `rest` and the gate handed the whole pipe over.
+
+An `as` stage keeps the input's identity for its body -- the body's `.` is the node
+the stage stood on, which is what real yq does (`.a.b | . as $x | key` is `"b"` in
+v4.53.3, `. as $x | parent | key` is `"a"`) -- and the bound variable is a value.
+`eval_owned_identity_as` evaluates the bind source at the stage's own position (its
+`key`/`path`/`file_index` reads resolve to constants, the same rewrite a computed
+navigation component gets), substitutes each bound value into the body with the
+`substitute_bound_var` the generic route already uses, and splices the substituted
+body in front of `rest` through the same pipe -- so every stage rule stays a single
+definition. `Expr::AsPattern` (destructuring, `?//`) is deliberately **not**
+admitted: its alternative-fallthrough rule lives in
+`each_pattern_alternatives_generic` and has no second definition here, and real yq's
+lexer rejects both spellings outright.
+
+**`PINNED_ARM_COUNT` stays at 44.** Re-run of the method above on the post-change
+tree, with all 44 handlers *and* the gate's three disjuncts instrumented, against a
+pre-change build of the same worktree (base `b05069ad5`) instrumented identically --
+so "moved" is measured, not inferred. Eleven of the 44 listed proof queries stop
+reaching any arm; **all eleven arms are still reachable** and the table above now
+carries the re-derived query for each (outputs pinned in
+`test_arm_audit_proof_queries_are_unmoved_by_the_gate_2416` alongside the old
+spellings). Document `D`:
+
+| Id  | Listed query before                         | Re-derived query                                       | Gate | Marker | Output          |
+|-----|---------------------------------------------|--------------------------------------------------------|------|--------|-----------------|
+| H1  | `.a.b \| . as $x \| path + []`               | `.a.b \| reduce (path) as $p ([]; . + $p) \| . + ["x"]` | R2   | fired  | `["a","b","x"]` |
+| H2  | `.a.b \| . as $x \| key + "x"`               | `.a.b \| reduce (key) as $k (""; . + $k) \| . + "x"`    | R2   | fired  | `"bx"`          |
+| H3  | `.a.b \| . as $x \| file_index + 1`          | `.a.b \| reduce (file_index) as $f (0; . + $f) \| . + 1` | R2  | fired  | `1`             |
+| A07 | `.c[.n]? \| . as $x \| key`                  | `.c[.n]? \| (key and parent)`                           | R2   | fired  | `true`          |
+| A08 | `.a? \| . as $x \| key`                      | `.a? \| (key and parent)`                               | R2   | fired  | `true`          |
+| A14 | `.a.b \| . as $x \| (key + "x") \| . == "bx"` | `.a.b \| (parent \| length) == 1`                       | R2   | fired  | `true`          |
+| A17 | `.a \| getpath(["b"]) \| . as $x \| key`     | `.a \| getpath(["b"]) \| (key and parent)`              | R1   | fired  | `true`          |
+| A19 | `.c[.n] \| . as $x \| key`                   | `.c[.n] \| (key and parent)`                            | R2   | fired  | `true`          |
+| A21 | `.a.b \| . as $x \| [key] + ["x"]`           | `.a.b \| [(key and parent)] + ["x"]`                    | R2   | fired  | `[true,"x"]`    |
+| A26 | `.a.b \| . as $x \| key + "x"`               | `.a.b \| . as $x \| (key and parent)`                   | R2   | fired  | `true`          |
+| A33 | `.a.b \| . as $x \| (key + "x") \| {z: .}`   | `.a.b \| . as $x \| (key and parent) \| {z: .}`         | R2   | fired  | `{"z":true}`    |
+
+Two things this run found that the change did **not** cause, recorded because they
+were wrong on the page rather than in the code:
+
+- **`A09` and `A13` were already stale.** Their listed query
+  (`.a.b | -(key|length)`) reaches *no* arm on the pre-change build either -- the
+  gate's `R3` marker fires from `path_context_single_native`'s own nested
+  consultation (the caveat below), while the pipe itself is answered by the owned
+  identity pipe, which has had an `Expr::Negate` arm since #2471. Both are still
+  reachable and both are re-derived above: `A09` on `.a[] | (key | tostring)`
+  (`R3`, `"b"`) and `A13` on `.a.b | -(parent|length)` (`R2`, `-1`), a `parent`
+  *operand* being the one read no route can name a position for.
+- **`A26` is the arm the migration was aimed at and it survives.** `and`/`or` has
+  no `owned_identity_rule`, so a body built from one still keeps the binding's
+  whole pipe eager, and the eager `Expr::As` arm is what steps the binding once it
+  does. The same holds for `map`, `reduce`/`foreach`, `label`/`def` and the bounded
+  consumers -- the rest of the `R2` stage cluster. **This change lowers no arm's
+  reachability to zero**, and the reason is the same structural one #2472 and #2473
+  recorded: an admission removes a *reason* for one stage shape, not the arm.
+
+The other 33 rows report the same disjunct and the same output they reported before,
+verified in the same run.
+
+### What the change is measured against
+
+A differential over 2,544 queries per mode (sixteen heads x five binders x
+thirty-three bodies, minus the `$x` rows whose binder does not bind one) on
+`{"a":{"b":1,"e":2},"c":[10,20],"n":0,"m":1,"s":"hi","u":null}`, comparing the
+pre-change binary, the post-change binary and the oracle. In yq mode: **136 answers
+changed, 114 of them from disagreeing with yq v4.53.3 to agreeing with it, 5 read as
+moving away and 17 changed without reaching agreement.**
+
+All 5 "away" rows and 11 of the 17 "neither" rows have the same head, `.c[-1]`, and
+the same cause -- a pre-existing walk defect this change makes reachable rather than
+introduces. `path_step_generic`'s `Expr::Index` arm resolves a negative index for the
+path *component* (`.c[-1] | key` is `1`, ADR-0021 decision 5) but still looks the
+element up with the index **as written** (`usize::try_from(idx)`, which fails for a
+negative `idx`), so the position it produces is `PathNode::Absent` and the value
+`rest` reads is `null`. It is demonstrable with no `as` anywhere in the filter, on
+the pre-change binary: `.c[-1] | [., key]` is `[null,1]` where yq answers `[20,1]`.
+The `as` rule routes more shapes through that position, so `.c[-1] | . as $x |
+map(key)` goes from `20` (eager, right) to `[]` (walked, wrong). Even on that head
+the change is net positive (48 toward, 5 away, 11 neither -- the `key` resolution
+dominates); fixing the lookup is a separate correctness change with its own
+differential, not part of this migration.
+
+The remaining 6 "neither" rows are two shapes, both sanctioned: four are
+`.a.x.y | ... | parent` answering `null` where the eager route answered `{}`, which
+ADR-0021 decision 7 records as the same answer for the same position (#2472), and
+two are `key | key` after a `getpath` head now applying `OwnedIdentityRule::KeyNode`
+(`.a.b | key | key` prints nothing in yq v4.53.3, where the eager evaluator prints
+`"b"`).
+
+The jq-mode half of the same matrix reports **168 changed**, of which 68 share the
+`.c[-1]` head above. jq 1.7.1 defines none of `key`/`parent`/`path/0`, so there is no
+oracle row to classify the rest against; what it *does* define -- `path(...)`,
+`paths`, destructuring and `?//` binding -- is pinned unchanged in
+`test_as_binding_keeps_the_input_identity_2563` (`tests/jq_cli_tests.rs`), all
+thirteen rows captured from `/usr/bin/jq` 1.7.1. The yq-mode captures are in the
+same-named test in `tests/yq_cli_tests.rs`, on a flow document and its block
+spelling, which yq answers identically.
+
+The instrumentation was reverted before this document was committed; nothing in the
+tree carries it.
+
 ## Result
 
 | Metric                                            | Before | After                 |
@@ -755,6 +865,7 @@ scalar rule. The walk is the side that matches the oracle, so the row is not ass
 | ... starved by #2522                               | --     | 0 (no row's query assigns) |
 | ... starved by #2558                               | --     | 0 (9 `?`-headed rows re-derived) |
 | ... starved by #2471's head-of-pipe half           | --     | 0 (`A07`/`A19` re-derived)       |
+| ... starved by #2563                                | --     | 0 (11 `as`-spelled rows re-derived) |
 | `PINNED_ARM_COUNT`                                 | 43     | 44                    |
 
 Nothing is deletable at this point in the spine. Doors 2 and 3 are closed as
@@ -788,14 +899,25 @@ evaluator, with no second route to check.
   rows needed a re-derived query and *none* of them was unreachable, so a table
   read without re-running would have claimed 14 deletable arms.
 - The `R2` cluster is now the *stage* shapes with no `owned_identity_rule`
-  (`and`/`or`, `map`, `reduce`/`foreach`, `as`/`label`/`def`, the bounded
-  consumers) plus a bare `parent` operand. #2473 gave `and`/`or` and
+  (`and`/`or`, `map`, `reduce`/`foreach`, `label`/`def`, `as PATTERN`, the
+  bounded consumers) plus a bare `parent` operand. #2473 gave `and`/`or` and
   `reduce`/`foreach` native `eval_single` arms, which removes `R3` for them but
   **not** `R2`: a native stage still hands over when the head can miss and no
   route can name the position. Giving those stages an `owned_identity_rule` is
   the remaining move for this reason; widening the absent route again buys
   nothing, because it already accepts every `rest` those stages are missing
-  from.
+  from. **`as $var` came off that list with #2563** (section above), and it is
+  the worked example of what such a rule buys and what it does not: eleven of
+  the 44 proof queries had to be re-derived and not one arm died, because every
+  other member of the cluster is still a body an `as` can hold.
+- **A defect this page's method surfaced, not caused (#2563's differential).**
+  `path_step_generic`'s `Expr::Index` arm resolves a negative index for the path
+  *component* but looks the element up with the index as written, so the walk
+  stands on `PathNode::Absent` where the element exists: on `c: [10, 20]`,
+  `.c[-1] | [., key]` is `[null,1]` here and `[20,1]` in yq v4.53.3, with no
+  `as`, no computed bracket and no `?` in the filter. It predates #2563 and is
+  reproducible on `b05069ad5`; every route that widens makes it reachable from
+  more shapes.
 - **`?` at the head was the single biggest source of `R2`; #2558 closed it.**
   It is admitted to `path_context_is_navigational` now, and what it does on a
   *scalar* input is the question that had to be answered: the step is

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -16073,6 +16073,36 @@ fn owned_identity_operand_resolvable(expr: &Expr) -> bool {
     !needs_path_context(expr) || path_context_absent_resolvable(expr)
 }
 
+/// An `as` stage's bind source (#2563). It is evaluated against the stage's
+/// *own* input -- the input whose position `id` describes -- so a
+/// `key`/`path`/`file_index` inside one is a constant for a fixed identity,
+/// resolved by the same rewrite a computed navigation component's reads get
+/// ([`owned_identity_resolve_component`]). `parent` is refused for the same
+/// reason it is refused in a component: the rewrite spells it as an
+/// `Expr::TrackedVar` holding a materialized value, and nothing about a
+/// binding needs that node.
+fn owned_identity_bind_supported(expr: &Expr) -> bool {
+    owned_identity_component_supported(expr)
+}
+
+/// The stages an `as` stage's body contributes to the pipe it is spliced
+/// into (#2563).
+///
+/// One definition so the gate ([`owned_identity_pipe_supported`]) and the
+/// evaluator ([`eval_owned_identity_as`]) split the body the same way: the
+/// gate sees it unsubstituted (`$x`) and the evaluator sees it with the
+/// bound value in place, and substitution never changes a *stage's* own node
+/// kind. The one node it does replace outright is a bare `Expr::Var`, which
+/// has no [`owned_identity_rule`] before substitution and none after
+/// (`Expr::TrackedVar` has none either), so such a stage is refused by the
+/// gate and the evaluator never meets it.
+fn owned_identity_body_stages(body: &Expr) -> &[Expr] {
+    match strip_parens(body) {
+        Expr::Pipe(stages) => stages,
+        other => core::slice::from_ref(other),
+    }
+}
+
 /// The static gate for the owned identity pipe: every stage of `stages` is
 /// navigation, a path-context builtin answered from the identity, or a stage
 /// with an [`owned_identity_rule`] whose own path-context builtins (if any)
@@ -16123,6 +16153,26 @@ fn owned_identity_pipe_supported(stages: &[Expr]) -> bool {
                 if needs_path_context(stage)
                     || !owned_identity_operand_supported(left)
                     || !owned_identity_operand_supported(right)
+                {
+                    return false;
+                }
+            }
+            // spine 2416 (#2563): an `as` stage keeps the input's identity
+            // for its body -- the body's `.` is the node this stage stands
+            // on, which is exactly what both references do (`.a.b | . as $x
+            // | key` is `"b"` in yq v4.53.3) -- so the body is spliced into
+            // this pipe with `$var` substituted and every stage of it is
+            // gated exactly as a stage written here would be. The bind
+            // source is evaluated at this same position, so its own
+            // `key`/`path`/`file_index` reads resolve to constants like a
+            // computed navigation component's do. `Expr::AsPattern`
+            // (destructuring, `?//`) is deliberately absent: its
+            // alternative-fallthrough rule lives in
+            // `each_pattern_alternatives_generic` and has no second
+            // definition here, so it keeps its pipe on the eager evaluator.
+            Expr::As { expr, body, .. } => {
+                if !owned_identity_bind_supported(expr)
+                    || !owned_identity_pipe_supported(owned_identity_body_stages(body))
                 {
                     return false;
                 }
@@ -16819,6 +16869,80 @@ fn owned_identity_placed_by<S: EvalSemantics, V: DocumentValue>(
     })
 }
 
+/// An `as` stage inside the owned identity pipe (#2563).
+///
+/// ADR-0021 decision 7's rule for a binding: the stage keeps the input's
+/// identity for its body -- the body's `.` is the node the stage stood on --
+/// and the bound variable is a *value*, substituted into the body exactly as
+/// the generic route's `each_as_generic` already does
+/// (`substitute_bound_var`, so a `. as $x` source still marks its uses
+/// `Expr::TrackedVar` and stays a `path()` trackability candidate). The
+/// substituted body is then spliced in front of `rest` and run through this
+/// same pipe, which is what keeps one definition of every stage rule instead
+/// of a second evaluator for what follows a binding.
+///
+/// Captured from yq v4.53.3 on `{a: {b: 1}, c: [10, 20], n: 0, m: 1}` (flow
+/// and block spellings alike; the full capture is
+/// `test_as_binding_keeps_the_input_identity_2563` in `tests/yq_cli_tests.rs`):
+///
+/// ```text
+/// .a.b | . as $x | key                    "b"
+/// .a.b | . as $x | path                   ["a","b"]
+/// .a.b | . as $x | parent | key           "a"
+/// .a.b | . as $x | [$x, key]              [1,"b"]
+/// .a.b | (. as $x | key) | . + "y"        "by"
+/// .a.b | . as $x | . as $y | key          "b"
+/// .a | to_entries | .[0] | . as $e | key  0
+/// .a? | . as $x | key                     "a"
+/// ```
+///
+/// The bind source's own outputs are collected before the body runs, the
+/// same eager bind `each_as_generic` performs, and an escape it raised is
+/// reported after every value it did produce -- the "deliver the prefix,
+/// then the escape" rule the rest of this route follows (#2495).
+#[allow(clippy::too_many_arguments)] // STYLE-0004: the four parts of the
+                                     // binding (`bind`/`var`/`body`/`rest`)
+                                     // plus this route's own
+                                     // value/identity/optional/sink quartet,
+                                     // every one threaded straight into the
+                                     // recursive `eval_owned_identity_pipe`
+                                     // call below.
+fn eval_owned_identity_as<S: EvalSemantics, V: DocumentValue>(
+    bind: &Expr,
+    var: &str,
+    body: &Expr,
+    rest: &[Expr],
+    value: &OwnedValue,
+    id: &OwnedIdentity<V>,
+    optional: bool,
+    sink: &mut dyn FnMut(GenericItem<V>) -> Demand,
+) -> Flow {
+    // The source stands where this stage stands, so its reads are constants
+    // -- the same rewrite a computed navigation component gets, and the same
+    // predicate gated it (`owned_identity_bind_supported`).
+    let resolved = match owned_identity_resolve_component::<S, V>(bind, id) {
+        Ok(e) => e,
+        Err(e) => return Flow::Escaped(Control::Error(e)),
+    };
+    let (bound_values, control) = owned_identity_values::<S>(&resolved, value, optional);
+    for bound in bound_values {
+        // `bind`, not `resolved`: `is_identity_passthrough` is a question
+        // about what the user wrote, and the rewrite only replaces reads
+        // inside it.
+        let substituted = substitute_bound_var(bind, body, var, &bound);
+        let mut stages: Vec<Expr> = owned_identity_body_stages(&substituted).to_vec();
+        stages.extend_from_slice(rest);
+        match eval_owned_identity_pipe::<S, V>(&stages, value.clone(), id.clone(), optional, sink) {
+            Flow::Exhausted => {}
+            other => return other,
+        }
+    }
+    match control {
+        Some(control) => Flow::Escaped(control),
+        None => Flow::Exhausted,
+    }
+}
+
 /// Continue a pipe from one owned value carrying its identity, honouring
 /// `sink`'s demand. Escapes from a downstream stage are carried out through
 /// `pending`, the same way [`eval_each_pipe_generic`]'s own driver does.
@@ -17196,6 +17320,11 @@ fn eval_owned_identity_pipe<S: EvalSemantics, V: DocumentValue>(
                 Ok(None) => Flow::Exhausted,
                 Err(e) => Flow::Escaped(Control::Error(e)),
             }
+        }
+        // spine 2416 (#2563): the binding keeps this stage's identity for
+        // its body -- see [`eval_owned_identity_as`].
+        Expr::As { expr, var, body } => {
+            eval_owned_identity_as::<S, V>(expr, var, body, rest, &value, &id, optional, sink)
         }
         _ => {
             let Some(rule) = owned_identity_rule(stage) else {
@@ -26741,7 +26870,50 @@ mod tests {
         assert!(eager(".a? | .b |= key"));
         assert!(eager(".a? | explode | key"));
         assert!(eager(".a? | map(key + \"x\")"));
-        assert!(eager(".a? | . as $x | key"));
+        // #2563: an `as` stage has an identity rule now -- the binding keeps
+        // the input's position for its body -- so a `?` head no longer keeps
+        // the pipe eager just because the stage after it binds a variable.
+        assert!(!eager(".a? | . as $x | key"));
+        assert!(!eager(".a.b | . as $x | key + \"x\""));
+        assert!(!eager(".a.b | . as $x | path + []"));
+        assert!(!eager(".a.b | . as $x | file_index + 1"));
+        assert!(!eager(".a.b | . as $x | [key] + [\"x\"]"));
+        assert!(!eager(".a.b | . as $x | (key + \"x\") | . == \"bx\""));
+        assert!(!eager(".a.b | . as $x | (key + \"x\") | {\"z\": .}"));
+        assert!(!eager(".a.b | . as $x | . as $y | key"));
+        assert!(!eager(".a.b | (. as $x | key) | . + \"y\""));
+        assert!(!eager(".a.b | (key) as $k | key"));
+        assert!(!eager(".c[.n] | . as $x | key"));
+        assert!(!eager(".c[.n]? | . as $x | key"));
+        // A `getpath` head is not navigation the walk models, so `is_node`
+        // is already false by the time the `as` stage is reached and the
+        // gate answers `true` -- but the absent route takes the pipe first
+        // now, the same "the gate is not the route that answers" split the
+        // `?`-headed rows above record.
+        assert!(eager(".a | getpath([\"b\"]) | . as $x | key"));
+        assert!(
+            path_context_absent_split(&pipe_stages(".a | getpath([\"b\"]) | . as $x | key"))
+                .is_some()
+        );
+        // ...but only where the *body* is itself something this pipe can
+        // follow. A body stage with no `owned_identity_rule` keeps the whole
+        // pipe eager exactly as it did before, and so does a bare `$x` stage
+        // (`Expr::Var` has no rule before substitution and `Expr::TrackedVar`
+        // has none after, so the gate refuses it either way).
+        assert!(eager(".a.b | . as $x | (key and parent)"));
+        assert!(eager(".a.b | . as $x | map(key + \"x\")"));
+        assert!(eager(".a.b | . as $x | $x | key"));
+        assert!(eager(".a.b | . as $x | reduce (key) as $k (\"\"; . + $k)"));
+        assert!(eager(".a.b | . as $x | label $o | (key, break $o)"));
+        // A bind source whose own reads cannot be resolved at this position
+        // (`parent` is a node, not a constant) is refused too.
+        assert!(eager(".a.b | (parent | key) as $k | key"));
+        // Destructuring and `?//` keep their pipes on the eager evaluator:
+        // `Expr::AsPattern`'s alternative-fallthrough rule has one
+        // definition (`each_pattern_alternatives_generic`) and no second one
+        // here.
+        assert!(eager(".a.b | . as [$x] | key"));
+        assert!(eager(".a? | . as [$x] | key"));
         assert!(eager(".[]? | .k | select(key == \"k\")"));
         assert!(!eager(".a[] | select(true) | key"));
         // #2471 (gate reason 1 of spine 2416), the head-of-pipe half: a

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -39232,6 +39232,95 @@ fn test_jq_update_filter_position_is_a_succinctly_extension_2522() -> Result<()>
 /// The `key`/`path`/`parent` rows are succinctly's jq-mode extension
 /// (`jq: error: key/0 is not defined` in real jq), so they follow yq's model
 /// for the builtin and jq's for the component.
+/// spine 2416 (#2563): an `as` stage keeps the input's identity for its body.
+///
+/// `owned_identity_rule` had no entry for `Expr::As`, so once a pipe had left
+/// the cursor domain -- an absent position, a value a stage had rebuilt -- a
+/// binding made `owned_identity_pipe_supported` decline and the gate handed
+/// the whole pipe to the eager evaluator. The rule is that the body's `.` is
+/// the node the stage stood on and the bound variable is a value: the body is
+/// spliced into the pipe with `$var` substituted the way `each_as_generic`
+/// already substitutes it.
+///
+/// jq 1.7.1 has no `key`/`parent`/`path/0` to capture, so what it pins here is
+/// that a binding is *transparent to a path expression* -- `path(...)` and
+/// `paths` see through it -- and that the destructuring spellings bind what jq
+/// binds. Captured 2026-09-07 from `/usr/bin/jq` 1.7.1 (`jq -c`) on the
+/// document below:
+///
+/// ```text
+/// $ jq 'path(. as $x | .a)'               ["a"]
+/// $ jq 'path(.a as $x | .c)'              ["c"]
+/// $ jq 'path(. as $x | $x | .a)'          ["a"]
+/// $ jq 'path(.a | . as $x | .b)'          ["a","b"]
+/// $ jq 'path(.a.b | . as $x | .)'         ["a","b"]
+/// $ jq '.a | . as $x | [paths]'           [["b"]]
+/// $ jq '[.a | . as $x | paths]'           [["b"]]
+/// $ jq '.a.b | . as $x | $x'              1
+/// $ jq '.a | . as {b: $b} | $b'           1
+/// $ jq '.c | . as [$x] | $x'              10
+/// $ jq '.c | . as {b: $b} ?// [$b] | $b'  10
+/// $ jq '.zzz as $v | [$v]'                [null]
+/// $ jq '.a.b | . as $x | del(.)'          null
+/// ```
+///
+/// The `key`/`path` rows below are succinctly's own extension surface (real
+/// jq answers `key/0 is not defined`), pinned so the route change is readable
+/// as "same answers, different route": every one of them is unchanged from
+/// before #2563, which is the whole claim.
+#[test]
+fn test_as_binding_keeps_the_input_identity_2563() -> anyhow::Result<()> {
+    let doc = r#"{"a":{"b":1},"c":[10,20],"n":0,"m":1,"s":"hi"}"#;
+    for (filter, want) in [
+        // The jq-captured half.
+        ("path(. as $x | .a)", "[\"a\"]"),
+        ("path(.a as $x | .c)", "[\"c\"]"),
+        ("path(. as $x | $x | .a)", "[\"a\"]"),
+        ("path(.a | . as $x | .b)", "[\"a\",\"b\"]"),
+        ("path(.a.b | . as $x | .)", "[\"a\",\"b\"]"),
+        (".a | . as $x | [paths]", "[[\"b\"]]"),
+        ("[.a | . as $x | paths]", "[[\"b\"]]"),
+        (".a.b | . as $x | $x", "1"),
+        (".a | . as {b: $b} | $b", "1"),
+        (".c | . as [$x] | $x", "10"),
+        (".c | . as {b: $b} ?// [$b] | $b", "10"),
+        (".zzz as $v | [$v]", "[null]"),
+        (".a.b | . as $x | del(.)", "null"),
+        // The same positions through the extension builtins the identity
+        // route now answers across a binding.
+        (".a.b | . as $x | key", "\"b\""),
+        (".a.b | . as $x | path", "[\"a\",\"b\"]"),
+        (".a.b | . as $x | key + \"x\"", "\"bx\""),
+        (".a.b | . as $x | path + []", "[\"a\",\"b\"]"),
+        (".a.b | . as $x | file_index + 1", "1"),
+        (".a.b | . as $x | [key] + [\"x\"]", "[\"b\",\"x\"]"),
+        (".a.b | . as $x | parent | key", "\"a\""),
+        (".a.b | . as $x | [$x, key]", "[1,\"b\"]"),
+        (".a.b | (. as $x | key) | . + \"y\"", "\"by\""),
+        (".a.b | . as $x | . as $y | key", "\"b\""),
+        (".a? | . as $x | key", "\"a\""),
+        (".a.x | . as $x | path", "[\"a\",\"x\"]"),
+        (".c[.n] | . as $x | key", "0"),
+        (".c[.n]? | . as $x | key", "0"),
+        (".a | to_entries | .[0] | . as $e | key", "0"),
+        // The `KeyNode` rule (#2471) reached across a binding: `key` keeps the
+        // position, a *second* `key` emits nothing.
+        (".a.b | . as $x | key | key", ""),
+        (".a.b | . as $x | key | path", "[\"a\",\"b\"]"),
+        (".a.b | . as $x | tostring | key", "\"b\""),
+        // A body stage with no `owned_identity_rule` keeps the whole pipe on
+        // the eager evaluator; its answers are unchanged either way, which is
+        // what makes the refusal free.
+        (".a.b | . as $x | (key and parent)", "true"),
+        (".c | . as [$x] | key + \"x\"", "\"cx\""),
+    ] {
+        let (out, err, code) = run_jq_full(&["-c", filter], Some(doc))?;
+        assert_eq!(code, 0, "`{filter}`: {out:?} {err}");
+        assert_eq!(out.trim_end(), want, "`{filter}`");
+    }
+    Ok(())
+}
+
 #[test]
 fn test_computed_bracket_head_is_walkable_2471() -> anyhow::Result<()> {
     let doc = r#"{"a":{"b":1},"c":[10,20],"n":0,"m":1,"s":"hi","k":"b","neg":-1}"#;

--- a/tests/jq_evaluator_parity_tests.rs
+++ b/tests/jq_evaluator_parity_tests.rs
@@ -2234,6 +2234,42 @@ fn test_arm_audit_proof_queries_are_unmoved_by_the_gate_2416() {
         // their unchanged listed queries above.
         (r".c[.n] | . as $x | key", &["0"]),
         (r".c[.n]? | . as $x | key", &["0"]),
+        // #2563's re-derived proof queries, same precedent once more: an
+        // `as` stage has an `owned_identity_rule` now (the binding keeps the
+        // input's position for its body), so every `as`-spelled row above --
+        // the eight #2558 re-derivations, the two #2471 head-of-pipe ones,
+        // `.a.b | . as $x | key + "x"` and
+        // `.a | getpath(["b"]) | . as $x | key` -- reports no arm at all.
+        // Eleven rows needed a new spelling; all eleven keep their outputs,
+        // which is what makes the move readable as "same outputs, different
+        // route". Verified with the arms instrumented (2026-09-07, method in
+        // `docs/plan/path-context-arm-reachability.md`): `H1`, `H3`, `A07`,
+        // `A08`, `A13`, `A14`, `A17`, `A19`, `A21` and `A33` each fire on
+        // their row below; `H2` fires on the
+        // `.a.b | reduce (key) as $k ("";  . + $k) | . + "x"` row already
+        // present above, `A09` on `.a[] | (key | tostring)`, and `A26` on
+        // `.a.b | . as $x | (key and parent)` above -- `and`/`or` has no
+        // `owned_identity_rule`, so a body built from one still keeps the
+        // binding's whole pipe on the eager evaluator.
+        (
+            r#".a.b | reduce (path) as $p ([]; . + $p) | . + ["x"]"#,
+            &[r#"["a","b","x"]"#],
+        ),
+        (
+            r".a.b | reduce (file_index) as $f (0; . + $f) | . + 1",
+            &["1"],
+        ),
+        (r".c[.n]? | (key and parent)", &["true"]),
+        (r".a? | (key and parent)", &["true"]),
+        (r".a.b | -(parent|length)", &["-1"]),
+        (r".a.b | (parent | length) == 1", &["true"]),
+        (r#".a | getpath(["b"]) | (key and parent)"#, &["true"]),
+        (r".c[.n] | (key and parent)", &["true"]),
+        (r#".a.b | [(key and parent)] + ["x"]"#, &[r#"[true,"x"]"#]),
+        (
+            r".a.b | . as $x | (key and parent) | {z: .}",
+            &[r#"{"z":true}"#],
+        ),
     ];
     for (filter, expected) in rows {
         // `path + []` is the audit's H1 row spelled against `.a.b`.

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -37094,6 +37094,14 @@ const OPTIONAL_HEAD_FLOW_2558: &str = "{\"a\": {\"b\": 1}, \"c\": [10, 20], \"s\
 /// not part of this rule, and asserting on both is what says so.
 const OPTIONAL_HEAD_BLOCK_2558: &str = "a:\n  b: 1\nc:\n  - 10\n  - 20\ns: hi\n";
 
+/// The flow-style document #2563's `as`-binding rows were captured on.
+const AS_BINDING_FLOW_2563: &str =
+    "{\"a\": {\"b\": 1}, \"c\": [10, 20], \"n\": 0, \"m\": 1, \"s\": \"hi\"}\n";
+
+/// The block-style spelling of [`AS_BINDING_FLOW_2563`]. Every row below was
+/// captured on both and yq v4.53.3 answers them identically.
+const AS_BINDING_BLOCK_2563: &str = "a:\n  b: 1\nc:\n  - 10\n  - 20\nn: 0\nm: 1\ns: hi\n";
+
 /// The flow-style document #2471's computed-bracket rows were captured on.
 const COMPUTED_HEAD_FLOW_2471: &str =
     "{\"a\": {\"b\": 1}, \"c\": [10, 20], \"n\": 0, \"m\": 1, \"s\": \"hi\", \"k\": \"b\", \"neg\": -1}\n";
@@ -37335,6 +37343,116 @@ fn test_optional_head_is_walkable_2558() -> Result<()> {
             stderr.contains("index [-5] out of range, array size is 2"),
             "`{doc}`: {stderr:?}"
         );
+    }
+    Ok(())
+}
+
+/// spine 2416 (#2563): an `as` stage keeps the input's identity for its body.
+///
+/// `owned_identity_rule` had no entry for `Expr::As`, so once a pipe had left
+/// the cursor domain -- an absent position, a value a stage had rebuilt -- a
+/// binding made `owned_identity_pipe_supported` decline and the gate handed
+/// the whole pipe to the eager evaluator. The rule real yq shows is that the
+/// body's `.` is the node the stage stood on: `key`/`path`/`parent` inside the
+/// body answer exactly as they do without the binding, and the bound variable
+/// is a value spliced in.
+///
+/// Captured 2026-09-07 from Homebrew yq v4.53.3 (`yq -o=json -I=0`), on both
+/// documents above, byte-identical between the two:
+///
+/// ```text
+/// $ yq '.a.b | . as $x | key'                        "b"
+/// $ yq '.a.b | . as $x | path'                       ["a","b"]
+/// $ yq '.a.b | . as $x | key + "x"'                  "bx"
+/// $ yq '.a.b | . as $x | path + []'                  ["a","b"]
+/// $ yq '.a.b | . as $x | file_index + 1'             1
+/// $ yq '.a.b | . as $x | [key] + ["x"]'              ["b","x"]
+/// $ yq '.a.b | . as $x | parent'                     {"b":1}
+/// $ yq '.a.b | . as $x | parent | key'               "a"
+/// $ yq '.a.b | . as $x | [$x, key]'                  [1,"b"]
+/// $ yq '.a.b | . as $x | ($x | key)'                 "b"
+/// $ yq '.a.b | (. as $x | key) | . + "y"'            "by"
+/// $ yq '.a.b | . as $x | . as $y | key'              "b"
+/// $ yq '.a.b | . as $x | select(key == "b") | path'  ["a","b"]
+/// $ yq '.a? | . as $x | key'                         "a"
+/// $ yq '.a? | . as $x | path'                        ["a"]
+/// $ yq '.a.x | . as $x | key'                        "x"
+/// $ yq '.a.x | . as $x | path'                       ["a","x"]
+/// $ yq '.c[.n] | . as $x | key'                      0
+/// $ yq '.c[.n]? | . as $x | key'                     0
+/// $ yq '.a | to_entries | .[0] | . as $e | key'      0
+/// $ yq '.a.b | . as $x | key | key'                  (nothing)
+/// $ yq '.a.b | . as $x | tostring | key'             "b"
+/// $ yq '.a.b | . as $x | length'                     1
+/// $ yq '. as $x | key'                               (nothing)
+/// $ yq '. as $x | path'                              []
+/// $ yq '.a.b as $x | $x'                             1
+/// $ yq '.c[] | . as $x | key'                        0 1
+/// $ yq '.a.b | . as $x | (key and parent)'           true
+/// ```
+///
+/// `.a.b | . as $x | key | key` is the row the migration *changes*: it
+/// answered `"b"` before, because the eager evaluator has no key-node flag,
+/// and matches yq's own nothing now (#2471's `OwnedIdentityRule::KeyNode`,
+/// reached across a binding for the first time).
+///
+/// Four rows captured in the same run are **not** asserted here, because they
+/// diverge from yq before this change as much as after it -- none is caused by
+/// the `as` rule, and each is reproducible with a binding that reads no path
+/// context at all:
+///
+/// ```text
+/// $ yq '.zzz as $v | [$v]'            []          succinctly [null]  (#2470/#2481)
+/// $ yq '(.zzz | key) as $k | $k'      (nothing)   succinctly "zzz"
+/// $ yq '(.zzz | key) as $k | $k + 1'  1           succinctly "zzz1"
+/// $ yq '.a.b | .c as $x | key'        "b"         succinctly (nothing)
+/// ```
+///
+/// The first three are yq's read-only-context rule for a key lookup that finds
+/// nothing (#2470), which succinctly applies to the *walk* but not to a bind
+/// source evaluated by the ordinary owned evaluator; the fourth is the same
+/// rule for a bind source that indexes a scalar (#2482).
+#[test]
+fn test_as_binding_keeps_the_input_identity_2563() -> Result<()> {
+    let args = &["-o", "json", "-I0"];
+    for doc in [AS_BINDING_FLOW_2563, AS_BINDING_BLOCK_2563] {
+        for (filter, expected) in [
+            (".a.b | . as $x | key", "\"b\""),
+            (".a.b | . as $x | path", "[\"a\",\"b\"]"),
+            (".a.b | . as $x | key + \"x\"", "\"bx\""),
+            (".a.b | . as $x | path + []", "[\"a\",\"b\"]"),
+            (".a.b | . as $x | file_index + 1", "1"),
+            (".a.b | . as $x | [key] + [\"x\"]", "[\"b\",\"x\"]"),
+            (".a.b | . as $x | parent", "{\"b\":1}"),
+            (".a.b | . as $x | parent | key", "\"a\""),
+            (".a.b | . as $x | [$x, key]", "[1,\"b\"]"),
+            (".a.b | . as $x | ($x | key)", "\"b\""),
+            (".a.b | (. as $x | key) | . + \"y\"", "\"by\""),
+            (".a.b | . as $x | . as $y | key", "\"b\""),
+            (
+                ".a.b | . as $x | select(key == \"b\") | path",
+                "[\"a\",\"b\"]",
+            ),
+            (".a? | . as $x | key", "\"a\""),
+            (".a? | . as $x | path", "[\"a\"]"),
+            (".a.x | . as $x | key", "\"x\""),
+            (".a.x | . as $x | path", "[\"a\",\"x\"]"),
+            (".c[.n] | . as $x | key", "0"),
+            (".c[.n]? | . as $x | key", "0"),
+            (".a | to_entries | .[0] | . as $e | key", "0"),
+            (".a.b | . as $x | key | key", ""),
+            (".a.b | . as $x | tostring | key", "\"b\""),
+            (".a.b | . as $x | length", "1"),
+            (". as $x | key", ""),
+            (". as $x | path", "[]"),
+            (".a.b as $x | $x", "1"),
+            (".c[] | . as $x | key", "0\n1"),
+            (".a.b | . as $x | (key and parent)", "true"),
+        ] {
+            let (output, code) = run_yq_stdin(filter, doc, args)?;
+            assert_eq!(code, 0, "`{filter}` on `{doc}`: {output:?}");
+            assert_eq!(output.trim_end(), expected, "`{filter}` on `{doc}`");
+        }
     }
     Ok(())
 }


### PR DESCRIPTION
## Summary

An `as` binding stage gets an owned identity rule: the bind source's path-context reads resolve at the stage's own position, the bound values are substituted into the body with the existing variable substitution, and the body runs through the owned identity pipe with the input's identity kept, so `.a.b | . as $x | key` is `"b"`, `.a? | . as $x | key` is `"a"`, and `.a.b | . as $x | key | key` is nothing (the key-node rule now reached across a binding), all as yq v4.53.3 answers. Destructuring patterns are deliberately not admitted (their `?//` fallthrough lives once in the generic evaluator, and yq's lexer rejects both spellings). No eager arm added.

28 yq rows on flow and block spellings and 13 jq 1.7.1 rows (`path(. as $x | .a)`, `[paths]` shapes, destructuring) are pinned; four pre-existing divergences on `$v` reads through a read-only clone are recorded, not asserted. Differential over 2,544 yq-mode queries: 114 toward yq, 5 away, 17 neither; every "away" row and most of the "neither" rows share one head, `.c[-1]`, and one pre-existing walk bug now filed as #2568 (the walk resolves a negative index for the path component but looks the element up with the unresolved index), which this rule merely routes more shapes onto.

## Pin

Stays at 44, measured on instrumented builds of both the base and the change: eleven listed proof queries stop reaching any arm, and all eleven arms remain reachable through re-derived queries, pinned in both spellings. The exact residue is now one sentence: any construct without an identity rule (`and`/`or`, `map`, `reduce`/`foreach`, `label`/`def`, a destructuring pattern, the bounded consumers) inside an `as` body, or a bare `parent` operand, keeps the whole pipe eager. Two audit rows were found already stale on the base (their listed query reached no arm there either) and re-derived.

## Verification

fmt; clippy on both CI legs with `-D warnings`; `cargo test` in the three configurations; `cargo doc -D warnings`; yq goldens 113 and jq goldens 633; oracle sweep 3168 cases, 0 unexpected, manifest unchanged; walk-versus-bridge parity and both guard tests unchanged.

Closes #2563 (spine 2416).
