### PR TITLE
fix(jq): convert 12 more single-arg try_parse_builtin sites to jq's arity error

### DIFF
--- a/src/jq/parser.rs
+++ b/src/jq/parser.rs
@@ -3277,24 +3277,18 @@ impl<'a> Parser<'a> {
         // Map functions
         if self.matches_keyword("map_values") {
             // Check map_values before map
+            let keyword_start = self.pos;
             self.consume_keyword("map_values");
-            self.skip_ws();
-            self.expect('(')?;
-            self.skip_ws();
-            let f = self.parse_expr()?;
-            self.skip_ws();
-            self.expect(')')?;
-            return Ok(Some(Builtin::MapValues(Box::new(f))));
+            return Ok(self
+                .parse_required_single_arg(keyword_start)?
+                .map(|f| Builtin::MapValues(Box::new(f))));
         }
         if self.matches_keyword("map") {
+            let keyword_start = self.pos;
             self.consume_keyword("map");
-            self.skip_ws();
-            self.expect('(')?;
-            self.skip_ws();
-            let f = self.parse_expr()?;
-            self.skip_ws();
-            self.expect(')')?;
-            return Ok(Some(Builtin::Map(Box::new(f))));
+            return Ok(self
+                .parse_required_single_arg(keyword_start)?
+                .map(|f| Builtin::Map(Box::new(f))));
         }
 
         // Reduction functions (no arguments)
@@ -3634,24 +3628,18 @@ impl<'a> Parser<'a> {
             return Ok(Some(Builtin::Scan(Box::new(re))));
         }
         if self.matches_keyword("join") {
+            let keyword_start = self.pos;
             self.consume_keyword("join");
-            self.skip_ws();
-            self.expect('(')?;
-            self.skip_ws();
-            let s = self.parse_expr()?;
-            self.skip_ws();
-            self.expect(')')?;
-            return Ok(Some(Builtin::Join(Box::new(s))));
+            return Ok(self
+                .parse_required_single_arg(keyword_start)?
+                .map(|s| Builtin::Join(Box::new(s))));
         }
         if self.matches_keyword("contains") {
+            let keyword_start = self.pos;
             self.consume_keyword("contains");
-            self.skip_ws();
-            self.expect('(')?;
-            self.skip_ws();
-            let b = self.parse_expr()?;
-            self.skip_ws();
-            self.expect(')')?;
-            return Ok(Some(Builtin::Contains(Box::new(b))));
+            return Ok(self
+                .parse_required_single_arg(keyword_start)?
+                .map(|b| Builtin::Contains(Box::new(b))));
         }
         if self.matches_keyword("inside") {
             self.reject_unless_jq_extensions("inside")?;
@@ -3688,25 +3676,19 @@ impl<'a> Parser<'a> {
             return Ok(Some(Builtin::Flatten));
         }
         if self.matches_keyword("group_by") {
+            let keyword_start = self.pos;
             self.consume_keyword("group_by");
-            self.skip_ws();
-            self.expect('(')?;
-            self.skip_ws();
-            let f = self.parse_expr()?;
-            self.skip_ws();
-            self.expect(')')?;
-            return Ok(Some(Builtin::GroupBy(Box::new(f))));
+            return Ok(self
+                .parse_required_single_arg(keyword_start)?
+                .map(|f| Builtin::GroupBy(Box::new(f))));
         }
         // Check unique_by before unique
         if self.matches_keyword("unique_by") {
+            let keyword_start = self.pos;
             self.consume_keyword("unique_by");
-            self.skip_ws();
-            self.expect('(')?;
-            self.skip_ws();
-            let f = self.parse_expr()?;
-            self.skip_ws();
-            self.expect(')')?;
-            return Ok(Some(Builtin::UniqueBy(Box::new(f))));
+            return Ok(self
+                .parse_required_single_arg(keyword_start)?
+                .map(|f| Builtin::UniqueBy(Box::new(f))));
         }
         if self.matches_keyword("unique") {
             self.consume_keyword("unique");
@@ -3735,14 +3717,11 @@ impl<'a> Parser<'a> {
             return Ok(Some(Builtin::FromEntries));
         }
         if self.matches_keyword("with_entries") {
+            let keyword_start = self.pos;
             self.consume_keyword("with_entries");
-            self.skip_ws();
-            self.expect('(')?;
-            self.skip_ws();
-            let f = self.parse_expr()?;
-            self.skip_ws();
-            self.expect(')')?;
-            return Ok(Some(Builtin::WithEntries(Box::new(f))));
+            return Ok(self
+                .parse_required_single_arg(keyword_start)?
+                .map(|f| Builtin::WithEntries(Box::new(f))));
         }
 
         // Phase 6: Type Conversions
@@ -3886,14 +3865,11 @@ impl<'a> Parser<'a> {
         }
         if self.matches_keyword("getpath") {
             self.reject_unless_jq_extensions("getpath")?;
+            let keyword_start = self.pos;
             self.consume_keyword("getpath");
-            self.skip_ws();
-            self.expect('(')?;
-            self.skip_ws();
-            let path = self.parse_expr()?;
-            self.skip_ws();
-            self.expect(')')?;
-            return Ok(Some(Builtin::GetPath(Box::new(path))));
+            return Ok(self
+                .parse_required_single_arg(keyword_start)?
+                .map(|path| Builtin::GetPath(Box::new(path))));
         }
 
         // Phase 8: Advanced Control Flow Builtins
@@ -3923,14 +3899,11 @@ impl<'a> Parser<'a> {
         // walk(f)
         if self.matches_keyword("walk") {
             self.reject_unless_jq_extensions("walk")?;
+            let keyword_start = self.pos;
             self.consume_keyword("walk");
-            self.skip_ws();
-            self.expect('(')?;
-            self.skip_ws();
-            let f = self.parse_expr()?;
-            self.skip_ws();
-            self.expect(')')?;
-            return Ok(Some(Builtin::Walk(Box::new(f))));
+            return Ok(self
+                .parse_required_single_arg(keyword_start)?
+                .map(|f| Builtin::Walk(Box::new(f))));
         }
 
         // isvalid(expr)
@@ -4023,25 +3996,19 @@ impl<'a> Parser<'a> {
         }
         // delpaths(paths)
         if self.matches_keyword("delpaths") {
+            let keyword_start = self.pos;
             self.consume_keyword("delpaths");
-            self.skip_ws();
-            self.expect('(')?;
-            self.skip_ws();
-            let paths = self.parse_expr()?;
-            self.skip_ws();
-            self.expect(')')?;
-            return Ok(Some(Builtin::DelPaths(Box::new(paths))));
+            return Ok(self
+                .parse_required_single_arg(keyword_start)?
+                .map(|paths| Builtin::DelPaths(Box::new(paths))));
         }
         // del(path) - delete value at path
         if self.matches_keyword("del") {
+            let keyword_start = self.pos;
             self.consume_keyword("del");
-            self.skip_ws();
-            self.expect('(')?;
-            self.skip_ws();
-            let path = self.parse_expr()?;
-            self.skip_ws();
-            self.expect(')')?;
-            return Ok(Some(Builtin::Del(Box::new(path))));
+            return Ok(self
+                .parse_required_single_arg(keyword_start)?
+                .map(|path| Builtin::Del(Box::new(path))));
         }
 
         // Phase 10: Math Functions
@@ -4578,14 +4545,11 @@ impl<'a> Parser<'a> {
         // isempty(expr) - returns true if expr produces no outputs
         if self.matches_keyword("isempty") {
             self.reject_unless_jq_extensions("isempty")?;
+            let keyword_start = self.pos;
             self.consume_keyword("isempty");
-            self.skip_ws();
-            self.expect('(')?;
-            self.skip_ws();
-            let expr = self.parse_expr()?;
-            self.skip_ws();
-            self.expect(')')?;
-            return Ok(Some(Builtin::IsEmpty(Box::new(expr))));
+            return Ok(self
+                .parse_required_single_arg(keyword_start)?
+                .map(|expr| Builtin::IsEmpty(Box::new(expr))));
         }
 
         // Phase 14: Recursive traversal (extends Phase 8)

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -20916,6 +20916,55 @@ fn test_single_arg_builtin_wrong_arity_reports_not_defined_2237() -> Result<()> 
     Ok(())
 }
 
+/// #2389: the first batch of ~40 further `try_parse_builtin` sites sharing
+/// #2237's own inline `self.expect('(')?`/`self.parse_expr()?`/
+/// `self.expect(')')?` shape, each individually oracle-verified (not a
+/// blind sweep, per that issue's own caution) before converting to
+/// `parse_required_single_arg`. All twelve are genuinely single-required-arg
+/// builtins with no comma-restricted argument, optional second argument, or
+/// other complication `has`/`select`/`min_by` didn't already have -- see
+/// #2389 for the full site survey and why the remaining sites (fixed/
+/// optional multi-arg builtins, and `strenv`'s bare-identifier argument)
+/// are out of scope for this same conversion.
+#[test]
+fn test_more_single_arg_builtins_wrong_arity_reports_not_defined_2389() -> Result<()> {
+    for (filter, name) in [
+        ("map", "map/0"),
+        ("map(1;2)", "map/2"),
+        ("map_values", "map_values/0"),
+        ("map_values(1;2)", "map_values/2"),
+        ("with_entries", "with_entries/0"),
+        ("with_entries(1;2)", "with_entries/2"),
+        ("walk", "walk/0"),
+        ("walk(1;2)", "walk/2"),
+        ("del", "del/0"),
+        ("del(1;2)", "del/2"),
+        ("delpaths", "delpaths/0"),
+        ("delpaths(1;2)", "delpaths/2"),
+        ("getpath", "getpath/0"),
+        ("getpath(1;2)", "getpath/2"),
+        ("group_by", "group_by/0"),
+        ("group_by(1;2)", "group_by/2"),
+        ("unique_by", "unique_by/0"),
+        ("unique_by(1;2)", "unique_by/2"),
+        ("join", "join/0"),
+        ("join(1;2)", "join/2"),
+        ("contains", "contains/0"),
+        ("contains(1;2)", "contains/2"),
+        ("isempty", "isempty/0"),
+        ("isempty(1;2)", "isempty/2"),
+    ] {
+        let (stdout, stderr, code) = run_jq_full(&["-nc", filter], None)?;
+        assert_eq!(stdout, "", "{filter}: stderr {stderr:?}");
+        assert!(
+            stderr.contains(&format!("{name} is not defined at <top-level>, line 1:")),
+            "{filter}: stderr {stderr:?}"
+        );
+        assert_eq!(code, 3, "{filter}: stdout: {stdout:?} stderr: {stderr:?}");
+    }
+    Ok(())
+}
+
 /// #2036: a user `def` can shadow a builtin of the same name, matching
 /// real jq -- the parser previously lowered a recognized builtin name to a
 /// typed `Expr::Builtin`/special-form node at parse time, before any `def`

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -1492,6 +1492,31 @@ fn test_yq_mode_single_arg_builtin_wrong_arity_unaffected_by_2237() -> Result<()
     Ok(())
 }
 
+/// #2389 sibling of the #2237 test above: the same carve-out for the 12
+/// more single-required-arg builtins #2389 converted to
+/// `parse_required_single_arg`, pinned via `map` (ungated, reachable in
+/// default yq mode -- unlike `getpath`/`walk`/`isempty` among the 12, which
+/// need `--jq-extensions` and are unaffected either way by this check).
+#[test]
+fn test_yq_mode_single_arg_builtin_wrong_arity_unaffected_by_2389() -> Result<()> {
+    let (out, stderr, code) = run_yq_stdin_with_stderr("map", "a: 1\n", &[])?;
+    assert_eq!(out, "", "stderr: {stderr}");
+    assert!(
+        stderr.contains("parse error: parse error at position 3: expected '(', found end of input"),
+        "stderr: {stderr}"
+    );
+    assert_eq!(code, 1, "stderr: {stderr}");
+
+    let (out, stderr, code) = run_yq_stdin_with_stderr("map(1;2)", "a: 1\n", &[])?;
+    assert_eq!(out, "", "stderr: {stderr}");
+    assert!(
+        stderr.contains("parse error: parse error at position 5: expected ')', found ';'"),
+        "stderr: {stderr}"
+    );
+    assert_eq!(code, 1, "stderr: {stderr}");
+    Ok(())
+}
+
 /// #2225 (review): the read-mode fix reaches yq mode too, not just jq mode
 /// -- `stderr` fires twice, once per start value, confirming `end` is
 /// re-evaluated fresh per `s` through `eval_generic::eval_slice_expr`


### PR DESCRIPTION
## Summary

#2389 asked for a per-site-verified (not blind) conversion of `try_parse_builtin`'s remaining ~40 inline `self.expect('(')?`/`self.parse_expr()?`/`self.expect(')')?` call sites to the shared `parse_required_single_arg` helper (#2237), which turns a wrong-arity call into jq's own "X/N is not defined" compile error instead of a raw parser error.

A full survey classified the 44 remaining sites: 27 are genuinely single-required-arg with no complications, 16 are fixed/optional multi-arg (out of scope for this helper, including `skip`/`nth` whose comma-restricted `n` argument the issue specifically warned not to disturb), and 1 (`strenv`) parses a bare identifier rather than an expression.

This PR converts the first 12 of the 27 simple sites: `map`, `map_values`, `with_entries`, `walk`, `del`, `delpaths`, `getpath`, `group_by`, `unique_by`, `join`, `contains`, `isempty`. Each was individually verified against the pinned jq 1.7.1 oracle for both the no-args and too-many-args wrong-arity shapes, plus `def`-shadowing sanity (unaffected). The remaining 15 simple sites, the 16 multi-arg sites, and `strenv` are tracked as a follow-up (#2573) rather than converted in the same sweep.

Fixes #2389

## Test plan
- [x] New regression test `test_more_single_arg_builtins_wrong_arity_reports_not_defined_2389` covers both wrong-arity shapes for all 12 builtins.
- [x] Live-verified against `/usr/bin/jq` 1.7.1: correct-arity behavior unchanged, wrong-arity error output byte-identical for all 12, `def <name>(x): ...` shadowing still works.
- [x] `cargo clippy --all-targets --all-features -- -D warnings` (and the other two CI clippy feature-set legs) — clean.
- [x] `cargo test --features cli,simd,regex,serde` — full suite green, verified by real process exit code.
- [x] `no_std` build + test (`--no-default-features --features portable-popcount`) — clean.
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --all-features` — clean.
- [x] `omni-dev coverage diff` — 100% patch coverage (48/48 new lines).