### PR TITLE
feat(yaml): widen comment storage to head/line/foot, no behavior change (#798)

### DIFF
--- a/src/bin/succinctly/yq_runner.rs
+++ b/src/bin/succinctly/yq_runner.rs
@@ -2627,10 +2627,7 @@ fn reconcile_presentation_at_depth(
                 mark @ Some(AnchorMark::Aliases(_)) if !is_write_target => mark.clone(),
                 _ => None,
             };
-            CommentTree::Leaf(NodeMeta {
-                anchor,
-                ..NodeMeta::empty()
-            })
+            CommentTree::Leaf(NodeMeta::empty_with_anchor(anchor))
         }
         // Both scalars, any variant/value: same node, only its value
         // changed - its own comment, style and anchor mark survive. Real
@@ -4087,10 +4084,7 @@ fn strip_presentation_style(tree: &CommentTree) -> CommentTree {
 /// currently-live independent crash path.
 fn strip_presentation_style_at_depth(tree: &CommentTree, depth: usize) -> CommentTree {
     assert_value_tree_depth(depth);
-    let meta = NodeMeta {
-        style: "",
-        ..tree.meta().clone()
-    };
+    let meta = tree.meta().with_style("");
     match tree {
         CommentTree::Leaf(_) => CommentTree::Leaf(meta),
         CommentTree::Array(_, items) => CommentTree::Array(

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -992,7 +992,7 @@ impl NodeMeta {
     }
 
     /// Standalone comment lines directly above this node, in source order
-    /// (#798 PR2). Always empty today -- see [`HeadFootComment`].
+    /// (#798 PR2). Always empty today -- capturing these is follow-up work.
     pub fn head_comment(&self) -> &[String] {
         self.head_foot_comment.as_deref().map_or(&[], |hf| &hf.head)
     }

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -939,14 +939,31 @@ pub struct NodeMeta {
     /// This node's `&anchor`/`*alias` syntax (issue #763), or `None` if it
     /// carried neither.
     pub anchor: Option<AnchorMark>,
-    /// Standalone comment lines directly above this node, one entry per
-    /// line, in source order (#798 PR2). Always empty today -- capturing
-    /// these is separate, follow-up work; this field only prepares a place
-    /// for that work to write into.
-    pub head_comment: Vec<String>,
-    /// Standalone comment lines directly below this node (#798 PR2). Always
-    /// empty today -- see [`Self::head_comment`].
-    pub foot_comment: Vec<String>,
+    /// Standalone head/foot comment lines (#798 PR2), boxed behind a single
+    /// `Option` rather than kept as two inline `Vec<String>` fields: a
+    /// review of this widening found that the extra ~48 stack bytes of two
+    /// always-empty `Vec`s was enough to make `reconcile_presentation_at_depth`
+    /// overflow the real stack *before* its own `MAX_VALUE_TREE_DEPTH` guard
+    /// could fire (`reconcile_presentation_panics_past_nesting_depth_limit_1005`).
+    /// `None` here costs one pointer and no allocation — exactly the
+    /// "always empty today" state every construction site below sets — and
+    /// only the (still unimplemented) capture work that fills these in pays
+    /// for the `Box`.
+    head_foot_comment: Option<Box<HeadFootComment>>,
+}
+
+/// The head/foot comment lines [`NodeMeta::head_foot_comment`] boxes away.
+/// One entry per standalone `#` line, in source order; consecutive lines
+/// join into one logical block (real yq treats them as one comment either
+/// way, and #1085 needs more than one comment associated with a single node
+/// at all). Always empty today -- capturing these is separate, follow-up
+/// work; this type only prepares a place for that work to write into.
+#[derive(Debug, Clone, Default)]
+struct HeadFootComment {
+    /// Standalone `#` lines directly above the node.
+    head: Vec<String>,
+    /// Standalone `#` lines directly below the node.
+    foot: Vec<String>,
 }
 
 impl NodeMeta {
@@ -958,8 +975,7 @@ impl NodeMeta {
             comment: None,
             style: "",
             anchor: None,
-            head_comment: Vec::new(),
-            foot_comment: Vec::new(),
+            head_foot_comment: None,
         }
     }
 
@@ -971,8 +987,47 @@ impl NodeMeta {
             comment,
             style,
             anchor: None,
-            head_comment: Vec::new(),
-            foot_comment: Vec::new(),
+            head_foot_comment: None,
+        }
+    }
+
+    /// Standalone comment lines directly above this node, in source order
+    /// (#798 PR2). Always empty today -- see [`HeadFootComment`].
+    pub fn head_comment(&self) -> &[String] {
+        self.head_foot_comment.as_deref().map_or(&[], |hf| &hf.head)
+    }
+
+    /// Standalone comment lines directly below this node (#798 PR2). Always
+    /// empty today -- see [`Self::head_comment`].
+    pub fn foot_comment(&self) -> &[String] {
+        self.head_foot_comment.as_deref().map_or(&[], |hf| &hf.foot)
+    }
+
+    /// [`Self::empty`] with `anchor` overridden — no comment, style or
+    /// head/foot comments. Used for a kind-changed node (container <->
+    /// scalar), which keeps at most an anchor mark, never presentation
+    /// (`yq_runner.rs`'s `reconcile_presentation_at_depth`). A method rather
+    /// than `NodeMeta { anchor, ..NodeMeta::empty() }` at the call site so
+    /// `head_foot_comment` can stay private across the bin/lib crate
+    /// boundary — functional-record-update requires every field visible at
+    /// the call site, not just the ones actually overridden.
+    pub fn empty_with_anchor(anchor: Option<AnchorMark>) -> Self {
+        Self {
+            anchor,
+            ..Self::empty()
+        }
+    }
+
+    /// This node's own metadata with `style` replaced, everything else
+    /// (comment, anchor, head/foot comments) kept as-is. Used by issue
+    /// #705's `-P` gate (`yq_runner.rs`'s `strip_presentation_style_at_depth`)
+    /// to clear style while keeping the rest untouched — see
+    /// [`Self::empty_with_anchor`] for why this is a method rather than a
+    /// struct-update literal at the call site.
+    pub fn with_style(&self, style: &'static str) -> Self {
+        Self {
+            style,
+            ..self.clone()
         }
     }
 }
@@ -1233,8 +1288,7 @@ fn to_owned_with_comments_at_depth<V: DocumentValue>(
         comment: own_comment,
         style: own_style,
         anchor: own_anchor,
-        head_comment: Vec::new(),
-        foot_comment: Vec::new(),
+        head_foot_comment: None,
     };
     if let Some(fields) = value.as_object() {
         let mut map = IndexMap::new();

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -939,26 +939,40 @@ pub struct NodeMeta {
     /// This node's `&anchor`/`*alias` syntax (issue #763), or `None` if it
     /// carried neither.
     pub anchor: Option<AnchorMark>,
+    /// Standalone comment lines directly above this node, one entry per
+    /// line, in source order (#798 PR2). Always empty today -- capturing
+    /// these is separate, follow-up work; this field only prepares a place
+    /// for that work to write into.
+    pub head_comment: Vec<String>,
+    /// Standalone comment lines directly below this node (#798 PR2). Always
+    /// empty today -- see [`Self::head_comment`].
+    pub foot_comment: Vec<String>,
 }
 
 impl NodeMeta {
-    /// Metadata-free: no comment, no style, no anchor. `const` so the
-    /// module's empty-tree `static` can be built from it.
+    /// Metadata-free: no comment, no style, no anchor, no head/foot
+    /// comments. `const` so the module's empty-tree `static` can be built
+    /// from it.
     pub const fn empty() -> Self {
         Self {
             comment: None,
             style: "",
             anchor: None,
+            head_comment: Vec::new(),
+            foot_comment: Vec::new(),
         }
     }
 
     /// The comment/style pair read straight off a live cursor, with no
-    /// anchor mark — the shape every caller predating #763 built.
+    /// anchor mark or head/foot comments — the shape every caller predating
+    /// #763 built.
     pub fn from_comment_and_style(comment: Option<String>, style: &'static str) -> Self {
         Self {
             comment,
             style,
             anchor: None,
+            head_comment: Vec::new(),
+            foot_comment: Vec::new(),
         }
     }
 }
@@ -1219,6 +1233,8 @@ fn to_owned_with_comments_at_depth<V: DocumentValue>(
         comment: own_comment,
         style: own_style,
         anchor: own_anchor,
+        head_comment: Vec::new(),
+        foot_comment: Vec::new(),
     };
     if let Some(fields) = value.as_object() {
         let mut map = IndexMap::new();

--- a/src/yaml/index.rs
+++ b/src/yaml/index.rs
@@ -20,7 +20,7 @@ use super::advance_positions::{build_cumulative_rank, OpenPositions};
 use super::end_positions::EndPositions;
 use super::error::YamlError;
 use super::light::YamlCursor;
-use super::parser::build_semi_index;
+use super::parser::{build_semi_index, NodeComments};
 use super::starts_seq_entry;
 
 /// Index structures for navigating YAML.
@@ -72,9 +72,10 @@ pub struct YamlIndex<W = Vec<u64>> {
     /// resolves to a tag by reference the way an alias resolves to an
     /// anchor, so this is a single side table, not three (#224).
     tags: BTreeMap<usize, String>,
-    /// Trailing same-line comments: BP position of the owning node → `(start, end)`
-    /// byte range of the raw `#...` comment text (issue #710).
-    line_comments: BTreeMap<usize, (u32, u32)>,
+    /// Head/line/foot comments, keyed by the BP position of the owning node.
+    /// See [`NodeComments`] -- only `line` (issue #710) is captured today;
+    /// `head`/`foot` are always empty (#798 PR2).
+    comments: BTreeMap<usize, NodeComments>,
     /// Line starts for line/column lookup (built lazily on first use).
     /// Only needed by `to_line_column()` and `to_offset()` (used by the
     /// `yq-locate` CLI and the `at_position` jq builtin).
@@ -156,7 +157,7 @@ impl YamlIndex<Vec<u64>> {
             bp_to_anchor: semi.bp_to_anchor,
             aliases: semi.aliases,
             tags: semi.tags,
-            line_comments: semi.line_comments,
+            comments: semi.comments,
             lines: OnceCell::new(),
             canonicalize_numbers: false,
         };
@@ -191,7 +192,7 @@ impl<W: AsRef<[u64]>> YamlIndex<W> {
         // position, last-wins) by inversion rather than #1353's per-
         // declaration tracking: this constructor takes a pre-built
         // `anchors` map with no per-declaration history left to recover,
-        // and (like `line_comments` below) has no caller in this codebase
+        // and (like `comments` below) has no caller in this codebase
         // today to regress on a redefined-anchor input.
         let bp_to_anchor: BTreeMap<usize, String> = anchors
             .iter()
@@ -216,10 +217,10 @@ impl<W: AsRef<[u64]>> YamlIndex<W> {
             bp_to_anchor,
             aliases,
             tags,
-            // `from_parts` predates line-comment tracking and has no caller
+            // `from_parts` predates comment tracking and has no caller
             // in this codebase today; a future caller that needs it can be
             // given an explicit parameter then.
-            line_comments: BTreeMap::new(),
+            comments: BTreeMap::new(),
             lines: OnceCell::new(),
             canonicalize_numbers: false,
         }
@@ -537,7 +538,23 @@ impl<W: AsRef<[u64]>> YamlIndex<W> {
     /// already-retained text rather than a stored string.
     #[inline]
     pub fn get_line_comment(&self, bp_pos: usize) -> Option<(u32, u32)> {
-        self.line_comments.get(&bp_pos).copied()
+        self.comments.get(&bp_pos).and_then(|c| c.line)
+    }
+
+    /// Get the standalone `#` comment lines directly above a BP position
+    /// (#798 PR2). Always empty today -- capturing these is separate,
+    /// follow-up work; this getter exists only so that work has a stable
+    /// place to read from.
+    #[inline]
+    pub fn get_head_comments(&self, bp_pos: usize) -> &[(u32, u32)] {
+        self.comments.get(&bp_pos).map_or(&[], |c| &c.head)
+    }
+
+    /// Get the standalone `#` comment lines directly below a BP position
+    /// (#798 PR2). Always empty today -- see [`Self::get_head_comments`].
+    #[inline]
+    pub fn get_foot_comments(&self, bp_pos: usize) -> &[(u32, u32)] {
+        self.comments.get(&bp_pos).map_or(&[], |c| &c.foot)
     }
 
     /// Resolve an alias at the given BP position to a cursor pointing to

--- a/src/yaml/index.rs
+++ b/src/yaml/index.rs
@@ -1065,6 +1065,43 @@ mod tests {
     }
 
     #[test]
+    fn test_head_and_foot_comments_always_empty_798() {
+        // head/foot comment capture is deliberately unimplemented today
+        // (#798 PR2) -- these getters exist only so that follow-up work has
+        // a stable place to read from. Exercise both the "position has
+        // other comment metadata" (`Some(NodeComments)`) and "position has
+        // none at all" (`None`) paths through the `map_or` default.
+        let yaml = b"a: 1 # keep this\nb: 2\n";
+        let index = YamlIndex::build(yaml).expect("valid YAML");
+        let root = index.root(yaml);
+        use crate::yaml::light::YamlValue;
+        let YamlValue::Sequence(docs) = root.value() else {
+            panic!("root is always the virtual document sequence");
+        };
+        let (doc_cursor, _) = docs.uncons_cursor().expect("at least one document");
+        let YamlValue::Mapping(fields) = doc_cursor.value() else {
+            panic!("expected a mapping document");
+        };
+        for field in fields {
+            let YamlValue::String(k) = field.key() else {
+                panic!("expected string keys");
+            };
+            let bp_pos = field.value_cursor().bp_position();
+            assert!(index.get_head_comments(bp_pos).is_empty());
+            assert!(index.get_foot_comments(bp_pos).is_empty());
+            if k.raw_bytes() == b"a" {
+                // This position does carry other comment metadata (a line
+                // comment), so `comments.get` takes the `Some` arm.
+                assert!(index.get_line_comment(bp_pos).is_some());
+            } else {
+                // This position has no entry in `comments` at all, so
+                // `map_or` falls through to its `&[]` default.
+                assert!(index.get_line_comment(bp_pos).is_none());
+            }
+        }
+    }
+
+    #[test]
     fn test_line_comment_on_sequence_items() {
         let yaml = b"a:\n  - 1 # first\n  - 2 # second\n";
         let index = YamlIndex::build(yaml).expect("valid YAML");

--- a/src/yaml/parser.rs
+++ b/src/yaml/parser.rs
@@ -83,6 +83,28 @@ struct BlockScalarHeader {
     explicit_indent: u8,
 }
 
+/// Head/line/foot comments attached to one node, keyed by its own bp
+/// position (#798 PR2). `head`/`foot` hold zero or more standalone `#` lines
+/// (consecutive lines join into one logical block, hence `Vec` rather than
+/// `Option` -- real yq treats them as one comment either way, and #1085
+/// needs more than one comment associated with a single node at all).
+///
+/// `head`/`foot` are always empty today -- capturing standalone comment
+/// lines is separate, follow-up work; this type only widens the storage
+/// shape so that work has somewhere to write. `line` alone is exactly the
+/// single-slot `(u32, u32)` this type replaces, with unchanged semantics.
+#[derive(Debug, Clone, Default)]
+pub struct NodeComments {
+    /// Standalone `#` lines directly above the node. Always empty today.
+    pub head: Vec<(u32, u32)>,
+    /// The node's own trailing same-line comment: `(start, end)` byte range
+    /// of the raw comment text, starting at `#` and running to end of line
+    /// (exclusive of the line break, inclusive of any trailing whitespace).
+    pub line: Option<(u32, u32)>,
+    /// Standalone `#` lines directly below the node. Always empty today.
+    pub foot: Vec<(u32, u32)>,
+}
+
 /// Output from parsing: the semi-index structures.
 #[derive(Debug)]
 pub struct SemiIndex {
@@ -121,12 +143,10 @@ pub struct SemiIndex {
     pub aliases: BTreeMap<usize, usize>,
     /// Explicit source tags: BP position → raw tag text (see [`YamlIndex::get_tag`](super::index::YamlIndex::get_tag))
     pub tags: BTreeMap<usize, String>,
-    /// Trailing same-line comments: BP position of the node the comment trails →
-    /// `(start, end)` byte range of the raw comment text, starting at `#` and
-    /// running to end of line (exclusive of the line break, inclusive of any
-    /// trailing whitespace). Only line comments (issue #710) — standalone
-    /// head/foot comments are not captured.
-    pub line_comments: BTreeMap<usize, (u32, u32)>,
+    /// Head/line/foot comments, keyed by the BP position of the node they
+    /// attach to. See [`NodeComments`] -- only `line` (issue #710) is
+    /// captured today; `head`/`foot` are always empty.
+    pub comments: BTreeMap<usize, NodeComments>,
 }
 
 /// Maximum nesting depth for recursively-parsed constructs (flow collections
@@ -207,10 +227,9 @@ struct Parser<'a, const HAS_CR: bool> {
     /// so a stale value can only equal the position of the exact node the
     /// property was scanned for — never any later node.
     pending_property_bp: Option<usize>,
-    /// Trailing same-line comments collected during parsing: bp_pos of the
-    /// owning node → `(start, end)` byte range of the raw `#...` comment text.
-    /// See [`SemiIndex::line_comments`].
-    line_comments: BTreeMap<usize, (u32, u32)>,
+    /// Head/line/foot comments collected during parsing, bp_pos of the
+    /// owning node → [`NodeComments`]. See [`SemiIndex::comments`].
+    comments: BTreeMap<usize, NodeComments>,
 
     /// A comment trailing a `&anchor`/`!tag` whose value is deferred to a
     /// later line, not yet attached to any node (#784).
@@ -318,7 +337,7 @@ impl<'a, const HAS_CR: bool> Parser<'a, HAS_CR> {
             aliases: BTreeMap::new(),
             tags: BTreeMap::new(),
             pending_property_bp: None,
-            line_comments: BTreeMap::new(),
+            comments: BTreeMap::new(),
             pending_head_comment: None,
             in_document: false,
             document_start_bp_pos: 0,
@@ -532,13 +551,17 @@ impl<'a, const HAS_CR: bool> Parser<'a, HAS_CR> {
     #[inline]
     fn maybe_capture_line_comment(&mut self, owner_bp_pos: usize) {
         if let Some(range) = self.scan_trailing_comment() {
-            self.line_comments.entry(owner_bp_pos).or_insert(range);
+            self.comments
+                .entry(owner_bp_pos)
+                .or_default()
+                .line
+                .get_or_insert(range);
         }
     }
 
     /// Like [`Self::maybe_capture_line_comment`], but the owning node doesn't
     /// exist yet: stash the comment's byte range in
-    /// [`Self::pending_head_comment`] instead of `line_comments` directly.
+    /// [`Self::pending_head_comment`] instead of `comments` directly.
     /// [`Self::take_pending_head_comment`] attaches it once that node opens
     /// (#784).
     ///
@@ -581,14 +604,18 @@ impl<'a, const HAS_CR: bool> Parser<'a, HAS_CR> {
     /// same-line capture for the same `owner_bp_pos` has already had its
     /// chance to run (e.g. after `maybe_capture_line_comment`/
     /// `set_bp_text_end`'s own call for that bp), never before. Both use the
-    /// same `entry().or_insert()` idiom, so whichever runs first wins the
-    /// slot — calling this first would silently destroy a node's own
-    /// genuine trailing comment in favor of an unrelated floated one instead
-    /// of just leaving the floated one to be dropped (#784 review).
+    /// same "leave an existing slot alone" idiom, so whichever runs first
+    /// wins the slot — calling this first would silently destroy a node's
+    /// own genuine trailing comment in favor of an unrelated floated one
+    /// instead of just leaving the floated one to be dropped (#784 review).
     #[inline]
     fn take_pending_head_comment(&mut self, owner_bp_pos: usize) {
         if let Some(range) = self.pending_head_comment.take() {
-            self.line_comments.entry(owner_bp_pos).or_insert(range);
+            self.comments
+                .entry(owner_bp_pos)
+                .or_default()
+                .line
+                .get_or_insert(range);
         }
     }
 
@@ -5349,7 +5376,7 @@ impl<'a, const HAS_CR: bool> Parser<'a, HAS_CR> {
             bp_to_anchor: core::mem::take(&mut self.bp_to_anchor),
             aliases: core::mem::take(&mut self.aliases),
             tags: core::mem::take(&mut self.tags),
-            line_comments: core::mem::take(&mut self.line_comments),
+            comments: core::mem::take(&mut self.comments),
         })
     }
 


### PR DESCRIPTION
## Summary

PR2 of issue #798's staged plan: widen the YAML comment side-table from a
single trailing-comment slot to a `head`/`line`/`foot` triple, as pure data
modeling — no capture logic, no new builtins, no behavior change. This is
what a follow-up PR needs to actually implement `head_comment`/`foot_comment`
reads and, eventually, `head_comment =`/`foot_comment =`/`comments =` writes
(PR1's grammar for those already parses and explicitly errors "not yet
supported" — see #2674 — since there was nowhere to write until now).

- `SemiIndex`/`Parser`/`YamlIndex`'s single-slot `line_comments: BTreeMap<usize,
  (u32, u32)>` → `comments: BTreeMap<usize, NodeComments>`, where
  `NodeComments { head: Vec<(u32,u32)>, line: Option<(u32,u32)>, foot:
  Vec<(u32,u32)> }`. `head`/`foot` are `Vec` rather than `Option` because
  consecutive standalone comment lines join into one logical block, and
  #1085 needs more than one comment associated with a single node at all.
- `YamlIndex::get_line_comment` keeps its exact name and signature — the
  actual byte-identical gate — now reading `.line` off the wider struct.
  Added (unused today, `pub` API surface for the follow-up PR)
  `get_head_comments`/`get_foot_comments`.
- `NodeMeta` (the jq/CommentTree side, `src/jq/eval_generic.rs`) gets
  matching `head_comment: Vec<String>`/`foot_comment: Vec<String>` fields,
  following the pattern its own doc comment already documents for adding a
  new metadata slot (the #763 anchor-mark amendment).
- `head`/`foot` are permanently empty in this PR — nothing populates them.

**Descoped from the triage's original PR2 description**: capturing
standalone `#` comment lines (hooking into `skip_newlines`/
`parse_document_line`, plus the blank-line-driven head/foot attachment-rule
matrix) is left for its own follow-up PR. The triage itself flagged this
specific piece as needing more design scrutiny than a mechanical type change
warrants, so it gets its own focused review rather than riding along with
the storage widening.

## Test plan

- [x] `cargo test --features cli --lib` (3618 passed)
- [x] `cargo test --features cli --test yq_cli_tests` (1739 passed, incl. the
      full `_710`/`_794`/`_765` comment-preservation block and PR1's
      `meta_assign_798` module, all byte-identical)
- [x] `cargo test --features cli --test yq_golden_tests` (all pinned-yq
      fixtures pass, several exercise `line_comment`)
- [x] `cargo test --features cli --test jq_cli_tests`,
      `jq_evaluator_parity_tests`, `yq_path_consistency_tests`,
      `yaml_test_suite`, `yaml_crlf_tests`, `yaml_tab_comment_tests`,
      `scopes_yaml_tests`, `yaml_locate_regression_test` (no regressions)
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo fmt --check`
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features`
- [x] `cargo bench --bench yaml_bench -- --quick` runs clean with no crash
      and throughput in the expected range. This was a sanity check, not a
      rigorous interleaved A/B (per this repo's own benchmarking discipline)
      — the change is allocation-neutral (`Vec::new()` doesn't allocate) and
      only widens the stored value for bp positions that already have a
      captured comment, so a full A/B didn't seem proportionate to the size
      of this change; happy to run one if reviewers want it before merge.