### PR TITLE
fix(yaml): reach across a document boundary for #798's comment attachment

### DIFF
--- a/src/yaml/index.rs
+++ b/src/yaml/index.rs
@@ -1243,6 +1243,63 @@ mod tests {
         )
     }
 
+    /// `head`/`foot` of document `di`'s own content node (0-indexed) — what
+    /// real yq answers `select(di==N) | . | head_comment` from. Used by the
+    /// multi-document boundary tests below, which reach past document 0.
+    fn doc_head_foot_at(yaml: &[u8], di: usize) -> (Vec<String>, Vec<String>) {
+        use crate::yaml::light::YamlValue;
+
+        let index = YamlIndex::build(yaml).expect("valid YAML");
+        let root = index.root(yaml);
+        let YamlValue::Sequence(docs) = root.value() else {
+            panic!("root is always the virtual document sequence"); // omni-dev: coverage tolerate-line reason="unreachable: YamlIndex::build always wraps the parsed document(s) in a virtual root Sequence, at TY index 0 (#798)"
+        };
+        let mut rest = docs;
+        for _ in 0..di {
+            let (_, tail) = rest.uncons_cursor().expect("document index in range");
+            rest = tail;
+        }
+        let (doc_cursor, _) = rest.uncons_cursor().expect("document index in range");
+        let bp = doc_cursor.bp_position();
+        (
+            raw_lines(yaml, index.get_head_comments(bp)),
+            raw_lines(yaml, index.get_foot_comments(bp)),
+        )
+    }
+
+    /// `head`/`foot` of a top-level mapping entry's *key* node within
+    /// document `di` (0-indexed). See [`Self::doc_head_foot_at`].
+    fn field_key_head_foot_in_doc(yaml: &[u8], di: usize, key: &str) -> (Vec<String>, Vec<String>) {
+        use crate::yaml::light::YamlValue;
+
+        let index = YamlIndex::build(yaml).expect("valid YAML");
+        let root = index.root(yaml);
+        let YamlValue::Sequence(docs) = root.value() else {
+            panic!("root is always the virtual document sequence"); // omni-dev: coverage tolerate-line reason="unreachable: YamlIndex::build always wraps the parsed document(s) in a virtual root Sequence, at TY index 0 (#798)"
+        };
+        let mut rest = docs;
+        for _ in 0..di {
+            let (_, tail) = rest.uncons_cursor().expect("document index in range");
+            rest = tail;
+        }
+        let (doc_cursor, _) = rest.uncons_cursor().expect("document index in range");
+        let YamlValue::Mapping(fields) = doc_cursor.value() else {
+            panic!("expected a mapping document"); // omni-dev: coverage tolerate-line reason="unreachable: every fixture field_key_head_foot_in_doc is called with in this test module is a top-level mapping (#798)"
+        };
+        for field in fields {
+            if let YamlValue::String(k) = field.key() {
+                if k.raw_bytes() == key.as_bytes() {
+                    let bp = field.key_cursor().bp_position();
+                    return (
+                        raw_lines(yaml, index.get_head_comments(bp)),
+                        raw_lines(yaml, index.get_foot_comments(bp)),
+                    );
+                }
+            } // omni-dev: coverage tolerate-line reason="unreachable: a mapping key is always emitted as YamlValue::String -- it is never type-inferred like a value (#222), so this if-let's pattern can never fail to match (#798)"
+        }
+        panic!("key {key} not found in document {di}"); // omni-dev: coverage tolerate-line reason="unreachable: every call to field_key_head_foot_in_doc in this test module passes a key that the fixture's document actually has (#798)"
+    }
+
     /// `head`/`foot` of a nested mapping entry's key, reached as
     /// `outer.inner` — the `.a.b | key | head_comment` shape.
     fn nested_key_head_foot(yaml: &[u8], outer: &str, inner: &str) -> (Vec<String>, Vec<String>) {
@@ -1481,6 +1538,40 @@ mod tests {
         );
     }
 
+    /// `blank_line_between`/`blank_line_precedes` (`src/yaml/parser.rs`)
+    /// both special-case a CRLF so it counts as one line break rather than
+    /// two -- otherwise a lone `\r\n` between a comment and the next node
+    /// would be misread as a blank line. Every shape here needs the CRLF
+    /// to sit *inside* the scanned range (not just at its edge) to actually
+    /// exercise that collapse, mirroring the LF originals:
+    /// `standalone_comment_attaches_forward_to_the_next_key_798`,
+    /// `a_blank_line_before_a_block_still_attaches_it_forward_798`,
+    /// `a_blank_line_after_a_block_attaches_it_back_to_the_previous_key_798`,
+    /// `a_trailing_block_at_eof_attaches_back_to_the_last_key_798`.
+    #[test]
+    fn crlf_blank_line_detection_collapses_each_crlf_to_one_break_798() {
+        // No blank line: forward-attaches to `b`, same as the LF case --
+        // `blank_line_between`'s scanned range holds exactly one CRLF, and
+        // must not miscount it as two breaks.
+        let (head, _) = field_key_head_foot(b"a: 1\r\n# mid\r\nb: 2\r\n", "b");
+        assert_eq!(head, ["# mid"]);
+
+        // A blank line *before* the comment: `blank_line_precedes` walks
+        // back over a CRLF to find the line before it.
+        let (head, _) = field_key_head_foot(b"a: 1\r\n\r\n# mid\r\nb: 2\r\n", "b");
+        assert_eq!(head, ["# mid"]);
+
+        // A blank line *after* the comment: `blank_line_between`'s scanned
+        // range now holds two full CRLFs back to back, so it must collapse
+        // the first before it can even reach the second.
+        let (_, foot) = field_key_head_foot(b"a: 1\r\n# mid\r\n\r\nb: 2\r\n", "a");
+        assert_eq!(foot, ["# mid"]);
+
+        // Trailing block at EOF, no next node at all.
+        let (_, foot) = field_key_head_foot(b"a: 1\r\nb: 2\r\n# trail\r\n", "b");
+        assert_eq!(foot, ["# trail"]);
+    }
+
     #[test]
     fn the_raw_range_keeps_the_hash_and_any_odd_spacing_798() {
         // `# ` (hash *space*) is stripped at read time, so a tab-separated
@@ -1499,6 +1590,102 @@ mod tests {
         let (head, foot) = virtual_root_head_foot(b"# only\n");
         assert_eq!(head, ["# only"]);
         assert!(foot.is_empty(), "{foot:?}");
+    }
+
+    /// A block sitting directly against a `---` boundary (no blank line
+    /// between it and the marker) stays with the *closing* document as its
+    /// own root foot, rather than following the ordinary
+    /// adjacent-attaches-forward rule onto the new document's head. Measured
+    /// against pinned yq v4.53.3:
+    /// `printf 'a: 1\n# mid\n---\nb: 2\n' | yq eval-all 'select(di==0) | . | foot_comment'`
+    /// => `mid`, with document 1's root head, `.a`'s key foot, and `.b`'s
+    /// key head all empty.
+    #[test]
+    fn a_block_adjacent_to_a_document_boundary_stays_with_the_closing_document_798() {
+        let yaml = b"a: 1\n# mid\n---\nb: 2\n";
+        let (_, doc0_foot) = doc_head_foot_at(yaml, 0);
+        assert_eq!(doc0_foot, ["# mid"]);
+        let (doc1_head, _) = doc_head_foot_at(yaml, 1);
+        assert!(doc1_head.is_empty(), "{doc1_head:?}");
+        let (_, a_foot) = field_key_head_foot_in_doc(yaml, 0, "a");
+        assert!(a_foot.is_empty(), "{a_foot:?}");
+        let (b_head, _) = field_key_head_foot_in_doc(yaml, 1, "b");
+        assert!(b_head.is_empty(), "{b_head:?}");
+    }
+
+    /// A block separated from the `---` boundary by a blank line takes the
+    /// ordinary path instead, attaching to `PREV` within the closing
+    /// document (its last key) exactly as it would without the boundary at
+    /// all. Measured: `.a | key | foot_comment` == "mid" for document 0;
+    /// document 0's own root foot is empty.
+    #[test]
+    fn a_block_separated_from_a_document_boundary_by_a_blank_attaches_to_prev_798() {
+        let yaml = b"a: 1\n# mid\n\n---\nb: 2\n";
+        let (_, a_foot) = field_key_head_foot_in_doc(yaml, 0, "a");
+        assert_eq!(a_foot, ["# mid"]);
+        let (_, doc0_foot) = doc_head_foot_at(yaml, 0);
+        assert!(doc0_foot.is_empty(), "{doc0_foot:?}");
+    }
+
+    /// A block right after `---`, with no blank line before the new
+    /// document's first key, attaches forward to that key's head exactly
+    /// like an ordinary in-document adjacent block -- unaffected by the
+    /// boundary since it never needs the no-`PREV` fallback. Measured:
+    /// `.b | key | head_comment` == "mid".
+    #[test]
+    fn a_block_right_after_a_document_boundary_attaches_forward_to_the_next_key_798() {
+        let yaml = b"a: 1\n---\n# mid\nb: 2\n";
+        let (b_head, _) = field_key_head_foot_in_doc(yaml, 1, "b");
+        assert_eq!(b_head, ["# mid"]);
+        let (_, doc0_foot) = doc_head_foot_at(yaml, 0);
+        assert!(doc0_foot.is_empty(), "{doc0_foot:?}");
+    }
+
+    /// A block right after `---`, separated from the new document's first
+    /// key by a blank line, has no `PREV` in the new document (nothing has
+    /// opened there yet) -- it reaches back across the boundary onto the
+    /// *closing* document's root foot instead of following the new
+    /// document's key forward. Measured: `select(di==0) | . | foot_comment`
+    /// == "mid"; `.b | key | head_comment` and document 1's own head are
+    /// both empty. This is the no-`PREV` fallback
+    /// [`Self::document_boundary_fallback_bp`] (`src/yaml/parser.rs`) exists
+    /// for.
+    #[test]
+    fn a_block_after_a_boundary_detached_by_a_blank_falls_back_to_the_closing_document_798() {
+        let yaml = b"a: 1\n---\n# mid\n\nb: 2\n";
+        let (_, doc0_foot) = doc_head_foot_at(yaml, 0);
+        assert_eq!(doc0_foot, ["# mid"]);
+        let (b_head, _) = field_key_head_foot_in_doc(yaml, 1, "b");
+        assert!(b_head.is_empty(), "{b_head:?}");
+        let (doc1_head, _) = doc_head_foot_at(yaml, 1);
+        assert!(doc1_head.is_empty(), "{doc1_head:?}");
+    }
+
+    /// The fallback is armed once per document and consumed the moment a
+    /// real node opens -- after `.b` opens as document 1's first key, a
+    /// *second*, later blank-detached block in the same document must fall
+    /// forward as usual (onto document 1's own head or later keys), never
+    /// reaching back across the boundary a second time.
+    #[test]
+    fn the_boundary_fallback_does_not_survive_past_the_first_key_of_the_new_document_798() {
+        let yaml = b"a: 1\n---\nb: 1\n\n# mid\n\nc: 2\n";
+        let (_, b_foot) = field_key_head_foot_in_doc(yaml, 1, "b");
+        assert!(b_foot.is_empty(), "{b_foot:?}");
+        let (c_head, _) = field_key_head_foot_in_doc(yaml, 1, "c");
+        assert_eq!(c_head, ["# mid"]);
+        let (_, doc0_foot) = doc_head_foot_at(yaml, 0);
+        assert!(doc0_foot.is_empty(), "{doc0_foot:?}");
+    }
+
+    /// A leading block before the very first document's own `---` has no
+    /// closing document to reach back to, so it must take the ordinary path
+    /// (document 0's own head) rather than being silently dropped by the
+    /// boundary-aware flush. Regression guard for the `old_root_bp: None`
+    /// arm of `flush_pending_head_lines_at_boundary`.
+    #[test]
+    fn a_leading_block_before_the_first_documents_own_marker_is_still_its_head_798() {
+        let (head, _) = doc_head_foot_at(b"# lead\n---\na: 1\n", 0);
+        assert_eq!(head, ["# lead"]);
     }
 
     #[test]

--- a/src/yaml/parser.rs
+++ b/src/yaml/parser.rs
@@ -282,6 +282,22 @@ struct Parser<'a, const HAS_CR: bool> {
     /// (#798). Distinguishes a block trailing real content (the document
     /// root's *foot*) from a comment-only document (its *head*).
     saw_head_foot_node: bool,
+    /// Whether [`Self::start_document`] has run at least once (#798) --
+    /// distinguishes "no previous document" (very first `start_document`
+    /// call) from "previous document's root is bp 0", which is otherwise
+    /// indistinguishable from the field's zero-initialized state.
+    seen_any_document: bool,
+    /// The root bp of whichever document [`Self::last_head_foot_bp`]'s `None`
+    /// currently means "nothing has opened in the *new* document yet",
+    /// rather than "a blank line detached the in-document `PREV`" (#798).
+    ///
+    /// Set at every [`Self::start_document`] to the document that just
+    /// closed (or `None` for the very first document), and cleared the
+    /// moment any node opens in the new document -- from then on an
+    /// in-document blank-line detachment must fall forward as usual, not
+    /// reach back across the boundary a second time. Consulted only by
+    /// [`Self::flush_pending_head_lines`]'s no-`PREV` fallback.
+    document_boundary_fallback_bp: Option<usize>,
 
     // Document tracking
     /// Whether we're currently inside a document
@@ -383,6 +399,8 @@ impl<'a, const HAS_CR: bool> Parser<'a, HAS_CR> {
             last_head_foot_bp: None,
             comment_watermark: 0,
             saw_head_foot_node: false,
+            seen_any_document: false,
+            document_boundary_fallback_bp: None,
             in_document: false,
             document_start_bp_pos: 0,
             pending_explicit_key: None,
@@ -691,6 +709,21 @@ impl<'a, const HAS_CR: bool> Parser<'a, HAS_CR> {
                 self.comments.entry(prev).or_default().foot.append(pending);
                 return;
             }
+            // No `PREV` in *this* document -- if nothing has opened here yet
+            // because we just crossed a `---`/`...` boundary, the block
+            // reaches back across it onto the document that just closed,
+            // rather than forward into this one (measured against pinned yq
+            // v4.53.3: `a: 1\n---\n# mid\n\nb: 2\n` puts `mid` on the first
+            // document's own foot, not `.b`'s head, #798).
+            if let Some(old_root) = self.document_boundary_fallback_bp {
+                let pending = &mut self.pending_head_lines;
+                self.comments
+                    .entry(old_root)
+                    .or_default()
+                    .foot
+                    .append(pending);
+                return;
+            }
         }
         let root = self.document_start_bp_pos;
         let pending = &mut self.pending_head_lines;
@@ -744,6 +777,53 @@ impl<'a, const HAS_CR: bool> Parser<'a, HAS_CR> {
         self.flush_pending_head_lines(Some(bp));
         self.last_head_foot_bp = Some(bp);
         self.saw_head_foot_node = true;
+        // A real node has now opened in this document, so a later blank
+        // line detaching *its own* `PREV` must fall forward as usual, not
+        // reach back across the document boundary a second time (#798).
+        self.document_boundary_fallback_bp = None;
+    }
+
+    /// [`Self::flush_pending_head_lines`], but called from
+    /// [`Self::start_document`] where the pending block may instead belong
+    /// to the document that's *closing*, not the one about to open (#798).
+    ///
+    /// Measured against pinned yq v4.53.3: a block sitting directly against
+    /// a `---`/`...` boundary (no blank line between the block and the
+    /// marker) stays with the closing document as its own root `foot`,
+    /// rather than following the ordinary adjacent-block-attaches-forward
+    /// rule onto the new document's `head` --
+    /// `a: 1\n# mid\n---\nb: 2\n` puts `mid` on document 0's `foot`, not
+    /// document 1's `head`. A block separated from the marker by a blank
+    /// line takes the ordinary path instead (delegated to
+    /// [`Self::flush_pending_head_lines`]), which already resolves it
+    /// correctly onto `PREV` — this runs before `last_head_foot_bp` is
+    /// reset below, so `PREV` is still the closing document's own last key.
+    ///
+    /// `old_root_bp` is `None` for the very first document (nothing to
+    /// reach back to), in which case this always defers to the ordinary
+    /// path.
+    fn flush_pending_head_lines_at_boundary(
+        &mut self,
+        next_bp: Option<usize>,
+        old_root_bp: Option<usize>,
+    ) {
+        if self.pending_head_lines.is_empty() {
+            return;
+        }
+        if let Some(old_root) = old_root_bp {
+            let block_end = self.pending_head_lines[self.pending_head_lines.len() - 1].1 as usize;
+            let adjacent_to_marker = !self.blank_line_between(block_end, self.pos);
+            if adjacent_to_marker {
+                let pending = &mut self.pending_head_lines;
+                self.comments
+                    .entry(old_root)
+                    .or_default()
+                    .foot
+                    .append(pending);
+                return;
+            }
+        }
+        self.flush_pending_head_lines(next_bp);
     }
 
     /// Whether a wholly blank line lies in `[from, to)` — i.e. whether the
@@ -1650,6 +1730,12 @@ impl<'a, const HAS_CR: bool> Parser<'a, HAS_CR> {
     /// This doesn't open a container - the document IS its content.
     fn start_document(&mut self) {
         self.in_document = true;
+        // The document that's closing, if any -- `document_start_bp_pos`
+        // still holds its root right up until the overwrite below.
+        // `seen_any_document` is the only way to tell "no previous document"
+        // apart from "its root happens to be bp 0" (#798).
+        let old_root_bp = self.seen_any_document.then_some(self.document_start_bp_pos);
+        self.seen_any_document = true;
         self.document_start_bp_pos = self.bp_pos;
         // A standalone comment block seen before this document's content
         // belongs to the document's own node, not to its first key -- real
@@ -1661,10 +1747,15 @@ impl<'a, const HAS_CR: bool> Parser<'a, HAS_CR> {
         //
         // Deliberately *before* `pending_head_comment` is cleared below:
         // that field is #784's single floated trailing comment, unrelated to
-        // this block.
+        // this block. Uses the boundary-aware flush, not the ordinary one:
+        // a block still pending here may belong to the *closing* document
+        // instead (see [`Self::flush_pending_head_lines_at_boundary`]).
         let root_bp = self.document_start_bp_pos;
-        self.flush_pending_head_lines(Some(root_bp));
+        self.flush_pending_head_lines_at_boundary(Some(root_bp), old_root_bp);
         self.last_head_foot_bp = None;
+        // Primes the no-`PREV` fallback for whatever comes next in the new
+        // document -- see [`Self::document_boundary_fallback_bp`].
+        self.document_boundary_fallback_bp = old_root_bp;
         // A comment deferred by an anchor in a *previous* document (#784)
         // has no node left to attach to once a new document starts -
         // `parse_document_line`'s own one-line grace period already covers


### PR DESCRIPTION
## Summary
- Code review of #2704 found the standalone-comment attachment it landed diverges from pinned yq v4.53.3 whenever a block sits next to a `---`/`...` document boundary, since `start_document` unconditionally reset `PREV` and treated the new document's root as the only fallback target.
- `document_boundary_fallback_bp` now carries the closing document's root across exactly this gap and is cleared the moment a real node opens in the new document, so a later in-document blank-line detachment still falls forward as usual.
- Also closes a patch-coverage gap the same review found: CRLF-collapse branches in `blank_line_between`/`blank_line_precedes` were reachable and correct but untested, since every existing CRLF probe happened to land on a zero-length scanned range.

## Test plan
- [x] `cargo test` (added CRLF variants of the existing attachment tests, chosen to land inside the scanned range)
- [x] Verified against pinned oracle: block adjacent to marker (no blank line) stays with the closing document's own root foot; block after marker, blank-detached from the new document's first key, falls back the same way