### PR TITLE
chore(scripts): ab-cli.py --extra-args, and pin explicit_tag's alias paths (#1448)

### DIFF
--- a/docs/guides/benchmarking.md
+++ b/docs/guides/benchmarking.md
@@ -816,6 +816,21 @@ to clear — an idle M4 Pro reads +0.09% median with a per-row range of -1.8%..+
 that number, #332's +1.1% median across 22 workloads was arguable; with it, the consistent
 sign was decisive, and the fix was restructured before merge.
 
+**Vary the tool flags when the change is flag-sensitive.** The harness passes `yq -o <fmt>
+-I0` and nothing else. `--extra-args` replaces that flag list, so a run can exercise `-P`,
+`--tab`, `-S`, or a different indent width. It needs the `=` form, since argparse reads a
+leading `-` as a flag of its own:
+
+```bash
+scripts/ab-cli.py --before ./succ-base --after ./succ-head --corpus <dir> --extra-args='-I4 -P'
+```
+
+Do **not** assume `-I0` and `-I2` reach different writers: succinctly renders them
+identically (both 2-space block), so neither flag alone tells you whether the block-style or
+flow-style writer ran. What decides that is the *corpus* — the `flow` generator pattern
+versus the block-shaped ones — so cover both patterns rather than trusting an indent flag to
+do it (#1448, which first assumed the opposite and had to re-check).
+
 ### 1. Interleave the two binaries; never run all of A then all of B
 
 Alternate them **within** each repetition, then compare min-of-N and median:

--- a/scripts/ab-cli.py
+++ b/scripts/ab-cli.py
@@ -24,6 +24,7 @@ import glob
 import hashlib
 import os
 import re
+import shlex
 import shutil
 import statistics
 import subprocess
@@ -53,6 +54,13 @@ def parse_args(argv=None):
     p.add_argument("--tool", default="yq", help="succinctly subcommand (default: yq)")
     p.add_argument("--queries", nargs="*", default=[".", ".[]"], help="queries to time")
     p.add_argument("--output", default="json", help="-o format passed to the tool")
+    p.add_argument("--extra-args", default=None,
+                   help="extra flags passed to the tool before the query, as one "
+                        "shell-quoted string. Must use the '=' form, since argparse reads a "
+                        "leading '-' as a flag: --extra-args='-I2 -P'. Defaults to '-I0' for "
+                        "--tool yq and nothing otherwise. yq's -I0 drives every value down "
+                        "the flow-style branches, so a change that only affects block-style "
+                        "rendering measures as neutral unless this is set (#1448)")
     p.add_argument("--reps", type=int, default=7, help="repetitions per configuration")
     p.add_argument("--control", action="store_true",
                    help="time --before against a copy of itself (noise floor)")
@@ -168,10 +176,18 @@ def run_text(cmd):
         return ""
 
 
+def tool_extra_args(args):
+    """`--extra-args` if given, else the per-tool default (rule 4: identical on both sides)."""
+    if args.extra_args is not None:
+        return shlex.split(args.extra_args)
+    return ["-I0"] if args.tool == "yq" else []
+
+
 def command(binary, args, query, path):
+    extra = tool_extra_args(args)
     if args.tool == "yq":
-        return [binary, args.tool, "-o", args.output, "-I0", query, path]
-    return [binary, args.tool, query, path]
+        return [binary, args.tool, "-o", args.output, *extra, query, path]
+    return [binary, args.tool, *extra, query, path]
 
 
 def digest(binary, args, query, path):
@@ -263,6 +279,7 @@ def main(argv=None):
     if status:
         print(status)
     print(f"inputs={len(inputs)} queries={args.queries} reps={args.reps}")
+    print(f"tool={args.tool} -o {args.output} extra-args={tool_extra_args(args)}")
     print()
 
     if not args.no_identity:

--- a/src/yaml/light.rs
+++ b/src/yaml/light.rs
@@ -12572,6 +12572,93 @@ mod tests {
         assert_eq!(value_tag(b"key: !custom v"), "!!str");
     }
 
+    /// [`YamlCursor::explicit_tag`] and its `explicit_tag_at` core across
+    /// every shape that decides whether the alias branch is taken (#1448).
+    ///
+    /// `explicit_tag_at` returns the tag at the node's own `bp_pos` unless
+    /// the value handed to it is an `Alias`, in which case it dereferences
+    /// to the anchor's tag (#903). The cases below pin both arms, plus the
+    /// two shapes where the answer is *not* derivable from `bp_pos` alone --
+    /// a sequence-item wrapper around an alias, and an alias to a tagged
+    /// anchor. A narrowing of that logic to a direct `index.aliases` lookup
+    /// keyed on `bp_pos` would answer `None` for the wrapper case, a silent
+    /// tag loss; the final assertion is what catches it.
+    #[test]
+    fn test_explicit_tag_alias_and_wrapper_paths_1448() {
+        fn tag_of_first_value(yaml: &[u8]) -> Option<String> {
+            let index = YamlIndex::build(yaml).unwrap();
+            let root = index.root(yaml);
+            if let YamlValue::Mapping(fields) = first_doc(root) {
+                if let Some(field) = fields.into_iter().next() {
+                    return field.value_cursor().explicit_tag().map(String::from);
+                }
+            }
+            panic!("no first field in {:?}", core::str::from_utf8(yaml));
+        }
+        fn tag_of_field(yaml: &[u8], want: &str) -> Option<String> {
+            let index = YamlIndex::build(yaml).unwrap();
+            let root = index.root(yaml);
+            if let YamlValue::Mapping(fields) = first_doc(root) {
+                for field in fields {
+                    if matches!(field.key().as_str(), Some(k) if k == want) {
+                        return field.value_cursor().explicit_tag().map(String::from);
+                    }
+                }
+            }
+            panic!("no field {want:?} in {:?}", core::str::from_utf8(yaml));
+        }
+
+        // No alias anywhere: the tag comes straight from this node.
+        assert_eq!(
+            tag_of_first_value(b"a: !!str 1\n").as_deref(),
+            Some("!!str")
+        );
+        assert_eq!(tag_of_first_value(b"a: 1\n"), None);
+
+        // A container's `value()` returns Mapping/Sequence before it can reach
+        // its `*` arm, so it is never an `Alias` -- even here, where an alias
+        // does exist elsewhere in the document.
+        let tagged_containers = b"a: &z 1\nm: !!map\n  k: *z\ns: !!seq\n  - *z\n";
+        assert_eq!(
+            tag_of_field(tagged_containers, "m").as_deref(),
+            Some("!!map")
+        );
+        assert_eq!(
+            tag_of_field(tagged_containers, "s").as_deref(),
+            Some("!!seq")
+        );
+
+        // An alias node carries no tag of its own, so #903's transparency
+        // must dereference to the anchor's tag.
+        assert_eq!(
+            tag_of_field(b"a: &x !!str 1\nb: *x\n", "b").as_deref(),
+            Some("!!str")
+        );
+        // ... and an alias to an untagged anchor still has no tag.
+        assert_eq!(tag_of_field(b"a: &x 1\nb: *x\n", "b"), None);
+
+        // A sequence-item *wrapper* around an alias. The wrapper is not a
+        // container and holds no tag at its own `bp_pos`, so the answer can
+        // only come from letting `value()` recurse into the child and
+        // dereference. This is the case the tempting narrowing to a direct
+        // `index.aliases`/`get_tag` lookup keyed on `bp_pos` would silently
+        // answer `None` for -- see this method's own doc comment.
+        let wrapped = b"a: &x !!str 1\nitems:\n  - *x\n";
+        let index = YamlIndex::build(wrapped).unwrap();
+        let root = index.root(wrapped);
+        let mut wrapper_tag = None;
+        if let YamlValue::Mapping(fields) = first_doc(root) {
+            for field in fields {
+                if matches!(field.key().as_str(), Some(k) if k == "items") {
+                    let seq = field.value_cursor();
+                    let item = seq.first_child().expect("sequence has an item");
+                    wrapper_tag = item.explicit_tag().map(String::from);
+                }
+            }
+        }
+        assert_eq!(wrapper_tag.as_deref(), Some("!!str"));
+    }
+
     /// `is_falsy` (the `DocumentCursor` trait method backing `select`,
     /// `if/then/else`, and `//`) must honor an explicit tag's resolution, not
     /// the scalar's own quoting - a quoted non-empty string is ordinarily


### PR DESCRIPTION
Relates to #1448 (which is now resolved by #1114/#2617, not by this PR — see below).

Two independent, small pieces of benchmarking and test infrastructure, plus an
honest record of a measurement that did not survive.

## What this PR started as, and why it shrank

It started as the perf fix for #1448's last open item: `YamlCursor::value()`
being re-derived 2-3x per rendered node on the YAML write path. Two changes,
measured on both pinned machines, came in at **-46% (7950X) / -37% (M4 Pro)** on
`-o yaml` against the then-current `main`.

While it was in review, `main` independently landed the same optimization —
`bb91825b9 perf(yq): reuse an already-resolved value in the deferred-value write
path` (#1114), then #2617 — and in a **better form**. Where this branch added a
runtime guard inside `explicit_tag`, `main` threads `explicit_tag_at(None)`
through all 16 call sites, so there is no check to pay for at all.

Re-measured against current `main`, both of the perf changes are gone:

| change | 7950X | M4 Pro |
|---|---|---|
| alias-probe guard | **+0.93%** (22/24 rows slower) | −0.02% |
| drop-glue restructuring | +0.40% | −0.38% |

Control noise: −0.01% (−0.7%..+1.0%) and −0.06% (−1.1%..+2.2%). So the guard is
now pure added cost on a path that is no longer hot, and the drop-glue change is
neutral because the ARM regression it existed to fix does not occur in `main`'s
implementation. **Both were dropped.** Keeping either would be paying for a win
that has already been banked elsewhere.

I also checked whether `main`'s `explicit_tag_at(None)` conversions broke alias
tag transparency at the sites that cannot derive the answer from `bp_pos` alone.
They do not — verified differentially against `yq` v4.53.3 on four alias/tag/
wrapper shapes.

## What is left

**`chore(scripts)` — `ab-cli.py --extra-args`.** `command()` passed
`yq -o <fmt> -I0` with no way to change it, so a run could not exercise `-P`,
`--tab`, `-S`, or another indent width. Defaults unchanged.

The accompanying guide note corrects an assumption this work started from — that
the hard-coded `-I0` routed everything through the flow-style writer and hid the
block one. It does not: succinctly renders `-I0` and `-I2` identically, and the
two measured within half a point of each other. What separates the writers is the
corpus (`flow` pattern vs the block-shaped ones). Checking that assumption did
surface a real divergence — succinctly's `-I0` indents 2 where real yq indents 4
— filed as **#2606**.

**`test(yaml)` — pin `explicit_tag`'s alias and wrapper paths.** `explicit_tag_at`
dereferences an alias to the anchor's tag (#903), otherwise reads the tag at the
node's own `bp_pos`. Two shapes are not derivable from `bp_pos` alone — an alias
to a tagged anchor, and a sequence-item wrapper around an alias — and neither had
a direct unit test. Given how much this function has been refactored recently
(#1114, #2617, #2621), that seems worth pinning.

The wrapper assertion is the load-bearing one: narrowing this logic to a direct
`index.aliases`/`get_tag` lookup keyed on `bp_pos` looks equivalent and is not,
answering `None` there instead of the anchor's tag — a silent tag loss. Verified
the test discriminates by disabling the alias arm and confirming it fails.

## Verification

Local gates green: the CI cli-gated `--test` list, `cargo test`,
`--no-default-features`, both clippy feature sets, `cargo fmt --check`, and
`RUSTDOCFLAGS="-D warnings" cargo doc`.
