### PR TITLE
test(jq): audit the post-loop tail with a walk-shaped rule (STYLE-0013-TAIL)

### DIFF
--- a/docs/STYLE_GUIDE.md
+++ b/docs/STYLE_GUIDE.md
@@ -611,6 +611,34 @@ child_tail_gap_ok(last_elem.as_ref(), b']')?;              // no container curso
 container_tail_gap_ok(cursor, last_elem.as_ref(), b']')?;  // container cursor in hand
 ```
 
+### The tail is a separate decision, with its own marker (#2404)
+
+A walk that validates its members must also validate its tail. That half is enforced
+separately, by `style_0013_tail_gap_is_routed_or_exempted`, and exempted separately with
+`// STYLE-0013-TAIL:` -- **a `// STYLE-0013:` marker does not exempt the tail.**
+
+The two are split because they fail independently and the tail half is the one that gets
+forgotten: #2349's fix hand-copied *both* halves, and it was the member half that got the
+attention. Five of the six walks the tail rule currently exempts already carried a member
+marker, so a shared marker would have let a decision nobody made stand in for one that
+matters.
+
+The tail rule asks nothing of a walk that does not validate members -- the unchecked
+`len`/`keys`/`collect_cursors` fast paths, `json::light`'s streaming writers and the
+YAML-only walks are all out of scope without needing a marker each. If your walk *does*
+check its children, end it in a tail helper:
+
+```rust
+tail_gap_ok(cursor, last.as_ref(), b'}')?;            // cursor or not, dispatches for you
+container_tail_gap_ok(c, last.as_ref(), b'}')?;       // holds a container cursor
+child_tail_gap_ok(last.as_ref(), b'}')?;              // children only
+```
+
+Prefer `container_tail_gap_ok`/`tail_gap_ok` when a container cursor is in scope:
+`child_tail_gap_ok` is documented as unable to see the zero-child `{,}`/`[,]` case, and
+hand-rolling its one-armed body inherits that blind spot -- which is exactly how #2594's
+live divergence survived #2211.
+
 A site that genuinely cannot route carries a `// STYLE-0013:` citation with a specific
 reason -- the same traceability STYLE-0004 requires of a lint suppression and STYLE-0012 of
 an unrouted materialization. "It is fine" is not a reason; name what the site needs that the

--- a/src/bin/succinctly/jq_runner.rs
+++ b/src/bin/succinctly/jq_runner.rs
@@ -5353,11 +5353,13 @@ fn standard_json_to_jq_value<'a, W: Clone + AsRef<[u64]>>(
     value: StandardJson<'a, W>,
     parent_cursor: &JsonCursor<'a, W>,
 ) -> Result<JqValue<'a, W>, EvalError> {
-    // STYLE-0013-TAIL: no tail helper is callable here -- this is the true
-    // top level, the one entry point with no cursor to give (the same
-    // documented gap `owned_from_standard_json_at_depth`'s own comment
-    // describes: there is nothing to reconstruct once nothing was ever
-    // passed). The resulting zero-child `{,}` acceptance is #2594.
+    // STYLE-0013-TAIL: `child_tail_gap_ok` is callable (both arms hold a
+    // child cursor) and would close the trailing-comma half. Only the
+    // zero-child half is genuinely blocked: that needs a *container* cursor,
+    // and this is the true top level -- the one entry point with none to
+    // give, the same documented gap `owned_from_standard_json_at_depth`'s
+    // own comment describes. Wiring in the callable half is a behaviour
+    // change; tracked with the rest in #2594.
     // STYLE-0013: `preceding_gap_ok` directly, not `key_delimiter_ok`/
     // `value_delimiter_ok` -- this is the CLI-crate lazy materializer, not
     // `DocumentFields`-generic, and its array/object arms below already
@@ -5905,11 +5907,13 @@ fn validate_json_delimiters<W: Clone + AsRef<[u64]>>(
     cursor: &JsonCursor<'_, W>,
     depth: usize,
 ) -> core::result::Result<(), EvalError> {
-    // STYLE-0013-TAIL: merges the empty-container and trailing-comma cases
-    // into one computed `gap_start` fed to `trailing_element_gap_ok`, rather
-    // than dispatching on `Option<last>` the way the helpers do -- so it
-    // cannot call one without restructuring the walk. The empty case is not
-    // actually covered by that merge; see #2594.
+    // STYLE-0013-TAIL: this walk does check both halves -- `gap_start` is
+    // `open_pos + 1` when no child was seen (`container_gap_ok`'s own body)
+    // and the last child's gap end otherwise -- but through
+    // `DocumentCursor::trailing_element_gap_ok(gap_start, ..)` with a
+    // pre-resolved position, which no `Option<last>`-dispatching helper in
+    // `TAIL_ROUTES` can express. Not a #2594 site: the empty case is
+    // covered here.
     // STYLE-0013: `preceding_gap_ok` directly, in both the array and
     // object arms below -- this is the CLI's own cold-path validator
     // (this function's own doc comment above explains why it exists
@@ -6113,11 +6117,13 @@ where
     Out: Write,
     Wrd: Clone + AsRef<[u64]>,
 {
-    // STYLE-0013-TAIL: same merged `gap_start` shape as
-    // `validate_json_delimiters` above, and the same #2594 gap. Whether this
-    // function's measured per-member perf rationale (#1643/#1676, cited in
-    // its `// STYLE-0013:` exemption) extends to the tail is a separate
-    // question -- the tail is one check per container, not per member.
+    // STYLE-0013-TAIL: same pre-resolved-position shape as
+    // `validate_json_delimiters` above -- an explicit `is_empty()` arm
+    // checking `trailing_element_gap_ok(open_pos + 1, ..)`, which is
+    // `container_gap_ok`'s body, and a `last_gap_end` arm for the rest. Both
+    // halves are covered, so this is not a #2594 site; it simply cannot
+    // route through a helper that dispatches on `Option<last>` instead of
+    // taking the gap position it already holds.
     // STYLE-0013: the object arm below calls `preceding_gap_ok` directly,
     // not `key_delimiter_ok`/`value_delimiter_ok` -- this is the streaming
     // writer's own single-walk validate-then-write pass (#1643), reusing

--- a/src/bin/succinctly/jq_runner.rs
+++ b/src/bin/succinctly/jq_runner.rs
@@ -5353,6 +5353,11 @@ fn standard_json_to_jq_value<'a, W: Clone + AsRef<[u64]>>(
     value: StandardJson<'a, W>,
     parent_cursor: &JsonCursor<'a, W>,
 ) -> Result<JqValue<'a, W>, EvalError> {
+    // STYLE-0013-TAIL: no tail helper is callable here -- this is the true
+    // top level, the one entry point with no cursor to give (the same
+    // documented gap `owned_from_standard_json_at_depth`'s own comment
+    // describes: there is nothing to reconstruct once nothing was ever
+    // passed). The resulting zero-child `{,}` acceptance is #2594.
     // STYLE-0013: `preceding_gap_ok` directly, not `key_delimiter_ok`/
     // `value_delimiter_ok` -- this is the CLI-crate lazy materializer, not
     // `DocumentFields`-generic, and its array/object arms below already
@@ -5900,6 +5905,11 @@ fn validate_json_delimiters<W: Clone + AsRef<[u64]>>(
     cursor: &JsonCursor<'_, W>,
     depth: usize,
 ) -> core::result::Result<(), EvalError> {
+    // STYLE-0013-TAIL: merges the empty-container and trailing-comma cases
+    // into one computed `gap_start` fed to `trailing_element_gap_ok`, rather
+    // than dispatching on `Option<last>` the way the helpers do -- so it
+    // cannot call one without restructuring the walk. The empty case is not
+    // actually covered by that merge; see #2594.
     // STYLE-0013: `preceding_gap_ok` directly, in both the array and
     // object arms below -- this is the CLI's own cold-path validator
     // (this function's own doc comment above explains why it exists
@@ -6103,6 +6113,11 @@ where
     Out: Write,
     Wrd: Clone + AsRef<[u64]>,
 {
+    // STYLE-0013-TAIL: same merged `gap_start` shape as
+    // `validate_json_delimiters` above, and the same #2594 gap. Whether this
+    // function's measured per-member perf rationale (#1643/#1676, cited in
+    // its `// STYLE-0013:` exemption) extends to the tail is a separate
+    // question -- the tail is one check per container, not per member.
     // STYLE-0013: the object arm below calls `preceding_gap_ok` directly,
     // not `key_delimiter_ok`/`value_delimiter_ok` -- this is the streaming
     // writer's own single-walk validate-then-write pass (#1643), reusing

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -314,12 +314,14 @@ pub fn to_owned<V: DocumentValue>(value: &V) -> Result<OwnedValue, EvalError> {
 /// `ends_unpaired` alone would be O(1), but it sees only a trailing orphan,
 /// never a bad key.
 fn malformed_object_member<F: DocumentFields>(fields: &F) -> Option<EvalError> {
-    // STYLE-0013-TAIL: a key-only walk (`uncons_key`) with neither a value
-    // cursor nor a container cursor, so none of the tail helpers is callable
-    // here -- they all take at least one. Its tail check is the
-    // `ends_unpaired()` below, which is the only one available at this
-    // resolution and catches a trailing orphan but not a zero-child `{,}`
-    // gap. That residue is #2594, reachable through `to_entries`.
+    // STYLE-0013-TAIL: `last_field_trailing_gap_ok` *is* callable here -- it
+    // takes exactly the `Option<key cursor>` this `uncons_key` walk yields,
+    // which is why it is in `TAIL_ROUTES` at all. It is not wired in because
+    // this walk does not track the last key cursor, and adding the check
+    // would newly reject documents this function accepts today: a behaviour
+    // change, not a refactor. The tail check it does make is
+    // `ends_unpaired()` below, which catches a trailing orphan but not a
+    // zero-child `{,}` gap. Tracked as #2594.
     let mut walk = fields.clone();
     let mut is_first = true;
     while let Some((key, cursor, rest)) = walk.uncons_key() {

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -314,6 +314,12 @@ pub fn to_owned<V: DocumentValue>(value: &V) -> Result<OwnedValue, EvalError> {
 /// `ends_unpaired` alone would be O(1), but it sees only a trailing orphan,
 /// never a bad key.
 fn malformed_object_member<F: DocumentFields>(fields: &F) -> Option<EvalError> {
+    // STYLE-0013-TAIL: a key-only walk (`uncons_key`) with neither a value
+    // cursor nor a container cursor, so none of the tail helpers is callable
+    // here -- they all take at least one. Its tail check is the
+    // `ends_unpaired()` below, which is the only one available at this
+    // resolution and catches a trailing orphan but not a zero-child `{,}`
+    // gap. That residue is #2594, reachable through `to_entries`.
     let mut walk = fields.clone();
     let mut is_first = true;
     while let Some((key, cursor, rest)) = walk.uncons_key() {

--- a/src/json/light.rs
+++ b/src/json/light.rs
@@ -1259,13 +1259,14 @@ impl<'a, W: AsRef<[u64]>> JsonFields<'a, W> {
     where
         W: Clone,
     {
-        // STYLE-0013-TAIL: hand-rolls `child_tail_gap_ok`'s single `Some(last)`
-        // arm rather than calling it, because this walk raises
-        // `malformed_json_text` (carrying the document text) where the helper
-        // raises `malformed_delimiter_error` -- swapping it changes the message
-        // on inputs that already error. It therefore also inherits that helper's
-        // documented blind spot: the zero-child `{,}` case, which only
-        // `container_tail_gap_ok`'s `None` arm sees. Tracked as #2594.
+        // STYLE-0013-TAIL: this is `child_tail_gap_ok`'s single `Some(last)` arm
+        // written out, and routing it there would be behaviour-preserving --
+        // `JsonCursor::malformed_delimiter_error()` *is*
+        // `EvalError::malformed_json_text(self.text)`, so the two raise the same
+        // value. It is left as-is because routing to that helper would fix
+        // nothing: it shares the blind spot this walk actually has, its `None`
+        // arm being `Ok(())`. What this needs is `container_tail_gap_ok`, whose
+        // `None` arm catches the zero-child `{,}` -- a behaviour change, #2594.
         let mut fields = *self;
         // (key's own text start, winning field, is this field the object's
         // first) -- same bookkeeping `find_cursor` keeps, needed so the
@@ -1371,8 +1372,9 @@ impl<'a, W: AsRef<[u64]>> JsonFields<'a, W> {
         W: Clone,
     {
         // STYLE-0013-TAIL: `find`'s cursor-returning twin, exempt for the same
-        // two reasons -- a different error value than the helper raises, and the
-        // same inherited zero-child `{,}` blind spot. Tracked as #2594.
+        // reason -- routing to `child_tail_gap_ok` is behaviour-preserving but
+        // pointless, and the `container_tail_gap_ok` that would actually close
+        // the zero-child `{,}` case changes behaviour. Tracked as #2594.
         let mut fields = *self;
         // (key's own text start, value cursor, is this field the object's
         // first) for the winning candidate seen so far.

--- a/src/json/light.rs
+++ b/src/json/light.rs
@@ -1259,6 +1259,13 @@ impl<'a, W: AsRef<[u64]>> JsonFields<'a, W> {
     where
         W: Clone,
     {
+        // STYLE-0013-TAIL: hand-rolls `child_tail_gap_ok`'s single `Some(last)`
+        // arm rather than calling it, because this walk raises
+        // `malformed_json_text` (carrying the document text) where the helper
+        // raises `malformed_delimiter_error` -- swapping it changes the message
+        // on inputs that already error. It therefore also inherits that helper's
+        // documented blind spot: the zero-child `{,}` case, which only
+        // `container_tail_gap_ok`'s `None` arm sees. Tracked as #2594.
         let mut fields = *self;
         // (key's own text start, winning field, is this field the object's
         // first) -- same bookkeeping `find_cursor` keeps, needed so the
@@ -1363,6 +1370,9 @@ impl<'a, W: AsRef<[u64]>> JsonFields<'a, W> {
     where
         W: Clone,
     {
+        // STYLE-0013-TAIL: `find`'s cursor-returning twin, exempt for the same
+        // two reasons -- a different error value than the helper raises, and the
+        // same inherited zero-child `{,}` blind spot. Tracked as #2594.
         let mut fields = *self;
         // (key's own text start, value cursor, is this field the object's
         // first) for the winning candidate seen so far.

--- a/tests/jq_member_validation_audit.rs
+++ b/tests/jq_member_validation_audit.rs
@@ -39,21 +39,41 @@
 //! Same answer, same shape as `jq_optional_suppression_audit.rs` (STYLE-0012,
 //! #2334), which this file is modelled on.
 //!
-//! # What it does not do
+//! # The second rule: the post-loop tail (#2404)
 //!
-//! It audits the **member** primitives only -- the pair `checked_key` and
-//! `delimiters_ok` own. It deliberately does not audit the post-loop tail
-//! (`container_gap_ok`, `trailing_element_gap_ok`), even though #2211 and
-//! #2243 drifted there too: those have many legitimate direct callers
-//! outside the walk shape (`json::light`'s streaming writers, `document.rs`'s
-//! key-only walks, the tail helpers themselves), so a name-based rule would
-//! be mostly noise and would train readers to add the marker reflexively.
-//! Auditing that half wants a rule shaped around *the walk* -- "a loop that
-//! unconses children must end in a tail helper" -- which is a different and
-//! larger piece of analysis than this file does.
+//! This file now carries two rules. The member rule above fires on a *call*
+//! -- a primitive reached for directly. The tail rule
+//! (`style_0013_tail_gap_is_routed_or_exempted`) fires on an *absence*: a
+//! walk that validated every member and then never checked its tail.
 //!
-//! It also does not decide whether a site *should* route. It only demands
-//! that somebody decided and wrote the reason down.
+//! A second rule was needed because the first cannot express that. #2211
+//! (`{,}`/`[,]` never checked) and #2243 (`{"a":1,}` accepted) were walks
+//! with no offending call anywhere in them -- nothing for a callee-keyed
+//! scan to catch -- and #2349 was the wrong answer that drift produced.
+//!
+//! The obvious formulation, auditing `container_gap_ok`/
+//! `trailing_element_gap_ok` by name, was rejected while writing #1803 and
+//! is still the wrong shape: those have many legitimate direct callers
+//! outside any walk (`json::light`'s streaming writers, the unchecked
+//! `len`/`keys`/`collect_cursors` fast paths, the tail helpers themselves),
+//! so it would be mostly noise and would train readers to add the marker
+//! reflexively.
+//!
+//! Keying on *the walk* avoids that. The gate is "does this function loop
+//! over a document's children (`WALK_METHODS`) **and** validate them
+//! (`MEMBER_VALIDATION`)?", and only such a function is asked to account for
+//! its tail. Everything named above falls outside it without an exemption,
+//! because none of them validates members -- the rule asks nothing of a walk
+//! that never decided to check its children in the first place.
+//!
+//! The tail marker is `// STYLE-0013-TAIL:`, deliberately not the member
+//! one. See [`TAIL_EXEMPT_MARKER`] for why sharing it would have made the
+//! rule vacuous on arrival.
+//!
+//! # What neither rule does
+//!
+//! Neither decides whether a site *should* route. They only demand that
+//! somebody decided and wrote the reason down.
 
 use proc_macro2::Span;
 use syn::spanned::Spanned as _;
@@ -116,9 +136,83 @@ const AUDITED: &[&str] = &[
     "preceding_gap_ok",
 ];
 
+/// The helpers `checked_key`/`delimiters_ok` own, plus the primitives
+/// themselves: calling any of these is what makes a function a *member-
+/// validating* walk, and so what puts it in scope for the tail rule below.
+///
+/// Deliberately wider than [`AUDITED`], which lists only the primitives a
+/// call site must not reach for directly. A walk that routes properly
+/// through `checked_key`/`delimiters_ok` is invisible to the member rule --
+/// and it is exactly as obliged to check its tail as one that does not.
+const MEMBER_VALIDATION: &[&str] = &[
+    "checked_key",
+    "delimiters_ok",
+    "resolve_display_key",
+    "key_delimiter_ok",
+    "value_delimiter_ok",
+    "preceding_delimiter_ok",
+    "preceding_gap_ok",
+];
+
+/// The tail helpers a member-validating walk may end in.
+///
+/// `last_field_trailing_gap_ok` is here for the key-only walks (`census`,
+/// `checked_len`) that never hold a value cursor to hand a general helper.
+const TAIL_ROUTES: &[&str] = &[
+    "child_tail_gap_ok",
+    "container_tail_gap_ok",
+    "tail_gap_ok",
+    "last_field_trailing_gap_ok",
+];
+
+/// The low-level tail primitives the helpers in [`TAIL_ROUTES`] own.
+///
+/// Listed only to keep a definition out of its own audit -- a call to one is
+/// not itself a violation. What the tail rule checks is the *absence* of a
+/// [`TAIL_ROUTES`] call, which catches hand-rolling one of these and
+/// omitting the tail entirely as the same finding, because they are the same
+/// bug: #2211 and #2243 were omissions, #2409's six copies were hand-rolls,
+/// and both shipped the same wrong answer.
+const TAIL_PRIMITIVES: &[&str] = &[
+    "trailing_element_gap_ok",
+    "container_gap_ok",
+    "trailing_gap_ok",
+    "empty_container_gap_ok",
+    "element_gap_ok",
+    "element_gap_ok_at",
+];
+
+/// Method names whose call in a loop head means "this loop unconses a
+/// document's children one at a time" -- the walk shape the tail rule keys
+/// on.
+///
+/// `uncons`/`uncons_cursor`/`uncons_key` are the three cursor-domain
+/// spellings; `children`/`cursor_iter` are the two iterator-domain ones.
+/// A `for x in <already-materialized Vec>` loop is deliberately *not* a walk
+/// here: its members were validated wherever that `Vec` was built, and the
+/// tail with them.
+const WALK_METHODS: &[&str] = &[
+    "uncons",
+    "uncons_cursor",
+    "uncons_key",
+    "children",
+    "cursor_iter",
+];
+
 /// The STYLE-0013 exemption marker, cited inline the way STYLE-0004's
 /// `#[allow]` citations and STYLE-0012's routing exemptions already are.
 const EXEMPT_MARKER: &str = "STYLE-0013:";
+
+/// The tail rule's own marker, deliberately *not* [`EXEMPT_MARKER`].
+///
+/// Sharing one marker would have made this rule vacuous on the day it
+/// landed: five of the six walks it currently finds already carry a
+/// `// STYLE-0013:` exemption for their member half, so a shared marker
+/// would have let the member decision silently stand in for a tail decision
+/// nobody made. That substitution is precisely the drift being audited --
+/// #2349's fix hand-copied *both* halves, and the member half is the one
+/// that got the attention.
+const TAIL_EXEMPT_MARKER: &str = "STYLE-0013-TAIL:";
 
 /// Lower bounds proving the scan actually looked at something.
 ///
@@ -153,6 +247,16 @@ struct Frame {
     /// that -- see `test_marker_does_not_leak_across_function_boundaries`.
     body_start: usize,
     body_end: usize,
+    /// Set when a loop in this function heads on one of [`WALK_METHODS`].
+    walks_children: bool,
+    /// Set when this function validates members at all (see
+    /// [`MEMBER_VALIDATION`]) -- routed or hand-rolled, both count.
+    validates_members: bool,
+    /// Set when this function ends its walk in one of [`TAIL_ROUTES`].
+    routes_tail: bool,
+    /// Line of the first walk loop, for the violation report -- the loop is
+    /// the thing missing a tail, so it is the useful place to point.
+    walk_line: usize,
 }
 
 struct Audit<'a> {
@@ -163,6 +267,10 @@ struct Audit<'a> {
     stack: Vec<Frame>,
     sites_examined: usize,
     violations: Vec<Site>,
+    /// Member-validating walks seen, whether or not they routed -- the tail
+    /// rule's own anti-vacuity counter.
+    walks_examined: usize,
+    tail_violations: Vec<Site>,
 }
 
 /// Whether a `// STYLE-0013:` marker appears anywhere inside this function's
@@ -221,6 +329,54 @@ fn line_of(span: Span) -> usize {
     span.start().line
 }
 
+/// Whether one line *is* a STYLE-0013-TAIL citation.
+///
+/// Same open-the-comment rule as [`is_marker_line`], and load-bearing for
+/// the same reason -- with the extra wrinkle that `// STYLE-0013:` is a
+/// prefix of nothing here: the two markers are checked independently, so a
+/// member exemption never reads as a tail one.
+fn is_tail_marker_line(line: &str) -> bool {
+    let t = line.trim_start();
+    let Some(rest) = t.strip_prefix("//") else {
+        return false;
+    };
+    rest.trim_start().starts_with(TAIL_EXEMPT_MARKER)
+}
+
+/// Whether a `// STYLE-0013-TAIL:` marker appears inside this function's own
+/// body. Clipped to the frame exactly as [`marker_in_body`] is.
+fn tail_marker_in_body(lines: &[&str], frame: &Frame) -> bool {
+    let lo = frame.body_start.saturating_sub(1);
+    let hi = frame.body_end.min(lines.len());
+    lines[lo..hi].iter().any(|l| is_tail_marker_line(l))
+}
+
+/// Whether an expression subtree contains a call to one of
+/// [`WALK_METHODS`], used on a loop's head to decide "is this a walk?".
+///
+/// Scans the whole head rather than matching one shape, because the same
+/// walk is spelled several ways across the audited files --
+/// `while let Some((f, rest)) = fields.uncons()`,
+/// `while let Some((c, next)) = elems.uncons_cursor()`,
+/// `for child in cursor.children()`. A subtree scan covers all of them
+/// without enumerating each.
+fn contains_walk_call(expr: &syn::Expr) -> bool {
+    struct Finder(bool);
+    impl<'ast> Visit<'ast> for Finder {
+        fn visit_expr(&mut self, node: &'ast syn::Expr) {
+            if let Some(name) = callee_name(node) {
+                if WALK_METHODS.contains(&name.as_str()) {
+                    self.0 = true;
+                }
+            }
+            visit::visit_expr(self, node);
+        }
+    }
+    let mut f = Finder(false);
+    f.visit_expr(expr);
+    f.0
+}
+
 impl<'a> Audit<'a> {
     fn new(file: &'static str, src: &'a str) -> Self {
         Self {
@@ -229,6 +385,8 @@ impl<'a> Audit<'a> {
             stack: Vec::new(),
             sites_examined: 0,
             violations: Vec::new(),
+            walks_examined: 0,
+            tail_violations: Vec::new(),
         }
     }
 
@@ -237,7 +395,69 @@ impl<'a> Audit<'a> {
             name,
             body_start: body.start().line,
             body_end: body.end().line,
+            walks_children: false,
+            validates_members: false,
+            routes_tail: false,
+            walk_line: 0,
         });
+    }
+
+    /// Evaluate the tail rule as the frame is popped.
+    ///
+    /// Deferred to the pop rather than checked at a call, because the
+    /// question is about the function as a whole: the tail call necessarily
+    /// comes *after* the loop, so at no single call site is the answer
+    /// known yet.
+    fn leave(&mut self) {
+        let Some(frame) = self.stack.pop() else {
+            return;
+        };
+        // A definition of one of the primitives or helpers is not a walk
+        // that owes a tail check -- it is the thing the walk routes through.
+        if MEMBER_VALIDATION.contains(&frame.name.as_str())
+            || TAIL_ROUTES.contains(&frame.name.as_str())
+            || TAIL_PRIMITIVES.contains(&frame.name.as_str())
+        {
+            return;
+        }
+        if !(frame.walks_children && frame.validates_members) {
+            return;
+        }
+        self.walks_examined += 1;
+        if frame.routes_tail || tail_marker_in_body(&self.lines, &frame) {
+            return;
+        }
+        self.tail_violations.push(Site {
+            file: self.file,
+            line: frame.walk_line,
+            func: frame.name.clone(),
+            callee: "<no tail helper after this walk>".to_string(),
+        });
+    }
+
+    /// Record what this expression tells us about the innermost frame.
+    fn note_expr(&mut self, expr: &syn::Expr) {
+        let is_walk_head = match expr {
+            syn::Expr::While(w) => contains_walk_call(&w.cond),
+            syn::Expr::ForLoop(f) => contains_walk_call(&f.expr),
+            _ => false,
+        };
+        let callee = callee_name(expr);
+        let Some(frame) = self.stack.last_mut() else {
+            return;
+        };
+        if is_walk_head && !frame.walks_children {
+            frame.walks_children = true;
+            frame.walk_line = line_of(expr.span());
+        }
+        if let Some(name) = callee {
+            if MEMBER_VALIDATION.contains(&name.as_str()) {
+                frame.validates_members = true;
+            }
+            if TAIL_ROUTES.contains(&name.as_str()) {
+                frame.routes_tail = true;
+            }
+        }
     }
 
     fn check_call(&mut self, expr: &syn::Expr) {
@@ -271,20 +491,20 @@ impl<'ast> Visit<'ast> for Audit<'_> {
     fn visit_item_fn(&mut self, node: &'ast syn::ItemFn) {
         self.enter(node.sig.ident.to_string(), node.block.span());
         visit::visit_item_fn(self, node);
-        self.stack.pop();
+        self.leave();
     }
 
     fn visit_impl_item_fn(&mut self, node: &'ast syn::ImplItemFn) {
         self.enter(node.sig.ident.to_string(), node.block.span());
         visit::visit_impl_item_fn(self, node);
-        self.stack.pop();
+        self.leave();
     }
 
     fn visit_trait_item_fn(&mut self, node: &'ast syn::TraitItemFn) {
         if let Some(block) = &node.default {
             self.enter(node.sig.ident.to_string(), block.span());
             visit::visit_trait_item_fn(self, node);
-            self.stack.pop();
+            self.leave();
         } else {
             visit::visit_trait_item_fn(self, node);
         }
@@ -292,24 +512,45 @@ impl<'ast> Visit<'ast> for Audit<'_> {
 
     fn visit_expr(&mut self, node: &'ast syn::Expr) {
         self.check_call(node);
+        self.note_expr(node);
         visit::visit_expr(self, node);
     }
 }
 
-fn run_audit() -> (Vec<Site>, usize, usize) {
-    let mut violations = Vec::new();
-    let mut examined = 0usize;
-    let mut files = 0usize;
+/// Everything one pass over `SOURCES` produces, for both rules.
+struct AuditReport {
+    violations: Vec<Site>,
+    examined: usize,
+    files: usize,
+    tail_violations: Vec<Site>,
+    walks_examined: usize,
+}
+
+fn run_audit_full() -> AuditReport {
+    let mut r = AuditReport {
+        violations: Vec::new(),
+        examined: 0,
+        files: 0,
+        tail_violations: Vec::new(),
+        walks_examined: 0,
+    };
     for (path, src) in SOURCES {
         let parsed = syn::parse_file(src)
             .unwrap_or_else(|e| panic!("STYLE-0013 audit could not parse {path}: {e}"));
         let mut audit = Audit::new(path, src);
         audit.visit_file(&parsed);
-        examined += audit.sites_examined;
-        violations.extend(audit.violations);
-        files += 1;
+        r.examined += audit.sites_examined;
+        r.violations.extend(audit.violations);
+        r.walks_examined += audit.walks_examined;
+        r.tail_violations.extend(audit.tail_violations);
+        r.files += 1;
     }
-    (violations, examined, files)
+    r
+}
+
+fn run_audit() -> (Vec<Site>, usize, usize) {
+    let r = run_audit_full();
+    (r.violations, r.examined, r.files)
 }
 
 #[test]
@@ -521,4 +762,250 @@ fn test_audit_catches_the_method_call_spelling() {
     audit.visit_file(&parsed);
     assert_eq!(audit.violations.len(), 1);
     assert_eq!(audit.violations[0].callee, "preceding_delimiter_ok");
+}
+
+/// Lower bound proving the tail scan is not vacuous.
+///
+/// Today it sees 14 member-validating walks across `SOURCES` (counted by
+/// instrumenting `run_audit_full`, not by hand). Same rule as
+/// `MIN_SITES_EXAMINED`: if a real refactor lowers the count past this, move
+/// the floor *and* say in the commit message what shrank.
+const MIN_WALKS_EXAMINED: usize = 10;
+
+/// STYLE-0013's second half (#2404): a walk that validates its members must
+/// also validate its tail.
+///
+/// The member rule above cannot express this. It fires on a *call*, and the
+/// bug here is an *absence* -- #2211 (`{,}`/`[,]` never checked) and #2243
+/// (`{"a":1,}` accepted) were both walks that validated every member and
+/// then simply stopped, with no call anywhere for a callee-keyed rule to
+/// catch. #2349 was the wrong answer that drift finally produced.
+///
+/// Keyed on the walk, which is what makes it low-noise where a name-based
+/// rule on `container_gap_ok`/`trailing_element_gap_ok` would not be: the
+/// streaming writers in `json::light`, the unchecked `len`/`keys`/
+/// `collect_cursors` fast paths, and the YAML-only walks all fall outside
+/// it without needing an exemption each, because none of them validates
+/// members. Only a walk that already decided to check its children is asked
+/// to account for its tail.
+#[test]
+fn style_0013_tail_gap_is_routed_or_exempted() {
+    let r = run_audit_full();
+
+    assert!(
+        r.walks_examined >= MIN_WALKS_EXAMINED,
+        "STYLE-0013 tail audit examined only {} member-validating walks, expected at least \
+         {MIN_WALKS_EXAMINED}. A vacuous scan passes green: check that `WALK_METHODS` and \
+         `MEMBER_VALIDATION` still match the code before lowering this floor.",
+        r.walks_examined
+    );
+
+    if !r.tail_violations.is_empty() {
+        let mut report = String::new();
+        for v in &r.tail_violations {
+            report.push_str(&format!("\n  {}:{} in `{}`", v.file, v.line, v.func));
+        }
+        panic!(
+            "STYLE-0013 tail violation: {} walk(s) validate their members but never reach a \
+             tail helper, and carry no `// STYLE-0013-TAIL:` exemption:{}\n\n\
+             A walk that checks every member and skips the tail accepts `{{,}}`, `[,]` and \
+             `{{\"a\":1,}}` -- see #2211/#2243/#2349. Fix by either (a) ending the walk in \
+             `tail_gap_ok` (holds a container cursor or not), `container_tail_gap_ok` (holds \
+             one; also catches the zero-child `{{,}}` case) or `child_tail_gap_ok` (children \
+             only), or (b) writing `// STYLE-0013-TAIL: <why this walk needs no tail check, \
+             or cannot use the helper>` inside the function. Note this marker is separate \
+             from `// STYLE-0013:` on purpose -- a member exemption is not a tail decision. \
+             See docs/STYLE_GUIDE.md.",
+            r.tail_violations.len(),
+            report
+        );
+    }
+}
+
+/// The tail rule fires on a member-validating walk that never reaches a
+/// tail helper -- the #2211/#2243 shape, where every member is checked and
+/// the loop simply ends.
+#[test]
+fn test_tail_audit_fires_on_a_walk_with_no_tail_check_2404() {
+    let src = r"
+        fn walks_an_object<F: DocumentFields>(fields: &F) -> Result<(), EvalError> {
+            let mut f = fields.clone();
+            while let Some((field, rest)) = f.uncons() {
+                field.delimiters_ok(&cursor)?;
+                f = rest;
+            }
+            Ok(())
+        }
+    ";
+    let parsed = syn::parse_file(src).expect("fixture parses");
+    let mut audit = Audit::new("fixture.rs", src);
+    audit.visit_file(&parsed);
+    assert_eq!(audit.walks_examined, 1, "the walk must be examined");
+    assert_eq!(audit.tail_violations.len(), 1);
+    assert_eq!(audit.tail_violations[0].func, "walks_an_object");
+}
+
+/// Ending the same walk in a tail helper clears it, with no marker needed.
+/// This is the path the rule wants people to take, so it must actually work.
+#[test]
+fn test_tail_audit_accepts_a_walk_routed_through_a_helper_2404() {
+    let src = r"
+        fn walks_an_object<F: DocumentFields>(fields: &F) -> Result<(), EvalError> {
+            let mut f = fields.clone();
+            let mut last = None;
+            while let Some((field, rest)) = f.uncons() {
+                field.delimiters_ok(&cursor)?;
+                last = Some(field.value_cursor);
+                f = rest;
+            }
+            container_tail_gap_ok(&c, last.as_ref(), b'}')?;
+            Ok(())
+        }
+    ";
+    let parsed = syn::parse_file(src).expect("fixture parses");
+    let mut audit = Audit::new("fixture.rs", src);
+    audit.visit_file(&parsed);
+    assert_eq!(audit.walks_examined, 1);
+    assert!(
+        audit.tail_violations.is_empty(),
+        "a walk routed through a tail helper must pass"
+    );
+}
+
+/// The tail marker is the documented escape hatch, so it has to work.
+#[test]
+fn test_tail_audit_accepts_a_tail_marked_walk_2404() {
+    let src = r"
+        fn walks_an_object<F: DocumentFields>(fields: &F) -> Result<(), EvalError> {
+            // STYLE-0013-TAIL: key-only walk, no cursor to hand a helper.
+            let mut f = fields.clone();
+            while let Some((field, rest)) = f.uncons() {
+                field.delimiters_ok(&cursor)?;
+                f = rest;
+            }
+            Ok(())
+        }
+    ";
+    let parsed = syn::parse_file(src).expect("fixture parses");
+    let mut audit = Audit::new("fixture.rs", src);
+    audit.visit_file(&parsed);
+    assert!(audit.tail_violations.is_empty());
+}
+
+/// **The reason the two markers are separate.**
+///
+/// A `// STYLE-0013:` exemption answers "why this walk reaches for the
+/// primitive directly". It says nothing about the tail, and must not be
+/// allowed to stand in for a tail decision -- five of the six walks this
+/// rule currently finds already carry one, so sharing a marker would have
+/// made the rule vacuous on the day it landed.
+#[test]
+fn test_member_marker_does_not_exempt_the_tail_2404() {
+    let src = r"
+        fn walks_an_object<F: DocumentFields>(fields: &F) -> Result<(), EvalError> {
+            // STYLE-0013: key-only walk, no value resolved to check a `:` against.
+            let mut f = fields.clone();
+            while let Some((field, rest)) = f.uncons() {
+                if !key_delimiter_ok::<F>(&field.key, &cursor, is_first) {
+                    return Err(f.malformed_member_error());
+                }
+                f = rest;
+            }
+            Ok(())
+        }
+    ";
+    let parsed = syn::parse_file(src).expect("fixture parses");
+    let mut audit = Audit::new("fixture.rs", src);
+    audit.visit_file(&parsed);
+    assert!(
+        audit.violations.is_empty(),
+        "the member half is exempted by its own marker"
+    );
+    assert_eq!(
+        audit.tail_violations.len(),
+        1,
+        "but the tail half is still unanswered"
+    );
+}
+
+/// A walk that does not validate members is out of scope entirely -- no
+/// marker required. This is what keeps the rule low-noise where a rule keyed
+/// on `container_gap_ok`/`trailing_element_gap_ok` by name would not be: the
+/// unchecked `len`/`keys`/`collect_cursors` fast paths and the YAML-only
+/// walks all land here.
+#[test]
+fn test_tail_audit_ignores_a_walk_that_validates_nothing_2404() {
+    let src = r"
+        fn counts<F: DocumentFields>(fields: &F) -> usize {
+            let mut f = fields.clone();
+            let mut n = 0;
+            while let Some((_field, rest)) = f.uncons() {
+                n += 1;
+                f = rest;
+            }
+            n
+        }
+    ";
+    let parsed = syn::parse_file(src).expect("fixture parses");
+    let mut audit = Audit::new("fixture.rs", src);
+    audit.visit_file(&parsed);
+    assert_eq!(audit.walks_examined, 0);
+    assert!(audit.tail_violations.is_empty());
+}
+
+/// A loop over an already-materialized collection is not a walk: its members
+/// were validated wherever that collection was built, and its tail with
+/// them. Pinned so the loop test stays keyed on the uncons/children shape
+/// rather than on "contains a loop".
+#[test]
+fn test_tail_audit_ignores_a_loop_over_a_materialized_vec_2404() {
+    let src = r"
+        fn over_a_vec(items: Vec<Field>) -> Result<(), EvalError> {
+            for field in items {
+                field.delimiters_ok(&cursor)?;
+            }
+            Ok(())
+        }
+    ";
+    let parsed = syn::parse_file(src).expect("fixture parses");
+    let mut audit = Audit::new("fixture.rs", src);
+    audit.visit_file(&parsed);
+    assert_eq!(
+        audit.walks_examined, 0,
+        "a `for x in vec` loop is not a child walk"
+    );
+    assert!(audit.tail_violations.is_empty());
+}
+
+/// A tail marker in one function must not excuse the next, exactly as the
+/// member marker must not -- same clipping, pinned separately because it is
+/// a separate marker with its own scan.
+#[test]
+fn test_tail_marker_does_not_leak_across_function_boundaries_2404() {
+    let src = r"
+        fn exempt_walk<F: DocumentFields>(fields: &F) -> Result<(), EvalError> {
+            // STYLE-0013-TAIL: nothing to check here.
+            let mut f = fields.clone();
+            while let Some((field, rest)) = f.uncons() {
+                field.delimiters_ok(&cursor)?;
+                f = rest;
+            }
+            Ok(())
+        }
+
+        fn unmarked_walk<F: DocumentFields>(fields: &F) -> Result<(), EvalError> {
+            let mut f = fields.clone();
+            while let Some((field, rest)) = f.uncons() {
+                field.delimiters_ok(&cursor)?;
+                f = rest;
+            }
+            Ok(())
+        }
+    ";
+    let parsed = syn::parse_file(src).expect("fixture parses");
+    let mut audit = Audit::new("fixture.rs", src);
+    audit.visit_file(&parsed);
+    assert_eq!(audit.walks_examined, 2);
+    assert_eq!(audit.tail_violations.len(), 1);
+    assert_eq!(audit.tail_violations[0].func, "unmarked_walk");
 }

--- a/tests/jq_member_validation_audit.rs
+++ b/tests/jq_member_validation_audit.rs
@@ -188,9 +188,21 @@ const TAIL_PRIMITIVES: &[&str] = &[
 ///
 /// `uncons`/`uncons_cursor`/`uncons_key` are the three cursor-domain
 /// spellings; `children`/`cursor_iter` are the two iterator-domain ones.
-/// A `for x in <already-materialized Vec>` loop is deliberately *not* a walk
-/// here: its members were validated wherever that `Vec` was built, and the
-/// tail with them.
+///
+/// A `for x in <collection bound earlier>` loop is **out of scope**, and this
+/// is the rule's known boundary rather than a claim that such loops are
+/// safe. An earlier draft of this comment justified the carve-out by saying
+/// those members were validated wherever the collection was built; review
+/// showed that is false for at least one site -- `eval_builtin`'s
+/// `to_entries` arm validates members inside the loop and hand-rolls its own
+/// tail, and is invisible here because its iterator is a local binding, not
+/// a call this scan can see in the loop head.
+///
+/// Covering it needs the binding traced back to its initializer, which is
+/// real dataflow rather than the syntactic match everything else here does.
+/// Left out deliberately: the shape this rule was written for is the
+/// cursor-domain walk, where all six of its current findings live. The gap
+/// is recorded in #2594 rather than papered over.
 const WALK_METHODS: &[&str] = &[
     "uncons",
     "uncons_cursor",
@@ -247,16 +259,28 @@ struct Frame {
     /// that -- see `test_marker_does_not_leak_across_function_boundaries`.
     body_start: usize,
     body_end: usize,
-    /// Set when a loop in this function heads on one of [`WALK_METHODS`].
-    walks_children: bool,
+    /// How many loops in this function head on one of [`WALK_METHODS`].
+    ///
+    /// A count, not a flag: a function with an object arm and an array arm
+    /// has two walks and owes two tail checks. A single boolean let either
+    /// arm's tail check exempt the other, so deleting `to_owned_at_depth`'s
+    /// array-arm `tail_gap_ok` -- reintroducing #2211's `[,]` exactly --
+    /// left the audit green. Found in review of this rule; pinned by
+    /// `test_tail_audit_counts_each_arm_separately_2404`.
+    walk_loops: usize,
     /// Set when this function validates members at all (see
     /// [`MEMBER_VALIDATION`]) -- routed or hand-rolled, both count.
     validates_members: bool,
-    /// Set when this function ends its walk in one of [`TAIL_ROUTES`].
-    routes_tail: bool,
+    /// How many [`TAIL_ROUTES`] calls this function makes, compared against
+    /// `walk_loops` rather than merely being non-zero.
+    tail_routes: usize,
     /// Line of the first walk loop, for the violation report -- the loop is
     /// the thing missing a tail, so it is the useful place to point.
     walk_line: usize,
+    /// Line ranges of `fn` items nested inside this one, excluded from the
+    /// marker scan so a marker belonging to a nested helper cannot exempt
+    /// its enclosing walk.
+    nested: Vec<(usize, usize)>,
 }
 
 struct Audit<'a> {
@@ -348,7 +372,18 @@ fn is_tail_marker_line(line: &str) -> bool {
 fn tail_marker_in_body(lines: &[&str], frame: &Frame) -> bool {
     let lo = frame.body_start.saturating_sub(1);
     let hi = frame.body_end.min(lines.len());
-    lines[lo..hi].iter().any(|l| is_tail_marker_line(l))
+    (lo..hi).any(|i| {
+        let line_no = i + 1;
+        // A marker inside a nested `fn` belongs to that helper, not to the
+        // walk that happens to enclose it. The member rule's own
+        // `test_nested_fn_does_not_inherit_the_parent_marker` pins the
+        // other direction; this is the same principle read upwards.
+        let in_nested = frame
+            .nested
+            .iter()
+            .any(|(s, e)| line_no >= *s && line_no <= *e);
+        !in_nested && is_tail_marker_line(lines[i])
+    })
 }
 
 /// Whether an expression subtree contains a call to one of
@@ -395,10 +430,11 @@ impl<'a> Audit<'a> {
             name,
             body_start: body.start().line,
             body_end: body.end().line,
-            walks_children: false,
+            walk_loops: 0,
             validates_members: false,
-            routes_tail: false,
+            tail_routes: 0,
             walk_line: 0,
+            nested: Vec::new(),
         });
     }
 
@@ -412,6 +448,9 @@ impl<'a> Audit<'a> {
         let Some(frame) = self.stack.pop() else {
             return;
         };
+        if let Some(parent) = self.stack.last_mut() {
+            parent.nested.push((frame.body_start, frame.body_end));
+        }
         // A definition of one of the primitives or helpers is not a walk
         // that owes a tail check -- it is the thing the walk routes through.
         if MEMBER_VALIDATION.contains(&frame.name.as_str())
@@ -420,11 +459,11 @@ impl<'a> Audit<'a> {
         {
             return;
         }
-        if !(frame.walks_children && frame.validates_members) {
+        if !(frame.walk_loops > 0 && frame.validates_members) {
             return;
         }
         self.walks_examined += 1;
-        if frame.routes_tail || tail_marker_in_body(&self.lines, &frame) {
+        if frame.tail_routes >= frame.walk_loops || tail_marker_in_body(&self.lines, &frame) {
             return;
         }
         self.tail_violations.push(Site {
@@ -446,16 +485,18 @@ impl<'a> Audit<'a> {
         let Some(frame) = self.stack.last_mut() else {
             return;
         };
-        if is_walk_head && !frame.walks_children {
-            frame.walks_children = true;
-            frame.walk_line = line_of(expr.span());
+        if is_walk_head {
+            if frame.walk_loops == 0 {
+                frame.walk_line = line_of(expr.span());
+            }
+            frame.walk_loops += 1;
         }
         if let Some(name) = callee {
             if MEMBER_VALIDATION.contains(&name.as_str()) {
                 frame.validates_members = true;
             }
             if TAIL_ROUTES.contains(&name.as_str()) {
-                frame.routes_tail = true;
+                frame.tail_routes += 1;
             }
         }
     }
@@ -1008,4 +1049,84 @@ fn test_tail_marker_does_not_leak_across_function_boundaries_2404() {
     assert_eq!(audit.walks_examined, 2);
     assert_eq!(audit.tail_violations.len(), 1);
     assert_eq!(audit.tail_violations[0].func, "unmarked_walk");
+}
+
+/// A function with an object arm and an array arm has **two** walks and owes
+/// **two** tail checks.
+///
+/// Found in review: with `routes_tail` as one boolean, either arm's tail
+/// check exempted the other. Deleting `to_owned_at_depth`'s array-arm
+/// `tail_gap_ok` -- reintroducing #2211's `[,]` bug exactly -- left the audit
+/// green. Verified by mutation that the counting form catches it.
+#[test]
+fn test_tail_audit_counts_each_arm_separately_2404() {
+    let src = r"
+        fn two_arms<F: DocumentFields>(v: &V) -> Result<(), EvalError> {
+            match v {
+                Object(fields) => {
+                    let mut f = fields.clone();
+                    let mut last = None;
+                    while let Some((field, rest)) = f.uncons() {
+                        field.delimiters_ok(&cursor)?;
+                        last = Some(field.value_cursor);
+                        f = rest;
+                    }
+                    tail_gap_ok(cursor, last.as_ref(), b'}')?;
+                }
+                Array(elems) => {
+                    let mut e = elems.clone();
+                    let mut last = None;
+                    while let Some((elem, rest)) = e.uncons_cursor() {
+                        elem.delimiters_ok(&cursor)?;
+                        last = Some(elem);
+                        e = rest;
+                    }
+                }
+            }
+            Ok(())
+        }
+    ";
+    let parsed = syn::parse_file(src).expect("fixture parses");
+    let mut audit = Audit::new("fixture.rs", src);
+    audit.visit_file(&parsed);
+    assert_eq!(audit.walks_examined, 1, "one function, examined once");
+    assert_eq!(
+        audit.tail_violations.len(),
+        1,
+        "two walks and one tail check must not pass -- the array arm is unguarded"
+    );
+}
+
+/// A marker inside a nested `fn` belongs to that helper, not to the walk
+/// enclosing it.
+///
+/// `test_nested_fn_does_not_inherit_the_parent_marker` pins the downward
+/// direction for the member rule; this is the same principle read upwards,
+/// and it was a real hole -- the frame's line range spans its nested items,
+/// so an unrelated nested marker silently exempted the outer walk.
+#[test]
+fn test_tail_marker_in_a_nested_fn_does_not_exempt_the_outer_walk_2404() {
+    let src = r"
+        fn outer_walk<F: DocumentFields>(fields: &F) -> Result<(), EvalError> {
+            fn inner_helper() -> bool {
+                // STYLE-0013-TAIL: this helper has no walk of its own.
+                true
+            }
+            let mut f = fields.clone();
+            while let Some((field, rest)) = f.uncons() {
+                field.delimiters_ok(&cursor)?;
+                f = rest;
+            }
+            Ok(())
+        }
+    ";
+    let parsed = syn::parse_file(src).expect("fixture parses");
+    let mut audit = Audit::new("fixture.rs", src);
+    audit.visit_file(&parsed);
+    assert_eq!(
+        audit.tail_violations.len(),
+        1,
+        "the nested helper's marker must not exempt `outer_walk`"
+    );
+    assert_eq!(audit.tail_violations[0].func, "outer_walk");
 }


### PR DESCRIPTION
## Summary

STYLE-0013's audit covers the **member** primitives only. The post-loop tail
was left out deliberately, and the module doc records why: a rule keyed on
`container_gap_ok`/`trailing_element_gap_ok` *by name* would be mostly noise,
since both have many legitimate direct callers outside any walk. It also
named the formulation that would work -- one keyed on **the walk**.

This adds that rule. The gate is:

> does this function loop over a document's children (`WALK_METHODS`) **and**
> validate them (`MEMBER_VALIDATION`)?

and only such a function is required to reach a tail helper. Of **44**
functions in `SOURCES` containing a child-walk loop, **14** qualify; 8
already route correctly and 6 are exempted here with their real reasons.
The streaming writers, the unchecked `len`/`keys`/`collect_cursors` fast
paths and the YAML-only walks all fall outside the gate without needing an
exemption each -- which is precisely the noise the callee-keyed version was
rejected for.

### Why the member rule could not be extended to cover it

It fires on a **call**; this bug is an **absence**. #2211 (`{,}`/`[,]` never
checked) and #2243 (`{"a":1,}` accepted) were walks that validated every member
and then simply stopped -- no offending call anywhere for a callee-keyed scan
to catch. #2349 was the wrong answer that drift finally produced.

### Why `// STYLE-0013-TAIL:` is a separate marker

Five of the six walks it exempts **already carry** a `// STYLE-0013:` marker
for their member half. Sharing the marker would have made this rule vacuous
on the day it landed, letting a member decision stand in for a tail decision
nobody made -- which is the exact drift being audited (#2349's fix
hand-copied both halves; the member half is the one that got the attention).
`test_member_marker_does_not_exempt_the_tail_2404` pins this.

## Two things I checked rather than assumed

**The issue's headline example is already fixed.** #2409/#2413 renamed
`push_generic_truthiness_cursor_error` and collapsed its hand-written
`match last_field { None => container_gap_ok, Some => trailing_element_gap_ok }`
into `container_tail_gap_ok`. The rule is justified by the six walks still
open, not by that one.

**The rule finds live bugs, not just style drift.** Filed as #2594: the
zero-child stray comma is still accepted by every filter but identity, on
documents real jq rejects outright.

| document | filter | jq 1.7.1 | succinctly |
|---|---|---|---|
| `{,}` | `.` | parse error | rejects (correct, #2211) |
| `{,}` | `.a` | parse error | `null` |
| `{,}` | `keys` | parse error | `[]` |
| `{,}` | `length` | parse error | `0` |
| `[,]` | `.[0]` | parse error | `null` |
| `[,]` | `to_entries` | parse error | `[]` |

Mechanism: `child_tail_gap_ok` is documented as unable to see the zero-child
case (its `None` arm is `Ok(())`); `container_tail_gap_ok` exists for exactly
that gap. Five walks hand-roll the former's one-armed body and inherit the
blind spot. The signature is that `{"a":1,}` is caught **everywhere** while
`{,}` is caught **nowhere**: the `Some(last)` arm they copied works, the
`None` arm they did not is the one that catches `{,}`.

## Scope

Test-only, as #2404 asks. **No production behaviour changes** -- the six
source edits are comment-only exemptions. Routing those sites is #2594's
job and is *not* a pure refactor: they raise
`malformed_json_text`/`malformed_member_error`/`malformed_element_error`
where the helpers raise `malformed_delimiter_error`, so swapping them
changes messages on inputs that already error.

## Test plan

- [x] `cargo test --features cli,simd,regex,serde` -- full suite, 7804 passed, 0 failed
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] Verified the new rule **fires** before the exemptions were added (6 findings,
      matching an independent prototype scan) and passes after
- [x] Divergences in the table above captured live against `/usr/bin/jq` 1.7.1

7 new unit tests pin the rule's design: fires on a walk with no tail check;
accepts one routed through a helper; accepts a tail-marked walk; **a member
marker does not exempt the tail**; ignores a walk that validates nothing;
ignores a `for x in vec` loop over an already-materialized collection; and
the tail marker does not leak across function boundaries.

Fixes #2404
