### PR TITLE
fix(yq): stop losing a redefined anchor's earlier declaration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`succinctly yq` no longer drops a redefined anchor's earlier
+  declaration on re-emission** (#1353): `a: &x 1\nb: &x 2\nc: *x` used to
+  print `a: 1` (the first `&x` silently gone) even though `c: *x` still
+  correctly resolved to `2` -- values were always right, only the earlier
+  `&x` syntax was lost on output. `YamlIndex`'s reverse anchor map
+  (`bp_to_anchor`) used to be built by inverting the forward map (`anchors`:
+  name -> position, last-wins by design, since that's the correct
+  resolution rule for an alias), so redefining a name silently discarded
+  every earlier declaration's position along with it. Fixed by having the
+  parser populate `bp_to_anchor` directly at each `&name` site
+  (`parse_anchor`/`record_key_anchor`), one entry per declaration, instead
+  of deriving it from the last-wins map. Since both the cursor-streaming
+  path and the DOM write path read the same `YamlCursor::anchor()` ->
+  `get_anchor_name`, this one fix covers both -- including combining
+  correctly with #1352's key-anchor fix on a redefined key anchor.
+
 - **`succinctly yq`'s cursor-streaming identity output no longer drops an
   anchor on a mapping key** (#1352): `&k key: 1` round-tripped as plain
   `key: 1` even on a no-op `.` query. The parser already indexed a key

--- a/src/yaml/index.rs
+++ b/src/yaml/index.rs
@@ -133,12 +133,10 @@ impl YamlIndex<Vec<u64>> {
         let ib_rank = build_ib_rank(&semi.ib);
         let containers_rank = build_containers_rank(&semi.containers);
 
-        // Build reverse anchor mapping (bp_pos → anchor_name)
-        let bp_to_anchor: BTreeMap<usize, String> = semi
-            .anchors
-            .iter()
-            .map(|(name, &bp_pos)| (bp_pos, name.clone()))
-            .collect();
+        // #1353: `semi.bp_to_anchor` is populated directly by the parser,
+        // one entry per `&name` declaration -- not derived from `semi.anchors`
+        // (name → position, last-wins) by inversion, which would silently
+        // drop every declaration but the final one when a name is redefined.
 
         // Convert bp_to_text to compact storage when positions are monotonic
         let open_positions = OpenPositions::build(&semi.bp_to_text, ib_len);
@@ -155,7 +153,7 @@ impl YamlIndex<Vec<u64>> {
             containers: semi.containers,
             containers_rank,
             anchors: semi.anchors,
-            bp_to_anchor,
+            bp_to_anchor: semi.bp_to_anchor,
             aliases: semi.aliases,
             tags: semi.tags,
             line_comments: semi.line_comments,
@@ -189,7 +187,12 @@ impl<W: AsRef<[u64]>> YamlIndex<W> {
         let ib_rank = build_ib_rank(ib.as_ref());
         let containers_rank = build_containers_rank(containers.as_ref());
 
-        // Build reverse anchor mapping
+        // Build reverse anchor mapping. Derived from `anchors` (name →
+        // position, last-wins) by inversion rather than #1353's per-
+        // declaration tracking: this constructor takes a pre-built
+        // `anchors` map with no per-declaration history left to recover,
+        // and (like `line_comments` below) has no caller in this codebase
+        // today to regress on a redefined-anchor input.
         let bp_to_anchor: BTreeMap<usize, String> = anchors
             .iter()
             .map(|(name, &bp_pos)| (bp_pos, name.clone()))

--- a/src/yaml/parser.rs
+++ b/src/yaml/parser.rs
@@ -112,6 +112,11 @@ pub struct SemiIndex {
     pub ty_len: usize,
     /// Anchor definitions: anchor name → BP position of the anchored value
     pub anchors: BTreeMap<String, usize>,
+    /// Reverse anchor mapping: BP position → its own anchor name, one entry
+    /// per `&name` declaration in source order (#1353) -- see the identically
+    /// named `Parser` field's doc comment for why this isn't derived from
+    /// `anchors` above by inversion.
+    pub bp_to_anchor: BTreeMap<usize, String>,
     /// Alias references: BP position of alias → target BP position (resolved at parse time)
     pub aliases: BTreeMap<usize, usize>,
     /// Explicit source tags: BP position → raw tag text (see [`YamlIndex::get_tag`](super::index::YamlIndex::get_tag))
@@ -173,8 +178,20 @@ struct Parser<'a, const HAS_CR: bool> {
     current_type: Option<NodeType>,
 
     // Anchor and alias tracking
-    /// Anchors collected during parsing: name → bp_pos of anchored value
+    /// Anchors collected during parsing: name → bp_pos of anchored value.
+    /// Last-wins on a redefined name, which is exactly the resolution rule
+    /// an alias needs (YAML: an alias refers to the most recent preceding
+    /// anchor of that name) — see `bp_to_anchor` below for the position
+    /// that rule intentionally discards.
     anchors: BTreeMap<String, usize>,
+    /// Reverse anchor mapping: bp_pos of the anchored value/key → its own
+    /// anchor name (#1353). Populated directly at each `&name` site
+    /// (`parse_anchor`/`record_key_anchor`), *not* derived from `anchors`
+    /// by inversion — inverting a last-wins map would silently lose every
+    /// declaration but the final one when a name is redefined, dropping
+    /// `&x` from `a: &x 1\nb: &x 2\nc: *x` on re-emission even though `a`'s
+    /// own declaration is still in the source and real yq keeps it.
+    bp_to_anchor: BTreeMap<usize, String>,
     /// Aliases collected during parsing: bp_pos → target bp_pos (resolved at parse time)
     aliases: BTreeMap<usize, usize>,
     /// Explicit source tags collected during parsing: bp_pos → raw tag text
@@ -297,6 +314,7 @@ impl<'a, const HAS_CR: bool> Parser<'a, HAS_CR> {
             type_stack: Vec::with_capacity(32),
             current_type: None,
             anchors: BTreeMap::new(),
+            bp_to_anchor: BTreeMap::new(),
             aliases: BTreeMap::new(),
             tags: BTreeMap::new(),
             pending_property_bp: None,
@@ -4963,6 +4981,10 @@ impl<'a, const HAS_CR: bool> Parser<'a, HAS_CR> {
         // YAML allows anchor redefinition - later definitions override earlier ones
         // Store placeholder - will be updated when value BP is opened
         self.anchors.insert(name.clone(), self.bp_pos);
+        // #1353: recorded per-declaration, alongside (not derived from) the
+        // last-wins `anchors` map above -- see `bp_to_anchor`'s own doc
+        // comment.
+        self.bp_to_anchor.insert(self.bp_pos, name.clone());
         self.pending_property_bp = Some(self.bp_pos);
 
         Ok(name)
@@ -4984,7 +5006,9 @@ impl<'a, const HAS_CR: bool> Parser<'a, HAS_CR> {
         self.advance();
         let name = self.parse_anchor_name()?;
         self.skip_inline_whitespace();
-        self.anchors.insert(name, self.bp_pos - 1);
+        self.anchors.insert(name.clone(), self.bp_pos - 1);
+        // #1353: see `parse_anchor`'s own matching insert above.
+        self.bp_to_anchor.insert(self.bp_pos - 1, name);
         self.pending_property_bp = Some(self.bp_pos - 1);
         Ok(())
     }
@@ -5308,6 +5332,7 @@ impl<'a, const HAS_CR: bool> Parser<'a, HAS_CR> {
             bp_len: self.bp_pos,
             ty_len: self.ty_pos,
             anchors: core::mem::take(&mut self.anchors),
+            bp_to_anchor: core::mem::take(&mut self.bp_to_anchor),
             aliases: core::mem::take(&mut self.aliases),
             tags: core::mem::take(&mut self.tags),
             line_comments: core::mem::take(&mut self.line_comments),

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -6173,6 +6173,44 @@ fn test_yaml_mapping_key_anchor_and_value_anchor_together_1352() -> Result<()> {
 }
 
 #[test]
+fn test_yaml_redefined_anchor_keeps_earlier_declaration_on_identity_output_1353() -> Result<()> {
+    // #1353: `bp_to_anchor` used to be built by inverting the last-wins
+    // `anchors` (name -> position) map, so a redefined `&x` silently lost
+    // its *first* declaration on re-emission even though the value (and
+    // the alias resolution) were both correct. Real yq keeps every
+    // declaration.
+    let input = "a: &x 1\nb: &x 2\nc: *x\n";
+    let (output, exit_code) = run_yq_stdin(".", input, &[])?;
+    assert_eq!(exit_code, 0);
+    assert_eq!(output, "a: &x 1\nb: &x 2\nc: *x\n");
+    Ok(())
+}
+
+#[test]
+fn test_yaml_redefined_anchor_resolves_to_most_recent_value_1353() -> Result<()> {
+    // The fix must not disturb alias *resolution* (last-wins is the correct
+    // rule for that, unlike re-emission) -- `c` must still read 2, not 1.
+    let input = "a: &x 1\nb: &x 2\nc: *x\n";
+    let (output, exit_code) = run_yq_stdin(".", input, &["-o", "json", "-I", "0"])?;
+    assert_eq!(exit_code, 0);
+    assert_eq!(output.trim(), r#"{"a":1,"b":2,"c":2}"#);
+    Ok(())
+}
+
+#[test]
+fn test_yaml_redefined_anchor_survives_dom_write_path_1353() -> Result<()> {
+    // The DOM write path (a write forces it) reads the same
+    // `YamlCursor::anchor()`/`get_anchor_name` this fix touches, so an
+    // unrelated write elsewhere in the document must not disturb either
+    // redefined declaration.
+    let input = "a: &x 1\nb: &x 2\nc: *x\nd: 3\n";
+    let (output, exit_code) = run_yq_stdin(".d = 5", input, &[])?;
+    assert_eq!(exit_code, 0);
+    assert_eq!(output, "a: &x 1\nb: &x 2\nc: *x\nd: 5\n");
+    Ok(())
+}
+
+#[test]
 fn test_yaml_anchored_tag_in_seq_item_resolves() -> Result<()> {
     // Consuming the anchor before dispatching means the tag is seen rather
     // than absorbed into a plain scalar, so `- &a !!str x` resolves to the


### PR DESCRIPTION
## Summary

YAML allows redefining an anchor name (`a: &x 1`, `b: &x 2`, `c: *x`) --
an alias resolves to the most recent preceding declaration, so `c`
correctly reads `2`. Real yq keeps every `&x` declaration when
re-emitting the document unchanged; succinctly silently dropped every
declaration but the last, printing `a: 1` even though the value/resolution
were always right.

`YamlIndex`'s reverse anchor map (`bp_to_anchor`: position -> name) used
to be built by inverting the forward map (`anchors`: name -> position,
which is correctly last-wins for alias resolution). Inverting a last-wins
map only produces one entry per name, discarding every earlier
declaration's own position along with it.

Fixed by having the parser populate `bp_to_anchor` directly at each
`&name` site (`parse_anchor`, `record_key_anchor`), one entry per
declaration, instead of deriving it from the last-wins `anchors` map.
Both the cursor-streaming path and the DOM write path read the same
`YamlCursor::anchor()` -> `get_anchor_name`, so this one fix covers both
-- including combining correctly with #1352's key-anchor fix on a
redefined key anchor.

`YamlIndex::from_parts` (confirmed zero callers in this codebase) keeps
the old inversion-derived behavior, since it takes a pre-built `anchors`
map with no per-declaration history left to recover.

Independent code review confirmed: `bp_pos` is never a placeholder
rewritten later, `bp_pos` uniqueness holds by construction, exactly two
anchor-recording call sites exist, and a `del()`-interaction divergence
found during testing is pre-existing #1350/ADR-0017 soundness-gate
behavior, unrelated to this fix.

Fixes #1353

## Test plan

- [x] `cargo build`, `cargo build --features cli`
- [x] `cargo test --features cli,simd,regex,serde` (0 failures)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` (clean)
- [x] `cargo fmt --check` (clean)
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features` (clean)
- [x] New regression tests: earlier declaration survives identity output,
      alias resolution unaffected (still reads most-recent value), DOM
      write path also fixed
- [x] Manually verified against the pinned oracle (Homebrew `yq` v4.53.3)
      across block/flow style, 3-way redefinition, key-anchor redefinition
      (#1352 interaction), and a `del()` interaction
- [x] Independent code review (no blocking issues)
