### PR TITLE
perf(jq): resolve a wrong-arity special form without re-parsing its args

### DIFF
--- a/src/jq/parser.rs
+++ b/src/jq/parser.rs
@@ -2934,8 +2934,12 @@ impl<'a> Parser<'a> {
         if self.mode == ParserMode::Jq {
             return self.wrong_arity_call_from_parsed(start_pos, args);
         }
-        self.expect(expected)?;
-        unreachable!("only called once `peek() != Some(expected)`, so `expect` must fail")
+        // `expect` is guaranteed to fail: every caller checks
+        // `peek() != Some(expected)` before calling. Mapped rather than
+        // followed by an `unreachable!` statement so the never-taken arm is
+        // part of this one expression, exactly as `expect_or_wrong_arity`
+        // writes the identical carve-out just below.
+        self.expect(expected).map(|()| unreachable!())
     }
 
     /// One shared definition of the 7-line argument-boundary checkpoint

--- a/src/jq/parser.rs
+++ b/src/jq/parser.rs
@@ -2015,8 +2015,9 @@ impl<'a> Parser<'a> {
             // `expect_or_wrong_arity`, #2391) instead removes this arm from
             // that fallback path entirely, exactly as it already does for
             // the other 7 forms.
-            if let Err(early) = self.expect_or_wrong_arity(')', start_pos) {
-                return early;
+            // #2686: hand the parsed `msg_expr` over instead of rewinding.
+            if self.peek() != Some(')') {
+                return self.wrong_arity_or_expect(start_pos, ')', vec![msg_expr]);
             }
             self.next();
             Some(Box::new(msg_expr))
@@ -2155,14 +2156,17 @@ impl<'a> Parser<'a> {
         // `expect(';')`, which raises its own natural error for that
         // specific mismatch, exactly as before this fix.
         if self.peek() == Some(')') && self.mode == ParserMode::Jq {
-            return self.rewind_to_wrong_arity_call(start_pos);
+            // #2686: `n` is already parsed; `wrong_arity_call_from_parsed`
+            // closes on the `)` we are sitting on and yields `limit/1`.
+            return self.wrong_arity_call_from_parsed(start_pos, vec![n]);
         }
         self.expect(';')?;
         self.skip_ws();
         let expr = self.parse_expr()?;
         self.skip_ws();
-        if let Err(early) = self.expect_or_wrong_arity(')', start_pos) {
-            return early;
+        // #2686: both arguments are in hand -- see `wrong_arity_or_expect`.
+        if self.peek() != Some(')') {
+            return self.wrong_arity_or_expect(start_pos, ')', vec![n, expr]);
         }
         self.next();
 
@@ -2188,15 +2192,17 @@ impl<'a> Parser<'a> {
         self.skip_ws();
         let cond = self.parse_expr()?;
         self.skip_ws();
-        if let Err(early) = self.expect_or_wrong_arity(';', start_pos) {
-            return early;
+        // #2686: `until(a)` -- one argument parsed, no rewind needed.
+        if self.peek() != Some(';') {
+            return self.wrong_arity_or_expect(start_pos, ';', vec![cond]);
         }
         self.next();
         self.skip_ws();
         let update = self.parse_expr()?;
         self.skip_ws();
-        if let Err(early) = self.expect_or_wrong_arity(')', start_pos) {
-            return early;
+        // #2686: `until(a;b;c)` -- the shape that measured 18 s at depth 24.
+        if self.peek() != Some(')') {
+            return self.wrong_arity_or_expect(start_pos, ')', vec![cond, update]);
         }
         self.next();
 
@@ -2222,15 +2228,16 @@ impl<'a> Parser<'a> {
         self.skip_ws();
         let cond = self.parse_expr()?;
         self.skip_ws();
-        if let Err(early) = self.expect_or_wrong_arity(';', start_pos) {
-            return early;
+        // #2686: same two shapes as `parse_until_expr`.
+        if self.peek() != Some(';') {
+            return self.wrong_arity_or_expect(start_pos, ';', vec![cond]);
         }
         self.next();
         self.skip_ws();
         let update = self.parse_expr()?;
         self.skip_ws();
-        if let Err(early) = self.expect_or_wrong_arity(')', start_pos) {
-            return early;
+        if self.peek() != Some(')') {
+            return self.wrong_arity_or_expect(start_pos, ')', vec![cond, update]);
         }
         self.next();
 
@@ -2256,8 +2263,9 @@ impl<'a> Parser<'a> {
         self.skip_ws();
         let expr = self.parse_expr()?;
         self.skip_ws();
-        if let Err(early) = self.expect_or_wrong_arity(')', start_pos) {
-            return early;
+        // #2686: `repeat(a;b)` -- the parsed `expr` is the call's first arg.
+        if self.peek() != Some(')') {
+            return self.wrong_arity_or_expect(start_pos, ')', vec![expr]);
         }
         self.next();
 
@@ -2280,8 +2288,9 @@ impl<'a> Parser<'a> {
             self.skip_ws();
             let expr = self.parse_expr()?;
             self.skip_ws();
-            if let Err(early) = self.expect_or_wrong_arity(')', start_pos) {
-                return early;
+            // #2686: `first(a;b)` -- one argument already parsed.
+            if self.peek() != Some(')') {
+                return self.wrong_arity_or_expect(start_pos, ')', vec![expr]);
             }
             self.next();
             Ok(Expr::FirstExpr(Box::new(expr)))
@@ -2303,8 +2312,9 @@ impl<'a> Parser<'a> {
             self.skip_ws();
             let expr = self.parse_expr()?;
             self.skip_ws();
-            if let Err(early) = self.expect_or_wrong_arity(')', start_pos) {
-                return early;
+            // #2686: same shape as `parse_first_expr`.
+            if self.peek() != Some(')') {
+                return self.wrong_arity_or_expect(start_pos, ')', vec![expr]);
             }
             self.next();
             Ok(Expr::LastExpr(Box::new(expr)))
@@ -2390,8 +2400,9 @@ impl<'a> Parser<'a> {
         self.skip_ws();
         let step = self.parse_expr()?;
         self.skip_ws();
-        if let Err(early) = self.expect_or_wrong_arity(')', start_pos) {
-            return early;
+        // #2686: `range(a;b;c;d)` -- all three parsed args handed over.
+        if self.peek() != Some(')') {
+            return self.wrong_arity_or_expect(start_pos, ')', vec![first, second, step]);
         }
         self.next();
 
@@ -2826,6 +2837,105 @@ impl<'a> Parser<'a> {
         self.pos = start_pos;
         let call = self.parse_func_call_or_error()?;
         self.parse_postfix(call)
+    }
+
+    /// [`Self::rewind_to_wrong_arity_call`] for a site that has **already
+    /// parsed** one or more argument expressions -- resolves the same
+    /// wrong-arity call without re-parsing them (#2686).
+    ///
+    /// The rewinding form re-parses the call's whole argument text from
+    /// `start_pos`. For a *nested* wrong-arity call that is
+    /// `O(2^depth)`: every level parses its argument subtree once on the
+    /// way in and once again on the rewind, and the rewind's own
+    /// `parse_expr` descends into the next level down, which does the same.
+    /// Measured before this existed, `until(` * 24 + `1;2;3` + `)` * 24 took
+    /// 18 s to *parse* where jq 1.7.1 rejects the same text in 20 ms, growing
+    /// ~1.9x per level. This is the same denial-of-service shape #2036 closed
+    /// twice (`wrap_shadowable_call`'s arg cloning, and
+    /// `retry_shadow_candidate_as_generic_call`'s `SHADOW_RETRY_BUDGET`); a
+    /// budget would only cap it, so this removes the exponent instead.
+    ///
+    /// The already-parsed `args` are exactly what a rewind would have
+    /// re-derived, so this picks up where the caller stopped: it continues
+    /// [`Self::parse_func_call_or_error`]'s own `;`-separated loop from the
+    /// current position, closes on `)`, and assembles the identical
+    /// `Expr::FuncCall` -- same name, same argument order, same `CallSite`
+    /// offset for #2085's diagnostics, and the same [`Self::parse_postfix`]
+    /// tail its rewinding sibling applies (`range(1;2;3;4).foo` must report
+    /// `range/4 is not defined`, not a syntax error).
+    ///
+    /// `start_pos` is read only to recover the call's *name*, which the
+    /// caller consumed as a keyword before it knew the arity was wrong; the
+    /// cursor is restored immediately, so no argument text is re-scanned.
+    ///
+    /// Call only in jq mode, same carve-out as the rewinding form.
+    fn wrong_arity_call_from_parsed(
+        &mut self,
+        start_pos: usize,
+        mut args: Vec<Expr>,
+    ) -> Result<Expr, ParseError> {
+        let resume = self.pos;
+        self.pos = start_pos;
+        let name = self.parse_ident()?;
+        self.pos = resume;
+
+        // `parse_func_call_or_error`'s own argument loop, entered mid-list.
+        // Every caller has just run `skip_ws`, which is where that loop
+        // expects to be when it inspects the separator.
+        loop {
+            match self.peek() {
+                Some(';') => {
+                    self.next();
+                    self.skip_ws();
+                    args.push(self.parse_expr()?);
+                    self.skip_ws();
+                }
+                Some(')') => break,
+                _ => {
+                    return Err(ParseError::new(
+                        "expected ';' or ')' in function arguments",
+                        self.pos,
+                    ));
+                }
+            }
+        }
+        self.expect(')')?;
+
+        self.call_sites.push(CallSite {
+            name: name.clone(),
+            arity: args.len(),
+            offset: start_pos,
+        });
+        let call = Expr::FuncCall {
+            name,
+            args,
+            builtin_fallback: None,
+        };
+        self.parse_postfix(call)
+    }
+
+    /// [`Self::expect_or_wrong_arity`] for the sites that hold already-parsed
+    /// arguments (#2686), routing to
+    /// [`Self::wrong_arity_call_from_parsed`] instead of a rewind.
+    ///
+    /// Shaped as "check, else return" rather than its sibling's
+    /// `Result<(), Result<..>>` so `args` is moved only on the failing
+    /// branch, which diverges -- the caller keeps using its own `cond`/
+    /// `update` bindings afterwards on the success path.
+    ///
+    /// Non-jq mode raises `expect`'s own natural error, identical to the
+    /// rewinding sibling's carve-out.
+    fn wrong_arity_or_expect(
+        &mut self,
+        start_pos: usize,
+        expected: char,
+        args: Vec<Expr>,
+    ) -> Result<Expr, ParseError> {
+        if self.mode == ParserMode::Jq {
+            return self.wrong_arity_call_from_parsed(start_pos, args);
+        }
+        self.expect(expected)?;
+        unreachable!("only called once `peek() != Some(expected)`, so `expect` must fail")
     }
 
     /// One shared definition of the 7-line argument-boundary checkpoint

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -46673,9 +46673,29 @@ fn test_wrong_arity_resolution_is_unchanged_2686() -> Result<()> {
         // still reach the resolver rather than becoming a syntax error.
         ("range(1;2;3;4).foo", 3, "range/4 is not defined"),
         ("until(1;2;3)[0]", 3, "until/3 is not defined"),
-        // A malformed separator inside the continued argument list keeps
-        // `parse_func_call_or_error`'s own wording.
-        ("until(1;2;3,)", 3, ""),
+        // A malformed separator inside the *continued* argument list -- the
+        // part this fix now parses itself rather than re-parsing -- keeps
+        // `parse_func_call_or_error`'s own wording and position.
+        (
+            "until(1;2;3 4)",
+            3,
+            "expected ';' or ')' in function arguments",
+        ),
+        (
+            "first(1;2 3)",
+            3,
+            "expected ';' or ')' in function arguments",
+        ),
+        (
+            "range(1;2;3;4 5)",
+            3,
+            "expected ';' or ')' in function arguments",
+        ),
+        (
+            "until(1;2;3]",
+            3,
+            "expected ';' or ')' in function arguments",
+        ),
     ] {
         let (_stdout, stderr, code) = run_jq_full(&["-nc", filter], None)?;
         assert_eq!(code, want_code, "`{filter}`: stderr {stderr:?}");

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -46575,3 +46575,142 @@ fn test_collection_literal_postfix_does_not_capture_destructuring_2667() -> Resu
 
     Ok(())
 }
+
+/// #2686: a **wrong-arity** call to one of the eight dedicated special-form
+/// parsers cost `O(2^depth)` to *parse* when nested.
+///
+/// `rewind_to_wrong_arity_call` re-parsed the call's whole argument text from
+/// `start_pos` to resolve it as a (possibly shadowed) generic call. Every
+/// level therefore parsed its argument subtree twice — once on the way in,
+/// once on the rewind — and the rewind's own `parse_expr` descended into the
+/// next level down, which did the same. Measured before the fix:
+/// `until(` × 24 + `1;2;3` + `)` × 24 took **18 s** where jq 1.7.1 rejects the
+/// same text in 20 ms, growing ~1.9× per level.
+///
+/// `wrong_arity_call_from_parsed` hands the already-parsed arguments over and
+/// continues the argument loop from where the caller stopped, so nothing is
+/// re-parsed and the exponent is gone rather than merely bounded — the third
+/// instance of the shape #2036 closed twice (`wrap_shadowable_call`'s arg
+/// cloning, and `retry_shadow_candidate_as_generic_call`'s
+/// `SHADOW_RETRY_BUDGET`).
+///
+/// **Every** wrong-arity form was affected, not only the 2-arity ones. The
+/// issue reported `first/2` as flat and inferred that `until`/`limit`'s two
+/// already-parsed sub-expressions were needed to trigger it; that was a
+/// generator artifact. `"first(" * d + "1;2" + ")" * d` nests the call in
+/// argument *one*, so every level except the innermost is `first/1` — correct
+/// arity, which never rewinds. Built so each level really is wrong-arity
+/// (`"first(" * d + "1" + ";2)" * d`), `first/2` blew up exactly like the
+/// rest: 147 ms at depth 14 against `until/3`'s 215 ms, both ~1.9×/level.
+/// Hence the table below covers all eight forms rather than the two named.
+///
+/// Same timing-guard shape and generous margin as
+/// `test_def_shadow_deep_nesting_does_not_blow_up_2036` and
+/// `test_module_def_shadow_deep_nesting_does_not_blow_up_2395`: at 40 levels
+/// a reintroduced `2^depth` is astronomical, not merely slow, so a wide margin
+/// still catches the regression while tolerating this suite's own parallel-CPU
+/// contention.
+#[test]
+fn test_wrong_arity_deep_nesting_does_not_blow_up_2686() -> Result<()> {
+    // (keyword, the wrong-arity argument tail at every level)
+    for (kw, tail) in [
+        ("until", ";2;3"),
+        ("while", ";2;3"),
+        ("limit", ";2;3"),
+        ("first", ";2"),
+        ("last", ";2"),
+        ("repeat", ";2"),
+        ("range", ";2;3;4"),
+        ("error", ";2"),
+        // `limit(x)` — the missing-second-argument shape, which resolves
+        // through its own dedicated early return rather than a trailing
+        // separator mismatch.
+        ("limit", ""),
+    ] {
+        let depth = 40;
+        let filter = format!("{kw}(").repeat(depth) + "1" + &format!("{tail})").repeat(depth);
+        let start = std::time::Instant::now();
+        let (_stdout, _stderr, code) = run_jq_full(&["-nc", &filter], None)?;
+        let elapsed = start.elapsed();
+        // Every row is a wrong-arity call, so every row must be rejected --
+        // the point is that it is rejected *quickly*, with the same answer
+        // the rewinding version gave.
+        assert_ne!(code, 0, "`{kw}` {depth} levels: expected a rejection");
+        assert!(
+            elapsed < std::time::Duration::from_secs(15),
+            "`{kw}` at {depth} levels took {elapsed:?} -- exponential parse blowup regressed"
+        );
+    }
+
+    Ok(())
+}
+
+/// #2686: the no-re-parse path must resolve a wrong-arity call to exactly
+/// what the rewinding path did — same message, same shadow resolution, same
+/// postfix handling.
+///
+/// Verified in bulk while making the change: 855 programs across all eight
+/// special forms × both modes (1710 pairs) — every argument count from 0 to
+/// 5, malformed separators, `def`-shadowed spellings, postfix chains,
+/// namespaced calls and nesting — produced byte-identical stdout, stderr and
+/// exit code against a binary built from the merge base. These rows are the
+/// load-bearing ones from that sweep, kept so the parity is pinned rather
+/// than only having been measured once.
+#[test]
+fn test_wrong_arity_resolution_is_unchanged_2686() -> Result<()> {
+    for (filter, want_code, want_fragment) in [
+        // The resolver's own name/arity diagnostic, not a raw parse error.
+        ("until(1;2;3)", 3, "until/3 is not defined"),
+        ("limit(1;2;3)", 3, "limit/3 is not defined"),
+        ("limit(1)", 3, "limit/1 is not defined"),
+        ("first(1;2)", 3, "first/2 is not defined"),
+        ("last(1;2)", 3, "last/2 is not defined"),
+        ("while(1;2;3)", 3, "while/3 is not defined"),
+        ("repeat(1;2)", 3, "repeat/2 is not defined"),
+        ("range(1;2;3;4)", 3, "range/4 is not defined"),
+        ("error(1;2)", 3, "error/2 is not defined"),
+        // #2237's postfix tail: a suffix after the wrong-arity call must
+        // still reach the resolver rather than becoming a syntax error.
+        ("range(1;2;3;4).foo", 3, "range/4 is not defined"),
+        ("until(1;2;3)[0]", 3, "until/3 is not defined"),
+        // A malformed separator inside the continued argument list keeps
+        // `parse_func_call_or_error`'s own wording.
+        ("until(1;2;3,)", 3, ""),
+    ] {
+        let (_stdout, stderr, code) = run_jq_full(&["-nc", filter], None)?;
+        assert_eq!(code, want_code, "`{filter}`: stderr {stderr:?}");
+        assert!(
+            stderr.contains(want_fragment),
+            "`{filter}`: stderr {stderr:?} lacks {want_fragment:?}"
+        );
+    }
+
+    // A `def` of the same name and arity still shadows -- the whole reason
+    // the wrong-arity path resolves as a generic call instead of raising.
+    for (filter, want) in [
+        ("def until(a;b;c): 42; until(1;2;3)", "42"),
+        ("def first(a;b): [a,b]; first(1;2)", "[1,2]"),
+        ("def range(a;b;c;d): 9; range(1;2;3;4)", "9"),
+        ("def limit(a): a; limit(7)", "7"),
+    ] {
+        let (stdout, stderr, code) = run_jq_full(&["-nc", filter], None)?;
+        assert_eq!(code, 0, "`{filter}`: stderr {stderr:?}");
+        assert_eq!(stdout.trim_end(), want, "`{filter}`");
+    }
+
+    // Correct-arity calls are untouched.
+    for (filter, want) in [
+        ("[limit(2; 1,2,3)]", "[1,2]"),
+        ("[range(1;5;2)]", "[1,3]"),
+        ("[range(3)]", "[0,1,2]"),
+        ("1 | until(. > 3; . + 1)", "4"),
+        ("[first(1,2)]", "[1]"),
+        ("[last(1,2)]", "[2]"),
+    ] {
+        let (stdout, stderr, code) = run_jq_full(&["-nc", filter], None)?;
+        assert_eq!(code, 0, "`{filter}`: stderr {stderr:?}");
+        assert_eq!(stdout.trim_end(), want, "`{filter}`");
+    }
+
+    Ok(())
+}

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -46604,6 +46604,18 @@ fn test_collection_literal_postfix_does_not_capture_destructuring_2667() -> Resu
 /// rest: 147 ms at depth 14 against `until/3`'s 215 ms, both ~1.9×/level.
 /// Hence the table below covers all eight forms rather than the two named.
 ///
+/// **Scope: the eight dedicated special-form parsers only.** The same shape
+/// still exists behind `parse_required_single_arg`, which rewinds *after*
+/// parsing its argument and signals "not a match" so its caller re-parses --
+/// so the ~30 single-argument builtins in `try_parse_builtin` (`has`,
+/// `select`, ...) keep it. Measured on this branch: `"has(" * d + "1" +
+/// ";2)" * d` costs 2.4 s at depth 18, identical to the merge base, where
+/// the forms below are flat. That is a different protocol
+/// (`Result<Option<_>>`, resolved by the caller's own shadow fallback rather
+/// than in place), so it is tracked separately rather than folded in here --
+/// this test deliberately does not cover it, and should not be read as
+/// saying the wider surface is fixed.
+///
 /// Same timing-guard shape and generous margin as
 /// `test_def_shadow_deep_nesting_does_not_blow_up_2036` and
 /// `test_module_def_shadow_deep_nesting_does_not_blow_up_2395`: at 40 levels

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -41688,3 +41688,36 @@ mod issue_1360_identity_not_jq_equality {
         Ok(())
     }
 }
+
+/// #2686 (yq half): the no-re-parse wrong-arity path keeps yq mode's own
+/// carve-out — `expect`'s natural parse error, never jq's "X/N is not
+/// defined".
+///
+/// `wrong_arity_or_expect` is the non-jq arm of the fix that replaced
+/// `rewind_to_wrong_arity_call` at the sites holding parsed arguments, and it
+/// reproduces the rewinding version's mode split exactly: name/arity
+/// resolution is jq vocabulary, and real yq has nothing to match it against,
+/// so borrowing jq's wording here would be a new divergence rather than a fix
+/// (ADR-0018). Kept in this file because the yq spawn helpers live here.
+#[test]
+fn test_wrong_arity_special_form_keeps_yq_parse_error_2686() -> Result<()> {
+    for (filter, want_fragment) in [
+        ("until(1;2;3)", "expected ')', found ';'"),
+        ("while(1;2;3)", "expected ')', found ';'"),
+        ("first(1;2)", "expected ')', found ';'"),
+        ("last(1;2)", "expected ')', found ';'"),
+    ] {
+        let (_stdout, stderr, code) = run_yq_stdin_with_stderr(filter, "a: 1\n", &[])?;
+        assert_ne!(code, 0, "`{filter}`: expected a rejection");
+        assert!(
+            stderr.contains(want_fragment),
+            "`{filter}`: stderr {stderr:?} lacks {want_fragment:?}"
+        );
+        assert!(
+            !stderr.contains("is not defined"),
+            "`{filter}`: yq mode must not borrow jq's name/arity wording: {stderr:?}"
+        );
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
Fixes #2686

## Summary

A wrong-arity call to one of the eight dedicated special-form parsers cost **O(2^depth)** to *parse* when nested. `until(` × 24 + `1;2;3` + `)` × 24 took **18 s** where jq 1.7.1 rejects the same text in 20 ms.

## Root cause

`rewind_to_wrong_arity_call` re-parsed the call's whole argument text from `start_pos` to resolve it as a (possibly shadowed) generic call. Every level therefore parsed its argument subtree **twice** — once on the way in, once on the rewind — and the rewind's own `parse_expr` descended into the next level down, which did the same: `T(d) = 2·T(d-1)`.

The parsers already hold the arguments a rewind would re-derive. `wrong_arity_call_from_parsed` takes them, continues `parse_func_call_or_error`'s own `;`-separated loop from where the caller stopped, and assembles the identical `Expr::FuncCall` — same name, argument order, `CallSite` offset for #2085's diagnostics, and the same `parse_postfix` tail. `start_pos` is read only to recover the name the caller consumed as a keyword; no argument text is re-scanned.

Nothing is re-parsed, so **the exponent is gone rather than bounded** — the issue's other option (a `SHADOW_RETRY_BUDGET`-style cap) would only have limited the damage.

Applied at the 11 sites holding parsed arguments. The 5 sites that fault on the opening `(` keep the rewinding path: they have parsed nothing, so there is no subtree to re-scan, and it is the path that also handles a namespaced `until::x(..)` call.

## Measured

Debug build, this machine. Before (`origin/main`) vs after:

| depth | `until/3` before | `first/2` before | `range/4` before | all forms after |
|------:|-----------------:|-----------------:|-----------------:|----------------:|
| 8  | 8 ms | 6 ms | 9 ms | ~5 ms |
| 10 | 17 ms | 13 ms | 23 ms | ~5 ms |
| 12 | 56 ms | 39 ms | 77 ms | ~5 ms |
| 14 | 215 ms | 147 ms | 290 ms | ~5 ms |
| 40 | (astronomical) | | | ~5 ms |

jq 1.7.1 is flat at ~3 ms throughout. After the fix every form is flat to depth 40.

## The issue's scope was too narrow, and its root-cause clue was a generator artifact

The issue reported `first/2` as flat and inferred that `until`/`limit`'s **two** already-parsed sub-expressions were needed to trigger the blowup, concluding "only the 2-arity forms".

Both are wrong, and the cause is the generator. `"first(" * d + "1;2" + ")" * d` nests the call in argument *one*, so every level except the innermost is `first/1` — **correct** arity, which never rewinds. Built so each level really is wrong-arity (`"first(" * d + "1" + ";2)" * d`), `first/2` blows up exactly like the rest, as does `range/4` — see the table above.

So the mechanism is plainly the rewind, with no special interaction, and this fix covers all eight forms rather than the two named.

## Behaviour is unchanged — checked, not argued

**855 programs × both modes = 1710 pairs, zero diffs** against a binary built from the merge base: byte-identical stdout, stderr and exit code. The corpus spans all eight special forms with every argument count from 0 to 5, malformed separators (`1;`, `;1`, `1;;2`, `1;2,3`), `def`-shadowed spellings at matching and non-matching arity, postfix chains (`.foo`, `[0]`), namespaced calls, bare keywords, and nesting at depths 2–3.

Pinned going forward by `test_wrong_arity_resolution_is_unchanged_2686` (resolver wording, postfix tail, shadowing, correct-arity controls) and `test_wrong_arity_special_form_keeps_yq_parse_error_2686` (the yq-mode carve-out — `expect`'s natural error, and jq's "is not defined" wording asserted *absent*, per ADR-0018).

## Test plan

- [x] `cargo build --features cli`
- [x] `cargo test --features cli,simd,regex,serde` — 8149 passed, 0 failed
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings`
- [x] `cargo fmt --check`
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features`
- [x] `omni-dev coverage diff` — **100% patch coverage** (62/62)
- [x] 1710-pair differential against a merge-base build — 0 diffs
- [x] Timing guard at depth 40 across all eight forms, same shape as `test_def_shadow_deep_nesting_does_not_blow_up_2036` / `..._2395`
- [x] Re-ran the full suite after rebasing onto current `main`


## Scope correction (from review)

The claim "the exponent is gone rather than bounded" holds for **the eight dedicated special-form parsers only**.

Review found the identical shape surviving behind `parse_required_single_arg`, which rewinds *after* parsing its argument and returns `Ok(None)` so the caller re-parses — so the ~30 single-argument builtins in `try_parse_builtin` (`has`, `select`, …) keep it. Independently confirmed pre-existing and untouched by this branch:

| filter | depth | merge base | this branch |
|---|---:|---:|---:|
| `"has(" * d + "1" + ";2)" * d` | 18 | 2424 ms | 2420 ms |
| `"select(" * d + "1" + ";2)" * d` | 18 | 2509 ms | 2532 ms |
| `"until(" * d + "1" + ";2;3)" * d` | 18 | 3345 ms | **6 ms** |

(`env` is already flat — it has its own hand-rolled rewind.)

That helper has a different return protocol (`Result<Option<_>>`, resolved by the caller's shadow fallback rather than in place), so it needs its own change rather than an extension of this one. Filed as **#2749**, and `test_wrong_arity_deep_nesting_does_not_blow_up_2686`'s doc comment now states the boundary explicitly so the wider surface isn't read as fixed.
