### PR TITLE
refactor(jq): collapse the wrong-arity rewind checkpoint hand-copied 18x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -134,6 +134,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **`src/jq/parser.rs`'s wrong-arity rewind checkpoint is now two shared
+  definitions instead of ~18 hand-copies** (#2391, a #2237 follow-up):
+  `expect_or_wrong_arity` for the eight dedicated special-form parsers
+  (`limit`/`until`/`while`/`repeat`/`first`/`last`/`range`/`error`, 15
+  sites, one more than the issue's own original count — `parse_error_expr`
+  gained a 15th copy after #2036 review, before this fix existed to catch
+  it) that resolve a mismatch via `rewind_to_wrong_arity_call`, and
+  `expect_or_none` for the `Result<Option<T>, ParseError>`-returning family
+  instead (`parse_required_single_arg`'s 2 sites, plus `env`'s own
+  hand-rolled duplicate of the identical block, 3 sites). Also settles the
+  issue's own noted "two spellings of the propagate-an-unreachable-Ok-Result
+  idiom" question as a side effect: both spellings now live only inside
+  these two helpers, in one consistent form. Every converted site's own
+  wrong-arity, valid-arity, shadowing, and yq-mode (no-rewind) behavior was
+  re-verified live against jq 1.7.1, per the issue's own explicit caution
+  after two real regressions in this exact area during #2237. No behavior
+  change.
+
 - **`eval_generic::eval_single` now pins its own unreachability claim with a
   `debug_assert`** (#2368, a #2334 follow-up). #2334's `owned_or_suppress!`/
   `Err(e) if suppresses(&e, optional)` routing in `fold_lazy_seq_stage`,

--- a/src/jq/parser.rs
+++ b/src/jq/parser.rs
@@ -1845,30 +1845,27 @@ impl<'a> Parser<'a> {
             self.skip_ws();
             let msg_expr = self.parse_expr()?;
             self.skip_ws();
-            if self.peek() != Some(')') {
-                // #2036 review round 2: unlike the other 7 shadowable
-                // special forms (until/limit/while/repeat/range/first/last),
-                // this arm used to propagate `Err` straight from `expect`
-                // for a wrong-arity `error(a;b)` call, relying on
-                // `parse_shadowable_special_form`'s own
-                // `retry_shadow_candidate_as_generic_call` fallback to
-                // recover it as a generic call. That fallback re-parses
-                // `input[start_pos..]` from scratch *in addition to* the
-                // `parse_expr()` call just above, which had already fully
-                // (and, for a nested wrong-arity shadow candidate,
-                // recursively-and-also-retried) parsed the same content --
-                // doubling the parse work at every nesting level and
-                // exhausting `shadow_retry_budget` at a depth as shallow as
-                // 7 for a legitimate, non-adversarial nested `def
-                // error(a;b): ...` shadow. Matching #2110/#2237's own
-                // internal-rewind pattern here (`rewind_to_wrong_arity_call`)
-                // instead removes this arm from that fallback path entirely,
-                // exactly as it already does for the other 7 forms.
-                if self.mode == ParserMode::Jq {
-                    return self.rewind_to_wrong_arity_call(start_pos);
-                }
-                self.expect(')')?;
-                unreachable!();
+            // #2036 review round 2: unlike the other 7 shadowable special
+            // forms (until/limit/while/repeat/range/first/last), this arm
+            // used to propagate `Err` straight from `expect` for a
+            // wrong-arity `error(a;b)` call, relying on
+            // `parse_shadowable_special_form`'s own
+            // `retry_shadow_candidate_as_generic_call` fallback to recover
+            // it as a generic call. That fallback re-parses
+            // `input[start_pos..]` from scratch *in addition to* the
+            // `parse_expr()` call just above, which had already fully (and,
+            // for a nested wrong-arity shadow candidate,
+            // recursively-and-also-retried) parsed the same content --
+            // doubling the parse work at every nesting level and exhausting
+            // `shadow_retry_budget` at a depth as shallow as 7 for a
+            // legitimate, non-adversarial nested `def error(a;b): ...`
+            // shadow. Matching #2110/#2237's own internal-rewind pattern
+            // here (`rewind_to_wrong_arity_call`, via
+            // `expect_or_wrong_arity`, #2391) instead removes this arm from
+            // that fallback path entirely, exactly as it already does for
+            // the other 7 forms.
+            if let Err(early) = self.expect_or_wrong_arity(')', start_pos) {
+                return early;
             }
             self.next();
             Some(Box::new(msg_expr))
@@ -1984,12 +1981,8 @@ impl<'a> Parser<'a> {
         let start_pos = self.pos;
         self.consume_keyword("limit");
         self.skip_ws();
-        if self.peek() != Some('(') {
-            if self.mode == ParserMode::Jq {
-                return self.rewind_to_wrong_arity_call(start_pos);
-            }
-            self.expect('(')?;
-            unreachable!();
+        if let Err(early) = self.expect_or_wrong_arity('(', start_pos) {
+            return early;
         }
         self.next();
         self.skip_ws();
@@ -2017,12 +2010,8 @@ impl<'a> Parser<'a> {
         self.skip_ws();
         let expr = self.parse_expr()?;
         self.skip_ws();
-        if self.peek() != Some(')') {
-            if self.mode == ParserMode::Jq {
-                return self.rewind_to_wrong_arity_call(start_pos);
-            }
-            self.expect(')')?;
-            unreachable!();
+        if let Err(early) = self.expect_or_wrong_arity(')', start_pos) {
+            return early;
         }
         self.next();
 
@@ -2041,34 +2030,22 @@ impl<'a> Parser<'a> {
         let start_pos = self.pos;
         self.consume_keyword("until");
         self.skip_ws();
-        if self.peek() != Some('(') {
-            if self.mode == ParserMode::Jq {
-                return self.rewind_to_wrong_arity_call(start_pos);
-            }
-            self.expect('(')?;
-            unreachable!();
+        if let Err(early) = self.expect_or_wrong_arity('(', start_pos) {
+            return early;
         }
         self.next();
         self.skip_ws();
         let cond = self.parse_expr()?;
         self.skip_ws();
-        if self.peek() != Some(';') {
-            if self.mode == ParserMode::Jq {
-                return self.rewind_to_wrong_arity_call(start_pos);
-            }
-            self.expect(';')?;
-            unreachable!();
+        if let Err(early) = self.expect_or_wrong_arity(';', start_pos) {
+            return early;
         }
         self.next();
         self.skip_ws();
         let update = self.parse_expr()?;
         self.skip_ws();
-        if self.peek() != Some(')') {
-            if self.mode == ParserMode::Jq {
-                return self.rewind_to_wrong_arity_call(start_pos);
-            }
-            self.expect(')')?;
-            unreachable!();
+        if let Err(early) = self.expect_or_wrong_arity(')', start_pos) {
+            return early;
         }
         self.next();
 
@@ -2087,34 +2064,22 @@ impl<'a> Parser<'a> {
         let start_pos = self.pos;
         self.consume_keyword("while");
         self.skip_ws();
-        if self.peek() != Some('(') {
-            if self.mode == ParserMode::Jq {
-                return self.rewind_to_wrong_arity_call(start_pos);
-            }
-            self.expect('(')?;
-            unreachable!();
+        if let Err(early) = self.expect_or_wrong_arity('(', start_pos) {
+            return early;
         }
         self.next();
         self.skip_ws();
         let cond = self.parse_expr()?;
         self.skip_ws();
-        if self.peek() != Some(';') {
-            if self.mode == ParserMode::Jq {
-                return self.rewind_to_wrong_arity_call(start_pos);
-            }
-            self.expect(';')?;
-            unreachable!();
+        if let Err(early) = self.expect_or_wrong_arity(';', start_pos) {
+            return early;
         }
         self.next();
         self.skip_ws();
         let update = self.parse_expr()?;
         self.skip_ws();
-        if self.peek() != Some(')') {
-            if self.mode == ParserMode::Jq {
-                return self.rewind_to_wrong_arity_call(start_pos);
-            }
-            self.expect(')')?;
-            unreachable!();
+        if let Err(early) = self.expect_or_wrong_arity(')', start_pos) {
+            return early;
         }
         self.next();
 
@@ -2133,23 +2098,15 @@ impl<'a> Parser<'a> {
         let start_pos = self.pos;
         self.consume_keyword("repeat");
         self.skip_ws();
-        if self.peek() != Some('(') {
-            if self.mode == ParserMode::Jq {
-                return self.rewind_to_wrong_arity_call(start_pos);
-            }
-            self.expect('(')?;
-            unreachable!();
+        if let Err(early) = self.expect_or_wrong_arity('(', start_pos) {
+            return early;
         }
         self.next();
         self.skip_ws();
         let expr = self.parse_expr()?;
         self.skip_ws();
-        if self.peek() != Some(')') {
-            if self.mode == ParserMode::Jq {
-                return self.rewind_to_wrong_arity_call(start_pos);
-            }
-            self.expect(')')?;
-            unreachable!();
+        if let Err(early) = self.expect_or_wrong_arity(')', start_pos) {
+            return early;
         }
         self.next();
 
@@ -2172,12 +2129,8 @@ impl<'a> Parser<'a> {
             self.skip_ws();
             let expr = self.parse_expr()?;
             self.skip_ws();
-            if self.peek() != Some(')') {
-                if self.mode == ParserMode::Jq {
-                    return self.rewind_to_wrong_arity_call(start_pos);
-                }
-                self.expect(')')?;
-                unreachable!();
+            if let Err(early) = self.expect_or_wrong_arity(')', start_pos) {
+                return early;
             }
             self.next();
             Ok(Expr::FirstExpr(Box::new(expr)))
@@ -2199,12 +2152,8 @@ impl<'a> Parser<'a> {
             self.skip_ws();
             let expr = self.parse_expr()?;
             self.skip_ws();
-            if self.peek() != Some(')') {
-                if self.mode == ParserMode::Jq {
-                    return self.rewind_to_wrong_arity_call(start_pos);
-                }
-                self.expect(')')?;
-                unreachable!();
+            if let Err(early) = self.expect_or_wrong_arity(')', start_pos) {
+                return early;
             }
             self.next();
             Ok(Expr::LastExpr(Box::new(expr)))
@@ -2226,12 +2175,8 @@ impl<'a> Parser<'a> {
         let start_pos = self.pos;
         self.consume_keyword("range");
         self.skip_ws();
-        if self.peek() != Some('(') {
-            if self.mode == ParserMode::Jq {
-                return self.rewind_to_wrong_arity_call(start_pos);
-            }
-            self.expect('(')?;
-            unreachable!();
+        if let Err(early) = self.expect_or_wrong_arity('(', start_pos) {
+            return early;
         }
         self.next();
         self.skip_ws();
@@ -2294,12 +2239,8 @@ impl<'a> Parser<'a> {
         self.skip_ws();
         let step = self.parse_expr()?;
         self.skip_ws();
-        if self.peek() != Some(')') {
-            if self.mode == ParserMode::Jq {
-                return self.rewind_to_wrong_arity_call(start_pos);
-            }
-            self.expect(')')?;
-            unreachable!();
+        if let Err(early) = self.expect_or_wrong_arity(')', start_pos) {
+            return early;
         }
         self.next();
 
@@ -2709,6 +2650,58 @@ impl<'a> Parser<'a> {
         self.parse_postfix(call)
     }
 
+    /// One shared definition of the 7-line argument-boundary checkpoint
+    /// hand-copied at ~15 sites (#2391) across the eight dedicated
+    /// special-form parsers that resolve a mismatch via
+    /// [`Self::rewind_to_wrong_arity_call`] (`parse_limit_expr`/
+    /// `parse_until_expr`/`parse_while_expr`/`parse_repeat_expr`/
+    /// `parse_first_expr`/`parse_last_expr`/`parse_range_expr`/
+    /// `parse_error_expr`): `if self.peek() != Some(expected) { if jq mode,
+    /// rewind and resolve as a (possibly shadowed) wrong-arity call;
+    /// otherwise raise `expect`'s own natural error }`.
+    ///
+    /// Returns `Ok(())` when the check passes -- the caller still owns its
+    /// own `self.next()` to actually consume `expected`, unchanged from
+    /// every site's original shape -- or `Err(result)` carrying exactly
+    /// what the caller should immediately `return`: `if let Err(early) =
+    /// self.expect_or_wrong_arity(expected, start_pos) { return early; }`.
+    fn expect_or_wrong_arity(
+        &mut self,
+        expected: char,
+        start_pos: usize,
+    ) -> Result<(), Result<Expr, ParseError>> {
+        if self.peek() == Some(expected) {
+            return Ok(());
+        }
+        if self.mode == ParserMode::Jq {
+            return Err(self.rewind_to_wrong_arity_call(start_pos));
+        }
+        Err(self.expect(expected).map(|()| unreachable!()))
+    }
+
+    /// [`Self::expect_or_wrong_arity`]'s sibling for the
+    /// `Result<Option<T>, ParseError>`-returning family instead
+    /// (`Self::parse_required_single_arg`, `env`'s own `env(VAR)` parsing,
+    /// #2391): a mismatch rewinds to `start_pos` and signals "not a match"
+    /// (`Ok(None)`) in jq mode, letting the caller's own shadow-candidate
+    /// fallback resolve it, rather than resolving the wrong-arity call
+    /// itself the way `expect_or_wrong_arity` does. yq mode raises
+    /// `expect`'s own natural error, same as its sibling.
+    fn expect_or_none<T>(
+        &mut self,
+        expected: char,
+        start_pos: usize,
+    ) -> Result<(), Result<Option<T>, ParseError>> {
+        if self.peek() == Some(expected) {
+            return Ok(());
+        }
+        if self.mode == ParserMode::Jq {
+            self.pos = start_pos;
+            return Err(Ok(None));
+        }
+        Err(self.expect(expected).map(|()| unreachable!()))
+    }
+
     /// Parse a format string: @text, @json, @uri, @dsv(delimiter), etc.
     fn parse_format_string(&mut self) -> Result<Expr, ParseError> {
         self.expect('@')?;
@@ -2911,25 +2904,18 @@ impl<'a> Parser<'a> {
     /// fix -- yq mode keeps the pre-#2237 raw ParseError unchanged.
     fn parse_required_single_arg(&mut self, start_pos: usize) -> Result<Option<Expr>, ParseError> {
         self.skip_ws();
-        if self.peek() != Some('(') {
-            if self.mode == ParserMode::Jq {
-                self.pos = start_pos;
-                return Ok(None);
-            }
-            // Not a rewind case (yq mode) -- `expect` raises the identical
-            // error the pre-#2237 unconditional `self.expect('(')?` did.
-            return self.expect('(').map(|()| unreachable!());
+        // #2391: `expect_or_none` -- yq mode's own not-a-rewind-case raises
+        // the identical error the pre-#2237 unconditional `self.expect('(')?`
+        // did, same as before this helper existed.
+        if let Err(early) = self.expect_or_none('(', start_pos) {
+            return early;
         }
         self.next();
         self.skip_ws();
         let arg = self.parse_expr()?;
         self.skip_ws();
-        if self.peek() != Some(')') {
-            if self.mode == ParserMode::Jq {
-                self.pos = start_pos;
-                return Ok(None);
-            }
-            return self.expect(')').map(|()| unreachable!());
+        if let Err(early) = self.expect_or_none(')', start_pos) {
+            return early;
         }
         self.next();
         Ok(Some(arg))
@@ -4262,12 +4248,10 @@ impl<'a> Parser<'a> {
                     }
                 };
                 self.skip_ws();
-                if self.peek() != Some(')') {
-                    if self.mode == ParserMode::Jq {
-                        self.pos = keyword_start;
-                        return Ok(None);
-                    }
-                    return self.expect(')').map(|()| unreachable!());
+                // #2391: expect_or_none -- same shared checkpoint
+                // `parse_required_single_arg` uses.
+                if let Err(early) = self.expect_or_none(')', keyword_start) {
+                    return early;
                 }
                 self.next();
                 return Ok(Some(Builtin::EnvObject(var_name)));

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -21107,6 +21107,9 @@ fn test_dedicated_parse_fn_wrong_arity_reports_not_defined_2237() -> Result<()> 
         ("repeat(1;2)", "repeat/2"),
         ("first(1;2)", "first/2"),
         ("last(1;2)", "last/2"),
+        // #2391: `error`'s own checkpoint (added later, by #2036 review
+        // round 2) was the one form this table never covered.
+        ("error(1;2)", "error/2"),
     ] {
         let (stdout, stderr, code) = run_jq_full(&["-nc", filter], None)?;
         assert_eq!(stdout, "", "{filter}: stderr {stderr:?}");

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -1517,6 +1517,35 @@ fn test_yq_mode_single_arg_builtin_wrong_arity_unaffected_by_2389() -> Result<()
     Ok(())
 }
 
+/// #2391 (review, patch-coverage gap): yq mode's own no-rewind branch,
+/// pinned for two sites the two tests above don't reach --
+/// `expect_or_wrong_arity`'s own yq-mode arm (never previously exercised
+/// for any of the eight dedicated special-form parsers in yq mode; `limit`
+/// stands in for all eight, which share the one definition) and `env`'s
+/// own hand-rolled second checkpoint (structurally identical to, but a
+/// distinct call site from, `parse_required_single_arg`'s own two sites
+/// the #2237/#2389 tests above already cover).
+#[test]
+fn test_yq_mode_wrong_arity_checkpoints_unaffected_by_2391() -> Result<()> {
+    let (out, stderr, code) =
+        run_yq_stdin_with_stderr("limit(1;2;3)", "a: 1\n", &["--jq-extensions"])?;
+    assert_eq!(out, "", "stderr: {stderr}");
+    assert!(
+        stderr.contains("parse error: parse error at position 9: expected ')', found ';'"),
+        "stderr: {stderr}"
+    );
+    assert_eq!(code, 1, "stderr: {stderr}");
+
+    let (out, stderr, code) = run_yq_stdin_with_stderr("env(FOO;BAR)", "a: 1\n", &[])?;
+    assert_eq!(out, "", "stderr: {stderr}");
+    assert!(
+        stderr.contains("parse error: parse error at position 7: expected ')', found ';'"),
+        "stderr: {stderr}"
+    );
+    assert_eq!(code, 1, "stderr: {stderr}");
+    Ok(())
+}
+
 /// #2225 (review): the read-mode fix reaches yq mode too, not just jq mode
 /// -- `stderr` fires twice, once per start value, confirming `end` is
 /// re-evaluated fresh per `s` through `eval_generic::eval_slice_expr`


### PR DESCRIPTION
## Summary

- `parse_limit_expr`/`parse_until_expr`/`parse_while_expr`/`parse_repeat_expr`/`parse_first_expr`/`parse_last_expr`/`parse_range_expr`/`parse_error_expr` each repeated the same 7-line argument-boundary checkpoint at every arg boundary (15 sites, one more than originally estimated — `parse_error_expr` gained a 15th copy via a later #2036 review commit, after this issue was filed).
- A related family (`parse_required_single_arg`'s 2 sites, `env`'s own hand-rolled duplicate) uses a structurally different `Ok(None)` shape instead of `rewind_to_wrong_arity_call`, needing its own helper.
- Adds `expect_or_wrong_arity` and `expect_or_none`, collapsing all 18 sites to one-liners.
- Also consolidates the two spellings of the propagate-an-unreachable-Ok-Result idiom the issue noted, as a side effect — both now live only inside these two helpers, in one form.
- No behavior change.

This is a high-risk area per the issue's own text: two real regressions previously surfaced from similar-looking-but-subtly-different code here during #2237 (an overly-broad checkpoint silently bypassing a sibling function's deliberate comma restriction, and the shared fallback's own fix breaking yq merge-flag scanning elsewhere). Both are confirmed unaffected by this diff — see test plan.

Fixes #2391

## Test plan

- [x] Every converted site's own wrong-arity, valid-arity, shadowing, and yq-mode (no-rewind) behavior re-verified live against jq 1.7.1 for all 8 forms (`limit`/`until`/`while`/`repeat`/`first`/`last`/`range`/`error`), plus `env(1)`/`env()`/`env(FOO)` and `has("a";"b")`
- [x] Confirmed the deliberately-untouched "inverse" site in `parse_limit_expr` (the narrowed comma-restriction check from PR #2387's own historical fix) really is a different pattern, not a missed conversion
- [x] Confirmed yq's merge-flag scanning (`*=+`/`*=?`/`*=n`, the second historical #2387 regression) is unaffected — the actual fix code is untouched by this diff, and its pinning test passes
- [x] Added one missing test row (`error(1;2)`'s own wrong-arity case — found by review as the one form no existing test covered outside its shadowing scenario)
- [x] `cargo build --features cli`
- [x] `cargo test --features cli,simd,regex,serde` — all 62 binaries pass, 0 failures
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings`
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features`
- [x] Independent code review verifying every one of the 18 converted call sites char-literal and position-variable by hand against the original inline code, given this area's history