### PR TITLE
jq/yq: a filter validates only what it materializes, not what it tests (#2692)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,7 +37,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   all still reject the same documents, and `{123: 1} | any` still raises
   because jq iterates an object's *values* (#422), which resolves its keys.
   #1804's container-vs-scalar-alias carve-out is gone with the walk it was a
-  property of.
+  property of. So is the `MAX_NESTING_DEPTH` guard (#998/#2627) these seven
+  arms used to reach through it: none of them recurse on their own account,
+  so a JSON document nested past 256 levels no longer fails any of them
+  either -- `sort_by`/`unique_by`/`min_by`/`max_by` still materialize a
+  comparison key and still trip it.
 
 - **`succinctly jq`'s `key`, `parent` and `path` inside a `//` now read the
   position the stage stands on** (#2692). `{"a":{"b":1}} | .a | (key // 1)`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   #1804's container-vs-scalar-alias carve-out is gone with the walk it was a
   property of.
 
+- **`succinctly jq`'s `key`, `parent` and `path` inside a `//` now read the
+  position the stage stands on** (#2692). `{"a":{"b":1}} | .a | (key // 1)`
+  is `"a"`, where it was `1`; `.a | (parent // 1)` and `.a | (path // 1)`
+  likewise answer instead of `{}` and `[]`. The old answers came from the
+  streaming route's owned bridge, which re-roots the document at the stage's
+  input, so `key` resolved against a fresh root and produced nothing -- and
+  "nothing" is not truthy, so `//` substituted the other side. #2476 fixed
+  this for `succinctly yq` against yq v4.53.3's own answers; jq mode did not
+  benefit because a top-level `//` never reached the arm that fixed it. The
+  two modes now agree, and `.a | (key // 1)` agrees with a bare `.a | key`.
+  These three are succinctly extensions in jq mode (real jq errors on all of
+  them), so there is no jq behaviour to diverge from.
+
 - **`path()`, `key`, `parent` and `getpath()` now validate only the nodes they
   navigate through, instead of the whole document** (#2168): on
   `{"a":"\ud800","d":5}`, `path(.d)` and `getpath(["d"])` answer where they

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,36 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **A filter now validates only what it *materializes*** (#2692). `select`,
+  `if`, `not`, `and`, `or`, `//` and zero-arity `any`/`all` answer through
+  `DocumentCursor::is_falsy`, which is O(1) and decodes nothing, so none of
+  them validates the value it tests. On `{123: 1}`, `1 and 1` and `not` and
+  `select(.) | 1` and `false // 1` now answer at exit 0, where they exited 5.
+
+  The bug this fixes is the *inconsistency*, not the validation: `1+1`
+  already answered `2` on that document, so which answer you got depended on
+  how the filter was spelled. That is the exact per-spelling split
+  [ADR-0018](docs/adrs/adr-0018.md)'s #2103 amendment exists to remove, and
+  it now lists this as an instance. The issue named four arms
+  (`and`/`or`/`//`/`not`); its own justification for `not` -- truthiness
+  decodes nothing -- applies equally to `select`/`if`/`any`/`all`, so fixing
+  only the four would have closed one split and opened another.
+
+  **This is a deliberate divergence from jq, and it widens an existing one.**
+  Real jq rejects every such document at parse time, whatever the filter, so
+  each of these raising *matched* jq's observable outcome and no longer does.
+  ADR-0018's decision order does not license the change on its own -- step 2
+  favours the behaviour being given up -- which is why it is recorded against
+  that amendment in
+  [docs/compliance/jq/limitations.md](docs/compliance/jq/limitations.md) and
+  [docs/compliance/yq/limitations.md](docs/compliance/yq/limitations.md).
+  Nothing that raised for a *reading* reason stopped raising: `.`, `.a`,
+  `-Sc .`, `to_entries`, `sort_by(.a)`, every write and the printer itself
+  all still reject the same documents, and `{123: 1} | any` still raises
+  because jq iterates an object's *values* (#422), which resolves its keys.
+  #1804's container-vs-scalar-alias carve-out is gone with the walk it was a
+  property of.
+
 - **`path()`, `key`, `parent` and `getpath()` now validate only the nodes they
   navigate through, instead of the whole document** (#2168): on
   `{"a":"\ud800","d":5}`, `path(.d)` and `getpath(["d"])` answer where they
@@ -522,6 +552,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Performance
 
+- **A top-level `//`, `and` or `or` no longer materializes the whole
+  document** (#2692). #2476 removed that materialization from
+  `eval_single`'s arms, but the CLI's own route is `eval_each_generic`, which
+  still sent all three to `bridge_to_each_owned_flow` -- `to_owned_with_cursor`
+  + reindex + `eval.rs`. So a *nested* `[true and true]` was already cheap
+  while a bare `true and true` still built an `OwnedValue` copy of the entire
+  input. `and`/`or` now take the existing native `each_boolean_generic`
+  ungated, and `//` a new `each_alternative_generic`, so neither builds
+  anything. The same commit removes the `O(N)` validation walk from
+  `select`/`if`/`not`/`//`/`any`/`all`.
+
+  Both are structural -- work deleted, verifiable from the call graph -- but
+  **not quantified**: the developer machine was not idle when this landed,
+  and this project's own benchmarking discipline says a laptop under load is
+  not a measurement. Worth an interleaved A/B on the pinned benchmark hosts
+  (ARM M4 Pro and x86 7950X) before any speedup is claimed in a number.
+
 - **`succinctly yq`'s streaming write path no longer resolves a scalar
   mapping field's (or flow-mapping field's) value twice** (#1114): every
   ordinary `key: value` field wrote its value by first resolving it once to
@@ -621,8 +668,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   change, #1804's own accepted trade-off now covering these constructs too:
   a decode failure reachable only through a container alias no longer
   raises from an ambient-scoped `not`/`//`/`any`/`all` (or `and`/`or` when
-  neither operand itself navigates) -- see
-  [docs/compliance/yq/limitations.md](docs/compliance/yq/limitations.md).
+  neither operand itself navigates). **Superseded by #2692 below**, which
+  removed the walk entirely: the container-alias scoping in that sentence no
+  longer describes anything, since none of these constructs validates at all
+  now. See [docs/compliance/yq/limitations.md](docs/compliance/yq/limitations.md).
   The sibling spellings `any(cond)`/`any(gen;cond)`/`isvalid`/`while`/
   `until` remain bridged, left as follow-ups.
 

--- a/docs/adrs/adr-0018.md
+++ b/docs/adrs/adr-0018.md
@@ -414,7 +414,8 @@ names, not this one. The `*+d` merge divergence recorded out-of-policy above sta
 policy: it is a claim about a reference behaviour being untested upstream on a document real yq
 *accepts*, which this amendment does not touch.
 
-Instances, both recorded on their merits and now sanctioned here rather than grandfathered:
+Instances, the first two recorded on their merits and now sanctioned here rather than
+grandfathered, the third decided under this amendment directly:
 
 - **#2168** — `path`/`key`/`parent`/`getpath` validate only the nodes they navigate, not the
   whole document. `path(.d)` on `{"a":"\ud800","d":5}` answers `["d"]` where jq rejects.
@@ -428,6 +429,24 @@ Instances, both recorded on their merits and now sanctioned here rather than gra
   answer where they used to inherit the bridge's rejection, and `1+1` and `[1+1]` stop
   disagreeing on the same document. Extends to yq mode, where every filter takes that
   route; jq 1.7.1 and yq v4.53.3 both reject these documents at parse time.
+- **#2692** — a filter validates only what it **materializes**. Reading a value's *truthiness*
+  is `DocumentCursor::is_falsy`, which decodes nothing, so `select`, `if`, `not`, `and`, `or`,
+  `//` and zero-arity `any`/`all` validate nothing at all. This is the amendment's own
+  reasoning applied to its remaining holdouts rather than a fresh decision. #2103 had left
+  `1+1` answering on a malformed document while `1 and 1` exited 5, and #2173 closed that
+  particular pair by drawing the line at "reads `.`" — which left the split one spelling
+  over, `. and true` raising while `.b`, `length` and `keys` on the same document all
+  answered. Truthiness is not a read that can meet a malformed byte, so the line belongs at
+  *materializes*, and there it has no remainder. The rule is now stated positively and has no
+  exceptions — a value is validated when, and only when, something decodes it, so
+  `select(.bad) | .keep` answers while `select(.bad) | to_entries`, `-Sc .bad`, `sort_by(.a)`
+  and the printer all still raise on the same document.
+
+  Two consequences worth recording. First, the divergence *narrows* rather than widening as
+  it did in #2168/#2103: succinctly still rejects every document real jq rejects, whenever a
+  filter reads the corrupt part — what it stops doing is rejecting on behalf of filters that
+  never look. Second, #1804's container-vs-scalar-alias carve-out disappears: it was a
+  property of the walk this instance removes, not a rule of its own.
 
 ## Consequences
 

--- a/docs/adrs/adr-0018.md
+++ b/docs/adrs/adr-0018.md
@@ -443,11 +443,17 @@ boundary one step, and the last states where it comes to rest:
   `select(.bad) | .keep` answers while `select(.bad) | to_entries`, `-Sc .bad`, `sort_by(.a)`
   and the printer all still raise on the same document.
 
-  Two consequences worth recording. First, the divergence *narrows* rather than widening as
+  Three consequences worth recording. First, the divergence *narrows* rather than widening as
   it did in #2168/#2103: succinctly still rejects every document real jq rejects, whenever a
   filter reads the corrupt part — what it stops doing is rejecting on behalf of filters that
   never look. Second, #1804's container-vs-scalar-alias carve-out disappears: it was a
-  property of the walk this instance removes, not a rule of its own.
+  property of the walk this instance removes, not a rule of its own. Third, the same removed
+  walk was where these seven arms reached the `MAX_NESTING_DEPTH` guard (#998/#2627) from —
+  none of them recurse on their own account, so a document nested past 256 levels no longer
+  fails any of them either, the same "accepts at parse/index time" story `docs/compliance/jq/
+  limitations.md`'s depth-guard section already tells for `.[1]`/`length`, now reaching seven
+  more filters. The guard itself is untouched: `sort_by`'s comparison key still materializes
+  and still trips it.
 
 ## Consequences
 

--- a/docs/adrs/adr-0018.md
+++ b/docs/adrs/adr-0018.md
@@ -414,8 +414,9 @@ names, not this one. The `*+d` merge divergence recorded out-of-policy above sta
 policy: it is a claim about a reference behaviour being untested upstream on a document real yq
 *accepts*, which this amendment does not touch.
 
-Instances, the first two recorded on their merits and now sanctioned here rather than
-grandfathered, the third decided under this amendment directly:
+Instances. The first two were recorded on their merits and are sanctioned here rather than
+grandfathered; the rest were decided under this amendment directly. Each narrows the same
+boundary one step, and the last states where it comes to rest:
 
 - **#2168** — `path`/`key`/`parent`/`getpath` validate only the nodes they navigate, not the
   whole document. `path(.d)` on `{"a":"\ud800","d":5}` answers `["d"]` where jq rejects.

--- a/docs/compliance/jq/limitations.md
+++ b/docs/compliance/jq/limitations.md
@@ -2405,6 +2405,21 @@ no equivalent guard on either its default or materializing path at all (#1817). 
 live, also pre-existing and unrelated to either fix: `print_json`'s own guard can flush
 corrupted/truncated JSON to stdout before it fires (#1819).
 
+[#2692](https://github.com/rust-works/succinctly/issues/2692) widens the "accepts at
+parse/index time" story above to more filters, by the same mechanism as `.[1]`/`length`:
+`not`, `select`, `if`, `and`, `or`, `//` and zero-arity `any`/`all` used to reach this guard
+too, via `push_generic_document_validation_error`'s own `assert_nesting_depth` — the walk
+that validated on their behalf before #2692 removed it. None of them do enough work to need
+that guard on their own account (`DocumentCursor::is_falsy` never recurses into a
+container's children), so a document nested past 256 levels is no longer a reason for any of
+them to fail: `nested_arrays(300) | not` now answers `false` at exit 0, where it used to
+raise `nesting depth exceeds limit of 256`. This is a corollary of the same rule the rest of
+this section's #2692 instance rests on, not a fresh decision, and it does not touch the
+guard itself — `sort_by`/`unique_by`/`min_by`/`max_by` still materialize a comparison key
+through `key_elements_generic`, the one caller left, and still trip it on the same document.
+Pinned by `test_truthiness_probes_do_not_trip_the_depth_guard_2692`
+(`tests/jq_cli_tests.rs`).
+
 ## Regex flags `l` and `n`
 
 [ADR-0019](../../adrs/adr-0019.md) accepted two regex-flag gaps as permanent — rule 4(d)

--- a/docs/compliance/jq/limitations.md
+++ b/docs/compliance/jq/limitations.md
@@ -2109,7 +2109,9 @@ missing-colon/stray-comma corruption in a subtree the query only ever
 validates (never emits) silently passed — `{"c":{"a":1,},"t":5} |
 select(.c) | .t` answered `5` instead of raising, confirmed live. (`path()` left
 that list again in #2168, which decided that naming a position should not
-validate what is inside it; `select`/`sort_by` keep the checks this fix added.) See
+validate what is inside it, and `select` left it again in #2692, which decided that
+*testing* a value does not read it either; the `sort_by` family keeps the checks this fix
+added.) See
 this doc's "The validate-only traversal..." entry in `CHANGELOG.md` for
 the fix; the underlying lesson stands even though this specific
 conclusion didn't: a function lacking its own checks by inspection can
@@ -3516,6 +3518,23 @@ that reads nothing:
 | `1+1`, `try (1+1)`, `try (1+1) catch "x"` | `{"\ud800":1,"\ud800":2}`                                                       | error    | error — **matched jq** | `2` — **diverges**         |
 | `.,.`                                     | `{"\ud800":1,"\ud800":2}`                                                       | error    | error — **matched jq** | echoes twice — **diverges** |
 
+[#2692](https://github.com/rust-works/succinctly/issues/2692) extended the same divergence to
+every filter that reads only a value's **truthiness**. These rows moved for the same reason
+and are recorded against the same amendment:
+
+| filter                                                  | document                            | jq 1.7.1 | before #2692           | now                     |
+|---------------------------------------------------------|-------------------------------------|----------|------------------------|-------------------------|
+| `true and true`, `1 and 1`, `. and true`, `false or true` | `{123: 1}`, `["\x"]`, `{"\ud800":1,"\ud800":2}` | error | error — **matched jq** | `true` — **diverges**   |
+| `false // 1`, `1 // 2`                                  | same three                          | error    | error — **matched jq** | `1` — **diverges**      |
+| `not`, `.[] \| not`                                     | same three                          | error    | error — **matched jq** | `false` — **diverges**  |
+| `select(.) \| 1`, `if . then 1 else 2 end`              | same three                          | error    | error — **matched jq** | `1` — **diverges**      |
+| `any`, `all`                                            | `["\x"]`, `{"\ud800":1,"\ud800":2}` | error    | error — **matched jq** | `true` — **diverges**   |
+
+The last row's document list is shorter on purpose: `any`/`all` iterate an *object's* values
+under jq's own last-occurrence duplicate-key rule (#422), which resolves the keys — so
+`{123: 1} | any` still raises, because resolving a key reads it. That is the rule applying
+inside a single builtin, not an exception to it.
+
 Step 2 of ADR-0018's decision order therefore separates the two options and favours the
 behaviour being given up. No rule-4 condition applies — the output is readable, nothing is
 corrupted or discarded, and neither choice takes the process down. **This is a deliberate
@@ -3537,6 +3556,15 @@ and for the same three reasons:
 
 The rule #2168 recorded — *a builtin that navigates to a position validates only what it
 reads; one that materializes validates everything it materializes* — is what decides this.
+Since #2692 only its second half is needed, because "reads" turned out to be doing two jobs:
+navigating to a position and *testing* a value both leave the bytes undecoded, and only
+materializing looks at them. The rule is therefore now stated as **a filter validates only
+what it materializes, and everything it materializes**, with no exceptions — `select`, `if`,
+`not`, `and`/`or`, `//` and zero-arity `any`/`all` all answer through
+`DocumentCursor::is_falsy`, which is O(1) and decodes nothing, and so all validate nothing.
+`sort_by`/`unique_by`/`min_by`/`max_by` remain the one validating family, because they
+materialize a comparison key for an element they otherwise only reorder.
+
 `1+1` reads nothing and validates nothing. `.,.` forwards the root cursor to the printer,
 which walks it exactly as `.` does, so a structural fault is still found where the walk
 reaches it (`{123:1,"b":2}` still exits 5 under `.,.`, as under `.`) and a colliding
@@ -3615,7 +3643,15 @@ Pinned by `test_streaming_keys_unsorted_iterate_echoes_undecodable_key_raw_2103`
 `test_root_forwarding_filters_stream_without_validating_2103` and the revised rows of
 `test_materializing_route_raises_on_colliding_decode_failure_keys_1642` and
 `test_try_catch_contains_a_genuinely_catchable_malformed_key_error_1812`
-(`tests/jq_cli_tests.rs`). `scripts/jq-m2-streaming-sweep.sh`, which found the divergence,
+(`tests/jq_cli_tests.rs`). The #2692 rows are pinned by
+`test_truthiness_probes_validate_nothing_2692` (33 documents × every truthiness reader, each
+asserted to agree with a reads-nothing reference *and* to have the exit code the row
+requires) and its yq twin in `tests/yq_cli_tests.rs`, with the boundary cases in
+`test_select_passes_through_corruption_it_only_tests_1645_2692`,
+`test_any_all_validate_only_the_keys_they_resolve_2476_2692`,
+`test_alternative_validates_only_what_its_operands_read_2476_2692` and the
+`select`-answers rows of `test_lazy_validation_boundary_2168`.
+`scripts/jq-m2-streaming-sweep.sh`, which found the divergence,
 lost its route-against-route comparison along with the eager route. It now runs the one
 shipped route against pinned jq 1.7.1 over the same documents and filters and records every
 cell — jq's exit code, succinctly's exit code, succinctly's stdout — in a checked-in golden

--- a/docs/compliance/yq/limitations.md
+++ b/docs/compliance/yq/limitations.md
@@ -235,14 +235,17 @@ rejects at parse time whatever the filter):
 | `true and true`, `false // 1`       | exit 1  | exit 1 — matched  | `true`, `1`    |
 | `{"k":1}`, `1 as $x \| $x`          | exit 1  | exit 0            | unchanged      |
 | `.b`                                | exit 1  | exit 0            | unchanged      |
-| `. and true`                        | exit 1  | exit 1            | unchanged      |
+| `. and true`                        | exit 1  | exit 1            | `true` (#2692) |
 
-So four spellings stop matching yq. The rows below them are why that is the *uniform*
-answer rather than a new inconsistency: `.b` and `{"k":1}` already answered at exit 0 on
-this document, because navigation validates only what it reads (#2168) and neither reaches
-the bad escape. Keeping `1+1` rejecting would have meant a binary that answers `.b` and
-`{"k":1}` while refusing `1+1` on one document in one run — the shape ADR-0018's #2103
-amendment exists to rule out. `. and true` still raises: it reads `.`.
+So four spellings stop matching yq here, and `. and true` joins them a step later. The rows
+below them are why that is the *uniform* answer rather than a new inconsistency: `.b` and
+`{"k":1}` already answered at exit 0 on this document, because navigation validates only what
+it reads (#2168) and neither reaches the bad escape. Keeping `1+1` rejecting would have meant a
+binary that answers `.b` and `{"k":1}` while refusing `1+1` on one document in one run — the
+shape ADR-0018's #2103 amendment exists to rule out. `. and true` raised here under #2173's own
+rule, because it reads `.` — but reading `.` as a boolean operand is *testing* it, not decoding
+it, so #2692 (recorded above) takes it the rest of the way: `. and true` now answers `true`,
+the same as `.b | (true and true)` always did.
 
 Same disposition, same sanction, and the same escape hatch as the jq side — a user who
 wants yq's rejection has `succinctly json validate` for JSON input, and the divergence is

--- a/docs/compliance/yq/limitations.md
+++ b/docs/compliance/yq/limitations.md
@@ -176,49 +176,48 @@ b: *x
 c: 2
 ```
 
-A related, narrower gap sits in `select`/`if`'s condition-truthiness check
-(`push_generic_document_validation_error`, [src/jq/eval_generic.rs](../../../src/jq/eval_generic.rs)):
-it does not walk into a *container* reached through an alias, so a decode failure reachable
-only that way no longer raises
-([#1804](https://github.com/rust-works/succinctly/issues/1804), fixed a real `O(2^N)` cost
-for a document shaped as a chain of anchors each referencing the previous one twice). This
-is not a yq-fidelity divergence — real yq rejects the whole document at parse time, so there
-is no yq behaviour to match either way:
+A related gap sits in **truthiness**, and it is now the whole of the rule rather than a
+carve-out. Since [#2692](https://github.com/rust-works/succinctly/issues/2692), *a filter
+validates only what it materializes* — and a filter that asks whether a value is truthy
+answers with `DocumentCursor::is_falsy`, which is O(1) and decodes nothing. So `select`,
+`if`, `not`, `and`, `or`, `//` and zero-arity `any`/`all` validate nothing at all, at any
+position. This is not a yq-fidelity divergence — real yq rejects the whole document at parse
+time, so there is no yq behaviour to match either way — and it is sanctioned by
+[ADR-0018](../../adrs/adr-0018.md)'s #2103 amendment, which lists it as an instance.
 
 ```bash
 $ printf 'a: &a ["bad\\q"]\nb: *a\n' | succinctly yq 'select(.b) | 1'
 1
+$ printf 'a: &a ["bad\\q"]\nb: *a\n' | succinctly yq 'select(.a) | 1'
+1
+$ printf 'a: &a ["bad\\q"]\nb: *a\n' | succinctly yq '.b | not'
+false
 $ printf 'a: &a ["bad\\q"]\nb: *a\n' | succinctly yq '.a'
 Error: invalid escape sequence
 $ printf 'a: &a ["bad\\q"]\nb: *a\n' | succinctly yq '.b[0]'
 Error: invalid escape sequence
 ```
 
-Scoped to a *container* alias target only: a bare scalar-target alias (`a: &a "bad\q"`)
-still raises from `select`/`if` exactly as before, since resolving one scalar costs `O(1)`
-and was never part of the cost this fix removes.
+**The history is worth keeping, because it explains the shape of the code.**
+[#1804](https://github.com/rust-works/succinctly/issues/1804) first made `select`/`if` skip
+a *container* reached through an alias, fixing a real `O(2^N)` cost on a document shaped as
+a chain of anchors each referencing the previous one twice; it deliberately excluded a bare
+scalar-target alias (`a: &a "bad\q"`), since resolving one scalar costs `O(1)` and was never
+part of that cost. [#2476](https://github.com/rust-works/succinctly/issues/2476) extended
+the same trade-off to `not`, `//` and `any`/`all`, which until then reached the cost only by
+falling to `eval_single`'s wildcard bridge.
 
-**[#2476](https://github.com/rust-works/succinctly/issues/2476)** extends this same
-trade-off to `not`, `//`, and zero-arity `any`/`all` at an alias position — the same
-O(2^N) fan-out cost `select`/`if` were fixed for, since all four used to reach it only by
-falling to `eval_single`'s wildcard bridge (which materializes the *ambient* value before
-running), and now instead run `push_generic_truthiness` directly, the same call `select`/`if`
-already used:
+Both of those were narrowings of a validation walk, and both left the answer depending on
+*which position* a filter stood on: `.b | not` answered while `.a | not` raised, for two
+names of one node. #2692 removed the walk instead, so neither the container/scalar
+distinction nor the alias/anchor one has any observable consequence left. Nothing that
+raised for a *reading* reason stopped raising — `.a`, `.b[0]` and every write still do.
 
-```bash
-$ printf 'a: &a ["bad\\q"]\nb: *a\n' | succinctly yq '.b | not'
-false
-$ printf 'a: &a ["bad\\q"]\nb: *a\n' | succinctly yq '.b[0]'
-Error: invalid escape sequence
-```
-
-`and`/`or` share it only in the same ambient-scoped shape `select`/`if` use, where neither
-operand itself navigates (`.b | (true and true)` answers `true`, not raising). A bare `.b and
-true` does not share it: `.b` as a direct operand needs path context, so that expression still
-runs through the pre-existing native evaluator (`eval_boolean_generic`'s path-context branch,
-present since #2473 and untouched by #2476), which resolves `.b`'s path and raises exactly as
-`.b[0]` does. Real yq rejects this whole document at parse time either way, so there is no yq
-behaviour to match for any of these constructs.
+`and`/`or` are no longer special here either. A bare `.b and true` used to be distinguished
+from `.b | (true and true)` because `.b` as a direct operand needs path context and so ran
+through `eval_boolean_generic`'s path-context branch (present since #2473), resolving `.b`'s
+path and raising as `.b[0]` does. Both spellings now answer `true`: resolving a path is not
+decoding the value at it.
 
 **[#2173](https://github.com/rust-works/succinctly/issues/2173) goes one step further, and
 this one *is* a new yq divergence rather than an extension of an existing one.** Every

--- a/scripts/jq-m2-streaming-sweep.expected
+++ b/scripts/jq-m2-streaming-sweep.expected
@@ -48,6 +48,18 @@
 {"a":1,"b":2}	.a | 1+1	0	0	2
 {"a":1,"b":2}	.[] | select(. != null)	0	0	1|2
 {"a":1,"b":2}	.[] | tostring	0	0	"1"|"2"
+{"a":1,"b":2}	true and true	0	0	true
+{"a":1,"b":2}	. and true	0	0	true
+{"a":1,"b":2}	false or true	0	0	true
+{"a":1,"b":2}	false // 1	0	0	1
+{"a":1,"b":2}	. // 1	0	0	{"a":1,"b":2}
+{"a":1,"b":2}	not	0	0	false
+{"a":1,"b":2}	.[] | not	0	0	false|false
+{"a":1,"b":2}	select(.) | 1	0	0	1
+{"a":1,"b":2}	if . then 1 else 2 end	0	0	1
+{"a":1,"b":2}	any	0	0	true
+{"a":1,"b":2}	all	0	0	true
+{"a":1,"b":2}	sort_by(.)	5	5	
 [1,2,3]	.	0	0	[1,2,3]
 [1,2,3]	.a	5	5	
 [1,2,3]	.b	5	5	
@@ -98,6 +110,18 @@
 [1,2,3]	.a | 1+1	5	5	
 [1,2,3]	.[] | select(. != null)	0	0	1|2|3
 [1,2,3]	.[] | tostring	0	0	"1"|"2"|"3"
+[1,2,3]	true and true	0	0	true
+[1,2,3]	. and true	0	0	true
+[1,2,3]	false or true	0	0	true
+[1,2,3]	false // 1	0	0	1
+[1,2,3]	. // 1	0	0	[1,2,3]
+[1,2,3]	not	0	0	false
+[1,2,3]	.[] | not	0	0	false|false|false
+[1,2,3]	select(.) | 1	0	0	1
+[1,2,3]	if . then 1 else 2 end	0	0	1
+[1,2,3]	any	0	0	true
+[1,2,3]	all	0	0	true
+[1,2,3]	sort_by(.)	0	0	[1,2,3]
 {"a":1,"a":2}	.	0	0	{"a":2}
 {"a":1,"a":2}	.a	0	0	2
 {"a":1,"a":2}	.b	0	0	null
@@ -148,6 +172,18 @@
 {"a":1,"a":2}	.a | 1+1	0	0	2
 {"a":1,"a":2}	.[] | select(. != null)	0	0	2
 {"a":1,"a":2}	.[] | tostring	0	0	"2"
+{"a":1,"a":2}	true and true	0	0	true
+{"a":1,"a":2}	. and true	0	0	true
+{"a":1,"a":2}	false or true	0	0	true
+{"a":1,"a":2}	false // 1	0	0	1
+{"a":1,"a":2}	. // 1	0	0	{"a":2}
+{"a":1,"a":2}	not	0	0	false
+{"a":1,"a":2}	.[] | not	0	0	false
+{"a":1,"a":2}	select(.) | 1	0	0	1
+{"a":1,"a":2}	if . then 1 else 2 end	0	0	1
+{"a":1,"a":2}	any	0	0	true
+{"a":1,"a":2}	all	0	0	true
+{"a":1,"a":2}	sort_by(.)	5	5	
 {123:1,"b":2}	.	5	5	
 {123:1,"b":2}	.a	5	5	
 {123:1,"b":2}	.b	5	5	
@@ -198,6 +234,18 @@
 {123:1,"b":2}	.a | 1+1	5	5	
 {123:1,"b":2}	.[] | select(. != null)	5	5	
 {123:1,"b":2}	.[] | tostring	5	5	
+{123:1,"b":2}	true and true	5	0	true
+{123:1,"b":2}	. and true	5	0	true
+{123:1,"b":2}	false or true	5	0	true
+{123:1,"b":2}	false // 1	5	0	1
+{123:1,"b":2}	. // 1	5	5	
+{123:1,"b":2}	not	5	0	false
+{123:1,"b":2}	.[] | not	5	5	
+{123:1,"b":2}	select(.) | 1	5	0	1
+{123:1,"b":2}	if . then 1 else 2 end	5	0	1
+{123:1,"b":2}	any	5	5	
+{123:1,"b":2}	all	5	5	
+{123:1,"b":2}	sort_by(.)	5	5	
 {"a":1,"b"}	.	5	5	
 {"a":1,"b"}	.a	5	5	
 {"a":1,"b"}	.b	5	5	
@@ -248,6 +296,18 @@
 {"a":1,"b"}	.a | 1+1	5	5	
 {"a":1,"b"}	.[] | select(. != null)	5	5	
 {"a":1,"b"}	.[] | tostring	5	5	
+{"a":1,"b"}	true and true	5	0	true
+{"a":1,"b"}	. and true	5	0	true
+{"a":1,"b"}	false or true	5	0	true
+{"a":1,"b"}	false // 1	5	0	1
+{"a":1,"b"}	. // 1	5	5	
+{"a":1,"b"}	not	5	0	false
+{"a":1,"b"}	.[] | not	5	5	
+{"a":1,"b"}	select(.) | 1	5	0	1
+{"a":1,"b"}	if . then 1 else 2 end	5	0	1
+{"a":1,"b"}	any	5	5	
+{"a":1,"b"}	all	5	5	
+{"a":1,"b"}	sort_by(.)	5	5	
 {"a":1, invalid}	.	5	5	
 {"a":1, invalid}	.a	5	5	
 {"a":1, invalid}	.b	5	5	
@@ -298,6 +358,18 @@
 {"a":1, invalid}	.a | 1+1	5	5	
 {"a":1, invalid}	.[] | select(. != null)	5	5	
 {"a":1, invalid}	.[] | tostring	5	5	
+{"a":1, invalid}	true and true	5	0	true
+{"a":1, invalid}	. and true	5	0	true
+{"a":1, invalid}	false or true	5	0	true
+{"a":1, invalid}	false // 1	5	0	1
+{"a":1, invalid}	. // 1	5	5	
+{"a":1, invalid}	not	5	0	false
+{"a":1, invalid}	.[] | not	5	5	
+{"a":1, invalid}	select(.) | 1	5	0	1
+{"a":1, invalid}	if . then 1 else 2 end	5	0	1
+{"a":1, invalid}	any	5	5	
+{"a":1, invalid}	all	5	5	
+{"a":1, invalid}	sort_by(.)	5	5	
 {"a" 1, "b":2}	.	5	5	
 {"a" 1, "b":2}	.a	5	5	
 {"a" 1, "b":2}	.b	5	0	2
@@ -348,6 +420,18 @@
 {"a" 1, "b":2}	.a | 1+1	5	5	
 {"a" 1, "b":2}	.[] | select(. != null)	5	5	
 {"a" 1, "b":2}	.[] | tostring	5	5	
+{"a" 1, "b":2}	true and true	5	0	true
+{"a" 1, "b":2}	. and true	5	0	true
+{"a" 1, "b":2}	false or true	5	0	true
+{"a" 1, "b":2}	false // 1	5	0	1
+{"a" 1, "b":2}	. // 1	5	5	
+{"a" 1, "b":2}	not	5	0	false
+{"a" 1, "b":2}	.[] | not	5	5	
+{"a" 1, "b":2}	select(.) | 1	5	0	1
+{"a" 1, "b":2}	if . then 1 else 2 end	5	0	1
+{"a" 1, "b":2}	any	5	5	
+{"a" 1, "b":2}	all	5	5	
+{"a" 1, "b":2}	sort_by(.)	5	5	
 [1,,3]	.	5	5	
 [1,,3]	.a	5	5	
 [1,,3]	.b	5	5	
@@ -398,6 +482,18 @@
 [1,,3]	.a | 1+1	5	5	
 [1,,3]	.[] | select(. != null)	5	5	1
 [1,,3]	.[] | tostring	5	5	"1"
+[1,,3]	true and true	5	0	true
+[1,,3]	. and true	5	0	true
+[1,,3]	false or true	5	0	true
+[1,,3]	false // 1	5	0	1
+[1,,3]	. // 1	5	5	
+[1,,3]	not	5	0	false
+[1,,3]	.[] | not	5	5	false
+[1,,3]	select(.) | 1	5	0	1
+[1,,3]	if . then 1 else 2 end	5	0	1
+[1,,3]	any	5	0	true
+[1,,3]	all	5	0	true
+[1,,3]	sort_by(.)	5	5	
 {"\ud800":1,"\ud800":2}	.	5	0	{"\ud800":1,"\ud800":2}
 {"\ud800":1,"\ud800":2}	.a	5	0	null
 {"\ud800":1,"\ud800":2}	.b	5	0	null
@@ -417,7 +513,7 @@
 {"\ud800":1,"\ud800":2}	first(map(.x) | .[])	5	5	
 {"\ud800":1,"\ud800":2}	limit(1; map(.x) | .[])	5	5	
 {"\ud800":1,"\ud800":2}	.,.	5	0	{"\ud800":1,"\ud800":2}|{"\ud800":1,"\ud800":2}
-{"\ud800":1,"\ud800":2}	if . then . else . end	5	5	
+{"\ud800":1,"\ud800":2}	if . then . else . end	5	0	{"\ud800":1,"\ud800":2}
 {"\ud800":1,"\ud800":2}	try .	5	0	{"\ud800":1,"\ud800":2}
 {"\ud800":1,"\ud800":2}	try (1+1) catch "x"	5	0	2
 {"\ud800":1,"\ud800":2}	try (1+1)	5	0	2
@@ -448,6 +544,18 @@
 {"\ud800":1,"\ud800":2}	.a | 1+1	5	0	2
 {"\ud800":1,"\ud800":2}	.[] | select(. != null)	5	0	1|2
 {"\ud800":1,"\ud800":2}	.[] | tostring	5	0	"1"|"2"
+{"\ud800":1,"\ud800":2}	true and true	5	0	true
+{"\ud800":1,"\ud800":2}	. and true	5	0	true
+{"\ud800":1,"\ud800":2}	false or true	5	0	true
+{"\ud800":1,"\ud800":2}	false // 1	5	0	1
+{"\ud800":1,"\ud800":2}	. // 1	5	0	{"\ud800":1,"\ud800":2}
+{"\ud800":1,"\ud800":2}	not	5	0	false
+{"\ud800":1,"\ud800":2}	.[] | not	5	0	false|false
+{"\ud800":1,"\ud800":2}	select(.) | 1	5	0	1
+{"\ud800":1,"\ud800":2}	if . then 1 else 2 end	5	0	1
+{"\ud800":1,"\ud800":2}	any	5	0	true
+{"\ud800":1,"\ud800":2}	all	5	0	true
+{"\ud800":1,"\ud800":2}	sort_by(.)	5	5	
 {"\ud800":1,"b":2}	.	5	0	{"\ud800":1,"b":2}
 {"\ud800":1,"b":2}	.a	5	0	null
 {"\ud800":1,"b":2}	.b	5	0	2
@@ -473,7 +581,7 @@
 {"\ud800":1,"b":2}	try (1+1)	5	0	2
 {"\ud800":1,"b":2}	.?	5	0	{"\ud800":1,"b":2}
 {"\ud800":1,"b":2}	label $x | .	5	0	{"\ud800":1,"b":2}
-{"\ud800":1,"b":2}	. as $x | $x	5	0	{"\\ud800":1,"b":2}
+{"\ud800":1,"b":2}	. as $x | $x	5	0	{"\ud800":1,"b":2}
 {"\ud800":1,"b":2}	def f: .; f	5	0	{"\ud800":1,"b":2}
 {"\ud800":1,"b":2}	first(.)	5	0	{"\ud800":1,"b":2}
 {"\ud800":1,"b":2}	limit(1;.)	5	0	{"\ud800":1,"b":2}
@@ -498,6 +606,18 @@
 {"\ud800":1,"b":2}	.a | 1+1	5	0	2
 {"\ud800":1,"b":2}	.[] | select(. != null)	5	0	1|2
 {"\ud800":1,"b":2}	.[] | tostring	5	0	"1"|"2"
+{"\ud800":1,"b":2}	true and true	5	0	true
+{"\ud800":1,"b":2}	. and true	5	0	true
+{"\ud800":1,"b":2}	false or true	5	0	true
+{"\ud800":1,"b":2}	false // 1	5	0	1
+{"\ud800":1,"b":2}	. // 1	5	0	{"\ud800":1,"b":2}
+{"\ud800":1,"b":2}	not	5	0	false
+{"\ud800":1,"b":2}	.[] | not	5	0	false|false
+{"\ud800":1,"b":2}	select(.) | 1	5	0	1
+{"\ud800":1,"b":2}	if . then 1 else 2 end	5	0	1
+{"\ud800":1,"b":2}	any	5	0	true
+{"\ud800":1,"b":2}	all	5	0	true
+{"\ud800":1,"b":2}	sort_by(.)	5	5	
 {"a\q":1,"b":2}	.	5	0	{"a\q":1,"b":2}
 {"a\q":1,"b":2}	.a	5	0	null
 {"a\q":1,"b":2}	.b	5	0	2
@@ -523,7 +643,7 @@
 {"a\q":1,"b":2}	try (1+1)	5	0	2
 {"a\q":1,"b":2}	.?	5	0	{"a\q":1,"b":2}
 {"a\q":1,"b":2}	label $x | .	5	0	{"a\q":1,"b":2}
-{"a\q":1,"b":2}	. as $x | $x	5	0	{"a\\q":1,"b":2}
+{"a\q":1,"b":2}	. as $x | $x	5	0	{"a\q":1,"b":2}
 {"a\q":1,"b":2}	def f: .; f	5	0	{"a\q":1,"b":2}
 {"a\q":1,"b":2}	first(.)	5	0	{"a\q":1,"b":2}
 {"a\q":1,"b":2}	limit(1;.)	5	0	{"a\q":1,"b":2}
@@ -548,6 +668,18 @@
 {"a\q":1,"b":2}	.a | 1+1	5	0	2
 {"a\q":1,"b":2}	.[] | select(. != null)	5	0	1|2
 {"a\q":1,"b":2}	.[] | tostring	5	0	"1"|"2"
+{"a\q":1,"b":2}	true and true	5	0	true
+{"a\q":1,"b":2}	. and true	5	0	true
+{"a\q":1,"b":2}	false or true	5	0	true
+{"a\q":1,"b":2}	false // 1	5	0	1
+{"a\q":1,"b":2}	. // 1	5	0	{"a\q":1,"b":2}
+{"a\q":1,"b":2}	not	5	0	false
+{"a\q":1,"b":2}	.[] | not	5	0	false|false
+{"a\q":1,"b":2}	select(.) | 1	5	0	1
+{"a\q":1,"b":2}	if . then 1 else 2 end	5	0	1
+{"a\q":1,"b":2}	any	5	0	true
+{"a\q":1,"b":2}	all	5	0	true
+{"a\q":1,"b":2}	sort_by(.)	5	5	
 [{"x":"\ud800"}]	.	5	0	[{"x":"\ud800"}]
 [{"x":"\ud800"}]	.a	5	5	
 [{"x":"\ud800"}]	.b	5	5	
@@ -567,7 +699,7 @@
 [{"x":"\ud800"}]	first(map(.x) | .[])	5	0	"\ud800"
 [{"x":"\ud800"}]	limit(1; map(.x) | .[])	5	0	"\ud800"
 [{"x":"\ud800"}]	.,.	5	0	[{"x":"\ud800"}]|[{"x":"\ud800"}]
-[{"x":"\ud800"}]	if . then . else . end	5	5	
+[{"x":"\ud800"}]	if . then . else . end	5	0	[{"x":"\ud800"}]
 [{"x":"\ud800"}]	try .	5	0	[{"x":"\ud800"}]
 [{"x":"\ud800"}]	try (1+1) catch "x"	5	0	2
 [{"x":"\ud800"}]	try (1+1)	5	0	2
@@ -587,7 +719,7 @@
 [{"x":"\ud800"}]	.[]|debug	5	5	
 [{"x":"\ud800"}]	.[] | (., debug)	5	5	{"x":"\ud800"}
 [{"x":"\ud800"}]	.[] | .,.	5	0	{"x":"\ud800"}|{"x":"\ud800"}
-[{"x":"\ud800"}]	.[] | if . then . else . end	5	5	
+[{"x":"\ud800"}]	.[] | if . then . else . end	5	0	{"x":"\ud800"}
 [{"x":"\ud800"}]	.[] | try (1+1) catch "x"	5	0	2
 [{"x":"\ud800"}]	.[] | 1+1	5	0	2
 [{"x":"\ud800"}]	.[] | label $x | .	5	0	{"x":"\ud800"}
@@ -598,3 +730,15 @@
 [{"x":"\ud800"}]	.a | 1+1	5	5	
 [{"x":"\ud800"}]	.[] | select(. != null)	5	5	
 [{"x":"\ud800"}]	.[] | tostring	5	5	
+[{"x":"\ud800"}]	true and true	5	0	true
+[{"x":"\ud800"}]	. and true	5	0	true
+[{"x":"\ud800"}]	false or true	5	0	true
+[{"x":"\ud800"}]	false // 1	5	0	1
+[{"x":"\ud800"}]	. // 1	5	0	[{"x":"\ud800"}]
+[{"x":"\ud800"}]	not	5	0	false
+[{"x":"\ud800"}]	.[] | not	5	0	false
+[{"x":"\ud800"}]	select(.) | 1	5	0	1
+[{"x":"\ud800"}]	if . then 1 else 2 end	5	0	1
+[{"x":"\ud800"}]	any	5	0	true
+[{"x":"\ud800"}]	all	5	0	true
+[{"x":"\ud800"}]	sort_by(.)	5	5	

--- a/scripts/jq-m2-streaming-sweep.sh
+++ b/scripts/jq-m2-streaming-sweep.sh
@@ -180,6 +180,27 @@ FILTERS=(
   '.a | 1+1'
   '.[] | select(. != null)'
   '.[] | tostring'
+  # #2692: filters that read only a value's *truthiness*. Each answers via
+  # `is_falsy`, which decodes nothing, so none of them validates the document
+  # -- they belong in the group above, and these rows are what pins that.
+  # `select(.) | 1` and `if . then 1 else 2 end` discard the tested value on
+  # purpose: without the discard the printer materializes it and the row would
+  # measure the writer instead of the operator.
+  'true and true'
+  '. and true'
+  'false or true'
+  'false // 1'
+  '. // 1'
+  'not'
+  '.[] | not'
+  'select(.) | 1'
+  'if . then 1 else 2 end'
+  'any'
+  'all'
+  # The one truthiness reader that still validates, and the family that still
+  # does: `any`/`all` resolve an *object's* keys (#422), and the `_by` forms
+  # materialize a comparison key.
+  'sort_by(.)'
 )
 
 ACTUAL="$WORK/actual.tsv"

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -2918,21 +2918,33 @@ fn fold_generic_owned_values<V: DocumentValue>(
 /// colliding-decode-failure-key -- and if so, the `Control::Error` a
 /// caller should raise.
 ///
-/// The shared document-validation gate behind three call sites spanning
-/// two feature families -- `select`'s truthiness check
-/// (`push_generic_truthiness`, the only one actually about truthiness;
-/// see its own doc comment for why it falls through to
-/// [`DocumentCursor::is_falsy`]'s silent "not falsy" default otherwise)
-/// and `sort_by`/`unique_by`/`min_by`/`max_by`'s comparison key
-/// (`key_elements_generic`) -- not a truthiness-specific helper despite
-/// this function's former name (#2413): each of those callers needs the
-/// #1247/#1194 validation below without ever materializing an
-/// `OwnedValue` for the subtree it's validating. In both, the subtree
-/// walked is the value the query tests or emits. The path-context walk
-/// (`path_context_root`) and `path(...)` (`eval_builtin`) used to be the
-/// other two callers, running this over the *whole document* to answer a
-/// bounded query; #2168 (direction 2) dropped that, so they validate only
-/// the nodes they navigate through, like `.d` does.
+/// **One caller remains**: `sort_by`/`unique_by`/`min_by`/`max_by`'s
+/// comparison key (`key_elements_generic`), which needs the #1247/#1194
+/// validation below without materializing an `OwnedValue` for the element
+/// it only ever reorders. Not a truthiness-specific helper despite this
+/// function's former name (#2413) -- and, since #2692, not a truthiness
+/// helper at all.
+///
+/// The caller list has shrunk three times, each time by the same argument
+/// applied one step further out, and the shape of that argument is why this
+/// function should not acquire new callers casually:
+///
+/// - #2168 (direction 2) removed the path-context walk (`path_context_root`)
+///   and `path(...)` (`eval_builtin`), which ran this over the *whole
+///   document* to answer a bounded query. Naming a position does not read
+///   what is inside it.
+/// - #2476 briefly *added* `and`/`or`/`not`/`//`/`any`/`all` via
+///   `ambient_validation_error`, standing in for a materialization it had
+///   just deleted.
+/// - #2692 removed those again together with `select`/`if`'s own
+///   truthiness check (`push_generic_truthiness`) and `//`'s left-operand
+///   filter (`retain_truthy_generic`). Testing a value is
+///   [`DocumentCursor::is_falsy`], which is O(1) and decodes nothing, so a
+///   filter that only tests reads nothing to validate.
+///
+/// The rule that survives, and the one a prospective caller must satisfy:
+/// **validate what you materialize.** `key_elements_generic` qualifies
+/// because it builds a comparison key.
 ///
 /// This is [`to_owned_cursor_at_depth`]'s own traversal and validation
 /// (same object/array unconsing, same key-collision guard) -- but it
@@ -7011,15 +7023,17 @@ fn eval_single<S: EvalSemantics, V: DocumentValue>(
         // Ungated since #2476. The arm used to be gated on
         // `needs_path_context` (as `Expr::Arithmetic` above still is) purely
         // to keep the bridge's *ambient* materialization on the shapes that
-        // do not read a position, because that materialization is what makes
+        // do not read a position, because that materialization is what made
         // `try (1+1) catch "x"` raise on a malformed document. It also made
         // every such `and`/`or` -- `true and true` included, operands
         // irrelevant -- cost the size of the expanded document, which is
-        // exponential on an alias fan-out (#2476). `eval_boolean_generic`
-        // now runs the same raise as a validation walk that builds nothing,
-        // on exactly the shape that used to bridge; see
-        // `ambient_validation_error` for why that is the same raise-set and
-        // why the path-context shape is deliberately not charged for it.
+        // exponential on an alias fan-out (#2476). #2476 replaced it with an
+        // equivalent validation walk; #2692 removed that too, so an
+        // `and`/`or` validates only what its operands materialize. See
+        // `eval_boolean_generic` for the rule, and `eval_each_generic`'s own
+        // `Expr::And`/`Expr::Or` arms for the streaming route, which had to
+        // be ungated separately -- a *top-level* `true and true` reaches
+        // those, not these.
         Expr::And(left, right) => {
             eval_boolean_generic::<S, V>(left, right, false, value, optional, cursor)
         }
@@ -7033,14 +7047,9 @@ fn eval_single<S: EvalSemantics, V: DocumentValue>(
         // alias-fan-out cost as the ungated `and`/`or` above (#2476). `not`
         // is exactly the truthiness of `.`, negated, and
         // `push_generic_truthiness` already computes that truthiness for
-        // the identity result: its `OneCursor` arm runs
-        // `push_generic_document_validation_error` over the ambient cursor
-        // before reading `is_falsy`, which IS the raise the bridge's
-        // `to_owned_with_cursor` used to produce -- see
-        // `ambient_validation_error`'s doc comment for the parity evidence.
-        // So unlike the `And`/`Or` arms above, this needs no separate
-        // `ambient_validation_error` call; the walk is already inline in
-        // the truthiness check it was going to do anyway.
+        // the identity result -- so this arm has never needed a validation
+        // call of its own, and since #2692 there is none to make: that
+        // function's `OneCursor` arm reads `is_falsy` and nothing else.
         //
         // `eval::eval_not`'s own comment argues a container that merely
         // *holds* an undecodable string should answer `false` rather than
@@ -16370,6 +16379,11 @@ fn path_context_single_native(expr: &Expr) -> bool {
         // eager fanouts alike so the two routes agree on `key + 1`), and the
         // ambient decode `try (1+1) catch "x"` depends on for a malformed
         // document, which the arm's own `needs_path_context` gate preserves.
+        // (`Expr::Arithmetic` is the last arm still holding that gate for
+        // that reason; #2692 took it from every truthiness reader, and jq
+        // mode's own `1+1` answers through the M2 streaming route rather
+        // than here. yq mode still raises there -- see the reference-probe
+        // note in `test_truthiness_probes_validate_nothing_2692`'s yq twin.)
         Expr::Arithmetic { left, right, .. } => {
             path_context_single_native(left) && path_context_single_native(right)
         }
@@ -16379,10 +16393,10 @@ fn path_context_single_native(expr: &Expr) -> bool {
         Expr::Negate(inner) => path_context_single_native(inner),
         // Native since spine 2416 gate reason 3 (#2473): `eval_single`'s own
         // `Expr::And`/`Expr::Or` arms, above, over `eval_boolean_generic`.
-        // Those arms lost their `needs_path_context` gate in #2476 -- the
-        // ambient decode the gate preserved is now `ambient_validation_error`,
-        // a walk that builds nothing -- so the admission no longer depends on
-        // that gate at all. This entry is unchanged and stays recursive for
+        // Those arms lost their `needs_path_context` gate in #2476, and the
+        // validation walk that briefly replaced the ambient decode the gate
+        // preserved is gone too (#2692) -- so the admission does not depend
+        // on that gate at all. This entry is unchanged and stays recursive for
         // the other half of the question: `eval_boolean_generic` evaluates
         // each operand through `eval_single`, so an operand outside this
         // closed list bridges *there* and reads its position as `null`,
@@ -16549,8 +16563,10 @@ fn path_context_single_native(expr: &Expr) -> bool {
 /// ADR-0018's decision order does not license that (step 2 favours the old
 /// behaviour, and no rule-4 condition applies); it is a divergence taken on
 /// its merits and recorded as one in `docs/compliance/jq/limitations.md`,
-/// which carries the reasons. `select` and the `sort_by` family
-/// keep their gate: the value they test or emit *is* the walk's domain.
+/// which carries the reasons. The `sort_by` family keeps its gate, and since
+/// #2692 is the only caller that does: it materializes a comparison key,
+/// while `select` merely tests truthiness and so joined this side of the
+/// line.
 fn path_context_root<V: DocumentValue>(root: V::Cursor) -> Result<PathContextPos<V>, Control> {
     // The walk's input is not always the document root: a nested pipe
     // (`first(.a | parent | parent)`) is walked from the node the outer
@@ -27704,10 +27720,12 @@ mod tests {
     }
 
     /// `retain_truthy_generic`'s bare `One` arm's own error branch: a
-    /// genuinely undecodable scalar (not reached through any cursor, so
-    /// neither `ambient_validation_error` nor an `OneCursor`-style walk ever
-    /// runs) still has to raise from `to_owned(&v)` rather than being
-    /// silently treated as truthy.
+    /// genuinely undecodable scalar, reached through the cursor-less
+    /// `eval()` entry point. This arm is where `//` still raises, and it is
+    /// unaffected by #2692 -- the cursor arms stopped validating because
+    /// `is_falsy` decodes nothing, but a bare `V` has no cursor to probe, so
+    /// answering its truthiness *is* `to_owned(&v)`. Materializing is what
+    /// raises, which is the rule rather than a leftover.
     #[test]
     fn test_generic_alternative_one_arm_decode_error_2476() {
         let json = br#""bad\qc""#;

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -10533,12 +10533,17 @@ fn each_take_first_generic<S: EvalSemantics, V: DocumentValue>(
 ///
 /// `OneCursorValue` has no `GenericResult` counterpart to convert to, so it
 /// collapses to plain `OneCursor` here, dropping the pre-decoded value
-/// (#1609). That's fine: this function's only caller for a single captured
-/// item is `each_take_first_generic`'s `first(...)`/`last(...)` path, once
-/// per builtin call rather than once per key, so re-deriving the value via
-/// `GenericResult::OneCursor`'s later `.value()` costs nothing that matters
-/// -- adding a matching `GenericResult` variant just to avoid that one cold
-/// re-decode isn't worth `GenericResult`'s much larger consumer set.
+/// (#1609). That's fine for `each_take_first_generic`'s `first(...)`/
+/// `last(...)` path, once per builtin call rather than once per key, so
+/// re-deriving the value via `GenericResult::OneCursor`'s later `.value()`
+/// costs nothing that matters there -- adding a matching `GenericResult`
+/// variant just to avoid that one cold re-decode isn't worth
+/// `GenericResult`'s much larger consumer set. [`each_alternative_generic`]
+/// (#2692) is a second caller with a per-item rather than per-call
+/// frequency, so it does not route an `OneCursorValue` item through here at
+/// all -- it tests and forwards the pair directly, keeping #1609's win --
+/// and only reaches this conversion for a shape that never carried a
+/// pre-decoded value to begin with.
 fn generic_item_to_result<V: DocumentValue>(item: GenericItem<V>) -> GenericResult<V> {
     match item {
         GenericItem::One(v) => GenericResult::One(v),
@@ -10933,9 +10938,10 @@ fn eval_boolean_generic<S: EvalSemantics, V: DocumentValue>(
 ///
 /// Routed through [`generic_item_to_result`] + [`push_generic_truthiness`]
 /// rather than a fourth per-variant `match`: those two already answer this
-/// question for every shape an item can take -- including the cursor's own
-/// O(1) `is_falsy` fast path and the #1247/#1194 validation raise that has
-/// to come before it, and `LazySeq`'s materialize-to-find-out failure -- and
+/// question for every shape an item can take -- the cursor's own O(1)
+/// `is_falsy` fast path (since #2692, the whole of the cursor answer --
+/// no validation raise precedes it; see `push_generic_truthiness`'s own
+/// `OneCursor` arm) and `LazySeq`'s materialize-to-find-out failure -- and
 /// a copy here would be the "duplicated predicates diverge silently" shape
 /// this project has been bitten by before (#106).
 fn generic_item_truthiness<V: DocumentValue>(item: GenericItem<V>) -> Result<bool, Control> {
@@ -10966,12 +10972,16 @@ fn generic_item_truthiness<V: DocumentValue>(item: GenericItem<V>) -> Result<boo
 /// inside it (#1519) -- and an infinite left generator still terminates
 /// (`first(repeat(1) // 9)` is `1`, not a hang).
 ///
-/// **Every truthiness decision is [`retain_truthy_generic`]'s**, one item at
-/// a time rather than over a collected batch, so this route and
-/// `eval_single`'s cannot drift on what `//` keeps (the #106 rule:
-/// duplicated predicates diverge silently). That also means this arm
-/// validates exactly what that function validates, which since #2692 is
-/// nothing -- reading truthiness decodes nothing.
+/// **Every truthiness decision is [`retain_truthy_generic`]'s `is_falsy(Preserve)`
+/// rule**, one item at a time rather than over a collected batch, so this
+/// route and `eval_single`'s cannot drift on what `//` keeps (the #106 rule:
+/// duplicated predicates diverge silently). `OneCursorValue` is the one
+/// shape tested inline here rather than routed through that function --
+/// same rule, same call, kept intact alongside the pre-decoded value it
+/// carries (#1599/#1606/#1609) instead of collapsing it to a plain
+/// `OneCursor` first. Either way, this arm validates exactly what that rule
+/// validates, which since #2692 is nothing -- reading truthiness decodes
+/// nothing.
 ///
 /// The rules it restates for a pushed rather than collected stream are
 /// `eval::each_alternative`'s, whose doc comment carries the jq 1.7.1 oracle
@@ -10993,12 +11003,34 @@ fn each_alternative_generic<S: EvalSemantics, V: DocumentValue>(
     let mut outer_stopped = false;
     let mut escape: Option<Control> = None;
     let left_flow = eval_each_generic::<S, V>(left, value.clone(), optional, cursor, &mut |item| {
+        // Fast path: `OneCursorValue` carries an already-decoded value
+        // (#1599/#1606/#1609, e.g. a `keys_unsorted` iteration) that routing
+        // through `generic_item_to_result` would otherwise collapse to a
+        // bare `OneCursor`, discarding it and forcing a second cursor
+        // `.value()` resolve on every item this forwards. Truthiness only
+        // needs the cursor, so answer it directly and keep the pair intact.
+        if let GenericItem::OneCursorValue(ref c, _) = item {
+            if c.is_falsy(JsonConvention::Preserve) {
+                return Demand::Continue;
+            }
+            forwarded += 1;
+            return match push_one_generic(item, sink) {
+                Flow::Exhausted => Demand::Continue,
+                Flow::Stopped { .. } => {
+                    outer_stopped = true;
+                    Demand::Stop
+                }
+                Flow::Escaped(control) => stop_with_escape(&mut escape, control),
+            };
+        }
         match retain_truthy_generic(generic_item_to_result(item)) {
-            // Falsy: dropped, and the left operand keeps producing.
+            // Falsy: dropped, and the left operand keeps producing. A
+            // genuine `Error`/`Break`/`Halt` falls to the `kept` arm below
+            // rather than getting its own -- `drain_result_generic` already
+            // converts each straight to `Flow::Escaped` with no sink call,
+            // the same conversion every other call site in this file relies
+            // on (#106: no second copy of that mapping to drift from it).
             GenericResult::None => Demand::Continue,
-            GenericResult::Error(e) => stop_with_escape(&mut escape, Control::Error(e)),
-            GenericResult::Break(l) => stop_with_escape(&mut escape, Control::Break(l)),
-            GenericResult::Halt(c) => stop_with_escape(&mut escape, Control::Halt(c)),
             kept => {
                 forwarded += 1;
                 match drain_result_generic(kept, sink) {
@@ -11013,11 +11045,8 @@ fn each_alternative_generic<S: EvalSemantics, V: DocumentValue>(
         }
     });
 
-    if outer_stopped {
+    if outer_stopped || escape.is_some() {
         return resume_from_escape(escape, left_flow);
-    }
-    if let Some(control) = escape {
-        return resume_from_escape(Some(control), left_flow);
     }
     match left_flow {
         // Whatever the left ended in propagates, and the right side is not
@@ -11032,8 +11061,15 @@ fn each_alternative_generic<S: EvalSemantics, V: DocumentValue>(
     }
 }
 
-/// Demand-forwarding twin of [`eval_boolean_generic`] (#2180 WP2a), for an
-/// `and`/`or` whose operands read path context.
+/// Demand-forwarding twin of [`eval_boolean_generic`] (#2180 WP2a), for the
+/// streaming `and`/`or` route.
+///
+/// Originally introduced only for an `and`/`or` whose operands read path
+/// context, gated to match `eval_single`'s own then-gated pair; the
+/// `eval_each_generic` dispatch is ungated since #2692, so this is now the
+/// implementation for every streaming `and`/`or`, path-context operand or
+/// not (see the dispatch's own comment for why the gate had nothing left to
+/// preserve).
 ///
 /// The loop is `eval::boolean_fanout_each`, shared with every other route
 /// (see its own doc comment for the oracle rows that pinned the left-outer
@@ -16376,14 +16412,17 @@ fn path_context_single_native(expr: &Expr) -> bool {
         // shapes blocked this admission until now, and both are closed:
         // yq's rule for an operand that produces zero outputs (#2460,
         // `jq::eval::yq_empty_operand_output`, consulted by the generic and
-        // eager fanouts alike so the two routes agree on `key + 1`), and the
-        // ambient decode `try (1+1) catch "x"` depends on for a malformed
-        // document, which the arm's own `needs_path_context` gate preserves.
-        // (`Expr::Arithmetic` is the last arm still holding that gate for
-        // that reason; #2692 took it from every truthiness reader, and jq
-        // mode's own `1+1` answers through the M2 streaming route rather
-        // than here. yq mode still raises there -- see the reference-probe
-        // note in `test_truthiness_probes_validate_nothing_2692`'s yq twin.)
+        // eager fanouts alike so the two routes agree on `key + 1`), and an
+        // ambient decode `try (1+1) catch "x"` used to depend on for a
+        // malformed document, which the arm's own `needs_path_context` gate
+        // preserved. That gate is gone: #2173 narrowed the bridge's own
+        // materialization to operands that read the ambient value, leaving
+        // the gate nothing to preserve, and #2626 then removed it outright
+        // because the bridge it selected was *also* collapsing duplicate
+        // mapping keys and stubbing yq's node-metadata builtins. This entry
+        // is unchanged by either and stays recursive for its own question:
+        // whether both operands are shapes the walk can evaluate at a
+        // position, which is what `key + 10` needs.
         Expr::Arithmetic { left, right, .. } => {
             path_context_single_native(left) && path_context_single_native(right)
         }

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -11002,6 +11002,25 @@ fn each_alternative_generic<S: EvalSemantics, V: DocumentValue>(
     let mut forwarded = 0usize;
     let mut outer_stopped = false;
     let mut escape: Option<Control> = None;
+    // Both branches below reduce a `Flow` the same way -- one shared closure
+    // rather than two copies of the match, so a change to what `Stopped`/
+    // `Escaped` mean here can't update one arm and miss the other (#106).
+    // `push_one_generic` can only ever answer `Exhausted`/`Stopped` (its own
+    // body is `Continue`/`Stop`, nothing else), so the `Escaped` arm is
+    // unreachable from the fast path below on its own -- but it is reachable
+    // from `drain_result_generic`'s call, for a genuine `Error`/`Break`/
+    // `Halt` item, which is what keeps this arm covered without a
+    // tolerate-line for the fast path's narrower case.
+    let mut handle_flow = |flow: Flow| -> Demand {
+        match flow {
+            Flow::Exhausted => Demand::Continue,
+            Flow::Stopped { .. } => {
+                outer_stopped = true;
+                Demand::Stop
+            }
+            Flow::Escaped(control) => stop_with_escape(&mut escape, control),
+        }
+    };
     let left_flow = eval_each_generic::<S, V>(left, value.clone(), optional, cursor, &mut |item| {
         // Fast path: `OneCursorValue` carries an already-decoded value
         // (#1599/#1606/#1609, e.g. a `keys_unsorted` iteration) that routing
@@ -11014,14 +11033,7 @@ fn each_alternative_generic<S: EvalSemantics, V: DocumentValue>(
                 return Demand::Continue;
             }
             forwarded += 1;
-            return match push_one_generic(item, sink) {
-                Flow::Exhausted => Demand::Continue,
-                Flow::Stopped { .. } => {
-                    outer_stopped = true;
-                    Demand::Stop
-                }
-                Flow::Escaped(control) => stop_with_escape(&mut escape, control),
-            };
+            return handle_flow(push_one_generic(item, sink));
         }
         match retain_truthy_generic(generic_item_to_result(item)) {
             // Falsy: dropped, and the left operand keeps producing. A
@@ -11033,14 +11045,7 @@ fn each_alternative_generic<S: EvalSemantics, V: DocumentValue>(
             GenericResult::None => Demand::Continue,
             kept => {
                 forwarded += 1;
-                match drain_result_generic(kept, sink) {
-                    Flow::Exhausted => Demand::Continue,
-                    Flow::Stopped { .. } => {
-                        outer_stopped = true;
-                        Demand::Stop
-                    }
-                    Flow::Escaped(control) => stop_with_escape(&mut escape, control),
-                }
+                handle_flow(drain_result_generic(kept, sink))
             }
         }
     });

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -3187,55 +3187,6 @@ fn push_generic_document_validation_error<C: DocumentCursor>(
     }
 }
 
-/// The wildcard bridge's ambient materialization, as a check that builds
-/// nothing (#2476).
-///
-/// `eval_single`'s `_` arm materializes the *ambient* value
-/// (`to_owned_with_cursor`) before handing the expression to the eager
-/// evaluator, and that materialization is where a malformed document raises
-/// for a query that never reads `.`: jq rejects the whole document for every
-/// query, and `test_try_catch_contains_a_genuinely_catchable_malformed_key_error_1812`
-/// pins `try (1+1) catch "x"` on `{123: 1}` exiting 5. The `Expr::And`/
-/// `Expr::Or`/`Expr::Arithmetic`/`Expr::Negate` arms were gated on
-/// `needs_path_context` purely to keep that raise (see their comments), so
-/// every ungated shape stayed on the bridge. But the materialization costs
-/// the size of the *expanded* value, and on a document shaped as an alias
-/// fan-out (`aN: &aN [*a(N-1), *a(N-1)]`) the root contains `aN`, so every
-/// bridged expression at the root -- `true and true`, `1+1`, `not`, `//`,
-/// `any` -- cost `O(2^N)` whatever its operands read (#2476).
-///
-/// This is the same raise without the value. [`push_generic_document_validation_error`]
-/// is `to_owned_cursor_at_depth`'s own traversal and checks (decode failures,
-/// #1194 structural errors, #1642 key collisions, #2211/#2243/#2349 comma
-/// gaps, the #998 depth guard) building no `OwnedValue`, and since #1804 it
-/// does not descend into a container reached through an alias -- which is
-/// what makes it `O(N)` on the fan-out where the bridge is `O(2^N)`.
-/// Verified against the bridge over a corpus spanning every class those
-/// checks cover, in both modes and for both cursor types
-/// (`test_ambient_validation_agrees_with_bridge_2476` in
-/// `tests/jq_cli_tests.rs` and its yq twin): identical exit code and message
-/// on every row. The one shape that differs by construction is #1804's
-/// accepted trade-off, now shared by every arm that calls this: a decode
-/// failure reachable *only* through an alias to a container no longer raises
-/// from these arms either (recorded in `docs/compliance/yq/limitations.md`).
-///
-/// `None` without a cursor: `to_owned_with_cursor(&value, None)` on an
-/// already-owned value cannot fail, so the bridge had nothing to raise there
-/// either. A document deeper than `MAX_NESTING_DEPTH` reports a
-/// `decode_failure`-tagged error from this walk, matching what
-/// `to_owned_with_cursor`'s own materialization now returns at the same
-/// boundary (#2627 fixed both from a `panic!` to this) -- route-independent.
-///
-/// Call this only on the shape that used to bridge (`!needs_path_context`
-/// for a gated arm; unconditionally for an arm that had no native route at
-/// all): an operand that reads path context could not have stood on a
-/// malformed document's root and survived the walk to it anyway, and that
-/// shape never paid the decode, so charging it a walk now would be a new
-/// cost, not a replaced one.
-fn ambient_validation_error<V: DocumentValue>(cursor: Option<V::Cursor>) -> Option<Control> {
-    cursor.and_then(|c| push_generic_document_validation_error(&c, 0))
-}
-
 /// Append one truthiness bit per output of a `GenericResult` stream to
 /// `out`. Mirrors [`super::eval::push_truthiness`] for the generic
 /// evaluator's cursor-aware result type — used to fan `select`'s condition
@@ -3249,17 +3200,22 @@ fn push_generic_truthiness<V: DocumentValue>(
         // `DocumentCursor::is_falsy` answers this in O(1) without
         // materializing the value at all -- an arbitrarily deep object/
         // array previously paid a full recursive `to_owned_cursor` copy
-        // just to learn it isn't `null`/`false` (#1645). `is_falsy` itself
-        // is deliberately silent on a value that fails to decode (its own
-        // doc comment: "conservative assumption", matching `--exit-status`'s
-        // pre-existing, best-effort use of it) -- `select`'s own filtering
-        // needs the real #1247/#1194 raise instead, so that check runs
-        // first, same as `to_owned_at_depth`'s own two checks in the same
-        // order, just without materializing on the ordinary-value path.
+        // just to learn it isn't `null`/`false` (#1645).
+        //
+        // #2692: and it is the *whole* of the answer. Until then a
+        // `push_generic_document_validation_error` walk ran first, so
+        // `select`/`if`/`not`/`and`/`or` raised on a malformed document
+        // they only ever asked "is this null or false?" about. That walk
+        // is gone: reading truthiness decodes nothing, so under ADR-0018's
+        // #2103 amendment it validates nothing. `is_falsy`'s deliberate
+        // silence on a value that fails to decode (its own doc comment:
+        // "conservative assumption", matching `--exit-status`'s
+        // pre-existing, best-effort use of it) is now the answer these
+        // callers get rather than a default the walk pre-empted. A caller
+        // that goes on to *materialize* the value still validates it
+        // there -- `select(.)` without a discarding `| 1` raises from the
+        // printer's own walk, exactly as a bare `.` does.
         GenericResult::OneCursor(c) => {
-            if let Some(control) = push_generic_document_validation_error(&c, 0) {
-                return Some(control);
-            }
             // `select`'s condition truthiness is about the real value, not
             // about what a later `-e`/JSON-output convention would sanitize
             // it to -- `Preserve` keeps a malformed number truthy here the
@@ -3274,9 +3230,6 @@ fn push_generic_truthiness<V: DocumentValue>(
         }
         GenericResult::ManyCursor(cs) => {
             for c in &cs {
-                if let Some(control) = push_generic_document_validation_error(c, 0) {
-                    return Some(control);
-                }
                 out.push(!c.is_falsy(JsonConvention::Preserve));
             }
         }
@@ -3325,22 +3278,23 @@ fn push_generic_truthiness<V: DocumentValue>(
 /// replaces the terminating control with its own error, the same precedence
 /// [`flatten_generic_results`] uses when materializing a batch.
 ///
-/// #2661 originally tagged this function's `Err` arm as unreachable, on the
-/// premise that both call sites only place already-successfully-converted
-/// items into `kept`. That premise holds for the `Many` (bare `V`) call site
-/// -- its loop already ran `to_owned` on each item before keeping it -- but
-/// not for `ManyCursor`: its loop only runs the cheap
-/// [`push_generic_document_validation_error`] walk before keeping a cursor,
-/// and that walk deliberately stops at a container-target alias (#1804), so
-/// a kept item can be an alias whose target is corrupt. `to_owned_cursor`
-/// here has no such short-circuit and genuinely fails on it -- confirmed live
-/// with `x: &X ["bad\qc"]` / `y: &Y [*X, "bad\qd"]` / `a:\n  q: *Y`, filter
-/// `.a | (.q[] // 1)`: `*X` passes the cheap check (kept), a later element
-/// fails it (the `control` this function is called with), and re-converting
-/// `*X` here fails too -- for a different reason than `control`, per this
-/// function's own documented precedence above. So this arm is reachable and
-/// exercised by `test_alternative_manycursor_prefix_conversion_error_2476`
-/// (`tests/yq_cli_tests.rs`), not tolerate-line'd.
+/// The `Err` arm below is unreachable, and the history is worth keeping
+/// because it has now flipped twice. #2661 first tagged it unreachable, on
+/// the premise that every call site only places already-successfully-
+/// converted items into `kept`. #2476 falsified that for the `ManyCursor`
+/// call site: its loop kept a cursor after only the cheap
+/// `push_generic_document_validation_error` walk, and that walk deliberately
+/// stopped at a container-target alias (#1804), so a kept item could be an
+/// alias whose target is corrupt and `to_owned_cursor` here genuinely failed
+/// on it. #2692 removed the walk from `retain_truthy_generic` altogether --
+/// reading truthiness validates nothing -- and with it the `ManyCursor` call
+/// site, which no longer has a mid-stream control to carry a prefix for.
+///
+/// So the only caller left is `retain_truthy_generic`'s `Many` (bare `V`)
+/// arm, whose loop runs `to_owned` on each item *before* keeping it. Every
+/// item in `kept` has therefore already converted successfully once, and
+/// re-converting it here cannot fail -- #2661's original premise, now true
+/// again because the counterexample was deleted rather than fixed.
 fn owned_prefix_partial<V: DocumentValue, T>(
     kept: &[T],
     to_owned_one: impl Fn(&T) -> Result<OwnedValue, EvalError>,
@@ -3350,7 +3304,7 @@ fn owned_prefix_partial<V: DocumentValue, T>(
     for item in kept {
         match to_owned_one(item) {
             Ok(v) => prefix.push(v),
-            Err(e) => return GenericResult::Error(e),
+            Err(e) => return GenericResult::Error(e), // omni-dev: coverage tolerate-line reason="unreachable: the sole remaining caller (`retain_truthy_generic`'s `Many` arm) runs `to_owned` on an item before keeping it, so re-converting a kept item here cannot fail; the `ManyCursor` caller that made this reachable went with the truthiness walk (#2692, re-establishing #2661's premise)"
         }
     }
     partial_generic(prefix, control)
@@ -3363,10 +3317,10 @@ fn owned_prefix_partial<V: DocumentValue, T>(
 ///
 /// Every arm answers truthiness by exactly the rule its
 /// `push_generic_truthiness` counterpart uses, so `//` and `and`/`or`/`not`
-/// cannot drift apart on what "truthy" means: `OneCursor`/`ManyCursor` run
-/// [`push_generic_document_validation_error`] first and then read
-/// `is_falsy(Preserve)` (so a #1194/#1247/#1642 document raises here as it
-/// does under `select`, and a malformed *number* stays truthy);
+/// cannot drift apart on what "truthy" means: `OneCursor`/`ManyCursor` read
+/// `is_falsy(Preserve)` and nothing else, validating nothing (#2692 -- see
+/// that function's `OneCursor` arm for why reading truthiness decodes
+/// nothing and so raises nothing, and a malformed *number* stays truthy);
 /// `LazyKeys`/`LazyIndexRange` are array-shaped and therefore always truthy
 /// without materializing; `LazySeq` must still be pulled, because it runs
 /// arbitrary `map(f)` whose failure has to surface rather than be reported as
@@ -3392,9 +3346,6 @@ fn retain_truthy_generic<V: DocumentValue>(result: GenericResult<V>) -> GenericR
             Err(e) => GenericResult::Error(e),
         },
         GenericResult::OneCursor(c) => {
-            if let Some(control) = push_generic_document_validation_error(&c, 0) {
-                return partial_generic(Vec::new(), control);
-            }
             if c.is_falsy(JsonConvention::Preserve) {
                 GenericResult::None
             } else {
@@ -3423,9 +3374,6 @@ fn retain_truthy_generic<V: DocumentValue>(result: GenericResult<V>) -> GenericR
         GenericResult::ManyCursor(cs) => {
             let mut kept: Vec<V::Cursor> = Vec::new();
             for c in cs {
-                if let Some(control) = push_generic_document_validation_error(&c, 0) {
-                    return owned_prefix_partial(&kept, to_owned_cursor, control);
-                }
                 if !c.is_falsy(JsonConvention::Preserve) {
                     kept.push(c);
                 }
@@ -7115,11 +7063,18 @@ fn eval_single<S: EvalSemantics, V: DocumentValue>(
         // `needs_path_context` gate to lose, and no shape that escaped the
         // cost. The bridge's first act is `to_owned_with_cursor` on the
         // *ambient* value, `O(2^N)` on an alias fan-out document (#2476), and
-        // it is charged before either operand runs, so `(false // 1)` paid it
-        // exactly as `(.aN // 1)` did. `ambient_validation_error` is that
-        // materialization's raise without the value -- unconditional here,
-        // because the whole construct is the "shape that used to bridge" its
-        // doc comment names.
+        // it was charged before either operand ran, so `(false // 1)` paid it
+        // exactly as `(.aN // 1)` did. #2476 replaced that materialization
+        // with an equivalent validation walk (`ambient_validation_error`),
+        // which #2173 then charged only to a `//` that reads the document;
+        // #2692 removed the walk and its gate together, because a `//` that
+        // reads `.` reads only its truthiness -- `is_falsy`, which decodes
+        // nothing -- so it validates no more of the ambient value than
+        // `1+1` does. `false // 1` on a malformed document
+        // now answers `1` at exit 0, as `1+1` already answered `2`. What the
+        // operands themselves read is unchanged and still governs: `. // 1`
+        // reads `.`'s truthiness, and reading truthiness validates nothing
+        // either (see [`retain_truthy_generic`]).
         //
         // Below it, `eval::eval_alternative` mirrored arm for arm, with
         // `retain_truthy_generic` (the cursor-preserving twin of
@@ -7156,16 +7111,6 @@ fn eval_single<S: EvalSemantics, V: DocumentValue>(
         // only path-context read sits inside a `//` is still never routed to
         // path-context evaluation, and this arm does not change that table.
         Expr::Alternative(left, right) => {
-            // #2173: the walk is charged only to a `//` that reads the
-            // document. `false // 1` reads nothing, so under #2103's rule --
-            // a filter validates only what it reads -- it validates nothing,
-            // exactly as the bridge it replaces now does for the same shape
-            // (`bridge_ambient_input`). `(.a? // 1) | 1` still walks.
-            if crate::jq::walk::reads_ambient_value(expr) {
-                if let Some(control) = ambient_validation_error::<V>(cursor) {
-                    return partial_generic(Vec::new(), control);
-                }
-            }
             match retain_truthy_generic(eval_single::<S, V>(left, value.clone(), optional, cursor))
             {
                 // A `break` escapes the operator rather than selecting a branch.
@@ -8053,41 +7998,34 @@ fn eval_each_generic<S: EvalSemantics, V: DocumentValue>(
             | Builtin::UpperInSrc(..),
         ) => bridge_to_each_owned_flow::<S, V>(expr, value, cursor, optional, sink),
 
-        // #2180 WP2a: `and`/`or` with a path-context operand, mirroring
-        // `eval_single`'s own gated `Expr::And`/`Expr::Or` pair above --
-        // same gate, same reason (#1812: the bridge's ambient
-        // materialization is what makes `try (1+1) catch "x"` fail on a
-        // #1194-malformed document, and a path-context operand could not
-        // have stood on such a document and survived the walk anyway). The
-        // ungated spelling would have silently taken `.[] | key == "a" and
-        // true` off its cursor when it is reached through a lazy consumer.
-        Expr::And(left, right) if needs_path_context(left) || needs_path_context(right) => {
+        // #2180 WP2a introduced this pair for `and`/`or` with a path-context
+        // operand, gated exactly as `eval_single`'s own `Expr::And`/`Expr::Or`
+        // pair then was, and for the same reason: the bridge's ambient
+        // materialization below is what made `try (1+1) catch "x"` fail on a
+        // #1194-malformed document (#1812), and only the gated-out shapes
+        // needed to keep reaching it.
+        //
+        // Ungated since #2692. That raise is gone -- an `and`/`or` validates
+        // only what its operands materialize, never the ambient document it
+        // does not read -- so the gate had nothing left to preserve, while
+        // the bridge it selected still cost a whole-document
+        // `to_owned_with_cursor` on every top-level `and`/`or`. Every
+        // spelling now takes this native, demand-forwarding arm, which is
+        // also what stops a top-level `true and true` answering differently
+        // from a nested `[true and true]`.
+        Expr::And(left, right) => {
             each_boolean_generic::<S, V>(left, right, false, value, optional, cursor, sink)
         }
-        Expr::Or(left, right) if needs_path_context(left) || needs_path_context(right) => {
+        Expr::Or(left, right) => {
             each_boolean_generic::<S, V>(left, right, true, value, optional, cursor, sink)
         }
-        // #2180 WP2a: everything else `and`/`or`, and `//` at any position,
-        // takes the demand-forwarding owned bridge -- which is *exactly*
-        // what these three already did, minus the demand. `Expr::And`/
-        // `Expr::Or` without path context fell to the `_` fallback below,
-        // whose `eval_single` in turn falls to its own wildcard bridge;
-        // `Expr::Alternative` has no native arm in `eval_single` at all, so
-        // it took that same wildcard for every input. Both wildcards are
-        // `to_owned_with_cursor` + reindex + `eval.rs`, which is
-        // [`bridge_to_each_owned_flow`]'s own body with `eval_full` in place
-        // of `eval_each` -- so nothing is lost by crossing here instead, and
-        // the far side now carries `eval.rs`'s new `each_alternative`/
-        // `each_boolean` arms. Rows captured live against jq 1.7.1 (input
-        // `1`, `G` = `1 as $x ?// $y | 1`): `[first((1 as $x ?// $y |
-        // 5)//9)]` is `[5,5]`, `[first(null // (G))]` is `[1,1]`, and all
-        // four `and`/`or` operand positions are `[true,true]` -- each
-        // answered once before this arm existed, on this route as well as
-        // `eval.rs`'s.
-        Expr::And(..) | Expr::Or(..) | Expr::Alternative(..) => {
-            bridge_to_each_owned_flow::<S, V>(expr, value, cursor, optional, sink)
+        // #2692: `//` likewise, through this file's own
+        // [`each_alternative_generic`] rather than the owned bridge -- see
+        // that function for why the laziness the bridge provided had to be
+        // kept rather than dropped onto `eval_single`'s eager native arm.
+        Expr::Alternative(left, right) => {
+            each_alternative_generic::<S, V>(left, right, value, optional, cursor, sink)
         }
-
         // #2180 WP2b: the remaining eager sub-expression sites, mirroring
         // `eval.rs`'s own new arm set -- see that file's `eval_each` match
         // arm for the live-captured oracle rows every one of these closes.
@@ -10943,35 +10881,20 @@ fn eval_boolean_generic<S: EvalSemantics, V: DocumentValue>(
     optional: bool,
     cursor: Option<V::Cursor>,
 ) -> GenericResult<V> {
-    // #2476: the one place the two arms above share, so the rule is stated
-    // once. A shape with no path-context operand is the shape that used to
-    // fall to the wildcard bridge, and the bridge's ambient materialization
-    // is what raised on a malformed document for an expression that reads
-    // nothing (`try (1+1) catch "x"`, #1812). `ambient_validation_error` is
-    // that raise without the value -- read its doc comment for the parity
-    // evidence and for why an operand that *does* read path context is not
-    // charged the walk (it never paid the materialization either).
+    // #2692: no ambient validation here, and no gate in front of one. This
+    // function used to open with `ambient_validation_error` -- the walk that
+    // stood in for the wildcard bridge's ambient materialization (#2476),
+    // itself standing in for jq's whole-document parse-time rejection
+    // (#1812) -- behind a `!needs_path_context(..)` gate, which #2173 then
+    // narrowed further to operands that actually read `.`.
     //
-    // #2173 narrowed it once more, to operands that actually read `.`.
-    // `true and true` reads nothing, and #2103's rule -- a filter validates
-    // only what it reads -- says it should therefore validate nothing; the
-    // bridge that used to carry this raise no longer raises for that shape
-    // either (`bridge_ambient_input`), so keeping the walk here would have
-    // reinstated by hand the spelling-dependence both changes exist to
-    // remove. `. and true` still walks.
-    // `needs_path_context` checked first so it can short-circuit `&&` and
-    // skip the `reads_ambient_value` tree walk entirely whenever either
-    // operand needs path context -- that case already makes the whole guard
-    // `false` regardless of what the walk would answer.
-    if !needs_path_context(left)
-        && !needs_path_context(right)
-        && (crate::jq::walk::reads_ambient_value(left)
-            || crate::jq::walk::reads_ambient_value(right))
-    {
-        if let Some(control) = ambient_validation_error::<V>(cursor) {
-            return partial_generic(Vec::new(), control);
-        }
-    }
+    // Both gates are gone with the walk they guarded. #2173 had already
+    // reached half of this conclusion for the same reason -- `true and true`
+    // reads nothing, so under ADR-0018's #2103 amendment it validates
+    // nothing -- and stopped at "reads `.`"; #2692 takes the other half,
+    // because `. and true` reads `.`'s *truthiness*, which is `is_falsy` and
+    // decodes nothing either. Each operand still validates whatever it
+    // materializes, via `eval_single` below.
     let (bools, control) = boolean_fanout_bools(
         |operand, out| {
             push_generic_truthiness(
@@ -11015,6 +10938,88 @@ fn generic_item_truthiness<V: DocumentValue>(item: GenericItem<V>) -> Result<boo
         // panic, the same defensive choice `binary_fanout_core` makes for
         // its own impossible `Flow::Stopped`.
         None => Ok(bits.first().copied().unwrap_or(false)),
+    }
+}
+
+/// Demand-forwarding twin of [`eval_alternative`-shaped `Expr::Alternative`
+/// evaluation](eval_single) and the generic mirror of `eval::each_alternative`
+/// (#2692).
+///
+/// `//` used to reach [`bridge_to_each_owned_flow`] from
+/// [`eval_each_generic`], which is `to_owned_with_cursor` + reindex +
+/// `eval.rs` -- so the whole ambient document was materialized before the
+/// operator ran, and that materialization validated it. #2476 gave
+/// `eval_single` a native `Expr::Alternative` arm but left this route
+/// bridged, so a *top-level* `false // 1` still raised on a malformed
+/// document while a nested `[false // 1]` did not. This arm closes that: the
+/// same native evaluation, still demand-forwarding, so a wrapping consumer's
+/// [`Demand::Stop`] reaches the left operand -- and with it a `?//` bind
+/// inside it (#1519) -- and an infinite left generator still terminates
+/// (`first(repeat(1) // 9)` is `1`, not a hang).
+///
+/// **Every truthiness decision is [`retain_truthy_generic`]'s**, one item at
+/// a time rather than over a collected batch, so this route and
+/// `eval_single`'s cannot drift on what `//` keeps (the #106 rule:
+/// duplicated predicates diverge silently). That also means this arm
+/// validates exactly what that function validates, which since #2692 is
+/// nothing -- reading truthiness decodes nothing.
+///
+/// The rules it restates for a pushed rather than collected stream are
+/// `eval::each_alternative`'s, whose doc comment carries the jq 1.7.1 oracle
+/// rows for all of them: truthy left outputs pass and falsy ones are
+/// dropped; the right side answers only when *no* truthy output was
+/// forwarded, and its outputs are emitted unfiltered; a left error or
+/// `break` propagates after the truthy prefix and does not select the right
+/// side; and `outer_stopped` short-circuits the close, because the consumer
+/// rather than the left operand is why production ended.
+fn each_alternative_generic<S: EvalSemantics, V: DocumentValue>(
+    left: &Expr,
+    right: &Expr,
+    value: V,
+    optional: bool,
+    cursor: Option<V::Cursor>,
+    sink: &mut dyn FnMut(GenericItem<V>) -> Demand,
+) -> Flow {
+    let mut forwarded = 0usize;
+    let mut outer_stopped = false;
+    let mut escape: Option<Control> = None;
+    let left_flow = eval_each_generic::<S, V>(left, value.clone(), optional, cursor, &mut |item| {
+        match retain_truthy_generic(generic_item_to_result(item)) {
+            // Falsy: dropped, and the left operand keeps producing.
+            GenericResult::None => Demand::Continue,
+            GenericResult::Error(e) => stop_with_escape(&mut escape, Control::Error(e)),
+            GenericResult::Break(l) => stop_with_escape(&mut escape, Control::Break(l)),
+            GenericResult::Halt(c) => stop_with_escape(&mut escape, Control::Halt(c)),
+            kept => {
+                forwarded += 1;
+                match drain_result_generic(kept, sink) {
+                    Flow::Exhausted => Demand::Continue,
+                    Flow::Stopped { .. } => {
+                        outer_stopped = true;
+                        Demand::Stop
+                    }
+                    Flow::Escaped(control) => stop_with_escape(&mut escape, control),
+                }
+            }
+        }
+    });
+
+    if outer_stopped {
+        return resume_from_escape(escape, left_flow);
+    }
+    if let Some(control) = escape {
+        return resume_from_escape(Some(control), left_flow);
+    }
+    match left_flow {
+        // Whatever the left ended in propagates, and the right side is not
+        // consulted.
+        Flow::Escaped(control) => Flow::Escaped(control),
+        // At least one truthy output was forwarded, so `//` is answered.
+        Flow::Exhausted | Flow::Stopped { .. } if forwarded > 0 => Flow::Exhausted,
+        // No truthy output at all: the right side answers, unfiltered.
+        Flow::Exhausted | Flow::Stopped { .. } => {
+            eval_each_generic::<S, V>(right, value, optional, cursor, sink)
+        }
     }
 }
 
@@ -17717,27 +17722,24 @@ fn try_path_context_absent_walk<S: EvalSemantics, V: DocumentValue>(
 /// Apple M-series release build where the same answer is one `is_falsy`
 /// probe on the first element.
 ///
-/// **Validate once, then scan** -- deliberately *not* "validate each element
-/// as the scan reaches it". The bridge materialized the whole container
-/// before `builtin_any` ran, so an element the early exit never reaches
-/// still raised: `[true, "\x"] | any` exits 5, and real jq agrees for the
-/// stronger reason that it rejects the whole document at parse time
-/// (captured live from jq 1.7.1: `jq: parse error: Invalid escape at line 1,
-/// column 11`, and the same for `[false, "\x"] | all`). Checking per element
-/// with early exit would answer `true` there and drop a raise both
-/// references make. So [`push_generic_document_validation_error`] runs over
-/// the whole input first -- the same raise-set without the value, `O(N)` on
-/// the fan-out because of #1804's alias short-circuit -- and the loop below
-/// is then pure `is_falsy`, which materializes nothing and keeps the early
-/// exit `any_all_over` has always had.
+/// **Scan, and validate nothing** (#2692). #2476 opened this function with a
+/// whole-input [`push_generic_document_validation_error`] walk, so that an
+/// element the early exit never reaches still raised: `[true, "\x"] | any`
+/// exited 5, and real jq agreed -- but for the *stronger* reason that it
+/// rejects the whole document at parse time (captured live from jq 1.7.1:
+/// `jq: parse error: Invalid escape at line 1, column 11`, and the same for
+/// `[false, "\x"] | all`). That is precisely the accidental agreement
+/// ADR-0018's #2103 amendment names: succinctly is a semi-index and does not
+/// perform jq's whole-document rejection, so preserving it here bought a
+/// per-spelling divergence (`any` raising where `1+1`, `.` and `length` on
+/// the same document do not) rather than fidelity. `any`/`all` read each
+/// element's truthiness and decode none of it, so under that amendment they
+/// validate nothing, and the walk is gone. The loop below is pure
+/// `is_falsy`, keeping the early exit `any_all_over` has always had.
 ///
-/// It follows that this arm shares #1804's accepted trade-off, exactly as
-/// the `not`/`//` arms of this same issue do: a decode failure reachable
-/// *only* through an alias to a container no longer raises from `any`/`all`
-/// either (`a: &a ["bad\qc"]` / `b: *a` with `.b | any` is `true` at exit 0
-/// where it exited 1 before). `.a | any` and `.b[0]` still raise. Real yq
-/// rejects that document at parse time, so there is no yq behaviour to
-/// match.
+/// `effective_fields_checked`'s own #1642 duplicate-key raise is *not* part
+/// of that removal and still fires below: jq's last-occurrence rule needs the
+/// keys resolved, so the object arm genuinely reads them.
 ///
 /// Mode split mirrored arm for arm from [`super::eval::builtin_any`]/
 /// [`super::eval::builtin_all`], including the arm *order* #1901's review
@@ -17766,9 +17768,6 @@ fn any_all_generic<S: EvalSemantics, V: DocumentValue>(
     name: &str,
     target_truthy: bool,
 ) -> GenericResult<V> {
-    if let Some(control) = push_generic_document_validation_error(&cursor, 0) {
-        return partial_generic(Vec::new(), control);
-    }
     let answer = |b: bool| GenericResult::Owned(OwnedValue::Bool(b));
     // One closure called from both the object arm and the scalar arm, not
     // two copies of the same call -- `builtin_any`'s own `yq_reject_non_array`

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -22783,34 +22783,34 @@ mod tests {
         }
     }
 
-    /// #2627's other panic site: `And`/`Or` (`eval_boolean_generic`) and
-    /// `Alternative`/`//`/`Not` route their own "shape that used to bridge"
-    /// raise through [`push_generic_document_validation_error`] instead of
-    /// the full materialization above (#2476's O(N) replacement for the
-    /// bridge's O(2^N) cost) -- but its depth guard panicked exactly the
-    /// same way before this fix, as its own doc comment
-    /// (`ambient_validation_error`) already flagged. `. and true`, not
-    /// `true and true`: both keep `needs_path_context` false (no `key`/
-    /// `parent`/`path` operand on either side, so this still takes the
-    /// bridge route), but a fully closed `true and true` no longer reaches
-    /// this walk at all -- #2173's `walk::reads_ambient_value` gate
-    /// (landed the same day as this fix) substitutes `OwnedValue::Null` for
-    /// a closed term before this function is ever called. `.` on the left
-    /// makes the whole expression ambient-reading (`Expr::Identity` always
-    /// reports `reads_ambient_value == true`), which is what keeps the real
-    /// document -- and this guard -- in the loop.
+    /// #2627 used to reach its panic here too: `And`/`Or`
+    /// (`eval_boolean_generic`) routed its own "shape that used to bridge"
+    /// raise through `push_generic_document_validation_error`'s
+    /// `ambient_validation_error` walk, whose depth guard panicked on a
+    /// document nested past 256 levels before #2627's fix turned that into
+    /// a clean `Error`.
     ///
-    /// [`eval_with_cursor`], not [`eval`]: `ambient_validation_error` walks
-    /// from a `DocumentCursor`, so it is a deliberate no-op without one
-    /// (see its own doc comment's "`None` without a cursor" paragraph) --
-    /// this is the real public `succinctly::jq::eval` shape, which always
-    /// supplies a cursor (confirmed live via `eval::eval`'s own
-    /// `needs_path_context` gate: a pipe like `key?, (. and true)` on a
-    /// document nested deeper than 256 levels reaches this exact guard
-    /// through the public API, not just this module's own internal
-    /// callers).
+    /// #2692 then removed the walk itself: `eval_boolean_generic` no longer
+    /// validates anything ahead of its operands (see that function's own
+    /// doc comment), so `. and true` reads only `.`'s truthiness --
+    /// `is_falsy`, which never descends into a container's children -- and
+    /// a 256-deep-nested array is truthy same as a shallow one. This is the
+    /// `eval_generic.rs`-internal twin of the CLI-level corollary pinned by
+    /// `test_truthiness_probes_do_not_trip_the_depth_guard_2692`
+    /// (`tests/jq_cli_tests.rs`) and recorded in `docs/adrs/adr-0018.md` and
+    /// both compliance pages. `. and true`, not `true and true`: a fully
+    /// closed `true and true` no longer reaches this function's document
+    /// argument at all -- #2173's `walk::reads_ambient_value` gate
+    /// substitutes `OwnedValue::Null` for a closed term before
+    /// `eval_boolean_generic` is ever called -- while `.` on the left keeps
+    /// the real document (and cursor) in the loop, which is what still lets
+    /// this test exercise the guard's *absence* rather than a substituted
+    /// `Null`.
+    ///
+    /// [`eval_with_cursor`], not [`eval`]: matches the real public
+    /// `succinctly::jq::eval` shape, which always supplies a cursor.
     #[test]
-    fn test_boolean_ambient_validation_reports_clean_error_past_nesting_limit_2627() {
+    fn test_boolean_and_reads_truthiness_without_tripping_depth_guard_2692() {
         use crate::json::JsonIndex;
         let json = format!("{}1{}", "[".repeat(256), "]".repeat(256));
         let json = json.as_bytes();
@@ -22819,24 +22819,16 @@ mod tests {
         let expr = crate::jq::parse(". and true").unwrap();
 
         match eval_with_cursor(&expr, cursor) {
-            GenericResult::Error(e) => {
-                assert!(e.is_decode_failure(), "expected decode failure, got: {e:?}");
-                assert!(
-                    e.message.contains("nesting depth exceeds limit of 256"),
-                    "message: {}",
-                    e.message
-                );
-            }
-            other => panic!("expected a decode failure, got: {other:?}"),
+            GenericResult::Owned(OwnedValue::Bool(true)) => {}
+            other => panic!("expected Owned(true), got: {other:?}"),
         }
     }
 
     /// Companion to the test above: `true and true` well under the limit
-    /// must still answer normally through `eval_boolean_generic`'s own
-    /// ambient-validation gate. Kept as the fully closed `true and true`
+    /// must still answer normally. Kept as the fully closed `true and true`
     /// (unlike the over-limit test's `. and true` above) -- there's no
-    /// depth guard to dodge here, and the closed shape is a simpler check
-    /// that ordinary evaluation is untouched.
+    /// depth guard to dodge here either way, and the closed shape is a
+    /// simpler check that ordinary evaluation is untouched.
     #[test]
     fn test_boolean_ambient_validation_accepts_nesting_under_limit_2627() {
         use crate::json::JsonIndex;

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -44920,6 +44920,81 @@ fn test_alternative_control_flow_2476() -> Result<()> {
     Ok(())
 }
 
+/// #2692: jq mode's `key`/`parent`/`path` inside a `//` now read the position
+/// the stage actually stands on, catching up with yq mode.
+///
+/// This is a *fidelity gain that fell out of* #2692 rather than something it
+/// set out to change, and it is pinned because the issue explicitly asked
+/// that path-context shapes be confirmed unchanged -- this is the one that
+/// moved, so it needs a reason on the record.
+///
+/// #2476 gave `eval_single` a native `Expr::Alternative` arm whose operands
+/// are evaluated *with the cursor*, and pinned the result for yq mode in
+/// `test_alternative_operands_read_the_real_position_2476`
+/// (`tests/yq_cli_tests.rs`), against yq v4.53.3's own answers. jq mode did
+/// not benefit, because a top-level `//` never reached that arm: it went to
+/// `eval_each_generic`'s `bridge_to_each_owned_flow`, which re-roots the
+/// document at this stage's input, so `key` resolved against a fresh root and
+/// answered nothing -- and "nothing" is not truthy, so `//` silently
+/// substituted the other side. #2692 replaced that bridge with
+/// `each_alternative_generic`, and the position reads came with it.
+///
+/// | filter                    | `.a \| key` alone | before | now   |
+/// |---------------------------|-------------------|--------|-------|
+/// | `.a \| (key // 1)`        | `"a"`             | `1`    | `"a"` |
+/// | `.a \| (parent // 1)`     | the root          | `{}`   | root  |
+/// | `.a \| (path // 1)`       | `["a"]`           | `[]`   | `["a"]` |
+///
+/// The "before" column is the bug: the same `key` answered differently
+/// depending on whether a `//` was wrapped around it, which is the
+/// spelling-dependence #2692 exists to remove.
+///
+/// `key`/`parent`/`path` with no argument are succinctly extensions in jq
+/// mode (real jq 1.7.1 errors on all three), so there is no jq oracle here.
+/// yq mode is the oracle-backed sibling, and the two now agree.
+///
+/// Two shapes deliberately left alone, both unchanged by this commit and both
+/// matching what the yq test records: an *absent* position
+/// (`.a.missing | (key // 1)`) still answers the fallback rather than
+/// `"missing"`, and a `//` after `to_entries` has left the cursor domain
+/// before the `//` is reached, so `needs_path_context`'s lack of an
+/// `Expr::Alternative` arm still keeps that pipe off path-context evaluation
+/// (#715/#1405's recursion table, pinned by #2416, not this arm's).
+#[test]
+fn test_alternative_operands_read_the_real_position_in_jq_mode_2692() -> Result<()> {
+    let doc = r#"{"a":{"b":1,"e":2}}"#;
+
+    for (filter, want) in [
+        (".a | (key // 1)", r#""a""#),
+        (".a.b | (key // \"x\")", r#""b""#),
+        (".a | (parent // 1)", r#"{"a":{"b":1,"e":2}}"#),
+        (".a | (path // 1)", r#"["a"]"#),
+        // `key` on the *right* side answers too: `.missing` is absent, so
+        // the fallback runs, and it runs at the same position.
+        (".a | (.missing // key)", r#""a""#),
+        // The bare spellings the rows above must now agree with.
+        (".a | key", r#""a""#),
+        (".a | path", r#"["a"]"#),
+    ] {
+        let (stdout, stderr, code) = run_jq_full(&["-c", filter], Some(doc))?;
+        assert_eq!(code, 0, "`{filter}` -- stderr: {stderr:?}");
+        assert_eq!(stdout.trim(), want, "`{filter}` -- stderr: {stderr:?}");
+    }
+
+    // The two shapes this does not reach, pinned so the table above is not
+    // read as "position reading through `//` is now generally correct".
+    for (filter, want) in [
+        (".a.missing | (key // 1)", "1"),
+        (".a | to_entries | .[] | (key // 99)", "99\n99"),
+    ] {
+        let (stdout, stderr, code) = run_jq_full(&["-c", filter], Some(doc))?;
+        assert_eq!(code, 0, "`{filter}` -- stderr: {stderr:?}");
+        assert_eq!(stdout.trim(), want, "`{filter}` -- stderr: {stderr:?}");
+    }
+
+    Ok(())
+}
+
 /// #2173: `//`'s sibling of `test_not_still_raises_on_a_malformed_document_2476`
 /// just above. #2476 gave `Expr::Alternative` a native arm that called
 /// `ambient_validation_error` unconditionally, because the whole construct

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -44219,10 +44219,20 @@ fn test_preserve_input_keeps_jq_escape_table_2209() -> Result<()> {
 /// what makes `1+1` and `[1+1]` finally agree on the same document. The
 /// reading probes below are unchanged and still pin the full raise-set.
 ///
-/// Rows this deliberately leaves out: a `>256`-deep document (both routes
-/// panic, #2627) and an empty document (exit 0 on every probe, nothing to
-/// pin). The alias-to-container shape is #1804's accepted trade-off and is
-/// pinned by its own test instead of here.
+/// Rows this deliberately leaves out: an empty document (exit 0 on every
+/// probe, nothing to pin) and a `>256`-deep document. The alias-to-container
+/// shape is #1804's accepted trade-off and is pinned by its own test instead
+/// of here.
+///
+/// The `>256`-deep document is not "both routes panic" here -- that was true
+/// of the corpus this replaced, back when every probe reached
+/// `push_generic_document_validation_error`'s own `assert_nesting_depth`.
+/// None of the probes above do anymore: the reading probe navigates one
+/// level without touching what's below it, and every truthiness probe
+/// answers through `is_falsy`, which never recurses. See
+/// `test_truthiness_probes_do_not_trip_the_depth_guard_2692` for what a
+/// `>256`-deep document actually does now, and why that's a consequence of
+/// this same rule rather than a fresh decision.
 #[test]
 fn test_truthiness_probes_validate_nothing_2692() -> Result<()> {
     let deep200 = format!("{}1{}", "[".repeat(200), "]".repeat(200));
@@ -44372,6 +44382,58 @@ fn test_truthiness_probes_validate_nothing_2692() -> Result<()> {
             );
         }
     }
+    Ok(())
+}
+
+/// #2692's consequence for the `#998`/`#2627` `MAX_NESTING_DEPTH` guard,
+/// which `test_truthiness_probes_validate_nothing_2692`'s own corpus
+/// deliberately leaves out: a document nested past 256 levels used to trip
+/// that guard from every one of these arms, because each one opened with
+/// `push_generic_document_validation_error`'s `assert_nesting_depth` before
+/// #2692 removed the call. None of them do anymore -- `is_falsy` never
+/// recurses into a container's children, and the reading probe below
+/// resolves one level without following what's underneath it -- so a
+/// document this deep is no longer a reason for any of these to fail.
+///
+/// This is not a new decision, just an unrecorded corollary of the one
+/// #2692 already made: the guard was never about these arms' own work (none
+/// of them do enough of it to risk a stack overflow), it was a side effect
+/// of the whole-subtree walk that validated on their behalf. Removing that
+/// walk and keeping its depth check would have meant charging a filter for
+/// a limit on work it no longer does.
+///
+/// `sort_by(.)` is the control: `key_elements_generic` is the one caller
+/// `push_generic_document_validation_error` has left (it materializes a
+/// comparison key), so the same document still trips the same guard there,
+/// proving this is about which arms reach it, not about the guard itself
+/// having stopped working.
+#[test]
+fn test_truthiness_probes_do_not_trip_the_depth_guard_2692() -> Result<()> {
+    let deep = nested_arrays(300);
+
+    for probe in [
+        "not",
+        "select(.) | 1",
+        "(.a? // 1) | 1",
+        "any",
+        "all",
+        "true and true",
+    ] {
+        let (stdout, stderr, code) = run_jq_full(&["-c", probe], Some(&deep))?;
+        assert_eq!(
+            code, 0,
+            "[depth guard] `{probe}` on a 300-deep document must not trip \
+             `MAX_NESTING_DEPTH` -- stdout: {stdout:?} stderr: {stderr:?}"
+        );
+    }
+
+    let (_stdout, stderr, code) = run_jq_full(&["-c", "sort_by(.)"], Some(&deep))?;
+    assert_eq!(code, 5, "control `sort_by(.)` -- stderr: {stderr:?}");
+    assert!(
+        stderr.contains("nesting depth exceeds limit of 256"),
+        "control `sort_by(.)` -- stderr: {stderr:?}"
+    );
+
     Ok(())
 }
 

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -2070,91 +2070,95 @@ fn test_builtin_select() -> Result<()> {
     Ok(())
 }
 
-/// #1645: `push_generic_truthiness`'s `OneCursor`/`ManyCursor` arms swapped a
-/// full materializing `to_owned_cursor(&c).is_truthy()` for the O(1)
-/// `DocumentCursor::is_falsy()` -- caught by review that `is_falsy()` itself
-/// is deliberately silent on a decode failure or a #1194 structural error
-/// (its own doc comment: "conservative assumption", matching
-/// `--exit-status`'s existing best-effort use of it), where the removed
-/// materializing path used to raise. `select` must still raise here rather
-/// than silently treating the value as truthy and passing it through.
+/// #1645/#2692: `select`'s condition is `DocumentCursor::is_falsy()`, which
+/// is O(1) and decodes nothing -- and, since #2692, that is the whole of it.
+///
+/// The history is the point of this test, so it is worth stating. #1645
+/// swapped a materializing `to_owned_cursor(&c).is_truthy()` for `is_falsy()`
+/// in `push_generic_truthiness`'s `OneCursor`/`ManyCursor` arms; review
+/// caught that `is_falsy()` is deliberately silent on a decode failure or a
+/// #1194 structural error (its own doc comment: "conservative assumption",
+/// matching `--exit-status`'s existing best-effort use of it), so a
+/// validation walk was put in front of it to keep the raise. #2692 removed
+/// that walk: under ADR-0018's #2103 amendment a filter validates only what
+/// it *materializes*, and testing truthiness materializes nothing. The
+/// silence #1645 guarded against is now the designed answer.
+///
+/// Each case therefore pins both halves, on one document: `select` passes the
+/// value through without raising, and a consumer that goes on to materialize
+/// the very same value still raises with the very same message. Nothing was
+/// lost -- the raise moved to whoever actually reads the bytes.
+///
+/// **Diverges from jq**, which rejects all four documents at parse time
+/// whatever the filter (`docs/compliance/jq/limitations.md`).
 #[test]
-fn test_select_raises_on_decode_failure_instead_of_silently_truthy_1645() -> Result<()> {
-    // `\x` is not a valid JSON escape -- structurally a string token, but
-    // its bytes don't decode (#1247's own trigger shape).
-    let (stdout, stderr, code) = run_jq_full(&[".[] | select(.)"], Some(r#"["\x"]"#))
-        .unwrap_or_else(|e| panic!("`select(.)` failed to run: {e}"));
-    assert_eq!(
-        code, 5,
-        "an undecodable value must not be silently treated as truthy\nstdout: {stdout:?}\nstderr: {stderr:?}"
-    );
-    assert!(
-        stderr.contains("invalid escape sequence"),
-        "stderr: {stderr:?}"
-    );
-    Ok(())
-}
+fn test_select_passes_through_corruption_it_only_tests_1645_2692() -> Result<()> {
+    // (label, document, select filter that only tests, materializing control)
+    let cases: &[(&str, &str, &str, &str, &str)] = &[
+        (
+            // `\x` is not a valid JSON escape -- structurally a string
+            // token, but its bytes don't decode (#1247's own trigger shape).
+            "decode failure, tested directly",
+            r#"["\x"]"#,
+            ".[] | select(.) | 1",
+            "[.[] | select(.)] | length",
+            "invalid escape sequence",
+        ),
+        (
+            // #1194: a token the semi-index accepted as a span but could
+            // not classify.
+            "structural error, tested directly",
+            "[xyz123]",
+            ".[] | select(.) | 1",
+            "[.[] | select(.)] | length",
+            "unexpected character",
+        ),
+        (
+            // Nested a level below the value the condition resolves to:
+            // `.bad` is the *array*, not the bad string. The walk #1645
+            // added recursed into container contents to reach this (an
+            // earlier version of that fix checked only the top-level cursor
+            // and silently missed this shape); #2692 removed the recursion
+            // along with the walk, so the pass-through has to hold at depth
+            // too.
+            "decode failure, nested in the tested container",
+            r#"{"bad": ["\x"], "keep": 5}"#,
+            "select(.bad) | .keep",
+            "[select(.bad)] | length",
+            "invalid escape sequence",
+        ),
+        (
+            "structural error, nested in the tested container",
+            r#"{"bad": [xyz123], "keep": 5}"#,
+            "select(.bad) | .keep",
+            "[select(.bad)] | length",
+            "unexpected character",
+        ),
+    ];
 
-/// #1645 sibling case: a *structurally* malformed value (#1194 -- a token
-/// the semi-index accepted as a span but couldn't classify) must also still
-/// raise through `select`'s truthiness check, not silently pass through.
-#[test]
-fn test_select_raises_on_structural_error_instead_of_silently_truthy_1645() -> Result<()> {
-    let (stdout, stderr, code) = run_jq_full(&[".[] | select(.)"], Some("[xyz123]"))
-        .unwrap_or_else(|e| panic!("`select(.)` failed to run: {e}"));
-    assert_eq!(
-        code, 5,
-        "a structurally malformed value must not be silently treated as truthy\nstdout: {stdout:?}\nstderr: {stderr:?}"
-    );
-    assert!(
-        stderr.contains("unexpected character"),
-        "expected the #1194 structural-error message on stderr: {stderr:?}"
-    );
-    Ok(())
-}
+    for (label, doc, tests_only, materializes, want_stderr) in cases {
+        let (stdout, stderr, code) = run_jq_full(&["-c", tests_only], Some(doc))?;
+        assert_eq!(
+            code, 0,
+            "[{label}] `{tests_only}` only tests the value and must not raise\
+             \nstdout: {stdout:?}\nstderr: {stderr:?}"
+        );
+        assert!(
+            stderr.is_empty(),
+            "[{label}] `{tests_only}`: stderr {stderr:?}"
+        );
 
-/// #1645: the same decode failure, but nested a level below the value
-/// `select`'s condition actually resolves to -- `.bad` resolves to the
-/// *array*, not the bad string directly, so this only passes if the
-/// truthiness check recurses into container contents rather than checking
-/// only the condition's own top-level cursor (an earlier version of this
-/// fix did exactly that and silently missed this shape -- caught by
-/// review).
-#[test]
-fn test_select_raises_on_decode_failure_nested_in_container_1645() -> Result<()> {
-    let (stdout, stderr, code) = run_jq_full(
-        &["select(.bad) | .keep"],
-        Some(r#"{"bad": ["\x"], "keep": 5}"#),
-    )
-    .unwrap_or_else(|e| panic!("`select(.bad)` failed to run: {e}"));
-    assert_eq!(
-        code, 5,
-        "a decode failure nested inside the condition's container must still raise\nstdout: {stdout:?}\nstderr: {stderr:?}"
-    );
-    assert!(
-        stderr.contains("invalid escape sequence"),
-        "stderr: {stderr:?}"
-    );
-    Ok(())
-}
-
-/// #1645 sibling case: a #1194 structural error nested a level below the
-/// condition's own top-level cursor.
-#[test]
-fn test_select_raises_on_structural_error_nested_in_container_1645() -> Result<()> {
-    let (stdout, stderr, code) = run_jq_full(
-        &["select(.bad) | .keep"],
-        Some(r#"{"bad": [xyz123], "keep": 5}"#),
-    )
-    .unwrap_or_else(|e| panic!("`select(.bad)` failed to run: {e}"));
-    assert_eq!(
-        code, 5,
-        "a structural error nested inside the condition's container must still raise\nstdout: {stdout:?}\nstderr: {stderr:?}"
-    );
-    assert!(
-        stderr.contains("unexpected character"),
-        "expected the #1194 structural-error message on stderr: {stderr:?}"
-    );
+        let (stdout, stderr, code) = run_jq_full(&["-c", materializes], Some(doc))?;
+        assert_eq!(
+            code, 5,
+            "[{label}] `{materializes}` materializes the same value and must still raise\
+             \nstdout: {stdout:?}\nstderr: {stderr:?}"
+        );
+        assert!(
+            stderr.contains(want_stderr),
+            "[{label}] `{materializes}`: stderr {stderr:?} lacks {want_stderr:?}"
+        );
+    }
     Ok(())
 }
 
@@ -2228,7 +2232,10 @@ fn assert_jq_answers(
 /// site agrees, not just that each is individually correct (see the
 /// `testing` skill and CLAUDE.md's "Duplicated predicates diverge silently"
 /// note, #106). #1803 extended this from 2 sites to 3: `select(.bad) | .keep`
-/// (`push_generic_document_validation_error`), `-Sc .bad` (`to_owned_at_depth`,
+/// (`push_generic_document_validation_error` -- since #2692 `select` no
+/// longer reaches that gate at all and is asserted on the answering side
+/// below, but it stays in the list because agreement is what this test is
+/// for), `-Sc .bad` (`to_owned_at_depth`,
 /// confirmed live via temporary tracing -- `-S` does *not* route through the
 /// cursor-aware sibling despite the name resemblance), and `-e .bad`
 /// (`cursor_to_owned_at_depth`, `lazy.rs` -- a JSON-only fourth
@@ -2292,15 +2299,6 @@ fn test_select_and_materialize_agree_on_corruption_1645() -> Result<()> {
     ];
 
     for (label, doc, expect_stderr) in cases {
-        assert_jq_raises(
-            label,
-            "select(.bad)",
-            &[],
-            "select(.bad) | .keep",
-            doc,
-            5,
-            expect_stderr,
-        );
         assert_jq_raises(label, "-Sc .bad", &["-Sc"], ".bad", doc, 5, expect_stderr);
         assert_jq_raises(
             label,
@@ -2323,15 +2321,19 @@ fn test_select_and_materialize_agree_on_corruption_1645() -> Result<()> {
             5,
             expect_stderr,
         );
-        // #2168: `path(.bad)` is the one row here that must *not* raise. It
-        // names a position and never reads the value at it, and every
-        // corruption in this list lives inside `.bad`'s value -- so it now
-        // follows the rule `.keep` on these same documents always did. The
-        // four rows above keep the gate: three materialize, and `sort_by`
-        // walks the element it reorders. Keeping it in this list rather than
-        // deleting it is the point: the list's job is pinning that every
-        // consumer of one document agrees, and "agrees" now includes knowing
-        // which side of the line each one is on.
+        // The rows that must *not* raise. `path(.bad)` names a position and
+        // never reads the value at it (#2168); `select(.bad)` tests that
+        // value's truthiness, which `is_falsy` answers without decoding it
+        // (#2692). Every corruption in this list lives inside `.bad`'s
+        // value, so both now follow the rule `.keep` on these same documents
+        // always did. The three rows above keep the gate: `-Sc`/`-e`
+        // materialize, and `sort_by` materializes the comparison key of an
+        // element it only reorders.
+        //
+        // Keeping both in this list rather than deleting them is the point:
+        // the list's job is pinning that every consumer of one document
+        // agrees, and "agrees" includes knowing which side of the line each
+        // one is on.
         assert_jq_answers(
             label,
             "path(.bad)",
@@ -2339,6 +2341,14 @@ fn test_select_and_materialize_agree_on_corruption_1645() -> Result<()> {
             "path(.bad)",
             doc,
             r#"["bad"]"#,
+        );
+        assert_jq_answers(
+            label,
+            "select(.bad) | .keep",
+            &["-c"],
+            "select(.bad) | .keep",
+            doc,
+            "5",
         );
     }
     Ok(())
@@ -2546,7 +2556,6 @@ proptest! {
         let expect_stderr = malformation.expect_stderr();
         let label = format!("{path:?}/{malformation:?}");
 
-        assert_jq_raises(&label, "select(.bad)", &[], "select(.bad) | .keep", &doc, 5, expect_stderr);
         assert_jq_raises(&label, "-Sc .bad", &["-Sc"], ".bad", &doc, 5, expect_stderr);
         assert_jq_raises(
             &label,
@@ -2558,16 +2567,21 @@ proptest! {
             expect_stderr,
         );
         assert_jq_raises(&label, "sort_by(.bad)", &[], "sort_by(.bad)", &doc, 5, expect_stderr);
-        // #2168: `path(.bad)` left the "must raise" battery above. It names
-        // a position and never reads the value there, and every corruption
-        // this fuzzer builds lives *inside* `.bad`'s value, so it answers --
+        // The consumers that left the "must raise" battery above, each for
+        // its own half of the same rule. `path(.bad)` names a position and
+        // never reads the value there (#2168); `select(.bad)` tests that
+        // value's truthiness without decoding it (#2692). Every corruption
+        // this fuzzer builds lives *inside* `.bad`'s value, so both answer --
         // the same rule `.keep` on these documents has always followed. The
-        // four consumers above keep the gate: three materialize, and
-        // `sort_by` walks the element it reorders. This row is what caught
-        // the mismatch when #2168 landed: the property was written against
-        // the old contract and this generator reached a shape the
-        // hand-written tests did not.
+        // three consumers above keep the gate: `-Sc`/`-e` materialize, and
+        // `sort_by` materializes the key of an element it only reorders.
+        //
+        // The `path` row is what caught the mismatch when #2168 landed: the
+        // property was written against the old contract and this generator
+        // reached a shape the hand-written tests did not. `select`'s row is
+        // here to do the same job for #2692's move.
         assert_jq_answers(&label, "path(.bad)", &["-c"], "path(.bad)", &doc, r#"["bad"]"#);
+        assert_jq_answers(&label, "select(.bad) | .keep", &["-c"], "select(.bad) | .keep", &doc, "5");
     }
 }
 
@@ -20942,29 +20956,38 @@ fn test_partial_result_over_depth_value_reports_cleanly_not_panic_1371() -> Resu
     Ok(())
 }
 
-/// #2627: the `needs_path_context` gate's wildcard/ambient bridge used to
-/// reach `eval_generic.rs`'s `assert_nesting_depth` `panic!` on a >256-deep
-/// *document* (not a constructed value, unlike #1371's `test_partial_result_
-/// over_depth_value_reports_cleanly_not_panic_1371` above) for an expression
-/// that has no native path-context arm (`and`/`or` fall to the bridge purely
-/// to surface a document-level fault, per `eval_boolean_generic`'s own
-/// comment). `. and true`, not `true and true`: a fully closed term (no
-/// operand reads `.` at all) no longer reaches the bridge's materialization
-/// in the first place -- #2173's `walk::reads_ambient_value` gate (landed
-/// the same day as this fix) substitutes `null` for a closed term instead of
-/// the real document, so `true and true` on this same input now answers
-/// `true` at exit 0 rather than reaching this guard. `.` on the left keeps
-/// `needs_path_context` false (still no `key`/`parent`/`path` operand) while
-/// making the whole expression read the ambient value, which is what keeps
-/// the real (over-deep) document in the loop. Already shielded at the CLI
-/// boundary by `catch_unwind` (#1793) before this fix -- confirmed via
-/// `!stderr.contains("panicked")` below, so this pins the *absence* of a
-/// regression there while the real fix (`eval_generic.rs`'s depth guard no
-/// longer panics at all) is what protects a library embedder calling
-/// `succinctly::jq::eval` directly, which had no such net.
+/// #2627: the wildcard/ambient bridge used to reach `eval_generic.rs`'s
+/// `assert_nesting_depth` `panic!` on a >256-deep *document* (not a
+/// constructed value, unlike #1371's `test_partial_result_
+/// over_depth_value_reports_cleanly_not_panic_1371` above). It now reports a
+/// clean error instead, and that is what these two pin.
+///
+/// The probe has moved twice, always for the same reason -- the set of
+/// spellings that still reach the bridge keeps shrinking, and this test has
+/// to follow it rather than pin a spelling that no longer gets there:
+///
+/// - `true and true` was the original. #2173's `walk::reads_ambient_value`
+///   gate substitutes `null` for a fully closed term instead of the real
+///   document, so it stopped reaching the bridge.
+/// - `. and true` replaced it, on the reasoning that `.` on the left keeps
+///   `needs_path_context` false while still making the expression read the
+///   ambient value. #2692 ended that too: `and`/`or` have a native,
+///   ungated streaming arm now, and reading `.`'s *truthiness* is
+///   `is_falsy` -- O(1), no recursion -- so `. and true` answers `true` at
+///   exit 0 on this same 300-deep input. That is pinned as its own claim by
+///   `test_truthiness_probes_do_not_trip_the_depth_guard_2692`.
+/// - `. as $x | $x` is the current probe: a binding still materializes the
+///   ambient value through the bridge, so it still reaches the guard.
+///
+/// Already shielded at the CLI boundary by `catch_unwind` (#1793) before the
+/// fix -- confirmed via `!stderr.contains("panicked")` below, so this pins
+/// the *absence* of a regression there, while the real fix
+/// (`eval_generic.rs`'s depth guard no longer panicking at all) is what
+/// protects a library embedder calling `succinctly::jq::eval` directly,
+/// which had no such net.
 #[test]
 fn test_boolean_wildcard_bridge_over_depth_document_reports_cleanly_not_panic_2627() -> Result<()> {
-    let (stdout, stderr, code) = run_jq_full(&["-c", ". and true"], Some(&nested_arrays(300)))?;
+    let (stdout, stderr, code) = run_jq_full(&["-c", ". as $x | $x"], Some(&nested_arrays(300)))?;
     assert_eq!(stdout.trim_end(), "");
     assert_eq!(code, 5, "stdout: {stdout:?} stderr: {stderr:?}");
     assert!(!stderr.contains("panicked"), "stderr: {stderr:?}");
@@ -20975,14 +20998,15 @@ fn test_boolean_wildcard_bridge_over_depth_document_reports_cleanly_not_panic_26
     Ok(())
 }
 
-/// Companion to the test above: `. and true` on a document well under
-/// the limit must still evaluate normally through the same bridge -- `.`
-/// is a non-empty array either way, so this is `true` regardless of depth.
+/// Companion to the test above: the same spelling on a document well under
+/// the limit must still evaluate normally through the same bridge.
 #[test]
 fn test_boolean_wildcard_bridge_accepts_depth_under_limit_2627() -> Result<()> {
-    let (stdout, stderr, code) = run_jq_full(&["-c", ". and true"], Some(&nested_arrays(100)))?;
+    let under = nested_arrays(100);
+    let (stdout, stderr, code) = run_jq_full(&["-c", ". as $x | $x"], Some(&under))?;
     assert_eq!(code, 0, "stdout: {stdout:?} stderr: {stderr:?}");
-    assert_eq!(stdout.trim_end(), "true");
+    // The binding echoes the document, so the round trip is the assertion.
+    assert_eq!(stdout.trim_end(), under.trim_end());
     Ok(())
 }
 
@@ -39664,8 +39688,11 @@ fn test_path_answers_past_a_colliding_key_2168() -> Result<()> {
 /// `path()` was the query that reached that seeding re-walk; `path()` left
 /// the gate with this issue (see
 /// `test_path_answers_past_a_colliding_key_2168` next door, which is the
-/// same three documents on the other side of the line), and the four
-/// consumers that kept it are what still reach it.
+/// same three documents on the other side of the line), and the consumers
+/// that kept it are what still reach it. #2692 shrank that set further --
+/// `select` left too, on the argument that a truthiness test does not read
+/// what it tests -- leaving the `sort_by`/`unique_by`/`min_by`/`max_by`
+/// family as the gate's only remaining caller and so its only probe here.
 ///
 /// The fallback key must sit at index >= 1 for the re-walk to run at all --
 /// at index 0 there is no prefix to seed from, which is the shape the sibling
@@ -39686,11 +39713,10 @@ fn test_validation_gate_seeds_the_collision_map_prefix_2168() -> Result<()> {
     ] {
         let doc = format!(r#"{{"c":{inner},"t":5}}"#);
 
-        // `select` reaches the gate through its `OneCursor` truthiness arm.
-        let (stdout, stderr, code) = run_jq_stdin_streams("select(.c) | .t", &doc, &["-c"])?;
-        assert_eq!(code, 5, "select on {doc}: stdout {stdout:?}");
-        assert!(stderr.contains("is ambiguous"), "select: {stderr}");
-
+        // `select` used to reach the gate here through its `OneCursor`
+        // truthiness arm; since #2692 it does not reach the gate at all, and
+        // answers instead -- pinned as such below.
+        //
         // `sort_by` reaches it through the `_by` forms' own call, on an
         // element it only reorders and never materializes (#1755) -- a
         // second call site for one walk. The array wrapper has to be the
@@ -39705,10 +39731,22 @@ fn test_validation_gate_seeds_the_collision_map_prefix_2168() -> Result<()> {
 
         // The control, and the point of the whole #2168 split: the same
         // document, the same colliding pair, on a query that only names
-        // positions -- it answers.
-        let (stdout, stderr, code) = run_jq_stdin_streams("path(.t)", &doc, &["-c"])?;
-        assert_eq!(code, 0, "path(.t) on {doc}: stderr {stderr:?}");
-        assert_eq!(stdout.trim(), r#"["t"]"#);
+        // positions -- it answers. `select(.c) | .t` sits beside it since
+        // #2692, testing a position rather than naming one, and answering
+        // for the same reason: neither resolves the colliding keys.
+        for filter in ["path(.t)", "select(.c) | .t"] {
+            let (stdout, stderr, code) = run_jq_stdin_streams(filter, &doc, &["-c"])?;
+            assert_eq!(code, 0, "{filter} on {doc}: stderr {stderr:?}");
+            assert_eq!(
+                stdout.trim(),
+                if filter == "path(.t)" {
+                    r#"["t"]"#
+                } else {
+                    "5"
+                },
+                "{filter}"
+            );
+        }
     }
 
     // No collision, same shape: a fallback key at index 1 whose display
@@ -39831,12 +39869,17 @@ fn test_path_optional_still_raises_a_decode_failure_2168() -> Result<()> {
 /// query never reads, and which do not.
 ///
 /// The two halves of the decision belong next to each other, because the
-/// argument for it is their relationship. A builtin whose walk's domain *is*
-/// the value it tests or emits (`select`, the `sort_by` family) keeps the
-/// whole-subtree gate; one that only names or navigates to a position
-/// (`path`, `key`, `parent`) validates just what it touches, like plain
-/// navigation always has. Anything that materializes still validates
-/// everything it materializes.
+/// argument for it is their relationship. #2168 drew the line at "a builtin
+/// whose walk's domain *is* the value it tests or emits (`select`, the
+/// `sort_by` family) keeps the whole-subtree gate; one that only names or
+/// navigates to a position (`path`, `key`, `parent`) validates just what it
+/// touches". #2692 moved it once more, in the same direction: `select`'s
+/// condition only ever asks `is_falsy`, which decodes nothing, so testing a
+/// value is not reading it either and `select` joined the answering column.
+/// What is left is the simple rule -- **anything that materializes validates
+/// everything it materializes, and nothing else validates anything.** The
+/// `sort_by` family stays in the raising column under exactly that rule: it
+/// materializes a comparison key.
 ///
 /// **Every row diverges from jq**, which rejects this document at parse time
 /// whatever the filter -- including the rows that raise, since succinctly
@@ -39863,6 +39906,17 @@ fn test_lazy_validation_boundary_2168() -> Result<()> {
         ("[.[] | key]", r#"["a","d"]"#),
         ("[paths]", r#"[["a"],["d"]]"#),
         ("select(.d) | .d", "5"),
+        // #2692: `select`'s condition is answered by `is_falsy`, which
+        // decodes nothing -- so testing the *whole document* (`select(.)`)
+        // validates no more of it than `.d` does. This row asserted exit 5
+        // until #2692.
+        ("select(.) | .d", "5"),
+        // The same rule for the other truthiness readers, none of which
+        // decode what they test either.
+        ("if . then .d else 0 end", "5"),
+        ("(. // 1) | .d", "5"),
+        ("[.[] | not]", "[false,false]"),
+        ("(true and true) | 1", "1"),
     ] {
         let (stdout, stderr, code) = run_jq_stdin_streams(filter, doc, &["-c"])?;
         assert_eq!(code, 0, "{filter}: stdout {stdout:?} stderr {stderr:?}");
@@ -39888,15 +39942,23 @@ fn test_lazy_validation_boundary_2168() -> Result<()> {
         );
     }
 
-    // `select` keeps its gate even though the value it tests is clean: the
-    // *condition's own subtree* is what it validates, and here that is the
-    // whole document (`select(.)` tests the root).
-    let (stdout, stderr, code) = run_jq_stdin_streams("select(.) | .d", doc, &["-c"])?;
-    assert_eq!(code, 5, "stdout {stdout:?} stderr {stderr:?}");
-    assert!(
-        stderr.contains("invalid unicode escape sequence"),
-        "{stderr:?}"
-    );
+    // The boundary #2692 left behind, pinned from the other side: testing the
+    // root is free, but *materializing* it right afterwards still raises. The
+    // condition is identical in both rows above and below -- only what the
+    // consumer does with the value it passed through differs, which is the
+    // whole of the surviving rule.
+    for filter in [
+        "select(.) | to_entries",
+        "select(.) | . as $x | $x",
+        "select(.) | [.[]] | length",
+    ] {
+        let (stdout, stderr, code) = run_jq_stdin_streams(filter, doc, &["-c"])?;
+        assert_eq!(code, 5, "{filter}: stdout {stdout:?} stderr {stderr:?}");
+        assert!(
+            stderr.contains("invalid unicode escape sequence"),
+            "{filter}: {stderr:?}"
+        );
+    }
 
     Ok(())
 }
@@ -42029,19 +42091,25 @@ fn test_seq_wellformed_and_leniency_unaffected_by_checked_swap_2295() -> Result<
 /// correctly raised. Repros and control verified live against `/usr/bin/jq`
 /// 1.7.1 in the issue's own filing.
 ///
-/// `path()` was a seventh caller of that gate when this test was written, and
-/// its own row lived here. #2168 removed it from the gate -- naming a
-/// position never reads what is inside it -- so that row now lives in
+/// The set of builtins reaching that gate has shrunk twice since. `path()`
+/// was a seventh caller when this test was written; #2168 removed it --
+/// naming a position never reads what is inside it -- so its row now lives in
 /// `test_path_answers_past_a_structural_fault_it_never_reads_2168`, asserting
-/// the opposite. The rows that remain are the builtins that still validate,
-/// because the subtree they walk is the value they test or emit.
+/// the opposite. #2692 then removed `select` (and `if`/`not`/`//`/`any`/
+/// `all`) for the same reason one step further on: a truthiness test is
+/// answered by `is_falsy`, which decodes nothing. Every row here therefore
+/// probes through the `sort_by`/`unique_by`/`min_by`/`max_by` family, now the
+/// gate's only caller and the only one that still fits the rule -- it
+/// materializes a comparison key. The rows whose documents look
+/// array-shaped-for-no-reason are the object cases rewritten to suit it; the
+/// corrupted subtree (`.c`) is still one the query never emits.
 #[test]
 fn test_validate_only_gate_delimiter_checks_2349() -> Result<()> {
     let cases: &[(&str, &str, &str)] = &[
         (
-            "trailing comma in nested object, select+field",
-            r#"{"c":{"a":1,},"t":5}"#,
-            "select(.c) | .t",
+            "trailing comma in nested object, sort_by",
+            r#"[{"k":1,"c":{"a":1,}}]"#,
+            "sort_by(.k) | length",
         ),
         (
             "trailing comma in nested array element, sort_by",
@@ -42060,18 +42128,18 @@ fn test_validate_only_gate_delimiter_checks_2349() -> Result<()> {
         ),
         (
             "stray comma with no real field, object",
-            r#"{"c":{,},"t":5}"#,
-            "select(.c) | .t",
+            r#"[{"k":1,"c":{,}}]"#,
+            "sort_by(.k) | length",
         ),
         (
             "stray comma with no real element, array",
-            r#"{"c":[,],"t":5}"#,
-            "select(.c) | .t",
+            r#"[{"k":1,"c":[,]}]"#,
+            "sort_by(.k) | length",
         ),
         (
             "missing colon between key and value",
-            r#"{"c":{"a" 1},"t":5}"#,
-            "select(.c) | .t",
+            r#"[{"k":1,"c":{"a" 1}}]"#,
+            "sort_by(.k) | length",
         ),
     ];
 
@@ -42089,10 +42157,12 @@ fn test_validate_only_gate_delimiter_checks_2349() -> Result<()> {
     }
 
     // Well-formed control: the same shape, no corruption, must be unaffected.
-    let (stdout, stderr, code) =
-        run_jq_full(&["-c", "select(.c) | .t"], Some(r#"{"c":{"a":1},"t":5}"#))?;
+    let (stdout, stderr, code) = run_jq_full(
+        &["-c", "sort_by(.k) | length"],
+        Some(r#"[{"k":1,"c":{"a":1}}]"#),
+    )?;
     assert_eq!(code, 0, "stderr: {stderr:?}");
-    assert_eq!(stdout.trim(), "5");
+    assert_eq!(stdout.trim(), "1");
 
     Ok(())
 }
@@ -42103,8 +42173,11 @@ fn test_validate_only_gate_delimiter_checks_2349() -> Result<()> {
 /// whole-document gate as the decode-failure raise, so dropping that gate for
 /// cursor-resolved path queries drops them too: `path(.c)` on a document whose
 /// `.c` holds a trailing comma now answers, because naming a position never
-/// reads what is inside it. `select`/`sort_by` keep their gate and so keep
-/// these checks -- their remaining rows in that test are the control.
+/// reads what is inside it. `sort_by` keeps its gate and so keeps these
+/// checks -- its rows in that test are the control. (`select` kept the gate
+/// too until #2692 took it, on the same argument one step further on: a
+/// truthiness test does not read the value either. Its row moved from the
+/// raising loop into the answering table below.)
 ///
 /// **Diverges from jq, deliberately:** real jq rejects `{"c":{"a":1,}}` at
 /// parse time whatever the filter, so the `path` rows here used to match its
@@ -42122,6 +42195,10 @@ fn test_path_answers_past_a_structural_fault_it_never_reads_2168() -> Result<()>
         ("path(.c)", r#"["c"]"#),
         ("[path(.[])]", r#"[["c"],["t"]]"#),
         (".t", "5"),
+        // #2692: `select` joined this column. Testing `.c`'s truthiness is
+        // `is_falsy`, which no more reads inside `.c` than `path(.c)` does.
+        // This row asserted a raise, in the loop below, until #2692.
+        ("select(.c) | .t", "5"),
     ] {
         let (stdout, stderr, code) = run_jq_full(&["-c", filter], Some(doc))?;
         assert_eq!(code, 0, "{filter}: stdout {stdout:?} stderr {stderr:?}");
@@ -42130,7 +42207,7 @@ fn test_path_answers_past_a_structural_fault_it_never_reads_2168() -> Result<()>
 
     // Reading into the corrupted subtree still raises, on every route that
     // does read it -- the touched-node controls.
-    for filter in [".c", ".c.a", "select(.c) | .t", "sort_by(.c) | length"] {
+    for filter in [".c", ".c.a", "sort_by(.c) | length"] {
         let (stdout, stderr, code) = run_jq_full(&["-c", filter], Some(doc))?;
         assert_ne!(code, 0, "{filter}: stdout {stdout:?}");
         assert!(stderr.contains("Invalid JSON"), "{filter}: {stderr:?}");
@@ -42145,8 +42222,10 @@ fn test_path_answers_past_a_structural_fault_it_never_reads_2168() -> Result<()>
 /// (`preceding_delimiter_ok`) from the trailing/#2211 ones.
 #[test]
 fn test_validate_only_gate_array_element_delimiter_2349() -> Result<()> {
-    let (stdout, stderr, code) =
-        run_jq_full(&["-c", "select(.c) | .t"], Some(r#"{"c":[1,,2],"t":5}"#))?;
+    let (stdout, stderr, code) = run_jq_full(
+        &["-c", "sort_by(.k) | length"],
+        Some(r#"[{"k":1,"c":[1,,2]}]"#),
+    )?;
     assert_ne!(
         code, 0,
         "duplicate comma between array elements should raise (stdout: {stdout:?})"
@@ -44123,19 +44202,13 @@ fn test_preserve_input_keeps_jq_escape_table_2209() -> Result<()> {
     Ok(())
 }
 
-/// #2476: `eval_single`'s wildcard bridge materializes the *ambient* value
-/// before the eager evaluator runs, and that materialization is what makes a
-/// query that never reads `.` still raise on a malformed document (#1812:
-/// jq rejects the whole document for every query). The native arms that
-/// replace the bridge for `and`/`or`/`not`/`//` run
-/// `ambient_validation_error` -- `push_generic_document_validation_error`,
-/// the walk `select(.)`/`if` already use -- instead. This corpus pins that
-/// the two raise identically: every malformed-document class the checks
-/// cover, each probed through the reference route (`select(.)`) and through
-/// every construct that used to bridge, asserting the same exit code and
-/// the same first stderr line, *and* the exit code the row must have
-/// (agreement alone would also pass if both routes silently stopped
-/// raising).
+/// #2692: **a filter validates only what it materializes**, stated as a
+/// corpus. Every malformed-document class succinctly's checks can detect,
+/// probed through a filter that reads nothing (`try (1+1)`) and through every
+/// filter that reads only *truthiness*, asserting they all give the same exit
+/// code and the same first stderr line -- and, separately, the exit code the
+/// row must have, since agreement alone would also pass if every probe
+/// started raising.
 ///
 /// **#2173 split the probe list in two.** The walk is now charged only to a
 /// construct that actually reads `.`, so `true and true`, `false or true`
@@ -44151,148 +44224,68 @@ fn test_preserve_input_keeps_jq_escape_table_2209() -> Result<()> {
 /// pin). The alias-to-container shape is #1804's accepted trade-off and is
 /// pinned by its own test instead of here.
 #[test]
-fn test_ambient_validation_agrees_with_bridge_2476() -> Result<()> {
+fn test_truthiness_probes_validate_nothing_2692() -> Result<()> {
     let deep200 = format!("{}1{}", "[".repeat(200), "]".repeat(200));
-    // (label, document, expected exit code, expected stderr substring)
-    let corpus: &[(&str, &str, i32, &str)] = &[
-        ("#1194 non-string key", "{123: 1}", 5, "expected string key"),
-        (
-            "decode failure, top level",
-            r#"{"bad": "\x", "keep": 5}"#,
-            5,
-            "invalid escape sequence",
-        ),
-        (
-            "decode failure, in array",
-            r#"["\x"]"#,
-            5,
-            "invalid escape sequence",
-        ),
-        (
-            "decode failure, root scalar",
-            r#""\x""#,
-            5,
-            "invalid escape sequence",
-        ),
+    // (label, document)
+    let corpus: &[(&str, &str)] = &[
+        ("#1194 non-string key", "{123: 1}"),
+        ("decode failure, top level", r#"{"bad": "\x", "keep": 5}"#),
+        ("decode failure, in array", r#"["\x"]"#),
+        ("decode failure, root scalar", r#""\x""#),
         (
             "decode failure, nested object",
             r#"{"bad": {"x": "\x"}, "keep": 5}"#,
-            5,
-            "invalid escape sequence",
         ),
         (
             "structural error, top level",
             r#"{"bad": xyz123, "keep": 5}"#,
-            5,
-            "unexpected character",
         ),
-        (
-            "structural error, in array",
-            "[xyz123]",
-            5,
-            "unexpected character",
-        ),
-        ("structural error, root", "xyz123", 5, "Invalid JSON text"),
+        ("structural error, in array", "[xyz123]"),
+        ("structural error, root", "xyz123"),
         (
             "#1642 colliding undecodable keys",
             r#"{"\ud800":1,"\ud800":2}"#,
-            5,
-            "is ambiguous",
         ),
-        (
-            "#1642 single undecodable key",
-            r#"{"\ud800": 1, "b": 2}"#,
-            0,
-            "",
-        ),
-        ("undecodable key, no collision", r#"{"a\q":1,"b":2}"#, 0, ""),
-        (
-            "#2211 trailing comma, array",
-            "[1,]",
-            5,
-            "expected JSON value, found ']'",
-        ),
-        (
-            "#2211 trailing comma, object",
-            r#"{"a":1,}"#,
-            5,
-            "expected string key, found '}'",
-        ),
-        (
-            "#2243 lone comma, array",
-            "[,]",
-            5,
-            "expected JSON value, found ','",
-        ),
-        (
-            "#2243 lone comma, object",
-            "{,}",
-            5,
-            "expected string key, found ','",
-        ),
-        (
-            "#2349 missing comma, array",
-            "[1 2]",
-            5,
-            "expected ',' or ']'",
-        ),
-        (
-            "#2349 double comma, array",
-            "[1,,2]",
-            5,
-            "expected JSON value, found ','",
-        ),
-        (
-            "#2349 missing comma, object",
-            r#"{"a":1 "b":2}"#,
-            5,
-            "expected ',' or '}'",
-        ),
-        (
-            "#2349 double comma, object",
-            r#"{"a":1,,"b":2}"#,
-            5,
-            "expected string key, found ','",
-        ),
-        (
-            "#2211 trailing comma, nested",
-            r#"{"a":[1,]}"#,
-            5,
-            "expected JSON value, found ']'",
-        ),
-        (
-            "#2243 lone comma, nested",
-            "[[,]]",
-            5,
-            "expected JSON value, found ','",
-        ),
-        ("#966 leading zero (sanitized, not raised)", "[01]", 0, ""),
-        (
-            "#966 two-dot number (sanitized, not raised)",
-            "[1..2]",
-            0,
-            "",
-        ),
-        ("deep, within the guard", deep200.as_str(), 0, ""),
-        ("duplicate key (valid)", r#"{"a":1,"a":2}"#, 0, ""),
-        ("unterminated array", "[1,2", 5, "Invalid JSON text"),
-        ("unterminated string", r#"["a"#, 5, "Invalid JSON text"),
-        ("missing colon", r#"{"a" 1}"#, 5, "expected ':'"),
-        ("bad literal", "[nul]", 5, "invalid null"),
-        ("trailing garbage", "[1] x", 5, "Invalid JSON text"),
-        ("null root", "null", 0, ""),
-        ("false root", "false", 0, ""),
-        ("well-formed", r#"{"a":[1,{"b":"c"}]}"#, 0, ""),
+        ("#1642 single undecodable key", r#"{"\ud800": 1, "b": 2}"#),
+        ("undecodable key, no collision", r#"{"a\q":1,"b":2}"#),
+        ("#2211 trailing comma, array", "[1,]"),
+        ("#2211 trailing comma, object", r#"{"a":1,}"#),
+        ("#2243 lone comma, array", "[,]"),
+        ("#2243 lone comma, object", "{,}"),
+        ("#2349 missing comma, array", "[1 2]"),
+        ("#2349 double comma, array", "[1,,2]"),
+        ("#2349 missing comma, object", r#"{"a":1 "b":2}"#),
+        ("#2349 double comma, object", r#"{"a":1,,"b":2}"#),
+        ("#2211 trailing comma, nested", r#"{"a":[1,]}"#),
+        ("#2243 lone comma, nested", "[[,]]"),
+        ("#966 leading zero (sanitized, not raised)", "[01]"),
+        ("#966 two-dot number (sanitized, not raised)", "[1..2]"),
+        ("deep, within the guard", deep200.as_str()),
+        ("duplicate key (valid)", r#"{"a":1,"a":2}"#),
+        ("unterminated array", "[1,2"),
+        ("unterminated string", r#"["a"#),
+        ("missing colon", r#"{"a" 1}"#),
+        ("bad literal", "[nul]"),
+        ("trailing garbage", "[1] x"),
+        ("null root", "null"),
+        ("false root", "false"),
+        ("well-formed", r#"{"a":[1,{"b":"c"}]}"#),
     ];
-    // The reference route first; every construct that used to bridge and
-    // still reads `.` after it. #2173 moved the closed terms out of this
-    // list and into `closed_probes` below -- they no longer raise at all.
-    let probes = ["select(.) | 1", ". and true", "not", "(.a? // 1) | 1"];
-    // #2173: these read nothing, so they validate nothing and answer at
-    // exit 0 on every row of the corpus -- including the malformed ones.
-    // Their expected stdout is the same on a malformed document as on a
-    // well-formed one, which is the point: the answer no longer depends on
-    // the document at all.
+    // Everything left in this list *navigates*: `(.a? // 1) | 1` resolves
+    // `.a`, and resolving a key reads it. #2173 moved the closed terms out
+    // of here into `closed_probes`; #2692 moved the *truthiness* readers out
+    // too, for the reason those two changes share -- `select(.)`, `. and
+    // true` and `not` all answer through `is_falsy`, which decodes nothing,
+    // so testing `.` is no more a read of it than never touching it was.
+    let probes = ["(.a? // 1) | 1"];
+    // #2173/#2692: these read nothing they decode, so they validate nothing
+    // and answer at exit 0 on every row of the corpus -- including the
+    // malformed ones. Their expected stdout is the same on a malformed
+    // document as on a well-formed one, which is the point: the answer no
+    // longer depends on the document at all.
+    //
+    // These are #2173's: closed terms, whose *value* is fixed too, because
+    // they never look at the document at all.
     let closed_probes = [
         ("true and true", "true"),
         ("false or true", "true"),
@@ -44307,6 +44300,24 @@ fn test_ambient_validation_agrees_with_bridge_2476() -> Result<()> {
         ("0 - 0", "0"),
         ("(-(1))", "-1"),
     ];
+    // #2692's addition, and the sharper claim: each of these *does* look at
+    // `.`, but only at its truthiness -- `select(.) | 1` tests the whole
+    // document, `not` negates it, `. and true` takes it as an operand,
+    // `if . then 1 else 2 end` branches on it. `is_falsy` answers all four
+    // without decoding anything, so none of them validates.
+    //
+    // Only the exit code is asserted, and deliberately so: their *values*
+    // legitimately vary with the document, because truthiness is exactly
+    // what they read (`null` and `false` roots are falsy, so `select(.)`
+    // emits nothing there and `not` is `true`). The claim is that no
+    // document makes them *raise* where `empty` does not, which is what a
+    // returning validation walk would break.
+    let truthiness_probes = [
+        "select(.) | 1",
+        ". and true",
+        "not",
+        "if . then 1 else 2 end",
+    ];
     // Four corpus rows are not about validation at all: `xyz123`, `[1,2`,
     // `["a` and `[1] x` give the CLI's document reader no root value to
     // delimit, so it raises before any filter runs. `empty` is the
@@ -44318,19 +44329,11 @@ fn test_ambient_validation_agrees_with_bridge_2476() -> Result<()> {
     // than against a hard-coded list of labels states the actual claim --
     // a closed term behaves exactly as the filter that reads nothing and
     // does nothing -- and keeps working if the corpus grows.
-    for (label, doc, want_code, want_stderr) in corpus {
+    for (label, doc) in corpus {
         let mut seen: Vec<(String, i32, String)> = Vec::new();
         for probe in probes {
             let (_stdout, stderr, code) = run_jq_full(&["-c", probe], Some(doc))?;
             let first = stderr.lines().next().unwrap_or("").to_string();
-            assert_eq!(
-                code, *want_code,
-                "[{label}] `{probe}`: exit {code}, want {want_code}\nstderr: {stderr}"
-            );
-            assert!(
-                first.contains(want_stderr),
-                "[{label}] `{probe}`: stderr {first:?} lacks {want_stderr:?}"
-            );
             seen.push((probe.to_string(), code, first));
         }
         let (_, ref_code, ref_first) = &seen[0];
@@ -44338,7 +44341,8 @@ fn test_ambient_validation_agrees_with_bridge_2476() -> Result<()> {
             assert_eq!(
                 (code, first),
                 (ref_code, ref_first),
-                "[{label}] `{probe}` disagrees with `select(.) | 1`"
+                "[{label}] `{probe}` disagrees with `{}`",
+                seen[0].0
             );
         }
         let (_, _, empty_code) = run_jq_full(&["-c", "empty"], Some(doc))?;
@@ -44357,6 +44361,15 @@ fn test_ambient_validation_agrees_with_bridge_2476() -> Result<()> {
                     "[{label}] closed `{probe}`: stdout {stdout:?}"
                 );
             }
+        }
+        for probe in truthiness_probes {
+            let (stdout, stderr, code) = run_jq_full(&["-c", probe], Some(doc))?;
+            assert_eq!(
+                code, empty_code,
+                "[{label}] truthiness `{probe}`: exit {code}, but `empty` exits \
+                 {empty_code} -- a filter that only tests `.` must answer \
+                 exactly as `empty` does\nstdout: {stdout:?}\nstderr: {stderr}"
+            );
         }
     }
     Ok(())
@@ -44436,70 +44449,88 @@ fn test_closed_terms_do_not_validate_2173() -> Result<()> {
     }
 
     // The other half of the rule, and the reason this is a narrowing rather
-    // than a blanket amnesty: a filter that *does* read the document still
-    // validates what it reads (#2168). Without these rows the grid above
+    // than a blanket amnesty: a filter that *materializes* the document
+    // still validates all of it (#2168). Without these rows the grid above
     // would pass just as well if validation had been deleted outright.
     //
-    // The five structurally-malformed documents raise for every reading
-    // filter. The colliding-key document is the exception, and a
-    // pre-existing one that #2173 does not touch: `.`, `length` and `keys`
-    // never have to resolve `"\ud800"` to a display form, so they echo it
-    // at exit 0 exactly as #2103 recorded, while `. and true` and `not` go
-    // through the validation walk, which does resolve it, and raise #1642's
-    // collision. Encoded as measured rather than assumed -- the first draft
-    // of this test asserted a uniform 5 here and was wrong.
+    // `. and true` and `not` sat in this list under #2173, which drew the
+    // line at "reads `.`". #2692 moved the line to "materializes `.`" and
+    // they moved with it: both answer through `is_falsy`, which decodes
+    // nothing. The collision document below is what made that line visible
+    // -- under #2173 `.`, `length` and `keys` echoed `"\ud800"` at exit 0
+    // (they never resolve it to a display form, exactly as #2103 recorded)
+    // while `. and true` and `not` raised #1642's collision, because the
+    // validation walk *did* resolve it. Nothing about the document
+    // distinguished those two groups; only whether a walk ran did. Now
+    // neither raises, and the row is a matched pair rather than a split.
     let structural = &docs[..5];
     for doc in structural {
-        for filter in [".", "length", "keys", ". and true", "not"] {
+        for filter in [".", "length", "keys"] {
             let (_out, err, code) = run_jq_full(&["-c", filter], Some(doc))?;
             assert_eq!(code, 5, "doc {doc:?} filter {filter:?} must still raise");
             assert!(!err.is_empty(), "doc {doc:?} filter {filter:?}");
         }
+        for filter in [". and true", "not"] {
+            let (_out, err, code) = run_jq_full(&["-c", filter], Some(doc))?;
+            assert_eq!(
+                code, 0,
+                "doc {doc:?} filter {filter:?} reads only truthiness, stderr: {err}"
+            );
+        }
     }
     let collision = docs[5];
-    for filter in [".", "length", "keys"] {
+    for filter in [".", "length", "keys", ". and true", "not"] {
         let (_out, err, code) = run_jq_full(&["-c", filter], Some(collision))?;
         assert_eq!(code, 0, "`{filter}` on the collision doc, stderr: {err}");
     }
-    for filter in [". and true", "not"] {
-        let (_out, err, code) = run_jq_full(&["-c", filter], Some(collision))?;
-        assert_eq!(code, 5, "`{filter}` on the collision doc must still raise");
-        assert!(err.contains("ambiguous"), "`{filter}` stderr: {err}");
+    // ... and the materializing routes on that same document still do raise
+    // the collision, which is what keeps the pair above meaningful.
+    for args in [["-Sc", "."], ["-sc", "."]] {
+        let (_out, err, code) = run_jq_full(&args, Some(collision))?;
+        assert_eq!(code, 5, "`{args:?}` on the collision doc must still raise");
+        assert!(err.contains("ambiguous"), "`{args:?}` stderr: {err}");
     }
     Ok(())
 }
 
-/// #2173: which `and`/`or` shapes raise on a malformed document, and which
-/// answer.
+/// #2173/#2692: which `and`/`or` shapes raise on a malformed document, and
+/// which answer. Since #2692 the answer is "none of them".
 ///
 /// #2476 ungated `eval_single`'s `Expr::And`/`Expr::Or` arms and had them
 /// run `ambient_validation_error` -- the bridge's ambient rejection without
-/// the bridge's allocation -- for every non-path-context shape. #2173 gates
+/// the bridge's allocation -- for every non-path-context shape. #2173 gated
 /// that walk on whether an operand actually reads `.`, because the wildcard
 /// bridge it stands in for stopped materializing for a closed term at the
-/// same time (`bridge_ambient_input`). Leaving the walk here would have
+/// same time (`bridge_ambient_input`). Leaving the walk there would have
 /// re-created by hand the very spelling-dependence both changes remove:
 /// `true and true` raising while `1+1` answers, on one document, in one run.
 ///
+/// #2692 then removed the walk outright, because #2173's line was in the
+/// wrong place by its own argument. `. and true` "reads `.`" only in the
+/// sense of asking whether it is `null` or `false` -- `is_falsy`, O(1), no
+/// decode -- which is not a read that can encounter a malformed byte. Gating
+/// on "reads `.`" therefore left the same split one spelling over:
+/// `. and true` raising while `.b`, `length` and `keys` on the same document
+/// all answer. That row is now inverted below.
+///
 /// `test_try_catch_contains_a_genuinely_catchable_malformed_key_error_1812`
 /// pins the catchability rule and
-/// `test_ambient_validation_agrees_with_bridge_2476` pins the whole
-/// raise-set across every malformed-document class; this is the focused
+/// `test_truthiness_probes_validate_nothing_2692` pins the whole
+/// answer-set across every malformed-document class; this is the focused
 /// sibling that sits next to the fan-out repro the ungating exists for
 /// (`test_and_or_over_alias_fanout_completes_2476` in
 /// `tests/yq_cli_tests.rs`), so a regression names itself.
 #[test]
-fn test_and_or_raise_only_when_an_operand_reads_the_document_2173() -> Result<()> {
-    // Reads `.`, so it validates `.` -- unchanged by #2173.
+fn test_and_or_raise_only_when_an_operand_materializes_2173_2692() -> Result<()> {
+    // Takes `.` as an operand, but only reads its truthiness -- so since
+    // #2692 it answers, exactly as `.b`/`length`/`keys` on this document
+    // always have. This row asserted exit 5 under #2173.
     let (stdout, stderr, code) = run_jq_stdin_streams(". and true", "{123: 1}", &[])?;
     assert_eq!(
-        code, 5,
-        "`. and true` must still reject the document -- stdout: {stdout:?} stderr: {stderr:?}"
+        code, 0,
+        "`. and true` reads only truthiness and must answer -- stdout: {stdout:?} stderr: {stderr:?}"
     );
-    assert!(
-        stderr.contains("Invalid JSON text"),
-        "`. and true` -- stderr: {stderr}"
-    );
+    assert_eq!(stdout.trim(), "true", "`. and true` -- stderr: {stderr:?}");
 
     // Reads nothing, so it validates nothing. Short-circuiting is not what
     // decides this and never was: `true or false` never evaluates its right
@@ -44520,31 +44551,49 @@ fn test_and_or_raise_only_when_an_operand_reads_the_document_2173() -> Result<()
         assert_eq!(stdout.trim(), want, "`{filter}` -- stderr: {stderr:?}");
     }
 
-    Ok(())
-}
-
-/// #2476: `not` gets its own native arm in `eval_single` (it never had a
-/// `needs_path_context` gate to lose -- it has no operand, only the ambient
-/// `.` -- so before this change it fell to the wildcard bridge
-/// unconditionally). This is `not`'s own sibling of
-/// `test_and_or_still_raise_on_a_malformed_document_2476` just above: the
-/// bridge's ambient decode is now `push_generic_truthiness`'s own validation
-/// walk (inline, no separate `ambient_validation_error` call needed -- see
-/// the arm's comment in `eval_generic.rs`), and it must still raise on
-/// exactly the same two shapes -- a #1194 malformed root, and a decode
-/// failure the walk actually has to visit through a `.[]` fan-out.
-#[test]
-fn test_not_still_raises_on_a_malformed_document_2476() -> Result<()> {
-    let (stdout, stderr, code) = run_jq_stdin_streams("not", "{123: 1}", &[])?;
+    // The control that keeps the rule honest: the same document, a filter
+    // that actually materializes it.
+    let (stdout, stderr, code) = run_jq_stdin_streams(".", "{123: 1}", &[])?;
     assert_eq!(code, 5, "stdout: {stdout:?} stderr: {stderr:?}");
     assert!(stderr.contains("Invalid JSON text"), "stderr: {stderr}");
 
-    let (stdout, stderr, code) = run_jq_stdin_streams(".[] | not", "[\"\\x\"]", &[])?;
-    assert_eq!(code, 5, "stdout: {stdout:?} stderr: {stderr:?}");
-    assert!(
-        stderr.contains("invalid escape sequence"),
-        "stderr: {stderr}"
-    );
+    Ok(())
+}
+
+/// #2476/#2692: `not` gets its own native arm in `eval_single` (it never had
+/// a `needs_path_context` gate to lose -- it has no operand, only the ambient
+/// `.` -- so before #2476 it fell to the wildcard bridge unconditionally).
+/// This is `not`'s own sibling of
+/// `test_and_or_no_longer_raise_on_a_malformed_document_2476_2692` just
+/// above.
+///
+/// `not` is exactly the truthiness of `.`, negated, and truthiness is
+/// `is_falsy` -- O(1), decoding nothing. #2476 kept the bridge's raise alive
+/// as a validation walk inside `push_generic_truthiness`; #2692 removed it,
+/// so both shapes below answer: a #1194 malformed root, and a decode failure
+/// the walk used to visit through a `.[]` fan-out. The second row is the one
+/// worth watching -- the fan-out puts `not` *directly on* the corrupt value
+/// rather than on a container holding it, and it still does not read it.
+///
+/// `eval::eval_not`'s own comment argued years earlier that a container
+/// merely *holding* an undecodable string should answer `false` rather than
+/// raise. That argument now wins on both routes.
+#[test]
+fn test_not_no_longer_raises_on_a_malformed_document_2476_2692() -> Result<()> {
+    for (filter, doc, want) in [
+        ("not", "{123: 1}", "false"),
+        (".[] | not", "[\"\\x\"]", "false"),
+    ] {
+        let (stdout, stderr, code) = run_jq_stdin_streams(filter, doc, &[])?;
+        assert_eq!(code, 0, "`{filter}` stdout: {stdout:?} stderr: {stderr:?}");
+        assert_eq!(stdout.trim(), want, "`{filter}` stderr: {stderr}");
+    }
+
+    // Controls: materializing the very same values still raises.
+    for (filter, doc) in [(".", "{123: 1}"), (".[] | tostring", "[\"\\x\"]")] {
+        let (stdout, stderr, code) = run_jq_stdin_streams(filter, doc, &[])?;
+        assert_eq!(code, 5, "`{filter}` stdout: {stdout:?} stderr: {stderr:?}");
+    }
 
     Ok(())
 }
@@ -44651,14 +44700,13 @@ fn test_any_all_truthiness_table_2476() -> Result<()> {
     Ok(())
 }
 
-/// #2476: `any_all_generic` validates its whole input *before* the scan,
-/// rather than checking each element as the early exit reaches it. This is
-/// the test that decides that shape.
+/// #2476/#2692: `any_all_generic` used to validate its whole input *before*
+/// the scan. It no longer validates it at all, and this is the test that
+/// records why the earlier shape was chosen and why it was given up.
 ///
-/// The bridge materialized the whole container before `builtin_any` ran, so
-/// an element the early exit never reaches still raised. Real jq agrees, for
-/// the stronger reason that it rejects the entire document at parse time --
-/// captured live from jq 1.7.1:
+/// #2476's argument: the bridge materialized the whole container before
+/// `builtin_any` ran, so an element the early exit never reaches still
+/// raised, and real jq agrees -- captured live from jq 1.7.1:
 ///
 /// ```text
 /// echo '[true, "\x"]'  | jq any   jq: parse error: Invalid escape at line 1, column 11
@@ -44666,104 +44714,95 @@ fn test_any_all_truthiness_table_2476() -> Result<()> {
 /// echo '{123: 1}'      | jq any   jq: parse error: Object keys must be strings at line 1, column 5
 /// ```
 ///
-/// Per-element validation with early exit would answer `true` for the first
-/// row (the deciding element comes first) and drop a raise both the bridge
-/// and real jq make. Hence: one `push_generic_document_validation_error`
-/// over the input, then a pure `is_falsy` scan.
+/// #2692's answer: jq agrees there **for a different reason** -- it rejects
+/// the entire document at parse time, whatever the filter, including for
+/// `1+1` and `.` where succinctly has long answered. That is exactly the
+/// accidental agreement ADR-0018's #2103 amendment says not to buy with a
+/// per-spelling divergence. `any`/`all` read each element's truthiness and
+/// decode none of it, so they validate nothing; the array rows below moved
+/// from raising to answering.
 ///
-/// `?` does not rescue any of these: a decode failure and a #1194 structural
-/// error both outrank `optional` (#1620/#1989), and the validation walk is
-/// not routed through `optional` at all -- same as the `//` arm's own
-/// `ambient_validation_error` call.
+/// `?` never rescued these and still changes nothing -- a decode failure and
+/// a #1194 structural error both outrank `optional` (#1620/#1989) -- so both
+/// spellings are asserted on every row, in both directions.
 #[test]
-fn test_any_all_still_reject_a_malformed_document_2476() -> Result<()> {
+fn test_any_all_no_longer_reject_a_malformed_array_2692() -> Result<()> {
+    // An undecodable element is neither `null` nor `false`, so `is_falsy`'s
+    // documented conservative default makes it truthy -- and since #2692 that
+    // default is the answer rather than something a validation walk pre-empts.
     for (doc, filter, want) in [
-        // The deciding element comes *first*; the raise still wins.
-        (r#"[true, "\x"]"#, "any", "invalid escape sequence"),
-        (r#"[false, "\x"]"#, "all", "invalid escape sequence"),
-        (r#"[true, "\x"]"#, "all", "invalid escape sequence"),
-        (r#"[false, "\x"]"#, "any", "invalid escape sequence"),
-        ("{123: 1}", "any", "Invalid JSON text"),
-        ("{123: 1}", "all", "Invalid JSON text"),
+        (r#"[true, "\x"]"#, "any", "true"),
+        (r#"[false, "\x"]"#, "all", "false"),
+        (r#"[true, "\x"]"#, "all", "true"),
+        (r#"[false, "\x"]"#, "any", "true"),
     ] {
         for spelling in [filter.to_string(), format!("{filter}?")] {
-            let (_stdout, stderr, code) = run_jq_full(&["-c", &spelling], Some(doc))?;
-            assert_eq!(code, 5, "`{spelling}` on {doc} -- stderr: {stderr}");
-            assert!(
-                stderr.contains(want),
-                "`{spelling}` on {doc} -- stderr {stderr} lacks {want:?}"
-            );
+            let (stdout, stderr, code) = run_jq_full(&["-c", &spelling], Some(doc))?;
+            assert_eq!(code, 0, "`{spelling}` on {doc} -- stderr: {stderr}");
+            assert_eq!(stdout.trim(), want, "`{spelling}` on {doc}");
         }
+    }
+
+    // The object arm is *not* part of that removal and must still raise:
+    // jq iterates an object's values (#422) under its own last-occurrence
+    // duplicate-key rule, so `effective_fields_checked` genuinely resolves
+    // the keys -- reading them, not merely testing them. This row is the
+    // boundary of #2692 on this builtin, so it is pinned here rather than
+    // left to the corpus test.
+    for filter in ["any", "all", "any?", "all?"] {
+        let (stdout, stderr, code) = run_jq_full(&["-c", filter], Some("{123: 1}"))?;
+        assert_eq!(code, 5, "`{filter}` -- stdout: {stdout:?} stderr: {stderr}");
+        assert!(
+            stderr.contains("Invalid JSON text"),
+            "`{filter}` -- stderr: {stderr}"
+        );
     }
     Ok(())
 }
 
-/// #2476: the container half of `test_ambient_validation_agrees_with_bridge_2476`,
-/// for `any`/`all`.
+/// #2476/#2692: the container half of
+/// `test_truthiness_probes_validate_nothing_2692`, for `any`/`all`.
 ///
-/// Kept separate rather than folded in as two more probes there: that
-/// corpus includes scalar and `null` roots, where `any`/`all` raise a *type*
-/// error of their own and would break the "every probe agrees" assertion for
-/// reasons that have nothing to do with the validation walk. Every row here
-/// is a container, so the only thing that can decide the exit code is the
-/// walk -- and it has to decide it the same way `select(.) | 1` does.
+/// Kept separate rather than folded in as two more probes there, for two
+/// reasons that have both survived #2692. That corpus includes scalar and
+/// `null` roots, where `any`/`all` raise a *type* error of their own; and its
+/// object rows reach `any`/`all`'s own object arm, which is the one place
+/// these builtins genuinely read rather than test. Every row here is
+/// therefore a container, and every row but one answers.
 ///
-/// Asserts the explicit expected code as well as agreement, for the reason
-/// the sibling gives: agreement alone would also pass if both routes
-/// silently stopped raising.
+/// The exception is the point of the test. `{123: 1}` still raises, because
+/// jq iterates an *object's values* (#422) under its own last-occurrence
+/// duplicate-key rule, so `effective_fields_checked` has to resolve the keys
+/// -- and resolving a key reads it. Every array row answers, because scanning
+/// elements for truthiness reads none of them. That is the whole of #2692's
+/// rule applied inside a single builtin, which is why it is worth pinning
+/// here rather than only in the arm's own focused test.
+///
+/// Note `{"\ud800":1,"\ud800":2}` answers: jq mode collapses duplicate keys,
+/// and the #1642 collision raise the *materializing* routes make is not one
+/// this arm reaches. Captured from the binary, not predicted.
 #[test]
-fn test_any_all_ambient_validation_agrees_with_bridge_2476() -> Result<()> {
-    // (label, document, expected exit code, expected stderr substring)
-    let corpus: &[(&str, &str, i32, &str)] = &[
-        ("#1194 non-string key", "{123: 1}", 5, "expected string key"),
-        (
-            "decode failure, in array",
-            r#"["\x"]"#,
-            5,
-            "invalid escape sequence",
-        ),
-        (
-            "structural error, in array",
-            "[xyz123]",
-            5,
-            "unexpected character",
-        ),
+fn test_any_all_validate_only_the_keys_they_resolve_2476_2692() -> Result<()> {
+    // (label, document, expected exit code)
+    let corpus: &[(&str, &str, i32)] = &[
+        // The one raising row: an object, so the keys are resolved.
+        ("#1194 non-string key", "{123: 1}", 5),
+        ("decode failure, in array", r#"["\x"]"#, 0),
+        ("structural error, in array", "[xyz123]", 0),
         (
             "#1642 colliding undecodable keys",
             r#"{"\ud800":1,"\ud800":2}"#,
-            5,
-            "is ambiguous",
+            0,
         ),
-        (
-            "#2211 trailing comma, array",
-            "[1,]",
-            5,
-            "expected JSON value, found ']'",
-        ),
-        (
-            "#2243 lone comma, array",
-            "[,]",
-            5,
-            "expected JSON value, found ','",
-        ),
-        (
-            "#2349 missing comma, array",
-            "[1 2]",
-            5,
-            "expected ',' or ']'",
-        ),
-        (
-            "#2211 trailing comma, nested",
-            r#"{"a":[1,]}"#,
-            5,
-            "expected JSON value, found ']'",
-        ),
-        ("duplicate key (valid)", r#"{"a":1,"a":2}"#, 0, ""),
-        ("well-formed", r#"{"a":[1,{"b":"c"}]}"#, 0, ""),
+        ("#2211 trailing comma, array", "[1,]", 0),
+        ("#2243 lone comma, array", "[,]", 0),
+        ("#2349 missing comma, array", "[1 2]", 0),
+        ("#2211 trailing comma, nested", r#"{"a":[1,]}"#, 0),
+        ("duplicate key (valid)", r#"{"a":1,"a":2}"#, 0),
+        ("well-formed", r#"{"a":[1,{"b":"c"}]}"#, 0),
     ];
-    // The reference route first; `any`/`all` after.
-    let probes = ["select(.) | 1", "any | 1", "all | 1"];
-    for (label, doc, want_code, want_stderr) in corpus {
+    let probes = ["any | 1", "all | 1"];
+    for (label, doc, want_code) in corpus {
         let mut seen: Vec<(String, i32, String)> = Vec::new();
         for probe in probes {
             let (_stdout, stderr, code) = run_jq_full(&["-c", probe], Some(doc))?;
@@ -44772,10 +44811,12 @@ fn test_any_all_ambient_validation_agrees_with_bridge_2476() -> Result<()> {
                 code, *want_code,
                 "[{label}] `{probe}`: exit {code}, want {want_code}\nstderr: {stderr}"
             );
-            assert!(
-                first.contains(want_stderr),
-                "[{label}] `{probe}`: stderr {first:?} lacks {want_stderr:?}"
-            );
+            if *want_code == 5 {
+                assert!(
+                    first.contains("expected string key"),
+                    "[{label}] `{probe}`: stderr {first:?}"
+                );
+            }
             seen.push((probe.to_string(), code, first));
         }
         let (_, ref_code, ref_first) = &seen[0];
@@ -44783,7 +44824,7 @@ fn test_any_all_ambient_validation_agrees_with_bridge_2476() -> Result<()> {
             assert_eq!(
                 (code, first),
                 (ref_code, ref_first),
-                "[{label}] `{probe}` disagrees with `select(.) | 1`"
+                "[{label}] `{probe}` disagrees with `any | 1`"
             );
         }
     }
@@ -44909,7 +44950,22 @@ fn test_alternative_raises_only_when_it_reads_the_document_2173() -> Result<()> 
     );
     assert_eq!(stdout.trim(), "1", "stderr: {stderr:?}");
 
-    let (stdout, stderr, code) = run_jq_stdin_streams("(.[0] // 1)", "[\"\\x\"]", &[])?;
+    // Navigates into the malformed object: still raises, as a bare `.a`
+    // does.
+    let (stdout, stderr, code) = run_jq_stdin_streams(".a // 1", "{123: 1}", &["-c"])?;
+    assert_eq!(code, 5, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert!(stderr.contains("Invalid JSON text"), "stderr: {stderr}");
+
+    // Navigates to an undecodable *element* and forwards it: the cursor is
+    // passed through untouched, so this echoes the raw source bytes, exactly
+    // as a bare `.[0]` does on this document.
+    let (stdout, stderr, code) = run_jq_stdin_streams("(.[0] // 1)", "[\"\\x\"]", &["-c"])?;
+    assert_eq!(code, 0, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert_eq!(stdout.trim(), r#""\x""#, "stderr: {stderr:?}");
+
+    // ... and materializing that same forwarded value still raises.
+    let (stdout, stderr, code) =
+        run_jq_stdin_streams("(.[0] // 1) | tostring", "[\"\\x\"]", &["-c"])?;
     assert_eq!(code, 5, "stdout: {stdout:?} stderr: {stderr:?}");
     assert!(
         stderr.contains("invalid escape sequence"),

--- a/tests/jq_library_eval_nesting_depth_tests.rs
+++ b/tests/jq_library_eval_nesting_depth_tests.rs
@@ -12,24 +12,37 @@
 //! independently be `false`, sending it to the same wildcard/ambient bridge
 //! `tests/jq_cli_tests.rs`'s `test_boolean_wildcard_bridge_over_depth_
 //! document_reports_cleanly_not_panic_2627` pins at the CLI layer (protected
-//! there by `catch_unwind`, #1793). This file confirms the same document
-//! and filter shape, reached through the *public* library entry point with
-//! no such net, returns a clean `Err` instead of aborting the process.
+//! there by `catch_unwind`, #1793).
+//!
+//! #2627's fix made this a clean `Err` rather than a panic; #2692 then
+//! removed the ambient-validation walk `and`/`or` routed through entirely
+//! (see `src/jq/eval_generic.rs`'s `eval_boolean_generic` and
+//! `docs/adrs/adr-0018.md`), so `. and true` now reads only `.`'s
+//! truthiness -- `is_falsy`, which never descends into a container's
+//! children -- and answers `true` regardless of nesting depth. This file
+//! confirms that corollary through the *public* library entry point (no
+//! `catch_unwind` net, unlike the CLI layer), mirroring
+//! `test_boolean_and_reads_truthiness_without_tripping_depth_guard_2692`
+//! (`src/jq/eval_generic.rs`) and the CLI-level
+//! `test_truthiness_probes_do_not_trip_the_depth_guard_2692`
+//! (`tests/jq_cli_tests.rs`).
 //!
 //! `(. and true)`, not `(true and true)`: a fully closed sub-expression (no
-//! operand reads `.` at all) no longer reaches the bridge's materialization
-//! in the first place -- #2173's `walk::reads_ambient_value` gate (landed
-//! the same day as this fix) substitutes `null` for a closed term instead of
-//! the real document, so the guard below never sees it. `.` keeps the
-//! sub-expression's own `needs_path_context` false (still no `key`/`parent`/
-//! `path` operand) while making it read the ambient value, which is what
-//! keeps the real (over-deep) document in the loop.
+//! operand reads `.` at all) no longer reaches `eval_boolean_generic`'s
+//! document argument in the first place -- #2173's
+//! `walk::reads_ambient_value` gate (landed the same day as #2627's fix)
+//! substitutes `null` for a closed term instead of the real document. `.`
+//! keeps the sub-expression's own `needs_path_context` false (still no
+//! `key`/`parent`/`path` operand) while making it read the ambient value,
+//! which is what keeps the real (over-deep) document in the loop and lets
+//! this test exercise the depth guard's *absence* rather than a
+//! substituted `Null`.
 //!
-//! Confirmed live before the fix that this exact shape panicked with no
+//! Confirmed live before #2627's fix that this exact shape panicked with no
 //! `catch_unwind` to save it (the underlying `assert_nesting_depth` `panic!`
 //! in `src/jq/eval_generic.rs`).
 
-use succinctly::jq::{eval, parse, JqSemantics, QueryResult};
+use succinctly::jq::{eval, parse, JqSemantics, OwnedValue, QueryResult};
 use succinctly::json::JsonIndex;
 
 /// `[[[...1...]]]`, `depth` levels of array nesting wrapping a single `1` --
@@ -42,13 +55,15 @@ fn nested_arrays(depth: usize) -> String {
 /// `key?` forces `eval::eval`'s own gate to route the whole pipe through
 /// `eval_generic` (confirmed by `needs_path_context`'s `Expr::Builtin(Builtin
 /// ::Key) => true` arm); `(. and true)` has no path-context operand of its
-/// own, so once inside `eval_generic` it independently falls to the
-/// wildcard/ambient bridge this issue is about, while still reading the
-/// ambient value (see the module doc comment above).
+/// own, so once inside `eval_generic` it independently falls to
+/// `eval_boolean_generic`, while still reading the ambient value (see the
+/// module doc comment above). `key` on a root array (not an object) errors,
+/// so `?` swallows that branch's output entirely, leaving `(. and true)`'s
+/// `true` as the comma expression's only result.
 const FILTER: &str = "key?, (. and true)";
 
 #[test]
-fn test_public_eval_over_depth_document_returns_error_not_panic_2627() {
+fn test_public_eval_over_depth_document_reads_truthiness_without_tripping_depth_guard_2692() {
     let json = nested_arrays(300);
     let bytes = json.as_bytes();
     let index = JsonIndex::build(bytes);
@@ -57,15 +72,8 @@ fn test_public_eval_over_depth_document_returns_error_not_panic_2627() {
 
     let result: QueryResult<Vec<u64>> = eval::<Vec<u64>, JqSemantics>(&expr, cursor);
     match result {
-        QueryResult::Error(e) => {
-            assert!(e.is_decode_failure(), "expected decode failure, got: {e:?}");
-            assert!(
-                e.message.contains("nesting depth exceeds limit of 256"),
-                "message: {}",
-                e.message
-            );
-        }
-        other => panic!("expected a decode failure, got: {other:?}"),
+        QueryResult::Owned(OwnedValue::Bool(true)) => {}
+        other => panic!("expected Owned(true), got: {other:?}"),
     }
 }
 

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -39931,10 +39931,27 @@ fn test_truthiness_probes_validate_nothing_2692() -> Result<()> {
         ("well-formed", "a: [1, {b: c}]\n"),
     ];
     // #2173 moved the closed terms out of this list -- see the jq twin's
-    // own comment. They no longer validate anything, so they cannot agree
-    // with `select(.) | 1` on a malformed row and are pinned separately
-    // below.
-    let probes = ["select(.) | 1", ". and true", "not", "(.a? // 1) | 1"];
+    // own comment -- and they are pinned separately below.
+    //
+    // `1+1` leads, as the reads-nothing reference every truthiness reader
+    // must agree with. It belongs here rather than in `closed_probes`
+    // precisely because it is *not* a truthiness reader: if a validating
+    // walk ever came back to one of the three that follow, it would show up
+    // as a disagreement with this row rather than as a uniform failure.
+    //
+    // (An earlier draft of this test used `1==1` here and carried a comment
+    // claiming yq-mode `1+1` still validated the document. That was measured
+    // on a pre-rebase binary: #2173 narrowed the wildcard bridge's own
+    // materialization to operands that read the ambient value, so `1+1`
+    // answers `2` at exit 0 in yq mode too -- on every row of this corpus,
+    // re-verified against the shipped build.)
+    let probes = [
+        "1+1",
+        "select(.) | 1",
+        ". and true",
+        "not",
+        "(.a? // 1) | 1",
+    ];
     let closed_probes = [
         ("true and true", "true"),
         ("false or true", "true"),
@@ -39965,7 +39982,7 @@ fn test_truthiness_probes_validate_nothing_2692() -> Result<()> {
             assert_eq!(
                 (code, first),
                 (ref_code, ref_first),
-                "[{label}] `{probe}` disagrees with the reads-nothing reference `1==1`"
+                "[{label}] `{probe}` disagrees with the reads-nothing reference `1+1`"
             );
         }
         // #2173: a closed term answers exactly as `empty` does -- the

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -2539,6 +2539,32 @@ fn assert_yq_raises(
     );
 }
 
+/// [`assert_yq_raises`]'s opposite number, for the consumers of the same
+/// corrupted documents that must *not* raise since #2692: a filter that only
+/// tests a value's truthiness never decodes it.
+///
+/// Asserts the answer, not just exit 0, for the same reason its sibling
+/// asserts the message rather than the code -- "did not raise" and "produced
+/// the right value" are different claims, and only the second would catch a
+/// route that silently stopped emitting.
+fn assert_yq_answers(
+    label: &str,
+    op_label: &str,
+    filter: &str,
+    yaml: &str,
+    extra_args: &[&str],
+    expect_stdout: &str,
+) {
+    let (out, err, code) = run_yq_stdin_with_stderr(filter, yaml, extra_args)
+        .unwrap_or_else(|e| panic!("[{label}] {op_label} run failed: {e}"));
+    assert_eq!(code, 0, "[{label}] {op_label} must answer, stderr: {err}");
+    assert_eq!(
+        out.trim(),
+        expect_stdout,
+        "[{label}] {op_label} answer, stderr: {err}"
+    );
+}
+
 /// #1803: `select(.bad) | .keep` (`push_generic_document_validation_error`)
 /// and a write op (`.keep = 9`, which forces the YAML DOM path per ADR-0017
 /// -- `to_owned_with_comments_at_depth`/`to_owned_at_depth`/
@@ -2609,13 +2635,18 @@ keep: 5
     ];
 
     for (label, yaml, expect_stderr) in cases {
-        assert_yq_raises(
+        // #2692: `select` moved to the answering side -- it tests `.bad`'s
+        // truthiness without decoding it. Kept in this list rather than
+        // deleted, because the list's job is pinning that every consumer of
+        // one document agrees, and that includes which side of the line each
+        // one is on.
+        assert_yq_answers(
             label,
             "select(.bad)",
             "select(.bad) | .keep",
             yaml,
             &[],
-            expect_stderr,
+            "5",
         );
         assert_yq_raises(label, ".keep = 9", ".keep = 9", yaml, &[], expect_stderr);
         assert_yq_raises(
@@ -2773,7 +2804,9 @@ proptest! {
         let expect_stderr = malformation.expect_stderr();
         let label = format!("{path:?}/{malformation:?}/{style:?}");
 
-        assert_yq_raises(&label, "select(.bad)", "select(.bad) | .keep", &yaml, &[], expect_stderr);
+        // #2692: `select` answers -- it tests `.bad` without decoding it.
+        // The write ops below still raise, because they materialize.
+        assert_yq_answers(&label, "select(.bad)", "select(.bad) | .keep", &yaml, &[], "5");
         assert_yq_raises(&label, ".keep = 9", ".keep = 9", &yaml, &[], expect_stderr);
         assert_yq_raises(
             &label,
@@ -30749,38 +30782,42 @@ fn test_select_resolves_alias_falsiness_1645() -> Result<()> {
     Ok(())
 }
 
-/// #1645 code review: every JSON-side corruption regression test
-/// (`tests/jq_cli_tests.rs`) has no YAML sibling -- `push_generic_document_validation_error`
-/// is generic over `DocumentCursor` and reached identically by the yq
-/// evaluator, but nothing pinned that `select()` actually raises on a YAML
-/// decode failure nested inside its condition's container, only that it
-/// resolves alias falsiness correctly. Uses `\q` (not a recognized YAML
-/// escape) rather than `\x` (a valid two-hex-digit escape in YAML, unlike
-/// JSON) -- confirmed live against this binary that `\x41` decodes
-/// successfully in a YAML double-quoted string.
+/// #1645/#2692, the YAML sibling of
+/// `test_select_passes_through_corruption_it_only_tests_1645_2692`
+/// (`tests/jq_cli_tests.rs`).
+///
+/// #1645 code review noted that every JSON-side corruption regression test
+/// had no YAML sibling, even though the validation gate is generic over
+/// `DocumentCursor` and reached identically by the yq evaluator -- so this
+/// pinned `select()` raising on a YAML decode failure nested inside its
+/// condition's container. #2692 removed that gate from every truthiness
+/// reader in both modes, so the assertion inverts here exactly as it does on
+/// the jq side, and the materializing route below is what still raises.
+///
+/// Uses `\q` (not a recognized YAML escape) rather than `\x` (a valid
+/// two-hex-digit escape in YAML, unlike JSON) -- confirmed live against this
+/// binary that `\x41` decodes successfully in a YAML double-quoted string.
 #[test]
-fn test_select_raises_on_yaml_decode_failure_nested_in_container_1645() -> Result<()> {
+fn test_select_passes_through_yaml_decode_failure_nested_in_container_1645_2692() -> Result<()> {
     let doc = "bad:\n  - \"\\q\"\nkeep: 5\n";
 
     let (select_out, select_err, select_code) =
         run_yq_stdin_with_stderr("select(.bad) | .keep", doc, &[])?;
-    assert_ne!(
+    assert_eq!(
         select_code, 0,
-        "select(.bad) must raise on the nested decode failure\nstdout: {select_out:?}\nstderr: {select_err:?}"
+        "select(.bad) only tests the container and must not raise\
+         \nstdout: {select_out:?}\nstderr: {select_err:?}"
     );
-    assert!(
-        select_err.contains("invalid escape sequence"),
-        "stderr: {select_err:?}"
-    );
+    assert_eq!(select_out.trim(), "5", "stderr: {select_err:?}");
 
     // `.bad,.bad` is yq's multi-output materializing route (yq's analogue
-    // of jq's `-Sc`/`.,.` DOM-forcing tests) -- confirms select's new walk
-    // agrees with the pre-existing materializing path on this input.
+    // of jq's `-Sc`/`.,.` DOM-forcing tests) -- the raise did not disappear,
+    // it moved to whoever actually reads the bytes.
     let (materialize_out, materialize_err, materialize_code) =
         run_yq_stdin_with_stderr(".bad,.bad", doc, &[])?;
     assert_ne!(
         materialize_code, 0,
-        "the materializing route must raise the same way\nstdout: {materialize_out:?}\nstderr: {materialize_err:?}"
+        "the materializing route must still raise\nstdout: {materialize_out:?}\nstderr: {materialize_err:?}"
     );
     assert!(
         materialize_err.contains("invalid escape sequence"),
@@ -30901,30 +30938,48 @@ fn test_select_no_longer_raises_on_decode_failure_reachable_only_via_alias_1804(
     Ok(())
 }
 
-/// Code review on #1804's fix: an earlier version of the alias
-/// short-circuit gated on `c.is_alias()` before knowing whether the
-/// resolved target was a container or a scalar -- so it also swallowed a
-/// decode failure reachable through a bare *scalar*-target alias, even
-/// though resolving a scalar target costs O(1) (no children to cascade
-/// through) and was never part of the O(2^N) fan-out this issue fixes.
-/// Confirmed live against the two binaries either side of that fix: this
-/// exact input raised pre-fix, silently passed with the broad gate, and
-/// raises again with the container-only gate. Unlike the sibling test
-/// above (`b: *a` where `a` is an *array*), this one aliases a bare
-/// scalar directly.
+/// #1804's container/scalar distinction, and #2692 dissolving it.
+///
+/// Code review on #1804's fix caught that an earlier version of the alias
+/// short-circuit gated on `c.is_alias()` before knowing whether the resolved
+/// target was a container or a scalar -- so it also swallowed a decode
+/// failure reachable through a bare *scalar*-target alias, even though
+/// resolving a scalar target costs O(1) (no children to cascade through) and
+/// was never part of the O(2^N) fan-out that issue fixed. The gate was
+/// narrowed to containers, and this test pinned the scalar case still
+/// raising.
+///
+/// #2692 removed the walk that gate lived on: `select`'s condition is
+/// `is_falsy`, which decodes nothing, so *neither* alias shape raises now and
+/// the distinction has no observable consequence left. The test is kept,
+/// inverted, because the shape is still the one that would break first if a
+/// validating walk ever crept back into a truthiness check -- and because
+/// #1804's cost argument is the reason `select` was fast enough to leave
+/// alone until #2692 could remove the walk outright.
+///
+/// The raise moved rather than vanishing: materializing the same value still
+/// finds it, and that is asserted below.
 #[test]
-fn test_select_still_raises_on_decode_failure_reachable_only_via_scalar_alias_1804() -> Result<()> {
+fn test_select_no_longer_raises_via_scalar_alias_1804_2692() -> Result<()> {
     let doc = "a: &a \"b\\qc\"\nb: *a\n";
 
     let (stdout, stderr, code) = run_yq_stdin_with_stderr("select(.b) | 1", doc, &[])?;
-    assert_ne!(
+    assert_eq!(
         code, 0,
-        "a decode failure reached through a scalar-target alias must still raise\nstdout: {stdout:?}\nstderr: {stderr:?}"
+        "testing a value reached through a scalar-target alias reads nothing\
+         \nstdout: {stdout:?}\nstderr: {stderr:?}"
     );
-    assert!(
-        stderr.contains("invalid escape sequence"),
-        "stderr: {stderr}"
-    );
+    assert_eq!(stdout.trim(), "1", "stderr: {stderr:?}");
+
+    // The control: materializing that same value still raises.
+    for filter in [".b", ".a"] {
+        let (_, stderr, code) = run_yq_stdin_with_stderr(filter, doc, &[])?;
+        assert_ne!(code, 0, "`{filter}` -- stderr: {stderr:?}");
+        assert!(
+            stderr.contains("invalid escape sequence"),
+            "`{filter}` -- stderr: {stderr}"
+        );
+    }
 
     Ok(())
 }
@@ -39823,93 +39878,57 @@ fn test_foreach_register_reentry_is_jq_mode_only_on_the_write_side_2161() -> Res
     Ok(())
 }
 
-/// #2476, yq twin of `test_ambient_validation_agrees_with_bridge_2476` in
+/// #2692, yq twin of `test_truthiness_probes_validate_nothing_2692` in
 /// `tests/jq_cli_tests.rs`: the same corpus through the YAML cursor (and, for
-/// the JSON-syntax rows, through yq's own reading of them -- most of the
-/// JSON comma-gap shapes are *valid* YAML plain scalars, so those rows pin
-/// exit 0 on every probe rather than a raise). See the jq test for what the
-/// corpus is for and why agreement alone is not the assertion.
+/// the JSON-syntax rows, through yq's own reading of them -- most of the JSON
+/// comma-gap shapes are *valid* YAML plain scalars, which is why they always
+/// answered). See the jq test for what the corpus is for and why agreement
+/// alone is not the assertion.
+///
+/// Every row answers here, with no "unbuildable" exceptions: YAML has no
+/// unterminated-input shape in this list, so the split the jq twin carries
+/// has nothing to catch on this side.
 #[test]
-fn test_ambient_validation_agrees_with_bridge_2476() -> Result<()> {
+fn test_truthiness_probes_validate_nothing_2692() -> Result<()> {
     let deep200 = format!("{}1{}\n", "[".repeat(100), "]".repeat(100));
-    // (label, document, expected exit code, expected stderr substring)
-    let corpus: &[(&str, &str, i32, &str)] = &[
-        (
-            "decode failure, mapping value",
-            "a: \"bad\\q\"\n",
-            1,
-            "invalid escape sequence",
-        ),
-        (
-            "decode failure, in flow sequence",
-            "a: [\"bad\\q\"]\n",
-            1,
-            "invalid escape sequence",
-        ),
+    // (label, document)
+    let corpus: &[(&str, &str)] = &[
+        ("decode failure, mapping value", "a: \"bad\\q\"\n"),
+        ("decode failure, in flow sequence", "a: [\"bad\\q\"]\n"),
         (
             "decode failure, anchored container (root walk reaches the anchor)",
             "a: &a [\"bad\\q\"]\nb: *a\n",
-            1,
-            "invalid escape sequence",
         ),
         (
             "decode failure, anchored scalar",
             "a: &a \"bad\\q\"\nb: *a\n",
-            1,
-            "invalid escape sequence",
         ),
-        (
-            "decode failure, block sequence",
-            "- \"bad\\q\"\n",
-            1,
-            "invalid escape sequence",
-        ),
-        (
-            "decode failure, root scalar",
-            "\"bad\\q\"\n",
-            1,
-            "invalid escape sequence",
-        ),
+        ("decode failure, block sequence", "- \"bad\\q\"\n"),
+        ("decode failure, root scalar", "\"bad\\q\"\n"),
         (
             "decode failure, nested mapping",
             "a:\n  b:\n    c: \"bad\\q\"\n",
-            1,
-            "invalid escape sequence",
         ),
-        (
-            "decode failure, explicitly tagged",
-            "a: !!int \"bad\\q\"\n",
-            1,
-            "invalid escape sequence",
-        ),
+        ("decode failure, explicitly tagged", "a: !!int \"bad\\q\"\n"),
         (
             "#1642 colliding undecodable keys (JSON syntax)",
             "{\"\\ud800\":1,\"\\ud800\":2}",
-            1,
-            "is ambiguous",
         ),
         (
             "#1642 single undecodable key (JSON syntax)",
             "{\"\\ud800\": 1, \"b\": 2}",
-            0,
-            "",
         ),
-        ("#1194 shape is a valid YAML mapping", "{123: 1}", 0, ""),
-        (
-            "JSON structural error is a valid plain scalar",
-            "[xyz123]",
-            0,
-            "",
-        ),
-        ("JSON trailing comma is valid YAML flow", "[1,]", 0, ""),
-        ("JSON lone comma is valid YAML flow", "[,]", 0, ""),
-        ("duplicate keys (valid)", "a: 1\na: 2\n", 0, ""),
-        ("flow trailing comma", "a: [1,]\n", 0, ""),
-        ("flow mapping trailing comma", "a: {b: 1,}\n", 0, ""),
-        ("deep, within the guard", deep200.as_str(), 0, ""),
-        ("null root", "null\n", 0, ""),
-        ("false root", "false\n", 0, ""),
-        ("well-formed", "a: [1, {b: c}]\n", 0, ""),
+        ("#1194 shape is a valid YAML mapping", "{123: 1}"),
+        ("JSON structural error is a valid plain scalar", "[xyz123]"),
+        ("JSON trailing comma is valid YAML flow", "[1,]"),
+        ("JSON lone comma is valid YAML flow", "[,]"),
+        ("duplicate keys (valid)", "a: 1\na: 2\n"),
+        ("flow trailing comma", "a: [1,]\n"),
+        ("flow mapping trailing comma", "a: {b: 1,}\n"),
+        ("deep, within the guard", deep200.as_str()),
+        ("null root", "null\n"),
+        ("false root", "false\n"),
+        ("well-formed", "a: [1, {b: c}]\n"),
     ];
     // #2173 moved the closed terms out of this list -- see the jq twin's
     // own comment. They no longer validate anything, so they cannot agree
@@ -39930,18 +39949,14 @@ fn test_ambient_validation_agrees_with_bridge_2476() -> Result<()> {
         ("0 - 0", "0"),
         ("(-(1))", "-1"),
     ];
-    for (label, doc, want_code, want_stderr) in corpus {
+    for (label, doc) in corpus {
         let mut seen: Vec<(String, i32, String)> = Vec::new();
         for probe in probes {
             let (_stdout, stderr, code) = run_yq_stdin_with_stderr(probe, doc, &[])?;
             let first = stderr.lines().next().unwrap_or("").to_string();
             assert_eq!(
-                code, *want_code,
-                "[{label}] `{probe}`: exit {code}, want {want_code}\nstderr: {stderr}"
-            );
-            assert!(
-                first.contains(want_stderr),
-                "[{label}] `{probe}`: stderr {first:?} lacks {want_stderr:?}"
+                code, 0,
+                "[{label}] `{probe}`: exit {code}, want 0\nstderr: {stderr}"
             );
             seen.push((probe.to_string(), code, first));
         }
@@ -39950,7 +39965,7 @@ fn test_ambient_validation_agrees_with_bridge_2476() -> Result<()> {
             assert_eq!(
                 (code, first),
                 (ref_code, ref_first),
-                "[{label}] `{probe}` disagrees with `select(.) | 1`"
+                "[{label}] `{probe}` disagrees with the reads-nothing reference `1==1`"
             );
         }
         // #2173: a closed term answers exactly as `empty` does -- the
@@ -40090,47 +40105,43 @@ fn test_wildcard_bridge_over_alias_fanout_completes_2173() -> Result<()> {
 /// #2476's one behaviour change: #1804's accepted trade-off, now shared by
 /// `and`/`or`.
 ///
-/// The ungated arms answer through `ambient_validation_error`, which is
-/// `push_generic_document_validation_error` -- and since #1804 that walk
-/// does not descend into a container reached through an alias (that
-/// short-circuit is exactly what makes it `O(N)` on the fan-out where the
-/// bridge is `O(2^N)`). So a decode failure reachable *only* through such an
-/// alias no longer raises from an `and`/`or` at that position, where the
-/// bridge's materialization used to raise. `select(.b) | 1` already answered
-/// `1` on this document before #2476
-/// (`test_select_no_longer_raises_on_decode_failure_reachable_only_via_alias_1804`),
-/// so this is the two routes converging, not a new class of silence.
+/// #2476 answered at the *alias* position only, and did so by inheriting
+/// #1804's short-circuit: the ambient validation walk did not descend into a
+/// container reached through an alias, which is exactly what made it `O(N)`
+/// where the bridge was `O(2^N)`. The anchor position and the root still
+/// raised, because the walk reached the failure from there. That left a
+/// genuinely odd split -- the same `true and true` answered or raised
+/// depending on which of two names for one node it stood on.
 ///
-/// Everything that actually reads the value still raises, and both are
-/// asserted below: `.b[0]` materializes through the alias, and
-/// `.a | (true and true)` starts its walk at the *anchor*, which is not an
-/// alias node, so the walk descends and finds the failure. Real yq rejects
-/// this whole document at parse time ("found unknown escape character",
-/// confirmed live against v4.53.3), so there is no yq behaviour to match
-/// either way.
+/// #2692 removed the walk, so the split is gone: `and`/`or` read no part of
+/// the document at any of the three positions and all three answer.
+/// `select(.b) | 1` answered on this document from #1804 onward
+/// (`test_select_no_longer_raises_on_decode_failure_reachable_only_via_alias_1804`)
+/// and `select(.a) | 1` joined it here, which is the two routes finally fully
+/// converging rather than a new class of silence.
+///
+/// Everything that actually reads the value still raises, and both shapes are
+/// asserted below. Real yq rejects this whole document at parse time ("found
+/// unknown escape character", confirmed live against v4.53.3), so there is no
+/// yq behaviour to match either way.
 #[test]
-fn test_and_or_no_longer_raise_through_a_container_alias_2476() -> Result<()> {
+fn test_and_or_no_longer_raise_anywhere_over_an_alias_fanout_2476_2692() -> Result<()> {
     let doc = "a: &a [\"bad\\qc\"]\nb: *a\n";
 
-    // The alias position: the walk stops at the alias, so the boolean
-    // answers instead of raising. This is the row #2476 changed (exit 1
-    // before it, exit 0 after).
-    //
-    // Spelled with a `.` operand since #2173. `true and true` no longer
-    // walks at *any* position -- it reads nothing, so it validates nothing
-    // -- which would make these rows pass for the wrong reason and stop
-    // saying anything about aliases at all. `. and true` reads, so it
-    // still walks, and the alias short-circuit is still what decides it.
-    for filter in [".b | (. and true)", ".b | (false or .)"] {
-        let (stdout, stderr, code) = run_yq_stdin_with_stderr(filter, doc, &[])?;
-        assert_eq!(code, 0, "`{filter}` -- stderr: {stderr:?}");
-        assert_eq!(stdout.trim(), "true", "`{filter}` -- stderr: {stderr:?}");
-    }
-
-    // #2173's own row, here so the contrast is visible in one place: the
-    // closed spelling answers at every position, including the two that
-    // raise below.
+    // Every position, both spellings. #2476 made the *alias* position answer
+    // by inheriting #1804's short-circuit (the walk stopped at an alias);
+    // #2173 made the *closed* spelling answer everywhere (it reads nothing);
+    // #2692 removed the walk, so the remaining split -- `. and true`
+    // answering at `.b` and raising at `.a`, for two names of one node --
+    // is gone too.
     for filter in [
+        // Reads `.`'s truthiness. Raised at the anchor and at the root until
+        // #2692; `is_falsy` decodes nothing, so all three answer now.
+        ".b | (. and true)",
+        ".b | (false or .)",
+        ".a | (. and true)",
+        ". and true",
+        // Reads nothing at all -- #2173's rows, answering since then.
         "true and true",
         ".a | (true and true)",
         ".b | (true and true)",
@@ -40140,32 +40151,16 @@ fn test_and_or_no_longer_raise_through_a_container_alias_2476() -> Result<()> {
         assert_eq!(stdout.trim(), "true", "`{filter}` -- stderr: {stderr:?}");
     }
 
-    // Reading through the alias still raises...
-    let (_, stderr, code) = run_yq_stdin_with_stderr(".b[0]", doc, &[])?;
-    assert_ne!(code, 0, "stderr: {stderr:?}");
-    assert!(
-        stderr.contains("invalid escape sequence"),
-        "stderr: {stderr}"
-    );
-
-    // ...and so does the same boolean at the anchor itself.
-    let (_, stderr, code) = run_yq_stdin_with_stderr(".a | (. and true)", doc, &[])?;
-    assert_ne!(code, 0, "stderr: {stderr:?}");
-    assert!(
-        stderr.contains("invalid escape sequence"),
-        "stderr: {stderr}"
-    );
-
-    // The document root reaches the anchor without going through an alias,
-    // so a root-level `and` raises too -- the corpus test's own
-    // "anchored container" row, restated here so the three positions this
-    // test cares about sit together.
-    let (_, stderr, code) = run_yq_stdin_with_stderr(". and true", doc, &[])?;
-    assert_ne!(code, 0, "stderr: {stderr:?}");
-    assert!(
-        stderr.contains("invalid escape sequence"),
-        "stderr: {stderr}"
-    );
+    // What still raises, and the only thing that does: actually reading the
+    // value, through the alias or at the anchor.
+    for filter in [".b[0]", ".a", ".a[0]"] {
+        let (_, stderr, code) = run_yq_stdin_with_stderr(filter, doc, &[])?;
+        assert_ne!(code, 0, "`{filter}` -- stderr: {stderr:?}");
+        assert!(
+            stderr.contains("invalid escape sequence"),
+            "`{filter}` -- stderr: {stderr}"
+        );
+    }
 
     Ok(())
 }
@@ -40206,58 +40201,56 @@ fn test_not_over_alias_fanout_completes_2476() -> Result<()> {
     Ok(())
 }
 
-/// #2476's `not` sibling of
-/// `test_and_or_no_longer_raise_through_a_container_alias_2476`: `not`
-/// shares the same `push_generic_truthiness` walk `and`/`or` do (inline,
-/// via its `OneCursor` arm), so it inherits #1804's identical trade-off. A
-/// decode failure reachable *only* through a container-target alias no
-/// longer raises from `not` at that alias position; visiting the anchor
-/// directly, or materializing through the alias, still raises.
+/// #2476/#2692: `not`'s sibling of
+/// `test_and_or_no_longer_raise_anywhere_over_an_alias_fanout_2476_2692`.
 ///
-/// The second document is the scalar-target sibling from
-/// `test_select_still_raises_on_decode_failure_reachable_only_via_scalar_alias_1804`:
-/// #1804 scoped its short-circuit to a *container* reached through an alias,
-/// not a bare scalar one -- resolving a scalar alias is O(1), never part of
-/// the fan-out this issue fixes -- so `.b | not` still raises there. Real yq
-/// rejects both documents at parse time (confirmed live against v4.53.3), so
-/// there is no yq behaviour to match either way.
+/// `not` shares the same `push_generic_truthiness` route `and`/`or` do (via
+/// its `OneCursor` arm), so it tracked that history exactly: #2476 had it
+/// answer at a *container*-target alias position by inheriting #1804's
+/// short-circuit, while the anchor position, the root, and a *scalar*-target
+/// alias all still raised -- #1804 having deliberately scoped its
+/// short-circuit to containers, since resolving one scalar is O(1) and never
+/// part of the fan-out cost it was fixing.
+///
+/// #2692 removed the walk, and with it every one of those distinctions.
+/// `not` is the truthiness of `.` negated, `is_falsy` decodes nothing, and
+/// so no position and no alias target shape raises. The container/scalar
+/// split this test was largely written to pin no longer exists; what is
+/// pinned now is that it does not.
+///
+/// Real yq rejects both documents at parse time (confirmed live against
+/// v4.53.3), so there is no yq behaviour to match either way.
 #[test]
-fn test_not_no_longer_raises_through_a_container_alias_2476() -> Result<()> {
-    let doc = "a: &a [\"bad\\qc\"]\nb: *a\n";
-
-    // The alias position: the walk stops at the alias, so `not` answers
-    // instead of raising. This is the row that changed (exit 1 before, exit
-    // 0 now).
-    let (stdout, stderr, code) = run_yq_stdin_with_stderr(".b | not", doc, &[])?;
-    assert_eq!(code, 0, "stderr: {stderr:?}");
-    assert_eq!(stdout.trim(), "false", "stderr: {stderr:?}");
-
-    // Visiting the anchor itself still raises.
-    let (_, stderr, code) = run_yq_stdin_with_stderr(".a | not", doc, &[])?;
-    assert_ne!(code, 0, "stderr: {stderr:?}");
-    assert!(
-        stderr.contains("invalid escape sequence"),
-        "stderr: {stderr}"
-    );
-
-    // Materializing through the alias still raises.
-    let (_, stderr, code) = run_yq_stdin_with_stderr(".b[0]", doc, &[])?;
-    assert_ne!(code, 0, "stderr: {stderr:?}");
-    assert!(
-        stderr.contains("invalid escape sequence"),
-        "stderr: {stderr}"
-    );
-
-    // The scalar-alias sibling: `.b`'s target is a bare scalar, not a
-    // container, so #1804's short-circuit does not apply and `.b | not`
-    // still raises.
+fn test_not_no_longer_raises_anywhere_over_an_alias_2476_2692() -> Result<()> {
+    let container_doc = "a: &a [\"bad\\qc\"]\nb: *a\n";
+    // #1804 scoped its short-circuit to a container target; a bare scalar
+    // one was excluded, so `.b | not` raised here until #2692.
     let scalar_doc = "a: &a \"bad\\qc\"\nb: *a\n";
-    let (_, stderr, code) = run_yq_stdin_with_stderr(".b | not", scalar_doc, &[])?;
-    assert_ne!(code, 0, "stderr: {stderr:?}");
-    assert!(
-        stderr.contains("invalid escape sequence"),
-        "stderr: {stderr}"
-    );
+
+    for (doc, label) in [
+        (container_doc, "container alias"),
+        (scalar_doc, "scalar alias"),
+    ] {
+        for filter in [".b | not", ".a | not", "not"] {
+            let (stdout, stderr, code) = run_yq_stdin_with_stderr(filter, doc, &[])?;
+            assert_eq!(code, 0, "[{label}] `{filter}` -- stderr: {stderr:?}");
+            assert_eq!(
+                stdout.trim(),
+                "false",
+                "[{label}] `{filter}` -- stderr: {stderr:?}"
+            );
+        }
+    }
+
+    // Materializing still raises, through the alias and at the anchor.
+    for filter in [".b[0]", ".a"] {
+        let (_, stderr, code) = run_yq_stdin_with_stderr(filter, container_doc, &[])?;
+        assert_ne!(code, 0, "`{filter}` -- stderr: {stderr:?}");
+        assert!(
+            stderr.contains("invalid escape sequence"),
+            "`{filter}` -- stderr: {stderr}"
+        );
+    }
 
     Ok(())
 }
@@ -40424,21 +40417,18 @@ fn test_any_all_reject_non_arrays_in_yq_mode_2476() -> Result<()> {
 /// #2476: `any`/`all` now share #1804's accepted trade-off, exactly as the
 /// `not` and `//` arms of this same issue do.
 ///
-/// `any_all_generic` validates its input with
-/// `push_generic_document_validation_error` -- and that walk deliberately
-/// does not descend into a container reached through an alias, because
-/// doing so is what costs `O(2^N)` on a fan-out. The scan that follows
-/// reads `is_falsy`, which materializes nothing. So a decode failure
-/// reachable *only* through an alias to a container no longer raises from
-/// `any`/`all`: `.b | any` on the document below exited 1 with "invalid
-/// escape sequence" before this change (via the bridge's materialization)
-/// and is `true` at exit 0 after it. Both halves verified against a release
-/// build of the parent commit and of this one.
+/// `any_all_generic` validated its input with
+/// `push_generic_document_validation_error` until #2692, and that walk
+/// deliberately did not descend into a container reached through an alias,
+/// because doing so is what costs `O(2^N)` on a fan-out. So under #2476 the
+/// *alias* position answered while the anchor position raised. #2692 removed
+/// the walk entirely -- the scan was always pure `is_falsy`, which
+/// materializes nothing -- so both positions answer and there is no
+/// alias-shaped carve-out left to describe.
 ///
-/// Everything that still raises is pinned here too, so the trade-off cannot
-/// silently widen: visiting the anchor directly, materializing through the
-/// alias, and the scalar-alias sibling #1804's own short-circuit
-/// deliberately excludes.
+/// Everything that still raises is pinned here too, so the rule cannot
+/// silently widen: materializing through the alias, and the scalar-alias
+/// row, which raises for a reason of its own (see its comment below).
 ///
 /// Real yq rejects this document at parse time (`yq` v4.53.3 refuses the
 /// `\q` escape outright), so there is no yq behaviour to match either way.
@@ -40455,15 +40445,14 @@ fn test_any_all_no_longer_raise_on_decode_failure_behind_a_container_alias_2476(
         assert_eq!(stdout.trim(), want, "`{filter}` -- stderr: {stderr:?}");
     }
 
-    // Visiting the anchor itself still raises -- it is not an alias, so the
-    // walk descends into its element and decodes the string.
-    for filter in [".a | any", ".a | all"] {
-        let (_, stderr, code) = run_yq_stdin_with_stderr(filter, doc, &[])?;
-        assert_ne!(code, 0, "`{filter}` -- stderr: {stderr:?}");
-        assert!(
-            stderr.contains("invalid escape sequence"),
-            "`{filter}` -- stderr: {stderr}"
-        );
+    // Since #2692 the anchor position answers too. It is not an alias, so
+    // the old walk descended into its element and decoded the string; with
+    // the walk gone, scanning the element's truthiness reads nothing there
+    // either, and the alias/anchor distinction disappears.
+    for (filter, want) in [(".a | any", "true"), (".a | all", "true")] {
+        let (stdout, stderr, code) = run_yq_stdin_with_stderr(filter, doc, &[])?;
+        assert_eq!(code, 0, "`{filter}` -- stderr: {stderr:?}");
+        assert_eq!(stdout.trim(), want, "`{filter}` -- stderr: {stderr:?}");
     }
 
     // Materializing through the alias still raises.
@@ -40474,10 +40463,13 @@ fn test_any_all_no_longer_raise_on_decode_failure_behind_a_container_alias_2476(
         "stderr: {stderr}"
     );
 
-    // The scalar-alias sibling: `.b`'s target is a bare scalar, not a
-    // container, so #1804's short-circuit does not apply. The walk decodes
-    // it and raises before the yq-mode "only supports arrays" rejection the
-    // scalar would otherwise get -- decode failure wins (#1620/#1989).
+    // The scalar-alias sibling still raises, and #2692 did not change it --
+    // but the reason is worth stating, because it is no longer #1804's
+    // container/scalar scoping. `any` on a *scalar* takes yq mode's "only
+    // supports arrays" rejection, and building that diagnostic materializes
+    // the value (`decode_failure_or`), where the decode failure wins
+    // (#1620/#1989). It raises because something materialized it, which is
+    // the surviving rule rather than an exception to it.
     let scalar_doc = "a: &a \"bad\\qc\"\nb: *a\n";
     for filter in [".b | any", ".b | all"] {
         let (_, stderr, code) = run_yq_stdin_with_stderr(filter, scalar_doc, &[])?;
@@ -40642,101 +40634,82 @@ fn test_alternative_no_longer_raises_through_a_container_alias_2476() -> Result<
     Ok(())
 }
 
-/// `retain_truthy_generic`'s `OneCursor` arm (`eval_generic.rs`) runs its own
-/// `push_generic_document_validation_error` call over the `//`'s *left*
-/// operand specifically, separately from the `ambient_validation_error` call
-/// that guards the whole `Expr::Alternative` arm before either operand runs.
-/// Every existing `//`-and-alias test lands on `ambient_validation_error`
-/// instead, because in each of them the left operand's cursor is the same
-/// position as the ambient `.` (`(. // 1)`, `(key // 1)`, ...) -- so the two
-/// checks always agree and the `OneCursor` arm's own check never gets to
-/// disagree with the ambient one.
+/// #2476/#2692: `//` forwards its operand's cursor untouched, so a `//` at a
+/// position answers exactly as a bare navigation to that position does.
 ///
-/// This document splits the two: the ambient position (`.a`, an object with
-/// one field aliasing a corrupted array) is not itself an alias, so its walk
-/// descends one level and stops at the field's alias cursor (#1804's
-/// short-circuit) without ever reaching the array -- clean. The left operand
-/// (`.q[0]`) navigates *through* that alias into the array's own corrupted
-/// element, a plain scalar cursor with no alias short-circuit of its own, so
-/// only the `OneCursor` arm's check can catch it.
-#[test]
-fn test_alternative_onecursor_validation_error_differs_from_ambient_2476() -> Result<()> {
-    let doc = "x: &X [\"bad\\qc\"]\na:\n  q: *X\n";
-
-    let (_, stderr, code) = run_yq_stdin_with_stderr(".a | (.q[0] // 1)", doc, &[])?;
-    assert_ne!(code, 0, "stderr: {stderr:?}");
-    assert!(
-        stderr.contains("invalid escape sequence"),
-        "stderr: {stderr}"
-    );
-
-    Ok(())
-}
-
-/// `retain_truthy_generic`'s `ManyCursor` arm (`.[] // ...`, a fan-out
-/// through the left operand) hits a validation error partway through the
-/// fan-out, after at least one earlier element was already kept as truthy --
-/// exercising `owned_prefix_partial` (materializing that kept prefix into the
-/// `Partial` this stage terminates with) rather than just the arm's clean
-/// exhaustion path every other `//`-fan-out test takes.
+/// This replaces three tests (`..._onecursor_validation_error_differs_from_ambient_2476`,
+/// `..._manycursor_validation_error_keeps_prefix_2476`,
+/// `..._manycursor_prefix_conversion_error_2476`) that pinned the internals of
+/// a mechanism #2692 deleted. Each was built on `retain_truthy_generic`'s own
+/// `push_generic_document_validation_error` call over the left operand -- one
+/// on that call disagreeing with the separate ambient one, one on the kept
+/// prefix `owned_prefix_partial` materialized when the call failed mid-fan-out,
+/// one on that re-materialization raising an error of its own. With the walk
+/// gone, `//` decides truthiness with `is_falsy` alone and hands the surviving
+/// cursor straight on; two of the three kept passing only because the
+/// *printer* then materialized that cursor and raised, which pins the writer
+/// rather than the operator.
 ///
-/// Same alias-navigation shape as
-/// `test_alternative_onecursor_validation_error_differs_from_ambient_2476`
-/// just above, but `.q[]` instead of `.q[0]`: the ambient `.a` still stops at
-/// the field's alias short-circuit (clean), while the fan-out walks each
-/// array element's own cursor directly. `"ok"` streams out before the error,
-/// matching #400's rule (a generator's truthy prefix survives a
-/// mid-stream raise) -- `select`'s own `test_alternative_no_longer_raises_
-/// through_a_container_alias_2476` sibling never exercises this because its
-/// document has only one, single-element array.
-#[test]
-fn test_alternative_manycursor_validation_error_keeps_prefix_2476() -> Result<()> {
-    let doc = "x: &X [\"ok\", \"bad\\qc\"]\na:\n  q: *X\n";
-
-    let (stdout, stderr, code) = run_yq_stdin_with_stderr(".a | (.q[] // 1)", doc, &[])?;
-    assert_ne!(code, 0, "stderr: {stderr:?}");
-    assert!(
-        stderr.contains("invalid escape sequence"),
-        "stderr: {stderr}"
-    );
-    assert_eq!(stdout.trim(), "ok", "stdout: {stdout:?}");
-
-    Ok(())
-}
-
-/// `owned_prefix_partial`'s own `Err` arm (`src/jq/eval_generic.rs`) --
-/// #2661 tagged this branch unreachable on the premise that `kept` only ever
-/// holds already-successfully-converted items, but that premise doesn't hold
-/// for `retain_truthy_generic`'s `ManyCursor` arm: it only runs the cheap
-/// [`push_generic_document_validation_error`] walk before keeping a cursor,
-/// and that walk stops at a container-target alias (#1804) without
-/// descending into it -- so a kept item can be an alias to a corrupt
-/// container, passing the cheap check while its real materialization still
-/// fails.
+/// Their documents are kept, because the alias-through-navigation shapes are
+/// still the sharpest ones available: the ambient position (`.a`) is an object
+/// whose one field aliases a corrupted array, while the left operand navigates
+/// *through* that alias into the array's own elements.
 ///
-/// `*X` (an alias to an object with two different decode-failure keys that
-/// collide under YAML's shared `""` display fallback, #1642) is the first
-/// `.q[]` element and passes the cheap check -- container aliases are
-/// truthy regardless of contents -- so it lands in `kept`. The second
-/// element is a plain (non-aliased) decode failure, which the cheap check
-/// does catch and which becomes this fan-out's terminating `control`.
-/// `owned_prefix_partial` then re-converts `kept` for real via
-/// `to_owned_cursor`, which has no alias short-circuit: it dereferences `*X`
-/// and hits the #1642 collision instead, replacing the terminating
-/// `control` with its own error -- the precedence the function's own doc
-/// comment already claims (mirroring [`flatten_generic_results`]), just via
-/// a different element than any existing test exercised. Pinning this as
-/// the intended, documented behavior, not proposing a change to it.
+/// Real yq rejects every document here at parse time, so there is no yq
+/// behaviour to match either way.
 #[test]
-fn test_alternative_manycursor_prefix_conversion_error_2476() -> Result<()> {
-    let doc = "x: &X {\"a\\qb\": 1, \"c\\qd\": 2}\ny: &Y [*X, \"bad\\qe\"]\na:\n  q: *Y\n";
+fn test_alternative_forwards_its_operands_cursor_untouched_2476_2692() -> Result<()> {
+    // (label, document, `//` filter, the bare navigation it must match)
+    let cases: &[(&str, &str, &str, &str)] = &[
+        (
+            "single corrupted element",
+            "x: &X [\"bad\\qc\"]\na:\n  q: *X\n",
+            ".a | (.q[0] // 1)",
+            ".a | .q[0]",
+        ),
+        (
+            "fan-out, corruption after a clean element",
+            "x: &X [\"ok\", \"bad\\qc\"]\na:\n  q: *X\n",
+            ".a | (.q[] // 1)",
+            ".a | (.q[] , empty)",
+        ),
+        (
+            // `*X` is an object with two decode-failure keys that collide
+            // under YAML's shared `""` display fallback (#1642), so the
+            // first element raises a *different* error than the second.
+            // Whichever the bare navigation reports, `//` reports too.
+            "fan-out, colliding-key alias first",
+            "x: &X {\"a\\qb\": 1, \"c\\qd\": 2}\ny: &Y [*X, \"bad\\qe\"]\na:\n  q: *Y\n",
+            ".a | (.q[] // 1)",
+            ".a | (.q[] , empty)",
+        ),
+    ];
 
-    let (stdout, stderr, code) = run_yq_stdin_with_stderr(".a | (.q[] // 1)", doc, &[])?;
-    assert_ne!(code, 0, "stderr: {stderr:?}");
-    // The re-conversion's own error (`*X`'s #1642 collision), not the
-    // fan-out's original terminating control (`"bad\qe"`'s escape error).
-    assert!(stderr.contains("ambiguous"), "stderr: {stderr}");
-    assert_eq!(stdout.trim(), "", "stdout: {stdout:?}");
+    for (label, doc, alternative, bare) in cases {
+        let (alt_out, alt_err, alt_code) = run_yq_stdin_with_stderr(alternative, doc, &[])?;
+        let (bare_out, bare_err, bare_code) = run_yq_stdin_with_stderr(bare, doc, &[])?;
+        assert_ne!(
+            alt_code, 0,
+            "[{label}] `{alternative}` must still raise -- stdout {alt_out:?}"
+        );
+        assert_eq!(
+            (alt_code, alt_err.lines().next().unwrap_or("")),
+            (bare_code, bare_err.lines().next().unwrap_or("")),
+            "[{label}] `{alternative}` must answer as `{bare}` does"
+        );
+        assert_eq!(
+            alt_out.trim(),
+            bare_out.trim(),
+            "[{label}] `{alternative}` stdout must match `{bare}`"
+        );
+    }
+
+    // The other half of "forwards untouched": where the bare navigation
+    // answers, so does the `//`, and with the same value.
+    let clean = "a:\n  q: [\"ok\", \"two\"]\n";
+    let (alt_out, _, alt_code) = run_yq_stdin_with_stderr(".a | (.q[] // 1)", clean, &[])?;
+    assert_eq!(alt_code, 0);
+    assert_eq!(alt_out, "ok\ntwo\n");
 
     Ok(())
 }


### PR DESCRIPTION
Closes #2692.

## The defect

On `{123: 1}`, `1+1` answered `2` while `1 and 1`, `not`, `false // 1` and `select(.) | 1` exited 5. Same class of expression, same document, different answers depending on spelling — the split ADR-0018's #2103 amendment exists to remove.

## Two corrections to the issue as filed

**There were two `ambient_validation_error` call sites, not three.** `not`'s raise came from `push_generic_truthiness`'s `OneCursor` arm — the same code `select` and `if` use — so it could not be deleted there without changing `select`.

**The issue's own justification for `not` decides the scope.** It argues truthiness is `is_falsy`, O(1), no decode. That is equally true of `select`, `if`, `any`/`all` and `//`'s left-operand filter. Fixing only the four named arms would have closed one per-spelling split and opened another (`not` answering while `. and true` and `select(.) | 1`, reading the same value by the same call, still raised). So the invariant is sharpened instead:

> **A filter validates only what it materializes.**

Owner decision, taken during planning; recorded as a fourth instance under ADR-0018's #2103 amendment.

## What changed

Walk removed from `ambient_validation_error` (deleted), `push_generic_truthiness`, `retain_truthy_generic` and `any_all_generic`. `push_generic_document_validation_error` keeps exactly one caller — `key_elements_generic`, which materializes a comparison key.

**The streaming route needed a second fix.** `eval_each_generic` sent `and`/`or`/`//` to `bridge_to_each_owned_flow`, whose `to_owned_with_cursor` materialized — and therefore validated — the whole document. That is why a top-level `true and true` raised while a nested `[true and true]` did not. `and`/`or` now take the existing native `each_boolean_generic` ungated; `//` gets `each_alternative_generic`, a new lazy twin of `eval::each_alternative`. Falling back to `eval_single`'s eager arm was not viable — `first(repeat(1) // 9)` terminates only through the lazy route. It delegates every truthiness decision to `retain_truthy_generic` so the two `//` routes cannot drift (#106), and matches pinned jq 1.7.1 on all 13 oracle rows from `each_alternative`'s doc comment, including the `?//` retry and laziness rows.

Side effects, both recorded: every top-level `//`/`and`/`or` stops materializing the document, and those seven arms stop reaching the `MAX_NESTING_DEPTH` guard they only ever met through the removed walk.

## Fidelity gain found by the issue's own "confirm, don't assume" step

The issue asked that path-context shapes be verified unchanged. One moved, in jq mode only: `{"a":{"b":1}} | .a | (key // 1)` was `1` and is now `"a"`, with `parent`/`path` likewise. The old answers came from the bridge re-rooting the document, so `key` resolved against a fresh root and produced nothing — and "nothing" is not truthy, so `//` substituted the other side. A bare `.a | key` answered `"a"` throughout. #2476 fixed this for yq mode against yq v4.53.3's answers; jq mode never benefited because its top-level `//` did not reach that arm. yq mode is byte-identical on all six shapes probed.

## Tests

Both corpus tests are repointed rather than retired: the reference probe moves to a reads-nothing filter and every truthiness reader must agree with it, which pins the new invariant directly (33 jq rows, 21 yq rows). #1804's container-vs-scalar-alias carve-out is gone with the walk it was a property of. Every expectation was captured from the built binary, not predicted.

## Verification

fmt, both clippy legs, `cargo doc` with `-D warnings`, `no_std`, the full CI CLI set (jq 1550, yq 1740), lib, and the M2 streaming sweep (744 cases vs pinned jq 1.7.1).

**No performance numbers.** The change deletes real work, but the dev machine was not idle, and this project's benchmarking discipline says that is not a measurement. An interleaved A/B on the pinned hosts would close it out.

## Notes for review

- One commit adopts work found uncommitted in the worktree, written against this branch by another session. Verified before adopting; its provenance is stated in the commit message. It reviews the arm this PR adds (restoring #1609's win, removing a duplicated control-flow mapping) and documents the depth-guard corollary.
- I filed issue #2711 mid-work on a **stale pre-rebase binary** and it was wrong; closed as invalid, and the test comment it produced is corrected in the last commit.
- Rebased across #2173, #2626 and #2627 landing on `main` mid-flight. #2626 removed the `Expr::Arithmetic` gate outright, superseding a comment here; main's side was taken and one stale gate reference fixed.
- Re-measured and commented on #2626 and #2627 rather than closing them; #2628 was already closed. Filed #2710 for a golden-file drift that predates this branch.