### PR TITLE
perf(jq): a filter that reads nothing stops materializing the document (#2173)

### DIFF
--- a/docs/adrs/adr-0018.md
+++ b/docs/adrs/adr-0018.md
@@ -422,6 +422,12 @@ Instances, both recorded on their merits and now sanctioned here rather than gra
   `try (1+1)`) no longer validates the ambient document, and `first`/`limit` over a fused
   `map(.x) | .[]` echo an undecodable value like the navigation they wrap. jq rejects all of
   them at parse time.
+- **#2173** — the same rule reaching the last route that was an exception to it. A filter
+  that provably reads nothing bridges with `null` instead of a materialized copy of the
+  document, so `[1+1]`, `[range(3)]`, `now|floor`, `$__loc__` and `true and true` now
+  answer where they used to inherit the bridge's rejection, and `1+1` and `[1+1]` stop
+  disagreeing on the same document. Extends to yq mode, where every filter takes that
+  route; jq 1.7.1 and yq v4.53.3 both reject these documents at parse time.
 
 ## Consequences
 

--- a/docs/compliance/jq/limitations.md
+++ b/docs/compliance/jq/limitations.md
@@ -3432,10 +3432,13 @@ which walks it exactly as `.` does, so a structural fault is still found where t
 reaches it (`{123:1,"b":2}` still exits 5 under `.,.`, as under `.`) and a colliding
 undecodable key, which the walk never has to resolve, is echoed as `.` echoes it. A filter
 whose only route is still the wildcard bridge — `. as $x | $x`, `if . then . else . end`,
-`[.]`, `{k: .}`, anything without a native streaming arm — still materializes and so still
-validates, which is the same rule applied to a route that reads the whole document, not an
-exception to it. (`label $x | .` is *not* one of those: it has a native arm and already
-answered at exit 0 on the eager route, as the matrix in 2 above records.)
+`[.]`, `{k: .}`, anything without a native streaming arm **that reads `.`** — still
+materializes and so still validates, which is the same rule applied to a route that reads
+the whole document, not an exception to it. (`label $x | .` is *not* one of those: it has a
+native arm and already answered at exit 0 on the eager route, as the matrix in 2 above
+records.) The four examples just named all read `.`, and all still materialize; what
+changed under #2173 is the bridge's behaviour for a filter that does **not** — see the
+next entry.
 
 The context that makes the loss survivable is the one #2168's entry states: succinctly
 already diverges on this whole class of document through `.` itself, deliberately, and a
@@ -3510,6 +3513,64 @@ table, `scripts/jq-m2-streaming-sweep.expected` (`--update` regenerates it). A c
 a table that matches; any cell that moves, in either direction, fails with a diff. The rows
 above are in that table at their post-#2103 values, so they are pinned rather than merely
 tolerated.
+
+### The wildcard bridge stops materializing for a filter that reads nothing (#2173)
+
+[#2103](https://github.com/rust-works/succinctly/issues/2103) above left one route out: a
+filter with no native streaming arm still fell to `eval_single`'s wildcard, and the
+wildcard's first act is `to_owned_with_cursor` on the *ambient* value — a complete
+`OwnedValue` copy of the document, built purely so the eager evaluator has an input to run
+against. Since that walk visits everything, it validated everything, so those spellings
+kept jq's whole-document rejection while the ones with a native arm had already lost it.
+On `{123: 1, "b": 2}`, one binary answered `1+1` with `2` at exit 0 and rejected `[1+1]` at
+exit 5. That is the spelling-dependence #1629/#1642/#2168 exist to remove, arrived at from
+a third direction.
+
+`bridge_ambient_input` hands a **closed term** — one that `jq::walk::reads_ambient_value`
+proves cannot consult `.` — `OwnedValue::Null` instead. Nothing is materialized, so nothing
+is validated. Captured against pinned jq 1.7.1 on `{123: 1, "b": 2}`, which it rejects at
+parse time for every filter:
+
+| filter                                            | jq 1.7.1 | succinctly before | succinctly now |
+|---------------------------------------------------|----------|-------------------|----------------|
+| `1+1`                                             | error    | `2` (exit 0)      | `2` — unchanged |
+| `[1+1]`                                           | error    | error             | `[2]`          |
+| `[range(3)]`, `range(3)`                          | error    | error             | `[0,1,2]`, `0 1 2` |
+| `now\|floor`, `$__loc__`                          | error    | error             | the value      |
+| `true and true`, `false or true`, `false // 1`    | error    | error             | `true`, `true`, `1` |
+
+The same three reasons #2103 records apply unchanged, and the first is the strongest here:
+*the agreement being given up was an accident.* Nothing decided that `[1+1]` should validate
+its input; `to_owned_with_cursor` validated because it needed a value to bridge with, and
+`1+1` escaped only because someone had written it a native arm. Sanctioned by ADR-0018's
+#2103 amendment, and now listed there as its own instance.
+
+**It also cost what #2103's own point 3 costs.** On a 16 MB `json generate` document,
+indicative single runs: `[1+1]` 443 MB / 0.75 s → 29 MB / 0.03 s; `[range(3)]` 446 MB /
+0.89 s → 29 MB; `false // 1` 445 MB / 0.86 s → 29 MB. In yq mode, where every filter takes
+`eval_single`, `1+1` went 476 MB / 0.90 s → 126 MB / 0.11 s on a 30 MB document. The
+baseline for both is a filter that already had a native arm.
+
+**What did not change.** A filter that reads `.` still materializes and still validates
+everything it materializes — `. as $x | $x`, `if . then . else . end`, `[.]`, `{k: .}`,
+`. and true`, `range(length; 3)`, and `.` itself all keep their exit 5. So do the
+materializing flag routes (`-S`, `-a`, `-s`, `-C`, `-n`), which never reach these sites and
+are #2662's. And a document whose *root* the reader cannot delimit at all — `xyz123`,
+`[1,2`, `["a`, `[1] x` — still fails for every filter including `empty`, because there is
+no value to skip reading; that is the reader, not a filter, and it matches jq.
+
+**#2476's arms moved with it.** `and`/`or`/`//` had been given `ambient_validation_error`
+— the same rejection as a walk that allocates nothing — days earlier, for the same shapes.
+Keeping it there while the bridge stopped raising would have re-created the split by hand,
+so the walk is now charged only to an operand that reads `.`. `not` is unchanged: it reads
+`.`'s truthiness, so it validates.
+
+Pinned by `test_closed_terms_do_not_validate_2173` (12 closed spellings x 6 malformed
+documents, plus 5 reading spellings that must still raise), the split probe lists in
+`test_ambient_validation_agrees_with_bridge_2476` and its yq twin, and
+`test_wildcard_bridge_over_alias_fanout_completes_2173`. The predicate's own soundness —
+if it calls a filter closed, the filter's output must not depend on the document — is
+`tests/jq_closed_term_tests.rs`.
 
 ### A fault found by walking to it leaves the prefix on stdout
 

--- a/docs/compliance/jq/limitations.md
+++ b/docs/compliance/jq/limitations.md
@@ -3531,13 +3531,13 @@ proves cannot consult `.` — `OwnedValue::Null` instead. Nothing is materialize
 is validated. Captured against pinned jq 1.7.1 on `{123: 1, "b": 2}`, which it rejects at
 parse time for every filter:
 
-| filter                                            | jq 1.7.1 | succinctly before | succinctly now |
-|---------------------------------------------------|----------|-------------------|----------------|
-| `1+1`                                             | error    | `2` (exit 0)      | `2` — unchanged |
-| `[1+1]`                                           | error    | error             | `[2]`          |
-| `[range(3)]`, `range(3)`                          | error    | error             | `[0,1,2]`, `0 1 2` |
-| `now\|floor`, `$__loc__`                          | error    | error             | the value      |
-| `true and true`, `false or true`, `false // 1`    | error    | error             | `true`, `true`, `1` |
+| filter                                          | jq 1.7.1 | succinctly before | succinctly now      |
+|-------------------------------------------------|----------|-------------------|---------------------|
+| `1+1`                                           | error    | `2` (exit 0)      | `2` — unchanged     |
+| `[1+1]`                                         | error    | error             | `[2]`               |
+| `[range(3)]`, `range(3)`                        | error    | error             | `[0,1,2]`, `0 1 2`  |
+| `now\|floor`, `$__loc__`                        | error    | error             | the value           |
+| `true and true`, `false or true`, `false // 1`  | error    | error             | `true`, `true`, `1` |
 
 The same three reasons #2103 records apply unchanged, and the first is the strongest here:
 *the agreement being given up was an accident.* Nothing decided that `[1+1]` should validate

--- a/docs/compliance/yq/limitations.md
+++ b/docs/compliance/yq/limitations.md
@@ -220,6 +220,41 @@ present since #2473 and untouched by #2476), which resolves `.b`'s path and rais
 `.b[0]` does. Real yq rejects this whole document at parse time either way, so there is no yq
 behaviour to match for any of these constructs.
 
+**[#2173](https://github.com/rust-works/succinctly/issues/2173) goes one step further, and
+this one *is* a new yq divergence rather than an extension of an existing one.** Every
+`succinctly yq` filter takes `eval_single`, so unlike jq mode nothing here had a native
+streaming arm to escape through: the wildcard bridge materialized the whole document for
+`1+1` as much as for `.a`, and validated it in passing. That rejection matched real yq,
+which parses eagerly. It no longer does, for a filter that provably reads nothing.
+
+Captured live against yq v4.53.3 on `a: "\x"` / `b: 5` (an invalid escape, which yq
+rejects at parse time whatever the filter):
+
+| filter                              | real yq | succinctly before | succinctly now |
+|-------------------------------------|---------|-------------------|----------------|
+| `1+1`, `[1+1]`                      | exit 1  | exit 1 — matched  | `2`, `- 2`     |
+| `true and true`, `false // 1`       | exit 1  | exit 1 — matched  | `true`, `1`    |
+| `{"k":1}`, `1 as $x \| $x`          | exit 1  | exit 0            | unchanged      |
+| `.b`                                | exit 1  | exit 0            | unchanged      |
+| `. and true`                        | exit 1  | exit 1            | unchanged      |
+
+So four spellings stop matching yq. The rows below them are why that is the *uniform*
+answer rather than a new inconsistency: `.b` and `{"k":1}` already answered at exit 0 on
+this document, because navigation validates only what it reads (#2168) and neither reaches
+the bad escape. Keeping `1+1` rejecting would have meant a binary that answers `.b` and
+`{"k":1}` while refusing `1+1` on one document in one run — the shape ADR-0018's #2103
+amendment exists to rule out. `. and true` still raises: it reads `.`.
+
+Same disposition, same sanction, and the same escape hatch as the jq side — a user who
+wants yq's rejection has `succinctly json validate` for JSON input, and the divergence is
+confined to documents real yq would refuse outright. Pinned by
+`test_closed_terms_do_not_validate_2173`'s yq twin behaviour through
+`test_ambient_validation_agrees_with_bridge_2476`'s closed-probe rows, and by
+`test_wildcard_bridge_over_alias_fanout_completes_2173`, which is also the memory guard:
+on #1804's fan-out shape (`aN: &aN [*a(N-1), *a(N-1)]`) the ambient materialization was
+`O(2^N)`, measured at 0.33 s / 1.31 s / 5.38 s / 22.70 s for N=18/20/22/24 and flat
+0.00 s after.
+
 **Resolved ([#1350](https://github.com/rust-works/succinctly/issues/1350)).**
 `enforce_anchor_soundness` takes a `sort_keys` argument and has always handled it correctly
 on the DOM path; the cursor-streaming path used to never call it, reproducing the unsound

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -8295,7 +8295,12 @@ fn each_repeat_generic<S: EvalSemantics, V: DocumentValue>(
     cursor: Option<V::Cursor>,
     sink: &mut dyn FnMut(GenericItem<V>) -> Demand,
 ) -> Flow {
-    let owned = match to_owned_with_cursor(&value, cursor) {
+    // `f` is `Repeat`'s only child and the wrapper contributes nothing of
+    // its own (`walk.rs`'s `node_reads_ambient` leaves `Expr::Repeat` to the
+    // "children decide" group), so `reads_ambient_value(f)` is exactly
+    // `Repeat`'s own closedness -- bridging here keeps `repeat(f)` in step
+    // with every other native arm this file gives the same treatment (#2173).
+    let owned = match bridge_ambient_input(f, &value, cursor) {
         Ok(v) => v,
         Err(e) if suppresses(&e, optional) => return Flow::Exhausted,
         Err(e) => return Flow::Escaped(Control::Error(e)),
@@ -10892,9 +10897,15 @@ fn eval_boolean_generic<S: EvalSemantics, V: DocumentValue>(
     // either (`bridge_ambient_input`), so keeping the walk here would have
     // reinstated by hand the spelling-dependence both changes exist to
     // remove. `. and true` still walks.
-    let reads_ambient =
-        crate::jq::walk::reads_ambient_value(left) || crate::jq::walk::reads_ambient_value(right);
-    if reads_ambient && !needs_path_context(left) && !needs_path_context(right) {
+    // `needs_path_context` checked first so it can short-circuit `&&` and
+    // skip the `reads_ambient_value` tree walk entirely whenever either
+    // operand needs path context -- that case already makes the whole guard
+    // `false` regardless of what the walk would answer.
+    if !needs_path_context(left)
+        && !needs_path_context(right)
+        && (crate::jq::walk::reads_ambient_value(left)
+            || crate::jq::walk::reads_ambient_value(right))
+    {
         if let Some(control) = ambient_validation_error::<V>(cursor) {
             return partial_generic(Vec::new(), control);
         }

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -725,6 +725,49 @@ fn to_owned_with_cursor<V: DocumentValue>(
     }
 }
 
+/// [`to_owned_with_cursor`], but skipped entirely when `expr` cannot read
+/// the value being materialized (#2173).
+///
+/// Every bridge into the eager evaluator materializes the *ambient* value
+/// only because `eval_on_owned`/`eval_each_owned` need some input to run
+/// against. When `expr` is a closed term — `[1+1]`, `[range(3)]`,
+/// `$__loc__`, `now | floor`, `true and true` — that input is never read, so
+/// `OwnedValue::Null` serves as well as a full copy of the document and
+/// costs nothing. Measured on a 16 MB document: `[1+1]` 443 MB → 29 MB peak
+/// RSS, 0.75 s → 0.04 s; in yq mode, where every filter takes
+/// [`eval_single`], `1+1` 476 MB → 125 MB.
+///
+/// **This also drops a validation the materialization was performing as a
+/// side effect, and that is the intended behaviour, not a casualty.**
+/// `to_owned_with_cursor` walks the whole document, so it raises on a
+/// malformed one for a filter that reads nothing — which is what real jq and
+/// yq do, since both parse eagerly. succinctly is a semi-index and does not:
+/// the raise fired only for the spellings that happened to reach a bridge,
+/// so `1+1` answered `2` at exit 0 while `[1+1]` exited 5 on the same
+/// document. ADR-0018's #2103 amendment governs exactly this class — where
+/// the reference's answer is a whole-document rejection the semi-index
+/// deliberately does not perform, take the *uniform* divergence, the one
+/// under which a value is treated the same however the filter spells its way
+/// to it. So a closed term now validates nothing in either mode, matching
+/// what `1+1` already did on jq's streaming route since #2103. Recorded in
+/// `docs/compliance/jq/limitations.md` and its yq twin; pinned by
+/// `test_closed_terms_do_not_validate_2173`.
+///
+/// A filter that *does* read the document is untouched here: it still
+/// materializes, and so still validates everything it materializes, which is
+/// #2168's rule unchanged.
+fn bridge_ambient_input<V: DocumentValue>(
+    expr: &Expr,
+    value: &V,
+    cursor: Option<V::Cursor>,
+) -> Result<OwnedValue, EvalError> {
+    if crate::jq::walk::reads_ambient_value(expr) {
+        to_owned_with_cursor(value, cursor)
+    } else {
+        Ok(OwnedValue::Null)
+    }
+}
+
 /// [`to_owned_with_cursor`] for the one job that must not fail: rendering a
 /// value into the text of an error that is *already* being raised.
 ///
@@ -2272,7 +2315,7 @@ fn bridge_to_full_evaluator<S: EvalSemantics, V: DocumentValue>(
     // today: `to_owned_with_cursor`'s only error paths are
     // `is_decode_failure()`-tagged, never suppressed regardless of
     // `optional`.
-    match to_owned_with_cursor(&value, cursor) {
+    match bridge_ambient_input(expr, &value, cursor) {
         Ok(owned) => eval_on_owned::<S, V>(expr, owned, optional),
         Err(e) if suppresses(&e, optional) => GenericResult::None,
         Err(e) => GenericResult::Error(e),
@@ -2296,7 +2339,7 @@ fn bridge_to_full_evaluator_flow<S: EvalSemantics, V: DocumentValue>(
     // `bridge_to_full_evaluator`'s own sibling fix above -- a suppressed
     // error produces zero items (the sink is never called), same as
     // `GenericResult::None`'s sink-free semantics elsewhere in this file.
-    match to_owned_with_cursor(&value, cursor) {
+    match bridge_ambient_input(expr, &value, cursor) {
         Ok(owned) => drain_result_generic(eval_on_owned::<S, V>(expr, owned, optional), sink),
         Err(e) if suppresses(&e, optional) => Flow::Exhausted,
         Err(e) => Flow::Escaped(Control::Error(e)),
@@ -2335,7 +2378,7 @@ fn bridge_to_each_owned_flow<S: EvalSemantics, V: DocumentValue>(
     optional: bool,
     sink: &mut dyn FnMut(GenericItem<V>) -> Demand,
 ) -> Flow {
-    match to_owned_with_cursor(&value, cursor) {
+    match bridge_ambient_input(expr, &value, cursor) {
         Ok(owned) => {
             eval_each_owned::<S>(expr, &owned, optional, &mut |v| sink(GenericItem::Owned(v)))
         }
@@ -7060,8 +7103,15 @@ fn eval_single<S: EvalSemantics, V: DocumentValue>(
         // only path-context read sits inside a `//` is still never routed to
         // path-context evaluation, and this arm does not change that table.
         Expr::Alternative(left, right) => {
-            if let Some(control) = ambient_validation_error::<V>(cursor) {
-                return partial_generic(Vec::new(), control);
+            // #2173: the walk is charged only to a `//` that reads the
+            // document. `false // 1` reads nothing, so under #2103's rule --
+            // a filter validates only what it reads -- it validates nothing,
+            // exactly as the bridge it replaces now does for the same shape
+            // (`bridge_ambient_input`). `(.a? // 1) | 1` still walks.
+            if crate::jq::walk::reads_ambient_value(expr) {
+                if let Some(control) = ambient_validation_error::<V>(cursor) {
+                    return partial_generic(Vec::new(), control);
+                }
             }
             match retain_truthy_generic(eval_single::<S, V>(left, value.clone(), optional, cursor))
             {
@@ -7397,7 +7447,14 @@ fn eval_single<S: EvalSemantics, V: DocumentValue>(
             // over the whole suite confirmed it: zero hits from any
             // parser-driven test). Whatever error escapes is caught, if at
             // all, by the caller's own `Expr::Optional`/`eval_try` boundary.
-            let owned = owned_or_err!(to_owned_with_cursor(&value, cursor));
+            // #2173: `bridge_ambient_input`, not `to_owned_with_cursor` --
+            // this arm is where `[1+1]`, `[range(3)]` and `$__loc__` each
+            // paid 443 MB on a 16 MB document for an input none of them
+            // read, and it is the whole of yq's route, so `1+1` paid it
+            // there too. A closed term bridges with `OwnedValue::Null`; the
+            // re-serialize and re-index below then cost nothing either,
+            // since they run on that `Null`.
+            let owned = owned_or_err!(bridge_ambient_input(expr, &value, cursor));
             let json_str = owned.to_json_for_reindex::<S>();
             let json_bytes = json_str.as_bytes();
             let index = JsonIndex::build(json_bytes);
@@ -10827,7 +10884,17 @@ fn eval_boolean_generic<S: EvalSemantics, V: DocumentValue>(
     // that raise without the value -- read its doc comment for the parity
     // evidence and for why an operand that *does* read path context is not
     // charged the walk (it never paid the materialization either).
-    if !needs_path_context(left) && !needs_path_context(right) {
+    //
+    // #2173 narrowed it once more, to operands that actually read `.`.
+    // `true and true` reads nothing, and #2103's rule -- a filter validates
+    // only what it reads -- says it should therefore validate nothing; the
+    // bridge that used to carry this raise no longer raises for that shape
+    // either (`bridge_ambient_input`), so keeping the walk here would have
+    // reinstated by hand the spelling-dependence both changes exist to
+    // remove. `. and true` still walks.
+    let reads_ambient =
+        crate::jq::walk::reads_ambient_value(left) || crate::jq::walk::reads_ambient_value(right);
+    if reads_ambient && !needs_path_context(left) && !needs_path_context(right) {
         if let Some(control) = ambient_validation_error::<V>(cursor) {
             return partial_generic(Vec::new(), control);
         }
@@ -18971,8 +19038,13 @@ fn eval_builtin<S: EvalSemantics, V: DocumentValue>(
             // level up) for whichever of the five #2184-fixed builtins
             // above reach here; unverified for the rest of this arm's
             // callers (tracked separately as #2280).
-            let owned = owned_or_suppress!(to_owned_with_cursor(&value, cursor), optional);
-            eval_on_owned::<S, _>(&Expr::Builtin(builtin.clone()), owned, optional)
+            // #2173: `bridge_ambient_input`, so a builtin whose answer comes
+            // from somewhere other than `.` -- `now`, `empty`, `env` -- stops
+            // materializing the document to compute it. `now | floor` was
+            // 445 MB on a 16 MB input before this.
+            let expr = Expr::Builtin(builtin.clone());
+            let owned = owned_or_suppress!(bridge_ambient_input(&expr, &value, cursor), optional);
+            eval_on_owned::<S, _>(&expr, owned, optional)
         }
     }
 }

--- a/src/jq/walk.rs
+++ b/src/jq/walk.rs
@@ -1297,6 +1297,20 @@ fn node_reads_ambient(node: &Expr) -> bool {
         // on. `error(f)` is fine -- `f` is a child.
         Expr::Error(inner) => inner.is_none(),
 
+        // An assignment's *output* is the input document with a
+        // modification applied, so it reads `.` however closed its path
+        // and value happen to be. `(1) = 5` on `{a: 1}` has two literal
+        // children and must still answer `{a: 1}` -- yq's own no-op for an
+        // untracked path (#1764) -- not `null`. Caught by
+        // `test_yq_untracked_bare_noncomma_branch_noop_1764` when these
+        // four fell through to the "children decide" group below; that is
+        // the wrong-`false` direction this predicate exists to avoid, so
+        // it is spelled out rather than inferred.
+        Expr::Assign { .. }
+        | Expr::Update { .. }
+        | Expr::CompoundAssign { .. }
+        | Expr::AlternativeAssign { .. } => true,
+
         // Reads unless the builtin is one of the few that ignore their input
         // entirely. Everything with an argument still reads: `map(1)`,
         // `select(true)` and `add` all consult `.` however closed the
@@ -1356,11 +1370,7 @@ fn node_reads_ambient(node: &Expr) -> bool {
         | Expr::AsPattern { .. }
         | Expr::Label { .. }
         | Expr::FuncDef { .. }
-        | Expr::DefCall { .. }
-        | Expr::Assign { .. }
-        | Expr::Update { .. }
-        | Expr::CompoundAssign { .. }
-        | Expr::AlternativeAssign { .. } => false,
+        | Expr::DefCall { .. } => false,
     }
 }
 

--- a/src/jq/walk.rs
+++ b/src/jq/walk.rs
@@ -1315,12 +1315,14 @@ fn node_reads_ambient(node: &Expr) -> bool {
         | Expr::MetaAssign { .. } => true,
 
         // Reads unless the builtin is one of the few that ignore their input
-        // entirely. Everything with an argument still reads: `map(1)`,
+        // entirely. Everything with an `Expr` argument still reads: `map(1)`,
         // `select(true)` and `add` all consult `.` however closed the
         // argument is, so this allowlist holds only builtins whose whole
         // answer comes from elsewhere -- the clock, the environment, the
-        // language itself. Verified against their `eval.rs` arms, each of
-        // which takes `_value`.
+        // language itself. `EnvObject`/`StrEnv` carry a plain `String` (the
+        // variable name), not an `Expr`, so there is no child for
+        // `any_subexpr` to miss either. Verified against their `eval.rs`
+        // arms, each of which takes `_value` or no value parameter at all.
         Expr::Builtin(builtin) => !matches!(
             builtin,
             Builtin::Empty
@@ -1329,6 +1331,8 @@ fn node_reads_ambient(node: &Expr) -> bool {
                 | Builtin::Infinite
                 | Builtin::NullLit
                 | Builtin::Env
+                | Builtin::EnvObject(_)
+                | Builtin::StrEnv(_)
                 | Builtin::Builtins
                 | Builtin::Halt
         ),

--- a/src/jq/walk.rs
+++ b/src/jq/walk.rs
@@ -1309,7 +1309,10 @@ fn node_reads_ambient(node: &Expr) -> bool {
         Expr::Assign { .. }
         | Expr::Update { .. }
         | Expr::CompoundAssign { .. }
-        | Expr::AlternativeAssign { .. } => true,
+        | Expr::AlternativeAssign { .. }
+        // yq's `PATH <slot> = value` (#798) is the same shape: it answers
+        // with the document, metadata written, leaving the value alone.
+        | Expr::MetaAssign { .. } => true,
 
         // Reads unless the builtin is one of the few that ignore their input
         // entirely. Everything with an argument still reads: `map(1)`,

--- a/src/jq/walk.rs
+++ b/src/jq/walk.rs
@@ -1240,11 +1240,11 @@ pub fn uses_cursor_metadata_builtins(expr: &Expr) -> bool {
 /// `false` means *closed term*: the expression's outputs are the same
 /// whatever the input is, so a caller about to materialize the input purely
 /// to have something to evaluate against can hand it `OwnedValue::Null`
-/// instead. That is what [`super::eval_generic::bridge_ambient_input`] does,
+/// instead. That is what `eval_generic::bridge_ambient_input` does,
 /// and on a 16 MB document it is the difference between 443 MB of peak RSS
 /// and 29 MB for `[1+1]`.
 ///
-/// **Conservative in exactly one direction.** [`node_reads_ambient`] is
+/// **Conservative in exactly one direction.** `node_reads_ambient` is
 /// exhaustive over `Expr` with no wildcard arm, so a new variant is a compile
 /// error rather than a silent "closed", and every node whose own semantics
 /// could reach `.` answers `true` even when a child would not. The failure

--- a/src/jq/walk.rs
+++ b/src/jq/walk.rs
@@ -1234,6 +1234,136 @@ pub fn uses_cursor_metadata_builtins(expr: &Expr) -> bool {
     })
 }
 
+/// Whether evaluating `expr` could consult the **ambient input value** (`.`)
+/// anywhere in its tree (#2173).
+///
+/// `false` means *closed term*: the expression's outputs are the same
+/// whatever the input is, so a caller about to materialize the input purely
+/// to have something to evaluate against can hand it `OwnedValue::Null`
+/// instead. That is what [`super::eval_generic::bridge_ambient_input`] does,
+/// and on a 16 MB document it is the difference between 443 MB of peak RSS
+/// and 29 MB for `[1+1]`.
+///
+/// **Conservative in exactly one direction.** [`node_reads_ambient`] is
+/// exhaustive over `Expr` with no wildcard arm, so a new variant is a compile
+/// error rather than a silent "closed", and every node whose own semantics
+/// could reach `.` answers `true` even when a child would not. The failure
+/// mode of a wrong `true` is a materialization we could have skipped; the
+/// failure mode of a wrong `false` is an expression silently evaluated
+/// against `null`. Only the first is acceptable, so anything unclear is
+/// `true`.
+///
+/// **Deliberately imprecise about pipes.** `1 | .` reads `1`, not the
+/// document, but this walk sees an `Expr::Identity` node and reports
+/// `true`. Teaching it that a pipe stage's ambient value is the previous
+/// stage's output is a refinement, not a correction — it would widen what
+/// counts as closed, never narrow it.
+///
+/// Same expanded-program requirement as [`uses_input_builtins`]: a call
+/// reachable only through an imported module body still counts.
+pub fn reads_ambient_value(expr: &Expr) -> bool {
+    any_subexpr(expr, &mut node_reads_ambient)
+}
+
+/// One node's own answer for [`reads_ambient_value`], ignoring its children —
+/// [`any_subexpr`] visits those separately.
+///
+/// Exhaustive on purpose: see [`reads_ambient_value`] for why a wildcard arm
+/// here would be a correctness hazard rather than a convenience.
+fn node_reads_ambient(node: &Expr) -> bool {
+    match node {
+        // Navigation and whole-value reads: these *are* the ambient value.
+        Expr::Identity
+        | Expr::Field(_)
+        | Expr::Index { .. }
+        | Expr::Slice { .. }
+        | Expr::Iterate
+        | Expr::RecursiveDescent
+        // `not` and `@base64` and friends all apply to `.`.
+        | Expr::Not
+        | Expr::Format(_) => true,
+
+        // Both emit `.` itself and test `cond` against it, and neither
+        // emission is a child this walk would otherwise see.
+        Expr::Until { .. } | Expr::While { .. } => true,
+
+        // An unresolved call carries no body to descend into (a resolved
+        // `Expr::DefCall` does, and `any_subexpr` follows it). Whatever the
+        // body turns out to be, assume it reads.
+        Expr::FuncCall { .. } | Expr::NamespacedCall { .. } => true,
+
+        // The trap in this predicate: bare `error` raises `.` *as* the error
+        // value, and `any_subexpr` gives `Error(None)` no child to catch it
+        // on. `error(f)` is fine -- `f` is a child.
+        Expr::Error(inner) => inner.is_none(),
+
+        // Reads unless the builtin is one of the few that ignore their input
+        // entirely. Everything with an argument still reads: `map(1)`,
+        // `select(true)` and `add` all consult `.` however closed the
+        // argument is, so this allowlist holds only builtins whose whole
+        // answer comes from elsewhere -- the clock, the environment, the
+        // language itself. Verified against their `eval.rs` arms, each of
+        // which takes `_value`.
+        Expr::Builtin(builtin) => !matches!(
+            builtin,
+            Builtin::Empty
+                | Builtin::Now
+                | Builtin::Nan
+                | Builtin::Infinite
+                | Builtin::NullLit
+                | Builtin::Env
+                | Builtin::Builtins
+                | Builtin::Halt
+        ),
+
+        // Everything below contributes nothing of its own: whether it reads
+        // `.` is entirely a question about its children, which `any_subexpr`
+        // visits. Spelled out rather than left to a `_` arm so that adding an
+        // `Expr` variant forces a decision here.
+        Expr::Literal(_)
+        | Expr::Loc { .. }
+        | Expr::Env
+        | Expr::Var(_)
+        | Expr::TrackedVar(_)
+        | Expr::Break(_)
+        | Expr::Paren(_)
+        | Expr::Shared(_)
+        | Expr::Optional(_)
+        | Expr::Array(_)
+        | Expr::Pipe(_)
+        | Expr::Comma(_)
+        | Expr::Object(_)
+        | Expr::StringInterpolation(_)
+        | Expr::Arithmetic { .. }
+        | Expr::Negate(_)
+        | Expr::Compare { .. }
+        | Expr::And(..)
+        | Expr::Or(..)
+        | Expr::Alternative(..)
+        | Expr::If { .. }
+        | Expr::Try { .. }
+        | Expr::IndexExpr { .. }
+        | Expr::SliceExpr { .. }
+        | Expr::Range { .. }
+        | Expr::Reduce { .. }
+        | Expr::Foreach { .. }
+        | Expr::Limit { .. }
+        | Expr::FirstExpr(_)
+        | Expr::LastExpr(_)
+        | Expr::NthExpr { .. }
+        | Expr::Repeat(_)
+        | Expr::As { .. }
+        | Expr::AsPattern { .. }
+        | Expr::Label { .. }
+        | Expr::FuncDef { .. }
+        | Expr::DefCall { .. }
+        | Expr::Assign { .. }
+        | Expr::Update { .. }
+        | Expr::CompoundAssign { .. }
+        | Expr::AlternativeAssign { .. } => false,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -44123,6 +44123,17 @@ fn test_ambient_validation_agrees_with_bridge_2476() -> Result<()> {
         ("false or true", "true"),
         ("false // 1", "1"),
     ];
+    // Four corpus rows are not about validation at all: `xyz123`, `[1,2`,
+    // `["a` and `[1] x` give the CLI's document reader no root value to
+    // delimit, so it raises before any filter runs. `empty` is the
+    // reference for that -- it has been native since long before #2173, so
+    // wherever *it* raises the failure belongs to the reader and not to any
+    // filter. Measured on the binaries either side of this change: `empty`
+    // exits 5 on exactly those four documents and 0 on the other 29, both
+    // before and after. Pinning the closed probes against `empty` rather
+    // than against a hard-coded list of labels states the actual claim --
+    // a closed term behaves exactly as the filter that reads nothing and
+    // does nothing -- and keeps working if the corpus grows.
     for (label, doc, want_code, want_stderr) in corpus {
         let mut seen: Vec<(String, i32, String)> = Vec::new();
         for probe in probes {
@@ -44146,17 +44157,22 @@ fn test_ambient_validation_agrees_with_bridge_2476() -> Result<()> {
                 "[{label}] `{probe}` disagrees with `select(.) | 1`"
             );
         }
+        let (_, _, empty_code) = run_jq_full(&["-c", "empty"], Some(doc))?;
         for (probe, want_stdout) in closed_probes {
             let (stdout, stderr, code) = run_jq_full(&["-c", probe], Some(doc))?;
             assert_eq!(
-                code, 0,
-                "[{label}] closed `{probe}`: exit {code}, want 0\nstderr: {stderr}"
+                code, empty_code,
+                "[{label}] closed `{probe}`: exit {code}, but `empty` exits \
+                 {empty_code} -- a filter that reads nothing must answer \
+                 exactly as `empty` does\nstderr: {stderr}"
             );
-            assert_eq!(
-                stdout.trim_end(),
-                want_stdout,
-                "[{label}] closed `{probe}`: stdout {stdout:?}"
-            );
+            if empty_code == 0 {
+                assert_eq!(
+                    stdout.trim_end(),
+                    want_stdout,
+                    "[{label}] closed `{probe}`: stdout {stdout:?}"
+                );
+            }
         }
     }
     Ok(())

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -8467,28 +8467,35 @@ fn test_and_or_keep_path_context_2473() -> Result<()> {
     Ok(())
 }
 
-/// Spine 2416 gate reason 3 (#2473) companion: the `and`/`or` arms are gated
-/// on `needs_path_context`, exactly like `Expr::Arithmetic`'s (#2475), so an
-/// `and`/`or` that reads no path context still takes the eager bridge and
-/// still pays its ambient decode on a #1194-malformed document.
+/// Spine 2416 gate reason 3 (#2473) companion, as #2173 left it: an
+/// `and`/`or` that reads nothing pays no ambient decode on a
+/// #1194-malformed document.
 ///
-/// `try (key and true) catch "x"` exits 0 with no output on the native route,
-/// which is not a regression this arm introduces: `try (key + 1) catch "x"`
-/// and `try (key == 1) catch "x"` already did, from the `Expr::Arithmetic`
-/// and `Expr::Compare` arms. It is pinned here so the *difference* between a
-/// gated and an ungated arm stays visible, alongside
+/// This test was written the other way up. When #2473 landed, the `and`/`or`
+/// arms were gated on `needs_path_context`, so a shape reading no path
+/// context fell to the wildcard bridge and inherited that bridge's
+/// whole-document materialization -- and therefore its rejection. #2476
+/// replaced the materialization with a walk, keeping the rejection; #2173
+/// then charged the walk only to shapes that read `.`, so `true and true`
+/// answers `true` here where it used to exit 5.
+///
+/// The `key and true` row is unchanged and is why the test is still worth
+/// keeping: it exits 0 with no output on the native route, as
+/// `try (key + 1) catch "x"` and `try (key == 1) catch "x"` already did from
+/// the `Expr::Arithmetic` and `Expr::Compare` arms. What the test now pins
+/// is that a path-context read and a closed term reach the same answer from
+/// opposite directions -- alongside
 /// `test_try_catch_contains_a_genuinely_catchable_malformed_key_error_1812`.
 #[test]
-fn test_and_or_without_path_context_still_pays_the_ambient_decode_2473() -> Result<()> {
+fn test_and_or_without_path_context_pays_no_ambient_decode_2173() -> Result<()> {
     let doc = "{123: 1}";
-    for filter in ["true and true", r#"try (true and true) catch "x""#] {
+    for (filter, want) in [
+        ("true and true", "true"),
+        (r#"try (true and true) catch "x""#, "true"),
+    ] {
         let (stdout, stderr, code) = run_jq_full(&["-c", filter], Some(doc))?;
-        assert_eq!(code, 5, "`{filter}` stdout: {stdout:?} stderr: {stderr}");
-        assert!(stdout.trim().is_empty(), "`{filter}` stdout: {stdout:?}");
-        assert!(
-            stderr.contains("Invalid JSON text"),
-            "`{filter}` stderr: {stderr}"
-        );
+        assert_eq!(code, 0, "`{filter}` stdout: {stdout:?} stderr: {stderr}");
+        assert_eq!(stdout.trim(), want, "`{filter}` stderr: {stderr}");
     }
     let (stdout, stderr, code) =
         run_jq_full(&["-c", r#"try (key and true) catch "x""#], Some(doc))?;
@@ -43955,6 +43962,15 @@ fn test_preserve_input_keeps_jq_escape_table_2209() -> Result<()> {
 /// (agreement alone would also pass if both routes silently stopped
 /// raising).
 ///
+/// **#2173 split the probe list in two.** The walk is now charged only to a
+/// construct that actually reads `.`, so `true and true`, `false or true`
+/// and `false // 1` moved to `closed_probes`, where they must answer at
+/// exit 0 on every row -- malformed or not -- with the same stdout either
+/// way. That is #2103's rule ("a filter validates only what it reads")
+/// applied to the last arms that were still an exception to it, and it is
+/// what makes `1+1` and `[1+1]` finally agree on the same document. The
+/// reading probes below are unchanged and still pin the full raise-set.
+///
 /// Rows this deliberately leaves out: a `>256`-deep document (both routes
 /// panic, #2627) and an empty document (exit 0 on every probe, nothing to
 /// pin). The alias-to-container shape is #1804's accepted trade-off and is
@@ -44093,15 +44109,19 @@ fn test_ambient_validation_agrees_with_bridge_2476() -> Result<()> {
         ("false root", "false", 0, ""),
         ("well-formed", r#"{"a":[1,{"b":"c"}]}"#, 0, ""),
     ];
-    // The reference route first; every construct that used to bridge after.
-    let probes = [
-        "select(.) | 1",
-        "true and true",
-        "false or true",
-        ". and true",
-        "not",
-        "false // 1",
-        "(.a? // 1) | 1",
+    // The reference route first; every construct that used to bridge and
+    // still reads `.` after it. #2173 moved the closed terms out of this
+    // list and into `closed_probes` below -- they no longer raise at all.
+    let probes = ["select(.) | 1", ". and true", "not", "(.a? // 1) | 1"];
+    // #2173: these read nothing, so they validate nothing and answer at
+    // exit 0 on every row of the corpus -- including the malformed ones.
+    // Their expected stdout is the same on a malformed document as on a
+    // well-formed one, which is the point: the answer no longer depends on
+    // the document at all.
+    let closed_probes = [
+        ("true and true", "true"),
+        ("false or true", "true"),
+        ("false // 1", "1"),
     ];
     for (label, doc, want_code, want_stderr) in corpus {
         let mut seen: Vec<(String, i32, String)> = Vec::new();
@@ -44126,18 +44146,129 @@ fn test_ambient_validation_agrees_with_bridge_2476() -> Result<()> {
                 "[{label}] `{probe}` disagrees with `select(.) | 1`"
             );
         }
+        for (probe, want_stdout) in closed_probes {
+            let (stdout, stderr, code) = run_jq_full(&["-c", probe], Some(doc))?;
+            assert_eq!(
+                code, 0,
+                "[{label}] closed `{probe}`: exit {code}, want 0\nstderr: {stderr}"
+            );
+            assert_eq!(
+                stdout.trim_end(),
+                want_stdout,
+                "[{label}] closed `{probe}`: stdout {stdout:?}"
+            );
+        }
     }
     Ok(())
 }
 
-/// #2476: `eval_single`'s `Expr::And`/`Expr::Or` arms lost their
-/// `needs_path_context` gate, and the gate existed for exactly one reason --
-/// an `and`/`or` reading no path context fell to the wildcard bridge, whose
-/// ambient `to_owned_with_cursor` is what rejects a malformed document for a
-/// query that never reads `.` (#1812: real jq rejects the whole document for
-/// every query). The arm runs `ambient_validation_error` in its place, so
-/// this pins the raise *through the ungated arm* rather than through the
-/// bridge that used to carry it.
+/// #2173: a filter that reads nothing answers the same on a malformed
+/// document as on a well-formed one, **whatever route its spelling takes**.
+///
+/// This is the test that says the split is gone. Before this change, whether
+/// a closed term inherited jq's whole-document rejection depended on nothing
+/// but which `match` arm the parser happened to hand it: `1+1` had a native
+/// streaming arm and answered `2`, while `[1+1]` -- the same closed term
+/// wrapped in a collector -- fell to `eval_single`'s wildcard, materialized
+/// 16 MB of document to have something to evaluate against, and exited 5.
+/// Same for `[range(3)]`, `$__loc__`, `now|floor`, `range(3)`,
+/// `true and true` and `false // 1`.
+///
+/// The corpus is the same six documents
+/// `test_root_forwarding_filters_stream_without_validating_2103` uses, one
+/// per malformed shape the codebase keeps deliberately distinct, and real jq
+/// 1.7.1 exits 5 on every cell of this grid -- it parses eagerly, so a fault
+/// anywhere fails every filter. succinctly is a semi-index and does not, and
+/// ADR-0018's #2103 amendment says that where the reference's answer is a
+/// whole-document rejection we deliberately do not perform, we take the
+/// *uniform* divergence rather than the one that depends on spelling. This
+/// grid is that uniformity, asserted.
+///
+/// `1+1` is a row on purpose: it already passed before #2173, and it is the
+/// control that makes the other rows mean something.
+#[test]
+fn test_closed_terms_do_not_validate_2173() -> Result<()> {
+    let docs = [
+        r#"{123:1,"b":2}"#,
+        r#"{"a":1,"b"}"#,
+        r#"{"a":1, invalid}"#,
+        r#"{"a" 1, "b":2}"#,
+        r"[1,,3]",
+        r#"{"\ud800":1,"\ud800":2}"#,
+    ];
+    // (filter, expected stdout) -- the expected output is the *same* on a
+    // malformed document as on any other, which is the property under test.
+    let closed = [
+        ("1+1", "2"),
+        ("[1+1]", "[2]"),
+        ("[range(3)]", "[0,1,2]"),
+        ("range(3)", "0\n1\n2"),
+        ("true and true", "true"),
+        ("false // 1", "1"),
+        (r#"{"k":1}"#, r#"{"k":1}"#),
+        ("if 1==1 then 2 else 3 end", "2"),
+        ("1 as $x | $x", "1"),
+        ("def f: 1; f", "1"),
+        ("[limit(1; 1,2)]", "[1]"),
+        ("empty", ""),
+    ];
+    for doc in docs {
+        for (filter, want) in closed {
+            let (out, err, code) = run_jq_full(&["-c", filter], Some(doc))?;
+            assert_eq!(code, 0, "doc {doc:?} filter {filter:?}, stderr: {err}");
+            assert!(
+                err.is_empty(),
+                "doc {doc:?} filter {filter:?}, stderr: {err}"
+            );
+            assert_eq!(out.trim_end(), want, "doc {doc:?} filter {filter:?}");
+        }
+    }
+
+    // The other half of the rule, and the reason this is a narrowing rather
+    // than a blanket amnesty: a filter that *does* read the document still
+    // validates what it reads (#2168). Without these rows the grid above
+    // would pass just as well if validation had been deleted outright.
+    //
+    // The five structurally-malformed documents raise for every reading
+    // filter. The colliding-key document is the exception, and a
+    // pre-existing one that #2173 does not touch: `.`, `length` and `keys`
+    // never have to resolve `"\ud800"` to a display form, so they echo it
+    // at exit 0 exactly as #2103 recorded, while `. and true` and `not` go
+    // through the validation walk, which does resolve it, and raise #1642's
+    // collision. Encoded as measured rather than assumed -- the first draft
+    // of this test asserted a uniform 5 here and was wrong.
+    let structural = &docs[..5];
+    for doc in structural {
+        for filter in [".", "length", "keys", ". and true", "not"] {
+            let (_out, err, code) = run_jq_full(&["-c", filter], Some(doc))?;
+            assert_eq!(code, 5, "doc {doc:?} filter {filter:?} must still raise");
+            assert!(!err.is_empty(), "doc {doc:?} filter {filter:?}");
+        }
+    }
+    let collision = docs[5];
+    for filter in [".", "length", "keys"] {
+        let (_out, err, code) = run_jq_full(&["-c", filter], Some(collision))?;
+        assert_eq!(code, 0, "`{filter}` on the collision doc, stderr: {err}");
+    }
+    for filter in [". and true", "not"] {
+        let (_out, err, code) = run_jq_full(&["-c", filter], Some(collision))?;
+        assert_eq!(code, 5, "`{filter}` on the collision doc must still raise");
+        assert!(err.contains("ambiguous"), "`{filter}` stderr: {err}");
+    }
+    Ok(())
+}
+
+/// #2173: which `and`/`or` shapes raise on a malformed document, and which
+/// answer.
+///
+/// #2476 ungated `eval_single`'s `Expr::And`/`Expr::Or` arms and had them
+/// run `ambient_validation_error` -- the bridge's ambient rejection without
+/// the bridge's allocation -- for every non-path-context shape. #2173 gates
+/// that walk on whether an operand actually reads `.`, because the wildcard
+/// bridge it stands in for stopped materializing for a closed term at the
+/// same time (`bridge_ambient_input`). Leaving the walk here would have
+/// re-created by hand the very spelling-dependence both changes remove:
+/// `true and true` raising while `1+1` answers, on one document, in one run.
 ///
 /// `test_try_catch_contains_a_genuinely_catchable_malformed_key_error_1812`
 /// pins the catchability rule and
@@ -44147,25 +44278,35 @@ fn test_ambient_validation_agrees_with_bridge_2476() -> Result<()> {
 /// (`test_and_or_over_alias_fanout_completes_2476` in
 /// `tests/yq_cli_tests.rs`), so a regression names itself.
 #[test]
-fn test_and_or_still_raise_on_a_malformed_document_2476() -> Result<()> {
-    for filter in [
-        "true and true",
-        ". and true",
-        "false or true",
-        // Short-circuiting cannot skip the check: it runs before the
-        // operands, exactly where the bridge's materialization used to.
-        "true or false",
-        "false and true",
+fn test_and_or_raise_only_when_an_operand_reads_the_document_2173() -> Result<()> {
+    // Reads `.`, so it validates `.` -- unchanged by #2173.
+    let (stdout, stderr, code) = run_jq_stdin_streams(". and true", "{123: 1}", &[])?;
+    assert_eq!(
+        code, 5,
+        "`. and true` must still reject the document -- stdout: {stdout:?} stderr: {stderr:?}"
+    );
+    assert!(
+        stderr.contains("Invalid JSON text"),
+        "`. and true` -- stderr: {stderr}"
+    );
+
+    // Reads nothing, so it validates nothing. Short-circuiting is not what
+    // decides this and never was: `true or false` never evaluates its right
+    // operand and `false and true` never evaluates its left, yet all four
+    // answer, because the question is what the *expression* can read, not
+    // which operand happens to run.
+    for (filter, want) in [
+        ("true and true", "true"),
+        ("false or true", "true"),
+        ("true or false", "true"),
+        ("false and true", "false"),
     ] {
         let (stdout, stderr, code) = run_jq_stdin_streams(filter, "{123: 1}", &[])?;
         assert_eq!(
-            code, 5,
-            "`{filter}` must still reject the document -- stdout: {stdout:?} stderr: {stderr:?}"
+            code, 0,
+            "`{filter}` reads nothing and must answer -- stdout: {stdout:?} stderr: {stderr:?}"
         );
-        assert!(
-            stderr.contains("Invalid JSON text"),
-            "`{filter}` -- stderr: {stderr}"
-        );
+        assert_eq!(stdout.trim(), want, "`{filter}` -- stderr: {stderr:?}");
     }
 
     Ok(())
@@ -44527,28 +44668,35 @@ fn test_alternative_control_flow_2476() -> Result<()> {
     Ok(())
 }
 
-/// #2476: `//`'s sibling of `test_not_still_raises_on_a_malformed_document_2476`
-/// just above. `Expr::Alternative` had no native arm at all, so unlike
-/// `and`/`or` there was no `needs_path_context` gate to drop -- the new arm
-/// calls `ambient_validation_error` unconditionally, because the whole
-/// construct is the "shape that used to bridge". These rows pin that the walk
-/// raises where the bridge's ambient materialization did: a #1194 malformed
-/// object key (raised for `false // 1`, which reads nothing at all, exactly
-/// as real jq rejects the document for every query), and a #1247 decode
-/// failure the walk actually visits.
+/// #2173: `//`'s sibling of `test_not_still_raises_on_a_malformed_document_2476`
+/// just above. #2476 gave `Expr::Alternative` a native arm that called
+/// `ambient_validation_error` unconditionally, because the whole construct
+/// was the "shape that used to bridge"; #2173 narrowed that to the shape
+/// that *reads*, since the bridge itself no longer materializes for a closed
+/// term either. So `.a // 1` still raises on a #1194 malformed object key
+/// and on a #1247 decode failure the walk visits, while `false // 1` --
+/// which reads nothing at all -- now answers, as `1+1` already did.
 #[test]
-fn test_alternative_still_raises_on_a_malformed_document_2476() -> Result<()> {
-    for filter in ["false // 1", ".a // 1"] {
-        let (stdout, stderr, code) = run_jq_stdin_streams(filter, "{123: 1}", &[])?;
-        assert_eq!(
-            code, 5,
-            "`{filter}` -- stdout: {stdout:?} stderr: {stderr:?}"
-        );
-        assert!(
-            stderr.contains("Invalid JSON text"),
-            "`{filter}` -- stderr: {stderr}"
-        );
-    }
+fn test_alternative_raises_only_when_it_reads_the_document_2173() -> Result<()> {
+    let (stdout, stderr, code) = run_jq_stdin_streams(".a // 1", "{123: 1}", &[])?;
+    assert_eq!(
+        code, 5,
+        "`.a // 1` -- stdout: {stdout:?} stderr: {stderr:?}"
+    );
+    assert!(
+        stderr.contains("Invalid JSON text"),
+        "`.a // 1` -- stderr: {stderr}"
+    );
+
+    // #2173: `false // 1` reads nothing, so it no longer walks the document
+    // and no longer raises -- the same move the wildcard bridge made for
+    // `[1+1]`, applied to the arm that replaced it here.
+    let (stdout, stderr, code) = run_jq_stdin_streams("false // 1", "{123: 1}", &[])?;
+    assert_eq!(
+        code, 0,
+        "`false // 1` reads nothing -- stdout: {stdout:?} stderr: {stderr:?}"
+    );
+    assert_eq!(stdout.trim(), "1", "stderr: {stderr:?}");
 
     let (stdout, stderr, code) = run_jq_stdin_streams("(.[0] // 1)", "[\"\\x\"]", &[])?;
     assert_eq!(code, 5, "stdout: {stdout:?} stderr: {stderr:?}");

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -44227,6 +44227,17 @@ fn test_closed_terms_do_not_validate_2173() -> Result<()> {
         ("def f: 1; f", "1"),
         ("[limit(1; 1,2)]", "[1]"),
         ("empty", ""),
+        // `repeat`'s native arm (`each_repeat_generic`) bridged with
+        // `to_owned_with_cursor` directly instead of the closed-term-aware
+        // `bridge_ambient_input`, so a closed `repeat(f)` kept validating
+        // the whole document after #2173 landed everywhere else.
+        ("[limit(1; repeat(1))]", "[1]"),
+        // `env(NAME)`/`strenv(NAME)` (`Builtin::EnvObject`/`Builtin::StrEnv`)
+        // take no `value` parameter at all, but `node_reads_ambient`'s
+        // allowlist omitted both -- a var guaranteed absent makes the `?`
+        // outcome deterministic across environments.
+        ("[env(NONEXISTENT_VAR_XYZ_2173)?]", "[]"),
+        ("[strenv(NONEXISTENT_VAR_XYZ_2173)?]", "[]"),
     ];
     for doc in docs {
         for (filter, want) in closed {

--- a/tests/jq_closed_term_tests.rs
+++ b/tests/jq_closed_term_tests.rs
@@ -99,6 +99,19 @@ const READING: &[&str] = &[
     "paths",
     "to_entries",
     "getpath([\"a\"])",
+    // Assignments: the output is the document with a modification, so they
+    // read `.` even when path and value are both closed. `(1) = 5` is the
+    // row that caught the missing arm (#1764's no-op turned into `null`).
+    "(1) = 5",
+    "1 = 5",
+    "(1+1) = 5",
+    "(1, 2) = 5",
+    ".a = 5",
+    "1 |= . + 1",
+    ".a += 1",
+    ".a //= 1",
+    "del(.a)",
+    "setpath([\"a\"]; 1)",
 ];
 
 fn outputs(doc: &str, filter: &str) -> Result<Vec<String>, String> {

--- a/tests/jq_closed_term_tests.rs
+++ b/tests/jq_closed_term_tests.rs
@@ -65,6 +65,16 @@ const CLOSED: &[&str] = &[
     "[1,2] as [$a,$b] | $a + $b",
     r#""x\(1+1)y""#,
     "label $out | (1, break $out)",
+    // `repeat`'s native arm materialized unconditionally, bypassing the
+    // predicate entirely -- caught only by a direct malformed-document
+    // probe (`test_closed_terms_do_not_validate_2173`), not this corpus,
+    // but still closed at the predicate level and belongs here too.
+    "[limit(1; repeat(1))]",
+    // `Builtin::EnvObject`/`Builtin::StrEnv` take no value parameter but
+    // were missing from `node_reads_ambient`'s allowlist. A var guaranteed
+    // absent keeps the `?` outcome document-independent.
+    "[env(NONEXISTENT_VAR_XYZ_2173)?]",
+    "[strenv(NONEXISTENT_VAR_XYZ_2173)?]",
 ];
 
 /// Filters that read the input. These must be reported as reading — a

--- a/tests/jq_closed_term_tests.rs
+++ b/tests/jq_closed_term_tests.rs
@@ -28,7 +28,7 @@
 //! them here would only freeze a limitation in place.
 
 use succinctly::jq::walk::reads_ambient_value;
-use succinctly::jq::{eval_generic, parse};
+use succinctly::jq::{eval_generic, parse, parse_with_mode, ParserMode};
 use succinctly::json::JsonIndex;
 
 /// Structurally unrelated, all well-formed: an object, an array, a scalar,
@@ -114,6 +114,19 @@ const READING: &[&str] = &[
     "setpath([\"a\"]; 1)",
 ];
 
+/// yq's metadata-assignment grammar (#798), which only the yq-mode parser
+/// accepts. `PATH <slot> = value` leaves the value alone and answers with
+/// the document, metadata written -- so like every other assignment shape
+/// it reads `.` however closed its operands are. Added when a rebase
+/// brought `Expr::MetaAssign` onto `main` and `node_reads_ambient`'s
+/// exhaustive match refused to compile until it was classified.
+const READING_YQ: &[&str] = &[
+    r#".a line_comment = "hi""#,
+    r#".a style = "flow""#,
+    r#".a anchor = "z""#,
+    r#".a line_comment |= "hi""#,
+];
+
 fn outputs(doc: &str, filter: &str) -> Result<Vec<String>, String> {
     let bytes = doc.as_bytes();
     let index = JsonIndex::build(bytes);
@@ -163,6 +176,15 @@ fn reading_terms_are_reported_as_reading_2173() {
             reads_ambient_value(&expr),
             "`{filter}` reads the input but was reported closed -- \
              `bridge_ambient_input` would evaluate it against null"
+        );
+    }
+    // yq's metadata-assignment grammar (#798) needs the yq-mode parser.
+    for filter in READING_YQ {
+        let expr =
+            parse_with_mode(filter, ParserMode::Yq).expect("yq filter should parse in yq mode");
+        assert!(
+            reads_ambient_value(&expr),
+            "`{filter}` answers with the document and was reported closed"
         );
     }
 }

--- a/tests/jq_closed_term_tests.rs
+++ b/tests/jq_closed_term_tests.rs
@@ -1,0 +1,206 @@
+//! #2173: the soundness of `jq::walk::reads_ambient_value`, tested against
+//! what it *means* rather than against a snapshot of what it currently says.
+//!
+//! The predicate decides whether an expression may be evaluated against
+//! `OwnedValue::Null` instead of a materialized copy of the whole input
+//! document (`bridge_ambient_input` in `src/jq/eval_generic.rs`). A wrong
+//! `true` costs a materialization nobody needed. A wrong `false` silently
+//! evaluates a user's filter against the wrong input — so that direction
+//! needs a test that cannot pass by agreeing with the implementation.
+//!
+//! The invariant here is that test: **if the predicate calls a filter
+//! closed, then the filter's output must not depend on the document.** Every
+//! closed filter is run against several structurally unrelated documents and
+//! every run must agree. A `.` that crept into the allowlist would make one
+//! of them disagree, whatever the predicate believes about itself.
+//!
+//! The reverse direction is deliberately *not* asserted. A pipe whose tail
+//! stage reads its own input — `now | type`, `[1,2,3] | length`,
+//! `reduce (1,2,3) as $x (0; . + $x)` — is closed in truth and reported as
+//! reading, because the walk sees an `Expr::Identity`-shaped read and does
+//! not know that `.` there means the previous stage's output rather than the
+//! document. So is `def f: 1; f` *at parse time*, where `f` is an unresolved
+//! `Expr::FuncCall` with no body to inspect; by the time
+//! `bridge_ambient_input` asks, the call is an `Expr::DefCall` whose body
+//! `any_subexpr` descends into, and the answer is closed. Both imprecisions
+//! are recorded in `reads_ambient_value`'s own doc comment and are safe by
+//! construction — they cost a materialization, never an answer — so pinning
+//! them here would only freeze a limitation in place.
+
+use succinctly::jq::walk::reads_ambient_value;
+use succinctly::jq::{eval_generic, parse};
+use succinctly::json::JsonIndex;
+
+/// Structurally unrelated, all well-formed: an object, an array, a scalar,
+/// an empty container, and a nested mix. If an expression reads *anything*
+/// from the input, one of these five will make it show.
+const DOCS: &[&str] = &[
+    r#"{"a":1,"b":{"c":[2,3]}}"#,
+    r#"[10,20,30]"#,
+    r#""a string""#,
+    r#"{}"#,
+    r#"{"a":[{"z":null},false],"q":"x"}"#,
+];
+
+/// Filters that read nothing. Every one of these must be reported closed
+/// *and* answer identically on all five documents.
+const CLOSED: &[&str] = &[
+    "1",
+    "1+1",
+    "[1+1]",
+    "[range(3)]",
+    "range(3)",
+    "$__loc__",
+    "empty",
+    "true and true",
+    "false or true",
+    "false // 1",
+    "-3",
+    r#"{"k":1}"#,
+    "if 1==1 then 2 else 3 end",
+    "1 as $x | $x",
+    "[limit(2; 1,2,3)]",
+    "first(4,5)",
+    r#"try error("boom") catch "caught""#,
+    "[1,2] as [$a,$b] | $a + $b",
+    r#""x\(1+1)y""#,
+    "label $out | (1, break $out)",
+];
+
+/// Filters that read the input. These must be reported as reading — a
+/// regression here is the dangerous direction, so they are pinned directly
+/// rather than only through the agreement property.
+const READING: &[&str] = &[
+    ".",
+    ".a",
+    ".[0]",
+    ".[]",
+    ".[1:2]",
+    "..",
+    "length",
+    "keys",
+    "not",
+    "@json",
+    "add",
+    "map(1)",
+    "select(true)",
+    ". and true",
+    "range(length; 3)",
+    "error",
+    r#"try error catch "caught""#,
+    "[.[]]",
+    "{k: .a}",
+    "1 + .a",
+    "if . then 1 else 2 end",
+    ". as $x | 1",
+    "def f: .a; f",
+    "[while(. < 3; . + 1)]",
+    "[.[] | 1]",
+    "paths",
+    "to_entries",
+    "getpath([\"a\"])",
+];
+
+fn outputs(doc: &str, filter: &str) -> Result<Vec<String>, String> {
+    let bytes = doc.as_bytes();
+    let index = JsonIndex::build(bytes);
+    let cursor = index.root(bytes);
+    let expr = parse(filter).map_err(|e| format!("parse {filter:?}: {e:?}"))?;
+    let values = eval_generic::eval_with_cursor(&expr, cursor)
+        .collect_owned()
+        .map_err(|e| format!("eval {filter:?}: {e:?}"))?;
+    Ok(values.iter().map(|v| v.to_json()).collect())
+}
+
+/// The soundness property: a filter the predicate calls closed must produce
+/// the same outputs whatever the document is.
+#[test]
+fn closed_terms_ignore_the_document_2173() {
+    for filter in CLOSED {
+        let expr = parse(filter).expect("filter should parse");
+        assert!(
+            !reads_ambient_value(&expr),
+            "`{filter}` should be recognised as closed"
+        );
+
+        let first =
+            outputs(DOCS[0], filter).unwrap_or_else(|e| panic!("`{filter}` on {:?}: {e}", DOCS[0]));
+        for doc in &DOCS[1..] {
+            let got = outputs(doc, filter).unwrap_or_else(|e| panic!("`{filter}` on {doc:?}: {e}"));
+            assert_eq!(
+                got, first,
+                "`{filter}` is reported closed but its output depends on the document \
+                 ({:?} vs {doc:?})",
+                DOCS[0]
+            );
+        }
+    }
+}
+
+/// The dangerous direction, pinned directly: anything that reads the input
+/// must say so, or `bridge_ambient_input` will hand it `null`.
+#[test]
+fn reading_terms_are_reported_as_reading_2173() {
+    for filter in READING {
+        let expr = parse(filter).expect("filter should parse");
+        assert!(
+            reads_ambient_value(&expr),
+            "`{filter}` reads the input but was reported closed -- \
+             `bridge_ambient_input` would evaluate it against null"
+        );
+    }
+}
+
+/// Bare `error` raises `.` itself, and `any_subexpr` gives `Expr::Error(None)`
+/// no child to catch that on — the one case in `node_reads_ambient` that
+/// needed its own arm rather than falling out of the recursion. Pinned
+/// separately because the corpus above would keep passing if the arm were
+/// deleted and the filter merely reported closed by accident of some other
+/// node.
+#[test]
+fn bare_error_reads_the_document_2173() {
+    assert!(reads_ambient_value(&parse("error").expect("parses")));
+    assert!(reads_ambient_value(
+        &parse("try error catch .").expect("parses")
+    ));
+    // `error(f)` has a child, so it is closed exactly when `f` is.
+    assert!(!reads_ambient_value(
+        &parse(r#"error("boom")"#).expect("parses")
+    ));
+    assert!(reads_ambient_value(&parse("error(.a)").expect("parses")));
+}
+
+/// The `Builtin` allowlist in `node_reads_ambient`, asserted at the
+/// predicate level only.
+///
+/// These answer from the clock, the environment or the language rather than
+/// from `.`, so they are closed — but `now` and `env` are not *constant*,
+/// which is why they cannot ride in the agreement corpus above. Every other
+/// builtin must be reported as reading, including ones whose arguments are
+/// themselves closed: `map(1)` and `select(true)` both iterate or test `.`
+/// however innocent their argument looks, and that distinction is the whole
+/// reason the allowlist is an allowlist rather than "has no children".
+#[test]
+fn input_independent_builtins_are_closed_2173() {
+    for filter in ["now", "empty", "env", "builtins", "nan", "infinite"] {
+        let expr = parse(filter).expect("filter should parse");
+        assert!(
+            !reads_ambient_value(&expr),
+            "`{filter}` answers from outside the document and should be closed"
+        );
+    }
+    for filter in [
+        "map(1)",
+        "select(true)",
+        "has(\"a\")",
+        "length",
+        "type",
+        "tostring",
+    ] {
+        let expr = parse(filter).expect("filter should parse");
+        assert!(
+            reads_ambient_value(&expr),
+            "`{filter}` consults `.` however closed its argument is"
+        );
+    }
+}

--- a/tests/jq_closed_term_tests.rs
+++ b/tests/jq_closed_term_tests.rs
@@ -36,9 +36,9 @@ use succinctly::json::JsonIndex;
 /// from the input, one of these five will make it show.
 const DOCS: &[&str] = &[
     r#"{"a":1,"b":{"c":[2,3]}}"#,
-    r#"[10,20,30]"#,
+    "[10,20,30]",
     r#""a string""#,
-    r#"{}"#,
+    "{}",
     r#"{"a":[{"z":null},false],"q":"x"}"#,
 ];
 
@@ -122,7 +122,10 @@ fn outputs(doc: &str, filter: &str) -> Result<Vec<String>, String> {
     let values = eval_generic::eval_with_cursor(&expr, cursor)
         .collect_owned()
         .map_err(|e| format!("eval {filter:?}: {e:?}"))?;
-    Ok(values.iter().map(|v| v.to_json()).collect())
+    Ok(values
+        .iter()
+        .map(succinctly::jq::OwnedValue::to_json)
+        .collect())
 }
 
 /// The soundness property: a filter the predicate calls closed must produce

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -21843,6 +21843,20 @@ fn test_yq_untracked_bare_noncomma_branch_noop_1764() -> Result<()> {
         assert_eq!(code, 0, "{filter}");
         let v: serde_json::Value = serde_json::from_str(&out)?;
         assert_eq!(v, serde_json::json!({"a": 1}), "{filter}");
+
+        // #2173: the same filters on the *default* YAML route, and through
+        // a following pipe stage. `-o json` is a DOM-forcing flag, so the
+        // rows above do not exercise the route ordinary `succinctly yq`
+        // takes -- an early cut of #2173's closed-term predicate answered
+        // `null` here while every `-o json` row above still passed.
+        let (out, code) = run_yq_stdin(filter, "a: 1\nb: 2\n", &[])?;
+        assert_eq!(code, 0, "{filter} (yaml route)");
+        assert_eq!(out.trim(), "a: 1\nb: 2", "{filter} (yaml route)");
+
+        let piped = format!("{filter} | length");
+        let (out, code) = run_yq_stdin(&piped, "a: 1\nb: 2\n", &[])?;
+        assert_eq!(code, 0, "{piped}");
+        assert_eq!(out.trim(), "2", "{piped}");
     }
     Ok(())
 }

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -39823,6 +39823,73 @@ fn test_and_or_over_alias_fanout_completes_2476() -> Result<()> {
     Ok(())
 }
 
+/// #2173: the wildcard bridge's own fan-out repro — the peak-work
+/// regression test the issue asks for, expressed as termination.
+///
+/// #2476 fixed the `and`/`or`/`not`/`//` arms; every *other* closed term
+/// still fell to `eval_single`'s wildcard, which materializes the ambient
+/// value through `to_owned_with_cursor`. On an alias fan-out that value
+/// expands to `O(2^N)`, so a 23-line document was enough to make `1+1` take
+/// longer than anyone would wait — for an input it never reads.
+///
+/// The same method as `test_and_or_over_alias_fanout_completes_2476` above,
+/// and for the same reason: **no wall-clock bound is asserted.** A
+/// regression to `O(2^N)` announces itself by hanging the suite, and a
+/// threshold would only add flakiness under this suite's own subprocess
+/// contention. What the test asserts is that the process finishes and gives
+/// the right answer.
+///
+/// Measured on the two binaries either side of the change, `yq '''1+1'''` on
+/// this document shape — the pre-fix column quadruples for every two levels
+/// while the post-fix column does not move at all, which is the removed
+/// term made visible:
+///
+/// | N  | bytes | before  | after  |
+/// |----|-------|---------|--------|
+/// | 18 | 389   | 0.33 s  | 0.00 s |
+/// | 20 | 435   | 1.31 s  | 0.00 s |
+/// | 22 | 481   | 5.38 s  | 0.00 s |
+/// | 24 | 527   | 22.70 s | 0.01 s |
+///
+/// N=26 is used below — around 90 s per filter before the fix and six
+/// filters to get through, so a regression does not merely run slowly, it
+/// stops the suite. It costs nothing to assert, because the post-fix side
+/// is flat: a closed term never looks at the document, so the fan-out is
+/// never expanded and N does not enter the cost at all. (A regression that
+/// reinstated only the *walk* — `O(N)` rather than `O(2^N)`, as #2476's
+/// arms do — would still pass here, and rightly: this test is about the
+/// materialization, and `test_closed_terms_do_not_validate_2173` in
+/// `jq_cli_tests.rs` is what pins the walk's absence.)
+///
+/// Every filter here is a closed term, and none of them mentions `a26` —
+/// that is the point. The cost never came from what they read; it came from
+/// the route they took.
+#[test]
+fn test_wildcard_bridge_over_alias_fanout_completes_2173() -> Result<()> {
+    let mut doc = String::from("a0: &a0 leaf\n");
+    for i in 1..=26 {
+        doc.push_str(&format!("a{i}: &a{i} [*a{}, *a{}]\n", i - 1, i - 1));
+    }
+
+    for (filter, want) in [
+        ("1+1", "2"),
+        ("[1+1]", "- 2"),
+        ("1 as $x | $x", "1"),
+        ("if 1==1 then 2 else 3 end", "2"),
+        ("false // 1", "1"),
+        // No `limit`/`range`/`now` rows: yq's own lexer rejects them
+        // without `--jq-extensions` (#1512), so their fan-out cost is
+        // pinned on the jq side instead.
+        (r#"{"k": 1}"#, "k: 1"),
+    ] {
+        let (stdout, stderr, code) = run_yq_stdin_with_stderr(filter, &doc, &[])?;
+        assert_eq!(code, 0, "`{filter}` -- stderr: {stderr:?}");
+        assert_eq!(stdout.trim(), want, "`{filter}` -- stderr: {stderr:?}");
+    }
+
+    Ok(())
+}
+
 /// #2476's one behaviour change: #1804's accepted trade-off, now shared by
 /// `and`/`or`.
 ///

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -39745,14 +39745,15 @@ fn test_ambient_validation_agrees_with_bridge_2476() -> Result<()> {
         ("false root", "false\n", 0, ""),
         ("well-formed", "a: [1, {b: c}]\n", 0, ""),
     ];
-    let probes = [
-        "select(.) | 1",
-        "true and true",
-        "false or true",
-        ". and true",
-        "not",
-        "false // 1",
-        "(.a? // 1) | 1",
+    // #2173 moved the closed terms out of this list -- see the jq twin's
+    // own comment. They no longer validate anything, so they cannot agree
+    // with `select(.) | 1` on a malformed row and are pinned separately
+    // below.
+    let probes = ["select(.) | 1", ". and true", "not", "(.a? // 1) | 1"];
+    let closed_probes = [
+        ("true and true", "true"),
+        ("false or true", "true"),
+        ("false // 1", "1"),
     ];
     for (label, doc, want_code, want_stderr) in corpus {
         let mut seen: Vec<(String, i32, String)> = Vec::new();
@@ -39776,6 +39777,27 @@ fn test_ambient_validation_agrees_with_bridge_2476() -> Result<()> {
                 (ref_code, ref_first),
                 "[{label}] `{probe}` disagrees with `select(.) | 1`"
             );
+        }
+        // #2173: a closed term answers exactly as `empty` does -- the
+        // filter that reads nothing and does nothing. Pinning against
+        // `empty` rather than a hard-coded exit code keeps the rows where
+        // the *reader* rejects the file (rather than a filter validating
+        // it) honest without listing them by label. See the jq twin.
+        let (_, _, empty_code) = run_yq_stdin_with_stderr("empty", doc, &[])?;
+        for (probe, want_stdout) in closed_probes {
+            let (stdout, stderr, code) = run_yq_stdin_with_stderr(probe, doc, &[])?;
+            assert_eq!(
+                code, empty_code,
+                "[{label}] closed `{probe}`: exit {code}, but `empty` exits \
+                 {empty_code}\nstderr: {stderr}"
+            );
+            if empty_code == 0 {
+                assert_eq!(
+                    stdout.trim(),
+                    want_stdout,
+                    "[{label}] closed `{probe}`: stdout {stdout:?}"
+                );
+            }
         }
     }
     Ok(())
@@ -39916,9 +39938,28 @@ fn test_and_or_no_longer_raise_through_a_container_alias_2476() -> Result<()> {
     let doc = "a: &a [\"bad\\qc\"]\nb: *a\n";
 
     // The alias position: the walk stops at the alias, so the boolean
-    // answers instead of raising. This is the row that changed (exit 1
-    // before, exit 0 now).
-    for filter in [".b | (true and true)", ".b | (false or true)"] {
+    // answers instead of raising. This is the row #2476 changed (exit 1
+    // before it, exit 0 after).
+    //
+    // Spelled with a `.` operand since #2173. `true and true` no longer
+    // walks at *any* position -- it reads nothing, so it validates nothing
+    // -- which would make these rows pass for the wrong reason and stop
+    // saying anything about aliases at all. `. and true` reads, so it
+    // still walks, and the alias short-circuit is still what decides it.
+    for filter in [".b | (. and true)", ".b | (false or .)"] {
+        let (stdout, stderr, code) = run_yq_stdin_with_stderr(filter, doc, &[])?;
+        assert_eq!(code, 0, "`{filter}` -- stderr: {stderr:?}");
+        assert_eq!(stdout.trim(), "true", "`{filter}` -- stderr: {stderr:?}");
+    }
+
+    // #2173's own row, here so the contrast is visible in one place: the
+    // closed spelling answers at every position, including the two that
+    // raise below.
+    for filter in [
+        "true and true",
+        ".a | (true and true)",
+        ".b | (true and true)",
+    ] {
         let (stdout, stderr, code) = run_yq_stdin_with_stderr(filter, doc, &[])?;
         assert_eq!(code, 0, "`{filter}` -- stderr: {stderr:?}");
         assert_eq!(stdout.trim(), "true", "`{filter}` -- stderr: {stderr:?}");
@@ -39933,7 +39974,7 @@ fn test_and_or_no_longer_raise_through_a_container_alias_2476() -> Result<()> {
     );
 
     // ...and so does the same boolean at the anchor itself.
-    let (_, stderr, code) = run_yq_stdin_with_stderr(".a | (true and true)", doc, &[])?;
+    let (_, stderr, code) = run_yq_stdin_with_stderr(".a | (. and true)", doc, &[])?;
     assert_ne!(code, 0, "stderr: {stderr:?}");
     assert!(
         stderr.contains("invalid escape sequence"),
@@ -39944,7 +39985,7 @@ fn test_and_or_no_longer_raise_through_a_container_alias_2476() -> Result<()> {
     // so a root-level `and` raises too -- the corpus test's own
     // "anchored container" row, restated here so the three positions this
     // test cares about sit together.
-    let (_, stderr, code) = run_yq_stdin_with_stderr("true and true", doc, &[])?;
+    let (_, stderr, code) = run_yq_stdin_with_stderr(". and true", doc, &[])?;
     assert_ne!(code, 0, "stderr: {stderr:?}");
     assert!(
         stderr.contains("invalid escape sequence"),


### PR DESCRIPTION
Closes #2173.

## The problem

Every bridge into the eager evaluator materializes the *ambient* value through `to_owned_with_cursor` — a complete `OwnedValue` copy of the document, re-serialized and re-indexed — purely so `eval_on_owned`/`eval_each_owned` have an input to run against. A filter that reads nothing paid for it anyway, and which filters those were depended on nothing but which `match` arm the parser happened to hand them.

On a 16 MB document, `1+1` peaked at 29 MB and `[1+1]` at 443 MB. Same closed term, same answer.

## The fix

`bridge_ambient_input` hands a closed term — one that `jq::walk::reads_ambient_value` proves cannot consult `.` — `OwnedValue::Null` instead. Five sites: the three `bridge_to_*` helpers and the two hand-inlined wildcards in `eval_single` and `eval_builtin`.

Peak RSS against merge-base `ab350e9f4`, interleaved, min of 3, three input sizes. The "before" column tracks document size; the "after" column is flat at the baseline a filter with a native arm already had:

| filter | 1 MB | 16 MB | 96 MB |
|---|---|---|---|
| `1` (baseline) | 10 → 10 | 29 → 29 | 129 → 129 |
| `[1+1]` | 31 → 10 | 442 → 29 | **2589 → 129** |
| `[range(3)]` | 31 → 10 | 443 → 29 | 2590 → 129 |
| `now\|floor` | 31 → 10 | 443 → 29 | 2589 → 129 |
| `$__loc__` | 31 → 10 | 443 → 29 | 2591 → 129 |
| `false // 1` | 31 → 10 | 443 → 29 | 2592 → 129 |
| `true and true` | 27 → 10 | 349 → 29 | 2032 → 129 |
| `. and true` *(reads `.`)* | 40 → 39 | 595 → 595 | 3515 → 3515 |
| `.` *(reads `.`)* | 12 → 12 | 62 → 62 | 440 → 440 |

yq is affected more, because every `succinctly yq` filter takes `eval_single`: `1+1` on a 30 MB document goes 476 MB / 0.90 s → 126 MB / 0.11 s against a 125 MB baseline.

## The behaviour change, and why it is the sanctioned one

That materialization was also validating, as a side effect of walking the whole document. Real jq and yq parse eagerly, so a malformed document fails every filter; succinctly is a semi-index and does not, so the rejection fired only for the spellings that happened to reach a bridge. On `{123: 1, "b": 2}` one binary answered `1+1` with `2` at exit 0 and rejected `[1+1]` at exit 5.

**ADR-0018's #2103 amendment governs exactly this class** — where the reference's answer is a whole-document rejection the semi-index deliberately does not perform, take the *uniform* divergence, the one under which a value is treated the same however the filter spells its way to it. A closed term now validates nothing, in either mode, matching what `1+1` has done on jq's streaming route since #2103. Recorded in both compliance pages and listed as an instance in the ADR.

Oracle rows captured live, not recalled — jq 1.7.1 and yq v4.53.3, both of which reject these documents at parse time whatever the filter.

**#2476's arms moved with it.** `and`/`or`/`//` had been given `ambient_validation_error` days earlier for the same shapes. Keeping the walk there while the bridge stopped raising would have re-created the split by hand, so it is now charged only to an operand that reads `.`. `not` is unchanged — it reads `.`'s truthiness.

**What did not move:** filters that read `.` (`. as $x | $x`, `[.]`, `{k: .}`, `. and true`, `range(length; 3)`, `.` itself); the materializing flag routes `-S`/`-a`/`-s`/`-C`/`-n`, which never reach these sites and are #2662's; and documents whose *root* the reader cannot delimit (`xyz123`, `[1,2`, `["a`, `[1] x`), where even `empty` still fails because there is no value to skip reading.

## The predicate

`reads_ambient_value` is `any_subexpr` plus a leaf classifier, so it inherits that walker's exhaustiveness over both `Expr` and `Builtin`. It is conservative in exactly one direction: anything unclear reports "reads". A wrong "reads" costs a materialization; a wrong "closed" would evaluate a filter against the wrong input.

Both guards earned their keep during this PR:

- The existing suite caught a wrong-`false` on **assignments**. `(1) = 5` has a literal path and a literal value, but its *output is the modified document*, so it reads `.`; the first cut answered `null` where yq's no-op for an untracked path (#1764) is the unchanged document.
- The **exhaustive match** caught `Expr::MetaAssign`, which landed on `main` mid-PR: a build failure rather than a silent "closed".

Deliberately imprecise about pipes — `now | type` is closed in truth and reported as reading, because the walk does not know that `.` there means the previous stage's output. That costs a materialization, never an answer; a refinement is filed as follow-up.

## Tests

- **`tests/jq_closed_term_tests.rs`** — the soundness property, tested against what the predicate *means* rather than a snapshot: if it calls a filter closed, that filter's output must be identical across five structurally unrelated documents. Plus the dangerous direction pinned directly (38 reading spellings, including 10 assignment forms and 4 yq metadata forms).
- **`test_closed_terms_do_not_validate_2173`** — the uniformity pin: 12 closed spellings × 6 malformed documents all answer at exit 0 with the output they give on a well-formed one, and 5 reading spellings still raise on all of them.
- **`test_wildcard_bridge_over_alias_fanout_completes_2173`** (yq, N=26) — the peak-work guard, as termination rather than a threshold, following `test_and_or_over_alias_fanout_completes_2476`. On #1804's fan-out shape the ambient materialization is `O(2^N)`: measured 0.33 / 1.31 / 5.38 / 22.70 s for N=18/20/22/24 before, and flat 0.00 s after.
- The two `test_ambient_validation_agrees_with_bridge_2476` corpora split their probe lists — reading probes keep the agreement assertion; closed probes are pinned against `empty`, the filter that reads nothing and does nothing, which states the claim without hard-coding which rows the *reader* rejects.
- **`test_yq_untracked_bare_noncomma_branch_noop_1764`** gained plain-YAML-route rows. It ran only with `-o json`, a DOM-forcing flag, which is why the assignment bug passed it; negative-tested by reverting the fix.

## Verification

- 61 suites, 8045 tests, green under CI's feature set; both clippy legs, `no_std`, `cargo fmt`, `cargo doc` with `-D warnings`.
- Output identity against the merge-base binary over 100 filter×document configurations in both modes: zero differ. Golden suites unchanged.
- Predicate overhead measured where it cannot help — a bridge site reached once per element over a 200k-element array — and is neutral-to-faster (`[.[] | 1+1] | length` 0.23 s → 0.10 s).
- `perf-guard`'s six baseline queries are all `.`/`keys_unsorted`, which read the document and are unchanged (0.15 s → 0.15 s, 0.03 s → 0.03 s); valgrind is macOS-unavailable, so the CI Linux legs confirm the instruction counts.

Timings are indicative single runs on a laptop that was **not** idle (~370-490% total CPU from the concurrent fleet) and are not an interleaved A/B in the sense `docs/guides/benchmarking.md` means. The peak-RSS figures, which are the claim, are interleaved, min-of-3, and deterministic under that load.

## Follow-ups to file

- Native cursor-forwarding arms so operands that read `.` also stop materializing: `Expr::Range`, and ungating `And`/`Or`/`Alternative` in `eval_each_generic`. Evidence above: `. and true` 3515 MB, `range(length; 3)` 444 MB at 96 MB input.
- Remove the now-dead `needs_path_context` gates on `eval_single`'s `Arithmetic`/`Negate`.
- `Pipe`-aware refinement of `reads_ambient_value`, so `1 | .` is recognised as closed.
- Should `. and true` validate the *whole* document when all it reads is the root's truthiness? #2103's rule says no; #2476's arm says yes. Left open deliberately.