### PR TITLE
fix(jq): gate Expr::Compare on needs_path_context so a malformed document raises

### DIFF
--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -6546,7 +6546,43 @@ fn eval_single<S: EvalSemantics, V: DocumentValue>(
         // so `("A"|stderr) == (("B"|stderr), ("C"|stderr))` now writes
         // `B A C A`, matching jq, instead of finishing right first (`B C A
         // A`).
-        Expr::Compare { op, left, right } => {
+        //
+        // **Gated on `needs_path_context`, like the `Expr::Arithmetic`/
+        // `Expr::And`/`Expr::Or` arms below** (#2581). This arm was ungated
+        // until then, which is the "pre-existing gap" those arms' own
+        // comments used to name: `1==1` on a #1194-malformed document
+        // (`{123: 1}`) answered `true`, where jq raises the document's own
+        // parse error on *every* query over it, including one that reads
+        // nothing. Live against jq 1.7.1:
+        //
+        // ```console
+        // $ printf '{123: 1}' | jq -c '1==1'
+        // jq: parse error: Object keys must be strings at line 1, column 5
+        // $ printf '{"a": {"bad": "\x"}, "b": 5}' | jq -c '.b == .b'
+        // jq: parse error: Invalid escape at line 1, column 18
+        // ```
+        //
+        // The gate keeps a comparison that reads no path context on the
+        // wildcard bridge, whose ambient materialization is what surfaces
+        // that decode failure; one that does read path context could not
+        // have stood on a malformed document's root and survived the walk
+        // anyway, and keeps the native arm.
+        //
+        // `uses_cursor_metadata_builtins` is the second half of the gate for
+        // the reason `eval_using`'s own doc comment already records for
+        // `input`/`inputs`: the bridge's re-serialize-and-reindex round trip
+        // cannot preserve a cursor-metadata builtin's real identity, so
+        // `select(di == 1)` over a multi-document stream would answer from a
+        // fixed-default stub instead of the live document index. The three
+        // sibling arms below carry only the `needs_path_context` half and
+        // look equally exposed -- unconfirmed, and tracked at #2584 rather
+        // than widened speculatively here.
+        Expr::Compare { op, left, right }
+            if needs_path_context(left)
+                || needs_path_context(right)
+                || crate::jq::walk::uses_cursor_metadata_builtins(left)
+                || crate::jq::walk::uses_cursor_metadata_builtins(right) =>
+        {
             eval_compare_generic::<S, V>(*op, left, right, value, optional, cursor)
         }
 
@@ -6557,7 +6593,7 @@ fn eval_single<S: EvalSemantics, V: DocumentValue>(
         // eager bridge used to hand it `null + 10`. That is what admits
         // `Expr::Arithmetic` to `path_context_single_native`.
         //
-        // **Gated on `needs_path_context`, unlike the `Expr::Compare` arm
+        // **Gated on `needs_path_context`, like the `Expr::Compare` arm
         // above.** The eager bridge materializes the ambient value on its
         // way through, and for a #1194-malformed document (`{123: 1}`) that
         // materialization is the decode failure jq answers *every* query on
@@ -6568,9 +6604,9 @@ fn eval_single<S: EvalSemantics, V: DocumentValue>(
         // arithmetic that reads no path context on the bridge, where it
         // still pays the ambient decode; arithmetic that does read path
         // context could not have been on a malformed document's root and
-        // survived the walk anyway. (`Expr::Compare`'s own arm already
-        // diverges here -- `1==1` on `{123: 1}` answers `true` -- which is a
-        // pre-existing gap, not one this arm widens.)
+        // survived the walk anyway. (`Expr::Compare`'s own arm carried
+        // exactly this gap -- `1==1` on `{123: 1}` answered `true` -- until
+        // #2581 gave it the same gate; see its comment above.)
         Expr::Arithmetic { left, right, .. }
             if needs_path_context(left) || needs_path_context(right) =>
         {
@@ -6617,8 +6653,8 @@ fn eval_single<S: EvalSemantics, V: DocumentValue>(
         // evaluator a document re-rooted at this stage's input.
         //
         // **Gated on `needs_path_context`, for the same reason the
-        // `Expr::Arithmetic` arm above is** (and the `Expr::Compare` arm is
-        // not): the bridge's ambient materialization is what makes
+        // `Expr::Arithmetic` and `Expr::Compare` arms above are**: the
+        // bridge's ambient materialization is what makes
         // `try (1+1) catch "x"` fail on a #1194-malformed document, and
         // `test_try_catch_contains_a_genuinely_catchable_malformed_key_error_1812`
         // pins that. An `and`/`or` that reads no path context stays on the

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -30859,13 +30859,53 @@ fn test_as_pattern_alternatives_retry_under_a_wrapping_consumer_1519() -> Result
         // span, matching `test_select_raises_on_decode_failure_instead_of_silently_truthy_1645`'s
         // shape) -- the already-decoded first item must survive as a
         // `Partial`, not be discarded by the second's bare error.
+        //
+        // #2581 moved the condition off `==`. With `Expr::Compare` now
+        // carrying the same `needs_path_context` gate as its
+        // `Arithmetic`/`And`/`Or` siblings, `$x == 1` reads no path
+        // context and so routes through the wildcard bridge, whose
+        // ambient materialization raises this document's decode failure
+        // before the `then` branch ever produces its item -- which is why
+        // the `==` spelling is pinned separately just below, at jq's own
+        // answer, rather than here. A bare truthiness test keeps the
+        // laziness this row is actually about.
+        (
+            &[
+                "-c",
+                r#"nth(0; 1 as $x ?// $y | (if $x then "ok" else .bad end))"#,
+            ],
+            Some(r#"{"bad": "\x"}"#),
+            "\"ok\"\n",
+            "jq: error (at <stdin>:0): invalid escape sequence in string",
+            5,
+        ),
+        // The `==` spelling of the row above, kept as its own case because
+        // #2581's gate changes what it does. **This row is a real jq 1.7.1
+        // capture and the row above is not** -- jq parses a document
+        // eagerly, so `{"bad": "\x"}` fails before any filter runs and
+        // *neither* spelling streams a prefix there:
+        //
+        // ```console
+        // $ printf '{"bad": "\x"}' | jq -c 'nth(0; 1 as $x ?// $y | (if $x == 1 then "ok" else .bad end))'
+        // jq: parse error: Invalid escape at line 1, column 12   # exit 5, empty stdout
+        // ```
+        //
+        // Before #2581 this row expected `"ok"` on stdout and was carried
+        // under this test's "every row is the real jq answer" header,
+        // which it never satisfied. succinctly now matches jq on stdout
+        // and exit code; the message text still differs, since the lazy
+        // index reports the failure at the span rather than as an
+        // up-front parse error. The prefix-streaming behaviour the old
+        // expectation encoded survives on the bare-truthiness row above,
+        // alongside its established sibling
+        // `test_array_iterate_lazy_limit_streams_confirmed_prefix_before_reaching_malformed_comma_1597`.
         (
             &[
                 "-c",
                 r#"nth(0; 1 as $x ?// $y | (if $x == 1 then "ok" else .bad end))"#,
             ],
             Some(r#"{"bad": "\x"}"#),
-            "\"ok\"\n",
+            "",
             "jq: error (at <stdin>:0): invalid escape sequence in string",
             5,
         ),
@@ -33083,6 +33123,84 @@ fn test_try_catch_contains_a_genuinely_catchable_malformed_key_error_1812() -> R
     assert_eq!(code, 5, "stdout: {stdout:?} stderr: {stderr}");
     assert!(stdout.trim().is_empty(), "stdout: {stdout:?}");
     assert!(stderr.contains("Invalid JSON text"), "stderr: {stderr}");
+
+    Ok(())
+}
+
+/// #2581: `Expr::Compare`'s native arm (`eval_compare_generic`) was the one
+/// member of its family left ungated, which the `Expr::Arithmetic`/
+/// `Expr::And`/`Expr::Or` arms' own comments named as a known, pre-existing
+/// exception ("`1==1` on `{123: 1}` answers `true` -- a pre-existing gap,
+/// not one this arm widens"). This test closes it: a comparison reading no
+/// path context now falls through to the wildcard bridge, whose ambient
+/// materialization surfaces the document-level decode failure that jq
+/// answers *every* query on such a document with.
+///
+/// Both shapes captured live against jq 1.7.1:
+///
+/// ```console
+/// $ printf '{123: 1}' | jq -c '1==1'
+/// jq: parse error: Object keys must be strings at line 1, column 5
+/// $ printf '{"a": {"bad": "\x"}, "b": 5}' | jq -c '.b == .b'
+/// jq: parse error: Invalid escape at line 1, column 18
+/// ```
+///
+/// succinctly's message text differs (the lazy index reports at the span,
+/// not as an up-front parse error) but the raise, the empty stdout and the
+/// exit code now match. `sort?` on the same documents already raised
+/// correctly before this fix, which is what confirmed the gap was specific
+/// to `Compare`'s own dispatch arm rather than an architectural limit.
+#[test]
+fn test_compare_raises_on_document_level_decode_failure_2581() -> Result<()> {
+    // #1194's malformed (non-string) object key.
+    for filter in ["1==1", r#"try (1==1) catch "x""#, "1 != 2", "1 < 2"] {
+        let (stdout, stderr, code) = run_jq_full(&["-c", filter], Some("{123: 1}"))?;
+        assert_eq!(code, 5, "`{filter}` -- stdout: {stdout:?} stderr: {stderr}");
+        assert!(stdout.trim().is_empty(), "`{filter}` -- stdout: {stdout:?}");
+        assert!(
+            stderr.contains("Invalid JSON text"),
+            "`{filter}` -- stderr: {stderr}"
+        );
+    }
+
+    // #1746/#2173's invalid-escape shape, including a comparison whose
+    // operands do read the document but never reach the malformed region.
+    for filter in ["1==1", ".b == .b", ".b == 5"] {
+        let (stdout, stderr, code) =
+            run_jq_full(&["-c", filter], Some(r#"{"a": {"bad": "\x"}, "b": 5}"#))?;
+        assert_eq!(code, 5, "`{filter}` -- stdout: {stdout:?} stderr: {stderr}");
+        assert!(stdout.trim().is_empty(), "`{filter}` -- stdout: {stdout:?}");
+        assert!(
+            stderr.contains("invalid escape sequence"),
+            "`{filter}` -- stderr: {stderr}"
+        );
+    }
+
+    // Control: a well-formed document is untouched by the gate.
+    for (filter, want) in [
+        ("1==1", "true\n"),
+        (".b == 5", "true\n"),
+        (".b == .b", "true\n"),
+        ("1 < 2", "true\n"),
+    ] {
+        let (stdout, stderr, code) = run_jq_full(&["-c", filter], Some(r#"{"a": 1, "b": 5}"#))?;
+        assert_eq!(
+            (stdout.as_str(), code),
+            (want, 0),
+            "`{filter}` -- stderr: {stderr}"
+        );
+    }
+
+    // Control: a comparison that *does* read path context keeps the native
+    // arm, so `key` still answers per-element rather than from a value the
+    // bridge re-rooted.
+    let (stdout, stderr, code) =
+        run_jq_full(&["-c", r#"[.[] | key == "a"]"#], Some(r#"{"a":1,"b":2}"#))?;
+    assert_eq!(
+        (stdout.as_str(), code),
+        ("[true,false]\n", 0),
+        "stderr: {stderr}"
+    );
 
     Ok(())
 }

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -38292,3 +38292,45 @@ fn test_as_binding_keeps_the_input_identity_2563() -> Result<()> {
     }
     Ok(())
 }
+
+/// #2581 companion: the second half of `Expr::Compare`'s new gate.
+///
+/// #2581 gave `Expr::Compare` the same `needs_path_context` gate its
+/// `Expr::Arithmetic`/`Expr::And`/`Expr::Or` siblings already carry, so an
+/// ungated comparison falls through to the wildcard bridge and pays the
+/// ambient decode that makes a document-level malformation raise the way
+/// real jq's eager parse does. `needs_path_context` alone is not a
+/// sufficient gate, though: a comparison over a *cursor-metadata* builtin
+/// (`di`, `line`, `column`, ...) reads no path context, yet cannot survive
+/// the bridge either -- its re-serialize-and-reindex round trip answers
+/// `di` from a fixed-default stub instead of the live document index, the
+/// same carve-out `eval_using`'s own doc comment records for
+/// `input`/`inputs`. Without `uses_cursor_metadata_builtins` in the gate,
+/// `select(di == 1)` over a multi-document stream picks the wrong documents.
+///
+/// Every row captured live against yq v4.53.3.
+///
+/// The three sibling arms carry only the `needs_path_context` half and look
+/// equally exposed to the same bug; that is unconfirmed and tracked at
+/// #2584 rather than widened speculatively alongside this fix.
+#[test]
+fn test_compare_over_document_index_keeps_native_arm_2581() -> Result<()> {
+    let doc = "a: 1\n---\na: 2\n---\na: 3\n";
+
+    for (filter, want) in [
+        ("select(di == 0) | .a", "1"),
+        ("select(di == 1) | .a", "2"),
+        ("select(di == 2) | .a", "3"),
+        ("select(di >= 1) | .a", "2\n---\n3"),
+        ("select(di != 1) | .a", "1\n---\n3"),
+    ] {
+        let (stdout, code) = run_yq_stdin(filter, doc, &[])?;
+        assert_eq!(
+            (stdout.trim_end(), code),
+            (want, 0),
+            "`{filter}` diverged from yq v4.53.3"
+        );
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary

`Expr::Compare`'s native arm (`eval_compare_generic`) was the one member of its family
left ungated. Its `Expr::Arithmetic`/`Expr::And`/`Expr::Or` siblings, gated by
#1812/#2286, name it in their own comments as a known exception:

> `Expr::Compare`'s own arm already diverges here -- `1==1` on `{123: 1}` answers `true`
> -- which is a pre-existing gap, not one this arm widens.

Real jq parses a document eagerly, so a document-level malformation fails **every** query
over it, including one that reads nothing. Live against the pinned oracle (`/usr/bin/jq`
1.7.1):

```console
$ printf '{123: 1}' | jq -c '1==1'
jq: parse error: Object keys must be strings at line 1, column 5
$ printf '{"a": {"bad": "\x"}, "b": 5}' | jq -c '.b == .b'
jq: parse error: Invalid escape at line 1, column 18
```

succinctly answered `true` for both. This gives the arm the same
`needs_path_context` gate, so a comparison reading no path context falls through to the
wildcard bridge whose ambient materialization surfaces the decode failure. stdout and exit
code now match jq; the message text still differs, since the lazy index reports at the span
rather than as an up-front parse error.

### The gate needs a second half the siblings lack

A comparison over a *cursor-metadata* builtin (`di`, `line`, `column`, ...) reads no path
context but cannot survive the bridge either — its re-serialize-and-reindex round trip
answers `di` from a fixed-default stub rather than the live document index, the same
carve-out `eval_using`'s doc comment already records for `input`/`inputs`. Without
`uses_cursor_metadata_builtins` in the gate, `select(di == 1)` over a multi-document
stream picks the wrong documents.

I negative-tested this half rather than assuming it: removing it makes both existing
`test_yaml_select_di_eq_n` and `test_yaml_select_di_comparison` fail (`left: 0, right: 1`).
The three sibling arms carry only the `needs_path_context` half and look equally exposed —
left alone rather than widened speculatively, tracked at #2584.

## A prior pass released this issue over two observations; both were oracle artifacts

An earlier session got the gate working but released the claim, citing a test regression
and an unexplained second output. Checking both against the oracle settles them:

**1. The "second value I have no explanation for" is what jq does.**  That session
observed `nth(0; 1 as $x ?// $y | $x + 100)` emitting `101` then `100` on unmodified
`main` and called it inexplicable. Real jq emits both on a *well-formed* document:

```console
$ echo '{"bad":1}' | jq -c 'nth(0; 1 as $x ?// $y | $x + 100)'
101
100
```

succinctly already matched jq. There was nothing to diagnose, and it was never an argument
against the gate.

**2. The "broken" test encoded a divergence from jq, and the gate fixes it.**
`test_as_pattern_alternatives_retry_under_a_wrapping_consumer_1519`'s malformed-document
row expected `"ok"` on stdout before the raise — under a test whose header states *"Every
row is the real jq 1.7.1 answer, captured live."* jq emits nothing there:

```console
$ printf '{"bad": "\x"}' | jq -c 'nth(0; 1 as $x ?// $y | (if $x == 1 then "ok" else .bad end))'
jq: parse error: Invalid escape at line 1, column 12   # exit 5, empty stdout
```

(Its expected stderr was also succinctly's own message, not jq's — so that row was never a
live capture.) The gate moves stdout and exit code onto jq's answer. I updated the row to
that, and added a sibling row using a bare truthiness test instead of `==` to keep the
`NthStream` prefix-preservation property the original row was written to pin, where
succinctly's laziness still applies.

## Oracle verification

Generated matrices rather than hand-picked cases:

| Sweep | Cases | Result |
|---|---|---|
| jq mode, 6 operators × 12 left × 10 right operands × 13 well-formed docs, plus `[.[]?\|...]`/`try`/`select` wrappings | 12,480 | **0 divergences from jq 1.7.1** |
| jq mode, 18 filters × 10 malformed docs | 180 | 23 divergences, **all pre-existing** (verified against a pre-fix build) |
| yq mode, comparisons over 11 docs incl. multi-doc/anchors/`di`/`line` | 7,854 | **0 outputs changed by this fix** (pre-fix vs post-fix build, byte-compared) |

The yq sweep matters because `eval_generic` is shared between both modes — I compared
pre-fix and post-fix binaries directly rather than only against real yq, since that
isolates *this change's* effect from the 2,532 pre-existing yq divergences in the same
matrix (container equality, `---` separators, `1.5` vs `"1.5"`).

## Residual divergences are pre-existing and family-wide, not introduced here

The 23 malformed-document divergences fall into two classes, both confirmed identical on a
pre-fix build:

- **`.a` on a document malformed elsewhere** — succinctly's lazy semi-indexing returns the
  value where jq's eager parse errors. The documented architectural trade-off; no
  comparison involved.
- **`first(1==1)` / `[limit(1; 1==1)]`** still answer `true`. This is *not* specific to
  `Compare`: the already-gated `Expr::Arithmetic` sibling has it too (`first(1+1)` → `2`,
  `[limit(1; 1+1)]` → `[2]` on `{123: 1}`), while `and`/`or` raise correctly. So these
  short-circuiting consumers bypass the bridge for the whole family. Filed as a follow-up
  rather than widened into this PR.

This change puts `Compare` exactly on par with `Arithmetic` — it does not introduce the
residual, and closes the bare and `try`-wrapped cases the issue actually reports.

## Test plan

- [x] `cargo build --features cli`
- [x] `cargo test --features cli,simd,regex,serde` — full suite green
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings` (the CI leg `--all-features` hides, since it enables `scalar-yaml`)
- [x] `cargo fmt --all -- --check`
- [x] `cargo test --no-default-features` (`no_std`)
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features`
- [x] Oracle diffs against `/usr/bin/jq` 1.7.1 and `yq` v4.53.3 directly (table above), not just golden fixtures
- [x] Negative-tested the `uses_cursor_metadata_builtins` half of the gate — removing it fails both `di` tests
- [x] New: `test_compare_raises_on_document_level_decode_failure_2581` (both malformation shapes, `try`-wrapped, well-formed controls, path-context control)
- [x] New: `test_compare_over_document_index_keeps_native_arm_2581` (every row captured live from yq v4.53.3)

Fixes #2581
