### PR TITLE
fix(yq): preserve a mapping key's anchor on identity output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`succinctly yq`'s cursor-streaming identity output no longer drops an
+  anchor on a mapping key** (#1352): `&k key: 1` round-tripped as plain
+  `key: 1` even on a no-op `.` query. The parser already indexed a key
+  anchor (`Parser::record_key_anchor`), but `write_yaml_field_key`
+  (`src/yaml/light.rs`) never asked for it -- unlike
+  `write_yaml_child_inline`'s existing `&anchor ` prefix for a *value*'s
+  own anchor (#763), which this mirrors. Covers both block and flow
+  mapping styles, `--sort-keys`, and combines correctly with a value's own
+  separate anchor on the same field. **Residual, not fixed here**: the DOM
+  write path (`=`, `|=`, `del()`, `-P`, `--arg`) still drops a key's anchor
+  -- see #2598.
+
 - **`succinctly jq`'s default (compact) JSON output now escapes a raw DEL
   byte (`0x7f`) in a string value or object key, matching real jq** (#2591):
   a bare `0x7f` byte is legal unescaped in JSON source (RFC 8259 only

--- a/src/yaml/light.rs
+++ b/src/yaml/light.rs
@@ -7274,6 +7274,14 @@ fn compact_child_indent(
 
 /// Write a mapping field's key.
 ///
+/// A key anchor (`&k key: 1`) is written first, mirroring
+/// `write_yaml_child_inline`'s own `&anchor ` prefix for a *value*'s
+/// anchor (#763) -- #1352: the parser already records a key anchor
+/// (`Parser::record_key_anchor`), but this writer never asked for it, so
+/// `&k key: 1` round-tripped as plain `key: 1` even on identity output.
+/// This is the cursor-streaming path only; the DOM write path (`=`, `|=`,
+/// `del()`, `-P`, `--arg`) still drops a key's anchor -- see #2598.
+///
 /// An explicit source tag (`!!str`, `!custom`, …) is preserved verbatim,
 /// matching real `yq` (#224). Otherwise, a literal (unquoted) `<<` merge
 /// key is tagged with `!!merge `, again matching real yq (a quoted `"<<"`
@@ -7283,6 +7291,11 @@ fn write_yaml_field_key<W: AsRef<[u64]>, Out: core::fmt::Write>(
     out: &mut Out,
     field: YamlField<'_, W>,
 ) -> StreamResult {
+    if let Some(anchor) = field.key_cursor().anchor() {
+        out.write_char('&')?;
+        out.write_str(anchor)?;
+        out.write_char(' ')?;
+    }
     let key = field.key();
     if let YamlValue::String(s) = &key {
         if let Some(tag) = field.key_cursor().explicit_tag() {

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -6136,6 +6136,43 @@ fn test_yaml_anchor_on_compact_mapping_key_binds_to_key() -> Result<()> {
 }
 
 #[test]
+fn test_yaml_mapping_key_anchor_survives_identity_output_1352() -> Result<()> {
+    // #1352: `Parser::record_key_anchor` already indexed a key anchor, but
+    // `write_yaml_field_key` never asked for it, so `&k key: 1` round-tripped
+    // as plain `key: 1` even on a no-op identity query -- matching real yq
+    // (v4.53.3) means the anchor must survive `.` unchanged. Block style
+    // (this case) and flow style are separate call sites in the writer
+    // (block-mapping vs flow-mapping loops both call `write_yaml_field_key`),
+    // so both get their own case here.
+    let input = "&k key: 1\n";
+    let (output, exit_code) = run_yq_stdin(".", input, &[])?;
+    assert_eq!(exit_code, 0);
+    assert_eq!(output, "&k key: 1\n");
+    Ok(())
+}
+
+#[test]
+fn test_yaml_mapping_key_anchor_survives_flow_identity_output_1352() -> Result<()> {
+    let input = "{&k key: 1}\n";
+    let (output, exit_code) = run_yq_stdin(".", input, &[])?;
+    assert_eq!(exit_code, 0);
+    assert_eq!(output, "{&k key: 1}\n");
+    Ok(())
+}
+
+#[test]
+fn test_yaml_mapping_key_anchor_and_value_anchor_together_1352() -> Result<()> {
+    // A key anchor and its value's own separate anchor (#763) must both
+    // survive together -- the key fix must not disturb the pre-existing
+    // value-anchor mechanism.
+    let input = "&k1 key: &v1 1\n";
+    let (output, exit_code) = run_yq_stdin(".", input, &[])?;
+    assert_eq!(exit_code, 0);
+    assert_eq!(output, "&k1 key: &v1 1\n");
+    Ok(())
+}
+
+#[test]
 fn test_yaml_anchored_tag_in_seq_item_resolves() -> Result<()> {
     // Consuming the anchor before dispatching means the tag is seen rather
     // than absorbed into a plain scalar, so `- &a !!str x` resolves to the


### PR DESCRIPTION
## Summary

Real yq preserves an anchor written on a mapping key (`&k key: 1`), not
just its value, but succinctly's cursor-streaming writer silently dropped
it -- `&k key: 1` round-tripped as plain `key: 1` even on a no-op `.`
query. The parser already recorded the key's anchor
(`Parser::record_key_anchor`, `src/yaml/parser.rs`), but
`write_yaml_field_key` (`src/yaml/light.rs`) never consulted it.

Fixed by mirroring `write_yaml_child_inline`'s existing `&anchor ` prefix
for a value's own anchor (#763): `write_yaml_field_key` now writes
`field.key_cursor().anchor()` first, before the key's tag/merge-key
handling. Covers both block and flow mapping styles, `--sort-keys`, and
combines correctly with a value's own separate anchor on the same field.

Independent code review confirmed anchor/tag ordering matches real yq
(`&k !!str key: 1`), the merge-key case (`&m <<: *base`), and that a later
alias to the key's own anchor correctly resolves to the key's scalar
rather than the value.

**Residual, not fixed here**: the DOM write path (`=`, `|=`, `del()`,
`-P`, `--arg`) still drops a key's anchor -- confirmed via a separate,
unrelated code path (`yaml_quote_key`/`emit_yaml_value` in
`yq_runner.rs`) -- filed as #2598.

Fixes #1352

## Test plan

- [x] `cargo build`, `cargo build --features cli`
- [x] `cargo test --features cli,simd,regex,serde` (0 failures)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` (clean)
- [x] `cargo fmt --check` (clean)
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features` (clean)
- [x] New regression tests: block style, flow style, key+value anchor
      combined
- [x] Manually verified against the pinned oracle (Homebrew `yq` v4.53.3)
      across anchor+tag ordering, merge-key anchors, `--sort-keys`, and
      key-anchor-as-alias-target
- [x] Independent code review (no issues found)
