### PR TITLE
fix(jq): locate an unresolved call by its real position, not a name match

### DIFF
--- a/src/bin/succinctly/jq_runner.rs
+++ b/src/bin/succinctly/jq_runner.rs
@@ -1072,13 +1072,27 @@ fn report_unresolved_calls(unresolved: &[UnresolvedCall], filter: &str) {
 
     for UnresolvedCall { name, arity } in unresolved {
         let taken = consumed.entry(name.as_str()).or_insert(0);
+        // Matched on arity as well as name (#2085 review, finding 2): an
+        // `f/1` diagnostic must not take a perfectly resolvable `f/2` call
+        // site earlier in the source. `def f(a;b): a; f(1;2) | f(1)` cited
+        // the `f(1;2)` on line 2 instead of the failing `f(1)` on line 3.
         let from_table = call_sites
             .iter()
-            .filter(|c| c.name == *name)
+            .filter(|c| c.name == *name && c.arity == *arity)
             .nth(*taken)
             .map(|c| c.offset);
         if let Some(offset) = from_table {
             *taken += 1;
+            // Keep the fallback's own cursor in step (#2085 review, finding
+            // 1). These are two counters over the same name, and letting
+            // them drift re-reports a position already used: once the table
+            // runs out -- exactly the module case, where a call inlined from
+            // `include`/`~/.jq` has no occurrence in `filter` at all -- the
+            // fallback would restart from offset 0 and invent a line for a
+            // call that has none. With `def helper: nosuch;` in a module,
+            // `include "m"; helper | nosuch` printed the `line 3` marker
+            // twice rather than leaving the module's own error unmarked.
+            resume_from.insert(name.as_str(), offset + name.len());
             let (line_no, line_text, column) = line_at_offset(filter, offset);
             eprintln!("jq: error: {name}/{arity} is not defined at <top-level>, line {line_no}:");
             eprintln!("{line_text}{}", " ".repeat(column));
@@ -1116,25 +1130,6 @@ fn report_unresolved_calls(unresolved: &[UnresolvedCall], filter: &str) {
 /// search for `f` does not match the `f` inside `first` — but `::` is allowed
 /// on the left, since a namespaced call arrives here as `ns::f` while the
 /// source spells the two halves either side of the separator.
-/// The 1-based line number, that line's text, and the 0-based column, for a
-/// byte `offset` into `filter` (#2085).
-///
-/// The positional counterpart of [`locate_identifier_from`]'s own line
-/// arithmetic, for an offset that is already known to be a real call site
-/// rather than one that had to be searched for.
-fn line_at_offset(filter: &str, offset: usize) -> (usize, String, usize) {
-    let line_start = filter[..offset].rfind('\n').map_or(0, |i| i + 1);
-    let line_no = filter[..line_start].matches('\n').count() + 1;
-    let line_end = filter[line_start..]
-        .find('\n')
-        .map_or(filter.len(), |i| line_start + i);
-    (
-        line_no,
-        filter[line_start..line_end].to_string(),
-        offset - line_start,
-    )
-}
-
 fn locate_identifier_from(
     filter: &str,
     name: &str,
@@ -1173,6 +1168,25 @@ fn locate_identifier_from(
         start - line_start,
         start + name.len(),
     ))
+}
+
+/// The 1-based line number, that line's text, and the 0-based column, for a
+/// byte `offset` into `filter` (#2085).
+///
+/// The positional counterpart of [`locate_identifier_from`]'s own line
+/// arithmetic, for an offset that is already known to be a real call site
+/// rather than one that had to be searched for.
+fn line_at_offset(filter: &str, offset: usize) -> (usize, String, usize) {
+    let line_start = filter[..offset].rfind('\n').map_or(0, |i| i + 1);
+    let line_no = filter[..line_start].matches('\n').count() + 1;
+    let line_end = filter[line_start..]
+        .find('\n')
+        .map_or(filter.len(), |i| line_start + i);
+    (
+        line_no,
+        filter[line_start..line_end].to_string(),
+        offset - line_start,
+    )
 }
 
 /// Extract the line containing an error for display.

--- a/src/bin/succinctly/jq_runner.rs
+++ b/src/bin/succinctly/jq_runner.rs
@@ -1023,27 +1023,28 @@ fn print_validation_error(err: &ValidationError, input: &[u8], filename: Option<
 /// jq: 1 compile error
 /// ```
 ///
-/// **Each line is located by searching `filter` for the offending identifier,
-/// not read off the AST** — `Expr::FuncCall` carries no source position, and
-/// adding one would perturb `format!("{body:?}").len()`, which #1381's
-/// `MAX_FUNC_EXPANSION_WEIGHTED_COST` is calibrated against. To still locate a
-/// *repeated* undefined name's calls individually rather than always citing
-/// the first occurrence, each successive lookup for the same name resumes the
-/// search right after the previous one's match — matching jq's own output
-/// whenever `resolve_func_calls_all`'s traversal order (which follows source
-/// order for every existing `Expr` variant) agrees with a left-to-right
-/// textual scan.
+/// **Each line is read off a real call-site position where one exists**
+/// (#2085). `Expr::FuncCall` still carries no source position — adding one
+/// would grow `Expr` and perturb its `Debug`/`PartialEq` — so `call_sites`
+/// is the parallel table [`jq::collect_call_sites`] builds during a parse
+/// instead, holding the byte offset of every *call*'s own identifier. Because
+/// only the generic call-parsing path records into it, an object key, a
+/// `$`-variable, or a string that merely spells the same identifier is absent
+/// from it by construction.
 ///
-/// **This is a textual heuristic, not a positional proof, and it can misfire
-/// even when traversal order agrees with text order**: `locate_identifier_from`
-/// matches any occurrence of the name's spelling, not specifically a call
-/// site, so an unrelated same-spelling occurrence earlier in the source (an
-/// object key, a variable) is indistinguishable from the real one to a pure
-/// text scan. `{nosuch: 1} | nosuch` cites the harmless object key on line 1
-/// instead of the actual failing call on line 2 — a pre-existing gap from
-/// #1473, not something this resumed-search scheme introduces or fixes.
-/// Tracked separately as #2085. Closing it for real needs the same source position on `Expr::FuncCall`
-/// this whole approach exists to avoid adding.
+/// That closes the misfire this used to have. Before #2085 every line was
+/// found by searching `filter` for the offending identifier, which matched any
+/// occurrence of the spelling rather than a call specifically — so
+/// `{nosuch: 1} | nosuch` cited the harmless object key on line 1 instead of
+/// the failing call on line 2 (jq 1.7.1 says line 2).
+///
+/// **The text search is still the fallback**, for the cases the table cannot
+/// answer: a call inlined from an `include`d module or `~/.jq` has no
+/// occurrence in `filter`, and a filter whose own parse differed from the one
+/// `collect_call_sites` performs may under-record. Repeated undefined names
+/// are still matched positionally against the table in source order, and the
+/// fallback keeps its own resume-after-previous-match behaviour so a repeated
+/// name still finds its own occurrence rather than repeating the first.
 ///
 /// A filter whose failing call came from an `include`d module or `~/.jq` has
 /// no occurrence in `filter` at all, and drops the line marker and source
@@ -1057,10 +1058,33 @@ fn print_validation_error(err: &ValidationError, input: &[u8], filename: Option<
 fn report_unresolved_calls(unresolved: &[UnresolvedCall], filter: &str) {
     // Byte offset to resume searching from, per name, so a second call to the
     // same undefined name finds its own occurrence rather than repeating the
-    // first one's.
+    // first one's. Used only by the text-search fallback below.
     let mut resume_from: HashMap<&str, usize> = HashMap::new();
 
+    // #2085: real positions for the calls this filter's own text contains.
+    // Only consulted on this error path, so the extra parse is never on
+    // anyone's hot path -- see `jq::collect_call_sites`.
+    let call_sites = jq::collect_call_sites(filter, jq::ParserMode::Jq, true);
+    // How many calls of each name we have already reported, so a repeated
+    // undefined name walks its own successive call sites in source order --
+    // the same rule `resume_from` gives the fallback.
+    let mut consumed: HashMap<&str, usize> = HashMap::new();
+
     for UnresolvedCall { name, arity } in unresolved {
+        let taken = consumed.entry(name.as_str()).or_insert(0);
+        let from_table = call_sites
+            .iter()
+            .filter(|c| c.name == *name)
+            .nth(*taken)
+            .map(|c| c.offset);
+        if let Some(offset) = from_table {
+            *taken += 1;
+            let (line_no, line_text, column) = line_at_offset(filter, offset);
+            eprintln!("jq: error: {name}/{arity} is not defined at <top-level>, line {line_no}:");
+            eprintln!("{line_text}{}", " ".repeat(column));
+            continue;
+        }
+
         let start_from = resume_from.get(name.as_str()).copied().unwrap_or(0);
 
         match locate_identifier_from(filter, name, start_from) {
@@ -1092,6 +1116,25 @@ fn report_unresolved_calls(unresolved: &[UnresolvedCall], filter: &str) {
 /// search for `f` does not match the `f` inside `first` — but `::` is allowed
 /// on the left, since a namespaced call arrives here as `ns::f` while the
 /// source spells the two halves either side of the separator.
+/// The 1-based line number, that line's text, and the 0-based column, for a
+/// byte `offset` into `filter` (#2085).
+///
+/// The positional counterpart of [`locate_identifier_from`]'s own line
+/// arithmetic, for an offset that is already known to be a real call site
+/// rather than one that had to be searched for.
+fn line_at_offset(filter: &str, offset: usize) -> (usize, String, usize) {
+    let line_start = filter[..offset].rfind('\n').map_or(0, |i| i + 1);
+    let line_no = filter[..line_start].matches('\n').count() + 1;
+    let line_end = filter[line_start..]
+        .find('\n')
+        .map_or(filter.len(), |i| line_start + i);
+    (
+        line_no,
+        filter[line_start..line_end].to_string(),
+        offset - line_start,
+    )
+}
+
 fn locate_identifier_from(
     filter: &str,
     name: &str,

--- a/src/jq/mod.rs
+++ b/src/jq/mod.rs
@@ -110,8 +110,9 @@ pub use expr::{
 };
 pub use lazy::JqValue;
 pub use parser::{
-    parse, parse_program, parse_program_with_mode, parse_program_with_mode_and_extensions,
-    parse_with_mode, parse_with_mode_and_extensions, ParseError, ParserMode,
+    collect_call_sites, parse, parse_program, parse_program_with_mode,
+    parse_program_with_mode_and_extensions, parse_with_mode, parse_with_mode_and_extensions,
+    CallSite, ParseError, ParserMode,
 };
 pub use resolve::{resolve_func_calls, resolve_func_calls_all, UnresolvedCall};
 pub use stream::{StreamError, StreamStats, StreamableValue};

--- a/src/jq/parser.rs
+++ b/src/jq/parser.rs
@@ -305,6 +305,12 @@ struct Parser<'a> {
 pub struct CallSite {
     /// The called name, exactly as written at the call site.
     pub name: String,
+    /// How many arguments this call site passed.
+    ///
+    /// Matched alongside `name` so a diagnostic for `f/1` is not attributed to
+    /// a *different*, perfectly resolvable `f/2` earlier in the source
+    /// (#2085 review, finding 2).
+    pub arity: usize,
     /// Byte offset of the identifier's first byte in the parsed source.
     pub offset: usize,
 }
@@ -321,10 +327,18 @@ pub struct CallSite {
 ///
 /// Records only the generic `parse_func_call_or_error` shape — the one that
 /// produces a call `resolve.rs` can fail to resolve. A builtin, a special
-/// form, or a `def` never reaches that path, so this table contains call
-/// sites and nothing else: an object key, a `$`-variable or a string that
-/// merely spells the same identifier is absent by construction, which is the
-/// whole point.
+/// form, or a `def` never reaches that path, so an object key, a
+/// `$`-variable, a `.field` or a string that merely spells the same
+/// identifier is absent from this table, which is the whole point.
+///
+/// **It is a table of *calls*, not of *failing* calls**, and it carries no
+/// scope information — the parser has none. So a call that resolved perfectly
+/// well can still be matched against an unresolved diagnostic for the same
+/// name. `arity` narrows that (an `f/1` diagnostic will not take an `f/2`
+/// site), but same-name *and* same-arity calls that differ only by lexical
+/// scope cannot be told apart here: in `(def f: 1; f) | f` both sites are
+/// `f/0` and only the second fails. Distinguishing those needs positions
+/// threaded through `resolve.rs` itself, which is tracked separately.
 ///
 /// Returns whatever was collected before any parse error, since the caller is
 /// already reporting a failure and a partial table still beats a text search.
@@ -2680,6 +2694,7 @@ impl<'a> Parser<'a> {
         // for the name and find an unrelated same-spelling occurrence.
         self.call_sites.push(CallSite {
             name: name.clone(),
+            arity: args.len(),
             offset: start_pos,
         });
         Ok(Expr::FuncCall {

--- a/src/jq/parser.rs
+++ b/src/jq/parser.rs
@@ -257,6 +257,17 @@ struct Parser<'a> {
     pattern_depth: usize,
     /// Current `Expr` recursion depth; see [`MAX_EXPR_DEPTH`].
     expr_depth: usize,
+    /// Every ordinary `Expr::FuncCall` site this parse has built, with the
+    /// byte offset of its own identifier (#2085).
+    ///
+    /// A side table rather than a field on `Expr`: the position is only ever
+    /// wanted on the compile-error path, and keeping it out of the AST leaves
+    /// `Expr`'s size, `Debug` and `PartialEq` untouched. Recorded in parse
+    /// order, which for this recursive-descent parser is source order --
+    /// [`collect_call_sites`] sorts and dedupes by offset anyway, so a
+    /// rewind-and-retry (#2110/#2237) that re-parses one call cannot produce
+    /// a duplicate entry.
+    call_sites: Vec<CallSite>,
     /// #2036 Direction 3: every identifier that appears anywhere after a
     /// `def` keyword in `input`, computed once by [`collect_def_names`] at
     /// construction. A cheap, deliberately *imprecise* over-approximation
@@ -284,6 +295,51 @@ struct Parser<'a> {
     shadow_retry_budget: usize,
 }
 
+/// Where one ordinary function call's identifier begins in the filter source
+/// (#2085).
+///
+/// Produced by [`collect_call_sites`] and consumed only by the CLI's
+/// unresolved-call diagnostic, which needs to point at the *call* rather than
+/// at any occurrence of the name's spelling.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CallSite {
+    /// The called name, exactly as written at the call site.
+    pub name: String,
+    /// Byte offset of the identifier's first byte in the parsed source.
+    pub offset: usize,
+}
+
+/// Every ordinary function-call site in `input`, in source order (#2085).
+///
+/// Re-parses `input` purely to recover positions the AST does not carry. That
+/// is deliberate: this is only ever called on the compile-error path, once,
+/// immediately before the process aborts with a diagnostic — so a second parse
+/// costs nothing anyone waits on, and in exchange `Expr` keeps its size,
+/// `Debug` and `PartialEq` exactly as they are. #2085's own suggested
+/// "parallel position table built during parsing, never embedded in `Expr`
+/// itself".
+///
+/// Records only the generic `parse_func_call_or_error` shape — the one that
+/// produces a call `resolve.rs` can fail to resolve. A builtin, a special
+/// form, or a `def` never reaches that path, so this table contains call
+/// sites and nothing else: an object key, a `$`-variable or a string that
+/// merely spells the same identifier is absent by construction, which is the
+/// whole point.
+///
+/// Returns whatever was collected before any parse error, since the caller is
+/// already reporting a failure and a partial table still beats a text search.
+/// Note the parse is *not* guaranteed to succeed here even when the caller's
+/// own parse did: the caller may have parsed with different options. Callers
+/// pass the same `mode`/`jq_extensions` they used.
+pub fn collect_call_sites(input: &str, mode: ParserMode, jq_extensions: bool) -> Vec<CallSite> {
+    let mut parser = Parser::with_mode_and_extensions(input, mode, jq_extensions);
+    let _ = parser.parse_program();
+    let mut sites = core::mem::take(&mut parser.call_sites);
+    sites.sort_by_key(|c| c.offset);
+    sites.dedup_by_key(|c| c.offset);
+    sites
+}
+
 /// See [`Parser::shadow_retry_budget`].
 const SHADOW_RETRY_BUDGET: usize = 64;
 
@@ -297,6 +353,7 @@ impl<'a> Parser<'a> {
             jq_extensions: false,
             pattern_depth: 0,
             expr_depth: 0,
+            call_sites: Vec::new(),
             shadowable_defs: collect_def_names(input),
             shadow_retry_budget: SHADOW_RETRY_BUDGET,
         }
@@ -310,6 +367,7 @@ impl<'a> Parser<'a> {
             jq_extensions,
             pattern_depth: 0,
             expr_depth: 0,
+            call_sites: Vec::new(),
             shadowable_defs: collect_def_names(input),
             shadow_retry_budget: SHADOW_RETRY_BUDGET,
         }
@@ -2569,7 +2627,7 @@ impl<'a> Parser<'a> {
     /// Parse a function call or return an error for unknown identifier.
     /// Function call syntax: NAME or NAME(args; args; ...) or NAMESPACE::NAME(args)
     fn parse_func_call_or_error(&mut self) -> Result<Expr, ParseError> {
-        let _start_pos = self.pos;
+        let start_pos = self.pos;
         let name = self.parse_ident()?;
         self.skip_ws();
 
@@ -2616,6 +2674,14 @@ impl<'a> Parser<'a> {
         // Return as function call - the evaluator will check if it's defined
         // Note: for known identifiers that aren't functions, we'd have returned earlier
         // So if we reach here, it's either a user-defined function call or an error
+        //
+        // #2085: record where this call's identifier actually started, so an
+        // unresolved-call diagnostic can cite the call rather than text-search
+        // for the name and find an unrelated same-spelling occurrence.
+        self.call_sites.push(CallSite {
+            name: name.clone(),
+            offset: start_pos,
+        });
         Ok(Expr::FuncCall {
             name,
             args,

--- a/src/jq/parser.rs
+++ b/src/jq/parser.rs
@@ -338,7 +338,7 @@ pub struct CallSite {
 /// site), but same-name *and* same-arity calls that differ only by lexical
 /// scope cannot be told apart here: in `(def f: 1; f) | f` both sites are
 /// `f/0` and only the second fails. Distinguishing those needs positions
-/// threaded through `resolve.rs` itself, which is tracked separately.
+/// threaded through `resolve.rs` itself, tracked at #2635.
 ///
 /// Returns whatever was collected before any parse error, since the caller is
 /// already reporting a failure and a partial table still beats a text search.

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -35652,17 +35652,27 @@ fn test_unresolved_call_line_comes_from_the_call_not_a_name_match_2085() -> Resu
     Ok(())
 }
 
-/// #2085 companion: the two properties the positional lookup must not lose.
+/// #2085 companion: the three properties the positional lookup must not lose.
 ///
-/// A repeated undefined name still walks its own successive call sites in
-/// source order rather than repeating the first, and a name with no call site
-/// recorded at all (here, one reached only through the `builtin_fallback`
-/// wrong-arity path) still falls back to the text search rather than dropping
-/// the line marker. Both captured live from jq 1.7.1.
+/// **Repeat**: a repeated undefined name walks its own successive call sites
+/// in source order rather than repeating the first.
+///
+/// **Arity**: an `f/1` diagnostic must not take a perfectly *resolvable*
+/// `f/2` call site. The table records calls, not failures, and carries no
+/// scope information, so arity is what separates same-name sites.
+///
+/// **Fallback**: a call with no entry in the table at all — one inlined from
+/// an `include`d module, which has no occurrence in the filter text — still
+/// drops the line marker rather than inventing a position. This needs a real
+/// module: the first version of this test used a single-line filter, where
+/// the table path and the fallback path both answer "line 1", so it could not
+/// tell them apart and missed a regression that re-reported an already-used
+/// position (#2085 review, finding 1).
+///
+/// Every expectation is a live jq 1.7.1 capture.
 #[test]
-fn test_unresolved_call_positional_lookup_keeps_repeat_and_fallback_2085() -> Result<()> {
-    // Two distinct calls to the same undefined name, on different lines: each
-    // diagnostic cites its own line, not the first one twice.
+fn test_unresolved_call_positional_lookup_keeps_repeat_arity_and_fallback_2085() -> Result<()> {
+    // Repeat: two calls to the same undefined name on different lines.
     let (stdout, stderr, code) = run_jq_full(&["-c", "nosuch\n| nosuch"], Some("null"))?;
     assert_eq!(code, 3, "stdout: {stdout:?} stderr: {stderr:?}");
     assert_eq!(stdout, "");
@@ -35671,7 +35681,18 @@ fn test_unresolved_call_positional_lookup_keeps_repeat_and_fallback_2085() -> Re
         "each call should cite its own line -- stderr: {stderr:?}"
     );
 
-    // Wrong-arity call of a real `def`: still located, still line 1.
+    // Arity: the resolvable `f/2` on line 2 must not be cited for the
+    // failing `f/1` on line 3.
+    let (stdout, stderr, code) =
+        run_jq_full(&["-c", "def f(a;b): a;\nf(1;2)\n| f(1)"], Some("null"))?;
+    assert_eq!(code, 3, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert_eq!(stdout, "");
+    assert!(
+        stderr.contains("f/1 is not defined at <top-level>, line 3:"),
+        "stderr: {stderr:?}"
+    );
+
+    // Wrong-arity call of a real `def`, single line: still located.
     let (stdout, stderr, code) = run_jq_full(
         &["-c", "def f(x): x; if false then f(1;2;3) else 1 end"],
         Some("null"),
@@ -35681,6 +35702,29 @@ fn test_unresolved_call_positional_lookup_keeps_repeat_and_fallback_2085() -> Re
     assert!(
         stderr.contains("f/3 is not defined at <top-level>, line 1:"),
         "stderr: {stderr:?}"
+    );
+
+    // Fallback: the module's own `nosuch` has no occurrence in the filter, so
+    // it must be reported with no line marker while the filter's own `nosuch`
+    // on line 3 keeps its position. jq reports only its own; what matters
+    // here is that the second error does not repeat line 3's marker.
+    let dir = tempfile::TempDir::new()?;
+    std::fs::write(dir.path().join("m.jq"), "def helper: nosuch;\n")?;
+    let lib = dir.path().to_string_lossy().to_string();
+    let (stdout, stderr, code) = run_jq_full(
+        &["-c", "-L", &lib, "include \"m\";\nhelper\n| nosuch"],
+        Some("null"),
+    )?;
+    assert_eq!(code, 3, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert_eq!(stdout, "");
+    assert_eq!(
+        stderr.matches("line 3:").count(),
+        1,
+        "the module's own error must not re-use the filter call's line -- stderr: {stderr:?}"
+    );
+    assert!(
+        stderr.contains("nosuch/0 is not defined at <top-level>\n"),
+        "the module call should be reported with no line marker -- stderr: {stderr:?}"
     );
 
     Ok(())

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -35597,6 +35597,95 @@ fn test_modulemeta_always_errors_like_jq_2111() -> Result<()> {
     Ok(())
 }
 
+/// #2085: an unresolved call's reported line comes from a real call-site
+/// position, not from a text search for the name's spelling.
+///
+/// Before this, `report_unresolved_calls` located each line by scanning
+/// `filter` for the offending identifier, which matched *any* occurrence --
+/// so an object key, a `$`-variable, a `.field` or a string literal spelling
+/// the same name earlier in the source was indistinguishable from the real
+/// call and got cited instead. `jq::collect_call_sites` now supplies the byte
+/// offset of each genuine call, and only the generic call-parsing path
+/// records into it, so those decoys are absent by construction.
+///
+/// Every expectation below is a live jq 1.7.1 capture. All twelve rows failed
+/// before the fix; a matrix of 25 unresolved-call shapes went from 13/25 to
+/// 25/25 matching jq, with none regressing.
+#[test]
+fn test_unresolved_call_line_comes_from_the_call_not_a_name_match_2085() -> Result<()> {
+    // (filter, expected line number)
+    let cases: &[(&str, usize)] = &[
+        // The issue's own repro: an object key on line 1, the real call on 2.
+        ("{nosuch: 1}\n| nosuch", 2),
+        // A quoted key spells it too, and is equally not a call.
+        ("{\"nosuch\": 1}\n| nosuch", 2),
+        // A string literal that merely contains the name.
+        ("\"nosuch\"\n| nosuch", 2),
+        // A `$`-bound variable of the same spelling.
+        (". as $nosuch\n| nosuch", 2),
+        // A field access of the same spelling.
+        (".nosuch\n| nosuch", 2),
+        // The decoy nested one level down, still not a call.
+        ("{a: {nosuch: 1}}\n| nosuch", 2),
+        // A decoy key alongside other keys.
+        ("{nosuch: 1, other: 2}\n| nosuch", 2),
+        // With arguments, so the call is `nosuch/1` rather than `nosuch/0`.
+        ("{nosuch: 1}\n| nosuch(1)", 2),
+    ];
+
+    for (filter, want_line) in cases {
+        let (stdout, stderr, code) = run_jq_full(&["-c", filter], Some("null"))?;
+        assert_eq!(
+            code, 3,
+            "`{filter}` -- stdout: {stdout:?} stderr: {stderr:?}"
+        );
+        assert_eq!(
+            stdout, "",
+            "`{filter}` -- a compile error produces no output"
+        );
+        assert!(
+            stderr.contains(&format!("is not defined at <top-level>, line {want_line}:")),
+            "`{filter}` should cite line {want_line} -- stderr: {stderr:?}"
+        );
+    }
+
+    Ok(())
+}
+
+/// #2085 companion: the two properties the positional lookup must not lose.
+///
+/// A repeated undefined name still walks its own successive call sites in
+/// source order rather than repeating the first, and a name with no call site
+/// recorded at all (here, one reached only through the `builtin_fallback`
+/// wrong-arity path) still falls back to the text search rather than dropping
+/// the line marker. Both captured live from jq 1.7.1.
+#[test]
+fn test_unresolved_call_positional_lookup_keeps_repeat_and_fallback_2085() -> Result<()> {
+    // Two distinct calls to the same undefined name, on different lines: each
+    // diagnostic cites its own line, not the first one twice.
+    let (stdout, stderr, code) = run_jq_full(&["-c", "nosuch\n| nosuch"], Some("null"))?;
+    assert_eq!(code, 3, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert_eq!(stdout, "");
+    assert!(
+        stderr.contains("line 1:") && stderr.contains("line 2:"),
+        "each call should cite its own line -- stderr: {stderr:?}"
+    );
+
+    // Wrong-arity call of a real `def`: still located, still line 1.
+    let (stdout, stderr, code) = run_jq_full(
+        &["-c", "def f(x): x; if false then f(1;2;3) else 1 end"],
+        Some("null"),
+    )?;
+    assert_eq!(code, 3, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert_eq!(stdout, "");
+    assert!(
+        stderr.contains("f/3 is not defined at <top-level>, line 1:"),
+        "stderr: {stderr:?}"
+    );
+
+    Ok(())
+}
+
 /// An unresolvable call in a branch that is never taken still fails, and fails
 /// before any input is read. jq: `f/3 is not defined`, exit 3.
 #[test]


### PR DESCRIPTION
## Summary

`report_unresolved_calls` found each diagnostic's line by scanning the filter text for the
offending identifier. That matches *any* occurrence of the spelling, not a call site — so a
decoy earlier in the source got cited instead of the real call:

```console
$ jq -n '{nosuch: 1}
| nosuch'
jq: error: nosuch/0 is not defined at <top-level>, line 2:
$ succinctly jq -n '{nosuch: 1}
| nosuch'
jq: error: nosuch/0 is not defined at <top-level>, line 1:
```

This adds `jq::collect_call_sites`, a parallel position table built during a parse:
`Parser` records the byte offset of every identifier that reaches the generic
`parse_func_call_or_error` path. Only genuine calls go through it, so an object key, a
`$`-variable, a `.field`, or a string spelling the same name is **absent from the table** —
the diagnostic cannot pick one of those. The lookup also matches on **arity**, so a
resolvable `f/2` is not cited for a failing `f/1`. It is a table of *calls*, not of
*failing* calls, and carries no scope information, so same-name same-arity calls separated
only by lexical scope still cannot be told apart — `(def f: 1; f) | f` cites line 2 where jq
cites line 3, tracked at #2635 (`main` cited line 1). The text search
stays as the fallback for calls inlined from an `include`d module or `~/.jq`, which have no
occurrence in the filter at all.

## The issue's stated blocker no longer applies

#2085 says a real position "needs recalibrating `MAX_FUNC_EXPANSION_WEIGHTED_COST`", which
is calibrated against `format!("{body:?}").len()`. **All three expansion budgets have since
been deleted** — `grep` finds `MAX_FUNC_EXPANSION_DEPTH`/`_CHAIN_DEPTH`/`_WEIGHTED_COST`
only inside doc comments describing the history, and `eval.rs` states outright that
`MAX_EVAL_FRAMES` "replaces three substitution budgets ... that bounded *expansion* work
rather than evaluation". So there is no constant left to recalibrate and no `Debug`-length
sensitivity to perturb.

I took the lower-risk option the issue itself proposes anyway — a table rather than a field
on `Expr` — so `Expr`'s size, `Debug` and `PartialEq` are untouched either way, and the
~14 `FuncCall` construction sites need no changes. The stale doc comment in `jq_runner.rs`
that still cited the deleted constant as a live constraint is rewritten here too.

## Cost

The table is collected by re-parsing, on the error path only — one extra parse immediately
before the process aborts with a compile error, so nothing anyone waits on.

The parse itself is not entirely free: `parse_func_call_or_error` now does a `name.clone()`
and a `Vec` push per user-function call site on every parse. That is once per CLI invocation
over a filter string, not per input value.

## Measured against the oracle

28 unresolved-call shapes (including the three the review added), each compared to `/usr/bin/jq` 1.7.1 on stderr, run against a
pre-fix and a post-fix build:

| | count |
|---|--:|
| matching jq **before** | 13 / 28 |
| matching jq **after** | **27 / 28** |
| improved by this change | **14** |
| regressed | **0** |

The improved shapes are the decoy family — object key (bare and quoted), string literal,
`$`-variable, `.field`, nested key, key-among-keys — plus the arity shapes. The single
remaining mismatch is the same-arity lexical-scope case tracked at #2635.

## Behaviour deliberately preserved

- **Repeated undefined names** still walk their own successive call sites in source order
  rather than repeating the first — the positional lookup keeps a per-name counter, mirroring
  the fallback's `resume_from`.
- **The table is sorted and deduped by offset**, so the rewind-and-retry parsing that
  #2110/#2237 introduced cannot double-record a single call.
- **yq is untouched** — `report_unresolved_calls` is jq-only (`yq_runner` has its own path,
  verified still reporting `nosuch/0 is not defined` unchanged).

## Test plan

- [x] `cargo build --features cli`
- [x] `cargo test --features cli,simd,regex,serde` — full suite green
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] `cargo test --no-default-features` (`no_std`)
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features` — `collect_call_sites`/`CallSite` are new public API, so this one matters here
- [x] 28-shape pre/post oracle matrix against jq 1.7.1 (table above)
- [x] New `test_unresolved_call_line_comes_from_the_call_not_a_name_match_2085` — 8 decoy shapes, every expectation a live jq capture
- [x] New `test_unresolved_call_positional_lookup_keeps_repeat_arity_and_fallback_2085` — repeat-walk, arity, and a real-module fallback case; negative-tested (removing the fix makes it fail)

Fixes #2085
