### PR TITLE
perf(yq): expose explicit_tag_at as pub, reuse it in two more converters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -293,6 +293,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   9-site version; the originally-measured 5-site subset on that box read
   -29.2% to -30.0%, which the added sites are not expected to reduce.
   Output byte-identical before/after in every run.
+- **Reused the same `explicit_tag_at` fix at two more call sites outside
+  `yaml::light`** (#2621, follow-up to #2619's own review): `src/jq/
+  eval.rs`'s `yaml_value_to_owned_checked` and the `succinctly` binary's
+  `yaml_to_owned_value` (owned-value/DOM conversion, e.g. `-P`, `load()`)
+  had the identical redundant `explicit_tag()` resolve on an
+  already-proven-non-alias cursor. `explicit_tag_at` is now `pub` (it
+  needed to reach a separate binary crate, not just another module in the
+  same crate) and both sites call it. Unlike the streaming paths #2619
+  closed, this one measured as noise on both pinned boxes (interleaved
+  manual A/B, `yq -P '.'` over a 20MB array of small records): effectively
+  flat on M4 Pro, a hair slower within noise on Zen 4. DOM conversion's own
+  allocation cost (`IndexMap`/`Vec`/`String` construction per node)
+  dwarfs a single skipped cursor resolve here, unlike the allocation-light
+  streaming write path. Landed anyway for the same reason #1114's
+  redundancy was worth finding in the first place -- a genuine, provably
+  unnecessary resolve, now closed everywhere in the crate it's reachable
+  from -- not for a performance claim this workload doesn't support.
+  Output byte-identical before/after in every run.
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -308,8 +308,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   dwarfs a single skipped cursor resolve here, unlike the allocation-light
   streaming write path. Landed anyway for the same reason #1114's
   redundancy was worth finding in the first place -- a genuine, provably
-  unnecessary resolve, now closed everywhere in the crate it's reachable
-  from -- not for a performance claim this workload doesn't support.
+  unnecessary resolve -- not for a performance claim this workload doesn't
+  support. One more site with the same shape remains, behind the generic
+  `DocumentCursor` trait rather than a concrete `YamlCursor`
+  (`eval_generic.rs`'s `yq_type_tag`); closing it needs the same accessor
+  added to the trait, a larger change than this follow-up's own scope.
   Output byte-identical before/after in every run.
 
 ### Removed

--- a/src/bin/succinctly/yq_runner.rs
+++ b/src/bin/succinctly/yq_runner.rs
@@ -841,8 +841,8 @@ fn yaml_to_owned_value<W: AsRef<[u64]>>(cursor: YamlCursor<'_, W>) -> Result<Own
             let mut arr = Vec::new();
             let mut rest = elements;
             // `uncons_resolved_cursor`, not `uncons_cursor`: the recursive
-            // call's own `cursor.explicit_tag()` above doesn't resolve a
-            // bare `-` sequence-item wrapper itself (see
+            // call's own `cursor.explicit_tag_at(None)` above doesn't
+            // resolve a bare `-` sequence-item wrapper itself (see
             // `YamlCursor::anchor`'s doc comment for why), so an
             // unresolved cursor here would silently drop an explicit tag
             // on a bare-dash-deferred scalar (#835).

--- a/src/bin/succinctly/yq_runner.rs
+++ b/src/bin/succinctly/yq_runner.rs
@@ -792,7 +792,10 @@ fn yaml_to_owned_value<W: AsRef<[u64]>>(cursor: YamlCursor<'_, W>) -> Result<Own
                 .as_str()
                 .map_err(|e| anyhow::anyhow!("invalid YAML string: {e}"))?;
 
-            if let Some(explicit) = cursor.explicit_tag() {
+            // #2621: `cursor.value()` above already proved `cursor` isn't
+            // `Alias` by matching `String`, so `None` skips a second
+            // resolve.
+            if let Some(explicit) = cursor.explicit_tag_at(None) {
                 if let Some(resolved) = resolve_tagged(&str_value, explicit) {
                     return Ok(resolved.to_owned_value_for_json_bridge(str_value));
                 }

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -41027,10 +41027,10 @@ fn yaml_value_to_owned_checked<W: Clone + AsRef<[u64]>>(
         YamlValue::Sequence(mut elements) => {
             let mut items = Vec::new();
             // `uncons_resolved_cursor`, not `uncons_cursor`: the recursive
-            // call's own `cursor.explicit_tag()` above doesn't resolve a
-            // bare `-` sequence-item wrapper itself, so an unresolved
-            // cursor here would silently drop an explicit tag on a
-            // bare-dash-deferred scalar loaded via the `load()` builtin
+            // call's own `cursor.explicit_tag_at(None)` above doesn't
+            // resolve a bare `-` sequence-item wrapper itself, so an
+            // unresolved cursor here would silently drop an explicit tag
+            // on a bare-dash-deferred scalar loaded via the `load()` builtin
             // (#835).
             while let Some((elem_cursor, rest)) = elements.uncons_resolved_cursor() {
                 items.push(yaml_value_to_owned_checked(elem_cursor)?);

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -41007,7 +41007,10 @@ fn yaml_value_to_owned_checked<W: Clone + AsRef<[u64]>>(
                 Err(e) => return Err(EvalError::decode_failure(e.message())),
             };
 
-            if let Some(explicit) = cursor.explicit_tag() {
+            // #2621: `cursor.value()` above already proved `cursor` isn't
+            // `Alias` by matching `String`, so `None` skips a second
+            // resolve.
+            if let Some(explicit) = cursor.explicit_tag_at(None) {
                 if let Some(resolved) = resolve_tagged(&str_value, explicit) {
                     return Ok(resolved.to_owned_value(str_value));
                 }

--- a/src/yaml/light.rs
+++ b/src/yaml/light.rs
@@ -2534,25 +2534,27 @@ impl<'a, W: AsRef<[u64]>> YamlCursor<'a, W> {
         self.explicit_tag_at(Some(&self.value()))
     }
 
-    /// Internal sibling of [`Self::explicit_tag`] for this module's call
-    /// sites that already know whether this cursor is an alias without a
-    /// fresh [`Self::value`] call (#1114 review, #2617, #2619) -- both
-    /// write paths (e.g. `write_deferred_value`) and read/query paths
-    /// (e.g. `tag()`, `is_falsy`) alike; nothing about the proof is
-    /// specific to writing. Not `pub`, deliberately: unlike
-    /// [`Self::stream_yaml_value_at`], where `None` always falls back to a
-    /// full resolve and so is unconditionally safe, `None` here skips the
-    /// alias check outright with no fallback -- safe only when the caller
-    /// can already prove the cursor isn't an alias, not a general-purpose
-    /// default. Pass `Some(&resolved)` when a prior `value()` call already
-    /// produced it (e.g. `write_deferred_value`'s `resolved` local on its
-    /// `absent` branch), or `None` when the proof is purely structural --
-    /// either a matched `YamlValue::String` on this same cursor (an alias
-    /// node parses to `YamlValue::Alias`, never `String`), or
-    /// `is_container()`/`is_yaml_cursor_container()` (a bitvector check;
-    /// a container position can never be an alias).
+    /// Sibling of [`Self::explicit_tag`] for a caller that already knows
+    /// whether this cursor is an alias without a fresh [`Self::value`] call
+    /// (#1114 review, #2617, #2619, #2621) -- write paths (e.g.
+    /// `write_deferred_value`), read/query paths (e.g. `tag()`,
+    /// `is_falsy`), and cross-crate owned-value conversion (e.g.
+    /// `src/jq/eval.rs`'s `yaml_value_to_owned_checked`, the `succinctly`
+    /// binary's own `yaml_to_owned_value`) alike; nothing about the proof
+    /// is specific to any one of those. `pub`, but **not** a
+    /// general-purpose default: unlike [`Self::stream_yaml_value_at`],
+    /// where `None` always falls back to a full resolve and so is
+    /// unconditionally safe, `None` here skips the alias check outright
+    /// with no fallback -- safe only when the caller can already prove the
+    /// cursor isn't an alias. Pass `Some(&resolved)` when a prior
+    /// `value()` call already produced it (e.g. `write_deferred_value`'s
+    /// `resolved` local on its `absent` branch), or `None` when the proof
+    /// is purely structural -- either a matched `YamlValue::String` on
+    /// this same cursor (an alias node parses to `YamlValue::Alias`, never
+    /// `String`), or `is_container()`/`is_yaml_cursor_container()` (a
+    /// bitvector check; a container position can never be an alias).
     #[inline]
-    fn explicit_tag_at(&self, known_value: Option<&YamlValue<'a, W>>) -> Option<&str> {
+    pub fn explicit_tag_at(&self, known_value: Option<&YamlValue<'a, W>>) -> Option<&str> {
         if let Some(YamlValue::Alias { target, .. }) = known_value {
             // Not `target.and_then(|t| t.explicit_tag())`: `t` is a local
             // `YamlCursor` moved into the closure, so a call through `&t`

--- a/src/yaml/light.rs
+++ b/src/yaml/light.rs
@@ -2535,24 +2535,32 @@ impl<'a, W: AsRef<[u64]>> YamlCursor<'a, W> {
     }
 
     /// Sibling of [`Self::explicit_tag`] for a caller that already knows
-    /// whether this cursor is an alias without a fresh [`Self::value`] call
-    /// (#1114 review, #2617, #2619, #2621) -- write paths (e.g.
-    /// `write_deferred_value`), read/query paths (e.g. `tag()`,
-    /// `is_falsy`), and cross-crate owned-value conversion (e.g.
-    /// `src/jq/eval.rs`'s `yaml_value_to_owned_checked`, the `succinctly`
-    /// binary's own `yaml_to_owned_value`) alike; nothing about the proof
-    /// is specific to any one of those. `pub`, but **not** a
-    /// general-purpose default: unlike [`Self::stream_yaml_value_at`],
-    /// where `None` always falls back to a full resolve and so is
-    /// unconditionally safe, `None` here skips the alias check outright
-    /// with no fallback -- safe only when the caller can already prove the
-    /// cursor isn't an alias. Pass `Some(&resolved)` when a prior
-    /// `value()` call already produced it (e.g. `write_deferred_value`'s
-    /// `resolved` local on its `absent` branch), or `None` when the proof
-    /// is purely structural -- either a matched `YamlValue::String` on
-    /// this same cursor (an alias node parses to `YamlValue::Alias`, never
-    /// `String`), or `is_container()`/`is_yaml_cursor_container()` (a
-    /// bitvector check; a container position can never be an alias).
+    /// whether this cursor is an alias, without paying for a fresh
+    /// [`Self::value`] call just to make that same check again.
+    ///
+    /// `#[doc(hidden)]`: `pub`, not `pub(crate)`, only because
+    /// `src/bin/succinctly/*` compiles as a separate crate from this
+    /// library and needs to reach this from `yaml_to_owned_value`
+    /// (`pub(crate)` cannot cross that boundary) -- not intended as public
+    /// library API (#2621), the same reason
+    /// [`crate::jq::eval_generic::path_context_pipe_streams_cursors`] is
+    /// `#[doc(hidden)]` too.
+    ///
+    /// **Not a general-purpose default -- passing `None` is only safe when
+    /// the caller can already prove this cursor isn't
+    /// [`YamlValue::Alias`]** (a matched `YamlValue::String`/`Null`/etc. on
+    /// this same cursor's own [`Self::value`], or a structural check such
+    /// as [`Self::is_container`] -- a container position can never be an
+    /// alias -- never by assumption). Unless you already have such a
+    /// proof in hand, call [`Self::explicit_tag`] instead. Passing `None`
+    /// without that proof does not panic: on an actual alias node it
+    /// silently returns the wrong tag (the alias node's own absent one,
+    /// rather than resolving through to the anchor's), which is a real,
+    /// hard-to-notice correctness bug, not a crash you'd catch in testing.
+    ///
+    /// Pass `Some(&resolved)` when a prior [`Self::value`] call already
+    /// produced it, or `None` only once that non-alias proof holds.
+    #[doc(hidden)]
     #[inline]
     pub fn explicit_tag_at(&self, known_value: Option<&YamlValue<'a, W>>) -> Option<&str> {
         if let Some(YamlValue::Alias { target, .. }) = known_value {


### PR DESCRIPTION
## Summary

Follow-up to #2619's own review, which listed two more sites with the
identical redundant-resolve shape but flagged them as needing a visibility
decision first rather than a drop-in swap:

- `src/jq/eval.rs`'s `yaml_value_to_owned_checked`
- the `succinctly` binary's own `yaml_to_owned_value`
  (`src/bin/succinctly/yq_runner.rs`)

Both match `cursor.value()` into `YamlValue::String` (proving non-`Alias`),
then call the un-optimized `explicit_tag()` anyway, paying for a second
resolve.

## Why this needed a visibility change

`explicit_tag_at` was module-private as of #2618's own review (added `pub`
originally with no real caller, found to be a footgun, narrowed back).
`src/jq/eval.rs` is in the same crate as `yaml::light`, so `pub(crate)`
would have reached it — but `src/bin/succinctly/yq_runner.rs` is part of
the **separate** `succinctly` binary crate, consuming the library only
through its `pub` surface (`use succinctly::yaml::{...}`). `pub(crate)`
would not have reached it. `explicit_tag_at` is now `pub`, with its
existing safety-contract doc comment (the `None` case requires the caller
to already have proof of non-`Alias`; unlike `stream_yaml_value_at`,
there's no fallback resolve) extended to name both new callers alongside
the module-internal ones.

## Benchmark

Unlike #2619's streaming paths, this one measured as **noise on both
pinned boxes** (interleaved manual A/B, `yq -P '.'` — the DOM-forcing flag
that reaches these converters — over a 20MB array of small records):
effectively flat on `johns-mac-mini` M4 Pro (7 reps, mixed sign, ~1%
band), a hair slower within noise on `terminus` Zen 4 (7 reps, ~1% band,
also mixed relative to run-to-run variance). Output byte-identical before
and after in every run.

This is expected, not a red flag: DOM/owned-value conversion allocates a
`String`/`Vec`/`IndexMap` per node, which dwarfs a single skipped cursor
resolve — a very different cost profile from the allocation-light
streaming write path #2619 optimized. Landed anyway for the same reason
the redundancy was worth finding in the first place: it's a genuine,
provably unnecessary resolve, now closed everywhere in the crate it's
reachable from, not landed on a performance claim this particular
workload doesn't support (documented honestly in the CHANGELOG entry
rather than inflated).

## Testing

- Full suite: `cargo test --features cli` — all green, 0 failed.
- `cargo clippy --all-targets --all-features -- -D warnings` clean.
- Local patch coverage: 100% (3/3 new lines).
- Confirmed the binary crate actually compiles against the new `pub`
  surface (`cargo build --features cli` builds both the lib and the
  `succinctly` binary target).

Closes #2621.