### PR TITLE
feat(yq): add head_comment/foot_comment getters (#798)

### DIFF
--- a/docs/compliance/yq/limitations.md
+++ b/docs/compliance/yq/limitations.md
@@ -3429,12 +3429,16 @@ ruled out), even though real yq supports every one of them:
 - **`tag =`, `head_comment =`, `foot_comment =`, `comments =`** raise `<slot> = ... is not
   yet supported`. Real yq's `.a tag = "!!str"` coerces the value's type, `.a head_comment
   = "hi"`/`.a foot_comment = "bye"` insert standalone comment lines, and `.a comments =
-  "x"` sets head, line and foot together. None has a write mechanism here yet: `NodeMeta`
-  (`src/jq/eval_generic.rs`) has no tag slot (#747), and head/foot comments have no backing
-  field at all (the single-slot `line_comments` side-table this issue's own triage plans to
-  widen — see #798's design-issue and triage comments). Tracked to land in PR2 (data-model
-  widening) through PR5 (`comments =`/`comments |=` and `...` recursive descent in yq
-  mode); cross-link #1079/#1080/#1085 above.
+  "x"` sets head, line and foot together. None has a write mechanism here yet, though the
+  reason has changed since this entry was written: `NodeMeta` (`src/jq/eval_generic.rs`)
+  still has no tag slot (#747), but head/foot comments *do* now have a backing field —
+  `NodeComments { head, line, foot }` (#2690), which the parser populates (#2704, #2718)
+  and the `head_comment`/`foot_comment` getters read (#2758). What is still missing on the
+  write side is the other half of that pipeline: `NodeMeta.head_foot_comment` is `None` at
+  every construction site, and neither emitter renders head/foot lines at all, so a write
+  would have nowhere to land and nothing to print it. See the identity-round-trip gap below.
+  Remaining: the write forms (`comments =`/`comments |=`) and `...` recursive descent in yq
+  mode; cross-link #1079/#1080/#1085 above.
 - **`style = "literal"`/`"folded"`/`"tagged"`** raise `style = "<name>" is not yet
   supported` (an unknown name still raises real yq's own `unknown style <name>`). Real yq
   renders all three (`a: |-\n  hello` / `a: >-\n  hello` / `a: !!int 1`); succinctly's DOM
@@ -3467,6 +3471,55 @@ Two rendering divergences, both readable back and both pinned:
   | .a + 1` is `2`). Done to the value rather than in the emitter so an existing
   tagged scalar whose cursor reports a quoted style (`a: !!int "5"`, #747) keeps its
   current (already divergent, pre-#798) rendering.
+
+### Metadata getters answer from the wrong node after `key` (#2763)
+
+A mapping entry's metadata lives on its **key** node, and succinctly loses the key node's
+cursor at a `key` stage, so every metadata builtin after `key` answers from a no-cursor
+default. Measured against pinned yq v4.53.3 on `a: # keyc\n  b: 1\n` (and `"qk": 1` for
+`style`):
+
+| `.a \| key \| …` | yq | succinctly |
+|---|---|---|
+| `line_comment` | `keyc` | `""` |
+| `line` / `column` | `1` / `1` | `0` / `0` |
+| `style` (quoted key) | `double` | `""` |
+| `head_comment` / `foot_comment` | the comment | `""` |
+| `tag`, `kind` | `!!str`, `scalar` | same — already correct |
+
+This is not specific to comments, and it is older than #798: `line_comment` has had it
+since #765's capture side landed, and `line`/`column`/`style` were never recorded at all.
+`head_comment`/`foot_comment` (#2758) inherit exactly the same gap rather than introducing
+a different one — deliberately, so one fix closes all six. The natural spelling is
+unaffected and correct: `.b | head_comment` is `""` in both tools, because the comment
+genuinely belongs to the key; only the explicit `| key |` step diverges.
+
+The cause is routing, not a missing read. `cursor_key` (`src/jq/eval_generic.rs`) already
+holds `field.key_cursor` and discards it, but a `... | key | <metadata>` pipe never reaches
+the position-carrying evaluator: `owned_identity_pipe_applies` gates on
+`rest.iter().any(needs_path_context)` and these builtins do not need path context, while
+widening that gate still loses to the walk route, which `path_context_walk_split` leaves a
+non-empty rest for and which evaluates the tail from a materialized node. #2763 records two
+designs that look right and are not — returning the key's cursor from `key` regresses
+`.a.b | key | path`, which is currently correct.
+
+Pinned by `head_foot_comment_798::key_node_head_comment_is_not_reachable_yet_798`
+(`tests/yq_cli_tests.rs`), which asserts the current wrong answers for both `head_comment`
+and `line_comment` so the fix updates them together.
+
+### Standalone comments are dropped from every YAML output route (#798)
+
+The parser captures head/foot comments and the getters read them, but no emitter prints
+them, so a round trip loses them — data loss, not just a missing getter. On
+`# lead\na: 1\n# mid\nb: 2\n\n# trail\n`, real yq keeps all three comments through `.`,
+`-P '.'`, `.a = 5`, `del(.b)` (minus `# mid`, which belongs to the deleted key) and
+`select(true)`; succinctly drops all of them on every one. `-o=json` drops them in both,
+which is correct.
+
+Two independent halves: the streaming emitter (`stream_yaml_value_at`, `src/yaml/light.rs`)
+reads comments straight off the live cursor at ~9 sites and never consults `NodeMeta` —
+plain `yq '.'` goes through here — while the DOM emitter (`emit_yaml_value_at_depth`,
+`yq_runner.rs`) does consult `NodeMeta` but is never given head/foot to print.
 
 Four known gaps this write shares with every other write form, none specific to #798:
 

--- a/src/jq/document.rs
+++ b/src/jq/document.rs
@@ -651,6 +651,31 @@ pub trait DocumentCursor: Sized + Copy + Clone {
         Ok(None)
     }
 
+    /// Get the standalone comment lines directly above this node — its
+    /// *head* comment (#798) — stripped of each line's leading `#`/space,
+    /// one entry per line in source order. Empty when the node has none, and
+    /// for formats without comments at all (e.g. JSON), mirroring
+    /// [`line_comment`](Self::line_comment)'s "not available" contract: the
+    /// builtin newline-joins these, so empty becomes `""`.
+    ///
+    /// For a mapping entry these belong to the *key* node, not the value —
+    /// real yq answers `.b | key | head_comment` and gives `""` for
+    /// `.b | head_comment`. A sequence item owns its own directly.
+    ///
+    /// Owned rather than borrowed for the same reason
+    /// [`line_comment`](Self::line_comment) is: a `Copy` cursor obtained
+    /// from `Option<V::Cursor>::and_then` has a borrow too short to hand
+    /// back slices of the source text.
+    fn head_comment(&self) -> Vec<String> {
+        Vec::new()
+    }
+
+    /// The standalone comment lines directly below this node — its *foot*
+    /// comment (#798). See [`head_comment`](Self::head_comment).
+    fn foot_comment(&self) -> Vec<String> {
+        Vec::new()
+    }
+
     /// Create a cursor at the specified byte offset (0-indexed).
     ///
     /// Returns None if:

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -10100,6 +10100,8 @@ fn eval_builtin<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
         Builtin::Column => builtin_column::<W>(),
         Builtin::DocumentIndex => builtin_document_index::<W>(),
         Builtin::LineComment => builtin_line_comment::<W>(),
+        // #798: no cursor domain here either, so the same empty string.
+        Builtin::HeadComment | Builtin::FootComment => builtin_line_comment::<W>(),
         Builtin::FileIndex => {
             // The ambient node origin (#2427) when the CLI installed one --
             // the ordinary multi-file path and `--eval-all` both do, per
@@ -23570,7 +23572,14 @@ fn yq_metadata_builtin_as_assign_path_error(path_expr: &Expr) -> Option<EvalErro
     }
     matches!(
         target,
-        Expr::Builtin(Builtin::LineComment | Builtin::Style | Builtin::Anchor | Builtin::Tag)
+        Expr::Builtin(
+            Builtin::LineComment
+                | Builtin::HeadComment
+                | Builtin::FootComment
+                | Builtin::Style
+                | Builtin::Anchor
+                | Builtin::Tag,
+        )
     )
     .then(|| EvalError::new("'|' expects 2 args but there is 1"))
 }

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -18085,6 +18085,32 @@ fn eval_builtin<S: EvalSemantics, V: DocumentValue>(
             None => GenericResult::Owned(OwnedValue::String(String::new())),
         },
 
+        // #798: the standalone comment lines above/below this node,
+        // newline-joined -- real yq returns one string, not a list, and ""
+        // when there are none.
+        //
+        // Answered from whatever cursor the pipe stands on, which reaches
+        // a sequence item and the document root but *not* a mapping
+        // entry's: those comments live on the entry's **key** node, and a
+        // `key` stage leaves the cursor domain, so `.b | key | head_comment`
+        // is still `""` where real yq answers the comment. That is the same
+        // gap `line_comment` has had since #765 -- `.a | key | line_comment`
+        // is `""` here and `keyc` in yq -- and closing it means routing a
+        // `... | key | <metadata>` pipe to a position-carrying evaluator,
+        // which the walk route currently intercepts. Tracked separately;
+        // these two builtins deliberately inherit the existing gap rather
+        // than inventing a second, different one.
+        Builtin::HeadComment => GenericResult::Owned(OwnedValue::String(
+            cursor
+                .map(|c| c.head_comment().join("\n"))
+                .unwrap_or_default(),
+        )),
+        Builtin::FootComment => GenericResult::Owned(OwnedValue::String(
+            cursor
+                .map(|c| c.foot_comment().join("\n"))
+                .unwrap_or_default(),
+        )),
+
         Builtin::Select(cond) => {
             // Evaluate condition with cursor context preserved.
             // This is critical for select(di == N) to work correctly.
@@ -19808,6 +19834,10 @@ fn owned_identity_rule(stage: &Expr) -> Option<OwnedIdentityRule> {
             | Builtin::Anchor
             | Builtin::DocumentIndex
             | Builtin::LineComment
+            // #798: same class as `line_comment` -- a metadata read that
+            // leaves the value standing where it stood.
+            | Builtin::HeadComment
+            | Builtin::FootComment
             | Builtin::SplitDoc
             | Builtin::Shuffle
             | Builtin::Trim

--- a/src/jq/expr.rs
+++ b/src/jq/expr.rs
@@ -1482,6 +1482,15 @@ pub enum Builtin {
     DocumentIndex,
     /// `line_comment` - return the trailing same-line comment text, or "" (yq, #710)
     LineComment,
+    /// `head_comment` - return the standalone comment lines directly above
+    /// this node, newline-joined, or "" (yq, #798). For a mapping entry
+    /// these live on the *key* node, so real yq answers
+    /// `.b | key | head_comment` and returns "" for `.b | head_comment`; a
+    /// sequence item owns its own directly.
+    HeadComment,
+    /// `foot_comment` - the standalone comment lines directly below this
+    /// node, newline-joined, or "" (yq, #798). See [`Self::HeadComment`].
+    FootComment,
     /// `file_index` / `fileIndex` / `fi` - return the 0-indexed origin file
     /// position within an `--eval-all` combined evaluation (yq/succinctly
     /// extension, #715). Resolves via the same `current_path`-derived

--- a/src/jq/parser.rs
+++ b/src/jq/parser.rs
@@ -4646,6 +4646,20 @@ impl<'a> Parser<'a> {
             return Ok(Some(Builtin::LineComment));
         }
 
+        // head_comment / foot_comment - yq: standalone comment lines above /
+        // below this node, or "" (#798). Ungated, exactly like
+        // `line_comment` above: neither is `ParserMode::Yq`-only nor behind
+        // `--jq-extensions`, so both parse in jq mode too and simply answer
+        // "" there, JSON having no comments.
+        if self.matches_keyword("head_comment") {
+            self.consume_keyword("head_comment");
+            return Ok(Some(Builtin::HeadComment));
+        }
+        if self.matches_keyword("foot_comment") {
+            self.consume_keyword("foot_comment");
+            return Ok(Some(Builtin::FootComment));
+        }
+
         // document_index / di - yq: return 0-indexed document position in multi-doc stream
         if self.matches_keyword("document_index") {
             self.consume_keyword("document_index");

--- a/src/jq/walk.rs
+++ b/src/jq/walk.rs
@@ -165,6 +165,8 @@ pub fn builtin_kids(builtin: &Builtin) -> BuiltinKids<'_> {
         | Builtin::Column
         | Builtin::DocumentIndex
         | Builtin::LineComment
+        | Builtin::HeadComment
+        | Builtin::FootComment
         | Builtin::FileIndex
         | Builtin::Shuffle
         | Builtin::Pivot
@@ -453,6 +455,8 @@ pub fn map_builtin_subexprs(builtin: &Builtin, f: &mut dyn FnMut(&Expr) -> Expr)
         | Builtin::Column
         | Builtin::DocumentIndex
         | Builtin::LineComment
+        | Builtin::HeadComment
+        | Builtin::FootComment
         | Builtin::FileIndex
         | Builtin::Shuffle
         | Builtin::Pivot
@@ -1231,6 +1235,8 @@ pub fn uses_cursor_metadata_builtins(expr: &Expr) -> bool {
                 | Builtin::Anchor
                 | Builtin::Style
                 | Builtin::LineComment
+                | Builtin::HeadComment
+                | Builtin::FootComment
                 | Builtin::AtOffset(_)
                 | Builtin::AtPosition(_, _)
         )

--- a/src/yaml/light.rs
+++ b/src/yaml/light.rs
@@ -2733,6 +2733,53 @@ impl<'a, W: AsRef<[u64]>> YamlCursor<'a, W> {
         Some(raw.strip_prefix("# ").unwrap_or(raw))
     }
 
+    /// The standalone `#` comment lines directly above this node — its
+    /// *head* comment (#798) — raw, `#` and all, one entry per line in
+    /// source order. Empty when there are none.
+    ///
+    /// A line whose bytes aren't valid UTF-8 is skipped, matching
+    /// [`Self::line_comment_raw`]'s tolerance: these getters serve output
+    /// paths that must keep rendering the rest of the document.
+    #[inline]
+    pub fn head_comment_raw(&self) -> impl Iterator<Item = &str> {
+        Self::decode_comment_lines(self.text, self.index.get_head_comments(self.bp_pos))
+    }
+
+    /// [`Self::head_comment_raw`]'s counterpart for the lines directly
+    /// *below* this node — its *foot* comment (#798).
+    #[inline]
+    pub fn foot_comment_raw(&self) -> impl Iterator<Item = &str> {
+        Self::decode_comment_lines(self.text, self.index.get_foot_comments(self.bp_pos))
+    }
+
+    /// Shared decode for [`Self::head_comment_raw`]/[`Self::foot_comment_raw`].
+    #[inline]
+    fn decode_comment_lines<'t>(
+        text: &'t [u8],
+        ranges: &'t [(u32, u32)],
+    ) -> impl Iterator<Item = &'t str> {
+        ranges.iter().filter_map(move |&(start, end)| {
+            core::str::from_utf8(&text[start as usize..end as usize]).ok()
+        })
+    }
+
+    /// This node's head comment with each line's leading `#` and at most one
+    /// following space stripped (#798) — the same `"# "`-only rule
+    /// [`Self::line_comment`] applies, so `#\ttabbed` and a bare `#` come
+    /// back verbatim, matching real yq.
+    #[inline]
+    pub fn head_comment(&self) -> impl Iterator<Item = &str> {
+        self.head_comment_raw()
+            .map(|raw| raw.strip_prefix("# ").unwrap_or(raw))
+    }
+
+    /// [`Self::head_comment`]'s counterpart for the foot comment (#798).
+    #[inline]
+    pub fn foot_comment(&self) -> impl Iterator<Item = &str> {
+        self.foot_comment_raw()
+            .map(|raw| raw.strip_prefix("# ").unwrap_or(raw))
+    }
+
     /// Get this node's trailing same-line comment, distinguishing "no
     /// comment" (`Ok(None)`) from "comment present but not valid UTF-8"
     /// (`Err(_)`) — unlike [`Self::line_comment`], which silently collapses
@@ -6706,6 +6753,20 @@ impl<'a, W: AsRef<[u64]> + Clone> DocumentCursor for YamlCursor<'a, W> {
     #[inline]
     fn line_comment_checked(&self) -> Result<Option<String>, core::str::Utf8Error> {
         YamlCursor::line_comment_checked(self).map(|opt| opt.map(ToString::to_string))
+    }
+
+    #[inline]
+    fn head_comment(&self) -> Vec<String> {
+        YamlCursor::head_comment(self)
+            .map(ToString::to_string)
+            .collect()
+    }
+
+    #[inline]
+    fn foot_comment(&self) -> Vec<String> {
+        YamlCursor::foot_comment(self)
+            .map(ToString::to_string)
+            .collect()
     }
 
     #[inline]

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -13773,6 +13773,130 @@ fn test_sort_keys_preserves_comments_710() -> Result<()> {
     Ok(())
 }
 
+/// #798: the `head_comment`/`foot_comment` getters. Every expectation was
+/// captured from pinned `yq` v4.53.3 before being written here.
+mod head_foot_comment_798 {
+    use super::{run_jq_stdin, run_yq_stdin, run_yq_stdin_with_stderr};
+    use anyhow::Result;
+
+    #[test]
+    fn a_leading_block_is_the_documents_head_798() -> Result<()> {
+        let (out, code) = run_yq_stdin(". | head_comment", "# lead\na: 1\n", &[])?;
+        assert_eq!(code, 0);
+        assert_eq!(out.trim_end(), "lead");
+        Ok(())
+    }
+
+    #[test]
+    fn consecutive_lines_join_with_a_newline_798() -> Result<()> {
+        let (out, code) = run_yq_stdin(". | head_comment", "# l1\n# l2\na: 1\n", &[])?;
+        assert_eq!(code, 0);
+        assert_eq!(out, "l1\nl2\n");
+        Ok(())
+    }
+
+    #[test]
+    fn a_trailing_block_detached_by_a_blank_is_the_documents_foot_798() -> Result<()> {
+        let (out, code) = run_yq_stdin(". | foot_comment", "a: 1\n\n# trail\n", &[])?;
+        assert_eq!(code, 0);
+        assert_eq!(out.trim_end(), "trail");
+        Ok(())
+    }
+
+    /// A sequence item owns its head/foot directly — no `key` step, unlike
+    /// a mapping entry.
+    #[test]
+    fn sequence_items_answer_directly_798() -> Result<()> {
+        let (out, code) = run_yq_stdin(".[1] | head_comment", "- 1\n# mid\n- 2\n", &[])?;
+        assert_eq!(code, 0);
+        assert_eq!(out.trim_end(), "mid");
+
+        let (out, code) = run_yq_stdin(".[0] | foot_comment", "- 1\n# mid\n\n- 2\n", &[])?;
+        assert_eq!(code, 0);
+        assert_eq!(out.trim_end(), "mid");
+
+        let (out, code) = run_yq_stdin(".[1] | foot_comment", "- 1\n- 2\n# trail\n", &[])?;
+        assert_eq!(code, 0);
+        assert_eq!(out.trim_end(), "trail");
+        Ok(())
+    }
+
+    /// Total function: always a string, `""` when absent, never an error —
+    /// including on computed values with no document position at all.
+    #[test]
+    fn always_a_string_never_an_error_798() -> Result<()> {
+        for filter in [
+            ".a | head_comment",
+            ".a | foot_comment",
+            "1 | head_comment",
+            "[1,2] | head_comment",
+            "(.a + 1) | head_comment",
+        ] {
+            let (out, err, code) = run_yq_stdin_with_stderr(filter, "a: 1\n", &[])?;
+            assert_eq!(code, 0, "[{filter}] stderr: {err}");
+            assert_eq!(out, "\n", "[{filter}] stdout: {out:?}");
+        }
+        let (out, code) = run_yq_stdin(".a | head_comment | type", "a: 1\n", &[])?;
+        assert_eq!(code, 0);
+        assert_eq!(out.trim_end(), "!!str");
+        Ok(())
+    }
+
+    /// A mapping entry's *value* has no head comment of its own — the
+    /// comment belongs to its key. Matching real yq, which also answers "".
+    #[test]
+    fn a_mapping_values_own_head_is_empty_798() -> Result<()> {
+        let (out, code) = run_yq_stdin(".b | head_comment", "# lead\na: 1\n# mid\nb: 2\n", &[])?;
+        assert_eq!(code, 0);
+        assert_eq!(out, "\n");
+        Ok(())
+    }
+
+    /// Known gap, deliberately inherited rather than newly invented: a
+    /// mapping entry's head/foot live on its **key** node, and a `key` stage
+    /// leaves the cursor domain, so this is `""` where real yq answers
+    /// `mid`. `line_comment` has had exactly this gap since #765
+    /// (`.a | key | line_comment` is `""` here, `keyc` in yq) — pinned so
+    /// the follow-up that closes it updates both together, deliberately.
+    #[test]
+    fn key_node_head_comment_is_not_reachable_yet_798() -> Result<()> {
+        let (out, code) = run_yq_stdin(".b | key | head_comment", "a: 1\n# mid\nb: 2\n", &[])?;
+        assert_eq!(code, 0);
+        assert_eq!(out, "\n");
+
+        let (out, code) = run_yq_stdin(".a | key | line_comment", "a: # keyc\n  b: 1\n", &[])?;
+        assert_eq!(code, 0);
+        assert_eq!(out, "\n");
+        Ok(())
+    }
+
+    /// Ungated, exactly like `line_comment`: both parse in jq mode too and
+    /// answer "" there, JSON having no comments.
+    #[test]
+    fn jq_mode_parses_them_and_answers_empty_798() -> Result<()> {
+        for filter in [".a | head_comment", ".a | foot_comment"] {
+            let (out, code) = run_jq_stdin(filter, "{\"a\": 1}", &[])?;
+            assert_eq!(code, 0, "[{filter}]");
+            assert_eq!(out, "\"\"\n", "[{filter}] stdout: {out:?}");
+        }
+        Ok(())
+    }
+
+    /// Real yq raises this for every metadata slot piped into an
+    /// assignment, `head_comment`/`foot_comment` included.
+    #[test]
+    fn piped_as_an_assign_lhs_raises_yqs_own_error_798() {
+        for filter in [".a | head_comment = \"x\"", ".a | foot_comment = \"x\""] {
+            let (_out, err, code) = run_yq_stdin_with_stderr(filter, "a: 1\n", &[]).expect("run");
+            assert_eq!(code, 1, "[{filter}] stderr: {err}");
+            assert!(
+                err.contains("'|' expects 2 args but there is 1"),
+                "[{filter}] stderr: {err}"
+            );
+        }
+    }
+}
+
 /// `line_comment` getter: strips `# ` (hash + one space) when present.
 #[test]
 fn test_line_comment_builtin_710() -> Result<()> {


### PR DESCRIPTION
## Summary

The parser has captured standalone comment lines into each node's `head`/`foot`
since #2704, but nothing could read them — the data was write-only. This adds
the two yq getters.

Working, and matching pinned yq v4.53.3:

| | |
|---|---|
| `. \| head_comment` on a leading block | the comment, `\n`-joined for multi-line |
| `. \| foot_comment` on a blank-detached trailing block | the comment |
| `.[1] \| head_comment`, `.[0] \| foot_comment` | sequence items answer directly, no `key` step |
| `.b \| head_comment` on a mapping value | `""` — the comment belongs to the key, as in yq |
| `1 \| …`, `[1,2] \| …`, `(.a+1) \| …` | `""` — total function, never raises |
| `succinctly jq '.a \| head_comment'` | `""`, ungated exactly like `line_comment` |
| `.a \| head_comment = "x"` | `'\|' expects 2 args but there is 1`, like every other slot |

`DocumentCursor` gains defaulted accessors, so the JSON side needs no code at
all.

## Scope note — narrower than I planned, and why

A mapping entry's head/foot live on its **key** node, and a `key` stage leaves
the cursor domain, so `.b | key | head_comment` is still `""` where yq answers
the comment.

I tried twice to close that and both designs were wrong:

1. **Make `key` return the key's cursor.** Killed by one probe: `.a.b | key |
   path` is `["a","b"]` in yq *and already correct here*, because `key`'s result
   deliberately stands at the value node (pinned by `OwnedIdentityRule::KeyNode`'s
   captured doc comment). That change would have regressed working behaviour to
   add a feature.
2. **Resolve the key cursor in `eval_owned_identity_stages`.** Right in shape,
   but unreachable: `owned_identity_pipe_applies` gates on
   `rest.iter().any(needs_path_context)`, and `line_comment` doesn't need path
   context — so the pipe never enters that route. Widening the gate got it no
   further, because `path_context_walk_split` leaves a non-empty rest and the
   **walk** route intercepts first, evaluating the tail from a materialized node
   with no cursor.

Closing it properly means changing how the walk route evaluates its rest — the
#2416 spine routing. That deserves its own PR and its own review, not a third
guess at the end of this one, so the machinery from attempt 2 is reverted rather
than left in as unreachable code.

**This is the same gap `line_comment` has had since #765** (`.a | key |
line_comment` is `""` here, `keyc` in yq). These two builtins inherit it rather
than inventing a second, different one, and a test pins both so the follow-up
updates them together.

## Test plan

- [x] 9 new tests in `tests/yq_cli_tests.rs`, every expectation captured from
      pinned yq v4.53.3 first — including the known gap, pinned deliberately
- [x] `cargo test --features cli`: lib 3677, `yq_cli_tests` 1753,
      `jq_cli_tests` 1584, `yq_golden_tests` byte-identical
- [x] **Spine gates green**: `jq_evaluator_parity_tests` (55),
      `jq_path_context_alphabet_tests` — `key`/`cursor_key` are untouched in
      the landed diff
- [x] **`omni-dev coverage diff` run before pushing** (not after CI): **patch
      coverage 100%, 53/53 new lines**
- [x] Depth-guard tests by exit code; `clippy -D warnings`, `fmt --check`,
      `RUSTDOCFLAGS="-D warnings" cargo doc`