### PR TITLE
perf(jq): decode each object key once, not twice (#965 item 10)

### DIFF
--- a/src/jq/document.rs
+++ b/src/jq/document.rs
@@ -843,6 +843,7 @@ pub trait DocumentValue: Sized + Clone {
     /// that fast path available: it decodes, and `key_hash_of` measured
     /// +10-12% on `wide_keys_unsorted` when a decoding check was tried
     /// before the raw span.
+    // omni-dev: coverage tolerate reason="unreachable: both implementors (StandardJson, YamlValue) override this to decode once; the default exists as the contract a future implementor inherits, and is deliberately the two-call sequence it replaces (#965)"
     fn decoded_key_str(&self) -> Result<Option<Cow<'_, str>>, &'static str> {
         if let Some(reason) = self.string_decode_error() {
             return Err(reason);
@@ -3719,6 +3720,19 @@ mod decoded_key_str_tests {
         assert_eq!(
             yaml_nth_key(b"a: &x {p: 1}\n*x: 1\n", 1),
             Some((String::new(), false))
+        );
+    }
+
+    /// An alias key whose target will not *decode* is a decode failure, not
+    /// a #222 stringification -- the one YAML shape that reaches the
+    /// `Alias` arm's preserved `string_decode_error` call and returns
+    /// `Err`. Distinguishable from the case above only by `is_fallback`,
+    /// since YAML has no raw-span override and both spell `""`.
+    #[test]
+    fn yaml_alias_key_to_an_undecodable_string_is_a_decode_failure_965() {
+        assert_eq!(
+            yaml_nth_key(b"a: &x \"b\\qc\"\n*x: 1\n", 1),
+            Some((String::new(), true))
         );
     }
 

--- a/src/jq/document.rs
+++ b/src/jq/document.rs
@@ -842,7 +842,9 @@ pub trait DocumentValue: Sized + Clone {
     /// [`key_raw_unescaped`](Self::key_raw_unescaped) in a caller that has
     /// that fast path available: it decodes, and `key_hash_of` measured
     /// +10-12% on `wide_keys_unsorted` when a decoding check was tried
-    /// before the raw span.
+    /// before the raw span. *Below* that probe it is the right call --
+    /// `key_hash_of` uses it there, and YAML, which has no raw-span
+    /// override at all, reaches it for every key.
     // omni-dev: coverage tolerate reason="unreachable: both implementors (StandardJson, YamlValue) override this to decode once; the default exists as the contract a future implementor inherits, and is deliberately the two-call sequence it replaces (#965)"
     fn decoded_key_str(&self) -> Result<Option<Cow<'_, str>>, &'static str> {
         if let Some(reason) = self.string_decode_error() {
@@ -1423,27 +1425,36 @@ fn ascii_key_hash(key: &[u8]) -> Option<u64> {
 /// `wide_keys_unsorted` (+10-12%) when this was tried in that order.
 ///
 /// Once off that fast path (an escape, non-ASCII bytes, or no raw span at
-/// all -- YAML never has one), checks `string_decode_error` before falling
-/// to [`key_string`](DocumentValue::key_string): YAML's `key_string()`
-/// override never returns `None` at all (#222 -- a complex or undecodable
-/// key stringifies to `""` rather than being dropped), so a YAML
-/// decode-failure key would otherwise hash its `""` fallback like a real
-/// key and silently collapse with any other undecodable key in the same
-/// object under `collapse: true` (#1385's "never a duplicate" rule exists
-/// precisely to prevent that) -- the same ordering
-/// [`key_display_string_kind`] already uses for the display-string case.
-/// A no-op for JSON off the fast path: its two checks are redundant with
-/// each other (both resolve via `as_str`), just no longer free to reach.
+/// all -- YAML never has one), asks
+/// [`decoded_key_str`](DocumentValue::decoded_key_str), which answers both
+/// halves of the old `string_decode_error()`-then-`key_string()` pair from
+/// one decode. It preserves that pair's *order*, which is what matters
+/// here: YAML's `key_string()` override never returns `None` at all (#222
+/// -- a complex or undecodable key stringifies to `""` rather than being
+/// dropped), so a YAML decode-failure key would otherwise hash its `""`
+/// fallback like a real key and silently collapse with any other
+/// undecodable key in the same object under `collapse: true` (#1385's
+/// "never a duplicate" rule exists precisely to prevent that). `Err` and
+/// `Ok(None)` both mean "no reliable identity" and both map to `None`,
+/// exactly as the two separate checks did.
+///
+/// The fused call goes *after* the raw-span probe, never before it: the
+/// +10-12% above is the cost of reaching any decode ahead of that fast
+/// path, and `decoded_key_str` is a decode. Below it, the saving is real
+/// and is YAML's in particular -- YAML has no `key_raw_unescaped`
+/// override, so every YAML key hash lands here and used to pay two full
+/// `YamlString` decodes (#965 item 10, the same redundancy
+/// [`key_display_string_kind`] shed).
 fn key_hash_of<V: DocumentValue>(key: &V) -> Option<u64> {
     if let Some(raw) = key.key_raw_unescaped() {
         if let Some(hash) = ascii_key_hash(raw) {
             return Some(hash);
         }
     }
-    if key.string_decode_error().is_some() {
-        return None;
-    }
-    key.key_string().map(|key| key_hash(key.as_bytes()))
+    key.decoded_key_str()
+        .ok()
+        .flatten()
+        .map(|key| key_hash(key.as_bytes()))
 }
 
 /// [`key_hash_of`] for a caller holding a whole field.
@@ -1467,17 +1478,18 @@ fn field_key_hash<V: DocumentValue, C: DocumentCursor>(field: &DocumentField<V, 
 /// than `None` for a key with no scalar form), so this costs YAML one
 /// predicate on a branch it never takes.
 ///
-/// `key_string()` first, `string_decode_error()` only on its `None` (#1677
-/// perf-guard finding): the ordinary case -- a key that decodes fine --
-/// answers from that one call alone, instead of paying for two independent
-/// full decodes of the same bytes (`key_string()`'s own `as_str()` and a
-/// second, separate `as_str()` inside `string_decode_error()`). Equivalent
-/// to the original `dec_err.is_none() && key_str.is_none()`: whenever
-/// `key_string()` is `Some`, that conjunction is already `false` regardless
-/// of `string_decode_error()`, so short-circuiting on it first changes
-/// nothing observable, only which (redundant) call gets skipped.
+/// This *is* [`decoded_key_str`](DocumentValue::decoded_key_str)'s middle
+/// outcome, so it asks for it directly rather than reconstructing it from
+/// two accessors: `Ok(None)` is defined as "the grammar never allowed this
+/// key", `Err` is #1247's decode failure, and `Ok(Some(_))` is an ordinary
+/// key. That is the same predicate the earlier
+/// `key_string().is_none() && string_decode_error().is_none()` computed --
+/// whenever `key_string()` is `Some`, the conjunction is already `false`
+/// regardless of the other call -- and it is one decode on *every* input
+/// rather than #1677's one-or-two, since the malformed path no longer
+/// needs a second, separate `as_str()` to confirm the cause.
 pub(crate) fn key_is_malformed<V: DocumentValue>(key: &V) -> bool {
-    key.key_string().is_none() && key.string_decode_error().is_none()
+    matches!(key.decoded_key_str(), Ok(None))
 }
 
 /// The string to show for a key, substituting a best-effort fallback when
@@ -3602,7 +3614,10 @@ mod tail_gap_receiver_tests {
 /// `(spelling, is_fallback)` output, which is what callers actually consume.
 #[cfg(test)]
 mod decoded_key_str_tests {
-    use super::{key_display_string_kind, DocumentValue};
+    use super::{
+        ascii_key_hash, key_display_string_kind, key_hash, key_hash_of, key_is_malformed,
+        DocumentValue,
+    };
     use crate::json::JsonIndex;
     use crate::yaml::YamlIndex;
 
@@ -3615,13 +3630,13 @@ mod decoded_key_str_tests {
         key_display_string_kind(&field.key()).map(|(key, fallback)| (key.into_owned(), fallback))
     }
 
-    /// `json_first_key` for a single-document YAML mapping.
+    /// [`json_first_key`]'s counterpart for a single-document YAML mapping.
     fn yaml_first_key(yaml: &[u8]) -> Option<(String, bool)> {
         yaml_nth_key(yaml, 0)
     }
 
-    /// `yaml_first_key` for the `nth` field, so an alias key can be reached
-    /// past the field that declares the anchor it names.
+    /// [`yaml_first_key`] generalised to the `nth` field, so an alias key
+    /// can be reached past the field that declares the anchor it names.
     fn yaml_nth_key(yaml: &[u8], nth: usize) -> Option<(String, bool)> {
         let index = YamlIndex::build(yaml).expect("valid YAML");
         let cursor = index.root(yaml);
@@ -3744,5 +3759,120 @@ mod decoded_key_str_tests {
             yaml_first_key(b"? [1, 2]\n: 1\n"),
             Some((String::new(), false))
         );
+    }
+
+    /// `key_hash_of` and `key_is_malformed` answered from the same
+    /// `string_decode_error()`/`key_string()` pair `key_display_string_kind`
+    /// did, in two *different* hand-written orders, and both now ask
+    /// `decoded_key_str` instead (#965 item 10).
+    ///
+    /// Both feed identity decisions -- `key_hash_of` decides what
+    /// `collapse: true` treats as a duplicate (#1385's "a key that will not
+    /// decode is never a duplicate"), `key_is_malformed` decides what raises
+    /// as #1194 -- so an answer that shifts on any key shape is a silent
+    /// data bug, not a cosmetic one. This asserts against the *pre-fusion
+    /// bodies*, recomputed inline, rather than against expected constants:
+    /// a constant would pin what the new code does, not that it still
+    /// agrees with what the old code did.
+    fn assert_fused_predicates_match_the_pair<V: DocumentValue>(key: &V, label: &str) {
+        // `key_hash_of`'s pre-fusion body, raw-span fast path included --
+        // that probe is unchanged, but the tail has to agree *behind* it.
+        let was_hash = if let Some(hash) = key.key_raw_unescaped().and_then(ascii_key_hash) {
+            Some(hash)
+        } else if key.string_decode_error().is_some() {
+            None
+        } else {
+            key.key_string().map(|k| key_hash(k.as_bytes()))
+        };
+        assert_eq!(
+            was_hash,
+            key_hash_of(key),
+            "key_hash_of disagrees on {label}"
+        );
+
+        // `key_is_malformed`'s pre-fusion body (#1677's reversed order).
+        let was_malformed = key.key_string().is_none() && key.string_decode_error().is_none();
+        assert_eq!(
+            was_malformed,
+            key_is_malformed(key),
+            "key_is_malformed disagrees on {label}"
+        );
+    }
+
+    /// Every JSON key shape the two predicates can be handed: escape-free
+    /// ASCII (the #1514 raw-span fast path), non-ASCII and escaped keys
+    /// (which fall past it), both decode-failure families, and the #1194
+    /// non-string key.
+    #[test]
+    fn json_fused_predicates_match_the_old_pair_965() {
+        for key in [
+            r#""a""#,
+            r#""""#,
+            r#""\u0041""#,
+            r#""a\/b""#,
+            r#""\\""#,
+            r#""\n""#,
+            r#""\u0000""#,
+            r#""\uD83D\uDE00""#,
+            "\"\u{e9}\"",
+            "\"\u{1f600}\"",
+            r#""\q""#,
+            r#""\ud800""#,
+            r#""\udfff""#,
+            r#""\ud800x""#,
+            r#""\uZZZZ""#,
+            r#""\u""#,
+            "123",
+            "true",
+            "null",
+        ] {
+            let doc = alloc::format!("{{{key}:1}}");
+            let bytes = doc.as_bytes();
+            let index = JsonIndex::build(bytes);
+            let cursor = index.root(bytes);
+            let fields = cursor.value().as_object().expect("an object");
+            let (field, _) = fields.uncons().expect("at least one field");
+            assert_fused_predicates_match_the_pair(&field.key(), key);
+        }
+    }
+
+    /// The YAML half, which matters more: YAML has no `key_raw_unescaped`
+    /// override, so *every* key here lands on the fused call rather than the
+    /// fast path. Covers both #222 fallback routes (complex key, alias to a
+    /// non-scalar), the alias-to-string hop, and an alias whose target will
+    /// not decode.
+    #[test]
+    fn yaml_fused_predicates_match_the_old_pair_965() {
+        for doc in [
+            "a: 1\n",
+            "\"\": 1\n",
+            "\"a\\u0041b\": 1\n",
+            "'sq': 1\n",
+            "123: 1\n",
+            "true: 1\n",
+            "null: 1\n",
+            "~: 1\n",
+            "\"\\\\\": 1\n",
+            "\"\\n\": 1\n",
+            "\"a\\qb\": 1\n",
+            "\"\\ud800\": 1\n",
+            "? [1, 2]\n: 1\n",
+            "? {a: 1}\n: 1\n",
+            "a: &x foo\n*x: 1\n",
+            "a: &x {p: 1}\n*x: 1\n",
+            "a: &x [1]\n*x: 1\n",
+            "a: &x null\n*x: 1\n",
+            "a: &x \"b\\qc\"\n*x: 1\n",
+        ] {
+            let bytes = doc.as_bytes();
+            let index = YamlIndex::build(bytes).expect("valid YAML");
+            let cursor = index.root(bytes);
+            let mapping = cursor.first_child().expect("document content");
+            let mut fields = mapping.value().as_object().expect("a mapping");
+            while let Some((field, rest)) = fields.uncons() {
+                assert_fused_predicates_match_the_pair(&field.key(), doc);
+                fields = rest;
+            }
+        }
     }
 }

--- a/src/jq/document.rs
+++ b/src/jq/document.rs
@@ -804,6 +804,52 @@ pub trait DocumentValue: Sized + Clone {
         self.as_str()
     }
 
+    /// This key's decoded string *and* the reason it would not decode, from
+    /// one decode rather than two.
+    ///
+    /// The same three outcomes a key-displaying caller already has to tell
+    /// apart, fused into one call:
+    ///
+    /// - `Err(reason)` -- the span is a string token whose bytes will not
+    ///   decode, exactly [`string_decode_error`](Self::string_decode_error)'s
+    ///   `Some(reason)` (#1247).
+    /// - `Ok(None)` -- a key the format's *grammar* never allowed, exactly
+    ///   [`key_string`](Self::key_string)'s `None` (#1194). Still raises.
+    /// - `Ok(Some(key))` -- the decoded key.
+    ///
+    /// Asking those two accessors separately costs two full decodes of the
+    /// same bytes on the *success* path, because neither format caches:
+    /// `string_decode_error` and `key_string` both resolve through the same
+    /// `as_str()`, which re-scans for the closing quote and, for a key
+    /// holding any escape, re-runs the decode into a fresh allocation
+    /// (#965 item 10). Every query that displays object keys pays it per
+    /// key -- `keys`, `keys_unsorted`, `.`, `to_entries`, `-S` -- so the
+    /// saving is on ordinary well-formed documents, not just malformed ones.
+    ///
+    /// Returns `&'static str` rather than an `EvalError` for the same reason
+    /// `string_decode_error` does: the check stays allocation-free and
+    /// `no_std`-compatible, with each format's own error type owning the
+    /// wording. A caller that needs a real error wraps it
+    /// (`EvalError::decode_failure`).
+    ///
+    /// The default is literally the two-call sequence it replaces, so an
+    /// implementation that does not override it is unchanged. `StandardJson`
+    /// and `YamlValue` override it to decode once; `YamlValue` keeps the
+    /// two-call path for its `Alias` arm alone, where the two accessors
+    /// genuinely disagree (see its override).
+    ///
+    /// Do not reach for this ahead of
+    /// [`key_raw_unescaped`](Self::key_raw_unescaped) in a caller that has
+    /// that fast path available: it decodes, and `key_hash_of` measured
+    /// +10-12% on `wide_keys_unsorted` when a decoding check was tried
+    /// before the raw span.
+    fn decoded_key_str(&self) -> Result<Option<Cow<'_, str>>, &'static str> {
+        if let Some(reason) = self.string_decode_error() {
+            return Err(reason);
+        }
+        Ok(self.key_string())
+    }
+
     /// This value's raw source bytes when it is a string key whose span
     /// needs no decoding -- byte-identical to what
     /// [`key_string`](Self::key_string) would return.
@@ -1457,23 +1503,30 @@ pub fn key_display_string<V: DocumentValue>(key: &V) -> Option<Cow<'_, str>> {
 /// [`key_display_string`], plus whether the string is the decode-failure
 /// **fallback** spelling (`true`) rather than a genuine decode (`false`).
 ///
-/// Must check `string_decode_error()` *first*, not `key_string()`: YAML's
-/// `key_string()` override never returns `None` at all (#222 -- a complex
-/// or undecodable key stringifies to `""` rather than being dropped), so
-/// checking it first would make every YAML decode-failure key silently
-/// report `is_fallback = false`, indistinguishable from a genuine key
-/// spelled `""`. JSON's two checks happen to be redundant with each other
-/// (`string_decode_error()` and `key_string()` both resolve via the same
-/// `as_str()`), but the order has to serve both formats' actual contracts,
-/// not just the cheaper one.
+/// The decode failure must beat the stringification, not the other way
+/// round: YAML's `key_string()` override never returns `None` at all (#222
+/// -- a complex or undecodable key stringifies to `""` rather than being
+/// dropped), so consulting it first would make every YAML decode-failure
+/// key silently report `is_fallback = false`, indistinguishable from a
+/// genuine key spelled `""`.
+///
+/// That ordering is no longer written here. It is
+/// [`DocumentValue::decoded_key_str`]'s contract -- one call, which returns
+/// the failure and the decoded key from a single decode instead of paying
+/// for two independent decodes of the same bytes on every well-formed key
+/// (#965 item 10). Callers that want the ordering right cannot now get it
+/// wrong by writing the two calls in the wrong sequence, because there is
+/// only one call.
 pub(crate) fn key_display_string_kind<V: DocumentValue>(key: &V) -> Option<(Cow<'_, str>, bool)> {
-    if key.string_decode_error().is_some() {
-        let fallback = key
-            .key_raw_source_span()
-            .map_or(Cow::Borrowed(""), String::from_utf8_lossy);
-        return Some((fallback, true));
+    match key.decoded_key_str() {
+        Err(_reason) => {
+            let fallback = key
+                .key_raw_source_span()
+                .map_or(Cow::Borrowed(""), String::from_utf8_lossy);
+            Some((fallback, true))
+        }
+        Ok(decoded) => decoded.map(|key| (key, false)),
     }
-    key.key_string().map(|key| (key, false))
 }
 
 /// Guards a display-keyed `IndexMap` (`to_owned`/`materialize`, #1642)
@@ -3530,5 +3583,151 @@ mod tail_gap_receiver_tests {
         let empty_index = JsonIndex::build(empty);
         let empty_root = empty_index.root(empty);
         container_tail_gap_ok(&empty_root, None, b'}').expect("an empty `{}` is well-formed");
+    }
+}
+
+/// #965 item 10: `key_display_string_kind` now asks
+/// [`DocumentValue::decoded_key_str`] once where it used to ask
+/// `string_decode_error()` and `key_string()` separately, decoding the same
+/// key bytes twice on every well-formed key.
+///
+/// The saving is only legitimate if the fused accessor answers *identically*
+/// on every shape either format can produce, so this pins the whole matrix
+/// rather than the happy path: both formats' plain, escaped-but-decodable
+/// and undecodable keys, JSON's #1194 structurally-invalid key, and every
+/// YAML variant that reaches the `""` fallback by a different route (#222).
+/// Each case is written against `key_display_string_kind`'s own
+/// `(spelling, is_fallback)` output, which is what callers actually consume.
+#[cfg(test)]
+mod decoded_key_str_tests {
+    use super::{key_display_string_kind, DocumentValue};
+    use crate::json::JsonIndex;
+    use crate::yaml::YamlIndex;
+
+    /// `key_display_string_kind` of the first field's key of a JSON object.
+    fn json_first_key(json: &[u8]) -> Option<(String, bool)> {
+        let index = JsonIndex::build(json);
+        let cursor = index.root(json);
+        let fields = cursor.value().as_object().expect("an object");
+        let (field, _) = fields.uncons().expect("at least one field");
+        key_display_string_kind(&field.key()).map(|(key, fallback)| (key.into_owned(), fallback))
+    }
+
+    /// `json_first_key` for a single-document YAML mapping.
+    fn yaml_first_key(yaml: &[u8]) -> Option<(String, bool)> {
+        yaml_nth_key(yaml, 0)
+    }
+
+    /// `yaml_first_key` for the `nth` field, so an alias key can be reached
+    /// past the field that declares the anchor it names.
+    fn yaml_nth_key(yaml: &[u8], nth: usize) -> Option<(String, bool)> {
+        let index = YamlIndex::build(yaml).expect("valid YAML");
+        let cursor = index.root(yaml);
+        let mapping = cursor.first_child().expect("document content");
+        let mut fields = mapping.value().as_object().expect("a mapping");
+        for _ in 0..nth {
+            let (_, rest) = fields.uncons().expect("enough fields");
+            fields = rest;
+        }
+        let (field, _) = fields.uncons().expect("enough fields");
+        key_display_string_kind(&field.key()).map(|(key, fallback)| (key.into_owned(), fallback))
+    }
+
+    #[test]
+    fn json_plain_key_decodes_once_and_is_not_a_fallback_965() {
+        assert_eq!(
+            json_first_key(br#"{"a":1}"#),
+            Some(("a".to_string(), false))
+        );
+    }
+
+    /// The case the second decode was most expensive for: an escape forces
+    /// `decode_escapes` to allocate, and the old two-call path allocated
+    /// twice.
+    #[test]
+    fn json_escaped_key_that_decodes_is_not_a_fallback_965() {
+        assert_eq!(
+            json_first_key(br#"{"aAb":1}"#),
+            Some(("aAb".to_string(), false))
+        );
+    }
+
+    #[test]
+    fn json_invalid_escape_key_still_falls_back_to_its_raw_span_965() {
+        assert_eq!(
+            json_first_key(br#"{"a\q":1}"#),
+            Some(("a\\q".to_string(), true))
+        );
+    }
+
+    #[test]
+    fn json_lone_surrogate_key_still_falls_back_to_its_raw_span_965() {
+        assert_eq!(
+            json_first_key(br#"{"\ud800":1}"#),
+            Some(("\\ud800".to_string(), true))
+        );
+    }
+
+    /// A key the grammar never allowed (#1194) must stay `None` -- the
+    /// caller's cue to raise -- and must not be confused with a decode
+    /// failure now that both travel through one accessor.
+    #[test]
+    fn json_non_string_key_still_reports_none_965() {
+        assert_eq!(json_first_key(br"{123: 1}"), None);
+    }
+
+    #[test]
+    fn yaml_plain_key_decodes_once_and_is_not_a_fallback_965() {
+        assert_eq!(yaml_first_key(b"a: 1\n"), Some(("a".to_string(), false)));
+    }
+
+    #[test]
+    fn yaml_escaped_key_that_decodes_is_not_a_fallback_965() {
+        assert_eq!(
+            yaml_first_key(b"\"a\\u0041b\": 1\n"),
+            Some(("aAb".to_string(), false))
+        );
+    }
+
+    /// YAML has no `key_raw_source_span` override, so its decode-failure
+    /// fallback is the empty spelling rather than JSON's raw span -- the
+    /// asymmetry #1678 depends on, unchanged.
+    #[test]
+    fn yaml_undecodable_key_still_falls_back_to_empty_965() {
+        assert_eq!(
+            yaml_first_key(b"\"a\\qb\": 1\n"),
+            Some((String::new(), true))
+        );
+    }
+
+    /// An alias key resolves exactly one hop, the depth `keys`/`.` themselves
+    /// resolve to (#1739). The `Alias` arm deliberately keeps the two-call
+    /// path, so this pins that keeping it changed nothing.
+    #[test]
+    fn yaml_alias_key_to_a_string_resolves_one_hop_965() {
+        assert_eq!(
+            yaml_nth_key(b"a: &x foo\n*x: 1\n", 1),
+            Some(("foo".to_string(), false))
+        );
+    }
+
+    /// An alias to a non-scalar has no scalar spelling, so #222's rule
+    /// applies: it stringifies to `""` rather than being dropped, and that
+    /// `""` is *not* a decode-failure fallback.
+    #[test]
+    fn yaml_alias_key_to_a_mapping_stringifies_to_empty_965() {
+        assert_eq!(
+            yaml_nth_key(b"a: &x {p: 1}\n*x: 1\n", 1),
+            Some((String::new(), false))
+        );
+    }
+
+    /// #222 again, by the other route: an explicit complex key.
+    #[test]
+    fn yaml_complex_key_stringifies_to_empty_965() {
+        assert_eq!(
+            yaml_first_key(b"? [1, 2]\n: 1\n"),
+            Some((String::new(), false))
+        );
     }
 }

--- a/src/jq/document.rs
+++ b/src/jq/document.rs
@@ -850,6 +850,7 @@ pub trait DocumentValue: Sized + Clone {
         }
         Ok(self.key_string())
     }
+    // omni-dev: coverage end
 
     /// This value's raw source bytes when it is a string key whose span
     /// needs no decoding -- byte-identical to what

--- a/src/json/light.rs
+++ b/src/json/light.rs
@@ -2778,6 +2778,25 @@ impl<'a, W: AsRef<[u64]> + Clone> DocumentValue for StandardJson<'a, W> {
         }
     }
 
+    /// One `as_str()` for both answers, where the trait default would run
+    /// two (#965 item 10).
+    ///
+    /// This type does not override `key_string()`, so it inherits
+    /// `as_str()` there -- meaning the default `decoded_key_str` decodes the
+    /// same span twice on the success path, discarding the first `Cow`
+    /// entirely. `JsonString::as_str` caches nothing: each call re-scans for
+    /// the closing quote, re-scans for a backslash, re-validates UTF-8, and
+    /// for an escaped key allocates a fresh `decode_escapes` buffer.
+    ///
+    /// `Ok(None)` for a non-`String` key preserves `key_string()`'s `None`
+    /// -- the #1194 fault a caller still has to raise on.
+    fn decoded_key_str(&self) -> Result<Option<Cow<'_, str>>, &'static str> {
+        match self {
+            StandardJson::String(s) => s.as_str().map(Some).map_err(JsonError::message),
+            _ => Ok(None),
+        }
+    }
+
     /// Unlike [`key_raw_unescaped`](Self::key_raw_unescaped), this answers
     /// for an escaped span too -- including one whose escape is invalid --
     /// since it exists only as a display fallback for a key that fails to

--- a/src/yaml/light.rs
+++ b/src/yaml/light.rs
@@ -6949,6 +6949,38 @@ impl<'a, W: AsRef<[u64]> + Clone> DocumentValue for YamlValue<'a, W> {
         Some(YamlValue::key_string(self))
     }
 
+    /// One `as_str()` for both answers on the `String` arm, where the trait
+    /// default would run two (#965 item 10). `YamlString::as_str` caches
+    /// nothing -- each call re-finds the closing quote, makes up to three
+    /// `contains()` passes to decide whether decoding is needed, and
+    /// allocates afresh when it is.
+    ///
+    /// The `Alias` arm deliberately keeps the two-call path. The two
+    /// accessors it would fuse do not agree there:
+    /// `string_decode_error` resolves the *whole* alias chain (#1191),
+    /// while `key_string`/`key_string_kind` resolve a single hop
+    /// (`target.value()`), so a 2+-hop alias key that decodes perfectly
+    /// well still reports the `""` fallback. Answering that arm from one
+    /// accessor would change what such a key renders as; that divergence
+    /// is real but is not #965's to decide, so this preserves it exactly.
+    ///
+    /// `Ok(Some(""))` for every other variant is #222's rule -- a complex
+    /// key stringifies rather than being dropped -- and matches what
+    /// `key_string()` returns for them today. Reaching it does not consult
+    /// `string_decode_error`, which is `None` for those variants anyway.
+    fn decoded_key_str(&self) -> Result<Option<Cow<'_, str>>, &'static str> {
+        match self {
+            YamlValue::String(s) => s.as_str().map(Some).map_err(YamlStringError::message),
+            YamlValue::Alias { .. } => {
+                if let Some(reason) = self.string_decode_error() {
+                    return Err(reason);
+                }
+                Ok(Some(YamlValue::key_string(self)))
+            }
+            _ => Ok(Some(Cow::Borrowed(""))),
+        }
+    }
+
     fn as_object(&self) -> Option<Self::Fields> {
         match self {
             YamlValue::Mapping(fields) => Some(fields.clone()),


### PR DESCRIPTION
## Summary

Closes #965's item 10, and reports item 7 as already resolved.

`key_display_string_kind` asked `string_decode_error()` and then `key_string()`. For both
formats those bottom out in the **same uncached `as_str()`** — a fresh quote scan, a fresh
backslash scan, a fresh UTF-8 validation, and for any escaped key a fresh `decode_escapes`
allocation. The first `Cow` was computed and thrown away, then recomputed.

This fuses the two questions into one `DocumentValue::decoded_key_str`, with three outcomes
matching the three callers already distinguish: `Err(reason)` (a decode failure, #1247),
`Ok(None)` (a key the grammar never allowed, #1194, still raises), `Ok(Some(k))` (the decoded
key). `StandardJson` and `YamlValue` override it to decode once.

**Item 7 needs no work.** The issue describes a key-decode guard hand-copied at six call sites
(`eval_generic.rs:136, 226, 653, 5529`, `lazy.rs:692, 761`). #1642/#1677/#1803 already
consolidated it into `key_hash_of` / `key_is_malformed` / `key_display_string_kind`; those line
numbers no longer hold the idiom. Only item 10 survived, and it had funnelled into a single
function.

### Design notes

- **`&'static str`, not `EvalError`.** The issue proposes `Result<Cow<str>, EvalError>`, which
  would break the `no_std` contract `string_decode_error`'s own doc comment states.
- **The default body is literally the two-call sequence it replaces**, so an implementor that
  does not override it is unchanged.
- **`key_hash_of` and `key_is_malformed` fuse too, in a follow-up commit.** They were the two
  remaining hand-rolled copies of the pair — and they wrote it in two *different* orders,
  each with a paragraph arguing its own was right, which is exactly the contradiction the
  accessor's contract exists to remove.
  `key_hash_of` keeps its `key_raw_unescaped()` probe strictly in front: the +10–12% on
  `wide_keys_unsorted` its doc records is the cost of reaching *any* decode ahead of that fast
  path, and `decoded_key_str` is a decode — but *below* the probe it is free to use, and that
  tail is where YAML lives, since YAML has no raw-span override and so paid two full
  `YamlString` decodes for every key hash.
  `key_is_malformed` becomes `matches!(.., Ok(None))`: the predicate *is* the accessor's middle
  outcome. Unchanged on the common path (#1677's `key_string()`-first already answered in one
  call there), one decode instead of two on the malformed path.
  Both feed identity decisions — `key_hash_of` decides what `collapse: true` calls a duplicate
  (#1385), `key_is_malformed` what raises as #1194 — so the added tests assert against each
  function's **pre-fusion body recomputed inline**, raw-span probe included, rather than against
  expected constants (a constant would pin what the new code does, not that it still agrees with
  the old): 19 JSON key spellings and 19 YAML documents. Verified they bite — dropping the
  decode-failure distinction from `key_is_malformed`, and letting `key_hash_of` hash a
  decode-failure key instead of returning `None`, each fail in both formats.
- **`YamlValue`'s `Alias` arm deliberately keeps the two-call path.** Its two accessors resolve
  to different depths — `string_decode_error` follows the whole chain (#1191),
  `key_string_kind` one hop (#1739, where a code-review round explicitly rejected chain
  resolution to keep `contains`/`keys` in agreement). Verified live that they cannot actually
  disagree: an alias may not carry an anchor, so an alias key's target is never itself an alias.
  Both succinctly and yq v4.53.3 reject `&y *x` in every syntactic form tried. The arm preserves
  the existing shape anyway rather than depending on that argument.
- The ordering invariant (the decode failure must beat the stringification, or YAML's #222 `""`
  masks it) is now stated once in the accessor's contract, where it is no longer expressible in
  the wrong order at a call site.

## Test plan

- [x] `cargo test --features cli,simd,regex,serde` — 60 test binaries, 0 failures, including
      `jq_member_validation_audit` (STYLE-0013) and `jq_optional_suppression_audit`
- [x] `cargo test --no-default-features` (no_std leg)
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings`
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features`, `cargo fmt --check`
- [x] Patch coverage 93%; the one reachable gap now has a test, the unreachable trait default is
      marked `tolerate`

### Equivalence, verified in both directions

Behaviour preservation is the whole risk, so it is checked three ways rather than asserted:

1. **The 12-case pin matrix passes against the old implementation too.** Reverting
   `key_display_string_kind` to its two-call body leaves all 12 green, so they pin behaviour
   rather than the new code.
2. **The matrix catches the bug it exists to prevent.** Mutating the YAML override to stringify
   first fails `yaml_undecodable_key_still_falls_back_to_empty_965` with `("", false)` vs
   `("", true)` — exactly the #222 masking that #1247 exists to stop.
3. **Byte-identical output, before vs after.** A merge-base binary versus this branch, over
   `-p wide` and `-p users` at 2 MB plus hand-built escaped/undecodable/non-string/complex-key
   edge inputs and 40 repo YAML fixtures, across `.`, `keys`, `keys_unsorted`, `to_entries`,
   `length`, `with_entries` and both `-o json` / `-o yaml`: identical on every configuration.

Output also matches `/usr/bin/jq` 1.7.1 on all `wide`/`users` configurations. The pre-existing
divergences on undecodable input (#1642) and YAML complex keys (#222) reproduce identically on
the baseline binary, so they are not introduced here.

## Performance

**CI's perf-guard reads +0.0% on all six rows, and that is correct — its matrix contains no
materializing key query.** It measures `keys_unsorted` (the *streaming* path,
`stream_lazy_keys_json`) and `identity`. On those, instruction counts are unchanged:
`wide_keys_unsorted` 346,419,354 → 346,421,694 (+0.0007%). LLVM appears to have already been
eliminating the redundant decode there.

The saving is on the **materializing** key paths, which that matrix does not cover. Measured with
`scripts/ab-cli.py`, interleaved, 9 reps, identity-gated, both binaries built
`CARGO_PROFILE_RELEASE_CODEGEN_UNITS=1` (rule 9), Apple M4 Pro, on AC power. Inputs are a 160K-key
flat object at ~3 MB (rule 2), in two variants: every key carrying an escape, and a same-shape
control with none.

| workload | min Δ | median Δ |
|---|---:|---:|
| escaped keys, `keys` | **−10.7%** | **−9.4%** |
| escaped keys, `to_entries` | −4.6% | −3.5% |
| escaped keys, `with_entries(.value=1)` | −4.3% | −2.8% |
| plain keys, `keys` | −4.5% | −4.6% |
| plain keys, `with_entries(.value=1)` | −2.3% | −2.8% |
| plain keys, `to_entries` | −0.8% | −0.7% |

median of medians −3.14%, **0/6 rows slower**.

**Noise floor**, same machine, same inputs, `--control` (the baseline binary against a copy of
itself): range −1.7%..+1.5%, 2/6 rows slower. The `escaped keys, to_entries` row specifically
reads −0.4% in control against −3.5%..−5.2% across two real runs.

The defensible claim is the **escaped-key `keys` row at −9.4%**: it is far outside the control's
range, it reproduces, and it has a named mechanism — that is the path where the discarded first
decode was a `decode_escapes` heap allocation, which CSE cannot remove. The plain-key rows are
smaller and closer to the floor; the sign is consistent across all six, which is the discipline's
own stated criterion for reading past single-row noise.

Caveat: five other agent sessions were active on the box, so this is not an exclusive-CPU
measurement. That is why the control was run on the same box in the same state rather than quoted
from the docs, and why the argument rests on the largest row plus reproduction rather than on the
median. ARM only — no x86_64 wall-clock figure (`terminus` was not used); the cachegrind rows
above do cover x86_64 and ARM64, and are neutral on both.

Two gaps this surfaced, both filed rather than fixed here:
- #2637 — no generator emits escaped object keys, so the strongest shape had to be hand-built for
  this PR and cannot enter the standing suite.
- The perf-guard matrix has no materializing key query (`keys` / `to_entries`), which is why a
  real several-percent win reads as +0.0% there. Noted on #2637.

## Related

- #2637, #2638 — follow-ups filed from this work.
- #2639 — an unrelated pre-existing bug found by review of this PR (`getpath`'s cursor walk is not
  tag-aware). Not touched here; this PR does not modify `eval_generic.rs`.
