### PR TITLE
perf(build): pin the release profile to one codegen unit + fat LTO (#2603)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -619,6 +619,7 @@ For detailed documentation on optimization techniques used in this project, see 
 - Re-derive a break-even before trusting it (#106: the issue's stated 12.5% dropped a bits-to-bytes conversion; the real gate was 3.125%)
 - A hash table is not automatically cheaper than a sort — above L3 a sort streams and a table does not, and which wins is architecture-dependent (#1514: the same table beat the sort on an M4 Pro and lost 24% to it on a 7950X at 7.1M keys)
 - To attribute a cost, build the binary again with the feature *disabled* and measure that — timings alone cannot separate what a check costs from what the code around it costs (#1514: it proved #1385's cost was 100% its probe, and caught a larger regression introduced by the fix)
+- A build profile is part of the measurement *and* of the shipped binary: at cargo's default 16 codegen units the same commit pair read -14% on x86_64 for a diff that could not reach the queries, and thin LTO left that class in place; `[profile.release]` pins one codegen unit plus fat LTO for it (#2603, closing the class #595/#1587/#2655 kept filing). Release builds compile ~3x slower; the debug loop is untouched
 
 ### Benchmarking Discipline
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,18 @@ include = [
     "README.md",
 ]
 
+# Pinned rather than left at cargo's default (codegen-units = 16, no LTO)
+# because the default made the shipped binary's speed depend on code the
+# query never runs: the same two commits, whose diff cannot reach a `length`
+# query, measured -14% apart on x86_64 at 16 codegen units and +2% apart
+# here (#2603; the same class as #595 and #1587). Thin LTO does not remove
+# that class -- a single codegen unit does. Release builds compile ~3x
+# slower for it; the debug builds `cargo test`/`clippy` use are untouched.
+# Measurements and the profiles rejected: docs/guides/benchmarking.md § 9.
+[profile.release]
+codegen-units = 1
+lto = "fat"
+
 [features]
 default = ["std"]
 

--- a/docs/guides/benchmarking.md
+++ b/docs/guides/benchmarking.md
@@ -944,10 +944,10 @@ touches and whether the signal is sensitive to each of them.
 
 ### 9. Pin the build profile before comparing two binaries
 
-`Cargo.toml` has no `[profile.release]`, so `cargo build --release` uses Rust's default
-`codegen-units = 16`, no LTO — the crate is split into 16 independently-optimized chunks, and
-changing code in one module can shift how LLVM lays out *unrelated* modules in the binary. That
-has nothing to do with the diff under test: `succinctly jq type`, a query that touches no keys,
+Until #2603, `Cargo.toml` had no `[profile.release]`, so `cargo build --release` used Rust's
+default `codegen-units = 16`, no LTO — the crate was split into 16 independently-optimized
+chunks, and changing code in one module could shift how LLVM laid out *unrelated* modules in the
+binary. That has nothing to do with the diff under test: `succinctly jq type`, a query that touches no keys,
 measured **+12% on an M4 Pro and +27% on a 7950X** between two binaries whose diff cannot reach
 that code path (#1587). It doesn't bisect to the same commit on both machines either — the
 signature of a placement artifact, not a real regression, which always gives the same answer on
@@ -959,30 +959,79 @@ placement drift between two genuinely *different* builds.
 
 Rebuilding both sides with `CARGO_PROFILE_RELEASE_CODEGEN_UNITS=1` removes it —
 `docs/plan/jq-duplicate-key-collapse.md` collapsed that same +12%/+27% pair to +0.2% this way,
-mid-investigation, before the practice was written down here. Set the env var for both
-`--before` and `--after` builds, then tell `scripts/ab-cli.py`/`scripts/perf-ab.py` what you did
-via `--before-profile`/`--after-profile` (free text, e.g. `codegen-units=1`) — the scripts
-cannot read a binary's codegen-units back out, so they only warn when the two builds' profiles
-are unrecorded or don't match:
+mid-investigation, before the practice was written down here. Since #2603 the crate's own
+`[profile.release]` pins `codegen-units = 1` and `lto = "fat"`, so a plain
+`cargo build --release` on both sides already satisfies this rule. The env-var form is still
+the right tool when one side predates #2603 (build *both* sides with it, so the profiles match
+rather than the pinned side inheriting the old default from its own `Cargo.toml`), and either
+way tell `scripts/ab-cli.py`/`scripts/perf-ab.py` what you did via
+`--before-profile`/`--after-profile` (free text, e.g. `codegen-units=1,lto=fat`) — the scripts
+cannot read a binary's profile back out, so they only warn when the two builds' profiles are
+unrecorded or don't match:
 
 ```bash
-CARGO_PROFILE_RELEASE_CODEGEN_UNITS=1 cargo build --release --features cli   # both checkouts
+CARGO_PROFILE_RELEASE_CODEGEN_UNITS=1 CARGO_PROFILE_RELEASE_LTO=fat \
+    cargo build --release --features cli   # both checkouts, when either predates #2603
 
 scripts/ab-cli.py --before ./succ-base --after ./succ-head \
-    --before-profile codegen-units=1 --after-profile codegen-units=1 \
+    --before-profile codegen-units=1,lto=fat --after-profile codegen-units=1,lto=fat \
     --corpus ~/wrk/bench-scratch/mycorpus
 ```
 
-The crate's actual `[profile.release]` is deliberately left at Rust's default: pinning
-`codegen-units = 1` there costs real compile time, with no benefit to the interactive
-edit-compile-test loop, which uses debug builds, not release — so this is a benchmarking-time
-convention, not a shipped build setting. Three interleaved clean `cargo build --release --features
-cli` reps (18-core Apple M5 Max, `Johns-M5-Pro-Max` — a development machine running concurrent
-work, not one of the idle bench boxes named elsewhere in this guide, so treat this as directional)
-measured **1.4x-1.9x slower** (median 1.8x; 28.9s/24.1s/31.2s at `codegen-units=16` vs
-51.4s/46.9s/42.3s paired at `codegen-units=1`). The multiplier scales with available parallelism —
-losing per-crate codegen concurrency costs more on a wider machine — so don't expect a fixed ratio
-across hardware.
+#### Why the shipped profile is pinned too (#2603)
+
+For a year this was a benchmarking-time convention only: the shipped profile stayed at the
+default because pinning costs compile time, and the interactive loop uses debug builds anyway.
+#2603 — the third layout anomaly filed rather than explained, after #595 and #1587 — measured
+what the default costs the *shipped* binary instead. One source tree (`8142a5899`), four
+profiles, each A/B'd against the default per rule 1 (7 interleaved reps, output identity gated:
+0 differences in 29 configurations per box, both boxes idle, control floors −0.05% M4 Pro /
++0.05% 7950X). Median of per-row medians, negative is faster than the default:
+
+| workload set                                 | M4 Pro cgu1 | M4 Pro thin | M4 Pro cgu1+fat | 7950X cgu1 | 7950X thin | 7950X cgu1+fat |
+|----------------------------------------------|-------------|-------------|-----------------|------------|------------|----------------|
+| jq `.`/`keys_unsorted`/`length`, 3 shapes    | +0.07%      | −0.35%      | −1.26%          | −4.01%     | −1.86%     | −6.12%         |
+| jq #2168 shapes, users 14/74 MB              | −0.06%      | −0.78%      | +0.05%          | −15.42%    | +0.58%     | −17.54%        |
+| yq `.`/`length`/`.[0]`, 3 shapes             | +1.16%      | −1.30%      | +0.24%          | −2.51%     | −0.43%     | −4.01%         |
+| clean `cargo build --release --features cli` | 53 s        | 27 s        | 73 s            | 57 s       | 25 s       | 76 s           |
+
+Default-profile build time: 26 s on the M4 Pro, 25 s on the 7950X. `cgu1` = `codegen-units=1`,
+`thin` = `lto="thin"` at 16 units, `cgu1+fat` = both. The medians hide the shape of the x86
+result: one codegen unit makes the 7950X's JSON index build **13-21% faster** (`length`,
+`keys_unsorted`, every #2168 row) and the jq identity print path **4-6% slower** (`cgu1+fat`;
+**10-13%** under `cgu1` alone), while `yq` improves on all nine rows. On the M4 Pro every
+profile is within ±1.5% of the default except `cgu1`'s YAML identity rows, a uniform +3.3%.
+
+The deciding measurement is not speed but *drift*. #2603's own commit pair (`3070562d6` →
+`417f0948d`, the `getpath` commit and its parent, a diff that cannot reach `keys_unsorted[0]`,
+`length` or `.[][0]`) was rebuilt under each profile and A/B'd on the issue's users 14/74 MB
+inputs:
+
+| profile  | M4 Pro median (range) | 7950X median (range)              |
+|----------|-----------------------|-----------------------------------|
+| default  | +0.35% (−1.0%..+0.7%) | **−14.13% (−16.8%..−11.8%, 6/6)** |
+| thin     | +0.25% (−0.0%..+0.8%) | +2.17% (−5.4%..+6.0%)             |
+| cgu1     | +0.63% (−1.4%..+1.4%) | −1.86% (−5.7%..+2.0%)             |
+| cgu1+fat | −0.71% (−2.8%..+0.3%) | +1.96% (+1.4%..+3.2%)             |
+
+Two things follow. The default-profile binary's speed on the index-build path is a **±15%
+lottery on x86_64** drawn by every unrelated commit — the −14% here is the 7950X's `cgu1`
+"win" above seen from the other side: the main-tip default build had drawn a bad layout, the
+`getpath` commit's had drawn a good one. And thin LTO does not close that lottery (a ±6% band on
+the same pair); one codegen unit does. `cgu1+fat` has the narrowest band of the four on both
+boxes and dominates `cgu1` alone on every speed row, so it is what `[profile.release]` pins.
+The +6.2% ARM cost #2603 was filed on did not reproduce on the same box with the same source
+under any profile, the default included (the mini's rustc had moved from the one that built the
+issue's binaries) — which is itself the layout diagnosis confirmed: the effect belonged to one
+compiler's partitioning of one tree, not to the code.
+
+What it costs: release builds compile **~3x slower** on both boxes (the earlier 1.4-1.9x figure
+for `cgu1` alone, from a busy M5 Max laptop, is superseded by the idle-box numbers above), and
+the x86 jq identity path gives back 4-6% — a *deterministic*, `cg_annotate`-attributable
+inlining outcome (#2655's second finding put an equivalent `Ir` delta in `json/light.rs`,
+`trees/bp.rs`, `document.rs` and `memcpy`), which is a fixable follow-up in a way a layout
+lottery never was — tracked as #2720. `[profile.bench]` inherits `release`, so `cargo bench`
+builds pay the same compile cost and measure the same code.
 
 Also worth knowing: #595's x86-only 12-28% `block_scalars` anomaly was closed as "expected, no
 action — binary code-layout artifact from the recompile," using cachegrind to show flat
@@ -1215,9 +1264,10 @@ test bench_name ... bench:  1,234 ns/iter (+/- 56)
 - **Platform**: CPU model and OS version
 - **Tool versions**: For comparison benchmarks (jq-1.6, yq v4.48.1)
 - **Build flags**: Any special RUSTFLAGS or features, and — for an A/B comparing two binaries —
-  whether `CARGO_PROFILE_RELEASE_CODEGEN_UNITS=1` was pinned on both sides (see [A/B
-  Benchmarking Method § 9](#a-b-benchmarking-method), #1587). Unstated means default
-  `codegen-units=16`, which can add its own ±10-27% independent of the change being measured.
+  which release profile built each side (see [A/B Benchmarking Method § 9](#a-b-benchmarking-method),
+  #1587). Since #2603 a plain `cargo build --release` is `codegen-units=1`, `lto="fat"`; a binary
+  built from a tree older than that is default `codegen-units=16`, which can add its own
+  ±10-27% independent of the change being measured, so say which.
 
 **Example**:
 ```markdown

--- a/docs/optimizations/targets.md
+++ b/docs/optimizations/targets.md
@@ -58,7 +58,11 @@ rustflags = [
     "-C", "codegen-units=1",
 ]
 
-# Profile for maximum performance
+# Profile for maximum performance -- codegen-units/lto here duplicate the
+# crate's own [profile.release] in Cargo.toml (pinned by #2603 for the same
+# reason: a placement-dependent regression the default 16-unit profile let
+# through). Only opt-level (already the release default) and strip are this
+# config's own addition; if either side changes, keep them consistent.
 [profile.release]
 opt-level = 3
 lto = "fat"

--- a/tests/data/perf-guard-baseline.json
+++ b/tests/data/perf-guard-baseline.json
@@ -1,18 +1,18 @@
 {
   "ARM64-Linux": {
-    "arrays_identity": 599251135,
-    "users_identity": 289464880,
-    "users_keys_unsorted": 44532034,
-    "users_yq_keys_unsorted": 72232441,
-    "wide_identity": 470132651,
-    "wide_keys_unsorted": 297330783
+    "arrays_identity": 594207638,
+    "users_identity": 289261734,
+    "users_keys_unsorted": 44367858,
+    "users_yq_keys_unsorted": 73041061,
+    "wide_identity": 467108181,
+    "wide_keys_unsorted": 291360706
   },
   "x86_64": {
-    "arrays_identity": 650895367,
-    "users_identity": 341765138,
-    "users_keys_unsorted": 69265169,
-    "users_yq_keys_unsorted": 82246619,
-    "wide_identity": 556763357,
-    "wide_keys_unsorted": 350914474
+    "arrays_identity": 659508283,
+    "users_identity": 354088795,
+    "users_keys_unsorted": 66351190,
+    "users_yq_keys_unsorted": 80986986,
+    "wide_identity": 578685455,
+    "wide_keys_unsorted": 346886468
   }
 }


### PR DESCRIPTION
Closes #2603. Refs #595, #1587, #2655.

## What

`[profile.release]` now pins `codegen-units = 1` and `lto = "fat"`. The crate previously shipped at cargo's default (16 codegen units, no LTO), the configuration every layout anomaly this repo has filed traces to: #595, #1587, #2603, and #2655's second finding.

## Why this and not another `#[inline]` attribute

#2603 measured and rejected the attribute: it fixed ARM and cost x86_64 +9.5%. So this PR asked the question the issue's second suggestion posed — what does the default profile cost the *shipped* binary — and measured it rather than guessing. One source tree (`8142a5899`), four profiles, each A/B'd against the default on both pinned boxes (`scripts/ab-cli.py`, 7 interleaved reps, output identity gated with 0 differences in 29 configurations per box, control floors −0.05% / +0.05%). Median of per-row medians, negative is faster than the default:

| workload set                                 | M4 Pro cgu1 | M4 Pro thin | M4 Pro cgu1+fat | 7950X cgu1 | 7950X thin | 7950X cgu1+fat |
|----------------------------------------------|-------------|-------------|-----------------|------------|------------|----------------|
| jq `.`/`keys_unsorted`/`length`, 3 shapes    | +0.07%      | −0.35%      | −1.26%          | −4.01%     | −1.86%     | −6.12%         |
| jq #2168 shapes, users 14/74 MB              | −0.06%      | −0.78%      | +0.05%          | −15.42%    | +0.58%     | −17.54%        |
| yq `.`/`length`/`.[0]`, 3 shapes             | +1.16%      | −1.30%      | +0.24%          | −2.51%     | −0.43%     | −4.01%         |
| clean `cargo build --release --features cli` | 53 s        | 27 s        | 73 s            | 57 s       | 25 s       | 76 s           |

(default build: 26 s M4 Pro, 25 s 7950X)

The deciding measurement is drift, not speed. #2603's own commit pair (`3070562d6` → `417f0948d`, a diff that cannot reach `keys_unsorted[0]`/`length`/`.[][0]`), rebuilt under each profile and A/B'd on the issue's inputs:

| profile  | M4 Pro median (range) | 7950X median (range)              |
|----------|-----------------------|-----------------------------------|
| default  | +0.35% (−1.0..+0.7)   | **−14.13% (−16.8..−11.8, 6/6)**   |
| thin     | +0.25% (−0.0..+0.8)   | +2.17% (−5.4..+6.0)               |
| cgu1     | +0.63% (−1.4..+1.4)   | −1.86% (−5.7..+2.0)               |
| cgu1+fat | −0.71% (−2.8..+0.3)   | +1.96% (+1.4..+3.2)               |

- At the default the shipped binary's index-build speed on x86_64 is a ±15% lottery drawn by every unrelated commit. The 7950X's "−15% under cgu1" in the first table is that same lottery seen from the other side: main-tip's default build had drawn a bad layout.
- Thin LTO does **not** close it (±6% on the same pair). One codegen unit does. `cgu1+fat` has the narrowest band on both boxes and beats `cgu1` alone on every speed row, so it is what's pinned.
- The +6.2% ARM cost the issue was filed on did not reproduce with the same source on the same box under any profile, the default included (the mini's rustc has moved since). That is the layout diagnosis confirmed, not contradicted: the effect belonged to one compiler's partitioning of one tree.

## What it costs

- Release builds compile ~3x slower on both boxes. Only `perf-guard` (three builds) and `release.yml` build release in CI; the debug builds `cargo test`/`clippy`/coverage use are untouched.
- x86_64 jq identity (`.`) gives back 4-6% (10-13% under `cgu1` without LTO, which is why fat was chosen). Unlike the lottery this is deterministic and `cg_annotate`-attributable — #2655's second comment already put an equivalent `Ir` delta in `json/light.rs`/`trees/bp.rs`/`document.rs`/`memcpy` inlining — so it is a fixable follow-up rather than noise.

## perf-guard

- **This PR's own perf-guard legs measure the profile change itself**, not a regression: the merge-base is built from its own default-profile `Cargo.toml`, the head from this one. On the 7950X the `cgu1+fat` build reads `wide_identity` +3.9% / `users_identity` +3.6% `Ir` and `users_keys_unsorted` −4.2% against the checked-in default-profile counts — inside the 5% threshold, but the runner's own partitioning of the merge-base side can add ±5% on top (#2655's second finding), so an x86 identity-row FAIL here is that artifact. The job is non-blocking. After merge every `push` run compares consecutive commits built alike, and #2655's CGU-partitioning false failures go with it.
- `tests/data/perf-guard-baseline.json`'s `x86_64` entry is regenerated from a `cgu1+fat` build on the 7950X (`--update-baseline`, reason: the profile changes every query's instruction count). The `ARM64-Linux` entry is **not** regenerated — neither pinned box is a Linux ARM host with valgrind — so that fallback entry is stale until someone with such a box refreshes it. Both entries are only fallbacks: `ci.yml` passes `--baseline-binary` on every `pull_request` and `push` run.

## Docs

- `docs/guides/benchmarking.md` § 9: the pin is now the shipped profile; env-var form kept for comparing against a pre-#2603 binary; full measurement record added.
- `CLAUDE.md`: one key-insight line.
