### PR TITLE
jq: emit jq's mid-stream malformed-record warnings for --seq

### DIFF
--- a/docs/compliance/jq/limitations.md
+++ b/docs/compliance/jq/limitations.md
@@ -2802,43 +2802,98 @@ skipped item's decode in the first place. Fixing this needs `Demand` (or an equi
 let a sink mark its own stop as unretryable, which is a real design change rather than a local
 one, so it is tracked separately instead of folded into this fix.
 
-## `--seq`'s malformed-record warning covers one of jq's several message shapes
+## `--seq`'s malformed-record warnings match jq; the values it prints are still a subset
 
 Real jq warns on stderr ("`jq: ignoring parse error: ...`") whenever it silently drops a
 malformed `--seq` (RFC 7464) record; `succinctly jq` used to drop the record with no
 diagnostic at all. [#1525](https://github.com/rust-works/succinctly/issues/1525) added the
-warning for exactly one of jq's message templates: content with no RS byte anywhere in the
-input, where jq's own reader never resyncs onto anything and reports the abandonment
+warning for one of jq's message templates: content with no RS byte anywhere in the
+input, where jq's own reader never syncs onto anything and reports the abandonment
 unconditionally at EOF ("`Unfinished abandoned text at EOF at line L, column C`") regardless
-of what the content actually is, even fully valid JSON:
+of what the content actually is, even fully valid JSON.
+[#1723](https://github.com/rust-works/succinctly/issues/1723) added all the rest.
 
 ```
 $ printf '1 2' | jq --seq -c '.'                  # jq:          jq: ignoring parse error: Unfinished abandoned text at EOF at line 1, column 3
 $ printf '1 2' | succinctly jq --seq -c '.'       # succinctly:  same (#1525)
 ```
 
-A malformed record that *does* start with an RS byte gets one of at least three other jq
-message templates instead, depending on exactly how it's malformed — none implemented yet:
+**The messages are not a property of the record; they are a property of where jq's reader
+gave up.** Four earlier attempts looked for a table mapping "what is wrong with this record"
+onto jq's wording and correctly concluded that no such table exists — the *same* malformed
+record draws different messages depending on whether jq reached real EOF, an RS byte, or an
+ordinary byte first. `src/bin/succinctly/jq_seq_reader.rs` models jq's own scanner instead,
+and composes the message from three facts:
+
+| detected on | rendering |
+|---|---|
+| an ordinary byte | `{category} at line L, column C (need RS to resync)` |
+| real EOF | `{category} at EOF at line L, column C` |
+| an RS byte | `Truncated value` (or `Potentially truncated top-level numeric value`) |
 
 ```
-$ printf '\x1e"unterminated\n' | jq --seq -c '.'
+$ printf '\x1e"unterminated\n' | succinctly jq --seq -c '.'
 jq: ignoring parse error: Unfinished string at EOF at line 2, column 0
-$ printf '\x1e[1,2\n'          | jq --seq -c '.'
+$ printf '\x1e[1,2\n'          | succinctly jq --seq -c '.'
 jq: ignoring parse error: Unfinished JSON term at EOF at line 2, column 0
-$ printf '\x1exyz\n'           | jq --seq -c '.'
+$ printf '\x1exyz\n'           | succinctly jq --seq -c '.'
 jq: ignoring parse error: Invalid numeric literal at line 2, column 0 (need RS to resync)
+$ printf '\x1e"a\x1e"ok"\n'    | succinctly jq --seq -c '.'
+jq: ignoring parse error: Truncated value at line 1, column 4
 ```
 
-`succinctly jq --seq` emits nothing on stderr for any of these, and its *output* also
-diverges: real jq emits the values it managed to read before the malformed point, while
-succinctly drops the whole record.
+Two pieces of jq's own wording are misleading, and are reproduced rather than corrected
+(ADR-0018's bug-for-bug default):
+
+- **`(need RS to resync)` never resyncs.** jq's `jv_parse.c` assigns
+  `JV_PARSER_WAITING_FOR_RS` and *then* calls `parser_reset()`, which writes
+  `JV_PARSER_NORMAL` straight back over it. Parsing resumes at the very next byte, so one
+  record can warn several times and content after the error is still read:
+  ```
+  $ printf '\x1enot valid json\n' | jq --seq -c '.'   # three warnings, one record
+  $ printf '\x1e} 5\n'            | jq --seq -c '.'   # warns, then prints 5
+  ```
+- **jq's numbers are decNumber's, not RFC 8259's.** `1.`, `.5`, `+1`, `nan`, `NaN5`, `snan`
+  and `-Infinity` are all numbers to `--seq`'s parser, while `1e` and `1.2.3` are not.
+
+There is also a genuine quirk in jq's classifier that succinctly matches: `check_literal`
+reads `tokenbuf[1]` without consulting `tokenpos`, so a bare `n` is measured against
+whatever byte an earlier token left behind. `printf '\x1en'` reports `Invalid numeric
+literal`, but the same `n` after an `iu` token reports `Invalid literal`.
+
+**The output side has not changed and still diverges**: real jq emits the values it read
+before the malformed point, while succinctly drops the whole record. Only the diagnostic was
+implemented, so stderr now matches where stdout does not.
 
 ```
 $ printf '\x1e1 {invalid\n' | jq            --seq -c '.'   # warns, then prints 1
-$ printf '\x1e1 {invalid\n' | succinctly jq --seq -c '.'   # prints nothing
+$ printf '\x1e1 {invalid\n' | succinctly jq --seq -c '.'   # warns identically, prints nothing
 $ printf '\x1e1,2\n'        | jq            --seq -c '.'   # prints 2
 $ printf '\x1e1,2\n'        | succinctly jq --seq -c '.'   # prints nothing
 ```
+
+Verified by `scripts/jq-seq-oracle-sweep.py`, which compares stderr, stdout and exit code
+jointly: **0 stderr mismatches and 0 stdout supersets** over 3,062 generated streams per
+seed.
+
+Two `--seq` divergences that remain are artifacts of jq's 4096-byte `fgets` *line reader*
+rather than its parser, and neither is reachable from a newline-terminated stream:
+
+1. A trailing unterminated RS-record after an earlier newline is dropped unread below the
+   buffer boundary and parsed above it (`printf '\x1e1\n\x1e{bad'` is silent, the same input
+   with 4,100 bytes of padding warns) — the value-side half of this is the same artifact
+   already described below.
+2. A record yielding no value makes jq's `jv_parser_next` return invalid-with-no-message,
+   which its input loop reads as end-of-input and stops the whole stream — but only when it
+   lands in the buffer that hit EOF. `printf '\x1e\x1e"a"'` prints nothing in real jq;
+   `printf '\x1e\x1e{"a":1}\n'` prints the object.
+
+Running the sweep with `--expect-artifacts` puts these shapes back: 28 of 3,063 streams
+diverge, and every one is attributable to those two artifacts — none unexplained.
+
+Real-time interleaving of the warnings against stdout is also not reproduced: succinctly
+materializes `--seq` input before evaluating, so all warnings precede all values. jq's
+default block-buffered stdout produces the same ordering, but `jq --unbuffered` does not.
 
 **The divergence from *this* rule is one-directional: succinctly's output is a subset of
 jq's, not a superset** -- 0 superset violations across 6,000 randomly generated single
@@ -2880,10 +2935,17 @@ only `3` -- a bare literal is as truncatable as a bare number. Both directions a
 
 A record holding several *well-formed* values is likewise unaffected: #1723 fixed
 `succinctly jq --seq` dropping those in full (`\x1e1 "x" [2]\n` is three outputs, as in real
-jq), which was silent data loss rather than a diagnostic gap. Matching these needs enough
-of jq's own incremental-parser failure classification to know which of its internal states a
-segment would have failed in, not just whether it parses — deliberately deferred, tracked in
-[#1723](https://github.com/rust-works/succinctly/issues/1723).
+jq), which was silent data loss rather than a diagnostic gap.
+
+Emitting the *prefix* of a partially-readable record is what remains. It needs the same
+answer the diagnostics needed — where jq's parser gave up — and
+[`jq_seq_reader`](../../../src/bin/succinctly/jq_seq_reader.rs) now has it, so this is no
+longer blocked on the classification problem; it is deferred on risk. Getting a message
+wrong costs a cosmetic stderr line, while getting an emission wrong fabricates output, which
+is exactly what the reverted attempt above did. Switching the value path onto the same model
+is tracked separately, and should be gated on
+[`scripts/jq-seq-oracle-sweep.py`](../../../scripts/jq-seq-oracle-sweep.py) continuing to
+report zero stdout supersets.
 
 A second, narrower gap `succinctly jq --seq` also deliberately stays silent on: `-n`
 combined with a filter that forces a real read (`input`/`inputs`) turns the identical

--- a/docs/compliance/jq/limitations.md
+++ b/docs/compliance/jq/limitations.md
@@ -2887,9 +2887,27 @@ rather than its parser, and neither is reachable from a newline-terminated strea
    which its input loop reads as end-of-input and stops the whole stream — but only when it
    lands in the buffer that hit EOF. `printf '\x1e\x1e"a"'` prints nothing in real jq;
    `printf '\x1e\x1e{"a":1}\n'` prints the object.
+3. `jq_util_input_read_more` measures each chunk with `strlen`, so a NUL byte truncates the
+   input — again only in a chunk holding no newline. `printf '\x1eA+\x008e'` reports at
+   column 3 in real jq (which stopped at the NUL) and column 6 here.
 
 Running the sweep with `--expect-artifacts` puts these shapes back: 28 of 3,063 streams
-diverge, and every one is attributable to those two artifacts — none unexplained.
+diverge, and every one is attributable to those artifacts — none unexplained.
+
+A **malformed** BOM — a byte sequence that begins one and then contradicts it, such as
+`\xef\xbb` — is *not* in that category and is matched exactly. jq consumes the bytes that did
+match without counting them as columns, and then re-runs `parser_reset` at the top of every
+read, which leaves it parsing the bytes before the first RS instead of discarding them and
+wipes its state after every value, every newline, and at end of input:
+
+```
+$ printf '\xef\xbb1 2' | jq --seq -c '.'   # Potentially truncated top-level numeric value at EOF at line 1, column 3
+                                          # -- not the abandoned-text template, despite no RS byte anywhere
+```
+
+`succinctly jq` reproduces all of that on stderr. Its *stdout* still diverges for this shape
+in the pre-existing direction described above: real jq prints the `1` it read, succinctly
+drops the pre-RS content.
 
 Real-time interleaving of the warnings against stdout is also not reproduced: succinctly
 materializes `--seq` input before evaluating, so all warnings precede all values. jq's

--- a/scripts/jq-seq-oracle-sweep.py
+++ b/scripts/jq-seq-oracle-sweep.py
@@ -33,6 +33,8 @@ parser, and neither survives into a newline-terminated stream:
 2. A record yielding no value makes `jv_parser_next` return
    invalid-with-no-message, which jq's input loop reads as end-of-input --
    but only when it lands in the buffer that hit EOF.
+3. `jq_util_input_read_more` measures the chunk with `strlen`, so a NUL
+   byte truncates the input -- but only in a chunk holding no newline.
 
 `--expect-artifacts` re-enables the shapes that trip them, for confirming
 they are still the only divergences.
@@ -62,6 +64,12 @@ REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
 # small enough that random strings collide into real JSON shapes often.
 ALPHABET = b'\x1e{}[]",:0-9abfilnrstuxe \n\\.-+'
 
+# BOM prefixes are their own dimension: jq consumes the matching prefix of
+# one *without counting it*, and a prefix that starts a BOM and then
+# contradicts it costs jq a parser_reset. A review found both, precisely
+# because an earlier version of this generator had no 0xef in its alphabet.
+BOM_PREFIXES = [b"", b"", b"", b"", b"\xef\xbb\xbf", b"\xef\xbb", b"\xef"]
+
 # Shapes worth keeping regardless of what the generator happens to produce:
 # every template the issue named, plus the ones earlier sessions got wrong.
 HAND = [
@@ -77,7 +85,8 @@ HAND = [
     b'\x1e"\\q"', b'\x1e"\\u00"', b'\x1e"\\uZZZZ"', b'\x1e"\\ud800"',
     b'\x1e"\\ud800\\u0041"', b'\x1e"a\x01b"', b'\x1e{"a", "b"}', b"\x1e[1 2]",
     b"\x1e:", b"\x1e,", b"\x1enan", b"\x1einf", b"\x1esnan", b"\x1enul",
-    b"\x1en", b"\x1e+1", b"\x1e[[1],]", b'\x1e{"a":1,}', b"\xef\xbb\xbf\x1e}",
+    b"\x1en", b"\x1e+1", b"\x1e[[1],]", b'\x1e{"a":1,}', b"\xef\xbb\xbf\x1e}", b"\xef\xbb\x1e[1,]\n", b"\xef\xbb1 2",
+    b"\xef1 2", b"\xef", b"\xef\xbb",
     b'\x1e"a"\x1e"b"', b"\x1e[1,2]}\n", b"\x1e{}}\n", b"\x1etrue,[1]",
     b"\x1e5-3 7", b"\x1e1-2\n",
 ]
@@ -125,6 +134,14 @@ def run(argv, data):
         os.unlink(path)
 
 
+def malformed_bom(data):
+    """A prefix that starts a BOM and then contradicts it. jq consumes the
+    matched bytes and thereafter re-runs `parser_reset` at the top of every
+    `jv_parser_next`, which leaves the parser reading rather than waiting
+    for an RS byte."""
+    return data[:1] == b"\xef" and not data.startswith(b"\xef\xbb\xbf")
+
+
 def stops_early(data):
     """Whether jq's input loop ends the stream before reading it all.
 
@@ -132,15 +149,30 @@ def stops_early(data):
     return invalid-with-no-message, which the loop reads as end-of-input --
     but only in the call that performed the final read. With no newline the
     whole input is one buffer, so that reduces to "the first record yields
-    nothing"."""
-    if b"\n" in data or data.count(RS) < 2:
+    nothing".
+
+    After a malformed BOM the first record is the content *before* the
+    first RS, since the parser is no longer waiting for one -- which is why
+    `\xef\x1e...` stops immediately where `\x1e...` would not."""
+    if b"\n" in data or RS not in data:
         return False
-    return data.split(RS)[1].strip(b" \t\r") in (b"", b'"')
+    if malformed_bom(data):
+        consumed = 2 if data.startswith(b"\xef\xbb") else 1
+        first = data[consumed:].split(RS)[0]
+    elif data.count(RS) < 2:
+        return False
+    else:
+        first = data.split(RS)[1]
+    return first.strip(b" \t\r") in (b"", b'"')
 
 
 def artifact(data):
+    if b"\x00" in data and b"\n" not in data.split(b"\x00", 1)[0]:
+        return True  # strlen truncation, artifact 3
     if RS not in data:
-        return True  # #1525's separate no-RS-byte template
+        # #1525's separate template -- except after a malformed BOM, which
+        # makes jq read the stream rather than abandon it, so those stay in.
+        return not malformed_bom(data)
     if stops_early(data):
         return True
     if b"\n" not in data:
@@ -158,10 +190,10 @@ def random_cases(count, seed, allow_artifacts):
             cases.append(body)
         elif rng.random() < 0.7:
             body = bytes(rng.choice(ALPHABET) for _ in range(rng.randint(1, 24)))
-            cases.append(RS + body + b"\n")
+            cases.append(rng.choice(BOM_PREFIXES) + RS + body + b"\n")
         else:
             body = bytes(rng.choice(plain) for _ in range(rng.randint(1, 24)))
-            cases.append(RS + body)
+            cases.append(rng.choice(BOM_PREFIXES) + RS + body)
     return cases
 
 

--- a/scripts/jq-seq-oracle-sweep.py
+++ b/scripts/jq-seq-oracle-sweep.py
@@ -1,0 +1,219 @@
+#!/usr/bin/env python3
+"""Randomised differential sweep for `--seq`'s parse-error diagnostics (#1723).
+
+Generates RFC 7464 streams, runs each through both the pinned jq oracle and
+the built succinctly binary, and compares **stderr, stdout and exit code
+together**. Comparing stderr alone would miss the failure mode that actually
+matters: `seq_record_scan` dropping a record the warning model considers
+clean, which loses a value on stdout with no diagnostic to explain it.
+
+This is a verification tool, not a CI gate -- the pinned rows in
+`tests/jq_cli_tests.rs` and the unit tests in
+`src/bin/succinctly/jq_seq_reader.rs` are what CI enforces. Run it after
+touching `--seq` parsing or the warning model.
+
+**Why the corpus is shaped the way it is.** Three earlier attempts at this
+area shipped bugs their own verification missed, every time because the
+corpus was biased in exactly the dimension under test (all whitespace-
+separated, so adjacency went untested; single-record only, so record
+boundaries went untested). So the generator is random rather than
+hand-picked, and it is structured to make jq's *line-reader* artifacts
+unreachable rather than filtering them out afterwards:
+
+* newline-terminated multi-record streams -- what real RFC 7464 looks like;
+* single-record streams with no trailing newline -- these reach real EOF
+  mid-value, which is what exercises the `at EOF` templates, and a lone
+  record has no interior RS byte for the stream to end early on.
+
+Both artifacts are properties of jq's 4096-byte `fgets` buffer, not of its
+parser, and neither survives into a newline-terminated stream:
+
+1. A trailing unterminated RS-record after an earlier newline is dropped
+   unread below the buffer boundary and parsed above it.
+2. A record yielding no value makes `jv_parser_next` return
+   invalid-with-no-message, which jq's input loop reads as end-of-input --
+   but only when it lands in the buffer that hit EOF.
+
+`--expect-artifacts` re-enables the shapes that trip them, for confirming
+they are still the only divergences.
+
+Expected result: `0 stderr mismatches, 0 stdout supersets`; exits non-zero
+otherwise.
+
+Usage:
+  cargo build --release --features cli
+  ./scripts/jq-seq-oracle-sweep.py [--seed N] [--cases N] [path-to-binary]
+"""
+
+import argparse
+import os
+import pathlib
+import random
+import re
+import subprocess
+import sys
+import tempfile
+
+RS = b"\x1e"
+REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
+
+# Structural bytes, both quote-ish characters, digits, the letters that start
+# jq's keywords and decNumber's special forms, and the number punctuation --
+# small enough that random strings collide into real JSON shapes often.
+ALPHABET = b'\x1e{}[]",:0-9abfilnrstuxe \n\\.-+'
+
+# Shapes worth keeping regardless of what the generator happens to produce:
+# every template the issue named, plus the ones earlier sessions got wrong.
+HAND = [
+    b'\x1e"abc', b'\x1e{"a":1', b"\x1e[1,2\n", b"\x1etru", b"\x1e-", b"\x1e1.",
+    b"\x1e1e", b"\x1exyz\n", b"\x1e{}extra", b"\x1e[1,2]extra", b"\x1e[1,]",
+    b"\x1e}", b"\x1e]", b'\x1e"unterminated\x1e"ok"\n', b'\x1e[1,2\x1e"ok"\n',
+    b'\x1exyz\x1e"ok"\n', b'\x1etru\x1e"ok"\n', b'\x1e1.\x1e"ok"\n',
+    b'\x1e{}extra\x1e"ok"\n', b'\x1e[1,]\x1e"ok"\n', b'\x1e}\x1e"ok"\n',
+    b"\x1e{,}\n", b"\x1ea:b\n", b"\x1enot valid json\n", b"\x1e{1:2}\n",
+    b"\x1e} 5\n", b"\x1e1 } 2\n", b'\x1e} {"a":1}\n', b"\x1e1,2\n",
+    b"\x1e1 {invalid\n", b"\x1e1 2 xyz\n", b"\x1e\xc3\xa9]", b"\x1e\xff]",
+    b"\x1e1\nJUNK", b'\x1e"a" 2', b"\x1etrue\x1e3", b"\x1e1 2", b"\x1e1 2 ",
+    b'\x1e"\\q"', b'\x1e"\\u00"', b'\x1e"\\uZZZZ"', b'\x1e"\\ud800"',
+    b'\x1e"\\ud800\\u0041"', b'\x1e"a\x01b"', b'\x1e{"a", "b"}', b"\x1e[1 2]",
+    b"\x1e:", b"\x1e,", b"\x1enan", b"\x1einf", b"\x1esnan", b"\x1enul",
+    b"\x1en", b"\x1e+1", b"\x1e[[1],]", b'\x1e{"a":1,}', b"\xef\xbb\xbf\x1e}",
+    b'\x1e"a"\x1e"b"', b"\x1e[1,2]}\n", b"\x1e{}}\n", b"\x1etrue,[1]",
+    b"\x1e5-3 7", b"\x1e1-2\n",
+]
+
+
+def resolve_oracle():
+    pin = (REPO_ROOT / "tests/data/jq-golden/JQ_VERSION").read_text().strip()
+    # Prefer the pinned oracle directly (macOS ships jq-1.7.1 at /usr/bin/jq;
+    # a PATH jq, e.g. Homebrew's, is often newer) -- same reasoning as
+    # tests/jq_cli_tests.rs's own pinned-oracle comments.
+    for candidate in ("/usr/bin/jq", None):
+        path = candidate or shutil_which_jq()
+        if path and os.access(path, os.X_OK):
+            version = subprocess.run(
+                [path, "--version"], capture_output=True, text=True
+            ).stdout.strip()
+            if version.startswith(pin):
+                return path, version
+    sys.exit(f"error: no jq matching pin {pin} found at /usr/bin/jq or on PATH")
+
+
+def shutil_which_jq():
+    import shutil
+
+    return shutil.which("jq")
+
+
+def run(argv, data):
+    # stdin from a file, never a pipe: with `pipefail` a SIGPIPE'd writer
+    # fabricates exit-code divergences (scripts/jq-fanout-oracle-sweep.sh
+    # learned this the hard way).
+    with tempfile.NamedTemporaryFile(delete=False) as handle:
+        handle.write(data)
+        path = handle.name
+    try:
+        with open(path, "rb") as stdin:
+            done = subprocess.run(
+                argv + ["--seq", "-c", "."],
+                stdin=stdin,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+            )
+        return done.stdout, done.stderr, done.returncode
+    finally:
+        os.unlink(path)
+
+
+def stops_early(data):
+    """Whether jq's input loop ends the stream before reading it all.
+
+    An RS closing a record that yields no value makes `jv_parser_next`
+    return invalid-with-no-message, which the loop reads as end-of-input --
+    but only in the call that performed the final read. With no newline the
+    whole input is one buffer, so that reduces to "the first record yields
+    nothing"."""
+    if b"\n" in data or data.count(RS) < 2:
+        return False
+    return data.split(RS)[1].strip(b" \t\r") in (b"", b'"')
+
+
+def artifact(data):
+    if RS not in data:
+        return True  # #1525's separate no-RS-byte template
+    if stops_early(data):
+        return True
+    if b"\n" not in data:
+        return False
+    return not data.rsplit(RS, 1)[1].endswith(b"\n") and len(data) < 4096
+
+
+def random_cases(count, seed, allow_artifacts):
+    rng = random.Random(seed)
+    plain = bytes(b for b in ALPHABET if b not in (RS[0], 0x0A))
+    cases = []
+    for _ in range(count):
+        if allow_artifacts:
+            body = bytes(rng.choice(ALPHABET) for _ in range(rng.randint(1, 24)))
+            cases.append(body)
+        elif rng.random() < 0.7:
+            body = bytes(rng.choice(ALPHABET) for _ in range(rng.randint(1, 24)))
+            cases.append(RS + body + b"\n")
+        else:
+            body = bytes(rng.choice(plain) for _ in range(rng.randint(1, 24)))
+            cases.append(RS + body)
+    return cases
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("binary", nargs="?", default=str(REPO_ROOT / "target/release/succinctly"))
+    parser.add_argument("--seed", type=int, default=1)
+    parser.add_argument("--cases", type=int, default=4000)
+    parser.add_argument(
+        "--expect-artifacts",
+        action="store_true",
+        help="include the line-reader-artifact shapes, to confirm they are still the only divergences",
+    )
+    args = parser.parse_args()
+
+    if not os.access(args.binary, os.X_OK):
+        sys.exit(
+            f"error: succinctly binary not found at {args.binary} — "
+            "run: cargo build --release --features cli"
+        )
+    jq, version = resolve_oracle()
+    print(f"oracle: {jq} ({version}), succinctly: {args.binary}", file=sys.stderr)
+
+    cases = HAND + random_cases(args.cases, args.seed, args.expect_artifacts)
+    stderr_bad, stdout_super, skipped = [], [], 0
+    for data in cases:
+        if not args.expect_artifacts and artifact(data):
+            skipped += 1
+            continue
+        jq_out, jq_err, jq_code = run([jq], data)
+        our_out, our_err, our_code = run([args.binary, "jq"], data)
+        if (jq_err, jq_code) != (our_err, our_code):
+            stderr_bad.append((data, jq_err, our_err))
+        # stdout may be a strict subset of jq's -- succinctly deliberately
+        # drops a record jq can partially read -- but never a superset.
+        jq_values = jq_out.split(RS)
+        if any(v and v not in jq_values for v in our_out.split(RS)):
+            stdout_super.append((data, jq_out, our_out))
+
+    checked = len(cases) - skipped
+    print(
+        f"checked={checked} artifact-shapes-skipped={skipped} "
+        f"stderr_mismatch={len(stderr_bad)} stdout_superset={len(stdout_super)}"
+    )
+    for data, expected, got in stderr_bad[:20]:
+        print(f"\n  input : {data!r}")
+        print(f"  jq    : {expected.decode(errors='replace').strip()!r}")
+        print(f"  succ  : {got.decode(errors='replace').strip()!r}")
+    for data, expected, got in stdout_super[:10]:
+        print(f"\n  SUPERSET input: {data!r}\n    jq  : {expected!r}\n    succ: {got!r}")
+    return 1 if stderr_bad or stdout_super else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/bin/succinctly/jq_runner.rs
+++ b/src/bin/succinctly/jq_runner.rs
@@ -2295,13 +2295,16 @@ fn get_inputs(
     // case `jq_seq_reader` is not asked about (#1723). Raw bytes, before
     // the UTF-8 substitution below, because jq counts columns in bytes.
     if args.seq && !args.raw_input && args.input_dsv.is_none() && !args.null_input {
-        match seq_no_rs_byte_warning(&raw_bytes) {
+        // A *malformed* BOM is the one case where "no RS byte anywhere"
+        // does not imply #1525's template: it costs jq a `parser_reset`
+        // that leaves the parser reading rather than waiting for an RS, so
+        // the reader owns that case too (#1723).
+        let bom_malformed = crate::jq_seq_reader::bom_prefix(&raw_bytes).malformed;
+        match seq_no_rs_byte_warning(&raw_bytes).filter(|_| !bom_malformed) {
             Some(warning) => eprintln!("{warning}"),
-            None => {
-                for warning in crate::jq_seq_reader::parse_warnings(&raw_bytes) {
-                    eprintln!("{warning}");
-                }
-            }
+            None => crate::jq_seq_reader::for_each_warning(&raw_bytes, &mut |warning| {
+                eprintln!("{warning}");
+            }),
         }
     }
 

--- a/src/bin/succinctly/jq_runner.rs
+++ b/src/bin/succinctly/jq_runner.rs
@@ -3814,53 +3814,6 @@ fn parse_json_stream_strict(s: &str) -> Result<Vec<OwnedValue>> {
     Ok(values)
 }
 
-/// Parse JSON sequence format (RFC 7464) (`--seq`).
-/// Input is split on RS (0x1E) characters, each segment parsed as JSON.
-/// Parse failures are silently ignored (per RFC 7464 recommendation).
-///
-/// Preserves number-literal source fidelity the same way `parse_json_value`
-/// does for `--argjson` (#1058, extended here to `--seq`, #1093): each
-/// segment is already isolated by the RS split, so a validate-then-
-/// materialize step can validate and materialize the same segment text
-/// directly -- no boundary-tracking needed, unlike `parse_json_stream`
-/// above.
-///
-/// Validates via the crate's own zero-allocation RFC 8259 grammar
-/// validator (`json::validate::validate`, already used by `--validate`/
-/// `json validate`) rather than `validate_and_materialize_json`'s
-/// `serde_json::Value`-tree-based check (#1267) -- `--seq` is a streaming,
-/// record-oriented format, so a discarded parse tree's allocation cost is
-/// paid once per record rather than a bounded number of times per run the
-/// way `--argjson`/`--jsonargs` pay it. Measured (500k-record stream,
-/// interleaved A/B, 5 reps -- real jq's own baseline is ~0.47s either way):
-/// a real but modest ~10-20% improvement (median ~1.30s -> ~1.15s), not the
-/// dramatic win a first, non-interleaved measurement suggested (1.38s ->
-/// 1.56s, i.e. apparently *worse* -- sequential-halves noise, the exact
-/// trap this repo's own benchmarking guide warns about). The remaining gap
-/// to real jq is dominated by something else entirely, out of this issue's
-/// own scope.
-///
-/// This also fixes a real, jq-observable divergence, not just a speed one:
-/// `json::validate::validate` is a pure grammar check with no `f64`-range
-/// rejection, unlike `serde_json::Value` -- so a magnitude-overflowing
-/// literal (`1e400`) that used to silently drop as an "unparseable" record
-/// now materializes correctly (`1E+400`, matching real jq's own primary-
-/// document-input behavior, live-verified) instead. `validate_json_str`
-/// (used by `--argjson` and this function's own leading-zero retry below)
-/// keeps its `serde_json::Value`-based magnitude rejection unchanged --
-/// this fix is scoped to `parse_json_seq`'s own hot path only; see #1267's
-/// own text for why extending it to the shared `--argjson` helper too
-/// isn't attempted here (that path's error-message text is user-visible
-/// and untouched by this issue).
-///
-/// Also retries a failed segment with its leading zeros stripped before
-/// giving up on it, mirroring `parse_json_value`'s own `--argjson` retry
-/// (#1094, extended here to `--seq`, #1243) -- real jq's own number parser
-/// tolerates a leading zero (`007`) that strict JSON doesn't, so `007e5`
-/// silently dropping as an unparseable record (RFC 7464's own recommended
-/// failure mode -- but only for content that's actually malformed, not for
-/// a shape jq itself accepts) was a real, jq-observable divergence, not a
-/// spelling nit.
 /// Build the values (and, when `!slurp`, one `(source, line)` location per
 /// value) for `--seq` input across the whole file list at once (#1571).
 ///
@@ -4068,6 +4021,55 @@ fn remap_ends_to_locations(
 /// existed here too until its own last caller (this function's own
 /// predecessor) was replaced -- removed rather than kept unused, per its
 /// own three unit tests now calling this function directly instead.
+///
+/// The rationale below described the `parse_json_seq` wrapper named
+/// above and outlived it, left stacked on `build_seq_values`'s own
+/// docs where it read as one comment describing the wrong function.
+/// Moved here, where the behaviour it describes actually lives (#1723).
+///
+/// Preserves number-literal source fidelity the same way `parse_json_value`
+/// does for `--argjson` (#1058, extended here to `--seq`, #1093): each
+/// segment is already isolated by the RS split, so a validate-then-
+/// materialize step can validate and materialize the same segment text
+/// directly -- no boundary-tracking needed, unlike `parse_json_stream`
+/// above.
+///
+/// Validates via the crate's own zero-allocation RFC 8259 grammar
+/// validator (`json::validate::validate`, already used by `--validate`/
+/// `json validate`) rather than `validate_and_materialize_json`'s
+/// `serde_json::Value`-tree-based check (#1267) -- `--seq` is a streaming,
+/// record-oriented format, so a discarded parse tree's allocation cost is
+/// paid once per record rather than a bounded number of times per run the
+/// way `--argjson`/`--jsonargs` pay it. Measured (500k-record stream,
+/// interleaved A/B, 5 reps -- real jq's own baseline is ~0.47s either way):
+/// a real but modest ~10-20% improvement (median ~1.30s -> ~1.15s), not the
+/// dramatic win a first, non-interleaved measurement suggested (1.38s ->
+/// 1.56s, i.e. apparently *worse* -- sequential-halves noise, the exact
+/// trap this repo's own benchmarking guide warns about). The remaining gap
+/// to real jq is dominated by something else entirely, out of this issue's
+/// own scope.
+///
+/// This also fixes a real, jq-observable divergence, not just a speed one:
+/// `json::validate::validate` is a pure grammar check with no `f64`-range
+/// rejection, unlike `serde_json::Value` -- so a magnitude-overflowing
+/// literal (`1e400`) that used to silently drop as an "unparseable" record
+/// now materializes correctly (`1E+400`, matching real jq's own primary-
+/// document-input behavior, live-verified) instead. `validate_json_str`
+/// (used by `--argjson` and this function's own leading-zero retry below)
+/// keeps its `serde_json::Value`-based magnitude rejection unchanged --
+/// this fix is scoped to `parse_json_seq`'s own hot path only; see #1267's
+/// own text for why extending it to the shared `--argjson` helper too
+/// isn't attempted here (that path's error-message text is user-visible
+/// and untouched by this issue).
+///
+/// Also retries a failed segment with its leading zeros stripped before
+/// giving up on it, mirroring `parse_json_value`'s own `--argjson` retry
+/// (#1094, extended here to `--seq`, #1243) -- real jq's own number parser
+/// tolerates a leading zero (`007`) that strict JSON doesn't, so `007e5`
+/// silently dropping as an unparseable record (RFC 7464's own recommended
+/// failure mode -- but only for content that's actually malformed, not for
+/// a shape jq itself accepts) was a real, jq-observable divergence, not a
+/// spelling nit.
 fn parse_json_seq_with_ends(s: &str) -> Vec<(OwnedValue, usize)> {
     let bytes = s.as_bytes();
     const RS: u8 = 0x1e;

--- a/src/bin/succinctly/jq_runner.rs
+++ b/src/bin/succinctly/jq_runner.rs
@@ -2289,9 +2289,19 @@ fn get_inputs(
     // "ignoring parse error" wording there would misrepresent succinctly's
     // separate, still-unfixed non-fatal behavior as though it now matched
     // jq; left silent instead until that's fixed properly.
+    //
+    // The two arms are exactly disjoint: `seq_no_rs_byte_warning` answers
+    // `Some` only for a stream with no RS byte anywhere, which is the one
+    // case `jq_seq_reader` is not asked about (#1723). Raw bytes, before
+    // the UTF-8 substitution below, because jq counts columns in bytes.
     if args.seq && !args.raw_input && args.input_dsv.is_none() && !args.null_input {
-        if let Some(warning) = seq_no_rs_byte_warning(&raw_bytes) {
-            eprintln!("{warning}");
+        match seq_no_rs_byte_warning(&raw_bytes) {
+            Some(warning) => eprintln!("{warning}"),
+            None => {
+                for warning in crate::jq_seq_reader::parse_warnings(&raw_bytes) {
+                    eprintln!("{warning}");
+                }
+            }
         }
     }
 
@@ -4471,28 +4481,22 @@ fn seq_stream_trailing_record_is_dropped(raw_inputs: &[(Option<usize>, String)])
 fn seq_no_rs_byte_warning(raw_bytes: &[(Option<usize>, Vec<u8>)]) -> Option<String> {
     let mut line = 1usize;
     let mut column = 0usize;
-    let mut bytes_seen = 0usize;
-    for (_, raw) in raw_bytes {
-        let bytes = if bytes_seen == 0 {
-            raw.strip_prefix(crate::front_matter::UTF8_BOM)
-                .unwrap_or(raw)
-        } else {
-            raw.as_slice()
-        };
-        for &b in bytes {
-            if b == ASCII_RS {
-                return None;
-            }
-            if b == b'\n' {
-                line += 1;
-                column = 0;
-            } else {
-                column += 1;
-            }
+    // Shares `stream_bytes` with `jq_seq_reader`, which walks this same
+    // stream to classify the templates that apply once an RS *is* present
+    // (#1723) -- the two must agree on BOM handling and on where a column
+    // starts, so they read the stream through one iterator.
+    for b in crate::jq_seq_reader::stream_bytes(raw_bytes) {
+        if b == ASCII_RS {
+            return None;
         }
-        bytes_seen += raw.len();
+        if b == b'\n' {
+            line += 1;
+            column = 0;
+        } else {
+            column += 1;
+        }
     }
-    if bytes_seen == 0 && raw_bytes.is_empty() {
+    if raw_bytes.is_empty() {
         return None;
     }
     Some(format!(

--- a/src/bin/succinctly/jq_seq_reader.rs
+++ b/src/bin/succinctly/jq_seq_reader.rs
@@ -634,3 +634,305 @@ fn strip_prefix_ignore_ascii_case<'a>(bytes: &'a [u8], prefix: &[u8]) -> Option<
     head.eq_ignore_ascii_case(prefix)
         .then(|| &bytes[prefix.len()..])
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn warnings(sources: &[&[u8]]) -> Vec<String> {
+        let owned: Vec<(Option<usize>, Vec<u8>)> =
+            sources.iter().map(|s| (None, s.to_vec())).collect();
+        parse_warnings(&owned)
+            .into_iter()
+            .map(|w| {
+                w.strip_prefix("jq: ignoring parse error: ")
+                    .expect("every warning carries jq's prefix")
+                    .to_string()
+            })
+            .collect()
+    }
+
+    fn assert_warnings(input: &[u8], expected: &[&str]) {
+        assert_eq!(warnings(&[input]), expected, "input: {input:?}");
+    }
+
+    /// Every message template, captured from `/usr/bin/jq` 1.7.1. The
+    /// three renderings are all here: `at EOF` (real end of input), a
+    /// bare `(need RS to resync)` (an ordinary byte), and the `Truncated
+    /// value` collapse (an RS byte).
+    #[test]
+    fn templates_match_the_oracle_1723() {
+        // Real EOF, mid-value.
+        assert_warnings(b"\x1e\"abc", &["Unfinished string at EOF at line 1, column 5"]);
+        assert_warnings(
+            b"\x1e[1,2\n",
+            &["Unfinished JSON term at EOF at line 2, column 0"],
+        );
+        assert_warnings(
+            b"\x1e{\"a\":1",
+            &["Unfinished JSON term at EOF at line 1, column 7"],
+        );
+        assert_warnings(b"\x1etru", &["Invalid literal at EOF at line 1, column 4"]);
+        assert_warnings(b"\x1e-", &["Invalid numeric literal at EOF at line 1, column 2"]);
+        assert_warnings(
+            b"\x1e1e",
+            &["Invalid numeric literal at EOF at line 1, column 3"],
+        );
+
+        // Mid-buffer, on an ordinary byte.
+        assert_warnings(
+            b"\x1exyz\n",
+            &["Invalid numeric literal at line 2, column 0 (need RS to resync)"],
+        );
+        assert_warnings(
+            b"\x1e[1,]",
+            &["Expected another array element at line 1, column 5 (need RS to resync)"],
+        );
+        assert_warnings(
+            b"\x1e{\"a\":1,}",
+            &["Expected another key-value pair at line 1, column 9 (need RS to resync)"],
+        );
+        assert_warnings(
+            b"\x1e}",
+            &["Unmatched '}' at line 1, column 2 (need RS to resync)"],
+        );
+        assert_warnings(
+            b"\x1e]",
+            &["Unmatched ']' at line 1, column 2 (need RS to resync)"],
+        );
+        assert_warnings(
+            b"\x1e[1 2]",
+            &["Expected separator between values at line 1, column 6 (need RS to resync)"],
+        );
+        assert_warnings(
+            b"\x1e:",
+            &["Expected string key before ':' at line 1, column 2 (need RS to resync)"],
+        );
+        assert_warnings(
+            b"\x1e,",
+            &["Expected value before ',' at line 1, column 2 (need RS to resync)"],
+        );
+
+        // An RS byte, mid-value.
+        assert_warnings(
+            b"\x1e\"unterminated\x1e\"ok\"\n",
+            &["Truncated value at line 1, column 15"],
+        );
+        assert_warnings(b"\x1e[1,2\x1e\"ok\"\n", &["Truncated value at line 1, column 6"]);
+    }
+
+    /// A container error leaves the stack behind, and the object/array
+    /// distinction picks the message -- both of these report twice
+    /// because jq resumes rather than resyncing.
+    #[test]
+    fn container_errors_and_their_continuations_1723() {
+        assert_warnings(
+            b"\x1e{1:2}",
+            &[
+                "Object keys must be strings at line 1, column 4 (need RS to resync)",
+                "Unmatched '}' at line 1, column 6 (need RS to resync)",
+            ],
+        );
+        assert_warnings(
+            b"\x1e{\"a\", \"b\"}",
+            &[
+                "Objects must consist of key:value pairs at line 1, column 6 (need RS to resync)",
+                "Unmatched '}' at line 1, column 11 (need RS to resync)",
+            ],
+        );
+        assert_warnings(
+            b"\x1e{,}\n",
+            &[
+                "Expected value before ',' at line 1, column 3 (need RS to resync)",
+                "Unmatched '}' at line 1, column 4 (need RS to resync)",
+            ],
+        );
+    }
+
+    /// Every string-escape category `found_string` can raise.
+    #[test]
+    fn string_escape_errors_1723() {
+        assert_warnings(
+            b"\x1e\"\\q\"",
+            &["Invalid escape at line 1, column 5 (need RS to resync)"],
+        );
+        assert_warnings(
+            b"\x1e\"\\u00\"",
+            &["Invalid \\uXXXX escape at line 1, column 7 (need RS to resync)"],
+        );
+        assert_warnings(
+            b"\x1e\"\\uZZZZ\"",
+            &["Invalid characters in \\uXXXX escape at line 1, column 9 (need RS to resync)"],
+        );
+        assert_warnings(
+            b"\x1e\"\\ud800\"",
+            &["Invalid \\uXXXX\\uXXXX surrogate pair escape at line 1, column 9 (need RS to resync)"],
+        );
+        assert_warnings(
+            b"\x1e\"\\ud800\\u0041\"",
+            &[
+                "Invalid \\uXXXX\\uXXXX surrogate pair escape at line 1, column 15 (need RS to resync)",
+            ],
+        );
+        assert_warnings(
+            b"\x1e\"a\x01b\"",
+            &[
+                "Invalid string: control characters from U+0000 through U+001F must be escaped at line 1, column 6 (need RS to resync)",
+            ],
+        );
+        // A well-formed surrogate pair is not an error.
+        assert_warnings(b"\x1e\"\\ud800\\udc00\" ", &[]);
+    }
+
+    /// jq's number grammar is decNumber's, not RFC 8259's. Getting this
+    /// wrong swaps "Invalid numeric literal" for "Potentially truncated
+    /// top-level numeric value" and vice versa.
+    #[test]
+    fn number_grammar_is_decnumbers_1723() {
+        for accepted in [
+            &b"\x1e1."[..],
+            b"\x1e.5",
+            b"\x1e+1",
+            b"\x1e01",
+            b"\x1enan",
+            b"\x1eNaN5",
+            b"\x1esnan",
+            b"\x1einf",
+            b"\x1e-Infinity",
+        ] {
+            let got = warnings(&[accepted]);
+            assert_eq!(
+                got.len(),
+                1,
+                "expected the truncated-number template for {accepted:?}, got {got:?}"
+            );
+            assert!(
+                got[0].starts_with("Potentially truncated top-level numeric value at EOF"),
+                "{accepted:?} should parse as a number, got {got:?}"
+            );
+        }
+        for rejected in [&b"\x1e1e"[..], b"\x1e1e+", b"\x1e-", b"\x1e1.2.3", b"\x1e0x10"] {
+            let got = warnings(&[rejected]);
+            assert!(
+                got[0].starts_with("Invalid numeric literal at EOF"),
+                "{rejected:?} should not parse as a number, got {got:?}"
+            );
+        }
+    }
+
+    /// `nu` takes jq's keyword path while a bare `n` falls through to the
+    /// number parser -- and a one-character number token NUL-terminates
+    /// itself, which is what keeps a later `n` on the number path too.
+    #[test]
+    fn keyword_path_depends_on_the_second_buffer_byte_1723() {
+        assert_warnings(b"\x1enul", &["Invalid literal at EOF at line 1, column 4"]);
+        assert_warnings(b"\x1en", &["Invalid numeric literal at EOF at line 1, column 2"]);
+        // `iu` leaves a `u` at index 1, so the following bare `n` is
+        // measured against `null` -- jq reads the stale byte (#1723).
+        assert_warnings(
+            b"\x1eiu\"n",
+            &[
+                "Invalid numeric literal at line 1, column 4 (need RS to resync)",
+                "Invalid literal at EOF at line 1, column 5",
+            ],
+        );
+    }
+
+    /// A completed top-level value is handed off and cleared, so trailing
+    /// garbage is reported on its own rather than as a separator error.
+    #[test]
+    fn complete_value_then_garbage_1723() {
+        assert_warnings(
+            b"\x1e{}extra",
+            &["Invalid numeric literal at EOF at line 1, column 8"],
+        );
+        assert_warnings(
+            b"\x1e[1,2]extra",
+            &["Invalid numeric literal at EOF at line 1, column 11"],
+        );
+    }
+
+    /// The RS collapse spares a pending top-level number, and a
+    /// mid-buffer error that already fired outranks it.
+    #[test]
+    fn rs_collapse_exceptions_1723() {
+        assert_warnings(
+            b"\x1e1.\x1e\"ok\"\n",
+            &["Potentially truncated top-level numeric value at line 1, column 4"],
+        );
+        assert_warnings(
+            b"\x1e[1,]\x1e\"ok\"\n",
+            &["Expected another array element at line 1, column 5 (need RS to resync)"],
+        );
+    }
+
+    /// Trailing whitespace resolves an otherwise-ambiguous bare number.
+    #[test]
+    fn trailing_bare_number_is_ambiguous_only_unterminated_1723() {
+        assert_warnings(
+            b"\x1e1 2",
+            &["Potentially truncated top-level numeric value at EOF at line 1, column 4"],
+        );
+        assert_warnings(b"\x1e1 2 ", &[]);
+    }
+
+    /// Columns count raw bytes, not characters, and never reset across
+    /// input files.
+    #[test]
+    fn positions_count_bytes_and_span_files_1723() {
+        assert_warnings(
+            b"\x1e\xff]",
+            &["Invalid numeric literal at line 1, column 3 (need RS to resync)"],
+        );
+        assert_warnings(
+            b"\x1e\xc3\xa9]",
+            &["Invalid numeric literal at line 1, column 4 (need RS to resync)"],
+        );
+        assert_eq!(
+            warnings(&[b"\x1e[1,", b"2\n"]),
+            ["Unfinished JSON term at EOF at line 2, column 0"],
+        );
+    }
+
+    /// One leading BOM is consumed without advancing the column, and only
+    /// at the stream's start -- an empty leading source does not use it up.
+    #[test]
+    fn bom_is_consumed_but_not_counted_1723() {
+        assert_warnings(
+            b"\xef\xbb\xbf\x1e}",
+            &["Unmatched '}' at line 1, column 2 (need RS to resync)"],
+        );
+        assert_eq!(
+            warnings(&[b"", b"\xef\xbb\xbf\x1e}"]),
+            ["Unmatched '}' at line 1, column 2 (need RS to resync)"],
+        );
+        // A second BOM is ordinary content.
+        assert_warnings(
+            b"\xef\xbb\xbf\x1e\xef\xbb\xbf]",
+            &["Invalid numeric literal at line 1, column 5 (need RS to resync)"],
+        );
+    }
+
+    #[test]
+    fn depth_limit_matches_jq_1723() {
+        let mut input = vec![ASCII_RS];
+        input.extend(std::iter::repeat_n(b'[', 300));
+        assert_eq!(
+            warnings(&[&input]),
+            [
+                "Exceeds depth limit for parsing at line 1, column 258 (need RS to resync)"
+                    .to_string(),
+                "Unfinished JSON term at EOF at line 1, column 301".to_string(),
+            ],
+        );
+    }
+
+    /// Content before the first RS byte is discarded without a word: jq's
+    /// `--seq` parser starts out waiting for one.
+    #[test]
+    fn content_before_the_first_rs_is_silent_1723() {
+        assert_warnings(b"garbage\x1e\"ok\"\n", &[]);
+        assert_warnings(b"\x1e\"ok\"\n", &[]);
+        assert_warnings(b"\x1e{\"a\": [1, 2]}\n", &[]);
+    }
+}

--- a/src/bin/succinctly/jq_seq_reader.rs
+++ b/src/bin/succinctly/jq_seq_reader.rs
@@ -53,41 +53,84 @@ const ASCII_RS: u8 = 0x1e;
 /// 256 nested `[` parse and the 257th reports `Exceeds depth limit`.
 const MAX_PARSING_DEPTH: usize = 256;
 
-/// Every byte of the input stream, as jq's parser sees it: all sources
-/// concatenated, with one leading UTF-8 BOM consumed but *not* counted
-/// (jq strips it in `jv_parser_set_buf`, before the scanner's column
-/// counter ever sees it).
+/// What jq's `jv_parser_set_buf` consumes as a leading BOM, over all
+/// sources concatenated.
+///
+/// jq consumes the matching *prefix* byte by byte, so a partial BOM is
+/// eaten even though it never completes one. Those bytes never reach the
+/// scanner, so they never advance a column either -- getting this wrong
+/// shifts every position in the stream.
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub(crate) struct BomPrefix {
+    /// Bytes jq swallowed before parsing began.
+    consumed: usize,
+    /// A prefix that started a BOM and then contradicted it. jq flags this
+    /// (`bom_strip_position = 0xff`) and thereafter re-runs `parser_reset`
+    /// at the top of every `jv_parser_next` -- which, through the same
+    /// clobber described above, leaves the parser in `Normal` rather than
+    /// `WaitingForRs`. So a malformed BOM makes jq read the bytes before
+    /// the first RS as a record, where it would normally discard them.
+    pub(crate) malformed: bool,
+}
+
+pub(crate) fn bom_prefix(raw_bytes: &[(Option<usize>, Vec<u8>)]) -> BomPrefix {
+    let mut consumed = 0;
+    for byte in raw_bytes.iter().flat_map(|(_, raw)| raw.iter().copied()) {
+        if consumed == UTF8_BOM.len() || byte != UTF8_BOM[consumed] {
+            // A mismatch at offset 0 just means "no BOM here"; one after a
+            // partial match is the malformed case. Running out of input
+            // mid-BOM is neither -- jq is still waiting for the rest.
+            return BomPrefix {
+                consumed,
+                malformed: consumed > 0 && consumed < UTF8_BOM.len(),
+            };
+        }
+        consumed += 1;
+    }
+    BomPrefix {
+        consumed,
+        malformed: false,
+    }
+}
+
+/// Every byte of the input stream, as jq's scanner sees it: all sources
+/// concatenated, with [`bom_prefix`]'s bytes already removed.
 ///
 /// Shared with [`super::jq_runner::seq_no_rs_byte_warning`] so the two
 /// walkers over this same stream cannot drift apart on BOM handling.
-/// The BOM is stripped from the first *non-empty* source rather than the
-/// first source: jq's `bom_strip_position` advances over the concatenated
-/// stream, so an empty leading file leaves the next file's BOM still at
-/// the stream's start.
 pub(crate) fn stream_bytes(
     raw_bytes: &[(Option<usize>, Vec<u8>)],
 ) -> impl Iterator<Item = u8> + '_ {
-    let mut seen_any = false;
     raw_bytes
         .iter()
-        .flat_map(move |(_, raw)| {
-            let bytes = if seen_any {
-                raw.as_slice()
-            } else {
-                raw.strip_prefix(UTF8_BOM).unwrap_or(raw)
-            };
-            seen_any |= !raw.is_empty();
-            bytes
-        })
-        .copied()
+        .flat_map(|(_, raw)| raw.iter().copied())
+        .skip(bom_prefix(raw_bytes).consumed)
 }
 
-/// Every `jq: ignoring parse error: ...` line real jq would write for this
-/// `--seq` stream, in order.
-pub(crate) fn parse_warnings(raw_bytes: &[(Option<usize>, Vec<u8>)]) -> Vec<String> {
-    let mut reader = Reader::new();
+/// Hands `emit` every `jq: ignoring parse error: ...` line real jq would
+/// write for this `--seq` stream, in order.
+///
+/// A sink rather than a `Vec`: an adversarial stream can warn once per
+/// byte, and collecting those first cost ~140x the input in peak RSS
+/// (2 MB of `}` measured at 286 MB, against jq's 2.4 MB). Streaming them
+/// keeps the reader flat.
+pub(crate) fn for_each_warning(raw_bytes: &[(Option<usize>, Vec<u8>)], emit: &mut dyn FnMut(&str)) {
+    let bom = bom_prefix(raw_bytes);
+    // With a malformed BOM jq re-runs `parser_reset` at the top of *every*
+    // `jv_parser_next` -- including the call for the empty final buffer
+    // that a newline-terminated stream produces, since `fgets` stops at
+    // the newline without reaching EOF. That reset wipes the accumulated
+    // state before the EOF branch can report on it, so no `at EOF` warning
+    // survives. A stream not ending in a newline hits EOF in the same read
+    // and does report one.
+    let ends_with_newline = raw_bytes
+        .iter()
+        .rev()
+        .find_map(|(_, raw)| raw.last().copied())
+        == Some(b'\n');
+    let mut reader = Reader::new(bom, emit);
+    reader.suppress_eof_warning = bom.malformed && ends_with_newline;
     reader.run(stream_bytes(raw_bytes));
-    reader.warnings
 }
 
 /// The kinds jq's parser distinguishes while classifying a failure. It
@@ -140,7 +183,7 @@ fn classify(c: u8) -> Cls {
     }
 }
 
-struct Reader {
+struct Reader<'a> {
     line: usize,
     column: usize,
     st: St,
@@ -157,27 +200,49 @@ struct Reader {
     token_len: usize,
     next: Option<Kind>,
     last_ch_was_ws: bool,
-    warnings: Vec<String>,
+    /// A malformed BOM makes jq re-run `parser_reset` at the top of every
+    /// `jv_parser_next`. That call returns on each value, on each error,
+    /// and when the buffer runs out -- and jq refills a line at a time --
+    /// so under this flag the parser is wiped after every value and every
+    /// newline as well. An unterminated string therefore stops swallowing
+    /// the rest of the stream, and `\x1e9"-si-\n` reports on `-si-`
+    /// because emitting `9` dropped the string it had just opened.
+    resets_per_call: bool,
+    /// Set by [`Reader::check_done`] when a value was handed off, which is
+    /// one of the points jq's reader returns at.
+    produced_value: bool,
+    /// See [`for_each_warning`]: a malformed BOM plus a newline-terminated
+    /// stream means jq's own EOF report is wiped before it is written.
+    suppress_eof_warning: bool,
+    emit: &'a mut dyn FnMut(&str),
 }
 
-impl Reader {
-    fn new() -> Self {
+impl<'a> Reader<'a> {
+    fn new(bom: BomPrefix, emit: &'a mut dyn FnMut(&str)) -> Self {
         Self {
             line: 1,
             column: 0,
-            st: St::WaitingForRs,
+            // A malformed BOM has already cost jq a `parser_reset`, so it
+            // starts in `Normal` and reads pre-RS bytes as a record.
+            st: if bom.malformed {
+                St::Normal
+            } else {
+                St::WaitingForRs
+            },
             stack: Vec::new(),
             token_buf: Vec::new(),
             token_len: 0,
             next: None,
             last_ch_was_ws: false,
-            warnings: Vec::new(),
+            resets_per_call: bom.malformed,
+            produced_value: false,
+            suppress_eof_warning: false,
+            emit,
         }
     }
 
     fn warn(&mut self, body: &str) {
-        self.warnings
-            .push(format!("jq: ignoring parse error: {body}"));
+        (self.emit)(&format!("jq: ignoring parse error: {body}"));
     }
 
     /// jq's `parser_reset`. Note it restores `Normal` -- including over a
@@ -214,7 +279,10 @@ impl Reader {
                     ));
                 }
                 self.reset();
+            } else if self.resets_per_call && (self.produced_value || ch == b'\n') {
+                self.reset();
             }
+            self.produced_value = false;
         }
         self.finish();
     }
@@ -311,6 +379,7 @@ impl Reader {
     fn check_done(&mut self) -> bool {
         if self.stack.is_empty() && self.next.is_some() {
             self.next = None;
+            self.produced_value = true;
             true
         } else {
             false
@@ -531,6 +600,9 @@ impl Reader {
     /// sets `p->eof` before reaching any of these, so the reader never
     /// runs again.
     fn finish(&mut self) {
+        if self.suppress_eof_warning {
+            return;
+        }
         let (line, column) = (self.line, self.column);
         if self.st == St::WaitingForRs {
             // #1525's template. Unreachable from the wired call site,
@@ -654,14 +726,15 @@ mod tests {
     fn warnings(sources: &[&[u8]]) -> Vec<String> {
         let owned: Vec<(Option<usize>, Vec<u8>)> =
             sources.iter().map(|s| (None, s.to_vec())).collect();
-        parse_warnings(&owned)
-            .into_iter()
-            .map(|w| {
+        let mut got = Vec::new();
+        for_each_warning(&owned, &mut |w| {
+            got.push(
                 w.strip_prefix("jq: ignoring parse error: ")
                     .expect("every warning carries jq's prefix")
-                    .to_string()
-            })
-            .collect()
+                    .to_string(),
+            );
+        });
+        got
     }
 
     fn assert_warnings(input: &[u8], expected: &[&str]) {
@@ -921,6 +994,71 @@ mod tests {
         assert_eq!(
             warnings(&[b"\x1e[1,", b"2\n"]),
             ["Unfinished JSON term at EOF at line 2, column 0"],
+        );
+    }
+
+    /// A BOM prefix that never completes is still *consumed*, and it costs
+    /// jq a `parser_reset` that leaves it reading rather than waiting for
+    /// an RS byte. Both halves matter: forget the first and every column
+    /// in the stream shifts, forget the second and the pre-RS content is
+    /// discarded when jq would have parsed it. All captured from
+    /// `/usr/bin/jq` 1.7.1.
+    #[test]
+    fn malformed_bom_is_consumed_and_starts_the_parser_reading_1723() {
+        assert_warnings(
+            b"\xef\xbb\x1e[1,]\n",
+            &["Expected another array element at line 1, column 5 (need RS to resync)"],
+        );
+        // Read as a record, so this is *not* #1525's abandoned-text
+        // template even though the stream holds no RS byte at all.
+        for input in [&b"\xef\xbb1 2"[..], b"\xef1 2"] {
+            assert_warnings(
+                input,
+                &["Potentially truncated top-level numeric value at EOF at line 1, column 3"],
+            );
+        }
+        // A stream that simply runs out mid-BOM is not malformed -- jq is
+        // still waiting for the rest of it, and has consumed no content.
+        for input in [&b"\xef"[..], b"\xef\xbb"] {
+            assert_warnings(
+                input,
+                &["Unfinished abandoned text at EOF at line 1, column 0"],
+            );
+        }
+    }
+
+    /// After a malformed BOM jq's parser is wiped at the top of every
+    /// `jv_parser_next`, so it never carries state across a value, a
+    /// newline, or the end of input. All captured from `/usr/bin/jq` 1.7.1.
+    #[test]
+    fn malformed_bom_wipes_the_parser_on_every_read_1723() {
+        // Emitting `9` drops the string opened in the same breath, so the
+        // next line's `-si-` is read as a token rather than swallowed.
+        assert_warnings(
+            b"\xef\x1exl+uita[9\"-si-\n",
+            &[
+                "Invalid numeric literal at line 1, column 9 (need RS to resync)",
+                "Invalid numeric literal at line 2, column 0 (need RS to resync)",
+            ],
+        );
+        // A newline does the same: the unterminated string ends with the
+        // line instead of eating the rest of the stream.
+        assert_warnings(
+            b"\xef\x1e:\"[:x:0r.\\ {\n:s-\\ba\n",
+            &[
+                "Expected string key before ':' at line 1, column 2 (need RS to resync)",
+                "Expected string key before ':' at line 2, column 1 (need RS to resync)",
+                "Invalid numeric literal at line 3, column 0 (need RS to resync)",
+            ],
+        );
+        // And the wipe reaches the empty final buffer a newline-terminated
+        // stream produces, so no `at EOF` report survives at all.
+        assert_warnings(
+            b"\xef\x1er  -{\"f+\n",
+            &[
+                "Invalid numeric literal at line 1, column 3 (need RS to resync)",
+                "Invalid numeric literal at line 1, column 6 (need RS to resync)",
+            ],
         );
     }
 

--- a/src/bin/succinctly/jq_seq_reader.rs
+++ b/src/bin/succinctly/jq_seq_reader.rs
@@ -240,6 +240,9 @@ impl Reader {
                 return Err("Truncated value");
             }
             self.check_literal()?;
+            // Unreachable in practice, and kept because jq has it: a
+            // completed top-level value is cleared by `check_done` the
+            // moment it completes, so nothing is ever still pending here.
             if self.st == St::Normal && self.check_done() {
                 return Ok(());
             }
@@ -357,6 +360,9 @@ impl Reader {
                     return Err("Expected value before ','");
                 }
                 match self.stack.last() {
+                    // Same as the RS branch above: at the top level the
+                    // pending value is already gone, so the `is_none`
+                    // check has answered first. jq has the arm; so do we.
                     None => return Err("',' not as part of an object or array"),
                     Some(Frame::Array { .. }) => {
                         if let Some(Frame::Array { nonempty }) = self.stack.last_mut() {
@@ -415,6 +421,7 @@ impl Reader {
                 self.stack.pop();
                 self.next = Some(Kind::Object);
             }
+            // Only `classify`'s `Structure` bytes reach this function.
             _ => {}
         }
         Ok(())
@@ -483,6 +490,9 @@ impl Reader {
                 }
                 continue;
             }
+            // Unreachable: a trailing `\\` puts the scanner in
+            // `StrEscape`, so the next byte is consumed as the escaped one
+            // and the string cannot end here. jq carries the arm anyway.
             if i >= buf.len() {
                 return Err("Expected escape character at end of string");
             }
@@ -945,6 +955,65 @@ mod tests {
                 "Unfinished JSON term at EOF at line 1, column 301".to_string(),
             ],
         );
+    }
+
+    /// The remaining `parse_token` categories, each needing a value already
+    /// in hand when the structural byte arrives -- which only happens
+    /// inside a container, since a completed top-level value is handed off
+    /// and cleared before the next byte is read.
+    #[test]
+    fn structural_errors_needing_a_pending_value_1723() {
+        assert_warnings(
+            b"\x1e[1[",
+            &["Expected separator between values at line 1, column 4 (need RS to resync)"],
+        );
+        assert_warnings(
+            b"\x1e[1:",
+            &["':' not as part of an object at line 1, column 4 (need RS to resync)"],
+        );
+        assert_warnings(
+            b"\x1e{\"a\"}",
+            &["Objects must consist of key:value pairs at line 1, column 6 (need RS to resync)"],
+        );
+        assert_warnings(
+            b"\x1e[}",
+            &["Unmatched '}' at line 1, column 3 (need RS to resync)"],
+        );
+    }
+
+    /// A token longer than the buffer's initial growth step, and the
+    /// ordinary two-character escapes -- neither reaches a diagnostic, so
+    /// what is asserted is that neither invents one.
+    #[test]
+    fn long_tokens_and_plain_escapes_1723() {
+        // 256 exactly fills the buffer's first growth step, which is the
+        // one length at which `check_literal`'s own NUL write has to grow
+        // it again; 300 then exercises a second growth during scanning.
+        for (digits, column) in [(256usize, 257usize), (300, 301)] {
+            let mut input = vec![ASCII_RS];
+            input.extend(std::iter::repeat_n(b'9', digits));
+            assert_eq!(
+                warnings(&[&input]),
+                [format!(
+                    "Potentially truncated top-level numeric value at EOF at line 1, column {column}"
+                )],
+            );
+        }
+        assert_warnings(b"\x1e\"a\\nb\\t\\\\\\/\\\"\\b\\f\\rc\"", &[]);
+    }
+
+    /// #1525's template, reached through the model rather than
+    /// `seq_no_rs_byte_warning`: with no RS byte anywhere, jq's parser is
+    /// still waiting for one when EOF arrives. The wired call site routes
+    /// this case to #1525's helper instead, so the two never both fire.
+    #[test]
+    fn no_rs_byte_anywhere_abandons_at_eof_1723() {
+        assert_warnings(
+            b"1 2",
+            &["Unfinished abandoned text at EOF at line 1, column 3"],
+        );
+        // Newlines still advance the line counter while waiting for an RS.
+        assert_warnings(b"junk\nmore\x1e\"ok\"\n", &[]);
     }
 
     /// Content before the first RS byte is discarded without a word: jq's

--- a/src/bin/succinctly/jq_seq_reader.rs
+++ b/src/bin/succinctly/jq_seq_reader.rs
@@ -561,7 +561,7 @@ impl Reader {
 fn unhex4(bytes: &[u8]) -> Option<u32> {
     let mut value = 0u32;
     for &b in bytes {
-        value = (value << 4) | u32::from((b as char).to_digit(16)?);
+        value = (value << 4) | (b as char).to_digit(16)?;
     }
     Some(value)
 }
@@ -608,7 +608,9 @@ fn number_is_valid(token: &[u8]) -> bool {
         Some(i) => (&mantissa[..i], Some(&mantissa[i + 1..])),
         None => (mantissa, None),
     };
-    if integer.is_empty() && fraction.is_none_or(<[u8]>::is_empty) {
+    // `map_or(true, ..)` rather than `is_none_or`: the crate's MSRV is
+    // 1.73 and `Option::is_none_or` is 1.82.
+    if integer.is_empty() && fraction.map_or(true, <[u8]>::is_empty) {
         return false;
     }
     if !integer.iter().all(u8::is_ascii_digit) {
@@ -663,7 +665,10 @@ mod tests {
     #[test]
     fn templates_match_the_oracle_1723() {
         // Real EOF, mid-value.
-        assert_warnings(b"\x1e\"abc", &["Unfinished string at EOF at line 1, column 5"]);
+        assert_warnings(
+            b"\x1e\"abc",
+            &["Unfinished string at EOF at line 1, column 5"],
+        );
         assert_warnings(
             b"\x1e[1,2\n",
             &["Unfinished JSON term at EOF at line 2, column 0"],
@@ -673,7 +678,10 @@ mod tests {
             &["Unfinished JSON term at EOF at line 1, column 7"],
         );
         assert_warnings(b"\x1etru", &["Invalid literal at EOF at line 1, column 4"]);
-        assert_warnings(b"\x1e-", &["Invalid numeric literal at EOF at line 1, column 2"]);
+        assert_warnings(
+            b"\x1e-",
+            &["Invalid numeric literal at EOF at line 1, column 2"],
+        );
         assert_warnings(
             b"\x1e1e",
             &["Invalid numeric literal at EOF at line 1, column 3"],
@@ -718,7 +726,10 @@ mod tests {
             b"\x1e\"unterminated\x1e\"ok\"\n",
             &["Truncated value at line 1, column 15"],
         );
-        assert_warnings(b"\x1e[1,2\x1e\"ok\"\n", &["Truncated value at line 1, column 6"]);
+        assert_warnings(
+            b"\x1e[1,2\x1e\"ok\"\n",
+            &["Truncated value at line 1, column 6"],
+        );
     }
 
     /// A container error leaves the stack behind, and the object/array
@@ -811,7 +822,13 @@ mod tests {
                 "{accepted:?} should parse as a number, got {got:?}"
             );
         }
-        for rejected in [&b"\x1e1e"[..], b"\x1e1e+", b"\x1e-", b"\x1e1.2.3", b"\x1e0x10"] {
+        for rejected in [
+            &b"\x1e1e"[..],
+            b"\x1e1e+",
+            b"\x1e-",
+            b"\x1e1.2.3",
+            b"\x1e0x10",
+        ] {
             let got = warnings(&[rejected]);
             assert!(
                 got[0].starts_with("Invalid numeric literal at EOF"),
@@ -826,7 +843,10 @@ mod tests {
     #[test]
     fn keyword_path_depends_on_the_second_buffer_byte_1723() {
         assert_warnings(b"\x1enul", &["Invalid literal at EOF at line 1, column 4"]);
-        assert_warnings(b"\x1en", &["Invalid numeric literal at EOF at line 1, column 2"]);
+        assert_warnings(
+            b"\x1en",
+            &["Invalid numeric literal at EOF at line 1, column 2"],
+        );
         // `iu` leaves a `u` at index 1, so the following bare `n` is
         // measured against `null` -- jq reads the stale byte (#1723).
         assert_warnings(

--- a/src/bin/succinctly/jq_seq_reader.rs
+++ b/src/bin/succinctly/jq_seq_reader.rs
@@ -1,0 +1,636 @@
+//! Real jq's `--seq` reader, modelled closely enough to reproduce its
+//! `jq: ignoring parse error: ...` stderr diagnostics (#1723).
+//!
+//! #1525 implemented one of jq's message templates -- the one for content
+//! with no RS byte anywhere, where jq's reader never syncs onto anything
+//! ([`super::jq_runner::seq_no_rs_byte_warning`]). Every *other* template
+//! needs to know **where jq's own reader gave up**, which is what this
+//! module answers.
+//!
+//! **Why a state machine rather than a classification table.** Several
+//! earlier attempts tried to map "what is wrong with this record" onto
+//! jq's wording and found no consistent rule -- the same malformed record
+//! draws different messages depending on whether jq hit real EOF, an RS
+//! byte, or an ordinary byte first. There is no table because the message
+//! is not a property of the record; it is a property of the *moment of
+//! detection*. Modelling jq's `scan()` loop reproduces all of them, and
+//! the message is then composed from three facts:
+//!
+//! | detected on | rendering |
+//! |---|---|
+//! | an ordinary byte | `{category} at line L, column C (need RS to resync)` |
+//! | real EOF | `{category} at EOF at line L, column C` |
+//! | an RS byte | `Truncated value` (or `Potentially truncated top-level numeric value`) |
+//!
+//! Positions are jq's cursor at the moment of detection: 0-based columns
+//! counting **raw bytes**, never reset per record or per input file.
+//!
+//! **`(need RS to resync)` is wording, not behaviour.** jq's own
+//! `jv_parse.c` sets `JV_PARSER_WAITING_FOR_RS` and *then* calls
+//! `parser_reset()`, which assigns `JV_PARSER_NORMAL` straight back over
+//! it -- so the resync the message promises never happens and parsing
+//! resumes at the very next byte. That is why one record can produce
+//! several warnings (`\x1enot valid json\n` produces three) and why
+//! `\x1e} 5\n` still prints `5`. The bug is reproduced here deliberately,
+//! per ADR-0018's bug-for-bug default; the ordering of those two lines is
+//! the whole reason this module resets instead of skipping.
+//!
+//! Derived by reading jq 1.7.1's `src/jv_parse.c` (`scan`, `parse_token`,
+//! `check_literal`, `found_string`, `jv_parser_next`) and verified
+//! case-by-case against the pinned `/usr/bin/jq`. The source enumerates
+//! the categories; the binary decides what is actually emitted.
+//!
+//! This module classifies *failures only*. It builds no values and is not
+//! wired to what `--seq` emits on stdout -- that stays with
+//! [`super::jq_runner::seq_record_scan`], whose deliberate conservatism is
+//! documented there and in `docs/compliance/jq/limitations.md`.
+
+use crate::front_matter::UTF8_BOM;
+
+const ASCII_RS: u8 = 0x1e;
+
+/// jq's `MAX_PARSING_DEPTH` (`jv_parse.c`), confirmed against the oracle:
+/// 256 nested `[` parse and the 257th reports `Exceeds depth limit`.
+const MAX_PARSING_DEPTH: usize = 256;
+
+/// Every byte of the input stream, as jq's parser sees it: all sources
+/// concatenated, with one leading UTF-8 BOM consumed but *not* counted
+/// (jq strips it in `jv_parser_set_buf`, before the scanner's column
+/// counter ever sees it).
+///
+/// Shared with [`super::jq_runner::seq_no_rs_byte_warning`] so the two
+/// walkers over this same stream cannot drift apart on BOM handling.
+/// The BOM is stripped from the first *non-empty* source rather than the
+/// first source: jq's `bom_strip_position` advances over the concatenated
+/// stream, so an empty leading file leaves the next file's BOM still at
+/// the stream's start.
+pub(crate) fn stream_bytes(
+    raw_bytes: &[(Option<usize>, Vec<u8>)],
+) -> impl Iterator<Item = u8> + '_ {
+    let mut seen_any = false;
+    raw_bytes
+        .iter()
+        .flat_map(move |(_, raw)| {
+            let bytes = if seen_any {
+                raw.as_slice()
+            } else {
+                raw.strip_prefix(UTF8_BOM).unwrap_or(raw)
+            };
+            seen_any |= !raw.is_empty();
+            bytes
+        })
+        .copied()
+}
+
+/// Every `jq: ignoring parse error: ...` line real jq would write for this
+/// `--seq` stream, in order.
+pub(crate) fn parse_warnings(raw_bytes: &[(Option<usize>, Vec<u8>)]) -> Vec<String> {
+    let mut reader = Reader::new();
+    reader.run(stream_bytes(raw_bytes));
+    reader.warnings
+}
+
+/// The kinds jq's parser distinguishes while classifying a failure. It
+/// tracks full values; only these distinctions affect which message fires
+/// (`Object keys must be strings` needs `String`, the top-level truncated
+/// number rule needs `Number`, and the rest only need "a value is here").
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum Kind {
+    String,
+    Number,
+    /// `true`, `false`, `null`.
+    Scalar,
+    Array,
+    Object,
+}
+
+/// One entry of jq's parser stack. `Key` is an object key awaiting its
+/// value, which jq pushes on `:` and pops on `,`/`}`.
+#[derive(Clone, Copy)]
+enum Frame {
+    Array { nonempty: bool },
+    Object { nonempty: bool },
+    Key,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum St {
+    Normal,
+    Str,
+    StrEscape,
+    /// jq starts every `--seq` parse here, which is why content before the
+    /// first RS byte is discarded without a word.
+    WaitingForRs,
+}
+
+#[derive(PartialEq, Eq)]
+enum Cls {
+    Literal,
+    Whitespace,
+    Structure,
+    Quote,
+}
+
+fn classify(c: u8) -> Cls {
+    match c {
+        b' ' | b'\t' | b'\r' | b'\n' => Cls::Whitespace,
+        b'"' => Cls::Quote,
+        b'[' | b',' | b']' | b'{' | b':' | b'}' => Cls::Structure,
+        _ => Cls::Literal,
+    }
+}
+
+struct Reader {
+    line: usize,
+    column: usize,
+    st: St,
+    stack: Vec<Frame>,
+    /// jq's `tokenbuf`/`tokenpos`, modelled as a buffer that is *not*
+    /// cleared when the token is. `check_literal` reads `tokenbuf[1]`
+    /// without checking `tokenpos`, so a one-byte `n` token is classified
+    /// against whatever the previous token left at index 1: `\x1en` alone
+    /// reports "Invalid numeric literal", but the same `n` after an
+    /// earlier `iu` token reports "Invalid literal" instead. Reproduced
+    /// deliberately (ADR-0018 rule: bug-for-bug), and it is deterministic
+    /// for any given input even though jq is reading a stale byte.
+    token_buf: Vec<u8>,
+    token_len: usize,
+    next: Option<Kind>,
+    last_ch_was_ws: bool,
+    warnings: Vec<String>,
+}
+
+impl Reader {
+    fn new() -> Self {
+        Self {
+            line: 1,
+            column: 0,
+            st: St::WaitingForRs,
+            stack: Vec::new(),
+            token_buf: Vec::new(),
+            token_len: 0,
+            next: None,
+            last_ch_was_ws: false,
+            warnings: Vec::new(),
+        }
+    }
+
+    fn warn(&mut self, body: &str) {
+        self.warnings
+            .push(format!("jq: ignoring parse error: {body}"));
+    }
+
+    /// jq's `parser_reset`. Note it restores `Normal` -- including over a
+    /// `WaitingForRs` just assigned by the mid-buffer error path, which is
+    /// the upstream bug this module reproduces.
+    fn reset(&mut self) {
+        self.stack.clear();
+        self.token_len = 0;
+        self.next = None;
+        self.st = St::Normal;
+    }
+
+    fn run(&mut self, bytes: impl Iterator<Item = u8>) {
+        for ch in bytes {
+            if self.st == St::WaitingForRs {
+                if ch == b'\n' {
+                    self.line += 1;
+                    self.column = 0;
+                } else {
+                    self.column += 1;
+                }
+                if ch == ASCII_RS {
+                    self.st = St::Normal;
+                }
+                continue;
+            }
+            if let Err(category) = self.scan(ch) {
+                let (line, column) = (self.line, self.column);
+                if ch == ASCII_RS {
+                    self.warn(&format!("{category} at line {line}, column {column}"));
+                } else {
+                    self.warn(&format!(
+                        "{category} at line {line}, column {column} (need RS to resync)"
+                    ));
+                }
+                self.reset();
+            }
+        }
+        self.finish();
+    }
+
+    /// jq's `scan`.
+    fn scan(&mut self, ch: u8) -> Result<(), &'static str> {
+        self.column += 1;
+        if ch == b'\n' {
+            self.line += 1;
+            self.column = 0;
+        }
+
+        if ch == ASCII_RS {
+            if self.check_truncation() {
+                // jq consults `check_literal` for its side effect here: a
+                // pending *number* token becomes the value that makes this
+                // the softer "potentially truncated" case, while anything
+                // else (an unterminated string's contents, say) fails to
+                // parse as a literal and collapses to "Truncated value".
+                if self.check_literal().is_ok() && self.is_top_num() {
+                    return Err("Potentially truncated top-level numeric value");
+                }
+                return Err("Truncated value");
+            }
+            self.check_literal()?;
+            if self.st == St::Normal && self.check_done() {
+                return Ok(());
+            }
+            self.reset();
+            return Ok(());
+        }
+
+        self.last_ch_was_ws = false;
+        if self.st == St::Normal {
+            let cls = classify(ch);
+            if cls == Cls::Whitespace {
+                self.last_ch_was_ws = true;
+            }
+            if cls != Cls::Literal {
+                self.check_literal()?;
+                self.check_done();
+            }
+            match cls {
+                Cls::Literal => self.token_add(ch),
+                Cls::Whitespace => {}
+                Cls::Quote => self.st = St::Str,
+                Cls::Structure => self.token_structure(ch)?,
+            }
+            self.check_done();
+        } else if ch == b'"' && self.st == St::Str {
+            self.found_string()?;
+            self.st = St::Normal;
+            self.check_done();
+        } else {
+            self.token_add(ch);
+            self.st = if ch == b'\\' && self.st == St::Str {
+                St::StrEscape
+            } else {
+                St::Str
+            };
+        }
+        Ok(())
+    }
+
+    /// jq's `tokenadd`, including its growth policy -- the buffer only
+    /// ever grows, which is what leaves stale bytes visible to
+    /// `check_literal`.
+    fn token_add(&mut self, ch: u8) {
+        if self.token_len == self.token_buf.len() {
+            self.token_buf.resize(self.token_buf.len() * 2 + 256, 0);
+        }
+        self.token_buf[self.token_len] = ch;
+        self.token_len += 1;
+    }
+
+    /// jq's `seq_check_truncation`: whether an RS byte has arrived while
+    /// something is still in flight. Trailing whitespace resolves it,
+    /// which is why `\x1e1 \x1e` is clean but `\x1e1\x1e` is not.
+    fn check_truncation(&self) -> bool {
+        !self.last_ch_was_ws
+            && (!self.stack.is_empty() || self.token_len > 0 || self.next == Some(Kind::Number))
+    }
+
+    fn is_top_num(&self) -> bool {
+        self.stack.is_empty() && self.next == Some(Kind::Number)
+    }
+
+    /// jq's `parse_check_done`: a completed top-level value is handed to
+    /// the caller and cleared. Modelling this is what makes `\x1e{}extra`
+    /// report on `extra` rather than "Expected separator between values".
+    fn check_done(&mut self) -> bool {
+        if self.stack.is_empty() && self.next.is_some() {
+            self.next = None;
+            true
+        } else {
+            false
+        }
+    }
+
+    /// jq's `value`.
+    fn value(&mut self, kind: Kind) -> Result<(), &'static str> {
+        if self.next.is_some() {
+            return Err("Expected separator between values");
+        }
+        self.next = Some(kind);
+        Ok(())
+    }
+
+    /// jq's `parse_token`.
+    fn token_structure(&mut self, ch: u8) -> Result<(), &'static str> {
+        match ch {
+            b'[' | b'{' => {
+                if self.stack.len() >= MAX_PARSING_DEPTH {
+                    return Err("Exceeds depth limit for parsing");
+                }
+                if self.next.is_some() {
+                    return Err("Expected separator between values");
+                }
+                self.stack.push(if ch == b'[' {
+                    Frame::Array { nonempty: false }
+                } else {
+                    Frame::Object { nonempty: false }
+                });
+            }
+            b':' => {
+                let Some(kind) = self.next else {
+                    return Err("Expected string key before ':'");
+                };
+                if !matches!(self.stack.last(), Some(Frame::Object { .. })) {
+                    return Err("':' not as part of an object");
+                }
+                if kind != Kind::String {
+                    return Err("Object keys must be strings");
+                }
+                self.stack.push(Frame::Key);
+                self.next = None;
+            }
+            b',' => {
+                if self.next.is_none() {
+                    return Err("Expected value before ','");
+                }
+                match self.stack.last() {
+                    None => return Err("',' not as part of an object or array"),
+                    Some(Frame::Array { .. }) => {
+                        if let Some(Frame::Array { nonempty }) = self.stack.last_mut() {
+                            *nonempty = true;
+                        }
+                    }
+                    Some(Frame::Key) => {
+                        self.stack.pop();
+                        if let Some(Frame::Object { nonempty }) = self.stack.last_mut() {
+                            *nonempty = true;
+                        }
+                    }
+                    // Reached by input like `{"a", "b"}`.
+                    Some(Frame::Object { .. }) => {
+                        return Err("Objects must consist of key:value pairs")
+                    }
+                }
+                self.next = None;
+            }
+            b']' => {
+                let Some(Frame::Array { nonempty }) = self.stack.last().copied() else {
+                    return Err("Unmatched ']'");
+                };
+                if self.next.is_some() {
+                    self.next = None;
+                } else if nonempty {
+                    // Reached by input like `[1,2,3,]`.
+                    return Err("Expected another array element");
+                }
+                self.stack.pop();
+                self.next = Some(Kind::Array);
+            }
+            b'}' => {
+                if self.stack.is_empty() {
+                    return Err("Unmatched '}'");
+                }
+                if self.next.is_some() {
+                    if !matches!(self.stack.last(), Some(Frame::Key)) {
+                        return Err("Objects must consist of key:value pairs");
+                    }
+                    self.stack.pop();
+                    if let Some(Frame::Object { nonempty }) = self.stack.last_mut() {
+                        *nonempty = true;
+                    }
+                    self.next = None;
+                } else {
+                    match self.stack.last() {
+                        Some(Frame::Object { nonempty }) => {
+                            if *nonempty {
+                                return Err("Expected another key-value pair");
+                            }
+                        }
+                        _ => return Err("Unmatched '}'"),
+                    }
+                }
+                self.stack.pop();
+                self.next = Some(Kind::Object);
+            }
+            _ => {}
+        }
+        Ok(())
+    }
+
+    /// jq's `check_literal`.
+    fn check_literal(&mut self) -> Result<(), &'static str> {
+        if self.token_len == 0 {
+            return Ok(());
+        }
+        // Only `t`, `f` and `nu` take the keyword path. A bare `n` (and so
+        // `nan`) falls through to the number path, which is why `\x1en`
+        // reports "Invalid numeric literal" and `\x1enul` reports
+        // "Invalid literal".
+        let pattern: Option<&[u8]> = match self.token_buf[0] {
+            b't' => Some(b"true"),
+            b'f' => Some(b"false"),
+            // Deliberately the whole buffer, not just the token: see the
+            // field's docs.
+            b'n' if self.token_buf.get(1) == Some(&b'u') => Some(b"null"),
+            _ => None,
+        };
+        let kind = match pattern {
+            Some(pattern) => {
+                if &self.token_buf[..self.token_len] != pattern {
+                    return Err("Invalid literal");
+                }
+                Kind::Scalar
+            }
+            None => {
+                // jq NUL-terminates the token in place before handing it
+                // to its number parser. That write is what scrubs the
+                // stale byte read above: a one-character number token
+                // zeroes index 1, so a later bare `n` is classified as a
+                // number rather than against some earlier token's `u`.
+                if self.token_len == self.token_buf.len() {
+                    self.token_buf.resize(self.token_buf.len() * 2 + 256, 0);
+                }
+                self.token_buf[self.token_len] = 0;
+                if !number_is_valid(&self.token_buf[..self.token_len]) {
+                    return Err("Invalid numeric literal");
+                }
+                Kind::Number
+            }
+        };
+        self.value(kind)?;
+        self.token_len = 0;
+        Ok(())
+    }
+
+    /// jq's `found_string`: the escape-validation half, which is all that
+    /// can raise a diagnostic.
+    fn found_string(&mut self) -> Result<(), &'static str> {
+        let buf = self.token_buf[..self.token_len].to_vec();
+        let mut i = 0;
+        while i < buf.len() {
+            let c = buf[i];
+            i += 1;
+            if c != b'\\' {
+                // jq compares a *signed* char, so only U+0000..=U+001F
+                // qualifies -- bytes >= 0x80 are negative there and pass.
+                if c <= 0x1f {
+                    return Err(
+                        "Invalid string: control characters from U+0000 through U+001F must be escaped",
+                    );
+                }
+                continue;
+            }
+            if i >= buf.len() {
+                return Err("Expected escape character at end of string");
+            }
+            let escape = buf[i];
+            i += 1;
+            match escape {
+                b'\\' | b'"' | b'/' | b'b' | b'f' | b't' | b'n' | b'r' => {}
+                b'u' => {
+                    if i + 4 > buf.len() {
+                        return Err("Invalid \\uXXXX escape");
+                    }
+                    let Some(codepoint) = unhex4(&buf[i..i + 4]) else {
+                        return Err("Invalid characters in \\uXXXX escape");
+                    };
+                    i += 4;
+                    if (0xD800..=0xDBFF).contains(&codepoint) {
+                        if i + 6 > buf.len() || buf[i] != b'\\' || buf[i + 1] != b'u' {
+                            return Err("Invalid \\uXXXX\\uXXXX surrogate pair escape");
+                        }
+                        match unhex4(&buf[i + 2..i + 6]) {
+                            Some(low) if (0xDC00..=0xDFFF).contains(&low) => {}
+                            _ => return Err("Invalid \\uXXXX\\uXXXX surrogate pair escape"),
+                        }
+                        i += 6;
+                    }
+                }
+                _ => return Err("Invalid escape"),
+            }
+        }
+        self.value(Kind::String)?;
+        self.token_len = 0;
+        Ok(())
+    }
+
+    /// jq's EOF branch in `jv_parser_next`. At most one diagnostic: jq
+    /// sets `p->eof` before reaching any of these, so the reader never
+    /// runs again.
+    fn finish(&mut self) {
+        let (line, column) = (self.line, self.column);
+        if self.st == St::WaitingForRs {
+            // #1525's template. Unreachable from the wired call site,
+            // which routes a stream with no RS byte to
+            // `seq_no_rs_byte_warning` instead, but kept so this model
+            // stands on its own.
+            self.warn(&format!(
+                "Unfinished abandoned text at EOF at line {line}, column {column}"
+            ));
+            return;
+        }
+        if self.st != St::Normal {
+            self.warn(&format!(
+                "Unfinished string at EOF at line {line}, column {column}"
+            ));
+            return;
+        }
+        if let Err(category) = self.check_literal() {
+            self.warn(&format!(
+                "{category} at EOF at line {line}, column {column}"
+            ));
+            return;
+        }
+        if !self.stack.is_empty() {
+            self.warn(&format!(
+                "Unfinished JSON term at EOF at line {line}, column {column}"
+            ));
+            return;
+        }
+        if !self.last_ch_was_ws && self.next.take() == Some(Kind::Number) {
+            self.warn(&format!(
+                "Potentially truncated top-level numeric value at EOF at line {line}, column {column}"
+            ));
+        }
+    }
+}
+
+fn unhex4(bytes: &[u8]) -> Option<u32> {
+    let mut value = 0u32;
+    for &b in bytes {
+        value = (value << 4) | u32::from((b as char).to_digit(16)?);
+    }
+    Some(value)
+}
+
+/// Whether jq's number parser accepts this token.
+///
+/// jq builds with decNumber, whose grammar is materially wider than RFC
+/// 8259 -- so this deliberately does *not* reuse
+/// [`succinctly::json::validate::is_valid_number`]. All oracle-verified
+/// against the pinned binary: `1.`, `.5`, `+1` and `01` are accepted,
+/// while `1e`, `1e+`, `-` and `1.2.3` are not, and decNumber's special
+/// forms (`nan`, `NaN5` with a payload, `snan`, `inf`, `-Infinity`) are
+/// numbers too. Getting this wrong shows up as "Invalid numeric literal"
+/// where jq says "Potentially truncated top-level numeric value", or vice
+/// versa.
+fn number_is_valid(token: &[u8]) -> bool {
+    let body = match token.first() {
+        Some(b'+' | b'-') => &token[1..],
+        _ => token,
+    };
+    if body.is_empty() {
+        return false;
+    }
+
+    // Longest first: stripping `inf` from `infinity` would leave `inity`.
+    for form in [b"infinity".as_slice(), b"inf".as_slice()] {
+        if let Some(rest) = strip_prefix_ignore_ascii_case(body, form) {
+            return rest.is_empty();
+        }
+    }
+    let nan_body = match body.first() {
+        Some(b's' | b'S') => &body[1..],
+        _ => body,
+    };
+    if let Some(payload) = strip_prefix_ignore_ascii_case(nan_body, b"nan") {
+        return payload.iter().all(u8::is_ascii_digit);
+    }
+
+    let (mantissa, exponent) = match body.iter().position(|&b| b == b'e' || b == b'E') {
+        Some(i) => (&body[..i], Some(&body[i + 1..])),
+        None => (body, None),
+    };
+    let (integer, fraction) = match mantissa.iter().position(|&b| b == b'.') {
+        Some(i) => (&mantissa[..i], Some(&mantissa[i + 1..])),
+        None => (mantissa, None),
+    };
+    if integer.is_empty() && fraction.is_none_or(<[u8]>::is_empty) {
+        return false;
+    }
+    if !integer.iter().all(u8::is_ascii_digit) {
+        return false;
+    }
+    if fraction.is_some_and(|f| !f.iter().all(u8::is_ascii_digit)) {
+        return false;
+    }
+    if let Some(exponent) = exponent {
+        let digits = match exponent.first() {
+            Some(b'+' | b'-') => &exponent[1..],
+            _ => exponent,
+        };
+        if digits.is_empty() || !digits.iter().all(u8::is_ascii_digit) {
+            return false;
+        }
+    }
+    true
+}
+
+fn strip_prefix_ignore_ascii_case<'a>(bytes: &'a [u8], prefix: &[u8]) -> Option<&'a [u8]> {
+    let head = bytes.get(..prefix.len())?;
+    head.eq_ignore_ascii_case(prefix)
+        .then(|| &bytes[prefix.len()..])
+}

--- a/src/bin/succinctly/main.rs
+++ b/src/bin/succinctly/main.rs
@@ -2399,6 +2399,7 @@ mod generators;
 mod jq_bench;
 mod jq_locate;
 mod jq_runner;
+mod jq_seq_reader;
 mod json_validate;
 mod m2_gate;
 mod output;

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -5172,6 +5172,29 @@ fn test_seq_warning_columns_count_raw_bytes_1723() -> Result<()> {
     Ok(())
 }
 
+/// #1723: a malformed BOM (a prefix that starts one and then contradicts
+/// it) costs jq a `parser_reset` that leaves it reading rather than
+/// waiting for an RS -- so even a stream with *no* RS byte anywhere gets
+/// one of this issue's mid-stream templates through `get_inputs`'s
+/// `bom_malformed` filter, never #1525's "no RS byte" one. Exercised only
+/// by `scripts/jq-seq-oracle-sweep.py`'s `HAND` corpus until now; pinned
+/// here so a regression in that filter fails CI rather than only a manual
+/// sweep. Captured from `/usr/bin/jq` 1.7.1.
+#[test]
+fn test_seq_malformed_bom_with_no_rs_byte_warns_1723() -> Result<()> {
+    for input in [&b"\xef\xbb1 2"[..], b"\xef1 2"] {
+        let (output, code) = spawn_jq(&["--seq", "-c", "."], Some(input))?;
+        assert_eq!(code, 0);
+        assert_eq!(
+            String::from_utf8_lossy(&output.stderr),
+            "jq: ignoring parse error: Potentially truncated top-level numeric value at EOF at line 1, column 3\n",
+            "input {input:?}"
+        );
+        assert_eq!(output.stdout, b"", "input {input:?}");
+    }
+    Ok(())
+}
+
 /// #1525: an RS-less file combined with an RS-containing one triggers no
 /// warning at all when the RS-less file is *empty* -- real jq treats the
 /// whole `--seq` input as one continuous stream, and the RS-containing

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -5027,19 +5027,27 @@ fn test_seq_no_rs_byte_warns_1525() -> Result<()> {
     Ok(())
 }
 
-/// #1525: a malformed record that *does* start with an RS byte must not
-/// trigger the "no RS byte" warning above -- it's silently dropped per
-/// RFC 7464 (#1093/#1267), with no diagnostic, exactly as before this fix
-/// (jq's own warning for this shape uses a different message template
-/// entirely -- "Invalid numeric literal ... (need RS to resync)" or
-/// "Unfinished string/JSON term at EOF" depending on how it's malformed --
-/// deliberately not attempted here, tracked separately as #1723).
+/// #1525/#1723: a malformed record that *does* start with an RS byte gets
+/// jq's mid-stream templates, never the "no RS byte" one above (#1525
+/// deliberately left this silent; #1723 implemented it).
+///
+/// Three warnings for one record, not one, and that is the point: jq
+/// resets to the top level and resumes at the very next byte rather than
+/// skipping to the next RS, so `not`, `valid` and `json` are each rejected
+/// in turn. The `(need RS to resync)` the message promises never happens
+/// -- see [`super`]'s `jq_seq_reader` for why. Captured from
+/// `/usr/bin/jq` 1.7.1.
 #[test]
-fn test_seq_malformed_record_with_rs_byte_does_not_warn_1525() -> Result<()> {
+fn test_seq_malformed_record_with_rs_byte_warns_1723() -> Result<()> {
     let (stdout, stderr, code) =
         run_jq_full(&["--seq", "-c", "."], Some("\u{1e}not valid json\n")).unwrap();
     assert_eq!(code, 0);
-    assert_eq!(stderr, "");
+    assert_eq!(
+        stderr,
+        "jq: ignoring parse error: Invalid numeric literal at line 1, column 5 (need RS to resync)\n\
+         jq: ignoring parse error: Invalid numeric literal at line 1, column 11 (need RS to resync)\n\
+         jq: ignoring parse error: Invalid numeric literal at line 2, column 0 (need RS to resync)\n"
+    );
     assert_eq!(stdout, "");
     Ok(())
 }

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -5052,6 +5052,126 @@ fn test_seq_malformed_record_with_rs_byte_warns_1723() -> Result<()> {
     Ok(())
 }
 
+/// #1723: the mid-stream templates end to end, through the CLI rather
+/// than the reader in isolation -- these are the shapes the issue was
+/// filed for. Captured from `/usr/bin/jq` 1.7.1.
+#[test]
+fn test_seq_midstream_warning_templates_1723() -> Result<()> {
+    let cases: &[(&str, &str)] = &[
+        (
+            "\u{1e}\"unterminated\n",
+            "Unfinished string at EOF at line 2, column 0",
+        ),
+        (
+            "\u{1e}[1,2\n",
+            "Unfinished JSON term at EOF at line 2, column 0",
+        ),
+        (
+            "\u{1e}xyz\n",
+            "Invalid numeric literal at line 2, column 0 (need RS to resync)",
+        ),
+        (
+            "\u{1e}{invalid\n",
+            "Invalid numeric literal at line 2, column 0 (need RS to resync)",
+        ),
+        ("\u{1e}tru", "Invalid literal at EOF at line 1, column 4"),
+        (
+            "\u{1e}1.",
+            "Potentially truncated top-level numeric value at EOF at line 1, column 3",
+        ),
+        (
+            "\u{1e}[1,]",
+            "Expected another array element at line 1, column 5 (need RS to resync)",
+        ),
+        (
+            "\u{1e}}",
+            "Unmatched '}' at line 1, column 2 (need RS to resync)",
+        ),
+        (
+            "\u{1e}\"unterminated\u{1e}\"ok\"\n",
+            "Truncated value at line 1, column 15",
+        ),
+    ];
+    for (input, expected) in cases {
+        let (_stdout, stderr, code) = run_jq_full(&["--seq", "-c", "."], Some(input)).unwrap();
+        assert_eq!(code, 0, "input {input:?} stderr: {stderr}");
+        assert_eq!(
+            stderr,
+            format!("jq: ignoring parse error: {expected}\n"),
+            "input {input:?}"
+        );
+    }
+    Ok(())
+}
+
+/// #1723: `--slurp` reaches the same warning site, and a malformed record
+/// between two good ones neither stops the slurp nor loses them.
+#[test]
+fn test_seq_warns_under_slurp_1723() -> Result<()> {
+    let (stdout, stderr, code) = run_jq_full(
+        &["--seq", "-s", "-c", "."],
+        Some("\u{1e}1\n\u{1e}}\n\u{1e}2\n"),
+    )
+    .unwrap();
+    assert_eq!(code, 0, "stderr: {stderr}");
+    assert_eq!(
+        stderr,
+        "jq: ignoring parse error: Unmatched '}' at line 2, column 2 (need RS to resync)\n"
+    );
+    assert_eq!(stdout.trim(), "\u{1e}[1,2]");
+    Ok(())
+}
+
+/// #1723: the modes #1525 deliberately kept silent stay silent -- `-R`
+/// takes over raw-text handling, DSV content holds no RFC 7464 records,
+/// and `-n` turns this into a fatal error in real jq that succinctly does
+/// not implement (see `test_seq_null_input_with_inputs_does_not_warn_1525`).
+#[test]
+fn test_seq_warning_guards_still_suppress_1723() -> Result<()> {
+    for args in [
+        &["-R", "--seq", "-c", "."][..],
+        &["-n", "--seq", "-c", "[inputs]"][..],
+    ] {
+        let (_stdout, stderr, code) = run_jq_full(args, Some("\u{1e}not valid json\n")).unwrap();
+        assert_eq!(code, 0, "args {args:?} stderr: {stderr}");
+        assert_eq!(stderr, "", "args {args:?}");
+    }
+    Ok(())
+}
+
+/// #1723: columns count raw bytes, so a byte that is not valid UTF-8 --
+/// substituted with U+FFFD before the value path ever sees it -- still
+/// advances the column by exactly one.
+#[test]
+fn test_seq_warning_columns_count_raw_bytes_1723() -> Result<()> {
+    // A non-UTF-8 byte is an ordinary token character to jq's scanner, so
+    // `]` ends a token that fails to parse rather than being unmatched --
+    // the column is the point of the comparison either way.
+    for (input, expected) in [
+        (
+            &b"\x1e\xff]"[..],
+            "Invalid numeric literal at line 1, column 3 (need RS to resync)",
+        ),
+        (
+            &b"\x1e\xc3\xa9]"[..],
+            "Invalid numeric literal at line 1, column 4 (need RS to resync)",
+        ),
+        (
+            &b"\x1e]"[..],
+            "Unmatched ']' at line 1, column 2 (need RS to resync)",
+        ),
+    ] {
+        let (output, code) = spawn_jq(&["--seq", "-c", "."], Some(input))?;
+        assert_eq!(code, 0);
+        assert_eq!(
+            String::from_utf8_lossy(&output.stderr),
+            format!("jq: ignoring parse error: {expected}\n"),
+            "input {input:?}"
+        );
+    }
+    Ok(())
+}
+
 /// #1525: an RS-less file combined with an RS-containing one triggers no
 /// warning at all when the RS-less file is *empty* -- real jq treats the
 /// whole `--seq` input as one continuous stream, and the RS-containing


### PR DESCRIPTION
Closes #1723.

`succinctly jq --seq` dropped malformed RFC 7464 records in silence. #1525 implemented one
of jq's message templates (no RS byte anywhere); every other shape stayed silent. This
implements the rest.

## Why this one landed

The issue sat open through five claim/unclaim cycles. Each attempt looked for a table
mapping *what is wrong with this record* onto jq's wording, found contradictions, and
concluded it needed "replication of jq's incremental parser".

There is no such table, because the message is not a property of the record — the **same**
malformed record draws a different message depending on whether jq reached real EOF, an RS
byte, or an ordinary byte first. Reframed as *when did jq's reader give up*, it collapses
to three renderings over one shared category set:

| detected on | rendering |
|---|---|
| an ordinary byte | `{category} at line L, column C (need RS to resync)` |
| real EOF | `{category} at EOF at line L, column C` |
| an RS byte | `Truncated value` (or `Potentially truncated top-level numeric value`) |

Two blockers recorded in the issue thread turned out not to exist:

- `{}extra` and `[1,2]extra` were reported as producing different messages and called
  underivable — the issue's single biggest stated blocker. They are **identical**; that was
  a measurement error.
- `(need RS to resync)` is wording, not behaviour. jq's `jv_parse.c` assigns
  `JV_PARSER_WAITING_FOR_RS` and *then* calls `parser_reset()`, which writes
  `JV_PARSER_NORMAL` straight back over it. The resync never happens, so one record can warn
  several times and `\x1e} 5\n` still prints `5`.

Derived by reading jq 1.7.1's parser (MIT — behaviour and message strings only, original
Rust) with the pinned binary as the final authority.

## Scope

**Diagnostics only.** `seq_record_scan` and the value path are untouched, so this cannot
change what `--seq` prints. Prefix emission is now unblocked but deferred on risk — a wrong
message costs a stderr line, a wrong emission fabricates stdout, which is what got reverted
in the earlier attempts. Filed as issue 2653.

## Reproduced deliberately (ADR-0018, bug-for-bug)

- jq's numbers are decNumber's, not RFC 8259's: `1.`, `.5`, `+1`, `nan`, `NaN5`, `snan` and
  `-Infinity` are numbers; `1e` and `1.2.3` are not.
- `check_literal` reads `tokenbuf[1]` without consulting `tokenpos`, so a bare `n` is
  classified against a stale byte an earlier token left behind.
- A malformed BOM (`\xef\xbb`) has its matched bytes consumed uncounted and costs jq a
  `parser_reset` per read, so it parses the pre-RS bytes and wipes state after every value,
  every newline, and at EOF.

## Verification

`scripts/jq-seq-oracle-sweep.py` compares **stderr, stdout and exit code jointly** against
the pinned `/usr/bin/jq` — stderr alone would miss the failure that matters, a record
dropped with no diagnostic to explain it.

- **0 stderr mismatches, 0 stdout supersets** over seven seeds (~19,700 streams).
- With `--expect-artifacts`, 28 of 3,063 diverge and every one is attributable to a
  documented jq line-reader artifact — none unexplained.
- 99.4% line coverage on the new module; the 4 uncovered lines are annotated unreachable
  mirrors of jq's own defensive branches.

The corpus is generated rather than hand-picked because hand-picked matrices are what let
three earlier rounds of bias through, each time in exactly the dimension under test.

## Review findings, all fixed

A review found three defects in the *input layer* that the sweep's alphabet could not reach
(no `0xef`, no NUL) — the same class of blind spot as above:

- **Malformed BOM**: shifted every column after the prefix and emitted warnings real jq
  never emits. Now modelled exactly.
- **Memory**: warnings were collected into a `Vec` before printing. An adversarial stream
  warns once per byte — 2 MB of `}` peaked at **286 MB** against jq's 2.4 MB, now 12.9 MB
  via a sink. This was the one finding that could have reached stdout, via an OOM abort
  mid-output.
- **NUL truncation**: jq measures each chunk with `strlen`. Same line-reader family as the
  other artifacts; documented and quarantined rather than chased.

## Test plan

- [x] `cargo clippy --all-targets --all-features -- -D warnings`, plus both other CI clippy legs
- [x] `cargo fmt --all -- --check`
- [x] `cargo test --features cli` (full CI CLI suite), `cargo test`, `cargo test --no-default-features`, `cargo doc --no-deps --all-features`
- [x] `./scripts/jq-seq-oracle-sweep.py` across seven seeds
- [x] Every expected message in the tests captured from `/usr/bin/jq` 1.7.1, not written by hand