### PR TITLE
perf(jq): echo already-canonical numbers instead of re-rendering them

### DIFF
--- a/src/jq/mod.rs
+++ b/src/jq/mod.rs
@@ -116,9 +116,9 @@ pub use parser::{
 pub use resolve::{resolve_func_calls, resolve_func_calls_all, UnresolvedCall};
 pub use stream::{StreamError, StreamStats, StreamableValue};
 pub use value::{
-    assert_value_tree_depth, format_number_jq_compat, is_jq_canonical_number,
-    jq_bare_float_display, jq_float_is_scientific, nesting_depth_exceeded_message, NumberRepr,
-    OwnedValue, MAX_VALUE_TREE_DEPTH,
+    assert_value_tree_depth, format_number_jq_compat, jq_bare_float_display,
+    jq_float_is_scientific, nesting_depth_exceeded_message, NumberRepr, OwnedValue,
+    MAX_VALUE_TREE_DEPTH,
 };
 // `pub(crate)`, not `pub`: only `yaml::light`'s alias-chain resolvers (#1191
 // code review, #1193/PR #1314) need this from outside `jq::value` --
@@ -126,3 +126,9 @@ pub use value::{
 // depth-guard helper on docs.rs with no external caller to justify the
 // exposure.
 pub(crate) use value::assert_depth;
+// `pub(crate)` for the same reason (#2206): `json::light`'s number
+// writer is the only caller, and the predicate is an implementation
+// detail of `format_number_jq_compat`'s fast path -- not something an
+// external caller has any use for, and not a contract worth freezing on
+// docs.rs.
+pub(crate) use value::is_jq_canonical_number;

--- a/src/jq/mod.rs
+++ b/src/jq/mod.rs
@@ -116,9 +116,9 @@ pub use parser::{
 pub use resolve::{resolve_func_calls, resolve_func_calls_all, UnresolvedCall};
 pub use stream::{StreamError, StreamStats, StreamableValue};
 pub use value::{
-    assert_value_tree_depth, format_number_jq_compat, jq_bare_float_display,
-    jq_float_is_scientific, nesting_depth_exceeded_message, NumberRepr, OwnedValue,
-    MAX_VALUE_TREE_DEPTH,
+    assert_value_tree_depth, format_number_jq_compat, is_jq_canonical_number,
+    jq_bare_float_display, jq_float_is_scientific, nesting_depth_exceeded_message, NumberRepr,
+    OwnedValue, MAX_VALUE_TREE_DEPTH,
 };
 // `pub(crate)`, not `pub`: only `yaml::light`'s alias-chain resolvers (#1191
 // code review, #1193/PR #1314) need this from outside `jq::value` --

--- a/src/jq/value.rs
+++ b/src/jq/value.rs
@@ -176,6 +176,77 @@ fn strip_insignificant_leading_zero_and_plus(s: &str) -> String {
         None => format!("{sign}{canonical_int}"),
     }
 }
+/// Whether [`format_number_jq_compat`] would return `raw` byte-for-byte,
+/// so a writer can echo the source span instead of allocating a `String`
+/// per number (#2206).
+///
+/// The M2 streaming path re-renders every number through
+/// `format_number_jq_compat`, which allocates unconditionally -- even for
+/// the overwhelmingly common case of a number that is *already* in jq's
+/// canonical form and comes back unchanged. On a 10 MB document that is
+/// several hundred thousand allocations, and it is what kept `-c .data`
+/// from reaching the raw-echo fast path's speed (measured: the echo path
+/// renders the same document 4x faster).
+///
+/// Deliberately conservative -- it answers "certainly unchanged", never
+/// "probably". Anything with an exponent, a leading `+`, an insignificant
+/// leading zero, or an absent integer part (`.5`, #1171) returns `false`
+/// and takes the full formatter, so a `true` here is always safe to echo.
+///
+/// Kept adjacent to the formatter it predicts, and pinned against it by
+/// `is_jq_canonical_number_agrees_with_the_formatter_2206`, which asserts
+/// the two agree on every spelling in the formatter's own test corpus --
+/// the "duplicated predicates diverge silently" hazard (`CLAUDE.md`, #106)
+/// applies squarely to a fast-path predicate that restates a formatter's
+/// rules.
+#[must_use]
+pub fn is_jq_canonical_number(raw: &[u8]) -> bool {
+    // One pass that answers *both* questions the writer needs -- "is this a
+    // valid RFC 8259 number" and "would the formatter hand back these exact
+    // bytes" -- so a `true` lets the caller skip `is_valid_number` *and*
+    // `format_number_jq_compat` together.
+    //
+    // Answering only the second (#2206's first attempt) is worth nothing:
+    // the caller still has to run `is_valid_number` for the lenient spans,
+    // and a second full scan costs more than the allocation it saves --
+    // measured at +1.3% to +2.0% on a 7950X, i.e. a net loss. The scan, not
+    // the allocation, is the expensive half.
+    let mut i = 0usize;
+    let n = raw.len();
+    if i < n && raw[i] == b'-' {
+        i += 1;
+    }
+    // Integer part: `0` alone, or a non-zero leading digit. Both RFC 8259's
+    // rule and the canonical form the formatter would produce -- `007` and
+    // `+7` fail here, which is exactly when the formatter rewrites them.
+    let int_start = i;
+    if i < n && raw[i] == b'0' {
+        i += 1;
+    } else {
+        while i < n && raw[i].is_ascii_digit() {
+            i += 1;
+        }
+    }
+    if i == int_start {
+        return false;
+    }
+    // Fraction: a `.` must be followed by at least one digit. `1.` is a
+    // scanner-lenient span RFC 8259 rejects and the `from_number_bytes`
+    // fallback rewrites to `1`, so it must not reach the echo.
+    if i < n && raw[i] == b'.' {
+        i += 1;
+        let frac_start = i;
+        while i < n && raw[i].is_ascii_digit() {
+            i += 1;
+        }
+        if i == frac_start {
+            return false;
+        }
+    }
+    // Any exponent (or trailing junk like `1.2.3`) leaves the canonical
+    // set: the formatter has its own reformatting path for exponents.
+    i == n
+}
 
 /// Format a raw JSON number string the way jq itself would print it.
 ///
@@ -4530,5 +4601,101 @@ mod tests {
         let over_b = linear_array_nest(MAX_VALUE_TREE_DEPTH);
         let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| over_a == over_b));
         assert!(result.is_err(), "== should panic at MAX_VALUE_TREE_DEPTH");
+    }
+
+    /// #2206: the fast-path predicate must agree with the formatter it
+    /// predicts, on every spelling either of them has an opinion about.
+    ///
+    /// `is_jq_canonical_number` restates part of
+    /// `format_number_jq_compat`'s rules so a writer can skip its
+    /// allocation. That is the "duplicated predicates diverge silently"
+    /// shape `CLAUDE.md` warns about (#106), and the divergence here would
+    /// be *silent wrong output* -- a number echoed verbatim that jq would
+    /// have reformatted. This asserts the exact contract the fast path
+    /// relies on: `true` implies the formatter is the identity.
+    ///
+    /// The reverse is deliberately not asserted. The predicate is allowed
+    /// to be conservative (say `false` where the formatter happens to be
+    /// the identity anyway); that only costs an allocation, never
+    /// correctness. Rows below marked `conservative` are exactly those.
+    #[test]
+    fn is_jq_canonical_number_agrees_with_the_formatter_2206() {
+        let corpus = [
+            // plain canonical spellings -- the case the fast path exists for
+            "0",
+            "1",
+            "42",
+            "-7",
+            "1000",
+            "0.5",
+            "-0.25",
+            "12.345",
+            "0.10",
+            "-0",
+            "123456789012345678",
+            "9.999",
+            // not canonical: the formatter rewrites these
+            "007",
+            "+7",
+            "-007",
+            "0007.5",
+            ".5",
+            "-.5",
+            "00",
+            "+0.5",
+            // exponent forms: the formatter has its own path for these
+            "1e100",
+            "1E5",
+            "1e-3",
+            "-2.5e+10",
+            "1E+100",
+            // degenerate / lenient spellings the scanner can still hand over
+            "",
+            "1.2.3",
+            "-",
+            "abc",
+        ];
+        for raw in corpus {
+            let bytes = raw.as_bytes();
+            let claims_canonical = is_jq_canonical_number(bytes);
+            // The writer consults the predicate only *inside* its
+            // `is_valid_number` gate, because a scanner-lenient span
+            // (`1.`) is sanitized by the `from_number_bytes` fallback
+            // rather than by the formatter -- and the formatter is the
+            // identity on `1.`, so a check against it alone would have
+            // called that row canonical. It is not: jq prints `1`. Asserting
+            // the same gate here keeps this test measuring the contract the
+            // writer actually relies on.
+            if !crate::json::validate::is_valid_number(bytes) {
+                continue;
+            }
+            let formatted = format_number_jq_compat(bytes);
+            if claims_canonical {
+                assert_eq!(
+                    formatted, raw,
+                    "is_jq_canonical_number({raw:?}) said the formatter is the \
+                     identity, but it returned {formatted:?} -- the fast path \
+                     would emit {raw:?} where jq prints {formatted:?}"
+                );
+            }
+        }
+    }
+
+    /// The predicate must actually fire on ordinary numbers, or #2206's
+    /// fast path is dead code that still passes the agreement test above.
+    #[test]
+    fn is_jq_canonical_number_accepts_ordinary_spellings_2206() {
+        for raw in ["0", "1", "42", "-7", "0.5", "-0.25", "12.345", "0.10"] {
+            assert!(
+                is_jq_canonical_number(raw.as_bytes()),
+                "{raw:?} is jq-canonical and must take the allocation-free path"
+            );
+        }
+        for raw in ["007", "+7", ".5", "1e100", "1E+100"] {
+            assert!(
+                !is_jq_canonical_number(raw.as_bytes()),
+                "{raw:?} is reformatted by jq and must not take the fast path"
+            );
+        }
     }
 }

--- a/src/jq/value.rs
+++ b/src/jq/value.rs
@@ -200,7 +200,7 @@ fn strip_insignificant_leading_zero_and_plus(s: &str) -> String {
 /// applies squarely to a fast-path predicate that restates a formatter's
 /// rules.
 #[must_use]
-pub fn is_jq_canonical_number(raw: &[u8]) -> bool {
+pub(crate) fn is_jq_canonical_number(raw: &[u8]) -> bool {
     // One pass that answers *both* questions the writer needs -- "is this a
     // valid RFC 8259 number" and "would the formatter hand back these exact
     // bytes" -- so a `true` lets the caller skip `is_valid_number` *and*
@@ -4649,8 +4649,17 @@ mod tests {
             "1e-3",
             "-2.5e+10",
             "1E+100",
-            // degenerate / lenient spellings the scanner can still hand over
+            // degenerate / lenient spellings the scanner can still hand
+            // over. `1.`/`01.` are the ones that matter most: the formatter
+            // is the *identity* on them, so a predicate checked only against
+            // it would call them canonical -- but jq prints `1`, because the
+            // writer's real fallback for an RFC-invalid span is
+            // `from_number_bytes`, not the formatter. That is the bug the
+            // first version of this fix shipped.
             "",
+            "1.",
+            "01.",
+            "-1.",
             "1.2.3",
             "-",
             "abc",
@@ -4658,14 +4667,23 @@ mod tests {
         for raw in corpus {
             let bytes = raw.as_bytes();
             let claims_canonical = is_jq_canonical_number(bytes);
-            // The writer consults the predicate only *inside* its
-            // `is_valid_number` gate, because a scanner-lenient span
-            // (`1.`) is sanitized by the `from_number_bytes` fallback
-            // rather than by the formatter -- and the formatter is the
-            // identity on `1.`, so a check against it alone would have
-            // called that row canonical. It is not: jq prints `1`. Asserting
-            // the same gate here keeps this test measuring the contract the
-            // writer actually relies on.
+            // The writer runs the predicate *ahead* of its
+            // `is_valid_number` gate, so "claims canonical" must imply
+            // "is a valid number" -- otherwise a scanner-lenient span
+            // (`1.`, `007`, `.5`, `1.2.3`) would be echoed verbatim where
+            // jq reformats it. This is the half the first version of this
+            // fix got wrong (`{"a":1.}` printed `1.`), so assert it
+            // directly rather than letting the skip below hide it.
+            assert!(
+                !claims_canonical || crate::json::validate::is_valid_number(bytes),
+                "is_jq_canonical_number({raw:?}) accepted a span \
+                 `is_valid_number` rejects -- the writer would echo it \
+                 verbatim, ahead of the fallback that sanitizes it"
+            );
+            // Beyond that implication the formatter has no opinion worth
+            // comparing on an invalid span: it is the identity on `1.`,
+            // while the writer's actual fallback (`from_number_bytes`)
+            // renders `1`.
             if !crate::json::validate::is_valid_number(bytes) {
                 continue;
             }

--- a/src/json/light.rs
+++ b/src/json/light.rs
@@ -2199,8 +2199,9 @@ use crate::jq::document::{
 use crate::jq::escape::{write_json_body_jq, write_json_body_yq};
 use crate::jq::stream::{StreamFailure, StreamResult};
 use crate::jq::{
-    format_number_jq_compat, nesting_depth_exceeded_message, nonfinite_display_string, EvalError,
-    JqSemantics, OwnedValue, YqSemantics, MAX_VALUE_TREE_DEPTH,
+    format_number_jq_compat, is_jq_canonical_number, nesting_depth_exceeded_message,
+    nonfinite_display_string, EvalError, JqSemantics, OwnedValue, YqSemantics,
+    MAX_VALUE_TREE_DEPTH,
 };
 
 /// A [`JsonError`] as the uncatchable decode failure (#1620) every
@@ -3359,6 +3360,29 @@ fn write_json_number<Out: core::fmt::Write>(
             out.write_str(text)
         }
         JsonConvention::JqCompat => {
+            // #2206: echo the source span when the formatter would hand
+            // back exactly these bytes. `format_number_jq_compat` returns
+            // an owned `String` unconditionally, so without this every
+            // number in the document costs an allocation purely to
+            // reproduce itself -- several hundred thousand of them on a
+            // 10 MB array, and the single reason `-c .data` could not
+            // reach the raw-echo fast path's throughput (that path renders
+            // the same document 4x faster; measured on both a 7950X and an
+            // M4 Pro, #2206).
+            //
+            // `is_jq_canonical_number` answers "certainly unchanged" only,
+            // and is pinned against the formatter by
+            // `is_jq_canonical_number_agrees_with_the_formatter_2206`.
+            // Ahead of `is_valid_number` on purpose: the predicate proves
+            // RFC-validity itself, so a `true` skips both that scan and the
+            // formatter's allocation. Ordering it *after* the gate instead
+            // leaves the scan in place and measures as a net loss (#2206).
+            // ASCII digits only, so the span is valid UTF-8 by construction.
+            if is_jq_canonical_number(raw) {
+                if let Ok(text) = core::str::from_utf8(raw) {
+                    return out.write_str(text);
+                }
+            }
             if crate::json::validate::is_valid_number(raw) {
                 return out.write_str(&format_number_jq_compat(raw));
             }

--- a/tests/data/perf-guard-baseline.json
+++ b/tests/data/perf-guard-baseline.json
@@ -1,18 +1,18 @@
 {
   "ARM64-Linux": {
-    "arrays_identity": 1054844086,
-    "users_identity": 343420725,
-    "users_keys_unsorted": 44469171,
-    "users_yq_keys_unsorted": 72214718,
-    "wide_identity": 622777831,
-    "wide_keys_unsorted": 321864371
+    "arrays_identity": 599251135,
+    "users_identity": 289464880,
+    "users_keys_unsorted": 44532034,
+    "users_yq_keys_unsorted": 72232441,
+    "wide_identity": 470132651,
+    "wide_keys_unsorted": 297330783
   },
   "x86_64": {
-    "arrays_identity": 1149137279,
-    "users_identity": 403081537,
-    "users_keys_unsorted": 69322632,
-    "users_yq_keys_unsorted": 82609293,
-    "wide_identity": 729461833,
-    "wide_keys_unsorted": 376704931
+    "arrays_identity": 650895367,
+    "users_identity": 341765138,
+    "users_keys_unsorted": 69265169,
+    "users_yq_keys_unsorted": 82246619,
+    "wide_identity": 556763357,
+    "wide_keys_unsorted": 350914474
   }
 }


### PR DESCRIPTION
## Summary

#2206 reported the M2 fast path regressing plain field access into a large
array, and named the output buffer as the cause. Measuring that first is what
found the real one — **both** of the issue's stated directions are net losses.

### What the issue blamed

| variant vs base | M4 Pro | 7950X |
|---|---|---|
| `String::with_capacity(span_len)` (pre-size the buffer) | +2.8% | +7.3% |
| no buffer, write straight to `out` | +9.6% | +12.9% |

The buffer is not the cost — it is a large win, and pre-sizing is worse than
letting it grow. Control floors: ±0.5% (M4 Pro), ±1.2% (7950X).

### The actual cost

Forcing the pre-#1576 DOM path and varying only the output convention
isolates it:

| shape | M2 vs DOM |
|---|---|
| `-c .data` (`JqCompat`) | **+23.6%** |
| `-c .data --preserve-input` | **−66.9%** |

The difference is that `--preserve-input` reaches the raw-echo fast path and
`JqCompat` cannot, because numbers must be canonicalized — and
`format_number_jq_compat` allocates a `String` unconditionally, including for
the common number that comes back byte-identical. On a 10 MB array that is
several hundred thousand allocations spent reproducing the input.

## The fix

`is_jq_canonical_number` answers both questions the writer needs in one pass —
is this a valid RFC 8259 number, and would the formatter return these exact
bytes — so a `true` skips `is_valid_number`'s scan **and** the allocation.

**Answering only the second question is worth nothing.** The first cut did
exactly that, sitting inside the existing `is_valid_number` gate, and measured
**+1.3% to +2.0% slower**: a redundant second scan costs more than the
allocation it saves. The scan, not the allocation, is the expensive half. That
negative result is recorded in the function's doc comment so the
cheaper-looking ordering is not retried.

## Measured (median of 9, interleaved, output-identity checked)

| machine | shape | vs base | vs DOM path |
|---|---|---|---|
| M4 Pro | pretty 2 MB | −5.2% | −10.1% |
| M4 Pro | pretty 10 MB | −5.3% | −11.8% |
| M4 Pro | `-c` 2 MB | −5.5% | +17.4% |
| M4 Pro | `-c` 10 MB | −6.0% | +18.5% |
| 7950X | pretty 2 MB | −1.1% | +1.6% |
| 7950X | pretty 10 MB | −0.7% | +2.8% |
| 7950X | `-c` 2 MB | −3.8% | +20.6% |
| 7950X | `-c` 10 MB | −1.6% | +24.0% |

#2206's own shape (pretty `.data`) is now **faster** than the DOM path on ARM
and within ~3% on x86, down from the reported +3.35%.

Compact output stays 18–24% behind the DOM path on both machines — bigger than
#2206's regression, on a shape it never measured. Filed as **#2608** rather
than widened into this PR.

## Correctness

No behaviour change, and the suite caught the one bug on the way. The first
predicate ran *ahead* of the `is_valid_number` gate while checking only
canonicality, so a scanner-lenient span (`1.`, which jq prints as `1`) was
echoed verbatim —
`test_stream_json_number_invalid_span_float_fallback_1576` failed on it. The
predicate now validates the span itself, which is what makes the early
ordering sound.

`is_jq_canonical_number_agrees_with_the_formatter_2206` pins the two against
each other over the formatter's own corpus, under the same validity gate the
writer applies. A fast-path predicate restating a formatter's rules is the
"duplicated predicates diverge silently" shape (#106), and here the divergence
would be silent wrong output.

## Test plan

- [x] `cargo test --features cli,simd,regex,serde` — 7789 passed, 0 failed
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] A/B on **both** pinned machines (M4 Pro `johns-mac-mini`, 7950X
      `terminus`), interleaved, with control runs establishing the noise floor
      on each, and output identity gated via `scripts/ab-cli.py`

Fixes #2206
