### PR TITLE
docs(jq): confirm eval_sub_replacement's stream_outputs is provably safe

### DIFF
--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -16197,8 +16197,10 @@ fn eval_sub_replacement<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     // field name (re-evaluated against `captures`, not the caller's `.`, so
     // it never reaches the outer document at all) -- all three raise
     // correctly today on an undecodable value, none of them through this
-    // function's own conversion. See `test_sub_replacement_decode_failure_*`
-    // below for the pinning tests.
+    // function's own conversion. See `test_sub_replacement_via_bound_var_*`,
+    // `test_sub_replacement_via_input_*`, and
+    // `test_sub_replacement_via_closure_param_*` in `tests/jq_cli_tests.rs`
+    // for the pinning tests.
     let materialized =
         eval_owned_input::<W, S>(replacement_expr, &captures, optional).materialize_cursor();
     let (values, trailing) = stream_outputs(materialized);

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -16175,6 +16175,30 @@ fn eval_sub_replacement<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     // `+`-operator wording (`"string (...) and number (...) cannot be
     // added"`) rather than a bespoke message. `stitch_replacement_rows`
     // (which holds the gap text) is what performs that `+`, via `arith_add`.
+    // #2165: plain `stream_outputs`, not `_checked`, is safe here -- confirmed
+    // by investigation, not assumed. `replacement_expr` runs with `.` bound to
+    // `captures` (see this function's own doc comment above), which is built
+    // by `capture_object` purely from `regex::Captures` substrings of the
+    // already-matched subject string; the `regex` crate operates on `&str`,
+    // so that subject was necessarily valid UTF-8 already, and every capture
+    // group is a clean substring of it (or absent). `captures` itself can
+    // therefore never carry undecodable content for `stream_outputs`'s
+    // unchecked fold to silently launder.
+    //
+    // The only way outer document content can reach `replacement_expr` at all
+    // is through a channel that already validates upstream, since jq's own
+    // dynamic scoping resets `.` to `captures` for this evaluation -- a bare
+    // (non-`$`) closure parameter is evaluated fresh against *this* `.`
+    // wherever referenced, so it cannot smuggle in a value tied to the
+    // caller's own `.` either. Live-verified against three shapes that do
+    // reach outer content: a `$var` bound via `. as $doc` (already checked at
+    // bind time per #1902/#1934), `input`/`inputs` (already checked at their
+    // own materialization), and a bare closure parameter capturing an outer
+    // field name (re-evaluated against `captures`, not the caller's `.`, so
+    // it never reaches the outer document at all) -- all three raise
+    // correctly today on an undecodable value, none of them through this
+    // function's own conversion. See `test_sub_replacement_decode_failure_*`
+    // below for the pinning tests.
     let materialized =
         eval_owned_input::<W, S>(replacement_expr, &captures, optional).materialize_cursor();
     let (values, trailing) = stream_outputs(materialized);

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -27503,6 +27503,74 @@ fn test_jq_nth_generic_still_surfaces_a_skipped_decode_failure_through_a_retry_2
     Ok(())
 }
 
+/// #2165: `eval_sub_replacement`'s own `stream_outputs` call (not `_checked`)
+/// was named alongside `fanout_arg`/`fanout_two_args` as a site sharing
+/// #2022's #1746-shaped bug (an unchecked fold silently substituting `""`
+/// for an undecodable value instead of raising). Investigation found the
+/// other two already fixed (by #1989, landed after #2165 was filed) and this
+/// one provably unreachable: `sub`/`gsub` evaluate their replacement filter
+/// with `.` bound to the match's `captures` object, built purely from
+/// already-decoded (`regex`-crate-validated) substrings -- `captures` itself
+/// can never carry undecodable content. The only way outer document data
+/// can reach the replacement at all is through a `$var` binding, which this
+/// test pins: `$doc.bad` is checked at bind time (`. as $doc`), so the
+/// decode failure still surfaces even though `eval_sub_replacement`'s own
+/// conversion never touches it.
+#[test]
+fn test_sub_replacement_via_bound_var_still_raises_on_decode_failure_2165() -> Result<()> {
+    let (stdout, stderr, code) = run_jq_full(
+        &[r#". as $doc | $doc.subject | sub("a"; $doc.bad)"#],
+        Some(r#"{"subject": "aa", "bad": "\x"}"#),
+    )
+    .expect("sub replacement via bound var repro runs");
+    assert_eq!(code, 5, "stdout: {stdout}\nstderr: {stderr}");
+    assert_eq!(stdout, "");
+    assert!(
+        stderr.contains("invalid escape sequence"),
+        "stderr: {stderr}"
+    );
+    Ok(())
+}
+
+/// #2165 sibling: `input`/`inputs` is the other channel that can hand outer
+/// document content to a replacement filter without going through a `$var`.
+/// It is already checked at its own materialization, so this raises too,
+/// again without `eval_sub_replacement`'s own conversion ever seeing the
+/// undecodable value.
+#[test]
+fn test_sub_replacement_via_input_still_raises_on_decode_failure_2165() -> Result<()> {
+    let (stdout, stderr, code) = run_jq_full(&[r#"sub("a"; input)"#], Some("\"aa\"\n\"\\x\"\n"))
+        .expect("sub replacement via input() repro runs");
+    assert_eq!(code, 5, "stdout: {stdout}\nstderr: {stderr}");
+    assert_eq!(stdout, "");
+    assert!(
+        stderr.contains("invalid escape sequence"),
+        "stderr: {stderr}"
+    );
+    Ok(())
+}
+
+/// #2165 sibling: a bare (non-`$`) closure parameter is jq's third channel
+/// for bringing outer-scoped content into a nested filter, but jq's dynamic
+/// scoping of `.` closes this one off entirely for `sub`'s replacement --
+/// `x` here is re-evaluated wherever referenced, against `.` at that point
+/// (`captures`, never the caller's own document), so `.bad` inside `wrap`'s
+/// body can never reach the outer, undecodable `.bad` field at all. This
+/// pins that unreachability directly: even with `bad` genuinely undecodable
+/// in the source document, the call succeeds, because `x` only ever sees
+/// `captures.bad` (absent, so `null`), not the outer field.
+#[test]
+fn test_sub_replacement_via_closure_param_cannot_reach_outer_decode_failure_2165() -> Result<()> {
+    let (stdout, stderr, code) = run_jq_full(
+        &[r#"def wrap(x): .subject | gsub("a"; x); wrap(.bad)"#],
+        Some(r#"{"subject": "aa", "bad": "\x"}"#),
+    )
+    .expect("sub replacement via closure param repro runs");
+    assert_eq!(code, 0, "stdout: {stdout}\nstderr: {stderr}");
+    assert_eq!(stdout, "\"\"\n");
+    Ok(())
+}
+
 /// The carve-out keys off the `line`/`at_offset`/... *builtins*, so a field
 /// or key that merely spells one of their names must not trip it -- that
 /// would quietly switch a filter back to the eager path and undo #1504's own


### PR DESCRIPTION
## Summary

#2165 named 5 `stream_outputs` (unchecked-decode) call sites as needing per-site verification, following #2022's original bug shape (an unchecked fold silently substituting `""` for an undecodable value instead of raising):

- `fanout_arg` and the 3 `fanout_two_args`/`fanout_regex_pattern_with_collected_flags` sites — **already fixed** by #1989, which landed after #2165 was filed but covers the exact same call sites (confirmed by reading current `main`: all four already call `stream_outputs_checked`).
- `eval_sub_replacement` — investigated and found **provably safe as-is**, per the issue's own suggested resolution for a site where no live gap exists.

`eval_sub_replacement` evaluates a `sub`/`gsub` replacement filter with `.` bound to the match's `captures` object, built purely from `regex`-crate-validated (hence already-decoded) substrings — `captures` itself can never carry undecodable content. The only channels that could bring outer document content into that evaluation are:
- a `$var` binding (`. as $doc | ... $doc.bad ...`) — already validated at bind time (#1902/#1934).
- `input`/`inputs` — already validated at their own materialization.
- a bare (non-`$`) closure parameter — jq's dynamic scoping of `.` means this is evaluated fresh against `captures`, never the caller's own `.`, so it structurally cannot reach outer document content at all.

All three confirmed live and pinned as regression tests.

Fixes #2165

## Test plan
- [x] Three new regression tests pin the investigation's live-verified findings (`test_sub_replacement_via_bound_var_still_raises_on_decode_failure_2165`, `test_sub_replacement_via_input_still_raises_on_decode_failure_2165`, `test_sub_replacement_via_closure_param_cannot_reach_outer_decode_failure_2165`).
- [x] `cargo clippy --all-targets --all-features -- -D warnings` (and the other two CI clippy feature-set legs) — clean.
- [x] `cargo test --features cli,simd,regex,serde` — full suite green, verified by real process exit code.
- [x] `no_std` build + test (`--no-default-features --features portable-popcount`) — clean.
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --all-features` — clean.
- [x] No behavioral change (doc comment + tests only), so no patch-coverage lines to cover.