### PR TITLE
fix(jq): re-enter foreach's fold register every step, not just the first

### DIFF
--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -28126,6 +28126,16 @@ fn resolve_reduce<'a, S: EvalSemantics>(
                     // every step *without* its own source-derived register
                     // (including reduce's own final emission below) is
                     // still checked against.
+                    //
+                    // **#2161**: `resolve_foreach`'s equivalent site no
+                    // longer treats provenance as the whole rule -- it also
+                    // consults `register_identical`, so a step whose
+                    // accumulator is still the register's own value
+                    // re-enters it. This site was deliberately left alone
+                    // (fixing it moves 696 more cases onto jq, measured),
+                    // so `path(reduce (1,2) as $k (.b; .a))` on `{"a":1}`
+                    // still refuses where the `foreach` spelling succeeds.
+                    // Tracked at #2632.
                     let last = branches.into_iter().last();
                     (acc_at_register, acc_snapshot) = reg.branch_provenance(last.as_ref());
                     acc = last.map(|b| b.value.into_owned());
@@ -28187,6 +28197,16 @@ fn resolve_reduce<'a, S: EvalSemantics>(
 /// EXTRACT) rather than folded away, and the source stream's own trailing
 /// control is applied per-fork after that fork's own inner loop (#534
 /// follow-up), not deferred until every fork has run.
+///
+/// **#2161 adds a fourth difference, and it is a divergence from
+/// [`resolve_reduce`] rather than a shared rule**: this function re-enters
+/// the fixed register on every source element, deciding each step's
+/// `at_register` from jq's own `jv_identical(current_input, value_at_path)`
+/// (via [`register_identical`]) *as well as* the previous step's
+/// [`FoldRegister::branch_provenance`]. `resolve_reduce`'s own carry-forward
+/// still uses provenance alone, so `path(reduce (1,2) as $k (.b; .a))` on
+/// `{"a":1}` still refuses where the `foreach` spelling now succeeds --
+/// tracked at #2632, not an intended asymmetry.
 #[allow(clippy::too_many_arguments)] // STYLE-0004: `snapshot` (#1591) joins `trackable` as the
                                      // ambient pair threaded verbatim through every one of
                                      // `resolve_node`'s ~20 recursive call sites in this file; a
@@ -28338,6 +28358,21 @@ fn resolve_foreach<'a, S: EvalSemantics>(
                 // `true` for a `null`/`bool` accumulator. Dropping either
                 // half regresses one of the two shapes below.
                 //
+                // **jq mode only**, for exactly the reason
+                // [`trackable_step_register_eligible`] gates its own
+                // re-establishment the same way: the new half turns a step
+                // that would have refused into one that navigates, and on
+                // the *write* side that is a write where yq no-ops. Live
+                // against yq v4.53.3, `(null | .a) = 5` on `null` is a
+                // no-op, so `(foreach (1) as $k (null; .a)) = 5` writing
+                // `a: 5` would be exactly the silent corruption that gate's
+                // doc comment calls "a worse outcome than the refusal it
+                // would replace". yq mode therefore stays refuse-only here,
+                // as it already is for the single-step and carried-forward
+                // shapes. The carried half is left ungated: it is the
+                // pre-existing behaviour, not something this change
+                // introduces.
+                //
                 // Live against jq 1.7.1, on `{"a":1}`:
                 //
                 // ```console
@@ -28360,7 +28395,8 @@ fn resolve_foreach<'a, S: EvalSemantics>(
                         trackable: reg.trackable,
                     },
                     state_at_register
-                        || (reg.trackable
+                        || (S::TAG == EvalTag::Jq
+                            && reg.trackable
                             && register_identical(&reg.value, &state, state_snapshot)),
                 ),
             };

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -28306,13 +28306,62 @@ fn resolve_foreach<'a, S: EvalSemantics>(
                     let at_register = register_identical(&step_reg.value, &state, state_snapshot);
                     (step_reg, at_register)
                 }
+                // #2161: `state_at_register` cannot come from the previous
+                // step's `branch_provenance`, which answers "did the last
+                // UPDATE branch end *at* the register's own path". The
+                // register is fixed for the whole fold and UPDATE almost
+                // always navigates away from it, so that answer is `false`
+                // from step 2 onward and every later step refuses its own
+                // navigation as untracked -- even though real jq re-enters
+                // each step from the register, not from the previous step's
+                // result.
+                //
+                // The register's own doc comment already states the model
+                // ("fixed once per INIT fork -- never advances across
+                // source-element iterations"): what decides a step is jq's
+                // `jv_identical(current_input, value_at_path)`, i.e. whether
+                // the accumulator coming into this step is still the
+                // register's own value. That is exactly the check the
+                // `Some(path)` arm above already performs via
+                // `register_identical`, and it is the missing *second* way
+                // a step can be at the register.
+                //
+                // It has to be an `||` rather than a replacement, because
+                // neither answer subsumes the other. `register_identical`
+                // demands `snapshot || Null | Bool` -- structural equality
+                // is not jq's pointer identity, so a container counts only
+                // when it is known to be the frozen node itself. So it
+                // answers `false` for step 1 of an object-valued register,
+                // where the carried `init_branch.trackable` is the correct
+                // `true`; and the carried provenance answers `false` from
+                // step 2 onward, where the identity check is the correct
+                // `true` for a `null`/`bool` accumulator. Dropping either
+                // half regresses one of the two shapes below.
+                //
+                // Live against jq 1.7.1, on `{"a":1}`:
+                //
+                // ```console
+                // $ jq -c 'path(foreach (1,2,3) as $k (.b; .a))'
+                // ["b","a"]
+                // ["b","a"]
+                // ["b","a"]
+                // ```
+                //
+                // and on `{"a":1,"b":{"a":{"a":9}}}` the same filter emits
+                // `["b","a"]` once and then raises "attempt to access
+                // element \"a\" of {\"a\":9}" -- the accumulator has stopped
+                // being the register's value, so step 2 is genuinely
+                // untracked. Both fall out of the identity check; neither
+                // falls out of the path comparison.
                 None => (
                     FoldRegister {
                         path: Rc::clone(&reg.path),
                         value: reg.value.clone(),
                         trackable: reg.trackable,
                     },
-                    state_at_register,
+                    state_at_register
+                        || (reg.trackable
+                            && register_identical(&reg.value, &state, state_snapshot)),
                 ),
             };
             let update_branches = match active_reg.resolve::<S>(

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -37675,6 +37675,106 @@ fn test_foreach_source_navigation_clobbers_register_2031() -> Result<()> {
     Ok(())
 }
 
+/// #2161: the fold register is fixed for the whole fold ("never advances
+/// across source-element iterations" -- see `register_identical`'s own doc
+/// comment), so every step re-enters UPDATE *from the register*, not from
+/// the previous step's result. `resolve_foreach` carried the next step's
+/// `at_register` from `FoldRegister::branch_provenance`, which answers "did
+/// the last UPDATE branch end at the register's own path" -- almost always
+/// `false`, since UPDATE's whole job is to navigate away from it. So step 1
+/// resolved and every later step refused its own identical navigation as
+/// untracked.
+///
+/// jq's actual rule is `jv_identical(current_input, value_at_path)`: a step
+/// is at the register when the accumulator coming into it is still the
+/// register's value. Both shapes below are live jq 1.7.1 captures, and they
+/// are what pins the fix to an `||` of the two checks rather than a swap --
+/// the first needs the identity half (a `null` accumulator keeps re-entering
+/// the register), the second needs the carried half (step 1 of an
+/// object-valued register, which structural equality alone will not accept
+/// as jq's pointer identity).
+#[test]
+fn test_foreach_reenters_register_every_step_not_just_the_first_2161() -> Result<()> {
+    // `.b` is absent, so the accumulator stays `null` -- identical to the
+    // register's own value at every step, so all three steps navigate.
+    let (stdout, stderr, code) = run_jq_full(
+        &["-c", "path(foreach (1,2,3) as $k (.b; .a))"],
+        Some(r#"{"a":1}"#),
+    )?;
+    assert_eq!(
+        (stdout.as_str(), code),
+        ("[\"b\",\"a\"]\n[\"b\",\"a\"]\n[\"b\",\"a\"]\n", 0),
+        "stderr: {stderr:?}"
+    );
+
+    // A deeper UPDATE repeats the same way.
+    let (stdout, stderr, code) = run_jq_full(
+        &["-c", "path(foreach (1,2) as $k (.b; .a.c))"],
+        Some(r#"{"a":1}"#),
+    )?;
+    assert_eq!(
+        (stdout.as_str(), code),
+        ("[\"b\",\"a\",\"c\"]\n[\"b\",\"a\",\"c\"]\n", 0),
+        "stderr: {stderr:?}"
+    );
+
+    // The counterpart that must still raise: once the accumulator stops
+    // being the register's value, the step is genuinely untracked. jq emits
+    // the first path, then raises naming the *accumulator*, not the
+    // register.
+    let (stdout, stderr, code) = run_jq_full(
+        &["-c", "path(foreach (1,2,3) as $k (.b; .a))"],
+        Some(r#"{"a":1,"b":{"a":{"a":9}}}"#),
+    )?;
+    assert_eq!(stdout, "[\"b\",\"a\"]\n", "stderr: {stderr:?}");
+    assert!(
+        stderr.contains(r#"attempt to access element "a" of {"a":9}"#),
+        "stderr: {stderr:?}"
+    );
+    assert_eq!(code, 5, "stdout: {stdout:?} stderr: {stderr:?}");
+
+    // Same shape one level deeper, to pin that the raise names the step's
+    // own input rather than anything about the register.
+    let (stdout, stderr, code) = run_jq_full(
+        &["-c", "path(foreach (1,2,3) as $k (.b; .a.a))"],
+        Some(r#"{"a":1,"b":{"a":{"a":9}}}"#),
+    )?;
+    assert_eq!(stdout, "[\"b\",\"a\",\"a\"]\n", "stderr: {stderr:?}");
+    assert!(
+        stderr.contains(r#"attempt to access element "a" of 9"#),
+        "stderr: {stderr:?}"
+    );
+    assert_eq!(code, 5, "stdout: {stdout:?} stderr: {stderr:?}");
+
+    // A non-navigating UPDATE leaves the accumulator *at* the register, so
+    // the carried-provenance half keeps answering `true` -- three plain
+    // `["b"]`, no raise, even though the value is an object.
+    let (stdout, stderr, code) = run_jq_full(
+        &["-c", "path(foreach (1,2,3) as $k (.b; .))"],
+        Some(r#"{"a":1,"b":{"a":{"a":9}}}"#),
+    )?;
+    assert_eq!(
+        (stdout.as_str(), code),
+        ("[\"b\"]\n[\"b\"]\n[\"b\"]\n", 0),
+        "stderr: {stderr:?}"
+    );
+
+    // INIT navigating to the document root behaves the same way: step 1
+    // tracks, step 2's accumulator (`1`) is no longer the register.
+    let (stdout, stderr, code) = run_jq_full(
+        &["-c", "path(foreach (1,2) as $k (.; .a))"],
+        Some(r#"{"a":1,"b":{"a":{"a":9}}}"#),
+    )?;
+    assert_eq!(stdout, "[\"a\"]\n", "stderr: {stderr:?}");
+    assert!(
+        stderr.contains(r#"attempt to access element "a" of 1"#),
+        "stderr: {stderr:?}"
+    );
+    assert_eq!(code, 5, "stdout: {stdout:?} stderr: {stderr:?}");
+
+    Ok(())
+}
+
 /// #2031's mixed-source variant: a source with *some* trackable branches
 /// and some untracked ones must still stream every branch before the
 /// trackable one, exactly as an all-untracked source already did (#1872) --

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -38292,3 +38292,48 @@ fn test_as_binding_keeps_the_input_identity_2563() -> Result<()> {
     }
     Ok(())
 }
+
+/// #2161's yq-mode gate. The `foreach` fold register fix lets a step whose
+/// accumulator is still the register's own value re-enter the register
+/// instead of refusing — which on the *write* side turns a refusal into a
+/// write. yq must not take that half.
+///
+/// Same rule, and the same reason, as `trackable_step_register_eligible`'s
+/// existing mode gate: real yq no-ops a field access against a scalar rather
+/// than navigating through it, so writing here would be silent data
+/// corruption rather than the fidelity win it is in jq mode. Confirmed live
+/// against yq v4.53.3 on the non-fold analogue, which is as close as the
+/// oracle gets (real yq's lexer rejects `foreach` outright):
+///
+/// ```console
+/// $ printf 'null\n' | yq '(null | .a) = 5'
+/// null
+/// ```
+///
+/// jq mode keeps the write — `jq -n '(foreach (1) as $k (null; .a)) = 5'` is
+/// `{"a":5}`, and `succinctly jq` matches it — so this is a mode divergence,
+/// not a missing fix. Pinned here because the un-gated version of #2161
+/// silently produced `a: 5` and only review caught it.
+#[test]
+fn test_foreach_register_reentry_is_jq_mode_only_on_the_write_side_2161() -> Result<()> {
+    for filter in [
+        "(foreach (1) as $k (null; .a)) = 5",
+        "(foreach (1,2) as $k (null; .a)) = 5",
+    ] {
+        let (stdout, stderr, code) = run_yq_stdin_with_stderr(filter, "null\n", &[])?;
+        assert_eq!(
+            code, 1,
+            "`{filter}` -- stdout: {stdout:?} stderr: {stderr:?}"
+        );
+        assert!(
+            stdout.trim().is_empty(),
+            "`{filter}` must not write: stdout: {stdout:?}"
+        );
+        assert!(
+            stderr.contains("Invalid path expression"),
+            "`{filter}` -- stderr: {stderr:?}"
+        );
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary

`resolve_foreach` decided each step's `at_register` from the previous step's
`FoldRegister::branch_provenance`, which answers *"did the last UPDATE branch end **at** the
register's own path"*. The register is fixed for the whole fold and UPDATE's whole job is to
navigate away from it — so that answer is `false` from step 2 onward, and every later step
refused its own identical navigation as untracked:

```console
$ echo '{"a":1}' | jq -c 'path(foreach (1,2,3) as $k (.b; .a))'
["b","a"]
["b","a"]
["b","a"]
$ echo '{"a":1}' | succinctly jq -c 'path(foreach (1,2,3) as $k (.b; .a))'
["b","a"]
jq: error (at <stdin>:1): Invalid path expression near attempt to access element "a" of null
```

`register_identical`'s own doc comment already states the model the code was missing — the
register is *"fixed once per INIT fork, never advances across source-element iterations"* —
so what decides a step is jq's `jv_identical(current_input, value_at_path)`: is the
accumulator arriving at this step still the register's value. That is exactly the check the
per-source-element override arm directly above already performs; this arm was comparing
paths instead.

I confirmed the issue's suggested `resolve_leaf`/`branch_provenance` diagnosis before
fixing, and derived jq's model from the oracle rather than from the issue text — six probe
shapes pin it, and the fix reproduces all six including error-message contents.

## Why it's an `||`, not a swap

My first version replaced the path comparison with the identity check, and it broke step 1
for object-valued registers. `register_identical` demands `snapshot || Null | Bool` —
structural equality is not jq's pointer identity, so a container counts only when it is
known to be the frozen node itself.

So neither half subsumes the other:

| | carried provenance | identity check |
|---|---|---|
| step 1, object-valued register | **correct `true`** | `false` (container, no snapshot) |
| step 2+, `null`/`bool` accumulator | `false` (path moved) | **correct `true`** |

Dropping either half regresses one of the shapes the new test pins, which is why the test
covers both directions rather than only the issue's repro.

## Oracle verification

A generated sweep — 4 source streams × 7 INITs × 11 UPDATEs × 12 documents, plus EXTRACT
variants, **12,048 cases** — captured from a pre-fix and a post-fix build and classified
against jq 1.7.1 case by case:

| | count |
|---|---|
| cases changed by this fix | 880 |
| ...now matching jq (fixed) | **880** |
| ...no longer matching (broken) | **0** |
| ...changed, neither matches | **0** |

stdout, stderr **and** exit code are all compared, so the error-message shapes are part of
the claim, not just the successful paths. Comparing pre-fix against post-fix directly is
what isolates *this change's* effect from the pre-existing divergences in the same matrix.

yq mode (`eval.rs` is shared): 1,620 fold cases captured both ways, **40 changed**, all the
same fix shape. `path` in yq mode is a `--jq-extensions`-gated jq extension that real yq's
lexer rejects outright, so there is no yq oracle to diverge from — following jq's model is
the correct behaviour for that surface.

## Not fixed here: `reduce` has the identical bug

The sweep still reports 728 divergences after this fix, and **all 728 are `reduce`**.
`resolve_reduce` carries the same path-comparison at its own carry-forward site and is
untouched by this PR.

I did prototype the analogous change there to make the follow-up actionable: it fixes 696
of the 728 and breaks 0, leaving 32. That is strong shared-root-cause evidence, but 696
behaviour changes in a second construct deserve their own PR and their own review rather
than riding along here. Filed as a follow-up with that measurement.

## Test plan

- [x] `cargo build --features cli`
- [x] `cargo test --features cli,simd,regex,serde` — full suite green (60 suites)
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] `cargo test --no-default-features` (`no_std`)
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features`
- [x] 12,048-case jq oracle sweep, pre/post classified against jq 1.7.1 (table above)
- [x] 1,620-case yq-mode pre/post capture
- [x] New `test_foreach_reenters_register_every_step_not_just_the_first_2161` — six live jq 1.7.1 shapes, covering both halves of the `||` and both the emit and the raise directions

Fixes #2161
