### PR TITLE
fix(jq): keep the prefix a failing nested path stage already reached

### DIFF
--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -38993,6 +38993,18 @@ fn walk_pipe<'v, S: EvalSemantics>(
     // Exactly the shape `eval_generic.rs`'s twin `path_walk_pipe_generic`
     // already uses, and for the reason its own comment gives: never un-emit
     // an output already produced.
+    //
+    // Two consequences worth knowing before touching this. The inner `?`
+    // makes a failure while walking `rest` for an *earlier* position win
+    // over `stepped` -- correct, since it comes first in generator order,
+    // and it changes the reported *message*, not just whether a prefix
+    // appears (`path((.a[] | .b) | .c[0:1])` on `{"a":[{"b":5},7]}` reports
+    // the `.c` failure, where propagating `stepped` first reported the `.b`
+    // one). And this function has no depth guard of its own: it relies on
+    // the `assert_value_tree_depth` at the top of `walk_path`, which it
+    // calls once per stage before recursing. The twin carries its own at
+    // entry -- an early return added *above* the `walk_path` call here would
+    // bypass the guard entirely.
     let mut reached = Vec::new();
     let stepped = walk_path::<S>(first, value, current_path, &mut reached, optional);
     for (path, val) in reached {

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -38975,12 +38975,32 @@ fn walk_pipe<'v, S: EvalSemantics>(
         return walk_path::<S>(first, value, current_path, out, optional);
     }
 
+    // #2680: the stage's `Result` is held back rather than `?`-propagated
+    // here. Positions it reached *before* failing come earlier in jq's
+    // generator order than its own error, so they still have to be walked
+    // through `rest` -- only then does the error surface. Propagating first
+    // dropped `reached` on the floor, and with it every path those positions
+    // would have named: `path((.a[] | .b) | .c[0:1])` on
+    // `{"a":[{"b":{}},5]}` printed the error alone, where jq prints
+    // `["a",0,"b","c",{"start":0,"end":1}]` and *then* the error.
+    //
+    // `out` is the caller's buffer, which is why the same pipe written flat
+    // (`path(.a[] | .b | .c[0:1])`) was already correct -- its earlier
+    // positions were pushed straight to `out` and survived the propagation.
+    // Only this local `reached` was lost, so only a *nested* (parenthesised)
+    // stage-1 pipe showed the bug.
+    //
+    // Exactly the shape `eval_generic.rs`'s twin `path_walk_pipe_generic`
+    // already uses, and for the reason its own comment gives: never un-emit
+    // an output already produced.
     let mut reached = Vec::new();
-    walk_path::<S>(first, value, current_path, &mut reached, optional)?;
+    let stepped = walk_path::<S>(first, value, current_path, &mut reached, optional);
     for (path, val) in reached {
+        // A failure *here* is earlier in generator order than `stepped`'s
+        // own, so it wins -- same as the twin.
         walk_pipe::<S>(rest, val, &path, out, optional)?;
     }
-    Ok(())
+    stepped
 }
 
 /// Take one path step: `component` names it, and the value evaluator decides

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -43194,6 +43194,103 @@ fn test_path_emits_nothing_when_the_failing_stage_reached_nothing_2680() -> Resu
     Ok(())
 }
 
+/// #2680, the subtlest consequence: when stage 1 fails *and* a later stage
+/// fails for an earlier position, the later error wins -- it comes first in
+/// jq's generator order. The reported *message* therefore changed, not just
+/// whether a prefix appears: `main` reported stage 1's `"b"` error, jq and
+/// this report `rest`'s `"c"` one.
+///
+/// This is what the inner loop's `?` buys, and nothing pinned it. Captured
+/// live from jq 1.7.1.
+#[test]
+fn test_path_reports_the_earlier_failure_when_both_stages_fail_2680() -> Result<()> {
+    // `.a[0].b` is 5, so stage 1 succeeds there and `.c` fails on it;
+    // `.a[1]` is 7, so stage 1 itself fails there. `rest`'s failure is
+    // earlier, so it is the one reported.
+    let (stdout, stderr, code) = run_jq_full(
+        &["-c", "path((.a[] | .b) | .c[0:1])"],
+        Some(r#"{"a":[{"b":5},7]}"#),
+    )?;
+    assert_ne!(code, 0, "stdout {stdout:?}");
+    assert!(
+        stderr.contains(r#"Cannot index number with string "c""#),
+        "the later stage's error must win, got: {stderr:?}"
+    );
+    assert!(
+        !stderr.contains(r#"Cannot index number with string "b""#),
+        "stage 1's own error must not be the one reported: {stderr:?}"
+    );
+
+    // Stage 1 reaching two positions, the *second* of which fails in `rest`:
+    // the first still emits, then that failure is reported.
+    let (stdout, stderr, code) = run_jq_full(
+        &["-c", "path((.a[] | .b) | .c[0:1])"],
+        Some(r#"{"a":[{"b":{}},{"b":5},7]}"#),
+    )?;
+    assert_ne!(code, 0, "stdout {stdout:?}");
+    assert_eq!(
+        stdout.trim_end(),
+        r#"["a",0,"b","c",{"start":0,"end":1}]"#,
+        "the position reached before either failure must still be emitted"
+    );
+    assert!(
+        stderr.contains(r#"Cannot index number with string "c""#),
+        "{stderr:?}"
+    );
+    Ok(())
+}
+
+/// #2680: the one *write* whose output moved. `setpath` consumes `path()`'s
+/// output, so a path that was previously dropped now reaches it and the
+/// write happens -- which is what jq does, since jq produced that path all
+/// along. Pinned because "a write appears where none did" is the kind of
+/// change that should never be inferred from a diff alone.
+///
+/// The write machinery itself (`del`/`=`/`|=`, via `set_path`/`update_path`/
+/// `delete_at_path`) is untouched by #2680 and its own behaviour is
+/// unchanged; only paths arriving *through* `path()` moved.
+#[test]
+fn test_path_prefix_reaches_setpath_2680() -> Result<()> {
+    let (stdout, stderr, code) = run_jq_full(
+        &["-c", "setpath(path((.a[] | .b) | .c); 9)"],
+        Some(r#"{"a":[{"b":{}},5]}"#),
+    )?;
+    assert_ne!(code, 0, "stdout {stdout:?}");
+    assert_eq!(
+        stdout.trim_end(),
+        r#"{"a":[{"b":{"c":9}},5]}"#,
+        "the recovered path must reach the write, as it does in jq"
+    );
+    assert!(
+        stderr.contains(r#"Cannot index number with string "b""#),
+        "{stderr:?}"
+    );
+    Ok(())
+}
+
+/// #2680's largest user-visible consequence: a truncating consumer now
+/// *succeeds*. `first` takes the recovered prefix and stops before the
+/// element that would have failed, so the program exits 0 with output where
+/// it previously exited 5 with none. jq 1.7.1 exits 0 here too.
+#[test]
+fn test_path_prefix_lets_a_truncating_consumer_succeed_2680() -> Result<()> {
+    for filter in [
+        "first(path((.a[] | .b) | .c[0:1]))",
+        "[limit(1; path((.a[] | .b) | .c[0:1]))]",
+    ] {
+        let (stdout, stderr, code) = run_jq_full(&["-c", filter], Some(r#"{"a":[{"b":{}},5]}"#))?;
+        assert_eq!(
+            code, 0,
+            "{filter}: must now succeed, stdout {stdout:?} stderr {stderr:?}"
+        );
+        assert!(
+            stdout.contains(r#"["a",0,"b","c",{"start":0,"end":1}]"#),
+            "{filter}: {stdout:?}"
+        );
+    }
+    Ok(())
+}
+
 /// #2349 control: the same gate's *array* elements must also validate the
 /// leading-comma/duplicate-comma shape (`[1,,2]`), not just the trailing
 /// stray-comma cases above -- a distinct `#1677` check

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -43110,6 +43110,90 @@ fn test_navigating_builtins_raise_regardless_of_input_type_2646() -> Result<()> 
     Ok(())
 }
 
+/// #2680: `walk_path`'s pipe walker must not un-emit paths a failing stage
+/// already reached. Positions produced *before* the error come earlier in
+/// jq's generator order than the error itself, so they still get walked
+/// through the remaining stages; only then does the error surface.
+///
+/// The parentheses are the whole difference, and the reason this hid: the
+/// same pipe written flat pushes its earlier positions straight to the
+/// caller's output buffer, which survives the error propagation. Only a
+/// *nested* stage-1 pipe buffers them locally, and that local buffer was
+/// being dropped. Both spellings are asserted here so a future change cannot
+/// fix one and lose the other. Captured live from jq 1.7.1.
+///
+/// The `[0:1]` is only there to force the DOM route --
+/// `path_expr_is_cursor_navigable` refuses a `Slice` -- so the walker under
+/// test is `eval.rs`'s `walk_pipe` rather than the cursor path.
+#[test]
+fn test_path_keeps_the_prefix_a_failing_nested_stage_reached_2680() -> Result<()> {
+    let doc = r#"{"a":[{"b":{}},5]}"#;
+
+    for (filter, want) in [
+        // nested (parenthesised) stage 1 -- the bug
+        (
+            "path((.a[] | .b) | .c[0:1])",
+            r#"["a",0,"b","c",{"start":0,"end":1}]"#,
+        ),
+        // a longer nested stage 1, same shape
+        (
+            "path((.a[] | .b | .c) | .d[0:1])",
+            r#"["a",0,"b","c","d",{"start":0,"end":1}]"#,
+        ),
+        // the flat spelling, which was already correct
+        (
+            "path(.a[] | .b | .c[0:1])",
+            r#"["a",0,"b","c",{"start":0,"end":1}]"#,
+        ),
+    ] {
+        let (stdout, stderr, code) = run_jq_full(&["-c", filter], Some(doc))?;
+        assert_ne!(code, 0, "{filter}: expected the error too, got {stdout:?}");
+        assert!(
+            stderr.contains(r#"Cannot index number with string "b""#),
+            "{filter}: {stderr:?}"
+        );
+        assert_eq!(
+            stdout.trim_end(),
+            want,
+            "{filter}: the prefix reached before the error must still be emitted"
+        );
+    }
+    Ok(())
+}
+
+/// #2680 boundary: a stage-1 failure with *nothing* reached before it stays
+/// output-free, and a nested pipe that never fails is unaffected. Without
+/// these, the fix above could have been "always emit something". jq 1.7.1
+/// agrees on every row.
+#[test]
+fn test_path_emits_nothing_when_the_failing_stage_reached_nothing_2680() -> Result<()> {
+    // The failing element comes *first*, so no position precedes the error.
+    let (stdout, stderr, code) =
+        run_jq_full(&["-c", "path((.a[] | .b) | .c[0:1])"], Some(r#"{"a":[5]}"#))?;
+    assert_ne!(code, 0, "stdout {stdout:?}");
+    assert!(
+        stderr.contains(r#"Cannot index number with string "b""#),
+        "{stderr:?}"
+    );
+    assert_eq!(
+        stdout.trim_end(),
+        "",
+        "nothing was reached before the error"
+    );
+
+    // No failure at all: every position is named, exit 0.
+    let (stdout, stderr, code) = run_jq_full(
+        &["-c", "[path((.a[] | .b) | .c[0:1])]"],
+        Some(r#"{"a":[{"b":{}},{"b":{}}]}"#),
+    )?;
+    assert_eq!(code, 0, "stderr {stderr:?}");
+    assert_eq!(
+        stdout.trim_end(),
+        r#"[["a",0,"b","c",{"start":0,"end":1}],["a",1,"b","c",{"start":0,"end":1}]]"#
+    );
+    Ok(())
+}
+
 /// #2349 control: the same gate's *array* elements must also validate the
 /// leading-comma/duplicate-comma shape (`[1,,2]`), not just the trailing
 /// stray-comma cases above -- a distinct `#1677` check


### PR DESCRIPTION
## Summary

`walk_pipe` (`src/jq/eval.rs` — the DOM route `path()` takes for anything not
cursor-navigable) `?`-propagated stage 1's error *before* walking the positions that stage
had already reached, so those positions never made it through the remaining stages:

```console
$ echo '{"a":[{"b":{}},5]}' | jq -c 'path((.a[] | .b) | .c[0:1])'
jq: error (at <stdin>:1): Cannot index number with string "b"
["a",0,"b","c",{"start":0,"end":1}]          # emitted, exit 5

$ echo '{"a":[{"b":{}},5]}' | succinctly jq -c 'path((.a[] | .b) | .c[0:1])'   # before
jq: error (at <stdin>:1): Cannot index number with string "b"
                                             # nothing, exit 5
```

Positions reached before a failure come earlier in jq's generator order than the failure
itself, so the stage's `Result` is now held back, `reached` is walked through `rest`, and
only then does the error surface.

This is verbatim the shape `eval_generic.rs`'s twin `path_walk_pipe_generic` already used
— including its comment giving the reason: *never un-emit an output already produced*. So
`eval.rs`'s walker was the outlier against its own sibling, which is what made the fix
four lines.

## Why the parentheses were the whole difference

`out` is the **caller's** buffer. The flat spelling pushes its earlier positions straight
there, where they survive the error propagation — which is why it was already correct:

```console
$ echo '{"a":[{"b":{}},5]}' | succinctly jq -c 'path(.a[] | .b | .c[0:1])'
jq: error (at <stdin>:1): Cannot index number with string "b"
["a",0,"b","c",{"start":0,"end":1}]          # correct, before this change
```

Only a *nested* stage-1 pipe buffers its positions in a local `reached`, and that local
buffer was what got dropped. Both spellings are now asserted, so a future change cannot
fix one and lose the other.

## Verification

A 70-case sweep — 10 filter shapes (`path`, `[path(...)]`, `del`, `=`, `?`, flat vs
nested, longer nested stage) × 7 documents (failing element first / last / absent, empty
array, object-valued, `null`) — against `/usr/bin/jq` 1.7.1:

- **69 of 70 match.**
- **Two rows changed from `main`, both to jq's answer**; nothing else moved.
- The single remaining difference is **pre-existing**, byte-identical on `main`, and about
  `?`'s scope rather than buffering: `(gen)?` keeps generating after an element raises
  where jq ends the generator. Filed as #2752 with its own repro, including the detail
  that the two tools *agree* when the failing element is last — which is what identifies
  it as the continuation question rather than this one.

The boundary is pinned too, so the fix can't degrade into "always emit something": a
stage-1 failure that reached nothing still emits nothing, and a nested pipe that never
fails is unaffected.

## Test plan

- [x] `cargo test --features cli,simd,regex,serde` — full suite, 62 binaries, 0 failures,
      **no existing test needed changing**
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] 70-case sweep vs jq 1.7.1 (above), plus a diff of every row against a `main` build
      to separate the fix from pre-existing behaviour
- [x] New `test_path_keeps_the_prefix_a_failing_nested_stage_reached_2680` (nested, longer
      nested, and the flat control) and
      `test_path_emits_nothing_when_the_failing_stage_reached_nothing_2680` (both boundary
      directions)

Fixes #2680