### PR TITLE
fix(yq): keep an anchor mark across a write that changes a node's kind

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `get_anchor_name`, this one fix covers both -- including combining
   correctly with #1352's key-anchor fix on a redefined key anchor.
 
+- **`succinctly yq`'s DOM write path (`=`, `|=`, `+=`, ...) no longer drops
+  an anchor when the write changes a node's kind** (#1359): a write that
+  turned an anchored container into a scalar (or vice versa), or an object
+  into an array, hit `reconcile_presentation_at_depth`'s "fresh node, no
+  presentation memory" arm, which cleared `&x` along with comment/style --
+  taking every `*x` alias to it down too, since nothing declared the name
+  any more. Real yq keeps the anchor across a kind change for the same
+  reason it keeps it across a same-kind write: the write replaces the
+  node's *value*, not its *identity*. Fixed by carrying an anchor
+  *declaration* through the kind-change arm unconditionally (matching the
+  same-kind arm just below it), and an *alias* mark only when the written
+  node was not itself a write target -- i.e. its kind changed purely as a
+  side effect of mirroring its anchor's own new value, not because it was
+  rebound directly. The latter distinction (found in code review) matters
+  because `propagate_assign_alias_marks` (#2497) only re-derives a stale
+  alias mark after a plain `=`/chain-of-`=` write; without it, a `|=`/`+=`
+  write landing exactly at an alias position could wrongly keep `*x` if a
+  later stage in the same pipe happened to give the position the same
+  value its anchor ended up with.
+
 - **`succinctly yq`'s cursor-streaming identity output no longer drops an
   anchor on a mapping key** (#1352): `&k key: 1` round-tripped as plain
   `key: 1` even on a no-op `.` query. The parser already indexed a key

--- a/src/bin/succinctly/yq_runner.rs
+++ b/src/bin/succinctly/yq_runner.rs
@@ -2541,10 +2541,10 @@ fn reconcile_presentation_at_depth(
             CommentTree::Array(own_meta, items)
         }
         // A kind change (container <-> scalar, or Object <-> Array) is a
-        // fresh node with no presentation memory of its own -- except the
-        // anchor mark, which is identity rather than presentation: `&x`
-        // names the *position*, and the position survives the write just
-        // like it does in the both-scalars arm below (#1359). `Leaf` is
+        // fresh node with no presentation memory of its own -- except an
+        // anchor *declaration*, which is identity rather than presentation:
+        // `&x` names the *position*, and the position survives the write
+        // just like it does in the both-scalars arm below (#1359). `Leaf` is
         // correct even when `result_value` is itself a container: every
         // descent into a child (`CommentTree::at_index`/`field`) already
         // falls back to the empty tree for a non-matching variant, the same
@@ -2553,12 +2553,40 @@ fn reconcile_presentation_at_depth(
         // memory of their own either way. Comment and style are still
         // dropped, since neither describes anything that survived the kind
         // change. [`enforce_anchor_soundness`], run afterwards, is what
-        // decides whether the carried mark is still emittable.
+        // decides whether a carried `Declares` mark is still emittable.
+        //
+        // An `Aliases` mark is handled differently (found in review): unlike
+        // a declaration, it isn't this node's own identity, it's a reference
+        // to someone else's. A write landing exactly *at* an alias position
+        // is a rebind that drops the reference -- the same rule the
+        // both-scalars arm's own doc comment cites via #1351 -- so it only
+        // survives here when this position was never itself a write target,
+        // i.e. its kind changed purely as a side effect of mirroring its
+        // anchor's own new value (an "untouched copy", #1351's own term).
+        // Checking `targets` rather than always dropping the mark matters:
+        // an untouched alias elsewhere in the same document (`c: *x` when
+        // only `.a`/`.b` are written) must keep referring to its anchor.
+        // Checking it rather than always *keeping* the mark matters too --
+        // for a target ending exactly here, [`propagate_assign_alias_marks`]
+        // (#2497) actively re-derives the mark after a plain `=`/chain-of-`=`
+        // write, but it does not cover `|=`/`+=`/other compound writes, which
+        // would otherwise have only `enforce_anchor_soundness`'s coincidental
+        // value-equality check as a backstop -- unsound, since
+        // `.b |= 5 | .a = 5` on `b: *x` can make `.b`'s freshly-written value
+        // equal `.a`'s by coincidence, wrongly keeping `*x`.
         (OwnedValue::Object(_) | OwnedValue::Array(_), _)
-        | (_, OwnedValue::Object(_) | OwnedValue::Array(_)) => CommentTree::Leaf(NodeMeta {
-            anchor: pristine_tree.meta().anchor.clone(),
-            ..NodeMeta::empty()
-        }),
+        | (_, OwnedValue::Object(_) | OwnedValue::Array(_)) => {
+            let is_write_target = targets.iter().any(|(steps, ..)| steps.is_empty());
+            let anchor = match &pristine_tree.meta().anchor {
+                mark @ Some(AnchorMark::Declares(_)) => mark.clone(),
+                mark @ Some(AnchorMark::Aliases(_)) if !is_write_target => mark.clone(),
+                _ => None,
+            };
+            CommentTree::Leaf(NodeMeta {
+                anchor,
+                ..NodeMeta::empty()
+            })
+        }
         // Both scalars, any variant/value: same node, only its value
         // changed - its own comment, style and anchor mark survive. Real
         // `yq` keeps `&x` across `.a = 99` for the same reason it keeps the

--- a/src/bin/succinctly/yq_runner.rs
+++ b/src/bin/succinctly/yq_runner.rs
@@ -2541,9 +2541,24 @@ fn reconcile_presentation_at_depth(
             CommentTree::Array(own_meta, items)
         }
         // A kind change (container <-> scalar, or Object <-> Array) is a
-        // fresh node with no presentation memory of its own.
+        // fresh node with no presentation memory of its own -- except the
+        // anchor mark, which is identity rather than presentation: `&x`
+        // names the *position*, and the position survives the write just
+        // like it does in the both-scalars arm below (#1359). `Leaf` is
+        // correct even when `result_value` is itself a container: every
+        // descent into a child (`CommentTree::at_index`/`field`) already
+        // falls back to the empty tree for a non-matching variant, the same
+        // outcome a freshly-built `Array`/`Object` with empty children would
+        // give, and a kind-changed node's children carry no presentation
+        // memory of their own either way. Comment and style are still
+        // dropped, since neither describes anything that survived the kind
+        // change. [`enforce_anchor_soundness`], run afterwards, is what
+        // decides whether the carried mark is still emittable.
         (OwnedValue::Object(_) | OwnedValue::Array(_), _)
-        | (_, OwnedValue::Object(_) | OwnedValue::Array(_)) => CommentTree::empty(),
+        | (_, OwnedValue::Object(_) | OwnedValue::Array(_)) => CommentTree::Leaf(NodeMeta {
+            anchor: pristine_tree.meta().anchor.clone(),
+            ..NodeMeta::empty()
+        }),
         // Both scalars, any variant/value: same node, only its value
         // changed - its own comment, style and anchor mark survive. Real
         // `yq` keeps `&x` across `.a = 99` for the same reason it keeps the

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -25355,6 +25355,66 @@ fn test_yaml_nested_write_through_alias_keeps_the_mark_763_1351() -> Result<()> 
 }
 
 // =============================================================================
+// #1359 - a write that changes an anchored node's *kind* (container <-> scalar,
+// or object <-> array) used to fall into `reconcile_presentation_at_depth`'s
+// "fresh node, no presentation memory" arm, which cleared the anchor mark
+// along with comment/style -- dropping `&x` (and detaching every `*x` alias
+// to it) even though the position, and hence the anchor, survives the write
+// exactly as it does for a same-kind write (the `..._763` tests above).
+// Every expected string is pinned against mikefarah/yq v4.53.3, run directly
+// against that binary.
+// =============================================================================
+
+#[test]
+fn test_yaml_kind_change_container_to_scalar_keeps_anchor_1359() -> Result<()> {
+    let input = "a: &x {p: 1}\nb: *x\n";
+    let (output, exit_code) = run_yq_stdin(".a = 5", input, &[])?;
+    assert_eq!(exit_code, 0);
+    assert_eq!(output, "a: &x 5\nb: *x\n");
+
+    // The alias's own value stays in step with the anchor's new one --
+    // `sync_aliased_paths` mirrors it, which is what keeps
+    // `enforce_anchor_soundness`'s rule 3 (equal value) satisfied.
+    let (json, exit_code) = run_yq_stdin(".a = 5", input, &["-o=json", "-I=0"])?;
+    assert_eq!(exit_code, 0);
+    assert_eq!(json.trim(), r#"{"a":5,"b":5}"#);
+    Ok(())
+}
+
+#[test]
+fn test_yaml_kind_change_scalar_to_container_keeps_anchor_1359() -> Result<()> {
+    let input = "a: &x 1\nb: *x\n";
+    let (output, exit_code) = run_yq_stdin(r#".a = {"p": 1}"#, input, &[])?;
+    assert_eq!(exit_code, 0);
+    assert_eq!(output, "a: &x\n  p: 1\nb: *x\n");
+    Ok(())
+}
+
+#[test]
+fn test_yaml_kind_change_object_to_array_keeps_anchor_1359() -> Result<()> {
+    // Object <-> Array is a kind change too, not just container <-> scalar.
+    let input = "a: &x {p: 1}\nb: *x\n";
+    let (output, exit_code) = run_yq_stdin(".a = [1, 2]", input, &[])?;
+    assert_eq!(exit_code, 0);
+    assert_eq!(output, "a: &x\n  - 1\n  - 2\nb: *x\n");
+    Ok(())
+}
+
+#[test]
+fn test_yaml_kind_change_at_alias_position_still_detaches_1359() -> Result<()> {
+    // Control: a kind-change write straight to the *alias* position (rather
+    // than the anchor) is the pre-existing #763 "ends at the alias" case --
+    // it detaches, same as a same-kind write there
+    // (`test_yaml_assign_to_alias_detaches_it_but_keeps_anchor_763` above).
+    // The kind-change arm must not change that.
+    let input = "a: &x 1\nb: *x\n";
+    let (output, exit_code) = run_yq_stdin(r#".b = {"p": 1}"#, input, &[])?;
+    assert_eq!(exit_code, 0);
+    assert_eq!(output, "a: &x 1\nb:\n  p: 1\n");
+    Ok(())
+}
+
+// =============================================================================
 // #2497 (split from #1351's "case 2") - a plain assignment (`.c = .b`) whose
 // value is a static read of an aliased node must itself alias, matching real
 // yq's node-copy semantics: `propagate_assign_alias_marks` in

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -25414,6 +25414,29 @@ fn test_yaml_kind_change_at_alias_position_still_detaches_1359() -> Result<()> {
     Ok(())
 }
 
+#[test]
+fn test_yaml_kind_change_via_update_assign_at_alias_position_detaches_1359() -> Result<()> {
+    // Found in review of this issue's own fix. `.b |= 5` is a kind-change
+    // write (object -> scalar) ending exactly at the alias position, same
+    // as the `=` control above, but reached through `|=` instead --
+    // `propagate_assign_alias_marks` (#2497) only re-derives the mark for a
+    // plain `=`/chain-of-`=`, so a first version of this fix that carried
+    // any `Aliases` mark through the kind-change arm unconditionally relied
+    // on `enforce_anchor_soundness`'s value-equality check as the only
+    // backstop here -- unsound, since a later stage in the same pipe
+    // (`.a = 5`) can coincidentally give `.b` the same value `.a` ends up
+    // with, wrongly keeping `*x`. `c` is a second, untouched alias to the
+    // same anchor: it must keep referring to `&x` even though its own kind
+    // also changes (object -> scalar) as a side effect of mirroring `.a`'s
+    // new value -- the fix must tell "this position was itself written"
+    // from "this position's kind changed only because its anchor's did".
+    let input = "a: &x {p: 1}\nb: *x\nc: *x\n";
+    let (output, exit_code) = run_yq_stdin(".b |= 5 | .a = 5", input, &[])?;
+    assert_eq!(exit_code, 0);
+    assert_eq!(output, "a: &x 5\nb: 5\nc: *x\n");
+    Ok(())
+}
+
 // =============================================================================
 // #2497 (split from #1351's "case 2") - a plain assignment (`.c = .b`) whose
 // value is a static read of an aliased node must itself alias, matching real


### PR DESCRIPTION
## Summary

`reconcile_presentation_at_depth`'s kind-change arm (container <-> scalar, or object <-> array) treated the written node as entirely fresh and dropped its `&anchor` along with comment/style — taking every `*alias` to it down too, since `enforce_anchor_soundness` can no longer find a declaration to resolve them against.

Real yq keeps the anchor across a kind change for the same reason it keeps it across a same-kind write: the write replaces the node's *value*, not its *identity*. This carries just the `anchor` slot of the pristine `NodeMeta` through the kind-change arm (comment/style still drop, since neither describes anything that survived the kind change) — `enforce_anchor_soundness`, run afterwards, is still what decides whether the carried mark is actually emittable.

`CommentTree::Leaf` is correct even when the new value is itself a container: every descent into a child (`CommentTree::at_index`/`field`) already falls back to the empty tree for a non-matching variant — the same outcome a freshly-built `Array`/`Object` with empty children would give — and a kind-changed node's children carry no presentation memory of their own either way. Verified this holds for both directions (container→scalar, scalar→container) and for object↔array.

Closes #1359

## Test plan
- [x] `cargo build --features cli`
- [x] `cargo test --features cli,simd,regex,serde` (full suite, debug build)
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings`
- [x] Diffed output against the pinned `yq` v4.53.3 oracle directly for every new case (both kind-change directions, object↔array, and the alias-position control), not just the golden fixtures
- [x] Added 4 new tests in `tests/yq_cli_tests.rs` alongside the existing `..._763` block