### PR TITLE
fix(jq): put and/or's collecting entry points on the lazy operand strategy

### DIFF
--- a/docs/compliance/jq/limitations.md
+++ b/docs/compliance/jq/limitations.md
@@ -3098,9 +3098,11 @@ to the wrapping consumer and evaluates the right side only when the left forward
 to exhaustion. `and`/`or` gained `each_boolean`, over a new **shared** demand-driven
 `boolean_fanout_each` — the `and`/`or` twin of what #1459/#1481 did to `binary_fanout_core` for
 `Compare`/`Arithmetic`: one loop, parameterised over how an operand's truthiness bits are
-enumerated, with the pre-existing eager callers (`eval_boolean`, `eval_generic.rs`'s
-`eval_boolean_generic`) passing the collecting strategy and the new arms passing
-`eval_each`/`eval_each_generic`. `eval_each_generic` gained its own
+enumerated. WP2a left the pre-existing callers (`eval_boolean`, `eval_generic.rs`'s
+`eval_boolean_generic`) on an eager strategy while the new arms passed
+`eval_each`/`eval_each_generic`; #2669 moved those two onto the lazy strategy as well and removed
+the eager one, so the parameter now selects only *what is done with the bits* (collect into a
+`Vec<bool>` vs forward to a sink), never how the operands are enumerated. `eval_each_generic` gained its own
 `Expr::Alternative`/`Expr::And`/`Expr::Or` arms too, since `first(...)` never reaches `eval.rs`'s.
 Every row confirmed live against jq 1.7.1 under both wrappers, input `1`:
 
@@ -3129,21 +3131,25 @@ are pinned in `test_short_circuit_side_effect_shapes_already_match_jq_820`.
 **The loop shape was captured, not assumed.** jq 1.7.1, `-cn`:
 `[("A"|debug, "B"|debug) and ("C"|debug, "D"|debug)]` writes `A A C C D B C C D` to stderr — the
 **left** operand is the outer loop and the right one is re-evaluated per non-short-circuiting left
-output, interleaved. succinctly's eager route wrote `A A B C C D C C D` (left finished first) and
-still does for a bare top-level `and`/`or`; only the lazy arms move to jq's order, exactly as
-`Expr::Compare` did between #1459 and #1481. `[(false,true) and ("C"|debug)]` writes `C` once, not
-twice, which is the short-circuit rule.
+output, interleaved. succinctly's eager route wrote `A A B C C D C C D` (left finished first),
+exactly as `Expr::Compare` did between #1459 and #1481. `[(false,true) and ("C"|debug)]` writes `C`
+once, not twice, which is the short-circuit rule.
 
-That leaves one **new, narrower residual**, the `and`/`or` half of what #1481 did for
-`eval_binary_fanout`: `eval_boolean` still passes the eager operand strategy, so a *bare*
-top-level `[("A"|stderr,"B"|stderr) and ("C"|stderr,"D"|stderr)]` writes `AABCCDCCD` where jq
-writes `AACCDBCCD`. The delivered values are identical for side-effect-free operands, and the same
-expression reached through a lazy consumer (`first(...)`) or as a binary operand (`0 + (...)`)
-already matches jq exactly. All three rows are pinned in
-`test_short_circuit_side_effect_leaks_820_932_987` and
-`test_short_circuit_side_effect_shapes_already_match_jq_820`; closing it means routing
-`eval_boolean` (and `eval_boolean_generic`) through the lazy strategy the shared loop already
-accepts, which is a separate change from WP2a's own rows.
+**That residual is closed by #2669 — `and`/`or` now match jq on every route.** WP2a's own
+`eval_each` arms took the lazy operand strategy while the *collecting* entry points
+(`eval_boolean`, `eval_generic.rs`'s `eval_boolean_generic`) kept the eager one, so
+`[("A"|stderr,"B"|stderr) and ("C"|stderr,"D"|stderr)]` wrote `AABCCDCCD` where jq writes
+`AACCDBCCD` — while the *same operands* reached through a lazy consumer (`first(...)`,
+`limit(...)`), as a binary operand (`0 + (...)`), or simply unwrapped at the top level already
+matched, since those routes take the lazy arm. #2669 put both collecting entry points on the same
+lazy strategy, which is the `eval_boolean` half of what #1481 did for `eval_binary_fanout`, and
+deleted the eager strategy outright so there is no second one left to drift. The rows moved from
+`test_short_circuit_side_effect_leaks_820_932_987` to
+`test_short_circuit_side_effect_shapes_already_match_jq_820`.
+
+The delivered values never differed here — it was stderr ordering only, for side-effect-free
+operands. With `input`/`inputs` operands the same ordering decides which value each operand
+consumes, which is #1481's own argument for closing it rather than documenting it.
 
 **`if`'s condition, `as`/`as`-pattern's bound source, `select`, unary minus, an index key, string
 interpolation, an object value and `range`'s bound no longer diverge either — #2180 WP2b closed that

--- a/docs/compliance/jq/limitations.md
+++ b/docs/compliance/jq/limitations.md
@@ -2450,6 +2450,30 @@ through `key_elements_generic`, the one caller left, and still trip it on the sa
 Pinned by `test_truthiness_probes_do_not_trip_the_depth_guard_2692`
 (`tests/jq_cli_tests.rs`).
 
+**#2669 applied that same rule to the one `and`/`or` route that had kept the old
+behaviour.** #2692 removed the validation walk, and the lazy arms took that immediately —
+but the *collecting* entry points (`eval_boolean`, `eval_boolean_generic`) still passed the
+eager operand strategy, whose `push_generic_truthiness` ran
+`push_generic_document_validation_error` per item. So on a malformed document the same
+expression answered differently depending only on which consumer wrapped it, measured on
+`main` before #2669:
+
+| filter (input `{"a":1,}`)     | before #2669 | after   |
+|-------------------------------|--------------|---------|
+| `(.,.) and true` (bare)       | `true`       | `true`  |
+| `first((.,.) and true)`       | `true`       | `true`  |
+| `[limit(2; (.,.) and true)]`  | `[true,true]`| `[true,true]` |
+| `[(.,.) and true]`            | **exit 5**   | `[true,true]` |
+
+Three of the four already accepted, so #2669's switch to the lazy strategy moved the fourth
+to join them rather than the reverse — the direction #2692 chose. Real jq rejects all four
+(it cannot parse the document at all), so this is the existing #2692 divergence applied
+consistently, not a new one. Whether a truthiness-only read should validate at all remains
+open as [#2701](https://github.com/rust-works/succinctly/issues/2701); #2669 does not
+settle that, it only removes the route-dependence. A route that genuinely reads a member
+(`.a and true`) still raises. Pinned by
+`test_boolean_routes_agree_on_a_malformed_document_2669`.
+
 ## Regex flags `l` and `n`
 
 [ADR-0019](../../adrs/adr-0019.md) accepted two regex-flag gaps as permanent — rule 4(d)

--- a/docs/compliance/jq/limitations.md
+++ b/docs/compliance/jq/limitations.md
@@ -2460,7 +2460,7 @@ expression answered differently depending only on which consumer wrapped it, mea
 
 | filter (input `{"a":1,}`)     | before #2669 | after   |
 |-------------------------------|--------------|---------|
-| `(.,.) and true` (bare)       | `true`       | `true`  |
+| `(.,.) and true` (bare)       | `true` `true` | `true` `true` |
 | `first((.,.) and true)`       | `true`       | `true`  |
 | `[limit(2; (.,.) and true)]`  | `[true,true]`| `[true,true]` |
 | `[(.,.) and true]`            | **exit 5**   | `[true,true]` |

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -8102,19 +8102,13 @@ fn eval_negate<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
 /// pairing has failed. `eval_operand` closes over whichever evaluator
 /// (plain vs. path-context) its caller wants.
 fn boolean_fanout_core<'a, W: Clone + AsRef<[u64]>>(
-    eval_operand: impl Fn(&Expr) -> QueryResult<'a, W>,
+    each_operand: impl Fn(&Expr, &mut dyn FnMut(bool) -> Demand) -> Flow,
     left: &Expr,
     right: &Expr,
     short_circuit: bool,
     rules: BinaryFanoutRules,
 ) -> QueryResult<'a, W> {
-    let (out, control) = boolean_fanout_bools(
-        |expr, bools| push_truthiness(eval_operand(expr), bools),
-        left,
-        right,
-        short_circuit,
-        rules,
-    );
+    let (out, control) = boolean_fanout_bools(each_operand, left, right, short_circuit, rules);
     match control {
         Some(control) => partial(out.into_iter().map(OwnedValue::Bool).collect(), control),
         None => bools_to_result(out),
@@ -8126,6 +8120,20 @@ fn boolean_fanout_core<'a, W: Clone + AsRef<[u64]>>(
 /// operand strategy pushes bits and this returns bits, leaving each caller
 /// to build its own result from them.
 ///
+/// Takes the **lazy** operand strategy, the same one [`each_boolean`] and
+/// `eval_generic::each_boolean_generic` pass (#2669). It used to build an
+/// eager one internally -- evaluate the whole operand into a `Vec<bool>`,
+/// then replay -- which cannot show jq's interleaving, because it has
+/// finished the left operand before the first pairing. That made a
+/// *collecting* consumer disagree with a truncating one on the same
+/// expression: captured live on jq 1.7.1,
+/// `[("A"|stderr,"B"|stderr) and ("C"|stderr,"D"|stderr)]` writes `AACCDBCCD`,
+/// where this route wrote `AABCCDCCD` while `first(..)`/`limit(..)` around
+/// the identical operands already matched. With both callers on the lazy
+/// strategy there is no second strategy left to drift -- the same conclusion
+/// #1481 reached for `Compare`/`Arithmetic`, whose eager entry point had the
+/// matching gap between #1459 and #1481.
+///
 /// The generic evaluator's `and`/`or` arm (`eval_generic::eval_boolean_generic`,
 /// spine 2416 gate reason 3) is the second caller. It threads a cursor into
 /// both operands, which `QueryResult` cannot carry, so sharing the *body*
@@ -8135,7 +8143,7 @@ fn boolean_fanout_core<'a, W: Clone + AsRef<[u64]>>(
 /// [`binary_fanout_core`] and `eval_generic::binary_fanout_each_generic`
 /// already follow for arithmetic and comparison.
 pub(crate) fn boolean_fanout_bools(
-    push_operand: impl Fn(&Expr, &mut Vec<bool>) -> Option<Control>,
+    each_operand: impl Fn(&Expr, &mut dyn FnMut(bool) -> Demand) -> Flow,
     left: &Expr,
     right: &Expr,
     short_circuit: bool,
@@ -8143,25 +8151,7 @@ pub(crate) fn boolean_fanout_bools(
 ) -> (Vec<bool>, Option<Control>) {
     let mut out: Vec<bool> = Vec::new();
     let flow = boolean_fanout_each(
-        // The eager operand strategy: evaluate the whole operand, then
-        // replay its bits through the demand-driven loop. The replay is
-        // what re-enters this same strategy for the *other* operand, so
-        // `push_operand` has to be `Fn` rather than `FnMut` -- exactly the
-        // re-entrancy note [`binary_fanout_each`]'s own `each_operand`
-        // carries. Both existing callers already supply an `Fn`.
-        |expr, bit_sink| {
-            let mut bools = Vec::new();
-            let control = push_operand(expr, &mut bools);
-            for bit in bools {
-                if bit_sink(bit) == Demand::Stop {
-                    return Flow::Stopped { pending: None };
-                }
-            }
-            match control {
-                Some(control) => Flow::Escaped(control),
-                None => Flow::Exhausted,
-            }
-        },
+        each_operand,
         left,
         right,
         short_circuit,
@@ -9427,8 +9417,17 @@ fn eval_boolean<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     optional: bool,
     short_circuit: bool,
 ) -> QueryResult<'a, W> {
+    // #2669: `eval_each`, not `eval_single` -- the operand strategy is what
+    // decides whether the loop can interleave, and this collecting entry
+    // point kept the eager one long after `each_boolean` had the lazy one.
+    // Identical closure to `each_boolean`'s; the two differ only in what
+    // they do with the bits.
     boolean_fanout_core(
-        move |expr| eval_single::<W, S>(expr, value.clone(), optional),
+        move |operand, bit_sink| {
+            eval_each::<W, S>(operand, value.clone(), optional, &mut |item| {
+                bit_sink(item.is_truthy())
+            })
+        },
         left,
         right,
         short_circuit,

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -6638,22 +6638,6 @@ fn each_alternative<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     }
 }
 
-/// Demand-forwarding twin of [`eval_boolean`] (#2180 WP2a) -- `and`/`or`
-/// with each pairing's boolean pushed to `sink` as it is decided.
-///
-/// The loop is [`boolean_fanout_each`]'s, shared with the eager route; this
-/// only supplies [`eval_each`] as the operand strategy (so the left
-/// operand's outputs and the right operand's per-output re-evaluations both
-/// stop when the consumer does) and adapts the `bool` the loop speaks to the
-/// `Item` the consumer expects. See [`boolean_fanout_each`] for the oracle
-/// rows that pinned the loop shape and the short-circuit rule, and
-/// [`eval_each`]'s own `Expr::And`/`Expr::Or` arms for the `?//` rows this
-/// closes.
-///
-/// `optional` is forwarded to the operands, matching [`eval_boolean`]'s own
-/// `eval_single` strategy rather than `eval_each_generic`'s hardcoded
-/// `false` for a comparison operand -- this arm shadows `eval_boolean`, so
-/// it has to make the same choice `eval_boolean` does.
 /// The one `and`/`or` operand strategy for this evaluator (#2669): drive
 /// `operand` through [`eval_each`] and hand each output's truthiness bit to
 /// `bit_sink`.
@@ -6675,6 +6659,22 @@ fn boolean_operand_bits<W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     })
 }
 
+/// Demand-forwarding twin of [`eval_boolean`] (#2180 WP2a) -- `and`/`or`
+/// with each pairing's boolean pushed to `sink` as it is decided.
+///
+/// The loop is [`boolean_fanout_each`]'s, and since #2669 the operand
+/// strategy is [`boolean_operand_bits`]'s, both shared with the collecting
+/// route; this only adapts the `bool` the loop speaks to the `Item` the
+/// consumer expects, and lets the consumer's [`Demand::Stop`] reach inside
+/// an operand (so the left operand's outputs and the right operand's
+/// per-output re-evaluations both stop when the consumer does). See
+/// [`boolean_fanout_each`] for the oracle rows that pinned the loop shape
+/// and the short-circuit rule, and [`eval_each`]'s own `Expr::And`/`Expr::Or`
+/// arms for the `?//` rows this closes.
+///
+/// `optional` is forwarded to the operands, the same choice [`eval_boolean`]
+/// makes (both go through [`boolean_operand_bits`]) rather than
+/// `eval_each_generic`'s hardcoded `false` for a comparison operand.
 fn each_boolean<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     left: &Expr,
     right: &Expr,
@@ -8118,8 +8118,8 @@ fn eval_negate<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
 /// has run its course. A control from evaluating the right operand for a
 /// given left output instead ends the whole expression immediately,
 /// matching jq's generator not asking for further left outputs once one
-/// pairing has failed. `eval_operand` closes over whichever evaluator
-/// (plain vs. path-context) its caller wants.
+/// pairing has failed. `each_operand` is the lazy operand strategy (#2669),
+/// closing over whichever evaluator its caller wants.
 fn boolean_fanout_core<'a, W: Clone + AsRef<[u64]>>(
     each_operand: impl Fn(&Expr, &mut dyn FnMut(bool) -> Demand) -> Flow,
     left: &Expr,
@@ -8201,15 +8201,21 @@ pub(crate) fn boolean_fanout_bools(
 /// copy of *this* loop for the lazy arms would have been a second chance at
 /// the same drift.
 ///
-/// The strategy differs by caller, never the loop:
+/// What differs by caller is only what is done with the bits, never the
+/// loop -- and, since #2669, never the strategy either:
 ///
-/// * [`boolean_fanout_bools`] passes the eager one (evaluate the whole
-///   operand into a `Vec<bool>`, then replay), which is what the two
-///   collecting callers -- [`eval_boolean`] and
-///   `eval_generic::eval_boolean_generic` -- had before WP2a and still have.
-/// * [`each_boolean`] and `eval_generic::each_boolean_generic` pass
-///   [`eval_each`]/`eval_each_generic`, so a wrapping consumer's
-///   [`Demand::Stop`] reaches *inside* an operand -- and, with it, a `?//`
+/// * [`boolean_fanout_bools`] collects them into a `Vec<bool>` for the two
+///   collecting callers, [`eval_boolean`] and
+///   `eval_generic::eval_boolean_generic`. Between WP2a and #2669 it built
+///   an eager strategy for them (evaluate the whole operand, then replay),
+///   which is why those two routes could not interleave.
+/// * [`each_boolean`] and `eval_generic::each_boolean_generic` forward them
+///   to a sink.
+///
+/// Every caller passes the lazy strategy ([`boolean_operand_bits`] /
+/// `boolean_operand_bits_generic`, over [`eval_each`]/`eval_each_generic`),
+/// so a wrapping consumer's [`Demand::Stop`] reaches *inside* an operand
+/// on every route -- and, with it, a `?//`
 ///   bind in there ([#1519](https://github.com/rust-works/succinctly/issues/1519)'s
 ///   retry-on-stop rule). Captured live against jq 1.7.1, input `1`:
 ///   `[first((1 as $x ?// $y | 1) and true)]` is `[true,true]`, and so are
@@ -8234,9 +8240,10 @@ pub(crate) fn boolean_fanout_bools(
 /// contributes that boolean *without evaluating the right operand at all*
 /// (which is what makes `false and error("x")` answer `false`); every other
 /// left output re-evaluates the whole right operand and contributes one
-/// boolean per right output. The eager strategy cannot show the
+/// boolean per right output. An eager strategy cannot show the
 /// interleaving -- it has already finished the left operand before the first
-/// pairing -- so only the lazy arms move to jq's own order here.
+/// pairing -- which is why the collecting routes kept the pre-WP2a order
+/// until #2669 put them on the lazy strategy too.
 ///
 /// Controls follow [`boolean_fanout_bools`]'s pre-WP2a rules unchanged
 /// (#400/#494): a *left* escape fires only after the ordinary per-output
@@ -53423,11 +53430,13 @@ mod tests {
         );
     }
 
-    /// #2180: `push_truthiness`' borrowed-`Many` arm. `and`/`or` collect
-    /// their operands' truthiness through it, and a document iteration
-    /// (`.[]`) is the shape that hands it borrowed values rather than owned
-    /// ones -- the arm this PR's rewiring of the boolean operators left
-    /// without a caller among the existing tests.
+    /// #2180: a document iteration (`.[]`) as an `and`/`or` operand -- the
+    /// shape that hands the operand strategy borrowed values rather than
+    /// owned ones. Written for `push_truthiness`' borrowed-`Many` arm, which
+    /// `and`/`or` collected through until #2669 moved them onto
+    /// `boolean_operand_bits` (`eval_each` per item); that arm is now reached
+    /// only through `eval_if`. The behaviour this pins is unchanged either
+    /// way, so the test stays with its original name.
     #[test]
     fn test_boolean_operand_borrowed_many_truthiness_2180() {
         query!(

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -6654,6 +6654,27 @@ fn each_alternative<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
 /// `eval_single` strategy rather than `eval_each_generic`'s hardcoded
 /// `false` for a comparison operand -- this arm shadows `eval_boolean`, so
 /// it has to make the same choice `eval_boolean` does.
+/// The one `and`/`or` operand strategy for this evaluator (#2669): drive
+/// `operand` through [`eval_each`] and hand each output's truthiness bit to
+/// `bit_sink`.
+///
+/// Shared by [`eval_boolean`] (collects the bits) and [`each_boolean`]
+/// (forwards them), which differ only in what they do with the bits, never in
+/// how the operands are enumerated -- the collecting route used to enumerate
+/// them eagerly and so could not interleave. One definition rather than the
+/// same closure twice (the #106 rule); `eval_generic.rs` carries the mirror
+/// `boolean_operand_bits_generic`.
+fn boolean_operand_bits<W: Clone + AsRef<[u64]>, S: EvalSemantics>(
+    operand: &Expr,
+    value: StandardJson<'_, W>,
+    optional: bool,
+    bit_sink: &mut dyn FnMut(bool) -> Demand,
+) -> Flow {
+    eval_each::<W, S>(operand, value, optional, &mut |item| {
+        bit_sink(item.is_truthy())
+    })
+}
+
 fn each_boolean<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     left: &Expr,
     right: &Expr,
@@ -6664,9 +6685,7 @@ fn each_boolean<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
 ) -> Flow {
     boolean_fanout_each(
         |operand, bit_sink| {
-            eval_each::<W, S>(operand, value.clone(), optional, &mut |item| {
-                bit_sink(item.is_truthy())
-            })
+            boolean_operand_bits::<W, S>(operand, value.clone(), optional, bit_sink)
         },
         left,
         right,
@@ -9424,9 +9443,7 @@ fn eval_boolean<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     // they do with the bits.
     boolean_fanout_core(
         move |operand, bit_sink| {
-            eval_each::<W, S>(operand, value.clone(), optional, &mut |item| {
-                bit_sink(item.is_truthy())
-            })
+            boolean_operand_bits::<W, S>(operand, value.clone(), optional, bit_sink)
         },
         left,
         right,

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -10948,12 +10948,14 @@ fn eval_compare_generic<S: EvalSemantics, V: DocumentValue>(
 /// `and`/`or` with the cursor threaded into both operands (spine 2416 gate
 /// reason 3, #2473) -- the boolean twin of [`eval_compare_generic`] above.
 ///
-/// The loop itself is `eval::boolean_fanout_bools`, shared with the eager
-/// route rather than copied, so #2460's zero-output-operand rule and #2470's
-/// read-only operand scope have one definition across both. What this adds is
-/// the operand strategy: `eval_single` *with* `cursor`, so `.[] | key == "a"
-/// and true` reads each element's own key instead of being handed a `null`
-/// by the eager bridge.
+/// The loop itself is `eval::boolean_fanout_bools`, shared with `eval.rs`'s
+/// own collecting route rather than copied, so #2460's zero-output-operand
+/// rule and #2470's read-only operand scope have one definition across both.
+/// What this adds is the cursor: the operand strategy is
+/// [`boolean_operand_bits_generic`] -- `eval_each_generic` *with* `cursor`
+/// since #2669, `eval_single` with it before -- so `.[] | key == "a" and
+/// true` reads each element's own key instead of being handed a `null` by
+/// the eager bridge.
 ///
 /// `short_circuit` is the truth value that ends the pairing -- `false` for
 /// `and`, `true` for `or` -- exactly as `eval::eval_and`/`eval::eval_or`
@@ -10979,14 +10981,15 @@ fn eval_boolean_generic<S: EvalSemantics, V: DocumentValue>(
     // nothing -- and stopped at "reads `.`"; #2692 takes the other half,
     // because `. and true` reads `.`'s *truthiness*, which is `is_falsy` and
     // decodes nothing either. Each operand still validates whatever it
-    // materializes, via `eval_single` below.
-    // #2669: `eval_each_generic`, not `eval_single` -- the operand strategy
-    // is what decides whether the loop can interleave, and this collecting
-    // entry point kept the eager one long after `each_boolean_generic` had
-    // the lazy one, so `[(..) and (..)]` ordered its operands differently
-    // from `first((..) and (..))` on the identical expression. Identical
-    // closure to `each_boolean_generic`'s; the two differ only in what they
-    // do with the bits.
+    // materializes, inside `boolean_operand_bits_generic`'s drive.
+    //
+    // #2669: that drive is `eval_each_generic`, not `eval_single`. The
+    // operand strategy is what decides whether the loop can interleave, and
+    // this collecting entry point kept an eager one long after
+    // `each_boolean_generic` had the lazy one, so `[(..) and (..)]` ordered
+    // its operands differently from `first((..) and (..))` on the identical
+    // expression. Same strategy as `each_boolean_generic` now, by
+    // construction; the two differ only in what they do with the bits.
     let (bools, control) = boolean_fanout_bools(
         |operand, bit_sink| {
             boolean_operand_bits_generic::<S, V>(operand, value.clone(), optional, cursor, bit_sink)
@@ -11141,29 +11144,6 @@ fn each_alternative_generic<S: EvalSemantics, V: DocumentValue>(
     }
 }
 
-/// Demand-forwarding twin of [`eval_boolean_generic`] (#2180 WP2a), for the
-/// streaming `and`/`or` route.
-///
-/// Originally introduced only for an `and`/`or` whose operands read path
-/// context, gated to match `eval_single`'s own then-gated pair; the
-/// `eval_each_generic` dispatch is ungated since #2692, so this is now the
-/// implementation for every streaming `and`/`or`, path-context operand or
-/// not (see the dispatch's own comment for why the gate had nothing left to
-/// preserve).
-///
-/// The loop is `eval::boolean_fanout_each`, shared with every other route
-/// (see its own doc comment for the oracle rows that pinned the left-outer
-/// nesting and the short-circuit rule); this supplies
-/// [`eval_each_generic`] *plus the cursor* as the operand strategy, so
-/// `key`/`parent`/`path` inside an operand still resolve against the node
-/// this stage stands on while a wrapping consumer's [`Demand::Stop`] reaches
-/// through to a generator -- or a `?//` bind (#1519) -- inside it.
-///
-/// The escape channel is per-strategy-call, not shared: a truthiness probe
-/// that fails (`generic_item_truthiness`'s `Err`) can only answer `Demand`
-/// to the loop, so the control it carries is recorded beside the drive and
-/// folded in as this operand's own `Flow::Escaped` -- the same out-of-band
-/// shape `fanout_arg_each`/`each_any_all_gen_cond` use in `eval.rs`.
 /// The one `and`/`or` operand strategy for this evaluator (#2669): drive
 /// `operand` through [`eval_each_generic`] and hand each output's truthiness
 /// bit to `bit_sink`.
@@ -11174,10 +11154,16 @@ fn each_alternative_generic<S: EvalSemantics, V: DocumentValue>(
 /// operands are enumerated, which is the whole point of #2669: the collecting
 /// route used to enumerate them eagerly and so could not interleave.
 ///
+/// The escape channel is per-strategy-call, not shared: a truthiness probe
+/// that fails (`generic_item_truthiness`'s `Err`) can only answer `Demand`
+/// to the loop, so the control it carries is recorded beside the drive and
+/// folded in as this operand's own `Flow::Escaped` -- the same out-of-band
+/// shape `fanout_arg_each`/`each_any_all_gen_cond` use in `eval.rs`.
+///
 /// One definition rather than the same closure written twice (the #106 rule).
-/// The first cut of #2669 did copy it, which would have left the
-/// `Err(control)` arm duplicated -- and that arm is reached by neither copy in
-/// the suite today, so a second one is a second thing to keep honest for no
+/// The first cut of #2669 did copy it, which would have left that
+/// `Err(control)` arm duplicated -- and it is reached by neither route in
+/// the suite today, so a second copy is a second thing to keep honest for no
 /// gain.
 fn boolean_operand_bits_generic<S: EvalSemantics, V: DocumentValue>(
     operand: &Expr,
@@ -11196,6 +11182,26 @@ fn boolean_operand_bits_generic<S: EvalSemantics, V: DocumentValue>(
     resume_from_escape(escape, flow)
 }
 
+/// Demand-forwarding twin of [`eval_boolean_generic`] (#2180 WP2a), for the
+/// streaming `and`/`or` route.
+///
+/// Originally introduced only for an `and`/`or` whose operands read path
+/// context, gated to match `eval_single`'s own then-gated pair; the
+/// `eval_each_generic` dispatch is ungated since #2692, so this is now the
+/// implementation for every streaming `and`/`or`, path-context operand or
+/// not (see the dispatch's own comment for why the gate had nothing left to
+/// preserve).
+///
+/// The loop is `eval::boolean_fanout_each`, and since #2669 the operand
+/// strategy is [`boolean_operand_bits_generic`]'s, both shared with the
+/// collecting route ([`eval_boolean_generic`]); this only forwards each
+/// pairing's boolean to `sink`. The strategy drives [`eval_each_generic`]
+/// *with the cursor*, so `key`/`parent`/`path` inside an operand still
+/// resolve against the node this stage stands on while a wrapping consumer's
+/// [`Demand::Stop`] reaches through to a generator -- or a `?//` bind
+/// (#1519) -- inside it. See the loop's own doc comment for the oracle rows
+/// that pinned the left-outer nesting and the short-circuit rule, and the
+/// strategy's for how a failed truthiness probe's control is carried out.
 fn each_boolean_generic<S: EvalSemantics, V: DocumentValue>(
     left: &Expr,
     right: &Expr,

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -10989,15 +10989,7 @@ fn eval_boolean_generic<S: EvalSemantics, V: DocumentValue>(
     // do with the bits.
     let (bools, control) = boolean_fanout_bools(
         |operand, bit_sink| {
-            let mut escape: Option<Control> = None;
-            let flow =
-                eval_each_generic::<S, V>(operand, value.clone(), optional, cursor, &mut |item| {
-                    match generic_item_truthiness(item) {
-                        Ok(bit) => bit_sink(bit),
-                        Err(control) => stop_with_escape(&mut escape, control),
-                    }
-                });
-            resume_from_escape(escape, flow)
+            boolean_operand_bits_generic::<S, V>(operand, value.clone(), optional, cursor, bit_sink)
         },
         left,
         right,
@@ -11172,6 +11164,38 @@ fn each_alternative_generic<S: EvalSemantics, V: DocumentValue>(
 /// to the loop, so the control it carries is recorded beside the drive and
 /// folded in as this operand's own `Flow::Escaped` -- the same out-of-band
 /// shape `fanout_arg_each`/`each_any_all_gen_cond` use in `eval.rs`.
+/// The one `and`/`or` operand strategy for this evaluator (#2669): drive
+/// `operand` through [`eval_each_generic`] and hand each output's truthiness
+/// bit to `bit_sink`.
+///
+/// Both callers use this -- [`eval_boolean_generic`], which collects the bits
+/// into a `Vec<bool>`, and [`each_boolean_generic`], which forwards them to a
+/// sink. They differ only in what they do with the bits, never in how the
+/// operands are enumerated, which is the whole point of #2669: the collecting
+/// route used to enumerate them eagerly and so could not interleave.
+///
+/// One definition rather than the same closure written twice (the #106 rule).
+/// The first cut of #2669 did copy it, which would have left the
+/// `Err(control)` arm duplicated -- and that arm is reached by neither copy in
+/// the suite today, so a second one is a second thing to keep honest for no
+/// gain.
+fn boolean_operand_bits_generic<S: EvalSemantics, V: DocumentValue>(
+    operand: &Expr,
+    value: V,
+    optional: bool,
+    cursor: Option<V::Cursor>,
+    bit_sink: &mut dyn FnMut(bool) -> Demand,
+) -> Flow {
+    let mut escape: Option<Control> = None;
+    let flow = eval_each_generic::<S, V>(operand, value, optional, cursor, &mut |item| {
+        match generic_item_truthiness(item) {
+            Ok(bit) => bit_sink(bit),
+            Err(control) => stop_with_escape(&mut escape, control),
+        }
+    });
+    resume_from_escape(escape, flow)
+}
+
 fn each_boolean_generic<S: EvalSemantics, V: DocumentValue>(
     left: &Expr,
     right: &Expr,
@@ -11183,15 +11207,7 @@ fn each_boolean_generic<S: EvalSemantics, V: DocumentValue>(
 ) -> Flow {
     boolean_fanout_each(
         |operand, bit_sink| {
-            let mut escape: Option<Control> = None;
-            let flow =
-                eval_each_generic::<S, V>(operand, value.clone(), optional, cursor, &mut |item| {
-                    match generic_item_truthiness(item) {
-                        Ok(bit) => bit_sink(bit),
-                        Err(control) => stop_with_escape(&mut escape, control),
-                    }
-                });
-            resume_from_escape(escape, flow)
+            boolean_operand_bits_generic::<S, V>(operand, value.clone(), optional, cursor, bit_sink)
         },
         left,
         right,

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -10980,12 +10980,24 @@ fn eval_boolean_generic<S: EvalSemantics, V: DocumentValue>(
     // because `. and true` reads `.`'s *truthiness*, which is `is_falsy` and
     // decodes nothing either. Each operand still validates whatever it
     // materializes, via `eval_single` below.
+    // #2669: `eval_each_generic`, not `eval_single` -- the operand strategy
+    // is what decides whether the loop can interleave, and this collecting
+    // entry point kept the eager one long after `each_boolean_generic` had
+    // the lazy one, so `[(..) and (..)]` ordered its operands differently
+    // from `first((..) and (..))` on the identical expression. Identical
+    // closure to `each_boolean_generic`'s; the two differ only in what they
+    // do with the bits.
     let (bools, control) = boolean_fanout_bools(
-        |operand, out| {
-            push_generic_truthiness(
-                eval_single::<S, V>(operand, value.clone(), optional, cursor),
-                out,
-            )
+        |operand, bit_sink| {
+            let mut escape: Option<Control> = None;
+            let flow =
+                eval_each_generic::<S, V>(operand, value.clone(), optional, cursor, &mut |item| {
+                    match generic_item_truthiness(item) {
+                        Ok(bit) => bit_sink(bit),
+                        Err(control) => stop_with_escape(&mut escape, control),
+                    }
+                });
+            resume_from_escape(escape, flow)
         },
         left,
         right,

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -12028,12 +12028,14 @@ fn test_break_via_ltrimstr_argument_reaches_outer_label_833() -> Result<()> {
 
 #[test]
 fn test_boolean_and_propagates_halt_from_right_operand() -> Result<()> {
-    // `push_truthiness`'s `Halt` arm (#791), reached through `eval_boolean`'s
-    // right-operand fork -- `and`/`or` are generators over both operands
-    // here, not scalar short-circuit operators, so the right operand's
-    // stream is pushed through `push_truthiness` once per non-short-circuiting
-    // left output. A halt while evaluating the right operand must escape
-    // immediately rather than contribute a truthiness bit. Verified against
+    // A halt from the right operand of `and` (#791). `and`/`or` are
+    // generators over both operands here, not scalar short-circuit
+    // operators, so the right operand is re-driven once per
+    // non-short-circuiting left output -- through `push_truthiness`'s `Halt`
+    // arm when this was written, and since #2669 through
+    // `boolean_operand_bits`' `eval_each` drive, whose `Flow::Escaped`
+    // carries the same halt. Either way it must escape immediately rather
+    // than contribute a truthiness bit. Verified against
     // jq 1.7.1: `jq -n 'true and halt_error(4)'` exits 4 with no output on
     // either stream (`.` at the point `halt_error` runs is still `null`,
     // which prints nothing).
@@ -12050,7 +12052,7 @@ fn test_arithmetic_propagates_halt_from_right_operand() -> Result<()> {
     // `binary_fanout_core`'s right-operand fork -- shared by every
     // arithmetic and comparison operator (#768). A halt while evaluating
     // the right operand must escape immediately, the `OwnedValue`-collecting
-    // analog of `push_truthiness`'s arm `and`/`or` use above. Verified
+    // analog of the escape `and`/`or` make above. Verified
     // against jq 1.7.1: `jq -n '1 + halt_error(6)'` exits 6 with no output
     // on either stream.
     let (stdout, stderr, code) = run_jq_full(&["-n", "1 + halt_error(6)"], None)?;
@@ -47061,7 +47063,7 @@ fn test_wrong_arity_resolution_is_unchanged_2686() -> Result<()> {
 ///
 /// | filter | main | now |
 /// |---|---|---|
-/// | `(.,.) and true` (bare) | `true` | `true` |
+/// | `(.,.) and true` (bare) | `true` `true` | `true` `true` |
 /// | `first((.,.) and true)` | `true` | `true` |
 /// | `[limit(2; (.,.) and true)]` | `[true,true]` | `[true,true]` |
 /// | `[(.,.) and true]` | **exit 5** | `[true,true]` |

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -30873,6 +30873,52 @@ type SideEffectCase = (
 #[test]
 fn test_short_circuit_side_effect_shapes_already_match_jq_820() -> Result<()> {
     let cases: &[SideEffectCase] = &[
+        // #2669: the eager `and`/`or` route, moved here from
+        // `test_short_circuit_side_effect_leaks_820_932_987`.
+        //
+        // #2180 WP2a gave `and`/`or` a demand-forwarding `eval_each` arm
+        // sharing one loop with the eager route, but left the *collecting*
+        // entry points (`eval_boolean`, `eval_boolean_generic`) passing the
+        // eager operand strategy -- which finishes the left operand before
+        // the first pairing, where jq re-runs the right operand per left
+        // output. #2669 put both on the lazy strategy, the `eval_boolean`
+        // side of what #1481 did for `eval_binary_fanout`, leaving no second
+        // strategy to drift.
+        //
+        // Captured live against jq 1.7.1 (`stderr` writes a comma's first
+        // branch twice in both tools, so read the sequence, not the repeat
+        // count):
+        //
+        //   jq, and now succinctly   A A  C C D  B  C C D
+        //   succinctly before #2669  A A B  C C D  C C D
+        //
+        // The delivered values never differed -- this was stderr ordering
+        // only for side-effect-free operands -- but with `input`/`inputs`
+        // operands the same ordering decides which value each operand sees,
+        // which is #1481's own argument for closing it.
+        (
+            &[
+                "-cn",
+                r#"[("A"|stderr, "B"|stderr) and ("C"|stderr, "D"|stderr)]"#,
+            ],
+            None,
+            "[true,true,true,true]\n",
+            "AACCDBCCD",
+            0,
+        ),
+        // The `or` spelling short-circuits on the first truthy left output,
+        // so it never reached the divergence -- kept beside its `and` twin
+        // so the pair reads together.
+        (
+            &[
+                "-cn",
+                r#"[("A"|stderr, "B"|stderr) or ("C"|stderr, "D"|stderr)]"#,
+            ],
+            None,
+            "[true,true]\n",
+            "AAB",
+            0,
+        ),
         // `limit(n)` pulls exactly `n` values, so a side effect sitting at
         // position `n` IS reached. Stopping at the first would suppress it.
         (
@@ -32310,34 +32356,6 @@ fn test_short_circuit_side_effect_leaks_820_932_987() -> Result<()> {
             None,
             "1\n",
             "I",
-            0,
-        ),
-        // ---- #2180 WP2a's own residual: the EAGER `and`/`or` route -------
-        // The `Expr::Compare` situation between #1459 and #1481, one
-        // operator over. WP2a gave `and`/`or` a demand-forwarding
-        // `eval_each` arm sharing one loop with the eager route, but left
-        // `eval_boolean` passing the *eager* operand strategy, so a bare
-        // top-level `and`/`or` still finishes its left operand before the
-        // first pairing where jq interleaves. Captured live against jq
-        // 1.7.1 (`stderr` writes a comma's first branch twice in both
-        // tools, so read the sequence, not the repeat count):
-        //
-        //   jq          A A  C C D  B  C C D   <- right re-run per left output
-        //   succinctly  A A B  C C D  C C D    <- left finished first
-        //
-        // Reaching the same expression through a lazy consumer or as a
-        // binary operand already agrees with jq -- see the two matching
-        // rows in `test_short_circuit_side_effect_shapes_already_match_jq_820`.
-        // Closing this is the `eval_boolean`-side half #1481 did for
-        // `eval_binary_fanout`, not WP2a's scope.
-        (
-            &[
-                "-cn",
-                r#"[("A"|stderr, "B"|stderr) and ("C"|stderr, "D"|stderr)]"#,
-            ],
-            None,
-            "[true,true,true,true]\n",
-            "AABCCDCCD",
             0,
         ),
         // ---- `binary_fanout_each`'s inner/outer `pending` asymmetry ------

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -47046,3 +47046,68 @@ fn test_wrong_arity_resolution_is_unchanged_2686() -> Result<()> {
 
     Ok(())
 }
+
+/// #2669: every route to `and`/`or` now agrees on a malformed document,
+/// which is #2692's rule applied to the one route that still had the old
+/// behaviour.
+///
+/// #2692 removed `push_generic_document_validation_error` from `and`/`or`'s
+/// behalf, deciding that *testing* a value does not read it. The lazy arms
+/// took that immediately, but the collecting entry points kept the eager
+/// operand strategy, whose `push_generic_truthiness` still ran the walk per
+/// item — so on `{"a":1,}` the identical expression answered differently
+/// depending only on which consumer wrapped it. Measured on `main` before
+/// this change:
+///
+/// | filter | main | now |
+/// |---|---|---|
+/// | `(.,.) and true` (bare) | `true` | `true` |
+/// | `first((.,.) and true)` | `true` | `true` |
+/// | `[limit(2; (.,.) and true)]` | `[true,true]` | `[true,true]` |
+/// | `[(.,.) and true]` | **exit 5** | `[true,true]` |
+///
+/// Three of the four already accepted; #2669 moved the fourth to join them
+/// rather than the reverse, because that is the direction #2692 chose. Real
+/// jq rejects **all four** — it cannot parse the document at all — so this is
+/// the pre-existing #2692 divergence being applied consistently, not a new
+/// one, and it is the reason the switch is not purely a stderr-ordering
+/// change. The open question of whether truthiness-only reads should
+/// validate at all is #2701; this test pins only that the routes agree.
+#[test]
+fn test_boolean_routes_agree_on_a_malformed_document_2669() -> Result<()> {
+    for doc in [r#"{"a":1,}"#, "{,}", "[1,]", r#"{"a":1,,"b":2}"#] {
+        // Every spelling of the same expression, one per route.
+        for (filter, want) in [
+            ("(.,.) and true", "true\ntrue"),
+            ("first((.,.) and true)", "true"),
+            ("[limit(2; (.,.) and true)]", "[true,true]"),
+            ("[(.,.) and true]", "[true,true]"),
+            ("[(.,.) and true] | length", "2"),
+            ("[(.,.) or false]", "[true,true]"),
+        ] {
+            let (stdout, stderr, code) = run_jq_full(&["-c", filter], Some(doc))?;
+            assert_eq!(
+                code, 0,
+                "doc={doc} `{filter}`: every route must agree (#2692's rule): {stderr:?}"
+            );
+            assert_eq!(stdout.trim_end(), want, "doc={doc} `{filter}`");
+        }
+    }
+
+    // The guard on the other side: a route that genuinely *reads* the
+    // document still raises on the same input, so this is not a blanket
+    // "and/or suppresses validation everywhere" change.
+    for (filter, doc) in [(".a and true", r#"{"a":1,}"#), ("[.a] and true", "{,}")] {
+        let (_stdout, stderr, code) = run_jq_full(&["-c", filter], Some(doc))?;
+        assert_ne!(
+            code, 0,
+            "`{filter}` on {doc}: reading a member must still raise"
+        );
+        assert!(
+            stderr.contains("Invalid JSON text"),
+            "`{filter}` on {doc}: stderr {stderr:?}"
+        );
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
Fixes #2669

## ⚠️ This changes more than stderr ordering — see "Second effect" below

## Summary

#2180 WP2a gave `and`/`or` a demand-forwarding `eval_each` arm sharing one loop with the eager route, but left the **collecting** entry points (`eval_boolean`, `eval_generic.rs`'s `eval_boolean_generic`) passing the eager operand strategy. That strategy evaluates a whole operand into a `Vec<bool>` and replays it, so it cannot show jq's interleaving — it has finished the left operand before the first pairing, where jq re-runs the right operand per non-short-circuiting left output.

Both now pass the same lazy strategy their `each_boolean`/`each_boolean_generic` twins already used — the `eval_boolean` half of what #1481 did for `eval_binary_fanout`. The eager strategy is **deleted**, not kept alongside, so no second strategy remains to drift.

## The issue's title isn't quite what diverged

A *bare* top-level `and`/`or` already matched: `("A"|stderr,"B"|stderr) and ("C"|stderr,"D"|stderr)` unwrapped writes `AACCDBCCD` on both, because that route takes the lazy arm. What diverged was every **collecting** context — `[...]`, `[...] | length`, `reduce`. The issue's *body* says this correctly ("the eager callers still pass the collecting operand strategy"); only its title says "bare top-level".

| filter (jq 1.7.1 stderr) | jq | before | after |
|---|---|---|---|
| `[(A,B) and (C,D)]` | `AACCDBCCD` | `AABCCDCCD` | `AACCDBCCD` |
| `(A,B) and (C,D)` bare | `AACCDBCCD` | `AACCDBCCD` | unchanged |
| `first((A,B) and (C,D))` | `AACC` | `AACC` | unchanged |

## Second effect: malformed documents, now route-consistent

**My first differential missed this** — it ran with `-n`, so `.` was always `null` and never a document cursor. A targeted probe caught it; re-running with documents on stdin surfaced it.

The eager strategy's `push_generic_truthiness` ran `push_generic_document_validation_error` per item; the lazy one does not. So switching strategies also stops the collecting route rejecting a malformed document.

**That is #2692's own landed rule, not a new decision.** #2692 removed that walk from `and`/`or`'s behalf, deciding that *testing* a value does not read it, and the lazy arms took it immediately. Measured on `main`, input `{"a":1,}`:

| filter | main | now |
|---|---|---|
| `(.,.) and true` (bare) | `true` | `true` |
| `first((.,.) and true)` | `true` | `true` |
| `[limit(2; (.,.) and true)]` | `[true,true]` | `[true,true]` |
| `[(.,.) and true]` | **exit 5** | `[true,true]` |

Three of the four already accepted, so this moves the fourth to join them rather than the reverse. Real jq rejects **all four** (it cannot parse the document), so this is the existing #2692 divergence applied consistently rather than a new one. A route that genuinely reads a member (`.a and true`) still raises.

It does **not** settle #2701 (whether a truthiness-only read should validate at all) — it only removes the route-dependence. Recorded in `limitations.md` beside #2692's entry and pinned by `test_boolean_routes_agree_on_a_malformed_document_2669`.

## Verification

Two differentials against a binary built from the merge base, both classifying every changed row against jq 1.7.1:

| corpus | pairs | fixed (now match jq) | **regressed** | changed, neither matches |
|---|---:|---:|---:|---:|
| `-n`, ordering-sensitive operands | 13,872 | **270** | **0** | 0 |
| documents on stdin, incl. malformed | 32,256 | 0 | **0** | 684 (all the malformed alignment above) |

yq mode: **3,136 programs, byte-identical values and exit codes.** Its ordering moved only on `stderr`, which real yq's lexer rejects outright (extension-only surface, no oracle); a shape real yq *can* express (`[(true,false) and (true,false)]`) agrees before and after.

## Also

The first cut left the operand closure duplicated per evaluator. Extracted as `boolean_operand_bits` / `boolean_operand_bits_generic` so the two callers differ only in what they do with the bits, never in how operands are enumerated — the claim this fix rests on, now true by construction (#106 rule). That also removed a duplicated `Err(control)` arm neither copy's suite reaches, taking patch coverage to 100% without a tolerate marker.

The pinned row moves from `test_short_circuit_side_effect_leaks_820_932_987` to `test_short_circuit_side_effect_shapes_already_match_jq_820`, with its `or` twin beside it.

## Test plan

- [x] `cargo build --features cli`
- [x] `cargo test --features cli,simd,regex,serde` — 8158 passed, 0 failed
- [x] both clippy legs `-D warnings`
- [x] `cargo fmt --check`
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features`
- [x] `omni-dev coverage diff` — **100% patch coverage** (27/27)
- [x] 13,872 + 32,256 pair differentials vs merge base, every changed row classified against jq 1.7.1 — **0 regressions**
- [x] 3,136-program yq value/exit differential — 0 diffs
- [x] Full suite re-run after rebasing onto current `main`