### PR TITLE
fix(jq): escape a raw DEL byte at #2591's three remaining call sites

### DIFF
--- a/src/bin/succinctly/jq_runner.rs
+++ b/src/bin/succinctly/jq_runner.rs
@@ -6111,12 +6111,15 @@ where
                     out.write_all(formatter.format_raw_number(n.raw_bytes()).as_bytes())?;
                 }
                 StandardJson::String(s) => {
-                    let raw = s.raw_bytes();
                     // Zero-copy optimization: if no escapes (backslash) and not ASCII mode,
                     // output raw bytes directly without decode/encode roundtrip.
-                    // This is valid because JSON strings without backslashes need no normalization.
-                    let content = &raw[1..raw.len().saturating_sub(1)]; // Content between quotes
-                    if !config.ascii_output && !content.contains(&b'\\') {
+                    // This is valid because JSON strings without backslashes need no
+                    // normalization -- except a raw DEL byte (0x7f) under jq's own escape
+                    // convention, which still re-encodes it on output even though it's
+                    // legal unescaped in source (#2591/#2592; see
+                    // `write_json_string_pretty`'s identical gate in src/json/light.rs).
+                    let (raw, escaped, has_del) = s.raw_and_escaped();
+                    if !(config.ascii_output || escaped || has_del && config.jq_compat) {
                         // Zero-copy: output raw bytes directly (includes quotes)
                         out.write_all(raw)?;
                     } else if let Ok(decoded) = s.as_str() {
@@ -6663,9 +6666,12 @@ where
                         ))
                         .into());
                     };
-                    let raw = k.raw_bytes();
-                    let content = &raw[1..raw.len().saturating_sub(1)];
-                    if !config.ascii_output && !content.contains(&b'\\') {
+                    // #2591/#2592: a raw DEL byte (0x7f) is legal unescaped
+                    // JSON source but still needs re-encoding under jq's own
+                    // escape convention -- see the sibling gate in
+                    // `write_json_string_pretty` (src/json/light.rs).
+                    let (raw, escaped, has_del) = k.raw_and_escaped();
+                    if !(config.ascii_output || escaped || has_del && config.jq_compat) {
                         out.write_all(raw)?;
                     } else if let Ok(decoded) = k.as_str() {
                         out.write_all(b"\"")?;
@@ -6712,9 +6718,12 @@ where
                         ))
                         .into());
                     };
-                    let raw = k.raw_bytes();
-                    let content = &raw[1..raw.len().saturating_sub(1)];
-                    if !config.ascii_output && !content.contains(&b'\\') {
+                    // #2591/#2592: a raw DEL byte (0x7f) is legal unescaped
+                    // JSON source but still needs re-encoding under jq's own
+                    // escape convention -- see the sibling gate in
+                    // `write_json_string_pretty` (src/json/light.rs).
+                    let (raw, escaped, has_del) = k.raw_and_escaped();
+                    if !(config.ascii_output || escaped || has_del && config.jq_compat) {
                         out.write_all(raw)?;
                     } else if let Ok(decoded) = k.as_str() {
                         out.write_all(b"\"")?;

--- a/src/bin/succinctly/jq_runner.rs
+++ b/src/bin/succinctly/jq_runner.rs
@@ -25,7 +25,7 @@ use succinctly::jq::{
     EvalError, Expr, FuncDefBound, JqSemantics, JqValue, OwnedValue, Param, Program, StreamStats,
     UnresolvedCall, MAX_VALUE_TREE_DEPTH,
 };
-use succinctly::json::light::{preceding_gap_ok, JsonCursor, StandardJson};
+use succinctly::json::light::{preceding_gap_ok, JsonCursor, JsonString, StandardJson};
 use succinctly::json::validate::{self, ValidationError};
 use succinctly::json::JsonIndex;
 
@@ -878,9 +878,41 @@ fn write_object_key<Out: Write, W: Clone + AsRef<[u64]>>(
     let StandardJson::String(key) = frame.cursor(field.key_bp).value() else {
         return Err(MalformedJsonError(EvalError::malformed_json_text(frame.text)).into());
     };
-    if !(config.ascii_output || field.escaped || field.has_del && config.jq_compat) {
-        out.write_all(field.raw)?;
-    } else if let Ok(decoded) = key.as_str() {
+    write_json_string_zero_copy(out, field.raw, field.escaped, field.has_del, key, config)?;
+    out.write_all(b":")?;
+    out.write_all(space_after_colon.as_bytes())?;
+    Ok(())
+}
+
+/// Writes a JSON string under `config`'s escaping convention, taking the
+/// zero-copy fast path when the source span needs no re-encoding.
+///
+/// `raw`/`escaped`/`has_del` are `s.raw_and_escaped()`'s own answer, taken as
+/// separate parameters (rather than recomputed here from `s`) because
+/// `write_object_key`'s caller already has to consult them a second time
+/// earlier, for duplicate-key collapse (#1385) -- rescanning here would pay
+/// for that a third time. Every other caller has nothing else to hoist them
+/// for and just passes `s.raw_and_escaped()` straight through.
+///
+/// #2591/#2592: `has_del && config.jq_compat` is the one extra case the
+/// zero-copy path cannot take under jq's own escape convention -- a raw DEL
+/// byte (`0x7f`) is legal unescaped JSON source, but jq's escape table still
+/// re-encodes it to `` on output. `--preserve-input`/yq's own
+/// `Preserve` convention (`!config.jq_compat`) leaves it raw, matching real
+/// yq. Shared by four call sites (this one plus three sibling ones in
+/// `print_json`/`keys_unsorted`, #2592) that used to each hand-roll this
+/// gate-and-branch shape independently.
+fn write_json_string_zero_copy<Out: Write>(
+    out: &mut Out,
+    raw: &[u8],
+    escaped: bool,
+    has_del: bool,
+    s: JsonString<'_>,
+    config: &OutputConfig,
+) -> Result<()> {
+    if !(config.ascii_output || escaped || has_del && config.jq_compat) {
+        out.write_all(raw)?;
+    } else if let Ok(decoded) = s.as_str() {
         out.write_all(b"\"")?;
         let text = if config.ascii_output {
             escape_json_string_ascii(&decoded)
@@ -890,10 +922,8 @@ fn write_object_key<Out: Write, W: Clone + AsRef<[u64]>>(
         out.write_all(text.as_bytes())?;
         out.write_all(b"\"")?;
     } else {
-        out.write_all(field.raw)?;
+        out.write_all(raw)?;
     }
-    out.write_all(b":")?;
-    out.write_all(space_after_colon.as_bytes())?;
     Ok(())
 }
 
@@ -6111,31 +6141,12 @@ where
                     out.write_all(formatter.format_raw_number(n.raw_bytes()).as_bytes())?;
                 }
                 StandardJson::String(s) => {
-                    // Zero-copy optimization: if no escapes (backslash) and not ASCII mode,
-                    // output raw bytes directly without decode/encode roundtrip.
-                    // This is valid because JSON strings without backslashes need no
-                    // normalization -- except a raw DEL byte (0x7f) under jq's own escape
-                    // convention, which still re-encodes it on output even though it's
-                    // legal unescaped in source (#2591/#2592; see
-                    // `write_json_string_pretty`'s identical gate in src/json/light.rs).
+                    // Zero-copy optimization when the source span needs no
+                    // re-encoding under jq's own escape convention -- see
+                    // `write_json_string_zero_copy`'s own doc comment
+                    // (#2591/#2592) for the raw-DEL-byte exception.
                     let (raw, escaped, has_del) = s.raw_and_escaped();
-                    if !(config.ascii_output || escaped || has_del && config.jq_compat) {
-                        // Zero-copy: output raw bytes directly (includes quotes)
-                        out.write_all(raw)?;
-                    } else if let Ok(decoded) = s.as_str() {
-                        // Has escapes or ASCII mode - decode and re-encode for normalization
-                        out.write_all(b"\"")?;
-                        let escaped = if config.ascii_output {
-                            escape_json_string_ascii(&decoded)
-                        } else {
-                            escape_json_string(&decoded)
-                        };
-                        out.write_all(escaped.as_bytes())?;
-                        out.write_all(b"\"")?;
-                    } else {
-                        // Decode failed - output raw bytes as fallback
-                        out.write_all(raw)?;
-                    }
+                    write_json_string_zero_copy(out, raw, escaped, has_del, s, config)?;
                 }
                 StandardJson::Array(elements) => {
                     if elements.is_empty() {
@@ -6666,25 +6677,12 @@ where
                         ))
                         .into());
                     };
-                    // #2591/#2592: a raw DEL byte (0x7f) is legal unescaped
-                    // JSON source but still needs re-encoding under jq's own
-                    // escape convention -- see the sibling gate in
-                    // `write_json_string_pretty` (src/json/light.rs).
+                    // Zero-copy optimization when the source span needs no
+                    // re-encoding under jq's own escape convention -- see
+                    // `write_json_string_zero_copy`'s own doc comment
+                    // (#2591/#2592) for the raw-DEL-byte exception.
                     let (raw, escaped, has_del) = k.raw_and_escaped();
-                    if !(config.ascii_output || escaped || has_del && config.jq_compat) {
-                        out.write_all(raw)?;
-                    } else if let Ok(decoded) = k.as_str() {
-                        out.write_all(b"\"")?;
-                        let escaped = if config.ascii_output {
-                            escape_json_string_ascii(&decoded)
-                        } else {
-                            escape_json_string(&decoded)
-                        };
-                        out.write_all(escaped.as_bytes())?;
-                        out.write_all(b"\"")?;
-                    } else {
-                        out.write_all(raw)?;
-                    }
+                    write_json_string_zero_copy(out, raw, escaped, has_del, k, config)?;
                 }
                 bail_if_keys_malformed(&keys, doc_text)?;
                 out.write_all(b"]")?;
@@ -6718,25 +6716,12 @@ where
                         ))
                         .into());
                     };
-                    // #2591/#2592: a raw DEL byte (0x7f) is legal unescaped
-                    // JSON source but still needs re-encoding under jq's own
-                    // escape convention -- see the sibling gate in
-                    // `write_json_string_pretty` (src/json/light.rs).
+                    // Zero-copy optimization when the source span needs no
+                    // re-encoding under jq's own escape convention -- see
+                    // `write_json_string_zero_copy`'s own doc comment
+                    // (#2591/#2592) for the raw-DEL-byte exception.
                     let (raw, escaped, has_del) = k.raw_and_escaped();
-                    if !(config.ascii_output || escaped || has_del && config.jq_compat) {
-                        out.write_all(raw)?;
-                    } else if let Ok(decoded) = k.as_str() {
-                        out.write_all(b"\"")?;
-                        let escaped = if config.ascii_output {
-                            escape_json_string_ascii(&decoded)
-                        } else {
-                            escape_json_string(&decoded)
-                        };
-                        out.write_all(escaped.as_bytes())?;
-                        out.write_all(b"\"")?;
-                    } else {
-                        out.write_all(raw)?;
-                    }
+                    write_json_string_zero_copy(out, raw, escaped, has_del, k, config)?;
                 }
                 bail_if_keys_malformed(&keys, doc_text)?;
                 out.write_all(separator.as_bytes())?;

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -3174,6 +3174,42 @@ fn test_keys_unsorted_pretty_output_escapes_raw_del_byte_2592() -> Result<()> {
     Ok(())
 }
 
+/// #2592 (code review): `--preserve-input` must leave a raw DEL byte
+/// unescaped at all three new sites, mirroring #2591's own
+/// `test_preserve_input_leaves_raw_del_byte_in_key_unescaped_2591` -- flagged
+/// by review as a test-coverage gap (the behavior was manually verified but
+/// not pinned by an automated test).
+#[test]
+fn test_preserve_input_leaves_raw_del_byte_in_streamed_value_unescaped_2592() -> Result<()> {
+    let input = "[\"x\x7fy\"]";
+    let (out, _, code) = run_jq_full(&["--preserve-input", "-c", ".[]"], Some(input))?;
+    assert_eq!(code, 0);
+    assert_eq!(out, "\"x\x7fy\"\n", "stdout: {out:?}");
+    Ok(())
+}
+
+/// #2592 (code review): `--preserve-input` twin for `keys_unsorted`'s
+/// compact-output loop.
+#[test]
+fn test_preserve_input_leaves_raw_del_byte_in_keys_unsorted_compact_unescaped_2592() -> Result<()> {
+    let input = "{\"x\x7fy\": 1}";
+    let (out, _, code) = run_jq_full(&["--preserve-input", "-c", "keys_unsorted"], Some(input))?;
+    assert_eq!(code, 0);
+    assert_eq!(out, "[\"x\x7fy\"]\n", "stdout: {out:?}");
+    Ok(())
+}
+
+/// #2592 (code review): `--preserve-input` twin for `keys_unsorted`'s
+/// pretty-output loop.
+#[test]
+fn test_preserve_input_leaves_raw_del_byte_in_keys_unsorted_pretty_unescaped_2592() -> Result<()> {
+    let input = "{\"x\x7fy\": 1}";
+    let (out, _, code) = run_jq_full(&["--preserve-input", "keys_unsorted"], Some(input))?;
+    assert_eq!(code, 0);
+    assert_eq!(out, "[\n  \"x\x7fy\"\n]\n", "stdout: {out:?}");
+    Ok(())
+}
+
 /// #1830: real jq flushes each result as it's produced and errors on
 /// first sighting a NUL, rather than buffering the whole multi-result
 /// stream before writing anything -- confirmed live against jq 1.7.1:

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -3135,6 +3135,45 @@ fn test_preserve_input_leaves_raw_del_byte_in_key_unescaped_2591() -> Result<()>
     Ok(())
 }
 
+/// #2592: #2591's three sibling call sites, deliberately left unfixed by
+/// that issue to keep it narrowly scoped -- `print_json`'s own
+/// `JqValue::Cursor` -> `StandardJson::String` arm (per-result streaming
+/// output, e.g. `.[]`) shares the identical zero-copy-fast-path bug shape
+/// as the value/key sites #2591 already fixed. Uses `\x7f` (a Rust escape
+/// compiling to the same raw byte #2591's own tests embed literally), not
+/// a JSON `\u007f` escape in the input text -- the latter would already
+/// contain a backslash and take the slow, always-correct path.
+#[test]
+fn test_streamed_value_output_escapes_raw_del_byte_2592() -> Result<()> {
+    let input = "[\"x\x7fy\", \"b\"]";
+    let (out, _, code) = run_jq_full(&["-c", ".[]"], Some(input))?;
+    assert_eq!(code, 0);
+    assert_eq!(out, "\"x\\u007fy\"\n\"b\"\n", "stdout: {out:?}");
+    Ok(())
+}
+
+/// #2592: `keys_unsorted`'s compact-output key-printing loop, a second
+/// sibling of #2591's fixed sites.
+#[test]
+fn test_keys_unsorted_compact_output_escapes_raw_del_byte_2592() -> Result<()> {
+    let input = "{\"x\x7fy\": 1}";
+    let (out, _, code) = run_jq_full(&["-c", "keys_unsorted"], Some(input))?;
+    assert_eq!(code, 0);
+    assert_eq!(out, "[\"x\\u007fy\"]\n", "stdout: {out:?}");
+    Ok(())
+}
+
+/// #2592: `keys_unsorted`'s pretty-output key-printing loop, the third
+/// sibling of #2591's fixed sites.
+#[test]
+fn test_keys_unsorted_pretty_output_escapes_raw_del_byte_2592() -> Result<()> {
+    let input = "{\"x\x7fy\": 1}";
+    let (out, _, code) = run_jq_full(&["keys_unsorted"], Some(input))?;
+    assert_eq!(code, 0);
+    assert_eq!(out, "[\n  \"x\\u007fy\"\n]\n", "stdout: {out:?}");
+    Ok(())
+}
+
 /// #1830: real jq flushes each result as it's produced and errors on
 /// first sighting a NUL, rather than buffering the whole multi-result
 /// stream before writing anything -- confirmed live against jq 1.7.1:


### PR DESCRIPTION
## Summary

#2591 fixed `succinctly jq`'s zero-copy fast path re-emitting a raw
(unescaped) `0x7f` DEL byte verbatim, but deliberately left three sibling
call sites with the identical bug shape unfixed to keep that change
narrowly scoped (all three in `print_json`, `src/bin/succinctly/jq_runner.rs`):

1. `JqValue::Cursor` -> `StandardJson::String` arm - per-result streaming
   output, e.g. `.[]`.
2. `keys_unsorted`'s compact-output key-printing loop.
3. `keys_unsorted`'s pretty-output key-printing loop.

All three only checked for a *source* backslash before echoing raw bytes
directly - a DEL byte with no accompanying backslash sailed through
unescaped even though real jq's own escape table always re-encodes it on
output. Confirmed live against jq 1.7.1: `.[]` over an array containing a
raw-DEL-bearing string echoed the byte unescaped where real jq escapes it
to the standard JSON `` sequence; same for `keys_unsorted` over an
object with a raw-DEL-bearing key.

Reuses `JsonString::raw_and_escaped()`'s existing `has_del` flag (added by
#2591) at each site, gated on `config.jq_compat` so `--preserve-input`
continues leaving DEL raw, matching real yq's own convention and #2591's
precedent gate exactly.

Fixes #2592

## Test plan

- [x] `cargo build --features cli`
- [x] `cargo test --features cli,simd,regex,serde` (full suite, 0 failures)
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings`
- [x] New tests for all three sites (`test_streamed_value_output_escapes_raw_del_byte_2592`,
      `test_keys_unsorted_compact_output_escapes_raw_del_byte_2592`,
      `test_keys_unsorted_pretty_output_escapes_raw_del_byte_2592`), each cross-checked
      live against `/usr/bin/jq` 1.7.1
- [x] Confirmed `--preserve-input` still leaves DEL raw at all three sites (unaffected)
- [x] `cargo llvm-cov` / `omni-dev coverage diff`: patch coverage 100% (6/6 new lines)
