### PR TITLE
perf(jq): path/key/parent/getpath validate only what they touch (#2168)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,44 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **`path()`, `key`, `parent` and `getpath()` now validate only the nodes they
+  navigate through, instead of the whole document** (#2168): on
+  `{"a":"\ud800","d":5}`, `path(.d)` and `getpath(["d"])` answer where they
+  used to raise `invalid unicode escape sequence` — matching `.d`, which has
+  always answered `5` on that document. The same applies to a structural fault
+  (`{"c":{"a":1,},"t":5} | .t | key`) and to #1642's colliding-undecodable-key
+  raise; `[path(.[])]` now names exactly the members `keys_unsorted` lists.
+  Reading the value still raises (`getpath(["a"]) | length`, `path(.a[])`), as
+  does every route that materializes — `select`, `sort_by`/`unique_by`/
+  `min_by`/`max_by`, `to_entries`, `.a |= 1`, and `path()`'s own fallback for a
+  filter shape it cannot walk with cursors.
+
+  The whole-document walk was inherited, not chosen: until #2151 these builtins
+  materialized the document to answer, that tree doubled as #1755/#1953's
+  validity gate, and #2061/#2151 kept an equivalent walk rather than move
+  semantics inside a performance change. It cost 67-75% of such a query's
+  runtime, making `.[0] | key` 3.0-4.1x the price of the `.[0]` it wraps. Real
+  jq 1.7.1 and yq v4.53.3 reject every affected document while parsing it — for
+  `.d` as much as for `path(.d)` — so ADR-0018's decision order reaches its
+  third step with no fidelity argument either way, and internal consistency
+  decides; `.d` had already set the rule. Recorded in
+  [docs/compliance/jq/limitations.md](docs/compliance/jq/limitations.md).
+
+  `getpath` was rewritten to walk cursors to get there (a string key into an
+  object, a number into an array; a slice descriptor materializes the one node
+  it has reached and hands the rest of the path to the owned table, which stays
+  the single definition of every step's meaning). It now costs what the
+  navigation it spells costs: `getpath([0])` on a 300 K-element array is 0.02 s
+  and 11.9 MiB against `.[0]`'s 0.02 s and 11.7 MiB, down from 0.06 s and
+  38.4 MiB. All 25 of its step rows were re-verified against jq 1.7.1, and the
+  #2053 constraint that `path_expr` is evaluated exactly once still holds on
+  every branch. One row moved away from jq as a consequence: an over-cap
+  numeric literal read through `getpath` now keeps its source spelling, as
+  `.big` already did, instead of being re-spelled `1E-301` by the reindex round
+  trip it no longer takes.
+
 ### Fixed
 
 - **`key`/`path` (no arg) followed by more pipe stages no longer falls back
@@ -52,6 +90,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
      (`conventions_differ_at_exactly_five_code_points`, up from three).
   **Residual, not fixed here**: the M2 streaming path itself still emits a
   *raw* (non-`\L`/`\P`-sourced) U+2028/U+2029 byte unescaped -- see #2607.
+
+- **`at_offset(f)`/`at_position(f; g)` accept an argument navigated from the
+  document** (#2168): `at_offset(.n)` and `at_position(.l; .c)` errored with
+  `at_offset requires a non-negative integer` on a document that plainly has
+  the integer at `.n`, while the same argument spelled `getpath(["n"])`
+  worked. The arm already accepted a document-sourced number; it just had no
+  case for one arriving as a cursor, which `.n` produces and `getpath` did
+  not. Found by #2168's own change breaking the `getpath` spelling (three
+  copies of the argument match, now one `position_arg_integer`), which is how
+  the older gap in the other two surfaced.
 
 - **`succinctly yq` no longer drops a redefined anchor's earlier
   declaration on re-emission** (#1353): `a: &x 1\nb: &x 2\nc: *x` used to

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `.big` already did, instead of being re-spelled `1E-301` by the reindex round
   trip it no longer takes.
 
+  Measured on the two pinned boxes, interleaved, medians of 7, output identity
+  gated (20 configurations, 0 differences on each). `.[][0] | key` and
+  `path(.)` on a 14 MB `users` document: **-68%** on an Apple M4 Pro (83 ->
+  27 ms) and **-62%** on a 7950X (124 -> 46 ms); on a 74 MB document, -70% and
+  -61%. A number-dense 20 MB array reads -23% and -37%, a string-dense one
+  -44% and -21%. `[.[][] | key] | length` -49% and -38%.
+
+  One caveat, measured rather than assumed: on the M4 Pro the getpath commit
+  also costs **+6.2%** on queries that contain no `getpath` at all (`length`,
+  `keys_unsorted[0]`, `.[][0]` -- uniform across 8 of 8 rows, against a
+  +-1.5% control floor). Three results place it in code layout rather than in
+  the new logic: the same binaries show no penalty on the 7950X (median
+  -0.11%), the penalty disappears on the same ARM box when both halves are
+  rebuilt with `codegen-units=1` (median +0.28%), and the affected queries
+  never execute the changed code. An `#[inline(never)]` on the new walk
+  removes it on ARM (-0.21%) and costs **+9.5%** on x86_64 for the same
+  unrelated queries, so it was measured and rejected rather than shipped:
+  cargo's default release profile splits this crate into 16 codegen units, and
+  the two architectures land on opposite sides of that split. Filed as #2603
+  rather than chased further with another guess.
+
 ### Fixed
 
 - **`key`/`path` (no arg) followed by more pipe stages no longer falls back

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,16 +21,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `min_by`/`max_by`, `to_entries`, `.a |= 1`, and `path()`'s own fallback for a
   filter shape it cannot walk with cursors.
 
-  The whole-document walk was inherited, not chosen: until #2151 these builtins
-  materialized the document to answer, that tree doubled as #1755/#1953's
-  validity gate, and #2061/#2151 kept an equivalent walk rather than move
-  semantics inside a performance change. It cost 67-75% of such a query's
-  runtime, making `.[0] | key` 3.0-4.1x the price of the `.[0]` it wraps. Real
-  jq 1.7.1 and yq v4.53.3 reject every affected document while parsing it — for
-  `.d` as much as for `path(.d)` — so ADR-0018's decision order reaches its
-  third step with no fidelity argument either way, and internal consistency
-  decides; `.d` had already set the rule. Recorded in
+  **This is a deliberate divergence from jq, and a newly introduced one.**
+  Real jq rejects these documents while parsing them, so `path(.d)` and
+  `getpath(["d"])` raising *matched* jq's observable outcome, and now they do
+  not. ADR-0018's decision order does not license the change — its step 2
+  favours the behaviour being given up, and no rule-4 condition applies — so
+  it is recorded on its merits, against the order's own answer, in
   [docs/compliance/jq/limitations.md](docs/compliance/jq/limitations.md).
+  (`key`/`parent` are exempt from that half: neither is a jq builtin, so there
+  is no jq oracle for them. All four diverge from yq, which has both.)
+
+  It was taken anyway because the agreement being given up was an accident of
+  an implementation detail rather than a decision: until #2151 these builtins
+  materialized the document to answer, that tree doubled as #1755/#1953's
+  validity gate, and #2061/#2075/#2151 each kept an equivalent walk rather
+  than move semantics inside a performance change, each recording that the
+  question was the project's to answer. The result made one read's answer
+  depend on its spelling — `.d` answered `5` where `path(.d)` refused, same
+  document, same run — and cost 67-75% of such a query's runtime, making
+  `.[0] | key` 3.0-4.1x the price of the `.[0]` it wraps. succinctly already
+  diverges on this whole class of document through `.d` itself, deliberately
+  and at a measured price, so the real choice was between diverging uniformly
+  and diverging according to how the read was spelled.
 
   `getpath` was rewritten to walk cursors to get there (a string key into an
   object, a number into an array; a slice descriptor materializes the one node

--- a/docs/compliance/jq/limitations.md
+++ b/docs/compliance/jq/limitations.md
@@ -4203,10 +4203,12 @@ $ printf '%s' '{"c":{"a":1,},"t":5}' | succinctly jq -c '.t | key'
 Real jq 1.7.1 rejects every one of those documents while parsing it, before any filter runs,
 and so does real yq v4.53.3 on the YAML spelling. So the reference separates none of these
 rows — it answers *nothing* here, `.d` included — and ADR-0018's decision order reaches its
-third step with no fidelity argument on either side. What decided it is internal
-consistency, and succinctly's own plain navigation had already set the rule: `.d` answered
-`5` on the first document and `.t` answered `5` on the second, long before `path(.d)` and
-`.t | key` refused them. Two spellings of one read disagreeing is the shape
+third step with no fidelity argument on either side. That step is performance and memory
+(ADR-0018's #2416 amendment): #2168 measured the pre-walk gate at 67-75% of such a query's
+runtime, making `.[0] | key` cost 3.0-4.1x the `.[0]` it wraps, and dropping it settles the
+tie. It also restores the internal consistency succinctly's own plain navigation had already
+set: `.d` answered `5` on the first document and `.t` answered `5` on the second, long before
+`path(.d)` and `.t | key` refused them. Two spellings of one read disagreeing is the shape
 [#1629](https://github.com/rust-works/succinctly/issues/1629)/[#1642](https://github.com/rust-works/succinctly/issues/1642)
 exist to remove.
 
@@ -4241,14 +4243,18 @@ same display spelling — where before, one answered and the other raised. The m
 routes (`-S`, `-s`, `.,.`) still raise on that document, because rendering both keys into
 one map is what the collision *is*.
 
-**One row moved away from jq.** A `NumberLiteral` longer than `REINDEX_LITERAL_LEN_CAP`
-disqualified a document from `getpath`'s native arm, sending the call through the reindex
-round trip, which re-spells it. jq prints `1E-301` for a 303-character literal and so did
-`getpath(["big"])`; `.big` printed all 303 characters, because preserving a document
-number's written form is deliberate (`DocumentValue::number_literal`,
+**One row moved away from jq, with no ADR-0018 carve-out.** A `NumberLiteral` longer than
+`REINDEX_LITERAL_LEN_CAP` disqualified a document from `getpath`'s native arm, sending the
+call through the reindex round trip, which re-spells it. jq prints `1E-301` for a
+303-character literal and so did `getpath(["big"])`; `.big` printed all 303 characters,
+because preserving a document number's written form is deliberate
+(`DocumentValue::number_literal`,
 [#387](https://github.com/rust-works/succinctly/issues/387)/[#966](https://github.com/rust-works/succinctly/issues/966)).
-Both spellings now print the source form. This trades a coincidental agreement with jq for
-agreement with succinctly's own read of the same node; the pre-existing divergence it joins
+Both spellings now print the source form. No rule-4 condition applies here, so ADR-0018's
+decision order does not license preferring this on its own terms — absent an exemption, step
+2 says the reference's `1E-301` should have stood. This is recorded as an accepted, if
+imperfect, side effect of unifying `getpath`'s number handling with `.big`'s rather than as a
+decision the order above actually reaches; the pre-existing divergence it joins
 is the entry above on the owned route's re-spelling.
 
 Pinned by `test_lazy_validation_boundary_2168` (the table above, as one test),

--- a/docs/compliance/jq/limitations.md
+++ b/docs/compliance/jq/limitations.md
@@ -4200,25 +4200,66 @@ $ printf '%s' '{"c":{"a":1,},"t":5}' | succinctly jq -c '.t | key'
 "t"
 ```
 
-Real jq 1.7.1 rejects every one of those documents while parsing it, before any filter runs,
-and so does real yq v4.53.3 on the YAML spelling. So the reference separates none of these
-rows — it answers *nothing* here, `.d` included — and ADR-0018's decision order reaches its
-third step with no fidelity argument on either side. That step is performance and memory
-(ADR-0018's #2416 amendment): #2168 measured the pre-walk gate at 67-75% of such a query's
-runtime, making `.[0] | key` cost 3.0-4.1x the `.[0]` it wraps, and dropping it settles the
-tie. It also restores the internal consistency succinctly's own plain navigation had already
-set: `.d` answered `5` on the first document and `.t` answered `5` on the second, long before
-`path(.d)` and `.t | key` refused them. Two spellings of one read disagreeing is the shape
-[#1629](https://github.com/rust-works/succinctly/issues/1629)/[#1642](https://github.com/rust-works/succinctly/issues/1642)
-exist to remove.
+**This loses fidelity that succinctly previously had, and the decision order does not
+license it.** An earlier draft of this entry claimed the reference "separates none of these
+rows", so that the order fell through to its performance step. That was wrong, and the
+correction is the important part of this record. Real jq 1.7.1 rejects every document above
+while parsing it, before any filter runs, and real yq v4.53.3 does the same on the YAML
+spelling — so the reference does have a behaviour here, and it is *reject*. Measured against
+the pinned binaries:
 
-The gate they lost was never a decision about these builtins. Until
-[#2151](https://github.com/rust-works/succinctly/issues/2151) they materialized the whole
-document to answer, and that materialization doubled as the #1755/#1953 validity check; when
-the tree went, an equivalent whole-document walk was kept in its place specifically so a
-performance change would not move semantics. #2168 measured what that cost — 67-75% of such
-a query's runtime, making `.[0] | key` 3.0-4.1x the price of the `.[0]` it wraps — and took
-the semantics question on its own.
+| filter on `{"a":"\ud800","d":5}` | jq 1.7.1 | succinctly before #2168 | succinctly after |
+|---|---|---|---|
+| `.d` | error | `5` — already diverged | `5` |
+| `path(.d)` | error | error — **matched jq** | `["d"]` — **diverges** |
+| `getpath(["d"])` | error | error — **matched jq** | `5` — **diverges** |
+
+Step 2 of ADR-0018's decision order therefore *does* separate the two options, and it favours
+the behaviour being given up: keeping the gate matched jq's observable outcome on those rows,
+and dropping it does not. The performance step is never reached. No rule-4 condition applies
+either — the output is readable, nothing is corrupted or discarded, and neither choice takes
+the process down. **This is a deliberate divergence taken against the order's own answer**,
+on the same footing as this section's other two entries recorded on their merits rather than
+under a carve-out.
+
+`key` and `parent` are the exception within the exception: neither is a jq builtin at all
+(`jq: error: key/0 is not defined`, exit 3), so for those two there is no jq oracle and no
+fidelity to lose. Only `path` and `getpath` are real divergences from jq. All four diverge
+from yq, which has `key`/`parent` and rejects these documents too.
+
+**Why it was taken anyway.** Three reasons, none of which is "the order allowed it":
+
+1. *The agreement being given up was an accident of an implementation detail.* Until
+   [#2151](https://github.com/rust-works/succinctly/issues/2151) these builtins materialized
+   the whole document to answer, and that materialization doubled as the #1755/#1953 validity
+   check. When the tree went, an equivalent whole-document walk was kept in its place
+   specifically so a performance change would not move semantics
+   ([#2061](https://github.com/rust-works/succinctly/issues/2061),
+   [#2075](https://github.com/rust-works/succinctly/issues/2075) and #2151 each say so, and
+   each declined the semantics question as the project's to answer). No one ever decided that
+   `path()` should validate: it re-derived jq's rejection as a side effect, for a different
+   reason than jq has, and only for the spellings that happened to materialize.
+2. *It made one read's answer depend on how it was spelled.* `.d` answered `5` and `path(.d)`
+   refused, on the same document, in the same run. Nothing can depend on that coherently — a
+   caller wanting jq's rejection would have to route through `path` and avoid `.d` — and it is
+   the shape [#1629](https://github.com/rust-works/succinctly/issues/1629)/[#1642](https://github.com/rust-works/succinctly/issues/1642)
+   exist to remove.
+3. *It cost 67-75% of such a query's runtime*, making `.[0] | key` 3.0-4.1x the price of the
+   `.[0]` it wraps. That is what made the question worth asking, but it is a reason for
+   acting, not a licence under the order.
+
+**The context that makes the loss survivable, and its limit.** succinctly already diverges on
+this whole class of document, through `.d` itself, and has since long before #2168: the
+semi-index accepts input jq's parser rejects, deliberately and at a measured price — always-on
+strict validation costs two thirds of the runtime of a cheap navigation query
+([`docs/plan/decode-failure-routing.md`](../../plan/decode-failure-routing.md), "Why not
+upfront validation for everyone"), which is the trade `CLAUDE.md`'s own "minimal validation"
+note describes. So the real choice was never "match jq or not" but "diverge uniformly, or
+diverge in a way that depends on the spelling". That is context, **not** a licence: ADR-0018's
+scope note explicitly warns that an evaluator behaviour may not be reframed as a spec-level
+input question to escape rule 4, and this entry does not claim otherwise. A user who wants
+jq's rejection has `--validate` and `succinctly json validate`, which run at roughly 1 GB/s —
+an order of magnitude cheaper than the walk this removes.
 
 **What still validates.** The rule is about reading, not about the builtin's name:
 

--- a/docs/compliance/jq/limitations.md
+++ b/docs/compliance/jq/limitations.md
@@ -1842,7 +1842,9 @@ apparently validates upstream, matching what this entry found). `select`,
 this same function without that upstream validation, and a trailing-comma/
 missing-colon/stray-comma corruption in a subtree the query only ever
 validates (never emits) silently passed — `{"c":{"a":1,},"t":5} |
-select(.c) | .t` answered `5` instead of raising, confirmed live. See
+select(.c) | .t` answered `5` instead of raising, confirmed live. (`path()` left
+that list again in #2168, which decided that naming a position should not
+validate what is inside it; `select`/`sort_by` keep the checks this fix added.) See
 this doc's "The validate-only traversal..." entry in `CHANGELOG.md` for
 the fix; the underlying lesson stands even though this specific
 conclusion didn't: a function lacking its own checks by inspection can
@@ -2941,7 +2943,11 @@ shows #1653's original ordering.
 That is not a leftover: the eager evaluator's `to_owned_with_cursor` on the ambient value
 doubles as a validity gate (#1194's structural checks, #1642's colliding-display-key raise)
 and also decides an undecodable key's spelling, and `eval_each_generic`'s native arms (#1596)
-do neither. Streaming such a filter would drop those checks.
+do neither. Streaming such a filter would drop those checks. (#2168 settled the same
+question for `path`/`key`/`parent`/`getpath` — see its entry below — but not this one: there
+the gate stood in front of a *navigation* that could carry the rule itself, where this one
+stands in front of a filter that forwards the root value unchanged, and the spelling half is
+untouched either way.)
 [#2103](https://github.com/rust-works/succinctly/issues/2103) tracks separating the two jobs;
 until it lands, those shapes stay on the eager route.
 
@@ -4177,6 +4183,89 @@ document-read number materializes as a short `NumberLiteral`, and yq mode's
 `key`/`parent` at all, so there is no oracle for the shape; what changed is a
 spelling succinctly used to preserve internally. Fixing it means giving the
 owned evaluator a non-reindexing path, not this door.
+
+### `path`/`key`/`parent`/`getpath` validate only what they touch — no carve-out; recorded on its merits (#2168)
+
+These four read a position rather than a value, and as of
+[#2168](https://github.com/rust-works/succinctly/issues/2168) they inspect only the nodes
+they navigate through. A corrupted value elsewhere in the document — an undecodable escape,
+a trailing comma, a colliding undecodable key — no longer makes them raise:
+
+```console
+$ printf '%s' '{"a":"\ud800","d":5}' | succinctly jq -c 'path(.d)'
+["d"]
+$ printf '%s' '{"a":"\ud800","d":5}' | succinctly jq -c 'getpath(["d"])'
+5
+$ printf '%s' '{"c":{"a":1,},"t":5}' | succinctly jq -c '.t | key'
+"t"
+```
+
+Real jq 1.7.1 rejects every one of those documents while parsing it, before any filter runs,
+and so does real yq v4.53.3 on the YAML spelling. So the reference separates none of these
+rows — it answers *nothing* here, `.d` included — and ADR-0018's decision order reaches its
+third step with no fidelity argument on either side. What decided it is internal
+consistency, and succinctly's own plain navigation had already set the rule: `.d` answered
+`5` on the first document and `.t` answered `5` on the second, long before `path(.d)` and
+`.t | key` refused them. Two spellings of one read disagreeing is the shape
+[#1629](https://github.com/rust-works/succinctly/issues/1629)/[#1642](https://github.com/rust-works/succinctly/issues/1642)
+exist to remove.
+
+The gate they lost was never a decision about these builtins. Until
+[#2151](https://github.com/rust-works/succinctly/issues/2151) they materialized the whole
+document to answer, and that materialization doubled as the #1755/#1953 validity check; when
+the tree went, an equivalent whole-document walk was kept in its place specifically so a
+performance change would not move semantics. #2168 measured what that cost — 67-75% of such
+a query's runtime, making `.[0] | key` 3.0-4.1x the price of the `.[0]` it wraps — and took
+the semantics question on its own.
+
+**What still validates.** The rule is about reading, not about the builtin's name:
+
+| shape | behaviour | why |
+|---|---|---|
+| `path(.d)`, `.d \| key`, `.d \| parent`, `getpath(["d"])` | answer | never read `.a` |
+| `path(.a)`, `getpath(["a"])` | answer, echoing raw bytes like `.a` | naming a position is not reading it |
+| `getpath(["a"]) \| length`, `path(.a[])`, `.a[] \| key` | raise | the value is read |
+| `path(if . then .d else null end)`, `path(.d \| select(true))`, `path(..)` | raise | not cursor-navigable; the fallback materializes, and validates all of it |
+| `select(f)`, `sort_by(f)`, `unique_by(f)`, `min_by(f)`, `max_by(f)` | raise | the subtree walked *is* the value tested or emitted |
+| `to_entries`, `map_values(f)`, `. as $x`, `.a \|= 1`, `[.[]]` | raise | materialize |
+
+The two `path(...)` spellings disagreeing is the residue of this change, not an oversight:
+the materializing fallback validates everything it materializes, which is the same rule
+applied to a route that reads the whole document.
+
+**What else stopped firing.** The #1194/#1677/#2211/#2243 structural checks and #1642's
+colliding-display-key raise rode on the same walk, so they no longer fire for these builtins
+on a subtree the query never reads. `[path(.[])]` now names exactly the members
+`keys_unsorted` lists, element for element, on a document with two undecodable keys of the
+same display spelling — where before, one answered and the other raised. The materializing
+routes (`-S`, `-s`, `.,.`) still raise on that document, because rendering both keys into
+one map is what the collision *is*.
+
+**One row moved away from jq.** A `NumberLiteral` longer than `REINDEX_LITERAL_LEN_CAP`
+disqualified a document from `getpath`'s native arm, sending the call through the reindex
+round trip, which re-spells it. jq prints `1E-301` for a 303-character literal and so did
+`getpath(["big"])`; `.big` printed all 303 characters, because preserving a document
+number's written form is deliberate (`DocumentValue::number_literal`,
+[#387](https://github.com/rust-works/succinctly/issues/387)/[#966](https://github.com/rust-works/succinctly/issues/966)).
+Both spellings now print the source form. This trades a coincidental agreement with jq for
+agreement with succinctly's own read of the same node; the pre-existing divergence it joins
+is the entry above on the owned route's re-spelling.
+
+Pinned by `test_lazy_validation_boundary_2168` (the table above, as one test),
+`test_path_answers_past_an_undecodable_sibling_2168`,
+`test_path_answers_past_a_colliding_key_2168`,
+`test_path_answers_past_a_structural_fault_it_never_reads_2168`,
+`test_getpath_touches_only_the_nodes_it_navigates_2168`,
+`test_getpath_cursor_walk_matches_jq_2168`,
+`test_getpath_keeps_a_document_numbers_spelling_2168` (`tests/jq_cli_tests.rs`), and
+`test_path_context_cursor_walk_skips_an_undecodable_sibling_2168` plus its yq-mode sibling
+(`tests/yq_cli_tests.rs`).
+
+**Still open.** [#2103](https://github.com/rust-works/succinctly/issues/2103) — the eager
+and streaming evaluators disagree about validating the *ambient* value, which is a different
+question this decision informs rather than closes: the eager route's own
+`to_owned_with_cursor` still validates a whole document that a streaming arm would not, and
+which spelling an undecodable key gets is still undecided.
 
 ## Provenance
 

--- a/docs/optimizations/access-patterns.md
+++ b/docs/optimizations/access-patterns.md
@@ -246,6 +246,14 @@ document: document-order walk 3.00 (mean and max), `.users[] | .name` 3.12 mean
 / 5 max (a draft that only reused the seed going forward left this shape's two
 backward asks per element at 23 probes each).
 
+#2168's second half then removed the walk from these queries altogether:
+`path`/`key`/`parent`/`getpath` validate only the nodes they navigate through
+now, so the shapes this seed was tuned for no longer traverse the document at
+all. The seed still pays for itself on everything that does walk in document
+order -- identity output, `to_owned`, `.[]` iteration, `select` and the
+`sort_by` family's own validation -- which is where the non-`key` rows below
+were always measured.
+
 End to end, Apple M4 Pro, interleaved A/B with output identity gated, medians of
 7 (PR #2578): `.[][0] | key` on a 14 MB `users` document 131.6 -> 84.6 ms
 (-36%), the same on a 20 MB `numbers` array 151.8 -> 84.5 ms (-44%), identity

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -14969,7 +14969,7 @@ fn builtin_fromjsonstream<W: Clone + AsRef<[u64]>>(
 /// but a read that lands nowhere is not an error: jq answers `null` for an
 /// index past either end, and for NaN, which reaches no element at all.
 /// `None` is that "no such element".
-fn resolve_read_index(key: &OwnedValue, len: usize) -> Option<usize> {
+pub(crate) fn resolve_read_index(key: &OwnedValue, len: usize) -> Option<usize> {
     // `as` saturates, so ±inf lands past the end and reads as `null`; NaN
     // returns `None` here same as it does from `numeric_key_to_index`.
     let index = numeric_key_to_index(key)?;
@@ -15097,7 +15097,23 @@ pub(crate) fn getpath_walk_owned<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
             QueryResult::Error(EvalError::path_must_be_array())
         };
     };
+    getpath_walk_owned_segments::<W, S>(root, path, optional)
+}
 
+/// [`getpath_walk_owned`]'s loop over an already-unwrapped path, so a walk
+/// can start partway along one.
+///
+/// Split out for #2168: `eval_generic`'s `getpath` walks the document with
+/// cursors now, and hands control back here at the first segment the cursor
+/// walk cannot answer without a value in hand -- a slice descriptor. That
+/// caller materializes the *one* node it has reached and passes the
+/// remaining segments, so this table stays the single definition of what
+/// every step means, rather than being partially restated over cursors.
+pub(crate) fn getpath_walk_owned_segments<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
+    root: &OwnedValue,
+    path: &[OwnedValue],
+    optional: bool,
+) -> QueryResult<'a, W> {
     let mut current: Cow<'_, OwnedValue> = Cow::Borrowed(root);
 
     for segment in path {
@@ -50607,7 +50623,6 @@ mod tests {
             (&b"[\"\xff\xfe\"]"[..], "all(.>0)"),
             (&b"[\"\xff\xfe\"]"[..], "any(.[]; true)"),
             (&b"[\"\xff\xfe\"]"[..], "all(.[]; true)"),
-            (&b"[\"\xff\xfe\"]"[..], ".[] | key"),
             (&b"[[\"\xff\xfe\"]]"[..], "combinations"),
             (&b"[\"\xff\xfe\"]"[..], "combinations(2)"),
             (&b"\"\xff\xfe\""[..], "debug"),
@@ -50628,6 +50643,18 @@ mod tests {
                 QueryResult::Error(e) if e.is_decode_failure() => {}
             );
         }
+
+        // `.[] | key` was in the list above until #2168. It names element 0's
+        // position and never reads the element, so it now answers `0` -- the
+        // same rule `.[]` itself already followed here, which echoes these raw
+        // bytes rather than raising. The row is kept, asserting the new
+        // answer, rather than deleted: the list's point is which builtins read
+        // a value, and this is the one that stopped.
+        query!(
+            &b"[\"\xff\xfe\"]"[..],
+            ".[] | key",
+            QueryResult::Owned(OwnedValue::Int(0)) => {}
+        );
 
         // `eval_single`'s yq-mode object slice arm is gated on
         // `S::TAG == EvalTag::Yq`, so `yq_query!`'s error pattern (which

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -13538,7 +13538,7 @@ fn getpath_walk_cursor<S: EvalSemantics, V: DocumentValue>(
                         // in `range` to `[0, len)`, so `get_cursor` cannot
                         // miss here.
                         let Some(elem) = elements.get_cursor(idx) else {
-                            break;
+                            break; // omni-dev: coverage tolerate-line reason="unreachable: `len_checked` and `SliceBounds::resolve` already bound every index in `range` to `[0, len)`, so `get_cursor` cannot miss (#2168)"
                         };
                         match to_owned_cursor(&elem) {
                             Ok(owned_elem) => items.push(owned_elem),
@@ -30402,5 +30402,123 @@ mod tests {
             cursor_ancestor(&at(".a.b[1]"), 4).is_none(),
             "above the root"
         );
+    }
+
+    /// #2168 coverage: `getpath_walk_cursor`'s `optional` parameter is
+    /// threaded "for real" -- seven of its exits consult it to decide
+    /// suppress-vs-raise -- but no CLI dispatch reaches the arm with
+    /// `optional = true` (`Expr::Optional`'s catch-all evaluates its inner
+    /// expression at the *ambient* `optional`, the documented `Map`/`Select`
+    /// precedent; see `Builtin::GetPath`'s own comment and
+    /// `test_optional_ignored_sites_2280`). Called directly, for the same
+    /// reason `test_generic_tostring_and_wildcard_respect_optional_2231`
+    /// calls `eval_builtin` directly: the behaviour is defensive, so nothing
+    /// behavioural can pin it, and left unpinned a later edit could drop the
+    /// threading with every test still green.
+    ///
+    /// Only three of those seven can actually behave differently, and they
+    /// are the three shapes below: the ones whose error is *not* a
+    /// materialization failure. The other four are the
+    /// `Err(e) if suppresses(&e, optional)` arms, and they are deliberately
+    /// not pinned here, because there is nothing to pin -- every error
+    /// `find_cursor`/`len_checked`/`to_owned_cursor` raise is
+    /// `decode_failure`-tagged (#2334's `debug_assert_materialization_error`
+    /// asserts exactly that), so the guard is always false and both settings
+    /// raise. `test_getpath_cursor_walk_corrupted_and_null_shapes_2168`
+    /// (`tests/jq_cli_tests.rs`) drives all four with real corrupted
+    /// documents, which is what keeps the guard itself live code.
+    #[test]
+    fn test_getpath_walk_cursor_threads_optional_2168() {
+        use crate::json::JsonIndex;
+        let json: &[u8] = br#"{"a":[1,2],"n":1}"#;
+        let index = JsonIndex::build(json);
+        let root = index.root(json);
+
+        // Not an array at all: `Path must be specified as an array`.
+        let not_a_path = OwnedValue::Int(0);
+        // A slice descriptor whose bounds are not integers:
+        // `Array/string slice indices must be integers`.
+        let bad_slice = OwnedValue::Array(vec![
+            OwnedValue::String("a".into()),
+            OwnedValue::Object(
+                core::iter::once(("start".to_string(), OwnedValue::String("x".into()))).collect(),
+            ),
+        ]);
+        // A segment whose kind the node cannot take: `Cannot index number
+        // with string "b"`.
+        let type_error = OwnedValue::Array(vec![
+            OwnedValue::String("n".into()),
+            OwnedValue::String("b".into()),
+        ]);
+
+        for (label, path) in [
+            ("non-array path", &not_a_path),
+            ("slice bounds", &bad_slice),
+            ("type error", &type_error),
+        ] {
+            match getpath_walk_cursor::<JqSemantics, crate::json::light::StandardJson<'_, Vec<u64>>>(
+                root, path, false,
+            ) {
+                GenericResult::Error(e) => {
+                    assert!(
+                        !e.is_decode_failure(),
+                        "[{label}] must be an ordinary error, not a decode failure: {e:?}"
+                    );
+                }
+                other => panic!("[{label}] expected a raise at optional=false, got: {other:?}"),
+            }
+            match getpath_walk_cursor::<JqSemantics, crate::json::light::StandardJson<'_, Vec<u64>>>(
+                root, path, true,
+            ) {
+                GenericResult::None => {}
+                other => panic!("[{label}] expected suppression at optional=true, got: {other:?}"),
+            }
+        }
+    }
+
+    /// #2168 coverage: `try_path_context_cursor_walk`'s own
+    /// `path_context_root` escape arm.
+    ///
+    /// Before this issue, `path_context_root` ran
+    /// `push_generic_document_validation_error` over the whole input, so any
+    /// corrupted document reached this arm. #2168 removed that gate, leaving
+    /// [`cursor_path_and_ancestors`] as the only thing that can still fail
+    /// here -- and it fails only when an *ancestor's own key* is not
+    /// string-shaped (#1995), which every CLI navigation to such a node trips
+    /// over earlier -- `find_cursor` and `.[]`'s own walk both raise before
+    /// the nested pipe starts, on all ~25 spellings tried under temporary
+    /// instrumentation during this review.
+    /// The non-sink route's own doc comment names `eval_with_cursor` as its
+    /// other caller, so that is the door used here.
+    #[test]
+    fn test_path_context_root_escape_on_a_non_string_ancestor_key_2168() {
+        use crate::json::JsonIndex;
+        // `.x`'s object has a numeric key, so the node under it has an
+        // ancestor whose key has no display spelling at all.
+        let json: &[u8] = br#"{"x":{1:{"z":3}}}"#;
+        let index = JsonIndex::build(json);
+        let root = index.root(json);
+
+        let outer = root.value().as_object().expect("root is an object");
+        let (x_field, _) = DocumentFields::uncons(&outer).expect("root has one field");
+        let inner = x_field
+            .value_cursor
+            .value()
+            .as_object()
+            .expect(".x is an object");
+        let (bad_field, _) = DocumentFields::uncons(&inner).expect(".x has one field");
+        assert!(
+            key_display_string(&bad_field.key).is_none(),
+            "the fixture's point is a key with no display spelling"
+        );
+
+        let expr = parse(". | key").expect("parses");
+        match eval_with_cursor(&expr, bad_field.value_cursor) {
+            GenericResult::Error(e) => assert!(
+                e.is_decode_failure(),
+                "a malformed member is a decode failure: {e:?}"
+            ),
+            other => panic!("expected the walk's root to escape, got: {other:?}"),
+        }
     }
 }

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -14915,9 +14915,12 @@ fn path_context_single_native(expr: &Expr) -> bool {
 /// step itself (`path_step_generic`: `find_cursor`'s #1677 delimiter scan,
 /// `effective_fields_checked`/`collect_cursors_checked`, the Iterate arm's
 /// `string_decode_error` raise). Real jq and yq both reject such a document
-/// at parse time, so every option here is an ADR-0018 divergence and the
-/// tie-break is internal consistency; recorded in
-/// `docs/compliance/jq/limitations.md`. `select` and the `sort_by` family
+/// at parse time, and until #2168 these builtins raised too -- so this gave
+/// up an agreement with the reference that plain navigation never had.
+/// ADR-0018's decision order does not license that (step 2 favours the old
+/// behaviour, and no rule-4 condition applies); it is a divergence taken on
+/// its merits and recorded as one in `docs/compliance/jq/limitations.md`,
+/// which carries the reasons. `select` and the `sort_by` family
 /// keep their gate: the value they test or emit *is* the walk's domain.
 fn path_context_root<V: DocumentValue>(root: V::Cursor) -> Result<PathContextPos<V>, Control> {
     // The walk's input is not always the document root: a nested pipe

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -2708,18 +2708,21 @@ fn push_generic_owned_values<V: DocumentValue>(
 /// colliding-decode-failure-key -- and if so, the `Control::Error` a
 /// caller should raise.
 ///
-/// The shared document-validation gate behind five call sites spanning
-/// four feature families -- `select`'s truthiness check
+/// The shared document-validation gate behind three call sites spanning
+/// two feature families -- `select`'s truthiness check
 /// (`push_generic_truthiness`, the only one actually about truthiness;
 /// see its own doc comment for why it falls through to
-/// [`DocumentCursor::is_falsy`]'s silent "not falsy" default otherwise),
-/// `sort_by`/`unique_by`/`min_by`/`max_by`'s comparison key
-/// (`key_elements_generic`), the path-context fast path
-/// (`path_context_root`), and `path(...)` (`eval_builtin`) -- not a
-/// truthiness-specific helper despite this function's former name
-/// (#2413): each of those five callers needs the #1247/#1194 validation
-/// below without ever materializing an `OwnedValue` for the subtree it's
-/// validating.
+/// [`DocumentCursor::is_falsy`]'s silent "not falsy" default otherwise)
+/// and `sort_by`/`unique_by`/`min_by`/`max_by`'s comparison key
+/// (`key_elements_generic`) -- not a truthiness-specific helper despite
+/// this function's former name (#2413): each of those callers needs the
+/// #1247/#1194 validation below without ever materializing an
+/// `OwnedValue` for the subtree it's validating. In both, the subtree
+/// walked is the value the query tests or emits. The path-context walk
+/// (`path_context_root`) and `path(...)` (`eval_builtin`) used to be the
+/// other two callers, running this over the *whole document* to answer a
+/// bounded query; #2168 (direction 2) dropped that, so they validate only
+/// the nodes they navigate through, like `.d` does.
 ///
 /// This is [`to_owned_cursor_at_depth`]'s own traversal and validation
 /// (same object/array unconsing, same key-collision guard) -- but it
@@ -12381,21 +12384,16 @@ fn path_step_generic<S: EvalSemantics, V: DocumentValue>(
                     // priority order as `scalar_fallback`/
                     // `decode_failure_or` elsewhere in this fix.
                     //
-                    // Currently unreachable via this function's only caller
-                    // (`Builtin::Path`, `eval_generic.rs`): confirmed via a
-                    // temporary debug probe that `path_step_generic` is
-                    // never even entered for a document containing an
-                    // undecodable scalar, because that caller's own
-                    // `push_generic_document_validation_error` pre-walk
-                    // (#1755/#1953's "validity gate", a whole-*document*
-                    // check run before any cursor walk) already raises the
-                    // identical `decode_failure` first, regardless of
-                    // whether the query's own path ever touches that
-                    // scalar. Kept anyway, matching the equivalent
-                    // defensive arm in `decode_failure_or`/`scalar_fallback`
-                    // elsewhere in this fix -- correct if a future caller of
-                    // this function ever reaches it without that same
-                    // upfront gate.
+                    // Live since #2168 (direction 2). This arm was written
+                    // defensively and documented as unreachable, because
+                    // every caller ran `push_generic_document_validation_
+                    // error` over the whole document first and raised the
+                    // identical `decode_failure` before the walk started.
+                    // That pre-walk is gone; this is now the place
+                    // `path(.a[])`/`.a[] | key` on `{"a":"\ud800"}` raise,
+                    // and the reason `[path(.[])]` still rejects a document
+                    // whose undecodable scalar the iteration reaches while
+                    // `path(.d)` no longer rejects one it never touches.
                     Err(EvalError::decode_failure(reason))
                 } else if S::TAG == EvalTag::Yq {
                     // #2346: see this arm's `PathNode::Absent` sibling
@@ -14656,16 +14654,25 @@ fn path_context_single_native(expr: &Expr) -> bool {
     }
 }
 
-/// The root position of a walk, once the document has passed the same
-/// validity gate the bridge's `to_owned_with_cursor` doubles as (#1755/#1953):
-/// dropping it would make these pipes start accepting documents they reject
-/// today. `push_generic_document_validation_error` is that same traversal and
-/// validation with the `OwnedValue` construction removed -- the same gate
-/// `Builtin::Path` runs, for the same reason.
+/// The root position of a walk.
+///
+/// No whole-document validation runs here (#2168, direction 2). Until then
+/// this ran `push_generic_document_validation_error` over the entire input
+/// before the first step, inherited from the bridge's `to_owned_with_cursor`
+/// that #2151 replaced: an O(document) traversal charged to answer
+/// `.[0] | key`, and 67-75% of that query's runtime on a 20 MB input. The
+/// rule now is the one plain navigation already followed -- `key`/`path`/
+/// `parent` validate only the nodes they navigate through or materialize,
+/// so `.d.e | key` answers on `{"a":"\ud800","d":{"e":5}}` exactly as `.d.e`
+/// does, and `.a | length` still raises. The per-node checks live in the
+/// step itself (`path_step_generic`: `find_cursor`'s #1677 delimiter scan,
+/// `effective_fields_checked`/`collect_cursors_checked`, the Iterate arm's
+/// `string_decode_error` raise). Real jq and yq both reject such a document
+/// at parse time, so every option here is an ADR-0018 divergence and the
+/// tie-break is internal consistency; recorded in
+/// `docs/compliance/jq/limitations.md`. `select` and the `sort_by` family
+/// keep their gate: the value they test or emit *is* the walk's domain.
 fn path_context_root<V: DocumentValue>(root: V::Cursor) -> Result<PathContextPos<V>, Control> {
-    if let Some(control) = push_generic_document_validation_error(&root, 0) {
-        return Err(control);
-    }
     // The walk's input is not always the document root: a nested pipe
     // (`first(.a | parent | parent)`) is walked from the node the outer
     // stage handed it (#2416 phase 3). `path`/`parent` are absolute, so the
@@ -16820,21 +16827,20 @@ fn eval_builtin<S: EvalSemantics, V: DocumentValue>(
             // on the document's *structure* along the path, never on a value
             // that has to be computed, so it can be walked with cursors.
             //
-            // The whole-document walk is not skipped, only the tree build:
-            // `to_owned_with_cursor` doubles as a validity gate (#1755/
-            // #1953), and dropping it would make `path(.d)` start accepting
-            // documents it rejects today. `push_generic_document_validation_error`
-            // is that same traversal and validation with the `OwnedValue`
-            // construction removed, so error behaviour is unchanged while the
-            // allocation is not paid.
+            // #2168 (direction 2): no whole-document validation runs before
+            // the walk any more. #2061 kept one (`push_generic_document_
+            // validation_error` over the entire input, the traversal
+            // `to_owned_with_cursor` had doubled as) so that `path(.d)` went
+            // on rejecting `{"a":"\ud800","d":5}`; that cost O(document) to
+            // answer a bounded query and was most of `path(.)`'s runtime.
+            // The rule is now the one `.d` already followed: validate only
+            // the nodes the walk navigates through, via `path_step_generic`'s
+            // own per-node checks. The owned fallback below, for a shape
+            // `path_expr_is_cursor_navigable` refuses, still materializes the
+            // whole document and therefore still raises on it -- that
+            // boundary is recorded with the rest of the decision in
+            // `docs/compliance/jq/limitations.md`.
             if let Some(root) = cursor.filter(|_| path_expr_is_cursor_navigable(path_expr)) {
-                if let Some(control) = push_generic_document_validation_error(&root, 0) {
-                    return match control {
-                        Control::Error(e) => GenericResult::Error(e),
-                        Control::Break(label) => GenericResult::Break(label),
-                        Control::Halt(code) => GenericResult::Halt(code),
-                    };
-                }
                 let mut out = Vec::new();
                 return match path_walk_generic::<S, V>(
                     path_expr,

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -12084,10 +12084,22 @@ fn path_walk_generic<S: EvalSemantics, V: DocumentValue>(
             // `path(.a?)` on an array still emits nothing, because there the
             // error comes before anything is produced -- which is the case
             // the discarded-branch version was checked against.
+            //
+            // #1620: a `decode_failure` is the one error `?` never swallows
+            // -- same rule as `Err(e) if e.is_decode_failure()` elsewhere in
+            // this file. Before #2168 this arm's inner call could not
+            // return one (the whole-document pre-walk always raised it
+            // first), so the unconditional `let _ =` was never wrong; now
+            // that the pre-walk is gone, `path(.a[]?)` on an undecodable
+            // string reached it silently, diverging from plain `.a[]?`
+            // navigation, which does raise.
             let mut branch = Vec::new();
-            let _ = path_walk_generic::<S, V>(inner, node, path, &mut branch);
+            let result = path_walk_generic::<S, V>(inner, node, path, &mut branch);
             out.append(&mut branch);
-            Ok(())
+            match result {
+                Err(e) if e.is_decode_failure() => Err(e),
+                _ => Ok(()),
+            }
         }
         Expr::Comma(exprs) => {
             for e in exprs {
@@ -12391,9 +12403,13 @@ fn path_step_generic<S: EvalSemantics, V: DocumentValue>(
                     // identical `decode_failure` before the walk started.
                     // That pre-walk is gone; this is now the place
                     // `path(.a[])`/`.a[] | key` on `{"a":"\ud800"}` raise,
-                    // and the reason `[path(.[])]` still rejects a document
-                    // whose undecodable scalar the iteration reaches while
-                    // `path(.d)` no longer rejects one it never touches.
+                    // and the reason `[path(.[][])]` still rejects a
+                    // document whose undecodable scalar the iteration
+                    // reaches while `path(.d)` no longer rejects one it
+                    // never touches. A single-level `[path(.[])]` does not
+                    // reach this arm at all -- iterating an object/array
+                    // only decodes keys and yields child cursors, it never
+                    // decodes a child scalar's own string content.
                     Err(EvalError::decode_failure(reason))
                 } else if S::TAG == EvalTag::Yq {
                     // #2346: see this arm's `PathNode::Absent` sibling
@@ -12436,12 +12452,20 @@ fn path_step_generic<S: EvalSemantics, V: DocumentValue>(
         }
         Expr::Optional(inner) => {
             // Same rule as `path_walk_generic`'s own `Optional` arm: the
-            // error is swallowed, the positions already reached are not.
+            // error is swallowed, the positions already reached are not --
+            // except a `decode_failure` (#1620), which `?` never swallows.
+            // This arm was unreachable before #2168 (the whole-document
+            // pre-walk always raised first); now that it is live, the
+            // unguarded discard let `path((.a[]?)|.x)` answer past an
+            // undecodable string that plain `(.a[])|.x` still raises on.
             let mut branch = Vec::new();
-            let _ =
+            let result =
                 path_step_generic::<S, V>(inner, node, path, collapse_duplicate_keys, &mut branch);
             out.append(&mut branch);
-            Ok(())
+            match result {
+                Err(e) if e.is_decode_failure() => Err(e),
+                _ => Ok(()),
+            }
         }
         // `path_expr_is_cursor_navigable` gates every caller, so nothing else
         // can arrive here.
@@ -13435,66 +13459,128 @@ fn getpath_walk_cursor<S: EvalSemantics, V: DocumentValue>(
             return GenericResult::Owned(OwnedValue::Null);
         }
 
-        if let (Some(fields), OwnedValue::String(key)) = (v.as_object(), segment) {
-            // `find_cursor`, not a hand-rolled scan: it carries the
-            // last-duplicate-wins rule and the #1677/#1995 member checks
-            // for the field it returns, so a corrupted member on the read
-            // path still raises here (STYLE-0013's routed form).
-            match fields.find_cursor(key) {
-                Ok(Some(field)) => {
-                    c = field;
-                    continue;
+        // Dispatch on the segment's own kind before touching `v` at all,
+        // rather than trying every accessor and letting the pattern/filter
+        // discard the ones that don't apply: `is_null`/`as_object`/
+        // `as_array` each independently walk a YAML alias's full chain
+        // (`resolve_alias_chain`), so calling the one the segment can't
+        // possibly use just to throw its result away paid for that walk
+        // for nothing (up to 3x per segment on an aliased node, once here
+        // and again in whichever accessor did apply).
+        match segment {
+            OwnedValue::String(key) => {
+                if let Some(fields) = v.as_object() {
+                    // `find_cursor`, not a hand-rolled scan: it carries the
+                    // last-duplicate-wins rule and the #1677/#1995 member
+                    // checks for the field it returns, so a corrupted
+                    // member on the read path still raises here
+                    // (STYLE-0013's routed form).
+                    return match fields.find_cursor(key) {
+                        Ok(Some(field)) => {
+                            c = field;
+                            continue;
+                        }
+                        Ok(None) => GenericResult::Owned(OwnedValue::Null),
+                        Err(e) if suppresses(&e, optional) => GenericResult::None,
+                        Err(e) => GenericResult::Error(e),
+                    };
                 }
-                Ok(None) => return GenericResult::Owned(OwnedValue::Null),
-                Err(e) if suppresses(&e, optional) => return GenericResult::None,
-                Err(e) => return GenericResult::Error(e),
             }
-        }
-
-        let segment_is_numeric = matches!(
-            segment,
-            OwnedValue::Int(_) | OwnedValue::Float(_) | OwnedValue::NumberLiteral(..)
-        );
-        if let Some(elements) = v.as_array().filter(|_| segment_is_numeric) {
-            let len = match elements.len_checked() {
-                Ok(len) => len,
-                Err(e) if suppresses(&e, optional) => return GenericResult::None,
-                Err(e) => return GenericResult::Error(e),
-            };
-            // `resolve_read_index` is jq's own rule, shared with the owned
-            // table rather than restated: a float truncates, a negative
-            // index counts back from the end, and anything landing outside
-            // either end -- NaN included -- reads as `null`.
-            match crate::jq::eval::resolve_read_index(segment, len)
-                .and_then(|idx| elements.get_cursor(idx))
-            {
-                Some(element) => {
-                    c = element;
-                    continue;
+            OwnedValue::Int(_) | OwnedValue::Float(_) | OwnedValue::NumberLiteral(..) => {
+                if let Some(elements) = v.as_array() {
+                    let len = match elements.len_checked() {
+                        Ok(len) => len,
+                        Err(e) if suppresses(&e, optional) => return GenericResult::None,
+                        Err(e) => return GenericResult::Error(e),
+                    };
+                    // `resolve_read_index` is jq's own rule, shared with the
+                    // owned table rather than restated: a float truncates,
+                    // a negative index counts back from the end, and
+                    // anything landing outside either end -- NaN included
+                    // -- reads as `null`.
+                    return match crate::jq::eval::resolve_read_index(segment, len)
+                        .and_then(|idx| elements.get_cursor(idx))
+                    {
+                        Some(element) => {
+                            c = element;
+                            continue;
+                        }
+                        None => GenericResult::Owned(OwnedValue::Null),
+                    };
                 }
-                None => return GenericResult::Owned(OwnedValue::Null),
             }
+            // A slice descriptor (`{"start":s,"end":e}`) builds a value the
+            // document does not contain, so the walk stops being a
+            // navigation here.
+            OwnedValue::Object(desc) => {
+                // Array fast path: materialize only the elements the slice
+                // keeps, not the whole container. Slicing is the one shape
+                // that would otherwise defeat this walk's own point --
+                // `getpath(["items", {"start":0,"end":1}])` on a 300K-
+                // element array answering a 1-element slice by deep-cloning
+                // all 300K elements first, the exact whole-container cost
+                // this function exists to avoid (see its own doc comment
+                // above).
+                if let Some(elements) = v.as_array() {
+                    let len = match elements.len_checked() {
+                        Ok(len) => len,
+                        Err(e) if suppresses(&e, optional) => return GenericResult::None,
+                        Err(e) => return GenericResult::Error(e),
+                    };
+                    let range = match SliceBounds::from_descriptor(desc) {
+                        Ok(bounds) => bounds.resolve(len),
+                        Err(_) if optional => return GenericResult::None,
+                        Err(e) => return GenericResult::Error(e),
+                    };
+                    let mut items = vec_with_capacity(range.len());
+                    for idx in range {
+                        // `len_checked`/`resolve` already bound every index
+                        // in `range` to `[0, len)`, so `get_cursor` cannot
+                        // miss here.
+                        let Some(elem) = elements.get_cursor(idx) else {
+                            break;
+                        };
+                        match to_owned_cursor(&elem) {
+                            Ok(owned_elem) => items.push(owned_elem),
+                            Err(e) if suppresses(&e, optional) => return GenericResult::None,
+                            Err(e) => return GenericResult::Error(e),
+                        }
+                    }
+                    let sliced = OwnedValue::Array(items);
+                    return if let Some(rest) = segments.get(i + 1..).filter(|r| !r.is_empty()) {
+                        query_result_to_generic::<V>(
+                            crate::jq::eval::getpath_walk_owned_segments::<Vec<u64>, S>(
+                                &sliced, rest, optional,
+                            ),
+                        )
+                    } else {
+                        GenericResult::Owned(sliced)
+                    };
+                }
+
+                // Not an array: string slicing and yq's object slicing
+                // (#1102) are rarer and smaller in practice, so materialize
+                // just this node -- not the root -- and let the owned table
+                // finish the remaining segments, keeping exactly one
+                // definition of every step past here.
+                let owned = owned_or_suppress!(to_owned_cursor(&c), optional);
+                return query_result_to_generic::<V>(
+                    crate::jq::eval::getpath_walk_owned_segments::<Vec<u64>, S>(
+                        &owned,
+                        &segments[i..],
+                        optional,
+                    ),
+                );
+            }
+            _ => {}
         }
 
-        // A slice descriptor (`{"start":s,"end":e}`) builds a value the
-        // document does not contain, so the walk stops being a navigation
-        // here. Materialize just this node -- not the root -- and let the
-        // owned table finish the remaining segments, so array slicing,
-        // string slicing, yq's object slicing (#1102) and every subsequent
-        // step keep exactly one definition.
-        if matches!(segment, OwnedValue::Object(_)) {
-            let owned = owned_or_suppress!(to_owned_cursor(&c), optional);
-            return query_result_to_generic::<V>(crate::jq::eval::getpath_walk_owned_segments::<
-                Vec<u64>,
-                S,
-            >(&owned, &segments[i..], optional));
-        }
-
-        // Everything else is the owned table's own `_` arm: a type error,
-        // reported with the same helper it uses so both routes word it
-        // identically. `tagged_type_name` rather than `type_name` for the
-        // reason every other cursor-side type error uses it -- an explicit
-        // YAML tag decides the name (#747).
+        // Everything else -- including a segment kind above whose accessor
+        // found `v` isn't that shape -- is the owned table's own `_` arm: a
+        // type error, reported with the same helper it uses so both routes
+        // word it identically. `tagged_type_name` rather than `type_name`
+        // for the reason every other cursor-side type error uses it -- an
+        // explicit YAML tag decides the name (#747).
         return if optional {
             GenericResult::None
         } else {

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -13351,6 +13351,167 @@ fn path_context_step_computed_slice<S: EvalSemantics, V: DocumentValue>(
     stepped.map_err(|c| path_context_component_escape::<S, V>(out, produced_from, c))
 }
 
+/// The integer argument of a position-navigation builtin (`at_offset`,
+/// `at_position`), from whichever result shape its argument expression
+/// produced. `None` means "not an integer", which each caller turns into its
+/// own message.
+///
+/// One definition for what were three copies of the same match, because
+/// #2168 had to add an arm to all of them and CLAUDE.md's rule about
+/// duplicated predicates diverging silently is exactly this shape. The new
+/// arm is `OneCursor`: `getpath(["n"])` answered with an `OwnedValue` until
+/// #2168 gave it a cursor walk, so `at_offset(getpath(["n"]))` -- which
+/// worked, and is pinned by
+/// `test_at_offset_and_at_position_accept_a_document_sourced_argument` --
+/// stopped being recognised. Reading the integer through the cursor restores
+/// it, and closes the gap that regression exposed: a plainly navigated
+/// argument (`at_offset(.n)`) never worked either, for want of this same arm,
+/// and nothing had noticed because no test spelled it.
+fn position_arg_integer<V: DocumentValue>(result: &GenericResult<V>) -> Option<i64> {
+    match result {
+        GenericResult::Owned(v) => v.as_i64(),
+        GenericResult::One(v) => v.as_i64(),
+        GenericResult::OneCursor(c) => c.value().as_i64(),
+        _ => None,
+    }
+}
+
+/// `getpath(p)` walked over cursors, resolving one already-evaluated path
+/// against the document without materializing it (#2168).
+///
+/// This is the read `.a[0].b` performs, spelled as data, and it now costs
+/// the same. Until #2168 this builtin materialized the **whole document**
+/// first: `getpath([0])` on a 300 K-element array cost 0.085 s and 75 MiB
+/// against `.[0]`'s 0.018 s and 10.7 MiB, to answer with one number. That
+/// tree was not waste at the time -- it doubled as the #1755/#1953 validity
+/// gate, so `{"a":"\ud800","d":5} | getpath(["d"])` raised where the same
+/// document's `.d` answered `5`. #2168 settled that inconsistency the other
+/// way: a read validates what it reads. See `path_context_root` for the
+/// same decision on `path`/`key`/`parent`, and
+/// `docs/compliance/jq/limitations.md` for the ADR-0018 record.
+///
+/// The step table below is deliberately **not** `path_step_generic`'s.
+/// That walk answers "where would this navigation land", under the mode's
+/// own navigation rules -- yq's negative-index raise (#2254), its
+/// absent-key and scalar-index no-ops (#2470/#2482), its numeric-index-on-
+/// mapping `null` (#2459). `getpath`'s contract is
+/// [`crate::jq::eval::getpath_walk_owned_segments`]'s table, which has none
+/// of those (its only mode fork is the yq object-slice arm, #1102), so this
+/// mirrors that one instead. Where the two would disagree the owned table
+/// wins, because it is what this builtin answered before and what
+/// `eval.rs`'s own route still answers.
+///
+/// Only two segment shapes are taken here -- a string key into an object, a
+/// number into an array -- because only those name a node the document
+/// already holds. A slice descriptor *computes* a value that is nowhere in
+/// the document, so at the first one this materializes the single node it
+/// has reached and hands the remaining segments back to the owned table.
+/// Every other pairing is a type error, raised straight from the cursor so
+/// that reporting it costs no materialization either (`getpath([0])` on a
+/// large object says `Cannot index object with number` without building
+/// it).
+fn getpath_walk_cursor<S: EvalSemantics, V: DocumentValue>(
+    root: V::Cursor,
+    path: &OwnedValue,
+    optional: bool,
+) -> GenericResult<V> {
+    let OwnedValue::Array(segments) = path else {
+        return if optional {
+            GenericResult::None
+        } else {
+            GenericResult::Error(EvalError::path_must_be_array())
+        };
+    };
+
+    let mut c = root;
+    for (i, segment) in segments.iter().enumerate() {
+        let v = c.value();
+
+        // jq: `null | getpath(["a"])` is `null`, and so is every deeper
+        // segment past it -- the owned table's own first arm, which also
+        // absorbs the "key not found" and "index out of range" exits below
+        // by walking on from a `null`.
+        if v.is_null() {
+            return GenericResult::Owned(OwnedValue::Null);
+        }
+
+        if let (Some(fields), OwnedValue::String(key)) = (v.as_object(), segment) {
+            // `find_cursor`, not a hand-rolled scan: it carries the
+            // last-duplicate-wins rule and the #1677/#1995 member checks
+            // for the field it returns, so a corrupted member on the read
+            // path still raises here (STYLE-0013's routed form).
+            match fields.find_cursor(key) {
+                Ok(Some(field)) => {
+                    c = field;
+                    continue;
+                }
+                Ok(None) => return GenericResult::Owned(OwnedValue::Null),
+                Err(e) if suppresses(&e, optional) => return GenericResult::None,
+                Err(e) => return GenericResult::Error(e),
+            }
+        }
+
+        let segment_is_numeric = matches!(
+            segment,
+            OwnedValue::Int(_) | OwnedValue::Float(_) | OwnedValue::NumberLiteral(..)
+        );
+        if let Some(elements) = v.as_array().filter(|_| segment_is_numeric) {
+            let len = match elements.len_checked() {
+                Ok(len) => len,
+                Err(e) if suppresses(&e, optional) => return GenericResult::None,
+                Err(e) => return GenericResult::Error(e),
+            };
+            // `resolve_read_index` is jq's own rule, shared with the owned
+            // table rather than restated: a float truncates, a negative
+            // index counts back from the end, and anything landing outside
+            // either end -- NaN included -- reads as `null`.
+            match crate::jq::eval::resolve_read_index(segment, len)
+                .and_then(|idx| elements.get_cursor(idx))
+            {
+                Some(element) => {
+                    c = element;
+                    continue;
+                }
+                None => return GenericResult::Owned(OwnedValue::Null),
+            }
+        }
+
+        // A slice descriptor (`{"start":s,"end":e}`) builds a value the
+        // document does not contain, so the walk stops being a navigation
+        // here. Materialize just this node -- not the root -- and let the
+        // owned table finish the remaining segments, so array slicing,
+        // string slicing, yq's object slicing (#1102) and every subsequent
+        // step keep exactly one definition.
+        if matches!(segment, OwnedValue::Object(_)) {
+            let owned = owned_or_suppress!(to_owned_cursor(&c), optional);
+            return query_result_to_generic::<V>(crate::jq::eval::getpath_walk_owned_segments::<
+                Vec<u64>,
+                S,
+            >(&owned, &segments[i..], optional));
+        }
+
+        // Everything else is the owned table's own `_` arm: a type error,
+        // reported with the same helper it uses so both routes word it
+        // identically. `tagged_type_name` rather than `type_name` for the
+        // reason every other cursor-side type error uses it -- an explicit
+        // YAML tag decides the name (#747).
+        return if optional {
+            GenericResult::None
+        } else {
+            GenericResult::Error(EvalError::cannot_index(
+                tagged_type_name(&v, Some(c)),
+                segment,
+            ))
+        };
+    }
+
+    // Landed on a real document node, so hand back its cursor: `getpath`
+    // then behaves exactly as the navigation it spells, down to echoing a
+    // string this evaluator would refuse to decode (`getpath(["a"])` and
+    // `.a` agree byte for byte, and both raise once something reads it).
+    GenericResult::OneCursor(c)
+}
+
 /// `getpath(p)` as one walk step from `pos` (spine 2416, walk residue):
 /// every component of each path `p` produces is taken by the literal step
 /// that spells it, so a chain that lands on a document node keeps its
@@ -16881,66 +17042,59 @@ fn eval_builtin<S: EvalSemantics, V: DocumentValue>(
             eval_on_owned::<S, _>(&Expr::Builtin(builtin.clone()), owned, optional)
         }
 
-        // #2053: mirrors `Builtin::Path`'s #1909 treatment above -- the `_`
-        // fallback below pays a materialize + re-serialize + re-index round
-        // trip of `value` *and* a second whole-document decode inside
-        // `eval::getpath_one_path`'s own `to_owned`, just to answer
-        // a single node lookup. Unlike `Path`, `getpath`'s root
-        // materialization is not waste to begin with (#1755/#1953): it is
-        // the exact same validity gate `to_owned_with_cursor` below already
-        // pays for -- `{"a":"\ud800","d":5} | getpath(["d"])` must still
-        // raise even though the walk never reaches `.a`, where `.d`/`keys`/
-        // `length` on the same document do not. Only the *second* decode
-        // and the reindex round trip go, not the first.
+        // #2168: `getpath(P)` reads one node, and now costs one read.
         //
-        // The bypass-vs-fallback decision below is made purely from
-        // `owned`'s own shape (`reindex_bridge_is_identity`), *before*
-        // `path_expr` is touched at all. A withdrawn earlier attempt at
-        // this fix (PR #2045) instead probed `path_expr`'s output shape and
-        // fell back to a second, full re-evaluation when the probe didn't
-        // fit a recognized pattern, which fired any side effect inside
-        // `path_expr` twice: `getpath(("a"|stderr))` printed `aa` instead
-        // of jq's `a`. `fanout_arg_generic` is the fix for that shape
-        // (#1687, already used by `limit`/`nth`/`has` above): it drives
-        // `path_expr` lazily, exactly once, against the *original* cursor
-        // `value` -- so a `path_expr` that never touches `.` (the
-        // overwhelmingly common `getpath([0])`/`getpath(["a","b"])` shape)
-        // costs nothing extra beyond evaluating a small literal, and one
-        // that does touch `.` reads it through the same cheap cursor
-        // navigation any other builtin's argument already gets, rather than
-        // a second reindex of the whole document.
+        // Two rewrites got it here. #2053 removed a materialize +
+        // re-serialize + re-index round trip and a second whole-document
+        // decode, leaving a single materialization of `value`; that one was
+        // load-bearing, because it doubled as the #1755/#1953 validity gate
+        // -- `{"a":"\ud800","d":5} | getpath(["d"])` raised on it, where
+        // the same document's `.d` answered `5`. #2168 decided that
+        // inconsistency in `.d`'s favour (see `path_context_root` for the
+        // same call on `path`/`key`/`parent`), which is what lets the tree
+        // go: `getpath_walk_cursor` navigates to the node and validates
+        // only what it reads on the way.
         //
-        // Each resolved path then walks `owned` -- already materialized
-        // above -- directly via `getpath_walk_owned`, which is
-        // `eval::getpath_one_path`'s own walk with its `to_owned`
-        // call lifted out (mirrors `builtin_path_on_owned`'s identical
-        // relationship to `builtin_path`). `optional` is threaded through
-        // for real here, unlike `Path`/`Key`/`Parent`/`FileIndex`'s
-        // hardcoded `false` above -- `getpath_walk_owned` uses it to decide
-        // whether an indexing failure partway through a path raises or
-        // suppresses, so hardcoding it would be a real correctness risk if
-        // dispatch ever changed to reach here with `optional = true`.
-        // Review found no such reachable path today (`Expr::Optional`'s
-        // catch-all evaluates its inner expression at the *ambient*
-        // `optional`, same as the already-documented `Map`/`Select`
-        // precedent at `test_generic_plain_map_optional_on_non_container_is_unreachable_via_parser_725`,
-        // so `getpath(P)?` never actually forces `optional = true` into
-        // this arm) -- confirmed by swapping in a hardcoded `false` here
-        // and finding it byte-identical across the full `getpath` test
-        // suite. Threading it for real costs nothing and removes the
-        // dependency on that reachability analysis staying true, so it
-        // stays -- but it is defensive, not currently load-bearing.
-        Builtin::GetPath(path_expr) => {
-            // #2280: owned_or_suppress!, not owned_or_err! -- this arm's own
-            // walk below already threads `optional` "for real" into
-            // `getpath_walk_owned`'s per-step suppress/raise decision, so
-            // leaving the initial materialization unconditional was an
-            // inconsistency inside the very arm whose comment documents the
-            // opposite intent. Defensive today for the same #2286 reason as
-            // the `Path` arm above -- see `test_optional_ignored_sites_2280`.
-            let owned = owned_or_suppress!(to_owned_with_cursor(&value, cursor), optional);
-            if reindex_bridge_is_identity(&owned) {
-                return fanout_arg_generic::<S, V, _>(
+        // `fanout_arg_generic` stays exactly as #2053 left it, and for its
+        // reason: it drives `path_expr` lazily and **exactly once** against
+        // the original cursor. A withdrawn earlier attempt (PR #2045)
+        // probed `path_expr`'s output shape and re-evaluated the whole
+        // expression on a fallback, firing any side effect inside it twice
+        // (`getpath(("a"|stderr))` printed `aa` where jq prints `a`).
+        // Nothing here probes, so nothing re-evaluates.
+        //
+        // `reindex_bridge_is_identity` and the `eval_on_owned` fallback are
+        // gone from this arm with the tree they guarded. Their job was to
+        // keep a value whose spelling the reindex round trip would not
+        // survive (a float, a NaN, an over-cap literal) on the bridge that
+        // produced it; a cursor walk re-spells nothing, so a landed node
+        // now prints its own source bytes -- which is what `.a` reading the
+        // same node has always printed. `Builtin::Path` above still uses
+        // the predicate for its own fallback.
+        //
+        // `optional` is threaded for real, as #2053 threaded it: the walk
+        // consults it per step to decide whether an indexing failure raises
+        // or suppresses. No dispatch reaches this arm with `optional =
+        // true` today (`Expr::Optional`'s catch-all evaluates its inner
+        // expression at the *ambient* `optional`, the documented `Map`/
+        // `Select` precedent), so this remains defensive rather than
+        // load-bearing -- see `test_optional_ignored_sites_2280`.
+        Builtin::GetPath(path_expr) => match cursor {
+            Some(root) => fanout_arg_generic::<S, V, _>(
+                path_expr,
+                value.clone(),
+                optional,
+                cursor,
+                |path_owned| getpath_walk_cursor::<S, V>(root, &path_owned, optional),
+            ),
+            // A computed input has no position in any document, so there is
+            // nothing to walk and nothing this arm could validate lazily:
+            // the value is already in hand, and the owned table reads it
+            // directly. Materialized once, outside the fan-out, so a
+            // generator path still pays for it once (#2053).
+            None => {
+                let owned = owned_or_suppress!(to_owned(&value), optional);
+                fanout_arg_generic::<S, V, _>(
                     path_expr,
                     value.clone(),
                     optional,
@@ -16953,10 +17107,9 @@ fn eval_builtin<S: EvalSemantics, V: DocumentValue>(
                             &owned, &path_owned, optional
                         ))
                     },
-                );
+                )
             }
-            eval_on_owned::<S, _>(&Expr::Builtin(builtin.clone()), owned, optional)
-        }
+        },
 
         Builtin::Empty => GenericResult::None,
 
@@ -17003,23 +17156,8 @@ fn eval_builtin<S: EvalSemantics, V: DocumentValue>(
         Builtin::AtOffset(offset_expr) => {
             // Evaluate the offset expression
             let offset_result = eval_single::<S, _>(offset_expr, value.clone(), false, cursor);
-            let offset = match offset_result {
-                GenericResult::Owned(v) => match v.as_i64() {
-                    Some(i) if i >= 0 => i as usize,
-                    _ => {
-                        return GenericResult::Error(EvalError::new(
-                            "at_offset requires a non-negative integer".to_string(),
-                        ))
-                    }
-                },
-                GenericResult::One(v) => match v.as_i64() {
-                    Some(i) if i >= 0 => i as usize,
-                    _ => {
-                        return GenericResult::Error(EvalError::new(
-                            "at_offset requires a non-negative integer".to_string(),
-                        ))
-                    }
-                },
+            let offset = match position_arg_integer(&offset_result) {
+                Some(i) if i >= 0 => i as usize,
                 _ => {
                     return GenericResult::Error(EvalError::new(
                         "at_offset requires a non-negative integer".to_string(),
@@ -17050,23 +17188,8 @@ fn eval_builtin<S: EvalSemantics, V: DocumentValue>(
         Builtin::AtPosition(line_expr, col_expr) => {
             // Evaluate the line expression
             let line_result = eval_single::<S, _>(line_expr, value.clone(), false, cursor);
-            let line = match line_result {
-                GenericResult::Owned(v) => match v.as_i64() {
-                    Some(i) if i > 0 => i as usize,
-                    _ => {
-                        return GenericResult::Error(EvalError::new(
-                            "at_position requires positive integers for line".to_string(),
-                        ))
-                    }
-                },
-                GenericResult::One(v) => match v.as_i64() {
-                    Some(i) if i > 0 => i as usize,
-                    _ => {
-                        return GenericResult::Error(EvalError::new(
-                            "at_position requires positive integers for line".to_string(),
-                        ))
-                    }
-                },
+            let line = match position_arg_integer(&line_result) {
+                Some(i) if i > 0 => i as usize,
                 _ => {
                     return GenericResult::Error(EvalError::new(
                         "at_position requires positive integers for line".to_string(),
@@ -17076,23 +17199,8 @@ fn eval_builtin<S: EvalSemantics, V: DocumentValue>(
 
             // Evaluate the column expression
             let col_result = eval_single::<S, _>(col_expr, value.clone(), false, cursor);
-            let col = match col_result {
-                GenericResult::Owned(v) => match v.as_i64() {
-                    Some(i) if i > 0 => i as usize,
-                    _ => {
-                        return GenericResult::Error(EvalError::new(
-                            "at_position requires positive integers for column".to_string(),
-                        ))
-                    }
-                },
-                GenericResult::One(v) => match v.as_i64() {
-                    Some(i) if i > 0 => i as usize,
-                    _ => {
-                        return GenericResult::Error(EvalError::new(
-                            "at_position requires positive integers for column".to_string(),
-                        ))
-                    }
-                },
+            let col = match position_arg_integer(&col_result) {
+                Some(i) if i > 0 => i as usize,
                 _ => {
                     return GenericResult::Error(EvalError::new(
                         "at_position requires positive integers for column".to_string(),
@@ -24341,40 +24449,59 @@ mod tests {
     #[test]
     fn test_at_offset_and_at_position_accept_a_document_sourced_argument() {
         // #387 wraps a materialized document number in `OwnedValue::NumberLiteral`
-        // instead of plain `Int`, so `getpath` (which returns `Owned`, not a lazy
-        // cursor) now hands `AtOffset`/`AtPosition` a `NumberLiteral` -- unhandled
-        // here previously, it fell to the `_` arm and errored "requires a
+        // instead of plain `Int`, so `getpath` (which returned `Owned`, not a lazy
+        // cursor) handed `AtOffset`/`AtPosition` a `NumberLiteral` -- unhandled
+        // here originally, it fell to the `_` arm and errored "requires a
         // non-negative integer" even though the value was a perfectly good 0.
+        //
+        // #2168 broke this test by giving `getpath` a cursor walk: the argument
+        // stopped arriving as an `OwnedValue` at all, and the `_` arm caught it
+        // again. `position_arg_integer` is the fix, and the `.n`/`.l`/`.c` rows
+        // below are the gap that regression exposed -- a plainly navigated
+        // argument had never worked either, and no test had spelled one, so the
+        // arm's "document-sourced" claim was only ever half true.
         let json = br#"{"n": 2, "l": 1, "c": 1}"#;
         let index = JsonIndex::build(json);
         let cursor = index.root(json);
 
-        let via_getpath = crate::jq::parse(r#"at_offset(getpath(["n"]))"#).unwrap();
-        let via_literal = crate::jq::parse("at_offset(2)").unwrap();
-        assert_eq!(
-            eval_with_cursor(&via_getpath, cursor)
+        let answer = |src: &str| {
+            let expr = crate::jq::parse(src).unwrap();
+            eval_with_cursor(&expr, cursor)
                 .into_owned()
                 .unwrap()
-                .unwrap(),
-            eval_with_cursor(&via_literal, cursor)
-                .into_owned()
                 .unwrap()
-                .unwrap(),
-        );
+        };
 
-        let via_getpath =
-            crate::jq::parse(r#"at_position(getpath(["l"]); getpath(["c"]))"#).unwrap();
-        let via_literal = crate::jq::parse("at_position(1; 1)").unwrap();
+        let want_offset = answer("at_offset(2)");
+        assert_eq!(answer(r#"at_offset(getpath(["n"]))"#), want_offset);
+        assert_eq!(answer("at_offset(.n)"), want_offset);
+
+        let want_position = answer("at_position(1; 1)");
         assert_eq!(
-            eval_with_cursor(&via_getpath, cursor)
-                .into_owned()
-                .unwrap()
-                .unwrap(),
-            eval_with_cursor(&via_literal, cursor)
-                .into_owned()
-                .unwrap()
-                .unwrap(),
+            answer(r#"at_position(getpath(["l"]); getpath(["c"]))"#),
+            want_position
         );
+        assert_eq!(answer("at_position(.l; .c)"), want_position);
+
+        // A non-integer argument is still refused, from every shape: the new
+        // arm reads an integer through a cursor, it does not coerce one.
+        // (`into_owned` renders an `Error` as `Ok(None)` -- see its own arms
+        // -- so the result is matched directly rather than through it. That
+        // rendering is also what made this test's original failure show up as
+        // an `Option::unwrap` panic rather than an error.)
+        for src in [
+            r#"at_offset(".")"#,
+            "at_offset(-1)",
+            "at_offset(.missing)",
+            "at_position(.n; 0)",
+        ] {
+            let expr = crate::jq::parse(src).unwrap();
+            let result = eval_with_cursor(&expr, cursor);
+            assert!(
+                matches!(result, GenericResult::Error(_)),
+                "{src} must still be refused, got {result:?}"
+            );
+        }
     }
 
     #[test]

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -32074,7 +32074,9 @@ fn test_getpath_still_raises_on_an_undecodable_sibling_2053() -> Result<()> {
 ///
 /// Pins that this is defensive, not a behavior change: a document-wide
 /// decode failure (`\ud800`, matching `test_getpath_still_raises_on_an_
-/// undecodable_sibling_2053`'s own repro) still raises -- uncatchable, per
+/// undecodable_sibling_2053`'s own repro) still raises *on these
+/// materializing spellings* (see the note in the body about #2168's
+/// cursor-navigable `path(.d)`) -- uncatchable, per
 /// #2286 tagging every one of these materializations' error paths
 /// `is_decode_failure()` -- through a bare call, a trailing `?`, and a
 /// `try`/`catch` wrapped in its own outer `?` (the exact shape #2231's
@@ -32099,20 +32101,28 @@ fn test_optional_ignored_sites_2280() -> Result<()> {
         assert_eq!(stdout, "", "{filter}: stderr {stderr:?}");
     }
 
-    // `@json` is not a blanket rejection of the whole document -- unlike
-    // `path`/`getpath` (whose own whole-document validity gate is pinned by
-    // `test_path_still_raises_on_an_undecodable_sibling_2061`/
-    // `test_getpath_still_raises_on_an_undecodable_sibling_2053`, and still
-    // raises on the decodable `.d` field below, same as those two), `@json`
-    // materializes only the already-navigated sub-cursor, so `.d | @json`
-    // succeeds on this same document even though `.a` is undecodable.
+    // Every row above raises because it *materializes* -- `@json` its own
+    // navigated sub-cursor, and the two `path(if ...)`/`getpath` shapes the
+    // whole document, since neither is cursor-navigable. That is what this
+    // test is about, and it is unchanged by #2168.
+    //
+    // What #2168 changed is the row below: the *cursor-navigable* spelling
+    // of the same query no longer walks the whole document, so `path(.d)`
+    // answers where `path(if true then .d else null end)` still raises.
+    // The two spellings of one query disagreeing is the residue of this
+    // decision, recorded in `docs/compliance/jq/limitations.md`; the
+    // materializing fallback is the one that keeps the old behaviour.
     let (stdout, code) = run_jq_stdin(".d | @json", doc, &["-c"])?;
     assert_eq!(code, 0);
     assert_eq!(stdout.trim(), "\"5\"");
-    let (_, _, code) = run_jq_stdin_streams("path(.d)", doc, &["-c"])?;
-    assert_eq!(code, 5, "path()'s whole-document gate should still fire");
-    let (_, _, code) = run_jq_stdin_streams(r#"getpath(["d"])"#, doc, &["-c"])?;
-    assert_eq!(code, 5, "getpath()'s whole-document gate should still fire");
+    let (stdout, _, code) = run_jq_stdin_streams("path(.d)", doc, &["-c"])?;
+    assert_eq!(code, 0, "#2168: the cursor-navigable path() answers");
+    assert_eq!(stdout, "[\"d\"]\n");
+    let (_, _, code) = run_jq_stdin_streams("path(if true then .d else null end)", doc, &["-c"])?;
+    assert_eq!(
+        code, 5,
+        "the materializing fallback still validates what it materializes"
+    );
 
     Ok(())
 }
@@ -36742,9 +36752,11 @@ fn test_path_validity_walk_lazy_collision_map_2061() -> Result<()> {
     assert_eq!(code, 0);
     assert_eq!(stdout, "[[\"a\"],[\"\\\\ud800\"],[\"b\"]]\n");
 
-    // A navigation that never visits the undecodable key still sees it,
-    // because the walk validates the whole document -- the behaviour #2061
-    // deliberately preserved rather than trading away for speed.
+    // A navigation that never visits the undecodable key answers normally.
+    // (Before #2168 this row passed for the opposite reason -- the walk
+    // validated the whole document and this particular key, being merely
+    // undecodable rather than *colliding*, was preserved rather than raised.
+    // Now nothing outside the navigated path is inspected at all.)
     let (stdout, code) = run_jq_stdin("path(.a)", r#"{"\ud800":1,"a":2}"#, &["-c"])?;
     assert_eq!(code, 0);
     assert_eq!(stdout, "[\"a\"]\n");
@@ -36752,43 +36764,188 @@ fn test_path_validity_walk_lazy_collision_map_2061() -> Result<()> {
     Ok(())
 }
 
-/// #2061: the collision the lazy map's guard exists to catch still raises --
-/// an undecodable key whose display spelling collides with a real key of that
-/// same name, which a display-keyed map cannot hold both of (#1642).
+/// #2168: the #1642 colliding-display-key raise was part of the same
+/// whole-document gate, so it too now fires only where the query touches the
+/// keys involved -- `path(.a)` answers where it used to raise `is ambiguous`.
 ///
+/// This reverses `test_path_validity_walk_still_raises_on_a_colliding_key_2061`.
+/// The collision is a property of *rendering two keys into one display map*,
+/// which a navigation to a third key never does; `keys_unsorted` on these same
+/// documents has always answered rather than raised, so the consistency rule
+/// #2168 settled makes `path`/`key` follow it.
+///
+/// The length agreement below is the point: whatever `keys_unsorted` is
+/// willing to list, `[path(.[])]` now names, element for element. (Their
+/// *spellings* still differ -- `keys_unsorted` echoes the raw source bytes,
+/// `path` reports the fallback display form -- which is #1385/#1642's own
+/// pre-existing divergence, pinned next door by
+/// `test_path_validity_walk_lazy_collision_map_2061`, not something this
+/// change moved.)
+///
+/// **No jq oracle:** real jq 1.7.1 rejects all three documents at parse time.
 /// Checked in all three positions relative to the clean key, since the lazy
-/// map only seeds itself from the prefix once a fallback key appears: getting
-/// the seeding wrong would turn one of these into a silent success.
+/// map only seeds itself from the prefix once a fallback key appears.
 #[test]
-fn test_path_validity_walk_still_raises_on_a_colliding_key_2061() -> Result<()> {
+fn test_path_answers_past_a_colliding_key_2168() -> Result<()> {
     for doc in [
         r#"{"\\ud800":1,"\ud800":2}"#,
         r#"{"\ud800":1,"\ud800":2}"#,
         r#"{"a":1,"\ud800":2,"\ud800":3}"#,
     ] {
         let (stdout, stderr, code) = run_jq_stdin_streams("path(.a)", doc, &["-c"])?;
-        assert_eq!(code, 5, "{doc}: stdout {stdout:?} stderr {stderr:?}");
-        assert_eq!(stdout, "", "{doc}");
-        assert!(stderr.contains("is ambiguous"), "{doc}: {stderr}");
+        assert_eq!(code, 0, "{doc}: stdout {stdout:?} stderr {stderr:?}");
+        assert_eq!(stdout, "[\"a\"]\n", "{doc}");
+
+        let (paths, _, code) = run_jq_stdin_streams("[path(.[])] | length", doc, &["-c"])?;
+        assert_eq!(code, 0, "{doc}");
+        let (keys, _, code) = run_jq_stdin_streams("keys_unsorted | length", doc, &["-c"])?;
+        assert_eq!(code, 0, "{doc}");
+        assert_eq!(
+            paths, keys,
+            "{doc}: [path(.[])] must name exactly the members keys_unsorted lists"
+        );
+    }
+
+    // The materializing routes are unchanged: rendering *is* the collision,
+    // so `-S` (sort keys, which must hold both in one map) still raises.
+    let (stdout, stderr, code) =
+        run_jq_stdin_streams(".", r#"{"\ud800":1,"\ud800":2}"#, &["-S", "-c"])?;
+    assert_eq!(code, 5, "stdout {stdout:?}");
+    assert!(stderr.contains("is ambiguous"), "{stderr}");
+
+    Ok(())
+}
+
+/// #2168: `path()` validates only the nodes it navigates through, so a
+/// `\uXXXX`-family decode failure in a *sibling* it never reaches no longer
+/// makes it raise -- the rule plain navigation already followed.
+///
+/// This reverses `test_path_still_raises_on_an_undecodable_sibling_2061`,
+/// which pinned the opposite. #2061 kept a whole-document gate here because
+/// the materialization it replaced had doubled as one; #2168 measured that
+/// gate at 67-75% of such a query's runtime and this project decided the
+/// consistency question it left open -- `.d` answered `5` on the same
+/// document `path(.d)` rejected.
+///
+/// **No jq oracle.** Real jq 1.7.1 rejects every document below at parse
+/// time (`Invalid \uXXXX\uXXXX surrogate pair escape`), for `.d` as much as
+/// for `path(.d)`, so it separates none of these rows; the contract pinned
+/// is succinctly's own lazy-validation rule (recorded as an ADR-0018
+/// divergence in `docs/compliance/jq/limitations.md`).
+#[test]
+fn test_path_answers_past_an_undecodable_sibling_2168() -> Result<()> {
+    for bad in [r"\ud800", r"\uZZZZ", r"\x", r"\u12"] {
+        let input = format!("{{\"a\":\"{bad}\",\"d\":5}}");
+
+        // The sibling is never navigated to: answer, don't raise.
+        let (stdout, stderr, code) = run_jq_stdin_streams("path(.d)", &input, &["-c"])?;
+        assert_eq!(code, 0, "{bad}: stdout {stdout:?} stderr {stderr:?}");
+        assert_eq!(stdout, "[\"d\"]\n", "{bad}");
+
+        // Landing *on* the undecodable node is still not a decode: `path`
+        // reports the position, and never reads the value there -- exactly
+        // as `.a` itself echoes the raw bytes at exit 0.
+        let (stdout, stderr, code) = run_jq_stdin_streams("path(.a)", &input, &["-c"])?;
+        assert_eq!(code, 0, "{bad}: stdout {stdout:?} stderr {stderr:?}");
+        assert_eq!(stdout, "[\"a\"]\n", "{bad}");
+
+        // Navigating *through* it does read it, and raises the same error
+        // the bare navigation does -- the touched-node control.
+        let (nav_out, nav_err, nav_code) = run_jq_stdin_streams(".a.b", &input, &["-c"])?;
+        let (stdout, stderr, code) = run_jq_stdin_streams("path(.a.b)", &input, &["-c"])?;
+        assert_eq!(code, 5, "{bad}: stdout {stdout:?} stderr {stderr:?}");
+        assert_eq!(stdout, "", "{bad}");
+        assert_eq!(
+            (stdout, stderr, code),
+            (nav_out, nav_err, nav_code),
+            "{bad}: path(.a.b) must fail exactly as .a.b does"
+        );
+
+        // Iterating over the undecodable scalar reaches it too
+        // (`path_step_generic`'s own `string_decode_error` arm, live since
+        // this change), where iterating over the *object* only names its
+        // children and stays clean.
+        let (stdout, stderr, code) = run_jq_stdin_streams("path(.a[])", &input, &["-c"])?;
+        assert_eq!(code, 5, "{bad}: stdout {stdout:?} stderr {stderr:?}");
+        assert!(
+            stderr.contains("invalid unicode escape sequence") || stderr.contains("invalid escape"),
+            "{bad}: {stderr}"
+        );
+        let (stdout, stderr, code) = run_jq_stdin_streams("[path(.[])]", &input, &["-c"])?;
+        assert_eq!(code, 0, "{bad}: stdout {stdout:?} stderr {stderr:?}");
+        assert_eq!(stdout, "[[\"a\"],[\"d\"]]\n", "{bad}");
     }
     Ok(())
 }
 
-/// #2061: a `\uXXXX`-family decode failure anywhere in the document still
-/// makes `path()` raise, unchanged from before this change.
+/// #2168's rule, stated once as a table: which builtins validate a node the
+/// query never reads, and which do not.
 ///
-/// This is the validity gate the cursor walk deliberately keeps: dropping it
-/// would have made `path()` roughly 8x faster still, but #1755/#1953 chose to
-/// raise on undecodable content rather than silently substitute, and a
-/// performance change is not the place to reverse that.
+/// The two halves of the decision belong next to each other, because the
+/// argument for it is their relationship. A builtin whose walk's domain *is*
+/// the value it tests or emits (`select`, the `sort_by` family) keeps the
+/// whole-subtree gate; one that only names or navigates to a position
+/// (`path`, `key`, `parent`) validates just what it touches, like plain
+/// navigation always has. Anything that materializes still validates
+/// everything it materializes.
+///
+/// **No jq oracle for any row:** real jq 1.7.1 rejects this document at parse
+/// time for every filter, `.d` included, so it cannot separate them. The
+/// contract is succinctly's own, recorded in
+/// `docs/compliance/jq/limitations.md`.
 #[test]
-fn test_path_still_raises_on_an_undecodable_sibling_2061() -> Result<()> {
-    for bad in [r"\ud800", r"\uZZZZ", r"\x", r"\u12"] {
-        let input = format!("{{\"a\":\"{bad}\",\"d\":5}}");
-        let (stdout, stderr, code) = run_jq_stdin_streams("path(.d)", &input, &["-c"])?;
-        assert_eq!(code, 5, "{bad}: stdout {stdout:?} stderr {stderr:?}");
-        assert_eq!(stdout, "", "{bad}");
+fn test_lazy_validation_boundary_2168() -> Result<()> {
+    let doc = r#"{"a":"\ud800","d":5}"#;
+
+    // Answers: never reads `.a`.
+    for (filter, want) in [
+        (".d", "5"),
+        ("keys", r#"["a","d"]"#),
+        ("length", "2"),
+        ("path(.d)", r#"["d"]"#),
+        (".d | key", r#""d""#),
+        (".d | path", r#"["d"]"#),
+        ("path(.a)", r#"["a"]"#),
+        (".a | key", r#""a""#),
+        ("[path(.[])]", r#"[["a"],["d"]]"#),
+        ("[.[] | key]", r#"["a","d"]"#),
+        ("[paths]", r#"[["a"],["d"]]"#),
+        ("select(.d) | .d", "5"),
+    ] {
+        let (stdout, stderr, code) = run_jq_stdin_streams(filter, doc, &["-c"])?;
+        assert_eq!(code, 0, "{filter}: stdout {stdout:?} stderr {stderr:?}");
+        assert_eq!(stdout.trim(), want, "{filter}");
     }
+
+    // Raises: reads `.a`, or emits/tests a subtree containing it.
+    for filter in [
+        ".a | length",    // reads the value
+        ".a | tostring",  // reads the value
+        "path(.a[])",     // iterating the scalar reads it
+        "to_entries",     // materializes every member
+        ". as $x | $x",   // materializes the binding
+        ".a |= 1",        // the write path materializes
+        "sort_by(.d)",    // the sort family keeps its gate
+        "[.[]] | length", // array construction materializes each element
+    ] {
+        let (stdout, stderr, code) = run_jq_stdin_streams(filter, doc, &["-c"])?;
+        assert_eq!(code, 5, "{filter}: stdout {stdout:?} stderr {stderr:?}");
+        assert!(
+            stderr.contains("invalid unicode escape sequence"),
+            "{filter}: {stderr:?}"
+        );
+    }
+
+    // `select` keeps its gate even though the value it tests is clean: the
+    // *condition's own subtree* is what it validates, and here that is the
+    // whole document (`select(.)` tests the root).
+    let (stdout, stderr, code) = run_jq_stdin_streams("select(.) | .d", doc, &["-c"])?;
+    assert_eq!(code, 5, "stdout {stdout:?} stderr {stderr:?}");
+    assert!(
+        stderr.contains("invalid unicode escape sequence"),
+        "{stderr:?}"
+    );
+
     Ok(())
 }
 
@@ -38637,15 +38794,22 @@ fn test_seq_wellformed_and_leniency_unaffected_by_checked_swap_2295() -> Result<
 }
 
 /// #2349: `push_generic_document_validation_error` -- the shared validation
-/// gate for `select`/`sort_by`/`unique_by`/`min_by`/`max_by`/`path()` -- had
-/// none of the `#1677`/`#2211`/`#2243` delimiter/gap checks its materializing
+/// gate for `select`/`sort_by`/`unique_by`/`min_by`/`max_by` -- had none of
+/// the `#1677`/`#2211`/`#2243` delimiter/gap checks its materializing
 /// siblings (`to_owned_cursor_at_depth` and friends) already run, so a
 /// document corrupted in a subtree the query only ever *validates* (never
 /// emits) passed silently instead of raising. Every row here is a document
-/// real jq rejects; before this fix, succinctly accepted all eight (exit 0)
+/// real jq rejects; before this fix, succinctly accepted all of them (exit 0)
 /// while the materializing control for the identical subtree already
 /// correctly raised. Repros and control verified live against `/usr/bin/jq`
 /// 1.7.1 in the issue's own filing.
+///
+/// `path()` was a seventh caller of that gate when this test was written, and
+/// its own row lived here. #2168 removed it from the gate -- naming a
+/// position never reads what is inside it -- so that row now lives in
+/// `test_path_answers_past_a_structural_fault_it_never_reads_2168`, asserting
+/// the opposite. The rows that remain are the builtins that still validate,
+/// because the subtree they walk is the value they test or emit.
 #[test]
 fn test_validate_only_gate_delimiter_checks_2349() -> Result<()> {
     let cases: &[(&str, &str, &str)] = &[
@@ -38668,11 +38832,6 @@ fn test_validate_only_gate_delimiter_checks_2349() -> Result<()> {
             "trailing comma in nested array element, min_by",
             r#"[{"a":2,"b":[1,]},{"a":1}]"#,
             "min_by(.a) | .a",
-        ),
-        (
-            "trailing comma in nested object, path()",
-            r#"{"c":{"a":1,}}"#,
-            "path(.c)",
         ),
         (
             "stray comma with no real field, object",
@@ -38709,6 +38868,46 @@ fn test_validate_only_gate_delimiter_checks_2349() -> Result<()> {
         run_jq_full(&["-c", "select(.c) | .t"], Some(r#"{"c":{"a":1},"t":5}"#))?;
     assert_eq!(code, 0, "stderr: {stderr:?}");
     assert_eq!(stdout.trim(), "5");
+
+    Ok(())
+}
+
+/// #2168: `path()`'s row moved out of `test_validate_only_gate_delimiter_checks_2349`.
+///
+/// The structural checks (#1194/#1677/#2211/#2243) rode on the same
+/// whole-document gate as the decode-failure raise, so dropping that gate for
+/// cursor-resolved path queries drops them too: `path(.c)` on a document whose
+/// `.c` holds a trailing comma now answers, because naming a position never
+/// reads what is inside it. `select`/`sort_by` keep their gate and so keep
+/// these checks -- their remaining rows in that test are the control.
+///
+/// **No jq oracle:** real jq rejects `{"c":{"a":1,}}` at parse time whatever
+/// the filter, `.t` included, so it separates none of these rows. What it is
+/// consistent with is succinctly's own `.t`, which has always answered `5`
+/// here (`docs/compliance/jq/limitations.md`, the lazy-validation trade-off).
+#[test]
+fn test_path_answers_past_a_structural_fault_it_never_reads_2168() -> Result<()> {
+    let doc = r#"{"c":{"a":1,},"t":5}"#;
+
+    for (filter, want) in [
+        ("path(.t)", r#"["t"]"#),
+        (".t | key", r#""t""#),
+        ("path(.c)", r#"["c"]"#),
+        ("[path(.[])]", r#"[["c"],["t"]]"#),
+        (".t", "5"),
+    ] {
+        let (stdout, stderr, code) = run_jq_full(&["-c", filter], Some(doc))?;
+        assert_eq!(code, 0, "{filter}: stdout {stdout:?} stderr {stderr:?}");
+        assert_eq!(stdout.trim(), want, "{filter}");
+    }
+
+    // Reading into the corrupted subtree still raises, on every route that
+    // does read it -- the touched-node controls.
+    for filter in [".c", ".c.a", "select(.c) | .t", "sort_by(.c) | length"] {
+        let (stdout, stderr, code) = run_jq_full(&["-c", filter], Some(doc))?;
+        assert_ne!(code, 0, "{filter}: stdout {stdout:?}");
+        assert!(stderr.contains("Invalid JSON"), "{filter}: {stderr:?}");
+    }
 
     Ok(())
 }

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -32340,6 +32340,166 @@ fn test_getpath_optional_matches_jq_on_the_cursor_walk_2168() -> Result<()> {
     Ok(())
 }
 
+/// #2168 coverage: the shapes `getpath`'s cursor walk answers or raises on
+/// *without* materializing the root, one row per step of the walk that has
+/// its own exit.
+///
+/// The walk replaced a whole-document materialization, so every step it now
+/// takes is code the old arm never had. `test_getpath_cursor_walk_matches_jq_2168`
+/// covers the well-formed navigation; this covers the four exits that only a
+/// corrupted or `null`-bearing document reaches, each against jq 1.7.1's own
+/// outcome (captured live).
+///
+/// jq's messages differ on the corrupted rows -- it rejects those documents
+/// at parse time and never gets as far as `getpath` -- so only the
+/// raise-vs-answer outcome is compared there, which is the same latitude
+/// `test_path_answers_past_a_structural_fault_it_never_reads_2168` takes.
+#[test]
+fn test_getpath_cursor_walk_corrupted_and_null_shapes_2168() -> Result<()> {
+    // `null` mid-path: jq walks on from it and answers `null`, at any depth
+    // and for either segment kind (real jq 1.7.1 agrees on both rows).
+    for filter in [r#"getpath(["a","b"])"#, r#"getpath(["a",0])"#] {
+        let (stdout, stderr, code) = run_jq_stdin_streams(filter, r#"{"a":null}"#, &["-c"])?;
+        assert_eq!(code, 0, "{filter}: stdout {stdout:?} stderr {stderr:?}");
+        assert_eq!(stdout.trim(), "null", "{filter}");
+    }
+
+    // Each row: a document whose corruption sits on the path the walk
+    // actually takes, so the step that reads it raises rather than silently
+    // walking past. `find_cursor`'s member check, `len_checked`'s element
+    // check, and the slice arm's per-element materialization are three
+    // separate checks inside the walk, hence three documents.
+    for (desc, doc, filter) in [
+        (
+            "malformed member on the navigated object",
+            r#"{"c":{"a":1,},"t":5}"#,
+            r#"getpath(["c","a"])"#,
+        ),
+        (
+            "malformed element in the indexed array",
+            r#"{"a":[1,,2],"t":5}"#,
+            r#"getpath(["a",0])"#,
+        ),
+        (
+            "malformed element in the sliced array",
+            r#"{"a":[1,,2],"t":5}"#,
+            r#"getpath(["a",{"start":0,"end":1}])"#,
+        ),
+        (
+            "undecodable element kept by the slice",
+            r#"{"a":["\ud800","b"]}"#,
+            r#"getpath(["a",{"start":0,"end":1}])"#,
+        ),
+    ] {
+        let (stdout, stderr, code) = run_jq_stdin_streams(filter, doc, &["-c"])?;
+        assert_ne!(code, 0, "{desc}: {filter} must raise, stdout {stdout:?}");
+        assert_eq!(stdout, "", "{desc}: {filter}, stderr {stderr:?}");
+    }
+
+    // The controls: the same two walk steps on clean documents, and a slice
+    // whose kept elements exclude the corrupted one -- the second is what
+    // makes the rows above claims about *what the walk touched*, not just
+    // "this document is bad somewhere".
+    for (desc, doc, filter, want) in [
+        (
+            "clean member",
+            r#"{"c":{"a":1},"t":5}"#,
+            r#"getpath(["c","a"])"#,
+            "1",
+        ),
+        (
+            "clean element",
+            r#"{"a":[1,2]}"#,
+            r#"getpath(["a",0])"#,
+            "1",
+        ),
+        (
+            "clean slice",
+            r#"{"a":[1,2]}"#,
+            r#"getpath(["a",{"start":0,"end":1}])"#,
+            "[1]",
+        ),
+        (
+            "slice past the undecodable element",
+            r#"{"a":["\ud800","b"]}"#,
+            r#"getpath(["a",{"start":1,"end":2}])"#,
+            r#"["b"]"#,
+        ),
+    ] {
+        let (stdout, stderr, code) = run_jq_stdin_streams(filter, doc, &["-c"])?;
+        assert_eq!(code, 0, "{desc}: stdout {stdout:?} stderr {stderr:?}");
+        assert_eq!(stdout.trim(), want, "{desc}");
+    }
+
+    Ok(())
+}
+
+/// #2168 coverage: `position_arg_integer` -- one definition for what were
+/// three copies of `at_offset`/`at_position`'s argument match -- rejects
+/// every result shape that is not a single integer.
+///
+/// The `_ => None` arm is the one this pins: an argument expression that
+/// produces *no* output, or *several*, is neither an integer nor a
+/// non-integer value, and before the shapes were unified each of the three
+/// copies had to get that right on its own. These are succinctly extensions,
+/// so there is no jq oracle for the wording -- the exit code and the
+/// message this evaluator already chose are what is being held still.
+#[test]
+fn test_position_builtin_argument_shapes_2168() -> Result<()> {
+    let doc = r#"{"a":[1,2]}"#;
+
+    for (filter, want_err) in [
+        // `_ => None`: empty and multi-output arguments.
+        (
+            "at_offset(empty)",
+            "at_offset requires a non-negative integer",
+        ),
+        (
+            "at_offset(1,2)",
+            "at_offset requires a non-negative integer",
+        ),
+        (
+            "at_position(empty; 1)",
+            "at_position requires positive integers for line",
+        ),
+        (
+            "at_position(1; empty)",
+            "at_position requires positive integers for column",
+        ),
+        // A single output that is not an integer, and an out-of-domain one:
+        // the same arm's `Some(i)` guards.
+        (
+            "at_offset(\"x\")",
+            "at_offset requires a non-negative integer",
+        ),
+        ("at_offset(-1)", "at_offset requires a non-negative integer"),
+        (
+            "at_position(0; 1)",
+            "at_position requires positive integers for line",
+        ),
+        (
+            "at_position(1; 0)",
+            "at_position requires positive integers for column",
+        ),
+    ] {
+        let (stdout, stderr, code) = run_jq_stdin_streams(filter, doc, &["-c"])?;
+        assert_eq!(code, 5, "{filter}: stdout {stdout:?} stderr {stderr:?}");
+        assert!(stderr.contains(want_err), "{filter}: {stderr:?}");
+    }
+
+    // The control: a document-sourced integer argument still works, through
+    // both the cursor shape (`.a[0]`) and `getpath`'s own (#2168's new
+    // `OneCursor` arm, already pinned by
+    // `test_at_offset_and_at_position_accept_a_document_sourced_argument`).
+    for filter in ["at_offset(.a[0])", r#"at_offset(getpath(["a",0]))"#] {
+        let (stdout, stderr, code) = run_jq_stdin_streams(filter, doc, &["-c"])?;
+        assert_eq!(code, 0, "{filter}: stdout {stdout:?} stderr {stderr:?}");
+        assert_eq!(stdout.trim(), r#""a""#, "{filter}");
+    }
+
+    Ok(())
+}
+
 /// #2280: `eval_generic.rs`'s `Expr::Format` arm (every `@format` builtin --
 /// this is the arm the CLI's default jq/yq dispatch actually reaches;
 /// `eval.rs`'s own sibling `eval_format` is library-API/reindex-bridge-only,
@@ -37126,6 +37286,74 @@ fn test_path_answers_past_a_colliding_key_2168() -> Result<()> {
         run_jq_stdin_streams(".", r#"{"\ud800":1,"\ud800":2}"#, &["-S", "-c"])?;
     assert_eq!(code, 5, "stdout {stdout:?}");
     assert!(stderr.contains("is ambiguous"), "{stderr}");
+
+    Ok(())
+}
+
+/// #2168 coverage: the validation gate's own **lazy collision map** still
+/// seeds itself from the prefix, on the consumers that kept the gate.
+///
+/// `push_generic_document_validation_error` builds the #1642 display-key map
+/// only from the point a decode-failure ("fallback") key first appears
+/// (#2061), then re-walks the object's earlier keys to seed it. Until #2168,
+/// `path()` was the query that reached that seeding re-walk; `path()` left
+/// the gate with this issue (see
+/// `test_path_answers_past_a_colliding_key_2168` next door, which is the
+/// same three documents on the other side of the line), and the four
+/// consumers that kept it are what still reach it.
+///
+/// The fallback key must sit at index >= 1 for the re-walk to run at all --
+/// at index 0 there is no prefix to seed from, which is the shape the sibling
+/// test's `-S` row already covers. Getting the seeding wrong turns one of
+/// these into a silent success, which is what #2061 wrote the
+/// three-position corpus for in the first place.
+///
+/// **Diverges from jq, deliberately** in the same direction and for the same
+/// reason as every other row on these documents: real jq 1.7.1 rejects all
+/// three at parse time, filter irrelevant.
+#[test]
+fn test_validation_gate_seeds_the_collision_map_prefix_2168() -> Result<()> {
+    // A clean key first, then the colliding pair: the map is seeded from
+    // index 0 only once the fallback at index 1 is met.
+    for inner in [
+        r#"{"a":1,"\ud800":2,"\ud800":3}"#,
+        r#"{"a":1,"\\ud800":2,"\ud800":3}"#,
+    ] {
+        let doc = format!(r#"{{"c":{inner},"t":5}}"#);
+
+        // `select` reaches the gate through its `OneCursor` truthiness arm.
+        let (stdout, stderr, code) = run_jq_stdin_streams("select(.c) | .t", &doc, &["-c"])?;
+        assert_eq!(code, 5, "select on {doc}: stdout {stdout:?}");
+        assert!(stderr.contains("is ambiguous"), "select: {stderr}");
+
+        // `sort_by` reaches it through the `_by` forms' own call, on an
+        // element it only reorders and never materializes (#1755) -- a
+        // second call site for one walk. The array wrapper has to be the
+        // *document*, not a `[...]` construction: collecting into one would
+        // materialize the element here and raise from there instead, which
+        // would pin nothing about this gate.
+        let array_doc = format!("[{inner}]");
+        let (stdout, stderr, code) =
+            run_jq_stdin_streams("sort_by(.a) | length", &array_doc, &["-c"])?;
+        assert_eq!(code, 5, "sort_by on {array_doc}: stdout {stdout:?}");
+        assert!(stderr.contains("is ambiguous"), "sort_by: {stderr}");
+
+        // The control, and the point of the whole #2168 split: the same
+        // document, the same colliding pair, on a query that only names
+        // positions -- it answers.
+        let (stdout, stderr, code) = run_jq_stdin_streams("path(.t)", &doc, &["-c"])?;
+        assert_eq!(code, 0, "path(.t) on {doc}: stderr {stderr:?}");
+        assert_eq!(stdout.trim(), r#"["t"]"#);
+    }
+
+    // No collision, same shape: a fallback key at index 1 whose display
+    // spelling is unique seeds the map and finds nothing, so the gate must
+    // stay quiet. Without this the rows above would pass for a gate that
+    // raised on any fallback key at all.
+    let doc = r#"{"c":{"a":1,"\ud800":2},"t":5}"#;
+    let (stdout, stderr, code) = run_jq_stdin_streams("select(.c) | .t", doc, &["-c"])?;
+    assert_eq!(code, 0, "stdout {stdout:?} stderr {stderr:?}");
+    assert_eq!(stdout.trim(), "5");
 
     Ok(())
 }

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -37130,6 +37130,46 @@ fn test_path_answers_past_an_undecodable_sibling_2168() -> Result<()> {
     Ok(())
 }
 
+/// #2168 (caught in review, not by the issue itself): `?` must never swallow
+/// a decode failure inside a `path(...)` expression, the same #1620 rule
+/// plain navigation already follows.
+///
+/// `path_walk_generic`'s and `path_step_generic`'s `Expr::Optional` arms
+/// each discard *every* error from their inner walk unconditionally
+/// (`let _ = ...`). Before this issue's own pre-walk gate was removed, an
+/// undecodable string always raised earlier, in the whole-document walk, so
+/// neither arm's discard was ever reachable with a `decode_failure` in hand.
+/// Once the gate came off, both arms went live with the wrong rule: swallow
+/// everything, `decode_failure` included.
+#[test]
+fn test_path_optional_still_raises_a_decode_failure_2168() -> Result<()> {
+    let doc = r#"{"a":"\ud800","d":5}"#;
+
+    for (filter, plain_nav) in [
+        // `Expr::Optional` reached directly from `path_walk_generic`'s own
+        // entry point.
+        ("path(.a[]?)", ".a[]?"),
+        // `Expr::Optional` as a pipe head, reached from
+        // `path_step_generic`'s sibling arm instead.
+        ("path((.a[]?)|.x)", "(.a[]?)|.x"),
+    ] {
+        let (_, nav_err, nav_code) = run_jq_stdin_streams(plain_nav, doc, &["-c"])?;
+        assert_eq!(nav_code, 5, "sanity: {plain_nav} itself must still raise");
+
+        let (stdout, stderr, code) = run_jq_stdin_streams(filter, doc, &["-c"])?;
+        assert_eq!(
+            code, 5,
+            "{filter}: `?` swallowed a decode failure -- stdout {stdout:?} stderr {stderr:?} \
+             (plain nav {plain_nav} raised {nav_err:?})"
+        );
+        assert!(
+            stderr.contains("invalid unicode escape sequence") || stderr.contains("invalid escape"),
+            "{filter}: {stderr:?}"
+        );
+    }
+    Ok(())
+}
+
 /// #2168's rule, stated once as a table: which builtins validate a node the
 /// query never reads, and which do not.
 ///

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -2188,6 +2188,37 @@ fn assert_jq_raises(
     );
 }
 
+/// [`assert_jq_raises`]'s opposite number, for the one consumer of the same
+/// corrupted documents that must *not* raise since #2168: a filter that only
+/// names a position never reads what is inside it.
+///
+/// Asserts the answer, not just exit 0, for the same reason its sibling
+/// asserts the message rather than the code -- "did not raise" and "produced
+/// the right path" are different claims, and only the second one would catch
+/// a walk that silently stopped emitting.
+fn assert_jq_answers(
+    label: &str,
+    op_label: &str,
+    extra_args: &[&str],
+    filter: &str,
+    doc: &str,
+    expect_stdout: &str,
+) {
+    let mut args: Vec<&str> = extra_args.to_vec();
+    args.push(filter);
+    let (out, err, actual_code) = run_jq_full(&args, Some(doc))
+        .unwrap_or_else(|e| panic!("[{label}] {op_label} run failed: {e}"));
+    assert_eq!(
+        actual_code, 0,
+        "[{label}] {op_label} must answer\nstdout: {out:?}\nstderr: {err:?}"
+    );
+    assert_eq!(
+        out.trim(),
+        expect_stdout,
+        "[{label}] {op_label} answer\nstderr: {err:?}"
+    );
+}
+
 /// #1645 code review: `push_generic_document_validation_error` is a second,
 /// hand-copied implementation of the same "walk and raise on corruption"
 /// predicate `to_owned_at_depth`/`to_owned_cursor_at_depth`/
@@ -2292,14 +2323,22 @@ fn test_select_and_materialize_agree_on_corruption_1645() -> Result<()> {
             5,
             expect_stderr,
         );
-        assert_jq_raises(
+        // #2168: `path(.bad)` is the one row here that must *not* raise. It
+        // names a position and never reads the value at it, and every
+        // corruption in this list lives inside `.bad`'s value -- so it now
+        // follows the rule `.keep` on these same documents always did. The
+        // four rows above keep the gate: three materialize, and `sort_by`
+        // walks the element it reorders. Keeping it in this list rather than
+        // deleting it is the point: the list's job is pinning that every
+        // consumer of one document agrees, and "agrees" now includes knowing
+        // which side of the line each one is on.
+        assert_jq_answers(
             label,
             "path(.bad)",
             &["-c"],
             "path(.bad)",
             doc,
-            5,
-            expect_stderr,
+            r#"["bad"]"#,
         );
     }
     Ok(())
@@ -2465,6 +2504,12 @@ fn fuzz_build_json_doc(path: &[FuzzContainer], malformation: FuzzMalformation) -
 // driven CLI paths to 5 (`sort_by`/`path()` joined `select`/`-Sc`/`-e` as
 // consumers of the same validation gate, #1755/#2069/#1953).
 //
+// #2168 then split those 5 into 4 + 1: `path()` stopped consuming that gate
+// and now asserts the opposite (it must answer), so this property pins the
+// *boundary* between the two behaviours rather than one shared behaviour.
+// That is the more valuable shape -- a change that moved a builtin to the
+// wrong side of the line now fails here whichever direction it moved.
+//
 // `ProptestConfig::with_cases` is turned down from proptest's own default
 // (256) because this drives five real subprocess spawns per case (a
 // `Command::new(env!("CARGO_BIN_EXE_succinctly"))` per
@@ -2513,7 +2558,16 @@ proptest! {
             expect_stderr,
         );
         assert_jq_raises(&label, "sort_by(.bad)", &[], "sort_by(.bad)", &doc, 5, expect_stderr);
-        assert_jq_raises(&label, "path(.bad)", &["-c"], "path(.bad)", &doc, 5, expect_stderr);
+        // #2168: `path(.bad)` left the "must raise" battery above. It names
+        // a position and never reads the value there, and every corruption
+        // this fuzzer builds lives *inside* `.bad`'s value, so it answers --
+        // the same rule `.keep` on these documents has always followed. The
+        // four consumers above keep the gate: three materialize, and
+        // `sort_by` walks the element it reorders. This row is what caught
+        // the mismatch when #2168 landed: the property was written against
+        // the old contract and this generator reached a shape the
+        // hand-written tests did not.
+        assert_jq_answers(&label, "path(.bad)", &["-c"], "path(.bad)", &doc, r#"["bad"]"#);
     }
 }
 

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -32094,8 +32094,12 @@ fn test_jq_getpath_fanout_all_outputs_still_resolve_1532() -> Result<()> {
 /// pinned -- `getpath(["a"])` and `.a` now match byte for byte, stderr and
 /// exit code included, on a document jq will not parse at all.
 ///
-/// **No jq oracle:** real jq 1.7.1 rejects all four documents at parse time,
-/// for `.d` as much as for `getpath(["d"])`.
+/// **Diverges from jq, deliberately.** Real jq 1.7.1 rejects all four
+/// documents at parse time, so the `getpath(["d"])` rows here used to match
+/// its outcome and no longer do. It rejects `.d` too, which succinctly has
+/// always answered, so what this buys is one answer per document rather than
+/// one per spelling. `docs/compliance/jq/limitations.md` records it, and why
+/// ADR-0018's decision order does not license it.
 #[test]
 fn test_getpath_touches_only_the_nodes_it_navigates_2168() -> Result<()> {
     for bad in [r"\ud800", r"\uZZZZ", r"\x", r"\u12"] {
@@ -37088,9 +37092,13 @@ fn test_path_validity_walk_lazy_collision_map_2061() -> Result<()> {
 /// `test_path_validity_walk_lazy_collision_map_2061`, not something this
 /// change moved.)
 ///
-/// **No jq oracle:** real jq 1.7.1 rejects all three documents at parse time.
-/// Checked in all three positions relative to the clean key, since the lazy
-/// map only seeds itself from the prefix once a fallback key appears.
+/// **Diverges from jq, deliberately:** real jq 1.7.1 rejects all three
+/// documents at parse time, so `path(.a)` here used to match its outcome and
+/// no longer does. `keys_unsorted` on the same documents has always answered,
+/// which is the consistency being bought; see
+/// `docs/compliance/jq/limitations.md`. Checked in all three positions
+/// relative to the clean key, since the lazy map only seeds itself from the
+/// prefix once a fallback key appears.
 #[test]
 fn test_path_answers_past_a_colliding_key_2168() -> Result<()> {
     for doc in [
@@ -37133,11 +37141,13 @@ fn test_path_answers_past_a_colliding_key_2168() -> Result<()> {
 /// consistency question it left open -- `.d` answered `5` on the same
 /// document `path(.d)` rejected.
 ///
-/// **No jq oracle.** Real jq 1.7.1 rejects every document below at parse
-/// time (`Invalid \uXXXX\uXXXX surrogate pair escape`), for `.d` as much as
-/// for `path(.d)`, so it separates none of these rows; the contract pinned
-/// is succinctly's own lazy-validation rule (recorded as an ADR-0018
-/// divergence in `docs/compliance/jq/limitations.md`).
+/// **Diverges from jq, deliberately.** Real jq 1.7.1 rejects every document
+/// below at parse time (`Invalid \uXXXX\uXXXX surrogate pair escape`), so
+/// the `path(.d)` rows here used to *match* jq's outcome and no longer do.
+/// jq rejects `.d` on the same documents too, which succinctly has always
+/// answered, so the choice was between diverging uniformly and diverging by
+/// spelling. Recorded, with why ADR-0018's decision order does not license
+/// it, in `docs/compliance/jq/limitations.md`.
 #[test]
 fn test_path_answers_past_an_undecodable_sibling_2168() -> Result<()> {
     for bad in [r"\ud800", r"\uZZZZ", r"\x", r"\u12"] {
@@ -37235,9 +37245,12 @@ fn test_path_optional_still_raises_a_decode_failure_2168() -> Result<()> {
 /// navigation always has. Anything that materializes still validates
 /// everything it materializes.
 ///
-/// **No jq oracle for any row:** real jq 1.7.1 rejects this document at parse
-/// time for every filter, `.d` included, so it cannot separate them. The
-/// contract is succinctly's own, recorded in
+/// **Every row diverges from jq**, which rejects this document at parse time
+/// whatever the filter -- including the rows that raise, since succinctly
+/// raises for a different reason and at a different stage. What changed with
+/// #2168 is that the answering column grew: `path`/`key`/`getpath` moved into
+/// it, giving up an agreement with jq's outcome that `.d` never had. The
+/// contract pinned is succinctly's own, recorded with its cost in
 /// `docs/compliance/jq/limitations.md`.
 #[test]
 fn test_lazy_validation_boundary_2168() -> Result<()> {
@@ -39227,10 +39240,12 @@ fn test_validate_only_gate_delimiter_checks_2349() -> Result<()> {
 /// reads what is inside it. `select`/`sort_by` keep their gate and so keep
 /// these checks -- their remaining rows in that test are the control.
 ///
-/// **No jq oracle:** real jq rejects `{"c":{"a":1,}}` at parse time whatever
-/// the filter, `.t` included, so it separates none of these rows. What it is
-/// consistent with is succinctly's own `.t`, which has always answered `5`
-/// here (`docs/compliance/jq/limitations.md`, the lazy-validation trade-off).
+/// **Diverges from jq, deliberately:** real jq rejects `{"c":{"a":1,}}` at
+/// parse time whatever the filter, so the `path` rows here used to match its
+/// outcome and no longer do. jq rejects `.t` too, which succinctly has always
+/// answered `5`, so what this buys is one answer per document instead of one
+/// per spelling (`docs/compliance/jq/limitations.md`, which records why the
+/// decision order does not license it).
 #[test]
 fn test_path_answers_past_a_structural_fault_it_never_reads_2168() -> Result<()> {
     let doc = r#"{"c":{"a":1,},"t":5}"#;

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -32025,31 +32025,259 @@ fn test_jq_getpath_fanout_all_outputs_still_resolve_1532() -> Result<()> {
     Ok(())
 }
 
-/// #2053: `eval_generic.rs`'s new native `Builtin::GetPath` bypass arm still
-/// materializes and validates the whole document exactly once before ever
-/// walking a path -- the same rule `test_path_still_raises_on_an_
-/// undecodable_sibling_2061` pins for `path()`. `getpath(["d"])` never
-/// reaches `.a`, but a `\uXXXX`-family decode failure anywhere in the
-/// document still raises, matching real jq's own eager whole-document parse
-/// (#1755/#1953) -- unlike plain navigation (`.d`, `keys`, `length`), which
-/// only decode what they touch and succeed on this same document. This is
-/// the whole-document validity gate the issue's fix explicitly could not
-/// drop: a naive cursor walk straight to `.d` would silently accept a
-/// document both real jq and `main` currently reject.
+/// #2168: `getpath(P)` reads only the nodes it navigates to, so an
+/// undecodable *sibling* no longer makes it raise -- and landing on the
+/// undecodable node itself is not a read either.
+///
+/// This reverses `test_getpath_still_raises_on_an_undecodable_sibling_2053`,
+/// whose own doc comment called the whole-document materialization behind it
+/// the gate "the issue's fix explicitly could not drop". #2168 dropped it:
+/// `.d` had always answered `5` on this document, and two spellings of one
+/// read disagreeing is the shape #1629/#1642 exist to remove.
+///
+/// Most rows are asserted against the *bare navigation* they spell rather
+/// than against a literal, because that agreement is the property being
+/// pinned -- `getpath(["a"])` and `.a` now match byte for byte, stderr and
+/// exit code included, on a document jq will not parse at all.
+///
+/// **No jq oracle:** real jq 1.7.1 rejects all four documents at parse time,
+/// for `.d` as much as for `getpath(["d"])`.
 #[test]
-fn test_getpath_still_raises_on_an_undecodable_sibling_2053() -> Result<()> {
+fn test_getpath_touches_only_the_nodes_it_navigates_2168() -> Result<()> {
     for bad in [r"\ud800", r"\uZZZZ", r"\x", r"\u12"] {
         let input = format!("{{\"a\":\"{bad}\",\"d\":5}}");
-        let (stdout, stderr, code) = run_jq_stdin_streams("getpath([\"d\"])", &input, &["-c"])?;
-        assert_eq!(code, 5, "{bad}: stdout {stdout:?} stderr {stderr:?}");
-        assert_eq!(stdout, "", "{bad}");
+
+        // The sibling is never navigated to.
+        let (stdout, stderr, code) = run_jq_stdin_streams(r#"getpath(["d"])"#, &input, &["-c"])?;
+        assert_eq!(code, 0, "{bad}: stdout {stdout:?} stderr {stderr:?}");
+        assert_eq!(stdout.trim(), "5", "{bad}");
+
+        // Each `getpath` spelling answers exactly as the navigation it
+        // spells -- including landing *on* the undecodable node (raw bytes,
+        // exit 0), reading it (`| length` raises), and navigating through
+        // it (the type error, not a decode failure).
+        for (getpath_filter, nav_filter) in [
+            (r#"getpath(["a"])"#, ".a"),
+            (r#"getpath(["a"]) | length"#, ".a | length"),
+            (r#"getpath(["a","x"])"#, ".a.x"),
+            (r#"getpath(["d"])"#, ".d"),
+        ] {
+            let got = run_jq_stdin_streams(getpath_filter, &input, &["-c"])?;
+            let want = run_jq_stdin_streams(nav_filter, &input, &["-c"])?;
+            assert_eq!(
+                got, want,
+                "{bad}: `{getpath_filter}` must answer exactly as `{nav_filter}`"
+            );
+        }
+
+        // Spelled out rather than left to the pairing above, so a future
+        // change that made *both* sides silently succeed still fails here.
+        // (The message differs by escape shape -- `\x` is "invalid escape
+        // sequence in string", the `\u` family "invalid unicode escape
+        // sequence" -- so this matches the substring they share.)
+        let (_, stderr, code) =
+            run_jq_stdin_streams(r#"getpath(["a"]) | length"#, &input, &["-c"])?;
+        assert_eq!(code, 5, "{bad}: stderr {stderr:?}");
+        assert!(stderr.contains("escape sequence"), "{bad}: {stderr:?}");
     }
 
-    // The raise above is `getpath`-specific, not a blanket rejection of the
-    // document -- plain navigation over the same input still succeeds.
-    let (stdout, code) = run_jq_stdin(".d", r#"{"a":"\ud800","d":5}"#, &["-c"])?;
+    Ok(())
+}
+
+/// #2168: the cursor walk answers every step exactly as jq 1.7.1 does.
+///
+/// `getpath`'s step rules stopped being one table when this builtin started
+/// walking cursors, so this pins the seam. Two segment shapes are taken over
+/// cursors (a string key into an object, a number into an array); a slice
+/// descriptor hands the rest of the path to the owned table
+/// (`eval::getpath_walk_owned_segments`) after materializing the one node it
+/// reached; everything else is a type error raised from the cursor. A row
+/// landing in the wrong one of those three is what this catches.
+///
+/// Every expectation was captured live from `/usr/bin/jq` 1.7.1 on the
+/// document below, e.g.:
+///
+/// ```console
+/// $ printf '%s' '{"a":[1,2],"s":"str","n":5,"o":{"k":1}}' | jq -c 'getpath(["a",-1])'
+/// 2
+/// $ printf '%s' '{"a":[1,2],"s":"str","n":5,"o":{"k":1}}' | jq -c 'getpath(["n",0])'
+/// jq: error (at <stdin>:0): Cannot index number with number
+/// ```
+#[test]
+fn test_getpath_cursor_walk_matches_jq_2168() -> Result<()> {
+    let doc = r#"{"a":[1,2],"s":"str","n":5,"o":{"k":1}}"#;
+
+    // (filter, jq's stdout) -- rows jq answers.
+    for (filter, want) in [
+        (r"getpath([])", doc),
+        (r#"getpath(["a"])"#, "[1,2]"),
+        (r#"getpath(["o"])"#, r#"{"k":1}"#),
+        (r#"getpath(["o","k"])"#, "1"),
+        (r#"getpath(["a",0])"#, "1"),
+        (r#"getpath(["a",-1])"#, "2"),
+        (r#"getpath(["a",1.5])"#, "2"),
+        (r#"getpath(["a",-9])"#, "null"),
+        (r#"getpath(["b","c"])"#, "null"),
+        (r#"getpath(["o","zz"])"#, "null"),
+        (r#"getpath(["o","zz","yy"])"#, "null"),
+        (r#"getpath(["a",{"start":0,"end":1}])"#, "[1]"),
+        (r#"getpath(["s",{"start":0,"end":1}])"#, r#""s""#),
+    ] {
+        let (stdout, stderr, code) = run_jq_stdin_streams(filter, doc, &["-c"])?;
+        assert_eq!(code, 0, "{filter}: stdout {stdout:?} stderr {stderr:?}");
+        assert_eq!(stdout.trim(), want, "{filter}");
+    }
+
+    // (filter, jq's message) -- rows jq refuses.
+    for (filter, want) in [
+        (r#"getpath("a")"#, "Path must be specified as an array"),
+        (r"getpath([0])", "Cannot index object with number"),
+        (r"getpath([nan])", "Cannot index object with number"),
+        (r"getpath([true])", "Cannot index object with boolean"),
+        (r"getpath([null])", "Cannot index object with null"),
+        (r"getpath([[1]])", "Cannot index object with array"),
+        (
+            r#"getpath([{"start":0}])"#,
+            "Cannot index object with object",
+        ),
+        (
+            r#"getpath(["a","c"])"#,
+            r#"Cannot index array with string "c""#,
+        ),
+        (
+            r#"getpath(["s","x"])"#,
+            r#"Cannot index string with string "x""#,
+        ),
+        (
+            r#"getpath(["n","x"])"#,
+            r#"Cannot index number with string "x""#,
+        ),
+        (r#"getpath(["n",0])"#, "Cannot index number with number"),
+        (
+            r#"getpath(["a",{"start":"x"}])"#,
+            "Array/string slice indices must be integers",
+        ),
+    ] {
+        let (stdout, stderr, code) = run_jq_stdin_streams(filter, doc, &["-c"])?;
+        assert_eq!(code, 5, "{filter}: stdout {stdout:?} stderr {stderr:?}");
+        assert!(stderr.contains(want), "{filter}: {stderr:?}");
+    }
+
+    Ok(())
+}
+
+/// #2168: a document number reached through `getpath` keeps its source
+/// spelling, because the walk hands back the document's own node.
+///
+/// This is the one row where #2168 moved `getpath` *away* from real jq, and
+/// it did so by moving it onto succinctly's own `.big`. A `NumberLiteral`
+/// longer than `REINDEX_LITERAL_LEN_CAP` used to disqualify the whole
+/// document from the native arm (`reindex_bridge_is_identity`), sending the
+/// call through the reindex round trip, which re-spells it: jq prints
+/// `1E-301`, and so did `getpath(["big"])`, while `.big` on the same
+/// document printed all 303 characters. Preserving a document number's
+/// written form is deliberate (`DocumentValue::number_literal`, #387/#966),
+/// so the round trip was the odd one out, not `.big`.
+///
+/// jq 1.7.1 prints `1E-301` for **both** spellings, so this trades one
+/// divergence for internal agreement rather than removing one; recorded in
+/// `docs/compliance/jq/limitations.md`.
+#[test]
+fn test_getpath_keeps_a_document_numbers_spelling_2168() -> Result<()> {
+    let long_literal = "0.".to_string() + &"0".repeat(300) + "1";
+    let doc = format!(r#"{{"a":1,"big":{long_literal}}}"#);
+
+    let (via_getpath, _, code) = run_jq_stdin_streams(r#"getpath(["big"])"#, &doc, &["-c"])?;
     assert_eq!(code, 0);
-    assert_eq!(stdout.trim(), "5");
+    let (via_nav, _, code) = run_jq_stdin_streams(".big", &doc, &["-c"])?;
+    assert_eq!(code, 0);
+    assert_eq!(
+        via_getpath, via_nav,
+        "getpath must spell a document number the way the bare read does"
+    );
+    assert_eq!(via_getpath.trim(), long_literal, "the source spelling");
+
+    // The short sibling in the same document is unaffected either way.
+    let (stdout, _, code) = run_jq_stdin_streams(r#"getpath(["a"])"#, &doc, &["-c"])?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout.trim(), "1");
+
+    Ok(())
+}
+
+/// #2168: reporting a type error costs no materialization either.
+///
+/// The cursor walk raises `Cannot index ...` straight from the node it is
+/// standing on, so the error arrives even on a document that could not be
+/// materialized at all. Before #2168 this same query answered with a decode
+/// failure, because building the tree came first and never got as far as
+/// noticing the path was ill-typed. This is the row that would regress if a
+/// later change routed type errors through the owned table for convenience:
+/// it would materialize the root to word the message.
+#[test]
+fn test_getpath_type_error_does_not_materialize_the_root_2168() -> Result<()> {
+    let doc = r#"{"a":"\ud800"}"#;
+
+    let (stdout, stderr, code) = run_jq_stdin_streams("getpath([0])", doc, &["-c"])?;
+    assert_eq!(code, 5, "stdout {stdout:?}");
+    assert!(
+        stderr.contains("Cannot index object with number"),
+        "expected the type error, not a decode failure: {stderr:?}"
+    );
+    assert!(
+        !stderr.contains("invalid unicode escape sequence"),
+        "the root must not have been materialized: {stderr:?}"
+    );
+
+    Ok(())
+}
+
+/// #2168: `?` on a `getpath` the cursor walk answers suppresses exactly what
+/// it suppressed before, and exactly what jq suppresses.
+///
+/// Every row is jq 1.7.1's own answer, captured live, and every row was also
+/// checked against the pre-#2168 binary: all three agree. Worth pinning
+/// anyway, because the mechanism underneath changed. Suppression here is
+/// `try`'s -- `Expr::Optional` catches an ordinary error around the whole
+/// call -- while the arm *also* threads an `optional` parameter into the
+/// walk for the per-step decision. Only the first is reachable through this
+/// syntax (the documented `Map`/`Select` precedent, see
+/// `test_optional_ignored_sites_2280`), so these rows pin the reachable
+/// behaviour and leave the threaded parameter as the defensive thing it is.
+///
+/// The `.s.x?` row is the point of comparison: `getpath(["s","x"])?` is the
+/// same read, and now suppresses the same way.
+#[test]
+fn test_getpath_optional_matches_jq_on_the_cursor_walk_2168() -> Result<()> {
+    let doc = r#"{"a":[1,2],"s":"str"}"#;
+
+    for (filter, want_code, want_stdout) in [
+        (r#"getpath(["s","x"])"#, 5, ""),
+        (r#"getpath(["s","x"])?"#, 0, ""),
+        (r".s.x", 5, ""),
+        (r".s.x?", 0, ""),
+        (r#"getpath(["a",{"start":"x"}])"#, 5, ""),
+        (r#"getpath(["a",{"start":"x"}])?"#, 0, ""),
+        (r#"getpath(["a",0])"#, 0, "1"),
+        (r#"getpath(["a",0])?"#, 0, "1"),
+    ] {
+        let (stdout, stderr, code) = run_jq_stdin_streams(filter, doc, &["-c"])?;
+        assert_eq!(
+            code, want_code,
+            "{filter}: stdout {stdout:?} stderr {stderr:?}"
+        );
+        assert_eq!(stdout.trim(), want_stdout, "{filter}");
+    }
+
+    // A decode failure is never suppressible (#1620), and `getpath` reaching
+    // one through the cursor walk is no exception.
+    let (stdout, stderr, code) = run_jq_stdin_streams(
+        r#"(getpath(["a"]) | length)?"#,
+        r#"{"a":"\ud800"}"#,
+        &["-c"],
+    )?;
+    assert_eq!(code, 5, "stdout {stdout:?} stderr {stderr:?}");
+    assert!(stderr.contains("escape sequence"), "{stderr:?}");
 
     Ok(())
 }
@@ -32075,8 +32303,9 @@ fn test_getpath_still_raises_on_an_undecodable_sibling_2053() -> Result<()> {
 /// Pins that this is defensive, not a behavior change: a document-wide
 /// decode failure (`\ud800`, matching `test_getpath_still_raises_on_an_
 /// undecodable_sibling_2053`'s own repro) still raises *on these
-/// materializing spellings* (see the note in the body about #2168's
-/// cursor-navigable `path(.d)`) -- uncatchable, per
+/// materializing spellings* (see the notes in the body about #2168's
+/// cursor-navigable `path(.d)`, and about `getpath`'s rows leaving this
+/// test entirely) -- uncatchable, per
 /// #2286 tagging every one of these materializations' error paths
 /// `is_decode_failure()` -- through a bare call, a trailing `?`, and a
 /// `try`/`catch` wrapped in its own outer `?` (the exact shape #2231's
@@ -32092,9 +32321,6 @@ fn test_optional_ignored_sites_2280() -> Result<()> {
         "path(if true then .a else null end)",
         "path(if true then .a else null end)?",
         r#"(try path(if true then .a else null end) catch "CAUGHT")?"#,
-        r#"getpath(["a"])"#,
-        r#"getpath(["a"])?"#,
-        r#"(try getpath(["a"]) catch "CAUGHT")?"#,
     ] {
         let (stdout, stderr, code) = run_jq_stdin_streams(filter, doc, &["-c"])?;
         assert_eq!(code, 5, "{filter}: stdout {stdout:?} stderr {stderr:?}");
@@ -32123,6 +32349,20 @@ fn test_optional_ignored_sites_2280() -> Result<()> {
         code, 5,
         "the materializing fallback still validates what it materializes"
     );
+
+    // `getpath`'s three rows left this test with #2168: it walks cursors
+    // now, so it has no materialization for `optional` to be ignored *by*,
+    // and every spelling below answers. `test_getpath_touches_only_the_
+    // nodes_it_navigates_2168` owns them.
+    for filter in [
+        r#"getpath(["a"])"#,
+        r#"getpath(["a"])?"#,
+        r#"(try getpath(["a"]) catch "CAUGHT")?"#,
+        r#"getpath(["d"])"#,
+    ] {
+        let (stdout, stderr, code) = run_jq_stdin_streams(filter, doc, &["-c"])?;
+        assert_eq!(code, 0, "{filter}: stdout {stdout:?} stderr {stderr:?}");
+    }
 
     Ok(())
 }
@@ -32410,10 +32650,13 @@ fn test_style_0012_routed_sites_still_raise_2334() -> Result<()> {
 }
 
 /// #2053, constraint 2 from the issue that split this fix off from #1909:
-/// `path_expr` must be evaluated exactly once, on *both* branches
-/// `eval_generic.rs`'s new native `Builtin::GetPath` arm can take -- the
-/// `reindex_bridge_is_identity`-gated bypass, and the pre-existing
-/// reindex-round-trip fallback kept for its numeric edge cases. A withdrawn
+/// `path_expr` must be evaluated exactly once, on every branch
+/// `eval_generic.rs`'s native `Builtin::GetPath` arm can take. #2168
+/// replaced those branches (the `reindex_bridge_is_identity`-gated bypass
+/// and its reindex-round-trip fallback are both gone) with a cursor walk and
+/// its mid-path hand-off to the owned table, so the rows below moved with
+/// them -- the constraint itself is unchanged, and is why neither rewrite
+/// was allowed to probe. A withdrawn
 /// earlier attempt at this fix (PR #2045) probed `path_expr`'s output shape
 /// and, on a shape it didn't recognise, discarded the probe and fell back to
 /// evaluating the whole unmodified expression a second time -- firing any
@@ -32435,36 +32678,45 @@ fn test_getpath_path_expr_evaluated_exactly_once_2053() -> Result<()> {
         "stderr: {stderr:?}"
     );
 
-    // Fallback branch: a `NumberLiteral` past `REINDEX_LITERAL_LEN_CAP`
-    // (256 chars) anywhere in the document makes `reindex_bridge_is_identity`
-    // return `false`, sending this call through the pre-existing
-    // reindex-round-trip path (`eval_on_owned` -> `eval::builtin_getpath` ->
-    // `fanout_arg`) instead -- the other place this property has to hold,
-    // since that path's own single evaluation of `path_expr` was left
-    // untouched by this fix.
-    let long_literal = "0.".to_string() + &"0".repeat(300) + "1";
-    let input = format!(r#"{{"a":1,"big":{long_literal}}}"#);
-    let (stdout, stderr, code) =
-        run_jq_stdin_streams(r#"getpath(("MARK2053"|stderr))"#, &input, &["-c"])?;
-    assert_eq!(code, 5, "stdout {stdout:?} stderr {stderr:?}");
+    // The other branch, since #2168: a slice descriptor sends the walk into
+    // the owned table partway along the path, so the whole expression is
+    // evaluated on a route that materializes a node mid-flight. The mark
+    // must still appear once, and the answer must still be jq's.
+    let (stdout, stderr, code) = run_jq_stdin_streams(
+        r#"getpath(("MARK2053"|stderr|["a",{"start":0,"end":1}]))"#,
+        r#"{"a":[1,2]}"#,
+        &["-c"],
+    )?;
+    assert_eq!(code, 0, "stdout {stdout:?} stderr {stderr:?}");
+    assert_eq!(stdout.trim(), "[1]", "stderr: {stderr:?}");
     assert_eq!(stderr.matches("MARK2053").count(), 1, "stderr: {stderr:?}");
-    assert!(
-        stderr.contains("Path must be specified as an array"),
-        "stderr: {stderr:?}"
-    );
+
+    // A generator path is the third shape that could double-fire: each
+    // resolved path drives its own walk, but the expression producing them
+    // runs once.
+    let (stdout, stderr, code) = run_jq_stdin_streams(
+        r#"[getpath(("MARK2053"|stderr|(["a"],["a",0])))]"#,
+        r#"{"a":[1,2]}"#,
+        &["-c"],
+    )?;
+    assert_eq!(code, 0, "stdout {stdout:?} stderr {stderr:?}");
+    assert_eq!(stdout.trim(), "[[1,2],1]", "stderr: {stderr:?}");
+    assert_eq!(stderr.matches("MARK2053").count(), 1, "stderr: {stderr:?}");
 
     Ok(())
 }
 
 /// #2053: a generator path (`getpath((["a"],["b"],["a"]))`) resolves every
-/// branch correctly off the *same* materialized root -- the native bypass
-/// arm's `owned: &OwnedValue` is shared (borrowed via `Cow`, never mutated)
-/// across every one of `fanout_arg_generic`'s per-path calls into
-/// `eval::getpath_walk_owned`, rather than re-materialized per path the way
-/// `eval::getpath_one_path` used to. Revisiting the same path twice (`["a"]`
-/// here) is a regression check for that sharing: nothing about walking it
-/// once should leave the shared root in a state where walking it again
-/// produces something different.
+/// branch correctly. #2053 pinned this against a *shared materialized root*
+/// (one `OwnedValue`, borrowed per path, replacing `eval::getpath_one_path`'s
+/// re-materialization per path); since #2168 there is no root tree at all and
+/// each path is its own cursor walk from the same document position. Both
+/// designs have to answer this identically, which is why the test outlives
+/// the mechanism it was written for. Revisiting the same path twice (`["a"]`
+/// here) remains the regression check: walking it once must leave nothing
+/// behind that changes the second walk (the walk holds a `Cell` sequential
+/// hint on the index since PR #2578, which is exactly the kind of state this
+/// row would catch).
 #[test]
 fn test_getpath_generator_path_shares_one_materialization_2053() -> Result<()> {
     let (stdout, code) = run_jq_stdin(

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -19438,6 +19438,59 @@ fn test_object_slice_getpath_malformed_descriptor_errors_1102() -> Result<()> {
     Ok(())
 }
 
+/// #2168, yq mode: `getpath` walks cursors now, and every step still answers
+/// from `eval::getpath_walk_owned_segments`'s table rather than the yq
+/// *navigation* rules.
+///
+/// The distinction is load-bearing and easy to lose. `path_step_generic` --
+/// the walk behind `.a[-5] | key` -- applies real yq's own rules: a negative
+/// index that stays negative raises (#2254), a numeric index on a mapping is
+/// an absent position (#2459), indexing a scalar is a silent no-op (#2482).
+/// `getpath`'s table has none of them: those rows are `null`, an error, and
+/// an error respectively. Reusing the navigation walk to save code would
+/// have changed all three, so this pins them.
+///
+/// `getpath` is a jq builtin real yq's lexer rejects outright, so it is a
+/// succinctly extension behind `--jq-extensions` (#1512, ADR-0018 rule 5) and
+/// there is no yq oracle for any row. What is pinned is that #2168 left every
+/// answer exactly as the materializing implementation gave it -- verified
+/// row-for-row against the pre-#2168 binary.
+#[test]
+fn test_getpath_keeps_the_owned_table_in_yq_mode_2168() -> Result<()> {
+    let doc = "a: [1, 2]\ns: x\no:\n  k: 1\n";
+    let args = ["-o=json", "-I=0", "--jq-extensions"];
+
+    for (filter, want) in [
+        // Not yq's negative-index raise: out of range reads as `null`.
+        (r#"getpath(["a",-5])"#, "null"),
+        (r#"getpath(["a",0])"#, "1"),
+        (r#"getpath(["o","k"])"#, "1"),
+        // The yq-only object-slice arm (#1102) still reached, through the
+        // walk's hand-off to the owned table.
+        (r#"getpath(["a",{"start":0,"end":1}])"#, "[1]"),
+        (r#"getpath(["o",{"start":0,"end":1}])"#, r#"["k"]"#),
+    ] {
+        let (out, code) = run_yq_stdin(filter, doc, &args)?;
+        assert_eq!(code, 0, "{filter}: {out:?}");
+        assert_eq!(out.trim(), want, "{filter}");
+    }
+
+    for (filter, want) in [
+        // Not yq's scalar-index no-op, and not its mapping-index `null`.
+        (
+            r#"getpath(["s","x"])"#,
+            r#"Cannot index string with string "x""#,
+        ),
+        (r#"getpath(["o",0])"#, "Cannot index object with number"),
+    ] {
+        let (_out, stderr, code) = run_yq_stdin_with_stderr(filter, doc, &args)?;
+        assert_eq!(code, 1, "{filter}: stderr {stderr}");
+        assert!(stderr.contains(want), "{filter}: {stderr}");
+    }
+
+    Ok(())
+}
+
 /// Known, deliberate gap: slicing an object with a genuine duplicate YAML
 /// key silently collapses it, the same root cause as this repo's other
 /// duplicate-mapping-key gaps (`OwnedValue::Object`'s `IndexMap`

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -30475,34 +30475,83 @@ fn test_path_context_cursor_walk_falls_back_2061() -> Result<()> {
     Ok(())
 }
 
-/// #2061: the validity gate is kept, only the tree build is dropped.
+/// #2168: the path-context walk (`key`/`path`/`parent`) validates only the
+/// nodes it navigates through -- an undecodable *sibling* it never visits no
+/// longer raises.
 ///
-/// `to_owned_with_cursor` doubles as a decode-failure gate (#1755/#1953), so
-/// a walk that reached the answer without decoding everything would silently
-/// start accepting documents these pipes reject today.
-/// `push_generic_document_validation_error` is that same traversal and
-/// validation without the `OwnedValue` construction.
+/// This reverses `test_path_context_cursor_walk_keeps_the_validity_gate_2061`.
+/// #2061 kept a whole-document gate here (`push_generic_document_validation_
+/// error`, the traversal the `to_owned_with_cursor` it replaced had doubled
+/// as); #2168 measured it at 67-75% of such a query's runtime and settled the
+/// consistency question it left open, since `.d.e` itself always answered on
+/// exactly these documents.
+///
+/// **No jq oracle** (`key`/`parent` are succinctly extensions in the first
+/// place, and real jq 1.7.1 rejects every document below at parse time). The
+/// contract pinned is succinctly's own lazy-validation rule, recorded in
+/// `docs/compliance/jq/limitations.md`.
 #[test]
-fn test_path_context_cursor_walk_keeps_the_validity_gate_2061() -> Result<()> {
-    // An undecodable *sibling* the walk never visits still raises.
+fn test_path_context_cursor_walk_skips_an_undecodable_sibling_2168() -> Result<()> {
     for input in [
         r#"{"a":"\ud800","d":{"e":5}}"#,
         r#"{"a":"\uZZZZ","d":{"e":5}}"#,
         r#"{"a":"\x","d":{"e":5}}"#,
         r#"{"a":"\u12","d":{"e":5}}"#,
     ] {
-        for filter in [".d.e | key", ".d.e | path", ".d.e | parent"] {
+        for (filter, want) in [
+            (".d.e | key", r#""e""#),
+            (".d.e | path", r#"["d","e"]"#),
+            (".d.e | parent", r#"{"e":5}"#),
+        ] {
             let (out, code) = run_jq_stdin(filter, input, &["-c"])?;
-            assert_ne!(code, 0, "`{filter}` on `{input}` must still raise: {out:?}");
-            assert_eq!(out, "", "`{filter}` on `{input}`");
+            assert_eq!(code, 0, "`{filter}` on `{input}`: {out:?}");
+            assert_eq!(out.trim(), want, "`{filter}` on `{input}`");
         }
+
+        // The node the query *does* read is still validated: reading the
+        // undecodable value raises exactly as the bare navigation does.
+        let (out, code) = run_jq_stdin(".a | length", input, &["-c"])?;
+        assert_ne!(code, 0, "`.a | length` on `{input}` must raise: {out:?}");
     }
 
-    // A well-formed document with the same shape answers normally, so the
-    // gate is not simply rejecting everything.
+    // A well-formed document with the same shape is unchanged.
     let (out, code) = run_jq_stdin(".d.e | key", r#"{"a":"ok","d":{"e":5}}"#, &["-c"])?;
     assert_eq!(code, 0);
     assert_eq!(out.trim(), r#""e""#);
+
+    Ok(())
+}
+
+/// #2168, yq mode: the same rule, reached through `succinctly yq` rather than
+/// `succinctly jq`, since the walk is one generic implementation shared by
+/// both modes (ADR-0018 rule 2's shared-builtin hazard -- a change verified
+/// in one mode has to be verified in the other).
+///
+/// **No yq oracle:** real yq v4.53.3 rejects this document while *scanning*
+/// it (`found invalid Unicode character escape code`), for `.d` as much as
+/// for `.d.e | key`, so it separates none of these rows.
+#[test]
+fn test_path_context_walk_skips_an_undecodable_sibling_yq_mode_2168() -> Result<()> {
+    let doc = "a: \"\\ud800\"\nd:\n  e: 5\n";
+    let args = ["-o=json", "-I=0"];
+
+    for (filter, want) in [
+        (".d.e | key", r#""e""#),
+        (".d.e | path", r#"["d","e"]"#),
+        (".d.e | parent", r#"{"e":5}"#),
+        (".d", r#"{"e":5}"#),
+    ] {
+        let (out, code) = run_yq_stdin(filter, doc, &args)?;
+        assert_eq!(code, 0, "`{filter}`: {out:?}");
+        assert_eq!(out.trim(), want, "`{filter}`");
+    }
+
+    // Reading the undecodable scalar still raises, and so does the gate the
+    // sort family keeps -- the two halves of the #2168 decision, side by side.
+    for filter in [".a", ".a | length", "sort_by(.d) | length"] {
+        let (out, code) = run_yq_stdin(filter, doc, &args)?;
+        assert_ne!(code, 0, "`{filter}` must raise: {out:?}");
+    }
 
     Ok(())
 }

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -19491,6 +19491,32 @@ fn test_getpath_keeps_the_owned_table_in_yq_mode_2168() -> Result<()> {
     Ok(())
 }
 
+/// #2168 (review follow-up): `getpath` still resolves an alias node
+/// correctly after `getpath_walk_cursor`'s segment-kind dispatch was
+/// rewritten to call `v.as_object()`/`v.as_array()` at most once per step
+/// (previously both were tried unconditionally every step, each
+/// independently re-walking a `YamlValue::Alias`'s full `resolve_alias_chain`
+/// -- a real cost, not just a redundant call, but not a correctness question
+/// either way). Pins that indexing through `*seq`/`*map` still lands on the
+/// aliased node's own children, one segment kind at a time.
+#[test]
+fn test_getpath_resolves_through_an_alias_2168() -> Result<()> {
+    let doc = "seq: &s [1, 2, 3]\nseq_alias: *s\nmap: &m\n  k: 1\nmap_alias: *m\n";
+    let args = ["-o=json", "-I=0", "--jq-extensions"];
+
+    for (filter, want) in [
+        (r#"getpath(["seq_alias",1])"#, "2"),
+        (r#"getpath(["map_alias","k"])"#, "1"),
+        (r#"getpath(["seq_alias",{"start":0,"end":2}])"#, "[1,2]"),
+    ] {
+        let (out, code) = run_yq_stdin(filter, doc, &args)?;
+        assert_eq!(code, 0, "{filter}: {out:?}");
+        assert_eq!(out.trim(), want, "{filter}");
+    }
+
+    Ok(())
+}
+
 /// Known, deliberate gap: slicing an object with a genuine duplicate YAML
 /// key silently collapses it, the same root cause as this repo's other
 /// duplicate-mapping-key gaps (`OwnedValue::Object`'s `IndexMap`

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -30606,9 +30606,12 @@ fn test_path_context_cursor_walk_skips_an_undecodable_sibling_2168() -> Result<(
 /// both modes (ADR-0018 rule 2's shared-builtin hazard -- a change verified
 /// in one mode has to be verified in the other).
 ///
-/// **No yq oracle:** real yq v4.53.3 rejects this document while *scanning*
-/// it (`found invalid Unicode character escape code`), for `.d` as much as
-/// for `.d.e | key`, so it separates none of these rows.
+/// **Diverges from yq, deliberately:** real yq v4.53.3 rejects this document
+/// while *scanning* it (`found invalid Unicode character escape code`), so
+/// these rows used to match its outcome and no longer do. It rejects `.d`
+/// too, which succinctly has always answered, so the choice was between
+/// diverging uniformly and diverging by spelling; recorded in
+/// `docs/compliance/jq/limitations.md`.
 #[test]
 fn test_path_context_walk_skips_an_undecodable_sibling_yq_mode_2168() -> Result<()> {
     let doc = "a: \"\\ud800\"\nd:\n  e: 5\n";

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -19517,6 +19517,75 @@ fn test_getpath_resolves_through_an_alias_2168() -> Result<()> {
     Ok(())
 }
 
+/// #2168 coverage, yq mode: the two arms that only a value with **no cursor**
+/// reaches.
+///
+/// A pipe stage that yields `GenericResult::One` -- a document value detached
+/// from its position -- hands the next stage `cursor = None`. yq's own
+/// `map` on a scalar is the shortest spelling of that (`map` passes a
+/// non-container through unchanged, #1820, where jq raises), so `.a | map(.)`
+/// is a value-without-a-position built out of live document nodes.
+///
+/// Both arms below are what that reaches:
+///
+/// * `position_arg_integer`'s `One` arm. #2168 unified `at_offset`'s and
+///   `at_position`'s three copies of this match into one function precisely
+///   because it had to add an arm to all of them; the `One` shape is the one
+///   no `at_offset(...)` spelling in the suite happened to produce.
+/// * `Builtin::GetPath`'s cursor-less arm. With a cursor, #2168 walks
+///   (`getpath_walk_cursor`); without one there is no position to walk from,
+///   so the value is materialized once, outside the fan-out, and
+///   `eval::getpath_walk_owned` reads it -- the pre-#2168 behaviour, kept
+///   exactly, for the one input shape that still needs it.
+///
+/// `getpath` is behind `--jq-extensions` in yq mode (#1512); `at_offset` is a
+/// succinctly extension in both modes. Neither has a yq oracle.
+#[test]
+fn test_position_arg_and_getpath_without_a_cursor_2168() -> Result<()> {
+    let doc = "a: 3\nb:\n  k: 1\n";
+
+    // `position_arg_integer`'s `One` arm: byte offset 3 of "a: 3\n..." is
+    // the `3`, so the answer doubles as proof the integer arrived intact.
+    let (out, code) = run_yq_stdin("at_offset(.a | map(.))", doc, &["-o=json", "-I=0"])?;
+    assert_eq!(code, 0, "{out:?}");
+    assert_eq!(out.trim(), "3");
+
+    // `Builtin::GetPath`'s cursor-less arm, answering and raising.
+    let args = ["-o=json", "-I=0", "--jq-extensions"];
+    for (filter, want) in [
+        (".a | map(.) | getpath([])", "3"),
+        (".b | map(.) | getpath([0])", "1"),
+    ] {
+        let (out, code) = run_yq_stdin(filter, doc, &args)?;
+        assert_eq!(code, 0, "{filter}: {out:?}");
+        assert_eq!(out.trim(), want, "{filter}");
+    }
+    for (filter, want) in [
+        (
+            ".a | map(.) | getpath(\"x\")",
+            "Path must be specified as an array",
+        ),
+        (
+            r#".a | map(.) | getpath(["x"])"#,
+            r#"Cannot index number with string "x""#,
+        ),
+    ] {
+        let (_out, stderr, code) = run_yq_stdin_with_stderr(filter, doc, &args)?;
+        assert_eq!(code, 1, "{filter}: stderr {stderr}");
+        assert!(stderr.contains(want), "{filter}: {stderr}");
+    }
+
+    // The control: the same reads *with* a cursor take the walk instead, and
+    // agree on every answer.
+    for (filter, want) in [(r#"getpath(["a"])"#, "3"), (r#"getpath(["b","k"])"#, "1")] {
+        let (out, code) = run_yq_stdin(filter, doc, &args)?;
+        assert_eq!(code, 0, "{filter}: {out:?}");
+        assert_eq!(out.trim(), want, "{filter}");
+    }
+
+    Ok(())
+}
+
 /// Known, deliberate gap: slicing an object with a genuine duplicate YAML
 /// key silently collapses it, the same root cause as this repo's other
 /// duplicate-mapping-key gaps (`OwnedValue::Object`'s `IndexMap`


### PR DESCRIPTION
Closes the perf half and the semantics half of #2168 (direction 2; direction 1 shipped as PR #2578).

## What changed

`path(f)`, `key`, `parent` and `getpath(P)` ran a whole-document validation walk before answering. It was O(document) to answer a bounded question, and #2168 measured it at **67-75%** of such a query's runtime — `.[0] | key` cost 3.0-4.1x the `.[0]` it wraps. These four now validate only the nodes they navigate through, which is the rule plain navigation already followed.

```console
$ printf '%s' '{"a":"\ud800","d":5}' | succinctly jq -c '.d'            # before and after
5
$ printf '%s' '{"a":"\ud800","d":5}' | succinctly jq -c 'path(.d)'      # before: exit 5
["d"]
$ printf '%s' '{"a":"\ud800","d":5}' | succinctly jq -c 'getpath(["d"])'  # before: exit 5
5
```

## This is a deliberate divergence from jq, and a newly introduced one

Stated up front because an earlier draft of this PR and its docs got it wrong. Real jq rejects these documents while parsing them, so the behaviour being removed **matched** jq's observable outcome:

| filter on `{"a":"\ud800","d":5}` | jq 1.7.1 | before this PR | after |
|---|---|---|---|
| `.d` | error | `5` — already diverged | `5` |
| `path(.d)` | error | error — **matched jq** | `["d"]` — **diverges** |
| `getpath(["d"])` | error | error — **matched jq** | `5` — **diverges** |

So ADR-0018's decision order **does** separate the options, and its step 2 favours the old behaviour. No rule-4 condition applies either. This is a divergence taken against the order's own answer, recorded as such in `docs/compliance/jq/limitations.md` alongside the two existing entries kept on their merits rather than under a carve-out. (`key`/`parent` are exempt from the fidelity half: neither is a jq builtin — `key/0 is not defined`, exit 3 — so only `path` and `getpath` diverge from jq. All four diverge from yq, which has both.)

**Why it was taken anyway.** Three reasons, none of them "the order allowed it":

1. **The agreement given up was an accident.** Until #2151 these builtins materialized the document to answer, and that tree doubled as #1755/#1953's validity check. When it went, an equivalent walk was kept *specifically so a performance change would not move semantics* — #2061, #2075 and #2151 each say so, and each defer the semantics question as the project's to answer. Nobody decided `path()` should validate; it re-derived jq's rejection as a side effect, for a different reason than jq has, and only for the spellings that happened to materialize.
2. **It made one read's answer depend on its spelling.** `.d` answered `5` while `path(.d)` refused, same document, same run — the shape #1629/#1642 exist to remove.
3. **It cost 67-75% of the query.**

**Context, explicitly not a licence.** succinctly already diverges on this whole document class through `.d` itself, deliberately and at a measured price: always-on strict validation costs two thirds of a cheap navigation query (`docs/plan/decode-failure-routing.md`). So the real choice was between diverging uniformly and diverging by spelling. ADR-0018's scope note warns against reframing evaluator behaviour as a spec-level input question to escape rule 4, and neither the entry nor this PR claims that exemption. A caller who wants jq's rejection has `--validate` / `succinctly json validate`, ~1 GB/s.

**What still validates**, because the rule is about reading rather than about a builtin's name:

| shape | behaviour | why |
|---|---|---|
| `path(.d)`, `.d \| key`, `.d \| parent`, `getpath(["d"])` | answer | never read `.a` |
| `path(.a)`, `getpath(["a"])` | answer, raw bytes, like `.a` | naming a position is not reading it |
| `getpath(["a"]) \| length`, `path(.a[])`, `.a[] \| key` | raise | the value is read |
| `path(if . then .d else null end)`, `path(..)` | raise | not cursor-navigable; the fallback materializes |
| `select(f)`, `sort_by(f)`, `unique_by(f)`, `min_by(f)`, `max_by(f)` | raise | the subtree walked **is** the value tested or emitted |
| `to_entries`, `map_values(f)`, `. as $x`, `.a \|= 1`, `[.[]]` | raise | materialize |

The #1194/#1677/#2211/#2243 structural checks and #1642's colliding-key raise rode on the same walk, so they stop firing on untouched subtrees too. `[path(.[])]` now names exactly the members `keys_unsorted` lists, element for element.

## getpath

Rewritten to walk cursors, which is what let its tree go. Two segment shapes are taken over cursors (a string key into an object, a number into an array); a slice descriptor materializes the **one** node reached and hands the remaining segments to `getpath_walk_owned_segments`, so the owned table stays the single definition of every step; everything else is a type error raised from the cursor, so `getpath([0])` reports `Cannot index object with number` without building the object.

The step table deliberately mirrors the owned table rather than `path_step_generic`, whose yq navigation rules (negative-index raise, scalar-index and absent-key no-ops, numeric-index-on-mapping null) `getpath` does not have. Reusing it would have changed three yq-mode answers.

- `getpath([0])` on a 300 K-element array: **0.06s / 38.4 MiB → 0.02s / 11.9 MiB**, matching `.[0]`'s 0.02s / 11.7 MiB.
- All 25 step rows re-verified against jq 1.7.1.
- #2053's constraint that `path_expr` is evaluated exactly once still holds on every branch — nothing probes, so nothing re-evaluates.
- One row moved *away* from jq: an over-cap numeric literal read through `getpath` now keeps its source spelling, as `.big` always has, instead of the reindex round trip's `1E-301`. Pinned and recorded.

## Also fixed

`at_offset(.n)` and `at_position(.l; .c)` never worked — the arm accepted a document-sourced integer only as an `OwnedValue`. `getpath` answering with a cursor broke the one spelling that did work, which is how the older gap surfaced. Three copies of that argument match are now one `position_arg_integer`.

## Measurements

Pinned boxes, interleaved, medians of 7, **output identity gated: 20 configurations, 0 differences on each**. Control run first (M4 Pro ±1.7%, 7950X ±10%).

| input | query | M4 Pro | 7950X |
|---|---|---|---|
| users 14 MB | `.[][0] \| key` | 83.1 → 26.6 ms (**-68%**) | 124.5 → 47.5 ms (**-62%**) |
| users 14 MB | `path(.)` | 83.8 → 26.8 ms (-68%) | 124.4 → 45.1 ms (-64%) |
| users 74 MB | `.[][0] \| key` | 407.9 → 121.0 ms (**-70%**) | 605.2 → 237.1 ms (**-61%**) |
| numbers 20 MB | `.[][0] \| key` | 77.8 → 59.9 ms (-23%) | 108.2 → 68.6 ms (-37%) |
| strings 18 MB | `.[][0] \| key` | 28.9 → 16.2 ms (-44%) | 71.6 → 56.5 ms (-21%) |
| users 74 MB | `[.[][] \| key] \| length` | 573 → 292 ms (-49%) | 1026 → 632 ms (-38%) |

### One caveat, and why it is not fixed here

On the M4 Pro the getpath commit costs **+6.2%** on queries containing no `getpath` at all (`length`, `keys_unsorted[0]`, `.[][0]`; 8 of 8 rows, against a ±1.5% control floor). Three results place it in code layout, not logic:

1. the affected queries never execute the changed code;
2. x86_64 shows nothing from the same binaries (median -0.11%, mixed signs);
3. the penalty disappears on the same ARM box when both halves are rebuilt with `codegen-units=1` (median +0.28%).

`#[inline(never)]` on the new walk removes it on ARM (-0.21%) and costs **+9.5% on x86_64** for the same unrelated queries, confirmed back to back in one session. The two architectures sit on opposite sides of one inline decision, so it was measured and rejected rather than shipped. Filed as #2603 rather than answered with another guess.

Bisected cleanly: the gate-removal commit alone is flat on controls (-1.4%..+1.0%) while already delivering -70%.

## Verification

- `cargo test --features cli,simd,regex,serde` — 0 failures (re-run after the rebase onto current `main`).
- clippy `--all-features` and both CI feature legs, `cargo fmt --check`, `--no-default-features` check, `cargo doc` with `-D warnings` — all clean.
- `scripts/jq-m2-streaming-sweep.sh` — byte-identical to `main` on both legs (shipped: 0 unexpected / 12 known / 0 oracle regressions; forced-stream: 30 / 22 / 19). This change moves nothing in #2103's worklist.

## Notes for review

- The decision here settles the policy question #2053 left open and informs #2103, which stays open for the eager-vs-streaming inconsistency and the undecodable-key spelling.
- Two of my own new tests were wrong before they were right, both corrected against the oracle: `getpath(["s","x"])?` exits 0 in jq, old succinctly and new alike, and the `\x` escape shape words its error differently from the `\u` family.

Closes #2168.
