### PR TITLE
feat(yaml): capture standalone comment lines into head/foot (#798)

### DIFF
--- a/benches/yaml_bench.rs
+++ b/benches/yaml_bench.rs
@@ -26,6 +26,30 @@ fn generate_simple_kv(pairs: usize) -> Vec<u8> {
     yaml
 }
 
+/// Generate a mapping carrying YAML comments (#798).
+///
+/// Every `ratio`-th entry is preceded by a standalone comment line when
+/// `standalone`, or carries a trailing one when not. Until this existed the
+/// whole `yaml_bench` corpus held no YAML comment at all -- every `#` in
+/// this file was a Rust doc comment -- so the parser's comment capture was
+/// structurally invisible to it, and an A/B of that code measured only
+/// noise. A benchmark cannot measure a shape it does not generate.
+fn generate_commented(pairs: usize, ratio: usize, standalone: bool) -> Vec<u8> {
+    let mut yaml = Vec::with_capacity(pairs * 32);
+    for i in 0..pairs {
+        let commented = ratio != 0 && i % ratio == 0;
+        if commented && standalone {
+            yaml.extend_from_slice(b"# a standalone comment line\n");
+        }
+        if commented && !standalone {
+            yaml.extend_from_slice(format!("key{i}: value{i} # a trailing comment\n").as_bytes());
+        } else {
+            yaml.extend_from_slice(format!("key{i}: value{i}\n").as_bytes());
+        }
+    }
+    yaml
+}
+
 /// Generate nested mapping structure.
 /// Creates a tree with specified depth and width at each level.
 fn generate_nested(depth: usize, width: usize) -> Vec<u8> {
@@ -517,6 +541,33 @@ fn bench_crlf(c: &mut Criterion) {
     group.finish();
 }
 
+/// Comment capture cost (#798): standalone `#` lines land in each node's
+/// `head`/`foot`, trailing ones in its `line`. `every_4th`/`every_2nd` bound
+/// how much a comment-dense document pays; `none` is the control, and must
+/// stay level with `yaml/simple_kv/1000`.
+fn bench_comments(c: &mut Criterion) {
+    let mut group = c.benchmark_group("yaml/comments");
+
+    for &(label, ratio, standalone) in &[
+        ("none", 0usize, true),
+        ("standalone_every_4th", 4, true),
+        ("standalone_every_2nd", 2, true),
+        ("trailing_every_4th", 4, false),
+        ("trailing_every_2nd", 2, false),
+    ] {
+        let yaml = generate_commented(1000, ratio, standalone);
+        group.throughput(Throughput::Bytes(yaml.len() as u64));
+        group.bench_with_input(BenchmarkId::from_parameter(label), &yaml, |b, yaml| {
+            b.iter(|| {
+                let index = YamlIndex::build(black_box(yaml)).unwrap();
+                black_box(index)
+            });
+        });
+    }
+
+    group.finish();
+}
+
 criterion_group!(
     benches,
     bench_simple_kv,
@@ -529,5 +580,6 @@ criterion_group!(
     bench_anchors,
     bench_prose_scalars,
     bench_crlf,
+    bench_comments,
 );
 criterion_main!(benches);

--- a/src/yaml/index.rs
+++ b/src/yaml/index.rs
@@ -1179,11 +1179,11 @@ mod tests {
         let index = YamlIndex::build(yaml).expect("valid YAML");
         let root = index.root(yaml);
         let YamlValue::Sequence(docs) = root.value() else {
-            panic!("root is always the virtual document sequence");
+            panic!("root is always the virtual document sequence"); // omni-dev: coverage tolerate-line reason="unreachable: YamlIndex::build always wraps the parsed document(s) in a virtual root Sequence, at TY index 0 (#798)"
         };
         let (doc_cursor, _) = docs.uncons_cursor().expect("at least one document");
         let YamlValue::Mapping(fields) = doc_cursor.value() else {
-            panic!("expected a mapping document");
+            panic!("expected a mapping document"); // omni-dev: coverage tolerate-line reason="unreachable: every fixture field_key_head_foot is called with in this test module is a top-level mapping (#798)"
         };
         for field in fields {
             if let YamlValue::String(k) = field.key() {
@@ -1194,9 +1194,9 @@ mod tests {
                         raw_lines(yaml, index.get_foot_comments(bp)),
                     );
                 }
-            }
+            } // omni-dev: coverage tolerate-line reason="unreachable: a mapping key is always emitted as YamlValue::String -- it is never type-inferred like a value (#222), so this if-let's pattern can never fail to match (#798)"
         }
-        panic!("key {key} not found");
+        panic!("key {key} not found"); // omni-dev: coverage tolerate-line reason="unreachable: every call to field_key_head_foot in this test module passes a key that the fixture's mapping actually has (#798)"
     }
 
     /// `head`/`foot` of a top-level sequence item's *content* node.
@@ -1206,11 +1206,11 @@ mod tests {
         let index = YamlIndex::build(yaml).expect("valid YAML");
         let root = index.root(yaml);
         let YamlValue::Sequence(docs) = root.value() else {
-            panic!("root is always the virtual document sequence");
+            panic!("root is always the virtual document sequence"); // omni-dev: coverage tolerate-line reason="unreachable: YamlIndex::build always wraps the parsed document(s) in a virtual root Sequence, at TY index 0 (#798)"
         };
         let (doc_cursor, _) = docs.uncons_cursor().expect("at least one document");
         let YamlValue::Sequence(items) = doc_cursor.value() else {
-            panic!("expected a sequence document");
+            panic!("expected a sequence document"); // omni-dev: coverage tolerate-line reason="unreachable: every fixture seq_item_head_foot is called with in this test module is a top-level sequence (#798)"
         };
         let mut rest = items;
         for _ in 0..idx {
@@ -1233,7 +1233,7 @@ mod tests {
         let index = YamlIndex::build(yaml).expect("valid YAML");
         let root = index.root(yaml);
         let YamlValue::Sequence(docs) = root.value() else {
-            panic!("root is always the virtual document sequence");
+            panic!("root is always the virtual document sequence"); // omni-dev: coverage tolerate-line reason="unreachable: YamlIndex::build always wraps the parsed document(s) in a virtual root Sequence, at TY index 0 (#798)"
         };
         let (doc_cursor, _) = docs.uncons_cursor().expect("at least one document");
         let bp = doc_cursor.bp_position();
@@ -1251,21 +1251,21 @@ mod tests {
         let index = YamlIndex::build(yaml).expect("valid YAML");
         let root = index.root(yaml);
         let YamlValue::Sequence(docs) = root.value() else {
-            panic!("root is always the virtual document sequence");
+            panic!("root is always the virtual document sequence"); // omni-dev: coverage tolerate-line reason="unreachable: YamlIndex::build always wraps the parsed document(s) in a virtual root Sequence, at TY index 0 (#798)"
         };
         let (doc_cursor, _) = docs.uncons_cursor().expect("at least one document");
         let YamlValue::Mapping(fields) = doc_cursor.value() else {
-            panic!("expected a mapping document");
+            panic!("expected a mapping document"); // omni-dev: coverage tolerate-line reason="unreachable: every fixture nested_key_head_foot is called with in this test module is a top-level mapping (#798)"
         };
         for field in fields {
             let YamlValue::String(k) = field.key() else {
-                continue;
+                continue; // omni-dev: coverage tolerate-line reason="unreachable: a mapping key is always emitted as YamlValue::String -- it is never type-inferred like a value (#222), so this let-else's pattern can never fail to match (#798)"
             };
             if k.raw_bytes() != outer.as_bytes() {
                 continue;
             }
             let YamlValue::Mapping(inner_fields) = field.value() else {
-                panic!("expected a nested mapping under {outer}");
+                panic!("expected a nested mapping under {outer}"); // omni-dev: coverage tolerate-line reason="unreachable: every fixture nested_key_head_foot is called with has a nested mapping under `outer` (#798)"
             };
             for inner_field in inner_fields {
                 if let YamlValue::String(ik) = inner_field.key() {
@@ -1276,10 +1276,10 @@ mod tests {
                             raw_lines(yaml, index.get_foot_comments(bp)),
                         );
                     }
-                }
+                } // omni-dev: coverage tolerate-line reason="unreachable: a mapping key is always emitted as YamlValue::String -- it is never type-inferred like a value (#222), so this if-let's pattern can never fail to match (#798)"
             }
         }
-        panic!("nested key {outer}.{inner} not found");
+        panic!("nested key {outer}.{inner} not found"); // omni-dev: coverage tolerate-line reason="unreachable: every call to nested_key_head_foot in this test module passes an outer.inner pair that the fixture actually has (#798)"
     }
 
     /// `head`/`foot` of the virtual root sequence itself — where a
@@ -1381,6 +1381,40 @@ mod tests {
         assert_eq!(doc_head, ["# l1", "# l2"]);
         let (doc_head, _) = doc_head_foot(b"# lead\n\na: 1\n");
         assert_eq!(doc_head, ["# lead"]);
+    }
+
+    #[test]
+    fn a_blank_first_line_before_a_leading_comment_is_still_a_head_798() {
+        // The document's very first line is itself blank, so there is no
+        // "line before" the comment to be blank in turn -- `blank_line_precedes`
+        // must treat start-of-input as "not blank" rather than reading behind
+        // position 0. Attachment is unaffected either way: nothing has opened
+        // yet, so the leading block still lands on the document as its head,
+        // same as the no-leading-blank case above.
+        let (doc_head, _) = doc_head_foot(b"\n# lead\na: 1\n");
+        assert_eq!(doc_head, ["# lead"]);
+    }
+
+    #[test]
+    fn nested_key_lookup_skips_earlier_non_matching_top_level_and_inner_keys_798() {
+        // Walk past a non-matching top-level key and a non-matching inner key
+        // before finding the target -- exercises the "keep looking" branch at
+        // both levels of the nested-key walk.
+        let yaml = b"x:\n  y: 1\na:\n  z: 1\n  # inner\n  b: 1\n";
+        let (head, _) = nested_key_head_foot(yaml, "a", "b");
+        assert_eq!(head, ["# inner"]);
+    }
+
+    #[test]
+    fn a_comment_between_a_directive_and_the_document_start_is_a_head_798() {
+        // The second whole-line-comment funnel: `skip_directive_gap_whitespace`
+        // (not `skip_newlines`) is what consumes a comment sitting between a
+        // `%YAML` directive and the document's `---`. It must still land on
+        // the document's content node as a head, same as any other leading
+        // block -- the directive itself carries no comment of its own.
+        let (doc_head, doc_foot) = doc_head_foot(b"%YAML 1.2\n# comment\n---\n\"foo\"\n");
+        assert_eq!(doc_head, ["# comment"]);
+        assert!(doc_foot.is_empty(), "{doc_foot:?}");
     }
 
     #[test]

--- a/src/yaml/index.rs
+++ b/src/yaml/index.rs
@@ -73,8 +73,7 @@ pub struct YamlIndex<W = Vec<u64>> {
     /// anchor, so this is a single side table, not three (#224).
     tags: BTreeMap<usize, String>,
     /// Head/line/foot comments, keyed by the BP position of the owning node.
-    /// See [`NodeComments`] -- only `line` (issue #710) is captured today;
-    /// `head`/`foot` are always empty (#798 PR2).
+    /// See [`NodeComments`].
     comments: BTreeMap<usize, NodeComments>,
     /// Line starts for line/column lookup (built lazily on first use).
     /// Only needed by `to_line_column()` and `to_offset()` (used by the
@@ -541,17 +540,20 @@ impl<W: AsRef<[u64]>> YamlIndex<W> {
         self.comments.get(&bp_pos).and_then(|c| c.line)
     }
 
-    /// Get the standalone `#` comment lines directly above a BP position
-    /// (#798 PR2). Always empty today -- capturing these is separate,
-    /// follow-up work; this getter exists only so that work has a stable
-    /// place to read from.
+    /// Get the standalone `#` comment lines directly above a BP position:
+    /// its *head* comment (#798), one entry per line in source order.
+    ///
+    /// Ranges are raw, `#` included, like [`Self::get_line_comment`] --
+    /// the caller strips a leading `"# "` at the point of use. A mapping
+    /// entry's head lives on its *key* node; a sequence item's on the
+    /// item's content node.
     #[inline]
     pub fn get_head_comments(&self, bp_pos: usize) -> &[(u32, u32)] {
         self.comments.get(&bp_pos).map_or(&[], |c| &c.head)
     }
 
-    /// Get the standalone `#` comment lines directly below a BP position
-    /// (#798 PR2). Always empty today -- see [`Self::get_head_comments`].
+    /// Get the standalone `#` comment lines directly below a BP position:
+    /// its *foot* comment (#798). See [`Self::get_head_comments`].
     #[inline]
     pub fn get_foot_comments(&self, bp_pos: usize) -> &[(u32, u32)] {
         self.comments.get(&bp_pos).map_or(&[], |c| &c.foot)
@@ -1065,12 +1067,13 @@ mod tests {
     }
 
     #[test]
-    fn test_head_and_foot_comments_always_empty_798() {
-        // head/foot comment capture is deliberately unimplemented today
-        // (#798 PR2) -- these getters exist only so that follow-up work has
-        // a stable place to read from. Exercise both the "position has
-        // other comment metadata" (`Some(NodeComments)`) and "position has
-        // none at all" (`None`) paths through the `map_or` default.
+    fn test_head_and_foot_comments_empty_without_standalone_lines_798() {
+        // Standalone comment lines are captured now (see the attachment
+        // tests below), but a document with none must leave both slots
+        // empty -- and a *trailing* comment must land in `line` only, never
+        // in head/foot. Exercises both the "position has other comment
+        // metadata" (`Some(NodeComments)`) and "position has none at all"
+        // (`None`) paths through the getters' `map_or` default.
         let yaml = b"a: 1 # keep this\nb: 2\n";
         let index = YamlIndex::build(yaml).expect("valid YAML");
         let root = index.root(yaml);
@@ -1153,6 +1156,315 @@ mod tests {
             }
         }
         None
+    }
+
+    /// Helpers for the standalone head/foot comment capture (#798). Each
+    /// returns the raw `#...` text of every captured line, in source order.
+    ///
+    /// White-box on purpose: nothing exposes `head`/`foot` to a query yet
+    /// (that is the follow-up PR's job), so the index getters are the only
+    /// surface where the capture can be pinned. Every expectation in the
+    /// tests below was captured from pinned `yq` v4.53.3 first.
+    fn raw_lines(yaml: &[u8], ranges: &[(u32, u32)]) -> Vec<String> {
+        ranges
+            .iter()
+            .map(|&(s, e)| String::from_utf8_lossy(&yaml[s as usize..e as usize]).into_owned())
+            .collect()
+    }
+
+    /// `head`/`foot` of a top-level mapping entry's *key* node.
+    fn field_key_head_foot(yaml: &[u8], key: &str) -> (Vec<String>, Vec<String>) {
+        use crate::yaml::light::YamlValue;
+
+        let index = YamlIndex::build(yaml).expect("valid YAML");
+        let root = index.root(yaml);
+        let YamlValue::Sequence(docs) = root.value() else {
+            panic!("root is always the virtual document sequence");
+        };
+        let (doc_cursor, _) = docs.uncons_cursor().expect("at least one document");
+        let YamlValue::Mapping(fields) = doc_cursor.value() else {
+            panic!("expected a mapping document");
+        };
+        for field in fields {
+            if let YamlValue::String(k) = field.key() {
+                if k.raw_bytes() == key.as_bytes() {
+                    let bp = field.key_cursor().bp_position();
+                    return (
+                        raw_lines(yaml, index.get_head_comments(bp)),
+                        raw_lines(yaml, index.get_foot_comments(bp)),
+                    );
+                }
+            }
+        }
+        panic!("key {key} not found");
+    }
+
+    /// `head`/`foot` of a top-level sequence item's *content* node.
+    fn seq_item_head_foot(yaml: &[u8], idx: usize) -> (Vec<String>, Vec<String>) {
+        use crate::yaml::light::YamlValue;
+
+        let index = YamlIndex::build(yaml).expect("valid YAML");
+        let root = index.root(yaml);
+        let YamlValue::Sequence(docs) = root.value() else {
+            panic!("root is always the virtual document sequence");
+        };
+        let (doc_cursor, _) = docs.uncons_cursor().expect("at least one document");
+        let YamlValue::Sequence(items) = doc_cursor.value() else {
+            panic!("expected a sequence document");
+        };
+        let mut rest = items;
+        for _ in 0..idx {
+            let (_, tail) = rest.uncons_cursor().expect("index in range");
+            rest = tail;
+        }
+        let (item, _) = rest.uncons_cursor().expect("index in range");
+        let bp = item.bp_position();
+        (
+            raw_lines(yaml, index.get_head_comments(bp)),
+            raw_lines(yaml, index.get_foot_comments(bp)),
+        )
+    }
+
+    /// `head`/`foot` of the document's own content node — what real yq
+    /// answers `. | head_comment` / `. | foot_comment` from.
+    fn doc_head_foot(yaml: &[u8]) -> (Vec<String>, Vec<String>) {
+        use crate::yaml::light::YamlValue;
+
+        let index = YamlIndex::build(yaml).expect("valid YAML");
+        let root = index.root(yaml);
+        let YamlValue::Sequence(docs) = root.value() else {
+            panic!("root is always the virtual document sequence");
+        };
+        let (doc_cursor, _) = docs.uncons_cursor().expect("at least one document");
+        let bp = doc_cursor.bp_position();
+        (
+            raw_lines(yaml, index.get_head_comments(bp)),
+            raw_lines(yaml, index.get_foot_comments(bp)),
+        )
+    }
+
+    /// `head`/`foot` of a nested mapping entry's key, reached as
+    /// `outer.inner` — the `.a.b | key | head_comment` shape.
+    fn nested_key_head_foot(yaml: &[u8], outer: &str, inner: &str) -> (Vec<String>, Vec<String>) {
+        use crate::yaml::light::YamlValue;
+
+        let index = YamlIndex::build(yaml).expect("valid YAML");
+        let root = index.root(yaml);
+        let YamlValue::Sequence(docs) = root.value() else {
+            panic!("root is always the virtual document sequence");
+        };
+        let (doc_cursor, _) = docs.uncons_cursor().expect("at least one document");
+        let YamlValue::Mapping(fields) = doc_cursor.value() else {
+            panic!("expected a mapping document");
+        };
+        for field in fields {
+            let YamlValue::String(k) = field.key() else {
+                continue;
+            };
+            if k.raw_bytes() != outer.as_bytes() {
+                continue;
+            }
+            let YamlValue::Mapping(inner_fields) = field.value() else {
+                panic!("expected a nested mapping under {outer}");
+            };
+            for inner_field in inner_fields {
+                if let YamlValue::String(ik) = inner_field.key() {
+                    if ik.raw_bytes() == inner.as_bytes() {
+                        let bp = inner_field.key_cursor().bp_position();
+                        return (
+                            raw_lines(yaml, index.get_head_comments(bp)),
+                            raw_lines(yaml, index.get_foot_comments(bp)),
+                        );
+                    }
+                }
+            }
+        }
+        panic!("nested key {outer}.{inner} not found");
+    }
+
+    /// `head`/`foot` of the virtual root sequence itself — where a
+    /// comment-only document's block lands, since such a document opens no
+    /// content node of its own.
+    fn virtual_root_head_foot(yaml: &[u8]) -> (Vec<String>, Vec<String>) {
+        let index = YamlIndex::build(yaml).expect("valid YAML");
+        let bp = index.root(yaml).bp_position();
+        (
+            raw_lines(yaml, index.get_head_comments(bp)),
+            raw_lines(yaml, index.get_foot_comments(bp)),
+        )
+    }
+
+    /// A block sticks to whatever it is *not* separated from by a blank
+    /// line, preferring forward. Every expectation here was captured from
+    /// pinned `yq` v4.53.3 before being written down; the triage note that
+    /// described this rule stated it backwards, which is why each row cites
+    /// the getter it was measured through.
+    #[test]
+    fn standalone_comment_attaches_forward_to_the_next_key_798() {
+        // `.b | key | head_comment` == "mid"; `.a | key | foot_comment` empty.
+        let (head, foot) = field_key_head_foot(b"a: 1\n# mid\nb: 2\n", "b");
+        assert_eq!(head, ["# mid"]);
+        assert!(foot.is_empty());
+        let (_, a_foot) = field_key_head_foot(b"a: 1\n# mid\nb: 2\n", "a");
+        assert!(a_foot.is_empty(), "{a_foot:?}");
+    }
+
+    #[test]
+    fn a_blank_line_before_a_block_still_attaches_it_forward_798() {
+        // Measured: `.b | key | head_comment` == "mid" (NOT `.a`'s foot).
+        let (head, _) = field_key_head_foot(b"a: 1\n\n# mid\nb: 2\n", "b");
+        assert_eq!(head, ["# mid"]);
+    }
+
+    #[test]
+    fn a_blank_line_after_a_block_attaches_it_back_to_the_previous_key_798() {
+        // Measured: `.a | key | foot_comment` == "mid" (NOT `.b`'s head).
+        let yaml = b"a: 1\n# mid\n\nb: 2\n";
+        let (_, a_foot) = field_key_head_foot(yaml, "a");
+        assert_eq!(a_foot, ["# mid"]);
+        let (b_head, _) = field_key_head_foot(yaml, "b");
+        assert!(b_head.is_empty(), "{b_head:?}");
+    }
+
+    #[test]
+    fn blank_lines_on_both_sides_still_attach_forward_798() {
+        let yaml = b"a: 1\n\n# mid\n\nb: 2\n";
+        let (b_head, _) = field_key_head_foot(yaml, "b");
+        assert_eq!(b_head, ["# mid"]);
+        let (_, a_foot) = field_key_head_foot(yaml, "a");
+        assert!(a_foot.is_empty(), "{a_foot:?}");
+    }
+
+    #[test]
+    fn a_blank_line_splits_one_run_into_two_independently_attached_blocks_798() {
+        // Measured: `m1` -> `.a`'s foot, `m2` -> `.b`'s head.
+        let yaml = b"a: 1\n# m1\n\n# m2\nb: 2\n";
+        let (_, a_foot) = field_key_head_foot(yaml, "a");
+        assert_eq!(a_foot, ["# m1"]);
+        let (b_head, _) = field_key_head_foot(yaml, "b");
+        assert_eq!(b_head, ["# m2"]);
+    }
+
+    #[test]
+    fn consecutive_comment_lines_form_one_block_798() {
+        let (head, _) = field_key_head_foot(b"a: 1\n# m1\n# m2\nb: 2\n", "b");
+        assert_eq!(head, ["# m1", "# m2"]);
+    }
+
+    #[test]
+    fn a_trailing_block_at_eof_attaches_back_to_the_last_key_798() {
+        let (_, foot) = field_key_head_foot(b"a: 1\nb: 2\n# trail\n", "b");
+        assert_eq!(foot, ["# trail"]);
+    }
+
+    #[test]
+    fn a_trailing_block_detached_by_a_blank_becomes_the_document_foot_798() {
+        // Measured: `. | foot_comment` == "trail", `.b | key | foot_comment` empty.
+        let yaml = b"a: 1\nb: 2\n\n# trail\n";
+        let (_, doc_foot) = doc_head_foot(yaml);
+        assert_eq!(doc_foot, ["# trail"]);
+        let (_, b_foot) = field_key_head_foot(yaml, "b");
+        assert!(b_foot.is_empty(), "{b_foot:?}");
+    }
+
+    #[test]
+    fn a_leading_block_attaches_to_the_document_not_its_first_key_798() {
+        // Measured: `. | head_comment` == "lead"; `.a | key | head_comment` empty.
+        let yaml = b"# lead\na: 1\n";
+        let (doc_head, _) = doc_head_foot(yaml);
+        assert_eq!(doc_head, ["# lead"]);
+        let (a_head, _) = field_key_head_foot(yaml, "a");
+        assert!(a_head.is_empty(), "{a_head:?}");
+
+        // Multi-line, and still the document's even with a blank after it.
+        let (doc_head, _) = doc_head_foot(b"# l1\n# l2\na: 1\n");
+        assert_eq!(doc_head, ["# l1", "# l2"]);
+        let (doc_head, _) = doc_head_foot(b"# lead\n\na: 1\n");
+        assert_eq!(doc_head, ["# lead"]);
+    }
+
+    #[test]
+    fn sequence_items_own_head_and_foot_directly_no_key_step_798() {
+        // Measured: `.[1] | head_comment`, `.[0] | foot_comment`, `.[1] | foot_comment`.
+        let (head, _) = seq_item_head_foot(b"- 1\n# mid\n- 2\n", 1);
+        assert_eq!(head, ["# mid"]);
+        let (_, foot) = seq_item_head_foot(b"- 1\n# mid\n\n- 2\n", 0);
+        assert_eq!(foot, ["# mid"]);
+        let (_, foot) = seq_item_head_foot(b"- 1\n- 2\n# trail\n", 1);
+        assert_eq!(foot, ["# trail"]);
+        // A leading block still belongs to the document, not to item 0.
+        let yaml = b"# lead\n- 1\n- 2\n";
+        let (doc_head, _) = doc_head_foot(yaml);
+        assert_eq!(doc_head, ["# lead"]);
+        let (item_head, _) = seq_item_head_foot(yaml, 0);
+        assert!(item_head.is_empty(), "{item_head:?}");
+    }
+
+    #[test]
+    fn nested_blocks_attach_to_the_nested_key_not_its_container_798() {
+        // Measured: `.a.b | key | head_comment` == "inner"; `.a | head_comment` empty.
+        let (head, _) = nested_key_head_foot(b"a:\n  # inner\n  b: 1\nc: 2\n", "a", "b");
+        assert_eq!(head, ["# inner"]);
+        // At EOF inside the nested block it becomes the deepest key's foot.
+        let (_, foot) = nested_key_head_foot(b"a:\n  b: 1\n  # tail\n", "a", "b");
+        assert_eq!(foot, ["# tail"]);
+    }
+
+    #[test]
+    fn indentation_does_not_affect_attachment_798() {
+        // A comment indented deeper or shallower than the following key
+        // still attaches to it -- measured, indentation is irrelevant.
+        let (head, _) = field_key_head_foot(b"a: 1\n      # deep\nb: 2\n", "b");
+        assert_eq!(head, ["# deep"]);
+        let (head, _) = field_key_head_foot(b"a:\n  b: 1\n# after\nc: 2\n", "c");
+        assert_eq!(head, ["# after"]);
+        let (head, _) = field_key_head_foot(b"a:\n  b: 1\n\n# after\nc: 2\n", "c");
+        assert_eq!(head, ["# after"]);
+    }
+
+    #[test]
+    fn a_hash_inside_a_scalar_is_content_never_a_comment_798() {
+        // Block scalar content and quoted scalars must capture nothing --
+        // measured, real yq reports no head comment for either.
+        let (head, _) = field_key_head_foot(b"a: |\n  # not a comment\n  real\nb: 2\n", "b");
+        assert!(head.is_empty(), "{head:?}");
+        let (head, _) = field_key_head_foot(b"a: \"# not a comment\"\nb: 2\n", "b");
+        assert!(head.is_empty(), "{head:?}");
+    }
+
+    #[test]
+    fn a_trailing_comment_is_never_recorded_as_standalone_798() {
+        // The `line` slot still owns it, and `head`/`foot` stay empty --
+        // the regression this whole PR must not cause.
+        let yaml = b"a: 1 # trailing\nb: 2\n";
+        let (head, foot) = field_key_head_foot(yaml, "a");
+        assert!(head.is_empty() && foot.is_empty(), "{head:?} {foot:?}");
+        let (head, foot) = field_key_head_foot(yaml, "b");
+        assert!(head.is_empty() && foot.is_empty(), "{head:?} {foot:?}");
+        assert_eq!(
+            field_line_comment_raw(yaml, "a").as_deref(),
+            Some("# trailing")
+        );
+    }
+
+    #[test]
+    fn the_raw_range_keeps_the_hash_and_any_odd_spacing_798() {
+        // `# ` (hash *space*) is stripped at read time, so a tab-separated
+        // or bare `#` must survive verbatim in the stored range -- measured,
+        // real yq returns `#\ttabbed   ` and `#` unchanged.
+        let (head, _) = field_key_head_foot(b"a: 1\n#\ttabbed   \nb: 2\n", "b");
+        assert_eq!(head, ["#\ttabbed   "]);
+        let (head, _) = field_key_head_foot(b"a: 1\n#\nb: 2\n", "b");
+        assert_eq!(head, ["#"]);
+    }
+
+    #[test]
+    fn a_comment_only_document_keeps_its_block_as_a_head_798() {
+        // Measured: `. | head_comment` == "only", foot empty. succinctly has
+        // no document content node here, so it lands on the virtual root.
+        let (head, foot) = virtual_root_head_foot(b"# only\n");
+        assert_eq!(head, ["# only"]);
+        assert!(foot.is_empty(), "{foot:?}");
     }
 
     #[test]

--- a/src/yaml/parser.rs
+++ b/src/yaml/parser.rs
@@ -84,24 +84,29 @@ struct BlockScalarHeader {
 }
 
 /// Head/line/foot comments attached to one node, keyed by its own bp
-/// position (#798 PR2). `head`/`foot` hold zero or more standalone `#` lines
-/// (consecutive lines join into one logical block, hence `Vec` rather than
-/// `Option` -- real yq treats them as one comment either way, and #1085
-/// needs more than one comment associated with a single node at all).
+/// position (#798). `head`/`foot` hold zero or more whole comment-only
+/// lines (consecutive lines are one logical block, hence `Vec` rather than
+/// `Option` -- real yq joins them with a newline either way, and #1085
+/// needs more than one comment associated with a single node at all);
+/// `line` is the node's own trailing same-line comment. A node can carry
+/// all three at once.
 ///
-/// `head`/`foot` are always empty today -- capturing standalone comment
-/// lines is separate, follow-up work; this type only widens the storage
-/// shape so that work has somewhere to write. `line` alone is exactly the
-/// single-slot `(u32, u32)` this type replaces, with unchanged semantics.
+/// Every range is raw, `#` included: the reader strips a leading `"# "` at
+/// the point of use, which is what makes `#\ttabbed` and a bare `#` come
+/// back verbatim, matching real yq.
 #[derive(Debug, Clone, Default)]
 pub struct NodeComments {
-    /// Standalone `#` lines directly above the node. Always empty today.
+    /// Standalone `#` lines directly above the node, in source order. For a
+    /// mapping entry these live on its *key* node; for a sequence item, on
+    /// the item's content node. See
+    /// [`Parser::record_standalone_comment`].
     pub head: Vec<(u32, u32)>,
     /// The node's own trailing same-line comment: `(start, end)` byte range
     /// of the raw comment text, starting at `#` and running to end of line
     /// (exclusive of the line break, inclusive of any trailing whitespace).
     pub line: Option<(u32, u32)>,
-    /// Standalone `#` lines directly below the node. Always empty today.
+    /// Standalone `#` lines directly below the node, in source order. See
+    /// [`Self::head`].
     pub foot: Vec<(u32, u32)>,
 }
 
@@ -144,8 +149,7 @@ pub struct SemiIndex {
     /// Explicit source tags: BP position → raw tag text (see [`YamlIndex::get_tag`](super::index::YamlIndex::get_tag))
     pub tags: BTreeMap<usize, String>,
     /// Head/line/foot comments, keyed by the BP position of the node they
-    /// attach to. See [`NodeComments`] -- only `line` (issue #710) is
-    /// captured today; `head`/`foot` are always empty.
+    /// attach to. See [`NodeComments`].
     pub comments: BTreeMap<usize, NodeComments>,
 }
 
@@ -243,6 +247,42 @@ struct Parser<'a, const HAS_CR: bool> {
     /// primary node (a mapping key or sequence item) actually opens.
     pending_head_comment: Option<(u32, u32)>,
 
+    /// A run of standalone `#` lines awaiting forward attachment as the
+    /// *next* node's `head` (#798). Distinct from
+    /// [`Self::pending_head_comment`], which despite its name carries a
+    /// single *trailing* comment floated past a deferred `&anchor`/`!tag`
+    /// (#784); this one carries whole comment-only lines.
+    ///
+    /// Lives on `Parser` rather than as a local threaded through the parse
+    /// functions on purpose: `Parser` is one struct in `build_semi_index`'s
+    /// frame, so a field here costs nothing per recursion level, whereas a
+    /// local in a recursive function is charged at every level and has twice
+    /// inverted a depth guard into a real stack overflow on this issue
+    /// (#798 PR1's `parse_assignment`, PR2's `NodeMeta`).
+    pending_head_lines: Vec<(u32, u32)>,
+    /// The most recently opened node that can own a head/foot comment: a
+    /// mapping *key* or a sequence item's *content* (#798). This is `PREV`
+    /// in [`Self::record_standalone_comment`]'s attachment rule.
+    ///
+    /// Deliberately not [`Self::last_open_bp_pos`], which is the last bp of
+    /// *any* kind: for an inline `k: v` that is the value node, while real
+    /// yq measurably attaches head/foot to the key
+    /// (`.b | key | foot_comment`, never `.b | foot_comment`).
+    last_head_foot_bp: Option<usize>,
+    /// High-water mark of recorded standalone-comment text (#798).
+    ///
+    /// Three `skip_newlines` call sites rewind after a speculative lookahead
+    /// (`following_value_is_null`, `parse_mapping_entry`'s anchored branch,
+    /// `parse_explicit_key`), so the same comment bytes pass through the
+    /// recorder more than once. Recording only ranges starting at or past
+    /// this mark makes the recorder idempotent without any call site needing
+    /// to know it is on a rewinding path.
+    comment_watermark: u32,
+    /// Whether any node that can own a head/foot comment has opened yet
+    /// (#798). Distinguishes a block trailing real content (the document
+    /// root's *foot*) from a comment-only document (its *head*).
+    saw_head_foot_node: bool,
+
     // Document tracking
     /// Whether we're currently inside a document
     in_document: bool,
@@ -339,6 +379,10 @@ impl<'a, const HAS_CR: bool> Parser<'a, HAS_CR> {
             pending_property_bp: None,
             comments: BTreeMap::new(),
             pending_head_comment: None,
+            pending_head_lines: Vec::new(),
+            last_head_foot_bp: None,
+            comment_watermark: 0,
+            saw_head_foot_node: false,
             in_document: false,
             document_start_bp_pos: 0,
             pending_explicit_key: None,
@@ -557,6 +601,224 @@ impl<'a, const HAS_CR: bool> Parser<'a, HAS_CR> {
                 .line
                 .get_or_insert(range);
         }
+    }
+
+    /// Record a *standalone* comment line — one whose line holds nothing but
+    /// whitespace before the `#` — for later attachment as some node's
+    /// `head` or `foot` (#798).
+    ///
+    /// **Record-only.** Never moves `self.pos` and never changes a branch:
+    /// the caller's `skip_to_eol` still does the consuming. That is the whole
+    /// safety argument for touching `skip_newlines` at all — nothing reads
+    /// `head`/`foot` yet, so a mis-*attributed* comment cannot change any
+    /// output, but a disturbed parser position would be a real regression.
+    ///
+    /// Two guards make this safe at every call site rather than only at the
+    /// ones known to be well-behaved:
+    ///
+    /// - [`Self::comment_watermark`] makes it idempotent under the three
+    ///   rewinding lookahead sites.
+    /// - the standalone check below rejects a *trailing* comment reached
+    ///   mid-line, which happens whenever `skip_newlines` is entered after a
+    ///   document marker (`--- # c` leaves the cursor past the marker, and
+    ///   the space arm then walks straight onto the `#`).
+    ///
+    /// Attachment follows the rule measured against pinned yq v4.53.3 — a
+    /// block of consecutive comment lines sticks to whatever it is *not*
+    /// separated from by a blank line, preferring forward:
+    ///
+    /// ```text
+    /// PREV && !blank_before && (blank_after || no NEXT) -> PREV.foot
+    /// else if NEXT                                      -> NEXT.head
+    /// else                                              -> ROOT.foot
+    /// ```
+    ///
+    /// Only `blank_before` is decidable here (the lines *after* the block
+    /// have not been scanned yet), so this records into
+    /// [`Self::pending_head_lines`] and leaves the whole decision to
+    /// [`Self::flush_pending_head_lines`], which runs once the next node
+    /// opens (or at EOF) and can see both sides.
+    fn record_standalone_comment(&mut self, start: usize, end: usize) {
+        let (start, end) = (start as u32, end as u32);
+        if start < self.comment_watermark {
+            return;
+        }
+        if !self.is_line_start_before(start as usize) {
+            return;
+        }
+        self.comment_watermark = end;
+        // A blank line between the pending block and this line ends that
+        // block: its `blank_after` is now known to be true, so settle it
+        // before starting a new one. Without this, `a: 1 / # m1 / <blank> /
+        // # m2 / b: 2` would merge both blocks onto `b`, where real yq
+        // splits them `m1` -> `.a`'s foot, `m2` -> `.b`'s head.
+        if let Some(&(_, last_end)) = self.pending_head_lines.last() {
+            if self.blank_line_between(last_end as usize, start as usize) {
+                self.resolve_pending_block_backward();
+            }
+        }
+        // A blank line before this comment detaches it from `PREV`, so the
+        // block can only ever go forward from here — drop the back-reference
+        // rather than tracking `blank_before` per block.
+        if self.pending_head_lines.is_empty() && self.blank_line_precedes(start as usize) {
+            self.last_head_foot_bp = None;
+        }
+        self.pending_head_lines.push((start, end));
+    }
+
+    /// Attach the pending standalone-comment block (#798), applying the
+    /// measured rule in [`Self::record_standalone_comment`]'s doc comment.
+    ///
+    /// `next_bp` is the node that just opened and would own the block as its
+    /// `head`, or `None` at end of input. Called at every point a node that
+    /// can own a head comment opens — a mapping key, a sequence item's
+    /// content, and a document's content node — plus once at end of parse.
+    /// A no-op when nothing is pending, which is the overwhelmingly common
+    /// case, so the hooks cost one `Vec::is_empty` each.
+    fn flush_pending_head_lines(&mut self, next_bp: Option<usize>) {
+        if self.pending_head_lines.is_empty() {
+            return;
+        }
+        // A blank line between the block and whatever follows detaches it
+        // forward; so does having nothing follow at all. Either way it falls
+        // back onto `PREV` — which `record_standalone_comment` has already
+        // set to `None` if a blank line detached the block backwards too.
+        let block_end = self.pending_head_lines[self.pending_head_lines.len() - 1].1 as usize;
+        let detached_forward = next_bp.is_none() || self.blank_line_between(block_end, self.pos);
+        if detached_forward {
+            if let Some(prev) = self.last_head_foot_bp {
+                let pending = &mut self.pending_head_lines;
+                self.comments.entry(prev).or_default().foot.append(pending);
+                return;
+            }
+        }
+        let root = self.document_start_bp_pos;
+        let pending = &mut self.pending_head_lines;
+        match next_bp {
+            Some(bp) => self.comments.entry(bp).or_default().head.append(pending),
+            // Nothing follows and nothing precedes it closely enough, so the
+            // block belongs to the document root -- as its *foot* normally,
+            // but as its *head* when the document never opened a node at all
+            // (a comment-only document, where real yq answers
+            // `. | head_comment`, not `foot_comment`).
+            None if self.saw_head_foot_node => {
+                self.comments.entry(root).or_default().foot.append(pending);
+            }
+            None => self.comments.entry(root).or_default().head.append(pending),
+        }
+    }
+
+    /// Settle a pending block whose forward attachment is already disproven
+    /// (a blank line follows it) onto `PREV`'s foot. A no-op when `PREV` is
+    /// unset, which means a blank line detached the block backwards too —
+    /// it stays pending and goes forward to whatever opens next.
+    fn resolve_pending_block_backward(&mut self) {
+        if self.pending_head_lines.is_empty() {
+            return;
+        }
+        if let Some(prev) = self.last_head_foot_bp {
+            let pending = &mut self.pending_head_lines;
+            self.comments.entry(prev).or_default().foot.append(pending);
+        }
+    }
+
+    /// Hook for "a node that can own a standalone comment just opened at
+    /// [`Self::last_open_bp_pos`]" (#798): attach any pending block as its
+    /// `head`, and make it the `PREV` a later block can attach its `foot` to.
+    ///
+    /// Called where a mapping *key* opens and where a sequence item's
+    /// *content* opens — the two nodes real yq answers `head_comment`/
+    /// `foot_comment` from. Not called for container opens, which own no
+    /// standalone comment of their own (a comment above a nested mapping's
+    /// first key belongs to that key, measured), and not for an inline
+    /// `k: v`'s value node.
+    fn attach_head_foot_to_key(&mut self) {
+        self.attach_head_foot_at(self.last_open_bp_pos);
+    }
+
+    /// [`Self::attach_head_foot_to_key`] for a node whose bp is known but
+    /// which has not opened yet — a sequence item's content, flushed *before*
+    /// `parse_value` runs so [`Self::flush_pending_head_lines`] still sees
+    /// `self.pos` at the content's own line rather than past the whole value.
+    fn attach_head_foot_at(&mut self, bp: usize) {
+        self.flush_pending_head_lines(Some(bp));
+        self.last_head_foot_bp = Some(bp);
+        self.saw_head_foot_node = true;
+    }
+
+    /// Whether a wholly blank line lies in `[from, to)` — i.e. whether the
+    /// text there holds two or more line breaks (`\r\n` counting once). One
+    /// break is just the end of the earlier line; a second means an empty
+    /// line came between.
+    fn blank_line_between(&self, from: usize, to: usize) -> bool {
+        let mut breaks = 0usize;
+        let mut p = from;
+        let end = to.min(self.input.len());
+        while p < end {
+            if is_line_break(self.input[p]) {
+                breaks += 1;
+                if breaks >= 2 {
+                    return true;
+                }
+                // CRLF is one break.
+                if self.input[p] == b'\r' && p + 1 < end && self.input[p + 1] == b'\n' {
+                    p += 1;
+                }
+            }
+            p += 1;
+        }
+        false
+    }
+
+    /// Whether everything between `pos` and the start of its line is inline
+    /// whitespace — i.e. `pos` begins a *standalone* comment rather than one
+    /// trailing content. See [`Self::record_standalone_comment`].
+    fn is_line_start_before(&self, pos: usize) -> bool {
+        let mut p = pos;
+        while p > 0 && Self::is_inline_whitespace(self.input[p - 1]) {
+            p -= 1;
+        }
+        p == 0 || is_line_break(self.input[p - 1])
+    }
+
+    /// Whether the line before the one containing `pos` is blank (empty or
+    /// whitespace only). Start of input is not a blank line.
+    ///
+    /// Read straight off the text rather than tracked as parser state, so it
+    /// cannot be confused by a `skip_newlines` call entered mid-line — see
+    /// [`Self::record_standalone_comment`].
+    fn blank_line_precedes(&self, pos: usize) -> bool {
+        // Step back over this line's indent to its opening break, then over
+        // that break, then check whether the line before it is empty.
+        let mut p = pos;
+        while p > 0 && Self::is_inline_whitespace(self.input[p - 1]) {
+            p -= 1;
+        }
+        if p == 0 {
+            return false;
+        }
+        // `p - 1` is the break that ended the previous line. A CRLF counts
+        // once: step back over the `\n` and then over a `\r` if it precedes.
+        let mut q = p - 1;
+        if self.input[q] == b'\n' && q > 0 && self.input[q - 1] == b'\r' {
+            q -= 1;
+        }
+        if q == 0 {
+            return false;
+        }
+        // Walk the previous line backwards; blank iff we reach another break
+        // (or the start of input) without meeting content.
+        let mut r = q;
+        while r > 0 && !is_line_break(self.input[r - 1]) {
+            if !Self::is_inline_whitespace(self.input[r - 1]) {
+                return false;
+            }
+            r -= 1;
+        }
+        // A whitespace-only run back to the start of input is a blank line
+        // only if it is non-empty; `r == q` means the previous "line" was
+        // empty, which is blank either way.
+        r < q || r > 0
     }
 
     /// Like [`Self::maybe_capture_line_comment`], but the owning node doesn't
@@ -1263,14 +1525,18 @@ impl<'a, const HAS_CR: bool> Parser<'a, HAS_CR> {
                 self.skip_line_break();
             } else if b == b'#' {
                 // Comment line
+                let comment_start = self.pos;
                 self.skip_to_eol();
+                self.record_standalone_comment(comment_start, self.pos);
             } else if b == b' ' {
                 // Check if rest of line is whitespace or comment
                 let start = self.pos;
                 self.skip_inline_whitespace();
                 if self.at_break() || self.peek() == Some(b'#') || self.peek().is_none() {
                     if self.peek() == Some(b'#') {
+                        let comment_start = self.pos;
                         self.skip_to_eol();
+                        self.record_standalone_comment(comment_start, self.pos);
                     }
                     continue;
                 }
@@ -1385,6 +1651,20 @@ impl<'a, const HAS_CR: bool> Parser<'a, HAS_CR> {
     fn start_document(&mut self) {
         self.in_document = true;
         self.document_start_bp_pos = self.bp_pos;
+        // A standalone comment block seen before this document's content
+        // belongs to the document's own node, not to its first key -- real
+        // yq answers `. | head_comment`, not `.a | key | head_comment`, for
+        // a leading `# lead` (#798). `document_start_bp_pos` is the bp the
+        // content node is about to take, and `end_document` synthesizes a
+        // node there even when the document turns out empty, so the block
+        // always lands on something real.
+        //
+        // Deliberately *before* `pending_head_comment` is cleared below:
+        // that field is #784's single floated trailing comment, unrelated to
+        // this block.
+        let root_bp = self.document_start_bp_pos;
+        self.flush_pending_head_lines(Some(root_bp));
+        self.last_head_foot_bp = None;
         // A comment deferred by an anchor in a *previous* document (#784)
         // has no node left to attach to once a new document starts -
         // `parse_document_line`'s own one-line grace period already covers
@@ -1465,13 +1745,20 @@ impl<'a, const HAS_CR: bool> Parser<'a, HAS_CR> {
             if is_line_break(b) {
                 self.skip_line_break();
             } else if b == b'#' {
+                // The second whole-line-comment funnel (#798): a comment
+                // before the first `---` of a document *with* directives is
+                // consumed here and never reaches `skip_newlines`.
+                let comment_start = self.pos;
                 self.skip_to_eol();
+                self.record_standalone_comment(comment_start, self.pos);
             } else if b == b' ' || b == b'\t' {
                 let start = self.pos;
                 self.skip_inline_whitespace();
                 if self.at_break() || self.peek() == Some(b'#') || self.peek().is_none() {
                     if self.peek() == Some(b'#') {
+                        let comment_start = self.pos;
                         self.skip_to_eol();
+                        self.record_standalone_comment(comment_start, self.pos);
                     }
                     continue;
                 }
@@ -2530,6 +2817,13 @@ impl<'a, const HAS_CR: bool> Parser<'a, HAS_CR> {
             // Parse the item value normally
             // Pass structure indent for block scalars (content must be > this)
             let bp_pos_before_value = self.bp_pos;
+            // A standalone comment above a sequence item attaches to the
+            // item's *content* node, which is about to open at
+            // `bp_pos_before_value` -- real yq answers `.[1] | head_comment`
+            // directly for one, with no `key` step (#798). Flushed before
+            // `parse_value` so the blank-line check still sees `self.pos` on
+            // the item's own line.
+            self.attach_head_foot_at(bp_pos_before_value);
             self.parse_value(indent)?;
             // Claim a comment deferred by an earlier anchor's deferred value
             // (#784): a plain-scalar item's own trailing comment lives on
@@ -2595,6 +2889,8 @@ impl<'a, const HAS_CR: bool> Parser<'a, HAS_CR> {
 
         // Open key node
         self.write_bp_open();
+        // Standalone comments attach to a mapping entry's *key* (#798).
+        self.attach_head_foot_to_key();
 
         // Check for a property on the key (`- &a k: v` / `- !!str k: v`) -
         // record it pointing to this key.
@@ -2838,6 +3134,8 @@ impl<'a, const HAS_CR: bool> Parser<'a, HAS_CR> {
 
         // Open key node
         self.write_bp_open();
+        // Standalone comments attach to a mapping entry's *key* (#798).
+        self.attach_head_foot_to_key();
 
         // Check for a property on the key - record it pointing to this key BP
         self.record_key_properties()?;
@@ -5330,6 +5628,11 @@ impl<'a, const HAS_CR: bool> Parser<'a, HAS_CR> {
         if self.peek().is_some() {
             self.parse_documents()?;
         }
+
+        // A standalone comment block still pending at EOF has no following
+        // node to head (#798): it becomes the last key/item's foot, or the
+        // document root's foot when a blank line detached it from that too.
+        self.flush_pending_head_lines(None);
 
         // Close any remaining open document
         self.end_document();

--- a/src/yaml/parser.rs
+++ b/src/yaml/parser.rs
@@ -714,7 +714,7 @@ impl<'a, const HAS_CR: bool> Parser<'a, HAS_CR> {
     /// it stays pending and goes forward to whatever opens next.
     fn resolve_pending_block_backward(&mut self) {
         if self.pending_head_lines.is_empty() {
-            return;
+            return; // omni-dev: coverage tolerate-line reason="unreachable: this function's sole caller (record_standalone_comment) only invokes it from inside a match on `pending_head_lines.last()`, so pending_head_lines is already known non-empty here (#798)"
         }
         if let Some(prev) = self.last_head_foot_bp {
             let pending = &mut self.pending_head_lines;


### PR DESCRIPTION
## Summary

PR2 (#2690) widened the YAML comment side-table to `NodeComments { head,
line, foot }` but left `head`/`foot` permanently empty. This fills them in:
whole-line `#` comments — previously walked over by `skip_newlines` and
discarded without a trace — are now recorded and attached to the node real
yq attaches them to. This is what PR3 (`head_comment`/`foot_comment`
get-forms) needs, and what #1085 and #1079's float-forward case are blocked
on.

## The attachment rule is measured, and the issue's own summary of it is wrong

Live-verified against pinned `yq` v4.53.3 across ~20 shapes. The triage note
says *"blank before → previous key's foot, blank after → next key's head"*;
the binary does the **opposite**. What it actually does — a block of
consecutive comment lines sticks to whatever it is *not* separated from by a
blank line, preferring forward:

```
PREV && !blank_before && (blank_after || no NEXT)  -> PREV.foot
else if NEXT                                       -> NEXT.head
else                                               -> ROOT.foot
```

Targets, also measured: a mapping entry's block lives on its **key** node
(`.b | key | head_comment`, never `.b | head_comment`), a sequence item's on
the **item content** (`.[1] | head_comment` directly), a leading block on the
**document** node rather than its first key, and a trailing block detached by
a blank on the document's **foot**. Indentation turns out to be irrelevant.

## Why this is safe to land

Nothing reads `head`/`foot` yet, so a mis-*attributed* comment cannot change
any output — the only way this PR could break anything is by disturbing the
parser. So the recorder only ever reads: it never moves `self.pos` and never
changes a branch. Two guards make it safe at *every* call site rather than
only the ones known to be well-behaved:

- a **watermark**, because three lookahead sites (`following_value_is_null`,
  `parse_mapping_entry`'s anchored branch, `parse_explicit_key`) rewind and
  push the same comment bytes through a second time;
- a **line-start check**, because `skip_newlines` can be entered mid-line
  after a document marker (`--- # c`) and would otherwise misfile a
  *trailing* comment as a standalone one.

`skip_directive_gap_whitespace` is wired up too — it is a second, independent
whole-line-comment funnel for the pre-`---` gap that never reaches
`skip_newlines`. `detect_block_content_indent` is deliberately left alone: it
is the one place a `#` line is skipped inside block-scalar content.

## Benchmark: the corpus could not see this code

`yaml_bench` contained **no YAML comment at all** — all five `#` in
`yaml_bench.rs` were Rust doc comments — so it was structurally unable to
measure comment capture, and an A/B against it returned pure noise (±20%,
signs flipping between rounds). This adds a `yaml/comments` group so the cost
is visible.

Measured by rebuilding with the capture disabled (this repo's own attribution
method), two independent harnesses agreeing:

| shape | effect |
|---|---|
| comment-free (control) | no change |
| trailing comments only (pre-existing `line` path) | no change |
| standalone comments, 1 line in 4 | ≈ +25% index build |
| standalone comments, every other line | ≈ +50% index build |

That is ≈40–60 ns per captured comment line, dominated by one `BTreeMap`
insert plus one `Vec` allocation — the same storage mechanism the existing
trailing-comment capture already uses. A first pass removed a double scan of
every comment line and a per-comment `Vec` realloc; what remains is the cost
of storing the data. A flat-arena representation could roughly halve it and
is the obvious follow-up, now that there is a benchmark that can see it.

**Caveat, stated plainly:** this box was not idle while measuring (load avg
22, another session's `rustc` at ~890% CPU), and one criterion round was
visibly contaminated (+78% on the `none` control, which this change cannot
touch). The direction and rough magnitude reproduce across both harnesses,
but the exact percentages want a quiet machine before anyone quotes them.

## Test plan

- [x] 16 new white-box tests in `src/yaml/index.rs` pinning the full measured
      matrix — forward/backward attachment, all four blank-line cells, EOF
      ±blank, a blank splitting one run into two independently attached
      blocks, nested, sequences, comment-only document, indentation
      irrelevance, `#` inside block/quoted scalars capturing nothing, and raw
      ranges keeping `#\ttabbed` / bare `#` verbatim
- [x] Updated `test_head_and_foot_comments_always_empty_798` from PR2, whose
      premise this PR invalidates
- [x] `cargo test --features cli` — lib (3637), bins (269), `yq_cli_tests`
      (1739), `yq_golden_tests`, `yaml_test_suite`, `yaml_crlf_tests` — every
      existing `line_comment` test and golden byte-identical
- [x] **Depth-guard tests run deliberately, checking process exit codes** —
      `test_expr_depth_limit_returns_parse_error_not_overflow_1156`,
      `deep_block_nesting_errors_instead_of_overflowing`,
      `deep_flow_nesting_errors_instead_of_overflowing`,
      `test_deep_flow_sequence_errors_instead_of_aborting`,
      `to_owned_panics_past_nesting_depth_limit_998`,
      `reconcile_presentation_panics_past_nesting_depth_limit_1005`. PR1 and
      PR2 each shipped a stack-overflow regression from frame growth, so all
      new state lives on `Parser` (one struct in `build_semi_index`'s frame)
      rather than as locals in the recursive parse functions
- [x] `cargo clippy --all-targets --all-features -- -D warnings`, `cargo fmt
      --check`, `RUSTDOCFLAGS="-D warnings" cargo doc`