### PR TITLE
fix(jq): emit recoverable --seq values before a malformed suffix

### DIFF
--- a/docs/compliance/jq/limitations.md
+++ b/docs/compliance/jq/limitations.md
@@ -2900,7 +2900,7 @@ skipped item's decode in the first place. Fixing this needs `Demand` (or an equi
 let a sink mark its own stop as unretryable, which is a real design change rather than a local
 one, so it is tracked separately instead of folded into this fix.
 
-## `--seq`'s malformed-record warnings match jq; the values it prints are still a subset
+## `--seq`'s malformed-record warnings and recoverable values match jq
 
 Real jq warns on stderr ("`jq: ignoring parse error: ...`") whenever it silently drops a
 malformed `--seq` (RFC 7464) record; `succinctly jq` used to drop the record with no
@@ -2959,15 +2959,14 @@ reads `tokenbuf[1]` without consulting `tokenpos`, so a bare `n` is measured aga
 whatever byte an earlier token left behind. `printf '\x1en'` reports `Invalid numeric
 literal`, but the same `n` after an `iu` token reports `Invalid literal`.
 
-**The output side has not changed and still diverges**: real jq emits the values it read
-before the malformed point, while succinctly drops the whole record. Only the diagnostic was
-implemented, so stderr now matches where stdout does not.
+The value path uses the same reader: values jq hands off before a malformed suffix are
+materialized, while values invalidated by the scan call that discovers the error are not.
 
 ```
 $ printf '\x1e1 {invalid\n' | jq            --seq -c '.'   # warns, then prints 1
-$ printf '\x1e1 {invalid\n' | succinctly jq --seq -c '.'   # warns identically, prints nothing
+$ printf '\x1e1 {invalid\n' | succinctly jq --seq -c '.'   # warns, then prints 1
 $ printf '\x1e1,2\n'        | jq            --seq -c '.'   # prints 2
-$ printf '\x1e1,2\n'        | succinctly jq --seq -c '.'   # prints nothing
+$ printf '\x1e1,2\n'        | succinctly jq --seq -c '.'   # prints 2
 ```
 
 Verified by `scripts/jq-seq-oracle-sweep.py`, which compares stderr, stdout and exit code
@@ -3003,17 +3002,15 @@ $ printf '\xef\xbb1 2' | jq --seq -c '.'   # Potentially truncated top-level num
                                           # -- not the abandoned-text template, despite no RS byte anywhere
 ```
 
-`succinctly jq` reproduces all of that on stderr. Its *stdout* still diverges for this shape
-in the pre-existing direction described above: real jq prints the `1` it read, succinctly
-drops the pre-RS content.
+`succinctly jq` reproduces this on both stderr and stdout, including the pre-RS `1` jq reads.
 
 Real-time interleaving of the warnings against stdout is also not reproduced: succinctly
 materializes `--seq` input before evaluating, so all warnings precede all values. jq's
 default block-buffered stdout produces the same ordering, but `jq --unbuffered` does not.
 
-**The divergence from *this* rule is one-directional: succinctly's output is a subset of
-jq's, not a superset** -- 0 superset violations across 6,000 randomly generated single
-records, where `main` has 787.
+The differential guard remains deliberately asymmetric: **0 stdout supersets** across the
+randomized corpus. A fabricated value is a correctness failure even where an unrelated jq
+line-reader artifact still leaves succinctly with extra output.
 
 That is a statement about malformed-record handling, not a guarantee about `--seq` as a
 whole. On multi-record streams a *separate, pre-existing* rule still diverges in the other
@@ -3029,39 +3026,10 @@ $ printf '\x1e"a"\n\x1e"b"\n'| jq --seq -c '.'   # "a" and "b"
 The trigger is a newline appearing *earlier in the stream*: once jq's reader has seen one, a
 later record must itself be newline-terminated to be emitted. succinctly keeps it either way
 (`printf '\x1e0007\n\x1e[]'` is `7` in jq, `7` and `[]` here) -- identical on `main`, so not
-introduced by this work. Measured over 2,000 multi-record streams: 133 such cases here
-against `main`'s 610, the reduction coming entirely from the malformed-record rules above. Reproducing the prefix needs the same thing the diagnostics
-do -- jq's `--seq` reader is a streaming lexer/parser with error recovery, and knowing which
-values survive means knowing where its parser gave up. A token scanner cannot substitute for
-it, and trying was actively harmful: an attempt to emit the prefix by scanning tokens and
-skipping bad ones **fabricated output**, printing values real jq never prints (`\x1e1-2\n`
-became `1` and `-2`, where jq lexes one malformed number and prints nothing). Requiring a
-*pending* token -- a number or bare `true`/`false`/`null`, neither of which carries a closing
-delimiter -- to be confirmed by whitespace or the start of a self-delimiting value is what
-rules that out, at the cost of dropping records jq can partially read. Strings, objects and
-arrays are exempt: they self-terminate, so `\x1e{"a":1}{"b":2}\n` and `\x1e1[1]\n` are two
-values apiece in both tools. Requiring whitespace after *every* token instead, as a first
-draft did, dropped 332 records real jq reads fully.
-
-The same pending-token rule applies at a record boundary, where `\x1etrue\x1e3\n` yields
-only `3` -- a bare literal is as truncatable as a bare number. Both directions are pinned by
-`test_seq_adjacent_tokens_never_fabricate_1723` and
-`test_seq_partially_readable_record_is_dropped_whole_1723`
-([tests/jq_cli_tests.rs](../../../tests/jq_cli_tests.rs)).
-
-A record holding several *well-formed* values is likewise unaffected: #1723 fixed
-`succinctly jq --seq` dropping those in full (`\x1e1 "x" [2]\n` is three outputs, as in real
-jq), which was silent data loss rather than a diagnostic gap.
-
-Emitting the *prefix* of a partially-readable record is what remains. It needs the same
-answer the diagnostics needed — where jq's parser gave up — and
-[`jq_seq_reader`](../../../src/bin/succinctly/jq_seq_reader.rs) now has it, so this is no
-longer blocked on the classification problem; it is deferred on risk. Getting a message
-wrong costs a cosmetic stderr line, while getting an emission wrong fabricates output, which
-is exactly what the reverted attempt above did. Switching the value path onto the same model
-is tracked separately, and should be gated on
-[`scripts/jq-seq-oracle-sweep.py`](../../../scripts/jq-seq-oracle-sweep.py) continuing to
-report zero stdout supersets.
+introduced by this work. The malformed-suffix path no longer shares that divergence: it is
+driven by [`jq_seq_reader`](../../../src/bin/succinctly/jq_seq_reader.rs), with
+[`scripts/jq-seq-oracle-sweep.py`](../../../scripts/jq-seq-oracle-sweep.py) guarding against
+stdout supersets.
 
 A second, narrower gap `succinctly jq --seq` also deliberately stays silent on: `-n`
 combined with a filter that forces a real read (`input`/`inputs`) turns the identical

--- a/src/bin/succinctly/jq_runner.rs
+++ b/src/bin/succinctly/jq_runner.rs
@@ -4074,131 +4074,23 @@ fn remap_ends_to_locations(
 /// a shape jq itself accepts) was a real, jq-observable divergence, not a
 /// spelling nit.
 fn parse_json_seq_with_ends(s: &str) -> Vec<(OwnedValue, usize)> {
-    let bytes = s.as_bytes();
-    const RS: u8 = 0x1e;
-
-    // Byte offset where each `s.split('\x1E')` segment begins: 0, then one
-    // past each RS byte -- enumerates the identical segments, in the
-    // identical order, `s.split('\x1E')` always has (segment 0, anything
-    // before the very first RS byte and ordinarily empty, included).
-    let mut segment_starts = vec![0usize];
-    segment_starts.extend(
-        bytes
-            .iter()
-            .enumerate()
-            .filter(|(_, &b)| b == RS)
-            .map(|(i, _)| i + 1),
-    );
-    let last_idx = segment_starts.len() - 1;
-    // `segment_starts` always holds a leading 0, so more than one entry
-    // means at least one RS byte was found.
-    let has_rs = segment_starts.len() > 1;
-
-    // The stream's own trailing record, when real jq's incremental reader
-    // never resolves it (malformed, or an ambiguous bare number at true
-    // EOF -- see `seq_trailing_record_is_dropped`), is silently dropped
-    let mut results = Vec::new();
-    for (i, &start) in segment_starts.iter().enumerate() {
-        let raw_end = segment_starts
-            .get(i + 1)
-            .map_or(bytes.len(), |&next| next - 1);
-
-        // Full (both-sides) trim to decide parse-eligibility -- matches
-        // the original per-segment `segment.trim()` check exactly.
-        let raw_segment = &s[start..raw_end];
-        let segment = raw_segment.trim();
-        if segment.is_empty() {
-            continue;
-        }
-        // Anything before the *first* RS byte is not a record at all, and
-        // real jq discards it however well-formed it is: `printf '"a"
-        // \x1e3\n' | jq --seq -c .` prints only `3`. Segment 0 is that
-        // prefix whenever the input has an RS byte -- and when it has none,
-        // segment 0 *is* the whole input and #1525's abandonment rule below
-        // owns it instead. (A review caught this: multi-value support made
-        // a pre-existing single-value leak here emit every value in the
-        // prefix, widening the divergence rather than introducing it.)
-        if has_rs && i == 0 {
-            continue;
-        }
-        // *No RS byte anywhere* is #1525's abandonment case: real jq drops
-        // the entire input, however well-formed its content is (`printf
-        // '1 2\n' | jq --seq -c .` prints nothing). Checked *before* the
-        // scan below, which would otherwise tokenize and validate the whole
-        // input only for it to be discarded. With an RS byte present there
-        // is nothing extra to do here -- `seq_record_scan` decides per value
-        // what a record yields, and returns nothing for one it drops.
-        if !has_rs {
-            continue;
-        }
-        // Scanned once and reused -- a review found this record being
-        // re-scanned up to three times, each pass allocating and
-        // re-tokenizing. The *untrimmed* text, so the pending-token rule can
-        // see the whitespace that trimming would remove. `i < last_idx`:
-        // this record is followed by another RS byte, the boundary at which
-        // a bare literal is truncatable.
-        let ranges = seq_record_scan(raw_segment, i < last_idx).values;
-
-        // `ranges` is exactly the set of values `seq_record_scan` decided
-        // this record yields -- empty for one it dropped, so there is no
-        // separate "does this parse" gate here.
-        for &(vs, ve) in &ranges {
+    crate::jq_seq_reader::value_ranges(s.as_bytes())
+        .into_iter()
+        .filter_map(|(start, end)| {
             // #2295: checked, not the bare materializer -- `seq_value_is_valid`
-            // (above, via `seq_record_scan`) already filters most malformed
-            // values via its own designed `validate::validate` depth guard,
-            // but reaching for the checked materializer here too costs
-            // nothing (a delimiter/depth `Err` folds into the same
-            // `else { continue }` a decode failure already takes below) and
-            // removes the reliance on that upstream guard's specific limit
-            // never drifting independently of this one.
-            let Ok(v) = json_bytes_to_owned_value_checked(&raw_segment.as_bytes()[vs..ve]) else {
-                // Parses but will not decode (#1247): dropped, exactly as
-                // the pre-#1723 path dropped it.
-                continue;
-            };
-            // Every value reports its own end. Handing the record's trimmed
-            // end to the *last* range was wrong once the pending-token rule
-            // could pop the real last token: the survivor then inherited a
-            // line past the value that was dropped (a review found
-            // `\x1e"a"\n\n\n2\x1e"z"\n` reporting line 3 where jq reports
-            // line 1). For a single-value record the two are identical
-            // anyway, since a value's end *is* the record's trimmed end.
-            let value_end = start + ve;
-            results.push((v, value_end));
-        }
-        // Genuine parse failures are silently ignored per RFC 7464
-    }
-
-    results
+            // (above, via the reader) already filters malformed values, but
+            // retain the checked materializer as defense in depth.
+            json_bytes_to_owned_value_checked(&s.as_bytes()[start..end])
+                .ok()
+                .map(|value| (value, end))
+        })
+        .collect()
 }
 
-/// Every JSON value a `--seq` record yields, as byte ranges into the record's
-/// *untrimmed* text.
-///
-/// **Conservative by construction: this never emits a value real jq would
-/// not.** A record whose tokens are not cleanly whitespace-separated, or any
-/// of whose tokens is not legal JSON, yields *nothing* -- the pre-#1723
-/// whole-record drop.
-///
-/// That conservatism is the point, and it was learned the hard way. An
-/// earlier version of this function tried to reproduce jq's own resync
-/// (emit the values before a malformed suffix, skip the bad token, carry
-/// on). jq's `--seq` reader is a streaming lexer/parser with error recovery,
-/// and a token scanner cannot imitate it: the attempt **fabricated output**,
-/// emitting values real jq never emits. `\x1e1-2\n` is the clearest case --
-/// jq lexes `1-2` as one malformed number and prints nothing, while a
-/// scanner reads `1` then `-2` and prints both. `\x1e1null\n`, `\x1e12true\n`
-/// and `\x1etrue1\n` all fail the same way, and `\x1e5-3 7\n` printed `-3`
-/// out of the middle of a bad token.
-///
-/// Requiring whitespace after every token is what makes that impossible:
-/// the adjacency a scanner mis-splits is exactly what this rejects. The cost
-/// is that a record jq *can* partially read is dropped instead -- a
-/// divergence in the safe direction, recorded in
-/// `docs/compliance/jq/limitations.md` rather than papered over. Reaching
-/// jq's own answer needs its incremental parser's failure classification,
-/// which is what #1723 asks for and is tracked there.
-fn seq_record_scan(raw_segment: &str, rs_terminated: bool) -> SeqRecordScan {
+/// Whether the final record remains unresolved at EOF. This deliberately
+/// retains only the location-related EOF question; values themselves come
+/// from `jq_seq_reader`, whose scan-call boundaries model jq's recovery.
+fn seq_record_ends_unresolved(raw_segment: &str, rs_terminated: bool) -> bool {
     let bytes = raw_segment.as_bytes();
     let mut values = Vec::new();
     let mut pos = 0;
@@ -4211,10 +4103,10 @@ fn seq_record_scan(raw_segment: &str, rs_terminated: bool) -> SeqRecordScan {
             break;
         }
         let Some(end) = scan_one_json_token(bytes, pos) else {
-            return SeqRecordScan::dropped();
+            return true;
         };
         if !seq_value_is_valid(&raw_segment[pos..end]) {
-            return SeqRecordScan::dropped();
+            return true;
         }
         // The delimiter check, and it applies only to *pending* tokens.
         //
@@ -4236,7 +4128,7 @@ fn seq_record_scan(raw_segment: &str, rs_terminated: bool) -> SeqRecordScan {
                 .get(end)
                 .is_some_and(|b| !b.is_ascii_whitespace() && !matches!(b, b'"' | b'{' | b'['))
         {
-            return SeqRecordScan::dropped();
+            return true;
         }
         values.push((pos, end));
         pos = end;
@@ -4255,33 +4147,7 @@ fn seq_record_scan(raw_segment: &str, rs_terminated: bool) -> SeqRecordScan {
         Some(_) => false,
         None => true,
     };
-    SeqRecordScan {
-        values,
-        trailing_unresolved,
-    }
-}
-
-/// What [`seq_record_scan`] found in one `--seq` record.
-struct SeqRecordScan {
-    /// Byte ranges, into the record's *untrimmed* text, of every value the
-    /// record yields.
-    values: Vec<(usize, usize)>,
-    /// Whether the record ends unresolved -- a malformed record, or one
-    /// whose final value is an ambiguous bare number. This is what leaves
-    /// real jq's incremental parser with no EOF position to report
-    /// (`<unknown>`, #1542), and it is *not* the same question as "yielded
-    /// nothing": `\x1e"a" 2` yields `"a"` and still ends unresolved.
-    trailing_unresolved: bool,
-}
-
-impl SeqRecordScan {
-    /// A record that yields nothing and ends unresolved.
-    fn dropped() -> Self {
-        Self {
-            values: Vec::new(),
-            trailing_unresolved: true,
-        }
-    }
+    trailing_unresolved
 }
 
 /// Whether the token at `start..end` is *pending* -- a number or a bare
@@ -4370,7 +4236,7 @@ fn seq_value_is_valid(value_text: &str) -> bool {
 ///
 /// Two shapes, both silently swallowed by real jq's own `--seq` reader:
 ///
-/// - **Genuinely malformed/truncated** -- [`seq_record_scan`] yields no values
+/// - **Genuinely malformed/truncated** -- the EOF scanner reports unresolved
 ///   (an unterminated string/object, e.g.), matching
 ///   [`parse_json_seq_with_ends`]'s own silent-drop rule (RFC 7464's
 ///   recommended failure mode, #1243).
@@ -4414,7 +4280,7 @@ fn seq_trailing_record_is_dropped(raw: &str) -> bool {
     // (untrimmed) so that rule can see the terminating whitespace.
     // `false`: this is the stream's trailing record by construction, so its
     // end is real EOF, never an RS byte.
-    seq_record_scan(tail, false).trailing_unresolved
+    seq_record_ends_unresolved(tail, false)
 }
 
 /// Whether `--seq -s`'s trailing record, read across every file on the

--- a/src/bin/succinctly/jq_seq_reader.rs
+++ b/src/bin/succinctly/jq_seq_reader.rs
@@ -40,10 +40,10 @@
 //! case-by-case against the pinned `/usr/bin/jq`. The source enumerates
 //! the categories; the binary decides what is actually emitted.
 //!
-//! This module classifies *failures only*. It builds no values and is not
-//! wired to what `--seq` emits on stdout -- that stays with
-//! [`super::jq_runner::seq_record_scan`], whose deliberate conservatism is
-//! documented there and in `docs/compliance/jq/limitations.md`.
+//! Besides diagnostics, the same state machine reports the byte ranges of
+//! values jq hands to its caller.  Keeping those two paths together matters:
+//! a value which looks complete to a token scanner can still be discarded by
+//! the scan call that discovers a malformed suffix (notably `1,2`).
 
 use crate::front_matter::UTF8_BOM;
 
@@ -130,7 +130,19 @@ pub(crate) fn for_each_warning(raw_bytes: &[(Option<usize>, Vec<u8>)], emit: &mu
         == Some(b'\n');
     let mut reader = Reader::new(bom, emit);
     reader.suppress_eof_warning = bom.malformed && ends_with_newline;
-    reader.run(stream_bytes(raw_bytes));
+    reader.run(stream_bytes(raw_bytes).enumerate());
+}
+
+/// Byte ranges of the values jq yields from one complete `--seq` stream.
+/// Ranges are into `bytes`, which must be the same UTF-8-normalized stream
+/// later handed to the materializer.  Diagnostics use the original bytes at
+/// their separate call site, so invalid UTF-8 retains jq's raw-byte columns.
+pub(crate) fn value_ranges(bytes: &[u8]) -> Vec<(usize, usize)> {
+    let bom = bom_prefix(&[(None, bytes.to_vec())]);
+    let mut ignore = |_: &str| {};
+    let mut reader = Reader::new(bom, &mut ignore);
+    reader.run(bytes.iter().copied().enumerate().skip(bom.consumed));
+    reader.values
 }
 
 /// The kinds jq's parser distinguishes while classifying a failure. It
@@ -211,6 +223,17 @@ struct Reader<'a> {
     /// Set by [`Reader::check_done`] when a value was handed off, which is
     /// one of the points jq's reader returns at.
     produced_value: bool,
+    /// The byte offset currently being scanned. `check_literal` finishes
+    /// before its delimiter, while strings and containers finish on the
+    /// current byte, so the completion site records the precise end here.
+    offset: usize,
+    value_start: Option<usize>,
+    value_end: usize,
+    /// A value is only committed after its entire `scan()` call succeeds.
+    /// jq therefore drops the tentative `1` in `1,2`, but has already handed
+    /// off the `1` in `1 {invalid}` when the space scan completed.
+    completed: Option<(usize, usize)>,
+    values: Vec<(usize, usize)>,
     /// See [`for_each_warning`]: a malformed BOM plus a newline-terminated
     /// stream means jq's own EOF report is wiped before it is written.
     suppress_eof_warning: bool,
@@ -236,6 +259,11 @@ impl<'a> Reader<'a> {
             last_ch_was_ws: false,
             resets_per_call: bom.malformed,
             produced_value: false,
+            offset: 0,
+            value_start: None,
+            value_end: 0,
+            completed: None,
+            values: Vec::new(),
             suppress_eof_warning: false,
             emit,
         }
@@ -253,10 +281,15 @@ impl<'a> Reader<'a> {
         self.token_len = 0;
         self.next = None;
         self.st = St::Normal;
+        self.value_start = None;
+        self.completed = None;
     }
 
-    fn run(&mut self, bytes: impl Iterator<Item = u8>) {
-        for ch in bytes {
+    fn run(&mut self, bytes: impl Iterator<Item = (usize, u8)>) {
+        let mut eof_offset = 0;
+        for (offset, ch) in bytes {
+            self.offset = offset;
+            eof_offset = offset + 1;
             if self.st == St::WaitingForRs {
                 if ch == b'\n' {
                     self.line += 1;
@@ -269,6 +302,15 @@ impl<'a> Reader<'a> {
                 }
                 continue;
             }
+            if self.st == St::Normal
+                && self.stack.is_empty()
+                && self.next.is_none()
+                && self.token_len == 0
+                && !ch.is_ascii_whitespace()
+                && ch != ASCII_RS
+            {
+                self.value_start = Some(offset);
+            }
             if let Err(category) = self.scan(ch) {
                 let (line, column) = (self.line, self.column);
                 if ch == ASCII_RS {
@@ -279,12 +321,23 @@ impl<'a> Reader<'a> {
                     ));
                 }
                 self.reset();
-            } else if self.resets_per_call && (self.produced_value || ch == b'\n') {
-                self.reset();
+            } else {
+                self.flush_completed();
+                if self.resets_per_call && (self.produced_value || ch == b'\n') {
+                    self.reset();
+                }
             }
             self.produced_value = false;
         }
+        self.offset = eof_offset;
         self.finish();
+    }
+
+    fn flush_completed(&mut self) {
+        if let Some(range) = self.completed.take() {
+            self.values.push(range);
+            self.produced_value = true;
+        }
     }
 
     /// jq's `scan`.
@@ -331,7 +384,14 @@ impl<'a> Reader<'a> {
             match cls {
                 Cls::Literal => self.token_add(ch),
                 Cls::Whitespace => {}
-                Cls::Quote => self.st = St::Str,
+                Cls::Quote => {
+                    // As with `1[1]`, a pending scalar can be followed by
+                    // an adjacent self-delimiting root string.
+                    if self.stack.is_empty() && self.next.is_none() {
+                        self.value_start = Some(self.offset);
+                    }
+                    self.st = St::Str;
+                }
                 Cls::Structure => self.token_structure(ch)?,
             }
             self.check_done();
@@ -379,7 +439,9 @@ impl<'a> Reader<'a> {
     fn check_done(&mut self) -> bool {
         if self.stack.is_empty() && self.next.is_some() {
             self.next = None;
-            self.produced_value = true;
+            if let Some(start) = self.value_start.take() {
+                self.completed = Some((start, self.value_end));
+            }
             true
         } else {
             false
@@ -404,6 +466,13 @@ impl<'a> Reader<'a> {
                 }
                 if self.next.is_some() {
                     return Err("Expected separator between values");
+                }
+                // A pending scalar can be followed immediately by a
+                // self-delimiting root value (`1[1]`). Its completion was
+                // queued earlier in this scan call; this delimiter begins
+                // the next root value.
+                if self.stack.is_empty() {
+                    self.value_start = Some(self.offset);
                 }
                 self.stack.push(if ch == b'[' {
                     Frame::Array { nonempty: false }
@@ -463,6 +532,7 @@ impl<'a> Reader<'a> {
                 }
                 self.stack.pop();
                 self.next = Some(Kind::Array);
+                self.value_end = self.offset + 1;
             }
             b'}' => {
                 if self.stack.is_empty() {
@@ -489,6 +559,7 @@ impl<'a> Reader<'a> {
                 }
                 self.stack.pop();
                 self.next = Some(Kind::Object);
+                self.value_end = self.offset + 1;
             }
             // Only `classify`'s `Structure` bytes reach this function.
             _ => {}
@@ -537,6 +608,7 @@ impl<'a> Reader<'a> {
             }
         };
         self.value(kind)?;
+        self.value_end = self.offset;
         self.token_len = 0;
         Ok(())
     }
@@ -592,6 +664,7 @@ impl<'a> Reader<'a> {
             }
         }
         self.value(Kind::String)?;
+        self.value_end = self.offset + 1;
         self.token_len = 0;
         Ok(())
     }
@@ -632,10 +705,13 @@ impl<'a> Reader<'a> {
             ));
             return;
         }
-        if !self.last_ch_was_ws && self.next.take() == Some(Kind::Number) {
+        if !self.last_ch_was_ws && self.next == Some(Kind::Number) {
             self.warn(&format!(
                 "Potentially truncated top-level numeric value at EOF at line {line}, column {column}"
             ));
+        } else {
+            self.check_done();
+            self.flush_completed();
         }
     }
 }
@@ -739,6 +815,17 @@ mod tests {
 
     fn assert_warnings(input: &[u8], expected: &[&str]) {
         assert_eq!(warnings(&[input]), expected, "input: {input:?}");
+    }
+
+    /// #2653: values are committed only after the scan call which completed
+    /// them has succeeded. Whitespace commits `1` before a malformed object;
+    /// a comma instead causes the same scan call to fail, so it is discarded.
+    #[test]
+    fn value_ranges_follow_jq_recovery_2653() {
+        assert_eq!(value_ranges(b"\x1e1 {invalid\n"), vec![(1, 2)]);
+        assert_eq!(value_ranges(b"\x1e1,2\n"), vec![(3, 4)]);
+        assert_eq!(value_ranges(b"\x1e1-2\n"), Vec::<(usize, usize)>::new());
+        assert_eq!(value_ranges(b"\x1e5-3 7\n"), vec![(5, 6)]);
     }
 
     /// Every message template, captured from `/usr/bin/jq` 1.7.1. The

--- a/src/bin/succinctly/jq_seq_reader.rs
+++ b/src/bin/succinctly/jq_seq_reader.rs
@@ -74,8 +74,17 @@ pub(crate) struct BomPrefix {
 }
 
 pub(crate) fn bom_prefix(raw_bytes: &[(Option<usize>, Vec<u8>)]) -> BomPrefix {
+    bom_prefix_from(raw_bytes.iter().flat_map(|(_, raw)| raw.iter().copied()))
+}
+
+/// Same rule as [`bom_prefix`], but scanning any byte iterator directly --
+/// so a single already-owned buffer (like `value_ranges`'s) never needs to
+/// be wrapped in a fresh `Vec` just to match [`bom_prefix`]'s multi-source
+/// signature. Only ever reads at most `UTF8_BOM.len() + 1` bytes before
+/// returning, so callers may pass an iterator over arbitrarily large input.
+fn bom_prefix_from(bytes: impl Iterator<Item = u8>) -> BomPrefix {
     let mut consumed = 0;
-    for byte in raw_bytes.iter().flat_map(|(_, raw)| raw.iter().copied()) {
+    for byte in bytes {
         if consumed == UTF8_BOM.len() || byte != UTF8_BOM[consumed] {
             // A mismatch at offset 0 just means "no BOM here"; one after a
             // partial match is the malformed case. Running out of input
@@ -138,7 +147,7 @@ pub(crate) fn for_each_warning(raw_bytes: &[(Option<usize>, Vec<u8>)], emit: &mu
 /// later handed to the materializer.  Diagnostics use the original bytes at
 /// their separate call site, so invalid UTF-8 retains jq's raw-byte columns.
 pub(crate) fn value_ranges(bytes: &[u8]) -> Vec<(usize, usize)> {
-    let bom = bom_prefix(&[(None, bytes.to_vec())]);
+    let bom = bom_prefix_from(bytes.iter().copied());
     let mut ignore = |_: &str| {};
     let mut reader = Reader::new(bom, &mut ignore);
     reader.run(bytes.iter().copied().enumerate().skip(bom.consumed));

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -36013,6 +36013,26 @@ fn test_seq_trailing_unresolved_still_reports_unknown_1723() -> Result<()> {
         ("\x1e\"a\"", "z.json:0", "single resolved value"),
         ("\x1e1", "<unknown>", "single unresolved bare number"),
         ("\x1e{\"a\":1", "<unknown>", "unterminated container"),
+        (
+            "\x1e\"a",
+            "<unknown>",
+            "unterminated string, not just container",
+        ),
+        (
+            "\x1e\"\\uZZZZ\"",
+            "<unknown>",
+            "scans as a complete string but fails strict validation",
+        ),
+        (
+            "\x1e1a",
+            "<unknown>",
+            "pending number token butts against a non-delimiter byte",
+        ),
+        (
+            "\x1etrue",
+            "z.json:0",
+            "bare literal alone at real EOF is still terminated, unlike a number",
+        ),
     ] {
         std::fs::write(&file, input)?;
         let (_out, stderr, _code) =

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -35947,36 +35947,31 @@ fn test_seq_value_error_location_marker_1723() -> Result<()> {
 /// them emitted values.
 #[test]
 fn test_seq_adjacent_tokens_never_fabricate_1723() -> Result<()> {
-    for (input, why) in [
-        ("\x1e1-2\n", "one malformed number, not `1` and `-2`"),
-        ("\x1e1null\n", "not `1` and `null`"),
-        ("\x1e12true\n", "not `12` and `true`"),
-        ("\x1etrue1\n", "not `true` and `1`"),
+    for (input, expected, why) in [
+        ("\x1e1-2\n", "", "one malformed number, not `1` and `-2`"),
+        ("\x1e1null\n", "", "not `1` and `null`"),
+        ("\x1e12true\n", "", "not `12` and `true`"),
+        ("\x1etrue1\n", "", "not `true` and `1`"),
         (
             "\x1e5-3 7\n",
+            "7\n",
             "must not print `-3` out of the middle of a bad token",
         ),
-        ("\x1e1.5true\n", "a fractional number is no different"),
-        ("\x1e0007null\n", "nor is a leading-zero one"),
+        ("\x1e1.5true\n", "", "a fractional number is no different"),
+        ("\x1e0007null\n", "", "nor is a leading-zero one"),
     ] {
         let (stdout, _stderr, code) = run_jq_full(&["--seq", "-c", "."], Some(input))?;
         let stripped: String = stdout.chars().filter(|&c| c != '\u{1e}').collect();
-        assert_eq!(stripped, "", "input {input:?} -- {why}");
+        assert_eq!(stripped, expected, "input {input:?} -- {why}");
         assert_eq!(code, 0, "input {input:?}");
     }
     Ok(())
 }
 
-/// #1723: the cost of never fabricating is that a record jq can *partially*
-/// read is dropped whole.
-///
-/// Recorded as a test, not just prose, so the divergence is visible and its
-/// direction is pinned: succinctly's output is always a subset of jq's here,
-/// never a superset. Reaching jq's own answer needs its incremental parser's
-/// failure classification, which is what #1723 still tracks.
+/// #2653: a malformed suffix preserves values jq handed off before it.
 #[test]
-fn test_seq_partially_readable_record_is_dropped_whole_1723() -> Result<()> {
-    for (input, jq_would_emit) in [
+fn test_seq_partially_readable_record_emits_jq_prefix_2653() -> Result<()> {
+    for (input, expected) in [
         ("\x1e1 {invalid\n", "1"),
         ("\x1e1,2\n", "2"),
         ("\x1e} 5\n", "5"),
@@ -35985,8 +35980,9 @@ fn test_seq_partially_readable_record_is_dropped_whole_1723() -> Result<()> {
         let (stdout, _stderr, code) = run_jq_full(&["--seq", "-c", "."], Some(input))?;
         let stripped: String = stdout.chars().filter(|&c| c != '\u{1e}').collect();
         assert_eq!(
-            stripped, "",
-            "input {input:?}: dropped whole; real jq emits {jq_would_emit}"
+            stripped,
+            format!("{expected}\n"),
+            "input {input:?}: jq emits {expected}"
         );
         assert_eq!(code, 0, "input {input:?}");
     }


### PR DESCRIPTION
## Summary
- `succinctly jq --seq` now materializes the value(s) real jq hands off before a malformed record's error point, instead of dropping the whole record (#2653). Wires `parse_json_seq_with_ends` onto `jq_seq_reader`'s state machine, which already models jq's incremental parser for the #1723 diagnostics, so classification and emission share one source of truth instead of drifting.
- Retires `seq_record_scan`'s deliberate whole-record-drop conservatism and the pending-token delimiter rule that existed only to make a token scanner safe.
- Follow-up perf fix: `value_ranges` was cloning the entire `--seq` input into a `Vec` just to match `bom_prefix`'s multi-file signature, for a BOM check that only ever reads a handful of bytes. Split out an iterator-generic `bom_prefix_from` so it scans the existing buffer instead.

## Test plan
- [x] `cargo test --features cli` (full suite, incl. doctests) — all green
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean
- [x] `./scripts/jq-seq-oracle-sweep.py --cases 3000` (two different seeds) — `stderr_mismatch=0 stdout_superset=0`, the gate #2653 asked for
- [x] Manually diffed several cases against the pinned `/usr/bin/jq` 1.7.1 oracle, including the issue's own examples and the pre-existing unrelated newline/multi-record divergence documented in `docs/compliance/jq/limitations.md` (confirmed still isolated, unaffected by this change)