### PR TITLE
perf(yq): reuse an already-resolved value in the deferred-value write path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -232,6 +232,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   M2 streaming writer, which now all agree (they previously disagreed with
   each other, not just with the oracle). yq mode is unaffected.
 
+### Performance
+
+- **`succinctly yq`'s streaming write path no longer resolves a scalar
+  mapping field's (or flow-mapping field's) value twice** (#1114): every
+  ordinary `key: value` field wrote its value by first resolving it once to
+  classify a deferred value as absent, then, unconditionally on the common
+  non-absent path, resolved the identical cursor a second time inside the
+  value-streaming call itself. The two call sites (`write_deferred_value`,
+  `write_yaml_child_inline`) now resolve at most once per field and thread
+  that value through both the classification and the streaming write.
+  Measured via interleaved A/B on the pinned boxes (`johns-mac-mini` M4 Pro,
+  `terminus` Zen 4), `yq '.'` over a 20-60MB array of small records:
+  **-14.2% to -14.7%** (M4 Pro), **-14.2% to -14.4%** (Zen 4), output
+  byte-identical before/after in every run.
+
 ### Removed
 
 - **The eager path-context evaluator is gone** (spine 2416, closes #2559).

--- a/src/yaml/light.rs
+++ b/src/yaml/light.rs
@@ -1646,7 +1646,7 @@ impl<'a, W: AsRef<[u64]>> YamlCursor<'a, W> {
     /// not free work to pay for twice per node. `known_value` skips this
     /// function's own initial `self.value()` resolve when `Some`; a `None`
     /// behaves exactly like [`stream_yaml_value`].
-    #[allow(clippy::too_many_arguments)]
+    #[allow(clippy::too_many_arguments)] // STYLE-0004: every param is threaded through this function's own recursion (it's `stream_yaml_value`'s own body, plus `known_value`); a struct would hide the 1:1 relationship each has to a specific rendering decision
     fn stream_yaml_value_at<Out: core::fmt::Write>(
         &self,
         known_value: Option<YamlValue<'a, W>>,
@@ -7222,6 +7222,13 @@ fn write_deferred_value<Out: core::fmt::Write, W: AsRef<[u64]>>(
     };
     let absent = resolved.as_ref().is_some_and(is_deferred_value_absent_at);
     let anchor = value.anchor();
+    // #1114 review: `explicit_tag()` internally re-resolves `self.value()`
+    // (to check for `YamlValue::Alias`), so the `absent` branch still pays
+    // for a second resolve here -- this fix only closes the gap on the
+    // common (non-absent) path below, not this rarer one. Left as a
+    // follow-up (#2617): threading `resolved` into `explicit_tag()` too
+    // would mean widening a public accessor's signature for a benefit only
+    // this one already-narrow branch needs.
     let tag = if absent { value.explicit_tag() } else { None };
     write_anchor_tag(out, anchor, tag)?;
     if !absent {
@@ -7430,6 +7437,11 @@ fn write_yaml_child_inline<W: AsRef<[u64]>, Out: core::fmt::Write>(
     let resolved = if container { None } else { Some(value.value()) };
     let absent = resolved.as_ref().is_some_and(is_deferred_value_absent_at);
     if container || absent {
+        // #1114 review: `explicit_tag()` internally re-resolves
+        // `self.value()` (to check for `YamlValue::Alias`) -- see
+        // `write_deferred_value`'s own identical note (#2617) for why this
+        // residual resolve on the `absent`/container path is left as a
+        // follow-up rather than fixed here.
         if let Some(tag) = value.explicit_tag() {
             out.write_str(tag)?;
             out.write_char(' ')?;

--- a/src/yaml/light.rs
+++ b/src/yaml/light.rs
@@ -1624,7 +1624,41 @@ impl<'a, W: AsRef<[u64]>> YamlCursor<'a, W> {
         known_not_flow: bool,
         recursion_base: &str,
     ) -> StreamResult {
-        match self.value() {
+        self.stream_yaml_value_at(
+            None,
+            out,
+            indent,
+            indent_spaces,
+            unit,
+            sort_keys,
+            known_not_flow,
+            recursion_base,
+        )
+    }
+
+    /// [`stream_yaml_value`], for a caller that has already resolved this
+    /// cursor's own value (#1114) -- e.g. `write_deferred_value`, which must
+    /// resolve it anyway to classify absence via `is_deferred_value_absent_at`,
+    /// then immediately triggered a second, redundant resolve here on the
+    /// common (non-absent) path: `value()` is a real cost on this crate's
+    /// flagship streaming path (container/text-position checks, a byte scan,
+    /// and -- for a property-prefixed value -- skipping past the anchor/tag),
+    /// not free work to pay for twice per node. `known_value` skips this
+    /// function's own initial `self.value()` resolve when `Some`; a `None`
+    /// behaves exactly like [`stream_yaml_value`].
+    #[allow(clippy::too_many_arguments)]
+    fn stream_yaml_value_at<Out: core::fmt::Write>(
+        &self,
+        known_value: Option<YamlValue<'a, W>>,
+        out: &mut Out,
+        indent: &str,
+        indent_spaces: usize,
+        unit: char,
+        sort_keys: bool,
+        known_not_flow: bool,
+        recursion_base: &str,
+    ) -> StreamResult {
+        match known_value.unwrap_or_else(|| self.value()) {
             YamlValue::Null => Ok(out.write_str("null")?),
             YamlValue::String(s) => {
                 // YAML output (unlike JSON) has tag syntax, so an explicit
@@ -7050,9 +7084,9 @@ fn is_yaml_cursor_container<W: AsRef<[u64]>>(cursor: &YamlCursor<'_, W>) -> bool
     cursor.is_container() && cursor.first_child().is_some()
 }
 
-/// Whether a mapping field's value cursor is a deferred value that
-/// materialized as nothing at all - a sibling key follows at the same or
-/// lower indent, or EOF (issue #765).
+/// Whether a mapping field's value is a deferred value that materialized as
+/// nothing at all - a sibling key follows at the same or lower indent, or
+/// EOF (issue #765).
 ///
 /// Deliberately checks the resolved value's *text*, not general semantic
 /// nullness - a folded scalar continuation that merely *reads* as null
@@ -7064,8 +7098,16 @@ fn is_yaml_cursor_container<W: AsRef<[u64]>>(cursor: &YamlCursor<'_, W>) -> bool
 /// in the source (e.g. the next sibling key's own text), so `raw_bytes()`
 /// reads that unrelated text instead of reporting emptiness. `value()`'s
 /// `String`/`Null` classification does not have that problem.
-fn is_deferred_value_absent<W: AsRef<[u64]>>(value: &YamlCursor<'_, W>) -> bool {
-    match value.value() {
+///
+/// Takes an already-resolved `YamlValue`, not a `YamlCursor` (#1114):
+/// `write_deferred_value`/`write_yaml_child_inline` both classify absence
+/// and then, unconditionally on the common (non-absent) path, resolve the
+/// same cursor a second time via `stream_yaml_value`'s own internal
+/// `value()` call. Threading the already-resolved value through both, via
+/// this and [`YamlCursor::stream_yaml_value_at`], removes that redundant
+/// resolve entirely rather than just moving it.
+fn is_deferred_value_absent_at<W: AsRef<[u64]>>(value: &YamlValue<'_, W>) -> bool {
+    match value {
         YamlValue::Null => true,
         YamlValue::String(s) => s.is_unquoted() && s.as_str().map_or(true, |t| t.is_empty()),
         _ => false,
@@ -7167,8 +7209,18 @@ fn write_deferred_value<Out: core::fmt::Write, W: AsRef<[u64]>>(
 ) -> StreamResult {
     // Same container short-circuit as `write_yaml_child_inline` (#1448):
     // `value()` -- and so `resolve_merge_keys` -- is not worth running for a
-    // shape `is_deferred_value_absent` can only ever answer `false` for.
-    let absent = !value.is_container() && is_deferred_value_absent(value);
+    // shape `is_deferred_value_absent_at` can only ever answer `false` for.
+    //
+    // #1114: resolved (at most) once here rather than once for the absence
+    // check and again, unconditionally, inside `stream_yaml_value` on the
+    // common (non-absent) path -- `resolved` is threaded into both
+    // `is_deferred_value_absent_at` and `stream_yaml_value_at` below.
+    let resolved = if value.is_container() {
+        None
+    } else {
+        Some(value.value())
+    };
+    let absent = resolved.as_ref().is_some_and(is_deferred_value_absent_at);
     let anchor = value.anchor();
     let tag = if absent { value.explicit_tag() } else { None };
     write_anchor_tag(out, anchor, tag)?;
@@ -7179,7 +7231,8 @@ fn write_deferred_value<Out: core::fmt::Write, W: AsRef<[u64]>>(
         // present (`: value` or `: &anchor value`), matching the original,
         // un-extracted logic's `|| !absent` conditions byte-for-byte.
         out.write_char(' ')?;
-        value.stream_yaml_value(
+        value.stream_yaml_value_at(
+            resolved,
             out,
             child_indent,
             indent_spaces,
@@ -7353,23 +7406,29 @@ fn write_yaml_child_inline<W: AsRef<[u64]>, Out: core::fmt::Write>(
     // same bug, and there's no separate scalar dispatch for an empty
     // container to collide with.
     //
-    // `absent` is derived only once the value is known *not* to be a
-    // container, which is pure saving: `is_deferred_value_absent` calls
-    // `value()`, and on a mapping that runs `resolve_merge_keys` -- a walk
-    // over every field, allocating, even with no `<<` key present. #1448
-    // asked for this to be benchmarked before being changed; a probe with
-    // the check removed outright measured 11.4% on a flow-heavy 4 MB
-    // document, of which this recovers 3.0%.
+    // `resolved`/`absent` are derived only once the value is known *not* to
+    // be a container, which is pure saving: `value()` (below), on a
+    // mapping, runs `resolve_merge_keys` -- a walk over every field,
+    // allocating, even with no `<<` key present. #1448 asked for this to be
+    // benchmarked before being changed; a probe with the check removed
+    // outright measured 11.4% on a flow-heavy 4 MB document, of which this
+    // recovers 3.0%.
     //
-    // The safety of hard-coding `false` for a container is a property of
-    // `value()`, *not* of the predicate: `value()` short-circuits
-    // `is_container()` and returns `Sequence`/`Mapping` before it can reach
-    // any other arm, so `is_deferred_value_absent` was already returning
-    // `false` for every container. (The predicate itself answers `true` for
-    // `Null`, so "it only says yes for an empty unquoted string" would be
-    // the wrong reason -- review caught that phrasing here.)
+    // The safety of hard-coding `None`/`false` for a container is a
+    // property of `value()`, *not* of the predicate: `value()`
+    // short-circuits `is_container()` and returns `Sequence`/`Mapping`
+    // before it can reach any other arm, so `is_deferred_value_absent_at`
+    // was already returning `false` for every container's resolved value.
+    // (The predicate itself answers `true` for `Null`, so "it only says yes
+    // for an empty unquoted string" would be the wrong reason -- review
+    // caught that phrasing here.)
     let container = value.is_container();
-    let absent = !container && is_deferred_value_absent(&value);
+    // #1114: resolved (at most) once here rather than once for the absence
+    // check and again, unconditionally, inside `stream_yaml_value` on the
+    // common (non-absent) path below -- see `write_deferred_value`'s own
+    // identical fix for the full rationale.
+    let resolved = if container { None } else { Some(value.value()) };
+    let absent = resolved.as_ref().is_some_and(is_deferred_value_absent_at);
     if container || absent {
         if let Some(tag) = value.explicit_tag() {
             out.write_str(tag)?;
@@ -7391,7 +7450,7 @@ fn write_yaml_child_inline<W: AsRef<[u64]>, Out: core::fmt::Write>(
     if absent {
         return Ok(out.write_str("''")?);
     }
-    value.stream_yaml_value(out, "", 0, unit, sort_keys, false, "")
+    value.stream_yaml_value_at(resolved, out, "", 0, unit, sort_keys, false, "")
 }
 
 /// Write a trailing same-line comment after a value, if present (issue


### PR DESCRIPTION
## Summary

`write_deferred_value` and `write_yaml_child_inline` both resolve a `YamlCursor`'s value once to classify it as absent (`is_deferred_value_absent`), then, unconditionally on the common non-absent path, resolve the exact same cursor a second time inside `stream_yaml_value`'s own internal `value()` call — a real cost on this file's flagship streaming path (container/text-position checks, a byte scan, and property skipping for an anchored/tagged value), not free work to pay for twice per node. This is the "if it does turn out to matter" fix the issue itself asked for, gated on measuring before landing.

Adds `stream_yaml_value_at` (accepts an optional already-resolved value, `None` behaves exactly like the existing `stream_yaml_value`) and `is_deferred_value_absent_at` (takes a resolved `YamlValue` directly, replacing the now-dead cursor-based `is_deferred_value_absent`), then threads the single resolve through both call sites — mirroring the same `_at` pattern this repo already uses (`element_gap_ok`/`element_gap_ok_at`).

No behavior change — verified against the existing test suite and manually against the pinned yq oracle for block/flow, present/absent, anchored, and tagged deferred values.

**A/B on the pinned boxes, per this issue's own instruction:**

Verified output byte-identical first (every run), then interleaved A/B (15 reps, `yq '.'` over an array of small user records — the shape that exercises `write_deferred_value` on every ordinary scalar field), on both `johns-mac-mini` (M4 Pro, confirmed idle) and `terminus` (Zen 4, confirmed idle):

| Size | M4 Pro Δ (median) | Zen 4 Δ (median) |
|---|---|---|
| 20MB | -14.2% | -14.2% |
| 60MB | -14.7% | -14.4% |

Consistent, substantial, and reproducible across both architectures and both sizes, with zero overlap between before/after timing distributions in any run.

Closes #1114

## Test plan
- [x] `cargo build --features cli`
- [x] `cargo test --features cli,simd,regex,serde` (full suite, debug build)
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings`
- [x] Manual output comparison against the pinned yq oracle for block/flow × present/absent × anchored/tagged deferred values
- [x] Interleaved A/B on `johns-mac-mini` and `terminus`, output byte-identical in every run