### PR TITLE
fix(jq): key/path followed by more stages no longer materializes the document

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`key`/`path` (no arg) followed by more pipe stages no longer falls back
+  to materializing the whole document once per element** (#2149, follow-up
+  to #2061). `.[] | key | tostring` (and any pipe shaped the same way,
+  provided nothing after `key`/`path` itself needs path context) used to
+  fail the fast cursor walk's static gate just because a stage followed
+  `key`/`path`, falling to a per-element `cursor_key` sibling scan that
+  costs O(position) per call -- O(n) calls, O(n^2) total. The gate
+  (`path_context_walk_split` in `src/jq/eval_generic.rs`) now recognizes a
+  navigational run ending on `key`/`path` as a walkable prefix too, the
+  same way it already recognized a single navigational first stage.
+  Live-verified: a 200,000-element array's `.[] | key | tostring` dropped
+  from ~131s user time to well under a second. A pipe with a *second*
+  `key`/`path`/`parent` after the first still falls back deliberately --
+  real yq's own answer for that shape doesn't settle into one coherent
+  rule to reproduce (`key | key` is empty, `key | (key + 100)` is a
+  constant unrelated to the element, `key | path` wraps the value itself,
+  all live-verified against v4.53.3).
 - **`succinctly yq`'s DOM output path now agrees with its streaming path on
   explicit tags and two Unicode separators** (#1982, Medium severity):
   1. **An explicit `!!str`/`!!int`/`!!bool`/`!!null` tag was silently lost

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -13761,7 +13761,7 @@ fn path_context_emitting_value<V: DocumentValue>(
             Some(key) => Ok(Some(key.clone())),
             None => Ok(None),
         },
-        _ => unreachable!("path_context_emitting_value called on a non-Key/PathNoArg expr"),
+        _ => unreachable!("path_context_emitting_value called on a non-Key/PathNoArg expr"), // omni-dev: coverage tolerate-line reason="unreachable: the sole caller (path_context_walk_generic's merged arm) only invokes this after matching Expr::Builtin(PathNoArg | Key) itself (#2149)"
     }
 }
 
@@ -13837,7 +13837,7 @@ fn path_context_walk_generic<S: EvalSemantics, V: DocumentValue>(
             match path_context_emitting_value(expr, pos) {
                 Ok(Some(v)) => Ok(sink(GenericItem::Owned(v))),
                 Ok(None) => Ok(Demand::Continue),
-                Err(e) => Err(Control::Error(e)),
+                Err(e) => Err(Control::Error(e)), // omni-dev: coverage tolerate-line reason="cursor_key's malformed-member-key error path, pre-existing before #2149's refactor merged this arm with PathNoArg's -- reachable only via the negative-index special case landing on an undecodable object key, not this fix's own scope"
             }
         }
         _ => {

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -13742,11 +13742,11 @@ fn path_component_step_expr(component: &OwnedValue) -> Option<Expr> {
     })
 }
 
-/// `key`/`path` (no arg)'s value at `pos` -- shared by
-/// `path_context_walk_generic`'s own terminal arm and
-/// `path_context_walk_pipe`'s emitting-stage-then-more-stages case (#2149).
-/// `Ok(None)` only for `key` at the document root, which emits nothing
-/// (see the caller's own doc comment for why).
+/// `key`/`path` (no arg)'s value at `pos` -- the sole caller is
+/// `path_context_walk_generic`'s own terminal arm, extracted only to keep
+/// that arm's body short once `PathNoArg`/`Key` were merged into one match
+/// arm (#2149). `Ok(None)` only for `key` at the document root, which
+/// emits nothing (see the caller's own doc comment for why).
 fn path_context_emitting_value<V: DocumentValue>(
     expr: &Expr,
     pos: &PathContextPos<V>,
@@ -13922,30 +13922,47 @@ fn path_context_walk_split(exprs: &[Expr]) -> Option<(&[Expr], &[Expr])> {
     Some((walked, rest))
 }
 
-/// (#2149) The length of a walkable prefix ending on `key`/`path` (no arg),
-/// for a pipe where that isn't already `exprs`'s bare first stage (the
-/// branch just above covers that case): a navigational run immediately
-/// followed by one emitting stage, with a `rest` that needs no path context
-/// of its own -- the same `!rest.iter().any(needs_path_context)` condition
-/// the first-stage-only branch already applies, generalized to a longer
-/// walked prefix.
+/// (#2149) The length of a walkable prefix ending on an emitting stage
+/// ([`path_context_is_cursor_walkable`] -- `key`/`path` bare or wrapped in
+/// `(..)`/`[..]`/a comma, exactly the shapes already admitted as a walkable
+/// pipe's *last* stage everywhere else in this file), for a pipe where that
+/// isn't already `exprs`'s bare first stage (the branch just above covers
+/// that case): a navigational run immediately followed by one such stage,
+/// with a `rest` that needs no path context of its own -- the same
+/// `!rest.iter().any(needs_path_context)` condition the first-stage-only
+/// branch already applies, generalized to a longer walked prefix. Reusing
+/// [`path_context_is_cursor_walkable`] rather than matching `Key`/
+/// `PathNoArg` directly matters: an earlier draft of this function did the
+/// latter and left `.[] | (key) | tostring` -- syntactically trivial to
+/// write, semantically identical to the fixed `.[] | key | tostring` --
+/// reproducing the exact O(n^2) blowup this fix exists to close, just one
+/// paren away (review caught this live: 0.04s vs 32.9s on a 100K-element
+/// array, byte-identical output either way).
 ///
 /// `rest` containing a *second* `key`/`path`/`parent` is refused rather
-/// than resolved: real yq's own answer for that shape does not settle into
-/// one coherent rule to reproduce (`key | key` is empty, `key | (key +
+/// than resolved -- not a judgment call but a structural one: the sink this
+/// walked prefix hands `rest` to ([`try_path_context_walk_sink`]/
+/// [`try_path_context_cursor_walk`]) evaluates it over the *plain emitted
+/// value*, with the cursor and trail already gone
+/// ([`path_context_pipe_is_walkable`]'s own doc: an emitting stage "may sit
+/// only as a pipe's *last* stage"), so a later path-context builtin has no
+/// position left to answer from regardless of what rule it should follow.
+/// (For what it's worth, real yq's own answer for that shape doesn't settle
+/// into one coherent rule either: `key | key` is empty, `key | (key +
 /// 100)` is a constant unrelated to the element, `key | path` wraps the
-/// value itself in an array -- all live-verified against v4.53.3), so it
-/// stays on the bridge, matching this function's own one-directional
-/// contract (declining costs an optimization, never an answer).
+/// value itself in an array -- all live-verified against v4.53.3 -- so
+/// there would be nothing to reproduce here even with a position to answer
+/// from.) Matching this function's own one-directional contract (declining
+/// costs an optimization, never an answer), the shape stays on the bridge.
 fn path_context_walked_emitting_prefix_len(exprs: &[Expr]) -> Option<usize> {
     let idx = exprs
         .iter()
         .position(|stage| !path_context_is_navigational(stage))?;
-    if idx == 0 || !matches!(exprs[idx], Expr::Builtin(Builtin::PathNoArg | Builtin::Key)) {
+    if !path_context_is_cursor_walkable(&exprs[idx]) {
         return None;
     }
     let rest = &exprs[idx + 1..];
-    if rest.is_empty() || rest.iter().any(needs_path_context) {
+    if rest.iter().any(needs_path_context) {
         return None;
     }
     Some(idx + 1)

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -13761,7 +13761,10 @@ fn path_context_emitting_value<V: DocumentValue>(
             Some(key) => Ok(Some(key.clone())),
             None => Ok(None),
         },
-        _ => unreachable!("path_context_emitting_value called on a non-Key/PathNoArg expr"), // omni-dev: coverage tolerate-line reason="unreachable: the sole caller (path_context_walk_generic's merged arm) only invokes this after matching Expr::Builtin(PathNoArg | Key) itself (#2149)"
+        // Unreachable: the sole caller (path_context_walk_generic's merged
+        // arm) only invokes this after matching
+        // `Expr::Builtin(PathNoArg | Key)` itself.
+        _ => unreachable!("path_context_emitting_value called on a non-Key/PathNoArg expr"),
     }
 }
 
@@ -13837,7 +13840,9 @@ fn path_context_walk_generic<S: EvalSemantics, V: DocumentValue>(
             match path_context_emitting_value(expr, pos) {
                 Ok(Some(v)) => Ok(sink(GenericItem::Owned(v))),
                 Ok(None) => Ok(Demand::Continue),
-                Err(e) => Err(Control::Error(e)), // omni-dev: coverage tolerate-line reason="cursor_key's malformed-member-key error path, pre-existing before #2149's refactor merged this arm with PathNoArg's -- reachable only via the negative-index special case landing on an undecodable object key, not this fix's own scope"
+                // `cursor_key`'s malformed-member-key error path, pre-existing
+                // before this refactor merged this arm with `PathNoArg`'s.
+                Err(e) => Err(Control::Error(e)),
             }
         }
         _ => {

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -13742,6 +13742,29 @@ fn path_component_step_expr(component: &OwnedValue) -> Option<Expr> {
     })
 }
 
+/// `key`/`path` (no arg)'s value at `pos` -- shared by
+/// `path_context_walk_generic`'s own terminal arm and
+/// `path_context_walk_pipe`'s emitting-stage-then-more-stages case (#2149).
+/// `Ok(None)` only for `key` at the document root, which emits nothing
+/// (see the caller's own doc comment for why).
+fn path_context_emitting_value<V: DocumentValue>(
+    expr: &Expr,
+    pos: &PathContextPos<V>,
+) -> Result<Option<OwnedValue>, EvalError> {
+    match expr {
+        Expr::Builtin(Builtin::PathNoArg) => Ok(Some(OwnedValue::Array(pos.path.clone()))),
+        Expr::Builtin(Builtin::Key) => match pos.path.last() {
+            Some(OwnedValue::Int(i)) if *i < 0 => match &pos.node {
+                PathNode::At(c) => cursor_key(c),
+                _ => Ok(Some(OwnedValue::Int(*i))),
+            },
+            Some(key) => Ok(Some(key.clone())),
+            None => Ok(None),
+        },
+        _ => unreachable!("path_context_emitting_value called on a non-Key/PathNoArg expr"),
+    }
+}
+
 /// Walk one emitting expression from `pos`, delivering each output to `sink`
 /// as it is produced.
 ///
@@ -13793,13 +13816,11 @@ fn path_context_walk_generic<S: EvalSemantics, V: DocumentValue>(
             walked?;
             Ok(sink(GenericItem::Owned(OwnedValue::Array(items))))
         }
-        Expr::Builtin(Builtin::PathNoArg) => Ok(sink(GenericItem::Owned(OwnedValue::Array(
-            pos.path.clone(),
-        )))),
         // `key` at the document root emits nothing: real yq prints nothing
         // there (#2421, captured live from v4.53.3), and jq has no `key` at
         // all, so its jq-mode extension follows yq. (The eager evaluator's
-        // `null` is #2421's remaining half.)
+        // `null` is #2421's remaining half.) `path` never has this case --
+        // the root's own path is `[]`, not absent.
         //
         // `key` is a property of the *node* (ADR-0021 decision 2) and the
         // trail's last component normally spells it, so reading the trail is
@@ -13810,19 +13831,15 @@ fn path_context_walk_generic<S: EvalSemantics, V: DocumentValue>(
         // is `1`, which is what yq v4.53.3 answers for `.c[-1] | key` on
         // `c: [10, 20]` (captured live; `[20,1]`, and `[10,0]` for `-2`).
         // Only then is the sibling scan paid, so `[.[] | key]` keeps its
-        // per-element constant.
-        Expr::Builtin(Builtin::Key) => match pos.path.last() {
-            Some(OwnedValue::Int(i)) if *i < 0 => match &pos.node {
-                PathNode::At(c) => match cursor_key(c) {
-                    Ok(Some(k)) => Ok(sink(GenericItem::Owned(k))),
-                    Ok(None) => Ok(Demand::Continue),
-                    Err(e) => Err(Control::Error(e)),
-                },
-                _ => Ok(sink(GenericItem::Owned(OwnedValue::Int(*i)))),
-            },
-            Some(key) => Ok(sink(GenericItem::Owned(key.clone()))),
-            None => Ok(Demand::Continue),
-        },
+        // per-element constant. Shared with `path_context_walk_pipe`'s own
+        // `Key`/`PathNoArg`-then-more-stages case (#2149).
+        Expr::Builtin(Builtin::PathNoArg | Builtin::Key) => {
+            match path_context_emitting_value(expr, pos) {
+                Ok(Some(v)) => Ok(sink(GenericItem::Owned(v))),
+                Ok(None) => Ok(Demand::Continue),
+                Err(e) => Err(Control::Error(e)),
+            }
+        }
         _ => {
             let mut heads = Vec::new();
             let stepped = path_context_step_generic::<S, V>(expr, pos, &mut heads);
@@ -13867,10 +13884,14 @@ fn path_context_walk_pipe<S: EvalSemantics, V: DocumentValue>(
 /// whole pipe to the materializing bridge. Decided entirely before any
 /// output, which is what lets the walk emit to a sink at all.
 ///
-/// Two shapes are walked: every stage (then `rest` is empty), or just the
-/// first stage when nothing after it needs path context. A pipe whose first
-/// stage is walkable but whose later stages need path context in a way the
-/// walk does not model (`.a | key | tostring`) goes to the bridge whole.
+/// Three shapes are walked: every stage (then `rest` is empty); just the
+/// first stage when nothing after it needs path context; or (#2149) a
+/// longer navigational run ending on `key`/`path` (no arg), again when
+/// nothing after it needs path context -- `.a | key | tostring` no longer
+/// goes to the bridge whole just because `tostring` follows `key`; only a
+/// *second* path-context builtin in `rest` still does (see
+/// [`path_context_walked_emitting_prefix_len`]'s own doc for why that
+/// narrower shape stays refused).
 ///
 /// A fan-out head used to be refused here and left to the eager evaluator,
 /// on the grounds that materializing a node per branch is a backward jump
@@ -13890,9 +13911,39 @@ fn path_context_walk_split(exprs: &[Expr]) -> Option<(&[Expr], &[Expr])> {
     } else if path_context_is_cursor_walkable(first) && !exprs[1..].iter().any(needs_path_context) {
         (&exprs[..1], &exprs[1..])
     } else {
-        return None;
+        let len = path_context_walked_emitting_prefix_len(exprs)?;
+        (&exprs[..len], &exprs[len..])
     };
     Some((walked, rest))
+}
+
+/// (#2149) The length of a walkable prefix ending on `key`/`path` (no arg),
+/// for a pipe where that isn't already `exprs`'s bare first stage (the
+/// branch just above covers that case): a navigational run immediately
+/// followed by one emitting stage, with a `rest` that needs no path context
+/// of its own -- the same `!rest.iter().any(needs_path_context)` condition
+/// the first-stage-only branch already applies, generalized to a longer
+/// walked prefix.
+///
+/// `rest` containing a *second* `key`/`path`/`parent` is refused rather
+/// than resolved: real yq's own answer for that shape does not settle into
+/// one coherent rule to reproduce (`key | key` is empty, `key | (key +
+/// 100)` is a constant unrelated to the element, `key | path` wraps the
+/// value itself in an array -- all live-verified against v4.53.3), so it
+/// stays on the bridge, matching this function's own one-directional
+/// contract (declining costs an optimization, never an answer).
+fn path_context_walked_emitting_prefix_len(exprs: &[Expr]) -> Option<usize> {
+    let idx = exprs
+        .iter()
+        .position(|stage| !path_context_is_navigational(stage))?;
+    if idx == 0 || !matches!(exprs[idx], Expr::Builtin(Builtin::PathNoArg | Builtin::Key)) {
+        return None;
+    }
+    let rest = &exprs[idx + 1..];
+    if rest.is_empty() || rest.iter().any(needs_path_context) {
+        return None;
+    }
+    Some(idx + 1)
 }
 
 /// Whether a pipe carrying path context streams cursors end to end: the
@@ -29257,8 +29308,21 @@ mod tests {
         // path context at all is the callers' question, asked before the
         // split; a plain `.a | tostring` never reaches it.)
         assert_eq!(split("(.a | key) | tostring"), Some((1, 1)));
-        // Nothing: the tail needs path context the walk cannot give it.
-        assert_eq!(split(".a | key | tostring"), None);
+        // #2149: the walk takes `key`/`path` (no arg) followed by more
+        // stages too, as long as the tail needs no path context of its own
+        // -- `.a | key | tostring` no longer goes to the bridge whole just
+        // because `tostring` follows `key` (the O(n^2) shape the issue
+        // reported: on a 200K-element array, `.[] | key | tostring` fell
+        // to the materializing bridge once per element).
+        assert_eq!(split(".a | key | tostring"), Some((2, 1)));
+        // Nothing: a *second* path-context builtin in the tail still isn't
+        // resolved -- real yq's own answer for that shape doesn't settle
+        // into one coherent rule (live-verified against v4.53.3: `key |
+        // key` is empty, `key | (key + 100)` is a constant unrelated to
+        // the element, `key | path` wraps the value itself), so it's left
+        // on the bridge rather than guessed at.
+        assert_eq!(split(".a | key | key"), None);
+        assert_eq!(split(".a | key | (key + 1)"), None);
         // A fan-out that materializes a node per branch is walked too since
         // spine 2416's exit; it used to be refused here.
         assert_eq!(split(".[] | .k | parent"), Some((3, 0)));
@@ -29443,11 +29507,24 @@ mod tests {
         assert!(!eager(".a.b | select(key == \"b\")"));
         assert!(!eager(".a | select(true) | key"));
         assert!(!eager(".a.b | if key == \"b\" then 1 else 2 end"));
-        assert!(!eager(".a.b | key | tostring"));
-        // `[key, path]` has no row here: the *walk* takes it end to end
-        // (`path_context_is_cursor_walkable` admits `[..]`, and its fan-out
-        // is paths-only), so it never reached the eager evaluator to begin
-        // with -- `path_context_absent_split` leaves those alone.
+        // `.a.b | key | tostring` has no row here either, as of #2149: the
+        // *walk* now takes `key`/`path` followed by a `rest` needing no
+        // path context of its own end to end
+        // (`path_context_walk_split`), so `path_context_absent_split`
+        // defers to it (its own guard, "if `path_context_walk_split`
+        // succeeds, return `None`") and this function is never reached for
+        // it in real dispatch either (`path_context_single_native`'s own
+        // `Expr::Pipe` arm checks `path_context_walk_split(exprs).is_some()`
+        // before this function, short-circuiting `||`). Calling `eager`
+        // directly on it, bypassing that ordering, now answers `true` --
+        // not a regression, just this pinned function's own isolated
+        // answer for an input no real caller reaches it with anymore,
+        // exactly the caveat this test's own header comment states.
+        //
+        // `[key, path]` has no row here either: the *walk* takes it end to
+        // end (`path_context_is_cursor_walkable` admits `[..]`, and its
+        // fan-out is paths-only), so it never reached the eager evaluator
+        // to begin with -- `path_context_absent_split` leaves those alone.
         assert!(
             !eager(".a[] | select(true) | key"),
             "iterate cannot yield absent"

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -21532,6 +21532,52 @@ fn test_def_shadow_deep_nesting_does_not_blow_up_2036() -> Result<()> {
     Ok(())
 }
 
+/// #2149: `key`/`path` (no arg) followed by more stages in the same pipe
+/// used to refuse the fast cursor walk entirely and fall back to
+/// materializing the whole document once per element -- `cursor_key`'s
+/// array arm answers "what index am I" with a sibling scan from the
+/// array's first element every time, so `.[] | key | tostring` cost
+/// O(position) per element, O(n) calls, O(n^2) total. Live-verified
+/// before the fix: a 200,000-element array took ~131s user time for
+/// `.[] | key | tostring` against ~0.6s for `.[] | key` alone -- a ~220x
+/// slowdown from one stage, confirming O(n^2) rather than a constant-factor
+/// cost (a ~100x growth in input size should cost ~100x more for O(n), but
+/// cost ~10,000x more for O(n^2); the actual ~131s/0.6s stands in between
+/// because `.[] | key` alone is not the true O(n) baseline for this
+/// comparison, only a sibling data point). Pinned as a timing regression
+/// guard, the same shape `test_def_shadow_deep_nesting_does_not_blow_up_2036`
+/// uses: a size a true O(n^2) blowup would multiply into tens of seconds,
+/// generous margin against a working O(n) fix.
+#[test]
+fn test_key_then_more_stages_does_not_blow_up_2149() -> Result<()> {
+    let n = 100_000;
+    let input = format!(
+        "[{}]",
+        (0..n)
+            .map(|i| format!("{{\"a\":{i}}}"))
+            .collect::<Vec<_>>()
+            .join(",")
+    );
+    let start = std::time::Instant::now();
+    let (stdout, stderr, code) = run_jq_full(&["-c", ".[] | key | tostring"], Some(&input))?;
+    let elapsed = start.elapsed();
+    assert_eq!(code, 0, "stderr: {stderr:?}");
+    let lines: Vec<&str> = stdout.trim_end().lines().collect();
+    assert_eq!(lines.len(), n);
+    assert_eq!(lines[0], "\"0\"");
+    assert_eq!(lines[n - 1], format!("\"{}\"", n - 1));
+    // See this test's own doc comment: a true O(n^2) regression at this
+    // size would cost tens of seconds, not merely approach this bound --
+    // extrapolating the live pre-fix measurement (~131s at 200,000
+    // elements) to 100,000 elements is ~33s. A working O(n) fix finishes
+    // in well under a second even under CI contention.
+    assert!(
+        elapsed < std::time::Duration::from_secs(15),
+        "{n} elements of `.[] | key | tostring` took {elapsed:?} -- O(n^2) regressed"
+    );
+    Ok(())
+}
+
 /// #2036 review, round 2: a genuinely empty `NAME()` must stay a syntax
 /// error even once `NAME` is a shadow candidate -- an earlier draft's
 /// arity-mismatch fallback (`Self::parse_func_call_or_error`) accepted `()`

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -21578,6 +21578,41 @@ fn test_key_then_more_stages_does_not_blow_up_2149() -> Result<()> {
     Ok(())
 }
 
+/// #2149 review: an earlier draft of the fix matched the emitting stage
+/// with a bare `Expr::Builtin(Key | PathNoArg)` pattern instead of the
+/// file's own general `path_context_is_cursor_walkable` predicate (which
+/// already treats `(key)`/`[key]`/`(key, path)` as equally walkable
+/// wherever an emitting stage is accepted elsewhere in this gate) --
+/// leaving `.[] | (key) | tostring`, one paren away from the shape
+/// `test_key_then_more_stages_does_not_blow_up_2149` pins, reproducing the
+/// exact same O(n^2) blowup: live-verified during review at 0.04s (fixed)
+/// vs 32.9s (the narrower draft) on a 100,000-element array, byte-identical
+/// output either way. Pinned the same way as its sibling test.
+#[test]
+fn test_parenthesized_key_then_more_stages_does_not_blow_up_2149() -> Result<()> {
+    let n = 100_000;
+    let input = format!(
+        "[{}]",
+        (0..n)
+            .map(|i| format!("{{\"a\":{i}}}"))
+            .collect::<Vec<_>>()
+            .join(",")
+    );
+    let start = std::time::Instant::now();
+    let (stdout, stderr, code) = run_jq_full(&["-c", ".[] | (key) | tostring"], Some(&input))?;
+    let elapsed = start.elapsed();
+    assert_eq!(code, 0, "stderr: {stderr:?}");
+    let lines: Vec<&str> = stdout.trim_end().lines().collect();
+    assert_eq!(lines.len(), n);
+    assert_eq!(lines[0], "\"0\"");
+    assert_eq!(lines[n - 1], format!("\"{}\"", n - 1));
+    assert!(
+        elapsed < std::time::Duration::from_secs(15),
+        "{n} elements of `.[] | (key) | tostring` took {elapsed:?} -- O(n^2) regressed"
+    );
+    Ok(())
+}
+
 /// #2036 review, round 2: a genuinely empty `NAME()` must stay a syntax
 /// error even once `NAME` is a shadow candidate -- an earlier draft's
 /// arity-mismatch fallback (`Self::parse_func_call_or_error`) accepted `()`


### PR DESCRIPTION
## Summary

`key`/`path` (no arg) followed by more pipe stages used to fail the fast
cursor walk's static gate just because *something* followed it, falling
back to materializing the whole document once per element.

```console
$ succinctly jq -c '.[] | key' big.json        # 200,000-element array: ~0.6s
$ succinctly jq -c '.[] | key | tostring' big.json   # ~131s user time
```

At 20,000 elements the same query took 1.32s; at 200,000, 131s -- a ~10x
input growth costing ~100x more time, confirming O(n²).

## Root cause

`cursor_key`'s array arm answers "what index am I" with a sibling scan
from the array's first element every time -- O(position) per call. Once
`path_context_walk_split` refuses a pipe (because something needs path
context after `key`/`path`), every element gets evaluated individually
through this path, so the O(n) calls x O(position) per call become O(n²)
total. `.[] | key` alone avoids this because the walk's own `Iterate` step
already assigns each element's index during its single forward pass, for
free.

## Fix

`path_context_walk_split` (`src/jq/eval_generic.rs`) now recognizes a
navigational run ending on `key`/`path` as a walkable prefix too, the same
way it already recognized a single navigational first stage -- as long as
`rest` (the stages after `key`/`path`) needs no path context of its own.
The walk answers `key`/`path`'s value directly (no `cursor_key` scan at
all in this shape) and hands `rest` to the ordinary fold, exactly like the
pre-existing single-stage case.

**Deliberately not attempted**: the issue's own "part 2" suggestion (a
*second* `key`/`path` later in the same pipe answering from the same
ambient position). Live-verified against yq v4.53.3 first: `key | key` is
empty, `key | (key + 100)` is a constant unrelated to the element, `key |
path` wraps the value itself in an array -- real yq's own answer doesn't
settle into one coherent rule worth reproducing, so that shape stays on
the bridge exactly as before (unchanged output, confirmed against a
pre-fix build across ~10 such shapes).

## Testing

- New regression test (`tests/jq_cli_tests.rs`,
  `test_key_then_more_stages_does_not_blow_up_2149`): 100,000-element
  array, `.[] | key | tostring`, output checked plus a generous 15s timing
  guard (a true O(n²) regression at this size would cost tens of seconds
  by extrapolation from the live pre-fix measurement).
- Updated two existing unit tests whose assertions pinned the old,
  narrower gate behavior (`path_context_walk_split_takes_whole_head_or_nothing_2416`,
  `path_context_needs_owned_position_pins_its_reasons_2416`) -- both
  legitimate drift from widening the gate, not regressions (traced and
  explained in the updated test comments).
- Manually diffed ~28 pipe shapes (jq and yq mode, JSON and YAML) between
  a pre-fix and post-fix build, including the "second key/path" shapes
  above -- all byte-identical except the one shape this PR targets.
- Full suite: `cargo test --features cli` -- all green, 0 failed.
- `cargo clippy --all-targets --all-features -- -D warnings` clean.
- Local patch coverage: 94.44% (34/36 new lines). The 2 uncovered lines
  are (a) a by-construction-unreachable `unreachable!()` fallback arm in a
  helper whose only caller already matched the same pattern, and (b)
  `cursor_key`'s malformed-member-key error propagation, pre-existing
  logic this PR only moved into a shared helper, not new behavior --
  reaching it requires a document malformation orthogonal to this fix.

Closes #2149.