### PR TITLE
fix(jq): yq's and/or now agrees with real yq on a zero-node literal operand

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`succinctly yq`'s `and`/`or` now agrees with real yq when a literal or
+  constructor operand's own upstream pipe stage produced zero nodes inside
+  `and`/`or`'s read-only context (#2470)** (#2540): `(.a.zz | true) and true`
+  was `false`, where real yq gives `true`. Real yq's `valueOperator`/
+  `operator_collect.go`/`operator_create_map.go` each special-case a
+  zero-node context by
+  re-emitting a node anyway — a literal always, an array unconditionally as
+  `[]` regardless of its own body, an object only when every field value also
+  independently qualifies — where `.`/`length` (a plain loop) correctly stay
+  empty. Fixed via a new pure `Expr` classifier,
+  `yq_empty_context_literal_or_constructor`, consulted by the one shared
+  `boolean_fanout_bools` both evaluators already call for `and`/`or`. Gated
+  on the read-only scope, so jq mode is unaffected. **Residual, not fixed
+  here**: `=`'s right side is reachable through the identical mechanism but
+  evaluates through a separate code path this fix does not reach — see
+  `docs/compliance/yq/limitations.md`.
+
 - **`to_owned_with_comments_at_depth`'s object and array arms now run the same
   #1677/#2211/#2243 delimiter checks their three sibling materializers always
   had** (#2405). It used to run none at all beyond #1642's key-collision guard

--- a/docs/compliance/yq/limitations.md
+++ b/docs/compliance/yq/limitations.md
@@ -2049,7 +2049,45 @@ comment for the full call-site list and `tests/yq_cli_tests.rs`'s
 unaffected (it keeps its own separate, unconditional-null rule), and a real container
 target keeps its own structural error.
 
-### An assignment's target is created before its right side runs — resolved (#2481)
+### An `and`/`or` operand's evaluation context — resolved for `and`/`or` (#2540); `=`'s right side remains open
+
+A literal or constructor is not really "empty" against a read-only, zero-node context in
+real yq the way `.`/`length`/a plain navigational read are: `valueOperator`
+(`pkg/yqlib/operator_value.go`) special-cases an empty `context.MatchingNodes` by
+re-emitting a copy of the literal node instead of looping zero times, and `[...]`/`{...}`
+(`operator_collect.go`/`operator_create_map.go`) carry the identical special case in their
+own operators — but not identically to each other. Captured live against yq v4.53.3 on
+`a: {b: 1}` (`.a.zz` genuinely absent, not `null`):
+
+| `EXPR` in `(.a.zz \| EXPR) and true` | produces (not "empty" for #2460's rule) |
+|---|---|
+| `true` / `5` / `"s"` | itself, unconditionally |
+| `[.]` / `[.a]` / `[1,2]` | `[]`, **regardless of the array's own body** — it loops zero times over the empty context, but the collected array is still emitted once |
+| `{"k": 1}` | `{"k": 1}` — every field's value also independently qualifies |
+| `{"k": .}` | nothing — `.` does not have this special case (`operator_self.go` returns its input context unchanged), so the *whole* object construction aborts, not just that field |
+| `{"k": 1, "j": .}` | nothing — one disqualifying field is enough; this is not a per-field union |
+| `.` / `length` / any other filter | nothing (propagates, matching the pre-existing #2460 oracle rows for `key`/`parent`) |
+
+Before [#2540](https://github.com/rust-works/succinctly/issues/2540), succinctly propagated
+the zero-node emptiness straight through the pipe for every `EXPR` shape, so `and`'s left
+operand registered as empty and #2460's own empty-operand rule short-circuited to `false`
+without ever consulting the literal/constructor's real value: `(.a.zz | true) and true` was
+`false` instead of `true`. Fixed as `jq::eval::yq_empty_context_literal_or_constructor`, a
+pure `Expr` classifier (recursing into a pipe's own last stage, and into an object's field
+values) shared by both evaluators through `jq::eval::boolean_fanout_bools` — the one
+definition `and`/`or` in both evaluators already share for #2460's own rule. Gated on
+`rules.read_only`, so jq mode and comparison operands are untouched. See
+`tests/yq_cli_tests.rs`'s `test_yq_empty_context_literal_or_constructor_and_operand_2540`
+and `test_yq_empty_context_constructor_value_shapes_2540` for the full captured matrix.
+
+**Residual, not yet fixed:** the issue's own prose also names `=`'s right side as reachable
+through the identical `DontAutoCreate` mechanism (#2470), and it is — `.x = (.a.zz | true)`
+is `x: true` in real yq, `x: 5` (i.e. unchanged) in succinctly (confirmed live against
+v4.53.3) — but `=`'s right side evaluates through a completely different code path
+(`jq::eval::yq_prepare_assign_targets`/`resolve_dynamic_indexes`, not
+`boolean_fanout_bools`) that #2540 did not touch. Tracked as a follow-up rather than folded
+in here, since fixing it needs its own trace through that separate mechanism, not a second
+call to the same classifier.
 
 Real yq's `assignUpdateOperator` (`pkg/yqlib/operator_assign.go`, v4.53.3) resolves and
 auto-creates the **left** side first, then evaluates the right side — through
@@ -2208,22 +2246,24 @@ the rows are pinned in `test_and_or_keep_path_context_2473` and
 #2460's empty-operand rule and #2470's read-only scope are what make the reparsed operands
 answer as they do, and both were already correct.
 
-**Residual gap** ([#2540](https://github.com/rust-works/succinctly/issues/2540)). One row in the
-#2506 sweep is a different mechanism and still diverges:
+**Resolved** ([#2540](https://github.com/rust-works/succinctly/issues/2540)). One row in the
+#2506 sweep was a different mechanism and diverged:
 
-| filter                       | real yq | succinctly |
-|------------------------------|---------|------------|
-| `(.a.zz \| true) and true`   | `true`  | `false`    |
-| `(.a.zz \| 5) and true`      | `true`  | `false`    |
-| `(.a.zz \| [.]) and true`    | `true`  | `false`    |
-| `(.a.zz \| .) and true`      | `false` | `false`    |
-| `(.a.zz \| length) and true` | `false` | `false`    |
+| filter                       | real yq | succinctly (before #2540) |
+|------------------------------|---------|----------------------------|
+| `(.a.zz \| true) and true`   | `true`  | `false`                     |
+| `(.a.zz \| 5) and true`      | `true`  | `false`                     |
+| `(.a.zz \| [.]) and true`    | `true`  | `false`                     |
+| `(.a.zz \| .) and true`      | `false` | `false`                     |
+| `(.a.zz \| length) and true` | `false` | `false`                     |
 
 Inside `and`'s read-only scope `.a.zz` yields nothing, and yq's `valueOperator`
 (`operator_value.go:11-14`) special-cases an **empty** context by emitting the literal once
-anyway -- as do the `[...]` and `{...}` constructors. succinctly propagates the empty, so
-the left operand is empty and #2460's rule short-circuits to `false`. `.` and `length` loop
-the context and so stay empty in both tools.
+anyway -- as do the `[...]` and `{...}` constructors. succinctly used to propagate the
+empty, so the left operand registered as empty and #2460's rule short-circuited to
+`false`; `.` and `length` loop the context and so correctly stayed empty in both tools
+throughout. See "An `and`/`or` operand's evaluation context" above (#2470's section) for
+the fix and its own residual (`=`'s right side, a separate code path #2540 did not reach).
 
 ### Ordering comparisons against a real `null` -- resolved for scalars ([#2483](https://github.com/rust-works/succinctly/issues/2483)); containers remain a residual gap
 

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -2581,10 +2581,25 @@ pub(crate) fn yq_empty_context_literal_or_constructor(expr: &Expr) -> Option<Own
             for entry in entries {
                 let key = match &entry.key {
                     ObjectKey::Literal(s) => s.clone(),
-                    ObjectKey::Expr(k) => match yq_empty_context_literal_or_constructor(k)? {
-                        OwnedValue::String(s) => s,
-                        _ => return None,
-                    },
+                    // #2540 review: a dynamic key's own qualifying value
+                    // still has to become a `String` the same way any other
+                    // object-construction key does (#2508/#2521) -- a
+                    // numeric/bool/null key stringifies rather than
+                    // disqualifying the object; only a genuinely
+                    // non-stringifiable key (`Array`/`Object`, which
+                    // `yq_object_key_stringify` already refuses) does that.
+                    // `YqSemantics` unconditionally, not a generic `S`: this
+                    // whole function only ever runs under `rules.read_only`,
+                    // which is yq-only by construction (see this function's
+                    // own doc comment), so there is no jq-mode call to get
+                    // this wrong for.
+                    ObjectKey::Expr(k) => {
+                        let v = yq_empty_context_literal_or_constructor(k)?;
+                        match &v {
+                            OwnedValue::String(s) => s.clone(),
+                            _ => yq_object_key_stringify::<YqSemantics>(&v)?,
+                        }
+                    }
                 };
                 let value = yq_empty_context_literal_or_constructor(&entry.value)?;
                 map.insert(key, value);

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -2533,6 +2533,69 @@ pub(crate) fn literal_to_owned(lit: &Literal) -> OwnedValue {
     OwnedValue::from(lit.clone())
 }
 
+/// **yq's "a literal or constructor against an empty context still yields
+/// one node" rule** (#2540), consulted only inside a
+/// [read-only context](yq_read_only_context) (#2470) when the operand
+/// expression produced zero outputs, right before that emptiness would
+/// otherwise reach [`yq_empty_operand_output`]'s (#2460) table. Shared
+/// between both evaluators (`eval.rs`'s [`read_only_operand_strategy`] and
+/// `eval_generic.rs`'s `read_only_operand_strategy_generic`) since it is
+/// pure `Expr` classification with no cursor/document dependency at all.
+///
+/// Real yq's `valueOperator` special-cases an empty `context.MatchingNodes`
+/// by re-emitting a copy of the literal node itself rather than looping zero
+/// times (`operator_value.go`); `[...]`/`{...}` share the identical
+/// zero-node special case in their own operators (`operator_collect.go`/
+/// `operator_create_map.go`), but **not identically** -- verified live
+/// against yq v4.53.3 with `.x = (.a.zz | EXPR)` on a document where `.a.zz`
+/// is genuinely absent (not `null`):
+///
+/// | `EXPR`            | produces (not "empty" for #2460's purposes) |
+/// |-------------------|----------------------------------------------|
+/// | `true`/`5`/`"s"`  | itself, unconditionally                       |
+/// | `[.]`/`[.a]`/`[1,2]` | `[]`, **regardless of the array's own body** -- it loops zero times over the (empty) context, but the collected array is still emitted once |
+/// | `{"k": 1}`        | `{"k": 1}` -- every field's value also independently qualifies |
+/// | `{"k": .}`        | nothing -- `.` does not have this special case (it propagates the emptiness, matching `operator_self.go`'s "return input context unchanged"), so the *whole* object construction aborts, not just that one field |
+/// | `{"k": 1, "j": .}` | nothing -- one disqualifying field is enough; this is not a per-field union |
+/// | `.`/`length`/any other filter | nothing (propagates, matching the pre-existing #2460 oracle rows for `key`/`parent`) |
+///
+/// A `Pipe` recurses into its own *last* stage only: a pipe's overall
+/// "what does the tail produce given an empty upstream" is governed
+/// entirely by the tail's own rule once every earlier stage has already
+/// contributed nothing, mirroring how yq's own pipe operator hands the
+/// (empty) context straight to the next operator without accumulating
+/// anything from a stage that produced zero nodes.
+///
+/// Deliberately does not special-case `Expr::Shared` (native since #2416
+/// phase 3, transparent to evaluation): unwrapping it here would be correct
+/// but is not exercised by any known query shape yet, so it is left for
+/// whoever hits it live rather than guessed at.
+pub(crate) fn yq_empty_context_literal_or_constructor(expr: &Expr) -> Option<OwnedValue> {
+    match super::eval_generic::strip_parens(expr) {
+        Expr::Literal(lit) => Some(literal_to_owned(lit)),
+        // Regardless of `body`: the collected array is emitted once even
+        // when its own body loops zero times over the empty context.
+        Expr::Array(_) => Some(OwnedValue::Array(Vec::new())),
+        Expr::Object(entries) => {
+            let mut map = IndexMap::new();
+            for entry in entries {
+                let key = match &entry.key {
+                    ObjectKey::Literal(s) => s.clone(),
+                    ObjectKey::Expr(k) => match yq_empty_context_literal_or_constructor(k)? {
+                        OwnedValue::String(s) => s,
+                        _ => return None,
+                    },
+                };
+                let value = yq_empty_context_literal_or_constructor(&entry.value)?;
+                map.insert(key, value);
+            }
+            Some(OwnedValue::Object(map))
+        }
+        Expr::Pipe(stages) => yq_empty_context_literal_or_constructor(stages.last()?),
+        _ => None,
+    }
+}
+
 /// Evaluate a comma expression (multiple outputs).
 fn eval_comma<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     exprs: &[Expr],
@@ -6889,8 +6952,24 @@ pub(crate) fn boolean_fanout_bools(
     // falls through to the other operand's own truthiness. The rule lives in
     // `yq_empty_operand_output`, not here, so `and`/`or` and the arithmetic/
     // comparison fanout share one definition of "this operand was empty".
+    //
+    // #2540: except that a literal/constructor operand was never really
+    // "empty" in real yq's own model to begin with -- its own operator
+    // special-cases a zero-node context and re-emits one node anyway (see
+    // `yq_empty_context_literal_or_constructor`'s own doc comment). Checked
+    // only when `rules.read_only` is set: this "empty" only exists because
+    // `and`/`or`'s own read-only context turned `.a.zz` into zero nodes in
+    // the first place (#2470), so the same gate that created the emptiness
+    // is what decides whether this rule can override it.
     if left_bools.is_empty() && left_control.is_none() {
-        left_bools.extend(empty_boolean_operand(rules.empty));
+        match rules
+            .read_only
+            .then(|| yq_empty_context_literal_or_constructor(left))
+            .flatten()
+        {
+            Some(v) => left_bools.push(v.is_truthy()),
+            None => left_bools.extend(empty_boolean_operand(rules.empty)),
+        }
     }
 
     let mut out = vec_with_capacity(left_bools.len());
@@ -6904,7 +6983,15 @@ pub(crate) fn boolean_fanout_bools(
             return (out, Some(control));
         }
         if out.len() == before {
-            out.extend(empty_boolean_operand(rules.empty));
+            // #2540: same rationale as the left-operand check above.
+            match rules
+                .read_only
+                .then(|| yq_empty_context_literal_or_constructor(right))
+                .flatten()
+            {
+                Some(v) => out.push(v.is_truthy()),
+                None => out.extend(empty_boolean_operand(rules.empty)),
+            }
         }
     }
 

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -34250,10 +34250,12 @@ fn test_yq_empty_context_constructor_value_shapes_2540() -> Result<()> {
 /// (`boolean_fanout_bools`'s second call site, reached only once the left
 /// operand's own truthiness does not already short-circuit the pairing) --
 /// the two tests above only ever put the interesting expression on the
-/// left. Also covers a dynamic object key (`{(EXPR): v}`): a literal key
-/// expression qualifies like any other literal, but a key expression that
-/// itself propagates the empty context (`.b | tostring` against the same
-/// zero-node upstream) voids the whole object, exactly like a
+/// left. Also covers a dynamic object key (`{(EXPR): v}`): a literal string
+/// key expression qualifies like any other literal, a literal *numeric* key
+/// stringifies the same way any other object-construction key does
+/// (#2508/#2521) rather than disqualifying the object, and a key expression
+/// that itself propagates the empty context (`.b | tostring` against the
+/// same zero-node upstream) voids the whole object, exactly like a
 /// disqualifying *value* does. Captured live against yq v4.53.3.
 #[test]
 fn test_yq_empty_context_literal_or_constructor_right_operand_and_dynamic_key_2540() -> Result<()> {
@@ -34262,6 +34264,7 @@ fn test_yq_empty_context_literal_or_constructor_right_operand_and_dynamic_key_25
         (r"true and (.a.zz | true)", "true"),
         (r"false or (.a.zz | true)", "true"),
         (r#"(.a.zz | {("k"): 1}) and true"#, "true"),
+        (r"(.a.zz | {(5): 1}) and true", "true"),
         (r"(.a.zz | {(.b|tostring): 1}) and true", "false"),
     ] {
         let (out, _, code) = run_yq_stdin_with_stderr(filter, DOC, &["-o", "json", "-I", "0"])?;

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -34246,6 +34246,31 @@ fn test_yq_empty_context_constructor_value_shapes_2540() -> Result<()> {
     Ok(())
 }
 
+/// #2540 sibling: the *right*-hand operand's own zero-node-literal check
+/// (`boolean_fanout_bools`'s second call site, reached only once the left
+/// operand's own truthiness does not already short-circuit the pairing) --
+/// the two tests above only ever put the interesting expression on the
+/// left. Also covers a dynamic object key (`{(EXPR): v}`): a literal key
+/// expression qualifies like any other literal, but a key expression that
+/// itself propagates the empty context (`.b | tostring` against the same
+/// zero-node upstream) voids the whole object, exactly like a
+/// disqualifying *value* does. Captured live against yq v4.53.3.
+#[test]
+fn test_yq_empty_context_literal_or_constructor_right_operand_and_dynamic_key_2540() -> Result<()> {
+    const DOC: &str = "a:\n  b: 1\n";
+    for (filter, want) in [
+        (r"true and (.a.zz | true)", "true"),
+        (r"false or (.a.zz | true)", "true"),
+        (r#"(.a.zz | {("k"): 1}) and true"#, "true"),
+        (r"(.a.zz | {(.b|tostring): 1}) and true", "false"),
+    ] {
+        let (out, _, code) = run_yq_stdin_with_stderr(filter, DOC, &["-o", "json", "-I", "0"])?;
+        assert_eq!(out.trim(), want, "`{filter}`");
+        assert_eq!(code, 0, "`{filter}`");
+    }
+    Ok(())
+}
+
 // =============================================================================
 // #2470: yq's read-only evaluation context (`Context.DontAutoCreate`)
 // =============================================================================

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -34194,6 +34194,58 @@ fn test_yq_all_four_empty_operand_shapes_are_indistinguishable_2460() -> Result<
     Ok(())
 }
 
+/// #2540: a literal or constructor `and`/`or` operand still yields its own
+/// one node even when the pipe stage feeding it produced zero nodes under
+/// `and`/`or`'s own read-only context (#2470) -- real yq's `valueOperator`/
+/// `operator_collect.go`/`operator_create_map.go` each special-case a
+/// zero-node context by re-emitting a node anyway, where `.`/`length`
+/// (`operator_self.go`, a plain loop) do not and correctly stay empty.
+///
+/// Captured live against Homebrew `yq` v4.53.3 on `a: {b: 1, c: false}\nx:
+/// true`, the same document and filters #2540's own issue body pins.
+#[test]
+fn test_yq_empty_context_literal_or_constructor_and_operand_2540() -> Result<()> {
+    const DOC: &str = "a:\n  b: 1\n  c: false\nx: true\n";
+    for (filter, want) in [
+        (r"(.a.zz | true) and true", "true"),
+        (r"(.a.zz | 5) and true", "true"),
+        (r#"(.a.zz | "s") and true"#, "true"),
+        (r"(.a.zz | [.]) and true", "true"),
+        (r#"(.a.zz | {"k":1}) and true"#, "true"),
+        (r"(.a.zz | .) and true", "false"),
+        (r"(.a.zz | length) and true", "false"),
+    ] {
+        let (out, _, code) = run_yq_stdin_with_stderr(filter, DOC, &["-o", "json", "-I", "0"])?;
+        assert_eq!(out.trim(), want, "`{filter}`");
+        assert_eq!(code, 0, "`{filter}`");
+    }
+    Ok(())
+}
+
+/// #2540 sibling: the disqualifying shapes that must still stay empty --
+/// `[.a]`/`[1,2]` (an array always re-emits, but the array constructor's own
+/// zero-node special case is independent of what its body would have
+/// produced) and `{"k": .}`/`{"k": 1, "j": .}` (an object re-emits only when
+/// *every* field value also independently qualifies; one disqualifying
+/// field voids the whole object, not just that field -- unlike an array,
+/// which never propagates its body's own emptiness at all). Captured live
+/// against yq v4.53.3.
+#[test]
+fn test_yq_empty_context_constructor_value_shapes_2540() -> Result<()> {
+    const DOC: &str = "a:\n  b: 1\n";
+    for (filter, want) in [
+        (r"(.a.zz | [.a]) and true", "true"),
+        (r"(.a.zz | [1,2]) and true", "true"),
+        (r#"(.a.zz | {"k": .}) and true"#, "false"),
+        (r#"(.a.zz | {"k": 1, "j": .}) and true"#, "false"),
+    ] {
+        let (out, _, code) = run_yq_stdin_with_stderr(filter, DOC, &["-o", "json", "-I", "0"])?;
+        assert_eq!(out.trim(), want, "`{filter}`");
+        assert_eq!(code, 0, "`{filter}`");
+    }
+    Ok(())
+}
+
 // =============================================================================
 // #2470: yq's read-only evaluation context (`Context.DontAutoCreate`)
 // =============================================================================


### PR DESCRIPTION
## Summary

- `and`/`or` evaluate both operands inside a read-only context (#2470) — `.a.zz` (absent) yields zero nodes there instead of `null`.
- Real yq's own operators differ on what a literal/constructor does with that zero-node context: a bare literal (`true`/`5`/`"s"`) re-emits its own value regardless; `[...]` always emits (an empty array, regardless of its own body — verified live that `[.a]`/`[1,2]` behave identically to `[.]`, all giving `[]`); `{...}` only emits when *every* field's value also independently qualifies (`{"k": 1}` emits, `{"k": .}` and `{"k": 1, "j": .}` do not, since `.` propagates the emptiness and one disqualifying field voids the whole object).
- `succinctly yq` treated all of these as genuinely empty, so `(.a.zz | true) and true` answered `false` instead of real yq's `true`.
- Adds `yq_empty_context_literal_or_constructor`, a pure `Expr` classifier, consulted from `boolean_fanout_bools` — the one place both evaluators already share for `and`/`or`'s empty-operand handling. Gated on `rules.read_only`, so jq mode and comparison operands are unaffected.
- **Residual, not fixed here**: `=`'s right side is reachable through the identical mechanism (confirmed live: `.x = (.a.zz | true)` is `x: true` in real yq) but evaluates through a separate code path this fix does not touch — documented in `docs/compliance/yq/limitations.md` as an explicit follow-up, not silently swept in.

Fixes #2540

## Test plan

- [x] Two new CLI tests: `test_yq_empty_context_literal_or_constructor_and_operand_2540` (the issue's own 7-row oracle table) and `test_yq_empty_context_constructor_value_shapes_2540` (4 more rows covering the array-body-independence and object-field-disqualification nuances)
- [x] Verified every new oracle claim live against the pinned yq binary (Homebrew v4.53.3), including the `=`-RHS residual
- [x] `cargo build --features cli`
- [x] `cargo test --features cli,simd,regex,serde` — all 62 binaries pass, 0 failures
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings`
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features`
- [x] Independently verified the classifier's `Array`/`Object`/`Pipe` arms by direct code reading, and confirmed `rules.read_only` is only ever true when `rules.empty` is `Some(EmptyOperandOp::Boolean)` inside `boolean_fanout_bools` (never a differently-typed operand rule), so the new `v.is_truthy()` push is always semantically well-typed for the context it runs in
- [x] Updated a pre-existing, now-stale "still diverges" note elsewhere in `docs/compliance/yq/limitations.md` (left behind when #2540 was originally filed during an unrelated PR's sweep) to point at the fix