### PR TITLE
fix(jq): --preserve-input no longer switches jq mode to yq's escape table

### DIFF
--- a/docs/reference/environment-variables.md
+++ b/docs/reference/environment-variables.md
@@ -169,8 +169,20 @@ SUCCINCTLY_EXPECT_SIMD=neon cargo test --test simd_expectation_tests            
 
 ### `SUCCINCTLY_PRESERVE_INPUT`
 
-Keeps the original formatting of numbers and escape sequences from the input, instead of normalizing
-them the way jq does (`4e4` → `4E+4`, `\b` → an escape sequence).
+Keeps the input's own number spelling (`4e4` stays `4e4` instead of jq's `4E+4`) and keeps every
+occurrence of a repeated object key instead of collapsing it to one field.
+
+It does **not** change which string-escape table is used: `succinctly jq` always writes jq's own
+(`\b`/`\f` short forms, DEL escaped as `\u007f`), with or without this variable. Until #2209 it
+silently switched the cursor-streaming path to *yq's* table (long `\u0008`/`\u000c` forms, DEL left
+raw), which diverged from real jq on plain navigation filters like `.a`; the escape table is a
+property of the mode you invoked, not of this variable.
+
+One nuance follows from "preserve" being literal on the compact path: with `-c`, an unmodified value
+is echoed straight from the source bytes, so its escape spelling survives exactly as written. Pretty
+output re-encodes through jq's table instead, so a source `\u0008` prints as `\b` there. Both agree
+with real jq wherever real jq has an opinion; they differ only on input spellings jq itself would
+have normalized.
 
 Accepts `1` or `true`, matched case-insensitively — so `TRUE` and `True` also work. Any other value,
 including `yes` and `0`, leaves the default alone. Equivalent to the `--preserve-input` flag; the flag

--- a/docs/reference/environment-variables.md
+++ b/docs/reference/environment-variables.md
@@ -172,17 +172,29 @@ SUCCINCTLY_EXPECT_SIMD=neon cargo test --test simd_expectation_tests            
 Keeps the input's own number spelling (`4e4` stays `4e4` instead of jq's `4E+4`) and keeps every
 occurrence of a repeated object key instead of collapsing it to one field.
 
-It does **not** change which string-escape table is used: `succinctly jq` always writes jq's own
-(`\b`/`\f` short forms, DEL escaped as `\u007f`), with or without this variable. Until #2209 it
-silently switched the cursor-streaming path to *yq's* table (long `\u0008`/`\u000c` forms, DEL left
-raw), which diverged from real jq on plain navigation filters like `.a`; the escape table is a
-property of the mode you invoked, not of this variable.
+It does **not** change which string-escape *table* is used: `succinctly jq` always writes jq's own
+(`\b`/`\f` short forms), with or without this variable. Until #2209 it silently switched the
+cursor-streaming path to *yq's* table (long `\u0008`/`\u000c` forms), which diverged from real jq
+on plain navigation filters like `.a`; the escape table is a property of the mode you invoked, not
+of this variable.
 
-One nuance follows from "preserve" being literal on the compact path: with `-c`, an unmodified value
-is echoed straight from the source bytes, so its escape spelling survives exactly as written. Pretty
-output re-encodes through jq's table instead, so a source `\u0008` prints as `\b` there. Both agree
-with real jq wherever real jq has an opinion; they differ only on input spellings jq itself would
-have normalized.
+It does still change escape *output* in one place, because "preserve" is literal on the compact
+path: with `-c`, an unmodified value is echoed straight from the source bytes, so whatever spelling
+the input used survives. Real jq would normalize it. On `{"a":"\u0008"}`:
+
+| command | output |
+|---------|--------|
+| `jq -c '.a'` | `"\b"` |
+| `succinctly jq -c '.a'` | `"\b"` |
+| `succinctly jq -c --preserve-input '.a'` | `"\u0008"` |
+| `succinctly jq --preserve-input '.a'` (pretty) | `"\b"` |
+
+That is this variable doing its job, not an escape-table choice — the compact path consults no
+table at all. Pretty output re-encodes, so it matches jq either way.
+
+Separately, and unrelated to this variable: a **raw** DEL byte present literally in the source is
+echoed through unescaped in every mode, where real jq prints `\u007f`. See
+[#2591](https://github.com/rust-works/succinctly/issues/2591).
 
 Accepts `1` or `true`, matched case-insensitively — so `TRUE` and `True` also work. Any other value,
 including `yes` and `0`, leaves the default alone. Equivalent to the `--preserve-input` flag; the flag

--- a/src/bin/succinctly/jq_runner.rs
+++ b/src/bin/succinctly/jq_runner.rs
@@ -1342,10 +1342,16 @@ pub fn run_jq(args: JqCommand) -> Result<i32> {
     // `output_config.jq_compat` already encodes the same
     // `--preserve-input`/`SUCCINCTLY_PRESERVE_INPUT=1` priority `JsonConvention`
     // needs (`OutputConfig::from_args`'s own doc comment).
+    // #2209: `JqPreserveInput`, never `Preserve` -- this is jq mode, and
+    // `Preserve` is yq's whole bundle, escape table included. Selecting it
+    // here made `--preserve-input` silently render strings through yq's
+    // table on the cursor-streaming path, a divergence from real jq that
+    // `--preserve-input` was never meant to cause (it is documented to
+    // affect number spelling and duplicate keys only).
     let json_numbers = if output_config.jq_compat {
         JsonConvention::JqCompat
     } else {
-        JsonConvention::Preserve
+        JsonConvention::JqPreserveInput
     };
 
     // Set up output writer

--- a/src/jq/document.rs
+++ b/src/jq/document.rs
@@ -85,16 +85,34 @@ impl IndentSpec {
 /// Which value-formatting convention JSON streaming should use (#1576).
 ///
 /// Covers finite number literals, control-character escaping, and
-/// duplicate object keys -- the three things `--preserve-input`/
-/// `jq_compat` toggles together (ADR-0018 rule 5), so one enum selects all
-/// three rather than three independent parameters that are never
-/// independently selectable in practice.
+/// duplicate object keys. One enum selects all three rather than three
+/// independent parameters, because a *mode* picks the whole bundle at
+/// once -- but the bundle is per-mode, not per-flag: `--preserve-input`
+/// moves jq mode between two of these variants without ever reaching
+/// yq's, since the escape table is a mode rule (ADR-0018) and
+/// `--preserve-input` is documented to affect numbers and duplicate keys
+/// only (#2209).
 ///
 /// - `Preserve`: echo the document's source number spelling verbatim
 ///   (`1e100` stays `1e100`), use yq's escape table (no `\b`/`\f` short
 ///   forms, DEL left raw), and keep every occurrence of a repeated object
 ///   key -- real yq's own convention (#1008), and the only one
 ///   `yq_runner.rs` ever selects, since yq has no `jq_compat` concept.
+///   Despite the name, this is *yq's* bundle -- jq mode never selects it,
+///   not even under `--preserve-input` (see `JqPreserveInput`).
+/// - `JqPreserveInput`: jq mode's `--preserve-input`/
+///   `SUCCINCTLY_PRESERVE_INPUT=1`. Echoes the source number spelling and
+///   keeps repeated object keys, exactly like `Preserve` -- but uses
+///   **jq's** escape table, like `JqCompat`. The escape table is a mode
+///   rule, and `--preserve-input` is documented (`docs/reference/
+///   environment-variables.md`) to preserve numbers and escape sequences,
+///   never to adopt the *other* tool's escape convention. Before #2209
+///   `jq_runner.rs` selected `Preserve` here, which silently rendered jq
+///   mode's strings through yq's table on the cursor-streaming path
+///   (the `\b` short form widened to its `\u0008` long form, and DEL
+///   left raw) while every other jq-mode writer
+///   kept jq's -- a divergence from real jq visible on any
+///   navigation-only filter (`.a`, `.`, `first(.a)`).
 /// - `JqCompat`: canonicalize number literals the way real jq's own reader
 ///   does (`format_number_jq_compat` -- strips a redundant leading zero,
 ///   canonicalizes exponent notation), use jq's escape table (`\b`/`\f`
@@ -106,11 +124,36 @@ impl IndentSpec {
 ///   `format_number_jq_compat`'s reformatting, both already used by the
 ///   jq CLI's non-streaming `print_json` path. `jq_runner.rs` selects this
 ///   unless `--preserve-input`/`SUCCINCTLY_PRESERVE_INPUT=1` is set, in
-///   which case it selects `Preserve` instead.
+///   which case it selects `JqPreserveInput` instead (#2209 -- never
+///   `Preserve`, which would cross into yq's escape table).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum JsonConvention {
     Preserve,
+    JqPreserveInput,
     JqCompat,
+}
+
+impl JsonConvention {
+    /// Whether number literals and repeated object keys are echoed from the
+    /// source rather than canonicalized/collapsed -- true for both of the
+    /// `--preserve-input`-shaped conventions, false only for `JqCompat`.
+    ///
+    /// Exists so the several sites that care about *that* axis alone don't
+    /// each have to spell out a two-variant pattern (and silently miss the
+    /// new variant the way a `== Preserve` check would, #2209).
+    #[must_use]
+    pub fn preserves_source_values(self) -> bool {
+        matches!(self, Self::Preserve | Self::JqPreserveInput)
+    }
+
+    /// Whether strings are escaped with jq's table (`\b`/`\f` short forms,
+    /// DEL escaped) rather than yq's. A *mode* rule, independent of
+    /// [`Self::preserves_source_values`] -- that independence is exactly
+    /// what #2209 fixed.
+    #[must_use]
+    pub fn uses_jq_escape_table(self) -> bool {
+        matches!(self, Self::JqCompat | Self::JqPreserveInput)
+    }
 }
 
 #[cfg(test)]

--- a/src/jq/stream.rs
+++ b/src/jq/stream.rs
@@ -361,9 +361,16 @@ pub fn stream_owned_value_json_jq<W: core::fmt::Write>(
 ///
 /// That pairing is exactly what `--preserve-input` is documented to mean —
 /// keep the document's own number spelling — without the escape-table
-/// change it was never meant to carry. Differs from
-/// [`stream_owned_value_json_jq_output`] in that one argument alone, and
-/// from [`stream_owned_value_json`] only in the escape table.
+/// change it was never meant to carry.
+///
+/// Differs from [`stream_owned_value_json_jq_output`] in the finite-literal
+/// formatter alone. Against [`stream_owned_value_json`] the escape table is
+/// the *headline* difference but not the only one: this also keeps jq's
+/// float display (`jq_bare_float_display`, so a computed `1.0 + 2.0` prints
+/// `3`) and jq's infinite-value rules, rather than yq's
+/// `format_float_with_fraction`. All three are jq-mode rules, which is the
+/// point — this is jq's convention with one axis relaxed, not yq's with one
+/// axis tightened.
 pub(crate) fn stream_owned_value_json_jq_preserve_input<W: core::fmt::Write>(
     value: &OwnedValue,
     out: &mut W,

--- a/src/jq/stream.rs
+++ b/src/jq/stream.rs
@@ -1798,6 +1798,50 @@ mod tests {
         assert_eq!(buf, "null");
     }
 
+    /// #2209: `JqPreserveInput` is jq mode under `--preserve-input` --
+    /// jq's escape table paired with the source number spelling. It is the
+    /// one convention neither pre-existing owned-value streamer could
+    /// express: `Preserve` carries yq's table, `JqCompat` canonicalizes
+    /// numbers.
+    ///
+    /// Covers `stream_owned_value_json_jq_preserve_input`, which no CLI
+    /// filter currently reaches -- every M2-eligible jq-mode filter that
+    /// produces an `OwnedValue` today falls back to the DOM path. It is
+    /// still live behind `GenericResult::stream_json`'s owned arms, which
+    /// forward whatever convention the runner selected, so the arm is
+    /// pinned here rather than left to a future filter to discover.
+    #[test]
+    fn test_stream_json_jq_preserve_input_pairs_jq_escapes_with_source_numbers_2209() {
+        // Number axis: the source spelling survives, as under `Preserve`,
+        // and is canonicalized only by `JqCompat`.
+        let literal = || OwnedValue::NumberLiteral(NumberRepr::Float(1.2e3), "1.2e3".into());
+        for (numbers, expected) in [
+            (JsonConvention::Preserve, "1.2e3"),
+            (JsonConvention::JqPreserveInput, "1.2e3"),
+            (JsonConvention::JqCompat, "1.2E+3"),
+        ] {
+            let mut buf = String::new();
+            literal()
+                .stream_json(&mut buf, IndentSpec::COMPACT, false, numbers)
+                .unwrap();
+            assert_eq!(buf, expected, "{numbers:?} number spelling");
+        }
+
+        // Escape axis: jq's table, unlike `Preserve`'s. U+0008 and DEL are
+        // two of the three code points the tables disagree on.
+        let s = || OwnedValue::String("\u{8}x\u{7f}".into());
+        for (numbers, expected) in [
+            (JsonConvention::JqCompat, "\"\\bx\\u007f\""),
+            (JsonConvention::JqPreserveInput, "\"\\bx\\u007f\""),
+            (JsonConvention::Preserve, "\"\\u0008x\u{7f}\""),
+        ] {
+            let mut buf = String::new();
+            s().stream_json(&mut buf, IndentSpec::COMPACT, false, numbers)
+                .unwrap();
+            assert_eq!(buf, expected, "{numbers:?} escape table");
+        }
+    }
+
     /// #930: unlike real output (above), jq's error-message value previews
     /// (`stream_owned_value_json_jq`, used by `describe()`/`dump_truncated()`
     /// in `src/jq/error.rs`) aren't constrained by RFC 8259 - jq's own

--- a/src/jq/stream.rs
+++ b/src/jq/stream.rs
@@ -199,6 +199,18 @@ impl StreamableValue for OwnedValue {
             JsonConvention::Preserve => {
                 stream_owned_value_json(self, out, 0, indent.width, indent.unit, sort_keys)
             }
+            // #2209: jq mode's `--preserve-input` keeps jq's escape table
+            // while still echoing source number spellings, so it can use
+            // neither of the two pre-existing streamers -- `Preserve`'s
+            // carries yq's table, `JqCompat`'s canonicalizes numbers.
+            JsonConvention::JqPreserveInput => stream_owned_value_json_jq_preserve_input(
+                self,
+                out,
+                0,
+                indent.width,
+                indent.unit,
+                sort_keys,
+            ),
             JsonConvention::JqCompat => stream_owned_value_json_jq_output(
                 self,
                 out,
@@ -339,6 +351,39 @@ pub fn stream_owned_value_json_jq<W: core::fmt::Write>(
         |negative| infinite_float_preview_text(negative).to_string(),
         preview_infinite_literal,
         format_number_jq_compat,
+    )
+}
+
+/// Stream an `OwnedValue` as JSON the way `jq --preserve-input` must
+/// (#2209): jq's escape table (`write_json_body_jq`, the mode's own rule),
+/// paired with `Preserve`'s verbatim finite-literal echo
+/// (`real_output_finite_literal`) instead of `format_number_jq_compat`.
+///
+/// That pairing is exactly what `--preserve-input` is documented to mean —
+/// keep the document's own number spelling — without the escape-table
+/// change it was never meant to carry. Differs from
+/// [`stream_owned_value_json_jq_output`] in that one argument alone, and
+/// from [`stream_owned_value_json`] only in the escape table.
+pub(crate) fn stream_owned_value_json_jq_preserve_input<W: core::fmt::Write>(
+    value: &OwnedValue,
+    out: &mut W,
+    current_indent: usize,
+    indent_spaces: usize,
+    unit: char,
+    sort_keys: bool,
+) -> core::fmt::Result {
+    stream_owned_value_json_with(
+        value,
+        out,
+        current_indent,
+        indent_spaces,
+        unit,
+        sort_keys,
+        write_json_body_jq,
+        jq_bare_float_display,
+        real_output_infinite_float,
+        real_output_infinite_literal,
+        real_output_finite_literal,
     )
 }
 

--- a/src/json/light.rs
+++ b/src/json/light.rs
@@ -2479,7 +2479,13 @@ impl<'a, W: AsRef<[u64]> + Clone> DocumentCursor for JsonCursor<'a, W> {
         sort_keys: bool,
         numbers: JsonConvention,
     ) -> StreamResult {
-        if indent.is_compact() && !sort_keys && numbers == JsonConvention::Preserve {
+        // #2209: `preserves_source_values`, not `== Preserve` -- jq mode's
+        // `--preserve-input` echoes the source span verbatim exactly as yq
+        // does (that is what "preserve" means on this path, and it predates
+        // #2209), so it must keep this fast path rather than falling into
+        // the re-encoding writer below and losing both the speed and the
+        // verbatim spelling.
+        if indent.is_compact() && !sort_keys && numbers.preserves_source_values() {
             if let Some(bytes) = self.raw_bytes() {
                 // SAFETY: JSON input is valid UTF-8 (checked during indexing)
                 let s = core::str::from_utf8(bytes).map_err(|_| core::fmt::Error)?;
@@ -3255,9 +3261,14 @@ fn write_json_string_pretty<Out: core::fmt::Write>(
     }
     let decoded = s.as_str().map_err(json_decode_failure)?;
     out.write_char('"')?;
-    match numbers {
-        JsonConvention::Preserve => write_json_body_yq(out, &decoded)?,
-        JsonConvention::JqCompat => write_json_body_jq(out, &decoded)?,
+    // #2209: keyed on the escape-table axis alone, never on
+    // `== Preserve`. jq mode's `--preserve-input` (`JqPreserveInput`)
+    // preserves numbers and duplicate keys but keeps *jq's* table --
+    // selecting yq's here was the divergence that issue fixed.
+    if numbers.uses_jq_escape_table() {
+        write_json_body_jq(out, &decoded)?;
+    } else {
+        write_json_body_yq(out, &decoded)?;
     }
     Ok(out.write_char('"')?)
 }
@@ -3292,7 +3303,10 @@ fn write_json_number<Out: core::fmt::Write>(
 ) -> core::fmt::Result {
     let raw = n.raw_bytes();
     match numbers {
-        JsonConvention::Preserve => {
+        // #2209: both source-preserving conventions echo the spelling
+        // verbatim -- they differ only in escape table, which is no
+        // concern of a number literal's.
+        JsonConvention::Preserve | JsonConvention::JqPreserveInput => {
             let text = core::str::from_utf8(raw).map_err(|_| core::fmt::Error)?;
             out.write_str(text)
         }
@@ -4274,10 +4288,18 @@ mod tests {
     // #1576 coverage: `write_json_string_pretty`'s escaping arms. The
     // zero-copy fast path only fires for a span with no `\`, so an escaped
     // string is what reaches the decode-and-re-encode tail -- and the arm
-    // taken there is `numbers`'s, not the output format's. `Preserve` is
-    // reachable from the CLI as `succinctly jq --preserve-input` with any
-    // non-compact/sorting output style (compact `Preserve` short-circuits
-    // to the raw echo in `stream_json` before this writer is reached).
+    // taken there is `numbers`'s, not the output format's.
+    //
+    // #2209 corrected this comment's original claim that `Preserve` is
+    // "reachable from the CLI as `succinctly jq --preserve-input`": it is
+    // not, and believing it was is what let jq mode render strings through
+    // yq's table. `Preserve` reaches this writer only from `yq_runner.rs`
+    // (yq mode, which always passes it); jq mode passes `JqCompat`, or
+    // `JqPreserveInput` under `--preserve-input`. `\t` below is one of the
+    // code points both tables agree on, so this test is blind to that
+    // distinction by construction -- see
+    // `test_stream_json_escape_table_is_mode_not_preserve_input_2209` for
+    // the three code points where they differ.
     #[test]
     fn test_stream_json_escaped_string_both_conventions_1576() {
         let json = br#"{"a": "x\ty"}"#;
@@ -4303,6 +4325,72 @@ mod tests {
         )
         .unwrap();
         assert_eq!(out, "{\n  \"a\": \"x\\ty\"\n}");
+    }
+
+    /// #2209: the escape table is a *mode* rule, not a `--preserve-input`
+    /// one. `JqPreserveInput` must agree with `JqCompat` and differ from
+    /// `Preserve` on exactly the three code points the two tables disagree
+    /// on (0x08, 0x0c, DEL) -- the set pinned by `jq::escape`'s own
+    /// `conventions_differ_at_exactly_three_code_points`. Before #2209 jq
+    /// mode's `--preserve-input` selected `Preserve` and so produced the yq
+    /// column here, diverging from real jq on any navigation-only filter.
+    #[test]
+    fn test_stream_json_escape_table_is_mode_not_preserve_input_2209() {
+        // The backslashes keep `write_json_string_pretty`'s zero-copy echo
+        // from firing, so the re-encoding tail (the arm under test) runs.
+        let json = br#"{"a": "\b\f\u007f"}"#;
+        let index = JsonIndex::build(json);
+        let render = |numbers| {
+            let mut out = String::new();
+            index
+                .root(json)
+                .stream_json(&mut out, IndentSpec::spaces(2), false, numbers)
+                .unwrap();
+            out
+        };
+
+        let jq = render(JsonConvention::JqCompat);
+        let preserve_input = render(JsonConvention::JqPreserveInput);
+        let yq = render(JsonConvention::Preserve);
+
+        // jq's table: short forms kept, DEL escaped.
+        assert!(jq.contains("\\b"), "jq lost the short form: {jq}");
+        assert!(jq.contains("\\f"), "jq lost the short form: {jq}");
+        assert!(jq.contains("\\u007f"), "jq left DEL raw: {jq}");
+        // yq's table: long forms only, DEL left raw.
+        assert!(yq.contains("\\u0008"), "yq table: {yq}");
+        assert!(yq.contains("\\u000c"), "yq table: {yq}");
+        assert!(yq.contains('\u{7f}'), "yq must leave DEL raw: {yq}");
+
+        assert_eq!(
+            preserve_input, jq,
+            "--preserve-input must keep jq mode's own escape table"
+        );
+        assert_ne!(
+            preserve_input, yq,
+            "--preserve-input must never adopt yq's escape table"
+        );
+    }
+
+    /// #2209: the fix must not cost `--preserve-input` its actual job.
+    /// Number spellings still survive verbatim under both preserving
+    /// conventions, and are canonicalized only by `JqCompat`.
+    #[test]
+    fn test_stream_json_preserve_input_still_preserves_numbers_2209() {
+        let json = br#"{"n": 1e100}"#;
+        let index = JsonIndex::build(json);
+        let render = |numbers| {
+            let mut out = String::new();
+            index
+                .root(json)
+                .stream_json(&mut out, IndentSpec::spaces(2), false, numbers)
+                .unwrap();
+            out
+        };
+
+        assert!(render(JsonConvention::Preserve).contains("1e100"));
+        assert!(render(JsonConvention::JqPreserveInput).contains("1e100"));
+        assert!(render(JsonConvention::JqCompat).contains("1E+100"));
     }
 
     // #1576 coverage: `stream_json_sequence`'s empty case. `map(...)` over

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -40085,28 +40085,42 @@ fn test_optional_head_is_walkable_2558() -> Result<()> {
 
 /// #2209: `--preserve-input` must not switch jq mode's string-escape
 /// convention. It is documented to preserve number spellings and duplicate
-/// keys; the escape table is a *mode* rule. Real jq 1.7.1 renders U+0008,
-/// U+000C and DEL as the short forms plus an escaped DEL (confirmed live
-/// against the pinned oracle) -- before this fix the pretty, non-`-c`
-/// cursor-streaming path rendered them through *yq's* table instead
+/// keys; the escape table is a *mode* rule. Before this fix the pretty,
+/// non-`-c` cursor-streaming path rendered strings through *yq's* table
 /// (long forms, DEL left raw) whenever `--preserve-input` was set.
+///
+/// The fixture spells the two short-form controls the **long** way on
+/// purpose. A fixture spelling them as jq itself would print is useless on
+/// the compact path, which echoes source bytes without consulting any
+/// escape table -- it would pass whatever the table did.
 #[test]
 fn test_preserve_input_keeps_jq_escape_table_2209() -> Result<()> {
-    let input = r#"{"a":"\b\f\u007f"}"#;
-    let expected = "\"\\b\\f\\u007f\"";
+    let input = r#"{"a":"\u0008\u000c"}"#;
+    // What real jq 1.7.1 prints for that value, verified live.
+    let jq_output = "\"\\b\\f\"";
 
-    // All four spellings of the same read must agree with real jq: the
-    // flag is orthogonal to the escape table, and so is `-c`.
-    for args in [
-        vec!["--preserve-input"],
-        vec![],
-        vec!["-c", "--preserve-input"],
-        vec!["-c"],
-    ] {
+    // Pretty is the path that regressed. It re-encodes, so it must use
+    // jq's table whether or not the flag is set.
+    for args in [vec!["--preserve-input"], vec![]] {
         let (out, code) = run_jq_stdin(".a", input, &args)?;
         assert_eq!(code, 0, "args={args:?}");
-        assert_eq!(out.trim_end(), expected, "args={args:?}");
+        assert_eq!(out.trim_end(), jq_output, "args={args:?}");
     }
+
+    // Compact without the flag re-encodes too, so it matches jq as well.
+    let (out, code) = run_jq_stdin(".a", input, &["-c"])?;
+    assert_eq!(code, 0);
+    assert_eq!(out.trim_end(), jq_output);
+
+    // Compact *with* the flag is the one place the two disagree, and it is
+    // not the escape table doing it: that path echoes the source span
+    // verbatim, so the long-form spelling survives. That is
+    // `--preserve-input` taking "preserve" literally, and it predates #2209.
+    // Pinned so the divergence stays deliberate rather than drifting back
+    // into an escape-table question. See #2591 for the related raw-DEL gap.
+    let (out, code) = run_jq_stdin(".a", input, &["-c", "--preserve-input"])?;
+    assert_eq!(code, 0);
+    assert_eq!(out.trim_end(), "\"\\u0008\\u000c\"");
 
     // The whole-document and generator shapes reach the same writer and
     // regressed identically, so pin them too.

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -40082,3 +40082,45 @@ fn test_optional_head_is_walkable_2558() -> Result<()> {
     }
     Ok(())
 }
+
+/// #2209: `--preserve-input` must not switch jq mode's string-escape
+/// convention. It is documented to preserve number spellings and duplicate
+/// keys; the escape table is a *mode* rule. Real jq 1.7.1 renders U+0008,
+/// U+000C and DEL as the short forms plus an escaped DEL (confirmed live
+/// against the pinned oracle) -- before this fix the pretty, non-`-c`
+/// cursor-streaming path rendered them through *yq's* table instead
+/// (long forms, DEL left raw) whenever `--preserve-input` was set.
+#[test]
+fn test_preserve_input_keeps_jq_escape_table_2209() -> Result<()> {
+    let input = r#"{"a":"\b\f\u007f"}"#;
+    let expected = "\"\\b\\f\\u007f\"";
+
+    // All four spellings of the same read must agree with real jq: the
+    // flag is orthogonal to the escape table, and so is `-c`.
+    for args in [
+        vec!["--preserve-input"],
+        vec![],
+        vec!["-c", "--preserve-input"],
+        vec!["-c"],
+    ] {
+        let (out, code) = run_jq_stdin(".a", input, &args)?;
+        assert_eq!(code, 0, "args={args:?}");
+        assert_eq!(out.trim_end(), expected, "args={args:?}");
+    }
+
+    // The whole-document and generator shapes reach the same writer and
+    // regressed identically, so pin them too.
+    for filter in [".", "first(.a)"] {
+        let (out, code) = run_jq_stdin(filter, input, &["--preserve-input"])?;
+        assert_eq!(code, 0, "filter={filter}");
+        assert!(
+            out.contains("\\b"),
+            "filter={filter} lost jq's short form: {out}"
+        );
+        assert!(
+            !out.contains("\\u0008"),
+            "filter={filter} used yq's escape table: {out}"
+        );
+    }
+    Ok(())
+}


### PR DESCRIPTION
## Summary

`succinctly jq --preserve-input` was rendering strings through **yq's**
escape table. The flag is documented to preserve number spelling and
duplicate object keys; it had no business touching string escapes.

The cause is that `jq_runner.rs` expressed it as `JsonConvention::Preserve`,
which is yq's *whole* convention bundle -- numbers, duplicate keys **and**
escape table. The escape table is a mode rule (ADR-0018), not a flag one, so
the two axes had to stop sharing a variant.

### Repro (pinned oracle, jq 1.7.1)

Document `{"a":"\b\f\u007f"}` -- the three code points the two tables
disagree on:

| | output |
|---|---|
| `jq '.a'` | `"\b\f\u007f"` |
| `succinctly jq --preserve-input '.a'` (before) | `"\u0008\u000c<raw DEL>"` |
| `succinctly jq --preserve-input '.a'` (after) | `"\b\f\u007f"` |

### Scope is narrower than the issue states

The issue describes this as affecting the M2 path broadly. It is confined to
the **pretty (non-`-c`) cursor-streaming** path, so it reproduced only on
navigation-only filters -- `.a`, `.`, `.["a"]`, `.a?`, `first(.a)`. Every other
jq-mode shape (`[.a]`, `{k:.a}`, `tostring`, `-c`, `-S`) already used jq's
table, which is what made the inconsistency invisible.

### Approach

Adds a third variant, `JsonConvention::JqPreserveInput` (source number
spellings and duplicate keys like `Preserve`, jq's escape table like
`JqCompat`), rather than splitting the enum into two independent axes.

The issue suggests threading a new parameter through `DocumentCursor::
stream_json` and its implementers, noting `JsonConvention` has "roughly 100
usage sites". It does -- but only **4 of the 91 `stream_json` call sites are
production**; the other 87 are tests. Threading a parameter would have buried
a 5-line semantic change under 87 lines of mechanical churn, which is exactly
the diff shape that hides regressions in review. The variant needs no call-
site changes and makes the compiler enumerate every real decision site.

Two decision sites compare with `==` and so are invisible to the compiler;
both were audited and correctly treat the new variant as source-preserving
(`is_falsy`'s malformed-number gate, and duplicate-key collapse).

### Things worth checking in review

- **yq mode is untouched.** `JsonCursor::stream_json` is reached from yq mode
  too (a macro in `yq_runner.rs` shared by both cursor types), so hardcoding
  jq's table there -- which a doc comment calling `JsonCursor` "jq's own JSON
  writer" invites -- would have regressed yq. `yq_runner.rs` still passes
  `Preserve` and its output is byte-identical.
- **`-c` is byte-identical.** The compact raw-echo fast path now gates on
  `preserves_source_values()` rather than `== Preserve`, so `--preserve-input`
  keeps both the fast path and its verbatim source echo.
- **`--preserve-input` still does its actual job** -- `1e100` stays `1e100`,
  duplicate keys are still kept. Pinned by a test.

Also corrects two comments that encoded the false premise behind the bug:
`JsonConvention`'s own claim that the three axes are "never independently
selectable in practice", and the #1576 test comment asserting `Preserve` is
reachable from the CLI as `succinctly jq --preserve-input` (it is not -- that
belief is what let jq mode adopt yq's table).

## Test plan

- [x] `cargo build --features cli`
- [x] `cargo test --features cli,simd,regex,serde` -- full suite, 0 failures,
      no pre-existing test changed behaviour
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings` (the leg where
      `--all-features` would hide the YAML SIMD backends)
- [x] `cargo fmt --all -- --check`
- [x] `RUSTDOCFLAGS=-D warnings cargo doc --no-deps` (new public methods)
- [x] `cargo check --no-default-features` (`no_std`)
- [x] Output diffed directly against pinned `jq` 1.7.1 and `yq` v4.53.3, not
      just golden fixtures

New tests: `test_stream_json_escape_table_is_mode_not_preserve_input_2209`,
`test_stream_json_preserve_input_still_preserves_numbers_2209`,
`test_preserve_input_keeps_jq_escape_table_2209`.

Fixes #2209
