### PR TITLE
fix(jq): let a postfix chain apply to an array/object literal

### DIFF
--- a/src/jq/parser.rs
+++ b/src/jq/parser.rs
@@ -1449,11 +1449,23 @@ impl<'a> Parser<'a> {
                 self.parse_postfix(paren)
             }
 
-            // Array construction
-            Some('[') => self.parse_array_construction(),
+            // Array construction. #2667: a collection literal is a primary
+            // term in jq's own grammar, exactly like the parenthesized form
+            // just above, so the postfix chain applies to it directly --
+            // `[1,2][]`, `[1,2][0]` and `[1,2][0:1]` are all valid jq 1.7.1
+            // and were parse errors here. Only `(...)` routed through
+            // `parse_postfix`, which is why `([1,2])[]` always worked.
+            Some('[') => {
+                let array = self.parse_array_construction()?;
+                self.parse_postfix(array)
+            }
 
-            // Object construction
-            Some('{') => self.parse_object_construction(),
+            // Object construction -- same #2667 fix, for `{a:1}.a` and
+            // `{a:1}["a"]`.
+            Some('{') => {
+                let object = self.parse_object_construction()?;
+                self.parse_postfix(object)
+            }
 
             // String literal or interpolation
             Some('"') => self.parse_string_or_interpolation(),

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -46050,3 +46050,91 @@ fn test_first_and_nth_over_inputs_keep_the_owned_bridge_2180() -> Result<()> {
 
     Ok(())
 }
+
+/// #2667: a postfix chain applied directly to an array or object *literal*
+/// (`[1,2][]`, `{a:1}.a`) was a parse error everywhere, top level included.
+///
+/// `parse_primary_inner` routed only the parenthesized form through
+/// `parse_postfix`, so `([1,2])[]` always worked and `[1,2][]` never did --
+/// valid jq programs rejected before evaluation, with no wrong output.
+/// A collection literal is a primary term in jq's own grammar, exactly like
+/// `(...)`, `$var` and a function call, all of which already accepted the
+/// suffix chain.
+///
+/// Every row captured live from jq 1.7.1. The last three are the shapes the
+/// issue did not list, found while probing it: an ordinary index, a
+/// string-key index, and a slice.
+///
+/// Real yq v4.53.3 accepts all of these too (checked live: `[1,2][]`,
+/// `{"a":1}.a`, `[1,2][0]`, `{"a":1}["a"]`), so both modes want the same
+/// answer and there is no ADR-0018 divergence to record.
+#[test]
+// Object-construction filters (`{a:1}.a`) read as format specs to clippy; same
+// allow `eval.rs`'s own jq-source test literals carry.
+#[allow(clippy::literal_string_with_formatting_args)]
+fn test_postfix_applies_directly_to_a_collection_literal_2667() -> Result<()> {
+    for (filter, want) in [
+        ("[1,2][]", "1\n2"),
+        ("{a:1}.a", "1"),
+        ("[[1,2][]]", "[1,2]"),
+        ("first([1,2][])", "1"),
+        ("[limit(1; [1,2][])]", "[1]"),
+        ("def f(g): g; f([1,2][])", "1\n2"),
+        (r"[first({a:(1 as $x ?// $y | 1)}.a)]", "[1,1]"),
+        ("[1,2][0]", "1"),
+        (r#"{a:1}["a"]"#, "1"),
+        ("[1,2][0:1]", "[1]"),
+        ("[1,2][-1]", "2"),
+        ("{a:{b:2}}.a.b", "2"),
+        ("[[1],[2]][0][0]", "1"),
+        ("{a:1}.a?", "1"),
+        ("[1,2][]?", "1\n2"),
+        // Whitespace and a newline between the literal and its suffix bind
+        // the same way in jq.
+        ("[1,2] [0]", "1"),
+        ("{a:1} .a", "1"),
+        ("[1,2]\n[0]", "1"),
+    ] {
+        let (stdout, stderr, code) = run_jq_full(&["-cn", filter], None)?;
+        assert_eq!(code, 0, "`{filter}` -- stderr: {stderr:?}");
+        assert_eq!(stdout.trim(), want, "`{filter}`");
+    }
+
+    Ok(())
+}
+
+/// #2667: making a collection literal a postfix target must not swallow the
+/// `[`/`{` that opens a **destructuring pattern** after `as`, which is the
+/// one place the same two characters follow a term and mean something else.
+///
+/// `[1,2] as [$a,$b]` has to keep binding a pattern rather than parsing as
+/// `[1,2]` indexed by `[$a,$b]`. It does, because `as` sits between them --
+/// but that is exactly the kind of thing a postfix widening breaks silently,
+/// so it is pinned rather than assumed. All rows captured from jq 1.7.1.
+#[test]
+// Object-construction filters (`{a:1}.a`) read as format specs to clippy; same
+// allow `eval.rs`'s own jq-source test literals carry.
+#[allow(clippy::literal_string_with_formatting_args)]
+fn test_collection_literal_postfix_does_not_capture_destructuring_2667() -> Result<()> {
+    for (filter, want) in [
+        ("[1,2] as [$a,$b] | $a", "1"),
+        ("[1,2] as [$a,$b] | [$a,$b]", "[1,2]"),
+        ("{a:1} as {a:$x} | $x", "1"),
+        (". as [$a] | $a", "null"),
+        ("[[1,2]] | .[] as [$a,$b] | $b", "2"),
+        ("[{a:1}] | .[] as {a:$v} | $v", "1"),
+        ("[[1,2],[3,4]] | .[] as [$a,$b] | $a+$b", "3\n7"),
+        ("[1,2] as $x | $x", "[1,2]"),
+        ("{a:1} as $x | $x.a", "1"),
+        // The literal-with-postfix form as a `reduce`/`foreach` source.
+        ("reduce [1,2][] as $x (0; .+$x)", "3"),
+        ("foreach [1,2][] as $x (0; .+$x)", "1\n3"),
+        ("[1,2][] as $x | $x", "1\n2"),
+    ] {
+        let (stdout, stderr, code) = run_jq_full(&["-cn", filter], None)?;
+        assert_eq!(code, 0, "`{filter}` -- stderr: {stderr:?}");
+        assert_eq!(stdout.trim(), want, "`{filter}`");
+    }
+
+    Ok(())
+}

--- a/tests/jq_computed_key_tests.rs
+++ b/tests/jq_computed_key_tests.rs
@@ -376,9 +376,12 @@ fn test_mixed_borrowed_and_owned_results() {
 // =============================================================================
 //
 // `getpath(...)` returns a materialized value, so these exercise the owned
-// branch of the same rules. A collection literal would be the obvious way to
-// write them; it does not parse here — see
-// `test_collection_literal_as_a_target_is_a_parse_error`.
+// branch of the same rules. A collection literal is the obvious way to write
+// them, and since #2667 it parses too — see
+// `test_collection_literal_as_a_target_2667`, which covers the same rules
+// spelled that way. The `getpath(...)` spellings below are kept as they are:
+// they were written against the owned branch and still exercise it, and
+// rewriting them would churn a lot of coverage for no new signal.
 
 #[test]
 fn test_owned_target_follows_the_same_rules() {

--- a/tests/jq_computed_key_tests.rs
+++ b/tests/jq_computed_key_tests.rs
@@ -446,15 +446,30 @@ fn test_owned_target_of_the_wrong_kind_errors() {
 }
 
 #[test]
-fn test_collection_literal_as_a_target_is_a_parse_error() {
-    // DIVERGENCE from jq 1.7.1, and independent of #360 — a constant key is
-    // rejected just the same. jq reads `[1,2,3][0]` as `1` and `{"a":1}["a"]`
-    // as `1`; here the postfix chain never attaches to a collection literal, so
-    // both are refused before evaluation. This is why every owned target above
-    // is spelled `getpath(...)`.
-    for src in ["[1,2,3][0]", r#"{"a":1}["a"]"#, "[1,2,3][(0,2)]"] {
-        assert!(parse(src).is_err(), "`{src}` unexpectedly parsed");
-    }
+fn test_collection_literal_as_a_target_2667() {
+    // Was a documented DIVERGENCE from jq 1.7.1: the postfix chain never
+    // attached to a collection literal, so `[1,2,3][0]` and `{"a":1}["a"]`
+    // were refused before evaluation. That is why every owned target above is
+    // spelled `getpath(...)` — those spellings still work and are left as
+    // they are, but they are no longer the only way to reach an owned target.
+    //
+    // #2667 made a collection literal a primary term in `parse_primary_inner`,
+    // like the parenthesized form it always worked through (`([1,2,3])[0]`).
+    // Every row below captured live from jq 1.7.1, including the multi-output
+    // and `nan` keys that exercise this file's own computed-key machinery.
+    check("null", "[1,2,3][0]", Outcome::values(&["1"]));
+    check("null", r#"{"a":1}["a"]"#, Outcome::values(&["1"]));
+    check("null", "[1,2,3][(0,2)]", Outcome::values(&["1", "3"]));
+    check("null", "[1,2,3][(nan,0)]", Outcome::values(&["null", "1"]));
+    check(
+        "null",
+        r#"{"a":1}[("a","b")]"#,
+        Outcome::values(&["1", "null"]),
+    );
+    check("null", "[1,2,3][0:2]", Outcome::values(&["[1,2]"]));
+    // The postfix forms this fix did *not* change still parse, and agree.
+    check("null", "([1,2,3])[0]", Outcome::values(&["1"]));
+    check("null", "[1,2,3] | .[0]", Outcome::values(&["1"]));
 }
 
 // =============================================================================


### PR DESCRIPTION
Fixes #2667

## Summary

A postfix applied directly to an array or object **literal** was a parse error everywhere, top level included — valid jq programs rejected before evaluation, with no wrong output.

Verified live against the pinned oracle (`/usr/bin/jq` 1.7.1):

| filter | jq 1.7.1 | before | after |
|---|---|---|---|
| `[1,2][]` | `1` `2` | parse error at position 5 | `1` `2` |
| `{a:1}.a` | `1` | parse error at position 5 | `1` |
| `[[1,2][]]` | `[1,2]` | parse error at position 6 | `[1,2]` |
| `first([1,2][])` | `1` | parse error at position 11 | `1` |
| `[limit(1; [1,2][])]` | `[1]` | parse error | `[1]` |
| `def f(g): g; f([1,2][])` | `1` `2` | parse error | `1` `2` |
| `[first({a:(1 as $x ?// $y \| 1)}.a)]` | `[1,1]` | parse error | `[1,1]` |

Three more the issue didn't list, found while verifying its premise:

| filter | jq 1.7.1 | before | after |
|---|---|---|---|
| `[1,2][0]` | `1` | parse error | `1` |
| `{a:1}["a"]` | `1` | parse error | `1` |
| `[1,2][0:1]` | `[1]` | parse error | `[1]` |

## Root cause

`parse_primary_inner` (`src/jq/parser.rs`) routed only the parenthesized form through `parse_postfix`:

```rust
Some('(') => { ...; self.parse_postfix(paren) }   // postfix chain applies
Some('[') => self.parse_array_construction(),     // ...and here it doesn't
Some('{') => self.parse_object_construction(),
```

That is exactly why `([1,2])[]` always worked and `[1,2][]` never did. A collection literal is a primary term in jq's own grammar, like `(...)`, `$var` and a function call — all of which already accepted the suffix chain. Both constructors have a single call site each, so the fix is the same two-line wrapping the paren arm already had.

## The one real ambiguity

`[`/`{` follows a term and means something else in exactly one place: a **destructuring pattern** after `as`. `[1,2] as [$a,$b]` must keep binding a pattern rather than parsing as `[1,2]` indexed by `[$a,$b]`.

It does, because `as` sits between them — but a postfix widening is precisely the kind of change that breaks that silently, so it is pinned across twelve shapes (`test_collection_literal_postfix_does_not_capture_destructuring_2667`) rather than assumed: array and object patterns, `.[] as [$a,$b]`, `?//`, and the literal-with-postfix form as a `reduce`/`foreach` source.

## Both modes agree

Real **yq v4.53.3** accepts `[1,2][]`, `{"a":1}.a`, `[1,2][0]` and `{"a":1}["a"]` too (checked live), and `succinctly yq` now matches. No ADR-0018 divergence to record.

## Test churn

`test_collection_literal_as_a_target_is_a_parse_error` (`tests/jq_computed_key_tests.rs`) pinned this as a deliberate divergence. Rewritten as `test_collection_literal_as_a_target_2667`, asserting jq's values for the same three filters plus the multi-output and `nan` keys that exercise that file's computed-key machinery. The `getpath(...)` spellings its neighbours use still work and are untouched — they are simply no longer the only way to reach an owned target.

## Out of scope (verified pre-existing)

`$__loc__.file` is `"<stdin>"` where jq says `"<top-level>"`. Reproduced on a build of `main` and with `-f`, so unrelated to this change; follow-up filed.

## Test plan

- [x] `cargo build --features cli`
- [x] `cargo test --features cli,simd,regex,serde` — 8131 passed, 0 failed
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings`
- [x] `cargo fmt --check`
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features`
- [x] `omni-dev coverage diff` — **100% patch coverage** (4/4)
- [x] Every row diffed directly against `/usr/bin/jq` 1.7.1, and the four yq rows against `yq` v4.53.3
- [x] Destructuring/`as`-pattern non-capture pinned across 12 shapes