### PR TITLE
fix(jq): resolve the inside of [f] on an untracked input inside path()

### DIFF
--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -27963,12 +27963,11 @@ fn resolve_node_sink<'a, S: EvalSemantics>(
         // static table cannot express because `inner` is arbitrary code.
         //
         // Resolving `inner` instead of evaluating it is what surfaces that
-        // navigation: the inner `Field`/`Index`/`Iterate`/`RecursiveDescent`
-        // arms already raise jq's exact wording against an untracked input,
-        // and a `TrackedVar` marker, a literal or `.` inside the brackets
-        // pass straight through, so `[5]`, `[$v]`, `[$v.b?]` and `[.]` stay
-        // accepted. jq drains the whole collect, so the inner bound is
-        // unlimited whatever the outer `keep` -- `keep` governs how many
+        // navigation: the inner `Field`/`Index`/`Slice`/`Iterate` arms raise
+        // jq's exact wording against an untracked input, and a literal, `.`
+        // or an empty constructor pass straight through, so `[5]`, `[.]` and
+        // `[]` stay accepted. jq drains the whole collect, so the inner bound
+        // is unlimited whatever the outer `keep` -- `keep` governs how many
         // *arrays* the consumer wants, and there is exactly one.
         //
         // Keyed on `!trackable`: a trackable input (`path([.a] | empty)`,
@@ -27978,21 +27977,54 @@ fn resolve_node_sink<'a, S: EvalSemantics>(
         // only (ADR-0018): real yq's lexer rejects every shape that reaches
         // here, so there is no yq oracle, and yq mode keeps `skip_untracked`.
         //
-        // **Also keyed on the brackets holding no `TrackedVar`.** A marker
-        // can *re-establish* tracking -- `$v` whose frozen value is still the
-        // live register is not navigation, it is the register (#1573) -- but
-        // that comparison happens one level up, in `resolve_seq_stage`,
-        // against a `carried_register` this function is not handed. Resolved
-        // from here with `trackable: false`, `[$v.b?]` saw `$v` as just
-        // another untracked value and refused `.b` on it, where jq (and the
-        // catch-all, by value) accepts. So the marker case keeps the
-        // catch-all, exactly as before; only pure navigation on the ambient
-        // input is intercepted. Re-establishment inside the brackets needs
-        // the register threaded down, which is #2759.
+        // **Also keyed on `inner` containing none of the shapes whose own
+        // untracked handling is wrong.** Evaluating by value had been
+        // *masking* those bugs inside brackets, and routing the brackets
+        // through the resolver unmasks them -- turning working programs into
+        // errors, the one direction this fix must never move. Each is a
+        // pre-existing bare-stage bug with its own oracle bracket, kept on
+        // the catch-all here rather than fixed in passing:
+        //
+        // - `TrackedVar`: a marker *re-establishes* tracking -- `$v` whose
+        //   frozen value is still the live register is not navigation, it is
+        //   the register (#1573) -- but that comparison happens one level up
+        //   in `resolve_seq_stage`, against a `carried_register` this
+        //   function is not handed. Resolved from here, `[$v.b?]` saw `$v` as
+        //   just another untracked value and refused `.b` where jq accepts.
+        //   #2759.
+        // - `GetPath`: `getpath([])` refuses *eagerly* on an untracked input
+        //   (its own `keys.is_empty()` arm), where jq treats it as a
+        //   passthrough and refuses only at the terminal. `path(1 |
+        //   [getpath([])] | empty)` is accepted by jq. #2764.
+        // - `Recurse`/`RecurseF`/`RecurseCond`/`RecursiveDescent`: the shared
+        //   `recurse_untracked_error` guard refuses eagerly whether or not
+        //   `f` navigates -- `recurse(empty)`, `recurse(.+1; .<3)` and a
+        //   caught `(..)?` are all accepted by jq. And its error is
+        //   uncatchable here, so `[try (..)]` cannot rescue it either. #2764.
+        // - `Optional`: the parser erases the parentheses in `(.a)?`, which
+        //   is jq's `try .a` (a *caught* path error), into `.a?`, which is
+        //   jq's `INDEX_OPT` (an uncaught one). Bare `[.a?]` happens to agree
+        //   with jq either way, but `[(.a)? | f]` does not, and this function
+        //   cannot tell the two spellings apart. #2764.
+        //
+        // The scan is O(|inner|), the same order as resolving it.
         Expr::Array(inner)
             if S::TAG == EvalTag::Jq
                 && !trackable
-                && !any_subexpr(inner, &mut |e| matches!(e, Expr::TrackedVar(_))) =>
+                && !any_subexpr(inner, &mut |e| {
+                    matches!(
+                        e,
+                        Expr::TrackedVar(_)
+                            | Expr::Optional(_)
+                            | Expr::RecursiveDescent
+                            | Expr::Builtin(
+                                Builtin::GetPath(_)
+                                    | Builtin::Recurse
+                                    | Builtin::RecurseF(_)
+                                    | Builtin::RecurseCond(_, _)
+                            )
+                    )
+                }) =>
         {
             let mut items = Vec::new();
             let flow = resolve_node_sink::<S>(

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -27947,6 +27947,77 @@ fn resolve_node_sink<'a, S: EvalSemantics>(
             resolve_nth_sink::<S>(n, expr, value, trackable, snapshot, frame, keep, sink)
         }
 
+        // #2689: array construction on an *untracked* input. jq's `[f]`
+        // (`gen_collect`) runs `f` with path tracking live -- unlike `{k:f}`,
+        // `if f`, `select(f)`, `try f`, an `as` source or `"\(f)"`, all of
+        // which suspend it -- so an INDEX/EACH inside the brackets on a value
+        // that is not `value_at_path` raises exactly as it would as a bare
+        // stage. Left to `resolve_leaf`'s catch-all, `[.a]` was evaluated
+        // *by value*: the `.a` inside succeeded, the array came back
+        // untracked, and a continuation that emitted nothing left nothing for
+        // `resolve_terminal` to object to. `path(1 | [.[]?] | empty)` and
+        // `path(. as {a:$v} | [.a] | ($v.b?) as $w | $w)` answered nothing at
+        // exit 0, and `del(...)` of the latter returned the document
+        // unchanged, where jq raises "near attempt to access element "a"" --
+        // the same accept-where-jq-refuses shape as #2646, on a leaf its
+        // static table cannot express because `inner` is arbitrary code.
+        //
+        // Resolving `inner` instead of evaluating it is what surfaces that
+        // navigation: the inner `Field`/`Index`/`Iterate`/`RecursiveDescent`
+        // arms already raise jq's exact wording against an untracked input,
+        // and a `TrackedVar` marker, a literal or `.` inside the brackets
+        // pass straight through, so `[5]`, `[$v]`, `[$v.b?]` and `[.]` stay
+        // accepted. jq drains the whole collect, so the inner bound is
+        // unlimited whatever the outer `keep` -- `keep` governs how many
+        // *arrays* the consumer wants, and there is exactly one.
+        //
+        // Keyed on `!trackable`: a trackable input (`path([.a] | empty)`,
+        // the plain-`as` control `path(.a as $v | [.a] | ...)`) is untouched
+        // and still takes the catch-all, so the seq-level register handling
+        // (`cannot_move_register`'s own `Array` arm) is unchanged. jq mode
+        // only (ADR-0018): real yq's lexer rejects every shape that reaches
+        // here, so there is no yq oracle, and yq mode keeps `skip_untracked`.
+        //
+        // **Also keyed on the brackets holding no `TrackedVar`.** A marker
+        // can *re-establish* tracking -- `$v` whose frozen value is still the
+        // live register is not navigation, it is the register (#1573) -- but
+        // that comparison happens one level up, in `resolve_seq_stage`,
+        // against a `carried_register` this function is not handed. Resolved
+        // from here with `trackable: false`, `[$v.b?]` saw `$v` as just
+        // another untracked value and refused `.b` on it, where jq (and the
+        // catch-all, by value) accepts. So the marker case keeps the
+        // catch-all, exactly as before; only pure navigation on the ambient
+        // input is intercepted. Re-establishment inside the brackets needs
+        // the register threaded down, which is #2759.
+        Expr::Array(inner)
+            if S::TAG == EvalTag::Jq
+                && !trackable
+                && !any_subexpr(inner, &mut |e| matches!(e, Expr::TrackedVar(_))) =>
+        {
+            let mut items = Vec::new();
+            let flow = resolve_node_sink::<S>(
+                inner,
+                value,
+                false,
+                snapshot,
+                frame,
+                Keep::AtMost(usize::MAX),
+                &mut |branch| {
+                    items.push(branch.value.into_owned());
+                    Demand::Continue
+                },
+            );
+            match flow {
+                ResolveFlow::Escaped(escape) => ResolveFlow::Escaped(escape),
+                ResolveFlow::Exhausted | ResolveFlow::Stopped => {
+                    match sink(PathBranch::untracked(Cow::Owned(OwnedValue::Array(items)))) {
+                        Demand::Continue => ResolveFlow::Exhausted,
+                        Demand::Stop => ResolveFlow::Stopped,
+                    }
+                }
+            }
+        }
+
         // Every remaining shape still resolves eagerly and reaches the sink
         // through `drain_path_result`, which is byte-identical to the eager
         // result for an always-`Continue` sink -- so this is a missed

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -43311,6 +43311,120 @@ fn test_path_prefix_lets_a_truncating_consumer_succeed_2680() -> Result<()> {
     Ok(())
 }
 
+/// #2689: an array constructor on an **untracked** input resolves its
+/// inside, so navigation within the brackets is refused as jq refuses it.
+///
+/// jq's `[f]` runs `f` with path tracking live (unlike `{k:f}`, `if f`,
+/// `select(f)`, `try f`, an `as` source, or `"\(f)"`, which all suspend
+/// it). Left to the evaluate-by-value catch-all, `[.a]` on a constructed
+/// value succeeded silently, and a continuation that emitted nothing left
+/// nothing to object to -- the same accept-where-jq-refuses shape as
+/// #2646, on a leaf a static table cannot express.
+///
+/// The issue reported this through a destructuring `as {a:$v}`, but the
+/// destructuring is not the cause -- it only supplies an untracked ambient
+/// value. The first rows below reproduce with no `as` at all. All captured
+/// live from jq 1.7.1.
+#[test]
+fn test_path_refuses_navigation_inside_array_on_untracked_input_2689() -> Result<()> {
+    for (filter, doc, element) in [
+        // no destructuring: the real root cause
+        ("path(1 | [.[]?] | empty)", "null", "iterate through 1"),
+        ("path(1 | [.a?] | empty)", "null", r#"element "a" of 1"#),
+        (
+            "path(. as $x | .a | $x | [.b] | empty)",
+            r#"{"a":1,"b":2}"#,
+            r#"element "b" of {"a":1,"b":2}"#,
+        ),
+        // the issue's own shape
+        (
+            "path(. as {a:$v0} | [.a] | ($v0.b?) as $v1 | $v1)",
+            r#"{"a":false}"#,
+            r#"element "a" of {"a":false}"#,
+        ),
+        // nested brackets, a comma, a pipe, and a postfix index inside
+        (
+            "path(. as {a:$v0} | [[.a]] | empty)",
+            r#"{"a":false}"#,
+            r#"element "a" of {"a":false}"#,
+        ),
+        (
+            "path(. as {a:$v0} | [.a, .b] | empty)",
+            r#"{"a":false}"#,
+            r#"element "a" of {"a":false}"#,
+        ),
+        (
+            "path(. as {a:$v0} | [.a][0] | empty)",
+            r#"{"a":false}"#,
+            r#"element "a" of {"a":false}"#,
+        ),
+    ] {
+        let (stdout, stderr, code) = run_jq_full(&["-c", filter], Some(doc))?;
+        assert_ne!(code, 0, "{filter} on {doc}: stdout {stdout:?}");
+        assert!(
+            stderr.contains("Invalid path expression near attempt to "),
+            "{filter} on {doc}: {stderr:?}"
+        );
+        assert!(stderr.contains(element), "{filter} on {doc}: {stderr:?}");
+    }
+    Ok(())
+}
+
+/// #2689 seen from the side that does damage: `del()` and `=` consume the
+/// same resolution, so the missing refusal was a **refused edit reported as
+/// a successful no-op** -- the document came back unchanged at exit 0 where
+/// jq exits 5. Captured live from jq 1.7.1.
+#[test]
+fn test_write_refuses_navigation_inside_array_on_untracked_input_2689() -> Result<()> {
+    for filter in [
+        "del(. as {a:$v0} | [.a] | ($v0.b?) as $v1 | $v1)",
+        "del(. as {a:$v0} | [.a] | select(false))",
+        "(. as {a:$v0} | [.a] | select(false)) = 1",
+    ] {
+        let (stdout, stderr, code) = run_jq_full(&["-c", filter], Some(r#"{"a":false}"#))?;
+        assert_ne!(
+            code, 0,
+            "{filter}: must refuse, not no-op; stdout {stdout:?}"
+        );
+        assert!(
+            stderr.contains(r#"near attempt to access element "a" of {"a":false}"#),
+            "{filter}: {stderr:?}"
+        );
+        assert_eq!(stdout.trim_end(), "", "{filter}: nothing written");
+    }
+    Ok(())
+}
+
+/// #2689's boundary, so the arm cannot degrade into "refuse every array on
+/// an untracked input". Each row is something jq accepts, and each is
+/// unchanged by the fix -- a trackable input, the plain-`as` control from
+/// the issue, a literal / identity / empty constructor, an object
+/// constructor (which jq evaluates with tracking *suspended*), and a
+/// `TrackedVar` inside the brackets, which the arm deliberately hands back to
+/// the catch-all because re-establishing the register needs machinery it is
+/// not given (#2759). All captured live from jq 1.7.1.
+#[test]
+fn test_array_on_untracked_input_boundary_2689() -> Result<()> {
+    for (filter, doc) in [
+        ("path([.a] | empty)", r#"{"a":false}"#),
+        (
+            "path(.a as $v0 | [.a] | ($v0.b?) as $v1 | $v1)",
+            r#"{"a":false}"#,
+        ),
+        ("path(. as {a:$v0} | [5] | empty)", r#"{"a":false}"#),
+        ("path(. as {a:$v0} | [.] | empty)", r#"{"a":false}"#),
+        ("path(. as {a:$v0} | [] | empty)", r#"{"a":false}"#),
+        ("path(. as {a:$v0} | {x:.a} | empty)", r#"{"a":false}"#),
+        ("path(. as {a:$v0} | [$v0] | empty)", r#"{"a":false}"#),
+        ("path(. as {a:$v0} | [$v0.b?] | empty)", r#"{"a":false}"#),
+    ] {
+        let (stdout, stderr, code) = run_jq_full(&["-c", filter], Some(doc))?;
+        assert_eq!(code, 0, "{filter}: must stay accepted; stderr {stderr:?}");
+        assert_eq!(stdout.trim_end(), "", "{filter}");
+    }
+    Ok(())
+}
+
 /// #2349 control: the same gate's *array* elements must also validate the
 /// leading-comma/duplicate-comma shape (`[1,,2]`), not just the trailing
 /// stray-comma cases above -- a distinct `#1677` check

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -43315,8 +43315,9 @@ fn test_path_prefix_lets_a_truncating_consumer_succeed_2680() -> Result<()> {
 /// inside, so navigation within the brackets is refused as jq refuses it.
 ///
 /// jq's `[f]` runs `f` with path tracking live (unlike `{k:f}`, `if f`,
-/// `select(f)`, `try f`, an `as` source, or `"\(f)"`, which all suspend
-/// it). Left to the evaluate-by-value catch-all, `[.a]` on a constructed
+/// `select(f)`, an `as` source, or `"\(f)"`, which all suspend it -- and
+/// unlike `try f`, which keeps it live but *catches* the resulting path
+/// error). Left to the evaluate-by-value catch-all, `[.a]` on a constructed
 /// value succeeded silently, and a continuation that emitted nothing left
 /// nothing to object to -- the same accept-where-jq-refuses shape as
 /// #2646, on a leaf a static table cannot express.
@@ -43329,8 +43330,8 @@ fn test_path_prefix_lets_a_truncating_consumer_succeed_2680() -> Result<()> {
 fn test_path_refuses_navigation_inside_array_on_untracked_input_2689() -> Result<()> {
     for (filter, doc, element) in [
         // no destructuring: the real root cause
-        ("path(1 | [.[]?] | empty)", "null", "iterate through 1"),
-        ("path(1 | [.a?] | empty)", "null", r#"element "a" of 1"#),
+        ("path(1 | [.[]] | empty)", "null", "iterate through 1"),
+        ("path(1 | [.a] | empty)", "null", r#"element "a" of 1"#),
         (
             "path(. as $x | .a | $x | [.b] | empty)",
             r#"{"a":1,"b":2}"#,
@@ -43392,6 +43393,26 @@ fn test_write_refuses_navigation_inside_array_on_untracked_input_2689() -> Resul
         );
         assert_eq!(stdout.trim_end(), "", "{filter}: nothing written");
     }
+
+    // The other direction: a write jq performs as a no-op must still be a
+    // no-op, not a refusal. These are the deferred shapes -- a first draft
+    // refused every one of them.
+    for (filter, doc) in [
+        ("del(. as {a:$v0} | [5] | select(false))", r#"{"a":false}"#),
+        (
+            "del(. as {a:$x} | [getpath([])] | select(false))",
+            r#"{"a":false}"#,
+        ),
+        ("(1 | [recurse(empty)] | select(false)) = 1", "null"),
+        (
+            "del([.a] | [(.a)? | type] | select(false))",
+            r#"{"a":{"b":{"c":1}}}"#,
+        ),
+    ] {
+        let (stdout, stderr, code) = run_jq_full(&["-c", filter], Some(doc))?;
+        assert_eq!(code, 0, "{filter}: must stay a no-op; stderr {stderr:?}");
+        assert_eq!(stdout.trim_end(), doc, "{filter}: document unchanged");
+    }
     Ok(())
 }
 
@@ -43399,10 +43420,17 @@ fn test_write_refuses_navigation_inside_array_on_untracked_input_2689() -> Resul
 /// an untracked input". Each row is something jq accepts, and each is
 /// unchanged by the fix -- a trackable input, the plain-`as` control from
 /// the issue, a literal / identity / empty constructor, an object
-/// constructor (which jq evaluates with tracking *suspended*), and a
-/// `TrackedVar` inside the brackets, which the arm deliberately hands back to
-/// the catch-all because re-establishing the register needs machinery it is
-/// not given (#2759). All captured live from jq 1.7.1.
+/// constructor (which jq evaluates with tracking *suspended*).
+///
+/// The last block is the set of shapes the arm deliberately hands back to
+/// the evaluate-by-value catch-all, because their own untracked handling is
+/// wrong as a bare stage and routing the brackets through it would turn
+/// working programs into errors -- which a first draft of this fix did, on
+/// 69 shapes. A `TrackedVar` cannot re-establish the register from inside
+/// the arm (#2759); `getpath([])` and the `recurse` family refuse eagerly
+/// where jq refuses only on real navigation; and `(.a)?` is jq's *caught*
+/// `try .a` but the parser stores it as the uncaught `.a?` (#2764). All
+/// captured live from jq 1.7.1.
 #[test]
 fn test_array_on_untracked_input_boundary_2689() -> Result<()> {
     for (filter, doc) in [
@@ -43415,8 +43443,13 @@ fn test_array_on_untracked_input_boundary_2689() -> Result<()> {
         ("path(. as {a:$v0} | [.] | empty)", r#"{"a":false}"#),
         ("path(. as {a:$v0} | [] | empty)", r#"{"a":false}"#),
         ("path(. as {a:$v0} | {x:.a} | empty)", r#"{"a":false}"#),
+        // deferred shapes -- accepted by jq, and must stay accepted here
         ("path(. as {a:$v0} | [$v0] | empty)", r#"{"a":false}"#),
         ("path(. as {a:$v0} | [$v0.b?] | empty)", r#"{"a":false}"#),
+        ("path(1 | [getpath([])] | empty)", "null"),
+        ("path(1 | [recurse(empty)] | empty)", "null"),
+        ("path(1 | [(..)?] | empty)", "null"),
+        ("path(1 | [(.a.b)? | type] | empty)", "null"),
     ] {
         let (stdout, stderr, code) = run_jq_full(&["-c", filter], Some(doc))?;
         assert_eq!(code, 0, "{filter}: must stay accepted; stderr {stderr:?}");


### PR DESCRIPTION
## Summary

jq's `[f]` (`gen_collect`) runs `f` with path tracking **live** — unlike `{k:f}`, `if f`,
`select(f)`, `try f`, an `as` source, or `"\(f)"`, which all suspend it. So an INDEX/EACH
inside the brackets on a value that is not `value_at_path` raises exactly as it would as a
bare stage.

`Expr::Array` had no arm in `resolve_node_sink`. On an untracked input it fell to
`resolve_leaf`'s catch-all and was evaluated **by value**: the `.a` inside succeeded, the
array came back untracked, and a continuation that emitted nothing left nothing for
`resolve_terminal` to object to.

```console
$ echo null | jq -c 'path(1 | [.[]?] | empty)'
jq: error (at <stdin>:1): Invalid path expression near attempt to iterate through 1
$ echo null | succinctly jq -c 'path(1 | [.[]?] | empty)'     # before
                                                              # nothing, exit 0
```

### The issue's framing was wrong, usefully

#2689 reported this through a destructuring `. as {a:$v0}` and identified the destructuring
as load-bearing. It isn't — it only *supplies* an untracked ambient value, and the shape
above has no `as` at all. The destructuring's own register move (#2649) was already
correct. The damaging form is the write:

```console
$ echo '{"a":false}' | jq -c 'del(. as {a:$v0} | [.a] | ($v0.b?) as $v1 | $v1)'
jq: error (at <stdin>:1): Invalid path expression near attempt to access element "a" of {"a":false}
$ echo '{"a":false}' | succinctly jq -c 'del(. as {a:$v0} | [.a] | ($v0.b?) as $v1 | $v1)'   # before
{"a":false}                                                    # exit 0 — a refused edit reported as success
```

## How

The new arm resolves `inner` instead of evaluating it, which is what surfaces the
navigation: the inner `Field`/`Index`/`Iterate` arms already raise jq's exact wording
against an untracked input, and a literal, `.`, or an empty constructor pass straight
through. jq drains the whole collect, so the inner bound is unlimited whatever the outer
`keep` — `keep` governs how many *arrays* the consumer wants, and there is one. Same
accept-where-jq-refuses shape as #2646, on a leaf its static table cannot express because
`inner` is arbitrary code.

### Two deliberate limits

- **Keyed on `!trackable`.** A trackable input (`path([.a] | empty)`) and the plain-`as`
  control from the issue (`path(.a as $v0 | [.a] | ...)`, which jq accepts) still take the
  catch-all, so the seq-level register handling (`cannot_move_register`'s own `Array` arm)
  is untouched.
- **Bails out when the brackets contain a `TrackedVar`.** A marker can *re-establish*
  tracking — `$v` whose frozen value is still the live register is not navigation
  (#1573) — but that comparison happens one level up in `resolve_seq_stage`, against a
  `carried_register` this function is not handed. My first cut without this guard resolved
  `[$v0.b?]` with `trackable: false`, saw `$v0` as just another untracked value, and
  refused `.b` where jq accepts. So the marker case keeps the catch-all exactly as before;
  #2759 records what the complete fix needs (thread the register, or intercept at the
  stage level — deferred because `resolve_seq_stage`'s register placement is the most
  intricate logic in the resolver and none of the reported shapes needed it).

jq mode only (ADR-0018): real yq's lexer rejects every shape that reaches here, so there
is no yq oracle and yq mode is untouched.

## Verification

**102-case sweep** — 17 filter shapes × 6 documents — against `/usr/bin/jq` 1.7.1, with
every row also diffed against a `main` build:

- **102 of 102 match jq.**
- **37 rows changed from `main`, every one to jq's answer** — including the `del()` and
  `= 1` write forms, and `path(. as {a:$v0} | [.a][0] | empty)`, which moved from a
  *wrong-wording* error to jq's exact message.
- Zero rows changed away from jq.

The boundary is pinned in both directions: a trackable input, the plain-`as` control,
literal/identity/empty constructors, an object constructor (tracking suspended in jq), and
a marker inside the brackets all stay accepted.

### Sibling gaps surfaced and filed, not fixed here

- **#2760** — `and`/`or` operands and unary minus have the identical opacity
  (`path(. as {a:$v0} | (.a and true) | empty)` is silently accepted; jq refuses). Needs
  its own oracle bracket because `and`/`or` short-circuit, so only the operand that runs
  is tracked.
- **#2761** — `..` on an untracked input says "with result" where jq says "near attempt
  to iterate through"; pre-existing on the bare-stage arm, now also visible inside `[..]`.

## Test plan

- [x] `cargo test --features cli,simd,regex,serde` — full suite, 62 binaries, 0 failures,
      **no existing test needed changing**
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] 102-case sweep vs jq 1.7.1 and vs `main` (above)
- [x] Existing #2649 destructuring matrix, #1573/#2042 register tests, and the #2646 tests
      all pass unchanged
- [x] New: `test_path_refuses_navigation_inside_array_on_untracked_input_2689` (7 shapes,
      including the no-`as` root cause and nested/comma/pipe/postfix insides),
      `test_write_refuses_navigation_inside_array_on_untracked_input_2689` (the `del`/`=`
      forms), and `test_array_on_untracked_input_boundary_2689` (8 must-stay-accepted rows)

Fixes #2689