### PR TITLE
perf(jq): borrow the document in path()'s walk instead of cloning it per branch

### DIFF
--- a/benches/jq_recurse_clone_bench.rs
+++ b/benches/jq_recurse_clone_bench.rs
@@ -16,13 +16,23 @@
 //! turns out to be a poor isolator: `builtin_path` calls
 //! `resolve_dynamic_indexes` (which drives `push_recursive_branches`) and
 //! *then* re-walks every one of the `depth + 1` resolved paths from the
-//! document root via `walk_path`/`step_into`, each step of which clones the
-//! value reached so far. That second pass was measured (`temp_probe`-style,
-//! not checked in) to cost **~250x** `push_recursive_branches`'s own share at
-//! depth 400 (1.9s vs 7-8ms) and scales worse than quadratically — so a
-//! `path(..)` benchmark would be dominated by `walk_path`, not by the
-//! function #668 targets, near-invisible to that fix, and would repeat
-//! exactly the mistake #675 was filed to correct in the first place.
+//! document root via `walk_path`/`step_into`. That second pass was measured
+//! (`temp_probe`-style, not checked in) to cost **~250x**
+//! `push_recursive_branches`'s own share at depth 400 (1.9s vs 7-8ms) and to
+//! scale worse than quadratically — so a `path(..)` benchmark would be
+//! dominated by `walk_path`, not by the function #668 targets, near-invisible
+//! to that fix, and would repeat exactly the mistake #675 was filed to
+//! correct in the first place.
+//!
+//! **Two corrections to the mechanism named above**, neither of which changes
+//! the conclusion (`del(..)`, not `path(..)`, is the isolator). The clone
+//! this paragraph blamed on "each step" of `walk_path`/`step_into` stopped
+//! being per-step at #2058, which made a single branch's walk O(depth) by
+//! navigating it destructively; what remained was one deep clone of the whole
+//! document per *resolved branch*, in `builtin_path_on_owned`. #2190 removed
+//! that one too — the walkers borrow the document now — so `path(..)`'s
+//! second pass is no longer quadratic in the branch count either. The figures
+//! above date from before both and should be read as history.
 //! `del(..)` instead reaches `resolve_del_path_branches` and then applies
 //! `delete_at_path`/`DeleteTrie` directly to the already-resolved static
 //! paths — no second walk of the original tree — so its cost tracks

--- a/benches/jq_recurse_clone_bench.rs
+++ b/benches/jq_recurse_clone_bench.rs
@@ -1,12 +1,12 @@
-//! Depth-scaling benchmark for `push_recursive_branches`/`resolve_recurse`'s
+//! Depth-scaling benchmark for `push_recursive_branches`/`resolve_recurse_sink`'s
 //! per-node clone cost (#668), split out of #675.
 //!
 //! `jq_recurse_depth_bench`'s query, `.. | .[.k]?`, does **not** reach
-//! `push_recursive_branches`/`resolve_recurse` (`src/jq/eval.rs`): bare `..`
+//! `push_recursive_branches`/`resolve_recurse_sink` (`src/jq/eval.rs`): bare `..`
 //! in value position dispatches to `eval_recursive_descent`/
 //! `collect_recursive`, which clones a cheap `StandardJson` cursor per node,
 //! not the materialized `OwnedValue` — see that benchmark's own corrected
-//! docstring. `push_recursive_branches`/`resolve_recurse` are reachable only
+//! docstring. `push_recursive_branches`/`resolve_recurse_sink` are reachable only
 //! through `resolve_node`, which `resolve_dynamic_indexes` calls solely when
 //! `needs_path_prepass` is true — true for `..`/`recurse` themselves, so only
 //! a *path-context* use (`path(..)`, `path(recurse(...))`, `=`, `|=`,

--- a/benches/jq_recurse_depth_bench.rs
+++ b/benches/jq_recurse_depth_bench.rs
@@ -11,12 +11,12 @@
 //!
 //! **This benchmark does not cover #668.** It was originally written
 //! attributing the O(depth^2) cost to `push_recursive_branches`/
-//! `resolve_recurse` (the `..`/`recurse` fan-out itself) rather than to
+//! `resolve_recurse_sink` (the `..`/`recurse` fan-out itself) rather than to
 //! `eval_index_expr`'s computed-key handling — plausible since the query
 //! below combines both, but wrong: PR #670 fixed `eval_index_expr` only, and
 //! that alone reproduced the full speedup, so the fan-out was never the
 //! bottleneck this benchmark measures. `push_recursive_branches`/
-//! `resolve_recurse` do still clone the value at every visited node
+//! `resolve_recurse_sink` do still clone the value at every visited node
 //! (`eval.rs:8595`, `8659`, `8664`), independently of this benchmark's
 //! query — that's #668, and #675 tracks adding a benchmark that isolates it
 //! (a query with no computed index, so it can't route through

--- a/benches/jq_write_path_bench.rs
+++ b/benches/jq_write_path_bench.rs
@@ -1189,6 +1189,100 @@ fn bench_path_recursive_def_ast(c: &mut Criterion) {
     group.finish();
 }
 
+// =============================================================================
+// #2190: `path()`'s per-branch cost, with the document held structurally fixed
+// =============================================================================
+
+/// Element counts for the #2190 group. Deliberately small and doubling: the
+/// point is the *exponent* between adjacent rows, not any single time, and at
+/// the pre-fix ~1.98 the largest row already costs ~3s.
+const LEADING_ITERATE_ELEMS: &[usize] = &[50, 100, 200, 400];
+
+/// How many comma branches each element fans out into. #2190's table A holds
+/// the resolved-path count fixed and widens this from 1 to 32 for free, so the
+/// width itself is not a term -- 8 is simply a middle value that keeps the
+/// resolved-path count interesting at small element counts.
+const LEADING_ITERATE_WIDTH: usize = 8;
+
+/// How deep the static tail after the comma runs.
+const LEADING_ITERATE_DEPTH: usize = 4;
+
+/// `{"foo": [{"b0": <chain>, ..., "b7": <chain>}, ...]}` where `<chain>` is
+/// `{"d":{"d":{"d":{"d":0}}}}` -- #2190's own repro document.
+fn leading_iterate_comma_doc(elems: usize) -> Vec<u8> {
+    let mut chain = String::from("0");
+    for _ in 0..LEADING_ITERATE_DEPTH {
+        chain = format!(r#"{{"d":{chain}}}"#);
+    }
+    let element = (0..LEADING_ITERATE_WIDTH)
+        .map(|b| format!(r#""b{b}":{chain}"#))
+        .collect::<Vec<_>>()
+        .join(",");
+    let elements = (0..elems)
+        .map(|_| format!("{{{element}}}"))
+        .collect::<Vec<_>>()
+        .join(",");
+    format!(r#"{{"foo":[{elements}]}}"#).into_bytes()
+}
+
+/// `[path(.foo[] | (.b0, ..., .b7) | .d | .d | .d | .d)] | length` over
+/// [`leading_iterate_comma_doc`] -- #2190's repro, and the one shape the
+/// groups above miss.
+///
+/// The distinguishing feature is a **leading** bare iterate. #888 removed this
+/// exact O(n^2) for a *trailing* one by deferring it (`resolve_dynamic_indexes`'s
+/// `defer_trailing_iterate`), which is what `jq_write_path_path_array` above
+/// covers; a leading one is still enumerated to one resolved branch per
+/// element before the walk runs, so the branch count scales with the document.
+/// The comma is what forces the enumeration -- at width 1 the parenthesised
+/// group is an `Expr::Paren`, not an `Expr::Comma`, `needs_path_prepass` is
+/// false, and the whole shape collapses to a single branch.
+///
+/// Before #2190 `builtin_path_on_owned` handed each of those branches a **deep
+/// clone of the whole document**, so the cost was `branches x nodes` and both
+/// factors grow with `elems` together: measured exponent ~1.98 (each doubling
+/// costing ~3.94x). The fix borrows the document instead, which should read
+/// ~1.0 here. Because `Throughput::Elements` is set, an exponent regression is
+/// visible directly in Criterion's ns/element column without eyeballing the
+/// raw timings.
+///
+/// Wrapped in `length` so the timed *output* stays O(1) — this repo's own
+/// benchmarking discipline warns that a shape whose output grows with the
+/// input measures the renderer as much as the evaluator.
+fn bench_path_leading_iterate_comma(c: &mut Criterion) {
+    let mut group = c.benchmark_group("jq_write_path_path_leading_iterate_comma");
+    let branches = (0..LEADING_ITERATE_WIDTH)
+        .map(|b| format!(".b{b}"))
+        .collect::<Vec<_>>()
+        .join(", ");
+    let tail = vec![".d"; LEADING_ITERATE_DEPTH].join(" | ");
+    let expr =
+        parse(&format!("[path(.foo[] | ({branches}) | {tail})] | length")).expect("must parse");
+
+    for &elems in LEADING_ITERATE_ELEMS {
+        let json = leading_iterate_comma_doc(elems);
+
+        // Guard the premise: one path per (element, comma branch) pair. A
+        // walk that silently drops branches would otherwise read as a
+        // speedup rather than a failure.
+        assert_eq!(
+            eval_one(&expr, &json),
+            OwnedValue::Int((elems * LEADING_ITERATE_WIDTH) as i64),
+            "elems={elems}: must report one path per element per comma branch"
+        );
+
+        let index = JsonIndex::build(&json);
+        group.throughput(Throughput::Elements((elems * LEADING_ITERATE_WIDTH) as u64));
+        group.bench_with_input(BenchmarkId::from_parameter(elems), &json, |b, json| {
+            b.iter(|| {
+                let cursor = index.root(black_box(json));
+                black_box(eval::<Vec<u64>, JqSemantics>(&expr, cursor))
+            });
+        });
+    }
+    group.finish();
+}
+
 criterion_group!(
     benches,
     bench_del_array,
@@ -1211,5 +1305,6 @@ criterion_group!(
     bench_path_paren_chain_ast,
     bench_path_if_fanout_ast,
     bench_path_recursive_def_ast,
+    bench_path_leading_iterate_comma,
 );
 criterion_main!(benches);

--- a/benches/jq_write_path_bench.rs
+++ b/benches/jq_write_path_bench.rs
@@ -1255,7 +1255,7 @@ fn bench_path_leading_iterate_comma(c: &mut Criterion) {
         .map(|b| format!(".b{b}"))
         .collect::<Vec<_>>()
         .join(", ");
-    let tail = vec![".d"; LEADING_ITERATE_DEPTH].join(" | ");
+    let tail = [".d"; LEADING_ITERATE_DEPTH].join(" | ");
     let expr =
         parse(&format!("[path(.foo[] | ({branches}) | {tail})] | length")).expect("must parse");
 

--- a/docs/compliance/jq/limitations.md
+++ b/docs/compliance/jq/limitations.md
@@ -919,6 +919,7 @@ Five residual divergences remain in this area:
   it cannot stop the fold (`[limit(1; path(foreach (1 as $x ?// $y | (stderr|1)) as $v (.;
   .)))]` is `[[],[]]` with two writes in jq — its `limit` break is retried by the source's
   `?//` and the retried output lands past the bound — and `[[]]` with one write here).
+  Tracked as [#2694](https://github.com/rust-works/succinctly/issues/2694).
 - **`recurse(f)`/`recurse(f; cond)` still collects one node's own `f` in full.**
   `resolve_recurse_sink` (#2235) streams each visited node to a bounded consumer as soon as
   it is popped, and defers `f`/`cond` for a node until its own delivery is accepted — so
@@ -931,7 +932,10 @@ Five residual divergences remain in this area:
   `.a` only in jq (the bound is satisfied by `.a`'s own self-emission before `.b` is ever
   asked for); both fire here. Same underlying cause as the bullet above — `resolve_against_cow`
   has no sink form either — narrower in practice since it only over-fires a node's own
-  later `f` outputs, not an entire subtree.
+  later `f` outputs, not an entire subtree. Tracked as
+  [#2693](https://github.com/rust-works/succinctly/issues/2693). Bare `..`/`recurse`, which
+  predates #2235 and was not part of that migration at all, has the same gap one level up —
+  tracked separately as [#2696](https://github.com/rust-works/succinctly/issues/2696).
 - **`E[K]` evaluates its target once where jq re-runs it per key.** jq compiles `E[K]` as
   `K as $k | E | .[$k]`, so a side effect in `E` fires once per output of `K`; here it fires
   once total — `[(.[] | stderr)[("a","b")]?]` on `[1,2]` writes `1212` in jq and `12` here.

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -32086,13 +32086,27 @@ fn value_after_components<S: EvalSemantics>(
 /// fix-direction note called the borrowing walker blocked. The agreement
 /// test is
 /// `navigate_static_component_agrees_with_eval_owned_fast_path`.
-enum StaticAccess {
-    /// The child is at this position: `IndexMap` entry `i`, or array element
-    /// `i`. Already bounds-checked, and already resolved from the end for a
-    /// negative index, so neither extraction re-derives either.
-    Slot(usize),
-    /// The step reads as `null`: a missing key, an out-of-range index (either
-    /// sign), or a step through `null` -- none of which is an error in jq.
+enum StaticAccess<'e> {
+    /// The child is this key of the object `current`, if the object has it --
+    /// "if" being the *extraction's* business, because that is the one place
+    /// the two sides genuinely differ in cost. Resolving the key to a slot
+    /// here instead would make the destructive side hash twice: once to find
+    /// the slot, and again inside `swap_remove_index` to re-find the bucket
+    /// the entry belongs to. That measured a systematic +1.7-3.3% across
+    /// every `jq_write_path_two_branch_{del,assign}_depth` point on an M4
+    /// Pro -- small, but a real cost charged to `=`/`|=`/`del()` for a
+    /// `path()` fix, so the key is carried verbatim and each side does its
+    /// own single hashed lookup (`swap_remove` or `get`).
+    Field(&'e str),
+    /// The child is array element `i` -- already bounds-checked, and already
+    /// resolved from the end for a negative index, so neither extraction
+    /// re-derives either. Unlike `Field` there is no hashing involved for an
+    /// array, so resolving it here costs nothing.
+    Index(usize),
+    /// The step reads as `null`: an out-of-range index (either sign), or a
+    /// step through `null` -- neither an error in jq. (A missing *key* is
+    /// `null` too, but it is not known to be missing until the lookup
+    /// happens, so it arrives through `Field` above.)
     Null,
     /// Not a bare `Field`/`Index` ([`Expr::Slice`] above all). Both
     /// extractions hand it to [`eval_static_component_fallback`], which
@@ -32105,18 +32119,14 @@ enum StaticAccess {
 ///
 /// Takes `current` by reference deliberately: the destructive navigator calls
 /// this *before* consuming its value, which is sound only because the answer
-/// borrows nothing from it.
-fn classify_static_component(
-    component: &Expr,
+/// borrows from `component` (the `'e` below) and never from `current`.
+fn classify_static_component<'e>(
+    component: &'e Expr,
     current: &OwnedValue,
-) -> Result<StaticAccess, EvalEscape> {
+) -> Result<StaticAccess<'e>, EvalEscape> {
     match component {
         Expr::Field(name) => match current {
-            // A missing key is `null`, not an error, exactly as
-            // `eval_owned_fast_path`'s own `Field` arm has it.
-            OwnedValue::Object(map) => Ok(map
-                .get_index_of(name.as_str())
-                .map_or(StaticAccess::Null, StaticAccess::Slot)),
+            OwnedValue::Object(_) => Ok(StaticAccess::Field(name.as_str())),
             OwnedValue::Null => Ok(StaticAccess::Null),
             other => Err(EvalError::cannot_index_with_field(owned_type_name(other), name).into()),
         },
@@ -32130,7 +32140,7 @@ fn classify_static_component(
                 Ok(usize::try_from(resolved)
                     .ok()
                     .filter(|&i| i < items.len())
-                    .map_or(StaticAccess::Null, StaticAccess::Slot))
+                    .map_or(StaticAccess::Null, StaticAccess::Index))
             }
             OwnedValue::Null => Ok(StaticAccess::Null),
             other => {
@@ -32205,15 +32215,18 @@ fn navigate_static_component<S: EvalSemantics>(
 ) -> Result<Option<OwnedValue>, EvalEscape> {
     Ok(Some(
         match classify_static_component(component, &current)? {
-            StaticAccess::Slot(i) => match current {
-                OwnedValue::Object(mut map) => map
-                    .swap_remove_index(i)
-                    .map_or(OwnedValue::Null, |(_, value)| value),
+            // A missing key is `null`, not an error, exactly as
+            // `eval_owned_fast_path`'s own `Field` arm has it.
+            StaticAccess::Field(name) => match current {
+                OwnedValue::Object(mut map) => map.swap_remove(name).unwrap_or(OwnedValue::Null),
+                // Unreachable: `classify_static_component` answers `Field`
+                // only for an object. `null` is what it would answer for a
+                // key that is not there anyway, so this needs no panic.
+                _ => OwnedValue::Null,
+            },
+            StaticAccess::Index(i) => match current {
                 OwnedValue::Array(mut items) => items.swap_remove(i),
-                // Unreachable: `classify_static_component` answers `Slot` only
-                // for the object/array it resolved the slot against. `null` is
-                // the answer it would give for a slot that is not there anyway,
-                // so this needs no panic of its own.
+                // Unreachable, and `null`, for the same reasons.
                 _ => OwnedValue::Null,
             },
             StaticAccess::Null => OwnedValue::Null,
@@ -32281,6 +32294,20 @@ impl WalkNode<'_> {
         }
     }
 
+    /// The child under object key `name`, or [`Self::Null`] if the object
+    /// does not have it (jq's missing-key rule). The key half of
+    /// [`Self::child_at`]'s positional lookup -- separate because an object
+    /// lookup is hashed, and doing it once per step rather than once in
+    /// [`classify_static_component`] and again here is what keeps the
+    /// destructive twin's cost exactly where it was (see
+    /// [`StaticAccess::Field`]).
+    fn field(&self, name: &str) -> Self {
+        self.pick(|value| match value {
+            OwnedValue::Object(map) => map.get(name),
+            _ => None,
+        })
+    }
+
     /// The child at positional `slot` -- the `IndexMap` entry or array element
     /// [`classify_static_component`] resolved, or the one
     /// [`Expr::Iterate`](Expr) is enumerating.
@@ -32292,11 +32319,24 @@ impl WalkNode<'_> {
     /// so keeps the type closed under navigation. Residue's child has no
     /// document to borrow from and is cloned into a fresh `Rc` instead.
     fn child_at(&self, slot: usize) -> Self {
+        self.pick(|value| slot_of(value, slot))
+    }
+
+    /// Apply a child selector, keeping this node's kind: a document node's
+    /// child is another document node and a residue node's child is more
+    /// residue. The one place the borrow-vs-clone rule is written down.
+    ///
+    /// `pick` is higher-ranked so that the `Doc` arm can instantiate it at
+    /// the *document's* `'v` rather than at the shorter lifetime of the
+    /// `&self` it was reached through -- that is what keeps the result a
+    /// `WalkNode<'v>`, and so keeps the type closed under navigation.
+    fn pick<F>(&self, pick: F) -> Self
+    where
+        F: for<'a> Fn(&'a OwnedValue) -> Option<&'a OwnedValue>,
+    {
         match self {
-            Self::Doc(value) => slot_of(value, slot).map_or(Self::Null, Self::Doc),
-            Self::Made(value) => {
-                slot_of(value, slot).map_or(Self::Null, |child| Self::made(child.clone()))
-            }
+            Self::Doc(value) => pick(value).map_or(Self::Null, Self::Doc),
+            Self::Made(value) => pick(value).map_or(Self::Null, |child| Self::made(child.clone())),
             Self::Null => Self::Null,
         }
     }
@@ -32324,7 +32364,8 @@ fn navigate_static_component_ref<'v, S: EvalSemantics>(
 ) -> Result<Option<WalkNode<'v>>, EvalEscape> {
     Ok(Some(
         match classify_static_component(component, current.value())? {
-            StaticAccess::Slot(slot) => current.child_at(slot),
+            StaticAccess::Field(name) => current.field(name),
+            StaticAccess::Index(slot) => current.child_at(slot),
             StaticAccess::Null => WalkNode::Null,
             StaticAccess::Fallback => {
                 return Ok(

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -32264,7 +32264,7 @@ enum WalkNode<'v> {
 /// would not survive the expression it appears in.
 static WALK_NODE_NULL: OwnedValue = OwnedValue::Null;
 
-impl<'v> WalkNode<'v> {
+impl WalkNode<'_> {
     /// A value the walk built, wrapped for buffering.
     fn made(value: OwnedValue) -> Self {
         Self::Made(Rc::new(value))
@@ -32285,10 +32285,12 @@ impl<'v> WalkNode<'v> {
     /// [`classify_static_component`] resolved, or the one
     /// [`Expr::Iterate`](Expr) is enumerating.
     ///
-    /// A document node's child is borrowed at the *document's* own lifetime
-    /// (hence `*value`, not `value`: re-borrowing through the `&self` here
-    /// would shorten it and break the closure property above). Residue's child
-    /// is cloned into a fresh `Rc`.
+    /// A document node's child is borrowed at the *document's* own lifetime,
+    /// not at the shorter one of the `&self` it was read through -- deref
+    /// coercion copies the inner `&'v` reference out rather than reborrowing
+    /// through it, which is what keeps the returned node a `WalkNode<'v>` and
+    /// so keeps the type closed under navigation. Residue's child has no
+    /// document to borrow from and is cloned into a fresh `Rc` instead.
     fn child_at(&self, slot: usize) -> Self {
         match self {
             Self::Doc(value) => slot_of(value, slot).map_or(Self::Null, Self::Doc),

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -32171,7 +32171,7 @@ fn eval_static_component_fallback<S: EvalSemantics>(
         values.len() <= 1,
         "eval_static_component_fallback: {component:?} produced {} outputs, but every \
          caller requires a single-valued tail (see needs_fanout_pass)",
-        values.len()
+        values.len() // omni-dev: coverage tolerate-line reason="unreachable in a passing suite by design -- a panic-message format argument for the #682 single-valued-tail pin, evaluated only if that assert's own condition is false (#2190)"
     );
     Ok(match values.len() {
         1 => Some(values.pop().expect("len checked")),
@@ -32222,12 +32222,12 @@ fn navigate_static_component<S: EvalSemantics>(
                 // Unreachable: `classify_static_component` answers `Field`
                 // only for an object. `null` is what it would answer for a
                 // key that is not there anyway, so this needs no panic.
-                _ => OwnedValue::Null,
+                _ => OwnedValue::Null, // omni-dev: coverage tolerate-line reason="unreachable: classify_static_component answers Field only for OwnedValue::Object, and it was handed this very value (#2190)"
             },
             StaticAccess::Index(i) => match current {
                 OwnedValue::Array(mut items) => items.swap_remove(i),
                 // Unreachable, and `null`, for the same reasons.
-                _ => OwnedValue::Null,
+                _ => OwnedValue::Null, // omni-dev: coverage tolerate-line reason="unreachable: classify_static_component answers Index only for OwnedValue::Array, and it was handed this very value (#2190)"
             },
             StaticAccess::Null => OwnedValue::Null,
             StaticAccess::Fallback => {
@@ -32304,7 +32304,7 @@ impl WalkNode<'_> {
     fn field(&self, name: &str) -> Self {
         self.pick(|value| match value {
             OwnedValue::Object(map) => map.get(name),
-            _ => None,
+            _ => None, // omni-dev: coverage tolerate-line reason="unreachable: the only caller reaches this after classify_static_component answered Field for this same value, which it does only for an object (#2190)"
         })
     }
 
@@ -32348,7 +32348,7 @@ fn slot_of(value: &OwnedValue, slot: usize) -> Option<&OwnedValue> {
     match value {
         OwnedValue::Object(map) => map.get_index(slot).map(|(_, child)| child),
         OwnedValue::Array(items) => items.get(slot),
-        _ => None,
+        _ => None, // omni-dev: coverage tolerate-line reason="unreachable: both callers establish the container first -- navigate_static_component_ref via classify_static_component's Index arm, and walk_path's Expr::Iterate arm by matching on the container itself (#2190)"
     }
 }
 
@@ -55750,7 +55750,7 @@ mod tests {
 
         let from_doc = WalkNode::Doc(&doc).child_at(1);
         let WalkNode::Doc(child) = from_doc else {
-            panic!("a document node's child must stay borrowed, not be copied");
+            panic!("a document node's child must stay borrowed, not be copied") // omni-dev: coverage tolerate-line reason="unreachable in a passing suite by design -- this is the failure message for the assertion the test exists to make (#2190)"
         };
         assert!(
             core::ptr::eq(child, &doc.as_array().expect("array")[1]),

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -32069,23 +32069,122 @@ fn value_after_components<S: EvalSemantics>(
     Ok(Some(current))
 }
 
-/// One step of [`value_after_components`]'s walk (#2058).
+/// Where a bare static [`Expr::Field`]/[`Expr::Index`] component lands, as a
+/// position in the container it was resolved against (#2190).
+///
+/// [`navigate_static_component`] (destructive, for `=`/`|=`/`del()`) and
+/// [`navigate_static_component_ref`] (borrowing, for `path()`) differ only in
+/// how they take that position *out* -- `swap_remove_index` versus
+/// `get_index`. Everything that could otherwise drift between them is decided
+/// once, in [`classify_static_component`]: the missing-key and out-of-bounds
+/// rules, the negative-index resolution, the step-through-`null` rule, and
+/// which error a container that cannot be indexed at all raises.
+///
+/// That is this repo's own "one definition, plus a test that the call sites
+/// agree" rule applied where a second navigator would otherwise have meant a
+/// *fourth* independent copy of jq's indexing rules -- the reason #2190's own
+/// fix-direction note called the borrowing walker blocked. The agreement
+/// test is
+/// `navigate_static_component_agrees_with_eval_owned_fast_path`.
+enum StaticAccess {
+    /// The child is at this position: `IndexMap` entry `i`, or array element
+    /// `i`. Already bounds-checked, and already resolved from the end for a
+    /// negative index, so neither extraction re-derives either.
+    Slot(usize),
+    /// The step reads as `null`: a missing key, an out-of-range index (either
+    /// sign), or a step through `null` -- none of which is an error in jq.
+    Null,
+    /// Not a bare `Field`/`Index` ([`Expr::Slice`] above all). Both
+    /// extractions hand it to [`eval_static_component_fallback`], which
+    /// borrows, so they share that arm verbatim rather than copying it.
+    Fallback,
+}
+
+/// Resolve `component` against `current` to a [`StaticAccess`] -- the one
+/// definition of jq's static-indexing rules that both navigators below share.
+///
+/// Takes `current` by reference deliberately: the destructive navigator calls
+/// this *before* consuming its value, which is sound only because the answer
+/// borrows nothing from it.
+fn classify_static_component(
+    component: &Expr,
+    current: &OwnedValue,
+) -> Result<StaticAccess, EvalEscape> {
+    match component {
+        Expr::Field(name) => match current {
+            // A missing key is `null`, not an error, exactly as
+            // `eval_owned_fast_path`'s own `Field` arm has it.
+            OwnedValue::Object(map) => Ok(map
+                .get_index_of(name.as_str())
+                .map_or(StaticAccess::Null, StaticAccess::Slot)),
+            OwnedValue::Null => Ok(StaticAccess::Null),
+            other => Err(EvalError::cannot_index_with_field(owned_type_name(other), name).into()),
+        },
+        Expr::Index { idx, .. } => match current {
+            OwnedValue::Array(items) => {
+                let resolved = if *idx < 0 {
+                    items.len() as i64 + idx
+                } else {
+                    *idx
+                };
+                Ok(usize::try_from(resolved)
+                    .ok()
+                    .filter(|&i| i < items.len())
+                    .map_or(StaticAccess::Null, StaticAccess::Slot))
+            }
+            OwnedValue::Null => Ok(StaticAccess::Null),
+            other => {
+                Err(EvalError::cannot_index_with_type(owned_type_name(other), "number").into())
+            }
+        },
+        _ => Ok(StaticAccess::Fallback),
+    }
+}
+
+/// The [`StaticAccess::Fallback`] step, answered by the value evaluator rather
+/// than by a second copy of its rules. Borrows `current`, so both navigators
+/// below share it unchanged.
+fn eval_static_component_fallback<S: EvalSemantics>(
+    component: &Expr,
+    current: &OwnedValue,
+) -> Result<Option<OwnedValue>, EvalEscape> {
+    let mut values = eval_owned_multi::<S>(component, current)?;
+    // Every caller hands this a tail already proven single-valued by
+    // construction (`resolve_seq`, gated on `needs_fanout_pass`) -- a
+    // `> 1` output count here is a genuine invariant violation, not
+    // the ordinary "component matched nothing" case (a missing key
+    // still yields exactly one output, `null`). #682 was exactly
+    // this: `Expr::Iterate` produced more than one output through
+    // this function, which silently discarded every branch but one
+    // instead of the fan-out its caller actually needed.
+    debug_assert!(
+        values.len() <= 1,
+        "eval_static_component_fallback: {component:?} produced {} outputs, but every \
+         caller requires a single-valued tail (see needs_fanout_pass)",
+        values.len()
+    );
+    Ok(match values.len() {
+        1 => Some(values.pop().expect("len checked")),
+        _ => None,
+    })
+}
+
+/// One step of [`value_after_components`]'s walk (#2058), taking its value by
+/// move -- the `=`/`|=`/`del()` side.
 ///
 /// A bare [`Expr::Field`]/[`Expr::Index`] -- the overwhelmingly common shape
-/// in a static tail (`.c.c.c...c[0]`) -- is handled here directly and
-/// destructively, mirroring [`eval_owned_fast_path`]'s own arms for those two
-/// (kept in sync deliberately: same missing-key/out-of-bounds ->
-/// `OwnedValue::Null` rule, same error types/messages for a non-indexable
-/// container) but consuming `current` instead of borrowing it.
-/// [`IndexMap::swap_remove`]/[`Vec::swap_remove`] -- not the order-preserving
-/// `shift_remove`/`Vec::remove` -- are what make this O(1) instead of O(n),
-/// and are safe here specifically because the container being consumed is
-/// *never read again*: every sibling still inside it is simply dropped, in
-/// whatever order swap-removal leaves them, the moment this function
-/// returns. (A container whose remaining order or contents an *other* live
-/// reference could still observe would need the order-preserving removal
-/// instead -- this one has no such reference; see `value_after_components`'s
-/// own doc comment for why.)
+/// in a static tail (`.c.c.c...c[0]`) -- is navigated destructively here.
+/// [`IndexMap::swap_remove_index`]/[`Vec::swap_remove`] -- not the
+/// order-preserving `shift_remove`/`Vec::remove` -- are what make this O(1)
+/// instead of O(n), and are safe here specifically because the container being
+/// consumed is *never read again*: every sibling still inside it is simply
+/// dropped, in whatever order swap-removal leaves them, the moment this
+/// function returns. (A container whose remaining order or contents an
+/// *other* live reference could still observe would need the order-preserving
+/// removal instead -- this one has no such reference; see
+/// `value_after_components`'s own doc comment for why. The borrowing twin,
+/// [`navigate_static_component_ref`], removes nothing at all and so carries no
+/// such requirement.)
 ///
 /// Anything else -- [`Expr::Slice`] (jq's own array slice keeps the sliced
 /// sub-range regardless, so there is no equivalent "don't clone the sibling"
@@ -32104,57 +32203,135 @@ fn navigate_static_component<S: EvalSemantics>(
     component: &Expr,
     current: OwnedValue,
 ) -> Result<Option<OwnedValue>, EvalEscape> {
-    match component {
-        Expr::Field(name) => Ok(Some(match current {
-            OwnedValue::Object(mut map) => map.swap_remove(name).unwrap_or(OwnedValue::Null),
-            OwnedValue::Null => OwnedValue::Null,
-            other => {
-                return Err(
-                    EvalError::cannot_index_with_field(owned_type_name(&other), name).into(),
-                );
+    Ok(Some(
+        match classify_static_component(component, &current)? {
+            StaticAccess::Slot(i) => match current {
+                OwnedValue::Object(mut map) => map
+                    .swap_remove_index(i)
+                    .map_or(OwnedValue::Null, |(_, value)| value),
+                OwnedValue::Array(mut items) => items.swap_remove(i),
+                // Unreachable: `classify_static_component` answers `Slot` only
+                // for the object/array it resolved the slot against. `null` is
+                // the answer it would give for a slot that is not there anyway,
+                // so this needs no panic of its own.
+                _ => OwnedValue::Null,
+            },
+            StaticAccess::Null => OwnedValue::Null,
+            StaticAccess::Fallback => {
+                return eval_static_component_fallback::<S>(component, &current)
             }
-        })),
-        Expr::Index { idx, .. } => Ok(Some(match current {
-            OwnedValue::Array(mut items) => {
-                let resolved = if *idx < 0 {
-                    items.len() as i64 + idx
-                } else {
-                    *idx
-                };
-                usize::try_from(resolved)
-                    .ok()
-                    .filter(|&i| i < items.len())
-                    .map_or(OwnedValue::Null, |i| items.swap_remove(i))
-            }
-            OwnedValue::Null => OwnedValue::Null,
-            other => {
-                return Err(
-                    EvalError::cannot_index_with_type(owned_type_name(&other), "number").into(),
-                );
-            }
-        })),
-        _ => {
-            let mut values = eval_owned_multi::<S>(component, &current)?;
-            // Every caller hands this a tail already proven single-valued by
-            // construction (`resolve_seq`, gated on `needs_fanout_pass`) -- a
-            // `> 1` output count here is a genuine invariant violation, not
-            // the ordinary "component matched nothing" case (a missing key
-            // still yields exactly one output, `null`). #682 was exactly
-            // this: `Expr::Iterate` produced more than one output through
-            // this function, which silently discarded every branch but one
-            // instead of the fan-out its caller actually needed.
-            debug_assert!(
-                values.len() <= 1,
-                "value_after_components: {component:?} produced {} outputs, but every \
-                 caller requires a single-valued tail (see needs_fanout_pass)",
-                values.len()
-            );
-            Ok(match values.len() {
-                1 => Some(values.pop().expect("len checked")),
-                _ => None,
-            })
+        },
+    ))
+}
+
+/// A node the `path()` walk stands on (#2190).
+///
+/// Mirrors `eval_generic::PathNode`'s own `At`/`Owned` split, minus the cursor
+/// variant this route has no use for: the document is **borrowed**, and only a
+/// value the walk itself *built* is owned.
+///
+/// The point is that this type is **closed under navigation** -- a child of a
+/// `WalkNode<'v>` is a `WalkNode<'v>` -- which is what lets
+/// [`walk_pipe`] keep buffering one stage's results in a plain `Vec` while
+/// still borrowing the document. `Cow<'v, OwnedValue>` cannot do that: `Vec`
+/// is invariant in its element type, so a stage reached *through* a
+/// `Cow::Owned` would have to hand its caller a `Cow` borrowed from that
+/// local buffer, at a strictly shorter lifetime. `Rc` breaks the chain --
+/// residue's children are cloned into a fresh `Rc` and so borrow nothing --
+/// at a cost paid only inside residue, exactly as
+/// `eval_generic::owned_nav_children` already pays it.
+///
+/// Before #2190 the walk took `OwnedValue` by move instead, which forced
+/// `builtin_path_on_owned` to deep-clone the whole document once per resolved
+/// branch: `branches x nodes`, an exponent of ~1.98 measured over resolved
+/// path count with the document size held fixed.
+enum WalkNode<'v> {
+    /// A node of the document being walked. Borrowed, never copied.
+    Doc(&'v OwnedValue),
+    /// A value the walk built rather than found -- a slice's array, or
+    /// [`eval_static_component_fallback`]'s output. `Rc` so that buffering it
+    /// in [`walk_pipe`] costs a refcount rather than a deep copy.
+    Made(Rc<OwnedValue>),
+    /// jq's `null`: a missing key, an out-of-range index, or a step through
+    /// `null`. Its own variant rather than a `Made(Rc::new(Null))` so the
+    /// common "the path names a place this document does not have" case
+    /// allocates nothing.
+    Null,
+}
+
+/// The `null` every [`WalkNode::Null`] hands out. A `static` rather than a
+/// promoted temporary because `OwnedValue` has drop glue, so `&OwnedValue::Null`
+/// would not survive the expression it appears in.
+static WALK_NODE_NULL: OwnedValue = OwnedValue::Null;
+
+impl<'v> WalkNode<'v> {
+    /// A value the walk built, wrapped for buffering.
+    fn made(value: OwnedValue) -> Self {
+        Self::Made(Rc::new(value))
+    }
+
+    /// What this node holds, for the steps that only need to *read* it --
+    /// deciding a component against it, or reporting jq's verdict for a step
+    /// that cannot be taken.
+    fn value(&self) -> &OwnedValue {
+        match self {
+            Self::Doc(value) => value,
+            Self::Made(value) => value,
+            Self::Null => &WALK_NODE_NULL,
         }
     }
+
+    /// The child at positional `slot` -- the `IndexMap` entry or array element
+    /// [`classify_static_component`] resolved, or the one
+    /// [`Expr::Iterate`](Expr) is enumerating.
+    ///
+    /// A document node's child is borrowed at the *document's* own lifetime
+    /// (hence `*value`, not `value`: re-borrowing through the `&self` here
+    /// would shorten it and break the closure property above). Residue's child
+    /// is cloned into a fresh `Rc`.
+    fn child_at(&self, slot: usize) -> Self {
+        match self {
+            Self::Doc(value) => slot_of(value, slot).map_or(Self::Null, Self::Doc),
+            Self::Made(value) => {
+                slot_of(value, slot).map_or(Self::Null, |child| Self::made(child.clone()))
+            }
+            Self::Null => Self::Null,
+        }
+    }
+}
+
+/// The value at positional `slot` of an object or an array -- the one
+/// container-agnostic accessor [`StaticAccess::Slot`] is defined against.
+fn slot_of(value: &OwnedValue, slot: usize) -> Option<&OwnedValue> {
+    match value {
+        OwnedValue::Object(map) => map.get_index(slot).map(|(_, child)| child),
+        OwnedValue::Array(items) => items.get(slot),
+        _ => None,
+    }
+}
+
+/// [`navigate_static_component`]'s borrowing twin -- the `path()` side (#2190).
+///
+/// Same rules, via the same [`classify_static_component`]; the only difference
+/// is that this one *reads* the resolved slot instead of removing it, so the
+/// document it walks is never consumed and never has to be cloned to be walked
+/// again by the next resolved branch.
+fn navigate_static_component_ref<'v, S: EvalSemantics>(
+    component: &Expr,
+    current: &WalkNode<'v>,
+) -> Result<Option<WalkNode<'v>>, EvalEscape> {
+    Ok(Some(
+        match classify_static_component(component, current.value())? {
+            StaticAccess::Slot(slot) => current.child_at(slot),
+            StaticAccess::Null => WalkNode::Null,
+            StaticAccess::Fallback => {
+                return Ok(
+                    eval_static_component_fallback::<S>(component, current.value())?
+                        .map(WalkNode::made),
+                )
+            }
+        },
+    ))
 }
 
 /// [`value_after_components`], except when `trackable` is false (#843): then
@@ -37754,13 +37931,14 @@ pub(crate) fn builtin_path_on_owned<'a, W: Clone + AsRef<[u64]>, S: EvalSemantic
         // the expression is concretely walked) needs the same treatment:
         // whatever earlier resolved expressions already streamed into
         // `reached` survives, and only this one stops the walk.
-        // One clone of the whole document per resolved branch (#2058) --
-        // `walk_path`/`walk_pipe`/`step_into` below take their value by move
-        // and navigate destructively, so this is the only clone this branch
-        // pays, however deep it walks. `owned` is shared across every branch
-        // in `exprs` (each needs its own independent walk from the document
-        // root), so it cannot be moved in directly here.
-        if let Err(e) = walk_path::<S>(expr, owned.clone(), &root, &mut reached, optional) {
+        //
+        // No clone at all (#2190). `owned` is shared across every branch in
+        // `exprs` -- each needs its own independent walk from the document
+        // root -- and before #2190 that meant handing each one a deep copy of
+        // the whole document, because the walkers navigated by move. They
+        // borrow now ([`WalkNode`]), so the shared `&OwnedValue` is walked
+        // directly, `branches` times, and the `branches x nodes` term is gone.
+        if let Err(e) = walk_path::<S>(expr, WalkNode::Doc(owned), &root, &mut reached, optional) {
             walk_error = Some(e);
             break;
         }
@@ -37809,24 +37987,27 @@ pub(crate) fn builtin_path_on_owned<'a, W: Clone + AsRef<[u64]>, S: EvalSemantic
 /// before it obey the same rules, and keeping two copies of them is what let
 /// `path(.b.c)` lose the path that `path(.b)` kept (#489).
 ///
-/// **Takes `value` by value, and consumes it destructively, for the same
-/// reason [`value_after_components`] does (#2058).** `builtin_path_on_owned`
-/// clones the document once per resolved branch at this function's one call
-/// site -- everything below navigates that clone by move, so a `d`-deep
-/// chain costs O(d) per branch instead of the O(d^2) a `.clone()` at every
-/// step used to cost (step `i` used to clone the whole remaining O(d-i)-sized
-/// subtree just to read one field out of it). This mirrors
-/// `value_after_components`'s own fix one level up: that one flattened
-/// `resolve_seq`'s pre-pass (which every one of `path()`/`=`/`del()` runs to
-/// turn a computed key into a resolved component list), while this one
-/// flattens `path()`'s *own* second walk over that resolved list -- the
-/// reason `path()` alone still read the full O(d^2) exponent even after the
-/// pre-pass was fixed, since `=`/`del()` never reach this function at all.
-fn walk_path<S: EvalSemantics>(
+/// **Borrows the document rather than consuming a private copy of it
+/// (#2190).** A [`WalkNode`] is either a node of the document itself or a
+/// value this walk built, so nothing here has to own the tree it navigates:
+/// `builtin_path_on_owned` hands every one of its resolved branches the same
+/// `&OwnedValue`. Before #2190 it handed each one a deep clone, because these
+/// three functions navigated by move -- `branches x nodes`, an exponent of
+/// ~1.98 measured against resolved path count alone.
+///
+/// A single branch's walk stays O(depth), which is what #2058 bought and what
+/// the move-based version existed to protect: a step reads its child out of
+/// the parent (`WalkNode::child_at`) rather than cloning the parent's whole
+/// remaining subtree to look inside it. #2058 achieved that by *consuming* the
+/// parent; borrowing achieves the same thing without needing a copy to consume
+/// in the first place. `value_after_components`, the `=`/`|=`/`del()` twin one
+/// level up, still navigates by move -- it genuinely needs an owned result --
+/// and is untouched.
+fn walk_path<'v, S: EvalSemantics>(
     expr: &Expr,
-    value: OwnedValue,
+    value: WalkNode<'v>,
     current_path: &Rc<PathTrail>,
-    out: &mut Vec<(Rc<PathTrail>, OwnedValue)>,
+    out: &mut Vec<(Rc<PathTrail>, WalkNode<'v>)>,
     optional: bool,
 ) -> Result<(), EvalEscape> {
     // Panics past `MAX_VALUE_TREE_DEPTH` levels (code review on #2058): a
@@ -37859,7 +38040,7 @@ fn walk_path<S: EvalSemantics>(
             step_into::<S>(
                 expr,
                 OwnedValue::String(name.clone()),
-                value,
+                &value,
                 current_path,
                 out,
                 optional,
@@ -37869,7 +38050,7 @@ fn walk_path<S: EvalSemantics>(
             step_into::<S>(
                 expr,
                 index_component_value(*idx, key.as_ref()),
-                value,
+                &value,
                 current_path,
                 out,
                 optional,
@@ -37884,7 +38065,7 @@ fn walk_path<S: EvalSemantics>(
             step_into::<S>(
                 expr,
                 slice_component_value(*start, start_key.as_ref(), *end, end_key.as_ref()),
-                value,
+                &value,
                 current_path,
                 out,
                 optional,
@@ -37894,27 +38075,31 @@ fn walk_path<S: EvalSemantics>(
         // The one step whose components come from the *value* rather than the
         // expression, so it reads them off the container directly. Anything
         // that is not a container still takes the evaluator's verdict, which
-        // is jq's `Cannot iterate over <t> (<v>)`. `value` is owned, so each
-        // element/entry moves into `out` directly rather than being cloned,
-        // and each element's own trail extension is O(1) (`PathTrail::extend`).
-        Expr::Iterate => match value {
-            OwnedValue::Array(arr) => {
-                for (i, val) in arr.into_iter().enumerate() {
+        // is jq's `Cannot iterate over <t> (<v>)`. Each child is reached by
+        // slot through `WalkNode::child_at`, so a document node's children are
+        // borrowed rather than copied (#2190), and each element's own trail
+        // extension is O(1) (`PathTrail::extend`). An object key is cloned --
+        // it names the path, so it has to be owned either way, and it is the
+        // same `clone()` the `Field` arm above already pays.
+        Expr::Iterate => match value.value() {
+            OwnedValue::Array(items) => {
+                for i in 0..items.len() {
                     out.push((
                         PathTrail::extend(current_path, OwnedValue::Int(i as i64)),
-                        val,
+                        value.child_at(i),
                     ));
                 }
             }
             OwnedValue::Object(entries) => {
-                for (key, val) in entries {
+                for i in 0..entries.len() {
+                    let (key, _) = entries.get_index(i).expect("i < len");
                     out.push((
-                        PathTrail::extend(current_path, OwnedValue::String(key)),
-                        val,
+                        PathTrail::extend(current_path, OwnedValue::String(key.clone())),
+                        value.child_at(i),
                     ));
                 }
             }
-            other => match eval_owned_multi::<S>(expr, &other) {
+            other => match eval_owned_multi::<S>(expr, other) {
                 Ok(_) => {}
                 // `?` silences only the genuine indexing error; a halt
                 // raised while producing the verdict still escapes (#791).
@@ -37949,20 +38134,23 @@ fn walk_path<S: EvalSemantics>(
 
 /// Walk a pipe of path steps, threading each value reached into the next step.
 ///
-/// `value` moves stage to stage -- see [`walk_path`]'s own doc comment for why
-/// that is the point of this whole rewrite (#2058): a straight-line chain of
-/// `Field`/`Index` stages now passes exactly one value along by move, never
-/// cloning the remaining document at any intermediate stage. `current_path`
-/// is an `Rc<PathTrail>` for the identical reason one level up: `rest` is
-/// already a borrowed `&[Expr]` slice here (no AST clone needed to recurse,
-/// unlike `eval_generic.rs`'s twin of this function, which has to rebuild an
-/// owned `Expr::Pipe` at each stage because its own per-step helper only
-/// takes a single `&Expr` -- see that function's own doc comment).
-fn walk_pipe<S: EvalSemantics>(
+/// A stage's results are buffered here before the next stage runs them, and
+/// that buffer is what dictates [`WalkNode`]'s shape: it must be closed under
+/// navigation, or `reached` below could not hold a stage's output at the same
+/// lifetime the caller's `out` expects (`Vec` is invariant in its element
+/// type, so a `Cow` borrowed from `reached` could never satisfy it). See
+/// [`WalkNode`]'s own doc comment.
+///
+/// `current_path` is an `Rc<PathTrail>` for the same reason one level up, and
+/// `rest` is already a borrowed `&[Expr]` slice here (no AST clone needed to
+/// recurse, unlike `eval_generic.rs`'s twin of this function, which has to
+/// rebuild an owned `Expr::Pipe` at each stage because its own per-step helper
+/// only takes a single `&Expr` -- see that function's own doc comment).
+fn walk_pipe<'v, S: EvalSemantics>(
     exprs: &[Expr],
-    value: OwnedValue,
+    value: WalkNode<'v>,
     current_path: &Rc<PathTrail>,
-    out: &mut Vec<(Rc<PathTrail>, OwnedValue)>,
+    out: &mut Vec<(Rc<PathTrail>, WalkNode<'v>)>,
     optional: bool,
 ) -> Result<(), EvalEscape> {
     let Some((first, rest)) = exprs.split_first() else {
@@ -37986,20 +38174,22 @@ fn walk_pipe<S: EvalSemantics>(
 /// Take one path step: `component` names it, and the value evaluator decides
 /// both what it reaches and whether it may be taken at all.
 ///
-/// Delegates the actual navigation to [`navigate_static_component`] -- the
-/// same destructive, move-based step [`value_after_components`] uses (#2058)
-/// -- rather than a second copy of jq's indexing rules here. `Err` is
-/// suppressed into no output under `?`, which is all `?` means on a path
-/// step.
-fn step_into<S: EvalSemantics>(
+/// Delegates the actual navigation to [`navigate_static_component_ref`],
+/// which decides the step through the very same
+/// [`classify_static_component`] that `=`/`|=`/`del()`'s destructive
+/// [`navigate_static_component`] uses -- one definition of jq's indexing
+/// rules, two extractions (#2058, #2190), rather than a second copy of them
+/// here. `Err` is suppressed into no output under `?`, which is all `?` means
+/// on a path step.
+fn step_into<'v, S: EvalSemantics>(
     step: &Expr,
     component: OwnedValue,
-    value: OwnedValue,
+    value: &WalkNode<'v>,
     current_path: &Rc<PathTrail>,
-    out: &mut Vec<(Rc<PathTrail>, OwnedValue)>,
+    out: &mut Vec<(Rc<PathTrail>, WalkNode<'v>)>,
     optional: bool,
 ) -> Result<(), EvalEscape> {
-    let reached = match navigate_static_component::<S>(step, value) {
+    let reached = match navigate_static_component_ref::<S>(step, value) {
         Ok(reached) => reached,
         // `?` turns only a genuine step error into no output; a halt raised
         // by the step still escapes (#791).
@@ -55426,6 +55616,117 @@ mod tests {
                  for {expr:?} on {input:?}"
             );
         }
+    }
+
+    /// #2190 pins the *other* half of the same drift risk. The two navigators
+    /// share [`classify_static_component`], so every rule they could disagree
+    /// on -- missing key, out of bounds either sign, negative-index
+    /// resolution, step through `null`, which `EvalError` a non-indexable
+    /// container raises -- has one definition and cannot drift by
+    /// construction. What is *not* shared is the extraction: `swap_remove_
+    /// index`/`Vec::swap_remove` against `get_index`/`<[_]>::get`, plus the
+    /// fallback's owned result being rewrapped as [`WalkNode::Made`]. This
+    /// pins those.
+    ///
+    /// The matrix is the sibling test's, plus the [`Expr::Slice`] rows it has
+    /// no reason to carry: `Slice` is the shape that reaches
+    /// [`eval_static_component_fallback`], and so the one case where the
+    /// borrowing navigator has to *build* its answer rather than borrow it.
+    #[test]
+    fn navigate_static_component_ref_agrees_with_navigate_static_component() {
+        let obj = || {
+            let mut m = indexmap::IndexMap::new();
+            m.insert("a".to_string(), OwnedValue::Int(1));
+            m.insert("b".to_string(), OwnedValue::Int(2));
+            OwnedValue::Object(m)
+        };
+        let arr = || {
+            OwnedValue::Array(vec![
+                OwnedValue::Int(10),
+                OwnedValue::Int(20),
+                OwnedValue::Int(30),
+            ])
+        };
+        let slice = |start: Option<i64>, end: Option<i64>| Expr::Slice {
+            start,
+            end,
+            start_key: None,
+            end_key: None,
+        };
+
+        let cases: Vec<(Expr, OwnedValue)> = vec![
+            // Field: present key, missing key, on null, on a type that
+            // cannot be field-indexed at all.
+            (Expr::Field("a".to_string()), obj()),
+            (Expr::Field("missing".to_string()), obj()),
+            (Expr::Field("a".to_string()), OwnedValue::Null),
+            (Expr::Field("a".to_string()), OwnedValue::Int(5)),
+            (Expr::Field("a".to_string()), arr()),
+            // Index: in bounds, negative-from-end, out of bounds (positive
+            // and negative), on null, on a type that cannot be
+            // position-indexed at all.
+            (Expr::index(1), arr()),
+            (Expr::index(-1), arr()),
+            (Expr::index(10), arr()),
+            (Expr::index(-10), arr()),
+            (Expr::index(0), OwnedValue::Null),
+            (Expr::index(0), OwnedValue::String("x".to_string())),
+            (Expr::index(0), obj()),
+            // Slice: the `eval_static_component_fallback` rows -- a sub-range,
+            // an open bound, a clamped one, and the two non-array inputs.
+            (slice(Some(0), Some(2)), arr()),
+            (slice(Some(1), None), arr()),
+            (slice(None, Some(1)), arr()),
+            (slice(Some(0), Some(99)), arr()),
+            (slice(Some(0), Some(2)), OwnedValue::Null),
+            (slice(Some(0), Some(2)), obj()),
+        ];
+
+        for (expr, input) in cases {
+            let destructive = navigate_static_component::<JqSemantics>(&expr, input.clone());
+            let borrowing =
+                navigate_static_component_ref::<JqSemantics>(&expr, &WalkNode::Doc(&input))
+                    .map(|reached| reached.map(|node| node.value().clone()));
+            assert_eq!(
+                destructive, borrowing,
+                "navigate_static_component_ref disagrees with navigate_static_component \
+                 for {expr:?} on {input:?}"
+            );
+        }
+    }
+
+    /// [`WalkNode`]'s closure property (#2190), asserted directly: a child of a
+    /// document node is the *same* node the document holds, and a child of walk
+    /// residue is a fresh copy -- which is what makes `WalkNode<'v>` closed
+    /// under navigation and so lets [`walk_pipe`] keep buffering a stage in a
+    /// plain `Vec`. Reached in practice by `path(.a[0:2][] | .b)`, where the
+    /// slice's fabricated array is the residue the rest of the pipe walks.
+    #[test]
+    fn walk_node_child_borrows_the_document_and_copies_residue() {
+        let doc = OwnedValue::Array(vec![OwnedValue::Int(10), OwnedValue::Int(20)]);
+
+        let from_doc = WalkNode::Doc(&doc).child_at(1);
+        let WalkNode::Doc(child) = from_doc else {
+            panic!("a document node's child must stay borrowed, not be copied");
+        };
+        assert!(
+            core::ptr::eq(child, &doc.as_array().expect("array")[1]),
+            "the child must be the document's own node, not a copy of it"
+        );
+
+        let residue = WalkNode::made(doc.clone());
+        let from_residue = residue.child_at(1);
+        assert!(
+            matches!(from_residue, WalkNode::Made(_)),
+            "residue's child must be owned -- it has no document to borrow from"
+        );
+        assert_eq!(*from_residue.value(), OwnedValue::Int(20));
+
+        // Out of range, on either kind, is jq's `null` rather than an error.
+        assert!(matches!(WalkNode::Doc(&doc).child_at(9), WalkNode::Null));
+        assert!(matches!(WalkNode::made(doc).child_at(9), WalkNode::Null));
+        assert!(matches!(WalkNode::Null.child_at(0), WalkNode::Null));
+        assert_eq!(*WalkNode::Null.value(), OwnedValue::Null);
     }
 
     /// The value matrix `eval_owned_pure`'s pinning tests run every
@@ -79356,7 +79657,7 @@ mod tests {
             let mut reached = Vec::new();
             let _ = walk_path::<JqSemantics>(
                 &unresolved(),
-                OwnedValue::Null,
+                WalkNode::Null,
                 &PathTrail::root(),
                 &mut reached,
                 false,
@@ -79373,7 +79674,7 @@ mod tests {
             let pipe = Expr::Pipe(vec![unresolved(), Expr::Field("a".to_string())]);
             let _ = walk_path::<JqSemantics>(
                 &pipe,
-                OwnedValue::Null,
+                WalkNode::Null,
                 &PathTrail::root(),
                 &mut reached,
                 false,
@@ -79474,7 +79775,7 @@ mod tests {
             let mut reached = Vec::new();
             let _ = walk_path::<JqSemantics>(
                 &unresolved(),
-                OwnedValue::Null,
+                WalkNode::Null,
                 &PathTrail::root(),
                 &mut reached,
                 false,
@@ -79490,7 +79791,7 @@ mod tests {
             let pipe = Expr::Pipe(vec![unresolved(), Expr::Field("a".to_string())]);
             let _ = walk_path::<JqSemantics>(
                 &pipe,
-                OwnedValue::Null,
+                WalkNode::Null,
                 &PathTrail::root(),
                 &mut reached,
                 false,

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -26993,14 +26993,9 @@ fn drain_path_result<'a>(
         Ok(branches) => (branches, None),
         Err((prefix, e)) => (prefix, Some(e)),
     };
-    for branch in branches {
-        if sink(branch) == Demand::Stop {
-            return ResolveFlow::Stopped;
-        }
-    }
-    match escape {
-        Some(e) => ResolveFlow::Escaped(e),
-        None => ResolveFlow::Exhausted,
+    match emit_branches(branches, sink) {
+        Demand::Stop => ResolveFlow::Stopped,
+        Demand::Continue => flow_result(escape),
     }
 }
 
@@ -27041,10 +27036,7 @@ fn resolve_cond_fork_sink(
             other => return other,
         }
     }
-    match cond_escape {
-        Some(e) => ResolveFlow::Escaped(e),
-        None => ResolveFlow::Exhausted,
-    }
+    flow_result(cond_escape)
 }
 
 /// `.[]`'s own path-branch construction (#1850), emitted one element at a
@@ -27755,84 +27747,10 @@ fn resolve_node_sink<'a, S: EvalSemantics>(
             emit_passthrough(value, trackable, snapshot, sink)
         }
 
-        // `a // b`: resolve `a`, pass only its truthy branches through — jq's
-        // `//` filters a multi-output left side rather than choosing all-or-
-        // nothing (`retain_truthy` is this rule's value-only twin) — and
-        // fall back to `b` only when none survive. An escape while resolving
-        // `a` propagates rather than falling back, matching `eval_alternative`:
-        // `//` only substitutes for falsy/absent output, never for a raised
-        // error. The truthy branches produced *before* that escape have
-        // already reached the sink, which is what makes the escape's own
-        // prefix jq's: the eager form this replaced (#2235) forwarded
-        // `left`'s escape with its prefix *unfiltered*, falsy branches
-        // included, so a fold whose source was `(.. , error("x")) // 9`
-        // would have run a step for a falsy element jq never bound
-        // (`path(reduce (((.[] | . and true), error("x")) // 9) as $i (.;
-        // stderr))` on `[true,false]` runs one step in jq 1.7.1, not two).
-        //
-        // #845: a *literal* `a` is the one exception — real jq only requires
-        // path-shape for whichever of `a`'s outputs actually survive the
-        // truthy filter, so `a` being itself falsy (`false`, `null`) must
-        // fall through to `b` without ever needing to resolve as a path at
-        // all: confirmed live, `path(false // .b)` on `{"a":10}` is `["b"]`,
-        // while `path(1 // .b)` still raises (`1` is truthy, and does need
-        // path-shape). A literal's own value is known statically, at zero
-        // evaluation cost and with no side effect to risk duplicating —
-        // unlike checking `a`'s general truthiness by evaluating it a
-        // *second* time (rejected in review: resolving `a` already evaluates
-        // it once by the time any failure is visible here, so a follow-up
-        // evaluation just to inspect truthiness double-fires anything `a`
-        // does — confirmed live, `path(stderr // .b)` wrote its input to
-        // stderr twice under that approach — and a catch-all on the retry's
-        // own outcome swallowed a `halt`/`break` the retry surfaced instead
-        // of letting it escape, same review round).
-        //
-        // A `Comma`-fanned `a` mixing a falsy/non-path sibling with a
-        // path-shaped or truthy one used to be the one shape this arm
-        // didn't handle (filed as #980): `Comma` used to commit to a
-        // sibling's own failure eagerly, before `//`'s truthy filter ever
-        // got a chance to see it. #1288's "`Expr::Comma` stops checking a
-        // position too early" fixed this incidentally, not this arm
-        // itself; confirmed live against jq 1.7.1, all eight shapes #980
-        // pinned (`path((.a, false) // .b)`, `path((false, .a) // .b)`,
-        // `path((.a, null) // .b)`, `path((null, false) // .b)`,
-        // `path((.x, .a) // .b)`, `path((false, false) // .b)`,
-        // `path((.a, false, .a) // .b)`, and the genuinely-still-erroring
-        // `path((.a, 1) // .b)`) now match.
-        //
-        // A downstream `Stop` propagates as-is; only `a` running to
-        // exhaustion with nothing truthy delivered falls through to `b`.
-        Expr::Alternative(left, right) => {
-            if let Expr::Literal(lit) = unwrap_paren(left) {
-                if !literal_to_owned(lit).is_truthy() {
-                    return resolve_node_sink::<S>(
-                        right, value, trackable, snapshot, frame, keep, sink,
-                    );
-                }
-            }
-            let mut emitted = false;
-            let flow = resolve_node_sink::<S>(
-                left,
-                value,
-                trackable,
-                snapshot,
-                frame,
-                keep,
-                &mut |branch| {
-                    if !branch.value.is_truthy() {
-                        return Demand::Continue;
-                    }
-                    emitted = true;
-                    sink(branch)
-                },
-            );
-            match flow {
-                ResolveFlow::Exhausted if !emitted => {
-                    resolve_node_sink::<S>(right, value, trackable, snapshot, frame, keep, sink)
-                }
-                other => other,
-            }
-        }
+        // `a // b`: see [`resolve_alternative_sink`].
+        Expr::Alternative(left, right) => resolve_alternative_sink::<S>(
+            left, right, value, trackable, snapshot, frame, keep, sink,
+        ),
 
         // #1440: `reduce`/`foreach` are real sugar over the same
         // variable-binding primitive every other construct uses (real jq
@@ -27888,49 +27806,44 @@ fn resolve_node_sink<'a, S: EvalSemantics>(
             patterns,
             init,
             update,
-        } => match patterns.as_slice() {
-            [Pattern::Var(_)] => resolve_reduce::<S>(
-                input,
-                &patterns[0],
-                init,
-                update,
-                value,
-                trackable,
-                snapshot,
-                frame,
-                keep,
-                sink,
-            ),
-            _ => drain_path_result(
-                resolve_leaf::<S>(expr, value, trackable, snapshot, keep),
-                sink,
-            ),
-        },
+        } if matches!(patterns.as_slice(), [Pattern::Var(_)]) => resolve_reduce::<S>(
+            input,
+            &patterns[0],
+            init,
+            update,
+            value,
+            trackable,
+            snapshot,
+            frame,
+            keep,
+            sink,
+        ),
         Expr::Foreach {
             input,
             patterns,
             init,
             update,
             extract,
-        } => match patterns.as_slice() {
-            [Pattern::Var(_)] => resolve_foreach::<S>(
-                input,
-                &patterns[0],
-                init,
-                update,
-                extract.as_deref(),
-                value,
-                trackable,
-                snapshot,
-                frame,
-                keep,
-                sink,
-            ),
-            _ => drain_path_result(
-                resolve_leaf::<S>(expr, value, trackable, snapshot, keep),
-                sink,
-            ),
-        },
+        } if matches!(patterns.as_slice(), [Pattern::Var(_)]) => resolve_foreach::<S>(
+            input,
+            &patterns[0],
+            init,
+            update,
+            extract.as_deref(),
+            value,
+            trackable,
+            snapshot,
+            frame,
+            keep,
+            sink,
+        ),
+        // A destructuring pattern or a `?//`-alternatives list falls back
+        // to the ordinary eager evaluator for both fold kinds alike — see
+        // the guarded arms' own doc comment above `Expr::Reduce` for why.
+        Expr::Reduce { .. } | Expr::Foreach { .. } => drain_path_result(
+            resolve_leaf::<S>(expr, value, trackable, snapshot, keep),
+            sink,
+        ),
 
         // `repeat(f)` (#1906) and the three bounded consumers below all
         // resolve through the sink now, so a bound threads through arbitrary
@@ -28414,6 +28327,106 @@ fn resolve_optional_sink<'a, S: EvalSemantics>(
     }
 }
 
+/// `a // b`: resolve `a`, pass only its truthy branches through — jq's
+/// `//` filters a multi-output left side rather than choosing all-or-
+/// nothing (`retain_truthy` is this rule's value-only twin) — and
+/// fall back to `b` only when none survive. An escape while resolving
+/// `a` propagates rather than falling back, matching `eval_alternative`:
+/// `//` only substitutes for falsy/absent output, never for a raised
+/// error. The truthy branches produced *before* that escape have
+/// already reached the sink, which is what makes the escape's own
+/// prefix jq's: the eager form this replaced (#2235) forwarded
+/// `left`'s escape with its prefix *unfiltered*, falsy branches
+/// included, so a fold whose source was `(.. , error("x")) // 9`
+/// would have run a step for a falsy element jq never bound
+/// (`path(reduce (((.[] | . and true), error("x")) // 9) as $i (.;
+/// stderr))` on `[true,false]` runs one step in jq 1.7.1, not two).
+///
+/// #845: a *literal* `a` is the one exception — real jq only requires
+/// path-shape for whichever of `a`'s outputs actually survive the
+/// truthy filter, so `a` being itself falsy (`false`, `null`) must
+/// fall through to `b` without ever needing to resolve as a path at
+/// all: confirmed live, `path(false // .b)` on `{"a":10}` is `["b"]`,
+/// while `path(1 // .b)` still raises (`1` is truthy, and does need
+/// path-shape). A literal's own value is known statically, at zero
+/// evaluation cost and with no side effect to risk duplicating —
+/// unlike checking `a`'s general truthiness by evaluating it a
+/// *second* time (rejected in review: resolving `a` already evaluates
+/// it once by the time any failure is visible here, so a follow-up
+/// evaluation just to inspect truthiness double-fires anything `a`
+/// does — confirmed live, `path(stderr // .b)` wrote its input to
+/// stderr twice under that approach — and a catch-all on the retry's
+/// own outcome swallowed a `halt`/`break` the retry surfaced instead
+/// of letting it escape, same review round).
+///
+/// A `Comma`-fanned `a` mixing a falsy/non-path sibling with a
+/// path-shaped or truthy one used to be the one shape this arm
+/// didn't handle (filed as #980): `Comma` used to commit to a
+/// sibling's own failure eagerly, before `//`'s truthy filter ever
+/// got a chance to see it. #1288's "`Expr::Comma` stops checking a
+/// position too early" fixed this incidentally, not this arm
+/// itself; confirmed live against jq 1.7.1, all eight shapes #980
+/// pinned (`path((.a, false) // .b)`, `path((false, .a) // .b)`,
+/// `path((.a, null) // .b)`, `path((null, false) // .b)`,
+/// `path((.x, .a) // .b)`, `path((false, false) // .b)`,
+/// `path((.a, false, .a) // .b)`, and the genuinely-still-erroring
+/// `path((.a, 1) // .b)`) now match.
+///
+/// A downstream `Stop` propagates as-is; only `a` running to
+/// exhaustion with nothing truthy delivered falls through to `b`.
+#[allow(clippy::too_many_arguments)] // STYLE-0004: matches the resolver's own established `left`/`right` + `value`/`trackable`/`snapshot`/`frame`/`keep`/`sink` argument set (`resolve_node_sink` and its siblings)
+fn resolve_alternative_sink<'a, S: EvalSemantics>(
+    left: &Expr,
+    right: &Expr,
+    value: &'a OwnedValue,
+    trackable: bool,
+    snapshot: &Snapshot,
+    frame: &Frame,
+    keep: Keep,
+    sink: &mut dyn FnMut(PathBranch<'a>) -> Demand,
+) -> ResolveFlow {
+    if let Expr::Literal(lit) = unwrap_paren(left) {
+        if !literal_to_owned(lit).is_truthy() {
+            return resolve_node_sink::<S>(right, value, trackable, snapshot, frame, keep, sink);
+        }
+    }
+    let mut emitted = false;
+    let flow = resolve_node_sink::<S>(
+        left,
+        value,
+        trackable,
+        snapshot,
+        frame,
+        keep,
+        &mut |branch| {
+            if !branch.value.is_truthy() {
+                return Demand::Continue;
+            }
+            emitted = true;
+            sink(branch)
+        },
+    );
+    match flow {
+        ResolveFlow::Exhausted if !emitted => {
+            resolve_node_sink::<S>(right, value, trackable, snapshot, frame, keep, sink)
+        }
+        other => other,
+    }
+}
+
+/// Flatten path components into one `Expr`, using `Expr::Pipe` only when
+/// there is more than one — the empty path is `Expr::Identity`. The one
+/// definition of that rule; [`wrap_optional_branch`], [`assemble_one_branch`]
+/// and `resolve_dynamic_indexes`'s own `append_trailing` all delegate to it
+/// rather than repeating the 0/1/N match independently.
+fn flatten_components(components: Vec<Expr>) -> Expr {
+    match components.len() {
+        0 => Expr::Identity,
+        1 => components.into_iter().next().expect("len checked"),
+        _ => Expr::Pipe(components),
+    }
+}
+
 /// Wrap a resolved branch's path in `Expr::Optional`, marking it as reached
 /// through a `?` — see [`resolve_optional_sink`]. Wrapping in `?` navigates
 /// nothing, so it neither grants nor removes trackability, nor, for the
@@ -28427,9 +28440,10 @@ fn wrap_optional_branch(branch: PathBranch<'_>) -> PathBranch<'_> {
         snapshot,
         register,
     } = branch;
-    let components = components.to_vec();
-    let inner_path = if components.len() == 1 {
-        components.into_iter().next().expect("len checked")
+    // `depth()`/`last()` are O(1); the O(depth) `to_vec()` flatten only runs
+    // in the `depth() != 1` arm, which is unreached *today* (see below).
+    let inner_path = if components.depth() == 1 {
+        components.last().expect("depth checked").clone()
     } else {
         // Unreached *today*, and deliberately not a panic: the postfix `?`
         // attaches to a single path element until #367, so `(.a.b)?`,
@@ -28440,7 +28454,7 @@ fn wrap_optional_branch(branch: PathBranch<'_>) -> PathBranch<'_> {
         // and jq writes `{"a":{"b":5},"k":"b"}` for it. `eval_generic` can
         // synthesize `Expr::Optional` around any expression too, so this
         // was never an invariant of the type.
-        Expr::Pipe(components)
+        flatten_components(components.to_vec())
     };
     PathBranch {
         path: PathPrefix::from_components([Expr::Optional(Box::new(inner_path))]),
@@ -30016,13 +30030,22 @@ struct FoldSourceAmbient<'v> {
     /// The frame `value` sits in (#2042): the fold's own for the document
     /// ambient, unknown for the later forks' `null`.
     frame: Frame,
+}
+
+impl FoldSourceAmbient<'_> {
     /// Whether a trackable SOURCE branch's own path is *relative to*
-    /// `reg.path` rather than absolute, so [`drive_fold_source`] has to
-    /// rebase it (its `relocate_base`). Only ever `true` on a `null`-ambient fork whose
-    /// register sits somewhere other than the root -- on the first fork the
-    /// ambient is the document itself, which is only ever at the register
-    /// when the register is the root.
-    relocate: bool,
+    /// `reg_path` rather than absolute, so [`drive_fold_source`] has to
+    /// rebase it. Only ever true on a `null`-ambient fork whose register
+    /// sits somewhere other than the root -- on the first fork the ambient
+    /// is the document itself, which is only ever at the register when the
+    /// register is the root, so `trackable && reg_path.depth() > 0` is
+    /// false there by construction (a trackable first-fork ambient implies
+    /// `reg_path` is already the root). Derived here rather than stored on
+    /// the struct, so [`fold_source_ambient`]'s two constructors can't drift
+    /// out of sync with it.
+    fn relocate_base<'r>(&self, reg_path: &'r Rc<PathPrefix>) -> Option<&'r Rc<PathPrefix>> {
+        (self.trackable && reg_path.depth() > 0).then_some(reg_path)
+    }
 }
 
 /// Which `.` a fold's SOURCE sees on INIT fork `fork_index`, and whether
@@ -30102,7 +30125,6 @@ fn fold_source_ambient<'v>(
             trackable: source_trackable,
             snapshot: source_snapshot,
             frame: frame.clone(),
-            relocate: false,
         };
     }
     // A later fork's ambient is `null`, so `branch_provenance`'s
@@ -30118,7 +30140,6 @@ fn fold_source_ambient<'v>(
         trackable: at_register,
         snapshot: Snapshot::No,
         frame: frame.unknown(),
-        relocate: at_register && reg.path.depth() > 0,
     }
 }
 
@@ -30206,7 +30227,7 @@ fn resolve_reduce<'a, S: EvalSemantics>(
             snapshot,
             frame,
         );
-        let relocate_base = ambient.relocate.then_some(&reg.path);
+        let relocate_base = ambient.relocate_base(&reg.path);
 
         // `Option`, not a bare `OwnedValue`, mirroring `eval_reduce`'s own
         // accumulator exactly: a step whose UPDATE produces zero outputs
@@ -30445,7 +30466,7 @@ fn resolve_foreach<'a, S: EvalSemantics>(
             snapshot,
             frame,
         );
-        let relocate_base = ambient.relocate.then_some(&reg.path);
+        let relocate_base = ambient.relocate_base(&reg.path);
 
         // `state`'s own provenance (#1590), mirroring `resolve_reduce`'s
         // `acc_at_register`/`acc_snapshot` exactly — see `FoldRegister::resolve`'s
@@ -33115,11 +33136,7 @@ fn assemble_one_branch(branch: &PathBranch<'_>) -> Expr {
         .into_iter()
         .map(strip_resolved_optional)
         .collect();
-    match components.len() {
-        0 => Expr::Identity,
-        1 => components.into_iter().next().expect("len checked"),
-        _ => Expr::Pipe(components),
-    }
+    flatten_components(components)
 }
 
 /// Resolve a top-level path expression and raise on the first branch that
@@ -33466,10 +33483,7 @@ fn resolve_dynamic_indexes<S: EvalSemantics>(
             other => vec![other],
         };
         components.extend(trailing.iter().cloned());
-        match components.len() {
-            1 => components.into_iter().next().expect("len checked"),
-            _ => Expr::Pipe(components),
-        }
+        flatten_components(components)
     }
 
     // The document `path()`/`=`/`|=`/`del()` were actually called on is

--- a/tests/data/jq-golden-known-failures.txt
+++ b/tests/data/jq-golden-known-failures.txt
@@ -95,7 +95,7 @@
 # output into an `OwnedValue::Array` via `eval_owned_expr`.
 #
 # recurse_f_dfs_sibling_order — seeded by #676 ahead of #635, pinning
-# `resolve_recurse`/`builtin_recurse_f`/`builtin_recurse_cond`'s
+# `resolve_recurse_sink`/`builtin_recurse_f`/`builtin_recurse_cond`'s
 # breadth-first FIFO queue (`queue.remove(0)`), which visited a branching
 # node's children level-by-level instead of jq's depth-first `def r: .,
 # (f | r); r;` definition — has since been fixed and dropped: all three

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -14777,7 +14777,7 @@ fn test_recurse_f_keeps_own_partial_fanout_before_error_842() -> Result<()> {
     // (`.a, .b[0]`) is a generator like any other comma expression: a
     // later output of that same call erroring must not retroactively
     // un-emit an earlier one it already produced. Before this fix,
-    // `resolve_recurse`/`builtin_recurse_f` dropped `f`'s own partial
+    // `resolve_recurse_sink`/`builtin_recurse_f` dropped `f`'s own partial
     // fan-out on error, matching neither jq's semantics nor the codebase's
     // existing "never un-emit an already-produced output" rule (#530,
     // #636, #694, #824). Verified against jq 1.7.1:
@@ -14802,7 +14802,7 @@ fn test_recurse_f_keeps_own_partial_fanout_before_error_842() -> Result<()> {
 
 #[test]
 fn test_resolve_recurse_keeps_f_partial_fanout_before_error_842() -> Result<()> {
-    // Issue #842's secondary repro (path position, `resolve_recurse`).
+    // Issue #842's secondary repro (path position, `resolve_recurse_sink`).
     // Same underlying bug as the value-position test above, in the
     // path-tracking evaluator `path(...)` uses. Verified against jq 1.7.1:
     // `echo '{"a":1,"b":2}' | jq -c 'path(recurse(if . == {"a":1,"b":2}
@@ -14824,7 +14824,7 @@ fn test_resolve_recurse_keeps_f_partial_fanout_before_error_842() -> Result<()> 
     Ok(())
 }
 
-/// #856: `resolve_recurse`'s null-child guard (`if matches!(child_value...,
+/// #856: `resolve_recurse_sink`'s null-child guard (`if matches!(child_value...,
 /// OwnedValue::Null) { continue; }` in its main loop) stopped recursion
 /// *into* a null child, as documented -- but the bare `continue` also
 /// discarded the null child's own path entirely, rather than still
@@ -14850,7 +14850,7 @@ fn test_resolve_recurse_emits_null_childs_own_path() -> Result<()> {
 
 /// Companion to the test above: a null child emitted as a leaf must not
 /// jump ahead of an *earlier* sibling's own subtree just because it has no
-/// descendants of its own. `resolve_recurse` gates the null-recursion bound
+/// descendants of its own. `resolve_recurse_sink` gates the null-recursion bound
 /// at the point a node is popped from its DFS stack (the same point every
 /// other node is emitted), not at child-collection time, specifically so a
 /// null child queued alongside a non-null sibling still waits its correct
@@ -14898,7 +14898,7 @@ fn test_resolve_recurse_cond_still_gates_null_child_emission() -> Result<()> {
     Ok(())
 }
 
-/// Review-driven regression guard on #854's own rewrite of `resolve_recurse`'s
+/// Review-driven regression guard on #854's own rewrite of `resolve_recurse_sink`'s
 /// `Some(cond)` arm: switching `cond`'s own evaluation to
 /// `eval_owned_multi_keep_partial` must not drop the pre-existing
 /// `is_null_current` gate that bounds recursion *past* a null node (#856) --
@@ -15061,7 +15061,7 @@ fn test_recurse_cond_keeps_already_approved_siblings_before_error_854() -> Resul
 
 #[test]
 fn test_resolve_recurse_cond_keeps_already_approved_siblings_before_error_854() -> Result<()> {
-    // Issue #854's secondary repro (path position, `resolve_recurse`).
+    // Issue #854's secondary repro (path position, `resolve_recurse_sink`).
     // Same underlying bug as the value-position test above, in the
     // path-tracking evaluator `path(...)` uses. Verified against jq 1.7.1:
     // `echo '[1,2,3]' | jq -c 'path(recurse(if type=="array" then .[] else
@@ -36462,7 +36462,7 @@ fn test_raw_input_still_substitutes_under_validate_1247() -> Result<()> {
 /// `test_fold_register_accepts_variable_snapshot_through_combinators_1591`
 /// in `src/jq/eval.rs`'s unit tests). `recurse`'s `if . == $x then .a else
 /// $x end` visits `.a`'s value, whose `else` branch hands back `$x`'s own
-/// frozen value with no navigation — a `resolve_recurse` seed/child-queueing
+/// frozen value with no navigation — a `resolve_recurse_sink` seed/child-queueing
 /// bug (three sites) dropped that mark, and separately `select` had no
 /// ambient `snapshot` parameter to inherit it from at all, so the value
 /// reaching `FoldRegister::identical` looked indistinguishable from a

--- a/tests/jq_computed_key_tests.rs
+++ b/tests/jq_computed_key_tests.rs
@@ -1406,7 +1406,7 @@ fn test_write_clobber_through_a_static_optional_comma_raises_instead_of_swallowi
 /// `[recurse(.a?)]`) queues a null child like any other value instead of
 /// filtering it out, so it is no longer bounded by pruning — it runs to its
 /// own 10,000-item `MAX_ITEMS` cutoff and emits the root followed by 9,999
-/// nulls. `resolve_recurse` (the path-tracking evaluator behind
+/// nulls. `resolve_recurse_sink` (the path-tracking evaluator behind
 /// `path(recurse(f) | ...)`) still has to prune the null child instead: its
 /// queue holds `(path, value)` pairs, so running it to the same cutoff would
 /// grow the path prefix by one component every round — quadratic, and
@@ -1424,7 +1424,7 @@ fn test_recurse_over_a_null_producing_filter() {
     let expected_out = format!("[{}]", values.join(","));
     check(doc, r"[recurse(.a?)]", Outcome::values(&[&expected_out]));
 
-    // `resolve_recurse` prunes the null child and stops after one output.
+    // `resolve_recurse_sink` prunes the null child and stops after one output.
     check(
         doc,
         r"[path(recurse(.a?) | objects | .[.k]?)]",
@@ -1435,7 +1435,7 @@ fn test_recurse_over_a_null_producing_filter() {
 /// The three parameterised `recurse` spellings, which
 /// `test_multi_output_path_components_fan_out` exercises only in its bare
 /// `recurse` form. Bare `recurse` is `..` and shares its resolver; these do
-/// not, because `f` is arbitrary — `resolve_recurse` re-implements
+/// not, because `f` is arbitrary — `resolve_recurse_sink` re-implements
 /// `builtin_recurse_f`/`builtin_recurse_cond`'s queue in order to thread path
 /// components alongside each value, so the thing worth pinning is that it
 /// still visits what those two visit.
@@ -1443,7 +1443,7 @@ fn test_recurse_over_a_null_producing_filter() {
 /// It does not follow them in *every* respect, and the difference is
 /// deliberate: when `f` yields an array those two descend into its elements
 /// (an artefact of collapsing a stream into one array), where jq and the
-/// resolver both stop at the array. See `resolve_recurse`'s own note.
+/// resolver both stop at the array. See `resolve_recurse_sink`'s own note.
 #[test]
 fn test_recurse_variants_fan_out_like_their_value_paths() {
     let doc = r#"{"x":{"k":"v","v":1},"y":{"k":"w","w":2}}"#;

--- a/tests/jq_recurse_depth_tests.rs
+++ b/tests/jq_recurse_depth_tests.rs
@@ -2,7 +2,7 @@
 //!
 //! De-risk step for #626 (threading a `Cow<'a, OwnedValue>` lifetime through
 //! `PathBranch`/`resolve_node` in `src/jq/eval.rs` to kill the O(subtree)
-//! clone-per-node cost in `push_recursive_branches`/`resolve_recurse`).
+//! clone-per-node cost in `push_recursive_branches`/`resolve_recurse_sink`).
 //! Every existing recurse/`..` golden fixture nests three levels deep at
 //! most, so nothing today would catch a lifetime bug that only corrupts or
 //! truncates output once recursion goes deeper than a handful of frames.
@@ -77,7 +77,7 @@ fn bare_recurse_correct_at_depth() {
     assert_eq!(run_paths(&json, "path(recurse)"), expected_paths(DEPTH));
 }
 
-/// `recurse(f; cond)` — the `resolve_recurse` stack-based path. `cond` stops
+/// `recurse(f; cond)` — the `resolve_recurse_sink` stack-based path. `cond` stops
 /// exactly at the `{}` leaf (its `.k` is `null`, not an object), producing
 /// the same path set as the bare form on this document.
 #[test]


### PR DESCRIPTION
Closes #2190.

## What was wrong

`builtin_path_on_owned` handed **every resolved branch its own deep clone of the whole
document**, because `walk_path`/`walk_pipe`/`step_into` navigated by move:

```rust
for expr in &exprs {                       // one Expr per resolved branch
    walk_path::<S>(expr, owned.clone(), &root, &mut reached, optional)
}
```

Cost was `branches × nodes`, and for #2190's shape both factors grow with the element
count together — hence the measured exponent of ~1.98. That model is also what makes the
issue's table C (pad the bytes, hold the path set fixed) read flat: clone cost tracks
*node* count, not byte count.

## What changed

**The walkers borrow.** A `WalkNode<'v>` is either a node of the document or a value the
walk itself built — a slice's array, or the fallback evaluator's output — with the latter
`Rc`-shared.

The reason for that shape is worth stating, because it is the non-obvious part: the type
has to be **closed under navigation** (a child of a `WalkNode<'v>` is a `WalkNode<'v>`),
which is what lets `walk_pipe` go on buffering a stage's results in a plain `Vec` with no
restructuring and no semantic change. `Cow<'v, OwnedValue>` cannot do that — `Vec` is
invariant in its element type, so a stage reached *through* a `Cow::Owned` would owe its
caller a borrow of a strictly shorter local buffer. `Rc` breaks the chain: residue's
children are cloned rather than borrowed, exactly as `eval_generic::owned_nav_children`
already does. It is compiler-enforced — if `WalkNode::pick` ever stopped returning the
document's own lifetime, the buffer would stop typechecking.

**The indexing rules got factored, not duplicated.** #2190 recorded this fix as blocked
on needing a by-reference twin of `navigate_static_component`, i.e. a fourth copy of jq's
indexing rules. But only its `Field`/`Index` arms are destructive at all — the `_`
fallback already borrowed — so `classify_static_component` now resolves a component to a
`StaticAccess`, and the destructive and borrowing navigators differ only in how they take
the child out. Which container each component may index, the step-through-`null` rule,
negative-index resolution, the bounds check, and which `EvalError` a non-indexable
container raises all have exactly one definition.
`navigate_static_component_ref_agrees_with_navigate_static_component` pins the pair.

`value_after_components`, and with it the whole `=`/`|=`/`del()` route, keeps its
move-based navigation — it genuinely needs an owned result.

## Results

Interleaved A/B per `docs/guides/benchmarking.md`, baseline = merge-base with `main`
(`31ab1d3ea`), same benchmark harness against both library versions, idle Apple M4 Pro,
`jq_write_path_path_leading_iterate_comma` (new group, in-process so no process-spawn
noise):

| elems | paths | base | head | speedup | base ratio | head ratio |
|------:|------:|---------:|--------:|--------:|-----------:|-----------:|
|    50 |   400 |   48.0 ms | 1.369 ms |   35.1x |          – |          – |
|   100 |   800 |  190.3 ms | 2.750 ms |   69.2x |      3.97x |      2.01x |
|   200 |  1600 |  755.3 ms | 5.530 ms |  136.6x |      3.97x |      2.01x |
|   400 |  3200 | 3017.8 ms | 11.15 ms |  270.7x |      4.00x |      2.02x |

**Exponent 1.99 → 1.01.** The scaling curve is the claim, not any single ratio. The
group sets `Throughput::Elements`, so it also reads directly off Criterion's own column:
base's throughput *halves* at every doubling (8.0 → 4.1 → 2.1 → 1.05 Kelem/s) where head
is flat at ~287 Kelem/s across the whole 16x range.

`jq_write_path_two_branch_path_depth` — two branches, no fan-out — improves 15-18% at
every depth, since even that shape no longer clones the document twice.

## Output identity

Gated before any timing was believed. A three-way differential (pre-change binary,
post-change binary, jq 1.7.1) over **7,700 `path()` shapes** — 200 hand-built plus 2,500
generated on each of three seeds — reports **0 pre-vs-post differences** in stdout,
stderr and exit code. The generator alphabet covers present/missing/computed fields,
in-bounds, negative and out-of-range indices, four slice spellings, bare iterates,
`?` suffixes, parenthesised comma groups and nested pipes, over random trees including
`null`, empty containers and heterogeneous arrays; half the expressions carry a forced
non-cursor-navigable component so they route through this walker rather than the cursor
walk.

The same sweep's jq leg reported 2 divergences, in both binaries equally — a pre-existing
prefix-discard bug, now filed as #2680.

## #2190's impact statement needs correcting

The issue says the CLI does not show this. That holds only for *cursor-navigable* path
expressions. `path_expr_is_cursor_navigable` refuses a `Slice`, so

```
sjq '[path(.foo[] | (.b0,…,.b7) | .d|.d|.d|.d | .[0:1])] | length'
```

reaches this route from the CLI and read the same ~1.95 exponent, up to 150x slower at
400 elements. Comment left on the issue.

## Checks

`cargo test --features cli` (60 binaries) · `--features cli,simd,regex,serde --workspace`
· `--no-default-features` (no_std) · `--features simd,scalar-yaml` · both `ci.yml` clippy
legs with `-D warnings` · `cargo doc` with `RUSTDOCFLAGS=-D warnings` · `cargo fmt --check`.

### A note on the middle commit

The first version of the refactor resolved an object key to an `IndexMap` *slot* in the
classifier, which made the destructive side hash twice per `Field` step (`get_index_of`,
then `swap_remove_index` re-finding the bucket) where it used to hash once. That showed
up as a systematic +1.7-3.3% across all eight `two_branch_{del,assign}_depth` points — a
cost charged to `=`/`|=`/`del()` for a `path()` fix. `StaticAccess::Field(&'e str)`
carries the key verbatim instead; the write-side deltas now straddle zero (−0.7% to
+1.0%, four of eight negative). Caught only because the neighbouring groups were
re-measured rather than assumed.
