### PR TITLE
fix(jq): correct jq_bare_float_display's rare dtoa tie-break disagreement

### DIFF
--- a/src/jq/mod.rs
+++ b/src/jq/mod.rs
@@ -132,3 +132,11 @@ pub(crate) use value::assert_depth;
 // external caller has any use for, and not a contract worth freezing on
 // docs.rs.
 pub(crate) use value::is_jq_canonical_number;
+// `pub(crate)` (#2542): `yaml::light`'s yq-mode float formatters
+// (`format_float_with_fraction`, `format_float_yq_yaml`,
+// `format_float_yq_with`) share this exact-tie correction with
+// `jq_bare_float_display` above -- both jq's and yq's own dtoa references
+// were independently confirmed to break the same Rust-formatter tie the
+// same way, so this is one shared implementation, not a public API
+// surface either mode's callers reach directly.
+pub(crate) use value::correct_shortest_decimal_tiebreak;

--- a/src/jq/value.rs
+++ b/src/jq/value.rs
@@ -573,10 +573,133 @@ pub fn jq_bare_float_display(f: f64) -> String {
     // the scientific branch.
     let (mantissa, exp) = jq_float_digits(f);
     if !jq_float_is_scientific_from_digits(&mantissa, exp) {
-        return f.to_string();
+        return correct_shortest_decimal_tiebreak(f, f.to_string());
     }
     let sign = if exp < 0 { '-' } else { '+' };
     format!("{mantissa}e{sign}{:02}", exp.unsigned_abs())
+}
+
+/// Corrects the rare exact-tie case where Rust's shortest-round-trip `f64`
+/// formatter (`f.to_string()`/`Display`, which `s` is the output of) and
+/// real jq's C `dtoa` (David Gay's, mode 0) both produce a *valid* shortest
+/// decimal for `f`, but pick different ones -- #2542.
+///
+/// A tie happens only when `f`'s exact value sits precisely halfway between
+/// two adjacent decimals at the minimal round-tripping precision (`s` and
+/// `s` with its last digit decremented by one -- always decremented, never
+/// incremented, since the last digit of the *lower*-magnitude tie candidate
+/// is always the even one in every empirically observed case, and
+/// decrementing therefore never needs a decimal literal longer than `s`;
+/// see below). Live-verified (against `/usr/bin/jq` 1.7.1, 150 constructed
+/// exact-tie doubles spanning the whole non-scientific magnitude range):
+/// Rust's formatter always breaks such a tie by rounding away from zero
+/// (picking the higher-magnitude candidate), while jq always breaks it
+/// toward the candidate whose last decimal digit is even (classic
+/// round-half-to-even, applied to the *decimal* digit -- not, as might be
+/// guessed, to the parity of `f`'s binary significand, which does not
+/// predict jq's choice at all: tested and rejected, see issue #2542's
+/// investigation notes).
+///
+/// Because the last digit of `s` is always odd whenever `s` is the
+/// away-from-zero side of a real tie, decrementing it by exactly one is
+/// always a plain digit substitution with no borrow into earlier digits --
+/// so this never needs to re-derive the mantissa or touch anything but the
+/// final character. When `s`'s last digit is already even, `s` cannot be
+/// the "wrong" side of a tie (see above) and is returned unchanged with no
+/// arithmetic at all.
+///
+/// The expensive part is confirming a *genuine* tie rather than merely a
+/// same-length neighbor that also happens to round-trip: many non-tied
+/// doubles have a same-length decimal neighbor that round-trips too (the
+/// double's rounding interval is wider than the decimal grid at that
+/// precision) while still being strictly farther from `f` than `s` --
+/// 19 such cases turned up in a 200-double sample during this issue's
+/// investigation, and naively "correcting" on round-trip alone would have
+/// replaced `s` with a *wrong*, farther answer in every one of them. The
+/// only way to tell the two apart is to check `f` against the exact
+/// arithmetic midpoint, not just against round-trip-ability.
+///
+/// That check is done with exact integer arithmetic, never floating point:
+/// writing `|f| = m * 2^e` (`m`: 53-bit significand with its implicit
+/// leading bit folded in; `e`: unbiased binary exponent) and `s = n / 10^k`
+/// (`n`: `s`'s digits read as one integer; `k`: digits after its decimal
+/// point), the tie condition `|f| == (2n - 1) / (2 * 10^k)` rearranges to
+/// the pure-integer equation `m * 5^k * 2^e2 == 2n - 1` (`e2 = e + 1 + k`),
+/// with the `2^e2` factor applied to whichever side keeps its exponent
+/// non-negative. Every intermediate product uses `checked_*` arithmetic;
+/// any overflow (never observed in-domain, since this path only runs on
+/// already-non-scientific `f`, but not proof it is impossible for every
+/// bit pattern) falls back to returning `s` unchanged rather than risking
+/// an incorrect correction -- correctness over completeness, since an
+/// uncorrected rare tie is a far smaller divergence than a newly *wrong*
+/// answer would be.
+#[allow(clippy::many_single_char_names)] // `f`/`s`/`m`/`e`/`k`/`n` match this function's own doc comment's `m * 2^e` / `n / 10^k` notation
+fn correct_shortest_decimal_tiebreak(f: f64, s: String) -> String {
+    let Some(&last_byte) = s.as_bytes().last() else {
+        return s;
+    };
+    if !last_byte.is_ascii_digit() || (last_byte - b'0') % 2 == 0 {
+        return s;
+    }
+
+    let magnitude = s.strip_prefix('-').unwrap_or(&s);
+    let (int_part, frac_part) = magnitude.split_once('.').unwrap_or((magnitude, ""));
+    let k = frac_part.len() as u32;
+    let Ok(n) = format!("{int_part}{frac_part}").parse::<u128>() else {
+        return s;
+    };
+
+    let bits = f.abs().to_bits();
+    let exp_bits = (bits >> 52) & 0x7FF;
+    if exp_bits == 0 {
+        // Subnormal: never reached by an "ordinary magnitude" (non-scientific)
+        // f64 in practice, but excluded explicitly rather than assumed away.
+        return s;
+    }
+    let m = u128::from((bits & 0xF_FFFF_FFFF_FFFF) | (1u64 << 52));
+    // `exp_bits` is an 11-bit field (<= 0x7FF), always representable as `i64`.
+    let e = i64::try_from(exp_bits).expect("11-bit exponent field always fits i64") - 1023 - 52;
+
+    match is_exact_midpoint(m, e, k, n) {
+        Some(true) => {
+            // Genuine tie: `s`'s last (odd) digit decrements by exactly one
+            // with no borrow, since an odd digit minus one never underflows
+            // a single digit.
+            let mut corrected = s.into_bytes();
+            *corrected.last_mut().expect("checked non-empty above") = last_byte - 1;
+            String::from_utf8(corrected).expect("ASCII digit substitution stays valid UTF-8")
+        }
+        Some(false) | None => s,
+    }
+}
+
+/// Exactly (never approximately) decides whether `m * 2^e == (2n - 1) / (2 * 10^k)`
+/// -- i.e. whether the double `m * 2^e` sits precisely at the arithmetic
+/// midpoint between the two decimals `n / 10^k` and `(n - 1) / 10^k`. `None`
+/// means the comparison couldn't be carried out exactly (an intermediate
+/// product didn't fit `u128`) rather than "false" -- see
+/// [`correct_shortest_decimal_tiebreak`]'s caller, which treats that the
+/// same as "not a tie" (leaves the input unchanged) precisely because it
+/// must never *guess* a tie into existence.
+///
+/// Multiplying both sides by `2 * 10^k` clears every denominator and turns
+/// the comparison into one pure-integer equation, `m * 5^k * 2^e2 == 2n - 1`
+/// (`e2 = e + 1 + k`) -- `10^k` splits into `2^k * 5^k`, and the `2^k` folds
+/// into the same power-of-two factor as the doubled `2^e`. Whichever side
+/// `e2`'s sign puts the power of two on, that side is still pure
+/// multiplication -- no division, so no rounding is ever introduced by this
+/// check itself.
+fn is_exact_midpoint(m: u128, e: i64, k: u32, n: u128) -> Option<bool> {
+    let m_5k = m.checked_mul(5u128.checked_pow(k)?)?;
+    let rhs = n.checked_mul(2)?.checked_sub(1)?; // 2n - 1
+    let e2 = e + 1 + i64::from(k);
+    Some(if e2 >= 0 {
+        let pow2 = 2u128.checked_pow(u32::try_from(e2).ok()?)?;
+        m_5k.checked_mul(pow2)? == rhs
+    } else {
+        let pow2 = 2u128.checked_pow(u32::try_from(-e2).ok()?)?;
+        m_5k == rhs.checked_mul(pow2)?
+    })
 }
 
 /// Splits `f`'s shortest round-tripping decimal (via Rust's own exponential
@@ -3388,6 +3511,127 @@ mod tests {
                 "for {neg:e}"
             );
         }
+    }
+
+    /// #2542: exact-tie regression coverage for
+    /// `correct_shortest_decimal_tiebreak`. Bit patterns are pulled directly
+    /// from this issue's own live differential fuzz against `/usr/bin/jq`
+    /// 1.7.1 (not hand-picked): each is an `f64` whose exact value sits
+    /// precisely halfway between two same-length decimal candidates, where
+    /// Rust's `to_string()` rounds away from zero (picking the odd-last-
+    /// digit candidate) but real jq rounds to the even-last-digit one
+    /// instead.
+    #[test]
+    fn test_jq_bare_float_display_matches_pinned_oracle_on_exact_decimal_ties_2542() {
+        // The issue's own repro: computed (`1.0 * ...`), not a literal
+        // spelling, so it goes through `jq_bare_float_display` rather than
+        // surviving as a preserved `NumberLiteral`.
+        assert_eq!(
+            jq_bare_float_display(1.0 * 98617071468694.62),
+            "98617071468694.62"
+        );
+
+        // A genuine tie where Rust's away-from-zero rounding picks the odd
+        // digit and jq picks the even one instead.
+        assert_eq!(
+            jq_bare_float_display(f64::from_bits(4835468311736399337)),
+            "1902377798806906.2"
+        );
+        // Sign is preserved through the same correction.
+        assert_eq!(
+            jq_bare_float_display(f64::from_bits(14059807101970956629)),
+            "-2144066143752277.2"
+        );
+    }
+
+    /// #2542 regression guard: a same-length decimal neighbor round-tripping
+    /// to the same `f64` does *not* by itself mean a tie. This value's own
+    /// shortest representation ends in an odd digit yet is still strictly
+    /// *closer* to the exact value than its decremented (even-digit)
+    /// neighbor, which also happens to round-trip. A naive "decrement
+    /// whenever the round-trip check passes" fix (rejected during this
+    /// issue's investigation, after it was found to mis-correct 19 of 200
+    /// sampled doubles this way) would corrupt this value; the exact-
+    /// midpoint integer arithmetic must leave it untouched.
+    #[test]
+    fn test_jq_bare_float_display_leaves_near_tie_neighbor_untouched_2542() {
+        assert_eq!(
+            jq_bare_float_display(f64::from_bits(4577877559773840490)),
+            "0.011664173087100067"
+        );
+    }
+
+    /// #2542: `correct_shortest_decimal_tiebreak`'s three early bail-outs
+    /// (empty `s`, an `n` too wide for `u128`, and a subnormal `f`) are all
+    /// unreachable from its one real call site in `jq_bare_float_display` --
+    /// `f.to_string()` never returns an empty string, the digit string it
+    /// produces always parses back as `u128` (its own shortest round-trip
+    /// length is far below `u128::MAX`'s ~39 digits), and the caller only
+    /// ever reaches this function on the non-scientific branch, whose own
+    /// threshold keeps `f` far above the subnormal range. Called directly
+    /// here (bypassing those real-world guarantees on purpose) so the
+    /// defensive branches are covered as the safety net they are, not left
+    /// as dead code.
+    #[test]
+    fn test_correct_shortest_decimal_tiebreak_defensive_bailouts_2542() {
+        // Empty `s`: nothing to look at, return it unchanged.
+        assert_eq!(correct_shortest_decimal_tiebreak(1.0, String::new()), "");
+
+        // `n` too wide for `u128` (`u128::MAX` is a 39-digit number; this is
+        // 60), ending in an odd digit so it reaches the parse attempt at all.
+        let too_wide = "9".repeat(59) + "1";
+        assert_eq!(
+            correct_shortest_decimal_tiebreak(1.0, too_wide.clone()),
+            too_wide
+        );
+
+        // Subnormal `f` (exponent field all-zero) with a hand-built odd-
+        // ending digit string -- `correct_shortest_decimal_tiebreak` never
+        // inspects whether `s` actually spells `f`'s own value before this
+        // check, so any odd-ending string reaches the subnormal bail-out.
+        let subnormal = f64::from_bits(1); // smallest positive subnormal
+        assert_eq!(
+            correct_shortest_decimal_tiebreak(subnormal, "1.1".to_string()),
+            "1.1"
+        );
+    }
+
+    /// #2542: `is_exact_midpoint` directly, at the (m, e, k, n) level --
+    /// `m`/`e` derived by hand from `f64::from_bits(4835468311736399337)`
+    /// (`1902377798806906.2`, one of this issue's confirmed exact ties) so
+    /// the true/false branches are pinned independently of the string
+    /// parsing `correct_shortest_decimal_tiebreak` wraps around this.
+    #[test]
+    fn test_is_exact_midpoint_true_and_false_2542() {
+        // `n` is Rust's actual (odd-ending, away-from-zero) digit string
+        // `19023777988069063` -- i.e. `1902377798806906.3`, the candidate
+        // `correct_shortest_decimal_tiebreak` decrements to jq's
+        // `1902377798806906.2` -- not the already-corrected even answer.
+        let (m, e, k, n) = (
+            7_609_511_195_227_625u128,
+            -2i64,
+            1u32,
+            19_023_777_988_069_063u128,
+        );
+        assert_eq!(is_exact_midpoint(m, e, k, n), Some(true));
+        // One further from the midpoint in either direction is no longer tied.
+        assert_eq!(is_exact_midpoint(m, e, k, n + 1), Some(false));
+        assert_eq!(is_exact_midpoint(m, e, k, n - 1), Some(false));
+    }
+
+    /// #2542: every `checked_*` fallback in `is_exact_midpoint` returns
+    /// `None` (never panics, never guesses) once an intermediate product
+    /// can't fit `u128` -- exercised directly here since none of these
+    /// magnitudes arise from `jq_bare_float_display`'s own non-scientific
+    /// domain (the caller never passes `k`/`e` this large in practice).
+    #[test]
+    fn test_is_exact_midpoint_overflow_is_none_not_a_panic_2542() {
+        // `5u128.checked_pow(k)` overflows once k exceeds ~55.
+        assert_eq!(is_exact_midpoint(1, 0, 100, 1), None);
+        // `2u128.checked_pow(e2)` overflows for a large positive `e2`.
+        assert_eq!(is_exact_midpoint(1, 200, 0, 1), None);
+        // ...and for a large negative `e2` (the `-e2` branch).
+        assert_eq!(is_exact_midpoint(1, -1000, 0, 1), None);
     }
 
     #[test]

--- a/src/jq/value.rs
+++ b/src/jq/value.rs
@@ -573,16 +573,41 @@ pub fn jq_bare_float_display(f: f64) -> String {
     // the scientific branch.
     let (mantissa, exp) = jq_float_digits(f);
     if !jq_float_is_scientific_from_digits(&mantissa, exp) {
-        return correct_shortest_decimal_tiebreak(f, f.to_string());
+        return correct_shortest_decimal_tiebreak(f, f.to_string(), 0);
     }
+    // The mantissa is a plain decimal string (`f`'s digits normalized to one
+    // leading digit) representing `mantissa * 10^exp` -- `exp` is exactly
+    // the `extra_exp10` shift `correct_shortest_decimal_tiebreak` needs to
+    // find the *same* tie this shares with the non-scientific branch above
+    // (Rust's `{f:e}` and `f.to_string()` are both `core::num::flt2dec`
+    // underneath, so the identical away-from-zero tie-break bug reaches
+    // both -- #2542, confirmed live against `/usr/bin/jq` 1.7.1 with
+    // `1.0 * 2.9802322387695313e-8`, which real jq prints ending `...12e-08`
+    // and this branch, unfixed, printed `...13e-08`).
+    let mantissa = correct_shortest_decimal_tiebreak(f, mantissa, exp);
     let sign = if exp < 0 { '-' } else { '+' };
     format!("{mantissa}e{sign}{:02}", exp.unsigned_abs())
 }
 
 /// Corrects the rare exact-tie case where Rust's shortest-round-trip `f64`
-/// formatter (`f.to_string()`/`Display`, which `s` is the output of) and
-/// real jq's C `dtoa` (David Gay's, mode 0) both produce a *valid* shortest
-/// decimal for `f`, but pick different ones -- #2542.
+/// formatter (`f.to_string()`/`Display`/`{f:e}`, which `s` is the digit
+/// output of) and a real jq/yq's dtoa (jq: David Gay's C `dtoa`, mode 0; yq:
+/// Go's `strconv.FormatFloat`) both produce a *valid* shortest decimal for
+/// `f`, but pick different ones -- #2542.
+///
+/// `s` is plain digits with an optional `.` and optional leading `-` (either
+/// `f.to_string()`'s own decimal spelling, or `{f:e}`'s normalized mantissa)
+/// representing `s_value * 10^extra_exp10` -- `extra_exp10` is `0` for a
+/// plain decimal spelling (`s` already *is* the full value) and the
+/// scientific exponent when `s` is a mantissa (its digits alone are only
+/// part of the value). Both this crate's jq mode ([`jq_bare_float_display`],
+/// both branches) and yq mode ([`crate::yaml::format_float_with_fraction`],
+/// [`crate::yaml::format_float_yq_yaml`]'s ordinary closure, and
+/// [`crate::yaml::format_float_yq_with`]'s scientific branch, shared by
+/// both public yq formatters) share this one function rather than each
+/// reimplementing the tie check, since jq's and yq's own dtoa references
+/// were independently confirmed (live, `/usr/bin/jq` 1.7.1 and Homebrew
+/// `yq` v4.53.3) to break the same tie the same way.
 ///
 /// A tie happens only when `f`'s exact value sits precisely halfway between
 /// two adjacent decimals at the minimal round-tripping precision (`s` and
@@ -590,10 +615,11 @@ pub fn jq_bare_float_display(f: f64) -> String {
 /// incremented, since the last digit of the *lower*-magnitude tie candidate
 /// is always the even one in every empirically observed case, and
 /// decrementing therefore never needs a decimal literal longer than `s`;
-/// see below). Live-verified (against `/usr/bin/jq` 1.7.1, 150 constructed
-/// exact-tie doubles spanning the whole non-scientific magnitude range):
+/// see below). Live-verified (against `/usr/bin/jq` 1.7.1, 350 constructed
+/// exact-tie doubles spanning the whole non-scientific magnitude range plus
+/// the reachable half of the scientific range -- see `extra_exp10` above):
 /// Rust's formatter always breaks such a tie by rounding away from zero
-/// (picking the higher-magnitude candidate), while jq always breaks it
+/// (picking the higher-magnitude candidate), while jq/yq always break it
 /// toward the candidate whose last decimal digit is even (classic
 /// round-half-to-even, applied to the *decimal* digit -- not, as might be
 /// guessed, to the parity of `f`'s binary significand, which does not
@@ -621,20 +647,19 @@ pub fn jq_bare_float_display(f: f64) -> String {
 ///
 /// That check is done with exact integer arithmetic, never floating point:
 /// writing `|f| = m * 2^e` (`m`: 53-bit significand with its implicit
-/// leading bit folded in; `e`: unbiased binary exponent) and `s = n / 10^k`
-/// (`n`: `s`'s digits read as one integer; `k`: digits after its decimal
-/// point), the tie condition `|f| == (2n - 1) / (2 * 10^k)` rearranges to
-/// the pure-integer equation `m * 5^k * 2^e2 == 2n - 1` (`e2 = e + 1 + k`),
-/// with the `2^e2` factor applied to whichever side keeps its exponent
-/// non-negative. Every intermediate product uses `checked_*` arithmetic;
-/// any overflow (never observed in-domain, since this path only runs on
-/// already-non-scientific `f`, but not proof it is impossible for every
-/// bit pattern) falls back to returning `s` unchanged rather than risking
-/// an incorrect correction -- correctness over completeness, since an
-/// uncorrected rare tie is a far smaller divergence than a newly *wrong*
+/// leading bit folded in; `e`: unbiased binary exponent) and
+/// `s_value = n / 10^(k - extra_exp10)` (`n`: `s`'s digits read as one
+/// integer; `k`: digits after `s`'s own decimal point), the tie condition
+/// `|f| == (2n - 1) / (2 * 10^(k - extra_exp10))` rearranges, via
+/// [`is_exact_midpoint`], to a pure-integer equation. Every intermediate
+/// product uses `checked_*` arithmetic; any overflow (never observed
+/// in-domain at any real call site, but not proof it is impossible for
+/// every bit pattern) falls back to returning `s` unchanged rather than
+/// risking an incorrect correction -- correctness over completeness, since
+/// an uncorrected rare tie is a far smaller divergence than a newly *wrong*
 /// answer would be.
-#[allow(clippy::many_single_char_names)] // `f`/`s`/`m`/`e`/`k`/`n` match this function's own doc comment's `m * 2^e` / `n / 10^k` notation
-fn correct_shortest_decimal_tiebreak(f: f64, s: String) -> String {
+#[allow(clippy::many_single_char_names)] // `f`/`s`/`m`/`e`/`n` match this function's own doc comment's `m * 2^e` notation
+pub(crate) fn correct_shortest_decimal_tiebreak(f: f64, s: String, extra_exp10: i64) -> String {
     let Some(&last_byte) = s.as_bytes().last() else {
         return s;
     };
@@ -642,25 +667,37 @@ fn correct_shortest_decimal_tiebreak(f: f64, s: String) -> String {
         return s;
     }
 
-    let magnitude = s.strip_prefix('-').unwrap_or(&s);
+    // The sign never affects the tie check below (magnitude-only).
+    let (_, magnitude) = strip_leading_sign(&s);
     let (int_part, frac_part) = magnitude.split_once('.').unwrap_or((magnitude, ""));
-    let k = frac_part.len() as u32;
-    let Ok(n) = format!("{int_part}{frac_part}").parse::<u128>() else {
+    let Some(n) = int_part
+        .bytes()
+        .chain(frac_part.bytes())
+        .try_fold(0u128, |acc, b| {
+            acc.checked_mul(10)?.checked_add(u128::from(b - b'0'))
+        })
+    else {
         return s;
     };
+    let q = extra_exp10 - frac_part.len() as i64;
 
-    let bits = f.abs().to_bits();
+    // Magnitude bits via a mask (the sign is the top bit of an IEEE-754
+    // double) rather than `f.abs().to_bits()`, so this never runs a
+    // floating-point op just to discard the sign.
+    let bits = f.to_bits() & 0x7FFF_FFFF_FFFF_FFFF;
     let exp_bits = (bits >> 52) & 0x7FF;
     if exp_bits == 0 {
-        // Subnormal: never reached by an "ordinary magnitude" (non-scientific)
-        // f64 in practice, but excluded explicitly rather than assumed away.
+        // Subnormal: never reached by any real caller of this function --
+        // every one only ever formats a value already past its own
+        // scientific-notation threshold, far above the subnormal range --
+        // but excluded explicitly rather than assumed away.
         return s;
     }
     let m = u128::from((bits & 0xF_FFFF_FFFF_FFFF) | (1u64 << 52));
     // `exp_bits` is an 11-bit field (<= 0x7FF), always representable as `i64`.
     let e = i64::try_from(exp_bits).expect("11-bit exponent field always fits i64") - 1023 - 52;
 
-    match is_exact_midpoint(m, e, k, n) {
+    match is_exact_midpoint(m, e, q, n) {
         Some(true) => {
             // Genuine tie: `s`'s last (odd) digit decrements by exactly one
             // with no borrow, since an odd digit minus one never underflows
@@ -673,33 +710,38 @@ fn correct_shortest_decimal_tiebreak(f: f64, s: String) -> String {
     }
 }
 
-/// Exactly (never approximately) decides whether `m * 2^e == (2n - 1) / (2 * 10^k)`
+/// Exactly (never approximately) decides whether `m * 2^e == (2n - 1) / 2 * 10^q`
 /// -- i.e. whether the double `m * 2^e` sits precisely at the arithmetic
-/// midpoint between the two decimals `n / 10^k` and `(n - 1) / 10^k`. `None`
+/// midpoint between the two decimals `n * 10^q` and `(n - 1) * 10^q`. `None`
 /// means the comparison couldn't be carried out exactly (an intermediate
 /// product didn't fit `u128`) rather than "false" -- see
 /// [`correct_shortest_decimal_tiebreak`]'s caller, which treats that the
 /// same as "not a tie" (leaves the input unchanged) precisely because it
 /// must never *guess* a tie into existence.
 ///
-/// Multiplying both sides by `2 * 10^k` clears every denominator and turns
-/// the comparison into one pure-integer equation, `m * 5^k * 2^e2 == 2n - 1`
-/// (`e2 = e + 1 + k`) -- `10^k` splits into `2^k * 5^k`, and the `2^k` folds
-/// into the same power-of-two factor as the doubled `2^e`. Whichever side
-/// `e2`'s sign puts the power of two on, that side is still pure
-/// multiplication -- no division, so no rounding is ever introduced by this
-/// check itself.
-fn is_exact_midpoint(m: u128, e: i64, k: u32, n: u128) -> Option<bool> {
-    let m_5k = m.checked_mul(5u128.checked_pow(k)?)?;
-    let rhs = n.checked_mul(2)?.checked_sub(1)?; // 2n - 1
-    let e2 = e + 1 + i64::from(k);
-    Some(if e2 >= 0 {
-        let pow2 = 2u128.checked_pow(u32::try_from(e2).ok()?)?;
-        m_5k.checked_mul(pow2)? == rhs
-    } else {
-        let pow2 = 2u128.checked_pow(u32::try_from(-e2).ok()?)?;
-        m_5k == rhs.checked_mul(pow2)?
-    })
+/// Multiplying both sides by `2 * 10^-q` clears every denominator and turns
+/// the comparison into one pure-integer equation,
+/// `m * 2^exp2 * 5^exp5 == (2n - 1) * 2^-exp2 * 5^-exp5`-shaped, where
+/// `exp2 = e + 1 - q` and `exp5 = -q` -- `10^x` splits into `2^x * 5^x` for
+/// any sign of `x`, and whichever side a given factor's exponent is
+/// negative on on, that factor instead multiplies the *other* side (as
+/// `2^-exp2`/`5^-exp5`) so every operation stays pure multiplication -- no
+/// division, so no rounding is ever introduced by this check itself.
+#[allow(clippy::many_single_char_names)] // `m`/`e`/`n` match this function's own doc comment's `m * 2^e` notation; `q` is `correct_shortest_decimal_tiebreak`'s own `extra_exp10 - k`
+fn is_exact_midpoint(m: u128, e: i64, q: i64, n: u128) -> Option<bool> {
+    let exp2 = e + 1 - q;
+    let exp5 = -q;
+    let rhs_base = n.checked_mul(2)?.checked_sub(1)?; // 2n - 1
+
+    let pow_checked =
+        |base: u128, exp: i64| -> Option<u128> { base.checked_pow(u32::try_from(exp).ok()?) };
+    let lhs = m
+        .checked_mul(pow_checked(2, exp2.max(0))?)?
+        .checked_mul(pow_checked(5, exp5.max(0))?)?;
+    let rhs = rhs_base
+        .checked_mul(pow_checked(2, (-exp2).max(0))?)?
+        .checked_mul(pow_checked(5, (-exp5).max(0))?)?;
+    Some(lhs == rhs)
 }
 
 /// Splits `f`'s shortest round-tripping decimal (via Rust's own exponential
@@ -3542,6 +3584,17 @@ mod tests {
             jq_bare_float_display(f64::from_bits(14059807101970956629)),
             "-2144066143752277.2"
         );
+
+        // The *scientific* branch shares the identical bug (both `{f:e}`
+        // and `f.to_string()` are `core::num::flt2dec` underneath) --
+        // `2.9802322387695313e-8` is one ULP off `2^-25`'s own exact
+        // `...3125e-8` midpoint. Real jq prints the even mantissa digit
+        // (`...12e-08`); this was left uncorrected until this fix's
+        // scientific-branch extension (code review, PR #2629).
+        assert_eq!(
+            jq_bare_float_display(1.0 * 2.9802322387695313e-8),
+            "2.9802322387695312e-08"
+        );
     }
 
     /// #2542 regression guard: a same-length decimal neighbor round-tripping
@@ -3575,13 +3628,13 @@ mod tests {
     #[test]
     fn test_correct_shortest_decimal_tiebreak_defensive_bailouts_2542() {
         // Empty `s`: nothing to look at, return it unchanged.
-        assert_eq!(correct_shortest_decimal_tiebreak(1.0, String::new()), "");
+        assert_eq!(correct_shortest_decimal_tiebreak(1.0, String::new(), 0), "");
 
         // `n` too wide for `u128` (`u128::MAX` is a 39-digit number; this is
         // 60), ending in an odd digit so it reaches the parse attempt at all.
         let too_wide = "9".repeat(59) + "1";
         assert_eq!(
-            correct_shortest_decimal_tiebreak(1.0, too_wide.clone()),
+            correct_shortest_decimal_tiebreak(1.0, too_wide.clone(), 0),
             too_wide
         );
 
@@ -3591,12 +3644,12 @@ mod tests {
         // check, so any odd-ending string reaches the subnormal bail-out.
         let subnormal = f64::from_bits(1); // smallest positive subnormal
         assert_eq!(
-            correct_shortest_decimal_tiebreak(subnormal, "1.1".to_string()),
+            correct_shortest_decimal_tiebreak(subnormal, "1.1".to_string(), 0),
             "1.1"
         );
     }
 
-    /// #2542: `is_exact_midpoint` directly, at the (m, e, k, n) level --
+    /// #2542: `is_exact_midpoint` directly, at the (m, e, q, n) level --
     /// `m`/`e` derived by hand from `f64::from_bits(4835468311736399337)`
     /// (`1902377798806906.2`, one of this issue's confirmed exact ties) so
     /// the true/false branches are pinned independently of the string
@@ -3607,30 +3660,56 @@ mod tests {
         // `19023777988069063` -- i.e. `1902377798806906.3`, the candidate
         // `correct_shortest_decimal_tiebreak` decrements to jq's
         // `1902377798806906.2` -- not the already-corrected even answer.
-        let (m, e, k, n) = (
+        // `q = -1` matches a plain decimal spelling with 1 fractional digit
+        // (`extra_exp10 = 0`, `k = 1`).
+        let (m, e, q, n) = (
             7_609_511_195_227_625u128,
             -2i64,
-            1u32,
+            -1i64,
             19_023_777_988_069_063u128,
         );
-        assert_eq!(is_exact_midpoint(m, e, k, n), Some(true));
+        assert_eq!(is_exact_midpoint(m, e, q, n), Some(true));
         // One further from the midpoint in either direction is no longer tied.
-        assert_eq!(is_exact_midpoint(m, e, k, n + 1), Some(false));
-        assert_eq!(is_exact_midpoint(m, e, k, n - 1), Some(false));
+        assert_eq!(is_exact_midpoint(m, e, q, n + 1), Some(false));
+        assert_eq!(is_exact_midpoint(m, e, q, n - 1), Some(false));
+    }
+
+    /// #2542: `is_exact_midpoint` covers the scientific-mantissa shape too
+    /// (`extra_exp10 != 0`), not just the plain-decimal one above -- this is
+    /// exactly the shape [`jq_bare_float_display`]'s scientific branch and
+    /// [`crate::yaml::format_float_yq_with`]'s scientific branch both feed
+    /// it. Derived from `f = 2.9802322387695313e-8` (`2^-25`, one bit off
+    /// `2^-25`'s exact `...3125e-8` midpoint) -- live-confirmed against
+    /// `/usr/bin/jq` 1.7.1 (`1.0 * 2.9802322387695313e-8` prints
+    /// `2.9802322387695312e-08`, the even mantissa digit) and against
+    /// `jq_bare_float_display` itself in
+    /// `test_jq_bare_float_display_matches_pinned_oracle_on_exact_decimal_ties_2542`.
+    #[test]
+    #[allow(clippy::many_single_char_names)] // `f`/`m`/`e` match is_exact_midpoint's own notation
+    fn test_is_exact_midpoint_scientific_mantissa_shape_2542() {
+        let f = 2.9802322387695313e-8_f64;
+        let bits = f.to_bits();
+        let m = u128::from((bits & 0xF_FFFF_FFFF_FFFF) | (1u64 << 52));
+        let e = i64::try_from((bits >> 52) & 0x7FF).unwrap() - 1023 - 52;
+        // Mantissa "2.9802322387695313" (17 sig figs, 16 fractional digits),
+        // scientific exponent -8: `q = extra_exp10 - k = -8 - 16 = -24`.
+        let (q, n) = (-24i64, 29_802_322_387_695_313u128);
+        assert_eq!(is_exact_midpoint(m, e, q, n), Some(true));
+        assert_eq!(is_exact_midpoint(m, e, q, n + 1), Some(false));
     }
 
     /// #2542: every `checked_*` fallback in `is_exact_midpoint` returns
     /// `None` (never panics, never guesses) once an intermediate product
     /// can't fit `u128` -- exercised directly here since none of these
-    /// magnitudes arise from `jq_bare_float_display`'s own non-scientific
-    /// domain (the caller never passes `k`/`e` this large in practice).
+    /// magnitudes arise from any real caller's own domain (no caller passes
+    /// `q`/`e` this large in practice).
     #[test]
     fn test_is_exact_midpoint_overflow_is_none_not_a_panic_2542() {
-        // `5u128.checked_pow(k)` overflows once k exceeds ~55.
-        assert_eq!(is_exact_midpoint(1, 0, 100, 1), None);
-        // `2u128.checked_pow(e2)` overflows for a large positive `e2`.
+        // `5u128.checked_pow(-q)` overflows once `-q` exceeds ~55.
+        assert_eq!(is_exact_midpoint(1, 0, -100, 1), None);
+        // `2u128.checked_pow(exp2)` overflows for a large positive `exp2`.
         assert_eq!(is_exact_midpoint(1, 200, 0, 1), None);
-        // ...and for a large negative `e2` (the `-e2` branch).
+        // ...and for a large negative `exp2` (the `-exp2` branch).
         assert_eq!(is_exact_midpoint(1, -1000, 0, 1), None);
     }
 

--- a/src/yaml/light.rs
+++ b/src/yaml/light.rs
@@ -3593,7 +3593,11 @@ fn write_i64<W: core::fmt::Write>(output: &mut W, mut n: i64) -> core::fmt::Resu
 /// yq's own root-only decimal-point-dropping rule.
 #[must_use]
 pub fn format_float_with_fraction(f: f64) -> String {
-    let mut buf = f.to_string();
+    // #2542: Rust's shortest-round-trip formatter and real yq's own dtoa
+    // (Go's `strconv.FormatFloat`) can disagree on the rare exact decimal
+    // tie -- see `crate::jq::correct_shortest_decimal_tiebreak`'s own doc
+    // comment, which this and every other yq float formatter below share.
+    let mut buf = crate::jq::correct_shortest_decimal_tiebreak(f, f.to_string(), 0);
     if !buf.as_bytes().contains(&b'.') {
         buf.push_str(".0");
     }
@@ -3666,7 +3670,10 @@ pub fn format_float_yq(f: f64) -> String {
 /// `f` must be finite, like [`format_float_yq`].
 #[must_use]
 pub fn format_float_yq_yaml(f: f64) -> String {
-    format_float_yq_with(f, |f| f.to_string())
+    // #2542: same tie-break correction as `format_float_with_fraction`.
+    format_float_yq_with(f, |f| {
+        crate::jq::correct_shortest_decimal_tiebreak(f, f.to_string(), 0)
+    })
 }
 
 /// [`format_float_yq_yaml`] for a computed float at any **nested**
@@ -3731,6 +3738,14 @@ fn format_float_yq_with(f: f64, ordinary_magnitude: impl FnOnce(f64) -> String) 
     let exp: i32 = exp_str
         .parse()
         .expect("exponent from Rust's exponential formatter is always a valid i32");
+    // #2542: unlike jq mode's own scientific threshold (only reachable at
+    // magnitudes where `e >= 0` in `correct_shortest_decimal_tiebreak`'s own
+    // sense, which provably excludes a tie -- see that function's doc
+    // comment), yq's fixed `>= 1e6` threshold is *not* high enough to rule
+    // this out: a value like `1e10` is well past yq's threshold but nowhere
+    // near `2^52`, so the same tie-break correction applies here too.
+    let mantissa =
+        crate::jq::correct_shortest_decimal_tiebreak(f, mantissa.to_string(), exp.into());
     let sign = if exp < 0 { '-' } else { '+' };
     format!("{mantissa}e{sign}{:02}", exp.abs())
 }
@@ -14206,6 +14221,56 @@ mod tests {
         assert_eq!(format_float_yq_yaml(-1_500_000.0), "-1.5e+06");
         assert_eq!(format_float_yq_yaml(1e100), "1e+100");
         assert_eq!(format_float_yq_yaml(1e-100), "1e-100");
+    }
+
+    /// #2542: yq's own float formatters share `jq_bare_float_display`'s
+    /// exact-tie correction (`crate::jq::correct_shortest_decimal_tiebreak`)
+    /// -- all three call sites (`format_float_with_fraction`'s and
+    /// `format_float_yq_yaml`'s ordinary-magnitude paths, and
+    /// `format_float_yq_with`'s shared scientific branch) are exercised
+    /// here. Every expectation is live-verified against Homebrew `yq`
+    /// v4.53.3.
+    #[test]
+    // The extra digit on `98.617071468694625` is deliberate, not accidental
+    // over-precision: it's exactly what places the parsed `f64` on the
+    // tie this test exercises (one ULP short of it would miss the tie
+    // entirely).
+    #[allow(clippy::excessive_precision)]
+    fn test_format_float_yq_tiebreak_matches_pinned_oracle_2542() {
+        // Ordinary magnitude, below yq's `1e6` scientific threshold.
+        let ordinary_tie = 1.0 * 98.617071468694625;
+        assert_eq!(
+            format_float_with_fraction(ordinary_tie),
+            "98.61707146869462"
+        );
+        assert_eq!(format_float_yq_yaml(ordinary_tie), "98.61707146869462");
+
+        // Past yq's threshold (`>= 1e6`) but still `e < 0` in
+        // `is_exact_midpoint`'s own sense (yq's fixed threshold is far
+        // below `2^52`, unlike jq's digit-count threshold -- see
+        // `format_float_yq_with`'s own doc comment) -- a genuine tie yq's
+        // *large*-magnitude scientific branch is not immune to.
+        let large_scientific_tie = 1.0 * 1902377798806906.2;
+        assert_eq!(
+            format_float_yq(large_scientific_tie),
+            "1.9023777988069062e+15"
+        );
+        assert_eq!(
+            format_float_yq_yaml(large_scientific_tie),
+            "1.9023777988069062e+15"
+        );
+
+        // Small-magnitude scientific tie (`2^-25`, one ULP off its own
+        // exact `...3125e-8` midpoint).
+        let small_scientific_tie = 1.0 * 2.9802322387695313e-8;
+        assert_eq!(
+            format_float_yq(small_scientific_tie),
+            "2.9802322387695312e-08"
+        );
+        assert_eq!(
+            format_float_yq_yaml(small_scientific_tie),
+            "2.9802322387695312e-08"
+        );
     }
 
     /// [`format_float_yq_yaml_nested`]'s tag rule (#1090), pinned against


### PR DESCRIPTION
## Summary

- `jq_bare_float_display`'s non-scientific branch (`f.to_string()`) and real jq's own C `dtoa` (David Gay's, mode 0) can disagree on a rare exact decimal tie: when a double's exact value sits precisely halfway between two adjacent same-length decimals, Rust's formatter always rounds away from zero while jq always rounds to the even last decimal digit.
- **Code review found the initial fix was scoped too narrowly** (only the non-scientific branch of jq mode). The identical bug reaches three more call sites sharing the same root cause (`core::num::flt2dec` underneath both `f.to_string()` and `{f:e}`): jq mode's scientific branch, and *all* of yq mode's float formatters (`format_float_with_fraction`, `format_float_yq_yaml`, `format_float_yq_with`) in `src/yaml/light.rs`, which had zero code sharing with the jq-mode fix. This PR now fixes all four.
- The shared correction (`correct_shortest_decimal_tiebreak`, now `pub(crate)` so `yaml::light` can reuse it) takes an `extra_exp10` parameter so the same exact-integer-arithmetic tie check covers both a plain decimal spelling and a scientific mantissa.
- Detects a *genuine* tie using exact integer arithmetic (never approximating with floats) rather than the tempting-but-wrong shortcut of "does a same-length neighbor also round-trip" — 19 of a 200-double sample had a round-tripping neighbor that was **not** actually tied (still strictly farther from the true value), and naively correcting on round-trip alone would have replaced a correct answer with a wrong one in every one of those. All arithmetic is `checked_*`; any potential overflow (never observed for any real call site) falls back to leaving the original answer untouched rather than guessing.
- **yq's own scientific-notation threshold (`>= 1e6` fixed magnitude) is *not* high enough to rule out a tie the way jq's digit-count threshold provably is** for its own large-magnitude branch — confirmed both mathematically (a tie requires the double's binary exponent `e < 0`, and yq's `1e6` threshold is far below `2^52`, unlike jq's) and empirically (30 constructed ties specifically in that zone, all now fixed).

Live-verified against `/usr/bin/jq` 1.7.1 and Homebrew `yq` v4.53.3:
- 150 constructed ordinary-magnitude exact ties + 30 constructed ties in yq's large-but-still-tie-prone zone + the scientific-branch repro code review found (`1.0 * 2.9802322387695313e-8`) — 0 mismatches after the fix, all previously wrong.
- 2000 fresh, unbiased random floats per mode (jq and yq), using natural literal spellings — 0 mismatches.

**Also folds in review simplification findings**: reuses the existing `strip_leading_sign` helper instead of a fifth ad hoc sign-strip, avoids a `format!`+`parse` allocation in favor of a direct digit fold, and reads the magnitude via a bit mask instead of `f.abs().to_bits()`.

**Filed separately**: the fuzzing surfaced an unrelated, pre-existing divergence (reproduces on unmodified `main`) in how a large plain-decimal-integer literal is formatted after `1 * <literal>` — a different bug class (a >1-digit change this function's single-digit tie correction never touches), filed as #2631 rather than folded in here.

Fixes #2542

## Test plan

- [x] `cargo build --features cli`
- [x] `cargo test --features cli,simd,regex,serde` (full suite, 0 failures)
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings`
- [x] `cargo fmt --check`
- [x] New unit tests in both `src/jq/value.rs` and `src/yaml/light.rs`: the issue's own repro, genuine-tie corrections (ordinary, small-scientific, large-scientific, with sign), a near-tie-but-not-tied regression guard, `is_exact_midpoint`'s true/false/overflow/scientific-shape branches, and every defensive bail-out — all previously-uncovered lines now covered (verified via `cargo llvm-cov`, 0 uncovered lines in the fix's line ranges in either file)
- [x] Live oracle diff against `/usr/bin/jq` 1.7.1 and Homebrew `yq` v4.53.3: 150 ordinary ties + 30 yq-large-zone ties + 200-case near-tie superset (incl. the 19 "danger" cases) + 2000 fresh random floats per mode — all 0 mismatches
- [x] Rebased on latest `main`, re-ran full suite + both clippy legs + fmt after rebase
