### PR TITLE
fix(yq): make the DOM output path agree with streaming on tags and two separators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`succinctly yq`'s DOM output path now agrees with its streaming path on
+  explicit tags and two Unicode separators** (#1982, Medium severity):
+  1. **An explicit `!!str`/`!!int`/`!!bool`/`!!null` tag was silently lost
+     on any DOM-forcing route** (`-P`, `--arg`, `-r`/`-j`/`-0`,
+     `--eval-all`, `--split-exp`, ...) -- `a: !!str 5` under `-P -o json`
+     printed the number `5` instead of the string `"5"`, changing the
+     value's type, not just its rendering. `to_owned_with_comments_at_depth`
+     (`src/jq/eval_generic.rs`)'s scalar arm called the cursor-*blind*
+     `to_owned_at_depth` unconditionally, even with a real, tag-bearing
+     cursor already in scope; `evaluate_yaml_cursor`'s `need_comments ==
+     false` arm (`-o json`, which never reads `CommentTree`) had the same
+     gap via `generic_to_owned(&c.value())`. Both now resolve through the
+     cursor-aware `tagged_scalar_to_owned`/`generic_to_owned_cursor`,
+     matching what the streaming path already did (#747).
+  2. **U+2028/U+2029 (line/paragraph separator) were emitted raw** instead
+     of escaped to `\u2028`/`\u2029` -- confirmed live that real yq (v4.53.3)
+     always escapes both in JSON output, regardless of source (a YAML
+     `\L`/`\P` escape, a raw UTF-8 byte already in a quoted scalar, or one
+     present in JSON input); real jq leaves both raw, so this is yq-only.
+     `write_json_body_yq` (`src/jq/escape.rs`) gained this as its one
+     addition beyond the shared control-character table, gated on a cheap
+     `contains(0xE2)` byte-existence probe so the common ASCII-only span
+     stays on its existing SIMD-scanned fast path
+     (`conventions_differ_at_exactly_five_code_points`, up from three).
+  **Residual, not fixed here**: the M2 streaming path itself still emits a
+  *raw* (non-`\L`/`\P`-sourced) U+2028/U+2029 byte unescaped -- see #2607.
+
 - **`succinctly yq` no longer drops a redefined anchor's earlier
   declaration on re-emission** (#1353): `a: &x 1\nb: &x 2\nc: *x` used to
   print `a: 1` (the first `&x` silently gone) even though `c: *x` still

--- a/src/bin/succinctly/yq_runner.rs
+++ b/src/bin/succinctly/yq_runner.rs
@@ -19,7 +19,8 @@ use succinctly::jq::document::{
 use succinctly::jq::escape::AsciiEscapeWriter;
 use succinctly::jq::eval_generic::{
     check_nesting_depth, eval_with_cursor_using, to_owned as generic_to_owned,
-    to_owned_with_comments, AnchorMark, CommentTree, GenericResult, NodeMeta,
+    to_owned_cursor as generic_to_owned_cursor, to_owned_with_comments, AnchorMark, CommentTree,
+    GenericResult, NodeMeta,
 };
 use succinctly::jq::stream::StreamFailure;
 use succinctly::jq::{
@@ -3027,8 +3028,16 @@ fn evaluate_yaml_cursor<W: AsRef<[u64]> + Clone>(
     // any other (#1247): report it and yield no documents, exactly as the
     // `GenericResult::Error` arm below does.
     let has_aliases = cursor.index().has_aliases();
+    // #1982 (code review): cursor-aware, not `generic_to_owned(&cursor.value())`
+    // -- the same "real cursor in scope but discarded" shape as the two sites
+    // this PR fixed, so a tag-forced value's own pristine snapshot doesn't
+    // silently resolve to the untagged type. Verified inert in practice today
+    // (every alias-sensitive-assign scenario tried matched the oracle either
+    // way, since #1351's `alias_identity` live-mirroring already produces a
+    // correct value before this snapshot's own comparison runs) -- fixed
+    // anyway since it costs nothing and closes the same gap defensively.
     let alias_sync_ctx = match (is_alias_sensitive_assign(expr) && has_aliases)
-        .then(|| generic_to_owned(&cursor.value()))
+        .then(|| generic_to_owned_cursor(&cursor))
     {
         Some(pristine) => {
             let Some(pristine) = sink.materialize(DiagStyle::Yq, pristine, &no_location()) else {
@@ -3094,11 +3103,21 @@ fn evaluate_yaml_cursor<W: AsRef<[u64]> + Clone>(
     // alongside the `OwnedValue` one, just to carry comment text - wasted
     // work when the caller can't use it (`-o json`'s output never reads
     // `CommentTree` at all; see `output_value`'s JSON branch) (#710).
+    //
+    // #1982: the `need_comments == false` arm must still resolve through
+    // the *cursor* (`generic_to_owned_cursor`, #747's tag-aware
+    // materializer), not `generic_to_owned(&c.value())` -- the latter
+    // takes a bare value with no cursor attached, so an explicit tag
+    // (`!!str 5`, `!!int "5"`, ...) has nowhere to be read from and
+    // silently stops applying the moment `-o json` sets `need_comments`
+    // to `false`. Confirmed live against yq v4.53.3: `!!str 5` must stay
+    // the string `"5"` under `-P -o json` exactly as it does under `-P`'s
+    // YAML output, which already went through the cursor-aware path.
     let owned_with_comments = |c: &YamlCursor<'_, W>| {
         if need_comments {
             to_owned_with_comments(&c.value(), Some(c))
         } else {
-            generic_to_owned(&c.value()).map(&no_comments)
+            generic_to_owned_cursor(c).map(&no_comments)
         }
     };
 

--- a/src/jq/escape.rs
+++ b/src/jq/escape.rs
@@ -5,9 +5,12 @@
 //! module is that single definition; every writer in the crate and in the CLI
 //! routes here rather than open-coding a `match` over `char`.
 //!
-//! See [`write_json_body_jq`] for the table both conventions are pinned to, and
-//! `conventions_differ_at_exactly_three_code_points` in this module's tests for
-//! the assertion that keeps them from drifting apart again (#385).
+//! See [`write_json_body_jq`] for the control-character table both
+//! conventions are pinned to, [`write_json_body_yq`] for yq's one addition
+//! beyond it (U+2028/U+2029, #1982), and
+//! `conventions_differ_at_exactly_five_code_points` in this module's tests
+//! for the assertion that keeps all five from drifting apart again (#385,
+//! #1982).
 
 #[cfg(not(test))]
 use alloc::string::String;
@@ -66,8 +69,11 @@ fn write_bmp_u_escape<W: Write>(out: &mut W, cp: u32) -> core::fmt::Result {
 /// | `0x80..=0x9f` (C1)   | raw            | raw            |
 /// | other non-ASCII      | raw            | raw            |
 ///
-/// The two conventions therefore differ at exactly three code points: `0x08`,
-/// `0x0c` and `0x7f`.
+/// The two conventions therefore differ at exactly three code points within
+/// this control-character table: `0x08`, `0x0c` and `0x7f`. Two more lie
+/// outside it entirely -- U+2028/U+2029, yq's own addition documented on
+/// [`write_json_body_yq`] (#1982) -- for five differences in total, per
+/// `conventions_differ_at_exactly_five_code_points`.
 ///
 /// The C1 row is the one that cost a bug (#385): `char::is_control()` is true
 /// for U+0080–U+009F, so branching on it escapes characters JSON does not
@@ -119,6 +125,25 @@ pub fn write_json_body_jq_ascii<W: Write>(out: &mut W, s: &str) -> core::fmt::Re
 /// (O3, #87): [`find_json_escape`] looks for `"`, `\` and `< 0x20`, which is
 /// exactly yq's escape set, and everything between two hits is copied as one
 /// span.
+///
+/// U+2028/U+2029 (line/paragraph separator) are yq's one addition beyond
+/// that set (#1982) — confirmed live against `mikefarah/yq` v4.53.3 that it
+/// always escapes them to `\u2028`/`\u2029` in JSON output, regardless of
+/// source (a YAML `\L`/`\P` escape, a raw UTF-8 byte in a quoted scalar, or
+/// one already present in JSON input); real jq leaves both raw, so
+/// [`write_json_body_jq`] is untouched. Each is a 3-byte UTF-8 sequence
+/// (`E2 80 A8`/`E2 80 A9`), so neither can trip `find_json_escape`'s
+/// single-byte scan (every one of `"`, `\`, `< 0x20` is a distinct byte
+/// value, and both separators' bytes are all `>= 0x80`) — a span the scan
+/// reports as escape-free is copied here byte for byte, so it still needs
+/// its own check. Gated on a cheap `contains(0xE2)` byte-existence probe
+/// first (mirroring this module's `contains_cr` precheck): only the lead
+/// byte both separators share with a broad swath of otherwise-ordinary
+/// non-ASCII text (curly quotes, em dash, bullets, ...), so almost every
+/// span skips the per-character walk entirely, and the two-hit case this
+/// exists for is rare enough in real documents that paying for it with a
+/// linear scan (rather than widening the shared SIMD scanner every caller
+/// of `find_json_escape` pays for) is the right trade.
 pub fn write_json_body_yq<W: Write>(out: &mut W, s: &str) -> core::fmt::Result {
     let bytes = s.as_bytes();
     let len = bytes.len();
@@ -128,7 +153,7 @@ pub fn write_json_body_yq<W: Write>(out: &mut W, s: &str) -> core::fmt::Result {
         let escape_pos = find_json_escape(bytes, i);
 
         if i < escape_pos {
-            out.write_str(&s[i..escape_pos])?;
+            write_yq_span_escaping_separators(out, &s[i..escape_pos])?;
         }
 
         i = escape_pos;
@@ -149,6 +174,31 @@ pub fn write_json_body_yq<W: Write>(out: &mut W, s: &str) -> core::fmt::Result {
         }
     }
 
+    Ok(())
+}
+
+/// Write a span [`write_json_body_yq`] has already confirmed contains none
+/// of `"`, `\` or a `< 0x20` control -- so the only thing left to check is
+/// U+2028/U+2029 (see that function's own doc comment). The `contains`
+/// probe is byte-level (not `char`), which is sound here: UTF-8 guarantees
+/// no other code point's encoding contains the standalone byte `0xE2` in a
+/// position that would false-positive this into the slow path incorrectly
+/// escaping something -- the slow path re-walks by `char` and only ever
+/// matches the two exact code points, so a same-byte false trigger (e.g.
+/// U+2014 em dash, U+2022 bullet) just costs an extra linear pass, never a
+/// wrong escape.
+#[inline]
+fn write_yq_span_escaping_separators<W: Write>(out: &mut W, span: &str) -> core::fmt::Result {
+    if !span.as_bytes().contains(&0xE2) {
+        return out.write_str(span);
+    }
+    for c in span.chars() {
+        match c {
+            '\u{2028}' => out.write_str("\\u2028")?,
+            '\u{2029}' => out.write_str("\\u2029")?,
+            c => out.write_char(c)?,
+        }
+    }
     Ok(())
 }
 
@@ -332,10 +382,11 @@ mod tests {
 
     /// Every code point the two conventions have to agree or disagree on:
     /// all of Latin-1 (C0, printable ASCII, DEL, C1, high Latin-1), a
-    /// multi-byte BMP character, a line separator, and an astral one.
+    /// multi-byte BMP character, the two separators (#1982), and an astral
+    /// one.
     fn corpus() -> Vec<char> {
         let mut cs: Vec<char> = (0u32..=0xFF).map(|c| char::from_u32(c).unwrap()).collect();
-        cs.extend(['é', '\u{2028}', '😀']);
+        cs.extend(['é', '\u{2028}', '\u{2029}', '😀']);
         cs
     }
 
@@ -343,8 +394,12 @@ mod tests {
     /// test that pins the delta. Asserting only that they *agree* would pass if
     /// both writers broke the same way, so this asserts the disagreement set
     /// exactly — and the next test asserts what each side renders there.
+    ///
+    /// Five, not three (#1982 added U+2028/U+2029 to yq's own table --
+    /// confirmed live against `mikefarah/yq` v4.53.3 that it escapes both
+    /// unconditionally in JSON output, where real jq leaves both raw).
     #[test]
-    fn conventions_differ_at_exactly_three_code_points() {
+    fn conventions_differ_at_exactly_five_code_points() {
         let mut differ: Vec<char> = Vec::new();
         for c in corpus() {
             let s = String::from(c);
@@ -352,16 +407,27 @@ mod tests {
                 differ.push(c);
             }
         }
-        assert_eq!(differ, vec!['\u{8}', '\u{c}', '\u{7f}']);
+        assert_eq!(
+            differ,
+            vec!['\u{8}', '\u{c}', '\u{7f}', '\u{2028}', '\u{2029}']
+        );
     }
 
     #[test]
-    fn the_three_differences_render_as_documented() {
+    fn all_five_differences_render_as_documented() {
         assert_eq!((jq("\u{8}"), yq("\u{8}")), ("\\b".into(), "\\u0008".into()));
         assert_eq!((jq("\u{c}"), yq("\u{c}")), ("\\f".into(), "\\u000c".into()));
         assert_eq!(
             (jq("\u{7f}"), yq("\u{7f}")),
             ("\\u007f".into(), "\u{7f}".into())
+        );
+        assert_eq!(
+            (jq("\u{2028}"), yq("\u{2028}")),
+            ("\u{2028}".into(), "\\u2028".into())
+        );
+        assert_eq!(
+            (jq("\u{2029}"), yq("\u{2029}")),
+            ("\u{2029}".into(), "\\u2029".into())
         );
     }
 

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -1315,15 +1315,25 @@ fn to_owned_with_comments_at_depth<V: DocumentValue>(
             CommentTree::Array(own_meta, comment_items),
         ))
     } else {
-        // #2358: `value` is scalar here (the object/array arms above
-        // return first), so `to_owned_at_depth`'s `cursor` parameter is
-        // never consulted on this path either -- passed through from this
-        // function's own parameter purely because it's already in scope,
-        // not because it matters.
-        Ok((
-            to_owned_at_depth(value, cursor, depth)?,
-            CommentTree::Leaf(own_meta),
-        ))
+        // #1982: unlike the container arms above (where `cursor` is only
+        // consulted for `tail_gap_ok`, per #2358's comment there), a
+        // scalar leaf's cursor matters on its own merits --
+        // `explicit_tag()` forces a specific resolution (`!!str 5` is the
+        // string `"5"`, not the number `5`, #224) that `to_owned_at_depth`'s
+        // value-only dispatch has no way to see (the tag lives on the
+        // cursor's `bp_pos`, not on the extracted `YamlValue` -- #747).
+        // Mirrors `to_owned_cursor_at_depth`'s own scalar arm, via the same
+        // shared `tagged_scalar_to_owned`, falling back to
+        // `to_owned_at_depth` when no tag applies (untagged, or a tag
+        // `resolve_tagged` doesn't recognize).
+        let owned = match cursor
+            .and_then(|c| c.explicit_tag())
+            .and_then(|tag| tagged_scalar_to_owned(tag, value))
+        {
+            Some(owned) => owned,
+            None => to_owned_at_depth(value, cursor, depth)?,
+        };
+        Ok((owned, CommentTree::Leaf(own_meta)))
     }
 }
 

--- a/src/json/light.rs
+++ b/src/json/light.rs
@@ -3270,8 +3270,11 @@ fn stream_json_pretty<W: AsRef<[u64]> + Clone, Out: core::fmt::Write>(
 /// under yq's own convention (`Preserve`), which agrees with source on
 /// every byte legal unescaped in JSON -- but jq's convention (`JqCompat`)
 /// diverges from that at exactly one such byte, DEL (`0x7f`, #2591:
-/// `jq::escape`'s own `conventions_differ_at_exactly_three_code_points`
-/// names all three differences; the other two, backspace/form-feed, always
+/// `jq::escape`'s own `conventions_differ_at_exactly_five_code_points`
+/// names all five differences (three within the control-character range
+/// this comment's own claim is scoped to, plus two multi-byte separators,
+/// #1982, that are out of scope for a single-*byte* fast path like this
+/// one); the other two control-range differences, backspace/form-feed, always
 /// arrive pre-escaped with a `\` and so never reach this fast path at all).
 /// `del_unsafe` below is what keeps a `JqCompat` span containing a raw DEL
 /// byte off this path. **Three call sites in
@@ -4377,9 +4380,11 @@ mod tests {
 
     /// #2209: the escape table is a *mode* rule, not a `--preserve-input`
     /// one. `JqPreserveInput` must agree with `JqCompat` and differ from
-    /// `Preserve` on exactly the three code points the two tables disagree
-    /// on (0x08, 0x0c, DEL) -- the set pinned by `jq::escape`'s own
-    /// `conventions_differ_at_exactly_three_code_points`. Before #2209 jq
+    /// `Preserve` on exactly the three control-range code points the two
+    /// tables disagree on (0x08, 0x0c, DEL) -- three of the five pinned by
+    /// `jq::escape`'s own `conventions_differ_at_exactly_five_code_points`
+    /// (the other two, U+2028/U+2029, are multi-byte and out of scope for
+    /// this control-range check). Before #2209 jq
     /// mode's `--preserve-input` selected `Preserve` and so produced the yq
     /// column here, diverging from real jq on any navigation-only filter.
     #[test]

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -2904,6 +2904,21 @@ fn test_default_json_output_escapes_nul_and_does_not_error() -> Result<()> {
 /// 0x7f byte in the Rust source (a `\x7f` escape), not a JSON `\u007f`
 /// escape sequence in the input text -- the latter would already contain
 /// a backslash and take the slow, always-correct path, testing nothing.
+/// #1982: real jq leaves U+2028/U+2029 (line/paragraph separator) raw in
+/// JSON output (confirmed live against jq 1.7.1) -- only yq's own
+/// convention escapes them (see the yq-mode sibling tests in
+/// yq_cli_tests.rs). Pins that write_json_body_yq's new escaping (added
+/// for #1982) is genuinely yq-scoped and never leaked into the shared
+/// control-character table write_json_body_jq also uses.
+#[test]
+fn test_line_paragraph_separators_stay_raw_in_jq_mode_1982() -> Result<()> {
+    let input = "{\"a\": \"x\u{2028}y\u{2029}z\"}";
+    let (out, _, code) = run_jq_full(&["-c", "."], Some(input))?;
+    assert_eq!(code, 0);
+    assert_eq!(out, "{\"a\":\"x\u{2028}y\u{2029}z\"}\n", "stdout: {out:?}");
+    Ok(())
+}
+
 #[test]
 fn test_default_json_output_escapes_raw_del_byte_in_value_2591() -> Result<()> {
     let input = "{\"a\": \"xy\"}";

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -4095,6 +4095,60 @@ fn test_slurp_json_explicit_tag_through_dom_path() -> Result<()> {
     Ok(())
 }
 
+/// #1982: `-P` forces the DOM path through a *different* conversion
+/// (`to_owned_with_comments_at_depth`, via #765's comment-tracking
+/// `owned_with_comments` closure in `evaluate_yaml_cursor`) than the
+/// `--slurp` case above (`yaml_to_owned_value`) -- so #224's fix landing
+/// for one didn't cover the other. Before this fix, `-P -o json` on
+/// `a: !!str 5` silently changed the value's type: `{"a": 5}` (a number)
+/// instead of the string `{"a": "5"}` real yq gives, because the scalar
+/// arm of `to_owned_with_comments_at_depth` called the cursor-*blind*
+/// `to_owned_at_depth` unconditionally, even though a real, tag-bearing
+/// cursor was already in scope.
+#[test]
+fn test_pretty_print_explicit_str_tag_through_dom_path_1982() -> Result<()> {
+    let (output, code) = run_yq_stdin(".", "a: !!str 5\n", &["-P", "-o", "json"])?;
+    assert_eq!(code, 0);
+    assert_eq!(output.trim(), "{\n  \"a\": \"5\"\n}");
+    Ok(())
+}
+
+/// #1982: sibling of the test above, covering the `need_comments == false`
+/// arm specifically -- `-o json`'s own output never reads `CommentTree`, so
+/// `evaluate_yaml_cursor`'s `owned_with_comments` closure skips
+/// `to_owned_with_comments` entirely and used to call the cursor-blind
+/// `generic_to_owned(&c.value())` instead, losing the tag exactly the same
+/// way. `-I0` alone (no `-P`) already forces materialization for `-o json`
+/// since M2 streaming only covers the identity query on a subset of
+/// shapes -- this pins the tag fix on that plainer, more common route too.
+#[test]
+fn test_output_json_explicit_int_tag_through_dom_path_1982() -> Result<()> {
+    let (output, code) = run_yq_stdin(".", "a: !!int \"5\"\n", &["-o", "json", "-I0"])?;
+    assert_eq!(code, 0);
+    assert_eq!(output.trim(), r#"{"a":5}"#);
+    Ok(())
+}
+
+/// #1982 part 2: real yq (v4.53.3) unconditionally escapes U+2028/U+2029
+/// (line/paragraph separator) in JSON output -- confirmed live, and true
+/// regardless of whether the source was a YAML \L/\P escape or a raw
+/// UTF-8 byte already in the string. succinctly's streaming YAML->JSON
+/// transcoder already special-cased this for the \L/\P spelling
+/// (`stream_transcode_double_quoted_to_json`), but the DOM path's own JSON
+/// string escaper (`write_json_body_yq`) had no equivalent, so any
+/// DOM-forcing route (`-P`, `--arg`, ...) emitted the two separators raw.
+#[test]
+fn test_line_paragraph_separators_escaped_through_dom_path_1982() -> Result<()> {
+    let (output, code) = run_yq_stdin(
+        ".",
+        "a: \"x\\Ly\\Pz\"\n",
+        &["-o", "json", "-I0", "--arg", "unused", "x"],
+    )?;
+    assert_eq!(code, 0);
+    assert_eq!(output.trim(), r#"{"a":"x\u2028y\u2029z"}"#);
+    Ok(())
+}
+
 /// #224: sibling of the test above, but the explicit tag (`!custom`) isn't
 /// one of the 5 core-schema tags, so `resolve_tagged` returns `None` and
 /// `yaml_to_owned_value` must fall through past the tag check to the


### PR DESCRIPTION
## Summary

`succinctly yq`'s DOM (materialized `OwnedValue`) output path disagreed
with both real yq and succinctly's own streaming path on two points,
reachable via any DOM-forcing route (`-P` without `-I0`, `--arg`/
`--argjson`, `-r`/`-j`/`-0`, `--eval-all`, `--split-exp`, or any filter
shape the M2 fast-path gate rejects):

1. **An explicit core-schema tag (`!!str`, `!!int`, `!!bool`, `!!null`)
   was silently dropped, changing the value's type**: `a: !!str 5` under
   `-P -o json` printed the number `5` instead of the string `"5"`. Two
   call sites had the same shape -- a real, tag-bearing cursor was in
   scope, but the code called a cursor-blind conversion function with no
   way to see the tag (it lives on the cursor's `bp_pos`, not on the
   extracted value, #747):
   - `to_owned_with_comments_at_depth`'s scalar arm (`eval_generic.rs`)
   - `evaluate_yaml_cursor`'s `owned_with_comments` closure (`yq_runner.rs`,
     the `-o json` / `need_comments == false` arm)

   Both now resolve through the cursor-aware `tagged_scalar_to_owned`/
   `generic_to_owned_cursor`, matching what the streaming path already did.

2. **U+2028/U+2029 (line/paragraph separator) were emitted raw** instead
   of escaped -- confirmed live that real yq always escapes both in JSON
   output regardless of source, where real jq leaves both raw (yq-only).
   `write_json_body_yq` gained this as its one addition beyond the shared
   control-character table, gated on a cheap byte-existence probe so the
   common ASCII-only span stays on its existing SIMD-scanned fast path.

Code review found a third site with the same cursor-blind shape
(`evaluate_yaml_cursor`'s `alias_sync_ctx`) -- verified inert in practice
today (five scenarios all matched the oracle either way, since #1351's
`alias_identity` live-mirroring already produces correct values before
this snapshot's own comparison runs), fixed anyway for defense in depth
since it costs nothing.

**Residual, not fixed here**: the M2 streaming path itself still emits a
raw (non-`\L`/`\P`-sourced) U+2028/U+2029 byte unescaped -- filed as #2607.

Fixes #1982

## Test plan

- [x] `cargo build`, `cargo build --features cli`
- [x] `cargo test --features cli,simd,regex,serde` (0 failures)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` (clean)
- [x] `cargo fmt --check` (clean)
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features` (clean)
- [x] New regression tests: tag-loss fix via `-P`/`-o json` (str + int
      tags), separator escaping via the DOM path, jq-mode non-regression
      (separators stay raw)
- [x] Manually verified against the pinned oracle (Homebrew `yq` v4.53.3,
      `/usr/bin/jq` 1.7.1) across `!!str`/`!!int`/`!!bool`/`!!null`, both
      `-P` and plain `-o json` routes, and the alias-sync defense-in-depth
      fix (5 scenarios)
- [x] Local A/B sanity check: no measurable regression on a 10MB JSON file
      through `succinctly yq -o json -I0 '.'`
- [x] Independent code review (found and fixed one additional
      defense-in-depth site; no blocking issues)
