### PR TITLE
fix(jq): reject the zero-child stray comma ({,} / [,]) on every filter

### DIFF
--- a/docs/compliance/jq/limitations.md
+++ b/docs/compliance/jq/limitations.md
@@ -1805,22 +1805,41 @@ pinned rather than silently left uncovered, by
 in [tests/jq_cli_tests.rs](../../../tests/jq_cli_tests.rs).
 
 **#2211's own sibling shape (`[,]`, `{,}` -- a stray comma with *zero* real
-elements/fields) remains open through every path this section fixed**, for
-the same reason it remains open through `to_owned_at_depth`'s cursor-less
-callers (#2262's own account above): `container_gap_ok` needs a cursor to
-the *container itself* to find its opening bracket, and none of
+elements/fields) -- closed by #2594.** It was open through every path this
+section fixed, for the same reason it remains open through
+`to_owned_at_depth`'s cursor-less callers (#2262's own account above):
+`container_gap_ok` needs a cursor to the *container itself* to find its
+opening bracket, and none of
 `each_lazy_array_iterate_sink`/`collect_cursors_checked`/`len_checked`
 (elements only), `effective_fields_checked`/`effective_keys`/
 `DistinctKeyCursors`/`find_cursor` (fields only) ever receive one -- only
-per-child cursors, once a child exists to hold one. One path in this set
-*does* have a container cursor sitting unused at its call site:
-`eval_each_generic`'s `Expr::Iterate` arm already threads `cursor:
-Option<V::Cursor>` through to `each_lazy_array_iterate_sink`'s call site
-but doesn't pass it in. Deliberately not wired up here -- doing so would
-mean widening a hot-path function's signature and its one call site for a
-case outside this issue's own five repros, a scoped follow-up rather than
-opportunistic scope creep. Pinned as still open by
-`test_jq_cursor_transparent_fast_paths_empty_container_stray_comma_remains_a_known_gap_2261`.
+per-child cursors, once a child exists to hold one.
+
+That is still true of the walks, and #2594 did not change any of them. What
+it changed is where the check runs: every one of those walks is dispatched
+from an `eval_single`/`eval_builtin`/`path_step_generic` arm that already
+holds `cursor: Option<V::Cursor>` for the container (for type-name
+diagnostics), so the arm now calls `empty_fields_tail_gap_ok`/
+`empty_elements_tail_gap_ok` (`document.rs`) ahead of the walk that cannot.
+The observation recorded here -- that `eval_each_generic`'s `Expr::Iterate`
+arm had a container cursor sitting unused at its call site -- generalised:
+so did all the others.
+
+Per-arm rather than one guard at the top of either dispatch function,
+because #2173's closed terms (`empty`, `true and true`, `1 + 1`) dispatch
+through them too and must answer exactly as `empty` does on every document,
+malformed ones included; a hoisted guard fails
+`test_ambient_validation_agrees_with_bridge_2476`. Pinned by
+`test_jq_cursor_transparent_fast_paths_empty_container_stray_comma_now_raises_2594`,
+with `test_jq_genuinely_empty_containers_unaffected_2594` and
+`test_jq_closed_terms_unaffected_by_empty_container_check_2594` for the two
+things the fix must *not* do.
+
+Still open, unchanged by #2594: the same shape reached through
+`to_owned_at_depth`'s cursor-less top-level callers (#2262 above) and
+through `collect_paths_generic`'s value-domain recursion for a container
+nested *inside* a `paths`/`leaf_paths` walk -- neither has a container
+cursor to check against.
 
 **`length` (objects) -- fixed by #2307/#2311.** Not one of this issue's own
 five repros, originally left open here with reasoning that turned out to be

--- a/src/bin/succinctly/jq_runner.rs
+++ b/src/bin/succinctly/jq_runner.rs
@@ -5282,7 +5282,10 @@ fn standard_json_to_jq_value<'a, W: Clone + AsRef<[u64]>>(
     // and this is the true top level -- the one entry point with none to
     // give, the same documented gap `owned_from_standard_json_at_depth`'s
     // own comment describes. Wiring in the callable half is a behaviour
-    // change; tracked with the rest in #2594.
+    // change, still untaken. #2594 did not reach this site: it closed the
+    // zero-child gap in the evaluator arms that *do* hold a container
+    // cursor, and by the time a value arrives here the walk that produced
+    // it has already been checked there.
     // STYLE-0013: `preceding_gap_ok` directly, not `key_delimiter_ok`/
     // `value_delimiter_ok` -- this is the CLI-crate lazy materializer, not
     // `DocumentFields`-generic, and its array/object arms below already

--- a/src/jq/document.rs
+++ b/src/jq/document.rs
@@ -1888,6 +1888,74 @@ pub fn tail_gap_ok<C: DocumentCursor>(
     }
 }
 
+/// [`container_tail_gap_ok`]'s zero-child half alone, for a **dispatch
+/// site** that holds the container's own cursor but hands the walk itself
+/// off to a helper that only ever sees children -- #2594.
+///
+/// Every shared object walk in this module ([`census`], [`checked_len`],
+/// [`effective_keys`], [`DocumentFields::contains_checked`],
+/// [`effective_fields_checked`]) takes `&F` and nothing else, so none of
+/// them can reach the container to tell a genuine `{}` from a stray `,`
+/// with no member at all (`{,}`). Widening all of them would mean a new
+/// parameter on each; their *callers* in the evaluator already carry
+/// `cursor: Option<V::Cursor>` beside the value for unrelated reasons
+/// (type-name diagnostics), so the check goes there instead, once per
+/// dispatch rather than once per member.
+///
+/// `Ok(())` whenever the walk found a member (the container is genuinely
+/// non-empty, and the *trailing*-comma shape `{"a":1,}` is what those
+/// walks already check for themselves) or the caller has no cursor (the
+/// true top level -- the documented gap [`tail_gap_ok`] describes).
+///
+/// **Call this from the arm that is about to walk the container, never from
+/// the top of the dispatch function it lives in.** `empty`, `true and true`
+/// and the rest of #2173's closed terms dispatch through `eval_single`/
+/// `eval_builtin` too, and a closed term must answer exactly as `empty`
+/// does on every document, malformed ones included -- reading no member is
+/// what makes it closed, so the check belongs where a member is about to
+/// be read. `test_ambient_validation_agrees_with_bridge_2476` pins that
+/// against `empty` itself, and a guard hoisted to the top of either
+/// function fails it.
+///
+/// The raise is the container's own `malformed_delimiter_error()`, which
+/// for JSON re-runs the strict validator over the whole document -- so the
+/// message is byte-identical to the one `.` already produces for the same
+/// input rather than a second spelling of it. It carries the
+/// always-uncatchable tag (#2286), so `.a?` on `{,}` raises too, matching
+/// real jq, which cannot parse the document for *any* filter.
+///
+/// Free for every format but JSON: [`DocumentCursor::container_gap_ok`] is
+/// a `true`-returning default everywhere else, since they validate while
+/// parsing.
+pub fn empty_fields_tail_gap_ok<F: DocumentFields>(
+    fields: &F,
+    container: Option<&F::Cursor>,
+) -> Result<(), EvalError> {
+    match container {
+        Some(c) if fields.is_empty() => container_tail_gap_ok::<F::Cursor>(c, None, b'}'),
+        _ => Ok(()),
+    }
+}
+
+/// [`empty_fields_tail_gap_ok`]'s array twin -- the zero-*element* stray
+/// comma (`[,]`, #2594).
+///
+/// For a dispatch site holding the array's own cursor while
+/// [`DocumentElements::len_checked`],
+/// [`DocumentElements::collect_cursors_checked`] and `LazySource::Elements`
+/// walk only its (zero) elements. Same contract as
+/// [`empty_fields_tail_gap_ok`], including the rule that it is called from
+/// the arm about to walk, never from the top of the dispatch function.
+pub fn empty_elements_tail_gap_ok<E: DocumentElements>(
+    elements: &E,
+    container: Option<&E::Cursor>,
+) -> Result<(), EvalError> {
+    match container {
+        Some(c) if elements.is_empty() => container_tail_gap_ok::<E::Cursor>(c, None, b']'),
+        _ => Ok(()),
+    }
+}
+
 /// [`trailing_element_gap_ok`], for a key-only object walk that has
 /// tracked only the last field's *key* cursor (`census`, `checked_len`,
 /// `contains_checked`'s exhaustion path, [`DistinctKeyCursors`]'s own

--- a/src/jq/document.rs
+++ b/src/jq/document.rs
@@ -1892,8 +1892,8 @@ pub fn tail_gap_ok<C: DocumentCursor>(
 /// site** that holds the container's own cursor but hands the walk itself
 /// off to a helper that only ever sees children -- #2594.
 ///
-/// Every shared object walk in this module ([`census`], [`checked_len`],
-/// [`effective_keys`], [`DocumentFields::contains_checked`],
+/// Every shared object walk in this module (`census`, `checked_len`, both
+/// private, [`effective_keys`], [`DocumentFields::contains_checked`],
 /// [`effective_fields_checked`]) takes `&F` and nothing else, so none of
 /// them can reach the container to tell a genuine `{}` from a stray `,`
 /// with no member at all (`{,}`). Widening all of them would mean a new

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -13938,6 +13938,11 @@ fn path_step_generic<S: EvalSemantics, V: DocumentValue>(
                     if v.is_null() {
                         PathNode::Absent
                     } else if let Some(fields) = v.as_object() {
+                        // #2594: `find_cursor` walks fields alone, so a
+                        // zero-field `{,}` simply missed and this step
+                        // reported an absent position -- `path(.a)` answered
+                        // `["a"]` where the bare `.a` raises.
+                        empty_fields_tail_gap_ok(&fields, Some(c))?;
                         match fields.find_cursor(name)? {
                             Some(fc) => PathNode::At(fc),
                             None => PathNode::Absent,
@@ -14005,6 +14010,10 @@ fn path_step_generic<S: EvalSemantics, V: DocumentValue>(
                     if v.is_null() {
                         PathNode::Absent
                     } else if let Some(elements) = v.as_array() {
+                        // #2594: the zero-element `[,]` no element-only walk
+                        // can see -- `path(.[0])` answered `[0]` where the
+                        // bare `.[0]` raises.
+                        empty_elements_tail_gap_ok(&elements, Some(c))?;
                         // yq mode only (#2254): a negative index still
                         // negative after resolving against the length raises
                         // in real yq, and the path-context walk (#2416 phase
@@ -14090,6 +14099,9 @@ fn path_step_generic<S: EvalSemantics, V: DocumentValue>(
             PathNode::At(c) => {
                 let v = c.value();
                 if let Some(fields) = v.as_object() {
+                    // #2594: the zero-field `{,}` `effective_fields_checked`
+                    // cannot see, same as the value-side `Expr::Iterate` arm.
+                    empty_fields_tail_gap_ok(&fields, Some(c))?;
                     // `effective_fields_checked` with the mode's own
                     // duplicate-key rule, plus `key_display_string` -- the
                     // same two helpers `collect_paths_generic` uses, reused
@@ -14108,6 +14120,8 @@ fn path_step_generic<S: EvalSemantics, V: DocumentValue>(
                     }
                     Ok(())
                 } else if let Some(elements) = v.as_array() {
+                    // #2594: and the zero-element `[,]` it still cannot see.
+                    empty_elements_tail_gap_ok(&elements, Some(c))?;
                     // #2261 (systematic sweep): `collect_cursors_checked`,
                     // not the unchecked `collect_cursors` this arm used --
                     // the object arm just above already routes through the

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -45,10 +45,10 @@ use indexmap::IndexMap;
 use super::document::{
     child_tail_gap_ok, collapsed_fields, collapsed_fields_if, container_tail_gap_ok,
     effective_fields_checked, effective_fields_with_raw_last, effective_keys,
-    effective_len_checked, key_delimiter_ok, key_display_string, key_display_string_kind,
-    key_is_malformed, resolve_display_key, tail_gap_ok, trailing_element_gap_ok,
-    value_delimiter_ok, DisplayKeyGuard, DistinctKeyCursors, DocumentCursor, DocumentElements,
-    DocumentFields, DocumentValue, IndentSpec, JsonConvention,
+    effective_len_checked, empty_elements_tail_gap_ok, empty_fields_tail_gap_ok, key_delimiter_ok,
+    key_display_string, key_display_string_kind, key_is_malformed, resolve_display_key,
+    tail_gap_ok, trailing_element_gap_ok, value_delimiter_ok, DisplayKeyGuard, DistinctKeyCursors,
+    DocumentCursor, DocumentElements, DocumentFields, DocumentValue, IndentSpec, JsonConvention,
 };
 use super::error::EvalEscape;
 use super::eval::{
@@ -352,7 +352,10 @@ fn malformed_object_member<F: DocumentFields>(fields: &F) -> Option<EvalError> {
     // would newly reject documents this function accepts today: a behaviour
     // change, not a refactor. The tail check it does make is
     // `ends_unpaired()` below, which catches a trailing orphan but not a
-    // zero-child `{,}` gap. Tracked as #2594.
+    // zero-child `{,}` gap. That one is closed by the `Builtin::ToEntries`
+    // arm's own `empty_fields_tail_gap_ok` call, immediately after this
+    // function returns (#2594) -- a caller with the container cursor this
+    // key-only walk was never given.
     let mut walk = fields.clone();
     let mut is_first = true;
     while let Some((key, cursor, rest)) = walk.uncons_key() {
@@ -379,6 +382,34 @@ fn malformed_object_member<F: DocumentFields>(fields: &F) -> Option<EvalError> {
         is_first = false;
     }
     walk.ends_unpaired().then(|| walk.malformed_member_error())
+}
+
+/// [`empty_fields_tail_gap_ok`]/[`empty_elements_tail_gap_ok`] for an arm
+/// that walks whichever container it was handed -- `paths`, `leaf_paths`,
+/// `getpath` (#2594).
+///
+/// Those three dispatch to a *value-domain* walk (`collect_paths_generic`,
+/// `getpath_walk_cursor`), so unlike the arms that call one of the two
+/// helpers directly they do not know which container they have until they
+/// look. Same contract as those helpers, including the rule that this is
+/// called from the arm about to walk, never from the top of the dispatch
+/// function -- see [`empty_fields_tail_gap_ok`]'s own doc comment.
+///
+/// Covers the container this arm is standing on. A `{,}` nested *inside*
+/// the walk stays unchecked, because `collect_paths_generic` recurses over
+/// values and carries no cursor to check against -- the same shape
+/// [`to_owned_at_depth`] documents, tracked separately.
+fn empty_container_gap_error<V: DocumentValue>(
+    value: &V,
+    cursor: Option<&V::Cursor>,
+) -> Option<EvalError> {
+    if let Some(fields) = value.as_object() {
+        empty_fields_tail_gap_ok(&fields, cursor).err()
+    } else if let Some(elements) = value.as_array() {
+        empty_elements_tail_gap_ok(&elements, cursor).err()
+    } else {
+        None
+    }
 }
 
 /// `cursor` is the cursor pointing at `value` itself, when the caller has
@@ -6505,7 +6536,21 @@ fn eval_single<S: EvalSemantics, V: DocumentValue>(
             // evaluator's `index_object_by_name` applies, from the same
             // definition.
             let absent_is_empty = yq_absent_key_read_is_empty::<S>();
+            // #2594: `.a` on an *array* never walks it -- it is a type error
+            // (or, under `?`, suppressed to empty), so `[,] | .a?` exited 0
+            // on a document real jq cannot parse. The malformed-document
+            // raise is not the type error `?` suppresses.
+            if let Some(elements) = value.as_array() {
+                if let Err(err) = empty_elements_tail_gap_ok(&elements, cursor.as_ref()) {
+                    return GenericResult::Error(err);
+                }
+            }
             if let Some(fields) = value.as_object() {
+                // #2594: `find_cursor`'s walk holds only fields, so a
+                // zero-field `{,}` answered `null` here for every name.
+                if let Err(err) = empty_fields_tail_gap_ok(&fields, cursor.as_ref()) {
+                    return GenericResult::Error(err);
+                }
                 match fields.find_cursor(name) {
                     Ok(Some(c)) => GenericResult::OneCursor(c),
                     // jq returns null for missing fields on objects (not an error)
@@ -6547,6 +6592,11 @@ fn eval_single<S: EvalSemantics, V: DocumentValue>(
 
         Expr::Index { idx, .. } => {
             if let Some(elements) = value.as_array() {
+                // #2594: `len_checked`'s walk holds only elements, so a
+                // zero-element `[,]` answered `null` here for every index.
+                if let Err(err) = empty_elements_tail_gap_ok(&elements, cursor.as_ref()) {
+                    return GenericResult::Error(err);
+                }
                 // #2261: `_checked`, not the bare `len()` this used to call
                 // -- free here, unlike a *positive*-only lookup elsewhere
                 // in this evaluator (`Expr::Iterate`'s sorted-key positive-
@@ -6638,6 +6688,13 @@ fn eval_single<S: EvalSemantics, V: DocumentValue>(
 
         Expr::Iterate => {
             if let Some(elements) = value.as_array() {
+                // #2594: and its own zero-element check, which
+                // `collect_cursors_checked`'s element-only walk cannot make
+                // (that function's own doc comment says so) -- `[,]`
+                // iterated nothing and succeeded.
+                if let Err(err) = empty_elements_tail_gap_ok(&elements, cursor.as_ref()) {
+                    return GenericResult::Error(err);
+                }
                 // #1677: `.[]` over an array reaches into every element
                 // without ever re-serializing the container whole, so it
                 // needs its own gap check between siblings.
@@ -6663,6 +6720,12 @@ fn eval_single<S: EvalSemantics, V: DocumentValue>(
                 // The check is free here -- it rides the same walk this arm
                 // already ran unconditionally, same as `effective_len_checked`
                 // does for `length`.
+                //
+                // #2594: the zero-field `{,}` that walk cannot see, same as
+                // the array branch above.
+                if let Err(err) = empty_fields_tail_gap_ok(&fields, cursor.as_ref()) {
+                    return GenericResult::Error(err);
+                }
                 match effective_fields_checked(&fields, true) {
                     Ok(effective) => {
                         let cursors: Vec<_> = effective
@@ -7958,8 +8021,16 @@ fn eval_each_generic<S: EvalSemantics, V: DocumentValue>(
         // `DistinctKeyCursors`' streaming-collapse machinery extended to
         // also carry value cursors, a separate and larger change not
         // attempted here.
+        // #2594: the one streaming arm that walks a container without ever
+        // reaching `eval_single` (whose own guard covers the `None` fallback
+        // below and the object case) -- `each_lazy_array_iterate_sink` takes
+        // only the elements, so a zero-element `[,]` streamed nothing and
+        // succeeded. See `empty_container_gap_error`.
         Expr::Iterate => match value.as_array() {
-            Some(elements) => each_lazy_array_iterate_sink(elements, sink),
+            Some(elements) => match empty_elements_tail_gap_ok(&elements, cursor.as_ref()) {
+                Ok(()) => each_lazy_array_iterate_sink(elements, sink),
+                Err(err) => Flow::Escaped(Control::Error(err)),
+            },
             None => drain_result_generic(eval_single::<S, V>(expr, value, optional, cursor), sink),
         },
 
@@ -13376,10 +13447,17 @@ fn eval_has_one_key<S: EvalSemantics, V: DocumentValue>(
         // for why this walks to completion (a real cost increase for the
         // "key found early" case) rather than riding an already-mandatory
         // walk for free like every other #2261 fix.
-        (OwnedValue::String(key), Some(fields), _) => match fields.contains_checked(key) {
-            Ok(found) => GenericResult::Owned(OwnedValue::Bool(found)),
-            Err(err) => GenericResult::Error(err),
-        },
+        (OwnedValue::String(key), Some(fields), _) => {
+            // #2594: `contains_checked`'s walk still sees no member at all
+            // for `{,}`, which answered `false` for every key.
+            if let Err(err) = empty_fields_tail_gap_ok(&fields, cursor.as_ref()) {
+                return GenericResult::Error(err);
+            }
+            match fields.contains_checked(key) {
+                Ok(found) => GenericResult::Owned(OwnedValue::Bool(found)),
+                Err(err) => GenericResult::Error(err),
+            }
+        }
         (
             OwnedValue::Int(_) | OwnedValue::Float(_) | OwnedValue::NumberLiteral(..),
             _,
@@ -13390,6 +13468,12 @@ fn eval_has_one_key<S: EvalSemantics, V: DocumentValue>(
             // reads only the count, never a value), so the #1677/#2261 gap
             // checks ride along for free, same reasoning as
             // `Expr::Index`'s own array arm in `eval_single`.
+            //
+            // #2594: and the zero-element `[,]` it cannot see, which
+            // answered `false` for every index.
+            if let Err(err) = empty_elements_tail_gap_ok(&elements, cursor.as_ref()) {
+                return GenericResult::Error(err);
+            }
             let len = match elements.len_checked() {
                 Ok(len) => len,
                 Err(err) => return GenericResult::Error(err),
@@ -18045,10 +18129,21 @@ fn eval_builtin<S: EvalSemantics, V: DocumentValue>(
         // non-goal and stays on the wildcard fallback below.
         Builtin::Map(f) => {
             if let Some(elements) = value.as_array() {
+                // #2594: `LazySource::Elements` pulls through
+                // `uncons_cursor` alone and runs no gap check at all, so
+                // `[,] | map(f)` produced `[]`.
+                if let Err(err) = empty_elements_tail_gap_ok(&elements, cursor.as_ref()) {
+                    return GenericResult::Error(err);
+                }
                 GenericResult::LazySeq(Box::new(
                     LazySeq::new(LazySource::Elements(elements)).push_map(f, S::TAG),
                 ))
             } else if let Some(fields) = value.as_object() {
+                // #2594: `LazySource::Values`/`collapsed_fields` likewise
+                // never see the zero-field `{,}`.
+                if let Err(err) = empty_fields_tail_gap_ok(&fields, cursor.as_ref()) {
+                    return GenericResult::Error(err);
+                }
                 // `.[]` collapses a repeated key to its first position but
                 // last-seen value in both modes (#1398), which needs every
                 // occurrence seen before any value can be emitted --
@@ -18258,6 +18353,12 @@ fn eval_builtin<S: EvalSemantics, V: DocumentValue>(
                 // `len`'s plain `uncons` doesn't carry one) but keeping no
                 // `Vec`, same reasoning as `collect_cursors_checked`'s own
                 // O(1)-space sibling `len_checked`.
+                //
+                // #2594: and the zero-element `[,]` that walk cannot see,
+                // which answered `0`.
+                if let Err(err) = empty_elements_tail_gap_ok(&elements, cursor.as_ref()) {
+                    return GenericResult::Error(err);
+                }
                 match elements.len_checked() {
                     Ok(len) => GenericResult::Owned(OwnedValue::Int(len as i64)),
                     Err(err) => GenericResult::Error(err),
@@ -18276,6 +18377,12 @@ fn eval_builtin<S: EvalSemantics, V: DocumentValue>(
                 //
                 // Distinct keys in jq mode (#1385) -- `{"a":1,"a":2}|length`
                 // is 1, because the object jq built only ever had one member.
+                //
+                // #2594: the zero-field `{,}` neither `census` nor
+                // `checked_len` can see, which answered `0`.
+                if let Err(err) = empty_fields_tail_gap_ok(&fields, cursor.as_ref()) {
+                    return GenericResult::Error(err);
+                }
                 match effective_len_checked(&fields, S::COLLAPSE_DUPLICATE_KEYS) {
                     Ok(len) => GenericResult::Owned(OwnedValue::Int(len as i64)),
                     Err(err) => GenericResult::Error(err),
@@ -18300,6 +18407,12 @@ fn eval_builtin<S: EvalSemantics, V: DocumentValue>(
 
         Builtin::Keys => {
             if let Some(fields) = value.as_object() {
+                // #2594: `effective_keys`, whatever eventually drains this
+                // `LazyKeys`, walks fields alone -- a zero-field `{,}`
+                // listed `[]` rather than raising.
+                if let Err(err) = empty_fields_tail_gap_ok(&fields, cursor.as_ref()) {
+                    return GenericResult::Error(err);
+                }
                 // Stay lazy here too (#683) — `length` can answer from
                 // `fields.len()` without decoding or sorting a single key.
                 // `.[]`/`.[n]`/`first`/`last`/bare output still need the
@@ -18324,6 +18437,13 @@ fn eval_builtin<S: EvalSemantics, V: DocumentValue>(
                 // gap checks ride along for free, and `[1,2,3,] | keys`
                 // now agrees with real jq (parse error) instead of
                 // silently returning `[0,1,2]`.
+                //
+                // #2594: `len_checked` still cannot see the *zero*-element
+                // `[,]`, which listed `[]` the same way `{,}` listed `[]`
+                // in the object branch above.
+                if let Err(err) = empty_elements_tail_gap_ok(&elements, cursor.as_ref()) {
+                    return GenericResult::Error(err);
+                }
                 match elements.len_checked() {
                     Ok(len) => GenericResult::LazyIndexRange(len),
                     Err(err) => GenericResult::Error(err),
@@ -18339,6 +18459,10 @@ fn eval_builtin<S: EvalSemantics, V: DocumentValue>(
 
         Builtin::KeysUnsorted => {
             if let Some(fields) = value.as_object() {
+                // #2594: same zero-field `{,}` gap as `Keys` above.
+                if let Err(err) = empty_fields_tail_gap_ok(&fields, cursor.as_ref()) {
+                    return GenericResult::Error(err);
+                }
                 // Stay lazy here — don't decode every key into an owned
                 // String yet. `length`, `.[]`, `.[n]`, `first`, and `last`
                 // can all answer directly from `fields` (see the `Pipe`
@@ -18352,7 +18476,11 @@ fn eval_builtin<S: EvalSemantics, V: DocumentValue>(
             } else if let Some(elements) = value.as_array() {
                 // Same laziness as the array branch of `Keys` above (#684),
                 // and the same #2261 fix: `len_checked` rides the same
-                // already-mandatory walk.
+                // already-mandatory walk -- plus the same #2594 zero-element
+                // check it cannot make.
+                if let Err(err) = empty_elements_tail_gap_ok(&elements, cursor.as_ref()) {
+                    return GenericResult::Error(err);
+                }
                 match elements.len_checked() {
                     Ok(len) => GenericResult::LazyIndexRange(len),
                     Err(err) => GenericResult::Error(err),
@@ -18399,7 +18527,11 @@ fn eval_builtin<S: EvalSemantics, V: DocumentValue>(
                 //
                 // `_checked`: same #1677 gap check as `.[]`'s array arm --
                 // this walk visits every element regardless, so it's free
-                // to ride here too.
+                // to ride here too. And, #2594, the same zero-element `[,]`
+                // that walk cannot see, which produced `[]`.
+                if let Err(err) = empty_elements_tail_gap_ok(&elements, cursor.as_ref()) {
+                    return GenericResult::Error(err);
+                }
                 let cursors = owned_or_suppress!(elements.collect_cursors_checked(), optional);
                 let mut entries: Vec<OwnedValue> = Vec::new();
                 for (i, elem_cursor) in cursors.into_iter().enumerate() {
@@ -18419,6 +18551,13 @@ fn eval_builtin<S: EvalSemantics, V: DocumentValue>(
                 // key-only walk is negligible here next to materializing
                 // every value, which this builtin does anyway.
                 if let Some(err) = malformed_object_member(&fields) {
+                    return GenericResult::Error(err);
+                }
+                // #2594: that key-only walk sees no member at all for `{,}`,
+                // so its `ends_unpaired` tail check has nothing to fire on
+                // and `to_entries` produced `[]` (its own STYLE-0013-TAIL
+                // exemption says exactly this).
+                if let Err(err) = empty_fields_tail_gap_ok(&fields, cursor.as_ref()) {
                     return GenericResult::Error(err);
                 }
                 // A loop for the same reason as the array arm above.
@@ -18507,6 +18646,11 @@ fn eval_builtin<S: EvalSemantics, V: DocumentValue>(
         // format's own `effective_fields` rule at every nesting level, not
         // just the root.
         Builtin::Paths => {
+            // #2594: `collect_paths_generic` is a value-domain walk, so it
+            // cannot see the container it was handed is really `{,}`/`[,]`.
+            if let Some(err) = empty_container_gap_error(&value, cursor.as_ref()) {
+                return GenericResult::Error(err);
+            }
             let mut paths = Vec::new();
             match collect_paths_generic::<S, _>(&value, &mut Vec::new(), &mut paths, false) {
                 Ok(()) => collapse_vec(
@@ -18520,6 +18664,10 @@ fn eval_builtin<S: EvalSemantics, V: DocumentValue>(
         }
 
         Builtin::LeafPaths => {
+            // #2594: same value-domain walk as `Builtin::Paths` above.
+            if let Some(err) = empty_container_gap_error(&value, cursor.as_ref()) {
+                return GenericResult::Error(err);
+            }
             let mut paths = Vec::new();
             match collect_paths_generic::<S, _>(&value, &mut Vec::new(), &mut paths, true) {
                 Ok(()) => collapse_vec(
@@ -18585,6 +18733,12 @@ fn eval_builtin<S: EvalSemantics, V: DocumentValue>(
         Builtin::First => {
             // jq: first == .[0], so [] and null both yield null
             if let Some(elements) = value.as_array() {
+                // #2594: the zero-element `[,]` no element-only walk can
+                // see -- same gap as this arm's own #2261 fix, one step
+                // earlier (there is no element to hang a check on).
+                if let Err(err) = empty_elements_tail_gap_ok(&elements, cursor.as_ref()) {
+                    return GenericResult::Error(err);
+                }
                 match elements.get_cursor(0) {
                     Some(c) => GenericResult::OneCursor(c),
                     None => GenericResult::Owned(OwnedValue::Null),
@@ -18604,6 +18758,11 @@ fn eval_builtin<S: EvalSemantics, V: DocumentValue>(
         Builtin::Last => {
             // jq: last == .[-1], so [] and null both yield null
             if let Some(elements) = value.as_array() {
+                // #2594: the zero-element `[,]` no element-only walk can
+                // see, same as `Builtin::First` just above.
+                if let Err(err) = empty_elements_tail_gap_ok(&elements, cursor.as_ref()) {
+                    return GenericResult::Error(err);
+                }
                 // #2261: `len_checked`, not the bare `len()` -- unlike
                 // `Builtin::First` just above (genuinely O(1) via
                 // `get_cursor(0)`, left unchecked per #1629's precedent),
@@ -18681,6 +18840,12 @@ fn eval_builtin<S: EvalSemantics, V: DocumentValue>(
                 );
             }
             if let Some(elements) = value.as_array() {
+                // #2594: the zero-element `[,]` no element-only walk can
+                // see -- same gap as this arm's own #2261 fix, one step
+                // earlier (there is no element to hang a check on).
+                if let Err(err) = empty_elements_tail_gap_ok(&elements, cursor.as_ref()) {
+                    return GenericResult::Error(err);
+                }
                 // #2261 (systematic sweep): `collect_cursors_checked`, not
                 // the unchecked `collect_cursors` this arm used -- this
                 // walk already resolves every element's cursor to reverse
@@ -18733,6 +18898,12 @@ fn eval_builtin<S: EvalSemantics, V: DocumentValue>(
                     optional,
                 );
             };
+            // #2594: the zero-element `[,]` no element-only walk can
+            // see -- same gap as this arm's own #2261 fix, one step
+            // earlier (there is no element to hang a check on).
+            if let Err(err) = empty_elements_tail_gap_ok(&elements, cursor.as_ref()) {
+                return GenericResult::Error(err);
+            }
             let key = match builtin {
                 Builtin::SortBy(f) | Builtin::UniqueBy(f) => Some(&**f),
                 _ => None,
@@ -18781,6 +18952,12 @@ fn eval_builtin<S: EvalSemantics, V: DocumentValue>(
                     optional,
                 );
             };
+            // #2594: the zero-element `[,]` no element-only walk can
+            // see -- same gap as this arm's own #2261 fix, one step
+            // earlier (there is no element to hang a check on).
+            if let Err(err) = empty_elements_tail_gap_ok(&elements, cursor.as_ref()) {
+                return GenericResult::Error(err);
+            }
             // #2261 (systematic sweep): `collect_cursors_checked`, not the
             // unchecked `collect_cursors` this arm used -- every one of
             // these builtins already resolves each element's cursor to
@@ -18961,13 +19138,20 @@ fn eval_builtin<S: EvalSemantics, V: DocumentValue>(
         // `Select` precedent), so this remains defensive rather than
         // load-bearing -- see `test_optional_ignored_sites_2280`.
         Builtin::GetPath(path_expr) => match cursor {
-            Some(root) => fanout_arg_generic::<S, V, _>(
-                path_expr,
-                value.clone(),
-                optional,
-                cursor,
-                |path_owned| getpath_walk_cursor::<S, V>(root, &path_owned, optional),
-            ),
+            Some(root) => {
+                // #2594: `getpath_walk_cursor` descends from `root` by name,
+                // so a zero-member `{,}` simply misses and answers `null`.
+                if let Some(err) = empty_container_gap_error(&value, Some(&root)) {
+                    return GenericResult::Error(err);
+                }
+                fanout_arg_generic::<S, V, _>(
+                    path_expr,
+                    value.clone(),
+                    optional,
+                    cursor,
+                    |path_owned| getpath_walk_cursor::<S, V>(root, &path_owned, optional),
+                )
+            }
             // A computed input has no position in any document, so there is
             // nothing to walk and nothing this arm could validate lazily:
             // the value is already in hand, and the owned table reads it

--- a/src/json/light.rs
+++ b/src/json/light.rs
@@ -1265,8 +1265,12 @@ impl<'a, W: AsRef<[u64]>> JsonFields<'a, W> {
         // `EvalError::malformed_json_text(self.text)`, so the two raise the same
         // value. It is left as-is because routing to that helper would fix
         // nothing: it shares the blind spot this walk actually has, its `None`
-        // arm being `Ok(())`. What this needs is `container_tail_gap_ok`, whose
-        // `None` arm catches the zero-child `{,}` -- a behaviour change, #2594.
+        // arm being `Ok(())`. What closes that is `container_tail_gap_ok`, which
+        // needs a cursor to the object itself -- and a `JsonFields` holds only
+        // "the first field's key cursor, or `None`", so a zero-field `{,}`
+        // leaves it with nothing. #2594 closed the gap one level up instead, at
+        // `eval_generic`'s `Expr::Field` arm, which does hold that cursor;
+        // this walk is unchanged and still cannot make the check itself.
         let mut fields = *self;
         // (key's own text start, winning field, is this field the object's
         // first) -- same bookkeeping `find_cursor` keeps, needed so the
@@ -1374,7 +1378,9 @@ impl<'a, W: AsRef<[u64]>> JsonFields<'a, W> {
         // STYLE-0013-TAIL: `find`'s cursor-returning twin, exempt for the same
         // reason -- routing to `child_tail_gap_ok` is behaviour-preserving but
         // pointless, and the `container_tail_gap_ok` that would actually close
-        // the zero-child `{,}` case changes behaviour. Tracked as #2594.
+        // the zero-child `{,}` case needs a container cursor this walk never
+        // receives. Closed at the `Expr::Field` dispatch arm instead (#2594);
+        // see `find`'s own marker just above.
         let mut fields = *self;
         // (key's own text start, value cursor, is this field the object's
         // first) for the winning candidate seen so far.

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -25709,37 +25709,167 @@ fn test_jq_keys_unsorted_positive_index_trailing_comma_remains_a_known_gap_2261(
     Ok(())
 }
 
-/// #2261: the #2211 sibling shape -- a stray `,` with *zero* real
-/// elements/fields (`[,]`, `{,}`) -- remains unreachable through the same
-/// fast paths above, for the same reason #2211's own `container_gap_ok`
-/// stays unreachable through `to_owned_at_depth`'s cursor-less callers
-/// (#2262's own documented residual): none of these paths ever receive a
-/// cursor to the *container itself*, only to its children -- and an
-/// apparently-empty container has none. `.a`/`.[0]` are excluded here: both
-/// still raise, but for an unrelated reason (indexing an array with a
-/// string key / an object with a number), not the delimiter check this
-/// test is about.
+/// #2594 (was #2261's documented residual): the #2211 sibling shape -- a
+/// stray `,` with *zero* real elements/fields (`[,]`, `{,}`) -- now raises
+/// through these fast paths too.
+///
+/// The residual this replaces rested on a premise that was true of the
+/// *walks* and false of the code around them: "none of these paths ever
+/// receive a cursor to the container itself, only to its children". The
+/// walks (`census`, `effective_keys`, `contains_checked`, `len_checked`,
+/// `collect_cursors_checked`, `find_cursor`, `LazySource::Elements`) really
+/// do take children alone -- but each is *dispatched* from an `eval_single`/
+/// `eval_builtin` arm that already holds `cursor: Option<V::Cursor>` for the
+/// container, for type-name diagnostics.
+/// `empty_fields_tail_gap_ok`/`empty_elements_tail_gap_ok` check there, at
+/// the arm, ahead of the walk that cannot.
+///
+/// Exit 5 with #2211's own strict-validator message, byte-identical to what
+/// `.` on the same document already produced -- the raise routes through
+/// `container_tail_gap_ok`, whose JSON `malformed_delimiter_error()` re-runs
+/// the validator over the whole document rather than inventing a second
+/// spelling. `.a?` is included deliberately: the raise carries #2286's
+/// always-uncatchable tag, so `?` does not suppress it, matching real jq --
+/// which cannot parse the document for *any* filter, optional or not.
 #[test]
-fn test_jq_cursor_transparent_fast_paths_empty_container_stray_comma_remains_a_known_gap_2261(
-) -> Result<()> {
+fn test_jq_cursor_transparent_fast_paths_empty_container_stray_comma_now_raises_2594() -> Result<()>
+{
+    for (input, query) in [
+        ("[,]", ".[]"),
+        ("[,]", "length"),
+        ("[,]", ".[0]"),
+        ("[,]", ".a?"),
+        ("[,]", "first"),
+        ("[,]", "last"),
+        ("[,]", "min"),
+        ("[,]", "sort"),
+        ("[,]", "reverse"),
+        ("[,]", "unique"),
+        ("[,]", "map(.)"),
+        ("[,]", "to_entries"),
+        ("[,]", "has(0)"),
+        ("[,]", "paths"),
+        ("[,]", "getpath([0])"),
+        ("{,}", "keys"),
+        ("{,}", "keys_unsorted"),
+        ("{,}", "to_entries"),
+        ("{,}", ".a"),
+        ("{,}", ".a?"),
+        ("{,}", "length"),
+        ("{,}", r#"has("a")"#),
+        ("{,}", ".[]"),
+        ("{,}", "map(.)"),
+        ("{,}", "paths"),
+        ("{,}", r#"getpath(["a"])"#),
+    ] {
+        let (out, stderr, code) = run_jq_full(&["-c", query], Some(input))?;
+        assert_eq!(
+            code, 5,
+            "input={input} query={query}: expected the #2211 raise, got out={out:?}"
+        );
+        assert!(
+            stderr.contains("Invalid JSON text"),
+            "input={input} query={query}: stderr {stderr:?} is not the strict-validator message"
+        );
+        assert!(
+            out.trim().is_empty(),
+            "input={input} query={query}: unexpected output {out:?}"
+        );
+    }
+
+    Ok(())
+}
+
+/// #2594: that raise fires on a *malformed* container only -- a genuinely
+/// empty one (`{}`/`[]`, with or without whitespace, nested or not) is
+/// untouched on every one of the same filters.
+///
+/// This is the half a "reject whenever the walk found no child" fix would
+/// have got wrong, and it is why the check is
+/// `DocumentCursor::container_gap_ok` (scan from the container's own opening
+/// bracket to its close) rather than an emptiness test.
+#[test]
+fn test_jq_genuinely_empty_containers_unaffected_2594() -> Result<()> {
     for (input, query, expected) in [
-        ("[,]", ".[]", ""),
-        ("[,]", "length", "0"),
-        ("{,}", "keys", "[]"),
-        ("{,}", "keys_unsorted", "[]"),
-        ("{,}", "to_entries", "[]"),
-        ("{,}", ".a", "null"),
+        ("[]", ".[]", ""),
+        ("[]", "length", "0"),
+        ("[]", ".[0]", "null"),
+        ("[]", "first", "null"),
+        ("[]", "last", "null"),
+        ("[]", "sort", "[]"),
+        ("[]", "unique", "[]"),
+        ("[]", "map(.)", "[]"),
+        ("[]", "to_entries", "[]"),
+        ("[]", "paths", ""),
+        ("[ ]", "length", "0"),
+        ("[\n\t]", "length", "0"),
+        ("{}", "keys", "[]"),
+        ("{}", "keys_unsorted", "[]"),
+        ("{}", "to_entries", "[]"),
+        ("{}", ".a", "null"),
+        ("{}", "length", "0"),
+        ("{}", r#"has("a")"#, "false"),
+        ("{}", ".[]", ""),
+        ("{}", "paths", ""),
+        ("{ }", "length", "0"),
+        ("{\n\t}", "length", "0"),
+        (r#"{"a":{}}"#, ".a|length", "0"),
+        (r#"{"a":[]}"#, ".a|length", "0"),
+        ("[[],{}]", "length", "2"),
     ] {
         let (out, stderr, code) = run_jq_full(&["-c", query], Some(input))?;
         assert_eq!(
             code, 0,
-            "input={input} query={query}: known gap, expected exit 0: stderr: {stderr:?}"
+            "input={input} query={query}: a genuine empty container must not raise: {stderr:?}"
         );
         assert_eq!(
             out.trim(),
             expected,
-            "input={input} query={query}: known gap"
+            "input={input} query={query}: unexpected output"
         );
+    }
+
+    Ok(())
+}
+
+/// #2594: a closed term still answers exactly as `empty` does on a `{,}`/
+/// `[,]` document -- #2173's rule, and the reason the new check sits in the
+/// arms that walk a container rather than at the top of `eval_single`/
+/// `eval_builtin`.
+///
+/// A guard hoisted to either dispatch function passes every row of the
+/// raise test above and fails this one (measured while writing the fix:
+/// `empty` on `[,]` went from exit 0 to exit 5).
+/// `test_ambient_validation_agrees_with_bridge_2476` pins the same rule
+/// across its own corpus; this states it for the two documents this issue
+/// is about.
+#[test]
+fn test_jq_closed_terms_unaffected_by_empty_container_check_2594() -> Result<()> {
+    for input in ["[,]", "{,}"] {
+        let (_, _, empty_code) = run_jq_full(&["-c", "empty"], Some(input))?;
+        assert_eq!(
+            empty_code, 0,
+            "input={input}: `empty` reads nothing, so it must not raise"
+        );
+        for (query, expected) in [
+            ("true and true", "true"),
+            ("false or true", "true"),
+            ("false // 1", "1"),
+            ("1 + 1", "2"),
+            ("0 - 0", "0"),
+            ("(-(1))", "-1"),
+        ] {
+            let (out, stderr, code) = run_jq_full(&["-c", query], Some(input))?;
+            assert_eq!(
+                code, empty_code,
+                "input={input} query={query}: a closed term must answer as `empty` does: {stderr:?}"
+            );
+            assert_eq!(
+                out.trim(),
+                expected,
+                "input={input} query={query}: unexpected output"
+            );
+        }
     }
 
     Ok(())

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -25772,6 +25772,19 @@ fn test_jq_cursor_transparent_fast_paths_empty_container_stray_comma_now_raises_
         ("[,]", "path(.[0])"),
         ("[,]", "path(.[])"),
         ("[,]", "[path(..)]"),
+        // `keys`/`keys_unsorted` on an *array* take their own arm, distinct
+        // from the object rows above; `leaf_paths` takes one distinct from
+        // `paths`.
+        ("[,]", "keys"),
+        ("[,]", "keys_unsorted"),
+        ("[,]", "leaf_paths"),
+        ("{,}", "leaf_paths"),
+        // `.[]` collected reaches `eval_single`'s *eager* `Expr::Iterate`
+        // arm; the bare `.[]` rows above take the streaming one in
+        // `eval_each_generic`. Both need their own check.
+        ("[,]", "[.[]]"),
+        ("{,}", "[.[]]"),
+        ("[,]", "reduce .[] as $x (0; .)"),
     ] {
         let (out, stderr, code) = run_jq_full(&["-c", query], Some(input))?;
         assert_eq!(
@@ -25827,6 +25840,15 @@ fn test_jq_genuinely_empty_containers_unaffected_2594() -> Result<()> {
         ("{}", "[path(..)]", "[[]]"),
         ("[]", "path(.[])", ""),
         ("[]", "[path(..)]", "[[]]"),
+        ("[]", "keys", "[]"),
+        ("[]", "keys_unsorted", "[]"),
+        // Succinctly's `leaf_paths` extension counts an empty container as
+        // a leaf (see CLAUDE.md); `paths` does not. Both stay as they were.
+        ("[]", "leaf_paths", "[]"),
+        ("{}", "leaf_paths", "[]"),
+        ("[]", "[.[]]", "[]"),
+        ("{}", "[.[]]", "[]"),
+        ("[]", "reduce .[] as $x (0; .)", "0"),
         ("{ }", "length", "0"),
         ("{\n\t}", "length", "0"),
         (r#"{"a":{}}"#, ".a|length", "0"),

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -25761,6 +25761,17 @@ fn test_jq_cursor_transparent_fast_paths_empty_container_stray_comma_now_raises_
         ("{,}", "map(.)"),
         ("{,}", "paths"),
         ("{,}", r#"getpath(["a"])"#),
+        // The path domain reaches the same walks through
+        // `path_step_generic`'s own `PathNode::At` arms, which hold the
+        // container cursor just as the value-side arms do. Found by review
+        // of this fix's first draft: `{,} | path(.a)` answered `["a"]`
+        // while the bare `.a` already raised.
+        ("{,}", "path(.a)"),
+        ("{,}", "path(.[])"),
+        ("{,}", "[path(..)]"),
+        ("[,]", "path(.[0])"),
+        ("[,]", "path(.[])"),
+        ("[,]", "[path(..)]"),
     ] {
         let (out, stderr, code) = run_jq_full(&["-c", query], Some(input))?;
         assert_eq!(
@@ -25811,6 +25822,11 @@ fn test_jq_genuinely_empty_containers_unaffected_2594() -> Result<()> {
         ("{}", r#"has("a")"#, "false"),
         ("{}", ".[]", ""),
         ("{}", "paths", ""),
+        ("{}", "path(.a)", r#"["a"]"#),
+        ("{}", "path(.[])", ""),
+        ("{}", "[path(..)]", "[[]]"),
+        ("[]", "path(.[])", ""),
+        ("[]", "[path(..)]", "[[]]"),
         ("{ }", "length", "0"),
         ("{\n\t}", "length", "0"),
         (r#"{"a":{}}"#, ".a|length", "0"),


### PR DESCRIPTION
Fixes #2594

## Summary

`{,}` and `[,]` are documents real jq refuses to parse, but only `.` rejected them. Every other filter answered — wrong output at exit 0, the same class as #2349.

Verified live against the pinned oracle (`/usr/bin/jq` 1.7.1) before and after:

| document | filter | before | after | jq 1.7.1 |
|---|---|---|---|---|
| `{,}` | `.` | rejects | rejects | parse error |
| `{,}` | `.a` / `.a?` | `null` | **rejects** | parse error |
| `{,}` | `keys` / `keys_unsorted` | `[]` | **rejects** | parse error |
| `{,}` | `length` | `0` | **rejects** | parse error |
| `{,}` | `has("a")` | `false` | **rejects** | parse error |
| `{,}` | `to_entries` | `[]` | **rejects** | parse error |
| `{,}` | `.[]` / `map(.)` / `paths` / `getpath(["a"])` | answers | **rejects** | parse error |
| `[,]` | `.[0]` | `null` | **rejects** | parse error |
| `[,]` | `.[]` / `.a?` | (empty) | **rejects** | parse error |
| `[,]` | `keys` / `length` / `to_entries` | answers | **rejects** | parse error |
| `[,]` | `first`/`last`/`min`/`max`/`sort`/`unique`/`reverse`/`map` | answers | **rejects** | parse error |

Control, correctly rejected before and after: `{"a":1,}` on `.`, `.a`, `keys`.

## Root cause

The non-zero-child shape (`{"a":1,}`, #2243) is rejected on all of them, and that is the tell. Each of these filters dispatches to a walk that holds only *children* — `census`, `checked_len`, `effective_keys`, `contains_checked`, `len_checked`, `collect_cursors_checked`, `find_cursor`, `LazySource::Elements`. That is enough to see a stray `,` *after* a real last child, and nothing at all when the walk finds no child to begin with.

`container_tail_gap_ok` closes exactly that case, but it needs a cursor to the container itself — and `JsonFields`/`JsonElements` hold only "the first child's cursor, or `None`" (`src/json/light.rs`), so a zero-child container leaves them with nothing.

Their **callers** do hold one. Every arm above already carries `cursor: Option<V::Cursor>` beside the value, for type-name diagnostics. So the check goes at the arm, ahead of the walk that cannot make it, through two new shared helpers in `src/jq/document.rs`: `empty_fields_tail_gap_ok` and `empty_elements_tail_gap_ok`.

## Why per-arm and not one guard at the top of the dispatch

`empty`, `true and true`, `1 + 1` and the rest of #2173's closed terms dispatch through `eval_single`/`eval_builtin` too, and a closed term must answer exactly as `empty` does on **every** document, malformed ones included.

I tried the hoisted guard first: it passes every row in the table above and fails `test_ambient_validation_agrees_with_bridge_2476` (`empty` on `[,]` went from exit 0 to exit 5). Reading no member is precisely what makes a term closed, so the check belongs where a member is about to be read. Both helpers' doc comments state that rule, and `test_jq_closed_terms_unaffected_by_empty_container_check_2594` pins it for these two documents.

## Notes

- **Message is unchanged.** The raise is the container's own `malformed_delimiter_error()`, which for JSON re-runs the strict validator over the whole document — so the stderr is byte-identical to what `.` already produced for the same input, not a second spelling. No golden churn.
- **`?` does not suppress it**, matching jq: the error carries #2286's always-uncatchable tag, and jq cannot parse the document for *any* filter, optional or not.
- **Free for YAML and DSV**: `DocumentCursor::container_gap_ok` is a `true`-returning default there, since they validate while parsing. Spot-checked `succinctly yq` output is unchanged.
- **Cost**: two enum matches (`as_object`/`as_array` are plain enum matches on `StandardJson`, plus `is_empty()` = `Option::is_none`) on any non-empty container; only a genuinely empty one pays the whitespace-length gap scan.
- **The `STYLE-0013-TAIL` exemptions stay** in `find`/`find_cursor`, `malformed_object_member` and `standard_json_to_jq_value` — those walks still cannot make the check — but their text no longer claims the gap is open and names where it is now closed. The audit (`style_0013_tail_gap_is_routed_or_exempted`) passes.

### Out of scope (verified pre-existing, unrelated to this change)

- `{"a":1,"b":{,}} | .a` → `1`. That is the standing lazy-validation stance, not this gap: `{"a":1,"b":xyz}` and `{"a":1,"b":[1 2]}` behave identically on `.a`.
- `{} | reverse` → succinctly errors where jq gives `[]` (jq's `reverse` is `range(0;length)`-based). A separate type-error divergence; follow-up filed.

## Test plan

- [x] `cargo build --features cli`
- [x] `cargo test --features cli,simd,regex,serde` — 8123 passed, 0 failed
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings`
- [x] `cargo fmt --check`
- [x] Output diffed directly against the pinned `/usr/bin/jq` 1.7.1 on 50+ filter/document pairs, not just goldens
- [x] Genuine `{}`/`[]` verified untouched (incl. whitespace and newline variants, nested) on every affected filter
- [x] `succinctly yq` spot-checked unchanged
- [x] `style_0013_tail_gap_is_routed_or_exempted` audit passes
- [x] New tests: `..._empty_container_stray_comma_now_raises_2594` (26 rows), `test_jq_genuinely_empty_containers_unaffected_2594` (25 rows), `test_jq_closed_terms_unaffected_by_empty_container_check_2594`