### PR TITLE
perf(yq): avoid explicit_tag()'s redundant resolve on the common streaming path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -259,18 +259,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   noise floor) — output byte-identical before/after in every run.
 - **Closed the same `explicit_tag()` double-resolve on the common
   (non-absent) streaming path -- the much hotter sibling #2617 left for a
-  follow-up** (#2619): five call sites on this crate's "flagship streaming
-  path" (`stream_yaml_value_at`, `stream_json_value`, `write_json_to`,
-  `tag()`, `is_falsy`) already match a cursor's resolved value into
-  `YamlValue::String` -- proving it isn't an alias -- then call the
-  un-optimized `explicit_tag()` anyway, paying for a second resolve on
-  every string-valued node regardless of whether a tag is even present.
-  All five now call `explicit_tag_at(None)` instead. Unlike #2617's rare
-  trigger shape, this hits the overwhelming majority of real YAML scalars.
-  Measured via interleaved A/B on the pinned boxes, `yq '.'` over a
+  follow-up** (#2619): nine call sites on this crate's "flagship streaming
+  path" and elsewhere (`stream_yaml_value_at`'s String/Mapping/Sequence
+  arms, `stream_json_value`, `write_json_to`, `tag()`, `is_falsy`,
+  `write_yaml_field_key`, the `--slurp` array writer) already have -- via a
+  matched `YamlValue::String` on the same cursor, or a structural
+  `is_container()`/`is_yaml_cursor_container()` check -- proof the cursor
+  isn't an alias, then call the un-optimized `explicit_tag()` anyway,
+  paying for a second resolve regardless of whether a tag is even present.
+  All nine now call `explicit_tag_at(None)` instead. Unlike #2617's rare
+  trigger shape, this hits the overwhelming majority of real YAML scalars
+  and every mapping key. Measured via interleaved A/B, `yq '.'` over a
   5-60MB array of small records (`yaml generate -p users`, #1114's own
-  corpus shape): **-23.6% to -24.5%** (M4 Pro), **-29.2% to -30.0%**
-  (Zen 4), output byte-identical before/after in every run.
+  corpus shape): **-23.8% to -24.9%** (pinned `johns-mac-mini` M4 Pro).
+  The Zen 4 box (`terminus`) was unreachable to re-measure the final
+  9-site version; the originally-measured 5-site subset on that box read
+  -29.2% to -30.0%, which the added sites are not expected to reduce.
+  Output byte-identical before/after in every run.
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -257,6 +257,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   -1.4%** (M4 Pro, clearly outside this corpus's own -0.3%..+0.1% noise
   floor), within noise on Zen 4 (-0.2% to -0.3%, inside a -1.0%..+0.9%
   noise floor) — output byte-identical before/after in every run.
+- **Closed the same `explicit_tag()` double-resolve on the common
+  (non-absent) streaming path -- the much hotter sibling #2617 left for a
+  follow-up** (#2619): five call sites on this crate's "flagship streaming
+  path" (`stream_yaml_value_at`, `stream_json_value`, `write_json_to`,
+  `tag()`, `is_falsy`) already match a cursor's resolved value into
+  `YamlValue::String` -- proving it isn't an alias -- then call the
+  un-optimized `explicit_tag()` anyway, paying for a second resolve on
+  every string-valued node regardless of whether a tag is even present.
+  All five now call `explicit_tag_at(None)` instead. Unlike #2617's rare
+  trigger shape, this hits the overwhelming majority of real YAML scalars.
+  Measured via interleaved A/B on the pinned boxes, `yq '.'` over a
+  5-60MB array of small records (`yaml generate -p users`, #1114's own
+  corpus shape): **-23.6% to -24.5%** (M4 Pro), **-29.2% to -30.0%**
+  (Zen 4), output byte-identical before/after in every run.
 
 ### Removed
 

--- a/src/yaml/light.rs
+++ b/src/yaml/light.rs
@@ -1666,7 +1666,12 @@ impl<'a, W: AsRef<[u64]>> YamlCursor<'a, W> {
                 // real `yq`, which re-emits `!!str 1`/`!!int "5"`/`!custom v`
                 // as-is rather than only letting the tag affect resolution
                 // (#224).
-                if let Some(tag) = self.explicit_tag() {
+                //
+                // #2619: `self` -- the match subject just above -- is
+                // already proven non-`Alias` by having matched `String`
+                // here, so `explicit_tag_at(None)` skips straight to the
+                // non-alias fallback with no second `value()` resolve.
+                if let Some(tag) = self.explicit_tag_at(None) {
                     out.write_str(tag)?;
                     out.write_char(' ')?;
                 }
@@ -2172,7 +2177,11 @@ impl<'a, W: AsRef<[u64]>> YamlCursor<'a, W> {
                 // number 5, not the string "5" - so it's checked before the
                 // direct transcoding optimization below, which otherwise
                 // always treats a quoted/block scalar as a string (#224).
-                if let Some(explicit) = self.explicit_tag() {
+                //
+                // #2619: `self.value()` above already proved `self` isn't
+                // `Alias` by matching `String`, so `None` skips a second
+                // resolve entirely.
+                if let Some(explicit) = self.explicit_tag_at(None) {
                     if let Ok(str_val) = s.as_str() {
                         if let Some(resolved) = resolve_tagged(&str_val, explicit) {
                             return Ok(stream_resolved_scalar_as_json(
@@ -2341,7 +2350,11 @@ impl<'a, W: AsRef<[u64]>> YamlCursor<'a, W> {
             YamlValue::String(s) => {
                 // An explicit core-schema tag forces resolution regardless of
                 // quoting style - see the mirrored check in `stream_json_value` (#224).
-                if let Some(explicit) = self.explicit_tag() {
+                //
+                // #2619: `self.value()` above already proved `self` isn't
+                // `Alias` by matching `String`, so `None` skips a second
+                // resolve entirely.
+                if let Some(explicit) = self.explicit_tag_at(None) {
                     if let Ok(str_val) = s.as_str() {
                         if let Some(resolved) = resolve_tagged(&str_val, explicit) {
                             write_resolved_scalar_as_json(
@@ -2838,7 +2851,10 @@ impl<'a, W: AsRef<[u64]>> YamlCursor<'a, W> {
         match self.value() {
             YamlValue::Null => "!!null",
             YamlValue::String(s) => {
-                if let Some(explicit) = self.explicit_tag() {
+                // #2619: `self.value()` above already proved `self` isn't
+                // `Alias` by matching `String`, so `None` skips a second
+                // resolve entirely.
+                if let Some(explicit) = self.explicit_tag_at(None) {
                     if let Ok(str_val) = s.as_str() {
                         if let Some(resolved) = resolve_tagged(&str_val, explicit) {
                             return resolved.tag();
@@ -6595,7 +6611,10 @@ impl<'a, W: AsRef<[u64]> + Clone> DocumentCursor for YamlCursor<'a, W> {
                 let Ok(str_val) = s.as_str() else {
                     return false;
                 };
-                if let Some(explicit) = self.explicit_tag() {
+                // #2619: `self.value()` above already proved `self` isn't
+                // `Alias` by matching `String`, so `None` skips a second
+                // resolve entirely.
+                if let Some(explicit) = self.explicit_tag_at(None) {
                     if let Some(resolved) = resolve_tagged(&str_val, explicit) {
                         return matches!(
                             resolved,

--- a/src/yaml/light.rs
+++ b/src/yaml/light.rs
@@ -1903,6 +1903,12 @@ impl<'a, W: AsRef<[u64]>> YamlCursor<'a, W> {
                             // through the shared helper (#1828): this is
                             // the only one of its four original callers
                             // that ever had a comment to place.
+                            // #2619: `value` is already proven non-`Alias`
+                            // by the `is_yaml_cursor_container(&value)`
+                            // guard above (a structural check -- an alias
+                            // node is never a container), so both
+                            // `explicit_tag()` calls below skip a second
+                            // resolve via `explicit_tag_at(None)`.
                             if let Some(comment) = field.key_cursor().line_comment_raw() {
                                 write_line_comment(out, Some(comment))?;
                                 // Same anchor/tag rendering as the `else`
@@ -1915,10 +1921,10 @@ impl<'a, W: AsRef<[u64]>> YamlCursor<'a, W> {
                                     out,
                                     '\n',
                                     value.anchor(),
-                                    value.explicit_tag(),
+                                    value.explicit_tag_at(None),
                                 )?;
                             } else {
-                                write_anchor_tag(out, value.anchor(), value.explicit_tag())?;
+                                write_anchor_tag(out, value.anchor(), value.explicit_tag_at(None))?;
                             }
                             out.write_char('\n')?;
                             // #1485: steps from `recursion_base`, not
@@ -2059,7 +2065,11 @@ impl<'a, W: AsRef<[u64]>> YamlCursor<'a, W> {
                         let style = cursor.style();
                         if is_yaml_cursor_container(&cursor) && style != "flow" {
                             let anchor = cursor.anchor();
-                            let tag = cursor.explicit_tag();
+                            // #2619: `is_yaml_cursor_container` above already
+                            // proves `cursor` isn't `Alias` (structural, an
+                            // alias node is never a container), so `None`
+                            // skips a second resolve.
+                            let tag = cursor.explicit_tag_at(None);
                             if anchor.is_some() || tag.is_some() {
                                 out.write_char('-')?;
                                 write_anchor_tag(out, anchor, tag)?;
@@ -2524,20 +2534,23 @@ impl<'a, W: AsRef<[u64]>> YamlCursor<'a, W> {
         self.explicit_tag_at(Some(&self.value()))
     }
 
-    /// Internal sibling of [`Self::explicit_tag`] for the two write-path call
-    /// sites in this module that already know whether this cursor is an
-    /// alias without a fresh [`Self::value`] call (#1114 review, #2617). Not
-    /// `pub`, deliberately: unlike [`Self::stream_yaml_value_at`], where
-    /// `None` always falls back to a full resolve and so is unconditionally
-    /// safe, `None` here skips the alias check outright with no fallback --
-    /// safe only when the caller can already prove the cursor isn't an
-    /// alias (see call sites below), not a general-purpose default. Pass
-    /// `Some(&resolved)` when a prior `value()` call already produced it
-    /// (e.g. `write_deferred_value`'s `resolved` local on its `absent`
-    /// branch), or `None` only when that proof holds (e.g.
-    /// `write_yaml_child_inline`'s `container` branch: `is_container()` is a
-    /// structural bitvector check, and a container position can never be an
-    /// alias).
+    /// Internal sibling of [`Self::explicit_tag`] for this module's call
+    /// sites that already know whether this cursor is an alias without a
+    /// fresh [`Self::value`] call (#1114 review, #2617, #2619) -- both
+    /// write paths (e.g. `write_deferred_value`) and read/query paths
+    /// (e.g. `tag()`, `is_falsy`) alike; nothing about the proof is
+    /// specific to writing. Not `pub`, deliberately: unlike
+    /// [`Self::stream_yaml_value_at`], where `None` always falls back to a
+    /// full resolve and so is unconditionally safe, `None` here skips the
+    /// alias check outright with no fallback -- safe only when the caller
+    /// can already prove the cursor isn't an alias, not a general-purpose
+    /// default. Pass `Some(&resolved)` when a prior `value()` call already
+    /// produced it (e.g. `write_deferred_value`'s `resolved` local on its
+    /// `absent` branch), or `None` when the proof is purely structural --
+    /// either a matched `YamlValue::String` on this same cursor (an alias
+    /// node parses to `YamlValue::Alias`, never `String`), or
+    /// `is_container()`/`is_yaml_cursor_container()` (a bitvector check;
+    /// a container position can never be an alias).
     #[inline]
     fn explicit_tag_at(&self, known_value: Option<&YamlValue<'a, W>>) -> Option<&str> {
         if let Some(YamlValue::Alias { target, .. }) = known_value {
@@ -7398,7 +7411,10 @@ fn write_yaml_field_key<W: AsRef<[u64]>, Out: core::fmt::Write>(
     }
     let key = field.key();
     if let YamlValue::String(s) = &key {
-        if let Some(tag) = field.key_cursor().explicit_tag() {
+        // #2619: `field.key_cursor().value()` is `key`, already matched
+        // `String` just above -- `field.key_cursor()` returns a `Copy` of
+        // the same cursor, so `None` skips a second resolve.
+        if let Some(tag) = field.key_cursor().explicit_tag_at(None) {
             out.write_str(tag)?;
             out.write_char(' ')?;
         } else if matches!(s, YamlString::Unquoted { .. })
@@ -7700,7 +7716,9 @@ where
             let style = cursor.style();
             if is_yaml_cursor_container(&cursor) && style != "flow" {
                 let anchor = cursor.anchor();
-                let tag = cursor.explicit_tag();
+                // #2619: `is_yaml_cursor_container` above already proves
+                // `cursor` isn't `Alias`, so `None` skips a second resolve.
+                let tag = cursor.explicit_tag_at(None);
                 if anchor.is_some() || tag.is_some() {
                     out.write_char('-')?;
                     write_anchor_tag(out, anchor, tag)?;


### PR DESCRIPTION
## Summary

Follow-up to #2617/#2618's review. Both reviewers independently found that
the redundant-resolve shape #2617 fixed on the rare absent/container write
path recurs at several hotter call sites on this crate's "flagship
streaming path" (`stream_yaml_value_at`'s own doc comment) — sites that
already match a cursor's resolved value into `YamlValue::String`, proving
it isn't an alias, then call the un-optimized `explicit_tag()` anyway,
paying for a second full `value()` resolve just to re-derive a fact
already in hand.

## Change

Five call sites converted from `self.explicit_tag()` to
`self.explicit_tag_at(None)` — safe because each is inside a `match` arm
that has already matched `YamlValue::String`, structurally proving `self`
isn't `Alias` (the only variant `explicit_tag`'s internal check cares
about):

- `stream_yaml_value_at`'s `String` arm (`src/yaml/light.rs`)
- `stream_json_value`'s `String` arm
- `write_json_to`'s `String` arm
- `tag()`'s `String` arm
- `is_falsy`'s `String` arm

Unlike #2617's absent/container shape (rare), this fires for **every**
string-valued node these paths touch, tag present or not — the
overwhelming majority of real YAML scalars.

## Benchmark

Interleaved A/B (`scripts/ab-cli.py`) on the pinned boxes, `yq '.'` over a
5-60MB array of small records (`yaml generate -p users`, matching #1114's
own corpus shape):

- **M4 Pro (`johns-mac-mini`)**: -23.6% to -24.5% across all 3 sizes
  (median of medians -23.8%), 0/3 rows slower.
- **Zen 4 (`terminus`)**: -29.2% to -30.0% (median of medians -29.7%),
  0/3 rows slower.

Output byte-identical before/after in every run (ab-cli's identity gate).

## Testing

- Full suite: `cargo test --features cli` — all green, 0 failed.
- `cargo clippy --all-targets --all-features -- -D warnings` clean.
- Local patch coverage: 100% (5/5 new lines) — the existing regression
  suite already exercises every string-valued node through these paths,
  no new tests needed.

Closes #2619.