### PR TITLE
fix(jq): a def from include/~/.jq can now shadow a builtin (#2395)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,44 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **A `def` loaded through `include` or `~/.jq` can now shadow a builtin of the
+  same name** (#2395, a #2036 follow-up). `jq -L . -nc 'include "mylib"; length'`
+  with `def length: "shadowed-from-module";` in the module answered `0` -- the
+  builtin -- where real jq answers `"shadowed-from-module"`. Every kind of
+  shadowable name was affected: ordinary builtins (`length`, `keys`, `type`,
+  `map`, `empty`, ...), the `not` keyword, the fixed-arity special forms
+  (`error`, `select`, `first`, `limit`, `path`, `getpath`), and `range`'s
+  one-argument sugar. `~/.jq`'s own defs were affected identically.
+
+  #2036 collects shadow-candidate names by scanning *the text being parsed*, and
+  the main filter's text can never contain an included module's `def`s: module
+  bodies are separate texts, loaded and inlined by `ModuleLoader::process_program`
+  only after that parse has finished. So `length` lowered straight to a builtin
+  node, and `resolve.rs`'s scope-aware check -- which by then would have found
+  the module's `FuncDef` plainly in scope -- had no call site to reconsider.
+
+  Fixed by feeding the names back into a second parse rather than rewriting the
+  assembled tree, which is the issue's own suggested direction but needs a
+  `Builtin` -> name map the crate does not have, and could not recover `range`'s
+  arity, whose sugar marker is itself only emitted for a name already known to be
+  a candidate. The loader now reports the def names that will land *unqualified*
+  in scope (`ModuleLoader::unqualified_def_names`), and the runner re-parses the
+  filter with those added via the new
+  `jq::parse_program_with_extra_shadowable_defs`. Widening the candidate set is
+  monotone -- it can only add a fallback wrapper to a parse that already
+  succeeded, or a retry to one that already failed -- so the second parse cannot
+  reject a program the first accepted. `load_module` memoizes, so nothing is read
+  or parsed twice; a filter with no `include` and no `~/.jq` skips the second
+  parse entirely and pays nothing.
+
+  `import "m" as ns` is deliberately excluded, matching jq: those defs enter
+  scope only as `ns::name`, so a bare `length` there is still the builtin
+  (`m::length` reaches the module's, and already did). Arity sensitivity carries
+  over from #2036 unchanged -- a module defining only `length/1` leaves the
+  zero-arity builtin intact -- as do the two scope boundaries: a `def` in the
+  main filter still beats a module's, and `include` is still not transitive.
+  `succinctly yq` is unaffected; it has no `-L` and never builds a module loader.
+
 - **An `as`-bound variable now stands at the node it was bound from, instead of
   being a value with no position** (#2072). Real yq's variables hold *nodes*,
   parent pointers and all, so `.a.b as $x | $x | key` is `"b"` there;

--- a/src/bin/succinctly/jq_runner.rs
+++ b/src/bin/succinctly/jq_runner.rs
@@ -57,6 +57,31 @@ pub struct ModuleLoader {
     auto_loaded_defs: Vec<(String, Vec<Param>, Expr)>,
 }
 
+/// Resolve a module path to a file path within `search_path`.
+///
+/// A free function rather than a `ModuleLoader` method (#2395): its only
+/// caller, [`ModuleLoader::ensure_module_loaded`], holds a mutable borrow of
+/// the module cache across the call, which an `&self` method could not
+/// coexist with. It reads nothing but the search path either way.
+fn resolve_module_in(search_path: &[PathBuf], module_path: &str) -> Option<PathBuf> {
+    // Add .jq extension if not present
+    let module_file = if module_path.ends_with(".jq") {
+        module_path.to_string()
+    } else {
+        format!("{module_path}.jq")
+    };
+
+    // Search in each path
+    for base in search_path {
+        let full_path = base.join(&module_file);
+        if full_path.is_file() {
+            return Some(full_path);
+        }
+    }
+
+    None
+}
+
 impl ModuleLoader {
     /// Create a new module loader with the given search paths.
     pub fn new(library_paths: &[PathBuf]) -> Self {
@@ -103,54 +128,50 @@ impl ModuleLoader {
         }
     }
 
-    /// Resolve a module path to a file path.
-    fn resolve_module(&self, module_path: &str) -> Option<PathBuf> {
-        // Add .jq extension if not present
-        let module_file = if module_path.ends_with(".jq") {
-            module_path.to_string()
-        } else {
-            format!("{module_path}.jq")
-        };
+    /// Load a module if it is not already cached, and borrow its function
+    /// definitions (name, params, body) in place.
+    ///
+    /// The borrowing form exists so a caller that only needs to *read* the
+    /// defs -- [`Self::unqualified_def_names`], which wants their names --
+    /// does not pay for a deep clone of every def body it is about to drop
+    /// (#2395). [`Self::load_module`] is this plus that clone, for callers
+    /// that need an owned copy.
+    fn ensure_module_loaded(
+        &mut self,
+        module_path: &str,
+    ) -> Result<&Vec<(String, Vec<Param>, Expr)>> {
+        // `entry` rather than `get`-then-insert: the borrow checker cannot
+        // see that an early `return` of `get`'s borrow ends it, so the
+        // `contains_key` spelling would need an unreachable `expect` on the
+        // re-lookup. The key allocation on the cached path is one short
+        // module-path string, against the file read and parse it replaces.
+        match self.loaded_modules.entry(module_path.to_string()) {
+            std::collections::btree_map::Entry::Occupied(entry) => Ok(entry.into_mut()),
+            std::collections::btree_map::Entry::Vacant(entry) => {
+                // Resolve the module path
+                let file_path =
+                    resolve_module_in(&self.search_path, module_path).ok_or_else(|| {
+                        anyhow::anyhow!("module '{module_path}' not found in search path")
+                    })?;
 
-        // Search in each path
-        for base in &self.search_path {
-            let full_path = base.join(&module_file);
-            if full_path.is_file() {
-                return Some(full_path);
+                // Read and parse the module
+                let contents = std::fs::read_to_string(&file_path)
+                    .with_context(|| format!("failed to read module: {}", file_path.display()))?;
+
+                let program = jq::parse_program(&contents).map_err(|e| {
+                    anyhow::anyhow!("parse error in module '{}': {}", file_path.display(), e)
+                })?;
+
+                // Extract function definitions from the expression
+                Ok(entry.insert(extract_func_defs(&program.expr)))
             }
         }
-
-        None
     }
 
-    /// Load a module and return its function definitions (name, params, body).
+    /// Load a module and return an owned copy of its function definitions
+    /// (name, params, body).
     pub fn load_module(&mut self, module_path: &str) -> Result<Vec<(String, Vec<Param>, Expr)>> {
-        // Check if already loaded
-        if let Some(defs) = self.loaded_modules.get(module_path) {
-            return Ok(defs.clone());
-        }
-
-        // Resolve the module path
-        let file_path = self
-            .resolve_module(module_path)
-            .ok_or_else(|| anyhow::anyhow!("module '{module_path}' not found in search path"))?;
-
-        // Read and parse the module
-        let contents = std::fs::read_to_string(&file_path)
-            .with_context(|| format!("failed to read module: {}", file_path.display()))?;
-
-        let program = jq::parse_program(&contents).map_err(|e| {
-            anyhow::anyhow!("parse error in module '{}': {}", file_path.display(), e)
-        })?;
-
-        // Extract function definitions from the expression
-        let defs = extract_func_defs(&program.expr);
-
-        // Cache the loaded module
-        self.loaded_modules
-            .insert(module_path.to_string(), defs.clone());
-
-        Ok(defs)
+        self.ensure_module_loaded(module_path).cloned()
     }
 
     /// Every def name this program's modules will put into the main filter's
@@ -178,8 +199,8 @@ impl ModuleLoader {
             .collect();
 
         for include in &program.includes {
-            let defs = self.load_module(&include.path)?;
-            names.extend(defs.into_iter().map(|(name, _, _)| name));
+            let defs = self.ensure_module_loaded(&include.path)?;
+            names.extend(defs.iter().map(|(name, _, _)| name.clone()));
         }
 
         Ok(names)

--- a/src/bin/succinctly/jq_runner.rs
+++ b/src/bin/succinctly/jq_runner.rs
@@ -5,7 +5,7 @@
 
 use anyhow::{Context, Result};
 use indexmap::IndexMap;
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 use std::io::{IsTerminal, Read, Write};
 use std::path::{Path, PathBuf};
 
@@ -151,6 +151,38 @@ impl ModuleLoader {
             .insert(module_path.to_string(), defs.clone());
 
         Ok(defs)
+    }
+
+    /// Every def name this program's modules will put into the main filter's
+    /// scope *unqualified*, for seeding the parser's shadow-candidate set
+    /// (#2395).
+    ///
+    /// That is `~/.jq`'s own defs plus every `include`d module's defs --
+    /// exactly the two sources [`Self::process_program`] inlines under their
+    /// bare names. `program.imports` is deliberately excluded: those defs are
+    /// inlined as `ns::name`, and real jq agrees they do not shadow
+    /// (`import "m" as m; length` is the builtin `length` even when the module
+    /// defines one; only `m::length` reaches the module's).
+    ///
+    /// Loading here rather than in `process_program` costs nothing:
+    /// [`Self::load_module`] memoizes on the module path, so the later
+    /// `process_program` re-reads and re-parses nothing. A module that cannot
+    /// be resolved fails here instead of there, one step earlier but still
+    /// after the main filter has parsed, so the caller's error and exit code
+    /// are unchanged.
+    pub fn unqualified_def_names(&mut self, program: &Program) -> Result<BTreeSet<String>> {
+        let mut names: BTreeSet<String> = self
+            .auto_loaded_defs
+            .iter()
+            .map(|(name, _, _)| name.clone())
+            .collect();
+
+        for include in &program.includes {
+            let defs = self.load_module(&include.path)?;
+            names.extend(defs.into_iter().map(|(name, _, _)| name));
+        }
+
+        Ok(names)
     }
 
     /// Process imports and includes, returning the modified expression with all functions defined.
@@ -1302,6 +1334,48 @@ pub fn run_jq(args: JqCommand) -> Result<i32> {
     // that names an undefined function, and one that includes a missing module
     // are all "jq could not compile this program".
     let mut module_loader = ModuleLoader::new(&args.library_path);
+
+    // #2395: re-parse the filter once the module-sourced def names are known,
+    // so a `def` arriving through `include` or `~/.jq` can shadow a builtin
+    // exactly as one written in the filter itself already does (#2036).
+    //
+    // The shadow-candidate set is a scan of the text being parsed, so the
+    // parse above -- the only one that can tell us *which* modules to load --
+    // is necessarily blind to their contents. Rather than rewrite the
+    // assembled tree afterwards (which would need a `Builtin` -> name map the
+    // crate does not have, and could not recover `range`'s arity, whose sugar
+    // marker is itself emitted only for a shadow candidate), feed the names
+    // back into a second parse. Widening the set is monotone, so this parse
+    // cannot fail where the first succeeded; the arm below is kept anyway
+    // rather than unwrapping a claim about another module's behavior.
+    //
+    // Skipped entirely when no module contributes a name -- including every
+    // filter with no `include` and no `~/.jq`, which is the overwhelmingly
+    // common case and pays nothing.
+    let module_def_names = match module_loader.unqualified_def_names(&program) {
+        Ok(names) => names,
+        Err(e) => {
+            eprintln!("jq: module error: {e}");
+            return Ok(exit_codes::COMPILE_ERROR);
+        }
+    };
+    let program = if module_def_names.is_empty() {
+        program
+    } else {
+        match jq::parse_program_with_extra_shadowable_defs(
+            &filter_str,
+            jq::ParserMode::Jq,
+            false,
+            &module_def_names,
+        ) {
+            Ok(program) => program,
+            Err(e) => {
+                eprintln!("jq: compile error: {e}");
+                return Ok(exit_codes::COMPILE_ERROR);
+            }
+        }
+    };
+
     let expr = match module_loader.process_program(&program) {
         Ok(expr) => expr,
         Err(e) => {

--- a/src/bin/succinctly/jq_runner.rs
+++ b/src/bin/succinctly/jq_runner.rs
@@ -1345,9 +1345,7 @@ pub fn run_jq(args: JqCommand) -> Result<i32> {
     // assembled tree afterwards (which would need a `Builtin` -> name map the
     // crate does not have, and could not recover `range`'s arity, whose sugar
     // marker is itself emitted only for a shadow candidate), feed the names
-    // back into a second parse. Widening the set is monotone, so this parse
-    // cannot fail where the first succeeded; the arm below is kept anyway
-    // rather than unwrapping a claim about another module's behavior.
+    // back into a second parse.
     //
     // Skipped entirely when no module contributes a name -- including every
     // filter with no `include` and no `~/.jq`, which is the overwhelmingly
@@ -1362,18 +1360,32 @@ pub fn run_jq(args: JqCommand) -> Result<i32> {
     let program = if module_def_names.is_empty() {
         program
     } else {
-        match jq::parse_program_with_extra_shadowable_defs(
+        // Widening the candidate set cannot make a program stop parsing, so
+        // this second parse succeeds whenever the first did.
+        //
+        // At a name the set newly covers, the parser's dedicated parse still
+        // runs first and, on success, is merely wrapped as a fallback -- no
+        // token is consumed differently and `pos` does not move. The only
+        // other outcome is that the dedicated parse *fails*, and there the
+        // widening is what rescues it: a candidate retries as a generic call
+        // (`retry_shadow_candidate_as_generic_call`) where a non-candidate
+        // propagates the error outright -- meaning the first parse would have
+        // failed at that same site. `SHADOW_RETRY_BUDGET` cannot flip the
+        // conclusion either, since it is charged only at those failing sites,
+        // which are therefore the identical set in both parses.
+        //
+        // The arm below is kept rather than unwrapped anyway: if that
+        // reasoning is ever wrong, falling back to the already-parsed program
+        // costs only this filter's module-sourced shadowing -- exactly the
+        // behavior before this fix -- where an error would reject a filter
+        // that compiles today and that real jq accepts.
+        jq::parse_program_with_extra_shadowable_defs(
             &filter_str,
             jq::ParserMode::Jq,
             false,
             &module_def_names,
-        ) {
-            Ok(program) => program,
-            Err(e) => {
-                eprintln!("jq: compile error: {e}");
-                return Ok(exit_codes::COMPILE_ERROR);
-            }
-        }
+        )
+        .unwrap_or(program) // omni-dev: coverage tolerate-line reason="unreachable: widening the shadow-candidate set never rejects a program the first parse accepted -- a newly covered name only wraps an already-successful dedicated parse, and a failing one would have propagated its error in the first parse too, so the retry budget is charged at the identical sites in both (#2395)"
     };
 
     let expr = match module_loader.process_program(&program) {

--- a/src/bin/succinctly/jq_runner.rs
+++ b/src/bin/succinctly/jq_runner.rs
@@ -186,11 +186,11 @@ impl ModuleLoader {
     /// defines one; only `m::length` reaches the module's).
     ///
     /// Loading here rather than in `process_program` costs nothing:
-    /// [`Self::load_module`] memoizes on the module path, so the later
-    /// `process_program` re-reads and re-parses nothing. A module that cannot
-    /// be resolved fails here instead of there, one step earlier but still
-    /// after the main filter has parsed, so the caller's error and exit code
-    /// are unchanged.
+    /// [`Self::ensure_module_loaded`] memoizes on the module path and this
+    /// only borrows the names out of it, so the later `process_program`
+    /// re-reads and re-parses nothing. A module that cannot be resolved fails
+    /// here instead of there, one step earlier but still after the main filter
+    /// has parsed, so the caller's error and exit code are unchanged.
     pub fn unqualified_def_names(&mut self, program: &Program) -> Result<BTreeSet<String>> {
         let mut names: BTreeSet<String> = self
             .auto_loaded_defs
@@ -1329,6 +1329,18 @@ pub fn run_jq(args: JqCommand) -> Result<i32> {
     // Get the filter expression
     let filter_str = get_filter(&args)?;
 
+    // The main filter is parsed *twice* (#2395 -- see the re-parse below), and
+    // the second result is the one that runs, so a drift between the two in
+    // mode or extensions would be silent: the first parse's shape would simply
+    // be discarded. One closure therefore owns that choice for both calls
+    // rather than each spelling it out. It reproduces `jq::parse_program`'s own
+    // defaults (`ParserMode::Jq`, extensions off -- `jq_extensions` is ignored
+    // in jq mode regardless), which is what this call site used before the
+    // second parse existed.
+    let parse_filter = |extra: &BTreeSet<String>| {
+        jq::parse_program_with_extra_shadowable_defs(&filter_str, jq::ParserMode::Jq, false, extra)
+    };
+
     // Parse the filter as a full program (with module directives).
     //
     // Returns the exit code rather than an `anyhow` error (#1473): a failed
@@ -1337,7 +1349,7 @@ pub fn run_jq(args: JqCommand) -> Result<i32> {
     // from `main`'s own reporting. Both were confirmed live against jq 1.7.1,
     // which exits 3 with no such line. Nothing else distinguished this arm
     // from a resolution failure below, so the two now answer identically.
-    let program = match jq::parse_program(&filter_str) {
+    let program = match parse_filter(&BTreeSet::new()) {
         Ok(program) => program,
         Err(e) => {
             eprintln!("jq: compile error: {e}");
@@ -1400,13 +1412,7 @@ pub fn run_jq(args: JqCommand) -> Result<i32> {
         // costs only this filter's module-sourced shadowing -- exactly the
         // behavior before this fix -- where an error would reject a filter
         // that compiles today and that real jq accepts.
-        jq::parse_program_with_extra_shadowable_defs(
-            &filter_str,
-            jq::ParserMode::Jq,
-            false,
-            &module_def_names,
-        )
-        .unwrap_or(program) // omni-dev: coverage tolerate-line reason="unreachable: widening the shadow-candidate set never rejects a program the first parse accepted -- a newly covered name only wraps an already-successful dedicated parse, and a failing one would have propagated its error in the first parse too, so the retry budget is charged at the identical sites in both (#2395)"
+        parse_filter(&module_def_names).unwrap_or(program) // omni-dev: coverage tolerate-line reason="unreachable: widening the shadow-candidate set never rejects a program the first parse accepted -- a newly covered name only wraps an already-successful dedicated parse, and a failing one would have propagated its error in the first parse too, so the retry budget is charged at the identical sites in both (#2395)"
     };
 
     let expr = match module_loader.process_program(&program) {

--- a/src/jq/mod.rs
+++ b/src/jq/mod.rs
@@ -110,9 +110,9 @@ pub use expr::{
 };
 pub use lazy::JqValue;
 pub use parser::{
-    collect_call_sites, parse, parse_program, parse_program_with_mode,
-    parse_program_with_mode_and_extensions, parse_with_mode, parse_with_mode_and_extensions,
-    CallSite, ParseError, ParserMode,
+    collect_call_sites, parse, parse_program, parse_program_with_extra_shadowable_defs,
+    parse_program_with_mode, parse_program_with_mode_and_extensions, parse_with_mode,
+    parse_with_mode_and_extensions, CallSite, ParseError, ParserMode,
 };
 pub use resolve::{resolve_func_calls, resolve_func_calls_all, UnresolvedCall};
 pub use stream::{StreamError, StreamStats, StreamableValue};

--- a/src/jq/parser.rs
+++ b/src/jq/parser.rs
@@ -377,17 +377,7 @@ const META_OP_KEYWORDS: &[(&str, MetaSlot)] = &[
 impl<'a> Parser<'a> {
     #[allow(dead_code)] // STYLE-0005: kept for tests and future use
     fn new(input: &'a str) -> Self {
-        Parser {
-            input,
-            pos: 0,
-            mode: ParserMode::Jq,
-            jq_extensions: false,
-            pattern_depth: 0,
-            expr_depth: 0,
-            call_sites: Vec::new(),
-            shadowable_defs: collect_def_names(input),
-            shadow_retry_budget: SHADOW_RETRY_BUDGET,
-        }
+        Self::with_mode_extensions_and_extra_defs(input, ParserMode::Jq, false, &BTreeSet::new())
     }
 
     fn with_mode_and_extensions(input: &'a str, mode: ParserMode, jq_extensions: bool) -> Self {

--- a/src/jq/parser.rs
+++ b/src/jq/parser.rs
@@ -391,6 +391,32 @@ impl<'a> Parser<'a> {
     }
 
     fn with_mode_and_extensions(input: &'a str, mode: ParserMode, jq_extensions: bool) -> Self {
+        Self::with_mode_extensions_and_extra_defs(input, mode, jq_extensions, &BTreeSet::new())
+    }
+
+    /// Like [`Self::with_mode_and_extensions`], but seeds
+    /// [`Self::shadowable_defs`] with `extra` on top of `input`'s own
+    /// [`collect_def_names`] scan (#2395).
+    ///
+    /// `input` is only ever the *main filter's* text, so its own scan cannot
+    /// see a `def` that arrives through `include` or `~/.jq` -- those module
+    /// bodies are separate texts, loaded and inlined after this parse
+    /// finishes. `extra` is how the caller hands those names in.
+    ///
+    /// It is an over-approximation on exactly the same terms as
+    /// `collect_def_names`'s own output: a name in `extra` that turns out not
+    /// to be in scope at a given call site costs one wasted double-parse
+    /// there and nothing more, because `resolve.rs`'s scope-aware check is
+    /// still what decides, per call site, whether the name is genuinely
+    /// shadowed.
+    fn with_mode_extensions_and_extra_defs(
+        input: &'a str,
+        mode: ParserMode,
+        jq_extensions: bool,
+        extra: &BTreeSet<String>,
+    ) -> Self {
+        let mut shadowable_defs = collect_def_names(input);
+        shadowable_defs.extend(extra.iter().cloned());
         Parser {
             input,
             pos: 0,
@@ -399,7 +425,7 @@ impl<'a> Parser<'a> {
             pattern_depth: 0,
             expr_depth: 0,
             call_sites: Vec::new(),
-            shadowable_defs: collect_def_names(input),
+            shadowable_defs,
             shadow_retry_budget: SHADOW_RETRY_BUDGET,
         }
     }
@@ -6206,7 +6232,56 @@ pub fn parse_program_with_mode_and_extensions(
     mode: ParserMode,
     jq_extensions: bool,
 ) -> Result<Program, ParseError> {
-    let mut parser = Parser::with_mode_and_extensions(input, mode, jq_extensions);
+    parse_program_with_extra_shadowable_defs(input, mode, jq_extensions, &BTreeSet::new())
+}
+
+/// Parse a complete jq program, additionally treating every name in `extra`
+/// as one a `def` in this program might shadow a builtin at (#2395).
+///
+/// [`parse_program`] and friends derive that set from `input` alone, which is
+/// correct for a `def` written in the filter itself but blind to one that
+/// arrives through `include` or `~/.jq`: those module bodies are separate
+/// texts, loaded and inlined only *after* the main filter has been parsed.
+/// Without their names, a call like `length` in `include "m"; length` lowers
+/// straight to a builtin node and never becomes a call site the
+/// scope-aware resolve pass could reconsider. The module loader collects the
+/// names that will land unqualified in scope and passes them here.
+///
+/// `extra` is an over-approximation on the same terms as the parser's own
+/// internal scan: a name that turns out not to be in scope at a given call
+/// site costs one wasted double-parse there and never a wrong answer, since
+/// [`resolve_func_calls`](crate::jq::resolve_func_calls) still decides
+/// shadowing per call site. Widening the set is monotone for parsing too --
+/// it can only add a fallback wrapper to a parse that already succeeded, or a
+/// retry to one that already failed -- so this never rejects a program
+/// [`parse_program_with_mode_and_extensions`] accepts.
+///
+/// # Examples
+///
+/// ```
+/// use std::collections::BTreeSet;
+/// use succinctly::jq::{parse_program_with_extra_shadowable_defs, ParserMode};
+///
+/// // `length` is not a def anywhere in this text, so the plain entry point
+/// // lowers it to the builtin; naming it in `extra` defers the decision to
+/// // the resolve pass instead.
+/// let extra = BTreeSet::from(["length".to_string()]);
+/// let prog = parse_program_with_extra_shadowable_defs(
+///     r#"include "m"; length"#,
+///     ParserMode::Jq,
+///     false,
+///     &extra,
+/// )
+/// .unwrap();
+/// assert_eq!(prog.includes.len(), 1);
+/// ```
+pub fn parse_program_with_extra_shadowable_defs(
+    input: &str,
+    mode: ParserMode,
+    jq_extensions: bool,
+    extra: &BTreeSet<String>,
+) -> Result<Program, ParseError> {
+    let mut parser = Parser::with_mode_extensions_and_extra_defs(input, mode, jq_extensions, extra);
     let program = parser.parse_program()?;
 
     // Ensure we consumed all input

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -22589,6 +22589,114 @@ fn test_module_def_shadow_deep_nesting_does_not_blow_up_2395() -> Result<()> {
     Ok(())
 }
 
+/// #2395: the module search path is tried in order and falls through -- a
+/// module absent from the first `-L` directory is still found in a later one.
+/// Confirmed live against jq 1.7.1, which resolves this identically.
+///
+/// Coverage-wise this is the only test that takes `resolve_module_in`'s loop
+/// past a non-matching candidate; every other module test in this file has the
+/// module in the first (and only) directory, so the miss-then-hit path went
+/// unexercised until the #2395 refactor surfaced it.
+#[test]
+fn test_module_search_path_falls_through_to_a_later_dir_2395() -> Result<()> {
+    let empty_dir = tempfile::tempdir()?;
+    let module_dir = tempfile::tempdir()?;
+    std::fs::write(
+        module_dir.path().join("mod.jq"),
+        "def length: \"s-length\";\n",
+    )?;
+    let (output, code) = spawn_with_signal_retry(
+        || {
+            let mut command = Command::new(succinctly_bin());
+            command
+                .args(["jq", "-L"])
+                .arg(empty_dir.path())
+                .arg("-L")
+                .arg(module_dir.path())
+                .args(["-nc", r#"include "mod"; length"#]);
+            command
+        },
+        None,
+    )?;
+    let stdout = String::from_utf8(output.stdout)?;
+    let stderr = String::from_utf8(output.stderr)?;
+    assert_eq!(code, 0, "stderr: {stderr:?}");
+    assert_eq!(stdout.trim_end(), r#""s-length""#);
+    Ok(())
+}
+
+/// #2395: a module whose own text does not parse is a compile error, exit 3 --
+/// not a panic, and not a silently ignored module. jq 1.7.1 also exits 3 here
+/// (its wording names the file and line, where succinctly reports the module
+/// path and a byte position -- the same pre-existing wording gap already
+/// recorded for `module not found`).
+#[test]
+fn test_module_with_a_syntax_error_is_a_compile_error_2395() -> Result<()> {
+    let temp_dir = tempfile::tempdir()?;
+    std::fs::write(temp_dir.path().join("bad.jq"), "def broken: ( ;\n")?;
+    let (output, code) = spawn_with_signal_retry(
+        || {
+            let mut command = Command::new(succinctly_bin());
+            command
+                .args(["jq", "-L"])
+                .arg(temp_dir.path())
+                .args(["-nc", r#"include "bad"; 1"#]);
+            command
+        },
+        None,
+    )?;
+    let stderr = String::from_utf8(output.stderr)?;
+    assert_eq!(code, 3, "stderr: {stderr:?}");
+    assert!(
+        stderr.contains("module error") && stderr.contains("parse error in module"),
+        "stderr: {stderr:?}"
+    );
+    Ok(())
+}
+
+/// Characterization test, **pinning a known divergence from jq**: succinctly
+/// resolves `include "m.jq"` to the file `m.jq`, where real jq appends `.jq`
+/// unconditionally and therefore looks for `m.jq.jq` -- so jq rejects this
+/// program with `module not found: m.jq` (exit 3) while succinctly runs it.
+///
+/// Verified live against jq 1.7.1 both ways: with only `m.jq` present jq errors
+/// and succinctly returns the module's def, and with `m.jq.jq` also present jq
+/// reads *that* file while succinctly still reads `m.jq`.
+///
+/// Pre-existing and unrelated to #2395, which only relocated the `ends_with(".jq")`
+/// arm responsible; tracked as issue 2702. This test exists so that arm is
+/// covered rather than silently untested, and **is expected to flip** when 2702
+/// is fixed -- at which point it should assert jq's `module not found` and exit
+/// 3 instead.
+#[test]
+fn test_include_with_explicit_jq_suffix_diverges_from_jq_2702() -> Result<()> {
+    let temp_dir = tempfile::tempdir()?;
+    std::fs::write(
+        temp_dir.path().join("mod.jq"),
+        "def length: \"s-length\";\n",
+    )?;
+    let (output, code) = spawn_with_signal_retry(
+        || {
+            let mut command = Command::new(succinctly_bin());
+            command
+                .args(["jq", "-L"])
+                .arg(temp_dir.path())
+                .args(["-nc", r#"include "mod.jq"; length"#]);
+            command
+        },
+        None,
+    )?;
+    let stdout = String::from_utf8(output.stdout)?;
+    let stderr = String::from_utf8(output.stderr)?;
+    assert_eq!(code, 0, "stderr: {stderr:?}");
+    assert_eq!(
+        stdout.trim_end(),
+        r#""s-length""#,
+        "succinctly resolves the explicit .jq suffix; real jq would error here (issue 2702)"
+    );
+    Ok(())
+}
+
 /// #1376: `succinctly jq` now supports arity overloading, matching real
 /// jq -- `def f(x): ...` and `def f(x;y): ...` are distinct functions
 /// (`f/1` and `f/2`), and both stay callable after the second definition.

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -22346,6 +22346,249 @@ fn test_def_shadow_nested_error_wrong_arity_realistic_depth_2036() -> Result<()>
     Ok(())
 }
 
+// =============================================================================
+// #2395: a `def` loaded via include/~/.jq can shadow a builtin
+// =============================================================================
+
+/// #2395: write `contents` as `mod.jq` in a fresh temp dir and run
+/// `succinctly jq -L <dir> <args...>`.
+///
+/// The `TempDir` is created, used and dropped inside this call, so the module
+/// file outlives the spawn (and nothing else). `-L` takes the path as an
+/// `OsStr`, which `run_jq_full`'s `&[&str]` cannot carry, so this goes through
+/// the raw `Command` builder the way `test_include_directive` already does.
+fn run_jq_with_module(contents: &str, args: &[&str]) -> Result<(String, String, i32)> {
+    let temp_dir = tempfile::tempdir()?;
+    std::fs::write(temp_dir.path().join("mod.jq"), contents)?;
+    let (output, code) = spawn_with_signal_retry(
+        || {
+            let mut command = Command::new(succinctly_bin());
+            command.args(["jq", "-L"]).arg(temp_dir.path()).args(args);
+            command
+        },
+        None,
+    )?;
+    Ok((
+        String::from_utf8(output.stdout)?,
+        String::from_utf8(output.stderr)?,
+        code,
+    ))
+}
+
+/// #2395: a `def` arriving through `include` shadows a builtin of the same
+/// name, exactly as one written in the filter itself already does (#2036).
+///
+/// #2036's shadow-candidate set is a scan of the text being parsed, and the
+/// main filter's text can never contain an included module's `def`s -- module
+/// bodies are separate texts, loaded and inlined only after that parse. So
+/// every one of these lowered straight to a builtin node and the scope-aware
+/// resolve pass never saw a call site to reconsider, however plainly the
+/// module's `def` was in scope by then.
+///
+/// The table spans all four sites that consult the candidate set: ordinary
+/// builtins (`length`, `keys`, `type`, ...), the `not` keyword, the
+/// fixed-arity special forms (`error`, `first`, `limit`), and `range`'s
+/// one-argument sugar, whose arity marker is itself only emitted for a
+/// shadow candidate. Every expected value captured live from jq 1.7.1.
+#[test]
+fn test_include_def_shadows_builtin_2395() -> Result<()> {
+    let module = concat!(
+        "def length: \"s-length\";\n",
+        "def not: \"s-not\";\n",
+        "def map(f): \"s-map\";\n",
+        "def empty: \"s-empty\";\n",
+        "def error: \"s-error\";\n",
+        "def select(f): \"s-select\";\n",
+        "def first(f): \"s-first\";\n",
+        "def limit(n;f): \"s-limit\";\n",
+        "def path(f): \"s-path\";\n",
+        "def getpath(p): \"s-getpath\";\n",
+        "def keys: \"s-keys\";\n",
+        "def tostring: \"s-tostring\";\n",
+        "def type: \"s-type\";\n",
+        "def recurse: \"s-recurse\";\n",
+        "def range(n): \"s-range\";\n",
+    );
+    for (call, want) in [
+        ("length", r#"["s-length"]"#),
+        ("true|not", r#"["s-not"]"#),
+        ("[1,2]|map(.)", r#"["s-map"]"#),
+        ("empty", r#"["s-empty"]"#),
+        ("error", r#"["s-error"]"#),
+        ("select(.)", r#"["s-select"]"#),
+        ("first(1,2)", r#"["s-first"]"#),
+        ("limit(1;1,2)", r#"["s-limit"]"#),
+        ("path(.a)", r#"["s-path"]"#),
+        (r#"getpath(["a"])"#, r#"["s-getpath"]"#),
+        ("keys", r#"["s-keys"]"#),
+        ("tostring", r#"["s-tostring"]"#),
+        ("type", r#"["s-type"]"#),
+        ("recurse", r#"["s-recurse"]"#),
+        ("range(3)", r#"["s-range"]"#),
+    ] {
+        let filter = format!(r#"include "mod"; [{call}]"#);
+        let (stdout, stderr, code) = run_jq_with_module(module, &["-nc", &filter])?;
+        assert_eq!(code, 0, "{filter}: stderr: {stderr:?}");
+        assert_eq!(stdout.trim_end(), want, "{filter}");
+    }
+    Ok(())
+}
+
+/// #2395: the `~/.jq` half of the same gap. Its defs are inlined under their
+/// bare names just like an `include`d module's, and were equally invisible to
+/// the prescan.
+#[test]
+fn test_home_jq_def_shadows_builtin_2395() -> Result<()> {
+    let temp_home = tempfile::tempdir()?;
+    std::fs::write(
+        temp_home.path().join(".jq"),
+        "def length: \"dotjq-length\";\ndef error: \"dotjq-error\";\n",
+    )?;
+    for (call, want) in [
+        ("length", r#"["dotjq-length"]"#),
+        ("error", r#"["dotjq-error"]"#),
+    ] {
+        let filter = format!("[{call}]");
+        let (output, code) = spawn_jq_with_env(&["-nc", &filter], "HOME", temp_home.path(), None)?;
+        let stdout = String::from_utf8(output.stdout)?;
+        let stderr = String::from_utf8(output.stderr)?;
+        assert_eq!(code, 0, "{filter}: stderr: {stderr:?}");
+        assert_eq!(stdout.trim_end(), want, "{filter}");
+    }
+    Ok(())
+}
+
+/// #2395: `import "m" as ns` must *not* shadow, and the exclusion is
+/// deliberate rather than an oversight -- jq puts an imported module's defs in
+/// scope only as `ns::name`, so a bare `length` there is still the builtin
+/// (confirmed live against jq 1.7.1, which prints `0` and `"s-length"` for
+/// these two). The fix therefore feeds only `include`/`~/.jq` names into the
+/// parser's candidate set, never `imports`.
+#[test]
+fn test_import_namespace_def_does_not_shadow_builtin_2395() -> Result<()> {
+    let module = "def length: \"s-length\";\n";
+    for (filter, want) in [
+        (r#"import "mod" as m; length"#, "0"),
+        (r#"import "mod" as m; m::length"#, r#""s-length""#),
+    ] {
+        let (stdout, stderr, code) = run_jq_with_module(module, &["-nc", filter])?;
+        assert_eq!(code, 0, "{filter}: stderr: {stderr:?}");
+        assert_eq!(stdout.trim_end(), want, "{filter}");
+    }
+    Ok(())
+}
+
+/// #2395: module-sourced shadowing is arity-sensitive in exactly the way
+/// same-file shadowing already is (#2036) -- a module that defines only
+/// `length/1` leaves the zero-arity builtin `length` intact, and one that
+/// defines only `limit/3` leaves the builtin `limit/2` intact. Both values
+/// captured from jq 1.7.1.
+///
+/// This is the part that would have been lost had the fix rewritten the
+/// assembled tree instead of re-parsing: the arity a wrapped call reports is
+/// derived from the shape the parser stashed, and for `range` the one-argument
+/// sugar's marker is only emitted when the name is already a candidate.
+#[test]
+fn test_module_def_shadow_respects_arity_2395() -> Result<()> {
+    let module = "def length(f): \"s-length-1\";\ndef limit(a;b;c): \"s-limit-3\";\n";
+    for (call, want) in [
+        ("length", "[0]"),
+        ("length(1)", r#"["s-length-1"]"#),
+        ("limit(1;1,2)", "[1]"),
+        ("limit(1;2;3)", r#"["s-limit-3"]"#),
+    ] {
+        let filter = format!(r#"include "mod"; [{call}]"#);
+        let (stdout, stderr, code) = run_jq_with_module(module, &["-nc", &filter])?;
+        assert_eq!(code, 0, "{filter}: stderr: {stderr:?}");
+        assert_eq!(stdout.trim_end(), want, "{filter}");
+    }
+    Ok(())
+}
+
+/// #2395 regression guard: a `def` in the main filter still beats a module's
+/// `def` of the same name (the module's is the outer scope), and a module
+/// included by *another* module does not reach the main filter's scope at all
+/// -- `include` is not transitive. Both confirmed live against jq 1.7.1;
+/// neither changed with this fix, and both are the cases a too-eager candidate
+/// set would break.
+#[test]
+fn test_module_shadow_scope_boundaries_unchanged_2395() -> Result<()> {
+    let module = "def length: \"s-length\";\n";
+    let (stdout, stderr, code) = run_jq_with_module(
+        module,
+        &["-nc", r#"include "mod"; def length: "main"; length"#],
+    )?;
+    assert_eq!(code, 0, "stderr: {stderr:?}");
+    assert_eq!(stdout.trim_end(), r#""main""#);
+
+    // main -> outer -> inner: `inner`'s `def length` must not reach here.
+    let temp_dir = tempfile::tempdir()?;
+    std::fs::write(temp_dir.path().join("inner.jq"), "def length: \"inner\";\n")?;
+    std::fs::write(
+        temp_dir.path().join("outer.jq"),
+        "include \"inner\";\ndef outerfn: \"outer\";\n",
+    )?;
+    let (output, code) = spawn_with_signal_retry(
+        || {
+            let mut command = Command::new(succinctly_bin());
+            command
+                .args(["jq", "-L"])
+                .arg(temp_dir.path())
+                .args(["-nc", r#"include "outer"; [length, outerfn]"#]);
+            command
+        },
+        None,
+    )?;
+    let stdout = String::from_utf8(output.stdout)?;
+    let stderr = String::from_utf8(output.stderr)?;
+    assert_eq!(code, 0, "stderr: {stderr:?}");
+    assert_eq!(stdout.trim_end(), r#"[0,"outer"]"#);
+    Ok(())
+}
+
+/// #2395 regression guard: an unresolvable module is still the same compile
+/// error with the same exit code, now that the loader runs one step earlier
+/// (the shadow-name collection resolves every `include` before the re-parse,
+/// where previously `process_program` was the first to touch them).
+#[test]
+fn test_module_not_found_still_reports_module_error_2395() -> Result<()> {
+    let (stdout, stderr, code) = run_jq_full(&["-nc", r#"include "nosuchmod"; 1"#], None)?;
+    assert_eq!(code, 3, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert!(
+        stderr.contains("module error") && stderr.contains("nosuchmod"),
+        "stderr: {stderr:?}"
+    );
+    Ok(())
+}
+
+/// #2395 guard against re-opening #2036's own confirmed parser DoS: a shadow
+/// candidate nested `depth` deep must not cost `O(2^depth)`. The candidate
+/// name here reaches the parser from a module rather than the filter text, so
+/// this is the module-sourced twin of
+/// `test_def_shadow_deep_nesting_does_not_blow_up_2036` -- and it additionally
+/// exercises the second parse the fix introduces, since both parses see the
+/// nesting.
+#[test]
+fn test_module_def_shadow_deep_nesting_does_not_blow_up_2395() -> Result<()> {
+    let depth = 60;
+    let filter = format!(
+        r#"include "mod"; {}.{}"#,
+        "first(".repeat(depth),
+        ")".repeat(depth)
+    );
+    let start = std::time::Instant::now();
+    let (stdout, stderr, code) =
+        run_jq_with_module("def first(f): \"s-first\";\n", &["-nc", &filter])?;
+    let elapsed = start.elapsed();
+    assert_eq!(code, 0, "stderr: {stderr:?}");
+    assert_eq!(stdout.trim_end(), r#""s-first""#);
+    assert!(
+        elapsed < std::time::Duration::from_secs(15),
+        "60-level nesting took {elapsed:?}; the parse is blowing up exponentially again"
+    );
+    Ok(())
+}
+
 /// #1376: `succinctly jq` now supports arity overloading, matching real
 /// jq -- `def f(x): ...` and `def f(x;y): ...` are distinct functions
 /// (`f/1` and `f/2`), and both stay callable after the second definition.


### PR DESCRIPTION
Fixes #2395.

## The bug

#2036 taught the parser that a user `def` can shadow a builtin of the same name, but
only for a `def` written in the main filter's own text. One arriving through a module
could not:

```console
$ cat mylib.jq
def length: "shadowed-from-module";
$ jq            -L . -nc 'include "mylib"; length'   # "shadowed-from-module"
$ succinctly jq -L . -nc 'include "mylib"; length'   # 0     <- wrong
```

Every kind of shadowable name was affected — ordinary builtins (`length`, `keys`, `type`,
`map`, `empty`, …), the `not` keyword, the fixed-arity special forms (`error`, `select`,
`first`, `limit`, `path`, `getpath`), and `range`'s one-argument sugar. `~/.jq`'s own defs
were affected identically. Not a regression from #2036: this case was already broken the
same way before it, since the parser had no shadow-check mechanism at all.

## Root cause

The shadow-candidate set is a lexical scan of **the text being parsed** —
`collect_def_names(input)`, stored as `Parser::shadowable_defs`. An included module's body
is a *separate* text, loaded and inlined by `ModuleLoader::process_program` only after the
main filter has been fully parsed. So `length` lowered straight to `Expr::Builtin(Length)`,
and `resolve.rs`'s scope-aware check — which by then would have found the module's
`FuncDef` plainly in scope — had no `Expr::FuncCall` node to reconsider.

## The fix

The issue suggested a tree-level pass over the assembled AST. I took a third option
instead: feed the module-sourced names back into a **second parse**.

- `ModuleLoader::unqualified_def_names` reports the def names that will land *unqualified*
  in scope (`~/.jq`'s defs plus every `include`d module's).
- `run_jq` re-parses the filter through the new
  `jq::parse_program_with_extra_shadowable_defs`, which unions those into the candidate set.

This reuses #2036's tested machinery verbatim rather than reimplementing its decisions at
tree level. The tree pass was rejected for two concrete reasons found while investigating:
it would need a 207-arm `Builtin -> name` map that does not exist anywhere in the crate
(`try_parse_builtin` is a one-way name → `Builtin` keyword chain), and it could not recover
`range`'s arity, because the `Expr::Paren` sugar marker that distinguishes `range(5)` from
`range(0;5)` is itself only emitted for a name already known to be a candidate.

**Cost.** `load_module` memoizes on the module path, so nothing is read or parsed twice. A
filter with no `include` and no `~/.jq` contributes no names and skips the second parse
entirely — the overwhelmingly common case pays nothing.

**Why the second parse cannot fail where the first succeeded.** `SHADOW_RETRY_BUDGET` is
charged only where a *dedicated* parse fails, and at such a site a non-candidate name
propagates its error outright — so the first parse would have failed there too. At a name
the widening newly covers, the dedicated parse still runs first and, on success, is merely
wrapped; no token is consumed differently and `pos` does not move. The charged sites are
therefore identical in both parses. The second commit records that argument in the code and
has the arm fall back to the already-parsed program rather than erroring: if the reasoning
is ever wrong, the cost is that filter's module-sourced shadowing (the behaviour before this
PR) instead of rejecting a filter that compiles today and that real jq accepts.

`import "m" as ns` is deliberately excluded, matching jq: those defs enter scope only as
`ns::name`, so a bare `length` there is still the builtin. `succinctly yq` is untouched — it
has no `-L` and never builds a module loader.

## Verification

Every expected value captured live from the pinned oracle (`jq-1.7.1-apple`), never written
from memory. All 19 oracle comparisons match, including the cases that must **not** change:

| case | jq | before | after |
|---|---|---|---|
| `include "m"; length` (+ 12 more builtins/special forms) | shadowed | builtin ✗ | shadowed ✓ |
| `~/.jq` defines `length` | shadowed | builtin ✗ | shadowed ✓ |
| `import "m" as m; length` | builtin | builtin ✓ | builtin ✓ |
| `import "m" as m; m::length` | shadowed | shadowed ✓ | shadowed ✓ |
| module defines only `length/1`, bare `length` | builtin | builtin ✓ | builtin ✓ |
| module defines only `limit/3`, `limit(1;1,2)` | builtin | builtin ✓ | builtin ✓ |
| transitive `include` (main → outer → inner) | does not leak | ✓ | ✓ |
| main-file `def` beats module `def` | main's | ✓ | ✓ |

7 new tests in `tests/jq_cli_tests.rs`, following the existing #2036 cluster's table-driven
shape. Reverting `src/` to the pre-fix commit fails exactly the 3 behavioural tests and
passes the 4 regression guards, so the tests demonstrably detect the bug rather than merely
describing it. The deep-nesting test is the module-sourced twin of
`test_def_shadow_deep_nesting_does_not_blow_up_2036`, guarding the new parse against the
`O(2^depth)` blowup #2036's own review found (60 levels parse in 0.03s).

Gates run locally, derived from `ci.yml`: `cargo test --features cli` (all suites),
`cargo test --no-default-features` (no_std), all three clippy legs with `-D warnings`,
`cargo fmt --all --check`, and `cargo doc --no-deps --all-features` with
`RUSTDOCFLAGS=-D warnings`. Patch coverage 100%.

## Follow-ups filed, not fixed here

- issue 2682 — `~/.jq` outranks an `include`d module of the same name; real jq gives `include`
  the higher priority. This is why the tests here deliberately avoid combining both sources
  on one name.
- issue 2683 — `succinctly yq` parses `include`/`import` and silently drops them; real yq
  rejects them at the lexer.

