### PR TITLE
perf(yq): avoid explicit_tag()'s redundant resolve on the absent/container deferred-value path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -246,6 +246,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `terminus` Zen 4), `yq '.'` over a 20-60MB array of small records:
   **-14.2% to -14.7%** (M4 Pro), **-14.2% to -14.4%** (Zen 4), output
   byte-identical before/after in every run.
+- **Closed a smaller residual of #1114 on the rarer absent/container
+  deferred-value path** (#2617): `explicit_tag()` still re-resolved a
+  cursor's value internally (to check for `YamlValue::Alias`) even when the
+  caller already had it in hand, or structurally knew a container position
+  can never be an alias. `explicit_tag_at` now takes that value (or `None`
+  for a container) directly. As expected from the much rarer trigger shape,
+  the measured win is far smaller than #1114's: interleaved A/B on the
+  pinned boxes, `yq '.'` over a 5-60MB flow-heavy document: **-0.7% to
+  -1.4%** (M4 Pro, clearly outside this corpus's own -0.3%..+0.1% noise
+  floor), within noise on Zen 4 (-0.2% to -0.3%, inside a -1.0%..+0.9%
+  noise floor) — output byte-identical before/after in every run.
 
 ### Removed
 

--- a/src/yaml/light.rs
+++ b/src/yaml/light.rs
@@ -2508,7 +2508,22 @@ impl<'a, W: AsRef<[u64]>> YamlCursor<'a, W> {
     /// `explicit_tag` was the one left out (#903 review).
     #[inline]
     pub fn explicit_tag(&self) -> Option<&str> {
-        if let YamlValue::Alias { target, .. } = self.value() {
+        self.explicit_tag_at(Some(&self.value()))
+    }
+
+    /// Sibling of [`Self::explicit_tag`] for a caller that already knows
+    /// whether this cursor is an alias without a fresh [`Self::value`] call
+    /// (#1114 review, #2617). Pass `Some(&resolved)` when a prior `value()`
+    /// call already produced it (e.g. `write_deferred_value`'s `resolved`
+    /// local on its `absent` branch), or `None` when the cursor is
+    /// structurally known not to be an alias without resolving at all (e.g.
+    /// `write_yaml_child_inline`'s `container` branch: `is_container()` is a
+    /// structural bitvector check, and a container position can never be an
+    /// alias) — `None` skips straight to the non-alias fallback exactly as
+    /// `Some(non_alias_value)` would, just without paying for the resolve.
+    #[inline]
+    pub fn explicit_tag_at(&self, known_value: Option<&YamlValue<'a, W>>) -> Option<&str> {
+        if let Some(YamlValue::Alias { target, .. }) = known_value {
             // Not `target.and_then(|t| t.explicit_tag())`: `t` is a local
             // `YamlCursor` moved into the closure, so a call through `&t`
             // ties the returned `&str` to that closure-local borrow even
@@ -2517,7 +2532,7 @@ impl<'a, W: AsRef<[u64]>> YamlCursor<'a, W> {
             // the elided lifetime resolves to `'a`, matching every other
             // `Alias` arm in this file that recurses via the cursor itself
             // rather than a getter call on it.
-            return target.and_then(|t| t.index.get_tag(t.bp_pos));
+            return (*target).and_then(|t| t.index.get_tag(t.bp_pos));
         }
         self.index.get_tag(self.bp_pos)
     }
@@ -7222,14 +7237,16 @@ fn write_deferred_value<Out: core::fmt::Write, W: AsRef<[u64]>>(
     };
     let absent = resolved.as_ref().is_some_and(is_deferred_value_absent_at);
     let anchor = value.anchor();
-    // #1114 review: `explicit_tag()` internally re-resolves `self.value()`
-    // (to check for `YamlValue::Alias`), so the `absent` branch still pays
-    // for a second resolve here -- this fix only closes the gap on the
-    // common (non-absent) path below, not this rarer one. Left as a
-    // follow-up (#2617): threading `resolved` into `explicit_tag()` too
-    // would mean widening a public accessor's signature for a benefit only
-    // this one already-narrow branch needs.
-    let tag = if absent { value.explicit_tag() } else { None };
+    // #1114 review, closed by #2617: `explicit_tag()` used to re-resolve
+    // `self.value()` internally (to check for `YamlValue::Alias`), paying
+    // for a second resolve on this `absent` branch even though `resolved`
+    // was already in hand. `explicit_tag_at` takes the already-resolved
+    // value directly instead.
+    let tag = if absent {
+        value.explicit_tag_at(resolved.as_ref())
+    } else {
+        None
+    };
     write_anchor_tag(out, anchor, tag)?;
     if !absent {
         // Neither `write_anchor_tag` nor the anchor/tag it may have
@@ -7437,12 +7454,12 @@ fn write_yaml_child_inline<W: AsRef<[u64]>, Out: core::fmt::Write>(
     let resolved = if container { None } else { Some(value.value()) };
     let absent = resolved.as_ref().is_some_and(is_deferred_value_absent_at);
     if container || absent {
-        // #1114 review: `explicit_tag()` internally re-resolves
-        // `self.value()` (to check for `YamlValue::Alias`) -- see
-        // `write_deferred_value`'s own identical note (#2617) for why this
-        // residual resolve on the `absent`/container path is left as a
-        // follow-up rather than fixed here.
-        if let Some(tag) = value.explicit_tag() {
+        // #1114 review, closed by #2617: `explicit_tag()` used to re-resolve
+        // `self.value()` internally on both this branch's shapes -- `resolved`
+        // is `None` for a container (never an alias, `is_container()` is a
+        // structural check independent of resolving) and `Some(v)` for the
+        // `absent` case, exactly matching `explicit_tag_at`'s own contract.
+        if let Some(tag) = value.explicit_tag_at(resolved.as_ref()) {
             out.write_str(tag)?;
             out.write_char(' ')?;
         }

--- a/src/yaml/light.rs
+++ b/src/yaml/light.rs
@@ -2511,18 +2511,22 @@ impl<'a, W: AsRef<[u64]>> YamlCursor<'a, W> {
         self.explicit_tag_at(Some(&self.value()))
     }
 
-    /// Sibling of [`Self::explicit_tag`] for a caller that already knows
-    /// whether this cursor is an alias without a fresh [`Self::value`] call
-    /// (#1114 review, #2617). Pass `Some(&resolved)` when a prior `value()`
-    /// call already produced it (e.g. `write_deferred_value`'s `resolved`
-    /// local on its `absent` branch), or `None` when the cursor is
-    /// structurally known not to be an alias without resolving at all (e.g.
+    /// Internal sibling of [`Self::explicit_tag`] for the two write-path call
+    /// sites in this module that already know whether this cursor is an
+    /// alias without a fresh [`Self::value`] call (#1114 review, #2617). Not
+    /// `pub`, deliberately: unlike [`Self::stream_yaml_value_at`], where
+    /// `None` always falls back to a full resolve and so is unconditionally
+    /// safe, `None` here skips the alias check outright with no fallback --
+    /// safe only when the caller can already prove the cursor isn't an
+    /// alias (see call sites below), not a general-purpose default. Pass
+    /// `Some(&resolved)` when a prior `value()` call already produced it
+    /// (e.g. `write_deferred_value`'s `resolved` local on its `absent`
+    /// branch), or `None` only when that proof holds (e.g.
     /// `write_yaml_child_inline`'s `container` branch: `is_container()` is a
     /// structural bitvector check, and a container position can never be an
-    /// alias) — `None` skips straight to the non-alias fallback exactly as
-    /// `Some(non_alias_value)` would, just without paying for the resolve.
+    /// alias).
     #[inline]
-    pub fn explicit_tag_at(&self, known_value: Option<&YamlValue<'a, W>>) -> Option<&str> {
+    fn explicit_tag_at(&self, known_value: Option<&YamlValue<'a, W>>) -> Option<&str> {
         if let Some(YamlValue::Alias { target, .. }) = known_value {
             // Not `target.and_then(|t| t.explicit_tag())`: `t` is a local
             // `YamlCursor` moved into the closure, so a call through `&t`


### PR DESCRIPTION
## Summary

Follow-up to #1114's review. #1114 closed the double-resolve of a deferred
value's cursor on the **common (non-absent)** path in
`write_deferred_value`/`write_yaml_child_inline`. A smaller redundancy
remained on the rarer **absent**/container path: `explicit_tag()` re-ran
`self.value()` internally just to check for `YamlValue::Alias`, even when the
caller already had the resolved value in hand (or structurally knew it
didn't need one at all).

## Change

Adds `explicit_tag_at`, a sibling of `explicit_tag` accepting
`Option<&YamlValue>` — the same shape `stream_yaml_value_at` already uses:

- `Some(&resolved)` when a prior `value()` call already produced it (the
  `absent` case in both call sites).
- `None` when the cursor is structurally known not to be an alias without
  resolving at all — a container position (`is_container()`'s own
  bitvector check) can never be an alias, so `write_yaml_child_inline`'s
  container branch now skips the resolve entirely.

`explicit_tag()` itself becomes a thin wrapper: `self.explicit_tag_at(Some(&self.value()))`.

## Benchmark

As expected from the much rarer trigger shape (issue's own framing), the
win is far smaller than #1114's own -14%. Interleaved A/B (`scripts/ab-cli.py`)
on the pinned boxes, `yq '.'` over a 5-60MB flow-heavy document
(`yaml generate -p flow`):

- **M4 Pro (`johns-mac-mini`)**: -0.7% to -1.4% across all 3 sizes, clearly
  outside this corpus's own control noise floor (-0.3%..+0.1%, mixed sign).
- **Zen 4 (`terminus`)**: -0.2% to -0.3%, within this corpus's wider noise
  floor (-1.0%..+0.9%, mixed sign) — directionally consistent but not
  distinguishable from noise on this architecture.

Output byte-identical before/after in every run (ab-cli's identity gate).

## Testing

- Existing regression suite (`test_deferred_absent_mapping_field_keeps_explicit_tag_1077`,
  `test_container_anchor_keeps_explicit_tag_1132`, `test_flow_anchor_keeps_explicit_tag_1115`,
  and siblings) already exercises both the absent and container branches
  through this exact code — no new tests needed; local patch coverage is
  100% (9/9 new lines).
- Full suite: `cargo test --features cli` — 3543 + 1635 + ... all green, 0 failed.
- `cargo clippy --all-targets --all-features -- -D warnings` clean.

Closes #2617.