### PR TITLE
fix(jq): stop the needs_path_context bridge panicking on deep documents

### DIFF
--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -104,6 +104,26 @@ use crate::json::JsonIndex;
 /// blast radius — see #998's own text, which names a hard process abort as
 /// an acceptable outcome alongside a clean error.
 ///
+/// #2627 revisited this for [`to_owned`]/[`to_owned_cursor`] specifically:
+/// by the time the `needs_path_context` gate's "wildcard bridge" (the arms
+/// that fall to these two when an expression like `1+1`/`true and true`
+/// doesn't need path context) started reaching this guard on an
+/// adversarially deep document, both functions had *already* grown a
+/// `Result<OwnedValue, EvalError>` signature for an unrelated reason
+/// (#1098/#1247 decode failures) and every one of their call sites already
+/// threaded that `Result` through. So the "blast radius" this guard's
+/// panic was bought to avoid no longer applied to those two — only the
+/// depth check's own signaling needed to change, from `assert_nesting_depth`
+/// to a `decode_failure`-tagged `Err`. Tagging it a decode failure (rather
+/// than reusing [`check_nesting_depth`]'s plain, catchable `EvalError`)
+/// keeps the same "escapes even a `try`/`catch` inside the running filter"
+/// property the panic had, matching real jq's own parse-time rejection
+/// (which the running filter, and any `try`/`catch` in it, never even gets
+/// a chance to see) — see `EvalError::is_decode_failure`'s own doc comment.
+/// [`to_owned_with_comments`] keeps the panic: it is reached only by
+/// `yq_runner.rs`'s comment/anchor-preserving DOM write path, not this
+/// bridge, and was out of #2627's scope.
+///
 /// 256, not the 128 `src/yaml/parser.rs`/`src/json/validate.rs` use for
 /// their own (unrelated) guards: `tests/jq_cli_tests.rs`'s
 /// `test_walk_deep_nesting_does_not_overflow_the_stack` already pins
@@ -280,15 +300,14 @@ fn to_owned_checked_at_depth<V: DocumentValue>(
 /// Note: The order of checks is important! Check containers first, then scalars,
 /// because YAML scalars may have type coercion (e.g., unquoted "true" is a bool).
 ///
-/// Panics past [`MAX_NESTING_DEPTH`] levels of nesting (#998) rather than
-/// recursing unbounded and overflowing the call stack. That guard stays a
-/// `panic!` even though this function is now fallible: unbounded recursion is
-/// a different failure class from a data error, and routing it through
-/// `EvalError` would make a stack-overflow guard catchable by `try`/`catch`.
-///
-/// Returns `Err` when a scalar the semi-index accepted as a string token
-/// cannot be *decoded* (#1098, #1247) -- see
-/// [`DocumentValue::string_decode_error`].
+/// Returns `Err` past [`MAX_NESTING_DEPTH`] levels of nesting (#998,
+/// #2627) rather than recursing unbounded and overflowing the call stack --
+/// a `decode_failure`-tagged `EvalError`, so it is just as unable to be
+/// swallowed by a `try`/`catch` in the running filter as the `panic!` this
+/// guard used to be (see [`MAX_NESTING_DEPTH`]'s own doc comment for why
+/// that swap is sound here specifically). Also returns `Err` when a scalar
+/// the semi-index accepted as a string token cannot be *decoded* (#1098,
+/// #1247) -- see [`DocumentValue::string_decode_error`].
 pub fn to_owned<V: DocumentValue>(value: &V) -> Result<OwnedValue, EvalError> {
     // #2358: the true top level has no cursor by design -- see
     // `to_owned_at_depth`'s own `cursor` parameter doc comment below.
@@ -370,7 +389,11 @@ fn to_owned_at_depth<V: DocumentValue>(
     cursor: Option<&V::Cursor>,
     depth: usize,
 ) -> Result<OwnedValue, EvalError> {
-    assert_nesting_depth(depth);
+    if depth >= MAX_NESTING_DEPTH {
+        return Err(EvalError::decode_failure(
+            super::value::nesting_depth_exceeded_message(MAX_NESTING_DEPTH),
+        ));
+    }
     // Check containers first (arrays and objects have no type ambiguity)
     if let Some(fields) = value.as_object() {
         let mut map = IndexMap::new();
@@ -500,8 +523,8 @@ fn to_owned_at_depth<V: DocumentValue>(
 /// just the top-level one. Call sites that already hold a cursor (rather
 /// than a bare value) should use this instead of `to_owned(&cursor.value())`.
 ///
-/// Panics past [`MAX_NESTING_DEPTH`] levels of nesting (#998), same as
-/// [`to_owned`].
+/// Returns `Err` past [`MAX_NESTING_DEPTH`] levels of nesting (#998,
+/// #2627), same as [`to_owned`].
 pub fn to_owned_cursor<C: DocumentCursor>(cursor: &C) -> Result<OwnedValue, EvalError> {
     let result = to_owned_cursor_at_depth(cursor, 0);
     // #2334: see `debug_assert_materialization_error`'s own doc comment --
@@ -601,7 +624,11 @@ fn to_owned_cursor_at_depth<C: DocumentCursor>(
     cursor: &C,
     depth: usize,
 ) -> Result<OwnedValue, EvalError> {
-    assert_nesting_depth(depth);
+    if depth >= MAX_NESTING_DEPTH {
+        return Err(EvalError::decode_failure(
+            super::value::nesting_depth_exceeded_message(MAX_NESTING_DEPTH),
+        ));
+    }
     let value = cursor.value();
     if let Some(fields) = value.as_object() {
         let mut map = IndexMap::new();
@@ -2930,7 +2957,11 @@ fn push_generic_document_validation_error<C: DocumentCursor>(
     c: &C,
     depth: usize,
 ) -> Option<Control> {
-    assert_nesting_depth(depth);
+    if depth >= MAX_NESTING_DEPTH {
+        return Some(Control::Error(EvalError::decode_failure(
+            super::value::nesting_depth_exceeded_message(MAX_NESTING_DEPTH),
+        )));
+    }
     let value = c.value();
     if let Some(fields) = value.as_object() {
         // #1804: do not walk *into* an alias's container target here. A
@@ -3181,9 +3212,10 @@ fn push_generic_document_validation_error<C: DocumentCursor>(
 ///
 /// `None` without a cursor: `to_owned_with_cursor(&value, None)` on an
 /// already-owned value cannot fail, so the bridge had nothing to raise there
-/// either. A document deeper than `MAX_NESTING_DEPTH` panics inside the walk
-/// exactly as it panicked inside the bridge's materialization (#2627, tracked,
-/// route-independent).
+/// either. A document deeper than `MAX_NESTING_DEPTH` reports a
+/// `decode_failure`-tagged error from this walk, matching what
+/// `to_owned_with_cursor`'s own materialization now returns at the same
+/// boundary (#2627 fixed both from a `panic!` to this) -- route-independent.
 ///
 /// Call this only on the shape that used to bridge (`!needs_path_context`
 /// for a gated arm; unconditionally for an arm that had no native route at
@@ -22550,6 +22582,145 @@ mod tests {
         assert!(matches!(owned, OwnedValue::Object(_)));
     }
 
+    /// #2627: the `needs_path_context` gate's wildcard/ambient bridge used
+    /// to reach [`assert_nesting_depth`]'s `panic!` on a >256-deep document
+    /// for an expression that never even reads `.` -- e.g. `1+1`, whose
+    /// gated native arm (`Expr::Arithmetic`) only fires when an operand
+    /// needs path context, so an ungated `1+1` falls to the catch-all `_`
+    /// arm's `to_owned_with_cursor` materialization
+    /// ([`to_owned_cursor_at_depth`]). Called through [`eval`] (not the CLI,
+    /// which already wraps evaluation in `catch_unwind`, #1793) so this
+    /// pins the library-embedder-facing gap directly: no panic, just a
+    /// `decode_failure`-tagged `Err`, same as real jq's own parse-time
+    /// "Exceeds depth limit for parsing" rejection (which a `try`/`catch`
+    /// inside the filter can't catch either, since jq's parser rejects the
+    /// document before the filter ever runs).
+    #[test]
+    fn test_arithmetic_wildcard_bridge_reports_clean_error_past_nesting_limit_2627() {
+        use crate::json::JsonIndex;
+        let json = format!("{}1{}", "[".repeat(256), "]".repeat(256));
+        let json = json.as_bytes();
+        let index = JsonIndex::build(json);
+        let cursor = index.root(json);
+        let value = cursor.value();
+        let expr = crate::jq::parse("1+1").unwrap();
+
+        match eval(&expr, value) {
+            GenericResult::Error(e) => {
+                assert!(e.is_decode_failure(), "expected decode failure, got: {e:?}");
+                assert!(
+                    e.message.contains("nesting depth exceeds limit of 256"),
+                    "message: {}",
+                    e.message
+                );
+            }
+            other => panic!("expected a decode failure, got: {other:?}"),
+        }
+    }
+
+    /// Companion to the test above: an ungated `1+1` well under the limit
+    /// must still answer normally through the same wildcard bridge.
+    #[test]
+    fn test_arithmetic_wildcard_bridge_accepts_nesting_under_limit_2627() {
+        use crate::json::JsonIndex;
+        let json = format!("{}1{}", "[".repeat(100), "]".repeat(100));
+        let json = json.as_bytes();
+        let index = JsonIndex::build(json);
+        let cursor = index.root(json);
+        let value = cursor.value();
+        let expr = crate::jq::parse("1+1").unwrap();
+
+        match eval(&expr, value) {
+            GenericResult::Owned(OwnedValue::Int(2)) => {}
+            other => panic!("expected Owned(2), got: {other:?}"),
+        }
+    }
+
+    /// #2627's other panic site: `And`/`Or` (`eval_boolean_generic`) and
+    /// `Alternative`/`//`/`Not` route their own "shape that used to bridge"
+    /// raise through [`push_generic_document_validation_error`] instead of
+    /// the full materialization above (#2476's O(N) replacement for the
+    /// bridge's O(2^N) cost) -- but its depth guard panicked exactly the
+    /// same way before this fix, as its own doc comment
+    /// (`ambient_validation_error`) already flagged. `true and true` has no
+    /// path-context operand on either side, so it takes this route.
+    ///
+    /// [`eval_with_cursor`], not [`eval`]: `ambient_validation_error` walks
+    /// from a `DocumentCursor`, so it is a deliberate no-op without one
+    /// (see its own doc comment's "`None` without a cursor" paragraph) --
+    /// this is the real public `succinctly::jq::eval` shape, which always
+    /// supplies a cursor (confirmed live via `eval::eval`'s own
+    /// `needs_path_context` gate: a pipe like `key?, (true and true)` on a
+    /// document nested deeper than 256 levels reaches this exact guard
+    /// through the public API, not just this module's own internal
+    /// callers).
+    #[test]
+    fn test_boolean_ambient_validation_reports_clean_error_past_nesting_limit_2627() {
+        use crate::json::JsonIndex;
+        let json = format!("{}1{}", "[".repeat(256), "]".repeat(256));
+        let json = json.as_bytes();
+        let index = JsonIndex::build(json);
+        let cursor = index.root(json);
+        let expr = crate::jq::parse("true and true").unwrap();
+
+        match eval_with_cursor(&expr, cursor) {
+            GenericResult::Error(e) => {
+                assert!(e.is_decode_failure(), "expected decode failure, got: {e:?}");
+                assert!(
+                    e.message.contains("nesting depth exceeds limit of 256"),
+                    "message: {}",
+                    e.message
+                );
+            }
+            other => panic!("expected a decode failure, got: {other:?}"),
+        }
+    }
+
+    /// Companion to the test above: `true and true` well under the limit
+    /// must still answer normally through `eval_boolean_generic`'s own
+    /// ambient-validation gate.
+    #[test]
+    fn test_boolean_ambient_validation_accepts_nesting_under_limit_2627() {
+        use crate::json::JsonIndex;
+        let json = format!("{}1{}", "[".repeat(100), "]".repeat(100));
+        let json = json.as_bytes();
+        let index = JsonIndex::build(json);
+        let cursor = index.root(json);
+        let expr = crate::jq::parse("true and true").unwrap();
+
+        match eval_with_cursor(&expr, cursor) {
+            GenericResult::Owned(OwnedValue::Bool(true)) => {}
+            other => panic!("expected Owned(true), got: {other:?}"),
+        }
+    }
+
+    /// [`eval_with_cursor`] twin of the two error tests above: the same
+    /// document reached with a cursor rather than a bare value, confirming
+    /// [`to_owned_with_cursor`]'s `Some(cursor)` branch
+    /// ([`to_owned_cursor_at_depth`]) is fixed too, not just the `None`
+    /// branch ([`to_owned_at_depth`]) that a cursor-less [`eval`] exercises.
+    #[test]
+    fn test_arithmetic_wildcard_bridge_with_cursor_reports_clean_error_past_nesting_limit_2627() {
+        use crate::json::JsonIndex;
+        let json = format!("{}1{}", "[".repeat(256), "]".repeat(256));
+        let json = json.as_bytes();
+        let index = JsonIndex::build(json);
+        let cursor = index.root(json);
+        let expr = crate::jq::parse("1+1").unwrap();
+
+        match eval_with_cursor(&expr, cursor) {
+            GenericResult::Error(e) => {
+                assert!(e.is_decode_failure(), "expected decode failure, got: {e:?}");
+                assert!(
+                    e.message.contains("nesting depth exceeds limit of 256"),
+                    "message: {}",
+                    e.message
+                );
+            }
+            other => panic!("expected a decode failure, got: {other:?}"),
+        }
+    }
+
     /// #2231 finding 3: `Builtin::ToString`'s own dedicated arm and the
     /// catch-all wildcard fallback arm both raised an ordinary #1194
     /// malformed-member error unconditionally, ignoring `optional` --
@@ -29643,10 +29814,17 @@ mod tests {
     /// adversarially deep input — confirmed live, `succinctly jq '.'` on a
     /// 200,000-level-deep document used to abort with a raw stack overflow
     /// (SIGABRT) before this guard existed. 255 levels (just under the
-    /// limit) must still materialize normally; 256 must panic cleanly
-    /// rather than recurse further.
+    /// limit) must still materialize normally; 256 must stop cleanly rather
+    /// than recurse further.
+    ///
+    /// 256 used to `panic!` here (#998); #2627 changed the guard's own
+    /// signaling to a `decode_failure`-tagged `Err` instead (see
+    /// [`MAX_NESTING_DEPTH`]'s doc comment for why that swap is sound: it
+    /// keeps the exact same "unreachable via `try`/`catch`" property the
+    /// panic had, without the process-abort blast radius), so this no
+    /// longer needs `catch_unwind` to observe the boundary.
     #[test]
-    fn to_owned_panics_past_nesting_depth_limit_998() {
+    fn to_owned_reports_clean_error_past_nesting_depth_limit_998() {
         let json = linear_nest(255);
         let index = JsonIndex::build(json.as_bytes());
         let cursor = index.root(json.as_bytes());
@@ -29660,11 +29838,16 @@ mod tests {
         let index = JsonIndex::build(json.as_bytes());
         let cursor = index.root(json.as_bytes());
         let value = cursor.value();
-        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| to_owned(&value)));
-        assert!(result.is_err(), "to_owned should panic at depth 256");
-        let result =
-            std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| to_owned_cursor(&cursor)));
-        assert!(result.is_err(), "to_owned_cursor should panic at depth 256");
+        let err = to_owned(&value).expect_err("to_owned should error at depth 256");
+        assert!(
+            err.is_decode_failure(),
+            "expected decode failure, got: {err:?}"
+        );
+        let err = to_owned_cursor(&cursor).expect_err("to_owned_cursor should error at depth 256");
+        assert!(
+            err.is_decode_failure(),
+            "expected decode failure, got: {err:?}"
+        );
     }
 
     /// #1017: `owned_from_standard_json` is a third, independent copy of the

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -106,7 +106,7 @@ use crate::json::JsonIndex;
 ///
 /// #2627 revisited this for [`to_owned`]/[`to_owned_cursor`] specifically:
 /// by the time the `needs_path_context` gate's "wildcard bridge" (the arms
-/// that fall to these two when an expression like `1+1`/`true and true`
+/// that fall to these two when an expression like `. + 1`/`. and true`
 /// doesn't need path context) started reaching this guard on an
 /// adversarially deep document, both functions had *already* grown a
 /// `Result<OwnedValue, EvalError>` signature for an unrelated reason
@@ -123,6 +123,15 @@ use crate::json::JsonIndex;
 /// [`to_owned_with_comments`] keeps the panic: it is reached only by
 /// `yq_runner.rs`'s comment/anchor-preserving DOM write path, not this
 /// bridge, and was out of #2627's scope.
+///
+/// A genuinely closed term (`1+1`, `true and true` -- no operand reads `.`
+/// anywhere) no longer reaches this guard at all: `bridge_ambient_input`
+/// (#2173's `walk::reads_ambient_value` gate, landed the same day as this
+/// fix) hands such a term `OwnedValue::Null` instead of the real document,
+/// so the depth check below never sees it. `. + 1`/`. and true` above are
+/// the minimal ambient-reading shapes that still route through the wildcard
+/// bridge while leaving `needs_path_context` false -- this guard, and its
+/// tests, deliberately use that shape rather than a fully closed one.
 ///
 /// 256, not the 128 `src/yaml/parser.rs`/`src/json/validate.rs` use for
 /// their own (unrelated) guards: `tests/jq_cli_tests.rs`'s
@@ -22584,13 +22593,21 @@ mod tests {
 
     /// #2627: the `needs_path_context` gate's wildcard/ambient bridge used
     /// to reach [`assert_nesting_depth`]'s `panic!` on a >256-deep document
-    /// for an expression that never even reads `.` -- e.g. `1+1`, whose
-    /// gated native arm (`Expr::Arithmetic`) only fires when an operand
-    /// needs path context, so an ungated `1+1` falls to the catch-all `_`
-    /// arm's `to_owned_with_cursor` materialization
-    /// ([`to_owned_cursor_at_depth`]). Called through [`eval`] (not the CLI,
-    /// which already wraps evaluation in `catch_unwind`, #1793) so this
-    /// pins the library-embedder-facing gap directly: no panic, just a
+    /// for an expression whose gated native arm (`Expr::Arithmetic`) only
+    /// fires when an operand needs path context, so an ungated arithmetic
+    /// expression falls to the catch-all `_` arm's `to_owned_with_cursor`
+    /// materialization ([`to_owned_cursor_at_depth`]). `. + 1`, not `1+1`:
+    /// a fully closed term (no operand reads `.` at all) no longer reaches
+    /// this materialization in the first place -- #2173's
+    /// `walk::reads_ambient_value` gate (`bridge_ambient_input`, landed the
+    /// same day as this fix) hands it `OwnedValue::Null` instead of the
+    /// real document, so the depth guard never sees it. `. + 1` keeps
+    /// `needs_path_context` false (routing through this same wildcard
+    /// bridge) while still reading `.` (`Expr::Identity` always reports
+    /// `reads_ambient_value == true`), so it's the minimal shape that still
+    /// exercises this guard. Called through [`eval`] (not the CLI, which
+    /// already wraps evaluation in `catch_unwind`, #1793) so this pins the
+    /// library-embedder-facing gap directly: no panic, just a
     /// `decode_failure`-tagged `Err`, same as real jq's own parse-time
     /// "Exceeds depth limit for parsing" rejection (which a `try`/`catch`
     /// inside the filter can't catch either, since jq's parser rejects the
@@ -22603,7 +22620,7 @@ mod tests {
         let index = JsonIndex::build(json);
         let cursor = index.root(json);
         let value = cursor.value();
-        let expr = crate::jq::parse("1+1").unwrap();
+        let expr = crate::jq::parse(". + 1").unwrap();
 
         match eval(&expr, value) {
             GenericResult::Error(e) => {
@@ -22619,7 +22636,10 @@ mod tests {
     }
 
     /// Companion to the test above: an ungated `1+1` well under the limit
-    /// must still answer normally through the same wildcard bridge.
+    /// must still answer normally through the same wildcard bridge. Kept as
+    /// the fully closed `1+1` (unlike the over-limit test's `. + 1` above)
+    /// -- there's no depth guard to dodge here, and the closed shape is a
+    /// simpler check that ordinary evaluation is untouched.
     #[test]
     fn test_arithmetic_wildcard_bridge_accepts_nesting_under_limit_2627() {
         use crate::json::JsonIndex;
@@ -22642,15 +22662,23 @@ mod tests {
     /// the full materialization above (#2476's O(N) replacement for the
     /// bridge's O(2^N) cost) -- but its depth guard panicked exactly the
     /// same way before this fix, as its own doc comment
-    /// (`ambient_validation_error`) already flagged. `true and true` has no
-    /// path-context operand on either side, so it takes this route.
+    /// (`ambient_validation_error`) already flagged. `. and true`, not
+    /// `true and true`: both keep `needs_path_context` false (no `key`/
+    /// `parent`/`path` operand on either side, so this still takes the
+    /// bridge route), but a fully closed `true and true` no longer reaches
+    /// this walk at all -- #2173's `walk::reads_ambient_value` gate
+    /// (landed the same day as this fix) substitutes `OwnedValue::Null` for
+    /// a closed term before this function is ever called. `.` on the left
+    /// makes the whole expression ambient-reading (`Expr::Identity` always
+    /// reports `reads_ambient_value == true`), which is what keeps the real
+    /// document -- and this guard -- in the loop.
     ///
     /// [`eval_with_cursor`], not [`eval`]: `ambient_validation_error` walks
     /// from a `DocumentCursor`, so it is a deliberate no-op without one
     /// (see its own doc comment's "`None` without a cursor" paragraph) --
     /// this is the real public `succinctly::jq::eval` shape, which always
     /// supplies a cursor (confirmed live via `eval::eval`'s own
-    /// `needs_path_context` gate: a pipe like `key?, (true and true)` on a
+    /// `needs_path_context` gate: a pipe like `key?, (. and true)` on a
     /// document nested deeper than 256 levels reaches this exact guard
     /// through the public API, not just this module's own internal
     /// callers).
@@ -22661,7 +22689,7 @@ mod tests {
         let json = json.as_bytes();
         let index = JsonIndex::build(json);
         let cursor = index.root(json);
-        let expr = crate::jq::parse("true and true").unwrap();
+        let expr = crate::jq::parse(". and true").unwrap();
 
         match eval_with_cursor(&expr, cursor) {
             GenericResult::Error(e) => {
@@ -22678,7 +22706,10 @@ mod tests {
 
     /// Companion to the test above: `true and true` well under the limit
     /// must still answer normally through `eval_boolean_generic`'s own
-    /// ambient-validation gate.
+    /// ambient-validation gate. Kept as the fully closed `true and true`
+    /// (unlike the over-limit test's `. and true` above) -- there's no
+    /// depth guard to dodge here, and the closed shape is a simpler check
+    /// that ordinary evaluation is untouched.
     #[test]
     fn test_boolean_ambient_validation_accepts_nesting_under_limit_2627() {
         use crate::json::JsonIndex;
@@ -22699,6 +22730,8 @@ mod tests {
     /// [`to_owned_with_cursor`]'s `Some(cursor)` branch
     /// ([`to_owned_cursor_at_depth`]) is fixed too, not just the `None`
     /// branch ([`to_owned_at_depth`]) that a cursor-less [`eval`] exercises.
+    /// `. + 1`, not `1+1`, for the same reason as the first test above: a
+    /// closed term no longer reaches this materialization at all.
     #[test]
     fn test_arithmetic_wildcard_bridge_with_cursor_reports_clean_error_past_nesting_limit_2627() {
         use crate::json::JsonIndex;
@@ -22706,7 +22739,7 @@ mod tests {
         let json = json.as_bytes();
         let index = JsonIndex::build(json);
         let cursor = index.root(json);
-        let expr = crate::jq::parse("1+1").unwrap();
+        let expr = crate::jq::parse(". + 1").unwrap();
 
         match eval_with_cursor(&expr, cursor) {
             GenericResult::Error(e) => {

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -20826,6 +20826,41 @@ fn test_partial_result_over_depth_value_reports_cleanly_not_panic_1371() -> Resu
     Ok(())
 }
 
+/// #2627: the `needs_path_context` gate's wildcard/ambient bridge used to
+/// reach `eval_generic.rs`'s `assert_nesting_depth` `panic!` on a >256-deep
+/// *document* (not a constructed value, unlike #1371's `test_partial_result_
+/// over_depth_value_reports_cleanly_not_panic_1371` above) for an expression
+/// that never reads `.` at all, e.g. `true and true` (`and`/`or` have no
+/// native path-context arm, so an ungated pair falls to the bridge purely to
+/// surface a document-level fault, per `eval_boolean_generic`'s own comment).
+/// Already shielded at the CLI boundary by `catch_unwind` (#1793) before this
+/// fix -- confirmed via `!stderr.contains("panicked")` below, so this pins
+/// the *absence* of a regression there while the real fix (`eval_generic.rs`'s
+/// depth guard no longer panics at all) is what protects a library embedder
+/// calling `succinctly::jq::eval` directly, which had no such net.
+#[test]
+fn test_boolean_wildcard_bridge_over_depth_document_reports_cleanly_not_panic_2627() -> Result<()> {
+    let (stdout, stderr, code) = run_jq_full(&["-c", "true and true"], Some(&nested_arrays(300)))?;
+    assert_eq!(stdout.trim_end(), "");
+    assert_eq!(code, 5, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert!(!stderr.contains("panicked"), "stderr: {stderr:?}");
+    assert!(
+        stderr.contains("nesting depth exceeds limit of 256"),
+        "stderr: {stderr:?}"
+    );
+    Ok(())
+}
+
+/// Companion to the test above: `true and true` on a document well under
+/// the limit must still evaluate normally through the same bridge.
+#[test]
+fn test_boolean_wildcard_bridge_accepts_depth_under_limit_2627() -> Result<()> {
+    let (stdout, stderr, code) = run_jq_full(&["-c", "true and true"], Some(&nested_arrays(100)))?;
+    assert_eq!(code, 0, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert_eq!(stdout.trim_end(), "true");
+    Ok(())
+}
+
 /// #1381 regression guard: the weighted-cost check must not fire before an
 /// *ordinary, non-chained* recursive `def` reaches its own
 /// `MAX_FUNC_EXPANSION_DEPTH` budget -- `deep(49)` (a thin single-argument

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -20830,17 +20830,25 @@ fn test_partial_result_over_depth_value_reports_cleanly_not_panic_1371() -> Resu
 /// reach `eval_generic.rs`'s `assert_nesting_depth` `panic!` on a >256-deep
 /// *document* (not a constructed value, unlike #1371's `test_partial_result_
 /// over_depth_value_reports_cleanly_not_panic_1371` above) for an expression
-/// that never reads `.` at all, e.g. `true and true` (`and`/`or` have no
-/// native path-context arm, so an ungated pair falls to the bridge purely to
-/// surface a document-level fault, per `eval_boolean_generic`'s own comment).
-/// Already shielded at the CLI boundary by `catch_unwind` (#1793) before this
-/// fix -- confirmed via `!stderr.contains("panicked")` below, so this pins
-/// the *absence* of a regression there while the real fix (`eval_generic.rs`'s
-/// depth guard no longer panics at all) is what protects a library embedder
-/// calling `succinctly::jq::eval` directly, which had no such net.
+/// that has no native path-context arm (`and`/`or` fall to the bridge purely
+/// to surface a document-level fault, per `eval_boolean_generic`'s own
+/// comment). `. and true`, not `true and true`: a fully closed term (no
+/// operand reads `.` at all) no longer reaches the bridge's materialization
+/// in the first place -- #2173's `walk::reads_ambient_value` gate (landed
+/// the same day as this fix) substitutes `null` for a closed term instead of
+/// the real document, so `true and true` on this same input now answers
+/// `true` at exit 0 rather than reaching this guard. `.` on the left keeps
+/// `needs_path_context` false (still no `key`/`parent`/`path` operand) while
+/// making the whole expression read the ambient value, which is what keeps
+/// the real (over-deep) document in the loop. Already shielded at the CLI
+/// boundary by `catch_unwind` (#1793) before this fix -- confirmed via
+/// `!stderr.contains("panicked")` below, so this pins the *absence* of a
+/// regression there while the real fix (`eval_generic.rs`'s depth guard no
+/// longer panics at all) is what protects a library embedder calling
+/// `succinctly::jq::eval` directly, which had no such net.
 #[test]
 fn test_boolean_wildcard_bridge_over_depth_document_reports_cleanly_not_panic_2627() -> Result<()> {
-    let (stdout, stderr, code) = run_jq_full(&["-c", "true and true"], Some(&nested_arrays(300)))?;
+    let (stdout, stderr, code) = run_jq_full(&["-c", ". and true"], Some(&nested_arrays(300)))?;
     assert_eq!(stdout.trim_end(), "");
     assert_eq!(code, 5, "stdout: {stdout:?} stderr: {stderr:?}");
     assert!(!stderr.contains("panicked"), "stderr: {stderr:?}");
@@ -20851,11 +20859,12 @@ fn test_boolean_wildcard_bridge_over_depth_document_reports_cleanly_not_panic_26
     Ok(())
 }
 
-/// Companion to the test above: `true and true` on a document well under
-/// the limit must still evaluate normally through the same bridge.
+/// Companion to the test above: `. and true` on a document well under
+/// the limit must still evaluate normally through the same bridge -- `.`
+/// is a non-empty array either way, so this is `true` regardless of depth.
 #[test]
 fn test_boolean_wildcard_bridge_accepts_depth_under_limit_2627() -> Result<()> {
-    let (stdout, stderr, code) = run_jq_full(&["-c", "true and true"], Some(&nested_arrays(100)))?;
+    let (stdout, stderr, code) = run_jq_full(&["-c", ". and true"], Some(&nested_arrays(100)))?;
     assert_eq!(code, 0, "stdout: {stdout:?} stderr: {stderr:?}");
     assert_eq!(stdout.trim_end(), "true");
     Ok(())

--- a/tests/jq_library_eval_nesting_depth_tests.rs
+++ b/tests/jq_library_eval_nesting_depth_tests.rs
@@ -1,0 +1,74 @@
+//! #2627: a library embedder calling `succinctly::jq::eval` directly (no
+//! CLI, no `catch_unwind`) must never see a raw panic on a >256-deep
+//! document, even for a filter that reads no path context at all.
+//!
+//! `eval::eval`'s own top-level gate (`needs_path_context`) routes a whole
+//! expression through `eval_generic` only when *some* part of it needs path
+//! context (`key`/`parent`/`path`/...). A bare `true and true`/`1+1` on its
+//! own therefore never reaches `eval_generic`'s internal materialization
+//! through the public API -- but a pipe that combines a path-context need
+//! with an otherwise-ungated sub-expression does, and once inside
+//! `eval_generic`, that sub-expression's own `needs_path_context` gate can
+//! independently be `false`, sending it to the same wildcard/ambient bridge
+//! `tests/jq_cli_tests.rs`'s `test_boolean_wildcard_bridge_over_depth_
+//! document_reports_cleanly_not_panic_2627` pins at the CLI layer (protected
+//! there by `catch_unwind`, #1793). This file confirms the same document
+//! and filter shape, reached through the *public* library entry point with
+//! no such net, returns a clean `Err` instead of aborting the process.
+//!
+//! Confirmed live before the fix that this exact shape panicked with no
+//! `catch_unwind` to save it (the underlying `assert_nesting_depth` `panic!`
+//! in `src/jq/eval_generic.rs`).
+
+use succinctly::jq::{eval, parse, JqSemantics, QueryResult};
+use succinctly::json::JsonIndex;
+
+/// `[[[...1...]]]`, `depth` levels of array nesting wrapping a single `1` --
+/// mirrors `jq_recurse_depth_tests.rs`'s own `linear_nest` and `jq_cli_tests
+/// .rs`'s `nested_arrays`.
+fn nested_arrays(depth: usize) -> String {
+    format!("{}1{}", "[".repeat(depth), "]".repeat(depth))
+}
+
+/// `key?` forces `eval::eval`'s own gate to route the whole pipe through
+/// `eval_generic` (confirmed by `needs_path_context`'s `Expr::Builtin(Builtin
+/// ::Key) => true` arm); `(true and true)` has no path-context operand of
+/// its own, so once inside `eval_generic` it independently falls to the
+/// wildcard/ambient bridge this issue is about.
+const FILTER: &str = "key?, (true and true)";
+
+#[test]
+fn test_public_eval_over_depth_document_returns_error_not_panic_2627() {
+    let json = nested_arrays(300);
+    let bytes = json.as_bytes();
+    let index = JsonIndex::build(bytes);
+    let cursor = index.root(bytes);
+    let expr = parse(FILTER).expect("parse failed");
+
+    let result: QueryResult<Vec<u64>> = eval::<Vec<u64>, JqSemantics>(&expr, cursor);
+    match result {
+        QueryResult::Error(e) => {
+            assert!(e.is_decode_failure(), "expected decode failure, got: {e:?}");
+            assert!(
+                e.message.contains("nesting depth exceeds limit of 256"),
+                "message: {}",
+                e.message
+            );
+        }
+        other => panic!("expected a decode failure, got: {other:?}"),
+    }
+}
+
+/// Companion: the same filter on a document well under the limit must still
+/// evaluate normally through the public API.
+#[test]
+fn test_public_eval_accepts_depth_under_limit_2627() {
+    let json = nested_arrays(100);
+    let bytes = json.as_bytes();
+    let index = JsonIndex::build(bytes);
+    let cursor = index.root(bytes);
+    let expr = parse(FILTER).expect("parse failed");
+
+    let result: QueryResult<Vec<u64>> = eval::<Vec<u64>, JqSemantics>(&expr, cursor);
+    assert!(!result.is_error(), "unexpected error: {result:?}");
+}

--- a/tests/jq_library_eval_nesting_depth_tests.rs
+++ b/tests/jq_library_eval_nesting_depth_tests.rs
@@ -1,10 +1,10 @@
 //! #2627: a library embedder calling `succinctly::jq::eval` directly (no
 //! CLI, no `catch_unwind`) must never see a raw panic on a >256-deep
-//! document, even for a filter that reads no path context at all.
+//! document, even for a filter whose own operand doesn't need path context.
 //!
 //! `eval::eval`'s own top-level gate (`needs_path_context`) routes a whole
 //! expression through `eval_generic` only when *some* part of it needs path
-//! context (`key`/`parent`/`path`/...). A bare `true and true`/`1+1` on its
+//! context (`key`/`parent`/`path`/...). A bare `. and true`/`. + 1` on its
 //! own therefore never reaches `eval_generic`'s internal materialization
 //! through the public API -- but a pipe that combines a path-context need
 //! with an otherwise-ungated sub-expression does, and once inside
@@ -15,6 +15,15 @@
 //! there by `catch_unwind`, #1793). This file confirms the same document
 //! and filter shape, reached through the *public* library entry point with
 //! no such net, returns a clean `Err` instead of aborting the process.
+//!
+//! `(. and true)`, not `(true and true)`: a fully closed sub-expression (no
+//! operand reads `.` at all) no longer reaches the bridge's materialization
+//! in the first place -- #2173's `walk::reads_ambient_value` gate (landed
+//! the same day as this fix) substitutes `null` for a closed term instead of
+//! the real document, so the guard below never sees it. `.` keeps the
+//! sub-expression's own `needs_path_context` false (still no `key`/`parent`/
+//! `path` operand) while making it read the ambient value, which is what
+//! keeps the real (over-deep) document in the loop.
 //!
 //! Confirmed live before the fix that this exact shape panicked with no
 //! `catch_unwind` to save it (the underlying `assert_nesting_depth` `panic!`
@@ -32,10 +41,11 @@ fn nested_arrays(depth: usize) -> String {
 
 /// `key?` forces `eval::eval`'s own gate to route the whole pipe through
 /// `eval_generic` (confirmed by `needs_path_context`'s `Expr::Builtin(Builtin
-/// ::Key) => true` arm); `(true and true)` has no path-context operand of
-/// its own, so once inside `eval_generic` it independently falls to the
-/// wildcard/ambient bridge this issue is about.
-const FILTER: &str = "key?, (true and true)";
+/// ::Key) => true` arm); `(. and true)` has no path-context operand of its
+/// own, so once inside `eval_generic` it independently falls to the
+/// wildcard/ambient bridge this issue is about, while still reading the
+/// ambient value (see the module doc comment above).
+const FILTER: &str = "key?, (. and true)";
 
 #[test]
 fn test_public_eval_over_depth_document_returns_error_not_panic_2627() {


### PR DESCRIPTION
## Summary

The `needs_path_context` gate's wildcard/ambient bridge — the materialization
path used for expressions like `1+1`/`true and true` that don't need path
context, purely to surface a document-level fault the same way real jq's
parser would — hit a hard `panic!` rather than a recoverable error past 256
levels of document nesting. The CLI already shields this with `catch_unwind`
(#1793), but a library embedder calling `succinctly::jq::eval` directly had
no such net and inherited a raw process abort.

`to_owned_at_depth`/`to_owned_cursor_at_depth`/`push_generic_document_
validation_error` already threaded `Result`/`Option<Control>` through every
one of their call sites for other error classes (decode failures, #1194
structural errors, #1642 key collisions). Only the depth guard's own
signaling needed to change: it now returns a `decode_failure`-tagged
`EvalError` instead of panicking, which stays just as unreachable by a
filter's own `try`/`catch` as the panic was (matching real jq's own
parse-time depth rejection, which the filter never gets a chance to run
against in the first place).

Out of scope, left as `panic!`: `to_owned_with_comments_at_depth` (only
reached by `yq_runner.rs`'s comment/anchor-preserving DOM write path, not
this bridge) and `owned_from_standard_json_at_depth` (a separate,
unrelated concern — filter-*constructed* output depth, #1017).

A same-day, unrelated fix (#2173) landed a closed-term short-circuit
(`walk::reads_ambient_value`) that substitutes `null` for a fully closed
term instead of materializing the real document — which meant this branch's
original `1+1`/`true and true` regression tests stopped exercising the
bridge at all after rebasing past it. They're updated to the minimal
ambient-reading equivalents (`. + 1`, `. and true`) that still read `.`
while keeping `needs_path_context` false, so the real (over-deep) document
stays in the loop.

Fixes #2627.

## Test plan
- [x] `cargo test --features cli --lib` (3600+ tests, all green)
- [x] `cargo test --features cli --test jq_cli_tests` (1549 tests, all green)
- [x] New `tests/jq_library_eval_nesting_depth_tests.rs` — exercises the
      actual public `succinctly::jq::eval` API end-to-end, confirming a
      library embedder gets a clean `Err`, not a panic
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features` clean
- [x] Live repro: `succinctly jq -c '. and true'`/`'not'`/`'false // 1'` on a
      300-deep document now go straight to the clean exit-5 error instead of
      panic-then-`catch_unwind`