### PR TITLE
refactor(jq): rename push_generic_truthiness_cursor_error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -130,6 +130,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   drives the same document/bound expression through all three and asserts
   they agree. No behavior change.
 
+- **`eval_generic.rs`'s `push_generic_truthiness_cursor_error` renamed to
+  `push_generic_document_validation_error`** (#2413). The function is the
+  shared document-validation gate behind five call sites spanning four
+  feature families (`select`'s truthiness check, `sort_by`/`unique_by`/
+  `min_by`/`max_by`'s comparison key, the path-context fast path, and
+  `path(...)`), and only the first of those is actually about truthiness —
+  the old name had already cost real coverage once (#2211/#2243 each added a
+  delimiter check to "the materializers" without noticing this walk, later
+  fixed by #2349) and left the function's own doc comment spending a
+  paragraph walking the name back. Purely mechanical everywhere except the
+  function's own doc comment, which is rewritten to lead with the shared
+  gate and its five callers, scoping the truthiness-specific reasoning to
+  the one caller it actually describes rather than stating it as the
+  function's own general property. No behavior change.
+
 - **`eval_generic::eval_index_expr`'s "promote `cursors`, preserving an
   in-flight `Control`'s priority over a secondary decode failure" dispatch is
   now one shared definition** (#2364), not three independent hand-copies
@@ -144,7 +159,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   cross-site test drives the same double-fault document/target through all
   three reachable ones and asserts they agree. No behavior change.
 
-- **`eval_generic::push_generic_truthiness_cursor_error`'s object/array arms now call
+- **`eval_generic::push_generic_document_validation_error`'s object/array arms now call
   `container_tail_gap_ok` instead of hand-inlining the `None`/`Some(last)`
   container-vs-trailing-gap dispatch** (#2409). No behavior change: this was the last
   hold-out of a dispatch shape that `to_owned_cursor_at_depth` (`eval_generic.rs`) and
@@ -793,7 +808,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **The validate-only traversal backing `select`/`sort_by`/`unique_by`/`min_by`/`max_by`/
   `path()` silently accepted invalid JSON in a subtree it only ever validates, never
-  materializes** (#2349, split out of #1803). `push_generic_truthiness_cursor_error`
+  materializes** (#2349, split out of #1803). `push_generic_document_validation_error`
   (`src/jq/eval_generic.rs`) is the shared validation gate for all six builtins, and both
   `path()` call sites' own doc comments claim it runs "that same traversal and validation"
   as the materializing `to_owned_cursor_at_depth` — but three follow-ups since it was
@@ -809,7 +824,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Error: Invalid JSON text: expected string key, found '}'
   ```
 
-  Fixed by adding the missing checks to `push_generic_truthiness_cursor_error`'s own
+  Fixed by adding the missing checks to `push_generic_document_validation_error`'s own
   object/array walk, mirroring `to_owned_cursor_at_depth`'s structure exactly (`is_first`/
   last-cursor tracking, `key_delimiter_ok`/`value_delimiter_ok` per object field,
   `preceding_delimiter_ok` per array element, `container_gap_ok`/`trailing_element_gap_ok`

--- a/docs/compliance/jq/limitations.md
+++ b/docs/compliance/jq/limitations.md
@@ -1824,7 +1824,7 @@ and differently-shaped problem than this section's own fixes):
 
 Two further leads from the same sweep were investigated and **not**
 reproduced live (so not reported as confirmed bugs, only as ruled out) at
-the time: `push_generic_truthiness_cursor_error` (`if COND then ... end`
+the time: `push_generic_document_validation_error` (`if COND then ... end`
 on a container condition) and `owned_from_standard_json_at_depth` (the
 `input`/`inputs`-with-cursor-metadata-builtins bridge, #1504) both lack
 their own internal gap checks by inspection, but every constructed repro
@@ -1833,7 +1833,7 @@ against each (`{"a":[1,2,3,]} | if .a then ... end`;
 something upstream of either function already validates for the shapes
 tried. Not chased further given no live reproduction *of those specific
 repros* — **update (#2349): a live, CLI-reachable gap in
-`push_generic_truthiness_cursor_error` was found and fixed after all**,
+`push_generic_document_validation_error` was found and fixed after all**,
 just not via `if...then...end` (whose own `Control::from(cond)` path
 apparently validates upstream, matching what this entry found). `select`,
 `sort_by`/`unique_by`/`min_by`/`max_by`, and `path()` all route through
@@ -1859,7 +1859,7 @@ function bytes that are already clean by construction: `input`/`inputs` validate
 in the input-reading pipeline before this function ever runs, and every other caller passes
 a fresh `to_json_for_reindex` re-serialization of an already-decoded `OwnedValue` -- text
 succinctly's own serializer produces, which by construction never carries a malformed
-delimiter. This is the structural difference from `push_generic_truthiness_cursor_error`'s
+delimiter. This is the structural difference from `push_generic_document_validation_error`'s
 real gap: that function walks the *original* document cursor directly, with no round-trip
 in between, so genuine source corruption reaches it; nothing here does. Recorded directly
 on the function (`src/jq/eval_generic.rs`) so a future re-check starts from "confirmed

--- a/docs/compliance/yq/limitations.md
+++ b/docs/compliance/yq/limitations.md
@@ -173,7 +173,7 @@ c: 2
 ```
 
 A related, narrower gap sits in `select`/`if`'s condition-truthiness check
-(`push_generic_truthiness_cursor_error`, [src/jq/eval_generic.rs](../../../src/jq/eval_generic.rs)):
+(`push_generic_document_validation_error`, [src/jq/eval_generic.rs](../../../src/jq/eval_generic.rs)):
 it does not walk into a *container* reached through an alias, so a decode failure reachable
 only that way no longer raises
 ([#1804](https://github.com/rust-works/succinctly/issues/1804), fixed a real `O(2^N)` cost

--- a/src/jq/document.rs
+++ b/src/jq/document.rs
@@ -1495,7 +1495,7 @@ impl DisplayKeyGuard {
 /// `to_owned`/`materialize` raise instead of silently dropping one of them.
 ///
 /// Shared by `eval_generic.rs`'s three `to_owned*_at_depth` conversions,
-/// its validate-only `push_generic_truthiness_cursor_error` (#1645),
+/// its validate-only `push_generic_document_validation_error` (#1645),
 /// `lazy.rs`'s `cursor_to_owned_at_depth`, and `succinctly-cli`'s
 /// `yq_runner.rs` `--input-format json` bridge (`pub` for that reason,
 /// same as [`DisplayKeyGuard`] and [`key_display_string`] before it) -- one
@@ -2846,7 +2846,7 @@ impl<V: DocumentValue, C: DocumentCursor> DocumentField<V, C> {
     /// leaving a sibling behind (#1975 found this walk missing from the CLI
     /// bridge; #2349 fixed the validate-only walk's own delimiter gap,
     /// directly via `key_delimiter_ok`/`value_delimiter_ok` rather than
-    /// through this method -- see `push_generic_truthiness_cursor_error`'s
+    /// through this method -- see `push_generic_document_validation_error`'s
     /// own STYLE-0013 note for why it still can't take the key half).
     /// `resolve_display_key`'s own doc already tracked the key half as a
     /// recurring cost; this method covers the delimiter half with it, so a

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -2666,13 +2666,24 @@ fn push_generic_owned_values<V: DocumentValue>(
 }
 
 /// Whether `c`'s subtree, at any depth, contains a value that cannot be
-/// honestly answered "truthy or falsy" at all -- a decode failure (a
-/// string token whose bytes don't decode), a structural error (a token
-/// the semi-index accepted as a span but couldn't classify, #1194), or a
-/// #1642 colliding-decode-failure-key -- and if so, the `Control::Error`
-/// a caller should raise instead of falling through to
-/// [`DocumentCursor::is_falsy`]'s own silent "not falsy" default for
-/// exactly these cases.
+/// honestly materialized at all -- a decode failure (a string token whose
+/// bytes don't decode), a structural error (a token the semi-index
+/// accepted as a span but couldn't classify, #1194), or a #1642
+/// colliding-decode-failure-key -- and if so, the `Control::Error` a
+/// caller should raise.
+///
+/// The shared document-validation gate behind five call sites spanning
+/// four feature families -- `select`'s truthiness check
+/// (`push_generic_truthiness`, the only one actually about truthiness;
+/// see its own doc comment for why it falls through to
+/// [`DocumentCursor::is_falsy`]'s silent "not falsy" default otherwise),
+/// `sort_by`/`unique_by`/`min_by`/`max_by`'s comparison key
+/// (`key_elements_generic`), the path-context fast path
+/// (`path_context_root`), and `path(...)` (`eval_builtin`) -- not a
+/// truthiness-specific helper despite this function's former name
+/// (#2413): each of those five callers needs the #1247/#1194 validation
+/// below without ever materializing an `OwnedValue` for the subtree it's
+/// validating.
 ///
 /// This is [`to_owned_cursor_at_depth`]'s own traversal and validation
 /// (same object/array unconsing, same key-collision guard) -- but it
@@ -2690,19 +2701,22 @@ fn push_generic_owned_values<V: DocumentValue>(
 /// or vice versa (`tagged_scalar_to_owned` requires `as_str()` to already
 /// have succeeded), so skipping it here cannot skip a real raise.
 ///
-/// For a scalar condition this keeps #1645's O(1) win in full: neither
-/// this walk nor `is_falsy()` afterward materializes anything. For a
-/// container condition, jq's own truthiness rule needs none of this --
-/// any object/array is unconditionally truthy regardless of contents --
-/// but this walk still visits the whole subtree anyway, because a
-/// corrupted value can be anywhere inside it and the #1247/#1194
-/// invariant this function exists to enforce is a property of the whole
-/// subtree, not of the truthiness question alone. That walk still
-/// allocates one `String` per object key (`resolve_display_key`'s own
-/// #1642 guard), so "no allocation" only ever describes the *value*
-/// side (no `OwnedValue`/`Vec` payload) -- not a claim that a
-/// container-shaped condition is free.
-fn push_generic_truthiness_cursor_error<C: DocumentCursor>(c: &C, depth: usize) -> Option<Control> {
+/// For `push_generic_truthiness`'s own scalar condition, this keeps
+/// #1645's O(1) win in full: neither this walk nor `is_falsy()` afterward
+/// materializes anything. For a container condition there, jq's own
+/// truthiness rule needs none of this -- any object/array is
+/// unconditionally truthy regardless of contents -- but this walk still
+/// visits the whole subtree anyway, because a corrupted value can be
+/// anywhere inside it and the #1247/#1194 invariant this function exists
+/// to enforce is a property of the whole subtree, whichever of the five
+/// callers is asking. That walk still allocates one `String` per object
+/// key (`resolve_display_key`'s own #1642 guard), so "no allocation" only
+/// ever describes the *value* side (no `OwnedValue`/`Vec` payload) -- not
+/// a claim that a container-shaped subtree is free.
+fn push_generic_document_validation_error<C: DocumentCursor>(
+    c: &C,
+    depth: usize,
+) -> Option<Control> {
     assert_nesting_depth(depth);
     let value = c.value();
     if let Some(fields) = value.as_object() {
@@ -2845,7 +2859,7 @@ fn push_generic_truthiness_cursor_error<C: DocumentCursor>(c: &C, depth: usize) 
             }
             index += 1;
             if let Some(control) =
-                push_generic_truthiness_cursor_error(&field.value_cursor, depth + 1)
+                push_generic_document_validation_error(&field.value_cursor, depth + 1)
             {
                 return Some(control);
             }
@@ -2887,7 +2901,7 @@ fn push_generic_truthiness_cursor_error<C: DocumentCursor>(c: &C, depth: usize) 
             if !elem_cursor.element_gap_ok(is_first) {
                 return Some(Control::Error(elem_cursor.malformed_delimiter_error()));
             }
-            if let Some(control) = push_generic_truthiness_cursor_error(&elem_cursor, depth + 1) {
+            if let Some(control) = push_generic_document_validation_error(&elem_cursor, depth + 1) {
                 return Some(control);
             }
             last_elem = Some(elem_cursor);
@@ -2909,7 +2923,7 @@ fn push_generic_truthiness_cursor_error<C: DocumentCursor>(c: &C, depth: usize) 
     } else if value.is_error() {
         // #2286: `decode_failure`, not `new` -- see `to_owned_at_depth`'s
         // own `is_error()` arm above for the full rationale; this is the
-        // truthiness-check sibling of that same class.
+        // validate-only sibling of that same class.
         Some(Control::Error(EvalError::decode_failure(
             value
                 .error_message()
@@ -2941,7 +2955,7 @@ fn push_generic_truthiness<V: DocumentValue>(
         // first, same as `to_owned_at_depth`'s own two checks in the same
         // order, just without materializing on the ordinary-value path.
         GenericResult::OneCursor(c) => {
-            if let Some(control) = push_generic_truthiness_cursor_error(&c, 0) {
+            if let Some(control) = push_generic_document_validation_error(&c, 0) {
                 return Some(control);
             }
             // `select`'s condition truthiness is about the real value, not
@@ -2958,7 +2972,7 @@ fn push_generic_truthiness<V: DocumentValue>(
         }
         GenericResult::ManyCursor(cs) => {
             for c in &cs {
-                if let Some(control) = push_generic_truthiness_cursor_error(c, 0) {
+                if let Some(control) = push_generic_document_validation_error(c, 0) {
                     return Some(control);
                 }
                 out.push(!c.is_falsy(JsonConvention::Preserve));
@@ -11652,7 +11666,7 @@ fn sort_key_generic<S: EvalSemantics, V: DocumentValue>(
 ///
 /// **Both arms carry `eval.rs`'s #1755 rule**, by different means: the `None`
 /// arm's own conversion is already the checked one, and the `Some(f)` arm
-/// runs `push_generic_truthiness_cursor_error` -- the same validation with the
+/// runs `push_generic_document_validation_error` -- the same validation with the
 /// `OwnedValue` construction removed. #2069 filed this as an accepted gap on
 /// the grounds that no live repro was known and the check would cost a full
 /// decode per element; both premises were wrong. The repro is
@@ -11680,7 +11694,7 @@ fn key_elements_generic<S: EvalSemantics, V: DocumentValue>(
                 // the bad element never reaches the output, so nothing else
                 // would ever have surfaced it.
                 //
-                // `push_generic_truthiness_cursor_error`, not
+                // `push_generic_document_validation_error`, not
                 // `to_owned_cursor`: it is that function's own traversal and
                 // validation with the `OwnedValue` construction removed, so
                 // the `_by` forms keep the point of this arm -- never
@@ -11688,7 +11702,7 @@ fn key_elements_generic<S: EvalSemantics, V: DocumentValue>(
                 // still raising on one that cannot be decoded. (Not free: it
                 // still allocates one `String` per object key, per
                 // `resolve_display_key`'s #1642 guard.)
-                if let Some(control) = push_generic_truthiness_cursor_error(&cursor, 0) {
+                if let Some(control) = push_generic_document_validation_error(&cursor, 0) {
                     return Err(control);
                 }
                 sort_key_generic::<S, V>(f, &cursor, optional)?
@@ -11743,7 +11757,7 @@ fn reordering_may_keep_cursors<V: DocumentValue>(cursor: Option<&V::Cursor>) -> 
 /// `key_elements_generic`'s `to_owned_cursor` materialization, on the premise
 /// that this was that materialization's only error channel. It is not:
 /// `key_elements_generic` funnels three things into this `Control` --
-/// `push_generic_truthiness_cursor_error`, `to_owned_cursor`, and
+/// `push_generic_document_validation_error`, `to_owned_cursor`, and
 /// `sort_key_generic`, which carries out *whatever the user's key filter
 /// raised* (`sort_by(error("x"))`, `min_by(.a)` on an array, ...).
 ///
@@ -12196,7 +12210,7 @@ fn path_step_generic<S: EvalSemantics, V: DocumentValue>(
                     // temporary debug probe that `path_step_generic` is
                     // never even entered for a document containing an
                     // undecodable scalar, because that caller's own
-                    // `push_generic_truthiness_cursor_error` pre-walk
+                    // `push_generic_document_validation_error` pre-walk
                     // (#1755/#1953's "validity gate", a whole-*document*
                     // check run before any cursor walk) already raises the
                     // identical `decode_failure` first, regardless of
@@ -13570,11 +13584,11 @@ fn path_context_single_native(expr: &Expr) -> bool {
 /// The root position of a walk, once the document has passed the same
 /// validity gate the bridge's `to_owned_with_cursor` doubles as (#1755/#1953):
 /// dropping it would make these pipes start accepting documents they reject
-/// today. `push_generic_truthiness_cursor_error` is that same traversal and
+/// today. `push_generic_document_validation_error` is that same traversal and
 /// validation with the `OwnedValue` construction removed -- the same gate
 /// `Builtin::Path` runs, for the same reason.
 fn path_context_root<V: DocumentValue>(root: V::Cursor) -> Result<PathContextPos<V>, Control> {
-    if let Some(control) = push_generic_truthiness_cursor_error(&root, 0) {
+    if let Some(control) = push_generic_document_validation_error(&root, 0) {
         return Err(control);
     }
     // The walk's input is not always the document root: a nested pipe
@@ -15385,12 +15399,12 @@ fn eval_builtin<S: EvalSemantics, V: DocumentValue>(
             // The whole-document walk is not skipped, only the tree build:
             // `to_owned_with_cursor` doubles as a validity gate (#1755/
             // #1953), and dropping it would make `path(.d)` start accepting
-            // documents it rejects today. `push_generic_truthiness_cursor_error`
+            // documents it rejects today. `push_generic_document_validation_error`
             // is that same traversal and validation with the `OwnedValue`
             // construction removed, so error behaviour is unchanged while the
             // allocation is not paid.
             if let Some(root) = cursor.filter(|_| path_expr_is_cursor_navigable(path_expr)) {
-                if let Some(control) = push_generic_truthiness_cursor_error(&root, 0) {
+                if let Some(control) = push_generic_document_validation_error(&root, 0) {
                     return match control {
                         Control::Error(e) => GenericResult::Error(e),
                         Control::Break(label) => GenericResult::Break(label),

--- a/src/yaml/light.rs
+++ b/src/yaml/light.rs
@@ -6914,7 +6914,7 @@ impl<'a, W: AsRef<[u64]> + Clone> DocumentValue for YamlValue<'a, W> {
             // `is_null`'s convention) but there is no real message to
             // return, so this falls to `None` -- every caller of this pair
             // already has its own fallback wording for a missing message
-            // (e.g. `push_generic_truthiness_cursor_error`'s
+            // (e.g. `push_generic_document_validation_error`'s
             // `unwrap_or("malformed value in document")`).
             YamlValue::Alias { target, .. } => {
                 target.and_then(|t| t.resolve_alias_chain()?.error_message())

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -2188,7 +2188,7 @@ fn assert_jq_raises(
     );
 }
 
-/// #1645 code review: `push_generic_truthiness_cursor_error` is a second,
+/// #1645 code review: `push_generic_document_validation_error` is a second,
 /// hand-copied implementation of the same "walk and raise on corruption"
 /// predicate `to_owned_at_depth`/`to_owned_cursor_at_depth`/
 /// `cursor_to_owned_at_depth` (`lazy.rs`) already implement for
@@ -2197,7 +2197,7 @@ fn assert_jq_raises(
 /// site agrees, not just that each is individually correct (see the
 /// `testing` skill and CLAUDE.md's "Duplicated predicates diverge silently"
 /// note, #106). #1803 extended this from 2 sites to 3: `select(.bad) | .keep`
-/// (`push_generic_truthiness_cursor_error`), `-Sc .bad` (`to_owned_at_depth`,
+/// (`push_generic_document_validation_error`), `-Sc .bad` (`to_owned_at_depth`,
 /// confirmed live via temporary tracing -- `-S` does *not* route through the
 /// cursor-aware sibling despite the name resemblance), and `-e .bad`
 /// (`cursor_to_owned_at_depth`, `lazy.rs` -- a JSON-only fourth
@@ -31664,7 +31664,7 @@ fn test_getpath_still_raises_on_an_undecodable_sibling_2053() -> Result<()> {
 ///
 /// `path(.a)` alone would not exercise `Builtin::Path`'s fixed line: a bare
 /// `Expr::Field` is cursor-navigable (`path_expr_is_cursor_navigable`), so
-/// it takes the pre-existing fast path (`push_generic_truthiness_cursor_error`)
+/// it takes the pre-existing fast path (`push_generic_document_validation_error`)
 /// instead, never reaching the fallback this PR changed -- confirmed live
 /// with temporary debug instrumentation during review. `path(if true then
 /// .a else null end)` is not cursor-navigable (`Expr::If` isn't in that
@@ -37995,7 +37995,7 @@ fn test_seq_wellformed_and_leniency_unaffected_by_checked_swap_2295() -> Result<
     Ok(())
 }
 
-/// #2349: `push_generic_truthiness_cursor_error` -- the shared validation
+/// #2349: `push_generic_document_validation_error` -- the shared validation
 /// gate for `select`/`sort_by`/`unique_by`/`min_by`/`max_by`/`path()` -- had
 /// none of the `#1677`/`#2211`/`#2243` delimiter/gap checks its materializing
 /// siblings (`to_owned_cursor_at_depth` and friends) already run, so a

--- a/tests/jq_member_validation_audit.rs
+++ b/tests/jq_member_validation_audit.rs
@@ -170,7 +170,7 @@ struct Audit<'a> {
 ///
 /// Function-level, not "the comment block attached to the call": a walk that
 /// cannot route is exempt *as a walk*, and its reason is one paragraph, not
-/// one per primitive it touches. `push_generic_truthiness_cursor_error` is
+/// one per primitive it touches. `push_generic_document_validation_error` is
 /// the case that settles it -- one exemption, two `resolve_display_key`
 /// calls, and requiring the paragraph twice would say less, not more.
 ///
@@ -191,7 +191,7 @@ fn marker_in_body(lines: &[&str], frame: &Frame) -> bool {
 /// `#[allow]` citations and STYLE-0012's exemptions are both written this
 /// way), and requiring it is load-bearing rather than pedantic: the first
 /// draft of this file used `contains`, and a sentence in
-/// `push_generic_truthiness_cursor_error`'s own comment -- "This marker is
+/// `push_generic_document_validation_error`'s own comment -- "This marker is
 /// the point of STYLE-0013: ..." -- silently exempted that function. The
 /// audit passed with its real marker deleted. A gate that a rule's own
 /// *explanation* can satisfy is not a gate; see
@@ -469,7 +469,7 @@ fn test_nested_fn_does_not_inherit_the_parent_marker() {
 ///
 /// Not hypothetical: this is the false negative the first draft of this file
 /// actually had, found by deleting a real marker from
-/// `push_generic_truthiness_cursor_error` and watching the audit stay green,
+/// `push_generic_document_validation_error` and watching the audit stay green,
 /// because that function's own explanation contains the words "the point of
 /// STYLE-0013:". The rule's rationale is exactly the prose most likely to
 /// name the rule, so this is the failure mode a `contains` check is *most*

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -2318,7 +2318,7 @@ fn assert_yq_raises(
     );
 }
 
-/// #1803: `select(.bad) | .keep` (`push_generic_truthiness_cursor_error`)
+/// #1803: `select(.bad) | .keep` (`push_generic_document_validation_error`)
 /// and a write op (`.keep = 9`, which forces the YAML DOM path per ADR-0017
 /// -- `to_owned_with_comments_at_depth`/`to_owned_at_depth`/
 /// `to_owned_cursor_at_depth` all get exercised together building it,
@@ -29092,7 +29092,7 @@ fn test_select_resolves_alias_falsiness_1645() -> Result<()> {
 }
 
 /// #1645 code review: every JSON-side corruption regression test
-/// (`tests/jq_cli_tests.rs`) has no YAML sibling -- `push_generic_truthiness_cursor_error`
+/// (`tests/jq_cli_tests.rs`) has no YAML sibling -- `push_generic_document_validation_error`
 /// is generic over `DocumentCursor` and reached identically by the yq
 /// evaluator, but nothing pinned that `select()` actually raises on a YAML
 /// decode failure nested inside its condition's container, only that it
@@ -29133,7 +29133,7 @@ fn test_select_raises_on_yaml_decode_failure_nested_in_container_1645() -> Resul
 
 /// #1804: a document shaped as a chain of anchors each referencing the
 /// previous one twice (`aN: &aN [*a(N-1), *a(N-1)]`) made
-/// `push_generic_truthiness_cursor_error`'s subtree walk cost `O(2^N)` --
+/// `push_generic_document_validation_error`'s subtree walk cost `O(2^N)` --
 /// every `select`/`if` condition unconditionally re-descended into both
 /// copies of each alias target. `DocumentCursor::is_alias` now short-circuits
 /// the walk at an alias node instead of resolving through it, since jq's own
@@ -29197,7 +29197,7 @@ fn test_select_and_if_truthiness_flat_over_alias_fanout_1804() -> Result<()> {
 ///
 /// Covers both container shapes -- the object branch and the array branch
 /// each carry their own `c.is_alias()` short-circuit in
-/// `push_generic_truthiness_cursor_error`, so an array-only test would
+/// `push_generic_document_validation_error`, so an array-only test would
 /// leave the object branch's check unexercised.
 #[test]
 fn test_select_no_longer_raises_on_decode_failure_reachable_only_via_alias_1804() -> Result<()> {
@@ -30199,7 +30199,7 @@ fn test_path_context_cursor_walk_falls_back_2061() -> Result<()> {
 /// `to_owned_with_cursor` doubles as a decode-failure gate (#1755/#1953), so
 /// a walk that reached the answer without decoding everything would silently
 /// start accepting documents these pipes reject today.
-/// `push_generic_truthiness_cursor_error` is that same traversal and
+/// `push_generic_document_validation_error` is that same traversal and
 /// validation without the `OwnedValue` construction.
 #[test]
 fn test_path_context_cursor_walk_keeps_the_validity_gate_2061() -> Result<()> {


### PR DESCRIPTION
## Summary

- `push_generic_truthiness_cursor_error` (`src/jq/eval_generic.rs`) is the shared document-validation gate behind five call sites spanning four feature families (`select`'s truthiness check, `sort_by`/`unique_by`/`min_by`/`max_by`'s comparison key, the path-context fast path, and `path(...)`), and only the first is actually about truthiness. The old name had already cost real coverage once — #2211/#2243 each added a delimiter check to "the materializers" without noticing this walk, later fixed by #2349, whose own summary named this rename as the cheapest fix that would have kept it in scope.
- Renamed to `push_generic_document_validation_error` across all 37 occurrences (definition, call sites, doc comments, compliance docs, test comments, CHANGELOG).
- The function's own doc comment is rewritten to lead with the shared gate and its five callers, scoping the truthiness-specific reasoning to the one caller it actually describes rather than stating it as the function's own general property.
- Also reworded one nearby inline comment ("truthiness-check sibling") that described the whole function via truthiness framing without naming it directly, so a bare identifier grep wouldn't have caught it.
- No behavior change.

Fixes #2413

## Test plan

- [x] `grep -rn "push_generic_truthiness_cursor_error"` (excluding target/.git) — zero remaining occurrences repo-wide
- [x] `cargo build --features cli`
- [x] `cargo test --features cli,simd,regex,serde` — all 62 binaries pass, 0 failures, including `tests/jq_member_validation_audit.rs`'s meta-tests
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings`
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features`
- [x] Independent code review, including rendering the doc comment via `cargo doc --document-private-items` to catch a markdown line-wrap bug that split an identifier across two lines mid-word, and reading every non-mechanical reference in its surrounding context (not just the identifier) to confirm no prose reads oddly under the new name