### PR TITLE
fix(yq): capture a bare sequence item's own trailing comment (#1079)

### DIFF
--- a/src/yaml/light.rs
+++ b/src/yaml/light.rs
@@ -353,11 +353,16 @@ impl<'a, W: AsRef<[u64]>> YamlCursor<'a, W> {
     /// the mapping/sequence node in place of its own first field (#835).
     ///
     /// [`Self::anchor`], [`Self::explicit_tag`], [`Self::style`], and the
-    /// `line_comment*` family all call this internally, so callers of those
-    /// never need to resolve first. [`Self::first_child`] deliberately does
-    /// **not** self-resolve (this method's own `first_child()` call below
-    /// would recurse), so a caller walking a value's fields/elements via
-    /// `first_child()` — [`is_yaml_cursor_container`],
+    /// `line_comment*` family deliberately do **not** call this internally
+    /// (each reads `self.bp_pos`/`self.index` directly — see their own doc
+    /// comments) since they're called on the hot per-field/per-item render
+    /// path where the caller already resolved `self`; paying to resolve
+    /// again there measured as a real streaming regression. Their callers
+    /// resolve at their own cursor's extraction point instead — see
+    /// `YamlElements`' `DocumentElements` impl. [`Self::first_child`]
+    /// likewise does **not** self-resolve (this method's own `first_child()`
+    /// call below would recurse), so a caller walking a value's
+    /// fields/elements via `first_child()` — [`is_yaml_cursor_container`],
     /// [`Self::stream_yaml_value`]'s `Mapping` arm, `merge_sources`,
     /// [`Self::write_leading_anchor`] — must still call this explicitly.
     ///
@@ -2026,18 +2031,40 @@ impl<'a, W: AsRef<[u64]>> YamlCursor<'a, W> {
                     // Block style
                     let mut first = true;
                     let mut elems = elements;
-                    // `uncons_resolved_cursor`, not `uncons_cursor`: this
-                    // loop reads `is_yaml_cursor_container`/`first_child`-
-                    // shaped properties of each item's *value*, so a bare
-                    // `-` item needs to already be resolved past its
-                    // sequence-item wrapper before it gets here — see
-                    // `uncons_resolved_cursor`'s own doc comment (#835).
-                    while let Some((cursor, rest)) = elems.uncons_resolved_cursor() {
+                    // `uncons_raw_cursor` + an explicit
+                    // `resolve_bare_seq_item`, rather than
+                    // `uncons_resolved_cursor` directly: this loop needs
+                    // both the true, never-unwrapped wrapper cursor -- to
+                    // read a bare item's own trailing comment off the
+                    // wrapper's bp (#1079; `uncons_cursor`'s own inline
+                    // heuristic isn't good enough here, see
+                    // `uncons_raw_cursor`'s doc comment) -- and the
+                    // resolved value cursor for the
+                    // `is_yaml_cursor_container`/`first_child`-shaped
+                    // properties it already read here before (#835). Same
+                    // one resolve per element either way.
+                    while let Some((raw, rest)) = elems.uncons_raw_cursor() {
+                        let cursor = raw.resolve_bare_seq_item();
                         if !first {
                             out.write_char('\n')?;
                             out.write_str(indent)?;
                         }
                         first = false;
+                        // A comment captured on a bare `-` wrapper itself
+                        // (#1079) -- only present when this item really was
+                        // a bare wrapper whose value deferred to the next
+                        // line; `raw.line_comment_raw()` reads
+                        // `raw.bp_position()` directly without resolving
+                        // (see `resolve_bare_seq_item`'s doc comment above,
+                        // corrected in this same change), so comparing
+                        // positions is what tells a real deferred item
+                        // apart from an already-compact one (`- x` on one
+                        // line, where `uncons_cursor` already returns the
+                        // value's own cursor and the two positions are
+                        // equal).
+                        let wrapper_comment = (raw.bp_position() != cursor.bp_position())
+                            .then(|| raw.line_comment_raw())
+                            .flatten();
                         // A non-empty, non-flow mapping/sequence value
                         // renders in real yq's "compact" form: `- ` shares
                         // its line with the value's own first field/element,
@@ -2070,7 +2097,33 @@ impl<'a, W: AsRef<[u64]>> YamlCursor<'a, W> {
                             // alias node is never a container), so `None`
                             // skips a second resolve.
                             let tag = cursor.explicit_tag_at(None);
-                            if anchor.is_some() || tag.is_some() {
+                            if let Some(comment) = wrapper_comment {
+                                // #1079: the item's own trailing comment
+                                // (no anchor -- `wrapper_comment` and a
+                                // property-prefixed item are mutually
+                                // exclusive; the parser only captures this
+                                // slot when `had_property == false`) stays
+                                // on the dash's own line, then the
+                                // container's content starts on the next
+                                // one -- same shape as the anchor/tag arm
+                                // below, comment in place of `&anchor`/
+                                // `!!tag`.
+                                out.write_char('-')?;
+                                out.write_char(' ')?;
+                                out.write_str(comment)?;
+                                out.write_char('\n')?;
+                                let child_indent = compact_yaml_indent(indent);
+                                out.write_str(&child_indent)?;
+                                cursor.stream_yaml_value(
+                                    out,
+                                    &child_indent,
+                                    indent_spaces,
+                                    unit,
+                                    sort_keys,
+                                    true,
+                                    recursion_base,
+                                )?;
+                            } else if anchor.is_some() || tag.is_some() {
                                 out.write_char('-')?;
                                 write_anchor_tag(out, anchor, tag)?;
                                 out.write_char('\n')?;
@@ -2135,6 +2188,28 @@ impl<'a, W: AsRef<[u64]>> YamlCursor<'a, W> {
                             // "compact" in real yq, deferred scalar values
                             // included -- `compact_yaml_indent`, not
                             // `deeper_yaml_indent`, is the right step here.
+                            if let Some(comment) = wrapper_comment {
+                                // #1079: real yq attaches a bare item's own
+                                // comment to the scalar node it defers to
+                                // (case C) -- an absent (null) value has no
+                                // node to attach it to and instead floats
+                                // it forward onto the next sibling item
+                                // (case D), which needs a multi-valued
+                                // head/line/foot comment slot this codebase
+                                // doesn't have yet (#798 PR2); only write
+                                // it here when the value actually
+                                // materializes. Gated on
+                                // `wrapper_comment.is_some()` (rare), so
+                                // this second `.value()` resolve -- on top
+                                // of the one `write_deferred_value` below
+                                // does internally -- only costs anything on
+                                // items that already carry this comment.
+                                if !is_deferred_value_absent_at(&cursor.value()) {
+                                    out.write_str(comment)?;
+                                    out.write_char('\n')?;
+                                    out.write_str(indent)?;
+                                }
+                            }
                             out.write_char('-')?;
                             let child_indent = compact_yaml_indent(indent);
                             write_deferred_value(
@@ -2145,7 +2220,32 @@ impl<'a, W: AsRef<[u64]>> YamlCursor<'a, W> {
                                 unit,
                                 sort_keys,
                             )?;
-                            write_line_comment(out, cursor.line_comment_raw())?;
+                            // A bare `- # c` item with nothing at all after
+                            // it (no key, no nested value) shares its bp
+                            // with the wrapper -- same as a genuine compact
+                            // scalar (`- foo # own`), since neither opens a
+                            // separate child node. `raw == cursor` covers
+                            // both shapes; only the absent one is a comment
+                            // `maybe_capture_line_comment` stashed here
+                            // earlier in this branch as a head-comment
+                            // slot (#1079), not a real same-line trailing
+                            // comment on a materialized node -- and real yq
+                            // never renders that inline either way (it
+                            // relocates or floats forward, #798 PR2), so
+                            // suppress it here instead of misrendering it.
+                            // A compact scalar's own genuine comment
+                            // (`is_deferred_value_absent_at` false there)
+                            // is unaffected.
+                            let own_comment = cursor.line_comment_raw();
+                            let own_comment = if own_comment.is_some()
+                                && raw.bp_position() == cursor.bp_position()
+                                && is_deferred_value_absent_at(&cursor.value())
+                            {
+                                None
+                            } else {
+                                own_comment
+                            };
+                            write_line_comment(out, own_comment)?;
                         }
                         elems = rest;
                     }
@@ -5103,6 +5203,35 @@ impl<'a, W: AsRef<[u64]>> YamlElements<'a, W> {
     pub fn uncons_resolved_cursor(&self) -> Option<(YamlCursor<'a, W>, Self)> {
         let (cursor, rest) = self.uncons_cursor()?;
         Some((cursor.resolve_bare_seq_item(), rest))
+    }
+
+    /// Like [`Self::uncons_cursor`], but never applies its same-line
+    /// "inline" heuristic ([`starts_inline_seq_entry`]) — always returns
+    /// the element exactly as stored, before any unwrapping.
+    ///
+    /// `uncons_cursor`'s heuristic only checks the byte immediately after
+    /// the `-` (a space or tab), which is true for `- # comment` just as
+    /// much as for `- foo` — a trailing comment with nothing else on the
+    /// line is not "content on the same line" in the sense that heuristic
+    /// means, but it satisfies the check anyway, so `uncons_cursor` already
+    /// unwraps past the wrapper for that shape before a caller ever sees
+    /// it. A caller that needs the wrapper's own bp itself — to read a
+    /// comment captured there when the value is genuinely deferred
+    /// (#1079) — needs this instead, then can call
+    /// [`YamlCursor::resolve_bare_seq_item`] itself for the resolved
+    /// value; that method's own `starts_seq_entry` check (unlike
+    /// `starts_inline_seq_entry`) doesn't need to distinguish same-line
+    /// from deferred at all — it unwraps whenever the wrapper structurally
+    /// has a child, which is the same outcome `uncons_cursor` +
+    /// `resolve_bare_seq_item` (i.e. [`Self::uncons_resolved_cursor`])
+    /// already produces for every other cursor shape.
+    #[inline]
+    pub(crate) fn uncons_raw_cursor(&self) -> Option<(YamlCursor<'a, W>, Self)> {
+        let element_cursor = self.element_cursor?;
+        let rest = YamlElements {
+            element_cursor: element_cursor.next_sibling(),
+        };
+        Some((element_cursor, rest))
     }
 
     /// Get the first element and the remaining elements.

--- a/src/yaml/parser.rs
+++ b/src/yaml/parser.rs
@@ -2359,14 +2359,18 @@ impl<'a, const HAS_CR: bool> Parser<'a, HAS_CR> {
 
         // Open the sequence item node
         self.write_bp_open_seq_item();
-        // Deliberately not a `take_pending_head_comment` call site (#784):
-        // this wrapper's own bp is never what the emitter reads for a
-        // trailing comment on this line — a plain-scalar item's line
-        // comment lives on the *scalar's* own bp (see the `take_pending_head_comment`
-        // call after `parse_value` below), and any other continuation
-        // (compact-mapping key, a nested `parse_mapping_entry`/
-        // `parse_sequence_item` reached via a fresh line dispatch) claims it
-        // at its own, already-instrumented key/wrapper-open site instead.
+        // Not a `take_pending_head_comment` call site (#784): a
+        // plain-scalar item's line comment lives on the *scalar's* own bp
+        // (see the `take_pending_head_comment` call after `parse_value`
+        // below), and any other continuation (compact-mapping key, a
+        // nested `parse_mapping_entry`/`parse_sequence_item` reached via a
+        // fresh line dispatch) claims it at its own, already-instrumented
+        // key/wrapper-open site instead. The wrapper's own bp *is* read for
+        // a bare item's (`had_property == false`) trailing comment when its
+        // value is deferred to the next line (#1079, below) — that comment
+        // has no node of its own yet, so the wrapper is the only bp
+        // available to key it against.
+        let wrapper_bp = self.last_open_bp_pos;
 
         // Skip `- `
         self.advance(); // -
@@ -2402,11 +2406,21 @@ impl<'a, const HAS_CR: bool> Parser<'a, HAS_CR> {
         if self.at_line_end() {
             // A trailing comment here belongs to this item's own deferred
             // value, not to the item's dash line (#784, same shape as
-            // `parse_mapping_entry`'s anchor case) - only when there was a
-            // property to defer it past; a bare `- # comment` has no anchor
-            // to blame the deferral on and is a separate, untouched gap.
+            // `parse_mapping_entry`'s anchor case). A property-prefixed
+            // item defers it past the property (`defer_line_comment`,
+            // #784); a bare item has no property to defer past, so it's
+            // captured against the item wrapper's own bp instead (#1079) —
+            // the emitter only renders it when the deferred value
+            // materializes into a real node (a mapping, nested sequence, or
+            // scalar). An absent (null) value has nothing to attach it to
+            // and the comment is dropped here, matching current behavior —
+            // real yq floats it forward onto the next sibling item instead,
+            // which needs a multi-valued head/line/foot comment slot this
+            // codebase doesn't have yet (#798 PR2).
             if had_property {
                 self.defer_line_comment();
+            } else {
+                self.maybe_capture_line_comment(wrapper_bp);
             }
 
             // An anchor records the *next* BP position as its target, and a

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -14442,6 +14442,129 @@ fn test_defer_line_comment_does_not_overwrite_already_pending_784() -> Result<()
 }
 
 // ============================================================================
+// Bare (no-anchor) sequence item's own trailing comment (#1079)
+// ============================================================================
+//
+// #784 (above) fixed this shape for a *property-prefixed* item (`- &x # c`);
+// this is the sibling gap for a *bare* item (`- # c`), same as #765 fixed
+// the mapping-key equivalent. Scoped to the three shapes where the deferred
+// value materializes into a real node - a mapping, a nested sequence, or a
+// scalar - since the comment is a `head_comment` on whichever node the
+// value contributes, per the issue's own oracle triage. An *absent* (null)
+// deferred value has no node to attach to; real yq instead floats the
+// comment forward onto the next sibling item that does exist, which needs a
+// multi-valued head/line/foot comment slot this codebase doesn't have yet
+// (#798 PR2) - that family stays exactly as it was (comment dropped), not a
+// regression, just not fixed here. Every expected string below was verified
+// byte-for-byte against the pinned real `yq` binary before being pinned.
+
+/// The issue's own repro: a bare item's trailing comment, value deferred to
+/// a nested mapping.
+#[test]
+fn test_bare_item_comment_preserved_with_nested_mapping_value_1079() -> Result<()> {
+    let (out, code) = run_yq_stdin(".", "- # comment\n  b: 1\n", &[])?;
+    assert_eq!(code, 0);
+    assert_eq!(out, "- # comment\n  b: 1\n");
+    Ok(())
+}
+
+/// Same shape, but the mapping has more than one field - the comment stays
+/// on the dash's own line regardless of how many fields follow.
+#[test]
+fn test_bare_item_comment_preserved_with_multi_field_mapping_value_1079() -> Result<()> {
+    let (out, code) = run_yq_stdin(".", "- # comment\n  b: 1\n  d: 2\n", &[])?;
+    assert_eq!(code, 0);
+    assert_eq!(out, "- # comment\n  b: 1\n  d: 2\n");
+    Ok(())
+}
+
+/// Same shape, but the deferred value is a nested sequence rather than a
+/// nested mapping.
+#[test]
+fn test_bare_item_comment_preserved_with_nested_sequence_value_1079() -> Result<()> {
+    let (out, code) = run_yq_stdin(".", "- # comment\n  - 1\n", &[])?;
+    assert_eq!(code, 0);
+    assert_eq!(out, "- # comment\n  - 1\n");
+    Ok(())
+}
+
+/// A bare item nested inside a mapping field - the comment stays on the
+/// dash's own line at the item's own indent, not the outer key's.
+#[test]
+fn test_bare_item_comment_preserved_with_nested_container_value_1079() -> Result<()> {
+    let (out, code) = run_yq_stdin(".", "a:\n  - # comment\n    b: 1\n", &[])?;
+    assert_eq!(code, 0);
+    assert_eq!(out, "a:\n  - # comment\n    b: 1\n");
+    Ok(())
+}
+
+/// The deferred value is a plain scalar rather than a container - real yq
+/// relocates the comment to its own standalone line at the item's own
+/// indent (column 0 at the top level), *above* the dash, rather than
+/// keeping it inline after `-`.
+#[test]
+fn test_bare_item_comment_relocates_above_scalar_value_1079() -> Result<()> {
+    let (out, code) = run_yq_stdin(".", "- # comment\n  x\n", &[])?;
+    assert_eq!(code, 0);
+    assert_eq!(out, "# comment\n- x\n");
+    Ok(())
+}
+
+/// Same shape, nested inside a mapping field - the relocated comment lands
+/// at the item's own (nested) indent, not column 0.
+#[test]
+fn test_bare_item_comment_relocates_above_nested_scalar_value_1079() -> Result<()> {
+    let (out, code) = run_yq_stdin(".", "a:\n  - # comment\n    x\n", &[])?;
+    assert_eq!(code, 0);
+    assert_eq!(out, "a:\n  # comment\n  - x\n");
+    Ok(())
+}
+
+/// The scalar value has its *own* trailing comment too - both survive,
+/// distinct bp slots (the item wrapper's vs. the scalar's own).
+#[test]
+fn test_bare_item_comment_and_own_scalar_comment_both_survive_1079() -> Result<()> {
+    let (out, code) = run_yq_stdin(".", "- # comment\n  x # own\n", &[])?;
+    assert_eq!(code, 0);
+    assert_eq!(out, "# comment\n- x # own\n");
+    Ok(())
+}
+
+/// Real `yq` doesn't expose this comment through any getter, matching
+/// #765's own equivalent pin (`test_key_comment_not_exposed_via_line_comment_getter_765`) -
+/// it only survives via full-tree re-serialization. `line_comment` on the
+/// value (`.[0]`) or a descendant (`.[0].b`) must stay blank.
+#[test]
+fn test_bare_item_comment_not_exposed_via_line_comment_getter_1079() -> Result<()> {
+    let input = "- # comment\n  b: 1\n";
+
+    let (out, code) = run_yq_stdin(".[0] | line_comment", input, &[])?;
+    assert_eq!(code, 0);
+    assert_eq!(out, "\n");
+
+    let (out, code) = run_yq_stdin(".[0].b | key | line_comment", input, &[])?;
+    assert_eq!(code, 0);
+    assert_eq!(out, "\n");
+
+    Ok(())
+}
+
+/// Known residual, out of scope for this fix: when the deferred value is
+/// *absent* (null - a sibling item follows at the same or lower indent),
+/// real yq floats the comment forward onto that sibling instead of
+/// attaching it here, which needs #798 PR2's multi-valued comment slot.
+/// Pinned as still-dropped (not the corrupted `- # c` inline rendering an
+/// earlier version of this fix produced) so a future #798 PR2 change has to
+/// deliberately update this test rather than silently drift.
+#[test]
+fn test_bare_item_comment_still_dropped_when_value_absent_1079() -> Result<()> {
+    let (out, code) = run_yq_stdin(".", "- # comment\n- 2\n", &[])?;
+    assert_eq!(code, 0);
+    assert_eq!(out, "-\n- 2\n");
+    Ok(())
+}
+
+// ============================================================================
 // Explicit-key (`? k ... : v`) trailing comment (#795)
 // ============================================================================
 //


### PR DESCRIPTION
## Summary

- A bare `- ` sequence item (no anchor) whose value is deferred to the next
  line dropped its trailing comment entirely — #765 fixed this exact shape
  for mapping keys, but the sequence-item sibling gap (noted while
  implementing #784) was left untouched.
- Scoped to the cases where the deferred value materializes into a real
  node — a mapping, a nested sequence, or a scalar — per the issue's own
  oracle triage (the comment is always a `head_comment` on whichever node
  the value contributes). The absent-value family (a sibling item follows
  immediately, or end-of-document) has no node to attach to; real yq floats
  the comment forward instead, which needs #798 PR2's multi-valued
  head/line/foot comment slot this codebase doesn't have yet — left as a
  pinned, unchanged residual (comment still dropped, not corrupted).
- Also fixes a bug this surfaced along the way: `YamlElements::uncons_cursor`'s
  own same-line "inline" heuristic only checks the byte immediately after
  the `-` (a space or tab), which is true for `- # comment` just as much as
  for real inline content like `- foo` — so it already unwraps past the item
  wrapper for a comment-only line before the emitter ever gets a chance to
  read the wrapper's own bp. Added `YamlElements::uncons_raw_cursor` to
  bypass that heuristic for the one caller that genuinely needs the raw,
  never-unwrapped wrapper cursor.
- Fixed a stale doc comment on `resolve_bare_seq_item` that inaccurately
  claimed several accessors (`anchor`, `explicit_tag`, `style`,
  `line_comment*`) self-resolve through it — each of those already
  documents, correctly, that it does not.

Every new/changed output below was verified byte-for-byte against the
pinned real `yq` v4.53.3.

## Test plan

- [x] `cargo test --features cli` — full suite (60 binaries) passes, no
      regressions
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean
- [x] New `tests/yq_cli_tests.rs` `..._1079` tests: mapping value, nested
      sequence value, nested container, multi-field mapping, scalar value
      relocation (top-level and nested), own-comment coexistence,
      `line_comment` getter invisibility, and a pinned residual for the
      out-of-scope absent-value shape
- [x] Existing `_784` (anchored sequence-item) and `_765` (mapping-key)
      regression guards still pass byte-identical
- [x] Manually diffed every oracle probe from the issue against real `yq`
      after the fix
- [ ] Interleaved A/B perf check (`yaml_bench sequences` / `dev bench yq`)
      not yet run on pinned hardware — flagging for a maintainer/CI perf
      gate to confirm; expected neutral (one extra `get_line_comment`
      lookup per bare-wrapper item, plus a second `.value()` resolve gated
      behind actually finding a comment)

Closes cases A/B/C of #1079; the absent-value family (D/E/K/L/O/R) stays
open, blocked on #798 PR2.