### PR TITLE
feat(jq): pull a path-mode fold's source by demand (#2235)

### DIFF
--- a/docs/compliance/jq/limitations.md
+++ b/docs/compliance/jq/limitations.md
@@ -893,7 +893,7 @@ adds the register threading that closes it instead of reopening it; re-run again
 succeeds" count for this whole fold-source area dropped from 67 to 3, with no increase in any
 other divergence category.
 
-Four residual divergences remain in this area:
+Five residual divergences remain in this area:
 
 - **A fold source whose navigation is discarded by a later non-navigating stage still
   clobbers jq's real path register, undetected.** `path(foreach (.a|tostring) as $k (.; .a))`
@@ -919,6 +919,19 @@ Four residual divergences remain in this area:
   it cannot stop the fold (`[limit(1; path(foreach (1 as $x ?// $y | (stderr|1)) as $v (.;
   .)))]` is `[[],[]]` with two writes in jq — its `limit` break is retried by the source's
   `?//` and the retried output lands past the bound — and `[[]]` with one write here).
+- **`recurse(f)`/`recurse(f; cond)` still collects one node's own `f` in full.**
+  `resolve_recurse_sink` (#2235) streams each visited node to a bounded consumer as soon as
+  it is popped, and defers `f`/`cond` for a node until its own delivery is accepted — so
+  `path(limit(1; recurse(if (.|debug) < 3 then .+1 else empty end)))` now runs `debug` zero
+  times in both jq and here, where the pre-#2235 collecting version ran it for every node up
+  to `RECURSE_MAX_ITEMS` regardless of the bound. What remains: `f` itself is still resolved
+  for an accepted node via `resolve_against_cow`, not streamed, so a multi-output `f`'s later
+  outputs fire even when only the first is ever consumed — confirmed live,
+  `path(limit(2; recurse((.a|debug), (.b|debug))))` on `{"a":1,"b":2}` writes `debug` for
+  `.a` only in jq (the bound is satisfied by `.a`'s own self-emission before `.b` is ever
+  asked for); both fire here. Same underlying cause as the bullet above — `resolve_against_cow`
+  has no sink form either — narrower in practice since it only over-fires a node's own
+  later `f` outputs, not an entire subtree.
 - **`E[K]` evaluates its target once where jq re-runs it per key.** jq compiles `E[K]` as
   `K as $k | E | .[$k]`, so a side effect in `E` fires once per output of `K`; here it fires
   once total — `[(.[] | stderr)[("a","b")]?]` on `[1,2]` writes `1212` in jq and `12` here.

--- a/docs/compliance/jq/limitations.md
+++ b/docs/compliance/jq/limitations.md
@@ -798,13 +798,15 @@ blames. That is the same catch-all wording every unresolvable filter already get
 is the general message-fidelity gap covered above, not a fold-specific one.
 
 **Fixed by [#1467](https://github.com/rust-works/succinctly/issues/1467),
-[#1872](https://github.com/rust-works/succinctly/issues/1872) and
-[#2031](https://github.com/rust-works/succinctly/issues/2031):** the fold's **source
+[#1872](https://github.com/rust-works/succinctly/issues/1872),
+[#2031](https://github.com/rust-works/succinctly/issues/2031) and
+[#2235](https://github.com/rust-works/succinctly/issues/2235):** the fold's **source
 expression** is now evaluated the same way jq evaluates it — `resolve_reduce`/
-`resolve_foreach` route the source through `resolve_fold_source`, which resolves it with
-tracking on via `resolve_node`, but only when the source's own AST contains a real
-navigation step (`Field`/`Index`/`Slice`/`Iterate`) anywhere — checked via `any_subexpr` —
-since only those can ever reach one of `resolve_node`'s raising arms in the first place. jq
+`resolve_foreach` route the source through `drive_fold_source`, which resolves it with
+tracking on via `resolve_node_sink`, one element at a time as the fold consumes them, but
+only when the source's own AST contains a real navigation step
+(`Field`/`Index`/`Slice`/`Iterate`) anywhere — checked via `any_subexpr` — since only those
+can ever reach one of `resolve_node`'s raising arms in the first place. jq
 evaluates the source "with tracking on" and fails only where it navigates *through* an
 untrackable value, so `reduce (1,2) / (.a) / (.[]) / (keys) / (range(2)) as $i (0; $x)` all
 resolve in both, and `reduce (keys[]) as $k (.; .)` raises "near attempt to iterate through"
@@ -812,18 +814,22 @@ in both too (live-verified against jq 1.7.1, both the `path(...)` read side and 
 `(reduce ...) = 9` write side).
 
 A source with no navigation step (`range(n)`, `keys`, a literal, or critically
-`input`/`inputs`) skips the resolver entirely and its values come from
-`eval_owned_expr_fork` as they always did. That gate is not an optimization: an earlier,
-ungated version of #1467's check evaluated an `input`/`inputs`-sourced fold *twice* — once
-for the check, once for the real value — silently desynchronizing the two evaluations'
-shared input-reader position, so the fold ran against the *second* input document while
-reporting an error that named the first (`reduce input as $x (0; $x)` over `10\n20\n30\n`:
-real jq names `10`, the ungated version named `20`). Caught in code review before merging.
+`input`/`inputs`) skips the resolver entirely and is driven by value through
+`eval_each_owned`, the same demand-driven producer the value evaluator uses. That gate is
+not an optimization: an earlier, ungated version of #1467's check evaluated an
+`input`/`inputs`-sourced fold *twice* — once for the check, once for the real value —
+silently desynchronizing the two evaluations' shared input-reader position, so the fold ran
+against the *second* input document while reporting an error that named the first (`reduce
+input as $x (0; $x)` over `10\n20\n30\n`: real jq names `10`, the ungated version named
+`20`). Caught in code review before merging. Since #2235 the gate is also what keeps
+`inputs` lazy: the resolver's leaf collects a generator before delivering it, where
+value-mode `each_inputs` pulls one document per demand (`[try path(foreach inputs as $i (.;
+error("u"))) catch .], input` over `1 2 3` answers `["u"]` then `2` in both).
 
 A source that *does* navigate is resolved **once**, in jq mode, and — when every resolved
 branch is *untracked* — those branches' values are the fold's real values; `Keep::AtMost`
 makes `resolve_leaf`'s general case keep every output rather than #987's first one. That
-closes both of #1467's original costs:
+closed both of #1467's original costs:
 
 1. A navigating source's outputs fire their side effects exactly as often as in jq: `. as $x
    | path(reduce (.[] | stderr) as $i (0; $x))` on `[1]` writes `1` once in both (measured
@@ -831,16 +837,36 @@ closes both of #1467's original costs:
    two-pass shape wrote it twice.
 2. `foreach` keeps the outputs a source legitimately streamed before the element that
    raises: `path(foreach (1,2,keys[]) as $k (.; .))` on `{"a":1}` streams `[]` twice before
-   raising, matching jq. The escape is carried out of `resolve_fold_source` *with* those
-   values and applied by `resolve_foreach`'s own per-element loop afterwards, exactly as it
-   already did for an ordinary `Partial` source. `reduce`'s output is single-shot, so it
-   still raises with nothing.
+   raising, matching jq. The escape is applied after the drive, once every element before
+   it has been folded. `reduce`'s output is single-shot, so it still emits nothing — but
+   since #2235 its prefix steps run first, as jq's do: `path(reduce (1,2,error("s")) as $i
+   (.; stderr))` on `{"a":1}` writes the state twice and then raises `s` in both.
 
 Keeping every output also made the check itself accurate. A stop-after-first resolver could
 miss the navigation entirely when it happened on a later output of the same leaf:
 `path(foreach (range(3) | (., if . == 2 then .a else empty end)) as $k (.; .))` on `{"a":1}`
 reported the untracked `Cannot index number with string "a"` where jq reports the tracked
 `near attempt to access element "a" of 2`; both now agree.
+
+**Since [#2235](https://github.com/rust-works/succinctly/issues/2235) the source is pulled by
+demand, and the resolver's stream is the fold's stream.** Until then `drive_fold_source`'s
+predecessor collected every resolved branch before the fold ran a single step, so a source's
+side effects all fired before the first step could refuse: `. as $x | path(foreach (.[] |
+stderr) as $i (0; $x))` on `[1,2,3]` wrote `123` where jq writes `1` once and raises on the
+first step's own untrackable emission. Three things had to move together. The source is
+resolved through `resolve_node_sink`, each element folded inside the sink before the next is
+pulled; the folds themselves emit through a sink, so `path()`'s terminal check
+(`resolve_terminal`) refuses the first untracked output before the fold pulls again; and the
+old fallback that re-evaluated an *erroring* source untracked (any escape that was neither
+`Halt` nor an untracked-navigation error) is gone. That fallback was itself the larger
+divergence: it double-fired side effects (`path(foreach ((.[]|stderr|empty), error("s")) as
+$i (.; .))` on `[1,2]` wrote `1212` for jq's `12`) and, by discarding the per-step register,
+turned a jq refusal into an answer — `[label $out | path(foreach (.[], break $out) as $i (.;
+.))]` on `[1,2]` printed `[[],[]]` at exit 0 where jq raises "Invalid path expression with
+result [1,2]", a write-side hazard. Every escape the resolver raises is now the fold's
+escape, which holds the resolver's arms to a stricter contract: an arm that escapes must
+already have delivered everything jq would have bound (`Expr::Alternative` forwarded its
+left side's escape prefix *unfiltered*, falsy branches included, and was fixed alongside).
 
 A *trackable* branch means the source is itself a path expression in jq's eyes, and — since
 [#2031](https://github.com/rust-works/succinctly/issues/2031) — that is no longer treated as
@@ -874,22 +900,25 @@ Four residual divergences remain in this area:
   on `{"a":1,"b":{"c":2}}` raises `Invalid path expression near attempt to access element "a"
   of {"a":1,"b":{"c":2}}` in jq; succinctly prints `["a"]`. `.a` genuinely navigates (moving
   jq's real register) before `tostring` — not itself a path primitive — discards that
-  provenance from the *source element's own* final value; `resolve_fold_source` only inspects
+  provenance from the *source element's own* final value; `drive_fold_source` only inspects
   each element's final `PathBranch.trackable`, so a source like this looks exactly like an
   ordinary computed value to it. Distinct from — and not closed by — #2031's fix, confirmed via
   `git stash` A/B against the pre-#2031 build on `main` too. Tracked as
   [#2159](https://github.com/rust-works/succinctly/issues/2159).
 
-- **An ordinary-error source is still evaluated twice, and now every output rather than just
-  the first.** `resolve_fold_source` treats only `Halt` and
-  `EvalError::is_untracked_navigation_error` as answers it can return; any *other* escape —
-  an ordinary runtime `Error`, a `break` — falls back to `eval_owned_expr_fork`, discarding
-  what the resolver produced, because those escapes have always been the untracked
-  evaluator's to report and the resolver's `Ok` prefix is only guaranteed to be *no longer*
-  than jq's, not equal to it. So `path(reduce ((.[] | stderr), error("x")) as $i (0; $x))`
-  on `[1,2,3]` writes `123` in jq and `123123` here. Fixing it means depending on the
-  resolver's prefix for erroring sources too, which is the stronger invariant this
-  deliberately does not yet assume.
+- **A generator the resolver reaches only through an eager arm is still collected before
+  its first element is folded.** `drive_fold_source` pulls by demand only as far as
+  `resolve_node_sink`'s lazy arms reach; `resolve_leaf`'s general case, an `if`/`select`
+  condition (`eval_owned_multi_keep_partial`), an `as` source (`resolve_bind_source`) and a
+  fold nested inside the source all materialize their own generator first. So `path(foreach
+  (inputs | .a) as $i (.; .))` drains every remaining input document where jq consumes one,
+  and `path(reduce (if (.[]|stderr) then 1 else 2 end) as $i (.; error("u")))` on
+  `[1,2,3]` writes `123` for jq's `1`. Same cause as [#2466](https://github.com/rust-works/succinctly/pull/2466)'s
+  own left-out list: `resolve_leaf` has no sink form. The consumer side has the same edge:
+  `path()` itself collects every path before its own consumer sees one, so a bound *outside*
+  it cannot stop the fold (`[limit(1; path(foreach (1 as $x ?// $y | (stderr|1)) as $v (.;
+  .)))]` is `[[],[]]` with two writes in jq — its `limit` break is retried by the source's
+  `?//` and the retried output lands past the bound — and `[[]]` with one write here).
 - **`E[K]` evaluates its target once where jq re-runs it per key.** jq compiles `E[K]` as
   `K as $k | E | .[$k]`, so a side effect in `E` fires once per output of `K`; here it fires
   once total — `[(.[] | stderr)[("a","b")]?]` on `[1,2]` writes `1212` in jq and `12` here.
@@ -900,8 +929,8 @@ Four residual divergences remain in this area:
   `foreach` *and* `path` outright (confirmed live against yq v4.53.3), so `succinctly yq`
   has no oracle for a fold's values, and `resolve_index_expr`'s yq-only `scalar_noop` arm
   would hand the *unchanged target* to the fold where the evaluator raises. `succinctly yq`
-  therefore still path-checks with `Keep::First` and takes its values from
-  `eval_owned_expr_fork`; only the jq-mode value reuse is new.
+  therefore still path-checks with `Keep::First` and then drives its values by value
+  through `eval_each_owned`; only the jq-mode value reuse is new.
 
 ## Duplicate object keys collapse, except under `--preserve-input`
 
@@ -4628,7 +4657,7 @@ functions) is what `test_parity_foreach_reduce_init_fork_source_reads_ambient_in
 
 The **third** evaluator — the path-context evaluator's `resolve_reduce`/`resolve_foreach`
 (`src/jq/eval.rs`) — is not part of that shared core and is not consistent with it here: its
-own SOURCE resolution (`resolve_fold_source`, added by #2031 for path-trackability, not for
+own SOURCE resolution (`drive_fold_source`, added by #2031 for path-trackability, not for
 this divergence) already re-runs once per INIT fork, inside the per-branch loop, using the
 real document every time rather than a cached value — architecturally the closest thing in
 this codebase to what a jq-matching fix would need, but it does not inject a synthetic

--- a/docs/plan/jq-bind-origin-frame.md
+++ b/docs/plan/jq-bind-origin-frame.md
@@ -97,7 +97,7 @@ between copies:
 ## Where the bind path comes from
 
 `resolve_bind_source` resolves an `as` source in path position — reusing the same
-value-vs-path fork `resolve_fold_source` already established for fold sources
+value-vs-path fork `drive_fold_source` already established for fold sources
 (`#1467`/`#2031`) — as **a witness only**: jq evaluates an `as` source with path tracking
 suspended (`subexp_nest > 0` in the real interpreter), so the source itself never moves the
 register (`path(.a as $y \| .b)` is `["b"]`, not an error) and never raises a path error of

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -25683,12 +25683,12 @@ fn needs_path_prepass(expr: &Expr) -> bool {
 ///
 /// This function instead answers a narrower question, asked only once
 /// `resolve_seq` has *already* been reached (a real computed key elsewhere
-/// in the pipe, or -- unconditionally -- `resolve_recurse` resolving `f`):
+/// in the pipe, or -- unconditionally -- `resolve_recurse_sink` resolving `f`):
 /// can its "nothing left needs resolving" fast path assume the remaining
 /// tail is single-valued? For `Iterate` the answer is no --
 /// [`value_after_components`] treats any component producing zero or more
 /// than one output as pruning the whole branch (`Ok(None)`, #2124), which
-/// `resolve_recurse` reads as "no children" and drops, silently discarding
+/// `resolve_recurse_sink` reads as "no children" and drops, silently discarding
 /// every result whenever a trailing `.foo[]`/`.foo[]?` reaches a 2+-element
 /// container (#682). Fanning it out through the same loop already used for
 /// a genuine computed key fixes that, without touching
@@ -25783,7 +25783,7 @@ fn push_path_components(out: &mut Vec<Expr>, expr: &Expr) {
 /// A thin adapter over [`eval_owned_multi_keep_partial`] that discards
 /// whatever prefix `expr` already produced before the escape — the right
 /// contract for every caller except `recurse`'s own children evaluation
-/// (`builtin_recurse_f`/`builtin_recurse_cond`/`resolve_recurse`), which
+/// (`builtin_recurse_f`/`builtin_recurse_cond`/`resolve_recurse_sink`), which
 /// call `eval_owned_multi_keep_partial` directly instead (#842).
 ///
 /// The one caller that must NOT use this — `update_path`'s `Expr::Identity`
@@ -25850,7 +25850,7 @@ fn eval_owned_multi_first<S: EvalSemantics>(
 /// `builtin_recurse_cond`, both evaluate `f` through this function
 /// directly), `builtin_in`'s own `xs`-evaluation step (also value
 /// position — the candidates to check `.` against can themselves be a
-/// multi-output generator with the same shape), `resolve_recurse`'s own
+/// multi-output generator with the same shape), `resolve_recurse_sink`'s own
 /// `cond`-evaluation step in path
 /// position (#854 — `cond` can itself be a multi-output generator whose own
 /// later output errors after an earlier one already fired truthy for the
@@ -25861,7 +25861,7 @@ fn eval_owned_multi_first<S: EvalSemantics>(
 /// `Select`/`If` arms (their `cond`), its `GetPath` arm (its `arg`), and
 /// `resolve_index_expr` (its `key`) — the same argument-can-itself-be-a-
 /// generator shape #842/#854 fixed for `recurse`, independently live at
-/// these 4 unrelated call sites too (#896). `resolve_recurse`'s own
+/// these 4 unrelated call sites too (#896). `resolve_recurse_sink`'s own
 /// `f`-evaluation step is the one exception: it resolves `f` through
 /// `resolve_node`/`resolve_against_cow` instead — a structurally different
 /// call whose `PathResolveResult` already threads a prefix through its own
@@ -27169,10 +27169,7 @@ fn resolve_limit_sink<'a, S: EvalSemantics>(
             other => return other,
         }
     }
-    match escape {
-        Some(e) => ResolveFlow::Escaped(e),
-        None => ResolveFlow::Exhausted,
-    }
+    flow_result(escape)
 }
 
 /// `path(nth(n; expr))` (#1952) — the arm `nth` had none of at all, which is
@@ -27243,10 +27240,7 @@ fn resolve_nth_sink<'a, S: EvalSemantics>(
             other => return other,
         }
     }
-    match escape {
-        Some(e) => ResolveFlow::Escaped(e),
-        None => ResolveFlow::Exhausted,
-    }
+    flow_result(escape)
 }
 
 /// Collecting adapter over [`resolve_node_sink`] — the shape every caller
@@ -27385,7 +27379,7 @@ fn resolve_node_sink<'a, S: EvalSemantics>(
         // `eval_owned_multi`/`eval_owned_expr`, and republishes `value` once
         // per truthy output rather than collapsing every output into one
         // always-truthy array (#628, mirroring #627's
-        // `builtin_recurse_cond`/`resolve_recurse` fix): confirmed against jq
+        // `builtin_recurse_cond`/`resolve_recurse_sink` fix): confirmed against jq
         // 1.7.1, `path(select((false,false)))` is empty (not `[[]]`), and
         // `path(select((true,true)))` forks into two branches, `[[],[]]`.
         // Keeping the partial prefix (rather than discarding it on a later
@@ -27463,6 +27457,36 @@ fn resolve_node_sink<'a, S: EvalSemantics>(
                 resolve_node_sink::<S>(branch, value, trackable, snapshot, frame, keep, sink)
             })
         }
+        // `E?` (bare postfix `?`, sugar for `try E`, #2235): streams through
+        // `resolve_node_sink` rather than collecting via `resolve_node`
+        // first, so a `?`-wrapped generator (`.[]?`, `(f)?`) interleaves its
+        // own side effects with whatever drives it — a fold source shaped
+        // `(.[] | stderr)?` no longer fires every `stderr` write before the
+        // fold's first step runs. See [`resolve_optional_sink`].
+        Expr::Optional(inner) => {
+            resolve_optional_sink::<S>(inner, value, trackable, snapshot, frame, keep, sink)
+        }
+        // `recurse(f)`/`recurse(f; cond)` (#2235): the parameterised
+        // spellings have no static shortcut the way bare `..`/`recurse` do
+        // (`f` is arbitrary, so the queue has to run) — always `trackable`
+        // here too, same guard as the bare spellings just below in
+        // `resolve_node_eager`. `resolve_recurse_sink` itself asserts this
+        // rather than re-deriving it (#843 review). Streams each visited
+        // node to `sink` as it is popped, so a bounded consumer no longer
+        // pays for nodes past the ones it actually asked for — see that
+        // function's own doc comment for what this does, and does not,
+        // close.
+        Expr::Builtin(Builtin::RecurseF(_) | Builtin::RecurseCond(_, _))
+            if !trackable && !snapshot.is_marked() =>
+        {
+            ResolveFlow::Escaped(recurse_untracked_error(value).1)
+        }
+        Expr::Builtin(Builtin::RecurseF(f)) => {
+            resolve_recurse_sink::<S>(f, None, value, trackable, snapshot, frame, keep, sink)
+        }
+        Expr::Builtin(Builtin::RecurseCond(f, cond)) => {
+            resolve_recurse_sink::<S>(f, Some(cond), value, trackable, snapshot, frame, keep, sink)
+        }
         // `try expr catch handler` (and `expr?`, sugar for `try expr`):
         // resolve `expr`; if that fails and there is no `catch`, prune the
         // branch exactly like `Optional`'s blanket arm above. With a
@@ -27482,15 +27506,11 @@ fn resolve_node_sink<'a, S: EvalSemantics>(
         Expr::Try { expr, catch } => {
             match resolve_node_sink::<S>(expr, value, trackable, snapshot, frame, keep, sink) {
                 ResolveFlow::Escaped(EvalEscape::Error(e)) if !e.is_uncatchable() => {
-                    drain_path_result(
-                        resolve_catch::<S>(catch.as_deref(), Vec::new(), e.payload(), frame, keep),
-                        sink,
-                    )
+                    resolve_catch_sink::<S>(catch.as_deref(), e.payload(), frame, keep, sink)
                 }
-                ResolveFlow::Escaped(EvalEscape::Break(_)) => drain_path_result(
-                    resolve_catch::<S>(catch.as_deref(), Vec::new(), OwnedValue::Null, frame, keep),
-                    sink,
-                ),
+                ResolveFlow::Escaped(EvalEscape::Break(_)) => {
+                    resolve_catch_sink::<S>(catch.as_deref(), OwnedValue::Null, frame, keep, sink)
+                }
                 other => other,
             }
         }
@@ -27867,165 +27887,6 @@ fn resolve_node_eager<'a, S: EvalSemantics>(
     keep: Keep,
 ) -> PathResolveResult<'a> {
     match expr {
-        Expr::Optional(inner) => match inner.as_ref() {
-            // `E[K]?` only covers a failure to *index* — evaluating `E` or `K`
-            // is not covered (see `eval_index_expr`'s doc comment, which the
-            // value-position evaluator already honors). The blanket catch below
-            // is right for every other `?`-wrapped node, where evaluation and
-            // indexing are the same step, but it would also swallow an error
-            // raised while computing `K` itself, e.g. `"str" | .[.k]? = 5`
-            // (#413). Only the bare shape needs intercepting, and that is jq's
-            // own distinction rather than a limit of what parses: `(.[.k])?` is
-            // `try .[.k]`, which catches everything inside it including the key,
-            // so `"str" | (.[.k])? = 5` is `"str"` there while
-            // `"str" | .[.k]? = 5` raises. A parenthesised key therefore *should*
-            // reach the blanket arm below. It cannot yet — the postfix `?` takes
-            // a path expression and nothing else until #367 — but when it can,
-            // this arm still wants to see only the bare shape.
-            Expr::IndexExpr { target, key } => {
-                resolve_index_expr::<S>(target, key, value, true, trackable, frame, keep)
-            }
-
-            // `E[S:T]?` is the same bare shape for slice bounds: only a
-            // failure to *slice* is covered, never `E`, `S`, or `T`'s own
-            // evaluation — see `resolve_slice_expr`'s doc comment.
-            Expr::SliceExpr { target, start, end } => {
-                resolve_slice_expr::<S>(target, start, end, value, true, trackable, frame, keep)
-            }
-
-            // Every other `?`-wrapped node (`.foo?`, `.[0]?`, ...): evaluation
-            // and indexing are the same step, so any failure anywhere
-            // underneath is the failure to index, and `?` covers all of it.
-            //
-            // The `Expr::Optional` wrapper below marks the branch as one `?`
-            // reached, for whatever downstream still wants to know that —
-            // but it is *not* an instruction to keep suppressing failures at
-            // write time. `resolve_dynamic_indexes` strips every such
-            // wrapper from the final component list before handing it to
-            // `set_path`/`update_path`/`delete_at_path`, because those
-            // functions apply an already-resolved path unconditionally, the
-            // same way jq's `setpath` never re-consults the `?` that
-            // `path()` already spent (#498's multi-branch case: a sibling
-            // write earlier in the same fan-out batch can still clobber the
-            // container this branch needs, and that failure must propagate
-            // regardless of this branch's own `?`).
-            _ => {
-                // A failure under `?` prunes just the error, keeping whatever
-                // was already resolved before it (confirmed live: `(.a,
-                // .b[0])?` prints `["a"]` and silently stops) — except
-                // `invalid_path_expression` (#530), which `?` does not
-                // suppress in jq at all: it is a statement that the filter is
-                // not a path expression, not a value error raised while
-                // collecting one (confirmed live: `path(("a")?)` still
-                // raises in jq).
-                //
-                // #843's "near attempt" error (`is_untracked_navigation_error`)
-                // has its own, narrower carve-out: `?` *does* usually suppress
-                // it (unlike `#530`'s classic message) — except when `inner`
-                // is itself one of the four bare navigation primitives this
-                // error can come from (`Field`/`Index`/`Iterate`/`Slice`),
-                // i.e. a *bare* postfix `?` (`.b?`, not `(.b)?`). Confirmed
-                // live against jq 1.7.1: `path(try (.a, error(5)) catch
-                // .b?)` still raises "near attempt to access element \"b\"
-                // of 5" (exit 5), while the parenthesized `(.b)?` — which
-                // also reaches this same generic arm, since `Paren` isn't
-                // one of the primitives either — suppresses the very same
-                // error and prints only `["a"]`. `try .b` (no catch, no `?`
-                // at all) matches the parenthesized form, not the bare one
-                // (also confirmed live) — jq's distinction is specific to
-                // postfix `?` binding directly to a bare primitive, not to
-                // "any wrapper around one", so this only needs to special-
-                // case `inner`'s shape right here, not `Expr::Try`'s own
-                // handling elsewhere. An *ordinary* failure to index (e.g.
-                // `"str" | path(.foo?)`) still prunes here exactly as it
-                // always did — this only withholds pruning for the specific
-                // #843 error kind.
-                //
-                // A `break $label` is pruned the same unconditional way,
-                // regardless of which label it targets — jq's `?`/bare `try`
-                // (no `catch`) always intercepts a break passing through
-                // (confirmed live: `label $out | ((.a, break $out)?)` is `1`
-                // and exits 0, never reaching `$out`; the value-position
-                // evaluator's `eval_try` already applies the same rule, #562)
-                // — never something to re-raise like the invalid-path-
-                // expression carve-out above.
-                let bare_navigation_primitive = matches!(
-                    inner.as_ref(),
-                    Expr::Field(_) | Expr::Index { .. } | Expr::Iterate | Expr::Slice { .. }
-                );
-                let branches =
-                    match resolve_node::<S>(inner, value, trackable, snapshot, frame, keep) {
-                        Ok(branches) => branches,
-                        // Only a genuine collection failure prunes to the
-                        // already-resolved prefix: `halt`/`halt_error(n)` is
-                        // never caught by `?`, in path expressions any more than
-                        // in value position (#791), an invalid-path-expression
-                        // complaint survives `?` too (#530), a decode failure
-                        // does as well -- matching the sibling `Expr::Try` arm's
-                        // `is_uncatchable()` guard, since `expr?` is documented
-                        // sugar for `try expr` and the two must agree (#1746) --
-                        // and — only for a bare navigation primitive — so does
-                        // #843's "near attempt" complaint.
-                        Err((prefix, EvalEscape::Error(e)))
-                            if !(e.is_uncatchable()
-                                || (bare_navigation_primitive
-                                    && e.is_untracked_navigation_error())) =>
-                        {
-                            prefix
-                        }
-                        Err((prefix, EvalEscape::Break(_))) => prefix,
-                        Err(escape) => return Err(escape),
-                    };
-                Ok(branches
-                    .into_iter()
-                    .map(
-                        |PathBranch {
-                             path: components,
-                             value: v,
-                             trackable,
-                             snapshot,
-                             register,
-                         }| {
-                            let components = components.to_vec();
-                            let inner_path = if components.len() == 1 {
-                                components.into_iter().next().expect("len checked")
-                            } else {
-                                // Unreached *today*, and deliberately not a panic: the
-                                // postfix `?` attaches to a single path element until
-                                // #367, so `(.a.b)?`, `(..)?` and `recurse?` are parse
-                                // errors, and `E[K]?` — which used to arrive here with
-                                // its target's components attached — now goes to
-                                // `resolve_index_expr`. #367 reopens it on purpose:
-                                // `(.a[.k])?` resolves through the `Paren` arm to
-                                // `["a","b"]`, two components, and jq writes
-                                // `{"a":{"b":5},"k":"b"}` for it. `eval_generic` can
-                                // synthesize `Expr::Optional` around any expression
-                                // too, so this was never an invariant of the type.
-                                Expr::Pipe(components)
-                            };
-                            PathBranch {
-                                // Wrapping in `?` navigates nothing, so it
-                                // neither grants nor removes trackability —
-                                // nor, for the same reason, the snapshot
-                                // provenance a `$x` inside it carries (#1466).
-                                path: PathPrefix::from_components([Expr::Optional(Box::new(
-                                    inner_path,
-                                ))]),
-                                value: v,
-                                // Same reason as `trackable`/`snapshot`
-                                // above: `?` navigates nothing, so a live
-                                // path register survives it untouched
-                                // (#1573).
-                                register,
-                                trackable,
-                                snapshot,
-                            }
-                        },
-                    )
-                    .collect())
-            }
-        },
-
         Expr::IndexExpr { target, key } => {
             resolve_index_expr::<S>(target, key, value, false, trackable, frame, keep)
         }
@@ -28055,18 +27916,16 @@ fn resolve_node_eager<'a, S: EvalSemantics>(
         // `&& !snapshot` (#1591): mirrors `getpath([])`'s own identical
         // carve-out just below — a deferred `$x` snapshot must reach the
         // recurse-specific arms below (which then correctly emit *self*
-        // with the mark intact, via `resolve_recurse`'s seed or
+        // with the mark intact, via `resolve_recurse_sink`'s seed or
         // `resolve_recursive_descent`'s root patch) rather than being
         // refused here before `f`/`cond` are ever even evaluated. Confirmed
         // live, `path(. as $x | reduce (1) as $i (0; $x | ..))` on
         // `{"a":1}` is `[[]]` in jq, not a refusal.
-        Expr::RecursiveDescent
-        | Expr::Builtin(
-            Builtin::Recurse
-            | Builtin::RecurseDown
-            | Builtin::RecurseF(_)
-            | Builtin::RecurseCond(_, _),
-        ) if !trackable && !snapshot.is_marked() => Err(recurse_untracked_error(value)),
+        Expr::RecursiveDescent | Expr::Builtin(Builtin::Recurse | Builtin::RecurseDown)
+            if !trackable && !snapshot.is_marked() =>
+        {
+            Err(recurse_untracked_error(value))
+        }
 
         // `..` fans out to every node in the tree (pre-order, self before
         // children), so each needs its own Field/Index chain rather than the
@@ -28076,7 +27935,7 @@ fn resolve_node_eager<'a, S: EvalSemantics>(
         // Bare `recurse` *is* `..` — jq defines it as `recurse(.[]?)` and
         // `[recurse]` and `[..]` agree output for output, so this arm
         // handles both spellings identically. Sharing `..`'s resolver rather
-        // than routing `.[]?` through `resolve_recurse` is both simpler and
+        // than routing `.[]?` through `resolve_recurse_sink` is both simpler and
         // what keeps the components bare: resolving under a `?` wraps each
         // one in `Expr::Optional`, which the walkers that *write*
         // (`set_path_steps`, `update_path`, `delete_at_path`) then have to
@@ -28086,16 +27945,6 @@ fn resolve_node_eager<'a, S: EvalSemantics>(
         // caught every recurse-family spelling otherwise.
         Expr::RecursiveDescent | Expr::Builtin(Builtin::Recurse | Builtin::RecurseDown) => {
             Ok(resolve_recursive_descent(value, trackable, snapshot))
-        }
-        // The parameterised spellings have no such shortcut: `f` is
-        // arbitrary, so the queue has to run — always `trackable` here too,
-        // same reason as just above. `resolve_recurse` itself asserts this
-        // rather than re-deriving it (#843 review).
-        Expr::Builtin(Builtin::RecurseF(f)) => {
-            resolve_recurse::<S>(f, None, value, trackable, snapshot, frame, keep)
-        }
-        Expr::Builtin(Builtin::RecurseCond(f, cond)) => {
-            resolve_recurse::<S>(f, Some(cond), value, trackable, snapshot, frame, keep)
         }
 
         // #844: a frozen variable snapshot from a statically-verified
@@ -28336,6 +28185,152 @@ fn resolve_node_eager<'a, S: EvalSemantics>(
         }
 
         other => resolve_leaf::<S>(other, value, trackable, snapshot, keep),
+    }
+}
+
+/// [`resolve_node_sink`]'s `Expr::Optional` arm (`E?`, and `E[K]?`/`E[S:T]?`
+/// bare-index/slice sugar) — #2235: streams the generic case through
+/// `resolve_node_sink` instead of collecting via `resolve_node` first, so a
+/// `?`-wrapped generator (`.[]?`, `(f)?`) interleaves its own side effects
+/// with whatever drives it, the same demand-driven guarantee
+/// `drive_fold_source` gives a fold source that runs through one.
+///
+/// `E[K]?`/`E[S:T]?` only cover a failure to *index*/*slice* — evaluating
+/// `E`, `K`, `S`, or `T` is not covered (see `resolve_index_expr`'s doc
+/// comment, which the value-position evaluator already honors) — and
+/// neither one is itself a generator source (`resolve_index_expr`/
+/// `resolve_slice_expr` each resolve exactly one target), so there is
+/// nothing to stream at this arm; delivered through the existing Vec-based
+/// resolvers via [`drain_path_result`]. A parenthesised key/bound instead
+/// reaches the blanket arm below: `(.[.k])?` is `try .[.k]`, which catches
+/// everything inside it including the key, so `"str" | (.[.k])? = 5` is
+/// `"str"` there while `"str" | .[.k]? = 5` raises (#413) — jq's own
+/// distinction, not a limit of what parses.
+///
+/// Every other `?`-wrapped node (`.foo?`, `.[0]?`, ...): evaluation and
+/// indexing are the same step, so any failure anywhere underneath is the
+/// failure to index, and `?` covers all of it. A failure under `?` prunes
+/// just the error, keeping whatever was already streamed to `sink` before
+/// it (confirmed live: `(.a, .b[0])?` prints `["a"]` and silently stops) —
+/// except `invalid_path_expression` (#530), which `?` does not suppress in
+/// jq at all: it is a statement that the filter is not a path expression,
+/// not a value error raised while collecting one (confirmed live:
+/// `path(("a")?)` still raises in jq).
+///
+/// #843's "near attempt" error (`is_untracked_navigation_error`) has its
+/// own, narrower carve-out: `?` *does* usually suppress it (unlike #530's
+/// classic message) — except when `inner` is itself one of the four bare
+/// navigation primitives this error can come from (`Field`/`Index`/
+/// `Iterate`/`Slice`), i.e. a *bare* postfix `?` (`.b?`, not `(.b)?`).
+/// Confirmed live against jq 1.7.1: `path(try (.a, error(5)) catch .b?)`
+/// still raises "near attempt to access element \"b\" of 5" (exit 5), while
+/// the parenthesized `(.b)?` — which also reaches this same generic arm,
+/// since `Paren` isn't one of the primitives either — suppresses the very
+/// same error and prints only `["a"]`. A `break $label` is pruned the same
+/// unconditional way, regardless of which label it targets — jq's `?`/bare
+/// `try` (no `catch`) always intercepts a break passing through (confirmed
+/// live: `label $out | ((.a, break $out)?)` is `1` and exits 0, never
+/// reaching `$out`).
+///
+/// A branch that streams through successfully is wrapped in `Expr::Optional`
+/// — marking it as one `?` reached, for whatever downstream still wants to
+/// know that, but not an instruction to keep suppressing failures at write
+/// time; every wrapper is stripped again by `strip_resolved_optional` before
+/// any resolved path reaches `set_path`/`update_path`/`delete_at_path` or
+/// `path()`'s own output. That universal strip is also why a branch that
+/// streamed out ahead of an escape that turns out to *propagate* (rather
+/// than prune) needs no separate unwrapped code path here, unlike the old
+/// eager version's `Err(escape) => return Err(escape)` short-circuit: the
+/// wrapper never survives to be observed either way.
+fn resolve_optional_sink<'a, S: EvalSemantics>(
+    inner: &Expr,
+    value: &'a OwnedValue,
+    trackable: bool,
+    snapshot: &Snapshot,
+    frame: &Frame,
+    keep: Keep,
+    sink: &mut dyn FnMut(PathBranch<'a>) -> Demand,
+) -> ResolveFlow {
+    match inner {
+        Expr::IndexExpr { target, key } => drain_path_result(
+            resolve_index_expr::<S>(target, key, value, true, trackable, frame, keep),
+            sink,
+        ),
+        Expr::SliceExpr { target, start, end } => drain_path_result(
+            resolve_slice_expr::<S>(target, start, end, value, true, trackable, frame, keep),
+            sink,
+        ),
+        _ => {
+            let bare_navigation_primitive = matches!(
+                inner,
+                Expr::Field(_) | Expr::Index { .. } | Expr::Iterate | Expr::Slice { .. }
+            );
+            let flow = resolve_node_sink::<S>(
+                inner,
+                value,
+                trackable,
+                snapshot,
+                frame,
+                keep,
+                &mut |branch| sink(wrap_optional_branch(branch)),
+            );
+            match flow {
+                // Only a genuine collection failure prunes: `halt`/
+                // `halt_error(n)` is never caught by `?`, in path
+                // expressions any more than in value position (#791), an
+                // invalid-path-expression complaint survives `?` too (#530),
+                // a decode failure does as well -- matching the sibling
+                // `Expr::Try` arm's `is_uncatchable()` guard, since `expr?`
+                // is documented sugar for `try expr` and the two must agree
+                // (#1746) -- and, only for a bare navigation primitive, so
+                // does #843's "near attempt" complaint.
+                ResolveFlow::Escaped(EvalEscape::Error(e))
+                    if !(e.is_uncatchable()
+                        || (bare_navigation_primitive && e.is_untracked_navigation_error())) =>
+                {
+                    ResolveFlow::Exhausted
+                }
+                ResolveFlow::Escaped(EvalEscape::Break(_)) => ResolveFlow::Exhausted,
+                other => other,
+            }
+        }
+    }
+}
+
+/// Wrap a resolved branch's path in `Expr::Optional`, marking it as reached
+/// through a `?` — see [`resolve_optional_sink`]. Wrapping in `?` navigates
+/// nothing, so it neither grants nor removes trackability, nor, for the
+/// same reason, the snapshot provenance a `$x` inside it carries (#1466),
+/// nor a live path register (#1573) -- all three pass through unchanged.
+fn wrap_optional_branch(branch: PathBranch<'_>) -> PathBranch<'_> {
+    let PathBranch {
+        path: components,
+        value,
+        trackable,
+        snapshot,
+        register,
+    } = branch;
+    let components = components.to_vec();
+    let inner_path = if components.len() == 1 {
+        components.into_iter().next().expect("len checked")
+    } else {
+        // Unreached *today*, and deliberately not a panic: the postfix `?`
+        // attaches to a single path element until #367, so `(.a.b)?`,
+        // `(..)?` and `recurse?` are parse errors, and `E[K]?` — which used
+        // to arrive here with its target's components attached — now goes
+        // to `resolve_index_expr`. #367 reopens it on purpose: `(.a[.k])?`
+        // resolves through the `Paren` arm to `["a","b"]`, two components,
+        // and jq writes `{"a":{"b":5},"k":"b"}` for it. `eval_generic` can
+        // synthesize `Expr::Optional` around any expression too, so this
+        // was never an invariant of the type.
+        Expr::Pipe(components)
+    };
+    PathBranch {
+        path: PathPrefix::from_components([Expr::Optional(Box::new(inner_path))]),
+        value,
+        register,
+        trackable,
+        snapshot,
     }
 }
 
@@ -28697,7 +28692,7 @@ fn untracked_branches(
 /// a *trackable* or a *deferred-snapshot* value through, and structural
 /// descent can't change which one `value` was). `snapshot` is different:
 /// `..`'s own *first* output is `.` — no navigation at all — so it inherits
-/// whatever `value` already was (mirroring `resolve_recurse`'s own seed),
+/// whatever `value` already was (mirroring `resolve_recurse_sink`'s own seed),
 /// but every other node in the tree is reached by genuine Field/Index
 /// descent, which breaks the mark regardless of ambient —
 /// `push_recursive_branches` never sees `snapshot` at all, so it keeps
@@ -29453,7 +29448,7 @@ impl FoldRegister {
 /// Six places below this call launder an `Err` into a short `Ok` --
 /// `Expr::Optional`'s blanket arm, `resolve_catch`'s no-`catch` case,
 /// `Expr::Label` on a matching break, `resolve_bounded_sink`'s
-/// satisfied-bound fold to `Exhausted`, `resolve_recurse`'s
+/// satisfied-bound fold to `Exhausted`, `resolve_recurse_sink`'s
 /// `RECURSE_MAX_ITEMS` cap, and `resolve_repeat_sink`'s round cap. The
 /// values they deliver are a fold's values here, so anyone changing one of
 /// those is changing a fold's values too.
@@ -30510,9 +30505,18 @@ fn resolve_foreach<'a, S: EvalSemantics>(
             if update_branches.is_empty() {
                 (state_at_register, state_snapshot) = reg.branch_provenance(None);
             }
-            for update_branch in &update_branches {
-                (state_at_register, state_snapshot) = reg.branch_provenance(Some(update_branch));
-                state = update_branch.value.clone().into_owned();
+            let last_branch_index = update_branches.len().wrapping_sub(1);
+            for (branch_index, update_branch) in update_branches.iter().enumerate() {
+                // Only the *last* branch carries forward as the next
+                // element's state (see the comment above this loop) — the
+                // others are read straight off `update_branch` below for
+                // EXTRACT/emission, so cloning `state` for them too is pure
+                // waste, doubled (or worse) by every extra UPDATE output.
+                if branch_index == last_branch_index {
+                    (state_at_register, state_snapshot) =
+                        reg.branch_provenance(Some(update_branch));
+                    state = update_branch.value.clone().into_owned();
+                }
                 if let Some(ext_expr) = &substituted_extract {
                     if let Some(control) = charge_budget(&mut budget, "foreach") {
                         return stop_with_escape(&mut aborted, control);
@@ -30527,26 +30531,22 @@ fn resolve_foreach<'a, S: EvalSemantics>(
                     // `identical()` check (#1590).
                     let (extract_at_register, extract_snapshot) =
                         extract_reg.branch_provenance(Some(update_branch));
-                    match extract_reg.resolve::<S>(
-                        ext_expr,
-                        update_branch.value.clone().into_owned(),
-                        extract_at_register,
-                        &extract_snapshot,
-                        keep,
+                    match drain_path_result(
+                        extract_reg.resolve::<S>(
+                            ext_expr,
+                            update_branch.value.clone().into_owned(),
+                            extract_at_register,
+                            &extract_snapshot,
+                            keep,
+                        ),
+                        sink,
                     ) {
-                        Ok(branches) => {
-                            if emit_branches(branches, sink) == Demand::Stop {
-                                downstream_stopped = true;
-                                return Demand::Stop;
-                            }
+                        ResolveFlow::Stopped => {
+                            downstream_stopped = true;
+                            return Demand::Stop;
                         }
-                        Err((prefix, e)) => {
-                            if emit_branches(prefix, sink) == Demand::Stop {
-                                downstream_stopped = true;
-                                return Demand::Stop;
-                            }
-                            return stop_with_escape(&mut aborted, e.into());
-                        }
+                        ResolveFlow::Escaped(e) => return stop_with_escape(&mut aborted, e.into()),
+                        ResolveFlow::Exhausted => {}
                     }
                 } else {
                     let emitted = if update_branch.trackable {
@@ -30588,30 +30588,32 @@ fn resolve_foreach<'a, S: EvalSemantics>(
 }
 
 /// Apply `Expr::Try`'s `catch` clause (if any) after `expr` failed to
-/// resolve as a path, keeping `prefix` — whatever `expr` had already
-/// resolved before the failure — ahead of the handler's own output. Shared
-/// by `resolve_node`'s `Expr::Try` arm's `Error` and `Break` cases, which
-/// differ only in what `payload` binds to: the raised error's own value for
-/// an ordinary failure, `null` for a `break` (mirroring the value-position
-/// `eval_try`'s treatment of jq's internal break marker, since #562's rule
-/// is "catch catches break the same way it catches error").
+/// resolve as a path, streaming its output straight to `sink` (#2235) —
+/// `expr`'s own already-resolved branches reached `sink` directly through
+/// `resolve_node_sink` before this ever runs, so there is no separate
+/// prefix to thread here. Shared by `resolve_node_sink`'s `Expr::Try` arm's
+/// `Error` and `Break` cases, which differ only in what `payload` binds to:
+/// the raised error's own value for an ordinary failure, `null` for a
+/// `break` (mirroring the value-position `eval_try`'s treatment of jq's
+/// internal break marker, since #562's rule is "catch catches break the
+/// same way it catches error").
 ///
-/// A no-catch `try` (or bare `?`, sugar for one) keeps just `prefix`
-/// (confirmed live: `path(try (.a, .b[0]))` prints `["a"]` and stops).
-/// With a `catch`, `catch_expr` resolves as a path expression too, and its
-/// output is appended after `prefix` — `catch`'s handler runs in addition
-/// to, not instead of, whatever the failed body already resolved (confirmed
-/// live: `path(try (.a, .x[0]) catch empty)` on `{"a":1,"x":5}` prints
-/// `["a"]`, not nothing).
+/// A no-catch `try` (or bare `?`, sugar for one) resolves nothing further
+/// (confirmed live: `path(try (.a, .b[0]))` prints `["a"]` and stops). With
+/// a `catch`, `catch_expr` resolves as a path expression too, and its
+/// output streams after whatever `expr` already delivered — `catch`'s
+/// handler runs in addition to, not instead of, whatever the failed body
+/// already resolved (confirmed live: `path(try (.a, .x[0]) catch empty)` on
+/// `{"a":1,"x":5}` prints `["a"]`, not nothing).
 ///
 /// If `catch_expr` itself then fails — with an ordinary error (including
 /// #530's "Invalid path expression"), a `break` targeting some outer label,
-/// or a `halt`/`halt_error` — `prefix` (and whatever partial output the
-/// handler itself already resolved before its own failure) is threaded into
-/// the returned `Err` rather than dropped, matching every other arm in this
-/// resolver (`Expr::Comma`, `Expr::As`, ...) that already keeps its
-/// accumulated prefix on the error path (#832; before this fix, all three
-/// escape kinds silently discarded `prefix` here — confirmed live:
+/// or a `halt`/`halt_error` — whatever the handler itself already streamed
+/// to `sink` before its own failure stays delivered, and the escape
+/// propagates through the returned `ResolveFlow`, matching every other arm
+/// in this resolver (`Expr::Comma`, `Expr::As`, ...) that already keeps its
+/// accumulated prefix on the error path (#832; before that fix, all three
+/// escape kinds silently discarded the prefix here — confirmed live:
 /// `path(try (.a, .x[0]) catch "x")` on `{"a":1,"x":5}` dropped `["a"]`
 /// before raising `"x"`'s own #530 error, and
 /// `label $out | path(try (.a, break $out) catch error("y"))` on `{"a":1}`
@@ -30649,38 +30651,38 @@ fn resolve_foreach<'a, S: EvalSemantics>(
 /// that motivated the original eager check: `try (.a, error({y:99})) catch
 /// select(true) = "X"` still raises rather than silently replacing the
 /// whole document, caught now by `resolve_dynamic_indexes` instead of here.
-fn resolve_catch<'a, S: EvalSemantics>(
+///
+/// Streams through [`resolve_against_cow_sink`] rather than collecting via
+/// [`resolve_against_cow`] (#2235): a catch handler that itself iterates a
+/// generator (e.g. `try f catch (.[] | stderr)`) streams that generator's
+/// own side effects to `sink` one at a time instead of batching them all
+/// ahead of whatever consumes them — the same demand-driven guarantee
+/// `drive_fold_source` gives a fold source that runs through `try`/`catch`.
+fn resolve_catch_sink<'a, S: EvalSemantics>(
     catch: Option<&Expr>,
-    prefix: Vec<PathBranch<'a>>,
     payload: OwnedValue,
     frame: &Frame,
     keep: Keep,
-) -> PathResolveResult<'a> {
+    sink: &mut dyn FnMut(PathBranch<'a>) -> Demand,
+) -> ResolveFlow {
     let Some(catch_expr) = catch else {
-        return Ok(prefix);
+        return ResolveFlow::Exhausted;
     };
-    let mut out = prefix;
     // A caught error/break payload is never a snapshot (#1591): jq's own
     // handler binding is unrelated to any `$x` frozen elsewhere in scope.
-    match resolve_against_cow::<S>(
+    resolve_against_cow_sink::<S>(
         catch_expr,
         Cow::Owned(payload),
         false,
         &Snapshot::No,
         &frame.unknown(),
         keep,
-    ) {
-        Ok(branches) => out.extend(branches),
-        Err((branches, e)) => {
-            out.extend(branches);
-            return Err((out, e));
-        }
-    }
-    Ok(out)
+        sink,
+    )
 }
 
 /// Shared "defer the escape, queue what's left" step for `recurse`'s three
-/// stack-driven implementations (`resolve_recurse`,
+/// stack-driven implementations (`resolve_recurse_sink`,
 /// `builtin_recurse_f`/`builtin_recurse_cond`) (#842, extended to `cond`'s
 /// own fan-out by #854).
 ///
@@ -30719,7 +30721,7 @@ fn queue_recurse_children<T>(
 }
 
 /// Shared `recurse(f; cond)` "gate one child through `cond`" step used by
-/// both `resolve_recurse` (path position) and `builtin_recurse_cond` (value
+/// both `resolve_recurse_sink` (path position) and `builtin_recurse_cond` (value
 /// position) — #854 added the identical "evaluate `cond` via
 /// `eval_owned_multi_keep_partial`, fork-push each truthy output, defer any
 /// `cond` error" sequence to each function by hand (#897: extracted, the
@@ -30729,9 +30731,9 @@ fn queue_recurse_children<T>(
 /// `cond` is evaluated on `child` unconditionally — even when the caller
 /// won't end up queueing anything for it (`gate: false`) — because a
 /// `cond` error/side effect must still surface even for a node whose
-/// children are otherwise pruned from further recursion (`resolve_recurse`'s
+/// children are otherwise pruned from further recursion (`resolve_recurse_sink`'s
 /// `is_null_current` rule, #856). `gate` is the one real divergence between
-/// the two call sites: `resolve_recurse` passes `!is_null_current` since a
+/// the two call sites: `resolve_recurse_sink` passes `!is_null_current` since a
 /// null node's own line of descent ends there; `builtin_recurse_cond` has no
 /// such rule and always passes `true` — the two evaluators don't actually
 /// share a growth-bounding policy, just this evaluation step.
@@ -30759,7 +30761,7 @@ fn eval_recurse_cond<S: EvalSemantics>(
 }
 
 /// Item cap shared by every `recurse`-family explicit-stack walker
-/// (`resolve_recurse`, `builtin_recurse_f`, `builtin_recurse_cond`) — a
+/// (`resolve_recurse_sink`, `builtin_recurse_f`, `builtin_recurse_cond`) — a
 /// single definition so a future retuning can't silently miss one of the
 /// three copies it used to be (#1023 review of #1021, echoing #106's
 /// "duplicated predicates diverge silently").
@@ -30772,7 +30774,7 @@ const RECURSE_MAX_ITEMS: usize = 10000;
 /// loop short instead. This matches the pre-existing `MAX_ITEMS` silent-
 /// truncation convention everywhere else in this file, rather than
 /// surfacing an error whose presence would otherwise depend on where the
-/// arbitrary cap happened to land — see `resolve_recurse`'s own matching
+/// arbitrary cap happened to land — see `resolve_recurse_sink`'s own matching
 /// check for the fuller rationale (#842 review).
 #[inline]
 fn finish_recurse_walk<'a, W>(
@@ -30879,7 +30881,11 @@ fn finish_recurse_walk<'a, W>(
 /// forces that node's branch back to `Cow::Owned`, so it costs exactly what
 /// it always did — no regression, but no improvement either, since a real
 /// per-node computation dominates over the clone anyway.
-fn resolve_recurse<'a, S: EvalSemantics>(
+#[allow(clippy::too_many_arguments)] // STYLE-0004: `sink` joins the resolver's own established
+                                     // ambient-threading parameter list (#2235); a context struct
+                                     // just for this one call site would diverge from that
+                                     // convention.
+fn resolve_recurse_sink<'a, S: EvalSemantics>(
     f: &Expr,
     cond: Option<&Expr>,
     value: &'a OwnedValue,
@@ -30887,28 +30893,56 @@ fn resolve_recurse<'a, S: EvalSemantics>(
     snapshot: &Snapshot,
     frame: &Frame,
     keep: Keep,
-) -> PathResolveResult<'a> {
-    // Every caller in `resolve_node` already short-circuits on the shared
-    // recurse-family untracked guard before ever reaching here (#843's
-    // "recurse's first output is `.` itself" rule) — this loop should only
-    // ever run starting from a value already known-trackable, *or* one the
-    // guard deliberately deferred because it's a frozen `$x` snapshot
-    // (#1591 loosened the guard to `!trackable && !snapshot`, specifically
-    // so this function's own seed can still emit *self* with the mark
-    // intact). `trackable`/`snapshot` are threaded as real parameters (not
-    // just documented as an invariant in prose) specifically so this
-    // assertion can catch a future refactor of that guard silently letting
-    // a value through that is neither, instead of depending on every call
-    // site to keep re-deriving the same guarantee (review finding on #843:
-    // an invariant that only lives in a comment is one a later edit can
-    // quietly break).
+    sink: &mut dyn FnMut(PathBranch<'a>) -> Demand,
+) -> ResolveFlow {
+    // Every caller in `resolve_node_sink` already short-circuits on the
+    // shared recurse-family untracked guard before ever reaching here
+    // (#843's "recurse's first output is `.` itself" rule) — this loop
+    // should only ever run starting from a value already known-trackable,
+    // *or* one the guard deliberately deferred because it's a frozen `$x`
+    // snapshot (#1591 loosened the guard to `!trackable && !snapshot`,
+    // specifically so this function's own seed can still emit *self* with
+    // the mark intact). `trackable`/`snapshot` are threaded as real
+    // parameters (not just documented as an invariant in prose)
+    // specifically so this assertion can catch a future refactor of that
+    // guard silently letting a value through that is neither, instead of
+    // depending on every call site to keep re-deriving the same guarantee
+    // (review finding on #843: an invariant that only lives in a comment is
+    // one a later edit can quietly break).
     debug_assert!(
         trackable || snapshot.is_marked(),
-        "resolve_recurse called with trackable=false, snapshot=false; the \
-         untracked recurse-family guard in resolve_node should have caught \
+        "resolve_recurse_sink called with trackable=false, snapshot=false; the \
+         untracked recurse-family guard in resolve_node_sink should have caught \
          this first"
     );
-    let mut outputs: Vec<PathBranch<'a>> = Vec::new();
+    // #2235: each node is delivered to `sink` as soon as it is popped, and
+    // `f`/`cond` are resolved for a node only *after* that node's own
+    // delivery is accepted — never before, and never for a node whose
+    // delivery already stopped the walk — so a bounded consumer (`limit`,
+    // `first`, an enclosing fold's own early stop, including a stop that
+    // fires immediately off the seed itself) no longer pays for `f`/`cond`
+    // on any node it never asked to see, all the way down to the seed
+    // needing none at all: `path(limit(1; recurse(if (.|debug) < 3 then .+1
+    // else empty end)))` runs `debug` zero times in both jq and here, and
+    // `path(limit(2; ...))` (the same seed, needing one more output) runs it
+    // once in both — this function no longer runs it for every node up to
+    // `RECURSE_MAX_ITEMS` regardless of what was asked for, the way the
+    // collecting version always did.
+    //
+    // **What this does not close**: `f` is still resolved for one *accepted*
+    // node in full via `resolve_against_cow`, so if `f` is itself a
+    // multi-output generator, every one of that node's own outputs (and
+    // their side effects) fires even when a bounded consumer only ever asks
+    // for the first child's own subtree — confirmed live, `path(limit(2;
+    // recurse((.a|debug), (.b|debug))))` on `{"a":1,"b":2}` writes `debug`
+    // for `.a` only in jq (the second call's own child, `.b`, is never
+    // asked for once the bound is satisfied by `.a`'s own self-emission);
+    // here both fire. Real jq's `f | select(cond) | r` pulls `f`'s own
+    // outputs one at a time, fully recursing into each (`r`) before asking
+    // `f` for the next — closing this needs `f`'s own generator interleaved
+    // with this function's recursion, not just streamed delivery of what it
+    // already produced in one shot. See limitations.md.
+    let mut emitted = 0usize;
     // The seed is `.` itself -- no navigation -- so it inherits whatever
     // `value` already was (#1591), same as `resolve_recursive_descent`'s own
     // root entry. Every subsequent node on the stack comes from `f`, and
@@ -30923,7 +30957,7 @@ fn resolve_recurse<'a, S: EvalSemantics>(
     // error/break/halt — see that function's doc comment (#842).
     let mut pending_error: Option<EvalEscape> = None;
 
-    while !stack.is_empty() && outputs.len() < RECURSE_MAX_ITEMS {
+    while !stack.is_empty() && emitted < RECURSE_MAX_ITEMS {
         // `snapshot` is *not* uniformly `false` across this walk, though
         // this comment claimed it was until #1591. The seed is a
         // `PathBranch::new` (so `false`), but children come from `f`, and
@@ -30948,7 +30982,8 @@ fn resolve_recurse<'a, S: EvalSemantics>(
         // `current.clone()` is cheap (`Cow`, #668). `prefix` is a
         // `PathPrefix` (#701): `Rc::clone` is O(1), not the O(path length)
         // `Vec<Expr>` clone this used to pay per node.
-        outputs.push(PathBranch {
+        emitted += 1;
+        if sink(PathBranch {
             path: Rc::clone(&prefix),
             value: current.clone(),
             register: None,
@@ -30964,7 +30999,10 @@ fn resolve_recurse<'a, S: EvalSemantics>(
             // caller actually observes, so it is the one whose provenance a
             // downstream `FoldRegister` reads.
             snapshot: node_snapshot.clone(),
-        });
+        }) == Demand::Stop
+        {
+            return ResolveFlow::Stopped;
+        }
 
         let is_null_current = matches!(current.as_ref(), OwnedValue::Null);
 
@@ -31104,11 +31142,14 @@ fn resolve_recurse<'a, S: EvalSemantics>(
 
     // Same pending_error/stack-drain rule `finish_recurse_walk` documents
     // (#842, #1023) — can't share that helper directly, since this returns
-    // `PathResolveResult`, not `QueryResult`.
+    // `ResolveFlow`, not `QueryResult`. Hitting `RECURSE_MAX_ITEMS` with the
+    // stack still non-empty silently truncates without raising
+    // `pending_error`, exactly as the collecting version always did — not
+    // this change's rule to revisit.
     if stack.is_empty() {
-        path_result(outputs, pending_error)
+        flow_result(pending_error)
     } else {
-        Ok(outputs)
+        ResolveFlow::Exhausted
     }
 }
 
@@ -37077,7 +37118,7 @@ fn builtin_recurse_f<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
         // output is visited as one node (not spliced into its elements)
         // (#490). Pushed reversed so the first child stays on top and its
         // whole subtree completes before the next sibling is reached
-        // (#635) — see `resolve_recurse`'s doc comment for the general
+        // (#635) — see `resolve_recurse_sink`'s doc comment for the general
         // shape this mirrors. An error aborts the whole traversal, same as
         // jq's `def r: ., (f | r); r;` (#636) — but not until whatever `f`
         // itself already produced at this node has had its own full
@@ -37116,7 +37157,7 @@ fn builtin_recurse_f<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
 /// (`f`'s children, with `cond`'s fork flattened in encounter order) into a
 /// local `next` buffer, then pushes `next` onto the stack reversed, so the
 /// first entry — and its whole subtree — is visited before the next one
-/// (#635). See `resolve_recurse`'s doc comment for the same mechanism
+/// (#635). See `resolve_recurse_sink`'s doc comment for the same mechanism
 /// spelled out in more depth.
 ///
 /// An error from `f` or `cond` aborts the whole traversal (#636), but not
@@ -37159,7 +37200,7 @@ fn builtin_recurse_cond<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
         let (children, mut deferred_error) = eval_owned_multi_keep_partial::<S>(f, &current);
 
         // Collected in encounter order, then pushed onto `stack` reversed —
-        // see `resolve_recurse`'s doc comment (#635) — so the first entry's
+        // see `resolve_recurse_sink`'s doc comment (#635) — so the first entry's
         // whole subtree completes before the next is reached.
         let mut next: Vec<OwnedValue> = Vec::new();
         for child in children {
@@ -37168,9 +37209,9 @@ fn builtin_recurse_cond<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
             // rather than discarding `next`'s already-approved siblings from
             // earlier in this same loop (#854) — see `eval_recurse_cond`'s
             // own doc comment (#897) for the shared mechanics, and
-            // `resolve_recurse`'s matching arm for the full jq 1.7.1
+            // `resolve_recurse_sink`'s matching arm for the full jq 1.7.1
             // confirmation. No `is_null_current`-style gate here: unlike
-            // `resolve_recurse`, this evaluator has no such rule, so `cond`
+            // `resolve_recurse_sink`, this evaluator has no such rule, so `cond`
             // always gates for real (`gate: true`).
             if let Some(e) = eval_recurse_cond::<S>(cond, &child, true, || {
                 next.push(child.clone());
@@ -79774,8 +79815,8 @@ mod tests {
     }
 
     #[test]
-    fn test_resolve_recurse_keeps_f_partial_fanout_before_error_842() {
-        // Issue #842's path-position repro (`resolve_recurse`, no `cond`).
+    fn test_resolve_recurse_sink_keeps_f_partial_fanout_before_error_842() {
+        // Issue #842's path-position repro (`resolve_recurse_sink`, no `cond`).
         // Confirmed against real jq 1.7.1:
         // `echo '{"a":1,"b":2}' | jq -c 'path(recurse(if . ==
         // {"a":1,"b":2} then (.a, .b[0]) else empty end))'` prints `[]`
@@ -79793,7 +79834,7 @@ mod tests {
     #[test]
     fn test_resolve_recurse_cond_keeps_f_partial_fanout_before_error_842() {
         // Same as the previous test, but with `cond` present (always `true`,
-        // so it never itself gates or errors) — exercises `resolve_recurse`'s
+        // so it never itself gates or errors) — exercises `resolve_recurse_sink`'s
         // `Some(cond)` arm through the same deferred-error path.
         assert_eq!(
             outputs(
@@ -79858,8 +79899,8 @@ mod tests {
     }
 
     #[test]
-    fn test_resolve_recurse_max_items_truncation_suppresses_a_pending_error_842() {
-        // Path-position sibling of the previous test: `resolve_recurse`'s
+    fn test_resolve_recurse_sink_max_items_truncation_suppresses_a_pending_error_842() {
+        // Path-position sibling of the previous test: `resolve_recurse_sink`'s
         // own `stack.is_empty()` check (its `else` branch, hit only when
         // `MAX_ITEMS` truncates the drain before a `pending_error` would
         // otherwise surface) needs the same coverage as
@@ -79882,7 +79923,7 @@ mod tests {
 
     /// #1023: cross-check that `finish_recurse_walk`'s `stack_is_empty` gate
     /// (now shared by `builtin_recurse_f`/`builtin_recurse_cond`) and
-    /// `resolve_recurse`'s own independent `stack.is_empty()` gate still
+    /// `resolve_recurse_sink`'s own independent `stack.is_empty()` gate still
     /// agree on the MAX_ITEMS-truncates-a-pending-error edge case, rather
     /// than relying only on the two sibling tests above individually
     /// matching their own hand-picked expectations -- an invariant test
@@ -79962,7 +80003,7 @@ mod tests {
 
     #[test]
     fn test_resolve_recurse_cond_keeps_already_approved_siblings_before_error_854() {
-        // Path-position sibling of the previous test (`resolve_recurse`'s
+        // Path-position sibling of the previous test (`resolve_recurse_sink`'s
         // `Some(cond)` arm). Confirmed against real jq 1.7.1:
         // `echo '[1,2,3]' | jq -c 'path(recurse(if type=="array" then .[]
         // else empty end; if . == 2 then error("boom") else true end))'`
@@ -80105,7 +80146,7 @@ mod tests {
 
     #[test]
     fn test_resolve_recurse_cond_keeps_already_approved_siblings_before_break_854() {
-        // Path-position counterpart of the previous test (`resolve_recurse`'s
+        // Path-position counterpart of the previous test (`resolve_recurse_sink`'s
         // `Some(cond)` arm) -- the value-position case above was covered,
         // but the path-tracking evaluator's own `break` handling through the
         // same deferred-`cond_err` mechanism wasn't separately pinned.
@@ -80190,7 +80231,7 @@ mod tests {
 
     #[test]
     fn test_resolve_recurse_cond_max_items_truncation_suppresses_a_pending_error_854() {
-        // Path-position sibling of the previous test: `resolve_recurse`'s
+        // Path-position sibling of the previous test: `resolve_recurse_sink`'s
         // own `stack.is_empty()` check needs the same coverage when the
         // deferred error is sourced from `cond` rather than `f`.
         let large_doc = format!(
@@ -80208,7 +80249,7 @@ mod tests {
 
     #[test]
     fn test_resolve_recurse_cond_and_builtin_recurse_cond_agree_897() {
-        // #897: `resolve_recurse`'s `Some(cond)` arm and `builtin_recurse_cond`
+        // #897: `resolve_recurse_sink`'s `Some(cond)` arm and `builtin_recurse_cond`
         // share their per-child "gate through cond, fork on truthy outputs"
         // step via `eval_recurse_cond` (extracted here) -- this test is the
         // "cross-implementation invariant test" the issue itself suggested as
@@ -84852,12 +84893,12 @@ mod tests {
         );
     }
 
-    /// #1591: `resolve_recurse` dropped the `snapshot` mark from `f`'s own
+    /// #1591: `resolve_recurse_sink` dropped the `snapshot` mark from `f`'s own
     /// output at three sites, and — beyond what that issue's own repro
     /// needed — the mark was never threaded as *ambient input* through
     /// `resolve_node`'s dispatch at all, so every "passes a value through
     /// without navigating" arm (`select`, the typeof filters, a no-key
-    /// `getpath([])`, an already-untracked bare `.`, and `resolve_recurse`'s
+    /// `getpath([])`, an already-untracked bare `.`, and `resolve_recurse_sink`'s
     /// own seed/`..`'s own root entry) rebuilt its branch as a plain
     /// computed one instead of inheriting whatever `value` already was.
     /// Fixed by giving `snapshot` the same ambient-parameter treatment
@@ -84900,11 +84941,11 @@ mod tests {
             // navigation) — bounded with `limit(1; ...)` to isolate that
             // one output from `.a`'s own genuinely-navigated child (which
             // no longer matches `$x` and *should* still refuse; see
-            // `test_resolve_recurse_field_navigation_into_snapshot_wording_gap_1591`).
+            // `test_resolve_recurse_sink_field_navigation_into_snapshot_wording_gap_1591`).
             // The shared recurse-family untracked guard (`resolve_node`'s
             // own `RecursiveDescent | Recurse | RecurseDown | RecurseF |
             // RecurseCond` arm) used to refuse *any* untracked value
-            // unconditionally, before `resolve_recurse`'s own seed or
+            // unconditionally, before `resolve_recurse_sink`'s own seed or
             // `resolve_recursive_descent`'s root patch ever got a chance to
             // recognise a deferred snapshot — closed by loosening the guard
             // to `!trackable && !snapshot`, the same carve-out
@@ -85026,7 +85067,7 @@ mod tests {
     }
 
     /// A narrow, cosmetic gap the guard-loosening above exposed rather than
-    /// caused: `resolve_recurse` was previously unreachable with an
+    /// caused: `resolve_recurse_sink` was previously unreachable with an
     /// untracked seed at all (its own `debug_assert!` required
     /// `trackable`), so nothing ever exercised what happens when `f`
     /// *itself* fails to navigate from one. Both sides still refuse (exit
@@ -85039,13 +85080,13 @@ mod tests {
     /// that function's own doc comment). `$x` reestablishes against the
     /// fold's register (the document root), so `recurse(.a?)` now runs with
     /// genuine `trackable: true` instead of hitting `resolve_leaf`'s
-    /// untracked-`Field` guard before `resolve_recurse` is ever reached —
+    /// untracked-`Field` guard before `resolve_recurse_sink` is ever reached —
     /// and *that* is what produces jq's own `#530` "with result 1" wording
     /// (`.a` on `$x`'s value, `1`, is not itself a further path-shaped
     /// value) instead of `#843`'s "near attempt" message. Confirmed live
     /// against jq 1.7.1: byte-identical message and exit code.
     #[test]
-    fn test_resolve_recurse_field_navigation_into_snapshot_wording_gap_1591() {
+    fn test_resolve_recurse_sink_field_navigation_into_snapshot_wording_gap_1591() {
         query!(br#"{"a":1}"#,
             "path(. as $x | reduce (1) as $i (0; $x | recurse(.a?)))",
             QueryResult::Error(e) => {

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -26731,7 +26731,7 @@ type PathResolveResult<'a> = Result<Vec<PathBranch<'a>>, (Vec<PathBranch<'a>>, E
 ///
 /// [`Keep::AtMost`] exists for the one context where that rule is wrong: a
 /// `reduce`/`foreach` *source*, which jq evaluates with tracking on while
-/// consuming **every** value it produces (see [`resolve_fold_source`]).
+/// consuming **every** value it produces (see [`drive_fold_source`]).
 /// There the leaf's outputs are the fold's real values, so truncating to
 /// the first silently runs the fold too few times. `AtMost(1)` is
 /// byte-identical to `First` — the two are kept distinct only so the
@@ -26793,6 +26793,29 @@ fn path_result(branches: Vec<PathBranch<'_>>, escape: Option<EvalEscape>) -> Pat
         Some(e) => Err((branches, e)),
         None => Ok(branches),
     }
+}
+
+/// [`path_result`]'s sink-shaped twin: how a producer that already
+/// delivered every branch ended.
+fn flow_result(escape: Option<EvalEscape>) -> ResolveFlow {
+    match escape {
+        Some(e) => ResolveFlow::Escaped(e),
+        None => ResolveFlow::Exhausted,
+    }
+}
+
+/// Deliver `branches` in order, stopping at the sink's first
+/// [`Demand::Stop`] and reporting it.
+fn emit_branches<'a>(
+    branches: Vec<PathBranch<'a>>,
+    sink: &mut dyn FnMut(PathBranch<'a>) -> Demand,
+) -> Demand {
+    for branch in branches {
+        if sink(branch) == Demand::Stop {
+            return Demand::Stop;
+        }
+    }
+    Demand::Continue
 }
 
 /// Peel any wrapping `Expr::Paren` down to the inner expression — `(false)`
@@ -27674,6 +27697,104 @@ fn resolve_node_sink<'a, S: EvalSemantics>(
             }
         }
 
+        // #1440: `reduce`/`foreach` are real sugar over the same
+        // variable-binding primitive every other construct uses (real jq
+        // has no fold-specific path machinery at all), so a path-trackable
+        // variable referenced inside UPDATE/EXTRACT should track the same
+        // way it does anywhere else — but until this arm existed, both
+        // fell to `resolve_leaf`'s catch-all, which evaluates the whole
+        // construct via the ordinary value evaluator and always marks the
+        // result untracked. See `resolve_reduce`/`resolve_foreach` and
+        // `FoldRegister` for the full model, derived empirically against
+        // jq 1.7.1.
+        //
+        // The guard is `[Pattern::Var(_)]` — exactly one alternative, and
+        // that alternative a bare `$var` — because everything outside it
+        // is a shape real jq itself refuses in path position, or one this
+        // resolver cannot model:
+        //
+        // - **A destructuring pattern** (`as [$i]`, `as {v:$v}`) is refused
+        //   by jq *unconditionally* here, even when it matches cleanly:
+        //   `path(. as $x | reduce ([1]) as [$i] (0; $x))` raises "near
+        //   attempt to access element 0 of [1]", and the object form raises
+        //   the analogous message (both confirmed live against jq 1.7.1),
+        //   while the bare-`$var` spelling of the same fold is `[]`. So
+        //   falling through to `resolve_leaf` for a destructuring pattern
+        //   is jq's own behaviour, not a divergence — matching it here is
+        //   what keeps `resolve_reduce`/`resolve_foreach` from *accepting*
+        //   a fold jq rejects (and, on the write side, mutating a document
+        //   jq leaves untouched). The refusal matches; only the wording
+        //   does not — the catch-all names the whole fold's own value
+        //   rather than the destructuring step jq blames, which is the
+        //   pre-existing `resolve_leaf` message gap, not a new one.
+        //
+        // - **`?//`-alternatives** (`patterns.len() > 1`) are the one case
+        //   where falling through *is* a divergence: real jq still tracks a
+        //   variable through them (confirmed live: `path(. as $x | reduce
+        //   (1) as $y ?// $z (0; $x))` is `[]`). #1365's retry machinery
+        //   (`try_reduce_step_alternatives`/`try_foreach_step_alternatives`,
+        //   plus its null-fill for names the matching alternative doesn't
+        //   bind) landed on `main` after this arm was designed and isn't
+        //   threaded through path-tracking, so refusing is the safe answer
+        //   until it is — a refuse-only divergence, never a wrong path,
+        //   documented in `docs/compliance/jq/limitations.md`.
+        //
+        // Both fallbacks are pinned by
+        // `test_reduce_foreach_path_dispatch_falls_back_1440`.
+        //
+        // Native to the sink since #2235: each fold emission goes straight
+        // downstream, so the terminal `path()` check (`resolve_terminal`)
+        // refuses the first untracked output before the fold pulls its
+        // source again, exactly as jq's generator does.
+        Expr::Reduce {
+            input,
+            patterns,
+            init,
+            update,
+        } => match patterns.as_slice() {
+            [Pattern::Var(_)] => resolve_reduce::<S>(
+                input,
+                &patterns[0],
+                init,
+                update,
+                value,
+                trackable,
+                snapshot,
+                frame,
+                keep,
+                sink,
+            ),
+            _ => drain_path_result(
+                resolve_leaf::<S>(expr, value, trackable, snapshot, keep),
+                sink,
+            ),
+        },
+        Expr::Foreach {
+            input,
+            patterns,
+            init,
+            update,
+            extract,
+        } => match patterns.as_slice() {
+            [Pattern::Var(_)] => resolve_foreach::<S>(
+                input,
+                &patterns[0],
+                init,
+                update,
+                extract.as_deref(),
+                value,
+                trackable,
+                snapshot,
+                frame,
+                keep,
+                sink,
+            ),
+            _ => drain_path_result(
+                resolve_leaf::<S>(expr, value, trackable, snapshot, keep),
+                sink,
+            ),
+        },
+
         // `repeat(f)` (#1906) and the three bounded consumers below all
         // resolve through the sink now, so a bound threads through arbitrary
         // combinator nesting rather than only reaching a generator that is
@@ -27976,91 +28097,6 @@ fn resolve_node_eager<'a, S: EvalSemantics>(
         Expr::Builtin(Builtin::RecurseCond(f, cond)) => {
             resolve_recurse::<S>(f, Some(cond), value, trackable, snapshot, frame, keep)
         }
-
-        // #1440: `reduce`/`foreach` are real sugar over the same
-        // variable-binding primitive every other construct uses (real jq
-        // has no fold-specific path machinery at all), so a path-trackable
-        // variable referenced inside UPDATE/EXTRACT should track the same
-        // way it does anywhere else — but until this arm existed, both
-        // fell to `resolve_leaf`'s catch-all, which evaluates the whole
-        // construct via the ordinary value evaluator and always marks the
-        // result untracked. See `resolve_reduce`/`resolve_foreach` and
-        // `FoldRegister` for the full model, derived empirically against
-        // jq 1.7.1.
-        //
-        // The guard is `[Pattern::Var(_)]` — exactly one alternative, and
-        // that alternative a bare `$var` — because everything outside it
-        // is a shape real jq itself refuses in path position, or one this
-        // resolver cannot model:
-        //
-        // - **A destructuring pattern** (`as [$i]`, `as {v:$v}`) is refused
-        //   by jq *unconditionally* here, even when it matches cleanly:
-        //   `path(. as $x | reduce ([1]) as [$i] (0; $x))` raises "near
-        //   attempt to access element 0 of [1]", and the object form raises
-        //   the analogous message (both confirmed live against jq 1.7.1),
-        //   while the bare-`$var` spelling of the same fold is `[]`. So
-        //   falling through to `resolve_leaf` for a destructuring pattern
-        //   is jq's own behaviour, not a divergence — matching it here is
-        //   what keeps `resolve_reduce`/`resolve_foreach` from *accepting*
-        //   a fold jq rejects (and, on the write side, mutating a document
-        //   jq leaves untouched). The refusal matches; only the wording
-        //   does not — the catch-all names the whole fold's own value
-        //   rather than the destructuring step jq blames, which is the
-        //   pre-existing `resolve_leaf` message gap, not a new one.
-        //
-        // - **`?//`-alternatives** (`patterns.len() > 1`) are the one case
-        //   where falling through *is* a divergence: real jq still tracks a
-        //   variable through them (confirmed live: `path(. as $x | reduce
-        //   (1) as $y ?// $z (0; $x))` is `[]`). #1365's retry machinery
-        //   (`try_reduce_step_alternatives`/`try_foreach_step_alternatives`,
-        //   plus its null-fill for names the matching alternative doesn't
-        //   bind) landed on `main` after this arm was designed and isn't
-        //   threaded through path-tracking, so refusing is the safe answer
-        //   until it is — a refuse-only divergence, never a wrong path,
-        //   documented in `docs/compliance/jq/limitations.md`.
-        //
-        // Both fallbacks are pinned by
-        // `test_reduce_foreach_path_dispatch_falls_back_1440`.
-        Expr::Reduce {
-            input,
-            patterns,
-            init,
-            update,
-        } => match patterns.as_slice() {
-            [Pattern::Var(_)] => resolve_reduce::<S>(
-                input,
-                &patterns[0],
-                init,
-                update,
-                value,
-                trackable,
-                snapshot,
-                frame,
-                keep,
-            ),
-            _ => resolve_leaf::<S>(expr, value, trackable, snapshot, keep),
-        },
-        Expr::Foreach {
-            input,
-            patterns,
-            init,
-            update,
-            extract,
-        } => match patterns.as_slice() {
-            [Pattern::Var(_)] => resolve_foreach::<S>(
-                input,
-                &patterns[0],
-                init,
-                update,
-                extract.as_deref(),
-                value,
-                trackable,
-                snapshot,
-                frame,
-                keep,
-            ),
-            _ => resolve_leaf::<S>(expr, value, trackable, snapshot, keep),
-        },
 
         // #844: a frozen variable snapshot from a statically-verified
         // identity-passthrough `as`-binding (see `is_identity_passthrough`
@@ -28528,7 +28564,7 @@ fn resolve_leaf<'a, S: EvalSemantics>(
     // every ordinary `path()`/`=`/`|=`/`del()` entry, which is exactly the
     // stop-after-first sink described above. A `reduce`/`foreach` *source*
     // passes [`Keep::AtMost`] instead, because jq's fold does ask the
-    // generator for every value — see [`resolve_fold_source`].
+    // generator for every value — see [`drive_fold_source`].
     let limit = keep.limit();
     let mut values: Vec<OwnedValue> = Vec::new();
     let flow = eval_each_owned::<S>(expr, value, false, &mut |v| {
@@ -29350,111 +29386,98 @@ impl FoldRegister {
     }
 }
 
-/// Resolve a `reduce`/`foreach` source expression to the values the fold
-/// iterates, plus whatever control terminated it -- shared by
-/// [`resolve_reduce`] and [`resolve_foreach`] (#1467, #1872).
+/// Drive a `reduce`/`foreach` SOURCE **by demand** in path context,
+/// handing each element to `step` as the source produces it -- the fold
+/// loop runs *inside* `step`, so the next element is pulled only once the
+/// previous step has resolved, and a step that answers [`Demand::Stop`]
+/// ends the pull with nothing past it ever evaluated. That is jq's own
+/// generator model: `. as $x | path(foreach (.[] | stderr) as $i (0; $x))`
+/// on `[1,2,3]` writes `1` to stderr once and then raises on the first
+/// step's untrackable UPDATE (jq 1.7.1), where the collect-then-loop shape
+/// this replaced (#2235) pulled the whole source first and wrote `123`.
 ///
-/// Real jq evaluates a fold's source "with tracking on" and raises when it
-/// navigates *through* a computed value (`. as $x | reduce (keys[]) as $k
-/// (.; .)` raises "near attempt to iterate through" -- `keys[]`'s `Iterate`
-/// reaches into `keys`'s own untracked output -- live-verified against jq
-/// 1.7.1), even though most sources (`.a`, `.[]`, `keys`, `range(n)`, a
-/// literal) are accepted. `resolve_node`'s existing recursive dispatch
-/// already gets every one of those cases right for any other tracked
-/// position in this file, so routing the source through it reuses that
-/// logic rather than re-deriving it.
+/// Returns the source's own trailing escape, if it ended in one, *after*
+/// every element before it has been delivered -- the caller applies it once
+/// its own per-step verdict (stashed beside the drive, see
+/// [`reclaim_fold_escape`]) has had its say, for `reduce` too: `path(reduce
+/// (1,2,error("s")) as $i (.; stderr))` runs both UPDATE steps before
+/// raising `s`, exactly as jq does. `Exhausted` and `Stopped` both answer
+/// `None`; a stop's own reason lives in the caller's slot, and a
+/// [`Flow::Stopped`]'s `pending` (an eager fallback's already-computed
+/// escape) is dropped, because jq would never have pulled that far.
+///
+/// **The resolver's stream is the fold's stream.** In jq mode every branch
+/// the resolver delivers, trackable or not, is a real fold value, carrying
+/// its own navigated path as [`FoldSourceValue::register_path`] (#2031;
+/// [`resolve_reduce`]/[`resolve_foreach`] seed a per-step register from it
+/// rather than discarding that provenance -- an earlier attempt that
+/// streamed the values without the register is what randomised
+/// differential fuzzing against jq 1.7.1 caught, eleven of four thousand
+/// generated folds, every one a source with a trackable branch). And every
+/// escape the resolver raises, of any kind, is the fold's escape. Until
+/// #2235 an escape that was neither `Halt` nor an untracked-navigation
+/// error fell back to re-evaluating the whole source untracked, on the
+/// theory that the resolver's prefix might be *shorter* than jq's. That
+/// re-evaluation was itself the divergence: it double-fired the source's
+/// side effects, and it discarded the per-step register, turning jq's
+/// refusal into an answer -- `[label $out | path(foreach (.[], break $out)
+/// as $i (.; .))]` on `[1,2]` printed `[[],[]]` at exit 0 where jq raises
+/// "Invalid path expression with result [1,2]". A streaming source cannot
+/// take that decision back after emitting anyway, so the contract is now
+/// the simpler one, and the resolver's own arms are held to it: an arm
+/// that escapes must have delivered everything jq would have bound first
+/// (`Expr::Alternative`'s unfiltered escape prefix was the one such arm,
+/// fixed alongside).
 ///
 /// **Gated on `any_subexpr` finding an actual navigation step
-/// (`Field`/`Index`/`Slice`/`Iterate`)
-/// anywhere in `source`** -- only such a step can ever reach one of
-/// `resolve_node`'s own raising arms in the first place, so a source with
-/// none (`range(n)`, `keys`, a literal, and critically `input`/`inputs`)
-/// goes straight to `eval_owned_expr_fork` and is never resolved here at
-/// all. This isn't just an optimization: an earlier, ungated version of
-/// #1467's check evaluated `input`/`inputs`-sourced folds *twice* -- once
-/// for the check, once more for the real value -- silently desynchronizing
-/// the two evaluations' shared input-reader position, so the fold ran
-/// against the *second* input document while reporting an error that named
-/// the first (`reduce input as $x (0; $x)` over `10\n20\n30\n`: real jq
-/// names `10`, the ungated version named `20`).
+/// (`Field`/`Index`/`Slice`/`Iterate`) anywhere in `source`** -- only such
+/// a step can ever reach one of the resolver's own raising arms, so a
+/// source with none (`range(n)`, `keys`, a literal, and critically
+/// `input`/`inputs`) is driven by value through [`eval_each_owned`] and
+/// never resolved here at all. `input`/`inputs` is why the gate is not just
+/// an optimisation: the resolver's leaf collects a generator before
+/// delivering it, which would drain the shared input reader
+/// (`reduce input as $x (0; $x)` over `10\n20\n30\n` names `10` in jq),
+/// where the value-mode `each_inputs` pulls one document per demand.
 ///
-/// For a navigating source in jq mode whose resolved branches are all
-/// **untracked**, there is exactly **one** evaluation: [`Keep::AtMost`]
-/// makes `resolve_leaf`'s general case keep every output instead of #987's
-/// first one, so those branches' values *are* the fold's real values. That
-/// is what closes both of #1467's documented costs at once:
+/// [`Keep::AtMost`] is the dial that keeps a multi-output leaf whole:
+/// `Keep::First` would narrow `range(3)` to its first value, which is not
+/// a shorter error prefix but a *wrong fold* -- `reduce (limit(2;
+/// range(5)), .a) as $i` would run two iterations instead of three -- and
+/// blinds the check itself (`path(foreach (range(3) | (., if . == 2 then .a
+/// else empty end)) as $k (.; .))` raises jq's "near attempt to access
+/// element" only once the leaf reaches its third output). A bounded
+/// consumer *inside* the source still narrows it (`first(range(2e9))`
+/// contributes one element, not two billion).
 ///
-/// - a navigating source's first output no longer fires its side effect
-///   twice (`. as $x | path(reduce (.[] | stderr) as $i (0; $x))` on `[1]`
-///   writes `1` once, matching jq);
-/// - `foreach` keeps the outputs a source legitimately streamed before the
-///   element that raises -- `path(foreach (1,2,keys[]) as $k (.; .))` on
-///   `{"a":1}` now streams `[]` twice before raising, as jq does (#1872).
-///   The escape is returned *with* those values rather than short-circuiting,
-///   and [`resolve_foreach`]'s own per-element loop applies it after
-///   streaming them, exactly as it already did for an ordinary `Partial`
-///   source.
+/// Six places below this call launder an `Err` into a short `Ok` --
+/// `Expr::Optional`'s blanket arm, `resolve_catch`'s no-`catch` case,
+/// `Expr::Label` on a matching break, `resolve_bounded_sink`'s
+/// satisfied-bound fold to `Exhausted`, `resolve_recurse`'s
+/// `RECURSE_MAX_ITEMS` cap, and `resolve_repeat_sink`'s round cap. The
+/// values they deliver are a fold's values here, so anyone changing one of
+/// those is changing a fold's values too.
 ///
-/// A *trackable* branch means the source is itself a path expression in
-/// jq's eyes, and jq's fold then behaves in a way #1467's original shape
-/// alone could not model: the source's own navigation clobbers the shared
-/// path register, so a later UPDATE step's own emission is checked against
-/// *that* clobbered position, not the fold's persistent, INIT-seeded one
-/// (`path(foreach (.a) as $k (.; .))` on `{"a":1}` exits 5 in jq — #2031).
-/// Every resolved branch, trackable or not, becomes a real source value
-/// here (`Keep::AtMost` above already guarantees these are jq's real fold
-/// values); a trackable branch's own path rides along as
-/// [`FoldSourceValue::register_path`] so [`resolve_reduce`]/
-/// [`resolve_foreach`] can seed a fresh, per-step register from it instead
-/// of silently discarding that provenance. An earlier, cruder attempt at
-/// this — streaming the resolved values without also threading the
-/// per-step register override — is what randomised differential fuzzing
-/// against jq 1.7.1 caught: it regressed eleven of four thousand generated
-/// folds, every one of them a source with a trackable branch, and zero
-/// without. The threading in `resolve_reduce`/`resolve_foreach` is what
-/// closes that gap rather than reopening it; see those functions' own doc
-/// comments for the register-clobber mechanism itself.
+/// A source with a `?//` re-enters `step` after a stop has been reported
+/// (#1519's retry, seen from the consuming side): the caller resets its
+/// slot on every entry and stashes through [`stop_with_escape`], which is
+/// what keeps a halted step from being retried -- `path(foreach (1 as $x
+/// ?// $y | 1) as $v (.; stderr | error("u")))` on `1` writes `1null` then
+/// raises `u` in jq 1.7.1 (the retry runs the step on the reset state),
+/// while the same shape with `halt_error` halts once.
 ///
-/// `Keep::First` would silently break both: it narrows a multi-output leaf
-/// like `range(3)` to its first value, which is not merely a shorter error
-/// prefix but a *wrong fold* -- `reduce (limit(2; range(5)), .a) as $i` would
-/// run two iterations instead of three. It also makes the check itself
-/// blind: `path(foreach (range(3) | (., if . == 2 then .a else empty end))
-/// as $k (.; .))` raises jq's tracked "near attempt to access element" only
-/// once the leaf is allowed to reach its third output.
-///
-/// **The invariant this now depends on is stronger than the one this file
-/// generally maintains.** A resolved prefix is only ever promised to be no
-/// *longer* than jq's; a *shorter* one has always been acceptable, because
-/// branches were previously discarded here.
-/// They are values now, so a short prefix is a wrong answer rather than a
-/// wrong error message. The `Err(_)` arm below deliberately falls back to
-/// `eval_owned_expr_fork` for any escape that is neither `Halt` nor
-/// `EvalError::is_untracked_navigation_error`, which covers the escapes
-/// this check exists to surface and leaves every other one to the untracked
-/// evaluator that has always answered them (and keeps
-/// `test_reduce_foreach_escapes_and_partial_prefix_1440`'s `foreach
-/// (1,2,error("s"))` prefix intact). It does **not** cover the six places
-/// that launder an `Err` into a short `Ok` below this call -- `Expr::Optional`'s
-/// blanket arm, `resolve_catch`'s no-`catch` case, `Expr::Label` on a
-/// matching break, `resolve_bounded_sink`'s satisfied-bound fold to
-/// `Exhausted`, `resolve_recurse`'s `RECURSE_MAX_ITEMS` cap, and
-/// `resolve_repeat_sink`'s round cap. Anyone changing
-/// one of those is changing a fold's values here too.
-///
-/// **`EvalTag::Jq` only.** Real yq's lexer rejects `reduce`, `foreach` *and*
-/// `path` outright (confirmed live against yq v4.53.3), so yq mode has no
-/// oracle to check a value against, and `resolve_index_expr`'s yq-only
-/// `scalar_noop` arm would feed the *unchanged target* into the fold where
-/// the evaluator raises. Yq keeps #1467's original two-pass shape: check
-/// with `Keep::First`, take the values from `eval_owned_expr_fork`.
-fn resolve_fold_source<S: EvalSemantics>(
+/// **`EvalTag::Jq` only.** Real yq's lexer rejects `reduce`, `foreach`
+/// *and* `path` outright (confirmed live against yq v4.53.3), so yq mode
+/// has no oracle to check a value against, and `resolve_index_expr`'s
+/// yq-only `scalar_noop` arm would feed the *unchanged target* into the
+/// fold where the evaluator raises. Yq keeps #1467's original two-pass
+/// shape: check with `Keep::First`, then drive the values by value.
+fn drive_fold_source<S: EvalSemantics>(
     source: &Expr,
-    value: &OwnedValue,
-    trackable: bool,
-    snapshot: &Snapshot,
-    frame: &Frame,
-) -> (Vec<FoldSourceValue>, Option<Control>) {
+    ambient: &FoldSourceAmbient<'_>,
+    relocate_base: Option<&Rc<PathPrefix>>,
+    step: &mut dyn FnMut(FoldSourceValue) -> Demand,
+) -> Option<Control> {
     let has_navigation = any_subexpr(source, &mut |e| {
         matches!(
             e,
@@ -29462,57 +29485,84 @@ fn resolve_fold_source<S: EvalSemantics>(
         )
     });
     if !has_navigation {
-        let (values, control) = eval_owned_expr_fork::<S>(source, value, false);
-        return (no_fold_register(values), control);
+        return drive_fold_source_by_value::<S>(source, ambient.value, step);
     }
-    let keep = if S::TAG == EvalTag::Jq {
-        Keep::AtMost(usize::MAX)
-    } else {
-        Keep::First
-    };
-    let resolved = resolve_node::<S>(source, value, trackable, snapshot, frame, keep);
     if S::TAG != EvalTag::Jq {
         // Yq: branches discarded, only the fatal escape kept (#1467's
         // original shape) -- see this function's doc comment.
-        return match resolved {
-            Err((_, e @ EvalEscape::Halt(_))) => (Vec::new(), Some(e.into())),
+        return match resolve_node::<S>(
+            source,
+            ambient.value,
+            ambient.trackable,
+            &ambient.snapshot,
+            &ambient.frame,
+            Keep::First,
+        ) {
+            Err((_, e @ EvalEscape::Halt(_))) => Some(e.into()),
             Err((_, EvalEscape::Error(e))) if e.is_untracked_navigation_error() => {
-                (Vec::new(), Some(Control::Error(e)))
+                Some(Control::Error(e))
             }
-            _ => {
-                let (values, control) = eval_owned_expr_fork::<S>(source, value, false);
-                (no_fold_register(values), control)
-            }
+            _ => drive_fold_source_by_value::<S>(source, ambient.value, step),
         };
     }
-    let (branches, escape) = match resolved {
-        Ok(branches) => (branches, None),
-        Err((prefix, e @ EvalEscape::Halt(_))) => (prefix, Some(e)),
-        Err((prefix, EvalEscape::Error(e))) if e.is_untracked_navigation_error() => {
-            (prefix, Some(EvalEscape::Error(e)))
-        }
-        // Any other escape is the untracked evaluator's to report -- see
-        // this function's doc comment.
-        Err(_) => {
-            let (values, control) = eval_owned_expr_fork::<S>(source, value, false);
-            return (no_fold_register(values), control);
-        }
-    };
-    // #2031: every resolved branch becomes a real source value regardless
-    // of its own trackability -- see this function's doc comment. A
-    // trackable branch's own path is threaded through as `register_path`
-    // rather than discarded.
-    let elements = branches
-        .into_iter()
-        .map(|b| {
-            let register_path = b.trackable.then(|| Rc::clone(&b.path));
-            FoldSourceValue {
-                value: b.value.into_owned(),
+    let flow = resolve_node_sink::<S>(
+        source,
+        ambient.value,
+        ambient.trackable,
+        &ambient.snapshot,
+        &ambient.frame,
+        Keep::AtMost(usize::MAX),
+        &mut |branch| {
+            // #2031: a trackable branch's own path rides along as
+            // `register_path` -- rebased onto the register for the one
+            // ambient shape whose paths come back relative to it
+            // (`FoldSourceAmbient::relocate`, #2388), mirroring
+            // `FoldRegister::relocate`'s own trackable arm.
+            let register_path = branch.trackable.then(|| match relocate_base {
+                Some(base) => PathPrefix::extend_many(base, branch.path.to_vec()),
+                None => Rc::clone(&branch.path),
+            });
+            step(FoldSourceValue {
+                value: branch.value.into_owned(),
                 register_path,
-            }
+            })
+        },
+    );
+    match flow {
+        ResolveFlow::Exhausted | ResolveFlow::Stopped => None,
+        ResolveFlow::Escaped(e) => Some(e.into()),
+    }
+}
+
+/// The value-mode half of [`drive_fold_source`]: the source driven through
+/// [`eval_each_owned`], each output a [`FoldSourceValue`] with no register
+/// provenance to seed a per-step register from.
+fn drive_fold_source_by_value<S: EvalSemantics>(
+    source: &Expr,
+    value: &OwnedValue,
+    step: &mut dyn FnMut(FoldSourceValue) -> Demand,
+) -> Option<Control> {
+    match eval_each_owned::<S>(source, value, false, &mut |value| {
+        step(FoldSourceValue {
+            value,
+            register_path: None,
         })
-        .collect();
-    (elements, escape.map(Control::from))
+    }) {
+        Flow::Exhausted | Flow::Stopped { .. } => None,
+        Flow::Escaped(control) => Some(control),
+    }
+}
+
+/// A fold's verdict once [`drive_fold_source`] returns: the step's own
+/// stashed escape wins over the source's trailing one (a stopped drive has
+/// no trailing escape; an escaped drive never stopped), and reclaiming the
+/// stash clears the non-retryable side channel [`stop_with_escape`] set,
+/// the same way [`resume_from_escape`] does for a [`Flow`]-shaped reclaim.
+fn reclaim_fold_escape(aborted: Option<Control>, source: Option<Control>) -> Option<Control> {
+    if aborted.is_some() {
+        clear_nonretryable_stop();
+    }
+    aborted.or(source)
 }
 
 /// One value a fold's source stream produced, alongside whether *that
@@ -29528,17 +29578,12 @@ fn resolve_fold_source<S: EvalSemantics>(
 /// `None` means this element was merely computed (a literal, `keys[]`'s
 /// own untracked output, ...), in which case UPDATE is checked against the
 /// fold's usual persistent register exactly as it always has been --
-/// [`resolve_fold_source`]'s pre-#2031 behaviour, unchanged for this case.
+/// [`drive_fold_source`]'s pre-#2031 behaviour, unchanged for this case.
 struct FoldSourceValue {
     value: OwnedValue,
     register_path: Option<Rc<PathPrefix>>,
 }
 
-/// [`FoldSourceValue`]s with no register provenance, for the two
-/// [`resolve_fold_source`] exits that never resolve through
-/// [`resolve_node`] at all (yq mode, and a source with no navigation
-/// shape) -- their values carry no path-navigation provenance to seed a
-/// per-step register from.
 /// Evaluate an `as`-binding's source in path position, for
 /// `resolve_node`'s `Expr::As` arm (#2042): each bound value paired with
 /// the [`Origin`] its marker should carry -- `Some(Origin::At { .. })` when
@@ -29848,20 +29893,10 @@ fn slice_witnesses_node(path: &PathPrefix, value: &OwnedValue) -> bool {
     }
 }
 
-fn no_fold_register(values: Vec<OwnedValue>) -> Vec<FoldSourceValue> {
-    values
-        .into_iter()
-        .map(|value| FoldSourceValue {
-            value,
-            register_path: None,
-        })
-        .collect()
-}
-
 /// The ambient `.` a fold's SOURCE runs against on **one** INIT fork, plus
 /// that ambient's own provenance relative to that fork's own
-/// [`FoldRegister`] -- exactly the trio [`resolve_fold_source`] takes
-/// (#2388).
+/// [`FoldRegister`] -- exactly what [`drive_fold_source`] resolves the
+/// source against (#2388).
 struct FoldSourceAmbient<'v> {
     value: &'v OwnedValue,
     trackable: bool,
@@ -29870,8 +29905,8 @@ struct FoldSourceAmbient<'v> {
     /// ambient, unknown for the later forks' `null`.
     frame: Frame,
     /// Whether a trackable SOURCE branch's own path is *relative to*
-    /// `reg.path` rather than absolute, so [`relocate_source_registers`]
-    /// has to rebase it. Only ever `true` on a `null`-ambient fork whose
+    /// `reg.path` rather than absolute, so [`drive_fold_source`] has to
+    /// rebase it (its `relocate_base`). Only ever `true` on a `null`-ambient fork whose
     /// register sits somewhere other than the root -- on the first fork the
     /// ambient is the document itself, which is only ever at the register
     /// when the register is the root.
@@ -29896,7 +29931,7 @@ struct FoldSourceAmbient<'v> {
 ///
 /// -- the `length` row is what rules out treating this as a mere
 /// trackability question: the *values* SOURCE produces differ per fork too,
-/// so the substituted ambient has to reach [`resolve_fold_source`] itself,
+/// so the substituted ambient has to reach [`drive_fold_source`] itself,
 /// not just its two `bool`s.
 ///
 /// In `path()` context that is what makes a navigating SOURCE raise on the
@@ -29975,20 +30010,6 @@ fn fold_source_ambient<'v>(
     }
 }
 
-/// Rebase every trackable SOURCE element's own
-/// [`register_path`](FoldSourceValue::register_path) onto `base`, for the
-/// one ambient shape whose resolved paths come back relative to the
-/// register rather than absolute -- see
-/// [`FoldSourceAmbient::relocate`] (#2388). Mirrors
-/// [`FoldRegister::relocate`]'s own trackable arm exactly.
-fn relocate_source_registers(elements: &mut [FoldSourceValue], base: &Rc<PathPrefix>) {
-    for elem in elements {
-        if let Some(path) = &elem.register_path {
-            elem.register_path = Some(PathPrefix::extend_many(base, path.to_vec()));
-        }
-    }
-}
-
 /// `path()`-tracking counterpart of [`eval_reduce`] — resolves
 /// `reduce EXPR as $var (INIT; UPDATE)` in path context, replicating
 /// `eval_reduce`'s own control flow (INIT forks, per-source-element UPDATE
@@ -30026,7 +30047,8 @@ fn resolve_reduce<'a, S: EvalSemantics>(
     snapshot: &Snapshot,
     frame: &Frame,
     keep: Keep,
-) -> PathResolveResult<'a> {
+    sink: &mut dyn FnMut(PathBranch<'a>) -> Demand,
+) -> ResolveFlow {
     // INIT resolved first, before SOURCE (#2031, reordered from the
     // original #1467/#1872 shape): confirmed live against jq 1.7.1 (via
     // `debug`-instrumented INIT/SOURCE/UPDATE clauses) that real jq
@@ -30047,10 +30069,9 @@ fn resolve_reduce<'a, S: EvalSemantics>(
             Err((prefix, e)) => (prefix, Some(e)),
         };
     if init_branches.is_empty() {
-        return path_result(Vec::new(), init_escape);
+        return flow_result(init_escape);
     }
 
-    let mut out: Vec<PathBranch<'a>> = Vec::new();
     // Shared across every INIT fork (#695), same "whole tree, not
     // per-branch" accounting `eval_reduce` itself uses.
     let mut budget = REDUCE_FOREACH_MAX_STEPS;
@@ -30073,56 +30094,7 @@ fn resolve_reduce<'a, S: EvalSemantics>(
             snapshot,
             frame,
         );
-        // Mirrors `eval_reduce`'s own source-stream handling: `reduce`'s
-        // output is always single-shot, so a `Partial` input just extracts
-        // the control and drops the prefix (there's no path-tracking
-        // analogue of "a prefix" for the source stream itself, same as the
-        // value evaluator). `reduce` therefore returns on *any* source
-        // escape here, including #1467's path-check escape — only
-        // `foreach` has a prefix to stream first (#1872). Whatever earlier
-        // INIT forks already emitted into `out` survives, same as any
-        // other mid-loop abort below.
-        let (mut input_values, input_escape) = resolve_fold_source::<S>(
-            input,
-            ambient.value,
-            ambient.trackable,
-            &ambient.snapshot,
-            &ambient.frame,
-        );
-        if ambient.relocate {
-            relocate_source_registers(&mut input_values, &reg.path);
-        }
-        if let Some(control) = input_escape {
-            return path_result(out, Some(control.into()));
-        }
-
-        // `eval_reduce`'s own substitution, minus the two things this
-        // function's `[Pattern::Var(_)]` gate (see `resolve_node`'s
-        // dispatch arm) rules out: #1365's `patterns`-matrix, and #1368's
-        // null-fill for names an alternative leaves unbound -- a bare
-        // `$var` pattern binds its one name unconditionally, so there is
-        // never an unbound name to fill. #2031: an element whose own
-        // navigation moved the register (`register_path.is_some()`) marks
-        // its substituted `$var` as `Expr::TrackedVar` rather than a plain
-        // value, so a bare `$var` reference inside UPDATE can itself
-        // recognise the per-step register `FoldRegister::relocate`'s
-        // `identical()` fallback checks it against below (confirmed live:
-        // `path(foreach (.a) as $k (0; $k))` is `["a"]` -- `$k`'s own
-        // frozen value must be told apart from a coincidentally-equal
-        // computed one, exactly the distinction `PathBranch::snapshot`
-        // already exists to carry).
-        let substituted_updates: Vec<Result<Expr, EvalError>> = input_values
-            .iter()
-            .map(|elem| {
-                extract_pattern_bindings(pattern, &elem.value, false).map(|b| {
-                    if elem.register_path.is_some() {
-                        substitute_var_tracked(update, &b[0].0, &b[0].1)
-                    } else {
-                        substitute_vars(update, as_var_refs(&b))
-                    }
-                })
-            })
-            .collect();
+        let relocate_base = ambient.relocate.then_some(&reg.path);
 
         // `Option`, not a bare `OwnedValue`, mirroring `eval_reduce`'s own
         // accumulator exactly: a step whose UPDATE produces zero outputs
@@ -30160,20 +30132,54 @@ fn resolve_reduce<'a, S: EvalSemantics>(
         // recognise `reg` itself when the two coincide (`identical()`'s
         // existing snapshot-gated fallback), exactly as any other
         // navigated value would.
-        for substituted in &substituted_updates {
+        //
+        // The source is driven by demand (#2235): each element runs its
+        // UPDATE step here, inside the drive, before the next one is
+        // pulled. `reduce` emits nothing per element, but the steps still
+        // run before a trailing source escape is raised, as jq's do
+        // (`path(reduce (1,2,error("s")) as $i (.; stderr))` writes twice
+        // then raises `s`); whatever earlier INIT forks already emitted
+        // has already reached the sink and survives an abort, same as
+        // before. `aborted` is this
+        // driver's out-of-band escape slot, reset on every entry because a
+        // `?//` in the source re-enters the callback after a stop was
+        // already reported (see `foreach_forks`'s identical `ended`).
+        let source_control = drive_fold_source::<S>(input, &ambient, relocate_base, &mut |elem| {
+            aborted = None;
             if let Some(control) = charge_budget(&mut budget, "reduce") {
-                aborted = Some(control);
-                break;
+                return stop_with_escape(&mut aborted, control);
             }
-            let substituted = match substituted {
-                Ok(expr) => expr,
-                Err(e) => {
-                    aborted = Some(Control::Error(e.clone()));
-                    break;
+            // `eval_reduce`'s own substitution, minus the two things this
+            // function's `[Pattern::Var(_)]` gate (see `resolve_node`'s
+            // dispatch arm) rules out: #1365's `patterns`-matrix, and
+            // #1368's null-fill for names an alternative leaves unbound --
+            // a bare `$var` pattern binds its one name unconditionally, so
+            // there is never an unbound name to fill. #2031: an element
+            // whose own navigation moved the register
+            // (`register_path.is_some()`) marks its substituted `$var` as
+            // `Expr::TrackedVar` rather than a plain value, so a bare
+            // `$var` reference inside UPDATE can itself recognise the
+            // per-step register `FoldRegister::relocate`'s `identical()`
+            // fallback checks it against below (confirmed live:
+            // `path(foreach (.a) as $k (0; $k))` is `["a"]` -- `$k`'s own
+            // frozen value must be told apart from a coincidentally-equal
+            // computed one, exactly the distinction `PathBranch::snapshot`
+            // already exists to carry).
+            let substituted = match extract_pattern_bindings(pattern, &elem.value, false) {
+                Ok(b) if elem.register_path.is_some() => {
+                    substitute_var_tracked(update, &b[0].0, &b[0].1)
                 }
+                Ok(b) => substitute_vars(update, as_var_refs(&b)),
+                Err(e) => return stop_with_escape(&mut aborted, Control::Error(e)),
             };
             let acc_input = acc.take().unwrap_or(OwnedValue::Null);
-            match reg.resolve::<S>(substituted, acc_input, acc_at_register, &acc_snapshot, keep) {
+            match reg.resolve::<S>(
+                &substituted,
+                acc_input,
+                acc_at_register,
+                &acc_snapshot,
+                keep,
+            ) {
                 Ok(branches) => {
                     // Only the last output of a multi-output UPDATE
                     // becomes the new accumulator (same rule as
@@ -30206,55 +30212,57 @@ fn resolve_reduce<'a, S: EvalSemantics>(
                     let last = branches.into_iter().last();
                     (acc_at_register, acc_snapshot) = reg.branch_provenance(last.as_ref());
                     acc = last.map(|b| b.value.into_owned());
+                    Demand::Continue
                 }
-                Err((_prefix, e)) => {
-                    // Whatever this step's UPDATE partially resolved
-                    // before erroring never becomes a real accumulator —
-                    // the whole fork aborts here, same as `eval_reduce`'s
-                    // own `aborted = Some(control); break;`.
-                    aborted = Some(e.into());
-                    break;
-                }
+                // Whatever this step's UPDATE partially resolved before
+                // erroring never becomes a real accumulator — the whole
+                // fork aborts here, same as `eval_reduce`'s own `aborted =
+                // Some(control); break;`, and nothing past this element is
+                // ever pulled from the source.
+                Err((_prefix, e)) => stop_with_escape(&mut aborted, e.into()),
             }
+        });
+        if let Some(control) = reclaim_fold_escape(aborted, source_control) {
+            return ResolveFlow::Escaped(control.into());
         }
-        match aborted {
-            Some(control) => return path_result(out, Some(control.into())),
-            None => {
-                // Final emission: the accumulator, re-checked against the
-                // same fixed register one more time — reduce's own exit
-                // back into its caller is itself a "re-entry" boundary,
-                // exactly like the reset between source-element
-                // iterations above, so a transient trackable result from
-                // the last UPDATE step does not automatically survive
-                // (confirmed live, see this function's own doc comment).
-                //
-                // The re-check is on the accumulator's *provenance*, not on
-                // its value (#1466): a value comparison promoted any
-                // reconstruction that happened to land on the register's
-                // value, which is exactly what jq's pointer-based
-                // `jv_identical` refuses. The branch handed to `relocate` is
-                // therefore built *relative* to the register — an empty path
-                // for "still at the register", which `relocate` then extends
-                // by `reg.path` exactly once — rather than absolute, which
-                // would prepend `reg.path` a second time.
-                let acc = acc.unwrap_or(OwnedValue::Null);
-                let final_branch = if acc_at_register {
-                    PathBranch::new(PathPrefix::root(), Cow::Owned(acc), true)
-                } else {
-                    // `demoted`, not `untracked`: an accumulator that is
-                    // still a frozen snapshot stays recognisable to an
-                    // *outer* register when this fold is itself nested
-                    // inside another one, and to `relocate`'s own
-                    // `identical` check just below when this register is
-                    // trackable but the last UPDATE never navigated back
-                    // to it.
-                    PathBranch::demoted(acc_snapshot, Cow::Owned(acc))
-                };
-                out.extend(reg.relocate(vec![final_branch]));
-            }
+        // Final emission: the accumulator, re-checked against the
+        // same fixed register one more time — reduce's own exit
+        // back into its caller is itself a "re-entry" boundary,
+        // exactly like the reset between source-element
+        // iterations above, so a transient trackable result from
+        // the last UPDATE step does not automatically survive
+        // (confirmed live, see this function's own doc comment).
+        //
+        // The re-check is on the accumulator's *provenance*, not on
+        // its value (#1466): a value comparison promoted any
+        // reconstruction that happened to land on the register's
+        // value, which is exactly what jq's pointer-based
+        // `jv_identical` refuses. The branch handed to `relocate` is
+        // therefore built *relative* to the register — an empty path
+        // for "still at the register", which `relocate` then extends
+        // by `reg.path` exactly once — rather than absolute, which
+        // would prepend `reg.path` a second time.
+        let acc = acc.unwrap_or(OwnedValue::Null);
+        let final_branch = if acc_at_register {
+            PathBranch::new(PathPrefix::root(), Cow::Owned(acc), true)
+        } else {
+            // `demoted`, not `untracked`: an accumulator that is
+            // still a frozen snapshot stays recognisable to an
+            // *outer* register when this fold is itself nested
+            // inside another one, and to `relocate`'s own
+            // `identical` check just below when this register is
+            // trackable but the last UPDATE never navigated back
+            // to it.
+            PathBranch::demoted(acc_snapshot, Cow::Owned(acc))
+        };
+        // Emitted through the sink as soon as this fork is done, so a
+        // terminal consumer's refusal (or a bound's stop) is seen before
+        // the next INIT fork ever drives the source (#2235).
+        if emit_branches(reg.relocate(vec![final_branch]), sink) == Demand::Stop {
+            return ResolveFlow::Stopped;
         }
     }
-    path_result(out, init_escape)
+    flow_result(init_escape)
 }
 
 /// `path()`-tracking counterpart of [`eval_foreach`] — see [`resolve_reduce`]
@@ -30290,7 +30298,8 @@ fn resolve_foreach<'a, S: EvalSemantics>(
     snapshot: &Snapshot,
     frame: &Frame,
     keep: Keep,
-) -> PathResolveResult<'a> {
+    sink: &mut dyn FnMut(PathBranch<'a>) -> Demand,
+) -> ResolveFlow {
     // Ambient `snapshot` threaded the same way `resolve_reduce` threads it
     // into its own INIT resolution — see that function's doc comment
     // (#1591). #2031: INIT resolved before SOURCE, same reordering as
@@ -30302,10 +30311,9 @@ fn resolve_foreach<'a, S: EvalSemantics>(
             Err((prefix, e)) => (prefix, Some(e)),
         };
     if init_branches.is_empty() {
-        return path_result(Vec::new(), init_escape);
+        return flow_result(init_escape);
     }
 
-    let mut out: Vec<PathBranch<'a>> = Vec::new();
     let mut budget = REDUCE_FOREACH_MAX_STEPS;
     // #2388: see `resolve_reduce`'s identical hoist.
     let null_ambient = OwnedValue::Null;
@@ -30325,55 +30333,7 @@ fn resolve_foreach<'a, S: EvalSemantics>(
             snapshot,
             frame,
         );
-        // Unlike `reduce`, a `Partial` source stream's own prefix is
-        // iterated below — mirrors `eval_foreach`'s identical rule, and
-        // #1467's path-check escape is now just another such trailing
-        // control rather than a short-circuit ahead of this call, which is
-        // what lets the elements produced before it still stream (#1872).
-        let (mut input_values, input_control) = resolve_fold_source::<S>(
-            input,
-            ambient.value,
-            ambient.trackable,
-            &ambient.snapshot,
-            &ambient.frame,
-        );
-        if ambient.relocate {
-            relocate_source_registers(&mut input_values, &reg.path);
-        }
-
-        // `eval_foreach`'s own substitution, minus the two things this
-        // function's `[Pattern::Var(_)]` gate (see `resolve_node`'s dispatch
-        // arm) rules out: #1365's `patterns`-matrix, and #1368's null-fill for
-        // names an alternative leaves unbound — a bare `$var` pattern binds its
-        // one name unconditionally, so there is never an unbound name to fill
-        // (same reasoning as `resolve_reduce`'s own substitution above). Fused
-        // into one `Vec` (rather than three parallel ones keyed by the same
-        // index, reusing `eval_foreach`'s own `ForeachStepAlternative` pair
-        // type) so the extract/update agreement is unrepresentable rather than
-        // merely unreachable-in-practice — see #1369. Each element's bindings
-        // are dropped as soon as they are consumed instead of being retained as
-        // a second full copy of the input stream for the rest of the call.
-        // #2031: a trackable element's `$var` is substituted as
-        // `Expr::TrackedVar` (into both UPDATE and EXTRACT), the same
-        // reasoning as `resolve_reduce`'s own substitution above.
-        let substituted: Vec<ForeachStepAlternative> = input_values
-            .iter()
-            .map(|elem| {
-                extract_pattern_bindings(pattern, &elem.value, false).map(|b| {
-                    if elem.register_path.is_some() {
-                        (
-                            substitute_var_tracked(update, &b[0].0, &b[0].1),
-                            extract.map(|ext| substitute_var_tracked(ext, &b[0].0, &b[0].1)),
-                        )
-                    } else {
-                        (
-                            substitute_vars(update, as_var_refs(&b)),
-                            extract.map(|ext| substitute_vars(ext, as_var_refs(&b))),
-                        )
-                    }
-                })
-            })
-            .collect();
+        let relocate_base = ambient.relocate.then_some(&reg.path);
 
         // `state`'s own provenance (#1590), mirroring `resolve_reduce`'s
         // `acc_at_register`/`acc_snapshot` exactly — see `FoldRegister::resolve`'s
@@ -30382,18 +30342,58 @@ fn resolve_foreach<'a, S: EvalSemantics>(
         let mut state_at_register = init_branch.trackable;
         let mut state_snapshot = init_branch.snapshot.clone();
         let mut aborted: Option<Control> = None;
-        'input: for (elem, step) in input_values.iter().zip(&substituted) {
+        // The source is driven by demand (#2235): each element is folded
+        // here, inside the drive, before the next one is pulled, so a step
+        // that raises stops the source with nothing past it evaluated --
+        // `. as $x | path(foreach (.[] | stderr) as $i (0; $x))` on
+        // `[1,2,3]` writes `1` once, as jq does. The source's own trailing
+        // escape is applied after the drive, per fork (#534 follow-up), so
+        // the elements before it still stream (#1872). `aborted` is this
+        // driver's out-of-band escape slot, reset on every entry because a
+        // `?//` in the source re-enters the callback after a stop was
+        // already reported (see `foreach_forks`'s identical `ended`).
+        // Every emission goes straight to the sink, so a terminal
+        // consumer's refusal of the first output -- or an outer bound's
+        // stop -- ends the drive right there. `downstream_stopped` is reset
+        // on entry like `aborted`: jq retries a source `?//` after either
+        // kind of stop and it is the retry's verdict that counts
+        // (`resolve_terminal` resets its own slot for the same reason). A
+        // bound *outside* `path()` cannot reach here at all -- `path()`
+        // collects before its consumer sees anything -- so the retried
+        // over-delivery jq shows there (`[limit(1; path(foreach (1 as $x
+        // ?// $y | (stderr|1)) as $v (.; .)))]` is `[[],[]]` in jq 1.7.1)
+        // is not reproduced; see limitations.md.
+        let mut downstream_stopped = false;
+        let source_control = drive_fold_source::<S>(input, &ambient, relocate_base, &mut |elem| {
+            downstream_stopped = false;
+            aborted = None;
             if let Some(control) = charge_budget(&mut budget, "foreach") {
-                aborted = Some(control);
-                break;
+                return stop_with_escape(&mut aborted, control);
             }
-            let (substituted_update, substituted_extract) = match step {
-                Ok((upd, ext)) => (upd, ext),
-                Err(e) => {
-                    aborted = Some(Control::Error(e.clone()));
-                    break;
-                }
-            };
+            // `eval_foreach`'s own substitution, minus the two things this
+            // function's `[Pattern::Var(_)]` gate (see `resolve_node`'s
+            // dispatch arm) rules out: #1365's `patterns`-matrix, and
+            // #1368's null-fill for names an alternative leaves unbound — a
+            // bare `$var` pattern binds its one name unconditionally, so
+            // there is never an unbound name to fill (same reasoning as
+            // `resolve_reduce`'s own substitution). Substituted per element
+            // as it arrives, into UPDATE and EXTRACT together so their
+            // agreement is unrepresentable rather than merely
+            // unreachable-in-practice (#1369). #2031: a trackable element's
+            // `$var` is substituted as `Expr::TrackedVar` (into both), the
+            // same reasoning as `resolve_reduce`'s own substitution.
+            let (substituted_update, substituted_extract) =
+                match extract_pattern_bindings(pattern, &elem.value, false) {
+                    Ok(b) if elem.register_path.is_some() => (
+                        substitute_var_tracked(update, &b[0].0, &b[0].1),
+                        extract.map(|ext| substitute_var_tracked(ext, &b[0].0, &b[0].1)),
+                    ),
+                    Ok(b) => (
+                        substitute_vars(update, as_var_refs(&b)),
+                        extract.map(|ext| substitute_vars(ext, as_var_refs(&b))),
+                    ),
+                    Err(e) => return stop_with_escape(&mut aborted, Control::Error(e)),
+                };
             // #2031: see `resolve_reduce`'s identical per-step register
             // override.
             let (active_reg, active_at_register) = match &elem.register_path {
@@ -30488,25 +30488,36 @@ fn resolve_foreach<'a, S: EvalSemantics>(
                 ),
             };
             let update_branches = match active_reg.resolve::<S>(
-                substituted_update,
-                state,
+                &substituted_update,
+                core::mem::replace(&mut state, OwnedValue::Null),
                 active_at_register,
                 &state_snapshot,
                 keep,
             ) {
                 Ok(branches) => branches,
-                Err((_prefix, e)) => {
-                    aborted = Some(e.into());
-                    break;
-                }
+                Err((_prefix, e)) => return stop_with_escape(&mut aborted, e.into()),
             };
+            // Each UPDATE output becomes the state *before* it is emitted --
+            // jq stores it first, then runs EXTRACT/emits -- so the last one
+            // carries forward as the next element's state (same rule as
+            // `eval_foreach`), with its provenance (#1590, mirroring
+            // `resolve_reduce`'s `acc_at_register`/`acc_snapshot`). The
+            // ordering is observable once a stop is retried by a source
+            // `?//`: the retried step re-enters from the refused output, not
+            // from the state before it, which is how `path(foreach (1 as $x
+            // ?// $y | if $x == 1 then 1 else 2 end) as $v (.; if $v == 2
+            // then . else $v end))` names `1` in jq 1.7.1's second refusal.
+            if update_branches.is_empty() {
+                (state_at_register, state_snapshot) = reg.branch_provenance(None);
+            }
             for update_branch in &update_branches {
-                if let Some(ext_expr) = substituted_extract {
+                (state_at_register, state_snapshot) = reg.branch_provenance(Some(update_branch));
+                state = update_branch.value.clone().into_owned();
+                if let Some(ext_expr) = &substituted_extract {
                     if let Some(control) = charge_budget(&mut budget, "foreach") {
-                        aborted = Some(control);
-                        break 'input;
+                        return stop_with_escape(&mut aborted, control);
                     }
-                    let extract_reg = active_reg.advance(update_branch, substituted_update, frame);
+                    let extract_reg = active_reg.advance(update_branch, &substituted_update, frame);
                     // `update_branch` is itself already relocated (it's
                     // `active_reg.resolve()`'s own output above), and
                     // `advance()` built `extract_reg` from this same
@@ -30523,49 +30534,57 @@ fn resolve_foreach<'a, S: EvalSemantics>(
                         &extract_snapshot,
                         keep,
                     ) {
-                        Ok(branches) => out.extend(branches),
+                        Ok(branches) => {
+                            if emit_branches(branches, sink) == Demand::Stop {
+                                downstream_stopped = true;
+                                return Demand::Stop;
+                            }
+                        }
                         Err((prefix, e)) => {
-                            out.extend(prefix);
-                            aborted = Some(e.into());
-                            break 'input;
+                            if emit_branches(prefix, sink) == Demand::Stop {
+                                downstream_stopped = true;
+                                return Demand::Stop;
+                            }
+                            return stop_with_escape(&mut aborted, e.into());
                         }
                     }
-                } else if update_branch.trackable {
-                    out.push(PathBranch::new(
-                        update_branch.path.clone(),
-                        update_branch.value.clone(),
-                        true,
-                    ));
                 } else {
-                    // `demoted`, not `untracked`: an emitted value that is
-                    // still a frozen snapshot must stay recognisable to an
-                    // outer register when this `foreach` is nested inside
-                    // another fold (#1466) — same rule as `relocate`'s own
-                    // demotion arm.
-                    out.push(PathBranch::demoted(
-                        update_branch.snapshot.clone(),
-                        update_branch.value.clone(),
-                    ));
+                    let emitted = if update_branch.trackable {
+                        PathBranch::new(
+                            update_branch.path.clone(),
+                            update_branch.value.clone(),
+                            true,
+                        )
+                    } else {
+                        // `demoted`, not `untracked`: an emitted value that is
+                        // still a frozen snapshot must stay recognisable to an
+                        // outer register when this `foreach` is nested inside
+                        // another fold (#1466) — same rule as `relocate`'s own
+                        // demotion arm.
+                        PathBranch::demoted(
+                            update_branch.snapshot.clone(),
+                            update_branch.value.clone(),
+                        )
+                    };
+                    if sink(emitted) == Demand::Stop {
+                        downstream_stopped = true;
+                        return Demand::Stop;
+                    }
                 }
             }
-            // Only the last UPDATE output carries forward as state for the
-            // next source element — same rule as `eval_foreach`. Its
-            // provenance carries forward too now (#1590), mirroring
-            // `resolve_reduce`'s `acc_at_register`/`acc_snapshot` update via
-            // `FoldRegister::branch_provenance`.
-            let last = update_branches.into_iter().last();
-            (state_at_register, state_snapshot) = reg.branch_provenance(last.as_ref());
-            state = last.map_or(OwnedValue::Null, |b| b.value.into_owned());
-        }
+            Demand::Continue
+        });
         // The source stream's own trailing control belongs to this fork
-        // too, applied after its own inner loop — mirrors `eval_foreach`'s
+        // too, applied after its own inner drive — mirrors `eval_foreach`'s
         // #534-follow-up fix exactly.
-        let aborted = aborted.or_else(|| input_control.clone());
-        if let Some(control) = aborted {
-            return path_result(out, Some(control.into()));
+        if downstream_stopped {
+            return ResolveFlow::Stopped;
+        }
+        if let Some(control) = reclaim_fold_escape(aborted, source_control) {
+            return ResolveFlow::Escaped(control.into());
         }
     }
-    path_result(out, init_escape)
+    flow_result(init_escape)
 }
 
 /// Apply `Expr::Try`'s `catch` clause (if any) after `expr` failed to
@@ -32724,7 +32743,29 @@ fn assemble_one_branch(branch: &PathBranch<'_>) -> Expr {
     }
 }
 
-/// Raise on the first branch that was computed rather than navigated to.
+/// Resolve a top-level path expression and raise on the first branch that
+/// was computed rather than navigated to -- **as it is produced**, so the
+/// producer stops there and nothing past it is ever evaluated (#2235).
+/// jq validates each output of `path(f)` the instant it is emitted: `. as
+/// $x | path(foreach (.[] | stderr) as $i (0; $x))` on `[1,2,3]` writes `1`
+/// once and raises on the first step's own emission, never pulling the
+/// source again. Checking a collected vector after the fact, as this did
+/// until #2235, let every side effect in `f` fire first.
+///
+/// The check runs through [`resolve_node_sink`] with `Keep::First`, the
+/// terminal demand: a collecting sink that records the first violation
+/// and answers [`Demand::Stop`]. The slot is reset on every entry, because
+/// a `?//` in a fold's source re-enters after a stop has been reported
+/// (#1519's retry, seen from the consuming side) and it is the retry's
+/// verdict that counts -- confirmed live against jq 1.7.1:
+/// `path(foreach (1 as $x ?// $y | if $x == 1 then 1 else 2 end) as $v
+/// (.; .; if $v == 1 then 1 else . end))` is `[]`, the first
+/// alternative's refused `1` retried into the second's accepted `.`. A
+/// violation found among branches a
+/// *later* sibling's escape stopped resolution with still wins over that
+/// escape (#1560: `path(.a | (1, error("boom")))` raises "Invalid path
+/// expression with result 1" and never reaches `error("boom")`); with the
+/// stop at production that ordering falls out by construction.
 ///
 /// This is the genuinely terminal position (#986): `resolve_dynamic_indexes`
 /// is the top-level entry for all four of `path()`, `del()`, `=` and `|=`,
@@ -32818,68 +32859,47 @@ fn assemble_one_branch(branch: &PathBranch<'_>) -> Expr {
 /// direction, not merely a cosmetic one. Left on the pre-existing raise
 /// until that ordering is implemented for real; tracked as a follow-up
 /// rather than guessed at here.
-fn reject_untracked_at_terminal(
-    branches: Vec<PathBranch<'_>>,
+fn resolve_terminal<'a, S: EvalSemantics>(
+    expr: &Expr,
+    input: &'a OwnedValue,
     near_iterate: bool,
     skip_untracked: bool,
-) -> Result<Vec<PathBranch<'_>>, (Vec<PathBranch<'_>>, EvalEscape)> {
-    let mut kept = vec_with_capacity(branches.len());
-    for branch in branches {
-        if !branch.trackable {
-            if skip_untracked {
-                continue;
+) -> PathResolveResult<'a> {
+    let mut kept: Vec<PathBranch<'a>> = Vec::new();
+    let mut violation: Option<EvalEscape> = None;
+    // `input` is the call's own fresh document root — never itself a
+    // frozen `$x` snapshot, so ambient `snapshot` starts `false` (#1591),
+    // and the document `path()`/`=`/`|=`/`del()` were actually called on is
+    // always fully trackable (the untracked marker, #843, exists only for
+    // the value `resolve_catch` synthesizes for a `catch` handler).
+    let flow = resolve_node_sink::<S>(
+        expr,
+        input,
+        true,
+        &Snapshot::No,
+        &Frame::enter(expr),
+        Keep::First,
+        &mut |branch| {
+            violation = None;
+            if !branch.trackable {
+                if skip_untracked {
+                    return Demand::Continue;
+                }
+                violation = Some(if near_iterate {
+                    EvalError::invalid_path_expression_near_iterate(&branch.value).into()
+                } else {
+                    EvalError::invalid_path_expression(&branch.value).into()
+                });
+                return Demand::Stop;
             }
-            let error = if near_iterate {
-                EvalError::invalid_path_expression_near_iterate(&branch.value).into()
-            } else {
-                EvalError::invalid_path_expression(&branch.value).into()
-            };
-            return Err((kept, error));
-        }
-        kept.push(branch);
+            kept.push(branch);
+            Demand::Continue
+        },
+    );
+    match (violation, flow) {
+        (Some(e), _) | (None, ResolveFlow::Escaped(e)) => Err((kept, e)),
+        (None, ResolveFlow::Exhausted | ResolveFlow::Stopped) => Ok(kept),
     }
-    Ok(kept)
-}
-
-/// Same terminal check as [`reject_untracked_at_terminal`], but also run
-/// over whatever a *later* sibling's own escape stopped resolution with.
-///
-/// jq validates each `Expr::Comma` sibling's path-validity the instant it
-/// is produced, before the next sibling ever runs (confirmed live:
-/// `path(.a | (1, error("boom")))` raises "Invalid path expression with
-/// result 1" -- the first branch's own violation -- and never reaches
-/// `error("boom")` at all; jq prints nothing to stdout). `resolve_node`'s
-/// `Expr::Comma` arm cannot replicate that ordering on its own (#986
-/// Stage 2's reasoning still holds: mid-pipe, it does not yet know
-/// whether it is terminal), so it always resolves every sibling before
-/// returning. When a *later* sibling's own escape is what stopped that
-/// resolution, the branches collected before it still carry whatever an
-/// earlier, terminal-but-untracked sibling produced -- and without this,
-/// that branch skips the terminal check an all-`Ok` result gets, both
-/// surfacing the later sibling's error instead of jq's real one and
-/// leaking that untracked branch's stale path into the assembled prefix
-/// (#1560).
-fn reject_untracked_prefix_too(
-    result: PathResolveResult<'_>,
-    near_iterate: bool,
-    skip_untracked: bool,
-) -> PathResolveResult<'_> {
-    let (prefix, escape) = match result {
-        Ok(branches) => (branches, None),
-        Err((prefix, e)) => (prefix, Some(e)),
-    };
-    // `?` here is the priority rule: a terminal violation found in
-    // `prefix` propagates immediately, discarding `escape` (a later
-    // sibling's own error/break/halt that never got the chance to run
-    // in real jq either) -- exactly `path_result`'s own `Some`/`None`
-    // combine once a violation-free `prefix` reaches it. When
-    // `skip_untracked` is set, `reject_untracked_at_terminal` never
-    // returns `Err` at all (#1764), so this `?` is a no-op there and
-    // `escape` -- a genuine error/break/halt, never just an untracked
-    // value -- still always propagates through `path_result` below
-    // unchanged.
-    let checked = reject_untracked_at_terminal(prefix, near_iterate, skip_untracked)?;
-    path_result(checked, escape)
 }
 
 /// What `del()`'s own path prepass resolved a `del(f)` argument to.
@@ -32932,7 +32952,7 @@ enum DelPaths<'a> {
 ///   the moment it hits an untracked one, so mirroring the skip here would
 ///   make `del()` delete *more* than real yq does for some argument
 ///   orderings (`del(.a, 1)` deletes nothing in real yq; `del(1, .a)`
-///   deletes `.a`). See [`reject_untracked_at_terminal`]'s own doc comment
+///   deletes `.a`). See [`resolve_terminal`]'s own doc comment
 ///   for the live-verified permutations.
 ///
 /// The `Err` half is just the escape: `builtin_del` discards the assembled
@@ -32946,21 +32966,7 @@ fn resolve_del_path_branches<'a, S: EvalSemantics>(
     if !needs_path_prepass(expr) {
         return Ok(DelPaths::Verbatim);
     }
-    // `input` is this call's own fresh document root — never itself a frozen
-    // `$x` snapshot, so ambient `snapshot` starts `false` (#1591), same as
-    // `resolve_dynamic_indexes`'s own top-level entry.
-    match reject_untracked_prefix_too(
-        resolve_node::<S>(
-            expr,
-            input,
-            true,
-            &Snapshot::No,
-            &Frame::enter(expr),
-            Keep::First,
-        ),
-        false,
-        false,
-    ) {
+    match resolve_terminal::<S>(expr, input, false, false) {
         Ok(branches) => {
             if branches.iter().any(|b| b.path.depth() == 0) {
                 Ok(DelPaths::Root)
@@ -33018,7 +33024,7 @@ fn resolve_del_path_branches<'a, S: EvalSemantics>(
 /// - Each branch would expand against the document as it stands *after* the
 ///   earlier branches' writes, not against `input`; jq computes the whole
 ///   path set first and applies it after (#498's clobber case).
-/// - `reject_untracked_at_terminal` below answers trackability for every
+/// - `resolve_terminal` below answers trackability for every
 ///   branch before any branch's iterability is tested, inverting the two
 ///   against `resolve_seq`'s per-branch interleaving: `del((.a, 1) | .[])`
 ///   on `{"a":7}` reports jq's "Cannot iterate over number (7)" only while
@@ -33093,11 +33099,11 @@ fn resolve_dynamic_indexes<S: EvalSemantics>(
     // handler, never for anything reaching this top-level entry point. That
     // is about the *input*; individual branches can still come back
     // untracked from `resolve_leaf`'s deferred catch-all (#986), which is
-    // what `reject_untracked_at_terminal` above answers for.
+    // what `resolve_terminal` above answers for.
 
     // #888: a bare trailing iterate never needs its per-element *value* here
     // — this function is always the terminal entry point (see
-    // `reject_untracked_at_terminal`'s own doc comment above), so nothing
+    // `resolve_terminal`'s own doc comment above), so nothing
     // downstream of it ever consults one. Left inside `resolve_seq`'s
     // fan-out loop, it gets fully enumerated into one static `Index(i)`
     // branch per array element, turning a computed key ahead of it into
@@ -33121,35 +33127,17 @@ fn resolve_dynamic_indexes<S: EvalSemantics>(
         }
     }
 
-    // #1764 review: computed once here, as a plain `bool`, rather than
-    // threading `S: EvalSemantics` itself into `reject_untracked_at_
-    // terminal`/`reject_untracked_prefix_too` -- those two are otherwise
-    // non-generic, so making them generic purely to evaluate one `S::TAG`
-    // comparison would monomorphize (and so duplicate the compiled code
-    // for) both of them per `EvalSemantics` impl, for zero behavioral
-    // benefit over resolving the same fact once, here, where `S` is
-    // already bound. Unconditional now that `del()` -- the one caller that
-    // wanted `false` in yq mode -- resolves through
-    // `resolve_del_path_branches` instead (#1690).
+    // #1764 review: computed once here, as a plain `bool`, and passed
+    // down rather than re-derived from `S::TAG` at each check --
+    // `resolve_terminal` is generic over `S` anyway (it resolves), but the
+    // rule itself is decided once, here, where every entry point shares
+    // it. Unconditional now that `del()` -- the one caller that wanted
+    // `false` in yq mode -- resolves through `resolve_del_path_branches`
+    // instead (#1690).
     let skip_untracked = S::TAG == EvalTag::Yq;
 
     if trailing.is_empty() {
-        // `input` is this call's own fresh document root — never itself a
-        // frozen `$x` snapshot, so ambient `snapshot` starts `false` here,
-        // same as it does at this function's other top-level entry point
-        // below (#1591).
-        return match reject_untracked_prefix_too(
-            resolve_node::<S>(
-                expr,
-                input,
-                true,
-                &Snapshot::No,
-                &Frame::enter(expr),
-                Keep::First,
-            ),
-            false,
-            skip_untracked,
-        ) {
+        return match resolve_terminal::<S>(expr, input, false, skip_untracked) {
             Ok(branches) => Ok(assemble_path_branches(branches)),
             Err((prefix, e)) => Err((assemble_path_branches(prefix), e)),
         };
@@ -33160,18 +33148,7 @@ fn resolve_dynamic_indexes<S: EvalSemantics>(
         1 => flat.into_iter().next().expect("len checked"),
         _ => Expr::Pipe(flat),
     };
-    match reject_untracked_prefix_too(
-        resolve_node::<S>(
-            &reduced_expr,
-            input,
-            true,
-            &Snapshot::No,
-            &Frame::enter(&reduced_expr),
-            Keep::First,
-        ),
-        true,
-        skip_untracked,
-    ) {
+    match resolve_terminal::<S>(&reduced_expr, input, true, skip_untracked) {
         Ok(branches) => Ok(assemble_path_branches(branches)
             .into_iter()
             .map(|e| append_trailing(e, &trailing))
@@ -70577,7 +70554,7 @@ mod tests {
     }
 
     /// #1560: `resolve_dynamic_indexes` only ran its terminal
-    /// untracked-branch check (`reject_untracked_at_terminal`) on
+    /// untracked-branch check (`resolve_terminal`) on
     /// `resolve_node`'s *Ok* result. When a later `Expr::Comma` sibling's own
     /// escape stopped resolution first, an earlier sibling's own terminal
     /// violation -- already sitting in the `Err` prefix -- skipped that check
@@ -71482,7 +71459,7 @@ mod tests {
     /// select(true) = "X"` used to silently replace the *entire input
     /// document* with `"X"` instead of raising and writing nothing.
     /// `resolve_dynamic_indexes`'s own terminal check
-    /// (`reject_untracked_at_terminal`) is the general fix, not a
+    /// (`resolve_terminal`) is the general fix, not a
     /// `select`-specific patch — moved there from `resolve_catch`'s own
     /// top-level check by #1297, since `resolve_catch` is not always
     /// terminal itself (see its doc comment).
@@ -84321,11 +84298,12 @@ mod tests {
         // it, raising with nothing.
         //
         // This source contains no navigation step, so
-        // `resolve_fold_source`'s `any_subexpr` gate routes it straight to
-        // `eval_owned_expr_fork` and it never reaches the tracked resolver
-        // at all. That makes it the canary for anyone loosening that gate:
-        // an ungated version of #1467's own check discarded this `[[], []]`
-        // prefix, which is how the gate got written in the first place.
+        // `drive_fold_source`'s `any_subexpr` gate drives it by value
+        // through `eval_each_owned` and it never reaches the tracked
+        // resolver at all. That makes it the canary for anyone loosening
+        // that gate: an ungated version of #1467's own check discarded
+        // this `[[], []]` prefix, which is how the gate got written in the
+        // first place.
         query!(
             br#"{"a":1}"#,
             r#"path(foreach (1,2,error("s")) as $i (.; .))"#,
@@ -84376,7 +84354,7 @@ mod tests {
     /// `fold_source_*_1872` golden; they are repeated in-process because a
     /// golden compares whole streams while these assert the *prefix
     /// length*, which is what a `Keep::First` regression in
-    /// `resolve_fold_source` would silently shorten.
+    /// `drive_fold_source` would silently shorten.
     #[test]
     fn test_fold_source_streams_prefix_before_fatal_escape_1872() {
         // The issue's own repro: elements `1` and `2` fold and emit, then
@@ -84446,7 +84424,7 @@ mod tests {
         );
     }
 
-    /// #1872: `Keep::AtMost` is introduced by `resolve_fold_source` and
+    /// #1872: `Keep::AtMost` is introduced by `drive_fold_source` and
     /// nowhere else, so an ordinary `path()` still sees #987's
     /// stop-after-first leaf. These are the shapes that would change if it
     /// ever leaked out of a fold source into `resolve_dynamic_indexes`'s

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -30505,18 +30505,19 @@ fn resolve_foreach<'a, S: EvalSemantics>(
             if update_branches.is_empty() {
                 (state_at_register, state_snapshot) = reg.branch_provenance(None);
             }
-            let last_branch_index = update_branches.len().wrapping_sub(1);
-            for (branch_index, update_branch) in update_branches.iter().enumerate() {
-                // Only the *last* branch carries forward as the next
-                // element's state (see the comment above this loop) — the
-                // others are read straight off `update_branch` below for
-                // EXTRACT/emission, so cloning `state` for them too is pure
-                // waste, doubled (or worse) by every extra UPDATE output.
-                if branch_index == last_branch_index {
-                    (state_at_register, state_snapshot) =
-                        reg.branch_provenance(Some(update_branch));
-                    state = update_branch.value.clone().into_owned();
-                }
+            for update_branch in &update_branches {
+                // Every output, not just the last: a review pass tried
+                // carrying only the last one (the others are read straight
+                // off `update_branch` for EXTRACT/emission, so the clone
+                // looked like waste) and the oracle disagreed -- once an
+                // earlier output's emission is refused and the source's
+                // `?//` retries, the retried step must see *that* output as
+                // its state, or `path(foreach (1 as $x ?// $y | if $x == 1
+                // then 1 else 2 end) as $v (.; if $v == 2 then . else (1, 2)
+                // end))` answers `[]` at exit 0 where jq 1.7.1 refuses with
+                // "result 1" -- a wrong accept, the write-side hazard class.
+                (state_at_register, state_snapshot) = reg.branch_provenance(Some(update_branch));
+                state = update_branch.value.clone().into_owned();
                 if let Some(ext_expr) = &substituted_extract {
                     if let Some(control) = charge_budget(&mut budget, "foreach") {
                         return stop_with_escape(&mut aborted, control);

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -27595,6 +27595,85 @@ fn resolve_node_sink<'a, S: EvalSemantics>(
             emit_passthrough(value, trackable, snapshot, sink)
         }
 
+        // `a // b`: resolve `a`, pass only its truthy branches through — jq's
+        // `//` filters a multi-output left side rather than choosing all-or-
+        // nothing (`retain_truthy` is this rule's value-only twin) — and
+        // fall back to `b` only when none survive. An escape while resolving
+        // `a` propagates rather than falling back, matching `eval_alternative`:
+        // `//` only substitutes for falsy/absent output, never for a raised
+        // error. The truthy branches produced *before* that escape have
+        // already reached the sink, which is what makes the escape's own
+        // prefix jq's: the eager form this replaced (#2235) forwarded
+        // `left`'s escape with its prefix *unfiltered*, falsy branches
+        // included, so a fold whose source was `(.. , error("x")) // 9`
+        // would have run a step for a falsy element jq never bound
+        // (`path(reduce (((.[] | . and true), error("x")) // 9) as $i (.;
+        // stderr))` on `[true,false]` runs one step in jq 1.7.1, not two).
+        //
+        // #845: a *literal* `a` is the one exception — real jq only requires
+        // path-shape for whichever of `a`'s outputs actually survive the
+        // truthy filter, so `a` being itself falsy (`false`, `null`) must
+        // fall through to `b` without ever needing to resolve as a path at
+        // all: confirmed live, `path(false // .b)` on `{"a":10}` is `["b"]`,
+        // while `path(1 // .b)` still raises (`1` is truthy, and does need
+        // path-shape). A literal's own value is known statically, at zero
+        // evaluation cost and with no side effect to risk duplicating —
+        // unlike checking `a`'s general truthiness by evaluating it a
+        // *second* time (rejected in review: resolving `a` already evaluates
+        // it once by the time any failure is visible here, so a follow-up
+        // evaluation just to inspect truthiness double-fires anything `a`
+        // does — confirmed live, `path(stderr // .b)` wrote its input to
+        // stderr twice under that approach — and a catch-all on the retry's
+        // own outcome swallowed a `halt`/`break` the retry surfaced instead
+        // of letting it escape, same review round).
+        //
+        // A `Comma`-fanned `a` mixing a falsy/non-path sibling with a
+        // path-shaped or truthy one used to be the one shape this arm
+        // didn't handle (filed as #980): `Comma` used to commit to a
+        // sibling's own failure eagerly, before `//`'s truthy filter ever
+        // got a chance to see it. #1288's "`Expr::Comma` stops checking a
+        // position too early" fixed this incidentally, not this arm
+        // itself; confirmed live against jq 1.7.1, all eight shapes #980
+        // pinned (`path((.a, false) // .b)`, `path((false, .a) // .b)`,
+        // `path((.a, null) // .b)`, `path((null, false) // .b)`,
+        // `path((.x, .a) // .b)`, `path((false, false) // .b)`,
+        // `path((.a, false, .a) // .b)`, and the genuinely-still-erroring
+        // `path((.a, 1) // .b)`) now match.
+        //
+        // A downstream `Stop` propagates as-is; only `a` running to
+        // exhaustion with nothing truthy delivered falls through to `b`.
+        Expr::Alternative(left, right) => {
+            if let Expr::Literal(lit) = unwrap_paren(left) {
+                if !literal_to_owned(lit).is_truthy() {
+                    return resolve_node_sink::<S>(
+                        right, value, trackable, snapshot, frame, keep, sink,
+                    );
+                }
+            }
+            let mut emitted = false;
+            let flow = resolve_node_sink::<S>(
+                left,
+                value,
+                trackable,
+                snapshot,
+                frame,
+                keep,
+                &mut |branch| {
+                    if !branch.value.is_truthy() {
+                        return Demand::Continue;
+                    }
+                    emitted = true;
+                    sink(branch)
+                },
+            );
+            match flow {
+                ResolveFlow::Exhausted if !emitted => {
+                    resolve_node_sink::<S>(right, value, trackable, snapshot, frame, keep, sink)
+                }
+                other => other,
+            }
+        }
+
         // `repeat(f)` (#1906) and the three bounded consumers below all
         // resolve through the sink now, so a bound threads through arbitrary
         // combinator nesting rather than only reaching a generator that is
@@ -27896,62 +27975,6 @@ fn resolve_node_eager<'a, S: EvalSemantics>(
         }
         Expr::Builtin(Builtin::RecurseCond(f, cond)) => {
             resolve_recurse::<S>(f, Some(cond), value, trackable, snapshot, frame, keep)
-        }
-
-        // `a // b`: resolve `a`, keep only its truthy branches — jq's `//`
-        // filters a multi-output left side rather than choosing all-or-
-        // nothing (`retain_truthy` is this rule's value-only twin) — and
-        // fall back to `b` only when none survive. An error while resolving
-        // `a` propagates rather than falling back, matching `eval_alternative`:
-        // `//` only substitutes for falsy/absent output, never for a raised
-        // error, and the `?` here already gives us that for free.
-        //
-        // #845: a *literal* `a` is the one exception — real jq only requires
-        // path-shape for whichever of `a`'s outputs actually survive the
-        // truthy filter, so `a` being itself falsy (`false`, `null`) must
-        // fall through to `b` without ever needing to resolve as a path at
-        // all: confirmed live, `path(false // .b)` on `{"a":10}` is `["b"]`,
-        // while `path(1 // .b)` still raises (`1` is truthy, and does need
-        // path-shape — the `?` below still fires for it, unchanged). A
-        // literal's own value is known statically, at zero evaluation cost
-        // and with no side effect to risk duplicating — unlike checking
-        // `a`'s general truthiness by evaluating it a *second* time
-        // (rejected in review: a `resolve_node` call already evaluates `a`
-        // once by the time any failure is visible here, so a follow-up
-        // evaluation just to inspect truthiness double-fires anything `a`
-        // does — confirmed live, `path(stderr // .b)` wrote its input to
-        // stderr twice under that approach — and a catch-all on the retry's
-        // own outcome swallowed a `halt`/`break` the retry surfaced instead
-        // of letting it escape, same review round).
-        //
-        // A `Comma`-fanned `a` mixing a falsy/non-path sibling with a
-        // path-shaped or truthy one used to be the one shape this arm
-        // didn't handle (filed as #980): `Comma` used to commit to a
-        // sibling's own failure eagerly, before `//`'s truthy filter ever
-        // got a chance to see it. #1288's "`Expr::Comma` stops checking a
-        // position too early" fixed this incidentally, not this arm
-        // itself; confirmed live against jq 1.7.1, all eight shapes #980
-        // pinned (`path((.a, false) // .b)`, `path((false, .a) // .b)`,
-        // `path((.a, null) // .b)`, `path((null, false) // .b)`,
-        // `path((.x, .a) // .b)`, `path((false, false) // .b)`,
-        // `path((.a, false, .a) // .b)`, and the genuinely-still-erroring
-        // `path((.a, 1) // .b)`) now match.
-        Expr::Alternative(left, right) => {
-            if let Expr::Literal(lit) = unwrap_paren(left) {
-                if !literal_to_owned(lit).is_truthy() {
-                    return resolve_node::<S>(right, value, trackable, snapshot, frame, keep);
-                }
-            }
-            let branches: Vec<PathBranch<'a>> =
-                resolve_node::<S>(left, value, trackable, snapshot, frame, keep)?
-                    .into_iter()
-                    .filter(|b| b.value.is_truthy())
-                    .collect();
-            if branches.is_empty() {
-                resolve_node::<S>(right, value, trackable, snapshot, frame, keep)
-            } else {
-                Ok(branches)
-            }
         }
 
         // #1440: `reduce`/`foreach` are real sugar over the same

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -472,7 +472,7 @@ fn to_owned_at_depth<V: DocumentValue>(
         // #2286: `decode_failure`, not `new` -- same uncatchable class as
         // every other `StandardJson::Error`/`is_error()` site this issue
         // fixed (confirmed live: this exact generic-evaluator `to_owned_at_depth`
-        // is what `resolve_fold_source`/`reduce`'s fold-source path calls,
+        // is what `drive_fold_source`/`reduce`'s fold-source path calls,
         // so `[1, xyz123] | try add catch "caught"` stayed wrongly catchable
         // until this arm was retagged too).
         Err(EvalError::decode_failure(

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -20459,7 +20459,7 @@ fn test_resolve_node_alternative_comma_three_siblings_mixed_980() -> Result<()> 
 /// forwarded `left`'s `Err` with its prefix *unfiltered* (`resolve_node(..)?`),
 /// so a consumer that launders the escape into a short `Ok` -- `?`, a
 /// matching `label`/`break` -- saw a falsy branch jq's `//` never emits.
-/// Invisible while `resolve_fold_source` re-evaluated an erroring source
+/// Invisible while `drive_fold_source` re-evaluated an erroring source
 /// untracked, and a wrong-fold hazard the moment the resolver's own prefix
 /// is trusted instead. All three captured from jq 1.7.1.
 #[test]
@@ -39427,7 +39427,7 @@ fn test_path_cursor_native_absent_nodes_and_pipes_2061() -> Result<()> {
     Ok(())
 }
 
-/// #1872: `resolve_fold_source` runs a navigating fold source **once**, with
+/// #1872: `drive_fold_source` runs a navigating fold source **once**, with
 /// tracking on, and the fold's real values come from that same evaluation --
 /// so a side effect embedded in the source fires exactly as often as it does
 /// in jq. Before #1872 the source was evaluated twice (once to path-check it,
@@ -39470,30 +39470,251 @@ fn fold_source_side_effect_fires_once_per_output_1872() -> Result<()> {
 /// `stderr`'s own path-trackability -- before that fix, this raised nowhere
 /// at all and instead answered wrongly with `[]` three times, exit 0.
 ///
-/// The one remaining divergence from jq is `stderr`'s own write *count*:
-/// `resolve_fold_source`'s `Keep::AtMost(usize::MAX)` (#1467) pulls the whole
-/// navigating source upfront, so all three writes happen before the fold
-/// loop ever inspects the first step's own UPDATE result -- jq's true
-/// demand-driven generator stops pulling the source the moment that first
-/// step fails to track, writing only once. Tracked separately (not #2234's
-/// own scope, which is specifically about stderr/debug's trackability, not
-/// fold-source pull laziness) -- filed as a follow-up.
+/// The write *count* matches since #2235: the source is pulled by demand
+/// (`drive_fold_source`), the fold emits each output straight to `path()`'s
+/// terminal check, and that check refuses the first step's emission before
+/// the source is ever pulled again. Before #2235 `Keep::AtMost(usize::MAX)`
+/// pulled the whole source upfront and all three writes fired first.
 #[test]
 fn fold_source_foreach_diverges_from_reduce_on_this_shape_1872() -> Result<()> {
+    for filter in [
+        ". as $x | path(foreach (.[] | stderr) as $i (0; $x))",
+        ". as $x | path(foreach (.[] | debug) as $i (0; $x))",
+    ] {
+        let (stdout, stderr, code) = run_jq_full(&["-c", filter], Some("[1,2,3]"))?;
+        assert_eq!(code, 5, "{filter}: stdout: {stdout:?} stderr: {stderr:?}");
+        assert_eq!(stdout, "", "{filter}");
+        let (writes, error) = stderr
+            .split_once("jq: error")
+            .unwrap_or_else(|| panic!("{filter}: no error on stderr: {stderr:?}"));
+        assert!(
+            writes == "1" || writes == "[\"DEBUG:\",1]\n",
+            "{filter}: one source write, then the raise -- got {writes:?}"
+        );
+        assert!(
+            error.contains("Invalid path expression with result [1,2,3]"),
+            "{filter}: stderr: {stderr:?}"
+        );
+    }
+    Ok(())
+}
+
+/// #2235: a path-mode fold pulls its source **by demand** -- one element,
+/// one step, then the next element -- and its outputs reach `path()`'s
+/// terminal check as they are emitted, so whatever stops the fold (a step
+/// that raises, a terminal refusal, an outer bound, a `break`) stops the
+/// source with nothing past it evaluated. `reduce` runs its prefix steps
+/// before a trailing source escape is raised, and an erroring source is no
+/// longer re-evaluated untracked (the old fallback double-fired side effects
+/// and discarded the per-step register, turning jq's refusal into an
+/// answer). Every row is captured from jq 1.7.1: `(input, filter, stdout,
+/// stderr, exit)`; stderr is compared whole, so a `stderr`/`debug` write
+/// count is pinned exactly.
+#[test]
+fn fold_source_is_pulled_by_demand_2235() -> Result<()> {
+    let e = |msg: &str| format!("jq: error (at <stdin>:0): {msg}\n");
+    let invalid = |v: &str| e(&format!("Invalid path expression with result {v}"));
+    for (input, filter, want_out, want_err, want_code) in [
+        // EXTRACT raises on the first element.
+        (
+            "[1,2,3]",
+            "path(foreach (.[] | stderr) as $i (.; .; error(\"u\")))",
+            String::new(),
+            format!("1{}", e("u")),
+            5,
+        ),
+        // A `reduce` step raises on the first element.
+        (
+            "[1,2,3]",
+            "path(reduce (.[]|stderr|.+0) as $i (.; if $i==1 then error(\"u\") else . end))",
+            String::new(),
+            format!("1{}", e("u")),
+            5,
+        ),
+        // `reduce` runs its prefix steps before the source's own escape --
+        // an error, a halt (which also writes its own input), a break.
+        (
+            r#"{"a":1}"#,
+            "path(reduce (1,2,error(\"s\")) as $i (.; stderr))",
+            String::new(),
+            format!("{{\"a\":1}}{{\"a\":1}}{}", e("s")),
+            5,
+        ),
+        (
+            r#"{"a":1}"#,
+            "path(reduce (1,2,halt_error(3)) as $i (.; stderr))",
+            String::new(),
+            "{\"a\":1}{\"a\":1}{\"a\":1}\n".to_string(),
+            3,
+        ),
+        (
+            r#"{"a":1}"#,
+            "[label $out | path(reduce (1,2,break $out) as $i (.; stderr))]",
+            "[]\n".to_string(),
+            "{\"a\":1}{\"a\":1}".to_string(),
+            0,
+        ),
+        // A step's `break` stops the pull.
+        (
+            "[1,2,3]",
+            "[label $out | path(reduce (.[]|stderr) as $i (.; if $i==2 then break $out else . end))]",
+            "[]\n".to_string(),
+            "12".to_string(),
+            0,
+        ),
+        // The old fallback's shapes: an ordinary error after a source output
+        // (`foreach` refuses step 1's emission first; `reduce` raises `s`
+        // after one write, not two), a `break` reached through the source,
+        // and an error with nothing delivered before it.
+        (
+            "[1,2,3]",
+            "path(foreach (.[] | stderr | ., error(\"s\")) as $i (.; .))",
+            String::new(),
+            format!("1{}", invalid("[1,2,3]")),
+            5,
+        ),
+        (
+            "[1,2]",
+            "path(reduce (.[]|stderr|(.,error(\"s\"))) as $i (.; .))",
+            String::new(),
+            format!("1{}", e("s")),
+            5,
+        ),
+        (
+            "[1,2]",
+            "[label $out | path(foreach (.[], break $out) as $i (.; .))]",
+            String::new(),
+            invalid("[1,2]"),
+            5,
+        ),
+        (
+            "[1,2]",
+            "[label $out | path(foreach ((.[]|stderr), break $out) as $i (.; .))]",
+            String::new(),
+            format!("1{}", invalid("[1,2]")),
+            5,
+        ),
+        (
+            "[1,2]",
+            "path(foreach ((.[]|stderr|empty), error(\"s\")) as $i (.; .))",
+            String::new(),
+            format!("12{}", e("s")),
+            5,
+        ),
+        // A halt later in the source is never reached once step 1 refuses.
+        (
+            "[1,2,3]",
+            "path(foreach (.[] | stderr | if . == 2 then halt_error else . end) as $i (.; .; .))",
+            String::new(),
+            format!("1{}", invalid("[1,2,3]")),
+            5,
+        ),
+        // A bound inside the source, and one outside the whole `path()`.
+        (
+            "[1,2,3]",
+            "path(foreach (limit(2; .[]|stderr)) as $i (.; .))",
+            String::new(),
+            format!("1{}", invalid("[1,2,3]")),
+            5,
+        ),
+        (
+            "[1,2,3,4]",
+            "[limit(2; path(foreach (.[]|stderr|.+0) as $i (0; .)))]",
+            String::new(),
+            format!("1{}", invalid("0")),
+            5,
+        ),
+        // Several INIT forks: the first fork's refusal stops everything; a
+        // later fork re-drives the source (with its side effects) only once
+        // the earlier one completed.
+        (
+            "[1,2,3]",
+            "path(foreach (.[]|stderr) as $i ((.,.); .))",
+            String::new(),
+            format!("1{}", invalid("[1,2,3]")),
+            5,
+        ),
+        (
+            "[1,2]",
+            "[path(foreach (.[]|stderr|.+0) as $i ((null,null); .))?]",
+            "[]\n".to_string(),
+            "1".to_string(),
+            0,
+        ),
+        (
+            "[1,2]",
+            "[path(reduce (.[]|stderr|.+0) as $i ((0,1); .))?]",
+            "[]\n".to_string(),
+            "12".to_string(),
+            0,
+        ),
+        // A `?//` in the source retries the step on the reset state after a
+        // step error, but never after a halt. A terminal refusal of the
+        // first alternative's output is retried too: into the second's
+        // accepted `.`, or -- when the retried step re-enters from the
+        // refused step's own output -- into a second refusal naming it.
+        (
+            "1",
+            "path(foreach (1 as $x ?// $y | 1) as $v (.; stderr | error(\"u\")))",
+            String::new(),
+            format!("1null{}", e("u")),
+            5,
+        ),
+        (
+            "1",
+            "path(foreach (1 as $x ?// $y | 1) as $v (.; stderr | halt_error))",
+            String::new(),
+            "11\n".to_string(),
+            5,
+        ),
+        (
+            r#"{"a":1}"#,
+            "path(foreach (1 as $x ?// $y | if $x == 1 then 1 else 2 end) as $v (.; .; if $v == 1 then 1 else . end))",
+            "[]\n".to_string(),
+            String::new(),
+            0,
+        ),
+        (
+            r#"{"a":1}"#,
+            "path(foreach (1 as $x ?// $y | if $x == 1 then 1 else 2 end) as $v (.; if $v == 2 then . else $v end))",
+            String::new(),
+            invalid("1"),
+            5,
+        ),
+        // `//` in the source: its escape prefix is truthy-filtered (one step,
+        // not two), and its left side is pulled by demand.
+        (
+            "[true,false]",
+            "path(reduce (((.[] | . and true), error(\"x\")) // 9) as $i (.; stderr))",
+            String::new(),
+            format!("[true,false]{}", e("x")),
+            5,
+        ),
+        (
+            "[1,2,3]",
+            "path(reduce ((.[]|stderr|.+0) // 9) as $i (.; if $i==2 then error(\"u\") else . end))",
+            String::new(),
+            format!("12{}", e("u")),
+            5,
+        ),
+    ] {
+        let (stdout, stderr, code) = run_jq_full(&["-c", filter], Some(input))?;
+        assert_eq!(code, want_code, "{filter}: stdout: {stdout:?} stderr: {stderr:?}");
+        assert_eq!(stdout, want_out, "{filter}");
+        assert_eq!(stderr, want_err, "{filter}");
+    }
+
+    // `inputs` stays on the lazy value-mode producer: one document per
+    // demand, the rest still readable afterwards.
     let (stdout, stderr, code) = run_jq_full(
-        &["-c", ". as $x | path(foreach (.[] | stderr) as $i (0; $x))"],
-        Some("[1,2,3]"),
+        &[
+            "-nc",
+            "[try path(foreach inputs as $i (.; error(\"u\"))) catch .], input",
+        ],
+        Some("1 2 3"),
     )?;
-    assert_eq!(code, 5, "stdout: {stdout:?} stderr: {stderr:?}");
-    assert_eq!(stdout, "");
-    assert!(
-        stderr.starts_with("123"),
-        "known divergence from jq's own single write -- see this test's doc comment; stderr: {stderr:?}"
-    );
-    assert!(
-        stderr.contains("Invalid path expression with result"),
-        "stderr: {stderr:?}"
-    );
+    assert_eq!(code, 0, "stderr: {stderr:?}");
+    assert_eq!(stdout, "[\"u\"]\n2\n");
     Ok(())
 }
 
@@ -39531,13 +39752,13 @@ fn fold_source_bounded_generator_stays_bounded_1872() -> Result<()> {
     Ok(())
 }
 
-/// #1872: `resolve_fold_source` now takes a navigating source's values from
-/// `resolve_node`'s own branches, which makes a *short* branch prefix a wrong
+/// #1872: `drive_fold_source` takes a navigating source's values from the
+/// resolver's own branches, which makes a *short* branch prefix a wrong
 /// answer rather than merely a wrong error message. Several arms below that
 /// call launder an `Err` into a truncated `Ok` -- `Expr::Optional`'s blanket
-/// arm, `Expr::Label` on a matching break, a satisfied bound -- and none of
-/// them is covered by the `Err(_)` fallback. Each case's value count is
-/// captured from jq 1.7.1.
+/// arm, `Expr::Label` on a matching break, a satisfied bound -- so their
+/// values are a fold's values. Each case's value count is captured from jq
+/// 1.7.1.
 #[test]
 fn fold_source_laundered_short_prefix_value_counts_1872() -> Result<()> {
     for (input, filter, want, why) in [
@@ -39567,15 +39788,15 @@ fn fold_source_laundered_short_prefix_value_counts_1872() -> Result<()> {
     Ok(())
 }
 
-/// #1872: a fold source that produces a *trackable* branch falls back to
-/// #1467's two-pass shape instead of reusing the resolved values, because
-/// jq's own fold then clobbers its path register and refuses to emit at all
-/// (#2031). These pin the fallback: stdout stays empty and the exit code
-/// stays 5, exactly as in jq — only the *message* differs, which is #2031's
-/// divergence and not this one's.
+/// #1872/#2031: a fold source that produces a *trackable* branch seeds that
+/// step's register from the element's own path, so jq's own fold clobbers
+/// its path register and refuses to emit at all. These pin the refusal:
+/// stdout stays empty and the exit code stays 5, exactly as in jq — only the
+/// *message* differs, which is #2031's divergence and not this one's.
 ///
-/// This is the arm that randomised differential fuzzing against jq 1.7.1
-/// added: without it, eleven of four thousand generated folds streamed a
+/// This is the shape randomised differential fuzzing against jq 1.7.1
+/// caught: an earlier attempt that streamed the resolved values without the
+/// per-step register let eleven of four thousand generated folds stream a
 /// prefix jq never streams. No golden can pin it, since a golden compares
 /// stderr byte-for-byte on a failing case and the message diverges.
 #[test]

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -20454,6 +20454,40 @@ fn test_resolve_node_alternative_comma_three_siblings_mixed_980() -> Result<()> 
     Ok(())
 }
 
+/// #2235: the escape prefix of `//`'s left side is filtered by truthiness
+/// exactly like its exhausted output. The eager `Expr::Alternative` arm
+/// forwarded `left`'s `Err` with its prefix *unfiltered* (`resolve_node(..)?`),
+/// so a consumer that launders the escape into a short `Ok` -- `?`, a
+/// matching `label`/`break` -- saw a falsy branch jq's `//` never emits.
+/// Invisible while `resolve_fold_source` re-evaluated an erroring source
+/// untracked, and a wrong-fold hazard the moment the resolver's own prefix
+/// is trusted instead. All three captured from jq 1.7.1.
+#[test]
+fn test_resolve_node_alternative_escape_prefix_is_truthy_filtered_2235() -> Result<()> {
+    for (input, filter, want) in [
+        (
+            "[true,false]",
+            "[path(((.[], error(\"x\")) // 9)?)]",
+            "[[0]]",
+        ),
+        (
+            "[false,true]",
+            "[path(((.[], error(\"x\")) // 9)?)]",
+            "[[1]]",
+        ),
+        (
+            "[true,false,true]",
+            "[label $o | path(((.[], break $o) // 9))]",
+            "[[0],[2]]",
+        ),
+    ] {
+        let (stdout, stderr, code) = run_jq_full(&["-c", filter], Some(input))?;
+        assert_eq!(code, 0, "{filter}: stdout: {stdout:?} stderr: {stderr:?}");
+        assert_eq!(stdout.trim_end(), want, "{filter}");
+    }
+    Ok(())
+}
+
 /// #980 boundary: a later sibling that is truthy but *not* path-shaped
 /// still raises -- the fix only lets *falsy* siblings through `//`'s
 /// filter uncontested, it doesn't exempt every non-path-shaped value.

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -39681,6 +39681,31 @@ fn fold_source_is_pulled_by_demand_2235() -> Result<()> {
             invalid("1"),
             5,
         ),
+        // ... and from a multi-output UPDATE's *first* output when that is
+        // the one refused: every output becomes the state before it is
+        // emitted, not only the last.
+        (
+            r#"{"a":1}"#,
+            "path(foreach (1 as $x ?// $y | if $x == 1 then 1 else 2 end) as $v (.; if $v == 2 then . else (1, 2) end))",
+            String::new(),
+            invalid("1"),
+            5,
+        ),
+        // Sources reached through `?` and `try`/`catch` stream too.
+        (
+            "[1,2,3]",
+            ". as $x | path(foreach ((.[] | stderr)?) as $i (0; $x))",
+            String::new(),
+            format!("1{}", invalid("[1,2,3]")),
+            5,
+        ),
+        (
+            r#"[{"a":1},{"a":2}]"#,
+            "path(foreach (.[] | stderr | (.a)?) as $i (.; .; error(\"u\")))",
+            String::new(),
+            format!("{{\"a\":1}}{}", e("u")),
+            5,
+        ),
         // `//` in the source: its escape prefix is truthy-filtered (one step,
         // not two), and its left side is pulled by demand.
         (
@@ -39700,6 +39725,33 @@ fn fold_source_is_pulled_by_demand_2235() -> Result<()> {
     ] {
         let (stdout, stderr, code) = run_jq_full(&["-c", filter], Some(input))?;
         assert_eq!(code, want_code, "{filter}: stdout: {stdout:?} stderr: {stderr:?}");
+        assert_eq!(stdout, want_out, "{filter}");
+        assert_eq!(stderr, want_err, "{filter}");
+    }
+
+    // `recurse(f)` delivers each node before resolving its `f`, so a bound
+    // never pays for `f` on a node it did not ask for: `limit(1)` runs
+    // `debug` zero times, `limit(2)` once and then refuses the computed
+    // child. Captured from jq 1.7.1.
+    for (filter, want_out, want_err, want_code) in [
+        (
+            "path(limit(1; recurse(if (.|debug) < 3 then .+1 else empty end)))",
+            "[]\n",
+            String::new(),
+            0,
+        ),
+        (
+            "path(limit(2; recurse(if (.|debug) < 3 then .+1 else empty end)))",
+            "[]\n",
+            format!("[\"DEBUG:\",0]\n{}", invalid("1")),
+            5,
+        ),
+    ] {
+        let (stdout, stderr, code) = run_jq_full(&["-c", filter], Some("0"))?;
+        assert_eq!(
+            code, want_code,
+            "{filter}: stdout: {stdout:?} stderr: {stderr:?}"
+        );
         assert_eq!(stdout, want_out, "{filter}");
         assert_eq!(stderr, want_err, "{filter}");
     }

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -31173,7 +31173,7 @@ fn test_runaway_recursion_errors_cleanly_in_yq_mode_1371() -> Result<()> {
     Ok(())
 }
 
-/// #1872 gates `resolve_fold_source`'s single tracked evaluation on
+/// #1872 gates `drive_fold_source`'s single tracked evaluation on
 /// `EvalTag::Jq`. Real yq's lexer rejects `reduce`, `foreach` *and* `path`
 /// outright (confirmed live against yq v4.53.3), so yq mode has no oracle to
 /// check a fold's values against, and `resolve_index_expr`'s yq-only


### PR DESCRIPTION
## Description

A path-mode `reduce`/`foreach` pulled its whole SOURCE before running a single step: `resolve_fold_source` resolved it through the collecting adapter with `Keep::AtMost(usize::MAX)`. jq's generator is demand-driven, so `. as $x | path(foreach (.[] | stderr) as $i (0; $x))` on `[1,2,3]` writes `1` once and raises on the first step's untrackable emission, where succinctly wrote `123` first (the issue's repro, same for `debug`).

Probing the fallback that PR #2466 left this issue out for turned up more than a write count. The `Err(_)` arm re-evaluated an erroring source untracked, which double-fired side effects **and** discarded the per-step register (#2031), turning a jq refusal into an answer:

| filter (input)                                                             | jq 1.7.1                         | before                              |
|----------------------------------------------------------------------------|----------------------------------|-------------------------------------|
| `path(foreach (.[] \| stderr \| ., error("s")) as $i (.; .))` (`[1,2,3]`)  | `1`, raise invalid-path, exit 5  | `11`, error s, stdout `[]`          |
| `[label $out \| path(foreach (.[], break $out) as $i (.; .))]` (`[1,2]`)   | raise invalid-path, exit 5       | **`[[],[]]`, exit 0** (write hazard)|
| `path(reduce (1,2,error("s")) as $i (.; stderr))` (`{"a":1}`)              | two UPDATE writes, then s        | no writes                           |
| `path(foreach ((.[]\|stderr\|empty), error("s")) as $i (.; .))` (`[1,2]`)  | `12`, error s                    | `1212`, error s                     |

Three things move together, because each alone leaves the pull eager:

1. **`drive_fold_source`** replaces collect-then-loop. The source resolves through `resolve_node_sink` (or, with no navigation step, by value through `eval_each_owned`, which keeps `input`/`inputs` on the lazy producer) and each element is folded inside the sink before the next is pulled. Every escape the resolver raises is the fold's escape; the untracked re-evaluation fallback is gone. `reduce` runs its prefix steps before a trailing source escape.
2. **`resolve_reduce`/`resolve_foreach` emit through a sink** and move into `resolve_node_sink`, so a consumer's stop reaches the fold. Their step closures stash escapes via `stop_with_escape` and reset their slots on entry, because a source `?//` retries the step after a stop; jq re-enters from the refused step's own output, so each UPDATE output becomes the state before it is emitted.
3. **`resolve_terminal`** replaces `reject_untracked_at_terminal`/`reject_untracked_prefix_too`: `path()`/`=`/`|=`/`del()` resolve through the sink and refuse the first untracked branch as it is produced.

Precondition, landed as its own commit: the `Expr::Alternative` resolver arm forwarded its left side's escape prefix unfiltered (falsy branches included). Invisible while the fallback re-evaluated, a wrong fold once the resolver's prefix is trusted (`[path(((.[], error("x")) // 9)?)]` on `[true,false]` was `[[0],[1]]`, jq `[[0]]`). Migrated to the sink.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Related Issue
Fixes #2235

Part of spine #2416.

## Changes Made
- `src/jq/eval.rs`: `drive_fold_source` / `drive_fold_source_by_value` / `reclaim_fold_escape`; `resolve_reduce` and `resolve_foreach` become sink-native arms of `resolve_node_sink`; `resolve_terminal`; `Expr::Alternative` lazy arm; `flow_result` / `emit_branches` helpers. `no_fold_register`, `relocate_source_registers`, `reject_untracked_at_terminal`, `reject_untracked_prefix_too` deleted.
- `tests/jq_cli_tests.rs`: `fold_source_is_pulled_by_demand_2235` (22 rows, stdout + stderr + exit compared whole, all captured from jq 1.7.1), `test_resolve_node_alternative_escape_prefix_is_truthy_filtered_2235`; the test that pinned the old `123` divergence now pins jq's `1`.
- `docs/compliance/jq/limitations.md`: fold-source section rewritten for the demand-driven contract; the "erroring source is evaluated twice" residual removed; two residuals recorded (below).

## Testing

**Automated Testing:**
- [x] All existing tests pass
- [x] New tests added for new functionality

**Manual Testing:**
- [ ] Tested on x86_64
- [x] Tested on aarch64/ARM (Apple Silicon)

### Test Commands
```bash
cargo fmt --check
cargo test --features cli,simd,regex,serde --no-fail-fast     # 7970 passed
cargo test; cargo test --features simd; cargo test --no-default-features
cargo clippy --all-targets --all-features -- -D warnings      # plus the two CI feature-set legs
RUSTDOCFLAGS=-Dwarnings cargo doc --no-deps --features cli
./scripts/jq-path-context-oracle-sweep.sh --summary           # 5508 cases, 0 unexpected, both modes
./scripts/jq-bind-origin-fuzz.py -n 2000                      # 24 refuse-only -> agree; the 6 fabricates are identical on main
```

32 probe rows diffed against `/usr/bin/jq` 1.7.1 on stdout, stderr and exit code: 30 match; the two that do not are the residuals below.

## Performance Impact
- [x] No performance impact

Same resolver, same `Keep` dial; the collecting vectors are replaced by sinks. Not benchmarked: no `perf-guard` query reaches a path-mode fold.

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [x] I have updated documentation as needed
- [x] My changes generate no new warnings

## Additional Notes

**Residuals, recorded in limitations.md:**
- A generator the resolver reaches only through an eager arm (`resolve_leaf`'s general case, an `if`/`select` condition, an `as` source, a nested fold) is still collected before its first element is folded: `path(foreach (inputs | .a) as $i (.; .))` drains the input queue where jq consumes one document.
- `path()` collects every path before its own consumer sees one, so a bound outside it cannot stop the fold: `[limit(1; path(foreach (1 as $x ?// $y | (stderr|1)) as $v (.; .)))]` is `[[],[]]` with two writes in jq (its `limit` break is retried by the source's `?//`) and `[[]]` with one write here.
- The `REDUCE_FOREACH_MAX_STEPS` cap (`100000`) is unchanged and pre-existing.
- Path-mode `?//` on a *navigating* source still refuses where jq retries (the `Expr::As` resolver arm has no retry); pre-existing, not touched here.



## Follow-up commits

- **`fix(jq): close remaining eager arms in the #2235 demand-driven migration`** (review pass): `Expr::Optional` (`E?`), `recurse(f)`/`recurse(f; cond)` and `try`/`catch`'s handler now stream through native sink forms (`resolve_optional_sink`, `resolve_recurse_sink`, `resolve_catch_sink`), so a fold source reached through any of them is pulled by demand too, and a bounded consumer no longer pays for `recurse` nodes it never asked for. Records the one gap it leaves (a single node's multi-output `f` is still resolved in one shot) in limitations.md.
- **`fix(jq): carry every foreach UPDATE output into the state, not only the last`**: the review pass carried only the last UPDATE output into the state to save a clone; jq stores each output before emitting it, which a source `?//` retried after a refused emission observes. `path(foreach (1 as $x ?// $y | if $x == 1 then 1 else 2 end) as $v (.; if $v == 2 then . else (1, 2) end))` answered `[]` at exit 0 where jq refuses. Restored, pinned, and the review pass's own streamed arms pinned alongside (they had shipped without tests).
