### PR TITLE
fix(jq): match jq's flatten depth must not be negative wording and ordering

### DIFF
--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -12770,12 +12770,28 @@ fn builtin_flatten_depth<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
                 // itself -- see `compare_values`'s own doc comment).
                 // Checked *after* the non-negative-int arm above so that
                 // arm still owns the success path unchanged.
+                //
+                // jq mode only: real yq's own grammar rejects every one of
+                // those shapes at *parse* time -- `flatten(null)`,
+                // `flatten(false)`, `flatten(-1)` are all "bad expression,
+                // please check expression syntax" (live-verified against
+                // v4.53.3; yq's `flatten` takes a bare non-negative integer
+                // literal token, nothing else). So there is no reachable yq
+                // behaviour here to match, and yq mode keeps the exact
+                // pre-#2747 wording below instead of acquiring jq's --
+                // review on this PR caught this widening changing yq-mode
+                // text with no yq oracle behind it.
                 ref other
-                    if compare_values(other, &OwnedValue::Int(0)) == core::cmp::Ordering::Less =>
+                    if S::TAG == EvalTag::Jq
+                        && compare_values(other, &OwnedValue::Int(0))
+                            == core::cmp::Ordering::Less =>
                 {
                     return QueryResult::Error(EvalError::new(
                         "flatten depth must not be negative",
                     ));
+                }
+                OwnedValue::Int(_) | OwnedValue::NumberLiteral(NumberRepr::Int(_), _) => {
+                    return QueryResult::Error(EvalError::new("depth must be non-negative"));
                 }
                 _ => return QueryResult::Error(EvalError::type_error("number", "non-number")),
             };

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -12760,8 +12760,22 @@ fn builtin_flatten_depth<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
                 OwnedValue::Int(d) | OwnedValue::NumberLiteral(NumberRepr::Int(d), _) if d >= 0 => {
                     d as usize
                 }
-                OwnedValue::Int(_) | OwnedValue::NumberLiteral(NumberRepr::Int(_), _) => {
-                    return QueryResult::Error(EvalError::new("depth must be non-negative"));
+                // #2747: jq defines this as `if $x < 0 then error(...) else
+                // _flatten($x) end`, where `$x < 0` is jq's own total
+                // ordering (`compare_values`), not a plain integer sign
+                // check -- so `null`/`false`/`true`/a negative float/`nan`
+                // all take this arm too, matching real jq (`null`, `false`
+                // and `true` all rank below every number in that ordering;
+                // `nan` orders as less than every other number, including
+                // itself -- see `compare_values`'s own doc comment).
+                // Checked *after* the non-negative-int arm above so that
+                // arm still owns the success path unchanged.
+                ref other
+                    if compare_values(other, &OwnedValue::Int(0)) == core::cmp::Ordering::Less =>
+                {
+                    return QueryResult::Error(EvalError::new(
+                        "flatten depth must not be negative",
+                    ));
                 }
                 _ => return QueryResult::Error(EvalError::type_error("number", "non-number")),
             };

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -28085,6 +28085,29 @@ fn test_load_yaml_multi_document_raises_on_any_bad_document_1801() -> Result<()>
     Ok(())
 }
 
+/// #2747: jq defines `flatten` as `if $x < 0 then error("flatten depth must
+/// not be negative") else _flatten($x) end`, where `$x < 0` is jq's own
+/// total ordering, not a plain integer sign check -- so `null`/`false`/
+/// `true`/a negative float/`nan` all raise the identical message a negative
+/// integer does, since each ranks (or, for `nan`, orders) below every
+/// number in that ordering. All values below are live jq 1.7.1 captures.
+#[test]
+fn test_flatten_negative_depth_message_matches_jq_across_ordering_2747() -> Result<()> {
+    for depth in ["-1", "-1.5", "null", "false", "true", "nan"] {
+        let filter = format!("flatten({depth})");
+        let (stdout, stderr, code) = run_jq_full(&["-c", &filter], Some("[[1]]"))?;
+        assert_eq!(
+            code, 5,
+            "`{filter}` -- stdout: {stdout:?} stderr: {stderr:?}"
+        );
+        assert!(
+            stderr.contains("flatten depth must not be negative"),
+            "`{filter}` -- stderr: {stderr:?}"
+        );
+    }
+    Ok(())
+}
+
 /// #1164 coverage: a negative `flatten` depth still errors even when the
 /// argument generator that produced it also has a trailing break -- the
 /// error arm wins outright (own-error-supersedes-argument's-escape, same
@@ -28097,7 +28120,10 @@ fn test_flatten_negative_depth_errors_even_with_trailing_break_1164() -> Result<
         Some("[[1]]"),
     )?;
     assert_ne!(code, 0);
-    assert!(err.contains("non-negative"), "err={err}");
+    assert!(
+        err.contains("flatten depth must not be negative"),
+        "err={err}"
+    );
     Ok(())
 }
 

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -39963,6 +39963,43 @@ fn test_reduce_register_reentry_is_jq_mode_only_on_the_write_side_2632() -> Resu
     Ok(())
 }
 
+/// #2747's yq-mode gate. jq's `flatten` widened, in jq mode, to reach the
+/// "flatten depth must not be negative" arm for `null`/`false`/`true`/a
+/// negative float via jq's own total ordering, not just a literal negative
+/// integer -- but real yq's own grammar rejects every one of those shapes
+/// (and even a bare negative integer literal) as `flatten`'s argument at
+/// *parse* time (`Error: bad expression, please check expression syntax`,
+/// live-verified against yq v4.53.3; yq's `flatten` takes a bare
+/// non-negative integer literal token, nothing else). So there is no
+/// reachable yq behaviour for the widening to match, and yq mode must keep
+/// its exact pre-#2747 wording -- caught by review on this PR, which found
+/// the first pass changed yq-mode text to jq's with no yq oracle behind it.
+#[test]
+fn test_flatten_negative_depth_widening_is_jq_mode_only_2747() -> Result<()> {
+    // Unaffected: same wording succinctly yq raised before #2747.
+    let (_stdout, stderr, code) = run_yq_stdin_with_stderr("[[1]] | flatten(-1)", "null\n", &[])?;
+    assert_eq!(code, 1, "stderr: {stderr:?}");
+    assert!(
+        stderr.contains("depth must be non-negative"),
+        "stderr: {stderr:?}"
+    );
+    assert!(
+        !stderr.contains("flatten depth must not be negative"),
+        "stderr: {stderr:?}"
+    );
+
+    for filter in ["[[1]] | flatten(null)", "[[1]] | flatten(false)"] {
+        let (_stdout, stderr, code) = run_yq_stdin_with_stderr(filter, "null\n", &[])?;
+        assert_eq!(code, 1, "`{filter}` -- stderr: {stderr:?}");
+        assert!(
+            stderr.contains("expected number, got non-number"),
+            "`{filter}` -- stderr: {stderr:?}"
+        );
+    }
+
+    Ok(())
+}
+
 /// #2692, yq twin of `test_truthiness_probes_validate_nothing_2692` in
 /// `tests/jq_cli_tests.rs`: the same corpus through the YAML cursor (and, for
 /// the JSON-syntax rows, through yq's own reading of them -- most of the JSON


### PR DESCRIPTION
## Summary

`flatten`'s negative-depth guard raised `depth must be non-negative` instead of real
jq's own wording (`flatten depth must not be negative`), and only caught a literal
negative `Int`/`NumberLiteral` — jq actually defines this as

```jq
def flatten($x): if $x < 0 then error("flatten depth must not be negative") else _flatten($x) end;
```

where `$x < 0` is jq's own total ordering (`null < false < true < number < string <
array < object`, with `nan` ordering below every number including itself) — not a plain
integer sign check. So `null`, `false`, `true`, a negative float, and `nan` all take this
same error arm in real jq, which the old code misclassified as a generic type error
instead.

```console
$ echo '{}' | jq -c '[1] | flatten(-1)'
jq: error (at <stdin>:1): flatten depth must not be negative
$ echo '{}' | jq -c '[1] | flatten(null)'
jq: error (at <stdin>:1): flatten depth must not be negative
$ echo '{}' | succinctly jq -c '[1] | flatten(-1)'   # before
jq: error (at <stdin>:1): depth must be non-negative
$ echo '{}' | succinctly jq -c '[1] | flatten(null)' # before
jq: error (at <stdin>:1): expected number, got non-number
```

Fixed by reusing the existing `compare_values` jq-ordering comparator (already shared by
`<`/`>`/`sort`/etc.) instead of hand-rolling a type match, so every case above lands on
the identical error real jq raises.

Filed #2755 for a separate, deeper divergence this investigation surfaced: a *positive*
non-integer or non-numeric depth (`2.0`, `"a"`, etc.) is still misclassified, since
`builtin_flatten` converts the depth to a `usize` up front rather than threading jq's own
lazy `$x != 0` / `$x - 1` recursion model — a materially larger change than this PR's
narrowly-scoped message/ordering fix.

Fixes #2747

## Test plan

- [x] `cargo build --features cli`
- [x] `cargo test --features cli,simd,regex,serde` (full suite, 0 failures)
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings`
- [x] Updated `test_flatten_negative_depth_errors_even_with_trailing_break_1164`'s stale
      message assertion
- [x] New `test_flatten_negative_depth_message_matches_jq_across_ordering_2747` covering
      `-1`, `-1.5`, `null`, `false`, `true`, `nan` — each cross-checked live against
      `/usr/bin/jq` 1.7.1
- [x] `cargo llvm-cov` / `omni-dev coverage diff`: patch coverage 100% (5/5 new lines)
