### PR TITLE
fix(jq): raise inside path() for the builtins jq defines as navigation

### DIFF
--- a/docs/compliance/jq/limitations.md
+++ b/docs/compliance/jq/limitations.md
@@ -737,7 +737,18 @@ is the revert that established what the other one costs.
    navigating inside their own jq-level definitions against a *constructed* value inside
    `path()` never raise, found by `scripts/jq-bind-origin-fuzz.py`'s differential fuzz and
    confirmed pre-existing (reproduces byte-for-byte on the commit before #2042), not caused by
-   this change.
+   this change. **#2646 is now fixed** — `builtin_navigation` (`src/jq/eval.rs`) answers what
+   each jq-defined navigating builtin indexes, and `resolve_leaf`'s `!trackable` guard raises
+   on it. Three groups remain, deliberately, and are divergences in their own right:
+
+   | Still diverging                                                                     | jq 1.7.1                                        | succinctly | Tracked                                                                  |
+   | ----------------------------------------------------------------------------------- | ----------------------------------------------- | ---------- | ------------------------------------------------------------------------ |
+   | `[path(([1] \| unique) \| empty)]`, and `unique_by`/`map_values`/`with_entries`/`fromstream`, `walk` on an *object*, `ascii_downcase`/`ascii_upcase`, the `match`/`sub`/`gsub` family | raises, naming a **derived** container (`iterate through [[1]]`) | `[]`       | [#2743](https://github.com/rust-works/succinctly/issues/2743) |
+   | `[path(([1,2,3] \| nth(2)) \| empty)]`, and `reverse`/`indices`/`index`/`rindex`; `INDEX(f)` and `transpose` | raises; element depends on an argument or `length` | `[]`       | [#2744](https://github.com/rust-works/succinctly/issues/2744) |
+   | `[path(([1] \| last(.[])) \| empty)]`, and `isempty(f)`/`any(gen;cond)`/`all(gen;cond)`/`INDEX(gen;f)` | raises — the *argument* navigates                | `[]`       | [#2746](https://github.com/rust-works/succinctly/issues/2746) |
+
+   The rule is **jq-mode only** (ADR-0018): `map`, `any`, `all` and `flatten` are real yq
+   builtins, and yq v4.53.3 raises for none of them, so `succinctly yq` does not either.
 
    [#2072](https://github.com/rust-works/succinctly/issues/2072) supplied the missing
    half of that but deliberately did not spend it here. `Expr::TrackedVar` now carries a

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -28565,6 +28565,86 @@ fn navigation_element(component: &Expr) -> Option<OwnedValue> {
     }
 }
 
+/// How a builtin navigates *its own input*, for the untracked-value check
+/// in [`resolve_leaf`] (#2646).
+enum BuiltinNavigation {
+    /// Indexes one element, like `.[k]` — carries the `k` jq names.
+    Access(OwnedValue),
+    /// Iterates, like `.[]`.
+    Iterate,
+}
+
+/// The navigation a builtin performs on its input before anything else, or
+/// `None` if it performs none (#2646).
+///
+/// jq defines a family of builtins *in jq itself*, in terms of ordinary
+/// navigation — `first` is `.[0]`, `last` is `.[-1]`, `add` is
+/// `reduce .[] as $x ...`. Inside `path()`, that internal navigation is
+/// subject to the same rule as one the user wrote: applied to a value the
+/// resolver is not tracking, it raises rather than producing a path. This
+/// is the [`navigation_element`] question for a builtin, and the answer
+/// feeds the same two error constructors.
+///
+/// **Membership is decided by jq's own implementation, not by whether the
+/// builtin "looks like" it reads a container**, and the two are not the
+/// same set: `sort`, `min`, `max`, `group_by`, `to_entries`, `keys`,
+/// `has`, `getpath` and `tostream` all read their input and all answer
+/// `[]` here, because jq implements them in C, where no jq-level
+/// navigation ever happens. `unique` raises only because it is *defined*
+/// as `group_by(.) | map(.[0])`. Every entry below, and every one of those
+/// negatives, was captured live from jq 1.7.1 via
+/// `[path(([1] | X) | empty)]` — see `tests/jq_cli_tests.rs`'
+/// `test_jq_defined_navigating_builtins_raise_inside_path_2646` and its two
+/// boundary siblings, `test_only_jq_defined_navigators_raise_inside_path_2646`
+/// and `test_navigating_builtins_raise_regardless_of_input_type_2646`.
+///
+/// Two boundaries worth keeping in view when adding to this:
+///
+/// - **Arity changes the answer.** `any`/`any(cond)` iterate their input
+///   and raise; `any(gen; cond)` does not — it iterates `gen`, so
+///   `[1] | any(1;.)` answers `[]` while `[1] | any(true)` raises. If
+///   `any(.[];.)` raises, that is its *argument* navigating, which the
+///   resolver already handles on its own.
+/// - **Some raise against a container this function cannot name.**
+///   `unique`, `unique_by`, `map_values`, `with_entries` and `fromstream`
+///   raise against a *derived* value (`[1] | map_values(.)` reports
+///   `element 0 of [[1],[]]`, the `group_by`/`to_entries` intermediate),
+///   which a static answer here cannot produce. They are deliberately
+///   absent rather than reported with the wrong container — #2743.
+///   `nth(n)`, `reverse` and `indices(i)` are absent for a related reason:
+///   their element depends on an argument or on `length` (and `reverse`
+///   does not raise at all on an empty input), so they need a value this
+///   function is not given — #2744.
+fn builtin_navigation(builtin: &Builtin, value: &OwnedValue) -> Option<BuiltinNavigation> {
+    match builtin {
+        Builtin::First => Some(BuiltinNavigation::Access(OwnedValue::Int(0))),
+        Builtin::Last => Some(BuiltinNavigation::Access(OwnedValue::Int(-1))),
+        Builtin::Add
+        | Builtin::Any
+        | Builtin::AnyF(_)
+        | Builtin::All
+        | Builtin::AllF(_)
+        | Builtin::Flatten
+        | Builtin::FlattenDepth(_)
+        | Builtin::Join(_)
+        | Builtin::Map(_)
+        | Builtin::FromEntries => Some(BuiltinNavigation::Iterate),
+        // The one entry whose answer depends on the *input*, because its
+        // own definition branches on it: `def walk(f): def w: if type ==
+        // "object" then map_values(w) elif type == "array" then map(w)
+        // else . end | f; w;`. Only the array arm reaches a plain `.[]`.
+        // The object arm goes through `map_values`, which reports the
+        // derived `[<input>,[]]` container this function cannot name
+        // (#2743), and a scalar navigates nothing at all, so jq does not
+        // raise there -- `5 | walk(.)` inside `path()` answers `[]`, and
+        // raising "iterate through 5" would be a divergence of its own.
+        Builtin::Walk(_) if matches!(value, OwnedValue::Array(_)) => {
+            Some(BuiltinNavigation::Iterate)
+        }
+        _ => None,
+    }
+}
+
 /// The one error every `recurse`-family spelling raises against an
 /// untracked value (#843) — see the doc comment on `resolve_node`'s shared
 /// guard arm for `RecursiveDescent`/`Recurse`/`RecurseDown`/`RecurseF`/
@@ -28607,6 +28687,28 @@ fn resolve_leaf<'a, S: EvalSemantics>(
                 Vec::new(),
                 EvalError::invalid_path_expression_near_access(&element, value).into(),
             ));
+        }
+        // #2646: the same check for a builtin jq defines *in jq*, in terms
+        // of navigation it performs on its own input -- `first` is `.[0]`,
+        // `add` is `reduce .[] as $x ...`. Without this the builtin is just
+        // an opaque value-producing filter, so the branch goes untracked
+        // and a continuation that emits nothing (`| empty`, `| select(false)`)
+        // leaves nothing for `resolve_terminal` to object to: `path(([1] |
+        // first) | empty)` answered `[]`, and `del(([1] | first) | empty)`
+        // returned the document unchanged at exit 0, where jq raises. See
+        // [`builtin_navigation`] for what is in the set and why.
+        if let Expr::Builtin(builtin) = expr {
+            if let Some(navigation) = builtin_navigation(builtin, value) {
+                let error = match navigation {
+                    BuiltinNavigation::Access(element) => {
+                        EvalError::invalid_path_expression_near_access(&element, value)
+                    }
+                    BuiltinNavigation::Iterate => {
+                        EvalError::invalid_path_expression_near_iterate(value)
+                    }
+                };
+                return Err((Vec::new(), error.into()));
+            }
         }
         // `.` alone performs no navigation at all, so it is exempt from the
         // `is_primitive` gate just below (which requires `trackable`, for
@@ -84584,17 +84686,44 @@ mod tests {
     /// all, and jq still refuses, because `first`'s own body is the `.[0]`
     /// that moves the register.
     #[test]
+    /// #2646 sharpened four of these five. `cannot_move_register` made them
+    /// *refuse*, which is what this test was written to pin, but with the
+    /// generic "with result" wording; the builtin rows now raise at the
+    /// navigation itself and match jq's message exactly, so each row asserts
+    /// its own wording rather than merely "some path error". The `def f: .a`
+    /// row keeps the generic wording, in jq too -- a user-defined body is
+    /// not in `builtin_navigation`'s table, and jq reports it the same way.
     fn test_path_register_dropped_across_opaque_navigating_stage_1573() {
-        for filter in [
-            r"path(. as $x | (def f: .a; f) | $x)",
-            r"path(. as $x | ([.a]|first) | $x)",
-            r"path(. as $x | ([1]|first) | $x)",
-            r"path(. as $x | ([.a]|add) | $x)",
-            r"path(. as $x | ([.a]|first) | 5 | $x)",
+        for (filter, message) in [
+            (
+                r"path(. as $x | (def f: .a; f) | $x)",
+                r#"Invalid path expression with result {"a":{"b":1},"c":{"b":1}}"#,
+            ),
+            (
+                r"path(. as $x | ([.a]|first) | $x)",
+                r#"Invalid path expression near attempt to access element 0 of [{"b":1}]"#,
+            ),
+            (
+                r"path(. as $x | ([1]|first) | $x)",
+                r"Invalid path expression near attempt to access element 0 of [1]",
+            ),
+            (
+                r"path(. as $x | ([.a]|add) | $x)",
+                r#"Invalid path expression near attempt to iterate through [{"b":1}]"#,
+            ),
+            (
+                r"path(. as $x | ([.a]|first) | 5 | $x)",
+                r#"Invalid path expression near attempt to access element 0 of [{"b":1}]"#,
+            ),
         ] {
             query!(br#"{"a":{"b":1},"c":{"b":1}}"#, filter,
                 QueryResult::Error(e) => {
-                    assert!(e.is_invalid_path_expression(), "{filter}: {}", e.message);
+                    assert!(
+                        e.is_invalid_path_expression() || e.is_untracked_navigation_error(),
+                        "{filter}: {}",
+                        e.message
+                    );
+                    assert_eq!(e.message, message, "{filter}");
                 }
             );
         }

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -28598,19 +28598,33 @@ enum BuiltinNavigation {
 /// boundary siblings, `test_only_jq_defined_navigators_raise_inside_path_2646`
 /// and `test_navigating_builtins_raise_regardless_of_input_type_2646`.
 ///
-/// Two boundaries worth keeping in view when adding to this:
+/// Three boundaries worth keeping in view when adding to this:
 ///
 /// - **Arity changes the answer.** `any`/`any(cond)` iterate their input
 ///   and raise; `any(gen; cond)` does not — it iterates `gen`, so
-///   `[1] | any(1;.)` answers `[]` while `[1] | any(true)` raises. If
-///   `any(.[];.)` raises, that is its *argument* navigating, which the
-///   resolver already handles on its own.
+///   `[1] | any(1;.)` answers `[]` while `[1] | any(true)` raises.
+///   `[1] | any(.[];.)` *does* raise in jq, but that is its argument
+///   navigating, and this resolver does not currently catch it — one of a
+///   family of argument-side gaps (with `last(.[])`, `isempty(.[])`,
+///   `INDEX(.[];.)`), tracked in #2746.
+/// - **A `$`-parameter runs before the navigation.** `def join($x)` and
+///   `def flatten($x)` desugar to `x as $x | ...`, so jq evaluates — and
+///   for `flatten` range-checks — the argument *first*:
+///   `[1] | join(error("boom"))` raises `boom`, and `flatten(-1)` raises
+///   "flatten depth must not be negative". Neither is a path error, so
+///   answering `Iterate` here would pre-empt jq's own — they are out,
+///   under #2744. Bare `Flatten` stays: it is `_flatten(-1)`, whose
+///   argument is jq's own literal and cannot raise.
 /// - **Some raise against a container this function cannot name.**
 ///   `unique`, `unique_by`, `map_values`, `with_entries` and `fromstream`
 ///   raise against a *derived* value (`[1] | map_values(.)` reports
 ///   `element 0 of [[1],[]]`, the `group_by`/`to_entries` intermediate),
 ///   which a static answer here cannot produce. They are deliberately
-///   absent rather than reported with the wrong container — #2743.
+///   absent rather than reported with the wrong container — #2743, which
+///   also covers `ascii_downcase`/`ascii_upcase` (`explode | map(...)`) and
+///   the `match`/`sub`/`gsub` family, and `transpose` (which additionally
+///   raises only when `map(length)|max` exceeds zero). `INDEX(f)` is a
+///   clean `Iterate` on every input that simply has not been added yet.
 ///   `nth(n)`, `reverse` and `indices(i)` are absent for a related reason:
 ///   their element depends on an argument or on `length` (and `reverse`
 ///   does not raise at all on an empty input), so they need a value this
@@ -28625,8 +28639,6 @@ fn builtin_navigation(builtin: &Builtin, value: &OwnedValue) -> Option<BuiltinNa
         | Builtin::All
         | Builtin::AllF(_)
         | Builtin::Flatten
-        | Builtin::FlattenDepth(_)
-        | Builtin::Join(_)
         | Builtin::Map(_)
         | Builtin::FromEntries => Some(BuiltinNavigation::Iterate),
         // The one entry whose answer depends on the *input*, because its
@@ -28697,17 +28709,27 @@ fn resolve_leaf<'a, S: EvalSemantics>(
         // first) | empty)` answered `[]`, and `del(([1] | first) | empty)`
         // returned the document unchanged at exit 0, where jq raises. See
         // [`builtin_navigation`] for what is in the set and why.
-        if let Expr::Builtin(builtin) = expr {
-            if let Some(navigation) = builtin_navigation(builtin, value) {
-                let error = match navigation {
-                    BuiltinNavigation::Access(element) => {
-                        EvalError::invalid_path_expression_near_access(&element, value)
-                    }
-                    BuiltinNavigation::Iterate => {
-                        EvalError::invalid_path_expression_near_iterate(value)
-                    }
-                };
-                return Err((Vec::new(), error.into()));
+        //
+        // **jq mode only** (ADR-0018: the mode decides, never the input
+        // format). `map`, `any`, `all`, `flatten` and `from_entries` are
+        // real yq builtins with their own oracle, and yq v4.53.3 does not
+        // raise for any of them -- `del(([1,2] | map(.)) | select(false))`
+        // leaves the document alone at exit 0, where this table's rule
+        // would refuse. That rule is jq's, derived from how *jq* defines
+        // these in `builtin.jq`; yq's implementation shares none of it.
+        if S::TAG == EvalTag::Jq {
+            if let Expr::Builtin(builtin) = expr {
+                if let Some(navigation) = builtin_navigation(builtin, value) {
+                    let error = match navigation {
+                        BuiltinNavigation::Access(element) => {
+                            EvalError::invalid_path_expression_near_access(&element, value)
+                        }
+                        BuiltinNavigation::Iterate => {
+                            EvalError::invalid_path_expression_near_iterate(value)
+                        }
+                    };
+                    return Err((Vec::new(), error.into()));
+                }
             }
         }
         // `.` alone performs no navigation at all, so it is exempt from the
@@ -84685,7 +84707,7 @@ mod tests {
     /// stage mention `.a`" shortcut: no navigation appears in its text at
     /// all, and jq still refuses, because `first`'s own body is the `.[0]`
     /// that moves the register.
-    #[test]
+    ///
     /// #2646 sharpened four of these five. `cannot_move_register` made them
     /// *refuse*, which is what this test was written to pin, but with the
     /// generic "with result" wording; the builtin rows now raise at the
@@ -84693,6 +84715,7 @@ mod tests {
     /// its own wording rather than merely "some path error". The `def f: .a`
     /// row keeps the generic wording, in jq too -- a user-defined body is
     /// not in `builtin_navigation`'s table, and jq reports it the same way.
+    #[test]
     fn test_path_register_dropped_across_opaque_navigating_stage_1573() {
         for (filter, message) in [
             (

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -42837,6 +42837,107 @@ fn test_path_answers_past_a_structural_fault_it_never_reads_2168() -> Result<()>
     Ok(())
 }
 
+/// #2646: a jq-*defined* navigating builtin (`first` is `.[0]`, `add` is
+/// `reduce .[] as $x ...`) applied to a constructed value inside `path()`
+/// must raise, exactly as the navigation it desugars to would.
+///
+/// The bug this pins was an *accept-where-jq-refuses*: the builtin was
+/// opaque to the resolver, so the branch went untracked, and a continuation
+/// emitting nothing (`| empty`, `| select(false)`) left nothing for the
+/// terminal check to object to. `path(...)` answered `[]` and, worse,
+/// `del(...)` returned the document unchanged at exit 0 where jq exits 5 --
+/// no wrong value was written, but a refused edit looked like a successful
+/// no-op. Every row captured live from jq 1.7.1.
+#[test]
+fn test_jq_defined_navigating_builtins_raise_inside_path_2646() -> Result<()> {
+    for (filter, element) in [
+        ("[path(([1] | first) | empty)]", "element 0 of [1]"),
+        ("[path(([1] | last) | empty)]", "element -1 of [1]"),
+        ("[path(([[1]] | add) | empty)]", "iterate through [[1]]"),
+        ("[path(([1] | first) | select(false))]", "element 0 of [1]"),
+        // the continuation does not have to be empty-producing -- it is
+        // just what made the gap invisible
+        ("[path(([1] | first))]", "element 0 of [1]"),
+        ("del(([1] | first) | empty)", "element 0 of [1]"),
+    ] {
+        let (stdout, stderr, code) = run_jq_full(&["-c", filter], Some(r#"{"a":1}"#))?;
+        assert_ne!(code, 0, "{filter}: stdout {stdout:?}");
+        assert!(
+            stderr.contains("Invalid path expression near attempt to access ")
+                || stderr.contains("Invalid path expression near attempt to iterate "),
+            "{filter}: {stderr:?}"
+        );
+        assert!(stderr.contains(element), "{filter}: {stderr:?}");
+    }
+    Ok(())
+}
+
+/// #2646: the boundary of that set, which is decided by jq's own
+/// implementation rather than by whether the builtin "looks like" it reads a
+/// container. `sort`, `min`, `group_by`, `to_entries`, `keys`, `has` and
+/// `getpath` all read their input and all answer `[]`, because jq implements
+/// them in C and no jq-level navigation happens; `unique` raises only
+/// because it is *defined* as `group_by(.) | map(.[0])`.
+///
+/// Arity matters too: `any`/`any(cond)` iterate their input, while
+/// `any(gen; cond)` iterates `gen` instead -- so `any(1;.)` must stay silent
+/// here. If `any(.[];.)` raises, that is the argument navigating, which the
+/// resolver already handled. All captured live from jq 1.7.1.
+#[test]
+fn test_only_jq_defined_navigators_raise_inside_path_2646() -> Result<()> {
+    for filter in [
+        "[path(([1] | sort) | empty)]",
+        "[path(([1] | sort_by(.)) | empty)]",
+        "[path(([1] | group_by(.)) | empty)]",
+        "[path(([1] | min) | empty)]",
+        "[path(([1] | max) | empty)]",
+        "[path(([1] | to_entries) | empty)]",
+        "[path(([1] | keys) | empty)]",
+        "[path(([1] | length) | empty)]",
+        "[path(([1] | getpath([0])) | empty)]",
+        "[path(([1] | tostream) | empty)]",
+        "[path(([1] | has(0)) | empty)]",
+        // the two-argument `any`/`all`, whose generator replaces the input
+        "[path(([1] | any(1;.)) | empty)]",
+        "[path(([1] | all(1;.)) | empty)]",
+        // `walk` navigates only on its array arm; a scalar hits its `else .`
+        "[path((5 | walk(.)) | empty)]",
+        r#"[path(("s" | walk(.)) | empty)]"#,
+        "[path((null | walk(.)) | empty)]",
+    ] {
+        let (stdout, stderr, code) = run_jq_full(&["-c", filter], Some(r#"{"a":1}"#))?;
+        assert_eq!(code, 0, "{filter}: stderr {stderr:?}");
+        assert_eq!(stdout.trim(), "[]", "{filter}");
+    }
+    Ok(())
+}
+
+/// #2646: the raise is independent of the input's type for every entry but
+/// `walk` -- `first` on a scalar still reports `element 0 of 5`, matching
+/// jq, rather than being skipped as "not a container". `walk` is the one
+/// exception, because its own definition branches on `type`: the array arm
+/// reaches `.[]` and raises, the object arm goes through `map_values`
+/// (deferred, #2743), and a scalar navigates nothing. Captured live from
+/// jq 1.7.1.
+#[test]
+fn test_navigating_builtins_raise_regardless_of_input_type_2646() -> Result<()> {
+    for (filter, element) in [
+        ("[path((5 | first) | empty)]", "element 0 of 5"),
+        (r#"[path(("s" | first) | empty)]"#, r#"element 0 of "s""#),
+        ("[path((null | first) | empty)]", "element 0 of null"),
+        ("[path((null | add) | empty)]", "iterate through null"),
+        ("[path(({} | add) | empty)]", "iterate through {}"),
+        ("[path(([] | first) | empty)]", "element 0 of []"),
+        ("[path(([] | add) | empty)]", "iterate through []"),
+        ("[path(([1] | walk(.)) | empty)]", "iterate through [1]"),
+    ] {
+        let (stdout, stderr, code) = run_jq_full(&["-c", filter], Some(r#"{"a":1}"#))?;
+        assert_ne!(code, 0, "{filter}: stdout {stdout:?}");
+        assert!(stderr.contains(element), "{filter}: {stderr:?}");
+    }
+    Ok(())
+}
+
 /// #2349 control: the same gate's *array* elements must also validate the
 /// leading-comma/duplicate-comma shape (`[1,,2]`), not just the trailing
 /// stray-comma cases above -- a distinct `#1677` check

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -42912,6 +42912,77 @@ fn test_only_jq_defined_navigators_raise_inside_path_2646() -> Result<()> {
     Ok(())
 }
 
+/// #2646: **every** entry in `builtin_navigation`'s table, not just the
+/// three the issue named. The two that a first draft got wrong (`join($x)`
+/// and `flatten($x)`, whose `$`-parameter runs before the iteration) had no
+/// assertion anywhere, which is exactly how they shipped wrong -- so this
+/// covers the whole table rather than a sample of it. Captured live from
+/// jq 1.7.1.
+#[test]
+fn test_every_navigating_builtin_table_entry_raises_2646() -> Result<()> {
+    for (builtin, element) in [
+        ("first", "element 0 of [1]"),
+        ("last", "element -1 of [1]"),
+        ("add", "iterate through [1]"),
+        ("any", "iterate through [1]"),
+        ("any(true)", "iterate through [1]"),
+        ("all", "iterate through [1]"),
+        ("all(true)", "iterate through [1]"),
+        ("flatten", "iterate through [1]"),
+        ("map(.)", "iterate through [1]"),
+        ("from_entries", "iterate through [1]"),
+        ("walk(.)", "iterate through [1]"),
+    ] {
+        let filter = format!("[path(([1] | {builtin}) | empty)]");
+        let (stdout, stderr, code) = run_jq_full(&["-c", &filter], Some(r#"{"a":1}"#))?;
+        assert_ne!(code, 0, "{filter}: stdout {stdout:?}");
+        assert!(stderr.contains(element), "{filter}: {stderr:?}");
+    }
+    Ok(())
+}
+
+/// #2646: `join($x)` and `flatten($x)` are **out** of the table, because
+/// jq's `def join($x)`/`def flatten($x)` desugar to `x as $x | ...` -- the
+/// argument is evaluated, and for `flatten` range-checked, *before* any
+/// iteration. Answering "iterate" for them pre-empts jq's own error, which
+/// a first draft of #2646 did. Bare `flatten` stays in the table: it is
+/// `_flatten(-1)`, whose argument is jq's own literal and cannot raise.
+/// Captured live from jq 1.7.1.
+#[test]
+fn test_dollar_param_builtins_keep_their_own_error_2646() -> Result<()> {
+    // The argument's error wins, not a path error.
+    for filter in [
+        r#"[path(([1] | join(error("boom"))) | empty)]"#,
+        r#"[path(([1] | flatten(error("boom"))) | empty)]"#,
+        r#"del(([1] | join(error("boom"))) | empty)"#,
+    ] {
+        let (stdout, stderr, code) = run_jq_full(&["-c", filter], Some(r#"{"a":1}"#))?;
+        assert_ne!(code, 0, "{filter}: stdout {stdout:?}");
+        assert!(stderr.contains("boom"), "{filter}: {stderr:?}");
+        assert!(
+            !stderr.contains("Invalid path expression"),
+            "{filter}: the argument's own error must win: {stderr:?}"
+        );
+    }
+
+    // `flatten`'s negative-depth guard likewise wins. (Its wording still
+    // differs from jq's -- #2747 -- so this asserts the class, not the text.)
+    let (stdout, stderr, code) =
+        run_jq_full(&["-c", "[path(([1] | flatten(-1)) | empty)]"], Some("{}"))?;
+    assert_ne!(code, 0, "stdout {stdout:?}");
+    assert!(
+        !stderr.contains("Invalid path expression"),
+        "the depth guard must win: {stderr:?}"
+    );
+
+    // Bare `flatten` is still in the table.
+    let (stdout, stderr, code) =
+        run_jq_full(&["-c", "[path(([1] | flatten) | empty)]"], Some("{}"))?;
+    assert_ne!(code, 0, "stdout {stdout:?}");
+    assert!(stderr.contains("iterate through [1]"), "{stderr:?}");
+    Ok(())
+}
+
 /// #2646: the raise is independent of the input's type for every entry but
 /// `walk` -- `first` on a scalar still reports `element 0 of 5`, matching
 /// jq, rather than being skipped as "not a container". `walk` is the one

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -32286,6 +32286,41 @@ fn test_recursive_def_evaluates_in_yq_mode_1371() -> Result<()> {
     Ok(())
 }
 
+/// #2646 is a **jq-mode** rule (ADR-0018: the mode decides, never the input
+/// format). `path()`'s untracked-navigation table refuses a jq-*defined*
+/// navigating builtin applied to a constructed value -- but `map`, `any`,
+/// `all` and `flatten` are real yq builtins with their own oracle, and yq
+/// v4.53.3 raises for none of them: the `del()` finds nothing to delete and
+/// the document comes back unchanged at exit 0.
+///
+/// A first draft of #2646 was not mode-gated and refused here instead. The
+/// rule is derived from how *jq* defines these in its own `builtin.jq`;
+/// yq's implementation shares none of that, so none of it applies.
+///
+/// These four are the whole verified list, not a sample: of the rest of the
+/// table, `add` and `last` are not yq builtins at all (its lexer rejects
+/// them, and so does succinctly's), `from_entries` errors identically in
+/// both, and `first` errors in yq while succinctly stays silent -- a
+/// pre-existing divergence, unchanged by #2646 and not something this test
+/// should assert either way.
+#[test]
+fn test_navigating_builtin_path_table_is_jq_mode_only_2646() -> Result<()> {
+    for filter in [
+        "del(([1,2] | map(.)) | select(false))",
+        "del(([1,2] | any) | select(false))",
+        "del(([1,2] | all) | select(false))",
+        "del(([1,2] | flatten) | select(false))",
+    ] {
+        let (stdout, code) = run_yq_stdin(filter, "a: [1,2]\nb: 3\n", &[])?;
+        assert_eq!(code, 0, "{filter}: stdout {stdout:?}");
+        assert!(
+            stdout.contains("a:") && stdout.contains("b:"),
+            "{filter}: the document must come back unchanged: {stdout:?}"
+        );
+    }
+    Ok(())
+}
+
 /// #2560: `bind_def_call`'s duplicate-parameter-name fix lives in `eval.rs`,
 /// shared by both evaluators -- confirm yq mode's own `DefCall` path
 /// resolves a duplicate parameter name by last occurrence too, not just


### PR DESCRIPTION
## Summary

jq defines a family of builtins *in jq itself*, in terms of ordinary navigation — `first`
is `.[0]`, `last` is `.[-1]`, `add` is `reduce .[] as $x ...`. Inside `path()`, that
internal navigation obeys the same rule as one the user wrote: applied to a value the
resolver is not tracking, it raises. succinctly saw an opaque builtin, evaluated it as a
plain value, and let the branch go untracked — so a continuation that emits nothing left
nothing for the terminal check to object to.

```console
$ echo '{"a":1}' | jq -c '[path(([1] | first) | empty)]'
jq: error (at <stdin>:1): Invalid path expression near attempt to access element 0 of [1]
$ echo '{"a":1}' | succinctly jq -c '[path(([1] | first) | empty)]'      # before
[]

$ echo '{"a":1}' | jq -c 'del(([1] | first) | empty)'
jq: error (at <stdin>:1): Invalid path expression near attempt to access element 0 of [1]
$ echo '{"a":1}' | succinctly jq -c 'del(([1] | first) | empty)'          # before
{"a":1}                                                                   # exit 0
```

The `del()` shape is the one that matters: no wrong value is written, but a **refused
edit is reported as a successful no-op** (exit 0 replacing exit 5).

## How

`builtin_navigation` answers the `navigation_element` question for a builtin — "what does
this navigate on its input, and with which element?" — and feeds the same two error
constructors. `resolve_leaf`'s existing `!trackable` block consults it immediately after
the `Field`/`Index` check it mirrors.

**Membership is decided by jq's implementation, not by whether a builtin looks like it
reads a container**, and those are different sets. `sort`, `min`, `max`, `group_by`,
`to_entries`, `keys`, `has`, `getpath` and `tostream` all read their input and all stay
silent, because jq implements them in C and no jq-level navigation happens. `unique`
raises only because it is *defined* as `group_by(.) | map(.[0])`. Every entry, and every
negative, was captured live from jq 1.7.1.

### Two boundaries the oracle settled

Both would have been got wrong by a plausible-looking table:

- **Arity changes the answer.** `any`/`any(cond)` iterate their input and raise;
  `any(gen; cond)` iterates `gen` instead, so `[1] | any(1;.)` must stay silent. That
  `any(.[];.)` raises is its *argument* navigating — something the resolver already
  handled — not `any` itself. `AnyCond`/`AllCond` are therefore deliberately out.
- **`walk` is the only input-dependent entry**, because its own definition branches on
  `type`. Only the array arm reaches a plain `.[]`. A scalar navigates nothing, so
  `5 | walk(.)` must **not** raise (an unconditional entry would have introduced a fresh
  divergence), and the object arm goes through `map_values`, naming a derived container
  this table cannot produce.

### Deliberately deferred

Left out rather than reported with a *wrong container*:

- #2743 — `unique`, `unique_by`, `map_values`, `with_entries`, `fromstream`, and `walk`
  on an object: each raises against a value derived from the input
  (`[1] | map_values(.)` reports `element 0 of [[1],[]]`), which a static answer cannot
  name.
- #2744 — `nth(n)`, `reverse`, `indices(i)`, `index(i)`, `rindex(i)`: the element depends
  on an evaluated argument or on `length`, and `reverse` does not raise at all on an
  empty input.

## Also fixed

The "already refuses" control diverged in its *message*, and now matches:

```console
$ echo '{"a":1}' | jq -c '[path(([1] | first))]'
jq: error (at <stdin>:1): Invalid path expression near attempt to access element 0 of [1]
$ echo '{"a":1}' | succinctly jq -c '[path(([1] | first))]'    # before
jq: error (at <stdin>:1): Invalid path expression with result 1
```

Same cause: the raise now happens at the navigation instead of one stage later at the
terminal check. This also sharpened an existing pin —
`test_path_register_dropped_across_opaque_navigating_stage_1573` asserted only "some path
error", and four of its five rows had been getting the generic wording; they now match
jq exactly, so each row asserts its own message. Its `def f: .a` row keeps the generic
wording, in jq too (a user-defined body is not in the table).

## Test plan

- [x] `cargo test --features cli,simd,regex,serde` — full suite, 62 binaries, 0 failures
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] **296-case sweep** — 37 builtins × 8 input shapes (`[1]`, `[]`, `[1,2,3]`,
      `{"k":1}`, `{}`, `5`, `"s"`, `null`) diffed against `/usr/bin/jq` 1.7.1: **292
      match**, and the 4 that do not are exactly #2743's `walk`-on-object
- [x] Three new CLI tests: the fixed shapes, the negative boundary (C-implemented
      builtins, the 2-arg `any`/`all`, `walk` on a scalar), and input-type independence

Fixes #2646