### PR TITLE
fix(jq): shadow a parameter's bare and $ namespaces independently

### DIFF
--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -34579,11 +34579,7 @@ fn substitute_var_impl(
             // f(1)` is `3` (bare -- outer reaches in), `3 as $g | def
             // f($g): $g; f(1)` is `1` (dollar-style -- shadowed), matching
             // this fix.
-            let shadowed = params
-                .iter()
-                .rev()
-                .find(|p| p.name() == var_name)
-                .is_some_and(Param::is_dollar);
+            let shadowed = params_bind_dollar(params, var_name);
             Expr::FuncDef {
                 name: name.clone(),
                 params: params.clone(),
@@ -48764,24 +48760,18 @@ pub(crate) fn bind_def_call<'e>(
 /// possibly a different, earlier position (`def f($a; a): $a; f(1;2)` is
 /// `1`: the trailing bare `a` shadows the bare namespace only, so the
 /// leading `$a`'s own binding is still what `$a` resolves to). Substituting
-/// the bare winner first, with `subst_dollar: false` so it only touches
-/// bare `Expr::FuncCall` nodes, then the `$` winner (if any) with
-/// `subst_dollar: true`, reproduces this correctly regardless of which
-/// position wins which namespace.
+/// the bare winner under [`BARE_NAMESPACE_ONLY`] and the `$` winner (if any)
+/// under [`DOLLAR_NAMESPACE_ONLY`] reproduces this, whichever position wins
+/// which namespace.
 ///
-/// **Why the order is what makes that sound.** `subst_dollar` gates exactly
-/// one arm of [`substitute_func_param_impl`] -- `Expr::Var` -- and no other:
-/// it never gates the bare `Expr::FuncCall` arm, and it never decides
-/// whether to recurse, since every shadow check it passes
-/// (`Expr::FuncDef`'s `body_shadowed`/`then_shadowed`, the
-/// `As`/`Reduce`/`Foreach`/`AsPattern` binder checks) reads only `param` and
-/// nodes neither pass rewrites. So the two passes walk *identically*, and
-/// the set of bare references the `$` pass can reach is exactly the set the
-/// bare pass already replaced with an (opaque) `Expr::Shared` -- its
-/// unconditional bare arm therefore has nothing left to clobber. The same
-/// property is what makes the same-winner case (a trailing `$`-style
-/// parameter) compose back into precisely the single `subst_dollar: true`
-/// pass this replaced.
+/// The two passes are independent: each rewrites a disjoint set of nodes
+/// ([`SubstScope`] gates the `Expr::Var` and bare `Expr::FuncCall` arms
+/// separately since #2555), so neither can consume or clobber what the other
+/// is looking for, and their order does not matter. Before #2555 the bare
+/// arm fired unconditionally, and this relied on the bare pass running first
+/// and leaving opaque `Expr::Shared` behind for the `$` pass to skip over --
+/// correct, but only by construction rather than by the flags actually
+/// saying so.
 ///
 /// One consequence worth keeping: when a duplicated name has *no* `$`-style
 /// occurrence at all, the `$` pass never runs, so a `$name` in the body is
@@ -48812,14 +48802,10 @@ fn bind_def_call_params(body: &Expr, params: &[Param], args: &[Expr]) -> Expr {
         let Some((first_param, first_arg)) = params_and_args.next() else {
             return body.clone(); // omni-dev: coverage tolerate-line reason="unreachable: bind_def_call only calls this for a non-empty params, and install_def_calls only builds a DefCall whose args.len() equals params.len(), so the zip is never empty here (#2560)"
         };
-        let mut result = substitute_func_param(
-            body,
-            first_param.name(),
-            &Expr::Shared(Rc::new(first_arg.clone())),
-        );
+        let mut result =
+            substitute_func_param(body, first_param, &Expr::Shared(Rc::new(first_arg.clone())));
         for (param, arg) in params_and_args {
-            result =
-                substitute_func_param(&result, param.name(), &Expr::Shared(Rc::new(arg.clone())));
+            result = substitute_func_param(&result, param, &Expr::Shared(Rc::new(arg.clone())));
         }
         return result;
     }
@@ -48855,7 +48841,7 @@ fn bind_def_call_params(body: &Expr, params: &[Param], args: &[Expr]) -> Expr {
             result.as_ref().unwrap_or(body),
             name,
             &Expr::Shared(Rc::new(bare_arg.clone())),
-            false,
+            BARE_NAMESPACE_ONLY,
         );
 
         if let Some((_, dollar_arg)) = by_name().rfind(|(p, _)| p.is_dollar()) {
@@ -48863,7 +48849,7 @@ fn bind_def_call_params(body: &Expr, params: &[Param], args: &[Expr]) -> Expr {
                 &substituted,
                 name,
                 &Expr::Shared(Rc::new(dollar_arg.clone())),
-                true,
+                DOLLAR_NAMESPACE_ONLY,
             );
         }
         result = Some(substituted);
@@ -49303,30 +49289,134 @@ fn sibling_frame_charge(frames: u32, position: u32, in_recursive_body: bool) -> 
 /// system enforces -- debug-only, since every real (release) call already
 /// goes through [`bind_def_call`], which constructs the wrapper itself.
 ///
-/// Substitute into `e` unless `shadowed`, in which case leave it untouched
-/// (`shadowed` means some binder between here and `e` already rebinds
-/// `param`, so nothing further down can still be `param`'s substituted
-/// argument -- see each call site's own shadow condition). Collapses the
-/// "binder shadows `param` -> clone; otherwise recurse" idiom `FuncDef`'s
-/// own arm below needs for its two *independent* `body`/`then` shadow
-/// conditions (#2096 review). `As`/`Reduce`/`Foreach`/`AsPattern` used to
-/// share this too, before #2095 hoisted each of their single shadow
-/// conditions to a match guard instead, so their own non-shadowed case could
-/// fall through to [`map_subexprs`]'s (`src/jq/walk.rs`) shared,
-/// unconditional-recursion arm rather than calling back in here.
-fn subst_unless_shadowed(
-    shadowed: bool,
-    e: &Expr,
-    param: &str,
-    arg: &Expr,
-    subst_dollar: bool,
-) -> Expr {
-    if shadowed {
+/// Substitute into `e` under `scope`, skipping the walk entirely once
+/// `scope` has nothing left to rewrite.
+///
+/// #2555: this used to be `subst_unless_shadowed(shadowed: bool, ..)`, back
+/// when a binder shadowed `param` in *both* namespaces or neither, so
+/// "shadowed" could clone the subtree outright. Now that the two namespaces
+/// shadow independently, a nested `def` can shadow the bare name while
+/// leaving `$param` free to reach through it, and cloning on the first
+/// shadow would drop that remaining substitution — so the narrowing lives
+/// in [`SubstScope`] and only an *empty* scope short-circuits. That empty
+/// case is exactly the old `shadowed` fast path (#2096 review), and
+/// `FuncDef`'s arm below is still the only caller: `As`/`Reduce`/`Foreach`/
+/// `AsPattern` hoisted their own single shadow conditions to match guards in
+/// #2095 so their non-shadowed case falls through to [`map_subexprs`]'s
+/// (`src/jq/walk.rs`) shared unconditional-recursion arm instead.
+fn subst_in_scope(e: &Expr, param: &str, arg: &Expr, scope: SubstScope) -> Expr {
+    if scope.is_empty() {
         e.clone()
     } else {
-        substitute_func_param_impl(e, param, arg, subst_dollar)
+        substitute_func_param_impl(e, param, arg, scope)
     }
 }
+
+/// Whether `params` binds `$name` -- the *last* parameter of that name
+/// decides, per jq's later-wins parameter shadowing (#2560), and only a
+/// `$`-style one binds the variable namespace at all.
+///
+/// One definition, two call sites: [`substitute_var_impl`]'s `Expr::FuncDef`
+/// arm (may an outer `$name` substitution reach into this def's body?) and
+/// [`substitute_func_param_impl`]'s (same question, for an outer
+/// *parameter*'s own `$name` references). They asked the identical question
+/// with separately-written code until #2555; `test_params_bind_dollar_agrees_with_both_shadow_sites_2555`
+/// pins that they still agree.
+fn params_bind_dollar(params: &[Param], name: &str) -> bool {
+    params
+        .iter()
+        .rev()
+        .find(|p| p.name() == name)
+        .is_some_and(Param::is_dollar)
+}
+
+/// Which of a function parameter's two namespaces a substitution may still
+/// rewrite at the current point in the tree (#2555, #2726).
+///
+/// jq keeps these genuinely separate. A bare `name` reference
+/// (`Expr::FuncCall { name, args: [] }`, jq's call-by-name spelling for a
+/// parameter) lives in the *filter* namespace; a `$name` reference
+/// (`Expr::Var`) lives in the *variable* namespace. What binds each differs,
+/// so what shadows each differs too, and collapsing the two into one flag
+/// was wrong in both directions:
+///
+/// - a `$`-style parameter binds **both** ([`Param`]'s own doc comment: `def
+///   h($param): param` alone is a compile error, "param is not defined", so
+///   `$`-style always occupies the bare namespace too), while a bare-style
+///   parameter binds **only** `bare` -- so a bare parameter must not
+///   substitute a `$name` reference at all (#2726: `def f(a): $a; f(1)` is a
+///   compile error in jq 1.7.1, and answered `1` here);
+/// - a nested `def`'s own matching parameter, or a nested zero-argument
+///   `def` of the same name, shadows only what it actually binds -- a
+///   *bare-only* nested parameter leaves an outer `$param` free to reach
+///   through it (#2555: `def f($param): def h(param): $param; h(1); f(99)`
+///   is `99` in jq 1.7.1, and answered `1` here).
+///
+/// Cleared per-namespace as the walk crosses a binder, never re-set: once a
+/// name is rebound, nothing deeper down is still this parameter's argument.
+#[derive(Clone, Copy)]
+struct SubstScope {
+    /// `$param` (`Expr::Var`) still resolves to this call's own argument.
+    /// Cleared by any binder that rebinds `$param` for real -- `1 as
+    /// $param`, a `reduce`/`foreach`/`?//` pattern binding it, or a nested
+    /// `def` whose own matching parameter is `$`-style.
+    dollar: bool,
+    /// Bare `param` (`Expr::FuncCall { args: [] }`) still resolves to this
+    /// call's own argument. Only a *filter*-namespace binder clears it -- a
+    /// nested `def`'s matching parameter (of either spelling, since both
+    /// bind the bare name) or a nested zero-argument `def` of that name. An
+    /// `as`/`reduce`/`foreach` binder never does, however it is spelled:
+    /// confirmed live against jq 1.7.1, `def f(g): 1 as $g | $g + g; 10 as
+    /// $g | f($g)` is `11` -- the inner `1 as $g` shadows the inner `$g`
+    /// (evaluating to `1`) and never the bare `g` (still the caller's `$g`,
+    /// `10`).
+    bare: bool,
+}
+
+impl SubstScope {
+    /// The scope a call-time parameter binding starts in: a `$`-style
+    /// parameter owns both namespaces, a bare-style one owns only `bare`.
+    fn for_param(param: &Param) -> Self {
+        Self {
+            dollar: param.is_dollar(),
+            bare: true,
+        }
+    }
+
+    fn without_dollar(self) -> Self {
+        Self {
+            dollar: false,
+            ..self
+        }
+    }
+
+    fn without_bare(self) -> Self {
+        Self {
+            bare: false,
+            ..self
+        }
+    }
+
+    /// Nothing left to rewrite -- every reference this substitution could
+    /// have claimed is now bound by something nearer.
+    fn is_empty(self) -> bool {
+        !self.dollar && !self.bare
+    }
+}
+
+/// Rewrite only bare `param` references, leaving every `$param` alone --
+/// [`bind_def_call_params`]' bare-winner pass over a duplicated name.
+const BARE_NAMESPACE_ONLY: SubstScope = SubstScope {
+    dollar: false,
+    bare: true,
+};
+
+/// Rewrite only `$param` references, leaving every bare `param` alone --
+/// [`bind_def_call_params`]' `$`-winner pass over a duplicated name.
+const DOLLAR_NAMESPACE_ONLY: SubstScope = SubstScope {
+    dollar: true,
+    bare: false,
+};
 
 /// Substitute a function parameter with an argument expression.
 ///
@@ -49342,22 +49432,15 @@ fn subst_unless_shadowed(
 /// mechanism (the parser threw away the `$`), so they still rely on this
 /// same substitution to resolve at all (`def f($x): $x; f(5)` is `5`).
 ///
-/// `subst_dollar` tracks whether `$param` still means "this call's own
-/// argument" at the current point in the tree -- true everywhere by
-/// default, and cleared for one binder's own bound-scope child the moment
-/// that binder rebinds `$param` for real (`1 as $param`, or a `reduce`/
-/// `foreach`/`?//` pattern that binds `$param`), since a `$param`
-/// reference past that point is the *local* binding, not `param`'s own
-/// value. It never gates a *bare* `param` reference, which stays in its
-/// own namespace regardless: confirmed live against jq 1.7.1,
-/// `def f(g): 1 as $g | $g + g; 10 as $g | f($g)` is `11` -- the inner
-/// `1 as $g` shadows only the inner `$g` (evaluates to `1`), never the
-/// bare `g` (substituted with the caller's own `$g`, `10`).
-fn substitute_func_param(expr: &Expr, param: &str, arg: &Expr) -> Expr {
-    substitute_func_param_impl(expr, param, arg, true)
+/// Which namespaces the substitution may rewrite, and what narrows that as
+/// the walk crosses each binder, is [`SubstScope`] -- `param`'s own spelling
+/// decides where it starts (#2726), and only a binder in the matching
+/// namespace clears it (#2555).
+fn substitute_func_param(expr: &Expr, param: &Param, arg: &Expr) -> Expr {
+    substitute_func_param_impl(expr, param.name(), arg, SubstScope::for_param(param))
 }
 
-fn substitute_func_param_impl(expr: &Expr, param: &str, arg: &Expr, subst_dollar: bool) -> Expr {
+fn substitute_func_param_impl(expr: &Expr, param: &str, arg: &Expr, scope: SubstScope) -> Expr {
     debug_assert!(
         matches!(arg, Expr::Shared(_)),
         "substitute_func_param's capture-hygiene argument (#2096) requires `arg` to be \
@@ -49376,17 +49459,12 @@ fn substitute_func_param_impl(expr: &Expr, param: &str, arg: &Expr, subst_dollar
         // exists at all (a `$`-style parameter's only binding mechanism)
         // and why it's gated on `subst_dollar` rather than firing
         // unconditionally the way the `FuncCall` arm below does.
-        Expr::Var(name) if subst_dollar && name == param => arg.clone(),
+        Expr::Var(name) if scope.dollar && name == param => arg.clone(),
         // #2095: does not recurse into `msg` -- see `map_subexprs`'s own doc
         // comment (`src/jq/walk.rs`) on its `Expr::Error` arm for why this is
         // preserved as a likely latent gap rather than fixed here.
         Expr::Error(msg) => Expr::Error(msg.clone()),
-        Expr::Builtin(b) => Expr::Builtin(substitute_func_param_in_builtin(
-            b,
-            param,
-            arg,
-            subst_dollar,
-        )),
+        Expr::Builtin(b) => Expr::Builtin(substitute_func_param_in_builtin(b, param, arg, scope)),
         // #2141: unlike the pre-fix code, `expr`/`input`/`init` (evaluated
         // in the *outer* scope) always keep the ambient `subst_dollar`, and
         // `body`/`update`/`extract` (the bound-scope child) only ever clear
@@ -49394,13 +49472,17 @@ fn substitute_func_param_impl(expr: &Expr, param: &str, arg: &Expr, subst_dollar
         // still applies to every child unconditionally -- a `$`-bound
         // binder can shadow `$param`, never a bare `param`.
         Expr::As { expr, var, body } => Expr::As {
-            expr: Box::new(substitute_func_param_impl(expr, param, arg, subst_dollar)),
+            expr: Box::new(substitute_func_param_impl(expr, param, arg, scope)),
             var: var.clone(),
             body: Box::new(substitute_func_param_impl(
                 body,
                 param,
                 arg,
-                subst_dollar && var != param,
+                if var == param {
+                    scope.without_dollar()
+                } else {
+                    scope
+                },
             )),
         },
         Expr::Reduce {
@@ -49409,13 +49491,16 @@ fn substitute_func_param_impl(expr: &Expr, param: &str, arg: &Expr, subst_dollar
             init,
             update,
         } => {
-            let still_dollar =
-                subst_dollar && !patterns.iter().any(|p| pattern_binds_var(p, param));
+            let bound_scope = if patterns.iter().any(|p| pattern_binds_var(p, param)) {
+                scope.without_dollar()
+            } else {
+                scope
+            };
             Expr::Reduce {
-                input: Box::new(substitute_func_param_impl(input, param, arg, subst_dollar)),
+                input: Box::new(substitute_func_param_impl(input, param, arg, scope)),
                 patterns: patterns.clone(),
-                init: Box::new(substitute_func_param_impl(init, param, arg, subst_dollar)),
-                update: Box::new(substitute_func_param_impl(update, param, arg, still_dollar)),
+                init: Box::new(substitute_func_param_impl(init, param, arg, scope)),
+                update: Box::new(substitute_func_param_impl(update, param, arg, bound_scope)),
             }
         }
         Expr::Foreach {
@@ -49425,16 +49510,19 @@ fn substitute_func_param_impl(expr: &Expr, param: &str, arg: &Expr, subst_dollar
             update,
             extract,
         } => {
-            let still_dollar =
-                subst_dollar && !patterns.iter().any(|p| pattern_binds_var(p, param));
+            let bound_scope = if patterns.iter().any(|p| pattern_binds_var(p, param)) {
+                scope.without_dollar()
+            } else {
+                scope
+            };
             Expr::Foreach {
-                input: Box::new(substitute_func_param_impl(input, param, arg, subst_dollar)),
+                input: Box::new(substitute_func_param_impl(input, param, arg, scope)),
                 patterns: patterns.clone(),
-                init: Box::new(substitute_func_param_impl(init, param, arg, subst_dollar)),
-                update: Box::new(substitute_func_param_impl(update, param, arg, still_dollar)),
+                init: Box::new(substitute_func_param_impl(init, param, arg, scope)),
+                update: Box::new(substitute_func_param_impl(update, param, arg, bound_scope)),
                 extract: extract
                     .as_deref()
-                    .map(|e| Box::new(substitute_func_param_impl(e, param, arg, still_dollar))),
+                    .map(|e| Box::new(substitute_func_param_impl(e, param, arg, bound_scope))),
             }
         }
         Expr::AsPattern {
@@ -49442,12 +49530,15 @@ fn substitute_func_param_impl(expr: &Expr, param: &str, arg: &Expr, subst_dollar
             patterns,
             body,
         } => {
-            let still_dollar =
-                subst_dollar && !patterns.iter().any(|p| pattern_binds_var(p, param));
+            let bound_scope = if patterns.iter().any(|p| pattern_binds_var(p, param)) {
+                scope.without_dollar()
+            } else {
+                scope
+            };
             Expr::AsPattern {
-                expr: Box::new(substitute_func_param_impl(expr, param, arg, subst_dollar)),
+                expr: Box::new(substitute_func_param_impl(expr, param, arg, scope)),
                 patterns: patterns.clone(),
-                body: Box::new(substitute_func_param_impl(body, param, arg, still_dollar)),
+                body: Box::new(substitute_func_param_impl(body, param, arg, bound_scope)),
             }
         }
         Expr::FuncDef {
@@ -49464,7 +49555,16 @@ fn substitute_func_param_impl(expr: &Expr, param: &str, arg: &Expr, subst_dollar
             // leave the `g` in `then` alone so the evaluator's own
             // innermost-first def lookup resolves it to the nested `def g`,
             // not to `param`'s substituted argument.
-            let then_shadowed = name == param && params.is_empty();
+            // #2555: bare-namespace only. A `def` binds a *filter* name and
+            // never a `$name`, so an outer `$param` reaches straight through
+            // one -- confirmed live against jq 1.7.1, `def f($a): def a: 99;
+            // $a; f(2)` is `2` (this used to block both namespaces and
+            // answered "undefined variable: $a").
+            let then_scope = if name == param && params.is_empty() {
+                scope.without_bare()
+            } else {
+                scope
+            };
             // #2283 review: this blanket "any matching param name shadows,
             // bare or `$`-style alike" is correct as-is for the *bare*
             // `param`-reference substitution this arm mostly exists for --
@@ -49481,50 +49581,40 @@ fn substitute_func_param_impl(expr: &Expr, param: &str, arg: &Expr, subst_dollar
             // shadow a bare substitution was wrong -- this line needed no
             // change once `Param` was available to check.
             //
-            // What *is* still wrong here, confirmed live and NOT fixed by
-            // this issue (tracked as a follow-up instead): this same
-            // blanket check also gates *`$param`-Var* substitution (via
-            // `subst_dollar` staying ambient into `body` below) whenever
-            // any matching param name exists, even a *bare* one -- but a
-            // bare nested parameter creates no `$name` binding at all, so
-            // an outer `$param` substitution should still reach through
-            // it. `def f($param): def h(param): $param; h(1); f(99)`
-            // answers `99` in jq (`h`'s own bare parameter doesn't touch
-            // `$param`, so it resolves to `f`'s own) but `1` here. Fixing
-            // this needs a second, independent `subst_bare`-style flag
-            // threaded through this whole function (this one gate
-            // conflates "block bare substitution" with "block
-            // `$`-substitution", and they need different shadowing rules)
-            // -- a materially larger change than this arm's own `Param`
-            // fix, out of scope here.
-            let body_shadowed = params.iter().any(|p| p.name() == param);
+            // #2555 splits the *other* half back out. This blanket check
+            // used to gate the `$param` substitution too, so an outer
+            // `$param` could not reach through a nested *bare-only*
+            // parameter either -- but a bare parameter creates no `$name`
+            // binding at all. Confirmed live against jq 1.7.1: `def
+            // f($param): def h(param): $param; h(1); f(99)` is `99` (`h`'s
+            // own bare parameter never touches `$param`), and answered `1`
+            // here. So the bare namespace is shadowed by a matching
+            // parameter of *either* spelling, while the `$` namespace is
+            // shadowed only when the binding one is `$`-style.
+            let mut body_scope = scope;
+            if params.iter().any(|p| p.name() == param) {
+                body_scope = body_scope.without_bare();
+            }
+            if params_bind_dollar(params, param) {
+                body_scope = body_scope.without_dollar();
+            }
             Expr::FuncDef {
                 name: name.clone(),
                 params: params.clone(),
-                body: Box::new(subst_unless_shadowed(
-                    body_shadowed,
-                    body,
-                    param,
-                    arg,
-                    subst_dollar,
-                )),
-                then: Box::new(subst_unless_shadowed(
-                    then_shadowed,
-                    then,
-                    param,
-                    arg,
-                    subst_dollar,
-                )),
+                body: Box::new(subst_in_scope(body, param, arg, body_scope)),
+                then: Box::new(subst_in_scope(then, param, arg, then_scope)),
                 // Rebuilt above, so any cache is stale (#2094).
                 bound: FuncDefBound::default(),
             }
         }
-        Expr::FuncCall { name, args, .. } if name == param && args.is_empty() => {
+        Expr::FuncCall { name, args, .. } if scope.bare && name == param && args.is_empty() => {
             // In jq, function parameters are bare identifiers that parse as
-            // zero-arg FuncCalls. This is a reference to the parameter --
-            // never gated on `subst_dollar` (see this function's own doc
-            // comment): a bare parameter has no `$`-namespace binder that
-            // could ever shadow it.
+            // zero-arg FuncCalls. This is a reference to the parameter.
+            //
+            // #2555: gated on `scope.bare`, not on `scope.dollar` -- only a
+            // *filter*-namespace binder (a nested `def`, or a nested def's
+            // own matching parameter) can shadow this, never an `as`/
+            // `reduce`/`foreach` binder, however that binder is spelled.
             arg.clone()
         }
 
@@ -49537,7 +49627,7 @@ fn substitute_func_param_impl(expr: &Expr, param: &str, arg: &Expr, subst_dollar
         // for the full variant-by-variant justification, including the arms
         // above that stay explicit here instead of ever reaching it.
         _ => map_subexprs(expr, &mut |sub| {
-            substitute_func_param_impl(sub, param, arg, subst_dollar)
+            substitute_func_param_impl(sub, param, arg, scope)
         }),
     }
 }
@@ -49564,12 +49654,12 @@ fn install_def_calls_in_builtin(
 
 /// Substitute function parameter in a builtin expression.
 ///
-/// #2141 review: takes `subst_dollar` rather than calling the public
-/// [`substitute_func_param`] (which always starts a fresh `true`) --
-/// a builtin argument is ordinary structural nesting, not a
-/// substitution-scope boundary, so the ambient `subst_dollar` an
-/// enclosing `As`/`Reduce`/`Foreach`/`AsPattern` binder may have already
-/// cleared must carry into it. Confirmed live: without this,
+/// #2141 review: takes the ambient [`SubstScope`] rather than calling the
+/// public [`substitute_func_param`] (which starts a fresh scope from the
+/// parameter's own spelling) -- a builtin argument is ordinary structural
+/// nesting, not a substitution-scope boundary, so whatever an enclosing
+/// `As`/`Reduce`/`Foreach`/`AsPattern`/`FuncDef` binder has already narrowed
+/// must carry into it. Confirmed live: without this,
 /// `def f(g): 1 as $g | select($g == 1); f(999)` answered nothing
 /// (`select`'s own `$g` was wrongly re-substituted with `f`'s argument,
 /// `999`, instead of staying `1` from the enclosing `1 as $g`) where jq
@@ -49578,10 +49668,10 @@ fn substitute_func_param_in_builtin(
     builtin: &Builtin,
     param: &str,
     arg: &Expr,
-    subst_dollar: bool,
+    scope: SubstScope,
 ) -> Builtin {
     map_builtin_subexprs(builtin, &mut |e| {
-        substitute_func_param_impl(e, param, arg, subst_dollar)
+        substitute_func_param_impl(e, param, arg, scope)
     })
 }
 
@@ -49858,6 +49948,82 @@ mod tests {
             "the later, bare parameter has no $-binding of its own -- the outer $a must \
              reach through"
         );
+    }
+
+    /// #2555: `params_bind_dollar` is one definition serving two shadow
+    /// sites that ask the identical question -- `substitute_var_impl`'s
+    /// `Expr::FuncDef` arm (may an outer `$name` value reach this def's
+    /// body?) and `substitute_func_param_impl`'s (may an outer *parameter*'s
+    /// own `$name` reach it?). They were written separately, and this pins
+    /// that they now answer alike, per this project's own lesson that
+    /// duplicated predicates diverge silently (#106).
+    ///
+    /// Each row is checked three ways: the predicate itself, and both call
+    /// sites observed through their own public entry points.
+    #[test]
+    fn test_params_bind_dollar_agrees_with_both_shadow_sites_2555() {
+        let bare = |n: &str| Param::Bare(n.to_string());
+        let dollar = |n: &str| Param::Dollar(n.to_string());
+
+        for (params, binds_dollar, label) in [
+            (vec![bare("a")], false, "bare alone binds no $a"),
+            (vec![dollar("a")], true, "$-style alone binds $a"),
+            (vec![bare("b")], false, "a different name binds nothing"),
+            (
+                vec![bare("a"), dollar("a")],
+                true,
+                "duplicate, $-style last -- last occurrence decides",
+            ),
+            (
+                vec![dollar("a"), bare("a")],
+                false,
+                "duplicate, bare last -- last occurrence decides",
+            ),
+            (
+                vec![dollar("a"), bare("a"), dollar("a")],
+                true,
+                "three occurrences, $-style last",
+            ),
+            (vec![], false, "no parameters at all"),
+        ] {
+            assert_eq!(
+                params_bind_dollar(&params, "a"),
+                binds_dollar,
+                "params_bind_dollar disagrees: {label}"
+            );
+
+            // Site 1 -- `substitute_var_impl`: an outer `$a` reaches the
+            // body exactly when these params do NOT bind `$a`.
+            let def = Expr::FuncDef {
+                name: "f".to_string(),
+                params: params.clone(),
+                body: Box::new(Expr::Var("a".to_string())),
+                then: Box::new(Expr::Identity),
+                bound: FuncDefBound::default(),
+            };
+            let Expr::FuncDef { body, .. } = substitute_var(&def, "a", &OwnedValue::Int(9)) else {
+                unreachable!("FuncDef arm always returns FuncDef"); // omni-dev: coverage tolerate-line reason="substitute_var_impl's FuncDef arm always returns FuncDef (#2283)"
+            };
+            let var_site_reached = *body != Expr::Var("a".to_string());
+            assert_eq!(
+                var_site_reached, !binds_dollar,
+                "substitute_var_impl disagrees with params_bind_dollar: {label}"
+            );
+
+            // Site 2 -- `substitute_func_param_impl`: an outer `$`-style
+            // parameter's own `$a` reaches the nested def's body under
+            // exactly the same condition.
+            let arg = Expr::Shared(Rc::new(Expr::Literal(Literal::Int(7))));
+            let substituted = substitute_func_param(&def, &Param::Dollar("a".to_string()), &arg);
+            let Expr::FuncDef { body, .. } = substituted else {
+                unreachable!("FuncDef arm always returns FuncDef"); // omni-dev: coverage tolerate-line reason="substitute_func_param_impl's FuncDef arm always returns FuncDef (#2555)"
+            };
+            let param_site_reached = *body != Expr::Var("a".to_string());
+            assert_eq!(
+                param_site_reached, !binds_dollar,
+                "substitute_func_param_impl disagrees with params_bind_dollar: {label}"
+            );
+        }
     }
 
     /// #2560: [`bind_def_call_params`] directly, at the AST level, rather
@@ -80851,7 +81017,11 @@ mod tests {
             slice_number
         );
         assert_eq!(
-            substitute_func_param(&slice_number, "x", &Expr::Shared(Rc::new(Expr::Identity))),
+            substitute_func_param(
+                &slice_number,
+                &Param::Bare("x".to_string()),
+                &Expr::Shared(Rc::new(Expr::Identity))
+            ),
             slice_number
         );
     }

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -49312,22 +49312,42 @@ fn subst_in_scope(e: &Expr, param: &str, arg: &Expr, scope: SubstScope) -> Expr 
     }
 }
 
-/// Whether `params` binds `$name` -- the *last* parameter of that name
-/// decides, per jq's later-wins parameter shadowing (#2560), and only a
-/// `$`-style one binds the variable namespace at all.
+/// Whether `params` binds `$name` at all -- i.e. whether an outer `$name`
+/// is shadowed for this def's whole body.
+///
+/// **`any`, not "the last one wins".** A parameter list asks three different
+/// questions about a repeated name, and only two of them are decided by the
+/// last occurrence:
+///
+/// 1. *Does anything here bind `$name`?* -- **this function**. Only a
+///    `$`-style parameter binds the variable namespace, and a later
+///    *bare* parameter of the same name does not unbind it: it shadows the
+///    filter namespace only, while the `$`-binding the earlier parameter
+///    established stays in scope for the body. Confirmed live against jq
+///    1.7.1: `def f($a): def h($a; a): $a; h(1;2); f(9)` is `1` -- `h`'s own
+///    leading `$a` still owns `$a` inside `h`, so the outer `9` must not
+///    reach it -- and `9 as $a | def f($a; a): $a; f(1;2)` is likewise `1`.
+/// 2. *Which argument does `$name` resolve to inside the def?* -- the last
+///    **`$`-style** occurrence, [`bind_def_call_params`]' own
+///    `rfind(is_dollar)`.
+/// 3. *Which argument does bare `name` resolve to?* -- the last occurrence
+///    of **any** spelling, since `$`-style binds the bare namespace too
+///    (#2560).
+///
+/// Reading (1) as (2)'s rule -- "the last parameter of this name, is it
+/// `$`-style?" -- gets `($a; a)` wrong in both directions: it let an outer
+/// `$a` leak into a body that binds its own, and it is what
+/// [`substitute_var_impl`]'s own copy of this check did before #2555.
 ///
 /// One definition, two call sites: [`substitute_var_impl`]'s `Expr::FuncDef`
-/// arm (may an outer `$name` substitution reach into this def's body?) and
-/// [`substitute_func_param_impl`]'s (same question, for an outer
-/// *parameter*'s own `$name` references). They asked the identical question
-/// with separately-written code until #2555; `test_params_bind_dollar_agrees_with_both_shadow_sites_2555`
-/// pins that they still agree.
+/// arm (may an outer `$name` *value* reach into this def's body?) and
+/// [`substitute_func_param_impl`]'s (the same question, for an outer
+/// *parameter*'s own `$name` references). They asked it with separately
+/// written code until #2555;
+/// `test_params_bind_dollar_agrees_with_both_shadow_sites_2555` pins that
+/// they still agree.
 fn params_bind_dollar(params: &[Param], name: &str) -> bool {
-    params
-        .iter()
-        .rev()
-        .find(|p| p.name() == name)
-        .is_some_and(Param::is_dollar)
+    params.iter().any(|p| p.is_dollar() && p.name() == name)
 }
 
 /// Which of a function parameter's two namespaces a substitution may still
@@ -49362,14 +49382,21 @@ struct SubstScope {
     /// `def` whose own matching parameter is `$`-style.
     dollar: bool,
     /// Bare `param` (`Expr::FuncCall { args: [] }`) still resolves to this
-    /// call's own argument. Only a *filter*-namespace binder clears it -- a
+    /// call's own argument. Only a *filter*-namespace binder clears it: a
     /// nested `def`'s matching parameter (of either spelling, since both
-    /// bind the bare name) or a nested zero-argument `def` of that name. An
-    /// `as`/`reduce`/`foreach` binder never does, however it is spelled:
-    /// confirmed live against jq 1.7.1, `def f(g): 1 as $g | $g + g; 10 as
-    /// $g | f($g)` is `11` -- the inner `1 as $g` shadows the inner `$g`
-    /// (evaluating to `1`) and never the bare `g` (still the caller's `$g`,
-    /// `10`).
+    /// bind the bare name), or -- in that def's `then` -- a nested
+    /// zero-argument `def` of the name. An `as`/`reduce`/`foreach` binder
+    /// never does, however it is spelled: confirmed live against jq 1.7.1,
+    /// `def f(g): 1 as $g | $g + g; 10 as $g | f($g)` is `11` -- the inner
+    /// `1 as $g` shadows the inner `$g` (evaluating to `1`) and never the
+    /// bare `g` (still the caller's `$g`, `10`).
+    ///
+    /// A nested zero-argument `def` does **not** clear this inside its own
+    /// `body`, where jq also has it in scope (`def` is recursive there).
+    /// That gap predates #2555 and is deliberately left alone: closing it
+    /// makes `def f(a): def a: a+1; a; f(1)` recurse forever, as jq does,
+    /// so it is a behaviour change that needs its own oracle matrix rather
+    /// than a drive-by. Tracked as #2737.
     bare: bool,
 }
 
@@ -49456,21 +49483,23 @@ fn substitute_func_param_impl(expr: &Expr, param: &str, arg: &Expr, scope: Subst
         // the caller's scope and cannot mention the callee's own parameters.
         Expr::Shared(inner) => Expr::Shared(Rc::clone(inner)),
         // See `substitute_func_param`'s own doc comment above for why this
-        // exists at all (a `$`-style parameter's only binding mechanism)
-        // and why it's gated on `subst_dollar` rather than firing
-        // unconditionally the way the `FuncCall` arm below does.
+        // exists at all (a `$`-style parameter's only binding mechanism).
+        // Gated on `scope.dollar`, the variable namespace -- the bare
+        // `FuncCall` arm below reads `scope.bare` instead, and the two
+        // narrow on different binders (#2555).
         Expr::Var(name) if scope.dollar && name == param => arg.clone(),
         // #2095: does not recurse into `msg` -- see `map_subexprs`'s own doc
         // comment (`src/jq/walk.rs`) on its `Expr::Error` arm for why this is
         // preserved as a likely latent gap rather than fixed here.
         Expr::Error(msg) => Expr::Error(msg.clone()),
         Expr::Builtin(b) => Expr::Builtin(substitute_func_param_in_builtin(b, param, arg, scope)),
-        // #2141: unlike the pre-fix code, `expr`/`input`/`init` (evaluated
-        // in the *outer* scope) always keep the ambient `subst_dollar`, and
-        // `body`/`update`/`extract` (the bound-scope child) only ever clear
-        // it, never the bare-`param` substitution the `FuncCall` arm below
-        // still applies to every child unconditionally -- a `$`-bound
-        // binder can shadow `$param`, never a bare `param`.
+        // #2141: `expr`/`input`/`init` (evaluated in the *outer* scope)
+        // always keep the ambient scope, and `body`/`update`/`extract` (the
+        // bound-scope child) only ever clear its `dollar` half. An
+        // `as`/`reduce`/`foreach`/`?//` binder binds a *variable*, so it can
+        // shadow `$param` and never a bare `param`, however it is spelled
+        // (#2555: that asymmetry is now in the flags rather than implicit in
+        // the bare arm firing unconditionally).
         Expr::As { expr, var, body } => Expr::As {
             expr: Box::new(substitute_func_param_impl(expr, param, arg, scope)),
             var: var.clone(),
@@ -49888,23 +49917,28 @@ mod tests {
     /// `#[cfg(feature = "std")]`: `ambient_frame_depth` itself is a no-op
     /// under `no_std` (see its own module doc comment) -- there is no
     /// no_std variant of this mechanism to test.
-    /// #2283 review: `substitute_var_impl`'s shadow check must resolve a
-    /// duplicate-named parameter list by its *last* occurrence (jq's own
-    /// later-wins shadowing precedence), not its first -- an earlier
-    /// version of this exact fix used `.position()` (first match) and let
-    /// an outer `$a` leak straight into `def f(a; $a): $a`'s body despite
-    /// the *later* `$a` parameter being `$`-style. Verified directly on
-    /// the substitution itself (bypassing `bind_def_call`'s own separate,
-    /// pre-existing, unrelated bug in duplicate-name *argument* binding --
-    /// confirmed live against jq 1.7.1 that `9 as $a | def f(a; $a): $a;
-    /// f(1;2)` end-to-end is `2` on jq but `1` even on unmodified `main`,
-    /// for a reason unconnected to shadowing -- so this test checks the
-    /// shadow decision in isolation): `f`'s own `$a` reference inside
-    /// `body` must remain an unsubstituted `Expr::Var`, not get replaced
-    /// with the outer `9`, whichever position the `$`-style parameter
-    /// sits at.
+    /// #2283 review, corrected by #2555: `substitute_var_impl`'s shadow
+    /// check blocks an outer `$a` whenever a duplicate-named parameter list
+    /// binds `$a` *anywhere*, not merely at its last occurrence.
+    ///
+    /// #2283 originally wrote this as "the last occurrence decides, is it
+    /// `$`-style?", fixing a real bug (an earlier draft used `.position()`,
+    /// the *first* match, and let an outer `$a` leak into
+    /// `def f(a; $a): $a`'s body). That rule is right for deciding *which
+    /// argument* a reference resolves to, and wrong for deciding *whether
+    /// the name is bound at all* -- a trailing bare parameter shadows only
+    /// the filter namespace and cannot unbind a leading `$a`. See
+    /// [`params_bind_dollar`]'s own doc comment for the three separate
+    /// questions.
+    ///
+    /// Both rows below are the end-to-end behaviour of jq 1.7.1, captured
+    /// live: `9 as $a | def f(a; $a): $a; f(1;2)` is `2` and
+    /// `9 as $a | def f($a; a): $a; f(1;2)` is `1` -- in both cases `f`'s
+    /// own binding wins and the outer `9` never appears. This test checks
+    /// the shadow decision in isolation, so `f`'s own `$a` reference inside
+    /// `body` must stay an unsubstituted `Expr::Var` either way.
     #[test]
-    fn test_duplicate_named_param_shadow_resolves_by_last_occurrence_2283() {
+    fn test_duplicate_named_param_shadow_blocks_whenever_dollar_is_bound_2283_2555() {
         let make_funcdef = |params: Vec<Param>| Expr::FuncDef {
             name: "f".to_string(),
             params,
@@ -49929,11 +49963,13 @@ mod tests {
              unsubstituted, not become Literal(9)"
         );
 
-        // `$`-style parameter first, bare last: `def f($a; a): $a` -- the
-        // *bare* trailing parameter no longer has a `$`-binding of its own
-        // at that position, so this one is NOT shadowed (matches
-        // `test_bare_nested_param_no_longer_shadows_outer_dollar_binding_2283`'s
-        // own single-parameter case).
+        // `$`-style parameter first, bare last: `def f($a; a): $a`. #2283
+        // read this as "not shadowed" -- the trailing bare parameter has no
+        // `$`-binding, so the outer `$a` was let through. That is wrong:
+        // the *leading* `$a` still binds `$a` for the whole body, and a
+        // later bare parameter of the same name shadows only the filter
+        // namespace. Confirmed live against jq 1.7.1:
+        // `9 as $a | def f($a; a): $a; f(1;2)` is `1`, never `9`.
         let dollar_first = make_funcdef(vec![
             Param::Dollar("a".to_string()),
             Param::Bare("a".to_string()),
@@ -49944,9 +49980,26 @@ mod tests {
         };
         assert_eq!(
             **body,
+            Expr::Var("a".to_string()),
+            "the leading $-style parameter binds $a for the whole body -- a trailing bare \
+             parameter shadows only the filter namespace, so the outer $a must NOT reach through"
+        );
+
+        // Neither spelling binds `$a`: nothing shadows it, so the outer
+        // value does reach the body. Confirmed live against jq 1.7.1,
+        // `9 as $a | def f(a; a): $a; f(1;2)` is `9`.
+        let no_dollar = make_funcdef(vec![
+            Param::Bare("a".to_string()),
+            Param::Bare("a".to_string()),
+        ]);
+        let substituted = substitute_var(&no_dollar, "a", &OwnedValue::Int(9));
+        let Expr::FuncDef { body, .. } = &substituted else {
+            unreachable!("FuncDef arm always returns FuncDef"); // omni-dev: coverage tolerate-line reason="substitute_var_impl's FuncDef arm always returns FuncDef (#2283)"
+        };
+        assert_eq!(
+            **body,
             Expr::Literal(Literal::Int(9)),
-            "the later, bare parameter has no $-binding of its own -- the outer $a must \
-             reach through"
+            "bare parameters create no $-binding at all -- the outer $a must reach through"
         );
     }
 
@@ -49972,17 +50025,26 @@ mod tests {
             (
                 vec![bare("a"), dollar("a")],
                 true,
-                "duplicate, $-style last -- last occurrence decides",
+                "duplicate, $-style last",
             ),
             (
+                // Not "the last occurrence decides": the trailing bare
+                // parameter shadows the *filter* namespace only, and cannot
+                // unbind the `$a` the leading one established. jq 1.7.1:
+                // `9 as $a | def f($a; a): $a; f(1;2)` is `1`, not `9`.
                 vec![dollar("a"), bare("a")],
-                false,
-                "duplicate, bare last -- last occurrence decides",
+                true,
+                "duplicate, bare last -- the earlier $-style one still binds $a",
             ),
             (
                 vec![dollar("a"), bare("a"), dollar("a")],
                 true,
                 "three occurrences, $-style last",
+            ),
+            (
+                vec![bare("a"), bare("a")],
+                false,
+                "duplicate, no $-style occurrence at all",
             ),
             (vec![], false, "no parameters at all"),
         ] {

--- a/src/jq/walk.rs
+++ b/src/jq/walk.rs
@@ -653,16 +653,19 @@ pub fn map_builtin_subexprs(builtin: &Builtin, f: &mut dyn FnMut(&Expr) -> Expr)
 /// - `Expr::FuncDef`: genuinely different in all three, not just in
 ///   *whether* something is shadowed but in what "shadowed" even means
 ///   (`install_def_calls`: same name and arity, and the fully-shadowed
-///   branch clones the whole node, preserving its cache; `substitute_func_param`:
-///   two independent conditions, one for `body` (a nested `def`'s own bare
-///   parameters) and one for `then` (a nested zero-arity `def` of the same
-///   name); `substitute_var_impl`: no shadow condition at all -- a nested
-///   `def`'s bare parameters live in a separate namespace from the `$`-bound
-///   name being substituted (#2141) and can never shadow it, so `body` and
-///   `then` are both always recursed) -- no shared unconditional shape
-///   exists to fall back to, so all three keep their own complete arm and
-///   never reach this
-///   function's own arm for it.
+///   branch clones the whole node, preserving its cache;
+///   `substitute_func_param`: since #2555, a per-namespace `SubstScope`
+///   rather than a boolean -- a nested matching parameter of *either*
+///   spelling shadows the bare name, a `$`-style one additionally shadows
+///   `$name`, and a nested zero-arity `def` of the name shadows the bare
+///   name in `then`, so a subtree can be shadowed in one namespace while
+///   the other still substitutes; `substitute_var_impl`: shadowed exactly
+///   when this def's own parameters bind `$name` (`params_bind_dollar`,
+///   shared with the above since #2555), since a nested `def`'s *bare*
+///   parameters live in a separate namespace from the `$`-bound name being
+///   substituted (#2141, #2283) and can never shadow it) -- no shared
+///   unconditional shape exists to fall back to, so all three keep their own
+///   complete arm and never reach this function's own arm for it.
 ///
 /// The five arms named above (`Shared`, `Error`, `Builtin`, `FuncDef`, and
 /// `install_def_calls`'s own `DefCall` policy) are therefore never actually

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -23154,6 +23154,64 @@ fn test_outer_dollar_param_reaches_through_nesting_2555() -> Result<()> {
     Ok(())
 }
 
+/// #2555 review: a repeated parameter name asks *three* different questions,
+/// and "does this list bind `$name` at all?" is the one **not** decided by
+/// the last occurrence. A trailing *bare* parameter shadows the filter
+/// namespace only -- it cannot unbind the `$a` an earlier `$`-style
+/// parameter established, which stays in scope for the whole body. So an
+/// outer `$a` must not reach into a def declared `($a; a)`.
+///
+/// The first four rows caught a regression in this PR's own first draft,
+/// which asked the question with the *last-occurrence* rule and let the
+/// outer value leak in. The last two are the same defect at the sibling
+/// call site (`substitute_var_impl`), which was wrong on `main` too --
+/// nothing had exercised a repeated `($a; a)` parameter list with an
+/// enclosing `$a` to leak. All confirmed live against jq 1.7.1.
+#[test]
+fn test_trailing_bare_param_does_not_unbind_an_earlier_dollar_one_2555() -> Result<()> {
+    for (filter, expected) in [
+        ("def f($a): def h($a; a): $a; h(1;2); f(9)", "1"),
+        ("def f($a): def h($a; a): [$a, a]; h(1;2); f(9)", "[1,2]"),
+        ("def f($a): def h($a; a; a): $a; h(1;2;3); f(9)", "1"),
+        ("def f($a): def h($a; a): def q: $a; q; h(1;2); f(9)", "1"),
+        // the `substitute_var_impl` sibling: an outer `as`-bound $a, rather
+        // than an outer parameter's own
+        ("9 as $a | def f($a; a): $a; f(1;2)", "1"),
+        ("5 as $a | def f($a;a): [$a, a]; f(1;2)", "[1,2]"),
+    ] {
+        let (stdout, stderr, code) = run_jq_full(&["-nc", filter], None)?;
+        assert_eq!(code, 0, "filter: {filter:?}, stderr: {stderr:?}");
+        assert_eq!(stdout.trim_end(), expected, "filter: {filter:?}");
+    }
+    Ok(())
+}
+
+/// #2555 review, the boundary either side of the rule above: a list with
+/// **no** `$`-style occurrence of the name binds no `$a`, so an outer one
+/// still reaches through; and the last-occurrence rule remains correct for
+/// the *other* two questions (which argument each namespace resolves to
+/// inside the def -- #2560). Confirmed live against jq 1.7.1.
+#[test]
+fn test_repeated_param_name_binding_questions_stay_distinct_2555() -> Result<()> {
+    for (filter, expected) in [
+        // no `$`-style occurrence at all -- outer $a reaches through
+        ("def f($a): def h(a; a): $a; h(1;2); f(9)", "9"),
+        // a `$`-style occurrence anywhere blocks it, leading or trailing
+        ("def f($a): def h(a; $a): $a; h(1;2); f(9)", "2"),
+        ("def f($a): def h($a; $a): $a; h(1;2); f(9)", "2"),
+        // ...and *which* argument $a then resolves to is still the last
+        // `$`-style occurrence, while bare `a` is the last of any spelling
+        ("def f($a; a): $a; f(1;2)", "1"),
+        ("def f($a; a): a; f(1;2)", "2"),
+        ("5 as $a | def f(a;a): $a + a; f(1;2)", "7"),
+    ] {
+        let (stdout, stderr, code) = run_jq_full(&["-nc", filter], None)?;
+        assert_eq!(code, 0, "filter: {filter:?}, stderr: {stderr:?}");
+        assert_eq!(stdout.trim_end(), expected, "filter: {filter:?}");
+    }
+    Ok(())
+}
+
 /// #2726: a **bare** parameter creates no `$`-binding, so `$a` in its body
 /// is not this call's argument. jq 1.7.1 rejects the program outright
 /// ("$a is not defined"); succinctly answered `1`, silently treating the
@@ -23174,6 +23232,27 @@ fn test_bare_param_does_not_create_a_dollar_binding_2726() -> Result<()> {
         stderr.contains("$a"),
         "the error should name the unbound variable, got: {stderr:?}"
     );
+    Ok(())
+}
+
+/// #2726, the shape of that rejection as it actually ships: an *evaluation*
+/// error, so `try`/`?` catch it, where jq's compile-time refusal cannot be
+/// caught by the program at all. Pinned rather than left implicit, because
+/// it is the visible consequence of #2734 (the general
+/// compile-vs-evaluation timing gap) landing on this newly-rejected
+/// program, and it is what a reader comparing against jq will hit first.
+#[test]
+fn test_bare_param_dollar_rejection_is_catchable_here_unlike_jq_2726() -> Result<()> {
+    // jq: compile error, exit 3, nothing catches it.
+    let (stdout, stderr, code) =
+        run_jq_full(&["-nc", r#"def f(a): try $a catch "caught"; f(1)"#], None)?;
+    assert_eq!(code, 0, "stderr: {stderr:?}");
+    assert_eq!(stdout.trim_end(), r#""caught""#);
+
+    // Same for postfix `?`, which suppresses it into an empty stream.
+    let (stdout, stderr, code) = run_jq_full(&["-nc", "def f(a): $a?; f(1)"], None)?;
+    assert_eq!(code, 0, "stderr: {stderr:?}");
+    assert_eq!(stdout.trim_end(), "");
     Ok(())
 }
 

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -23057,31 +23057,142 @@ fn test_mixed_bare_and_dollar_params_in_one_def_2283() -> Result<()> {
     Ok(())
 }
 
-/// #2283 review: `substitute_func_param_impl`'s own `Expr::FuncDef` arm has
-/// a *different*, deeper, NOT-fixed-here gap next to the one this issue
-/// closed in `substitute_var_impl` -- pinned as a known gap per this
-/// project's convention rather than left silently wrong. `Param` confirms
-/// a nested def's own matching parameter (bare *or* `$`-style) correctly
-/// shadows an outer *bare* `param` substitution (`$`-style desugars to
-/// bind the bare namespace too, confirmed live: `def h($param): param`
-/// alone is a compile error, "param is not defined", so `$`-style alone
-/// never leaves bare `param` unbound) -- but the same blanket check also
-/// blocks an outer `$param`(dollar) substitution from reaching a nested
-/// *bare*-only parameter's body, which it should not (a bare parameter
-/// creates no `$`-binding of its own). Needs a second, independent
-/// `subst_bare`-style flag threaded through `substitute_func_param_impl`
-/// the way `subst_dollar` already is -- a materially larger change than
-/// #2283's own `Param` type, tracked separately as #2555. jq 1.7.1 answers
-/// `99` (`h`'s own bare parameter doesn't touch `$param`, so it resolves
-/// to `f`'s own); this answers `1` (`h`'s own argument, wrongly captured).
+/// #2555: an outer `$param` substitution reaches *through* a nested def's
+/// own **bare-only** parameter, because a bare parameter creates no
+/// `$`-binding to shadow it with. `substitute_func_param_impl`'s
+/// `Expr::FuncDef` arm used to answer this with one blanket
+/// "any matching parameter name shadows" check, which is right for the bare
+/// namespace and wrong for the `$` one -- it answered `1` (`h`'s own
+/// argument, wrongly captured) where jq 1.7.1 answers `99`. `SubstScope`
+/// now narrows the two namespaces independently.
+///
+/// The bare half of that check was and remains correct: a nested matching
+/// parameter of *either* spelling shadows a bare `param` reference, since a
+/// `$`-style parameter binds the bare namespace too (`def h($param): param`
+/// alone is a compile error, "param is not defined") -- pinned by
+/// `test_dollar_style_nested_param_still_shadows_bare_substitution_2555`
+/// below.
 #[test]
-fn test_bare_nested_param_wrongly_shadows_outer_dollar_func_param_known_gap_2283() -> Result<()> {
+fn test_outer_dollar_param_reaches_through_a_bare_nested_param_2555() -> Result<()> {
     let (stdout, stderr, code) = run_jq_full(
         &["-nc", "def f($param): def h(param): $param; h(1); f(99)"],
         None,
     )?;
     assert_eq!(code, 0, "stderr: {stderr:?}");
-    assert_eq!(stdout.trim_end(), "1");
+    assert_eq!(stdout.trim_end(), "99");
+    Ok(())
+}
+
+/// #2555, the other half of the split: a nested matching parameter still
+/// shadows the **bare** namespace whichever way it is spelled, and a
+/// `$`-style one still shadows the `$` namespace as well. These are the
+/// cases the pre-#2555 blanket check got right, pinned so that narrowing the
+/// `$` half cannot quietly widen this one. All confirmed live against
+/// jq 1.7.1.
+#[test]
+fn test_dollar_style_nested_param_still_shadows_bare_substitution_2555() -> Result<()> {
+    for (filter, expected) in [
+        // bare outer, bare nested -- nested wins the bare namespace
+        ("def f(param): def h(param): param; h(1); f(5)", "1"),
+        // bare outer, `$`-style nested -- still wins the bare namespace
+        ("def f(param): def h($param): param; h(1); f(5)", "1"),
+        // `$`-style outer, `$`-style nested -- wins both namespaces
+        ("def f($param): def h($param): $param; h(1); f(99)", "1"),
+        // `$`-style outer, bare nested, *bare* reference -- nested wins
+        ("def f($a): def h(a): a; h(0); f(1)", "0"),
+    ] {
+        let (stdout, stderr, code) = run_jq_full(&["-nc", filter], None)?;
+        assert_eq!(code, 0, "filter: {filter:?}, stderr: {stderr:?}");
+        assert_eq!(stdout.trim_end(), expected, "filter: {filter:?}");
+    }
+    Ok(())
+}
+
+/// #2555: a nested zero-argument `def` of the parameter's name shadows the
+/// *filter* namespace only -- a `def` binds no `$name` at all, so an outer
+/// `$param` reaches straight through it. The pre-#2555 `then_shadowed`
+/// check blocked both namespaces, so the first row below failed outright
+/// with "undefined variable: $a". Confirmed live against jq 1.7.1.
+#[test]
+fn test_nested_zero_arg_def_shadows_only_the_bare_namespace_2555() -> Result<()> {
+    for (filter, expected) in [
+        ("def f($a): def a: 99; $a; f(2)", "2"),
+        // the bare half of the same shape, unchanged: the nested `def` wins
+        ("def f($a): def a: 99; a; f(2)", "99"),
+        ("def f(a): def a: 99; a; f(2)", "99"),
+        ("def f(g): def g: 99; g; f(1)", "99"),
+    ] {
+        let (stdout, stderr, code) = run_jq_full(&["-nc", filter], None)?;
+        assert_eq!(code, 0, "filter: {filter:?}, stderr: {stderr:?}");
+        assert_eq!(stdout.trim_end(), expected, "filter: {filter:?}");
+    }
+    Ok(())
+}
+
+/// #2555: the reach-through has to survive every kind of nesting between
+/// the outer `$param` and its reference, not just a nested def's immediate
+/// body -- through a builtin argument, through a `reduce`, and through a
+/// second def level. Each of these answered the innermost argument before
+/// the fix. All confirmed live against jq 1.7.1.
+#[test]
+fn test_outer_dollar_param_reaches_through_nesting_2555() -> Result<()> {
+    for (filter, expected) in [
+        ("def f($a): def h(a): [a, $a]; h(0); f(1)", "[0,1]"),
+        ("def f($a): def h(a): select($a == 1); h(0); f(1)", "null"),
+        (
+            "def f($a): def h(a): reduce range(2) as $i (0; . + $a); h(0); f(7)",
+            "14",
+        ),
+        ("def f($a): def h(a): def g(a): $a; g(2); h(1); f(3)", "3"),
+        // ...but a genuine local `$a` binder in between still shadows it.
+        ("def f($a): def h(a): (1 as $a | $a); h(0); f(9)", "1"),
+    ] {
+        let (stdout, stderr, code) = run_jq_full(&["-nc", filter], None)?;
+        assert_eq!(code, 0, "filter: {filter:?}, stderr: {stderr:?}");
+        assert_eq!(stdout.trim_end(), expected, "filter: {filter:?}");
+    }
+    Ok(())
+}
+
+/// #2726: a **bare** parameter creates no `$`-binding, so `$a` in its body
+/// is not this call's argument. jq 1.7.1 rejects the program outright
+/// ("$a is not defined"); succinctly answered `1`, silently treating the
+/// bare parameter as if it had been written `$a`. It now rejects it the
+/// same way it rejects any other unbound variable (see
+/// `test_bare_param_does_not_bind_dollar_leaves_outer_binding_2726` for the
+/// case where an enclosing binder *does* supply one).
+///
+/// Divergence that remains, and is not this issue's: jq rejects at compile
+/// time (exit 3), succinctly at evaluation (exit 5). That is how succinctly
+/// reports *every* unbound variable -- plain `$nope` diverges identically on
+/// unmodified `main` -- so it is a general gap, tracked separately.
+#[test]
+fn test_bare_param_does_not_create_a_dollar_binding_2726() -> Result<()> {
+    let (stdout, stderr, code) = run_jq_full(&["-nc", "def f(a): $a; f(1)"], None)?;
+    assert_ne!(code, 0, "stdout: {stdout:?}");
+    assert!(
+        stderr.contains("$a"),
+        "the error should name the unbound variable, got: {stderr:?}"
+    );
+    Ok(())
+}
+
+/// #2726: with the bare parameter no longer claiming `$a`, an enclosing
+/// binder's `$a` is what the body sees -- and the bare reference still
+/// resolves to the parameter. Confirmed live against jq 1.7.1.
+#[test]
+fn test_bare_param_does_not_bind_dollar_leaves_outer_binding_2726() -> Result<()> {
+    for (filter, expected) in [
+        ("9 as $a | def f(a): $a; f(1)", "9"),
+        ("9 as $a | def f(a): a; f(1)", "1"),
+        ("9 as $a | def f(a): [a, $a]; f(1)", "[1,9]"),
+        // a `$`-style parameter, by contrast, does claim `$a`
+        ("9 as $a | def f($a): $a; f(1)", "1"),
+    ] {
+        let (stdout, stderr, code) = run_jq_full(&["-nc", filter], None)?;
+        assert_eq!(code, 0, "filter: {filter:?}, stderr: {stderr:?}");
+        assert_eq!(stdout.trim_end(), expected, "filter: {filter:?}");
+    }
     Ok(())
 }
 


### PR DESCRIPTION
## Summary

`substitute_func_param_impl` carried a single `subst_dollar` flag for two genuinely
separate jq namespaces. A bare `name` reference (`Expr::FuncCall { args: [] }`, jq's
call-by-name spelling for a parameter) lives in the *filter* namespace; `$name`
(`Expr::Var`) lives in the *variable* namespace. What binds each differs, so what
shadows each differs — and collapsing them into one flag was wrong in **both**
directions.

This replaces the flag with `SubstScope { dollar, bare }`, narrowed per-namespace as the
walk crosses each binder. Three bugs fall out. All rows below confirmed live against
jq 1.7.1.

### 1. #2555 — an outer `$param` could not reach through a nested bare-only parameter

The `Expr::FuncDef` arm blocked both namespaces whenever a nested def had a matching
parameter. But a *bare* parameter binds no `$name` at all, so there is nothing there to
shadow `$param` with:

| program | jq 1.7.1 | before | after |
|---|---|---|---|
| `def f($param): def h(param): $param; h(1); f(99)` | `99` | `1` | `99` |
| `def f($a): def h(a): [a, $a]; h(0); f(1)` | `[0,1]` | `[0,0]` | `[0,1]` |
| `def f($a): def h(a): select($a == 1); h(0); f(1)` | `null` | *(no output)* | `null` |
| `def f($a): def h(a): reduce range(2) as $i (0; . + $a); h(0); f(7)` | `14` | `0` | `14` |
| `def f($a): def h(a): def g(a): $a; g(2); h(1); f(3)` | `3` | `2` | `3` |

The issue only had the first row; the rest are the same conflation reached through a
builtin argument, a `reduce`, and a second def level.

### 2. A third instance the issue does not name

The same arm's `then` check (`then_shadowed`, #2077) also blocked both namespaces, for a
nested **zero-argument `def`** of the parameter's name. A `def` binds a filter name and
never a `$name`, so this one did not merely answer wrongly — it failed outright:

| program | jq 1.7.1 | before | after |
|---|---|---|---|
| `def f($a): def a: 99; $a; f(2)` | `2` | `error: undefined variable: $a` | `2` |

### 3. #2726 — a bare parameter wrongly claimed `$name`

The substitution entered with `subst_dollar: true` regardless of the parameter's own
spelling, so a bare parameter bound `$name` as if it had been written `$name`:

| program | jq 1.7.1 | before | after |
|---|---|---|---|
| `def f(a): $a; f(1)` | compile error, `$a is not defined` | `1` | rejects |
| `9 as $a \| def f(a): $a; f(1)` | `9` | `9` | `9` |
| `9 as $a \| def f(a): [a, $a]; f(1)` | `[1,9]` | `[1,1]` | `[1,9]` |

It now rejects by the same route succinctly rejects any other unbound variable. That
route still differs from jq in *timing* — jq refuses at compile time (exit 3), this at
evaluation (exit 5) — but identically for a bare `$nope` involving no `def` at all, so
that gap is general and pre-existing; filed as #2734.

### The bare half is unchanged, and pinned

A nested matching parameter of **either** spelling still shadows a bare reference, since
a `$`-style parameter binds the bare namespace too (`def h($param): param` alone is a
compile error, *"param is not defined"*). `def f(param): def h($param): param; h(1); f(5)`
is still `1`, `def f($a): def a: 99; a; f(2)` still `99`, and
`def f(g): 1 as $g | $g + g; 10 as $g | f($g)` still `11` — an `as` binder never touches
the bare namespace however it is spelled.

### Two things fall out

- **`bind_def_call_params`' two passes (#2560) now say what they mean.**
  `BARE_NAMESPACE_ONLY` and `DOLLAR_NAMESPACE_ONLY` rewrite disjoint node sets, so their
  order stops being load-bearing. Previously the bare arm fired unconditionally and
  correctness rested on the bare pass running first and leaving opaque `Expr::Shared`
  behind — right, but only by construction rather than by the flags saying so.
- **`subst_unless_shadowed` becomes `subst_in_scope`.** It can no longer clone on the
  first shadow, because a subtree can be shadowed in one namespace while the other still
  has substituting to do; only an *empty* scope short-circuits now (which is exactly the
  old fast path).

### Shared predicate

Folds the duplicated "does this parameter list bind `$name`?" logic — written separately
in `substitute_var_impl` and now needed here — into one `params_bind_dollar`, with
`test_params_bind_dollar_agrees_with_both_shadow_sites_2555` checking each row three
ways (the predicate, and both call sites through their public entry points). This repo
has been bitten by duplicated predicates diverging silently (#106).

## Test plan

- [x] `cargo test --features cli,simd,regex,serde` — full suite, 62 binaries, 0 failures
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] Every row in all four tables above diffed directly against `/usr/bin/jq` (1.7.1)
- [x] 20 must-not-regress shapes re-checked against the oracle, plus the whole #2560
      duplicate-parameter matrix (13 shapes), all unchanged
- [x] The known-gap test `test_bare_nested_param_wrongly_shadows_outer_dollar_func_param_known_gap_2283`
      is replaced by `test_outer_dollar_param_reaches_through_a_bare_nested_param_2555`,
      pinning jq's real answer — it was the *only* test in the suite that failed against
      this change
- [x] New: 4 `_2555` CLI tests, 2 `_2726` CLI tests, and the shared-predicate agreement
      test

Fixes #2555, Fixes #2726