### PR TITLE
fix(jq): arithmetic and unary minus answer from the document, not a copy of it (#2626)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,44 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`succinctly yq` no longer answers arithmetic from a collapsed copy of the
+  document** (#2626). `printf 'b: 1\na: 2\nb: 3\n' | succinctly yq 'length + 0'`
+  answered `2` while the same binary's bare `length` answered `3` — and real yq
+  v4.53.3 answers `3` for both. Adding `+ 0` changed how many keys the document
+  had. `length * -1` and `-length` were wrong the same way.
+
+  `eval_single`'s `Expr::Arithmetic` and `Expr::Negate` arms matched only when an
+  operand needed path context; every other arithmetic fell to the wildcard bridge,
+  whose first act is `to_owned_with_cursor` — an `IndexMap` walk that collapses
+  duplicate mapping keys before either operand runs. Both arms now take their
+  native, cursor-threaded route unconditionally. Unary minus needed the fix twice:
+  `eval_each_generic` has a bridging `Expr::Negate` arm of its own, so fixing only
+  `eval_single`'s left `-length` at `-3` while `first(-length)` still answered
+  `-2`. `each_negate_generic` mirrors `eval::each_negate`, with the
+  demand-forwarding and `?//`-retry behaviour verified unchanged against jq 1.7.1.
+
+  The same bridge re-rooted the value at a fresh JSON serialization, which silently
+  stubbed every yq node-metadata builtin `needs_path_context` does not cover:
+  `.b | (line + 0)` answered `0` where `.b | line` answers `2`, `(anchor + "")` and
+  `(style + "")` answered `""`, and `di + 0` answered `0` for every document in a
+  multi-document stream. All now match their bare spellings and yq v4.53.3.
+
+  **Leaving the bridge also means arithmetic stops validating the whole document,
+  and the raise-set moves with it** — `[length + 0]` and `(-length)` on a malformed
+  document now answer where they used to exit 5. That is #2173's rule one level in:
+  the split it removed was between filters, and this one was between two spellings
+  of the same read (`length` answered, `length + 0` raised, `first(length + 0)`
+  answered). An operand that actually reads the malformed scalar still raises.
+  Recorded in [docs/compliance/jq/limitations.md](docs/compliance/jq/limitations.md)
+  under ADR-0018's #2103 amendment, and pinned by
+  `test_arithmetic_validates_only_what_it_reads_2626`.
+
+  One residual, recorded in
+  [docs/compliance/yq/limitations.md](docs/compliance/yq/limitations.md): an operand
+  whose own value is a duplicate-keyed container still collapses when it is folded
+  to an `OwnedValue` (`. + {}`), the representation limit ADR-0017 declares out of
+  scope (#796).
+
 - **A `def` loaded through `include` or `~/.jq` can now shadow a builtin of the
   same name** (#2395, a #2036 follow-up). `jq -L . -nc 'include "mylib"; length'`
   with `def length: "shadowed-from-module";` in the module answered `0` -- the

--- a/docs/compliance/jq/limitations.md
+++ b/docs/compliance/jq/limitations.md
@@ -3682,6 +3682,40 @@ documents, plus 5 reading spellings that must still raise), the split probe list
 if it calls a filter closed, the filter's output must not depend on the document — is
 `tests/jq_closed_term_tests.rs`.
 
+### Arithmetic and unary minus validate only what they read (#2626)
+
+[#2173](https://github.com/rust-works/succinctly/issues/2173) above stopped the wildcard
+bridge materializing for a *closed* term. `eval_single`'s `Expr::Arithmetic` and
+`Expr::Negate` arms were still gated on `needs_path_context`, so an arithmetic that **does**
+read `.` — `length + 0` — kept falling to that bridge and validating the whole document,
+while the same read spelled without the arithmetic did not. That is the same
+spelling-dependence one level in: not between filters, but between two spellings of one.
+
+On `{"a": "bad\x", "b": 5}`, which jq 1.7.1 rejects at parse time for every filter:
+
+| filter          | jq 1.7.1 | succinctly before | succinctly now |
+|-----------------|----------|-------------------|----------------|
+| `length`        | error    | `2` (exit 0)      | `2` — unchanged |
+| `length + 0`    | error    | `2` — unchanged   | `2` — unchanged |
+| `[length + 0]`  | error    | error             | `[2]`          |
+| `(-length)`     | error    | error             | `-2`           |
+| `.b + 0`        | error    | `5`               | `5` — unchanged |
+
+Dropping the gate is what closes it: both arms now take their native, cursor-threaded route
+on every input, so nothing materializes and nothing validates beyond what the operands
+actually read. Nothing replaces the bridge's ambient decode, and that is the point rather
+than an omission — it is the accident #2173's own entry describes, arrived at from a fourth
+direction. An operand that *does* read the malformed scalar still raises: `.a + ""` and
+`(.a + "") | length` both exit 5, exactly as bare `.a` does.
+
+`eval_each_generic`'s own `Expr::Negate` arm bridged too, and had to move with them, or
+`-length` and `first(-length)` would have disagreed.
+
+Sanctioned by ADR-0018's #2103 amendment, like the two entries above. Pinned by
+`test_arithmetic_validates_only_what_it_reads_2626` in `tests/yq_cli_tests.rs` (where the
+duplicate-key half of #2626 is also pinned) and by the arithmetic rows added to
+`test_closed_terms_do_not_validate_2173`'s closed-probe lists in both suites.
+
 ### A fault found by walking to it leaves the prefix on stdout
 
 succinctly is a semi-index and finds a malformed document only when the walk reaches the

--- a/docs/compliance/yq/limitations.md
+++ b/docs/compliance/yq/limitations.md
@@ -684,6 +684,43 @@ it landed:
   needs to reorder/slice entries, not just stream them) — a real representation limit, not a
   missed wiring like the three above.
 
+**[#2626](https://github.com/rust-works/succinctly/issues/2626) closed one member that was
+missing from that list: arithmetic.** `eval_single`'s `Expr::Arithmetic`/`Expr::Negate` arms
+matched only when an operand needed path context, so every other arithmetic fell to the same
+wildcard bridge — and collapsed the document before either operand ran. The binary
+contradicted itself:
+
+```bash
+$ printf 'b: 1\na: 2\nb: 3\n' | succinctly yq 'length'       # 3
+$ printf 'b: 1\na: 2\nb: 3\n' | succinctly yq 'length + 0'   # 2  (was), 3 (now); yq: 3
+$ printf 'b: 1\na: 2\nb: 3\n' | succinctly yq 'length * -1'  # -2 (was), -3 (now); yq: -3
+```
+
+Unary minus needed the same fix twice, because it has two bridging arms: `eval_single`'s and
+`eval_each_generic`'s own. Fixing only the first left `-length` at `-3` while `first(-length)`
+still answered `-2` — the same filter contradicting itself by position — so
+`each_negate_generic` gives the lazy route a native arm too. Real yq has no unary minus, so
+the oracle for those rows is its own spelling, `length * -1`.
+
+The same bridge re-rooted the value at a fresh JSON serialization, which stubbed every yq
+node-metadata builtin `needs_path_context` does not cover: `.b | (line + 0)` answered `0`
+where `.b | line` answers `2`, `(anchor + "")`/`(style + "")` answered `""`, and `di + 0`
+answered `0` for every document. All of those now agree with their bare spellings, and with
+yq v4.53.3. Pinned by `test_arithmetic_reads_the_real_document_2626`.
+
+Two things it does not fix. `generic_item_into_owned` still folds each *operand* to an
+`OwnedValue`, so an operand whose own value is a duplicate-keyed container collapses there
+(`. + {}`) — the `OwnedValue::Object` representation limit ADR-0017 declares out of scope
+(#796), the same residual `reduce`'s bindings have above. And `column` inside an arithmetic
+now agrees with succinctly's own bare `column`, which itself answers the value's column where
+yq answers the anchor's — a pre-existing divergence in the builtin, unrelated to the bridge
+([#2712](https://github.com/rust-works/succinctly/issues/2712)).
+
+Leaving the bridge also means arithmetic stops validating the whole document, which is a
+deliberate divergence in its own right and is recorded under
+[jq Limitations § Arithmetic and unary minus validate only what they read](../jq/limitations.md#arithmetic-and-unary-minus-validate-only-what-they-read-2626)
+— the arms are shared, so the rule is one rule.
+
 **[#1975](https://github.com/rust-works/succinctly/issues/1975) found this same `parse_input`/
 `to_owned_canonicalizing_numbers` bridge — #1343's still-open DOM fallback for `--slurp`/
 `--eval-all`, and `--inplace`'s DOM-forcing flags — had neither the #1194 unpaired-tail check

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -57,12 +57,12 @@ use super::eval::{
     classify_nth_n, classify_parent_n, clear_nonretryable_stop, collapse_vec,
     collect_pattern_var_names, compare_values, debug_assert_materialization_error,
     enter_def_call_frame, entries_to_object, eval_each_owned, eval_full as full_eval,
-    eval_reduce_with_values, extract_pattern_bindings, finish_fork_from_flow, finish_short_circuit,
-    fold_escaped_generator_prefix, foreach_forks, format_owned, has_type_mismatch_is_permissive,
-    index_component_value, index_in_array_bounds, index_one_owned as index_owned_by_key,
-    is_pure_chain_link, is_retryable_stop, literal_to_owned, mark_nonretryable_escape,
-    needs_path_context, numeric_key_to_array_index, numeric_key_to_index, numeric_length_owned,
-    owned_bound_to_i64, owned_to_expr, owned_to_string, param_names,
+    eval_reduce_with_values, extract_pattern_bindings, finish_fork_flow, finish_fork_from_flow,
+    finish_short_circuit, fold_escaped_generator_prefix, foreach_forks, format_owned,
+    has_type_mismatch_is_permissive, index_component_value, index_in_array_bounds,
+    index_one_owned as index_owned_by_key, is_pure_chain_link, is_retryable_stop, literal_to_owned,
+    mark_nonretryable_escape, needs_path_context, numeric_key_to_array_index, numeric_key_to_index,
+    numeric_length_owned, owned_bound_to_i64, owned_to_expr, owned_to_string, param_names,
     pattern_alternatives_var_names, prefer_pending_control, resume_from_escape, select_emits,
     slice_component_value, slice_object_as_yq_children, slice_owned_value_read,
     stop_with_downstream, stop_with_error, stop_with_escape, streams_escaped_generator_prefix,
@@ -6948,25 +6948,34 @@ fn eval_single<S: EvalSemantics, V: DocumentValue>(
         // eager bridge used to hand it `null + 10`. That is what admits
         // `Expr::Arithmetic` to `path_context_single_native`.
         //
-        // **Gated on `needs_path_context`, unlike the `Expr::Compare` arm
-        // above.** The eager bridge materializes the ambient value on its
-        // way through, and for a #1194-malformed document (`{123: 1}`) that
-        // materialization is the decode failure jq answers *every* query on
-        // that document with -- including one that never reads `.`, like
-        // `try (1+1) catch "x"` (exit 5, live-verified against jq 1.7.1 and
-        // pinned by `test_try_catch_contains_a_genuinely_catchable_malformed_key_error_1812`).
-        // An ungated arm here would answer `2` and lose that. The gate keeps
-        // arithmetic that reads no path context on the bridge, where it
-        // still pays the ambient decode; arithmetic that does read path
-        // context could not have been on a malformed document's root and
-        // survived the walk anyway. (`Expr::Compare`'s own arm already
-        // diverges here -- `1==1` on `{123: 1}` answers `true` -- which is a
-        // pre-existing gap, not one this arm widens.)
-        Expr::Arithmetic { left, right, .. }
-            if needs_path_context(left) || needs_path_context(right) =>
-        {
-            collect_each_generic::<S, V>(expr, value, optional, cursor)
-        }
+        // **Ungated since #2626.** The gate kept an arithmetic whose
+        // operands read no position on the eager bridge, whose first act is
+        // `to_owned_with_cursor` -- and that materialization does two things
+        // the gate was not asking for. It collapses duplicate mapping keys
+        // through its `IndexMap`, so `length + 0` on `b: 1\na: 2\nb: 3\n`
+        // answered `2` in yq mode where this binary's own bare `length`
+        // answers `3` and yq v4.53.3 answers `3`. And it re-roots the value
+        // at a fresh JSON serialization, which stubs every yq node-metadata
+        // builtin `needs_path_context` does not cover: `.b | (line + 0)`
+        // answered `0` where `.b | line` answers `2`, `(anchor + "")` and
+        // `(style + "")` answered `""`, and `di + 0` answered `0` for every
+        // document in a stream.
+        //
+        // The gate's stated purpose was the bridge's *ambient decode* --
+        // the raise a malformed document produces for a filter that reads
+        // nothing (`try (1+1) catch "x"`, #1812). Nothing replaces it here,
+        // and that is the point rather than an omission: #2103 recorded
+        // that a filter validates only what it reads, and #2173 applied it
+        // to exactly this bridge, so a closed term already answers instead
+        // of raising. What was left was the *document-reading* half, where
+        // the split was between one spelling and another rather than
+        // between filters -- on `a: "bad\q"`, `length` answered `1`,
+        // `first(length + 0)` answered `1`, and only `length + 0` raised,
+        // because only it bridged. Removing the gate removes that last
+        // spelling dependence too; the divergence is recorded in
+        // `docs/compliance/yq/limitations.md` and pinned by
+        // `test_arithmetic_validates_only_what_it_reads_2626`.
+        Expr::Arithmetic { .. } => collect_each_generic::<S, V>(expr, value, optional, cursor),
 
         // Spine 2416 (the exit): unary minus over a path-context operand.
         // The eager evaluator carried this as `eval_negate_with_path_context`
@@ -6982,10 +6991,13 @@ fn eval_single<S: EvalSemantics, V: DocumentValue>(
         // select((file_index * -1) == -1)]'` is `[20]` -- the read happens at
         // the node either way.
         //
-        // Gated on `needs_path_context` for the same #1812 reason as the
-        // `Expr::Arithmetic` arm above: an ungated arm would stop paying the
-        // bridge's ambient decode on a malformed document.
-        Expr::Negate(inner) if needs_path_context(inner) => {
+        // Ungated since #2626, for the reasons the `Expr::Arithmetic` arm
+        // above gives at length: the gate kept an ungated `-x` on the
+        // bridge, and the bridge collapsed duplicate mapping keys on its way
+        // through. `-length` on `b: 1\na: 2\nb: 3\n` answered `-2` where
+        // bare `length` answers `3` and `length * -1` -- real yq's own
+        // spelling, since yq has no unary minus -- now answers `-3`.
+        Expr::Negate(inner) => {
             let (values, control) =
                 stream_owned_outputs_generic::<S, V>(inner, value, optional, cursor);
             let mut out: Vec<OwnedValue> = vec_with_capacity(values.len());
@@ -8065,8 +8077,17 @@ fn eval_each_generic<S: EvalSemantics, V: DocumentValue>(
             let mut acc = Vec::new();
             each_object_entries_generic::<S, V>(entries, value, optional, cursor, &mut acc, sink)
         }
-        Expr::Negate(operand) if !needs_path_context(operand) => {
-            bridge_to_each_owned_flow::<S, V>(expr, value, cursor, optional, sink)
+        // Ungated since #2626. This arm bridged an operand that reads no
+        // position, and `bridge_to_each_owned_flow`'s materialization
+        // collapses duplicate mapping keys, so `first(-length)` answered
+        // `-2` on `b: 1\na: 2\nb: 3\n` once `eval_single`'s own
+        // `Expr::Negate` arm had been fixed to answer `-3` -- the same
+        // filter contradicting itself by position, which is the shape #2626
+        // was filed about. `each_negate_generic` is `eval::each_negate` with
+        // the cursor threaded through, so the demand-forwarding and
+        // `?//`-retry rows that arm pins are the same definition here.
+        Expr::Negate(operand) => {
+            each_negate_generic::<S, V>(operand, value, optional, cursor, sink)
         }
         // jq mode only -- yq mode's string interpolation isn't a fan-out
         // generator at all (`eval::eval_string_interpolation`'s own doc
@@ -10999,6 +11020,58 @@ fn each_boolean_generic<S: EvalSemantics, V: DocumentValue>(
         binary_fanout_rules::<S>(EmptyOperandOp::Boolean),
         &mut |bit| sink(GenericItem::Owned(OwnedValue::Bool(bit))),
     )
+}
+
+/// Unary minus with the cursor threaded into its operand (#2626) -- the
+/// generic twin of [`super::eval::each_negate`], arm for arm.
+///
+/// `eval_each_generic`'s `Expr::Negate` arm bridged an operand that reads no
+/// position, which materializes the ambient value and so collapses duplicate
+/// mapping keys before the operand runs. That made the same filter answer
+/// differently by position once `eval_single`'s own `Expr::Negate` arm was
+/// fixed: `-length` on `b: 1\na: 2\nb: 3\n` was `-3` and `first(-length)`
+/// was still `-2`.
+///
+/// The loop is `eval::each_negate`'s, not a new rule: forward each operand
+/// output through `arith_negate` as it arrives, stop the whole fan-out on a
+/// type error rather than skipping the pairing, keep the prefix already
+/// negated, and let [`super::eval::finish_fork_flow`] apply the #1902 rule
+/// that an ambient `?` never suppresses a decode failure.
+fn each_negate_generic<S: EvalSemantics, V: DocumentValue>(
+    operand: &Expr,
+    value: V,
+    optional: bool,
+    cursor: Option<V::Cursor>,
+    sink: &mut dyn FnMut(GenericItem<V>) -> Demand,
+) -> Flow {
+    let mut outer_stopped = false;
+    let mut escape: Option<Control> = None;
+    let flow = eval_each_generic::<S, V>(operand, value, optional, cursor, &mut |item| {
+        let owned = match generic_item_into_owned(item) {
+            Ok(v) => v,
+            Err(control) => return stop_with_escape(&mut escape, control),
+        };
+        match crate::jq::eval::arith_negate::<S>(owned) {
+            Ok(negated) => {
+                if sink(GenericItem::Owned(negated)) == Demand::Stop {
+                    outer_stopped = true;
+                    Demand::Stop
+                } else {
+                    Demand::Continue
+                }
+            }
+            Err(e) => stop_with_escape(&mut escape, Control::Error(e)),
+        }
+    });
+
+    if outer_stopped {
+        return flow;
+    }
+    let control = escape.or(match flow {
+        Flow::Exhausted | Flow::Stopped { .. } => None,
+        Flow::Escaped(control) => Some(control),
+    });
+    finish_fork_flow(control, optional)
 }
 
 /// Shared resolution of [`each_take_first_generic`]'s and

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -3415,6 +3415,16 @@ fn test_duplicate_keys_collapse_last_wins_1385() -> Result<()> {
         ("[.[]]", "[3,2]"),
         ("[paths]", r#"[["b"],["a"]]"#),
         ("to_entries|length", "2"),
+        // #2626 control. In yq mode the same three answered `2` from a
+        // *collapsed copy* of the document while bare `length` answered 3,
+        // and giving `Expr::Arithmetic`/`Expr::Negate` native arms moved
+        // them to 3. Here `2` is the right answer and must not move with
+        // them: jq really does build an object with one `b`, so
+        // `COLLAPSE_DUPLICATE_KEYS` makes the streaming route agree with the
+        // collapsed one. Captured from /usr/bin/jq 1.7.1.
+        ("length + 0", "2"),
+        ("(keys|length) + 0", "2"),
+        ("(-length)", "-2"),
     ] {
         let (out, _, code) = run_jq_full(&["-c", filter], Some(input))?;
         assert_eq!(code, 0, "filter {filter}");
@@ -31096,6 +31106,19 @@ fn test_short_circuit_side_effect_shapes_already_match_jq_820() -> Result<()> {
             "",
             0,
         ),
+        // #2626: the same row on the *generic* route. `-n` gives the
+        // evaluator no cursor, so the row above runs `eval.rs`'s own
+        // `each_negate`; with a document on stdin there is a cursor and
+        // `each_negate_generic` -- which that arm bridged to before #2626 --
+        // is what has to forward the demand. It was written to mirror
+        // `each_negate` precisely so these cannot drift.
+        (
+            &["-c", r#"first(-((1, ("B"|stderr))))"#],
+            Some("null"),
+            "-1\n",
+            "",
+            0,
+        ),
         // An index key: the first key already satisfies `first`, so a
         // second key generated after it is never reached.
         (
@@ -44124,6 +44147,15 @@ fn test_ambient_validation_agrees_with_bridge_2476() -> Result<()> {
         ("true and true", "true"),
         ("false or true", "true"),
         ("false // 1", "1"),
+        // #2626 gave `Expr::Arithmetic`/`Expr::Negate` native arms in
+        // `eval_single`, and unary minus one in `eval_each_generic` too, so
+        // neither reaches a bridge on any route now. The answer is #2173's
+        // either way: a term that reads nothing validates nothing.
+        // `(-(1))`, not `-1`, because the parser constant-folds the latter
+        // into a literal that never reaches `Expr::Negate`.
+        ("1 + 1", "2"),
+        ("0 - 0", "0"),
+        ("(-(1))", "-1"),
     ];
     // Four corpus rows are not about validation at all: `xyz123`, `[1,2`,
     // `["a` and `[1] x` give the CLI's document reader no root value to

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -1282,6 +1282,11 @@ fn test_1398_dup_key_format_parity_across_filters() -> Result<()> {
         ),
         ("[.[]]", "[3,2]"),
         (".b", "3"),
+        // #2626: `length + 0` answered 2 here while bare `length` answered
+        // 3, because an arithmetic with no path-context operand fell to the
+        // wildcard bridge and its `IndexMap` collapsed the repeat before
+        // either operand ran. yq v4.53.3 answers 3 for both, captured live.
+        ("length + 0", "3"),
     ];
     for (filter, expected) in cases {
         let (json_out, json_code) =
@@ -1301,6 +1306,153 @@ fn test_1398_dup_key_format_parity_across_filters() -> Result<()> {
             "filter {filter:?} on YAML input"
         );
     }
+    Ok(())
+}
+
+/// #2626: arithmetic and unary minus answer from the *real* document, not
+/// from a materialized copy of it.
+///
+/// `eval_single`'s `Expr::Arithmetic`/`Expr::Negate` arms matched only when
+/// an operand needed path context, so an expression whose operands read no
+/// position fell to the wildcard bridge -- and the bridge's first act is
+/// `to_owned_with_cursor`, an `IndexMap` walk that collapses duplicate
+/// mapping keys and re-roots the value at a fresh JSON serialization. Two
+/// families lost information that way, and both were internal
+/// contradictions rather than mere divergences: the same binary answered
+/// differently for `X` and `X + 0`.
+///
+/// Every expectation below captured live from yq v4.53.3:
+///
+/// ```console
+/// $ printf 'b: 1\na: 2\nb: 3\n' | yq -o=json -I=0 'length + 0'        # 3
+/// $ printf 'b: 1\na: 2\nb: 3\n' | yq -o=json -I=0 '(keys|length) + 0'  # 3
+/// $ printf 'b: 1\na: 2\nb: 3\n' | yq -o=json -I=0 'length * -1'        # -3
+/// $ printf 'a: !!str 5\nb: &anc [1,2]\n' | yq -o=json -I=0 '.b | (line + 0)'    # 2
+/// $ printf 'a: !!str 5\nb: &anc [1,2]\n' | yq -o=json -I=0 '.b | (anchor + "")' # "anc"
+/// $ printf 'a: !!str 5\nb: &anc [1,2]\n' | yq -o=json -I=0 '.b | (style + "")'  # "flow"
+/// $ printf 'a: 1\n---\nb: 2\n' | yq -o=json -I=0 'di + 0'              # 0 then 1
+/// ```
+///
+/// Real yq has no unary minus, so `-length` has no oracle of its own; its
+/// yq-spelled twin `length * -1` is the oracle row, and `(-length)` is
+/// asserted alongside it as internal consistency.
+///
+/// **`column` is deliberately absent.** succinctly's own bare `.b | column`
+/// answers 9 where yq v4.53.3 answers 4 (yq reports the anchor's column,
+/// succinctly the value's). This change makes `(column + 0)` agree with
+/// succinctly's bare `column` -- internally consistent, still divergent --
+/// so pinning it here would pin the wrong number. Filed as #2712.
+#[test]
+fn test_arithmetic_reads_the_real_document_2626() -> Result<()> {
+    let dup = "b: 1\na: 2\nb: 3\n";
+    for (filter, expected) in [
+        ("length", "3"),
+        ("length + 0", "3"),
+        ("0 + length", "3"),
+        ("(keys|length) + 0", "3"),
+        ("(to_entries|length) + 0", "3"),
+        ("length * -1", "-3"),
+        // Parenthesized so the leading `-` is not read as a CLI flag; the
+        // parse is the same `Expr::Negate`.
+        ("(-length)", "-3"),
+        // Under a lazy consumer these take `eval_each_generic`'s own arms.
+        // Its `Expr::Negate` arm bridged too, so `first(-length)` was the
+        // last spelling still answering `-2` once the arms above were fixed.
+        ("first(length + 0)", "3"),
+        ("first(-length)", "-3"),
+    ] {
+        let (out, code) = run_yq_stdin(filter, dup, &["-o=json", "-I=0"])?;
+        assert_eq!(code, 0, "filter {filter}");
+        assert_eq!(out.trim(), expected, "filter {filter}");
+    }
+
+    // The node-metadata family: none of `line`/`anchor`/`style`/`di` is in
+    // `needs_path_context`, so all of them were silently stubbed inside an
+    // arithmetic by the bridge's re-rooting -- `(line + 0)` was 0, and
+    // `(anchor + "")`/`(style + "")` were empty strings.
+    let meta = "a: !!str 5\nb: &anc [1,2]\n";
+    for (filter, expected) in [
+        (".b | line", "2"),
+        (".b | (line + 0)", "2"),
+        (".b | anchor", "\"anc\""),
+        (".b | (anchor + \"\")", "\"anc\""),
+        (".b | style", "\"flow\""),
+        (".b | (style + \"\")", "\"flow\""),
+    ] {
+        let (out, code) = run_yq_stdin(filter, meta, &["-o=json", "-I=0"])?;
+        assert_eq!(code, 0, "filter {filter}");
+        assert_eq!(out.trim(), expected, "filter {filter}");
+    }
+
+    // `di` inside an arithmetic answered 0 for every document, where bare
+    // `di` already counted correctly.
+    let multidoc = "a: 1\n---\nb: 2\n";
+    for filter in ["di", "di + 0"] {
+        let (out, code) = run_yq_stdin(filter, multidoc, &["-o=json", "-I=0"])?;
+        assert_eq!(code, 0, "filter {filter}");
+        assert_eq!(out, "0\n1\n", "filter {filter}");
+    }
+
+    Ok(())
+}
+
+/// #2626: an arithmetic validates only what it reads, like every other
+/// filter since #2103 -- and unlike the bridge it used to take.
+///
+/// Removing the `needs_path_context` gate removes the last spelling on
+/// which a *document-reading* filter still validated the whole document.
+/// The split this closes was not between filters but between two spellings
+/// of one: on `a: "bad\q"` / `b: 5`, `length` answered `2`,
+/// `first(length + 0)` answered `2`, and only `length + 0` raised, because
+/// only it bridged.
+///
+/// **This is a deliberate divergence, and the raise-set moves with it.**
+/// Real yq rejects this document at parse time for *every* filter (v4.53.3:
+/// `Error: bad file ...: yaml: while scanning ...`, exit 1, captured live
+/// for `length`, `length + 0`, `.b` and `.b + 0` alike), so there is no yq
+/// answer to match on any row here. ADR-0018's #2103 amendment governs the
+/// class: where the reference's answer is a whole-document rejection the
+/// semi-index deliberately does not perform, take the *uniform* divergence
+/// rather than the one that depends on how the filter spells its way to the
+/// value. Recorded in `docs/compliance/yq/limitations.md`.
+#[test]
+fn test_arithmetic_validates_only_what_it_reads_2626() -> Result<()> {
+    let doc = "a: \"bad\\q\"\nb: 5\n";
+
+    // Reads the key count, not the bad scalar: every spelling agrees.
+    for (filter, expected) in [
+        ("length", "2"),
+        ("length + 0", "2"),
+        ("0 + length", "2"),
+        ("first(length + 0)", "2"),
+        ("(keys|length)", "2"),
+        ("(keys|length) + 0", "2"),
+        ("(-length)", "-2"),
+    ] {
+        let (stdout, stderr, code) = run_yq_stdin_with_stderr(filter, doc, &["-o=json", "-I=0"])?;
+        assert_eq!(code, 0, "`{filter}` -- stderr: {stderr:?}");
+        assert_eq!(stdout.trim(), expected, "`{filter}` -- stderr: {stderr:?}");
+    }
+
+    // Navigating past the bad scalar is likewise unaffected by the `+ 0`.
+    for (filter, expected) in [(".b", "5"), (".b + 0", "5")] {
+        let (stdout, stderr, code) = run_yq_stdin_with_stderr(filter, doc, &["-o=json", "-I=0"])?;
+        assert_eq!(code, 0, "`{filter}` -- stderr: {stderr:?}");
+        assert_eq!(stdout.trim(), expected, "`{filter}` -- stderr: {stderr:?}");
+    }
+
+    // The other half of the rule, and what keeps this from being a hole:
+    // an arithmetic that actually *reads* the malformed scalar still
+    // raises, exactly as the bare read does.
+    for filter in [".a", ".a + \"\"", "(.a + \"\") | length"] {
+        let (_, stderr, code) = run_yq_stdin_with_stderr(filter, doc, &["-o=json", "-I=0"])?;
+        assert_ne!(code, 0, "`{filter}` -- stderr: {stderr:?}");
+        assert!(
+            stderr.contains("invalid escape sequence"),
+            "`{filter}` -- stderr: {stderr}"
+        );
+    }
+
     Ok(())
 }
 
@@ -39768,6 +39920,15 @@ fn test_ambient_validation_agrees_with_bridge_2476() -> Result<()> {
         ("true and true", "true"),
         ("false or true", "true"),
         ("false // 1", "1"),
+        // #2626 gave `Expr::Arithmetic`/`Expr::Negate` native arms, so they
+        // reach `bridge_ambient_input`'s closed-term path no longer -- they
+        // never materialize at all now. Either way the answer is #2173's:
+        // a term that reads nothing validates nothing. `(-(1))`, not `-1`,
+        // because the parser constant-folds the latter into a literal that
+        // never reaches `Expr::Negate`.
+        ("1 + 1", "2"),
+        ("0 - 0", "0"),
+        ("(-(1))", "-1"),
     ];
     for (label, doc, want_code, want_stderr) in corpus {
         let mut seen: Vec<(String, i32, String)> = Vec::new();


### PR DESCRIPTION
Closes #2626.

## The bug

`succinctly yq` contradicted itself on a document with duplicate mapping keys — adding `+ 0` changed how many keys the document had:

```console
$ printf 'b: 1\na: 2\nb: 3\n' | succinctly yq 'length'       # 3    (yq v4.53.3: 3)
$ printf 'b: 1\na: 2\nb: 3\n' | succinctly yq 'length + 0'   # 2    (yq v4.53.3: 3)
$ printf 'b: 1\na: 2\nb: 3\n' | succinctly yq 'length * -1'  # -2   (yq v4.53.3: -3)
```

`eval_single`'s `Expr::Arithmetic` and `Expr::Negate` arms matched only when an operand needed path context; every other arithmetic fell to the wildcard bridge, whose first act is `to_owned_with_cursor` — an `IndexMap` walk that collapses duplicates before either operand runs.

The same bridge re-roots the value at a fresh JSON serialization, which silently stubbed every yq node-metadata builtin `needs_path_context` does not cover. That half was not in the issue:

| filter | before | after | yq v4.53.3 |
|---|---|---|---|
| `.b \| (line + 0)` | `0` | `2` | `2` |
| `.b \| (anchor + "")` | `""` | `"anc"` | `"anc"` |
| `.b \| (style + "")` | `""` | `"flow"` | `"flow"` |
| `di + 0` (2 docs) | `0 0` | `0 1` | `0 1` |

**Unary minus bridges in two places**, so one arm was not enough: with only `eval_single`'s fixed, `-length` answered `-3` while `first(-length)` still answered `-2` — the same filter contradicting itself by position, which is the shape the issue is about. `each_negate_generic` mirrors `eval::each_negate` arm for arm, so the demand-forwarding and `?//`-retry rules stay one definition. Verified against jq 1.7.1 that `first(-((1, ("B"|stderr))))` still writes `-1` with empty stderr and the `?//` retry still reaches through unary minus.

## The raise-set moves, deliberately

The gates' stated purpose was the bridge's ambient decode (#1812). **Nothing replaces it, and that is the point.** #2103 recorded that a filter validates only what it reads and #2173 applied it to this very bridge, so a closed term already answered instead of raising. What was left was the document-reading half, where the split was between *two spellings of one read* rather than between filters — on `a: "bad\q"`:

```
length             → 1, exit 0
first(length + 0)  → 1, exit 0
length + 0         → raises        ← only because it bridged
```

So `[length + 0]` and `(-length)` on a malformed document now answer where they used to exit 5. An operand that actually reads the malformed scalar still raises (`.a + ""` exits 5, as bare `.a` does). Recorded as its own entry in `docs/compliance/jq/limitations.md` under ADR-0018's #2103 amendment, beside #2103's and #2173's.

Nothing had pinned the old spelling-dependent raise, so **no existing expectation was rewritten** — the whole suite passes unchanged.

## Performance

Removing a whole-document materialization. Interleaved A/B per `docs/guides/benchmarking.md` rule 1, output identity gated first, 7 reps, medians:

| case | before | after | delta |
|---|---|---|---|
| `length + 0` 1 MB | 52.6 ms | 10.0 ms | **−80.9%** |
| `length + 0` 4 MB | 190.3 ms | 26.8 ms | **−85.9%** |
| `(-length)` 4 MB | 191.0 ms | 26.3 ms | **−86.2%** |
| `[.items[] \| (.name + "!")] \| length` 1 MB | 51.1 ms | 12.4 ms | **−75.7%** |
| `[.items[] \| .containers[] \| .env[] \| (.v + 1)] \| length` 1 MB | 49.6 ms | 26.3 ms | **−47.0%** |
| `reduce range(50000) as $i (0; . + $i)`, tiny ambient | 16.9 ms | 17.0 ms | +0.5% |
| `reduce range(50000) as $i (0; . + $i)`, 4 MB ambient | 22.6 ms | 22.4 ms | −0.9% |
| identity `.` (control) | 21.4 ms | 21.4 ms | −0.1% |
| jq identity `.` (control) | 17.0 ms | 16.8 ms | −1.1% |

The win growing with input size (−80.9% at 1 MB → −85.9% at 4 MB) is the signature of removing an O(n) materialization, which corroborates the mechanism.

**Caveat, stated rather than buried:** these are from an M5 Max laptop that was *not* idle (a Python process at ~99%), not one of the pinned bench machines. They are indicative. The controls and the two neutral rows are the load-bearing part — nothing regressed — and the wins are far outside any plausible noise band.

`1 + 1` on an alias fan-out is unchanged at 0.04 s: #2173's closed-term path already fixed that, so it is **not** a win of this PR.

## Verification

- Every expectation captured live from `yq` v4.53.3 and `/usr/bin/jq` 1.7.1.
- Full local CI equivalent, all green: CI's 13 cli-gated targets, `cargo test`, `cargo test --no-default-features`, all three clippy legs, `RUSTDOCFLAGS="-D warnings" cargo doc`, `cargo fmt --check`.
- New: `test_arithmetic_reads_the_real_document_2626` (duplicate keys, the metadata family, both lazy spellings) and `test_arithmetic_validates_only_what_it_reads_2626` (the divergence, plus the reads-it-still-raises half). `length + 0` added to #1398's format-parity table; arithmetic closed terms added to #2173's closed-probe lists in both suites; jq-mode control rows pinning that `2` stays `2` there.

## Residuals, filed not fixed

- **#2712** — `column` answers the value's column where yq answers the anchor's. This PR makes `(column + 0)` agree with succinctly's own bare `column`: internally consistent, still divergent. `test_arithmetic_reads_the_real_document_2626` deliberately omits it and says why, so it does not pin the wrong number.
- **#2713** — `eval_each_generic` still bridges ungated `and`/`or`/`//`, so #2476's fix stays positional the way unary minus's did until this PR.
- An operand whose own *value* is a duplicate-keyed container still collapses when folded to an `OwnedValue` (`. + {}`) — ADR-0017's declared out-of-scope representation limit (#796). Recorded in the yq compliance page.
