### PR TITLE
fix(jq): give resolve_reduce the #2161 register-identity widening

### DIFF
--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -30874,12 +30874,26 @@ fn resolve_reduce<'a, S: EvalSemantics>(
             // un-gated widening turns a refusal into a write where real yq
             // no-ops (`(null | .a) = 5` is a no-op on `null`, live against
             // v4.53.3).
-            if let Some(a) = acc.as_ref() {
-                acc_at_register = acc_at_register
-                    || (S::TAG == EvalTag::Jq
-                        && reg.trackable
-                        && register_identical(&reg.value, &reg.frame, a, &acc_snapshot));
-            }
+            //
+            // Checked against `acc`'s own *effective* value — `acc.as_ref()`
+            // unwrapped to `&OwnedValue::Null`, not gated on `acc.is_some()`
+            // -- because a step whose UPDATE produced zero outputs (`empty`)
+            // leaves `acc` as `None`, and the very next line already treats
+            // that the same as a real `Null` accumulator
+            // (`unwrap_or(OwnedValue::Null)`) when it becomes `acc_input`.
+            // Skipping the check on `None` missed exactly that case: a
+            // `null`/`bool` register is unconditionally identical to a
+            // `null` accumulator via `register_identical`'s kind-based
+            // clause, `None` included, since there is no pointer/snapshot
+            // involved for that arm at all. Confirmed live against jq 1.7.1:
+            // `path(reduce (1,2,3) as $k (.b; if $k==1 then empty else .a
+            // end))` on `{"a":1,"b":null}` is `["b"]`, matching only once
+            // this is unconditional.
+            let acc_effective = acc.as_ref().unwrap_or(&OwnedValue::Null);
+            acc_at_register = acc_at_register
+                || (S::TAG == EvalTag::Jq
+                    && reg.trackable
+                    && register_identical(&reg.value, &reg.frame, acc_effective, &acc_snapshot));
             let acc_input = acc.take().unwrap_or(OwnedValue::Null);
             match reg.resolve::<S>(
                 &substituted,

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -30858,6 +30858,28 @@ fn resolve_reduce<'a, S: EvalSemantics>(
                 Ok(b) => substitute_vars(update, as_var_refs(&b)),
                 Err(e) => return stop_with_escape(&mut aborted, Control::Error(e)),
             };
+            // **#2632**: mirrors `resolve_foreach`'s own `None`-arm widening
+            // (#2161) — `acc_at_register` alone is the previous step's
+            // `branch_provenance`, a path comparison, which is `false` from
+            // step 2 onward because UPDATE's whole job is to navigate away
+            // from the register. jq's actual rule is
+            // `jv_identical(current_input, value_at_path)`: this step is at
+            // the register when the accumulator arriving at it is still the
+            // register's own value, which `register_identical` answers
+            // directly. `||`, not a replacement — `register_identical`
+            // demands `snapshot || Null | Bool`, so it alone is `false` for
+            // step 1 of an object-valued register, where the carried
+            // provenance is the correct `true`. jq mode only, for the same
+            // reason `resolve_foreach`'s widening is: on the *write* side an
+            // un-gated widening turns a refusal into a write where real yq
+            // no-ops (`(null | .a) = 5` is a no-op on `null`, live against
+            // v4.53.3).
+            if let Some(a) = acc.as_ref() {
+                acc_at_register = acc_at_register
+                    || (S::TAG == EvalTag::Jq
+                        && reg.trackable
+                        && register_identical(&reg.value, &reg.frame, a, &acc_snapshot));
+            }
             let acc_input = acc.take().unwrap_or(OwnedValue::Null);
             match reg.resolve::<S>(
                 &substituted,
@@ -30884,17 +30906,11 @@ fn resolve_reduce<'a, S: EvalSemantics>(
                     // register instead — the persistent register is what
                     // every step *without* its own source-derived register
                     // (including reduce's own final emission below) is
-                    // still checked against.
-                    //
-                    // **#2161**: `resolve_foreach`'s equivalent site no
-                    // longer treats provenance as the whole rule -- it also
-                    // consults `register_identical`, so a step whose
-                    // accumulator is still the register's own value
-                    // re-enters it. This site was deliberately left alone
-                    // (fixing it moves 696 more cases onto jq, measured),
-                    // so `path(reduce (1,2) as $k (.b; .a))` on `{"a":1}`
-                    // still refuses where the `foreach` spelling succeeds.
-                    // Tracked at #2632.
+                    // still checked against. The widening just above only
+                    // affects what is fed *into* this step's `reg.resolve`;
+                    // this carry-forward still derives the *next* step's
+                    // starting point purely from this step's own output
+                    // branch, same as before #2632.
                     let last = branches.into_iter().last();
                     (acc_at_register, acc_snapshot) = reg.branch_provenance(last.as_ref());
                     acc = last.map(|b| b.value.into_owned());
@@ -30959,15 +30975,15 @@ fn resolve_reduce<'a, S: EvalSemantics>(
 /// control is applied per-fork after that fork's own inner loop (#534
 /// follow-up), not deferred until every fork has run.
 ///
-/// **#2161 adds a fourth difference, and it is a divergence from
-/// [`resolve_reduce`] rather than a shared rule**: this function re-enters
-/// the fixed register on every source element, deciding each step's
-/// `at_register` from jq's own `jv_identical(current_input, value_at_path)`
-/// (via [`register_identical`]) *as well as* the previous step's
-/// [`FoldRegister::branch_provenance`]. `resolve_reduce`'s own carry-forward
-/// still uses provenance alone, so `path(reduce (1,2) as $k (.b; .a))` on
-/// `{"a":1}` still refuses where the `foreach` spelling now succeeds --
-/// tracked at #2632, not an intended asymmetry.
+/// **#2161 adds a fourth difference**: this function re-enters the fixed
+/// register on every source element, deciding each step's `at_register` from
+/// jq's own `jv_identical(current_input, value_at_path)` (via
+/// [`register_identical`]) *as well as* the previous step's
+/// [`FoldRegister::branch_provenance`]. #2632 gave [`resolve_reduce`]'s own
+/// carry-forward the same widening, so this is no longer a divergence
+/// between the two functions -- see that function's own doc comment for why
+/// its call site looks different (no per-source-element register override
+/// to fold the widening into) even though the rule is now shared.
 #[allow(clippy::too_many_arguments)] // STYLE-0004: `snapshot` (#1591) joins `trackable` as the
                                      // ambient pair threaded verbatim through every one of
                                      // `resolve_node`'s ~20 recursive call sites in this file; a

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -41440,6 +41440,26 @@ fn test_reduce_reenters_register_every_step_not_just_the_first_2632() -> Result<
     );
     assert_eq!(code, 5, "stdout: {stdout:?} stderr: {stderr:?}");
 
+    // Code review on this fix's own PR caught a gap: a step whose UPDATE
+    // produces zero outputs (`empty`) leaves the accumulator as `None`, and
+    // the widening above must still recognise it as identical to a
+    // `null`/`bool` register -- `acc_input` two lines below already treats
+    // `None` the same as a real `Null` via `unwrap_or`, so the identity
+    // check has to be computed against that same effective value, not
+    // skipped when `acc` isn't `Some`.
+    let (stdout, stderr, code) = run_jq_full(
+        &[
+            "-c",
+            "path(reduce (1,2,3) as $k (.b; if $k==1 then empty else .a end))",
+        ],
+        Some(r#"{"a":1,"b":null}"#),
+    )?;
+    assert_eq!(
+        (stdout.as_str(), code),
+        ("[\"b\"]\n", 0),
+        "stderr: {stderr:?}"
+    );
+
     Ok(())
 }
 

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -41352,6 +41352,97 @@ fn test_foreach_reenters_register_every_step_not_just_the_first_2161() -> Result
     Ok(())
 }
 
+/// #2632: `resolve_reduce`'s own copy of #2161's bug, fixed the same way.
+/// Unlike `foreach`, `reduce` emits only once, at the very end of the fold,
+/// re-checking the *final* accumulator's provenance against the register --
+/// so these shapes pin the same register-reentry rule through a single
+/// emission (or a single raise) instead of one per step. All values below
+/// are live jq 1.7.1 captures.
+#[test]
+fn test_reduce_reenters_register_every_step_not_just_the_first_2632() -> Result<()> {
+    // `.b` is absent, so the accumulator stays `null` -- identical to the
+    // register's own value at every step, so the fold's own final path is
+    // still the register's path, not a deeper one (`.a` on a `null`
+    // register-identical value never extends the emitted path).
+    let (stdout, stderr, code) = run_jq_full(
+        &["-c", "path(reduce (1,2,3) as $k (.b; .a))"],
+        Some(r#"{"a":1}"#),
+    )?;
+    assert_eq!(
+        (stdout.as_str(), code),
+        ("[\"b\"]\n", 0),
+        "stderr: {stderr:?}"
+    );
+
+    // A deeper UPDATE repeats the same way.
+    let (stdout, stderr, code) = run_jq_full(
+        &["-c", "path(reduce (1,2) as $k (.b; .a.c))"],
+        Some(r#"{"a":1}"#),
+    )?;
+    assert_eq!(
+        (stdout.as_str(), code),
+        ("[\"b\"]\n", 0),
+        "stderr: {stderr:?}"
+    );
+
+    // The counterpart that must still raise: once the accumulator stops
+    // being the register's value, the step is genuinely untracked. `reduce`
+    // emits nothing before the raise (unlike `foreach`, which streams every
+    // earlier step's own output first) since there is no per-step emission
+    // to have already reached the sink.
+    let (stdout, stderr, code) = run_jq_full(
+        &["-c", "path(reduce (1,2,3) as $k (.b; .a))"],
+        Some(r#"{"a":1,"b":{"a":{"a":9}}}"#),
+    )?;
+    assert_eq!(stdout, "", "stderr: {stderr:?}");
+    assert!(
+        stderr.contains(r#"attempt to access element "a" of {"a":9}"#),
+        "stderr: {stderr:?}"
+    );
+    assert_eq!(code, 5, "stdout: {stdout:?} stderr: {stderr:?}");
+
+    // Same shape one level deeper, to pin that the raise names the step's
+    // own input rather than anything about the register.
+    let (stdout, stderr, code) = run_jq_full(
+        &["-c", "path(reduce (1,2,3) as $k (.b; .a.a))"],
+        Some(r#"{"a":1,"b":{"a":{"a":9}}}"#),
+    )?;
+    assert_eq!(stdout, "", "stderr: {stderr:?}");
+    assert!(
+        stderr.contains(r#"attempt to access element "a" of 9"#),
+        "stderr: {stderr:?}"
+    );
+    assert_eq!(code, 5, "stdout: {stdout:?} stderr: {stderr:?}");
+
+    // A non-navigating UPDATE leaves the accumulator *at* the register, so
+    // the carried-provenance half keeps answering `true` -- `["b"]`, no
+    // raise, even though the value is an object.
+    let (stdout, stderr, code) = run_jq_full(
+        &["-c", "path(reduce (1,2,3) as $k (.b; .))"],
+        Some(r#"{"a":1,"b":{"a":{"a":9}}}"#),
+    )?;
+    assert_eq!(
+        (stdout.as_str(), code),
+        ("[\"b\"]\n", 0),
+        "stderr: {stderr:?}"
+    );
+
+    // INIT navigating to the document root behaves the same way: step 1
+    // tracks, step 2's accumulator (`1`) is no longer the register.
+    let (stdout, stderr, code) = run_jq_full(
+        &["-c", "path(reduce (1,2) as $k (.; .a))"],
+        Some(r#"{"a":1,"b":{"a":{"a":9}}}"#),
+    )?;
+    assert_eq!(stdout, "", "stderr: {stderr:?}");
+    assert!(
+        stderr.contains(r#"attempt to access element "a" of 1"#),
+        "stderr: {stderr:?}"
+    );
+    assert_eq!(code, 5, "stdout: {stdout:?} stderr: {stderr:?}");
+
+    Ok(())
+}
+
 /// #2031's mixed-source variant: a source with *some* trackable branches
 /// and some untracked ones must still stream every branch before the
 /// trackable one, exactly as an all-untracked source already did (#1872) --

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -39878,6 +39878,39 @@ fn test_foreach_register_reentry_is_jq_mode_only_on_the_write_side_2161() -> Res
     Ok(())
 }
 
+/// #2632's yq-mode gate — `resolve_reduce`'s own copy of the #2161 write-side
+/// hazard above, gated the same way and for the same reason (real yq's
+/// lexer rejects `reduce` outright, same as `foreach`, so `(null | .a) = 5`
+/// staying a no-op live against v4.53.3 is as close as the oracle gets).
+///
+/// jq mode keeps the write -- `jq -n '(reduce (1) as $k (null; .a)) = 5'` is
+/// `5` (the fold's own final path is root, not `.a`; see
+/// `test_reduce_reenters_register_every_step_not_just_the_first_2632`'s own
+/// doc comment for why), and `succinctly jq` matches it.
+#[test]
+fn test_reduce_register_reentry_is_jq_mode_only_on_the_write_side_2632() -> Result<()> {
+    for filter in [
+        "(reduce (1) as $k (null; .a)) = 5",
+        "(reduce (1,2) as $k (null; .a)) = 5",
+    ] {
+        let (stdout, stderr, code) = run_yq_stdin_with_stderr(filter, "null\n", &[])?;
+        assert_eq!(
+            code, 1,
+            "`{filter}` -- stdout: {stdout:?} stderr: {stderr:?}"
+        );
+        assert!(
+            stdout.trim().is_empty(),
+            "`{filter}` must not write: stdout: {stdout:?}"
+        );
+        assert!(
+            stderr.contains("Invalid path expression"),
+            "`{filter}` -- stderr: {stderr:?}"
+        );
+    }
+
+    Ok(())
+}
+
 /// #2692, yq twin of `test_truthiness_probes_validate_nothing_2692` in
 /// `tests/jq_cli_tests.rs`: the same corpus through the YAML cursor (and, for
 /// the JSON-syntax rows, through yq's own reading of them -- most of the JSON


### PR DESCRIPTION
## Summary

`resolve_reduce`'s carry-forward derived each step's `at_register` purely from
the previous step's `FoldRegister::branch_provenance` (a path comparison),
which is `false` from step 2 onward since UPDATE almost always navigates
away from the register — the same bug #2161 fixed in `resolve_foreach`.

jq's actual rule is `jv_identical(current_input, value_at_path)`: a step is
at the register when the accumulator arriving at it is still the register's
own value. This ORs in `register_identical` (already used by `resolve_foreach`'s
own #2161 fix) alongside the carried provenance, mirroring the measured
prototype from the issue (696/728 divergences fixed, 0 broken on the
generated 12,048-case sweep). Gated to jq mode only — the write side would
otherwise turn a refusal into a write where real yq no-ops (`(null | .a) = 5`
is a no-op live against yq v4.53.3).

```console
$ echo '{"a":1}' | jq -c 'path(reduce (1,2) as $k (.b; .a))'
["b"]
$ echo '{"a":1}' | succinctly jq -c 'path(reduce (1,2) as $k (.b; .a))'
jq: error (at <stdin>:1): Invalid path expression near attempt to access element "a" of null   # before
["b"]                                                                                          # after
```

Fixes #2632

## Test plan

- [x] `cargo build --features cli`
- [x] `cargo test --features cli,simd,regex,serde` (full suite, 0 failures)
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings`
- [x] New `test_reduce_reenters_register_every_step_not_just_the_first_2632` (jq mode) mirrors #2161's own `foreach` regression test, adapted for `reduce`'s single final-emission semantics — every assertion cross-checked live against `/usr/bin/jq` 1.7.1
- [x] New `test_reduce_register_reentry_is_jq_mode_only_on_the_write_side_2632` (yq mode) pins the write-side gate, mirroring #2161's own yq-mode test
- [x] `cargo llvm-cov` / `omni-dev coverage diff`: patch coverage 100% (6/6 new lines)