### PR TITLE
fix(jq): boolean, alternative and any/all constructs stop bridging the ambient value (#2476)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -395,6 +395,46 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (`eval_generic.rs`'s `yq_type_tag`); closing it needs the same accessor
   added to the trait, a larger change than this follow-up's own scope.
   Output byte-identical before/after in every run.
+- **`and`/`or`/`not`/`//`/zero-arity `any`/`all` no longer materialize the
+  ambient document on an alias-heavy input** (#2476): each used to fall to
+  `eval_single`'s wildcard bridge -- `and`/`or` only when neither operand
+  needed path context, `not`/`//`/`any`/`all` unconditionally, since none of
+  the four had a native arm at all -- whose first act is
+  `to_owned_with_cursor` on the *ambient* value. On a document shaped as a
+  chain of anchors each referencing the previous one twice (`aN: &aN
+  [*a(N-1), *a(N-1)]`), that cost is `O(2^N)` regardless of what the
+  operands read: `true and true` was exactly as slow as `.aN and true`.
+  Every one of these now runs a single `O(N)` ambient validation walk
+  (`push_generic_document_validation_error`, the same one `select`/`if`
+  already used, alias-aware since #1804) and evaluates natively. Interleaved
+  A/B, release build, Apple M5 Max, `chain20.yaml` (N=20, `succinctly yq`,
+  median of 3): `.a20 and true` 1.48s -> 5.4ms, `.a20 or false` 1.49s ->
+  5.5ms, `.a20 | not` 0.73s -> 5.4ms, `(.a20 // 1) | length` 1.91s -> 5.4ms,
+  `.a20 | any` 0.84s -> 5.4ms, `.a20 | all` 0.91s -> 5.6ms, `true and true`
+  1.51s -> 5.7ms -- output identical before/after on every row, and N=22
+  completes in ~5ms where the baseline needs several seconds (a single
+  baseline run at N=22 measured 5.9s for both `true and true` and `.a22 and
+  true`, confirming the cost is operand-independent at that size too).
+  Ordinary (non-alias) input is not just neutral but faster, since the
+  bridge's materialization was never alias-specific: interleaved A/B over a
+  2MB `users` array (10 reps, min/median, output identical throughout),
+  `[.users[] | select(.active and .score)] | length` is -22%/-20% under
+  `succinctly yq` and -30%/-28% under `succinctly jq`, `[.users[] | (.score
+  // 0)] | length` is -39%/-41% and -55%/-54%, `.users | any`/`.users | all`
+  are -51%/-53% and -65%/-72% (yq), -65%/-64% and -73%/-72% (jq); plain `.`
+  identity is unaffected (+1.8%/-1.6% median, inside this run's own +1.2%
+  control-binary-vs-itself noise floor on this machine). `//`'s surviving
+  left-hand output also now keeps its cursor instead of an owned copy, so
+  `.a // .b` on YAML keeps anchors, flow style and comments the way a bare
+  `.b` already did, and an operand like `(key // 1)` now reads the real
+  position instead of always answering the fallback. One shared behaviour
+  change, #1804's own accepted trade-off now covering these constructs too:
+  a decode failure reachable only through a container alias no longer
+  raises from an ambient-scoped `not`/`//`/`any`/`all` (or `and`/`or` when
+  neither operand itself navigates) -- see
+  [docs/compliance/yq/limitations.md](docs/compliance/yq/limitations.md).
+  The sibling spellings `any(cond)`/`any(gen;cond)`/`isvalid`/`while`/
+  `until` remain bridged, left as follow-ups.
 
 ### Removed
 

--- a/docs/compliance/yq/limitations.md
+++ b/docs/compliance/yq/limitations.md
@@ -194,6 +194,28 @@ Scoped to a *container* alias target only: a bare scalar-target alias (`a: &a "b
 still raises from `select`/`if` exactly as before, since resolving one scalar costs `O(1)`
 and was never part of the cost this fix removes.
 
+**[#2476](https://github.com/rust-works/succinctly/issues/2476)** extends this same
+trade-off to `not`, `//`, and zero-arity `any`/`all` at an alias position — the same
+O(2^N) fan-out cost `select`/`if` were fixed for, since all four used to reach it only by
+falling to `eval_single`'s wildcard bridge (which materializes the *ambient* value before
+running), and now instead run `push_generic_truthiness` directly, the same call `select`/`if`
+already used:
+
+```bash
+$ printf 'a: &a ["bad\\q"]\nb: *a\n' | succinctly yq '.b | not'
+false
+$ printf 'a: &a ["bad\\q"]\nb: *a\n' | succinctly yq '.b[0]'
+Error: invalid escape sequence
+```
+
+`and`/`or` share it only in the same ambient-scoped shape `select`/`if` use, where neither
+operand itself navigates (`.b | (true and true)` answers `true`, not raising). A bare `.b and
+true` does not share it: `.b` as a direct operand needs path context, so that expression still
+runs through the pre-existing native evaluator (`eval_boolean_generic`'s path-context branch,
+present since #2473 and untouched by #2476), which resolves `.b`'s path and raises exactly as
+`.b[0]` does. Real yq rejects this whole document at parse time either way, so there is no yq
+behaviour to match for any of these constructs.
+
 **Resolved ([#1350](https://github.com/rust-works/succinctly/issues/1350)).**
 `enforce_anchor_soundness` takes a `sort_keys` argument and has always handled it correctly
 on the DOM path; the cursor-streaming path used to never call it, reproducing the unsound

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -6686,6 +6686,37 @@ fn eval_single<S: EvalSemantics, V: DocumentValue>(
             eval_boolean_generic::<S, V>(left, right, true, value, optional, cursor)
         }
 
+        // `not` is unary and reads only the ambient value -- it has no
+        // operand for a `needs_path_context` gate to key on, so it fell to
+        // the wildcard bridge below unconditionally, paying the same
+        // alias-fan-out cost as the ungated `and`/`or` above (#2476). `not`
+        // is exactly the truthiness of `.`, negated, and
+        // `push_generic_truthiness` already computes that truthiness for
+        // the identity result: its `OneCursor` arm runs
+        // `push_generic_document_validation_error` over the ambient cursor
+        // before reading `is_falsy`, which IS the raise the bridge's
+        // `to_owned_with_cursor` used to produce -- see
+        // `ambient_validation_error`'s doc comment for the parity evidence.
+        // So unlike the `And`/`Or` arms above, this needs no separate
+        // `ambient_validation_error` call; the walk is already inline in
+        // the truthiness check it was going to do anyway.
+        //
+        // `eval::eval_not`'s own comment argues a container that merely
+        // *holds* an undecodable string should answer `false` rather than
+        // raise. That argument doesn't change what the CLI does here: it
+        // raised before this arm existed (via the bridge's decode) and
+        // still raises now (via the same decode, run as a walk instead of
+        // a materialization), so this is a faster route to the same
+        // raise-set, not a behaviour change.
+        Expr::Not => {
+            let identity = cursor.map_or(GenericResult::One(value), GenericResult::OneCursor);
+            let mut bits = vec_with_capacity(1);
+            if let Some(control) = push_generic_truthiness(identity, &mut bits) {
+                return partial_generic(Vec::new(), control);
+            }
+            GenericResult::Owned(OwnedValue::Bool(!bits[0]))
+        }
+
         // Array construction: collect every output of the inner expression
         // into one array. Handled natively (mirrors `eval::eval_array_construction`)
         // so a builtin with its own cursor-native, duplicate-key-preserving fix

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -3109,6 +3109,23 @@ fn push_generic_truthiness<V: DocumentValue>(
 /// cursors `//` exists to keep. A prefix element that fails to convert
 /// replaces the terminating control with its own error, the same precedence
 /// [`flatten_generic_results`] uses when materializing a batch.
+///
+/// #2661 originally tagged this function's `Err` arm as unreachable, on the
+/// premise that both call sites only place already-successfully-converted
+/// items into `kept`. That premise holds for the `Many` (bare `V`) call site
+/// -- its loop already ran `to_owned` on each item before keeping it -- but
+/// not for `ManyCursor`: its loop only runs the cheap
+/// [`push_generic_document_validation_error`] walk before keeping a cursor,
+/// and that walk deliberately stops at a container-target alias (#1804), so
+/// a kept item can be an alias whose target is corrupt. `to_owned_cursor`
+/// here has no such short-circuit and genuinely fails on it -- confirmed live
+/// with `x: &X ["bad\qc"]` / `y: &Y [*X, "bad\qd"]` / `a:\n  q: *Y`, filter
+/// `.a | (.q[] // 1)`: `*X` passes the cheap check (kept), a later element
+/// fails it (the `control` this function is called with), and re-converting
+/// `*X` here fails too -- for a different reason than `control`, per this
+/// function's own documented precedence above. So this arm is reachable and
+/// exercised by `test_alternative_manycursor_prefix_conversion_error_2476`
+/// (`tests/yq_cli_tests.rs`), not tolerate-line'd.
 fn owned_prefix_partial<V: DocumentValue, T>(
     kept: &[T],
     to_owned_one: impl Fn(&T) -> Result<OwnedValue, EvalError>,
@@ -3118,7 +3135,7 @@ fn owned_prefix_partial<V: DocumentValue, T>(
     for item in kept {
         match to_owned_one(item) {
             Ok(v) => prefix.push(v),
-            Err(e) => return GenericResult::Error(e), // omni-dev: coverage tolerate-line reason="unreachable: both call sites only place already-successfully-converted items into `kept` before this re-converts them via the same pure `to_owned`/`to_owned_cursor` function, which cannot fail the second time on the same input (#2661)"
+            Err(e) => return GenericResult::Error(e),
         }
     }
     partial_generic(prefix, control)

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -16394,6 +16394,121 @@ fn try_path_context_absent_walk<S: EvalSemantics, V: DocumentValue>(
     Some(partial_generic(owned, control))
 }
 
+/// `any`/`all` (zero-arity) over the cursor, instead of through the
+/// wildcard bridge's ambient materialization (#2476).
+///
+/// Neither builtin had an arm in [`eval_builtin`] at all, so both fell to
+/// its `_` wildcard, whose first act is `to_owned_with_cursor` on the value
+/// they were applied to. On an alias fan-out document (`aN: &aN [*a(N-1),
+/// *a(N-1)]`) that expansion is `O(2^N)`: `.a22 | any` took 5.95s on an
+/// Apple M-series release build where the same answer is one `is_falsy`
+/// probe on the first element.
+///
+/// **Validate once, then scan** -- deliberately *not* "validate each element
+/// as the scan reaches it". The bridge materialized the whole container
+/// before `builtin_any` ran, so an element the early exit never reaches
+/// still raised: `[true, "\x"] | any` exits 5, and real jq agrees for the
+/// stronger reason that it rejects the whole document at parse time
+/// (captured live from jq 1.7.1: `jq: parse error: Invalid escape at line 1,
+/// column 11`, and the same for `[false, "\x"] | all`). Checking per element
+/// with early exit would answer `true` there and drop a raise both
+/// references make. So [`push_generic_document_validation_error`] runs over
+/// the whole input first -- the same raise-set without the value, `O(N)` on
+/// the fan-out because of #1804's alias short-circuit -- and the loop below
+/// is then pure `is_falsy`, which materializes nothing and keeps the early
+/// exit `any_all_over` has always had.
+///
+/// It follows that this arm shares #1804's accepted trade-off, exactly as
+/// the `not`/`//` arms of this same issue do: a decode failure reachable
+/// *only* through an alias to a container no longer raises from `any`/`all`
+/// either (`a: &a ["bad\qc"]` / `b: *a` with `.b | any` is `true` at exit 0
+/// where it exited 1 before). `.a | any` and `.b[0]` still raise. Real yq
+/// rejects that document at parse time, so there is no yq behaviour to
+/// match.
+///
+/// Mode split mirrored arm for arm from [`super::eval::builtin_any`]/
+/// [`super::eval::builtin_all`], including the arm *order* #1901's review
+/// fixed there: the yq rejection must precede any `optional` wildcard, or
+/// `any?` on a `!!map` silently answers nothing instead of raising. The
+/// generic side spells `scalar_fallback` as [`decode_failure_or`], which is
+/// the same "decode failure wins over `optional`" precedence (#1620/#1989),
+/// and [`document_value_type_tag`] is [`super::eval::yaml_type_tag`]'s
+/// generic twin -- the *untagged* tag, which is what real yq's message
+/// quotes. Captured from yq v4.53.3: `{a: 1} | any` is `Error: any only
+/// supports arrays, was !!map`, and `1`/`null`/`"s"`/`true` give `!!int`/
+/// `!!null`/`!!str`/`!!bool`. jq mode iterates an object's *values* instead
+/// (#422), through [`effective_fields_checked`] with the mode's own
+/// duplicate-key rule, because the bridge collapsed duplicates on the way
+/// into `OwnedValue` and jq keeps the last occurrence:
+/// `{"a":true,"a":false} | any` is `false` in jq 1.7.1, not `true`.
+///
+/// `target_truthy` is the single bit that separates the two builtins, the
+/// same parameter [`super::eval::any_all_over`] takes: `any` stops at the
+/// first truthy element, `all` at the first falsy one, and an exhausted
+/// container answers `!target_truthy`.
+fn any_all_generic<S: EvalSemantics, V: DocumentValue>(
+    value: &V,
+    optional: bool,
+    cursor: V::Cursor,
+    name: &str,
+    target_truthy: bool,
+) -> GenericResult<V> {
+    if let Some(control) = push_generic_document_validation_error(&cursor, 0) {
+        return partial_generic(Vec::new(), control);
+    }
+    let answer = |b: bool| GenericResult::Owned(OwnedValue::Bool(b));
+    // One closure called from both the object arm and the scalar arm, not
+    // two copies of the same call -- `builtin_any`'s own `yq_reject_non_array`
+    // for the same reason (#1901 review).
+    let yq_reject_non_array = || {
+        decode_failure_or(value, optional, || {
+            GenericResult::Error(EvalError::yq_only_supports_arrays(
+                name,
+                document_value_type_tag(value),
+            ))
+        })
+    };
+    if let Some(elements) = value.as_array() {
+        let mut elems = elements;
+        while let Some((elem_cursor, rest)) = elems.uncons_cursor() {
+            // `Preserve`, the same convention `push_generic_truthiness`/
+            // `retain_truthy_generic` read truthiness under, so `any`/`all`
+            // and `select`/`//`/`not` cannot drift on what truthy means.
+            let truthy = !elem_cursor.is_falsy(JsonConvention::Preserve);
+            if truthy == target_truthy {
+                return answer(target_truthy);
+            }
+            elems = rest;
+        }
+        answer(!target_truthy)
+    } else if let Some(fields) = value.as_object() {
+        if S::TAG == EvalTag::Yq {
+            return yq_reject_non_array();
+        }
+        match effective_fields_checked(&fields, S::COLLAPSE_DUPLICATE_KEYS) {
+            Ok(fields) => {
+                for field in fields {
+                    let truthy = !field.value_cursor.is_falsy(JsonConvention::Preserve);
+                    if truthy == target_truthy {
+                        return answer(target_truthy);
+                    }
+                }
+                answer(!target_truthy)
+            }
+            Err(err) => GenericResult::Error(err),
+        }
+    } else if S::TAG == EvalTag::Yq {
+        yq_reject_non_array()
+    } else {
+        decode_failure_or(value, optional, || {
+            GenericResult::Error(EvalError::cannot_iterate_with(
+                S::TAG,
+                &to_owned_for_diagnostic(value, Some(cursor)),
+            ))
+        })
+    }
+}
+
 fn eval_builtin<S: EvalSemantics, V: DocumentValue>(
     builtin: &Builtin,
     value: V,
@@ -17707,6 +17822,24 @@ fn eval_builtin<S: EvalSemantics, V: DocumentValue>(
                 Ok((path, _)) => GenericResult::Owned(OwnedValue::Int(file_index_for_path(&path))),
                 Err(e) => GenericResult::Error(e),
             }
+        }
+
+        // #2476: both were falling to the `_` wildcard below, whose ambient
+        // `to_owned_with_cursor` is `O(2^N)` on an alias fan-out.
+        //
+        // Gated on `cursor.is_some()` because the wildcard is already the
+        // right answer without one: the value is then already owned,
+        // `to_owned_with_cursor(&value, None)` cannot fail, and
+        // `eval_on_owned` runs `builtin_any`/`builtin_all` themselves. A
+        // second copy of their mode split here -- a decision tree #422/
+        // #1755/#1901/#1989 have each corrected once already -- would be
+        // two definitions of one behaviour for no speedup at all.
+        Builtin::Any if cursor.is_some() => {
+            any_all_generic::<S, V>(&value, optional, cursor.expect("guarded"), "any", true)
+        }
+
+        Builtin::All if cursor.is_some() => {
+            any_all_generic::<S, V>(&value, optional, cursor.expect("guarded"), "all", false)
         }
 
         _ => {

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -2973,6 +2973,54 @@ fn push_generic_document_validation_error<C: DocumentCursor>(
     }
 }
 
+/// The wildcard bridge's ambient materialization, as a check that builds
+/// nothing (#2476).
+///
+/// `eval_single`'s `_` arm materializes the *ambient* value
+/// (`to_owned_with_cursor`) before handing the expression to the eager
+/// evaluator, and that materialization is where a malformed document raises
+/// for a query that never reads `.`: jq rejects the whole document for every
+/// query, and `test_try_catch_contains_a_genuinely_catchable_malformed_key_error_1812`
+/// pins `try (1+1) catch "x"` on `{123: 1}` exiting 5. The `Expr::And`/
+/// `Expr::Or`/`Expr::Arithmetic`/`Expr::Negate` arms were gated on
+/// `needs_path_context` purely to keep that raise (see their comments), so
+/// every ungated shape stayed on the bridge. But the materialization costs
+/// the size of the *expanded* value, and on a document shaped as an alias
+/// fan-out (`aN: &aN [*a(N-1), *a(N-1)]`) the root contains `aN`, so every
+/// bridged expression at the root -- `true and true`, `1+1`, `not`, `//`,
+/// `any` -- cost `O(2^N)` whatever its operands read (#2476).
+///
+/// This is the same raise without the value. [`push_generic_document_validation_error`]
+/// is `to_owned_cursor_at_depth`'s own traversal and checks (decode failures,
+/// #1194 structural errors, #1642 key collisions, #2211/#2243/#2349 comma
+/// gaps, the #998 depth guard) building no `OwnedValue`, and since #1804 it
+/// does not descend into a container reached through an alias -- which is
+/// what makes it `O(N)` on the fan-out where the bridge is `O(2^N)`.
+/// Verified against the bridge over a corpus spanning every class those
+/// checks cover, in both modes and for both cursor types
+/// (`test_ambient_validation_agrees_with_bridge_2476` in
+/// `tests/jq_cli_tests.rs` and its yq twin): identical exit code and message
+/// on every row. The one shape that differs by construction is #1804's
+/// accepted trade-off, now shared by every arm that calls this: a decode
+/// failure reachable *only* through an alias to a container no longer raises
+/// from these arms either (recorded in `docs/compliance/yq/limitations.md`).
+///
+/// `None` without a cursor: `to_owned_with_cursor(&value, None)` on an
+/// already-owned value cannot fail, so the bridge had nothing to raise there
+/// either. A document deeper than `MAX_NESTING_DEPTH` panics inside the walk
+/// exactly as it panicked inside the bridge's materialization (#2627, tracked,
+/// route-independent).
+///
+/// Call this only on the shape that used to bridge (`!needs_path_context`
+/// for a gated arm; unconditionally for an arm that had no native route at
+/// all): an operand that reads path context could not have stood on a
+/// malformed document's root and survived the walk to it anyway, and that
+/// shape never paid the decode, so charging it a walk now would be a new
+/// cost, not a replaced one.
+fn ambient_validation_error<V: DocumentValue>(cursor: Option<V::Cursor>) -> Option<Control> {
+    cursor.and_then(|c| push_generic_document_validation_error(&c, 0))
+}
+
 /// Append one truthiness bit per output of a `GenericResult` stream to
 /// `out`. Mirrors [`super::eval::push_truthiness`] for the generic
 /// evaluator's cursor-aware result type — used to fan `select`'s condition

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -3118,7 +3118,7 @@ fn owned_prefix_partial<V: DocumentValue, T>(
     for item in kept {
         match to_owned_one(item) {
             Ok(v) => prefix.push(v),
-            Err(e) => return GenericResult::Error(e),
+            Err(e) => return GenericResult::Error(e), // omni-dev: coverage tolerate-line reason="unreachable: both call sites only place already-successfully-converted items into `kept` before this re-converts them via the same pure `to_owned`/`to_owned_cursor` function, which cannot fail the second time on the same input (#2661)"
         }
     }
     partial_generic(prefix, control)
@@ -26097,6 +26097,121 @@ mod tests {
             result.collect_owned().unwrap(),
             vec![OwnedValue::Int(1), OwnedValue::Int(1)]
         );
+    }
+
+    /// `retain_truthy_generic`'s bare `GenericResult::One` arm (#2476) --
+    /// distinct from its `OneCursor` sibling every CLI-level `//` test
+    /// exercises: `Expr::Identity` only answers `One(value)` when the ambient
+    /// cursor is already `None` (`eval_single`'s own arm:
+    /// `cursor.map_or(GenericResult::One(value), GenericResult::OneCursor)`),
+    /// and the CLI's `eval_each_with_cursor` always starts from `Some` (see
+    /// `test_json_multi_stage_pipe_first_stage_bare_one_without_cursor`'s own
+    /// doc comment for the same reachability argument). Only the cursor-less
+    /// `eval()` entry point used here reaches it.
+    ///
+    /// A truthy `.` survives the `//` filter unchanged; a falsy one is
+    /// dropped, so the right side answers instead -- mirroring `retain_truthy
+    /// _generic`'s `OneCursor` arm one level up.
+    #[test]
+    fn test_generic_alternative_one_arm_truthy_and_falsy_2476() {
+        let json = br"1";
+        let index = JsonIndex::build(json);
+        let value = index.root(json).value();
+        let result = eval(&crate::jq::parse(". // 5").unwrap(), value);
+        assert!(matches!(result, GenericResult::One(_)));
+        assert_eq!(result.collect_owned().unwrap(), vec![OwnedValue::Int(1)]);
+
+        let json = br"false";
+        let index = JsonIndex::build(json);
+        let value = index.root(json).value();
+        let result = eval(&crate::jq::parse(". // 5").unwrap(), value);
+        assert!(
+            matches!(
+                result,
+                GenericResult::Owned(OwnedValue::NumberLiteral(NumberRepr::Int(5), _))
+            ),
+            "{result:?}"
+        );
+    }
+
+    /// `retain_truthy_generic`'s bare `One` arm's own error branch: a
+    /// genuinely undecodable scalar (not reached through any cursor, so
+    /// neither `ambient_validation_error` nor an `OneCursor`-style walk ever
+    /// runs) still has to raise from `to_owned(&v)` rather than being
+    /// silently treated as truthy.
+    #[test]
+    fn test_generic_alternative_one_arm_decode_error_2476() {
+        let json = br#""bad\qc""#;
+        let index = JsonIndex::build(json);
+        let value = index.root(json).value();
+        let result = eval(&crate::jq::parse(". // 5").unwrap(), value);
+        assert!(result.is_error(), "{result:?}");
+    }
+
+    /// `retain_truthy_generic`'s bare `GenericResult::Many` arm (#2476) --
+    /// the `Vec<V>` sibling of the `One` arm just above, reachable the same
+    /// way: only from the cursor-less `eval()` entry point, via `select`'s
+    /// own cursor-less multi-output shape (same source
+    /// `test_generic_result_collect_owned_bare_many_variant` above uses).
+    ///
+    /// Every output is a copy of the same input, so both truthy (`1`, kept
+    /// as `Many`) and falsy (`false`, filtered down to `None` so the right
+    /// side answers) are exercised by varying the input rather than the
+    /// generator.
+    #[test]
+    fn test_generic_alternative_many_arm_truthy_and_falsy_2476() {
+        let json = br"1";
+        let index = JsonIndex::build(json);
+        let value = index.root(json).value();
+        let result = eval(&crate::jq::parse("select(true,true) // 5").unwrap(), value);
+        assert!(matches!(result, GenericResult::Many(_)), "{result:?}");
+        assert_eq!(
+            result.collect_owned().unwrap(),
+            vec![OwnedValue::Int(1), OwnedValue::Int(1)]
+        );
+
+        let json = br"false";
+        let index = JsonIndex::build(json);
+        let value = index.root(json).value();
+        let result = eval(&crate::jq::parse("select(true,true) // 5").unwrap(), value);
+        assert!(
+            matches!(
+                result,
+                GenericResult::Owned(OwnedValue::NumberLiteral(NumberRepr::Int(5), _))
+            ),
+            "{result:?}"
+        );
+    }
+
+    /// `retain_truthy_generic`'s bare `Many` arm's own error branch --
+    /// `owned_prefix_partial`'s other call site (`ManyCursor`'s is pinned by
+    /// `test_alternative_manycursor_validation_error_keeps_prefix_2476` in
+    /// `tests/yq_cli_tests.rs`). Deliberately *not* `.[]`: `Expr::Iterate`
+    /// always answers `ManyCursor` (`collect_cursors_checked` derives a
+    /// cursor per element regardless of whether the ambient root carried
+    /// one), so it would silently exercise the `ManyCursor` arm above
+    /// instead -- an earlier version of this test made exactly that
+    /// mistake, passing on the right externally-visible shape
+    /// (`owned_prefix_partial` is `to_owned`/`to_owned_cursor`-generic, so
+    /// both arms produce an identical `Partial` here) while covering the
+    /// wrong line.
+    ///
+    /// `select(true,true)`'s bare-`Many` arm only ever repeats *the same*
+    /// input value (`pass_n`'s `(n, None) => Many(repeat(value.clone())...)`
+    /// in `eval_builtin`'s own `Builtin::Select` arm), so there is no way to
+    /// keep a truthy element ahead of a distinct failing one the way the
+    /// `ManyCursor` sibling test does -- a malformed root fails on the very
+    /// first copy, with `kept` still empty. `owned_prefix_partial`'s own
+    /// loop body (the part that walks a *non-empty* `kept`) is already
+    /// covered via that `ManyCursor` sibling; this test's job is only line
+    /// 3181 itself (`Many`'s own `Err` arm).
+    #[test]
+    fn test_generic_alternative_many_arm_decode_error_2476() {
+        let json = br#""bad\qc""#;
+        let index = JsonIndex::build(json);
+        let value = index.root(json).value();
+        let result = eval(&crate::jq::parse("select(true,true) // 5").unwrap(), value);
+        assert!(result.is_error(), "{result:?}");
     }
 
     #[test]

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -6660,25 +6660,29 @@ fn eval_single<S: EvalSemantics, V: DocumentValue>(
             finish_fork_generic(out, control, optional)
         }
 
-        // Spine 2416 gate reason 3 (#2473): `and`/`or` with a path-context
-        // operand, through `eval_boolean_generic` -- `eval::boolean_fanout_bools`
-        // with `eval_single` *plus the cursor* as the operand strategy. Without
+        // Spine 2416 gate reason 3 (#2473): `and`/`or` through
+        // `eval_boolean_generic` -- `eval::boolean_fanout_bools` with
+        // `eval_single` *plus the cursor* as the operand strategy. Without
         // this arm `.[] | key == "a" and true` fell to the wildcard bridge
         // below, which materializes the ambient value and hands the eager
         // evaluator a document re-rooted at this stage's input.
         //
-        // **Gated on `needs_path_context`, for the same reason the
-        // `Expr::Arithmetic` arm above is** (and the `Expr::Compare` arm is
-        // not): the bridge's ambient materialization is what makes
-        // `try (1+1) catch "x"` fail on a #1194-malformed document, and
-        // `test_try_catch_contains_a_genuinely_catchable_malformed_key_error_1812`
-        // pins that. An `and`/`or` that reads no path context stays on the
-        // bridge and keeps paying the decode; one that does could not have
-        // stood on a malformed document's root and survived the walk anyway.
-        Expr::And(left, right) if needs_path_context(left) || needs_path_context(right) => {
+        // Ungated since #2476. The arm used to be gated on
+        // `needs_path_context` (as `Expr::Arithmetic` above still is) purely
+        // to keep the bridge's *ambient* materialization on the shapes that
+        // do not read a position, because that materialization is what makes
+        // `try (1+1) catch "x"` raise on a malformed document. It also made
+        // every such `and`/`or` -- `true and true` included, operands
+        // irrelevant -- cost the size of the expanded document, which is
+        // exponential on an alias fan-out (#2476). `eval_boolean_generic`
+        // now runs the same raise as a validation walk that builds nothing,
+        // on exactly the shape that used to bridge; see
+        // `ambient_validation_error` for why that is the same raise-set and
+        // why the path-context shape is deliberately not charged for it.
+        Expr::And(left, right) => {
             eval_boolean_generic::<S, V>(left, right, false, value, optional, cursor)
         }
-        Expr::Or(left, right) if needs_path_context(left) || needs_path_context(right) => {
+        Expr::Or(left, right) => {
             eval_boolean_generic::<S, V>(left, right, true, value, optional, cursor)
         }
 
@@ -9561,6 +9565,19 @@ fn eval_boolean_generic<S: EvalSemantics, V: DocumentValue>(
     optional: bool,
     cursor: Option<V::Cursor>,
 ) -> GenericResult<V> {
+    // #2476: the one place the two arms above share, so the rule is stated
+    // once. A shape with no path-context operand is the shape that used to
+    // fall to the wildcard bridge, and the bridge's ambient materialization
+    // is what raised on a malformed document for an expression that reads
+    // nothing (`try (1+1) catch "x"`, #1812). `ambient_validation_error` is
+    // that raise without the value -- read its doc comment for the parity
+    // evidence and for why an operand that *does* read path context is not
+    // charged the walk (it never paid the materialization either).
+    if !needs_path_context(left) && !needs_path_context(right) {
+        if let Some(control) = ambient_validation_error::<V>(cursor) {
+            return partial_generic(Vec::new(), control);
+        }
+    }
     let (bools, control) = boolean_fanout_bools(
         |operand, out| {
             push_generic_truthiness(
@@ -14805,11 +14822,18 @@ fn path_context_single_native(expr: &Expr) -> bool {
         Expr::Negate(inner) => path_context_single_native(inner),
         // Native since spine 2416 gate reason 3 (#2473): `eval_single`'s own
         // `Expr::And`/`Expr::Or` arms, above, over `eval_boolean_generic`.
-        // Same `needs_path_context` gate and same reason as `Expr::Arithmetic`
-        // just above, and the loop those arms run is `eval::boolean_fanout_bools`,
-        // so #2460's rule for an operand that produces zero outputs -- `key and
-        // true` at the document root is `false` in real yq, not nothing -- is
-        // the same definition on this route as on the eager one.
+        // Those arms lost their `needs_path_context` gate in #2476 -- the
+        // ambient decode the gate preserved is now `ambient_validation_error`,
+        // a walk that builds nothing -- so the admission no longer depends on
+        // that gate at all. This entry is unchanged and stays recursive for
+        // the other half of the question: `eval_boolean_generic` evaluates
+        // each operand through `eval_single`, so an operand outside this
+        // closed list bridges *there* and reads its position as `null`,
+        // exactly as for `Expr::Arithmetic` just above.
+        // The loop those arms run is `eval::boolean_fanout_bools`, so #2460's
+        // rule for an operand that produces zero outputs -- `key and true` at
+        // the document root is `false` in real yq, not nothing -- is the same
+        // definition on this route as on the eager one.
         Expr::And(left, right) | Expr::Or(left, right) => {
             path_context_single_native(left) && path_context_single_native(right)
         }

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -3097,6 +3097,144 @@ fn push_generic_truthiness<V: DocumentValue>(
     None
 }
 
+/// Materialize the truthy prefix a [`retain_truthy_generic`] arm had already
+/// kept, so a control that terminated the stream mid-way can still carry it
+/// (#400's rule, via [`partial_generic`]).
+///
+/// Only the borrowed-value/borrowed-cursor arms need this: `GenericResult::
+/// Partial` can only hold `OwnedValue`, so the kept prefix has to leave the
+/// document domain at exactly this point and nowhere else -- which is why the
+/// retaining arms accumulate `V`/`V::Cursor` and call this only on the
+/// terminating branch, instead of converting as they go and losing the
+/// cursors `//` exists to keep. A prefix element that fails to convert
+/// replaces the terminating control with its own error, the same precedence
+/// [`flatten_generic_results`] uses when materializing a batch.
+fn owned_prefix_partial<V: DocumentValue, T>(
+    kept: &[T],
+    to_owned_one: impl Fn(&T) -> Result<OwnedValue, EvalError>,
+    control: Control,
+) -> GenericResult<V> {
+    let mut prefix = vec_with_capacity(kept.len());
+    for item in kept {
+        match to_owned_one(item) {
+            Ok(v) => prefix.push(v),
+            Err(e) => return GenericResult::Error(e),
+        }
+    }
+    partial_generic(prefix, control)
+}
+
+/// Keep only the truthy outputs of a stream, cursor-backed where they were
+/// cursor-backed — the *filtering* twin of [`push_generic_truthiness`] just
+/// above, and the generic evaluator's mirror of [`super::eval::retain_truthy`]
+/// (#2476).
+///
+/// Every arm answers truthiness by exactly the rule its
+/// `push_generic_truthiness` counterpart uses, so `//` and `and`/`or`/`not`
+/// cannot drift apart on what "truthy" means: `OneCursor`/`ManyCursor` run
+/// [`push_generic_document_validation_error`] first and then read
+/// `is_falsy(Preserve)` (so a #1194/#1247/#1642 document raises here as it
+/// does under `select`, and a malformed *number* stays truthy);
+/// `LazyKeys`/`LazyIndexRange` are array-shaped and therefore always truthy
+/// without materializing; `LazySeq` must still be pulled, because it runs
+/// arbitrary `map(f)` whose failure has to surface rather than be reported as
+/// "truthy" before the array is known to exist at all.
+///
+/// The difference from `push_generic_truthiness` is what it does with a
+/// surviving output: it returns it *unchanged*, still an `OneCursor`/
+/// `ManyCursor` into the source document, which is what lets `.a // .b` in yq
+/// mode print whatever a bare `.b` would print. The eager
+/// [`super::eval::retain_truthy`] cannot do that -- its first act is
+/// `materialize_cursor()` -- which is precisely the loss `//` used to take by
+/// bridging.
+///
+/// A terminating `Error`/`Break`/`Halt` is returned as-is and a `Partial`
+/// keeps its control with its own prefix filtered, matching
+/// `super::eval::retain_truthy`'s `Partial` arm and #400's rule: `(1, false,
+/// error("x")) // 2` is `1` and then the error, not `1 false`.
+fn retain_truthy_generic<V: DocumentValue>(result: GenericResult<V>) -> GenericResult<V> {
+    match result {
+        GenericResult::One(v) => match to_owned(&v) {
+            Ok(owned) if owned.is_truthy() => GenericResult::One(v),
+            Ok(_) => GenericResult::None,
+            Err(e) => GenericResult::Error(e),
+        },
+        GenericResult::OneCursor(c) => {
+            if let Some(control) = push_generic_document_validation_error(&c, 0) {
+                return partial_generic(Vec::new(), control);
+            }
+            if c.is_falsy(JsonConvention::Preserve) {
+                GenericResult::None
+            } else {
+                GenericResult::OneCursor(c)
+            }
+        }
+        GenericResult::Many(vs) => {
+            let mut kept: Vec<V> = Vec::new();
+            for v in vs {
+                match to_owned(&v) {
+                    Ok(owned) => {
+                        if owned.is_truthy() {
+                            kept.push(v);
+                        }
+                    }
+                    Err(e) => return owned_prefix_partial(&kept, to_owned, Control::Error(e)),
+                }
+            }
+            collapse_vec(
+                kept,
+                || GenericResult::None,
+                GenericResult::One,
+                GenericResult::Many,
+            )
+        }
+        GenericResult::ManyCursor(cs) => {
+            let mut kept: Vec<V::Cursor> = Vec::new();
+            for c in cs {
+                if let Some(control) = push_generic_document_validation_error(&c, 0) {
+                    return owned_prefix_partial(&kept, to_owned_cursor, control);
+                }
+                if !c.is_falsy(JsonConvention::Preserve) {
+                    kept.push(c);
+                }
+            }
+            cursor_vec_to_generic_result(kept)
+        }
+        // Always truthy, and returned untouched so a `keys // []` keeps the
+        // laziness #140/#684 gave it.
+        result @ (GenericResult::LazyKeys { .. } | GenericResult::LazyIndexRange(_)) => result,
+        // Pulled rather than passed through, for the reason
+        // `push_generic_truthiness`'s own `LazySeq` arm gives: the array is
+        // truthy *if it can be built*, and a `map(f)` that fails has to say
+        // so here. `materialize_atomic` already returns the built array, so
+        // handing that back loses nothing but the laziness the pull just
+        // ended anyway.
+        GenericResult::LazySeq(seq) => match seq.materialize_atomic() {
+            Ok(array) => GenericResult::Owned(array),
+            Err(control) => partial_generic(Vec::new(), control),
+        },
+        GenericResult::None => GenericResult::None,
+        GenericResult::Owned(v) => {
+            if v.is_truthy() {
+                GenericResult::Owned(v)
+            } else {
+                GenericResult::None
+            }
+        }
+        GenericResult::ManyOwned(mut vs) => {
+            vs.retain(OwnedValue::is_truthy);
+            owned_vec_to_generic_result(vs)
+        }
+        GenericResult::Partial(mut vs, control) => {
+            vs.retain(OwnedValue::is_truthy);
+            partial_generic(vs, control)
+        }
+        result @ (GenericResult::Error(_) | GenericResult::Break(_) | GenericResult::Halt(_)) => {
+            result
+        }
+    }
+}
+
 /// Flatten a batch of per-element results into one `Vec<OwnedValue>`.
 ///
 /// A bare `Error`/`Break`/`Partial` must never appear in `items` — callers
@@ -6715,6 +6853,70 @@ fn eval_single<S: EvalSemantics, V: DocumentValue>(
                 return partial_generic(Vec::new(), control);
             }
             GenericResult::Owned(OwnedValue::Bool(!bits[0]))
+        }
+
+        // `//` had no native arm at all, so like `Expr::Not` above it fell to
+        // the wildcard bridge unconditionally -- there was no
+        // `needs_path_context` gate to lose, and no shape that escaped the
+        // cost. The bridge's first act is `to_owned_with_cursor` on the
+        // *ambient* value, `O(2^N)` on an alias fan-out document (#2476), and
+        // it is charged before either operand runs, so `(false // 1)` paid it
+        // exactly as `(.aN // 1)` did. `ambient_validation_error` is that
+        // materialization's raise without the value -- unconditional here,
+        // because the whole construct is the "shape that used to bridge" its
+        // doc comment names.
+        //
+        // Below it, `eval::eval_alternative` mirrored arm for arm, with
+        // `retain_truthy_generic` (the cursor-preserving twin of
+        // `eval::retain_truthy`) in place of the eager filter: keep the left's
+        // truthy outputs, let a `break` escape the operator, propagate an
+        // error rather than substituting for it (#160 -- `?` on the left is
+        // how you ask for substitution, `.a? // 3`), and evaluate the right
+        // only when nothing truthy survived. `false // (null, 7)` is `null, 7`
+        // because the right's outputs are emitted unfiltered, which falls out
+        // of only the left going through the filter.
+        //
+        // The surviving outputs stay `OneCursor`/`ManyCursor` into the source
+        // document, so this is a visible fidelity gain as well as a speedup,
+        // not only a faster route to the same bytes. Measured on `a: null`
+        // with `.a // .b`, before this arm vs after vs yq v4.53.3: an
+        // anchored flow mapping `b: &x {c: 1, d: 2}` printed as an expanded
+        // block mapping and now prints `&x {c: 1, d: 2}` as yq does; a plain
+        // flow mapping keeps its flow style; a trailing `c: 1 # trailing`
+        // keeps its comment. What `//` does NOT gain is anything a bare `.b`
+        // does not already have -- a comment on its own line above `c: 1` is
+        // still dropped, and duplicate mapping keys still collapse -- because
+        // this arm's whole contribution is handing `.b`'s own result through
+        // untouched. Those two remain gaps in the `.b` route itself.
+        //
+        // Evaluating the operands through `eval_single` *with the cursor* is a
+        // second, larger gain: while this bridged, both operands ran against a
+        // document re-rooted at this stage's input, so `key`/`parent` resolved
+        // to nothing there -- and "nothing" is not truthy, so `//` silently
+        // substituted the other side for it. `.a | (key // 1)` was `1` and is
+        // now `a`, yq v4.53.3's own answer
+        // (`test_alternative_operands_read_the_real_position_2476`). What that
+        // test's own comment records as still unreached is deliberate:
+        // `needs_path_context` has no `Expr::Alternative` arm, so a pipe whose
+        // only path-context read sits inside a `//` is still never routed to
+        // path-context evaluation, and this arm does not change that table.
+        Expr::Alternative(left, right) => {
+            if let Some(control) = ambient_validation_error::<V>(cursor) {
+                return partial_generic(Vec::new(), control);
+            }
+            match retain_truthy_generic(eval_single::<S, V>(left, value.clone(), optional, cursor))
+            {
+                // A `break` escapes the operator rather than selecting a branch.
+                GenericResult::Break(label) => GenericResult::Break(label),
+                // No truthy output on the left, so the right side answers.
+                GenericResult::None => eval_single::<S, V>(right, value, optional, cursor),
+                // An error on the left propagates, matching jq 1.7.1:
+                // `(error("x")) // 1` exits 5, and so does
+                // `(null, error("x")) // 2` -- nothing truthy survived, but
+                // the right side still never runs.
+                error @ GenericResult::Error(_) => error,
+                kept => kept,
+            }
         }
 
         // Array construction: collect every output of the inner expression

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -41856,6 +41856,227 @@ fn test_not_truthiness_table_2476() -> Result<()> {
     Ok(())
 }
 
+/// #2476: bare `any`/`all` answer from the cursor now (`any_all_generic`),
+/// where both used to fall to `eval_builtin`'s `_` wildcard and its ambient
+/// `to_owned_with_cursor`. This pins the truthiness and type tables the new
+/// arm has to reproduce, every row captured live from jq 1.7.1:
+///
+/// ```text
+/// [] | any                   false      [] | all                   true
+/// [null] | any               false      [null] | all               false
+/// [0] | any                  true       [0] | all                  true
+/// [false,false] | any        false      [true,"A"] | all           true
+/// {"a":false,"b":1} | any    true       {"a":false,"b":1} | all    false
+/// 1 | any      exit 5, Cannot iterate over number (1)
+/// "s" | any    exit 5, Cannot iterate over string ("s")
+/// null | any   exit 5, Cannot iterate over null (null)
+/// true | any   exit 5, Cannot iterate over boolean (true)
+/// ```
+///
+/// The object rows are #422: jq's `any` is `[.[] | .]` folded, and `.[]`
+/// over an object iterates its *values*, so an object is accepted here
+/// (real yq rejects it -- `test_any_all_reject_non_arrays_in_yq_mode_2476`
+/// in `tests/yq_cli_tests.rs` has that half).
+///
+/// The duplicate-key rows are why the native arm goes through
+/// `effective_fields_checked` with the mode's own collapse rule rather than
+/// walking every field: the bridge collapsed duplicates on the way into
+/// `OwnedValue`, and jq keeps the *last* occurrence. Captured live:
+/// `{"a":true,"a":false} | any` is `false`, not `true`, and
+/// `{"a":false,"a":true} | all` is `true`, not `false`.
+#[test]
+fn test_any_all_truthiness_table_2476() -> Result<()> {
+    for (doc, filter, want) in [
+        ("[]", "any", "false"),
+        ("[]", "all", "true"),
+        ("[null]", "any", "false"),
+        ("[null]", "all", "false"),
+        ("[0]", "any", "true"),
+        ("[0]", "all", "true"),
+        ("[false,false]", "any", "false"),
+        ("[false,false]", "all", "false"),
+        (r#"[true,"A"]"#, "any", "true"),
+        (r#"[true,"A"]"#, "all", "true"),
+        (r#"{"a":false,"b":1}"#, "any", "true"),
+        (r#"{"a":false,"b":1}"#, "all", "false"),
+        // Duplicate keys collapse to the last value before either builtin
+        // sees them (jq mode only).
+        (r#"{"a":true,"a":false}"#, "any", "false"),
+        (r#"{"a":true,"a":false}"#, "all", "false"),
+        (r#"{"a":false,"a":true}"#, "any", "true"),
+        (r#"{"a":false,"a":true}"#, "all", "true"),
+    ] {
+        let (stdout, code) = run_jq_stdin(filter, doc, &["-c"])?;
+        assert_eq!(code, 0, "`{filter}` on {doc}");
+        assert_eq!(stdout.trim(), want, "`{filter}` on {doc}");
+    }
+
+    // Every non-container raises, with the value quoted back.
+    for (doc, want) in [
+        ("1", "Cannot iterate over number (1)"),
+        (r#""s""#, r#"Cannot iterate over string ("s")"#),
+        ("null", "Cannot iterate over null (null)"),
+        ("true", "Cannot iterate over boolean (true)"),
+    ] {
+        for filter in ["any", "all"] {
+            let (_stdout, stderr, code) = run_jq_full(&["-c", filter], Some(doc))?;
+            assert_eq!(code, 5, "`{filter}` on {doc} -- stderr: {stderr}");
+            assert!(
+                stderr.contains(want),
+                "`{filter}` on {doc} -- stderr {stderr} lacks {want:?}"
+            );
+        }
+    }
+
+    // `?` suppresses the *type* error (`1 | any?` is empty at exit 0), the
+    // same split the bridge produced before this change. The decode-failure
+    // half is `test_any_all_still_reject_a_malformed_document_2476` below.
+    let (stdout, stderr, code) = run_jq_full(&["-c", "any?"], Some("1"))?;
+    assert_eq!(code, 0, "stderr: {stderr}");
+    assert_eq!(stdout.trim(), "");
+
+    Ok(())
+}
+
+/// #2476: `any_all_generic` validates its whole input *before* the scan,
+/// rather than checking each element as the early exit reaches it. This is
+/// the test that decides that shape.
+///
+/// The bridge materialized the whole container before `builtin_any` ran, so
+/// an element the early exit never reaches still raised. Real jq agrees, for
+/// the stronger reason that it rejects the entire document at parse time --
+/// captured live from jq 1.7.1:
+///
+/// ```text
+/// echo '[true, "\x"]'  | jq any   jq: parse error: Invalid escape at line 1, column 11
+/// echo '[false, "\x"]' | jq all   jq: parse error: Invalid escape at line 1, column 12
+/// echo '{123: 1}'      | jq any   jq: parse error: Object keys must be strings at line 1, column 5
+/// ```
+///
+/// Per-element validation with early exit would answer `true` for the first
+/// row (the deciding element comes first) and drop a raise both the bridge
+/// and real jq make. Hence: one `push_generic_document_validation_error`
+/// over the input, then a pure `is_falsy` scan.
+///
+/// `?` does not rescue any of these: a decode failure and a #1194 structural
+/// error both outrank `optional` (#1620/#1989), and the validation walk is
+/// not routed through `optional` at all -- same as the `//` arm's own
+/// `ambient_validation_error` call.
+#[test]
+fn test_any_all_still_reject_a_malformed_document_2476() -> Result<()> {
+    for (doc, filter, want) in [
+        // The deciding element comes *first*; the raise still wins.
+        (r#"[true, "\x"]"#, "any", "invalid escape sequence"),
+        (r#"[false, "\x"]"#, "all", "invalid escape sequence"),
+        (r#"[true, "\x"]"#, "all", "invalid escape sequence"),
+        (r#"[false, "\x"]"#, "any", "invalid escape sequence"),
+        ("{123: 1}", "any", "Invalid JSON text"),
+        ("{123: 1}", "all", "Invalid JSON text"),
+    ] {
+        for spelling in [filter.to_string(), format!("{filter}?")] {
+            let (_stdout, stderr, code) = run_jq_full(&["-c", &spelling], Some(doc))?;
+            assert_eq!(code, 5, "`{spelling}` on {doc} -- stderr: {stderr}");
+            assert!(
+                stderr.contains(want),
+                "`{spelling}` on {doc} -- stderr {stderr} lacks {want:?}"
+            );
+        }
+    }
+    Ok(())
+}
+
+/// #2476: the container half of `test_ambient_validation_agrees_with_bridge_2476`,
+/// for `any`/`all`.
+///
+/// Kept separate rather than folded in as two more probes there: that
+/// corpus includes scalar and `null` roots, where `any`/`all` raise a *type*
+/// error of their own and would break the "every probe agrees" assertion for
+/// reasons that have nothing to do with the validation walk. Every row here
+/// is a container, so the only thing that can decide the exit code is the
+/// walk -- and it has to decide it the same way `select(.) | 1` does.
+///
+/// Asserts the explicit expected code as well as agreement, for the reason
+/// the sibling gives: agreement alone would also pass if both routes
+/// silently stopped raising.
+#[test]
+fn test_any_all_ambient_validation_agrees_with_bridge_2476() -> Result<()> {
+    // (label, document, expected exit code, expected stderr substring)
+    let corpus: &[(&str, &str, i32, &str)] = &[
+        ("#1194 non-string key", "{123: 1}", 5, "expected string key"),
+        (
+            "decode failure, in array",
+            r#"["\x"]"#,
+            5,
+            "invalid escape sequence",
+        ),
+        (
+            "structural error, in array",
+            "[xyz123]",
+            5,
+            "unexpected character",
+        ),
+        (
+            "#1642 colliding undecodable keys",
+            r#"{"\ud800":1,"\ud800":2}"#,
+            5,
+            "is ambiguous",
+        ),
+        (
+            "#2211 trailing comma, array",
+            "[1,]",
+            5,
+            "expected JSON value, found ']'",
+        ),
+        (
+            "#2243 lone comma, array",
+            "[,]",
+            5,
+            "expected JSON value, found ','",
+        ),
+        (
+            "#2349 missing comma, array",
+            "[1 2]",
+            5,
+            "expected ',' or ']'",
+        ),
+        (
+            "#2211 trailing comma, nested",
+            r#"{"a":[1,]}"#,
+            5,
+            "expected JSON value, found ']'",
+        ),
+        ("duplicate key (valid)", r#"{"a":1,"a":2}"#, 0, ""),
+        ("well-formed", r#"{"a":[1,{"b":"c"}]}"#, 0, ""),
+    ];
+    // The reference route first; `any`/`all` after.
+    let probes = ["select(.) | 1", "any | 1", "all | 1"];
+    for (label, doc, want_code, want_stderr) in corpus {
+        let mut seen: Vec<(String, i32, String)> = Vec::new();
+        for probe in probes {
+            let (_stdout, stderr, code) = run_jq_full(&["-c", probe], Some(doc))?;
+            let first = stderr.lines().next().unwrap_or("").to_string();
+            assert_eq!(
+                code, *want_code,
+                "[{label}] `{probe}`: exit {code}, want {want_code}\nstderr: {stderr}"
+            );
+            assert!(
+                first.contains(want_stderr),
+                "[{label}] `{probe}`: stderr {first:?} lacks {want_stderr:?}"
+            );
+            seen.push((probe.to_string(), code, first));
+        }
+        let (_, ref_code, ref_first) = &seen[0];
+        for (probe, code, first) in &seen[1..] {
+            assert_eq!(
+                (code, first),
+                (ref_code, ref_first),
+                "[{label}] `{probe}` disagrees with `select(.) | 1`"
+            );
+        }
+    }
+    Ok(())
+}
+
 /// #2476: `//`'s jq semantics table, after `Expr::Alternative` gained its own
 /// native arm in `eval_single` (it had none before, so it fell to the
 /// wildcard bridge unconditionally). Every row was captured live from the

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -41809,3 +41809,49 @@ fn test_and_or_still_raise_on_a_malformed_document_2476() -> Result<()> {
 
     Ok(())
 }
+
+/// #2476: `not` gets its own native arm in `eval_single` (it never had a
+/// `needs_path_context` gate to lose -- it has no operand, only the ambient
+/// `.` -- so before this change it fell to the wildcard bridge
+/// unconditionally). This is `not`'s own sibling of
+/// `test_and_or_still_raise_on_a_malformed_document_2476` just above: the
+/// bridge's ambient decode is now `push_generic_truthiness`'s own validation
+/// walk (inline, no separate `ambient_validation_error` call needed -- see
+/// the arm's comment in `eval_generic.rs`), and it must still raise on
+/// exactly the same two shapes -- a #1194 malformed root, and a decode
+/// failure the walk actually has to visit through a `.[]` fan-out.
+#[test]
+fn test_not_still_raises_on_a_malformed_document_2476() -> Result<()> {
+    let (stdout, stderr, code) = run_jq_stdin_streams("not", "{123: 1}", &[])?;
+    assert_eq!(code, 5, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert!(stderr.contains("Invalid JSON text"), "stderr: {stderr}");
+
+    let (stdout, stderr, code) = run_jq_stdin_streams(".[] | not", "[\"\\x\"]", &[])?;
+    assert_eq!(code, 5, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert!(
+        stderr.contains("invalid escape sequence"),
+        "stderr: {stderr}"
+    );
+
+    Ok(())
+}
+
+/// #2476: `not`'s jq truthiness table, unaffected by the native arm (only
+/// `null`/`false` are falsy in jq -- `0`, `""`, and `[]` are all truthy, so
+/// `not` on them is `false`). Verified live against the pinned oracle
+/// `/usr/bin/jq` 1.7.1 for every row before writing it down here.
+#[test]
+fn test_not_truthiness_table_2476() -> Result<()> {
+    for (input, want) in [
+        ("null", "true"),
+        ("false", "true"),
+        ("0", "false"),
+        ("\"\"", "false"),
+        ("[]", "false"),
+    ] {
+        let (stdout, code) = run_jq_stdin("not", input, &[])?;
+        assert_eq!(code, 0, "input={input}");
+        assert_eq!(stdout.trim(), want, "input={input}");
+    }
+    Ok(())
+}

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -41579,3 +41579,192 @@ fn test_preserve_input_keeps_jq_escape_table_2209() -> Result<()> {
     }
     Ok(())
 }
+
+/// #2476: `eval_single`'s wildcard bridge materializes the *ambient* value
+/// before the eager evaluator runs, and that materialization is what makes a
+/// query that never reads `.` still raise on a malformed document (#1812:
+/// jq rejects the whole document for every query). The native arms that
+/// replace the bridge for `and`/`or`/`not`/`//` run
+/// `ambient_validation_error` -- `push_generic_document_validation_error`,
+/// the walk `select(.)`/`if` already use -- instead. This corpus pins that
+/// the two raise identically: every malformed-document class the checks
+/// cover, each probed through the reference route (`select(.)`) and through
+/// every construct that used to bridge, asserting the same exit code and
+/// the same first stderr line, *and* the exit code the row must have
+/// (agreement alone would also pass if both routes silently stopped
+/// raising).
+///
+/// Rows this deliberately leaves out: a `>256`-deep document (both routes
+/// panic, #2627) and an empty document (exit 0 on every probe, nothing to
+/// pin). The alias-to-container shape is #1804's accepted trade-off and is
+/// pinned by its own test instead of here.
+#[test]
+fn test_ambient_validation_agrees_with_bridge_2476() -> Result<()> {
+    let deep200 = format!("{}1{}", "[".repeat(200), "]".repeat(200));
+    // (label, document, expected exit code, expected stderr substring)
+    let corpus: &[(&str, &str, i32, &str)] = &[
+        ("#1194 non-string key", "{123: 1}", 5, "expected string key"),
+        (
+            "decode failure, top level",
+            r#"{"bad": "\x", "keep": 5}"#,
+            5,
+            "invalid escape sequence",
+        ),
+        (
+            "decode failure, in array",
+            r#"["\x"]"#,
+            5,
+            "invalid escape sequence",
+        ),
+        (
+            "decode failure, root scalar",
+            r#""\x""#,
+            5,
+            "invalid escape sequence",
+        ),
+        (
+            "decode failure, nested object",
+            r#"{"bad": {"x": "\x"}, "keep": 5}"#,
+            5,
+            "invalid escape sequence",
+        ),
+        (
+            "structural error, top level",
+            r#"{"bad": xyz123, "keep": 5}"#,
+            5,
+            "unexpected character",
+        ),
+        (
+            "structural error, in array",
+            "[xyz123]",
+            5,
+            "unexpected character",
+        ),
+        ("structural error, root", "xyz123", 5, "Invalid JSON text"),
+        (
+            "#1642 colliding undecodable keys",
+            r#"{"\ud800":1,"\ud800":2}"#,
+            5,
+            "is ambiguous",
+        ),
+        (
+            "#1642 single undecodable key",
+            r#"{"\ud800": 1, "b": 2}"#,
+            0,
+            "",
+        ),
+        ("undecodable key, no collision", r#"{"a\q":1,"b":2}"#, 0, ""),
+        (
+            "#2211 trailing comma, array",
+            "[1,]",
+            5,
+            "expected JSON value, found ']'",
+        ),
+        (
+            "#2211 trailing comma, object",
+            r#"{"a":1,}"#,
+            5,
+            "expected string key, found '}'",
+        ),
+        (
+            "#2243 lone comma, array",
+            "[,]",
+            5,
+            "expected JSON value, found ','",
+        ),
+        (
+            "#2243 lone comma, object",
+            "{,}",
+            5,
+            "expected string key, found ','",
+        ),
+        (
+            "#2349 missing comma, array",
+            "[1 2]",
+            5,
+            "expected ',' or ']'",
+        ),
+        (
+            "#2349 double comma, array",
+            "[1,,2]",
+            5,
+            "expected JSON value, found ','",
+        ),
+        (
+            "#2349 missing comma, object",
+            r#"{"a":1 "b":2}"#,
+            5,
+            "expected ',' or '}'",
+        ),
+        (
+            "#2349 double comma, object",
+            r#"{"a":1,,"b":2}"#,
+            5,
+            "expected string key, found ','",
+        ),
+        (
+            "#2211 trailing comma, nested",
+            r#"{"a":[1,]}"#,
+            5,
+            "expected JSON value, found ']'",
+        ),
+        (
+            "#2243 lone comma, nested",
+            "[[,]]",
+            5,
+            "expected JSON value, found ','",
+        ),
+        ("#966 leading zero (sanitized, not raised)", "[01]", 0, ""),
+        (
+            "#966 two-dot number (sanitized, not raised)",
+            "[1..2]",
+            0,
+            "",
+        ),
+        ("deep, within the guard", deep200.as_str(), 0, ""),
+        ("duplicate key (valid)", r#"{"a":1,"a":2}"#, 0, ""),
+        ("unterminated array", "[1,2", 5, "Invalid JSON text"),
+        ("unterminated string", r#"["a"#, 5, "Invalid JSON text"),
+        ("missing colon", r#"{"a" 1}"#, 5, "expected ':'"),
+        ("bad literal", "[nul]", 5, "invalid null"),
+        ("trailing garbage", "[1] x", 5, "Invalid JSON text"),
+        ("null root", "null", 0, ""),
+        ("false root", "false", 0, ""),
+        ("well-formed", r#"{"a":[1,{"b":"c"}]}"#, 0, ""),
+    ];
+    // The reference route first; every construct that used to bridge after.
+    let probes = [
+        "select(.) | 1",
+        "true and true",
+        "false or true",
+        ". and true",
+        "not",
+        "false // 1",
+        "(.a? // 1) | 1",
+    ];
+    for (label, doc, want_code, want_stderr) in corpus {
+        let mut seen: Vec<(String, i32, String)> = Vec::new();
+        for probe in probes {
+            let (_stdout, stderr, code) = run_jq_full(&["-c", probe], Some(doc))?;
+            let first = stderr.lines().next().unwrap_or("").to_string();
+            assert_eq!(
+                code, *want_code,
+                "[{label}] `{probe}`: exit {code}, want {want_code}\nstderr: {stderr}"
+            );
+            assert!(
+                first.contains(want_stderr),
+                "[{label}] `{probe}`: stderr {first:?} lacks {want_stderr:?}"
+            );
+            seen.push((probe.to_string(), code, first));
+        }
+        let (_, ref_code, ref_first) = &seen[0];
+        for (probe, code, first) in &seen[1..] {
+            assert_eq!(
+                (code, first),
+                (ref_code, ref_first),
+                "[{label}] `{probe}` disagrees with `select(.) | 1`"
+            );
+        }
+    }
+    Ok(())
+}

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -41768,3 +41768,44 @@ fn test_ambient_validation_agrees_with_bridge_2476() -> Result<()> {
     }
     Ok(())
 }
+
+/// #2476: `eval_single`'s `Expr::And`/`Expr::Or` arms lost their
+/// `needs_path_context` gate, and the gate existed for exactly one reason --
+/// an `and`/`or` reading no path context fell to the wildcard bridge, whose
+/// ambient `to_owned_with_cursor` is what rejects a malformed document for a
+/// query that never reads `.` (#1812: real jq rejects the whole document for
+/// every query). The arm runs `ambient_validation_error` in its place, so
+/// this pins the raise *through the ungated arm* rather than through the
+/// bridge that used to carry it.
+///
+/// `test_try_catch_contains_a_genuinely_catchable_malformed_key_error_1812`
+/// pins the catchability rule and
+/// `test_ambient_validation_agrees_with_bridge_2476` pins the whole
+/// raise-set across every malformed-document class; this is the focused
+/// sibling that sits next to the fan-out repro the ungating exists for
+/// (`test_and_or_over_alias_fanout_completes_2476` in
+/// `tests/yq_cli_tests.rs`), so a regression names itself.
+#[test]
+fn test_and_or_still_raise_on_a_malformed_document_2476() -> Result<()> {
+    for filter in [
+        "true and true",
+        ". and true",
+        "false or true",
+        // Short-circuiting cannot skip the check: it runs before the
+        // operands, exactly where the bridge's materialization used to.
+        "true or false",
+        "false and true",
+    ] {
+        let (stdout, stderr, code) = run_jq_stdin_streams(filter, "{123: 1}", &[])?;
+        assert_eq!(
+            code, 5,
+            "`{filter}` must still reject the document -- stdout: {stdout:?} stderr: {stderr:?}"
+        );
+        assert!(
+            stderr.contains("Invalid JSON text"),
+            "`{filter}` -- stderr: {stderr}"
+        );
+    }
+
+    Ok(())
+}

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -41855,3 +41855,125 @@ fn test_not_truthiness_table_2476() -> Result<()> {
     }
     Ok(())
 }
+
+/// #2476: `//`'s jq semantics table, after `Expr::Alternative` gained its own
+/// native arm in `eval_single` (it had none before, so it fell to the
+/// wildcard bridge unconditionally). Every row was captured live from the
+/// pinned oracle `/usr/bin/jq` 1.7.1 before being written down here, and the
+/// arm mirrors `eval::eval_alternative`, which these rows already held for
+/// the bridged route -- so the table's real job is to pin that the *native*
+/// route did not drift from either.
+///
+/// The rules the rows encode: `//` emits every left output that is neither
+/// `null` nor `false` (`0`, `""`, `[]` are all truthy in jq, so they answer
+/// and the right side never runs); the right side runs only when *no* truthy
+/// left output survived, and its own outputs are then emitted unfiltered
+/// (`false // (null, 7)` is `null, 7`, not `7`).
+#[test]
+fn test_alternative_truthiness_table_2476() -> Result<()> {
+    for (filter, input, want) in [
+        ("null // 1", "null", "1"),
+        ("false // 1", "null", "1"),
+        ("0 // 1", "null", "0"),
+        ("\"\" // 1", "null", "\"\""),
+        ("[] // 1", "null", "[]"),
+        // Truthy outputs are kept one by one, not collapsed to the first.
+        ("(null, 2, false, 3) // 9", "null", "2\n3"),
+        // The right side is emitted unfiltered -- `null` survives there.
+        ("false // (null, 7)", "null", "null\n7"),
+        // An empty left stream is "no truthy output", so the right answers.
+        ("empty // 1", "null", "1"),
+        (".a // .b", "{\"a\": null, \"b\": 5}", "5"),
+        // `0` is truthy, so `.b` is never reached.
+        (".a // .b", "{\"a\": 0, \"b\": 5}", "0"),
+        // `?` on the left is how an error is turned into "no output" -- `.a`
+        // on an array raises, and the suppressed stream lets `1` answer.
+        (".a? // 1", "[1]", "1"),
+        // Filtering happens per output of the left, `.[]` included.
+        (".[] // 1", "[null, 1]", "1"),
+    ] {
+        let (stdout, stderr, code) = run_jq_stdin_streams(filter, input, &["-c"])?;
+        assert_eq!(code, 0, "`{filter}` on {input} -- stderr: {stderr:?}");
+        assert_eq!(
+            stdout.trim(),
+            want,
+            "`{filter}` on {input} -- stderr: {stderr:?}"
+        );
+    }
+    Ok(())
+}
+
+/// #2476: the control-flow half of `//`'s semantics, split out from the value
+/// table above because these rows are about exit codes and stderr rather than
+/// stdout. Captured live from `/usr/bin/jq` 1.7.1.
+///
+/// An error on the left *propagates* -- `//` substitutes for a falsy or
+/// absent output, never for a raised one -- and that holds even when nothing
+/// truthy survived, which is the row that proves the right side is not
+/// reached (`(null, error("x")) // 2` prints no `2`). A `break` escapes the
+/// operator entirely rather than selecting a branch. `(1, error("x")) // 2`
+/// is #400's rule: the truthy prefix is kept and *then* the error terminates
+/// the stream.
+#[test]
+fn test_alternative_control_flow_2476() -> Result<()> {
+    // jq 1.7.1: exit 5, stdout empty, `jq: error (at <stdin>:0): x`.
+    let (stdout, stderr, code) = run_jq_stdin_streams("(error(\"x\")) // 1", "null", &["-c"])?;
+    assert_eq!(code, 5, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert_eq!(stdout.trim(), "", "stderr: {stderr:?}");
+    assert!(stderr.contains('x'), "stderr: {stderr}");
+
+    // jq 1.7.1: exit 5, stdout `1`, same diagnostic -- the truthy prefix
+    // survives the error that follows it.
+    let (stdout, stderr, code) = run_jq_stdin_streams("(1, error(\"x\")) // 2", "null", &["-c"])?;
+    assert_eq!(code, 5, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert_eq!(stdout.trim(), "1", "stderr: {stderr:?}");
+
+    // jq 1.7.1: exit 5, stdout empty. Nothing truthy survived, but `2` is
+    // still never printed -- an error is not an absent output.
+    let (stdout, stderr, code) =
+        run_jq_stdin_streams("(null, error(\"x\")) // 2", "null", &["-c"])?;
+    assert_eq!(code, 5, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert_eq!(stdout.trim(), "", "stderr: {stderr:?}");
+
+    // jq 1.7.1: exit 0, no output at all -- the `break` escapes `//` rather
+    // than being read as "no truthy output" and selecting `1`.
+    let (stdout, stderr, code) =
+        run_jq_stdin_streams("label $out | (break $out) // 1", "null", &["-c"])?;
+    assert_eq!(code, 0, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert_eq!(stdout.trim(), "", "stderr: {stderr:?}");
+
+    Ok(())
+}
+
+/// #2476: `//`'s sibling of `test_not_still_raises_on_a_malformed_document_2476`
+/// just above. `Expr::Alternative` had no native arm at all, so unlike
+/// `and`/`or` there was no `needs_path_context` gate to drop -- the new arm
+/// calls `ambient_validation_error` unconditionally, because the whole
+/// construct is the "shape that used to bridge". These rows pin that the walk
+/// raises where the bridge's ambient materialization did: a #1194 malformed
+/// object key (raised for `false // 1`, which reads nothing at all, exactly
+/// as real jq rejects the document for every query), and a #1247 decode
+/// failure the walk actually visits.
+#[test]
+fn test_alternative_still_raises_on_a_malformed_document_2476() -> Result<()> {
+    for filter in ["false // 1", ".a // 1"] {
+        let (stdout, stderr, code) = run_jq_stdin_streams(filter, "{123: 1}", &[])?;
+        assert_eq!(
+            code, 5,
+            "`{filter}` -- stdout: {stdout:?} stderr: {stderr:?}"
+        );
+        assert!(
+            stderr.contains("Invalid JSON text"),
+            "`{filter}` -- stderr: {stderr}"
+        );
+    }
+
+    let (stdout, stderr, code) = run_jq_stdin_streams("(.[0] // 1)", "[\"\\x\"]", &[])?;
+    assert_eq!(code, 5, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert!(
+        stderr.contains("invalid escape sequence"),
+        "stderr: {stderr}"
+    );
+
+    Ok(())
+}

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -39231,3 +39231,112 @@ fn test_alternative_no_longer_raises_through_a_container_alias_2476() -> Result<
 
     Ok(())
 }
+
+/// `retain_truthy_generic`'s `OneCursor` arm (`eval_generic.rs`) runs its own
+/// `push_generic_document_validation_error` call over the `//`'s *left*
+/// operand specifically, separately from the `ambient_validation_error` call
+/// that guards the whole `Expr::Alternative` arm before either operand runs.
+/// Every existing `//`-and-alias test lands on `ambient_validation_error`
+/// instead, because in each of them the left operand's cursor is the same
+/// position as the ambient `.` (`(. // 1)`, `(key // 1)`, ...) -- so the two
+/// checks always agree and the `OneCursor` arm's own check never gets to
+/// disagree with the ambient one.
+///
+/// This document splits the two: the ambient position (`.a`, an object with
+/// one field aliasing a corrupted array) is not itself an alias, so its walk
+/// descends one level and stops at the field's alias cursor (#1804's
+/// short-circuit) without ever reaching the array -- clean. The left operand
+/// (`.q[0]`) navigates *through* that alias into the array's own corrupted
+/// element, a plain scalar cursor with no alias short-circuit of its own, so
+/// only the `OneCursor` arm's check can catch it.
+#[test]
+fn test_alternative_onecursor_validation_error_differs_from_ambient_2476() -> Result<()> {
+    let doc = "x: &X [\"bad\\qc\"]\na:\n  q: *X\n";
+
+    let (_, stderr, code) = run_yq_stdin_with_stderr(".a | (.q[0] // 1)", doc, &[])?;
+    assert_ne!(code, 0, "stderr: {stderr:?}");
+    assert!(
+        stderr.contains("invalid escape sequence"),
+        "stderr: {stderr}"
+    );
+
+    Ok(())
+}
+
+/// `retain_truthy_generic`'s `ManyCursor` arm (`.[] // ...`, a fan-out
+/// through the left operand) hits a validation error partway through the
+/// fan-out, after at least one earlier element was already kept as truthy --
+/// exercising `owned_prefix_partial` (materializing that kept prefix into the
+/// `Partial` this stage terminates with) rather than just the arm's clean
+/// exhaustion path every other `//`-fan-out test takes.
+///
+/// Same alias-navigation shape as
+/// `test_alternative_onecursor_validation_error_differs_from_ambient_2476`
+/// just above, but `.q[]` instead of `.q[0]`: the ambient `.a` still stops at
+/// the field's alias short-circuit (clean), while the fan-out walks each
+/// array element's own cursor directly. `"ok"` streams out before the error,
+/// matching #400's rule (a generator's truthy prefix survives a
+/// mid-stream raise) -- `select`'s own `test_alternative_no_longer_raises_
+/// through_a_container_alias_2476` sibling never exercises this because its
+/// document has only one, single-element array.
+#[test]
+fn test_alternative_manycursor_validation_error_keeps_prefix_2476() -> Result<()> {
+    let doc = "x: &X [\"ok\", \"bad\\qc\"]\na:\n  q: *X\n";
+
+    let (stdout, stderr, code) = run_yq_stdin_with_stderr(".a | (.q[] // 1)", doc, &[])?;
+    assert_ne!(code, 0, "stderr: {stderr:?}");
+    assert!(
+        stderr.contains("invalid escape sequence"),
+        "stderr: {stderr}"
+    );
+    assert_eq!(stdout.trim(), "ok", "stdout: {stdout:?}");
+
+    Ok(())
+}
+
+/// `retain_truthy_generic`'s `LazyKeys`/`LazyIndexRange` arm: both are
+/// returned from `//`'s left operand untouched, without materializing --
+/// `keys`/`keys_unsorted` on either an object or an array is unconditionally
+/// truthy (#140/#684), so `//` never even needs to look at what's inside.
+/// One row per variant, since they are two different `GenericResult` arms
+/// sharing one match pattern.
+#[test]
+fn test_alternative_lazy_keys_passthrough_2476() -> Result<()> {
+    let (stdout, stderr, code) =
+        run_yq_stdin_with_stderr(".a | (keys // [])", "a:\n  x: 1\n  y: 2\n", &[])?;
+    assert_eq!(code, 0, "stderr: {stderr:?}");
+    assert_eq!(stdout.trim(), "- x\n- y", "stdout: {stdout:?}");
+
+    let (stdout, stderr, code) =
+        run_yq_stdin_with_stderr(".a | (keys // [])", "a: [1, 2, 3]\n", &[])?;
+    assert_eq!(code, 0, "stderr: {stderr:?}");
+    assert_eq!(stdout.trim(), "- 0\n- 1\n- 2", "stdout: {stdout:?}");
+
+    Ok(())
+}
+
+/// `retain_truthy_generic`'s `LazySeq` arm: `map(f)`'s result must still be
+/// *pulled* (unlike the `LazyKeys`/`LazyIndexRange` arm just above) because
+/// `f` runs arbitrary code that can fail -- `materialize_atomic`'s `Err`
+/// has to surface as the `//`'s own answer rather than being silently
+/// treated as "truthy" before the array is known to exist. The happy path
+/// (`Ok`) hands back the built array as an owned value; the failing path
+/// (`Err`) turns into a `Partial` with the error as its control.
+#[test]
+fn test_alternative_lazy_seq_materializes_before_truthiness_2476() -> Result<()> {
+    let doc = "a: [1, 2, 3]\n";
+
+    let (stdout, stderr, code) = run_yq_stdin_with_stderr(".a | (map(.+1) // [])", doc, &[])?;
+    assert_eq!(code, 0, "stderr: {stderr:?}");
+    assert_eq!(stdout.trim(), "- 2\n- 3\n- 4", "stdout: {stdout:?}");
+
+    let (_, stderr, code) = run_yq_stdin_with_stderr(
+        ".a | (map(if . == 2 then error(\"boom\") else . end) // [])",
+        doc,
+        &[],
+    )?;
+    assert_ne!(code, 0, "stderr: {stderr:?}");
+    assert!(stderr.contains("boom"), "stderr: {stderr}");
+
+    Ok(())
+}

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -38860,3 +38860,187 @@ fn test_not_no_longer_raises_through_a_container_alias_2476() -> Result<()> {
 
     Ok(())
 }
+
+/// #2476: `//` over the same alias fan-out `and`/`or`/`not` were fixed
+/// against. Like `not`, `Expr::Alternative` had no native arm in
+/// `eval_single` at all -- and so no `needs_path_context` gate to lose --
+/// which meant every `//` fell to the wildcard bridge and paid its `O(2^N)`
+/// ambient materialization before either operand ran. `(false // 1)` is the
+/// row that makes that concrete: it reads nothing, and it still took as long
+/// as `(.a22 // 1)` did.
+///
+/// Asserts completion and the correct value, not a wall-clock bound -- same
+/// rationale as `test_not_over_alias_fanout_completes_2476` above (a
+/// regression hangs the suite rather than failing an assert). N=22 here for
+/// the same reason it is 22 there; the release binary at N=24 went from 40.5s
+/// to 0.73s on an Apple M-series.
+#[test]
+fn test_alternative_over_alias_fanout_completes_2476() -> Result<()> {
+    let mut doc = String::from("a0: &a0 leaf\n");
+    for i in 1..=22 {
+        doc.push_str(&format!("a{i}: &a{i} [*a{}, *a{}]\n", i - 1, i - 1));
+    }
+
+    for (filter, want) in [
+        // The fan-out itself is truthy, so `1` never answers; `length` then
+        // reads the two-element array through the cursor `//` handed on.
+        ("(.a22 // 1) | length", "2"),
+        // Same filter without the parens -- `//` binds tighter than `|`.
+        (".a22 // 1 | length", "2"),
+        // An absent left output falls through to the right...
+        ("(.missing // 1)", "1"),
+        // ...as does a falsy one that reads nothing at all. This row paid
+        // the full fan-out before this change.
+        ("(false // 1)", "1"),
+        // A truthy scalar answers for itself.
+        ("(.a0 // 1)", "leaf"),
+    ] {
+        let (stdout, stderr, code) = run_yq_stdin_with_stderr(filter, &doc, &[])?;
+        assert_eq!(code, 0, "`{filter}` -- stderr: {stderr:?}");
+        assert_eq!(stdout.trim(), want, "`{filter}` -- stderr: {stderr:?}");
+    }
+
+    Ok(())
+}
+
+/// #2476: the native `//` arm hands the left's surviving outputs -- and the
+/// right's, when the left had none -- straight through as
+/// `OneCursor`/`ManyCursor`, where the bridge used to materialize them into
+/// an `OwnedValue` first. In yq mode that is a fidelity gain, not just a
+/// speedup: everything the cursor carries survives.
+///
+/// Captured live from yq v4.53.3 on this exact document: `.a // .b` prints
+/// `&x {c: 1, d: 2} # trailing` -- anchor, flow style and trailing comment
+/// all intact. succinctly printed an expanded block mapping (`c: 1` / `d: 2`,
+/// no anchor, no comment) before this change and prints yq's line
+/// byte-for-byte after it, so this moves toward the oracle. The `.b` row
+/// asserts the reason: `//` gains nothing of its own here, it simply stops
+/// destroying what a bare `.b` already produced.
+#[test]
+fn test_alternative_keeps_the_cursor_it_hands_on_2476() -> Result<()> {
+    let doc = "a: null\nb: &x {c: 1, d: 2} # trailing\n";
+    let want = "&x {c: 1, d: 2} # trailing";
+
+    let (stdout, stderr, code) = run_yq_stdin_with_stderr(".a // .b", doc, &[])?;
+    assert_eq!(code, 0, "stderr: {stderr:?}");
+    assert_eq!(stdout.trim(), want, "stderr: {stderr:?}");
+
+    // The same bytes a bare `.b` gives -- `//` is now transparent to it.
+    let (stdout, stderr, code) = run_yq_stdin_with_stderr(".b", doc, &[])?;
+    assert_eq!(code, 0, "stderr: {stderr:?}");
+    assert_eq!(stdout.trim(), want, "stderr: {stderr:?}");
+
+    // And the surviving *left* output is cursor-backed too, not only the
+    // fallback: here `.b` is truthy, so it answers from the left position.
+    let (stdout, stderr, code) = run_yq_stdin_with_stderr(".b // 1", doc, &[])?;
+    assert_eq!(code, 0, "stderr: {stderr:?}");
+    assert_eq!(stdout.trim(), want, "stderr: {stderr:?}");
+
+    Ok(())
+}
+
+/// #2476's second fidelity gain from the native `//` arm, and the one that
+/// changes an *answer* rather than a rendering: an operand that reads the
+/// ambient position now reads the real one.
+///
+/// While `//` bridged, both operands were handed to the eager evaluator
+/// against a document re-rooted at this stage's input, so `key`/`parent`
+/// resolved to nothing there -- and since "nothing" is not truthy, `//`
+/// substituted the right side for it. Evaluating the left through
+/// `eval_single` *with the cursor* is what fixes this: it reaches the same
+/// `Expr::Builtin(Builtin::Key)`/`Builtin::Parent` arms `key` alone already
+/// used. Every row below was captured live from yq v4.53.3 and is what
+/// succinctly now prints; the "before" column is recorded here because it was
+/// silently wrong rather than an error:
+///
+/// | filter                    | yq v4.53.3        | before  |
+/// |---------------------------|-------------------|---------|
+/// | `.a \| (key // 1)`        | `a`               | `1`     |
+/// | `.a.b \| (key // "x")`    | `b`               | `x`     |
+/// | `.a \| (parent // 1)`     | `a: {b: 1, e: 2}` | `1`     |
+/// | `.a \| (.missing // key)` | `a`               | (empty) |
+///
+/// One shape this does *not* reach, unchanged in either direction:
+/// `.a | to_entries | .[] | (key // 99)` is `0`, `1` in yq and `99`, `99`
+/// here, before and after. `needs_path_context` has no `Expr::Alternative`
+/// arm at all (it falls to that function's `_ => false`), so a pipe whose
+/// only path-context read is inside a `//` is never routed to path-context
+/// evaluation, and `to_entries` has already left the cursor domain by then.
+/// That is #715/#1405's recursion list, not this arm's, and deliberately not
+/// touched here -- #2416 pins that table.
+#[test]
+fn test_alternative_operands_read_the_real_position_2476() -> Result<()> {
+    let doc = "a: {b: 1, e: 2}\n";
+
+    for (filter, want) in [
+        (".a | (key // 1)", "a"),
+        (".a.b | (key // \"x\")", "b"),
+        (".a | (parent // 1)", "a: {b: 1, e: 2}"),
+        // `key` on the *right* side answers too: `.missing` is absent, so
+        // the fallback runs, and it runs at the same position.
+        (".a | (.missing // key)", "a"),
+    ] {
+        let (stdout, stderr, code) = run_yq_stdin_with_stderr(filter, doc, &[])?;
+        assert_eq!(code, 0, "`{filter}` -- stderr: {stderr:?}");
+        assert_eq!(stdout.trim(), want, "`{filter}` -- stderr: {stderr:?}");
+    }
+
+    Ok(())
+}
+
+/// #2476's `//` sibling of
+/// `test_not_no_longer_raises_through_a_container_alias_2476` just above.
+/// The native arm's `ambient_validation_error` call is
+/// `push_generic_document_validation_error`, and since #1804 that walk does
+/// not descend into a container reached through an alias -- the short-circuit
+/// that makes it `O(N)` where the bridge is `O(2^N)`. So `//` inherits the
+/// identical accepted trade-off: a decode failure reachable *only* through a
+/// container-target alias no longer raises from a `//` standing at that alias
+/// position.
+///
+/// Everything that actually reads the value still raises: the anchor itself,
+/// materializing through the alias, and the scalar-target sibling (#1804
+/// scoped its short-circuit to containers, since resolving a scalar alias is
+/// O(1) and never part of the fan-out). Real yq rejects both documents at
+/// parse time (confirmed live against v4.53.3), so there is no yq behaviour
+/// to match either way.
+#[test]
+fn test_alternative_no_longer_raises_through_a_container_alias_2476() -> Result<()> {
+    let doc = "a: &a [\"bad\\qc\"]\nb: *a\n";
+
+    // The alias position: the walk stops at the alias, so the array is
+    // truthy and answers for itself. This is the row that changed (exit 1
+    // before, exit 0 now).
+    let (stdout, stderr, code) = run_yq_stdin_with_stderr(".b | (. // 1) | length", doc, &[])?;
+    assert_eq!(code, 0, "stderr: {stderr:?}");
+    assert_eq!(stdout.trim(), "1", "stderr: {stderr:?}");
+
+    // Visiting the anchor itself still raises.
+    let (_, stderr, code) = run_yq_stdin_with_stderr(".a | (. // 1)", doc, &[])?;
+    assert_ne!(code, 0, "stderr: {stderr:?}");
+    assert!(
+        stderr.contains("invalid escape sequence"),
+        "stderr: {stderr}"
+    );
+
+    // Materializing through the alias still raises.
+    let (_, stderr, code) = run_yq_stdin_with_stderr(".b[0]", doc, &[])?;
+    assert_ne!(code, 0, "stderr: {stderr:?}");
+    assert!(
+        stderr.contains("invalid escape sequence"),
+        "stderr: {stderr}"
+    );
+
+    // The scalar-alias sibling: `.b`'s target is a bare scalar, not a
+    // container, so #1804's short-circuit does not apply and `//` still
+    // raises there.
+    let scalar_doc = "a: &a \"bad\\qc\"\nb: *a\n";
+    let (_, stderr, code) = run_yq_stdin_with_stderr(".b | (. // 1)", scalar_doc, &[])?;
+    assert_ne!(code, 0, "stderr: {stderr:?}");
+    assert!(
+        stderr.contains("invalid escape sequence"),
+        "stderr: {stderr}"
+    );
+
+    Ok(())
+}

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -39155,6 +39155,15 @@ fn test_alternative_keeps_the_cursor_it_hands_on_2476() -> Result<()> {
 /// evaluation, and `to_entries` has already left the cursor domain by then.
 /// That is #715/#1405's recursion list, not this arm's, and deliberately not
 /// touched here -- #2416 pins that table.
+///
+/// A second, distinct gap: this arm's position-reading fix above is for a
+/// *present* left/ambient position. An *absent* one is still wrong in both
+/// directions -- `.a.missing | (key // 1)` is `1` here (should be `missing`,
+/// yq v4.53.3's own answer) on this branch, and identically `1` on `main`
+/// pre-#2476 (`//` still bridging there) -- so this is not a regression this
+/// arm introduced, just one it does not close. Root cause not chased down
+/// here; flagged so this table is not read as "position-reading through `//`
+/// is now generally correct."
 #[test]
 fn test_alternative_operands_read_the_real_position_2476() -> Result<()> {
     let doc = "a: {b: 1, e: 2}\n";

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -39294,6 +39294,43 @@ fn test_alternative_manycursor_validation_error_keeps_prefix_2476() -> Result<()
     Ok(())
 }
 
+/// `owned_prefix_partial`'s own `Err` arm (`src/jq/eval_generic.rs`) --
+/// #2661 tagged this branch unreachable on the premise that `kept` only ever
+/// holds already-successfully-converted items, but that premise doesn't hold
+/// for `retain_truthy_generic`'s `ManyCursor` arm: it only runs the cheap
+/// [`push_generic_document_validation_error`] walk before keeping a cursor,
+/// and that walk stops at a container-target alias (#1804) without
+/// descending into it -- so a kept item can be an alias to a corrupt
+/// container, passing the cheap check while its real materialization still
+/// fails.
+///
+/// `*X` (an alias to an object with two different decode-failure keys that
+/// collide under YAML's shared `""` display fallback, #1642) is the first
+/// `.q[]` element and passes the cheap check -- container aliases are
+/// truthy regardless of contents -- so it lands in `kept`. The second
+/// element is a plain (non-aliased) decode failure, which the cheap check
+/// does catch and which becomes this fan-out's terminating `control`.
+/// `owned_prefix_partial` then re-converts `kept` for real via
+/// `to_owned_cursor`, which has no alias short-circuit: it dereferences `*X`
+/// and hits the #1642 collision instead, replacing the terminating
+/// `control` with its own error -- the precedence the function's own doc
+/// comment already claims (mirroring [`flatten_generic_results`]), just via
+/// a different element than any existing test exercised. Pinning this as
+/// the intended, documented behavior, not proposing a change to it.
+#[test]
+fn test_alternative_manycursor_prefix_conversion_error_2476() -> Result<()> {
+    let doc = "x: &X {\"a\\qb\": 1, \"c\\qd\": 2}\ny: &Y [*X, \"bad\\qe\"]\na:\n  q: *Y\n";
+
+    let (stdout, stderr, code) = run_yq_stdin_with_stderr(".a | (.q[] // 1)", doc, &[])?;
+    assert_ne!(code, 0, "stderr: {stderr:?}");
+    // The re-conversion's own error (`*X`'s #1642 collision), not the
+    // fan-out's original terminating control (`"bad\qe"`'s escape error).
+    assert!(stderr.contains("ambiguous"), "stderr: {stderr}");
+    assert_eq!(stdout.trim(), "", "stdout: {stdout:?}");
+
+    Ok(())
+}
+
 /// `retain_truthy_generic`'s `LazyKeys`/`LazyIndexRange` arm: both are
 /// returned from `//`'s left operand untouched, without materializing --
 /// `keys`/`keys_unsorted` on either an object or an array is unconditionally

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -38768,3 +38768,95 @@ fn test_and_or_no_longer_raise_through_a_container_alias_2476() -> Result<()> {
 
     Ok(())
 }
+
+/// #2476: `not` over the same alias fan-out `and`/`or` were fixed against.
+/// `not` never had a `needs_path_context` gate to lose (it has no operand,
+/// only the ambient `.`), so before this change it fell to the wildcard
+/// bridge unconditionally and paid the same `O(2^N)` materialization at
+/// every one of these positions. This test asserts completion (a regression
+/// hangs the suite) and the correct truthiness, not a wall-clock bound --
+/// same rationale as `test_and_or_over_alias_fanout_completes_2476` above.
+///
+/// `.a22[0] | not` and `not` at the root are worth spelling out: the first
+/// lands the cursor *on* an alias node directly (`.a22`'s own two children
+/// are `*a21`), so the walk stops at depth 1 without ever entering the
+/// fan-out; the second starts at the document root, which is not itself an
+/// alias, but every one of its 23 top-level values whose children are alias
+/// nodes stops there too -- so both are `O(N)`, not `O(1)` or `O(2^N)`.
+#[test]
+fn test_not_over_alias_fanout_completes_2476() -> Result<()> {
+    let mut doc = String::from("a0: &a0 leaf\n");
+    for i in 1..=22 {
+        doc.push_str(&format!("a{i}: &a{i} [*a{}, *a{}]\n", i - 1, i - 1));
+    }
+
+    for (filter, want) in [
+        (".a22 | not", "false"),
+        (".a22[0] | not", "false"),
+        (".a0 | not", "false"),
+        ("null | not", "true"),
+        ("not", "false"),
+    ] {
+        let (stdout, stderr, code) = run_yq_stdin_with_stderr(filter, &doc, &[])?;
+        assert_eq!(code, 0, "`{filter}` -- stderr: {stderr:?}");
+        assert_eq!(stdout.trim(), want, "`{filter}` -- stderr: {stderr:?}");
+    }
+
+    Ok(())
+}
+
+/// #2476's `not` sibling of
+/// `test_and_or_no_longer_raise_through_a_container_alias_2476`: `not`
+/// shares the same `push_generic_truthiness` walk `and`/`or` do (inline,
+/// via its `OneCursor` arm), so it inherits #1804's identical trade-off. A
+/// decode failure reachable *only* through a container-target alias no
+/// longer raises from `not` at that alias position; visiting the anchor
+/// directly, or materializing through the alias, still raises.
+///
+/// The second document is the scalar-target sibling from
+/// `test_select_still_raises_on_decode_failure_reachable_only_via_scalar_alias_1804`:
+/// #1804 scoped its short-circuit to a *container* reached through an alias,
+/// not a bare scalar one -- resolving a scalar alias is O(1), never part of
+/// the fan-out this issue fixes -- so `.b | not` still raises there. Real yq
+/// rejects both documents at parse time (confirmed live against v4.53.3), so
+/// there is no yq behaviour to match either way.
+#[test]
+fn test_not_no_longer_raises_through_a_container_alias_2476() -> Result<()> {
+    let doc = "a: &a [\"bad\\qc\"]\nb: *a\n";
+
+    // The alias position: the walk stops at the alias, so `not` answers
+    // instead of raising. This is the row that changed (exit 1 before, exit
+    // 0 now).
+    let (stdout, stderr, code) = run_yq_stdin_with_stderr(".b | not", doc, &[])?;
+    assert_eq!(code, 0, "stderr: {stderr:?}");
+    assert_eq!(stdout.trim(), "false", "stderr: {stderr:?}");
+
+    // Visiting the anchor itself still raises.
+    let (_, stderr, code) = run_yq_stdin_with_stderr(".a | not", doc, &[])?;
+    assert_ne!(code, 0, "stderr: {stderr:?}");
+    assert!(
+        stderr.contains("invalid escape sequence"),
+        "stderr: {stderr}"
+    );
+
+    // Materializing through the alias still raises.
+    let (_, stderr, code) = run_yq_stdin_with_stderr(".b[0]", doc, &[])?;
+    assert_ne!(code, 0, "stderr: {stderr:?}");
+    assert!(
+        stderr.contains("invalid escape sequence"),
+        "stderr: {stderr}"
+    );
+
+    // The scalar-alias sibling: `.b`'s target is a bare scalar, not a
+    // container, so #1804's short-circuit does not apply and `.b | not`
+    // still raises.
+    let scalar_doc = "a: &a \"bad\\qc\"\nb: *a\n";
+    let (_, stderr, code) = run_yq_stdin_with_stderr(".b | not", scalar_doc, &[])?;
+    assert_ne!(code, 0, "stderr: {stderr:?}");
+    assert!(
+        stderr.contains("invalid escape sequence"),
+        "stderr: {stderr}"
+    );
+
+    Ok(())
+}

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -29579,13 +29579,14 @@ fn test_select_raises_on_yaml_decode_failure_nested_in_container_1645() -> Resul
 /// N=30 would not finish within any reasonable bound); post-fix, N=30
 /// completes in single-digit milliseconds.
 ///
-/// `if`/`select` only -- `and`/`or`/`not`/`//`/`any` are NOT fixed by this
-/// change (confirmed live: `.a20 and true` still took 109s at N=26) because
-/// `eval_single` has no native arm for them and they bridge through
-/// `full_eval` (the eager/materializing evaluator), which this walk is never
-/// consulted from. That gap is tracked separately, coupled to the #2416
-/// migration that would need to give them a native arm the way `if` already
-/// has one.
+/// `if`/`select` only, when this landed -- `and`/`or`/`not`/`//`/`any` were
+/// NOT fixed by it (confirmed live then: `.a20 and true` still took 109s at
+/// N=26), because `eval_single` had no native arm for them and they bridged
+/// through `full_eval` (the eager/materializing evaluator), which this walk
+/// is never consulted from. #2476 closed that for `and`/`or` by ungating
+/// their native arms and running this same walk from them
+/// (`test_and_or_over_alias_fanout_completes_2476` below); the remaining
+/// constructs are still tracked there.
 #[test]
 fn test_select_and_if_truthiness_flat_over_alias_fanout_1804() -> Result<()> {
     let mut doc = String::from("a0: &a0 leaf\n");
@@ -38659,5 +38660,111 @@ fn test_ambient_validation_agrees_with_bridge_2476() -> Result<()> {
             );
         }
     }
+    Ok(())
+}
+
+/// #2476: `and`/`or` over an alias fan-out completes in milliseconds.
+///
+/// `eval_single`'s `Expr::And`/`Expr::Or` arms were gated on
+/// `needs_path_context`, so an `and`/`or` whose operands read no position
+/// fell to the wildcard bridge, and the bridge's first act is to materialize
+/// the *ambient* value. On this document (#1804's shape: `aN: &aN [*a(N-1),
+/// *a(N-1)]`) the root contains `aN`, so the cost was `O(2^N)` for every
+/// such expression whatever its operands read -- `true and true` blew up as
+/// badly as `.aN and true`. The arms are ungated now and run
+/// `ambient_validation_error`, the walk `select`/`if` already used, which
+/// #1804 taught not to descend through an alias.
+///
+/// Measured on the two binaries either side of the change, N=24,
+/// `.a24 and true`: 42.5s before, 0.01s after. This test uses N=22 and
+/// asserts no wall-clock bound -- a regression to `O(2^N)` announces itself
+/// by hanging the suite, and a threshold would only add flakiness under this
+/// suite's own subprocess contention.
+///
+/// `true and true` and `.a0 and true` are rows here on purpose: they never
+/// touch `a22`, and pre-fix they were just as exponential, which is the
+/// whole point about *where* the cost came from.
+#[test]
+fn test_and_or_over_alias_fanout_completes_2476() -> Result<()> {
+    let mut doc = String::from("a0: &a0 leaf\n");
+    for i in 1..=22 {
+        doc.push_str(&format!("a{i}: &a{i} [*a{}, *a{}]\n", i - 1, i - 1));
+    }
+
+    for filter in [
+        ".a22 and true",
+        ".a22 or false",
+        "true and true",
+        ".a0 and true",
+    ] {
+        let (stdout, stderr, code) = run_yq_stdin_with_stderr(filter, &doc, &[])?;
+        assert_eq!(code, 0, "`{filter}` -- stderr: {stderr:?}");
+        assert_eq!(stdout.trim(), "true", "`{filter}` -- stderr: {stderr:?}");
+    }
+
+    Ok(())
+}
+
+/// #2476's one behaviour change: #1804's accepted trade-off, now shared by
+/// `and`/`or`.
+///
+/// The ungated arms answer through `ambient_validation_error`, which is
+/// `push_generic_document_validation_error` -- and since #1804 that walk
+/// does not descend into a container reached through an alias (that
+/// short-circuit is exactly what makes it `O(N)` on the fan-out where the
+/// bridge is `O(2^N)`). So a decode failure reachable *only* through such an
+/// alias no longer raises from an `and`/`or` at that position, where the
+/// bridge's materialization used to raise. `select(.b) | 1` already answered
+/// `1` on this document before #2476
+/// (`test_select_no_longer_raises_on_decode_failure_reachable_only_via_alias_1804`),
+/// so this is the two routes converging, not a new class of silence.
+///
+/// Everything that actually reads the value still raises, and both are
+/// asserted below: `.b[0]` materializes through the alias, and
+/// `.a | (true and true)` starts its walk at the *anchor*, which is not an
+/// alias node, so the walk descends and finds the failure. Real yq rejects
+/// this whole document at parse time ("found unknown escape character",
+/// confirmed live against v4.53.3), so there is no yq behaviour to match
+/// either way.
+#[test]
+fn test_and_or_no_longer_raise_through_a_container_alias_2476() -> Result<()> {
+    let doc = "a: &a [\"bad\\qc\"]\nb: *a\n";
+
+    // The alias position: the walk stops at the alias, so the boolean
+    // answers instead of raising. This is the row that changed (exit 1
+    // before, exit 0 now).
+    for filter in [".b | (true and true)", ".b | (false or true)"] {
+        let (stdout, stderr, code) = run_yq_stdin_with_stderr(filter, doc, &[])?;
+        assert_eq!(code, 0, "`{filter}` -- stderr: {stderr:?}");
+        assert_eq!(stdout.trim(), "true", "`{filter}` -- stderr: {stderr:?}");
+    }
+
+    // Reading through the alias still raises...
+    let (_, stderr, code) = run_yq_stdin_with_stderr(".b[0]", doc, &[])?;
+    assert_ne!(code, 0, "stderr: {stderr:?}");
+    assert!(
+        stderr.contains("invalid escape sequence"),
+        "stderr: {stderr}"
+    );
+
+    // ...and so does the same boolean at the anchor itself.
+    let (_, stderr, code) = run_yq_stdin_with_stderr(".a | (true and true)", doc, &[])?;
+    assert_ne!(code, 0, "stderr: {stderr:?}");
+    assert!(
+        stderr.contains("invalid escape sequence"),
+        "stderr: {stderr}"
+    );
+
+    // The document root reaches the anchor without going through an alias,
+    // so a root-level `and` raises too -- the corpus test's own
+    // "anchored container" row, restated here so the three positions this
+    // test cares about sit together.
+    let (_, stderr, code) = run_yq_stdin_with_stderr("true and true", doc, &[])?;
+    assert_ne!(code, 0, "stderr: {stderr:?}");
+    assert!(
+        stderr.contains("invalid escape sequence"),
+        "stderr: {stderr}"
+    );
+
     Ok(())
 }

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -38903,6 +38903,193 @@ fn test_alternative_over_alias_fanout_completes_2476() -> Result<()> {
     Ok(())
 }
 
+/// #2476: bare `any`/`all` over the same alias fan-out `and`/`or`/`not`/`//`
+/// were fixed against. Neither had an arm in `eval_builtin` at all, so both
+/// fell to its `_` wildcard, whose first act is `to_owned_with_cursor` on
+/// the value they were applied to -- `O(2^N)` when that value is the
+/// fan-out. `any_all_generic` validates the input once with the walk
+/// (`push_generic_document_validation_error`, which #1804 stops at a
+/// container alias) and then answers from `is_falsy` alone, so the first
+/// element decides.
+///
+/// Asserts completion and the correct value, not a wall-clock bound -- same
+/// rationale as `test_alternative_over_alias_fanout_completes_2476` above (a
+/// regression hangs the suite rather than failing an assert). N=22 here for
+/// the same reason it is 22 there; the release binary at N=22 went from
+/// 5.95s to 0.02s on an Apple M-series.
+///
+/// `[.a22] | any` is deliberately absent: array construction materializes
+/// its outputs by design (the output *is* the expanded tree), so that shape
+/// is out of scope for this fix and would still hang.
+#[test]
+fn test_any_all_over_alias_fanout_completes_2476() -> Result<()> {
+    let mut doc = String::from("a0: &a0 leaf\n");
+    for i in 1..=22 {
+        doc.push_str(&format!("a{i}: &a{i} [*a{}, *a{}]\n", i - 1, i - 1));
+    }
+
+    for (filter, want) in [
+        // The fan-out's first element is a truthy container, so `any` stops
+        // there and `all` finds no falsy element in the two it walks.
+        (".a22 | any", "true"),
+        (".a22 | all", "true"),
+        // The input is itself an alias here, which is the shape the walk
+        // short-circuits on outright.
+        (".a22[0] | any", "true"),
+        (".a22[0] | all", "true"),
+    ] {
+        let (stdout, stderr, code) = run_yq_stdin_with_stderr(filter, &doc, &[])?;
+        assert_eq!(code, 0, "`{filter}` -- stderr: {stderr:?}");
+        assert_eq!(stdout.trim(), want, "`{filter}` -- stderr: {stderr:?}");
+    }
+
+    Ok(())
+}
+
+/// #2476: `any`/`all` reject a non-array input in yq mode, and the native
+/// arm has to keep doing so -- with real yq's own wording, and with the
+/// #1901 arm *order* that puts the rejection ahead of `optional` (an
+/// earlier version of the eager code had them the other way round, which
+/// made `any?` on a `!!map` silently answer nothing).
+///
+/// Every row captured live from yq v4.53.3:
+///
+/// ```text
+/// {a: 1} | any   Error: any only supports arrays, was !!map     (exit 1)
+/// {a: 1} | all   Error: all only supports arrays, was !!map     (exit 1)
+/// 1 | any        Error: any only supports arrays, was !!int     (exit 1)
+/// null | any     Error: any only supports arrays, was !!null    (exit 1)
+/// "s" | any      Error: any only supports arrays, was !!str     (exit 1)
+/// true | any     Error: any only supports arrays, was !!bool    (exit 1)
+/// [1] | any      true                                           (exit 0)
+/// [] | any       false                                          (exit 0)
+/// [] | all       true                                           (exit 0)
+/// [null, 1] | any  true    [null, 1] | all  false               (exit 0)
+/// ```
+///
+/// `!!int`/`!!null`/... is the *untagged* tag (`document_value_type_tag`,
+/// the generic twin of `eval::yaml_type_tag`), which is what real yq's
+/// message quotes -- not `tag`'s cursor-aware answer.
+#[test]
+fn test_any_all_reject_non_arrays_in_yq_mode_2476() -> Result<()> {
+    for (doc, filter, want_tag) in [
+        ("a: 1\n", "any", "!!map"),
+        ("a: 1\n", "all", "!!map"),
+        ("1\n", "any", "!!int"),
+        ("1\n", "all", "!!int"),
+        ("null\n", "any", "!!null"),
+        ("null\n", "all", "!!null"),
+        ("\"s\"\n", "any", "!!str"),
+        ("true\n", "any", "!!bool"),
+        ("1.5\n", "any", "!!float"),
+    ] {
+        let (_, stderr, code) = run_yq_stdin_with_stderr(filter, doc, &[])?;
+        assert_eq!(code, 1, "`{filter}` on {doc:?} -- stderr: {stderr:?}");
+        let name = if filter == "any" { "any" } else { "all" };
+        assert!(
+            stderr.contains(&format!("{name} only supports arrays, was {want_tag}")),
+            "`{filter}` on {doc:?} -- stderr: {stderr}"
+        );
+    }
+
+    // Arrays answer, with yq's own truthiness (`null` is falsy, `0` is not).
+    for (doc, filter, want) in [
+        ("[1]\n", "any", "true"),
+        ("[1]\n", "all", "true"),
+        ("[]\n", "any", "false"),
+        ("[]\n", "all", "true"),
+        ("[null, 1]\n", "any", "true"),
+        ("[null, 1]\n", "all", "false"),
+        ("[0]\n", "any", "true"),
+    ] {
+        let (stdout, stderr, code) = run_yq_stdin_with_stderr(filter, doc, &[])?;
+        assert_eq!(code, 0, "`{filter}` on {doc:?} -- stderr: {stderr:?}");
+        assert_eq!(stdout.trim(), want, "`{filter}` on {doc:?}");
+    }
+
+    // #1901's arm order: `?` does not get to swallow the rejection ahead of
+    // it, but it does suppress the type error itself once reached -- the
+    // same split the before-this-change bridge produced (`{a: 1} | any?`
+    // and `1 | any?` are both empty at exit 0).
+    for doc in ["a: 1\n", "1\n"] {
+        let (stdout, stderr, code) = run_yq_stdin_with_stderr("any?", doc, &[])?;
+        assert_eq!(code, 0, "{doc:?} -- stderr: {stderr:?}");
+        assert_eq!(stdout.trim(), "", "{doc:?}");
+    }
+
+    Ok(())
+}
+
+/// #2476: `any`/`all` now share #1804's accepted trade-off, exactly as the
+/// `not` and `//` arms of this same issue do.
+///
+/// `any_all_generic` validates its input with
+/// `push_generic_document_validation_error` -- and that walk deliberately
+/// does not descend into a container reached through an alias, because
+/// doing so is what costs `O(2^N)` on a fan-out. The scan that follows
+/// reads `is_falsy`, which materializes nothing. So a decode failure
+/// reachable *only* through an alias to a container no longer raises from
+/// `any`/`all`: `.b | any` on the document below exited 1 with "invalid
+/// escape sequence" before this change (via the bridge's materialization)
+/// and is `true` at exit 0 after it. Both halves verified against a release
+/// build of the parent commit and of this one.
+///
+/// Everything that still raises is pinned here too, so the trade-off cannot
+/// silently widen: visiting the anchor directly, materializing through the
+/// alias, and the scalar-alias sibling #1804's own short-circuit
+/// deliberately excludes.
+///
+/// Real yq rejects this document at parse time (`yq` v4.53.3 refuses the
+/// `\q` escape outright), so there is no yq behaviour to match either way.
+/// Recorded in `docs/compliance/yq/limitations.md` under #1804.
+#[test]
+fn test_any_all_no_longer_raise_on_decode_failure_behind_a_container_alias_2476() -> Result<()> {
+    let doc = "a: &a [\"bad\\qc\"]\nb: *a\n";
+
+    // `.b` is an alias to a container: the walk stops at it, and the scan
+    // reads the one element's truthiness without decoding it.
+    for (filter, want) in [(".b | any", "true"), (".b | all", "true")] {
+        let (stdout, stderr, code) = run_yq_stdin_with_stderr(filter, doc, &[])?;
+        assert_eq!(code, 0, "`{filter}` -- stderr: {stderr:?}");
+        assert_eq!(stdout.trim(), want, "`{filter}` -- stderr: {stderr:?}");
+    }
+
+    // Visiting the anchor itself still raises -- it is not an alias, so the
+    // walk descends into its element and decodes the string.
+    for filter in [".a | any", ".a | all"] {
+        let (_, stderr, code) = run_yq_stdin_with_stderr(filter, doc, &[])?;
+        assert_ne!(code, 0, "`{filter}` -- stderr: {stderr:?}");
+        assert!(
+            stderr.contains("invalid escape sequence"),
+            "`{filter}` -- stderr: {stderr}"
+        );
+    }
+
+    // Materializing through the alias still raises.
+    let (_, stderr, code) = run_yq_stdin_with_stderr(".b[0]", doc, &[])?;
+    assert_ne!(code, 0, "stderr: {stderr:?}");
+    assert!(
+        stderr.contains("invalid escape sequence"),
+        "stderr: {stderr}"
+    );
+
+    // The scalar-alias sibling: `.b`'s target is a bare scalar, not a
+    // container, so #1804's short-circuit does not apply. The walk decodes
+    // it and raises before the yq-mode "only supports arrays" rejection the
+    // scalar would otherwise get -- decode failure wins (#1620/#1989).
+    let scalar_doc = "a: &a \"bad\\qc\"\nb: *a\n";
+    for filter in [".b | any", ".b | all"] {
+        let (_, stderr, code) = run_yq_stdin_with_stderr(filter, scalar_doc, &[])?;
+        assert_ne!(code, 0, "`{filter}` -- stderr: {stderr:?}");
+        assert!(
+            stderr.contains("invalid escape sequence"),
+            "`{filter}` -- stderr: {stderr}"
+        );
+    }
+
+    Ok(())
+}
+
 /// #2476: the native `//` arm hands the left's surviving outputs -- and the
 /// right's, when the left had none -- straight through as
 /// `OneCursor`/`ManyCursor`, where the bridge used to materialize them into

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -38537,3 +38537,127 @@ fn test_foreach_register_reentry_is_jq_mode_only_on_the_write_side_2161() -> Res
 
     Ok(())
 }
+
+/// #2476, yq twin of `test_ambient_validation_agrees_with_bridge_2476` in
+/// `tests/jq_cli_tests.rs`: the same corpus through the YAML cursor (and, for
+/// the JSON-syntax rows, through yq's own reading of them -- most of the
+/// JSON comma-gap shapes are *valid* YAML plain scalars, so those rows pin
+/// exit 0 on every probe rather than a raise). See the jq test for what the
+/// corpus is for and why agreement alone is not the assertion.
+#[test]
+fn test_ambient_validation_agrees_with_bridge_2476() -> Result<()> {
+    let deep200 = format!("{}1{}\n", "[".repeat(100), "]".repeat(100));
+    // (label, document, expected exit code, expected stderr substring)
+    let corpus: &[(&str, &str, i32, &str)] = &[
+        (
+            "decode failure, mapping value",
+            "a: \"bad\\q\"\n",
+            1,
+            "invalid escape sequence",
+        ),
+        (
+            "decode failure, in flow sequence",
+            "a: [\"bad\\q\"]\n",
+            1,
+            "invalid escape sequence",
+        ),
+        (
+            "decode failure, anchored container (root walk reaches the anchor)",
+            "a: &a [\"bad\\q\"]\nb: *a\n",
+            1,
+            "invalid escape sequence",
+        ),
+        (
+            "decode failure, anchored scalar",
+            "a: &a \"bad\\q\"\nb: *a\n",
+            1,
+            "invalid escape sequence",
+        ),
+        (
+            "decode failure, block sequence",
+            "- \"bad\\q\"\n",
+            1,
+            "invalid escape sequence",
+        ),
+        (
+            "decode failure, root scalar",
+            "\"bad\\q\"\n",
+            1,
+            "invalid escape sequence",
+        ),
+        (
+            "decode failure, nested mapping",
+            "a:\n  b:\n    c: \"bad\\q\"\n",
+            1,
+            "invalid escape sequence",
+        ),
+        (
+            "decode failure, explicitly tagged",
+            "a: !!int \"bad\\q\"\n",
+            1,
+            "invalid escape sequence",
+        ),
+        (
+            "#1642 colliding undecodable keys (JSON syntax)",
+            "{\"\\ud800\":1,\"\\ud800\":2}",
+            1,
+            "is ambiguous",
+        ),
+        (
+            "#1642 single undecodable key (JSON syntax)",
+            "{\"\\ud800\": 1, \"b\": 2}",
+            0,
+            "",
+        ),
+        ("#1194 shape is a valid YAML mapping", "{123: 1}", 0, ""),
+        (
+            "JSON structural error is a valid plain scalar",
+            "[xyz123]",
+            0,
+            "",
+        ),
+        ("JSON trailing comma is valid YAML flow", "[1,]", 0, ""),
+        ("JSON lone comma is valid YAML flow", "[,]", 0, ""),
+        ("duplicate keys (valid)", "a: 1\na: 2\n", 0, ""),
+        ("flow trailing comma", "a: [1,]\n", 0, ""),
+        ("flow mapping trailing comma", "a: {b: 1,}\n", 0, ""),
+        ("deep, within the guard", deep200.as_str(), 0, ""),
+        ("null root", "null\n", 0, ""),
+        ("false root", "false\n", 0, ""),
+        ("well-formed", "a: [1, {b: c}]\n", 0, ""),
+    ];
+    let probes = [
+        "select(.) | 1",
+        "true and true",
+        "false or true",
+        ". and true",
+        "not",
+        "false // 1",
+        "(.a? // 1) | 1",
+    ];
+    for (label, doc, want_code, want_stderr) in corpus {
+        let mut seen: Vec<(String, i32, String)> = Vec::new();
+        for probe in probes {
+            let (_stdout, stderr, code) = run_yq_stdin_with_stderr(probe, doc, &[])?;
+            let first = stderr.lines().next().unwrap_or("").to_string();
+            assert_eq!(
+                code, *want_code,
+                "[{label}] `{probe}`: exit {code}, want {want_code}\nstderr: {stderr}"
+            );
+            assert!(
+                first.contains(want_stderr),
+                "[{label}] `{probe}`: stderr {first:?} lacks {want_stderr:?}"
+            );
+            seen.push((probe.to_string(), code, first));
+        }
+        let (_, ref_code, ref_first) = &seen[0];
+        for (probe, code, first) in &seen[1..] {
+            assert_eq!(
+                (code, first),
+                (ref_code, ref_first),
+                "[{label}] `{probe}` disagrees with `select(.) | 1`"
+            );
+        }
+    }
+    Ok(())
+}


### PR DESCRIPTION
## Summary

Fixes #2476. `and`/`or`/`not`/`//` and zero-arity `any`/`all` were `O(2^N)` on an alias
fan-out document (`aN: &aN [*a(N-1), *a(N-1)]`). The issue's root-cause reading was close but
the mechanism is narrower: the cost is not in the operands at all. Every one of these reached
`eval_single`'s wildcard bridge, whose first act is `to_owned_with_cursor` on the *ambient*
value, so `true and true` and `1+1` at the root cost exactly what `.aN and true` did.
`and`/`or` already had a native arm (#2473) gated on `needs_path_context` purely to keep
#1812's raise on a malformed document (`try (1+1) catch "x"` on `{123: 1}` must exit 5 in jq
mode); `not`/`//`/`any`/`all` had no arm at all.

## Mechanism

`ambient_validation_error`: `push_generic_document_validation_error` over the ambient cursor,
the walk `select(.)`/`if` already use. It is `to_owned_cursor_at_depth`'s own checks without
building a value, and since #1804 it does not descend into a container reached through an
alias, so it is `O(N)` where the bridge was `O(2^N)`. Parity with the bridge was measured, not
assumed: a corpus covering every malformed-document class the checks cover (#1194, #1247,
#1642, #1645, #2211/#2243/#2349, depth guard, both modes, both cursor types) agrees on exit code
and message on every row, and is pinned as `test_ambient_validation_agrees_with_bridge_2476` in
both CLI suites, asserting each row's own expected exit code as well as agreement.

Then, one commit per construct:

- `and`/`or`: gate dropped; `eval_boolean_generic` runs the walk on exactly the shape that used
  to bridge. The path-context shape was already native and is not charged the walk.
- `not`: the truthiness of `.`, negated, via `push_generic_truthiness` (which already runs the
  walk inline for a cursor).
- `//`: `retain_truthy_generic` twin of the eager `retain_truthy`, mirroring `eval_alternative`
  arm for arm (16-row oracle table against jq 1.7.1, all matching). Surviving left outputs keep
  their cursor, so `.a // .b` on YAML keeps anchors, flow style and comments as real yq does,
  and `(key // 1)` operands now read the real position instead of always falling back.
- zero-arity `any`/`all`: validate once over the input, then an early-exit `is_falsy` scan;
  mode split mirrors `builtin_any`/`builtin_all` in order (#1901/#1989). jq mode's object arm
  goes through `effective_fields_checked` because the bridge collapsed duplicate keys and jq
  keeps the last (`{"a":true,"a":false} | any` is `false`, captured live).

No routing table (`needs_path_context`, `path_context_single_native`, `owned_identity_*`,
`path_context_needs_eager`) was touched; #2416's pin at 44 arms is unaffected.

## Behaviour change (one, shared)

#1804's accepted trade-off now covers these constructs at an alias position: a decode failure
reachable only through an alias to a container no longer raises from `.b | not`,
`.b | (. // 1)`, `.b | any`, `.b | (true and true)` on `a: &a ["bad\q"]` / `b: *a`. `.b[0]`,
`.a | not`, `.b and true` (path-context operand) and the scalar-alias sibling still raise. Real
yq rejects the document at parse time, so there is no yq behaviour to match. Recorded in
`docs/compliance/yq/limitations.md` and pinned bidirectionally against a pre-fix binary.

## Measurements (Apple M5 Max, release, interleaved A/B, output identical on every row)

Fan-out, N=20, `succinctly yq`, median of 3:

| filter                  | main    | this PR |
|-------------------------|---------|---------|
| `.a20 and true`         | 1.48s   | 5.4ms   |
| `.a20 or false`         | 1.49s   | 5.5ms   |
| `.a20 \| not`           | 0.73s   | 5.4ms   |
| `(.a20 // 1) \| length` | 1.91s   | 5.4ms   |
| `.a20 \| any`           | 0.84s   | 5.4ms   |
| `.a20 \| all`           | 0.91s   | 5.6ms   |
| `true and true`         | 1.51s   | 5.7ms   |

N=24: `.a24 and true` 42.5s to 7.6ms, `(.a24 // 1) | length` ~40s to ~10ms, `.a24 | any` 13.1s
to 10ms.

Ordinary 2 MB `users` input, 10 reps, median: `select(.active and .score)` -20% (yq) / -28%
(jq), `(.score // 0)` -41% / -54%, `.users | any` -51% / -64%, `.users | all` -53% / -72%,
identity `.` within the +1.2% control-vs-itself noise floor. Faster because the bridge's
materialization was never alias-specific. x86 not measured on this PR; the perf-guard CI legs
cover both architectures.

## Out of scope, filed

- #2658: `any(cond)`, `any(gen; cond)`, `isvalid`, `while`/`until` remain bridged; each carries
  semantics that make it more than a one-arm mirror (audit table in the issue).
- #2659: the `Arithmetic`/`Negate` gate. Tried on this branch and reverted: it flips a #1765 pin
  (`(… ?// … | key) + 0`), which is a #2416 routing decision, not a perf fix.
- Inherent, not fixable here: `[.aN]`, `.aN as $x`, `.aN == .aN`, `-o json` (the output is the
  expanded tree).

## Verification

Each step ran the whole `cargo test --features cli` (7849 passed, 0 failed at the last code
commit), both CI clippy legs with `-D warnings`, `cargo fmt --check`, `cargo doc` with
`-D warnings`; the yq golden suite is unchanged. Perf guard needs valgrind and could not run on
Apple Silicon; CI runs it.
