### PR TITLE
fix(jq): resolve a duplicate def parameter name by its last occurrence

### DIFF
--- a/src/bin/succinctly/yq_runner.rs
+++ b/src/bin/succinctly/yq_runner.rs
@@ -9580,7 +9580,7 @@ mod tests {
                 params: if args.is_empty() {
                     Vec::new()
                 } else {
-                    vec!["v".into()]
+                    vec![succinctly::jq::Param::Bare("v".to_string())]
                 },
                 body,
             }),

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -48759,7 +48759,7 @@ fn bind_def_call_params(body: &Expr, params: &[Param], args: &[Expr]) -> Expr {
         // behaviour, not a panic.
         let mut params_and_args = params.iter().zip(args.iter());
         let Some((first_param, first_arg)) = params_and_args.next() else {
-            return body.clone();
+            return body.clone(); // omni-dev: coverage tolerate-line reason="unreachable: bind_def_call only calls this for a non-empty params, and install_def_calls only builds a DefCall whose args.len() equals params.len(), so the zip is never empty here (#2560)"
         };
         let mut result = substitute_func_param(
             body,
@@ -48792,7 +48792,7 @@ fn bind_def_call_params(body: &Expr, params: &[Param], args: &[Expr]) -> Expr {
             // Unreachable for a well-formed `DefCall` (same arity invariant
             // as the non-duplicate path above); skipping rather than
             // unwrapping keeps a malformed one from taking the process down.
-            continue;
+            continue; // omni-dev: coverage tolerate-line reason="unreachable: `name` was just read from `params`, so the zip over (params, args) has a matching pair unless args is shorter than params, which install_def_calls' own arity guard rules out (#2560)"
         };
         result = substitute_func_param_impl(
             &result,

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -48737,11 +48737,32 @@ pub(crate) fn bind_def_call<'e>(
 /// the bare winner first, with `subst_dollar: false` so it only touches
 /// bare `Expr::FuncCall` nodes, then the `$` winner (if any) with
 /// `subst_dollar: true`, reproduces this correctly regardless of which
-/// position wins which namespace: the bare pass's insertions become
-/// `Expr::Shared`, already opaque to the `$` pass's own (unconditional)
-/// bare-matching arm by the time it runs. Verified against every bare/`$`
-/// ordering and combined bare-and-`$`-reference body jq 1.7.1 can express
-/// for two, and for three, duplicated parameters --
+/// position wins which namespace.
+///
+/// **Why the order is what makes that sound.** `subst_dollar` gates exactly
+/// one arm of [`substitute_func_param_impl`] -- `Expr::Var` -- and no other:
+/// it never gates the bare `Expr::FuncCall` arm, and it never decides
+/// whether to recurse, since every shadow check it passes
+/// (`Expr::FuncDef`'s `body_shadowed`/`then_shadowed`, the
+/// `As`/`Reduce`/`Foreach`/`AsPattern` binder checks) reads only `param` and
+/// nodes neither pass rewrites. So the two passes walk *identically*, and
+/// the set of bare references the `$` pass can reach is exactly the set the
+/// bare pass already replaced with an (opaque) `Expr::Shared` -- its
+/// unconditional bare arm therefore has nothing left to clobber. The same
+/// property is what makes the same-winner case (a trailing `$`-style
+/// parameter) compose back into precisely the single `subst_dollar: true`
+/// pass this replaced.
+///
+/// One consequence worth keeping: when a duplicated name has *no* `$`-style
+/// occurrence at all, the `$` pass never runs, so a `$name` in the body is
+/// left for an enclosing binder -- which is what jq does
+/// (`5 as $a | def f(a;a): $a + a; f(1;2)` is `7`; the blanket
+/// `subst_dollar: true` fold this replaced captured `$a` as the parameter
+/// and answered `6`).
+///
+/// Verified against every bare/`$` ordering and combined
+/// bare-and-`$`-reference body jq 1.7.1 can express for two, and for three,
+/// duplicated parameters --
 /// `test_bind_def_call_params_resolves_each_namespace_by_its_own_last_occurrence_2560`
 /// below, plus `tests/jq_cli_tests.rs`' own `test_duplicate_named_param_*_2560`
 /// family end to end.
@@ -48773,7 +48794,13 @@ fn bind_def_call_params(body: &Expr, params: &[Param], args: &[Expr]) -> Expr {
         return result;
     }
 
-    let mut result = body.clone();
+    // `None` until the first substitution, so that one rebuilds `body`
+    // itself rather than a copy of it -- the same O(body size)-per-bound-call
+    // allocation `bind_def_call`'s own #2094 comment above exists to avoid,
+    // which seeding this loop with `body.clone()` would put straight back
+    // (once per recursion level, for a recursive `def` that also duplicates a
+    // parameter name).
+    let mut result: Option<Expr> = None;
     let mut substituted_names: Vec<&str> = Vec::new();
     for param in params {
         let name = param.name();
@@ -48794,23 +48821,26 @@ fn bind_def_call_params(body: &Expr, params: &[Param], args: &[Expr]) -> Expr {
             // unwrapping keeps a malformed one from taking the process down.
             continue; // omni-dev: coverage tolerate-line reason="unreachable: `name` was just read from `params`, so the zip over (params, args) has a matching pair unless args is shorter than params, which install_def_calls' own arity guard rules out (#2560)"
         };
-        result = substitute_func_param_impl(
-            &result,
+        let mut substituted = substitute_func_param_impl(
+            result.as_ref().unwrap_or(body),
             name,
             &Expr::Shared(Rc::new(bare_arg.clone())),
             false,
         );
 
         if let Some((_, dollar_arg)) = by_name().rfind(|(p, _)| p.is_dollar()) {
-            result = substitute_func_param_impl(
-                &result,
+            substituted = substitute_func_param_impl(
+                &substituted,
                 name,
                 &Expr::Shared(Rc::new(dollar_arg.clone())),
                 true,
             );
         }
+        result = Some(substituted);
     }
-    result
+    // `unwrap_or_else`: same unreachable arity mismatch as the `else` arms
+    // above -- every distinct name substitutes at least once otherwise.
+    result.unwrap_or_else(|| body.clone()) // omni-dev: coverage tolerate-line reason="unreachable: `params` is non-empty here (bind_def_call's own guard) and its first entry is never skipped, so at least one substitution always ran (#2560)"
 }
 
 /// Evaluate an `Expr::DefCall` in the plain evaluator (#1371).

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -2705,15 +2705,7 @@ fn eval_single<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
             body,
             then,
             bound,
-        } => eval_func_def::<W, S>(
-            name,
-            &param_names(params),
-            body,
-            then,
-            bound,
-            value,
-            optional,
-        ),
+        } => eval_func_def::<W, S>(name, params, body, then, bound, value, optional),
         Expr::FuncCall {
             name,
             args,
@@ -5317,7 +5309,7 @@ fn eval_each<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
             then,
             bound,
         } => {
-            let bound_then = bind_def(name, &param_names(params), body, then, bound);
+            let bound_then = bind_def(name, params, body, then, bound);
             eval_each::<W, S>(&bound_then, value, optional, sink)
         }
 
@@ -48409,7 +48401,7 @@ fn dedup_keep_last_binding(bindings: Vec<(String, OwnedValue)>) -> Vec<(String, 
 /// itself evaluates.
 fn eval_func_def<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     name: &str,
-    params: &[String],
+    params: &[Param],
     body: &Expr,
     then: &Expr,
     bound: &FuncDefBound,
@@ -48491,19 +48483,6 @@ mod ambient_frame_depth {
     }
 }
 
-/// The bare identifier of each of `params`, regardless of bare-vs-`$`
-/// spelling -- #2283: `bind_def`/`FuncDefData`'s own `params: Vec<String>`
-/// only ever needs the bare call-binding name (both spellings bind that
-/// identically; only `substitute_var_impl`/`substitute_func_param_impl`'s
-/// shadow checks need `Param`'s own `Bare`/`Dollar` distinction, and they
-/// run on the still-`Expr::FuncDef`-shaped tree before this conversion
-/// ever happens), so every one of `Expr::FuncDef`'s four evaluation arms
-/// converts once here rather than `bind_def` itself taking `&[Param]` and
-/// converting on every one of its own many (test-included) call sites.
-pub(crate) fn param_names(params: &[Param]) -> Vec<String> {
-    params.iter().map(|p| p.name().to_string()).collect()
-}
-
 /// Install `def name(params): body` over `then`, the shared first half of
 /// every `Expr::FuncDef` evaluation arm (#1371).
 ///
@@ -48529,7 +48508,7 @@ pub(crate) fn param_names(params: &[Param]) -> Vec<String> {
 /// all like [`BoundBody`] does.
 pub(crate) fn bind_def(
     name: &str,
-    params: &[String],
+    params: &[Param],
     body: &Expr,
     then: &Expr,
     bound: &FuncDefBound,
@@ -48721,24 +48700,117 @@ pub(crate) fn bind_def_call<'e>(
         // recursion level, since this whole function is gated by `bound`).
         // A zero-parameter `def` needs no substitution at all, so it skips
         // straight to installing over `&def.body` with no clone whatsoever.
-        let mut params_and_args = def.params.iter().zip(args.iter());
-        let installed_body = match params_and_args.next() {
-            Some((param, arg)) => {
-                let mut body =
-                    substitute_func_param(&def.body, param, &Expr::Shared(Rc::new(arg.clone())));
-                for (param, arg) in params_and_args {
-                    body = substitute_func_param(&body, param, &Expr::Shared(Rc::new(arg.clone())));
-                }
-                // `true`: this is `def`'s own body, the scope that repeats
-                // once per actual recursive level -- see
-                // `sibling_frame_charge`'s own doc comment (#2135 code
-                // review, Finding 1).
-                install_def_calls(&body, def, frames + 1, true)
-            }
-            None => install_def_calls(&def.body, def, frames + 1, true),
+        let installed_body = if def.params.is_empty() {
+            install_def_calls(&def.body, def, frames + 1, true)
+        } else {
+            let body = bind_def_call_params(&def.body, &def.params, args);
+            // `true`: this is `def`'s own body, the scope that repeats
+            // once per actual recursive level -- see
+            // `sibling_frame_charge`'s own doc comment (#2135 code
+            // review, Finding 1).
+            install_def_calls(&body, def, frames + 1, true)
         };
         Ok(Rc::new(installed_body))
     })
+}
+
+/// Substitute every parameter of a `def` call into its own body (#2560).
+///
+/// The common case -- no two parameters share a name -- is exactly the
+/// pre-#2560 code: one `substitute_func_param` fold per parameter, left to
+/// right, each substitution's `Expr::Shared` insertion opaque to the next
+/// (same cost, same behavior). A duplicate parameter name (rare -- `def
+/// f(a; $a): ...`) broke under that fold: sequential substitution resolves
+/// to the *first* occurrence, but jq's own parameter list is a chain of
+/// nested scopes, innermost (last) first, so a later same-named parameter
+/// entirely shadows an earlier one -- confirmed live against jq 1.7.1,
+/// `def f(a; $a): $a; f(1;2)` is `2`, not `1`.
+///
+/// A `$`-style parameter binds *both* the bare and `$` namespace ([`Param`]'s
+/// own doc comment); a bare-style parameter only the bare one. So for each
+/// distinct duplicated name, the bare namespace resolves to the *last*
+/// parameter overall with that name (whichever kind), and the `$` namespace
+/// resolves to the last `$`-style parameter with that name, if any --
+/// possibly a different, earlier position (`def f($a; a): $a; f(1;2)` is
+/// `1`: the trailing bare `a` shadows the bare namespace only, so the
+/// leading `$a`'s own binding is still what `$a` resolves to). Substituting
+/// the bare winner first, with `subst_dollar: false` so it only touches
+/// bare `Expr::FuncCall` nodes, then the `$` winner (if any) with
+/// `subst_dollar: true`, reproduces this correctly regardless of which
+/// position wins which namespace: the bare pass's insertions become
+/// `Expr::Shared`, already opaque to the `$` pass's own (unconditional)
+/// bare-matching arm by the time it runs. Verified against every bare/`$`
+/// ordering and combined bare-and-`$`-reference body jq 1.7.1 can express
+/// for two, and for three, duplicated parameters --
+/// `test_bind_def_call_params_resolves_each_namespace_by_its_own_last_occurrence_2560`
+/// below, plus `tests/jq_cli_tests.rs`' own `test_duplicate_named_param_*_2560`
+/// family end to end.
+fn bind_def_call_params(body: &Expr, params: &[Param], args: &[Expr]) -> Expr {
+    let has_duplicate_names = params
+        .iter()
+        .enumerate()
+        .any(|(i, p)| params[i + 1..].iter().any(|q| q.name() == p.name()));
+
+    if !has_duplicate_names {
+        // `zip` truncates to the shorter side, exactly as the pre-#2560
+        // fold did -- an arity mismatch cannot reach here (`install_def_calls`
+        // only builds a `DefCall` whose `args.len()` equals `params.len()`),
+        // and if one ever did, leaving the body unsubstituted is the old
+        // behaviour, not a panic.
+        let mut params_and_args = params.iter().zip(args.iter());
+        let Some((first_param, first_arg)) = params_and_args.next() else {
+            return body.clone();
+        };
+        let mut result = substitute_func_param(
+            body,
+            first_param.name(),
+            &Expr::Shared(Rc::new(first_arg.clone())),
+        );
+        for (param, arg) in params_and_args {
+            result =
+                substitute_func_param(&result, param.name(), &Expr::Shared(Rc::new(arg.clone())));
+        }
+        return result;
+    }
+
+    let mut result = body.clone();
+    let mut substituted_names: Vec<&str> = Vec::new();
+    for param in params {
+        let name = param.name();
+        if substituted_names.contains(&name) {
+            continue;
+        }
+        substituted_names.push(name);
+
+        let by_name = || {
+            params
+                .iter()
+                .zip(args.iter())
+                .filter(|(p, _)| p.name() == name)
+        };
+        let Some((_, bare_arg)) = by_name().next_back() else {
+            // Unreachable for a well-formed `DefCall` (same arity invariant
+            // as the non-duplicate path above); skipping rather than
+            // unwrapping keeps a malformed one from taking the process down.
+            continue;
+        };
+        result = substitute_func_param_impl(
+            &result,
+            name,
+            &Expr::Shared(Rc::new(bare_arg.clone())),
+            false,
+        );
+
+        if let Some((_, dollar_arg)) = by_name().rfind(|(p, _)| p.is_dollar()) {
+            result = substitute_func_param_impl(
+                &result,
+                name,
+                &Expr::Shared(Rc::new(dollar_arg.clone())),
+                true,
+            );
+        }
+    }
+    result
 }
 
 /// Evaluate an `Expr::DefCall` in the plain evaluator (#1371).
@@ -49728,6 +49800,80 @@ mod tests {
         );
     }
 
+    /// #2560: [`bind_def_call_params`] directly, at the AST level, rather
+    /// than only through the CLI (`tests/jq_cli_tests.rs`'s own
+    /// `test_duplicate_named_param_*_2560` family). Each expectation below
+    /// is what jq 1.7.1 answers for the equivalent program.
+    ///
+    /// The `$`-first/bare-last row is the one that pins the two winners
+    /// apart: `$a` must still resolve to the *leading* `$`-style
+    /// parameter's argument (the trailing bare parameter creates no
+    /// `$`-binding to shadow it with), while a bare `a` reference in the
+    /// same body resolves to the *trailing* one -- so a single "last
+    /// argument wins" rule, applied to both namespaces at once, would pass
+    /// every other row here and still be wrong.
+    #[test]
+    fn test_bind_def_call_params_resolves_each_namespace_by_its_own_last_occurrence_2560() {
+        let bare = |name: &str| Param::Bare(name.to_string());
+        let dollar = |name: &str| Param::Dollar(name.to_string());
+        let args = || {
+            vec![
+                Expr::Literal(Literal::Int(1)),
+                Expr::Literal(Literal::Int(2)),
+            ]
+        };
+        let dollar_ref = || Expr::Var("a".to_string());
+        let bare_ref = || Expr::FuncCall {
+            name: "a".to_string(),
+            args: Vec::new(),
+            builtin_fallback: None,
+        };
+        // `Expr::Shared`-wrapped, since that is what the substitution
+        // inserts (#2096 capture hygiene).
+        let shared = |n: i64| Expr::Shared(Rc::new(Expr::Literal(Literal::Int(n))));
+
+        // `def f(a; $a): $a` -- the issue's own repro: the `$` namespace
+        // resolves to the trailing `$`-style parameter (`2`), not the
+        // leading bare one (`1`, what the pre-#2560 fold answered).
+        assert_eq!(
+            bind_def_call_params(&dollar_ref(), &[bare("a"), dollar("a")], &args()),
+            shared(2)
+        );
+        // `def f(a; $a): a` -- a `$`-style parameter binds the bare
+        // namespace too, so it shadows the leading bare parameter there
+        // as well.
+        assert_eq!(
+            bind_def_call_params(&bare_ref(), &[bare("a"), dollar("a")], &args()),
+            shared(2)
+        );
+        // `def f($a; a): $a` -- the trailing *bare* parameter shadows only
+        // the bare namespace, so `$a` keeps the leading parameter's `1`.
+        assert_eq!(
+            bind_def_call_params(&dollar_ref(), &[dollar("a"), bare("a")], &args()),
+            shared(1)
+        );
+        // `def f($a; a): a` -- and the bare reference in that same shape
+        // still follows the trailing parameter.
+        assert_eq!(
+            bind_def_call_params(&bare_ref(), &[dollar("a"), bare("a")], &args()),
+            shared(2)
+        );
+
+        // No duplicate name: the untouched fast path, one substitution per
+        // parameter (`def f(a; $b): [a, $b]`).
+        assert_eq!(
+            bind_def_call_params(
+                &Expr::Array(Box::new(Expr::Comma(vec![
+                    bare_ref(),
+                    Expr::Var("b".to_string()),
+                ]))),
+                &[bare("a"), dollar("b")],
+                &args(),
+            ),
+            Expr::Array(Box::new(Expr::Comma(vec![shared(1), shared(2)]))),
+        );
+    }
+
     #[test]
     fn test_bind_def_memoizes_per_node_2094() {
         let Expr::FuncDef {
@@ -49741,9 +49887,9 @@ mod tests {
             panic!("expected a top-level FuncDef");
         };
 
-        let first = bind_def(&name, &param_names(&params), &body, &then, &bound);
+        let first = bind_def(&name, &params, &body, &then, &bound);
         let first_ptr = Rc::as_ptr(&first);
-        let second = bind_def(&name, &param_names(&params), &body, &then, &bound);
+        let second = bind_def(&name, &params, &body, &then, &bound);
         assert!(
             Rc::ptr_eq(&first, &second),
             "a second call at the same depth sharing the same FuncDefBound must reuse the \
@@ -49754,7 +49900,7 @@ mod tests {
         // An independent node's own cache cell is untouched by the one
         // above -- confirms the cache is keyed per-node, not global.
         let fresh_cache = FuncDefBound::default();
-        let third = bind_def(&name, &param_names(&params), &body, &then, &fresh_cache);
+        let third = bind_def(&name, &params, &body, &then, &fresh_cache);
         assert!(
             !Rc::ptr_eq(&first, &third),
             "a different FuncDefBound must compute its own Rc, not see another node's cache"
@@ -49786,7 +49932,7 @@ mod tests {
 
         // No ambient depth entered yet: a fresh top-level `def` still seeds
         // from `0`, matching every evaluator's actual call site.
-        match &*bind_def(&name, &param_names(&params), &body, &then, &cache) {
+        match &*bind_def(&name, &params, &body, &then, &cache) {
             Expr::DefCall { frames, .. } => assert_eq!(*frames, 0),
             other => panic!("expected DefCall, got {other:?}"),
         }
@@ -49798,7 +49944,7 @@ mod tests {
         // FuncDef node.
         {
             let _guard = enter_def_call_frame(MAX_EVAL_FRAMES - 1);
-            match &*bind_def(&name, &param_names(&params), &body, &then, &cache) {
+            match &*bind_def(&name, &params, &body, &then, &cache) {
                 Expr::DefCall { frames, .. } => assert_eq!(*frames, MAX_EVAL_FRAMES - 1),
                 other => panic!("expected DefCall, got {other:?}"),
             }
@@ -49808,7 +49954,7 @@ mod tests {
         // `def` reached *after* the nested call returns -- a sibling, not
         // something nested inside it -- does not inherit a depth that no
         // longer applies to it.
-        match &*bind_def(&name, &param_names(&params), &body, &then, &cache) {
+        match &*bind_def(&name, &params, &body, &then, &cache) {
             Expr::DefCall { frames, .. } => assert_eq!(*frames, 0),
             other => panic!("expected DefCall, got {other:?}"),
         }
@@ -49843,7 +49989,7 @@ mod tests {
 
         let cache = FuncDefBound::default();
 
-        let first = bind_def(&name, &param_names(&params), &body, &then, &cache);
+        let first = bind_def(&name, &params, &body, &then, &cache);
         let first_frames = match &*first {
             Expr::DefCall { frames, .. } => *frames,
             other => panic!("expected DefCall, got {other:?}"),
@@ -49854,7 +50000,7 @@ mod tests {
         // node being reached again through an `Expr::Shared` wrapper
         // threaded into a deeper recursive `DefCall`'s substituted body.
         let _guard = enter_def_call_frame(500);
-        let second = bind_def(&name, &param_names(&params), &body, &then, &cache);
+        let second = bind_def(&name, &params, &body, &then, &cache);
         let second_frames = match &*second {
             Expr::DefCall { frames, .. } => *frames,
             other => panic!("expected DefCall, got {other:?}"),
@@ -49897,7 +50043,7 @@ mod tests {
 
         let _guard = enter_def_call_frame(MAX_EVAL_FRAMES);
         let cache = FuncDefBound::default();
-        let bound_then = bind_def(&name, &param_names(&params), &body, &then, &cache);
+        let bound_then = bind_def(&name, &params, &body, &then, &cache);
         let Expr::DefCall {
             def,
             args,
@@ -87781,7 +87927,7 @@ mod tests {
                 params: if args.is_empty() {
                     Vec::new()
                 } else {
-                    vec!["v".into()]
+                    vec![Param::Bare("v".to_string())]
                 },
                 body,
             }),

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -62,7 +62,7 @@ use super::eval::{
     has_type_mismatch_is_permissive, index_component_value, index_in_array_bounds,
     index_one_owned as index_owned_by_key, is_pure_chain_link, is_retryable_stop, literal_to_owned,
     mark_nonretryable_escape, needs_path_context, numeric_key_to_array_index, numeric_key_to_index,
-    numeric_length_owned, owned_bound_to_i64, owned_to_expr, owned_to_string, param_names,
+    numeric_length_owned, owned_bound_to_i64, owned_to_expr, owned_to_string,
     pattern_alternatives_var_names, prefer_pending_control, resume_from_escape, select_emits,
     slice_component_value, slice_object_as_yq_children, slice_owned_value_read,
     stop_with_downstream, stop_with_error, stop_with_escape, streams_escaped_generator_prefix,
@@ -7890,7 +7890,7 @@ fn eval_each_generic<S: EvalSemantics, V: DocumentValue>(
             then,
             bound,
         } => {
-            let bound_then = bind_def(name, &param_names(params), body, then, bound);
+            let bound_then = bind_def(name, params, body, then, bound);
             eval_each_generic::<S, V>(&bound_then, value, optional, cursor, sink)
         }
 
@@ -14389,7 +14389,7 @@ fn path_context_is_navigational_at(expr: &Expr, unfolded: u8) -> bool {
         } => {
             unfolded < OWNED_IDENTITY_DEF_UNFOLD_LIMIT
                 && path_context_is_navigational_at(
-                    &bind_def(name, &param_names(params), body, then, bound),
+                    &bind_def(name, params, body, then, bound),
                     unfolded + 1,
                 )
         }
@@ -14852,7 +14852,7 @@ fn path_context_step_generic<S: EvalSemantics, V: DocumentValue>(
             then,
             bound,
         } => {
-            let installed = bind_def(name, &param_names(params), body, then, bound);
+            let installed = bind_def(name, params, body, then, bound);
             path_context_step_generic::<S, V>(&installed, pos, out)
         }
         Expr::DefCall {
@@ -16254,10 +16254,7 @@ fn step_can_yield_absent(expr: &Expr, incoming: bool) -> bool {
             body,
             then,
             bound,
-        } => step_can_yield_absent(
-            &bind_def(name, &param_names(params), body, then, bound),
-            incoming,
-        ),
+        } => step_can_yield_absent(&bind_def(name, params, body, then, bound), incoming),
         Expr::DefCall {
             def,
             args,
@@ -16348,13 +16345,7 @@ fn path_context_stage_preserves_node(expr: &Expr) -> bool {
             body,
             then,
             bound,
-        } => path_context_stage_preserves_node(&bind_def(
-            name,
-            &param_names(params),
-            body,
-            then,
-            bound,
-        )),
+        } => path_context_stage_preserves_node(&bind_def(name, params, body, then, bound)),
         Expr::DefCall {
             def,
             args,
@@ -20092,7 +20083,7 @@ fn owned_identity_pipe_supported_at(stages: &[Expr], unfolded: u8) -> bool {
                 if unfolded >= OWNED_IDENTITY_DEF_UNFOLD_LIMIT {
                     return false;
                 }
-                let installed = bind_def(name, &param_names(params), def_body, then, bound);
+                let installed = bind_def(name, params, def_body, then, bound);
                 if !owned_identity_pipe_supported_at(
                     owned_identity_body_stages(&installed),
                     unfolded + 1,
@@ -22115,7 +22106,7 @@ fn eval_owned_identity_stages<S: EvalSemantics, V: DocumentValue>(
             then,
             bound,
         } => {
-            let installed = bind_def(name, &param_names(params), body, then, bound);
+            let installed = bind_def(name, params, body, then, bound);
             eval_owned_identity_spliced::<S, V>(&installed, rest, value, id, optional, tail)
         }
         Expr::DefCall {
@@ -31553,7 +31544,7 @@ mod tests {
 
         let _guard = enter_def_call_frame(crate::jq::eval::MAX_EVAL_FRAMES);
         let cache = FuncDefBound::default();
-        let defcall = bind_def(&name, &param_names(&params), &body, &then, &cache);
+        let defcall = bind_def(&name, &params, &body, &then, &cache);
         assert!(
             matches!(&*defcall, Expr::DefCall { frames, .. } if *frames == crate::jq::eval::MAX_EVAL_FRAMES),
             "expected bind_def to seed frames from the ambient depth"

--- a/src/jq/expr.rs
+++ b/src/jq/expr.rs
@@ -957,8 +957,13 @@ impl core::fmt::Debug for FuncDefBound {
 pub struct FuncDefData {
     /// Function name.
     pub name: String,
-    /// Parameter names (empty for a no-argument definition).
-    pub params: Vec<String>,
+    /// Parameters, each still carrying its bare-vs-`$` spelling (empty for a
+    /// no-argument definition) -- #2560: `bind_def_call`'s own call-time
+    /// argument binding needs `Param`'s `Bare`/`Dollar` distinction to
+    /// resolve a duplicate parameter name the same way jq's later-wins
+    /// shadowing does, not just the bare identifier `param_names` used to
+    /// reduce this to.
+    pub params: Vec<Param>,
     /// Function body.
     pub body: Expr,
 }
@@ -2387,7 +2392,7 @@ mod tests {
         let call = |bound| Expr::DefCall {
             def: Rc::new(FuncDefData {
                 name: "f".into(),
-                params: alloc_vec(["n"]),
+                params: vec![Param::Bare("n".to_string())],
                 body: Expr::Identity,
             }),
             args: vec![Expr::Literal(Literal::Int(1))],
@@ -2474,11 +2479,5 @@ mod tests {
                 "the cache must not affect Debug output ({label})"
             );
         }
-    }
-
-    /// Helper: `Vec<String>` from string literals, without repeating the
-    /// `to_string` dance at each call site.
-    fn alloc_vec<const N: usize>(names: [&str; N]) -> Vec<String> {
-        names.iter().map(|n| (*n).to_string()).collect()
     }
 }

--- a/src/jq/walk.rs
+++ b/src/jq/walk.rs
@@ -25,9 +25,9 @@ use alloc::rc::Rc;
 #[cfg(test)]
 use std::rc::Rc;
 
-#[cfg(test)]
-use super::FuncDefData;
 use super::{BoundBody, Builtin, Expr, FuncDefBound, ObjectEntry, ObjectKey, StringPart};
+#[cfg(test)]
+use super::{FuncDefData, Param};
 
 /// The sub-expressions a [`Builtin`] owns, in source order.
 ///
@@ -1905,7 +1905,7 @@ mod tests {
     fn map_subexprs_defcall_default_maps_args_and_resets_bound() {
         let def = Rc::new(FuncDefData {
             name: "f".into(),
-            params: vec!["x".into()],
+            params: vec![Param::Bare("x".to_string())],
             body: Expr::Identity,
         });
         let original = Expr::DefCall {

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -23152,6 +23152,22 @@ fn test_duplicate_named_param_combined_bare_and_dollar_reference_2560() -> Resul
     Ok(())
 }
 
+/// #2560 follow-on: a duplicated name with *no* `$`-style occurrence must
+/// leave a `$name` in the body to whatever encloses the `def`, because a
+/// bare parameter creates no `$`-binding at all. This is the assertion that
+/// stops the `is_dollar` filter in `bind_def_call_params` from being
+/// "simplified" into always running the `$` pass: doing that would re-capture
+/// the outer `$a` as the parameter and answer `6`, which is what the
+/// pre-#2560 blanket `subst_dollar: true` fold did. jq 1.7.1 answers `7`.
+#[test]
+fn test_duplicate_bare_named_param_leaves_an_outer_dollar_binding_alone_2560() -> Result<()> {
+    let (stdout, stderr, code) =
+        run_jq_full(&["-nc", "5 as $a | def f(a;a): $a + a; f(1;2)"], None)?;
+    assert_eq!(code, 0, "stderr: {stderr:?}");
+    assert_eq!(stdout.trim_end(), "7");
+    Ok(())
+}
+
 /// #2560 follow-on: three duplicated parameters, not just two -- the
 /// winner-selection must scan the *whole* remaining list, not just check
 /// one neighbor. Confirmed live against jq 1.7.1.

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -23085,24 +23085,85 @@ fn test_bare_nested_param_wrongly_shadows_outer_dollar_func_param_known_gap_2283
     Ok(())
 }
 
-/// #2283 review: `bind_def_call`'s own argument-binding for a duplicate
-/// parameter name is *separately* broken, confirmed present on
-/// unmodified `main` (i.e. entirely unrelated to #2283's own shadow-check
-/// fix -- not a regression, and not fixed here) -- pinned as a known gap,
-/// tracked separately as #2560. jq 1.7.1 resolves `$a` to the *second* occurrence's own argument (`2`,
-/// ordinary later-wins parameter shadowing); this resolves to the first
-/// occurrence's argument (`1`) instead. See
-/// `test_duplicate_named_param_shadow_resolves_by_last_occurrence_2283`
-/// (`src/jq/eval.rs`) for direct, isolated confirmation that #2283's own
-/// shadow-check logic (which outer-`$var` substitution reaches a nested
-/// def's body) already resolves duplicate names correctly by the *last*
-/// occurrence -- this remaining gap is specifically in argument binding at
-/// call time, a different mechanism.
+/// #2560: `bind_def_call`'s own argument-binding for a duplicate parameter
+/// name now resolves by jq's ordinary later-wins parameter shadowing, the
+/// same rule `test_duplicate_named_param_shadow_resolves_by_last_occurrence_2283`
+/// (`src/jq/eval.rs`) already confirmed for the unrelated outer-`$var`
+/// shadow-check -- this was specifically call-time argument binding, a
+/// different mechanism, previously resolving to the *first* occurrence's
+/// argument (`1`) instead of the *second*'s (`2`). Confirmed live against
+/// jq 1.7.1.
 #[test]
-fn test_duplicate_named_param_argument_binding_known_gap_2283() -> Result<()> {
+fn test_duplicate_named_param_argument_binding_resolves_by_last_occurrence_2560() -> Result<()> {
     let (stdout, stderr, code) = run_jq_full(&["-nc", "9 as $a | def f(a; $a): $a; f(1;2)"], None)?;
     assert_eq!(code, 0, "stderr: {stderr:?}");
+    assert_eq!(stdout.trim_end(), "2");
+    Ok(())
+}
+
+/// #2560 follow-on: two same-*kind* duplicated parameters resolve by last
+/// occurrence too, not just the mixed bare/`$` shape above -- both bare and
+/// both `$`-style. Confirmed live against jq 1.7.1.
+#[test]
+fn test_duplicate_named_param_same_kind_resolves_by_last_occurrence_2560() -> Result<()> {
+    let (stdout, stderr, code) = run_jq_full(&["-nc", "def f(a;a): a; f(1;2)"], None)?;
+    assert_eq!(code, 0, "stderr: {stderr:?}");
+    assert_eq!(stdout.trim_end(), "2");
+
+    let (stdout, stderr, code) = run_jq_full(&["-nc", "def f($a;$a): $a; f(1;2)"], None)?;
+    assert_eq!(code, 0, "stderr: {stderr:?}");
+    assert_eq!(stdout.trim_end(), "2");
+    Ok(())
+}
+
+/// #2560 follow-on: a `$`-style parameter *before* a trailing bare parameter
+/// of the same name is the one shape where the winner differs by namespace --
+/// the trailing bare parameter shadows the bare namespace only, so the
+/// leading `$a`'s own binding is still what `$a` itself resolves to (`1`,
+/// not `2`), while a bare *reference* in the body follows the trailing
+/// parameter (`2`). Confirmed live against jq 1.7.1: this is the one
+/// duplicate-parameter shape that does *not* simply "last argument wins" for
+/// every reference in the body.
+#[test]
+fn test_duplicate_named_param_dollar_first_bare_last_splits_by_namespace_2560() -> Result<()> {
+    let (stdout, stderr, code) = run_jq_full(&["-nc", "def f($a; a): $a; f(1;2)"], None)?;
+    assert_eq!(code, 0, "stderr: {stderr:?}");
     assert_eq!(stdout.trim_end(), "1");
+
+    let (stdout, stderr, code) = run_jq_full(&["-nc", "def f($a; a): a; f(1;2)"], None)?;
+    assert_eq!(code, 0, "stderr: {stderr:?}");
+    assert_eq!(stdout.trim_end(), "2");
+    Ok(())
+}
+
+/// #2560 follow-on: a body referencing *both* the bare and `$` occurrence of
+/// a duplicated name must resolve each independently, per the namespace
+/// rule above -- not just whichever single reference the other pinned tests
+/// happen to use. Confirmed live against jq 1.7.1.
+#[test]
+fn test_duplicate_named_param_combined_bare_and_dollar_reference_2560() -> Result<()> {
+    let (stdout, stderr, code) = run_jq_full(&["-nc", "def f($a; a): $a + a; f(1;2)"], None)?;
+    assert_eq!(code, 0, "stderr: {stderr:?}");
+    assert_eq!(stdout.trim_end(), "3");
+
+    let (stdout, stderr, code) = run_jq_full(&["-nc", "def f(a; $a): $a + a; f(1;2)"], None)?;
+    assert_eq!(code, 0, "stderr: {stderr:?}");
+    assert_eq!(stdout.trim_end(), "4");
+    Ok(())
+}
+
+/// #2560 follow-on: three duplicated parameters, not just two -- the
+/// winner-selection must scan the *whole* remaining list, not just check
+/// one neighbor. Confirmed live against jq 1.7.1.
+#[test]
+fn test_duplicate_named_param_three_occurrences_2560() -> Result<()> {
+    let (stdout, stderr, code) = run_jq_full(&["-nc", "def f(a;a;a): a; f(1;2;3)"], None)?;
+    assert_eq!(code, 0, "stderr: {stderr:?}");
+    assert_eq!(stdout.trim_end(), "3");
+
+    let (stdout, stderr, code) = run_jq_full(&["-nc", "def f($a;$a;a): $a + a; f(1;2;3)"], None)?;
+    assert_eq!(code, 0, "stderr: {stderr:?}");
+    assert_eq!(stdout.trim_end(), "5");
     Ok(())
 }
 

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -32286,6 +32286,23 @@ fn test_recursive_def_evaluates_in_yq_mode_1371() -> Result<()> {
     Ok(())
 }
 
+/// #2560: `bind_def_call`'s duplicate-parameter-name fix lives in `eval.rs`,
+/// shared by both evaluators -- confirm yq mode's own `DefCall` path
+/// resolves a duplicate parameter name by last occurrence too, not just
+/// `succinctly jq`'s (`tests/jq_cli_tests.rs`'s
+/// `test_duplicate_named_param_argument_binding_resolves_by_last_occurrence_2560`,
+/// pinned against jq 1.7.1: `2`). `def` is itself a succinctly extension
+/// here (see this file's own `test_recursive_def_evaluates_in_yq_mode_1371`
+/// just above), so this pins parity with succinctly's own jq-mode answer
+/// rather than a yq reference.
+#[test]
+fn test_duplicate_named_param_argument_binding_resolves_by_last_occurrence_yq_2560() -> Result<()> {
+    let (stdout, code) = run_yq_stdin("def f(a; $a): $a; f(1;2)", "a: 1\n", &[])?;
+    assert_eq!(code, 0, "stdout: {stdout:?}");
+    assert_eq!(stdout.trim_end(), "2");
+    Ok(())
+}
+
 /// #1371: the generic evaluator's own demand-driven `DefCall`/`Shared` arms.
 /// A truncating consumer must not run the rest of a definition's body, nor the
 /// rest of an argument, after it already has its answer -- the same property


### PR DESCRIPTION
## Summary

`bind_def_call` folded each `(param, arg)` pair through `substitute_func_param` in
order, so a `def` whose parameter list repeats a name resolved every reference to the
**first** occurrence's argument — the first substitution consumed the matching AST nodes
and left the later, actually in-scope parameter nothing to replace. jq's parameter list
is a chain of nested scopes, innermost last, so a later same-named parameter shadows an
earlier one.

Confirmed live against jq 1.7.1, and present in **both** modes before this change (one
shared `bind_def_call`):

```console
$ jq -nc 'def f(a; $a): $a; f(1;2)'
2
$ succinctly jq -nc 'def f(a; $a): $a; f(1;2)'   # before
1
```

### The part that isn't just "last argument wins"

A `$`-style parameter binds **both** the bare namespace and its own `$name`; a
bare-style parameter binds **only** the bare one. So the two namespaces can have
different winners, and a single last-wins rule gets one of them wrong:

| program | jq 1.7.1 | before | after |
|---|---|---|---|
| `def f(a; $a): $a; f(1;2)` | `2` | `1` | `2` |
| `def f(a; $a): a; f(1;2)` | `2` | `1` | `2` |
| `def f($a; a): $a; f(1;2)` | `1` | `1` | `1` |
| `def f($a; a): a; f(1;2)` | `2` | `1` | `2` |
| `def f($a; a): $a + a; f(1;2)` | `3` | `2` | `3` |
| `def f(a; $a): $a + a; f(1;2)` | `4` | `2` | `4` |
| `def f(a;a;a): a; f(1;2;3)` | `3` | `1` | `3` |
| `def f($a;$a;a): $a + a; f(1;2;3)` | `5` | `2` | `5` |
| `def f(a;$a;$a): $a + a; f(1;2;3)` | `6` | `2` | `6` |

The `$`-first/bare-last row is the discriminating one: `$a` still resolves to the
*leading* `$`-style parameter (the trailing bare parameter creates no `$`-binding to
shadow it with) while a bare `a` in the same body resolves to the *trailing* one.

New `bind_def_call_params` substitutes the bare winner first with `subst_dollar: false`
(so it only rewrites bare `Expr::FuncCall` nodes), then the `$` winner with
`subst_dollar: true`. The ordering is what makes it correct: the bare pass's insertions
are already `Expr::Shared`, which `substitute_func_param_impl` treats as opaque, so the
`$` pass's unconditional bare-matching arm has nothing left to clobber.

**Non-duplicate parameter lists keep the identical single fold, at the identical cost** —
the duplicate-aware path is behind a `has_duplicate_names` scan over a list that is
almost always 0-3 entries.

### Supporting change

`FuncDefData::params` becomes `Vec<Param>` so the bare-vs-`$` spelling survives to call
time. The `param_names` helper existed only to strip it, so it is gone and every
`bind_def` call site passes `params` straight through — a net deletion at ~15 sites.

## Test plan

- [x] `cargo build --features cli`
- [x] `cargo test --features cli,simd,regex,serde` — full suite, 0 failures
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] Every row in the table above diffed directly against `/usr/bin/jq` (1.7.1), not
      just against golden fixtures
- [x] New regression tests: `test_duplicate_named_param_*_2560` in
      `tests/jq_cli_tests.rs` (5 tests covering same-kind duplicates, the namespace
      split, combined bare+`$` reference bodies, and three occurrences), the yq-mode
      parity test in `tests/yq_cli_tests.rs`, and
      `test_bind_def_call_params_resolves_each_namespace_by_its_own_last_occurrence_2560`
      exercising the helper directly at AST level in `src/jq/eval.rs`
- [x] The previously pinned known-gap test
      (`test_duplicate_named_param_argument_binding_known_gap_2283`) is renamed and
      flipped to jq's real answer

Fixes #2560