### PR TITLE
fix(jq): resolve the walk's negative index before the element lookup (#2568)

### DIFF
--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -12233,11 +12233,30 @@ fn path_step_generic<S: EvalSemantics, V: DocumentValue>(
                             if S::TAG == EvalTag::Yq && resolved >= 0 {
                                 component = OwnedValue::Int(resolved);
                             }
+                            // #2568: the element the walk stands on has to be
+                            // the element the *resolved* index names, not the
+                            // index as written -- `usize::try_from(idx)` here
+                            // always failed for a negative `idx`, so the walk
+                            // stood on `PathNode::Absent` even when the
+                            // resolved position existed (`.c[-1] | [., key]`
+                            // was `[null,1]` where yq answers `[20,1]`,
+                            // mode-independent since jq's own `.c[-1]` reads
+                            // the last element too). `resolved as usize`
+                            // mirrors the value-side `Expr::Index` arm above
+                            // (this file, `resolved as usize` on `elements`):
+                            // a still-negative `resolved` in jq mode (out of
+                            // range, no raise there) wraps to a huge `usize`
+                            // that `get_cursor` simply misses, same as an
+                            // ordinary out-of-bounds read.
+                            elements
+                                .get_cursor(resolved as usize)
+                                .map_or(PathNode::Absent, PathNode::At)
+                        } else {
+                            usize::try_from(idx)
+                                .ok()
+                                .and_then(|i| elements.get_cursor(i))
+                                .map_or(PathNode::Absent, PathNode::At)
                         }
-                        usize::try_from(idx)
-                            .ok()
-                            .and_then(|i| elements.get_cursor(i))
-                            .map_or(PathNode::Absent, PathNode::At)
                     } else if v.as_object().is_some() && yq_numeric_index_on_object_is_null::<S>() {
                         // #2459: yq mode only -- a numeric index on a
                         // mapping is an absent position, same as the

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -7934,6 +7934,75 @@ fn test_as_pattern_alternatives_path_context_still_a_known_gap_1663() -> Result<
     Ok(())
 }
 
+/// #2568: `path()`'s own component is untouched by the fix below -- it
+/// reports the index as written, jq 1.7.1's own convention (ADR-0018).
+/// Captured live from `/usr/bin/jq` 1.7.1 on `{"c":[10,20]}`:
+/// `path(.c[-1])` is `["c",-1]`, `path(.c[-2])` is `["c",-2]`,
+/// `path(.c[-3])` (out of range) is `["c",-3]` -- all three unchanged
+/// across the fix, since `path()` only ever reads the accumulated trail,
+/// never the node the walk stands on.
+#[test]
+fn test_negative_index_path_component_unaffected_by_lookup_fix_2568() -> Result<()> {
+    let doc = r#"{"c":[10,20]}"#;
+    for (filter, want) in [
+        ("path(.c[-1])", r#"["c",-1]"#),
+        ("path(.c[-2])", r#"["c",-2]"#),
+        ("path(.c[-3])", r#"["c",-3]"#),
+    ] {
+        let (stdout, _, code) = run_jq_full(&["-c", filter], Some(doc))?;
+        assert_eq!(code, 0, "`{filter}`: {stdout:?}");
+        assert_eq!(stdout.trim(), want, "`{filter}`");
+    }
+    Ok(())
+}
+
+/// #2568: `path_step_generic`'s `Expr::Index` arm resolved a negative index
+/// for the path component but looked the element up with the index as
+/// written (`usize::try_from(idx)`, always `None` for a negative `idx`), so
+/// the walk stood on `PathNode::Absent` where the element existed --
+/// mode-independent, since the lookup itself never depended on
+/// `S::TAG`. No jq oracle for `key` (a succinctly extension, real jq has
+/// none), so this pins the actual before/after rather than a reference
+/// answer; `path()`'s own component is unaffected (see the test above).
+/// Captured on this issue's own pre-fix build (`_verify-2568-prefix`,
+/// `7b4f4f4fe`): `.c[-1] | [., key]` was `[null,-1]`, `.c[-2] | [., key]`
+/// was `[null,-2]`, `.c[-1]? | [., key]` was `[null,-1]` -- all three
+/// stood on `PathNode::Absent`. Object/array construction's own `key`
+/// answers the node's own cursor position once the walk lands on a real
+/// cursor (`test_object_construction_keeps_path_context_2416`'s "key
+/// inside {..} answers the node's own key"), which is why `key` here
+/// reads `1`/`0` post-fix rather than the unresolved `-1`/`-2` `path()`
+/// keeps -- a documented consequence of landing on the right cursor, not
+/// a second convention this issue introduces. Out of range and the
+/// mapping control are both unaffected (`usize::try_from`/the object-index
+/// arm neither one touched).
+#[test]
+fn test_negative_index_lookup_resolves_element_2568() -> Result<()> {
+    let doc = r#"{"c":[10,20]}"#;
+    for (filter, want) in [
+        (".c[-1] | [., key]", "[20,1]"),
+        (".c[-2] | [., key]", "[10,0]"),
+        (".c[-3] | [., key]", "[null,-3]"),
+        (".c[-1]? | [., key]", "[20,1]"),
+    ] {
+        let (stdout, _, code) = run_jq_full(&["-c", filter], Some(doc))?;
+        assert_eq!(code, 0, "`{filter}`: {stdout:?}");
+        assert_eq!(stdout.trim(), want, "`{filter}`");
+    }
+
+    // Control: a numeric index on a mapping still raises in jq mode
+    // (`eval_generic.rs`'s object branch, untouched by this fix) --
+    // confirmed live against `/usr/bin/jq` 1.7.1.
+    let (_, stderr, code) = run_jq_full(&["-c", ".c[-1]"], Some(r#"{"c":{"x":10,"y":20}}"#))?;
+    assert_eq!(code, 5, "{stderr:?}");
+    assert!(
+        stderr.contains("Cannot index object with number"),
+        "{stderr:?}"
+    );
+
+    Ok(())
+}
+
 /// #1765 item 3: `Expr::Reduce`/`Expr::Foreach`'s `input`/`INIT` now resolve
 /// `key`/`parent`/`file_index` against the caller's own ambient position,
 /// mirroring `Expr::Limit`'s own hybrid dispatch above -- `input`/`INIT`

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -30887,6 +30887,62 @@ fn test_negative_index_path_component_is_resolved_in_yq_mode_2416() -> Result<()
     Ok(())
 }
 
+/// #2568: `path_step_generic`'s `Expr::Index` arm resolved a negative index
+/// to the yq-mode path *component* (the test above) but still looked the
+/// element up with the index **as written** (`usize::try_from(idx)`, always
+/// `None` for negative `idx`), so the walk stood on `PathNode::Absent`
+/// where the element existed -- `.c[-1] | [., key]` was `[null,1]` here,
+/// `[20,1]` in yq v4.53.3. Every row captured live from yq v4.53.3 on
+/// `c: [10, 20]`, present and out of range, on flow and block spellings,
+/// in an `as` body and after `?` (which does not suppress the yq
+/// out-of-range error -- #2254). The lookup fix is mode-independent (jq's
+/// own `.c[-1]` reads the last element too), pinned separately in
+/// `jq_cli_tests.rs`'s `test_negative_index_lookup_resolves_element_2568`.
+#[test]
+fn test_negative_index_lookup_resolves_element_in_yq_mode_2568() -> Result<()> {
+    for doc in ["c: [10, 20]\n", "c:\n  - 10\n  - 20\n"] {
+        for (filter, want) in [
+            (".c[-1] | [., key]", "[20,1]"),
+            (".c[-2] | [., key]", "[10,0]"),
+            (".c[-1] | path", r#"["c",1]"#),
+            (".c[-1] | . + 1", "21"),
+            (".c[-1] as $x | [$x, (.c[-1] | key)]", "[20,1]"),
+            (".c[-1]? | [., key]", "[20,1]"),
+        ] {
+            let (out, code) = run_yq_stdin(filter, doc, &["-o", "json", "-I0"])?;
+            assert_eq!(code, 0, "`{filter}` on {doc:?}: {out:?}");
+            assert_eq!(out.trim(), want, "`{filter}` on {doc:?}");
+        }
+
+        // Out of range: still absent, and real yq's own out-of-range error
+        // survives `?` unconditionally (#2254) -- both bare and `?`-suffixed
+        // reach the same yq_negative_index_check this fix left alone.
+        for filter in [".c[-3] | [., key]", ".c[-3]? | [., key]"] {
+            let (_, stderr, code) = run_yq_stdin_with_stderr(filter, doc, &["-o", "json"])?;
+            assert_eq!(code, 1, "`{filter}` on {doc:?}: {stderr:?}");
+            assert_eq!(
+                stderr.trim(),
+                "Error: index [-3] out of range, array size is 2",
+                "`{filter}` on {doc:?}"
+            );
+        }
+    }
+
+    // Control: a numeric index on a mapping is untouched -- that's
+    // `yq_numeric_index_on_object_is_null`'s own branch (#2459), not the
+    // array branch this fix touches, so the component stays the written,
+    // unresolved index. Confirmed live against yq v4.53.3.
+    let (out, code) = run_yq_stdin(
+        ".c[-1] | [., key]",
+        "c:\n  x: 10\n  y: 20\n",
+        &["-o", "json", "-I0"],
+    )?;
+    assert_eq!(code, 0, "{out:?}");
+    assert_eq!(out.trim(), "[null,-1]");
+
+    Ok(())
+}
+
 /// #1332, closed by spine 2416's phase 3: object construction is native in
 /// the generic evaluator with the cursor threaded into every key and value,
 /// so `key` inside `{..}` answers the node's own key. Every row captured


### PR DESCRIPTION
Closes #2568
Refs spine 2416

`path_step_generic`'s `Expr::Index` arm (`src/jq/eval_generic.rs`) resolved a negative index for the walk's path *component* but still looked the element up with the index as written (`usize::try_from(idx)`, always `None` for a negative index), so the walk stood on `PathNode::Absent` where the element existed. On `c: [10, 20]`, `.c[-1] | [., key]` was `[null,1]` here where yq v4.53.3 answers `[20,1]`. The lookup fix is mode-independent: jq's own `.c[-1]` reads the last element too, and jq mode's reported *component* (`path(.c[-1])` = `["c",-1]`) is untouched.

Fix: use the already-computed `resolved` index for the element lookup (`elements.get_cursor(resolved as usize)`), mirroring the pattern the value-side `Expr::Index` arm in the same file already uses. Out of range stays absent (jq) or still raises (yq, #2254), unaffected.

Captured live from `/usr/bin/jq` 1.7.1 and Homebrew `yq` v4.53.3 before pinning, in both modes, present and out of range, in an `as` body and after `?`. The bug only reproduces when something downstream forces the path-context walk for the whole pipe *and* the walked node's own value is read at the negative-index position; `path(...)`-only reads and the `as` binding's own source were never affected (confirmed identical on a pre-fix build). Tests added in `tests/jq_cli_tests.rs` and `tests/yq_cli_tests.rs` with the captures in doc comments.

Verification: `cargo fmt --all -- --check`, `cargo clippy --all-targets --all-features -- -D warnings`, `cargo test --features cli` (0 failures), `scripts/jq-path-context-oracle-sweep.sh --summary` (3168 cases, 0 unexpected, 1133 known).
