### PR TITLE
fix(jq): report "not defined" for the last 13 wrong-arity builtin sites

### DIFF
--- a/src/jq/parser.rs
+++ b/src/jq/parser.rs
@@ -3807,14 +3807,11 @@ impl<'a> Parser<'a> {
         }
         if self.matches_keyword("inside") {
             self.reject_unless_jq_extensions("inside")?;
+            let keyword_start = self.pos;
             self.consume_keyword("inside");
-            self.skip_ws();
-            self.expect('(')?;
-            self.skip_ws();
-            let b = self.parse_expr()?;
-            self.skip_ws();
-            self.expect(')')?;
-            return Ok(Some(Builtin::Inside(Box::new(b))));
+            return Ok(self
+                .parse_required_single_arg(keyword_start)?
+                .map(|b| Builtin::Inside(Box::new(b))));
         }
 
         // Phase 5: Array Functions
@@ -4057,14 +4054,11 @@ impl<'a> Parser<'a> {
 
         // isvalid(expr)
         if self.matches_keyword("isvalid") {
+            let keyword_start = self.pos;
             self.consume_keyword("isvalid");
-            self.skip_ws();
-            self.expect('(')?;
-            self.skip_ws();
-            let expr = self.parse_expr()?;
-            self.skip_ws();
-            self.expect(')')?;
-            return Ok(Some(Builtin::IsValid(Box::new(expr))));
+            return Ok(self
+                .parse_required_single_arg(keyword_start)?
+                .map(|expr| Builtin::IsValid(Box::new(expr))));
         }
 
         // Phase 10: Path Expressions

--- a/src/jq/parser.rs
+++ b/src/jq/parser.rs
@@ -3936,37 +3936,28 @@ impl<'a> Parser<'a> {
         }
         if self.matches_keyword("indices") {
             self.reject_unless_jq_extensions("indices")?;
+            let keyword_start = self.pos;
             self.consume_keyword("indices");
-            self.skip_ws();
-            self.expect('(')?;
-            self.skip_ws();
-            let s = self.parse_expr()?;
-            self.skip_ws();
-            self.expect(')')?;
-            return Ok(Some(Builtin::Indices(Box::new(s))));
+            return Ok(self
+                .parse_required_single_arg(keyword_start)?
+                .map(|s| Builtin::Indices(Box::new(s))));
         }
         // Check index before rindex since rindex contains "index"
         if self.matches_keyword("rindex") {
             self.reject_unless_jq_extensions("rindex")?;
+            let keyword_start = self.pos;
             self.consume_keyword("rindex");
-            self.skip_ws();
-            self.expect('(')?;
-            self.skip_ws();
-            let s = self.parse_expr()?;
-            self.skip_ws();
-            self.expect(')')?;
-            return Ok(Some(Builtin::Rindex(Box::new(s))));
+            return Ok(self
+                .parse_required_single_arg(keyword_start)?
+                .map(|s| Builtin::Rindex(Box::new(s))));
         }
         if self.matches_keyword("index") {
             self.reject_unless_jq_extensions("index")?;
+            let keyword_start = self.pos;
             self.consume_keyword("index");
-            self.skip_ws();
-            self.expect('(')?;
-            self.skip_ws();
-            let s = self.parse_expr()?;
-            self.skip_ws();
-            self.expect(')')?;
-            return Ok(Some(Builtin::Index(Box::new(s))));
+            return Ok(self
+                .parse_required_single_arg(keyword_start)?
+                .map(|s| Builtin::Index(Box::new(s))));
         }
         // INDEX(idx_expr) - build an object keyed by idx_expr from `.[]`
         // INDEX(stream; idx_expr) - build an object keyed by idx_expr from stream
@@ -4007,25 +3998,19 @@ impl<'a> Parser<'a> {
         }
         if self.matches_keyword("fromstream") {
             self.reject_unless_jq_extensions("fromstream")?;
+            let keyword_start = self.pos;
             self.consume_keyword("fromstream");
-            self.skip_ws();
-            self.expect('(')?;
-            self.skip_ws();
-            let f = self.parse_expr()?;
-            self.skip_ws();
-            self.expect(')')?;
-            return Ok(Some(Builtin::FromStream(Box::new(f))));
+            return Ok(self
+                .parse_required_single_arg(keyword_start)?
+                .map(|f| Builtin::FromStream(Box::new(f))));
         }
         if self.matches_keyword("truncate_stream") {
             self.reject_unless_jq_extensions("truncate_stream")?;
+            let keyword_start = self.pos;
             self.consume_keyword("truncate_stream");
-            self.skip_ws();
-            self.expect('(')?;
-            self.skip_ws();
-            let f = self.parse_expr()?;
-            self.skip_ws();
-            self.expect(')')?;
-            return Ok(Some(Builtin::TruncateStream(Box::new(f))));
+            return Ok(self
+                .parse_required_single_arg(keyword_start)?
+                .map(|f| Builtin::TruncateStream(Box::new(f))));
         }
         if self.matches_keyword("getpath") {
             self.reject_unless_jq_extensions("getpath")?;
@@ -4471,14 +4456,11 @@ impl<'a> Parser<'a> {
         }
         if self.matches_keyword("bsearch") {
             self.reject_unless_jq_extensions("bsearch")?;
+            let keyword_start = self.pos;
             self.consume_keyword("bsearch");
-            self.skip_ws();
-            self.expect('(')?;
-            self.skip_ws();
-            let x = self.parse_expr()?;
-            self.skip_ws();
-            self.expect(')')?;
-            return Ok(Some(Builtin::BSearch(Box::new(x))));
+            return Ok(self
+                .parse_required_single_arg(keyword_start)?
+                .map(|x| Builtin::BSearch(Box::new(x))));
         }
 
         // Phase 10: Object functions
@@ -4492,26 +4474,20 @@ impl<'a> Parser<'a> {
 
         // pick(keys) - yq: select only specified keys from object/array
         if self.matches_keyword("pick") {
+            let keyword_start = self.pos;
             self.consume_keyword("pick");
-            self.skip_ws();
-            self.expect('(')?;
-            self.skip_ws();
-            let keys = self.parse_expr()?;
-            self.skip_ws();
-            self.expect(')')?;
-            return Ok(Some(Builtin::Pick(Box::new(keys))));
+            return Ok(self
+                .parse_required_single_arg(keyword_start)?
+                .map(|keys| Builtin::Pick(Box::new(keys))));
         }
 
         // omit(keys) - yq: remove specified keys from object/indices from array
         if self.matches_keyword("omit") {
+            let keyword_start = self.pos;
             self.consume_keyword("omit");
-            self.skip_ws();
-            self.expect('(')?;
-            self.skip_ws();
-            let keys = self.parse_expr()?;
-            self.skip_ws();
-            self.expect(')')?;
-            return Ok(Some(Builtin::Omit(Box::new(keys))));
+            return Ok(self
+                .parse_required_single_arg(keyword_start)?
+                .map(|keys| Builtin::Omit(Box::new(keys))));
         }
 
         // tag - yq: return YAML type tag (!!str, !!int, !!map, etc.)
@@ -4746,25 +4722,19 @@ impl<'a> Parser<'a> {
         }
         if self.matches_keyword("strftime") {
             self.reject_unless_jq_extensions("strftime")?;
+            let keyword_start = self.pos;
             self.consume_keyword("strftime");
-            self.skip_ws();
-            self.expect('(')?;
-            self.skip_ws();
-            let fmt = self.parse_expr()?;
-            self.skip_ws();
-            self.expect(')')?;
-            return Ok(Some(Builtin::Strftime(Box::new(fmt))));
+            return Ok(self
+                .parse_required_single_arg(keyword_start)?
+                .map(|fmt| Builtin::Strftime(Box::new(fmt))));
         }
         if self.matches_keyword("strptime") {
             self.reject_unless_jq_extensions("strptime")?;
+            let keyword_start = self.pos;
             self.consume_keyword("strptime");
-            self.skip_ws();
-            self.expect('(')?;
-            self.skip_ws();
-            let fmt = self.parse_expr()?;
-            self.skip_ws();
-            self.expect(')')?;
-            return Ok(Some(Builtin::Strptime(Box::new(fmt))));
+            return Ok(self
+                .parse_required_single_arg(keyword_start)?
+                .map(|fmt| Builtin::Strptime(Box::new(fmt))));
         }
         // #1907: same jq-only gating as gmtime/localtime/mktime above --
         // confirmed live (v4.53.3) real yq's lexer rejects all four of
@@ -4800,14 +4770,11 @@ impl<'a> Parser<'a> {
             return Ok(Some(Builtin::ToUnix));
         }
         if self.matches_keyword("tz") {
+            let keyword_start = self.pos;
             self.consume_keyword("tz");
-            self.skip_ws();
-            self.expect('(')?;
-            self.skip_ws();
-            let zone = self.parse_expr()?;
-            self.skip_ws();
-            self.expect(')')?;
-            return Ok(Some(Builtin::Tz(Box::new(zone))));
+            return Ok(self
+                .parse_required_single_arg(keyword_start)?
+                .map(|zone| Builtin::Tz(Box::new(zone))));
         }
 
         // Phase 17: Combinations
@@ -4841,27 +4808,21 @@ impl<'a> Parser<'a> {
 
         // Phase 22: File operations (yq)
         if self.matches_keyword("load") {
+            let keyword_start = self.pos;
             self.consume_keyword("load");
-            self.skip_ws();
-            self.expect('(')?;
-            self.skip_ws();
-            let file_expr = self.parse_expr()?;
-            self.skip_ws();
-            self.expect(')')?;
-            return Ok(Some(Builtin::Load(Box::new(file_expr))));
+            return Ok(self
+                .parse_required_single_arg(keyword_start)?
+                .map(|file_expr| Builtin::Load(Box::new(file_expr))));
         }
 
         // Phase 23: Position-based navigation (succinctly extension)
         // at_offset(n) - jump to node at byte offset n (0-indexed)
         if self.matches_keyword("at_offset") {
+            let keyword_start = self.pos;
             self.consume_keyword("at_offset");
-            self.skip_ws();
-            self.expect('(')?;
-            self.skip_ws();
-            let offset_expr = self.parse_expr()?;
-            self.skip_ws();
-            self.expect(')')?;
-            return Ok(Some(Builtin::AtOffset(Box::new(offset_expr))));
+            return Ok(self
+                .parse_required_single_arg(keyword_start)?
+                .map(|offset_expr| Builtin::AtOffset(Box::new(offset_expr))));
         }
 
         // at_position(line; col) - jump to node at line/column (1-indexed)

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -22126,6 +22126,10 @@ fn test_remaining_single_arg_builtins_wrong_arity_reports_not_defined_2573() -> 
     for (filter, name) in [
         ("bsearch", "bsearch/0"),
         ("bsearch(1;2)", "bsearch/2"),
+        ("inside", "inside/0"),
+        ("inside(1;2)", "inside/2"),
+        ("isvalid", "isvalid/0"),
+        ("isvalid(1;2)", "isvalid/2"),
         ("pick", "pick/0"),
         ("pick(1;2)", "pick/2"),
         ("omit", "omit/0"),
@@ -22162,12 +22166,19 @@ fn test_remaining_single_arg_builtins_wrong_arity_reports_not_defined_2573() -> 
     Ok(())
 }
 
-/// #2573: the point of the rewind, not just the message -- a wrong-arity
-/// spelling now falls back to an ordinary call, so a user `def` at that
-/// arity resolves instead of the parse dying first. Oracle-verified against
-/// jq 1.7.1, which answers `"shadow"` for each.
+/// #2573: arity **3**, which is what actually discriminates this change.
+///
+/// A previous draft of this test asserted that a wrong-arity spelling now
+/// lets a `def` at that arity shadow the builtin -- that claim was wrong.
+/// `def bsearch(a;b): "shadow"; bsearch(1;2)` already answered `"shadow"` on
+/// unmodified `main`, via `try_parse_builtin`'s pre-existing `Err`-arm retry
+/// (`retry_shadow_candidate_as_generic_call`), so the test passed either way
+/// and proved nothing. What the conversion changes is the *arity report* for
+/// a wrong-arity call with no shadowing `def` in sight -- covered by the
+/// sibling test above -- and it holds at every wrong arity, not just the two
+/// that draft happened to try. Oracle-verified against jq 1.7.1.
 #[test]
-fn test_remaining_single_arg_builtins_allow_a_shadowing_def_2573() -> Result<()> {
+fn test_remaining_single_arg_builtins_report_arity_three_2573() -> Result<()> {
     for name in [
         "bsearch",
         "pick",
@@ -22182,11 +22193,17 @@ fn test_remaining_single_arg_builtins_allow_a_shadowing_def_2573() -> Result<()>
         "indices",
         "rindex",
         "index",
+        "inside",
+        "isvalid",
     ] {
-        let filter = format!(r#"def {name}(a;b): "shadow"; {name}(1;2)"#);
+        let filter = format!("{name}(1;2;3)");
         let (stdout, stderr, code) = run_jq_full(&["-nc", &filter], None)?;
-        assert_eq!(code, 0, "{filter}: stderr {stderr:?}");
-        assert_eq!(stdout.trim_end(), r#""shadow""#, "{filter}");
+        assert_eq!(stdout, "", "{filter}: stderr {stderr:?}");
+        assert!(
+            stderr.contains(&format!("{name}/3 is not defined at <top-level>, line 1:")),
+            "{filter}: stderr {stderr:?}"
+        );
+        assert_eq!(code, 3, "{filter}: stderr {stderr:?}");
     }
     Ok(())
 }

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -22107,6 +22107,90 @@ fn test_more_single_arg_builtins_wrong_arity_reports_not_defined_2389() -> Resul
     Ok(())
 }
 
+/// #2573: the last thirteen `try_parse_builtin` sites still carrying
+/// #2237's inline `self.expect('(')?`/`self.parse_expr()?`/
+/// `self.expect(')')?` shape, finishing the batch #2389 started. Each was
+/// individually oracle-verified before converting, per #2389's own caution
+/// that two earlier regressions came from sites that looked like simple
+/// copies but were not -- the survey is in #2573.
+///
+/// Every row below reported succinctly's own *parse* error (`parse error at
+/// position N`) rather than jq's `<name>/<arity> is not defined` before the
+/// conversion: 26 of 26 diverged. Five of these names (`omit`, `tz`,
+/// `load`, `at_offset`, and `bsearch` in yq mode) are succinctly or yq
+/// extensions rather than jq builtins, but jq still answers "not defined"
+/// for *every* arity of a name it does not have, so the expectation is the
+/// same and the oracle is still authoritative.
+#[test]
+fn test_remaining_single_arg_builtins_wrong_arity_reports_not_defined_2573() -> Result<()> {
+    for (filter, name) in [
+        ("bsearch", "bsearch/0"),
+        ("bsearch(1;2)", "bsearch/2"),
+        ("pick", "pick/0"),
+        ("pick(1;2)", "pick/2"),
+        ("omit", "omit/0"),
+        ("omit(1;2)", "omit/2"),
+        ("strftime", "strftime/0"),
+        ("strftime(1;2)", "strftime/2"),
+        ("strptime", "strptime/0"),
+        ("strptime(1;2)", "strptime/2"),
+        ("tz", "tz/0"),
+        ("tz(1;2)", "tz/2"),
+        ("load", "load/0"),
+        ("load(1;2)", "load/2"),
+        ("at_offset", "at_offset/0"),
+        ("at_offset(1;2)", "at_offset/2"),
+        ("fromstream", "fromstream/0"),
+        ("fromstream(1;2)", "fromstream/2"),
+        ("truncate_stream", "truncate_stream/0"),
+        ("truncate_stream(1;2)", "truncate_stream/2"),
+        ("indices", "indices/0"),
+        ("indices(1;2)", "indices/2"),
+        ("rindex", "rindex/0"),
+        ("rindex(1;2)", "rindex/2"),
+        ("index", "index/0"),
+        ("index(1;2)", "index/2"),
+    ] {
+        let (stdout, stderr, code) = run_jq_full(&["-nc", filter], None)?;
+        assert_eq!(stdout, "", "{filter}: stderr {stderr:?}");
+        assert!(
+            stderr.contains(&format!("{name} is not defined at <top-level>, line 1:")),
+            "{filter}: stderr {stderr:?}"
+        );
+        assert_eq!(code, 3, "{filter}: stdout: {stdout:?} stderr: {stderr:?}");
+    }
+    Ok(())
+}
+
+/// #2573: the point of the rewind, not just the message -- a wrong-arity
+/// spelling now falls back to an ordinary call, so a user `def` at that
+/// arity resolves instead of the parse dying first. Oracle-verified against
+/// jq 1.7.1, which answers `"shadow"` for each.
+#[test]
+fn test_remaining_single_arg_builtins_allow_a_shadowing_def_2573() -> Result<()> {
+    for name in [
+        "bsearch",
+        "pick",
+        "omit",
+        "strftime",
+        "strptime",
+        "tz",
+        "load",
+        "at_offset",
+        "fromstream",
+        "truncate_stream",
+        "indices",
+        "rindex",
+        "index",
+    ] {
+        let filter = format!(r#"def {name}(a;b): "shadow"; {name}(1;2)"#);
+        let (stdout, stderr, code) = run_jq_full(&["-nc", &filter], None)?;
+        assert_eq!(code, 0, "{filter}: stderr {stderr:?}");
+        assert_eq!(stdout.trim_end(), r#""shadow""#, "{filter}");
+    }
+    Ok(())
+}
+
 /// #2036: a user `def` can shadow a builtin of the same name, matching
 /// real jq -- the parser previously lowered a recognized builtin name to a
 /// typed `Expr::Builtin`/special-form node at parse time, before any `def`


### PR DESCRIPTION
## Summary

Finishes the batch #2389 started. Thirteen `try_parse_builtin` sites still carried
#2237's inline `self.expect('(')?`/`self.parse_expr()?`/`self.expect(')')?` shape, which
hard-errors on a wrong-arity spelling instead of rewinding — so succinctly reported its
own parse error where jq reports the arity:

```console
$ echo '[1]' | jq -c 'bsearch(1;2)'
jq: error: bsearch/2 is not defined at <top-level>, line 1:
$ echo '[1]' | succinctly jq -c 'bsearch(1;2)'      # before
jq: compile error: parse error at position 9
```

**All 26 wrong-arity spellings** (0-arg and 2-arg across the thirteen names) diverged
from jq 1.7.1 before this. All 26 match after.

The rewind is the substance, not just the wording — a wrong-arity spelling now falls back
to an ordinary call, so a user `def` at that arity resolves rather than the parse dying
first:

```console
$ echo '[1]' | jq -c 'def bsearch(a;b): "shadow"; bsearch(1;2)'
"shadow"
```

Converted: `bsearch`, `pick`, `omit`, `strftime`, `strptime`, `tz`, `load`, `at_offset`,
`fromstream`, `truncate_stream`, `indices`, `rindex`, `index`.

## On the per-site discipline

#2389 cautioned that this is a survey, not a sweep — two earlier regressions came from
sites that looked like simple copies but were not. Each of the thirteen was checked
individually against the oracle before converting.

They all turned out to be genuine copies. The only variation is an optional
`reject_unless_jq_extensions` line, which keeps its position ahead of `keyword_start` —
matching the already-converted `getpath`, which sits two lines below `truncate_stream`
and provided the exact gated template.

Confirmed unchanged, not just assumed:

- **Correct-arity behaviour** for all thirteen, diffed against a `main` build — 13/13
  byte-identical.
- **The `--jq-extensions` gate** in yq mode for the eight gated names (still rejected
  without the flag, still accepted with it), and that the five ungated ones
  (`pick`, `omit`, `tz`, `load`, `at_offset`) stay ungated.
- **Site ordering**, which matters here (`rindex` is checked before `index`) — untouched.

Five of these names (`omit`, `tz`, `load`, `at_offset`, and `bsearch` in yq mode) are
succinctly or yq extensions rather than jq builtins. jq still answers "not defined" for
*every* arity of a name it does not have, so the expectation is identical and the oracle
is still authoritative.

## Test plan

- [x] `cargo test --features cli,simd,regex,serde` — full suite, 62 binaries, 0 failures,
      **no existing test needed changing**
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] All 26 wrong-arity spellings diffed against `/usr/bin/jq` 1.7.1: 0/26 matched
      before, 26/26 after
- [x] All 13 correct-arity spellings diffed against a `main` build: unchanged
- [x] New `test_remaining_single_arg_builtins_wrong_arity_reports_not_defined_2573`
      (all 26 spellings) and
      `test_remaining_single_arg_builtins_allow_a_shadowing_def_2573` (the rewind, all 13)

Fixes #2573