### PR TITLE
fix(jq): make the evaluator's resource caps uncatchable by ?/try/catch

### DIFF
--- a/docs/compliance/jq/limitations.md
+++ b/docs/compliance/jq/limitations.md
@@ -4570,9 +4570,9 @@ The five evaluator-imposed caps documented in this file -- `range`'s `MAX_RANGE`
 `while`/`until`'s `WHILE_UNTIL_MAX_STEPS` (#534/#2087), `reduce`/`foreach`'s
 `REDUCE_FOREACH_MAX_STEPS` (#695/#2079), `repeat`'s `MAX_ITERATIONS` (#2014), and a recursive
 `def` past `MAX_EVAL_FRAMES` (#1371) -- raise as `ErrorKind::ResourceLimit`
-(`src/jq/error.rs`), which every `?`/`try`/`catch` boundary treats exactly like a decode
-failure: never suppressed, never handed to the handler. Before #2132 they were plain errors,
-and the catch swallowed them:
+(`src/jq/error.rs`), which every catch boundary treats exactly like a decode failure: never
+suppressed by `?`, never handed to `catch`, and never a reason for `?//` to try the next
+destructuring alternative. Before #2132 they were plain errors, and the catch swallowed them:
 
 ```console
 $ echo null | jq -c '[range(100001)?] | length'            # jq 1.7.1 -- no cap at all
@@ -4602,9 +4602,19 @@ retroactively discards it: `range(100001)?` prints `0` through `99999` and *then
 stderr at exit 5, as #2089 established for the un-suppressed form. An early-stopping
 consumer never reaches the cap at all (`[limit(5; range(100001))?]` is `[0,1,2,3,4]`).
 
+**`?//` is a catch boundary too.** Review of the first cut found the destructuring-alternative
+retry (`try_pattern_alternatives`, `each_pattern_alternatives` and its generic twin, and
+`reduce`/`foreach`'s `is_retryable_control`) still consulting `is_decode_failure()` alone --
+#1620/#1660's own exclusion -- so a cap raised inside a `?//` body read as "try the next
+alternative": `[. as $x ?// $y | if $x != null then range(100002) else 1 end] | length`
+answered `100001` at exit 0. All of them, and `suppresses` (the ambient-`?` rule every fold
+construct shares), now use the one value-position predicate the `?`/`try` dispatch points
+always did.
+
 Pinned by `test_resource_limit_caps_are_uncatchable_2132`,
-`test_resource_limit_prefix_still_streams_before_the_cap_2132` and
-`test_resource_limit_tag_leaves_ordinary_errors_catchable_2132` (`tests/jq_cli_tests.rs`),
+`test_resource_limit_prefix_still_streams_before_the_cap_2132`,
+`test_resource_limit_tag_leaves_ordinary_errors_catchable_2132` and
+`test_resource_limit_is_not_a_destructuring_retry_2132` (`tests/jq_cli_tests.rs`),
 `resource_limit_is_uncatchable_by_tag_not_message_2132` (`src/jq/error.rs`), and the yq
 twin `test_resource_limit_caps_are_uncatchable_in_yq_mode_2132`.
 

--- a/docs/compliance/jq/limitations.md
+++ b/docs/compliance/jq/limitations.md
@@ -2718,6 +2718,8 @@ match.
 
 ## Recursive `def`s: what a native call stack costs that jq's own does not — #1371
 
+> The `MAX_EVAL_FRAMES` raise is uncatchable by `?`/`try`/`catch` since #2132 -- see "Every resource cap is uncatchable" below.
+
 `succinctly jq` used to substitute a `def`'s body into each call site before evaluating
 anything, which cannot terminate for a self-recursive `def` (expansion has no way to see
 that `n == 0` will eventually hold) and so had to be bounded by three guards. The
@@ -4019,6 +4021,8 @@ than silently left unrecorded. See
 
 ### `repeat(f)` under `limit`/`first` (value mode): fixed (#2014); the eager fallback and path mode still cap, in two different ways
 
+> Both `MAX_ITERATIONS` raises are uncatchable by `?`/`try`/`catch` since #2132 -- see "Every resource cap is uncatchable" below.
+
 `repeat(f)` (`def repeat(f): f, repeat(f);`) has no base case at all: an `f`
 that never errors and never produces a value on some round recurses forever.
 Confirmed live that real jq itself hangs on this rather than raising or
@@ -4125,6 +4129,8 @@ demand-driven treatment to `resolve_repeat_sink` would close this the
 same way.
 
 ### `reduce`/`foreach`'s own step budget (#695/#2079): bounds genuine fanout, not ordinary element count
+
+> The budget's raise is uncatchable by `?`/`try`/`catch` since #2132 -- see "Every resource cap is uncatchable" below.
 
 `REDUCE_FOREACH_MAX_STEPS` (`src/jq/eval.rs`) is a shared step budget charged
 against `reduce`/`foreach` once per UPDATE eval, and -- `foreach` only --
@@ -4294,6 +4300,8 @@ extrapolated) rather than the tens of minutes a further 10x would cost at
 the same pathological shape.
 
 ### `while`/`until`'s own step budget (#534/#2087): the identical bug #2079 already fixed for `reduce`/`foreach`
+
+> The budget's raise is uncatchable by `?`/`try`/`catch` since #2132 -- see "Every resource cap is uncatchable" below.
 
 `WHILE_UNTIL_MAX_STEPS` (`src/jq/eval.rs`) is a shared step budget for
 `while`/`until`'s backtracking-generator evaluation, decremented once per
@@ -4503,6 +4511,8 @@ same one a computed bracket's component stream gets.
 
 ### `range`'s own accumulation cap (#2089): a resource-exhaustion guard, now raising instead of silently truncating
 
+> The cap's raise is uncatchable by `?`/`try`/`catch` since #2132 -- see "Every resource cap is uncatchable" just below.
+
 `MAX_RANGE` (`src/jq/eval.rs`, `100000`, shared by `eval_range_values` and
 `eval_range_values_f64`) caps how many values a single `(from, to, step)`
 combination will accumulate before raising, mirroring
@@ -4553,6 +4563,50 @@ own repro table didn't happen to list, not new ones introduced by this fix.
   needs its own oracle verification before choosing a direction. Tracked as
   [#2131](https://github.com/rust-works/succinctly/issues/2131). **Fixed**:
   see the next section.
+
+### Every resource cap is uncatchable by `?`/`try`/`catch` (#2132) -- shared by the five cap sections
+
+The five evaluator-imposed caps documented in this file -- `range`'s `MAX_RANGE` (#2089, above),
+`while`/`until`'s `WHILE_UNTIL_MAX_STEPS` (#534/#2087), `reduce`/`foreach`'s
+`REDUCE_FOREACH_MAX_STEPS` (#695/#2079), `repeat`'s `MAX_ITERATIONS` (#2014), and a recursive
+`def` past `MAX_EVAL_FRAMES` (#1371) -- raise as `ErrorKind::ResourceLimit`
+(`src/jq/error.rs`), which every `?`/`try`/`catch` boundary treats exactly like a decode
+failure: never suppressed, never handed to the handler. Before #2132 they were plain errors,
+and the catch swallowed them:
+
+```console
+$ echo null | jq -c '[range(100001)?] | length'            # jq 1.7.1 -- no cap at all
+100001
+$ echo null | succinctly jq -c '[range(100001)?] | length'  # before #2132
+100000                                                       # exit 0 -- silently truncated
+$ echo null | succinctly jq -c 'def f: f; try f catch "caught"'  # before #2132
+"caught"
+```
+
+That was exactly the silent-wrong-data class #2089 closed for the *un-suppressed* spelling,
+re-opened one `?` away. The caps are succinctly's own, with no jq counterpart, so a `?`/`try`
+written against jq semantics cannot have meant "accept a truncated result" -- under ADR-0018's
+decision order this is rule 4(b) (matching the reference's catch semantics for an error the
+reference cannot raise would corrupt data), decided identically in both modes since the caps
+are not a reference behaviour in either.
+
+**Ordinary errors are unchanged, and that is jq's own rule, not a residual.** Real jq keeps the
+prefix a generator produced and catches only the terminal error -- `[(1,2,error("x"),3)?]` is
+`[1,2]`, `[try (1,2,error("x"),3) catch "c"]` is `[1,2,"c"]` -- and succinctly matches it.
+The issue's broad reading ("discard what already came out") would have been a divergence.
+Nor does the tag look at message text: a user's own
+`error("range: maximum iterations exceeded")` is still caught (#1660's lesson).
+
+**The prefix still streams.** A cap is an error that ends the stream, not one that
+retroactively discards it: `range(100001)?` prints `0` through `99999` and *then* the error on
+stderr at exit 5, as #2089 established for the un-suppressed form. An early-stopping
+consumer never reaches the cap at all (`[limit(5; range(100001))?]` is `[0,1,2,3,4]`).
+
+Pinned by `test_resource_limit_caps_are_uncatchable_2132`,
+`test_resource_limit_prefix_still_streams_before_the_cap_2132` and
+`test_resource_limit_tag_leaves_ordinary_errors_catchable_2132` (`tests/jq_cli_tests.rs`),
+`resource_limit_is_uncatchable_by_tag_not_message_2132` (`src/jq/error.rs`), and the yq
+twin `test_resource_limit_caps_are_uncatchable_in_yq_mode_2132`.
 
 ### `range`'s `i64` fast path at extreme magnitude (#2131, #2219): overflow-checked in place, extending the same #2089 hang-avoidance divergence
 

--- a/docs/compliance/yq/limitations.md
+++ b/docs/compliance/yq/limitations.md
@@ -3526,6 +3526,28 @@ output is unaffected, since neither appears in JSON
 for the feature-level gaps (position builtins after DOM conversion; `file_index`/`key`/
 `document_index` inside object literals or `any`/`all`).
 
+## Evaluator resource caps apply in yq mode too, and are uncatchable (#2132)
+
+The five caps `succinctly jq` documents -- `MAX_RANGE`, `WHILE_UNTIL_MAX_STEPS`,
+`REDUCE_FOREACH_MAX_STEPS`, `repeat`'s `MAX_ITERATIONS`, `MAX_EVAL_FRAMES` -- are shared
+evaluator limits, so they apply to `succinctly yq` as well; real yq v4.53.3 has none of them.
+The reachable ones without `--jq-extensions` are `while`/`until` and a recursive `def`
+(`range`/`repeat` are gated, #1512). Since #2132 the raise is `ErrorKind::ResourceLimit`,
+which `?`/`try`/`catch` never swallow, in both modes alike:
+
+```console
+$ printf 'a: 1\n' | succinctly yq '[.a | while(true; .+1)?] | length'
+Error: while: maximum iterations exceeded
+$ printf 'a: 1\n' | succinctly yq 'def f: f; try f catch "caught"'
+Error: f/0 exceeded maximum recursion depth
+```
+
+This is a rule 4(b) decision, not a mode difference: the caps are not a reference behaviour in
+either tool, so there is no yq catch semantics to match, and letting `try` swallow one would
+report a truncated result as a clean answer. See the jq page's "Every resource cap is
+uncatchable" section for the full account and oracle rows; pinned by
+`test_resource_limit_caps_are_uncatchable_in_yq_mode_2132` (`tests/yq_cli_tests.rs`).
+
 ## Where the two modes deliberately differ from each other
 
 Not divergences — these are ADR-0018 rule 2 working correctly. The same filter text means

--- a/src/jq/error.rs
+++ b/src/jq/error.rs
@@ -95,6 +95,12 @@ pub enum ErrorKind {
     /// See [`EvalError::is_untracked_navigation_error`] -- ordinarily
     /// catchable, with one narrow bare-postfix-`?` exception.
     UntrackedNavigation,
+    /// See [`EvalError::is_resource_limit`] -- always uncatchable (#2132).
+    /// An evaluator-imposed cap (`MAX_RANGE`, `WHILE_UNTIL_MAX_STEPS`,
+    /// `REDUCE_FOREACH_MAX_STEPS`, `repeat`'s `MAX_ITERATIONS`,
+    /// `MAX_EVAL_FRAMES`) that has no jq counterpart, so no `?`/`try` can
+    /// have been written to expect it.
+    ResourceLimit,
 }
 
 /// A stream terminator: what ended a sequence of outputs when it wasn't
@@ -1251,12 +1257,51 @@ impl EvalError {
         matches!(self.value, EvalErrorPayload::Kind(ErrorKind::DecodeFailure))
     }
 
+    /// An evaluator-imposed resource cap was exceeded (#2132): `range`'s
+    /// `MAX_RANGE`, `while`/`until`'s `WHILE_UNTIL_MAX_STEPS`,
+    /// `reduce`/`foreach`'s `REDUCE_FOREACH_MAX_STEPS`, `repeat`'s
+    /// `MAX_ITERATIONS`, or a recursive `def` past `MAX_EVAL_FRAMES`.
+    ///
+    /// These are succinctly's own limits with no jq counterpart --
+    /// `[range(100001)?] | length` is `100001` in jq 1.7.1, which has no cap
+    /// -- so a `?`/`try` written against jq semantics cannot have meant
+    /// "accept a truncated result". Letting the catch swallow the cap
+    /// reopened exactly the silent-wrong-data class #2089 closed:
+    /// `[range(100001)?] | length` answered `100000` at exit 0, and
+    /// `def f: f; try f catch "caught"` answered `"caught"`. Tagged
+    /// uncatchable instead, the same machinery as [`Self::decode_failure`]:
+    /// never suppressed by `?`, never handed to `catch`, still an ordinary
+    /// error to the CLI (exit 5), and still carried through `Partial` so the
+    /// prefix emitted before the cap reaches the output as #2089 established.
+    ///
+    /// Under ADR-0018's decision order this is rule 4(b) -- matching the
+    /// reference's catch semantics for an error the reference cannot raise
+    /// would corrupt data -- decided identically in both modes, since the
+    /// caps are not a reference behaviour in either.
+    ///
+    /// Ordinary user-raised or type errors are deliberately *not* this:
+    /// jq keeps the prefix and catches the terminal error
+    /// (`[(1,2,error("x"),3)?]` is `[1,2]`), succinctly matches it, and
+    /// nothing here changes that. A user's own
+    /// `error("range: maximum iterations exceeded")` stays catchable too --
+    /// the tag, not the message, decides (#1660's lesson).
+    pub fn resource_limit(message: impl Into<String>) -> Self {
+        Self::with_kind(message, ErrorKind::ResourceLimit)
+    }
+
+    /// Whether this is a [`Self::resource_limit`] -- see there for why it is
+    /// always uncatchable (#2132).
+    pub fn is_resource_limit(&self) -> bool {
+        matches!(self.value, EvalErrorPayload::Kind(ErrorKind::ResourceLimit))
+    }
+
     /// Whether this error class is *always* uncatchable, with no positional
     /// nuance — [`Self::is_invalid_path_expression`],
-    /// [`Self::is_decode_failure`], or [`Self::is_yq_negative_index_error`]
-    /// (#2254). Unlike [`Self::is_untracked_navigation_error`], which
+    /// [`Self::is_decode_failure`], [`Self::is_yq_negative_index_error`]
+    /// (#2254), or [`Self::is_resource_limit`] (#2132). Unlike
+    /// [`Self::is_untracked_navigation_error`], which
     /// genuinely depends on *where* the error was caught (a bare postfix `?`
-    /// on the primitive that raised it vs. anything else), all three mean
+    /// on the primitive that raised it vs. anything else), all four mean
     /// the same thing at every call site that checks them: never suppressed
     /// by `?`, never handed to a `catch` handler. `resolve_node`'s
     /// `Expr::Try` and `Expr::Optional` arms (`?`'s two path-context
@@ -1276,11 +1321,13 @@ impl EvalError {
         self.is_invalid_path_expression()
             || self.is_decode_failure()
             || self.is_yq_negative_index_error()
+            || self.is_resource_limit()
     }
 
     /// [`Self::is_uncatchable`], narrowed to the subset that also applies at
-    /// *value* position -- a decode failure or a yq negative-index raise,
-    /// but not [`Self::is_invalid_path_expression`]. That third condition is
+    /// *value* position -- a decode failure, a yq negative-index raise, or a
+    /// resource-limit raise (#2132), but not
+    /// [`Self::is_invalid_path_expression`]. That third condition is
     /// meaningful only in path context (`path()`/`getpath`'s own walker,
     /// `resolve_node`) and was never verified against value position, so
     /// widening a value-position dispatch point to the full
@@ -1303,7 +1350,7 @@ impl EvalError {
     /// the deleted eager path-context evaluator's own `Expr::Optional`/`Expr::Try`
     /// arms (`eval.rs`).
     pub fn is_uncatchable_at_value_position(&self) -> bool {
-        self.is_decode_failure() || self.is_yq_negative_index_error()
+        self.is_decode_failure() || self.is_yq_negative_index_error() || self.is_resource_limit()
     }
 
     /// `Cannot check whether <container> has a <key type> key`.
@@ -2011,5 +2058,32 @@ mod tests {
             EvalError::urid_invalid_escape(b"%\xe4\xb8").message,
             r#"invalid URL escape "%\xe4\xb8""#
         );
+    }
+
+    /// #2132: a resource-limit raise is uncatchable at both predicates, and
+    /// a user's own `error(..)` carrying the identical *message* is not --
+    /// the tag decides, never the text. That second half is the #1660 class
+    /// of bug `ErrorKind` exists to make structurally impossible: a
+    /// message-matching classifier once forced a user's
+    /// `error("invalid escape sequence")` uncatchable because it collided
+    /// with a literal list.
+    #[test]
+    fn resource_limit_is_uncatchable_by_tag_not_message_2132() {
+        let capped = EvalError::resource_limit("range: maximum iterations exceeded");
+        assert!(capped.is_resource_limit());
+        assert!(capped.is_uncatchable());
+        assert!(capped.is_uncatchable_at_value_position());
+        // Not any *other* kind: the predicates must not overlap.
+        assert!(!capped.is_decode_failure());
+        assert!(!capped.is_invalid_path_expression());
+
+        let user = EvalError::new("range: maximum iterations exceeded");
+        assert!(!user.is_resource_limit());
+        assert!(!user.is_uncatchable());
+        assert!(!user.is_uncatchable_at_value_position());
+
+        // Message text is unchanged by the tag -- every existing
+        // message-asserting test stays valid.
+        assert_eq!(capped.message, user.message);
     }
 }

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -27271,8 +27271,10 @@ fn resolve_repeat_sink<'a, S: EvalSemantics>(
                 }
             });
         if over_budget {
+            // #2132: `resource_limit`, not `new` -- a cap `?`/`try` must not
+            // swallow. Same for every other raise below; see the constructor.
             return ResolveFlow::Escaped(
-                EvalError::new("repeat: maximum iterations exceeded".to_string()).into(),
+                EvalError::resource_limit("repeat: maximum iterations exceeded").into(),
             );
         }
         if stopped {
@@ -35062,7 +35064,8 @@ pub(crate) const REPEAT_WIDTH_BUDGET: usize = 10_000;
 /// `what` names the construct in the resulting error message.
 pub(crate) fn charge_budget(budget: &mut usize, what: &str) -> Option<Control> {
     if *budget == 0 {
-        return Some(Control::Error(EvalError::new(format!(
+        // #2132: uncatchable -- see `EvalError::resource_limit`.
+        return Some(Control::Error(EvalError::resource_limit(format!(
             "{what}: maximum iterations exceeded"
         ))));
     }
@@ -37695,7 +37698,8 @@ fn until_step<S: EvalSemantics>(
 ) -> Result<(), Control> {
     loop {
         if *budget == 0 {
-            return Err(Control::Error(EvalError::new(
+            // #2132: uncatchable -- see `EvalError::resource_limit`.
+            return Err(Control::Error(EvalError::resource_limit(
                 "until: maximum iterations exceeded",
             )));
         }
@@ -37788,7 +37792,8 @@ fn while_step<S: EvalSemantics>(
             // `finish_fork` at the call site like every other termination
             // cause, so `outputs` gathered before the cap no longer vanish
             // (deliberate minor behavior change — not pinned by any test).
-            return Err(Control::Error(EvalError::new(
+            // #2132: uncatchable -- see `EvalError::resource_limit`.
+            return Err(Control::Error(EvalError::resource_limit(
                 "while: maximum iterations exceeded",
             )));
         }
@@ -38004,7 +38009,10 @@ fn eval_repeat<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
         }
     }
 
-    let control = Control::Error(EvalError::new("repeat: maximum iterations exceeded"));
+    // #2132: uncatchable -- see `EvalError::resource_limit`.
+    let control = Control::Error(EvalError::resource_limit(
+        "repeat: maximum iterations exceeded",
+    ));
     finish_fork(outputs, Some(control), optional)
 }
 
@@ -38109,7 +38117,10 @@ const MAX_RANGE: usize = 100000;
 /// wanted every value (its sink kept answering [`Demand::Continue`]) hits a
 /// [`MAX_RANGE`]-truncated batch -- shared so callers can't drift in wording.
 fn range_max_exceeded_error() -> EvalError {
-    EvalError::new("range: maximum iterations exceeded")
+    // #2132: uncatchable -- `[range(100001)?] | length` answered `100000`
+    // at exit 0 with a plain `new`, the silent truncation #2089 closed for
+    // the un-suppressed spelling. See `EvalError::resource_limit`.
+    EvalError::resource_limit("range: maximum iterations exceeded")
 }
 
 /// Helper to generate range values, capped at [`MAX_RANGE`] per call --
@@ -49023,7 +49034,10 @@ pub(crate) fn bind_def_call<'e>(
 ) -> Result<&'e Rc<Expr>, EvalError> {
     bound.get_or_try_init(|| {
         if frames >= MAX_EVAL_FRAMES {
-            return Err(EvalError::new(format!(
+            // #2132: uncatchable -- `def f: f; try f catch "caught"` answered
+            // `"caught"` at exit 0 with a plain `new`. See
+            // `EvalError::resource_limit`.
+            return Err(EvalError::resource_limit(format!(
                 "{}/{} exceeded maximum recursion depth",
                 def.name,
                 def.params.len()

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -4420,8 +4420,11 @@ fn eval_owned_expr_fork<S: EvalSemantics>(
 /// react, so it correctly leaves `Break` alone and only ever silences a
 /// trailing `Error`.
 /// Whether `e` should be suppressed under an ambient `optional`: true for
-/// an ordinary error, false for a decode failure (#1620), which `optional`
-/// never suppresses. One definition for a rule `finish_fork` below,
+/// an ordinary error, false for anything
+/// [`EvalError::is_uncatchable_at_value_position`] -- a decode failure
+/// (#1620), a yq negative-index raise (#2254, documented as never
+/// suppressed by `optional`), or a resource-limit raise (#2132), none of
+/// which `optional` may suppress. One definition for a rule `finish_fork` below,
 /// `finish_fork_generic` (`eval_generic.rs`), and every `eval_reduce`/
 /// `eval_foreach` input/INIT arm all need, instead of each hand-copying
 /// `optional && !e.is_decode_failure()` -- this exact condition already
@@ -4430,7 +4433,13 @@ fn eval_owned_expr_fork<S: EvalSemantics>(
 /// drift); one shared predicate is the actual fix for a bug class that
 /// otherwise recurs every time a new match arm needs the same check.
 pub(crate) fn suppresses(e: &EvalError, optional: bool) -> bool {
-    optional && !e.is_decode_failure()
+    // #2132: the shared value-position predicate, not `is_decode_failure()`
+    // alone -- a resource cap under an ambient `?` was reporting a truncated
+    // fold as a clean answer, the same class #1620 closed for decode
+    // failures. Every `?`/`try` dispatch site already consults this
+    // predicate; this was the one suppression rule still spelling out one
+    // of its members by hand.
+    optional && !e.is_uncatchable_at_value_position()
 }
 
 /// Fold `e` into a terminal suppress-or-raise `QueryResult`, per
@@ -5852,10 +5861,14 @@ fn each_pattern_alternatives<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
                 }
                 return Flow::Stopped { pending };
             }
-            // #1620/#1660: same decode-failure exclusion as
+            // #1620/#1660: same uncatchable exclusion as
             // `try_pattern_alternatives` -- always propagates, `is_last` or
-            // not.
-            Flow::Escaped(Control::Error(e)) if e.is_decode_failure() => {
+            // not. #2132 widened it from `is_decode_failure()` to the shared
+            // value-position predicate: a resource cap raised inside a `?//`
+            // body was read as "this alternative failed, try the next", and
+            // the truncated body passed as the next alternative's clean
+            // answer.
+            Flow::Escaped(Control::Error(e)) if e.is_uncatchable_at_value_position() => {
                 return Flow::Escaped(Control::Error(e));
             }
             // #1457: `Break` falls through like `Error`, not immediately
@@ -30536,6 +30549,7 @@ fn resolve_as_pattern<'a, S: EvalSemantics>(
                 ResolveFlow::Escaped(EvalEscape::Error(e)) => {
                     if is_last
                         || e.is_decode_failure()
+                        || e.is_resource_limit()
                         || e.is_untracked_navigation_error()
                         || e.is_invalid_path_expression()
                     {
@@ -36385,7 +36399,10 @@ fn detach_from_temp_document<'a, W: Clone + AsRef<[u64]>>(
 /// guard against a future change reopening a path to one.
 fn is_retryable_control(control: &Control, is_last: bool) -> bool {
     match control {
-        Control::Error(e) if e.is_decode_failure() => false,
+        // #2132: the shared value-position predicate -- a resource cap is
+        // no more a reason to try the next alternative than a decode
+        // failure is.
+        Control::Error(e) if e.is_uncatchable_at_value_position() => false,
         Control::Error(_) | Control::Break(_) => !is_last,
         Control::Halt(_) => false,
     }
@@ -48471,7 +48488,10 @@ fn try_pattern_alternatives<W: Clone + AsRef<[u64]>, S: EvalSemantics>(
             // alternative failed to match, try the next one" -- it always
             // propagates, `is_last` or not, the same way `eval_try` never
             // suppresses it regardless of whether a `catch` handler exists.
-            QueryResult::Error(e) if e.is_decode_failure() => {
+            // #2132: widened from `is_decode_failure()` to the shared
+            // value-position predicate, same reasoning as
+            // `each_pattern_alternatives`.
+            QueryResult::Error(e) if e.is_uncatchable_at_value_position() => {
                 return Ok((carried, Some(Control::Error(e))));
             }
             QueryResult::Error(e) => {

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -9054,7 +9054,12 @@ fn each_pattern_alternatives_generic<S: EvalSemantics, V: DocumentValue>(
             // `eval_single`'s wildcard fallback -- confirmed by removing
             // this arm and observing the exact silently-wrong-value bug
             // #1660 fixes elsewhere reappear here too.
-            Flow::Escaped(Control::Error(e)) if e.is_decode_failure() => {
+            //
+            // #2132: widened from `is_decode_failure()` to the shared
+            // value-position predicate, in step with `eval.rs`'s
+            // `each_pattern_alternatives` -- a resource cap inside a `?//`
+            // body must not read as "try the next alternative" either.
+            Flow::Escaped(Control::Error(e)) if e.is_uncatchable_at_value_position() => {
                 return Flow::Escaped(Control::Error(e));
             }
             // #1457: `Break` falls through like `Error`, not immediately

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -47466,3 +47466,83 @@ fn test_resource_limit_tag_leaves_ordinary_errors_catchable_2132() -> Result<()>
 
     Ok(())
 }
+
+/// #2132, second half (review finding): the `?//` destructuring-alternative
+/// retry is a catch boundary too, and it was still consulting
+/// `is_decode_failure()` alone -- #1620/#1660's own exclusion -- rather than
+/// the shared value-position predicate. So a cap raised *inside* a `?//`
+/// body read as "this alternative failed, try the next", and the truncated
+/// body passed as the next alternative's clean answer: measured before the
+/// fix, `[. as $x ?// $y | if $x != null then range(100002) else 1 end] |
+/// length` answered `100001` at exit 0 (jq 1.7.1: `100002`).
+///
+/// Every `?//` site now uses `is_uncatchable_at_value_position()`, the same
+/// predicate the six `?`/`try` dispatch points already did: eager
+/// (`try_pattern_alternatives`), streaming (`each_pattern_alternatives` and
+/// its generic twin), and the `reduce`/`foreach` source form
+/// (`is_retryable_control`). `suppresses`, the ambient-`?` rule every fold
+/// construct shares, was the last one spelling a member out by hand and is
+/// on the same predicate now.
+#[test]
+fn test_resource_limit_is_not_a_destructuring_retry_2132() -> Result<()> {
+    for (label, doc, filter, want_err) in [
+        (
+            "eager ?//, range",
+            "1",
+            "[. as $x ?// $y | if $x != null then range(100002) else 1 end] | length",
+            "range: maximum iterations exceeded",
+        ),
+        (
+            "eager ?//, recursion",
+            "1",
+            "[. as $x ?// $y | if $x != null then (def f: f; f) else 1 end]",
+            "f/0 exceeded maximum recursion depth",
+        ),
+        (
+            "streaming ?// under limit",
+            "[[1]]",
+            "[limit(300000; .[] as [$y] ?// $z | if $y != null then range(100002) else $z end)] | length",
+            "range: maximum iterations exceeded",
+        ),
+        (
+            "reduce source ?//",
+            "null",
+            "[reduce (1,2) as $x ?// $y (0; if $x != null then range(100002) else 1 end)]",
+            "range: maximum iterations exceeded",
+        ),
+        (
+            "foreach source ?//",
+            "null",
+            "[foreach (1,2) as $x ?// $y (0; if $x != null then range(100002) else 1 end; .)] | length",
+            "foreach: maximum iterations exceeded",
+        ),
+        (
+            "ambient ? over a fold (suppresses)",
+            "null",
+            "[(reduce range(50001) as $x ((0,1); .+$x))?] | length",
+            "reduce: maximum iterations exceeded",
+        ),
+    ] {
+        let (stdout, stderr, code) = run_jq_full(&["-c", filter], Some(doc))?;
+        assert_eq!(code, 5, "[{label}] `{filter}`: stdout {stdout:?} stderr {stderr:?}");
+        assert!(stderr.contains(want_err), "[{label}] stderr {stderr:?}");
+    }
+
+    // Ordinary errors inside a `?//` body still fall through to the next
+    // alternative -- jq's own rule, each row captured from jq 1.7.1.
+    for (doc, filter, want) in [
+        (
+            "[1]",
+            r#". as [$a] ?// $b | if $a != null then error("x") else "second" end"#,
+            r#""second""#,
+        ),
+        ("[1]", "[1] as [$a] ?// $b | $b", "null"),
+        ("[[1,2]]", ".[] as [$a] ?// [$b] | [$a,$b]", "[1,null]"),
+    ] {
+        let (stdout, stderr, code) = run_jq_full(&["-c", filter], Some(doc))?;
+        assert_eq!(code, 0, "`{filter}`: stderr {stderr:?}");
+        assert_eq!(stdout.trim_end(), want, "`{filter}`");
+    }
+
+    Ok(())
+}

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -47286,3 +47286,183 @@ fn test_boolean_routes_agree_on_a_malformed_document_2669() -> Result<()> {
 
     Ok(())
 }
+
+/// #2132: an evaluator-imposed resource cap is **uncatchable** -- never
+/// suppressed by `?`, never handed to `catch` -- under all three spellings,
+/// for every guard.
+///
+/// These caps (`MAX_RANGE`, `WHILE_UNTIL_MAX_STEPS`, `REDUCE_FOREACH_MAX_STEPS`,
+/// `repeat`'s `MAX_ITERATIONS`, `MAX_EVAL_FRAMES`) are succinctly's own, with
+/// no jq counterpart: `[range(100001)?] | length` is `100001` in jq 1.7.1,
+/// which has no cap at all. A `?`/`try` written against jq semantics cannot
+/// have meant "accept a truncated result", so letting the catch swallow the
+/// cap reopened the silent-wrong-data class #2089 closed for the
+/// un-suppressed spelling. Measured before this fix:
+/// `[range(100001)?] | length` answered `100000` at exit 0,
+/// `[try range(100001) catch "caught"] | length` answered `100001` (prefix
+/// plus the handler's value), and `def f: f; try f catch "caught"` answered
+/// `"caught"`.
+///
+/// Under ADR-0018's decision order this is rule 4(b) -- matching the
+/// reference's catch semantics for an error it cannot raise would corrupt
+/// data -- and it is `ErrorKind::ResourceLimit` riding the same uncatchable
+/// machinery as a decode failure (#1840), not a `Control::Halt`: the CLI
+/// still prints it and exit-codes it as an ordinary error (5), and it still
+/// flows through `Partial` so the prefix streamed before the cap reaches
+/// stdout, exactly as #2089 established.
+#[test]
+fn test_resource_limit_caps_are_uncatchable_2132() -> Result<()> {
+    for (label, expr, want_err) in [
+        (
+            "MAX_RANGE",
+            "range(100001)",
+            "range: maximum iterations exceeded",
+        ),
+        (
+            "WHILE_UNTIL_MAX_STEPS/while",
+            "while(true; .+1)",
+            "while: maximum iterations exceeded",
+        ),
+        (
+            "WHILE_UNTIL_MAX_STEPS/until",
+            "until(false; .+1)",
+            "until: maximum iterations exceeded",
+        ),
+        // Genuine fan-out past the shared reduce/foreach budget -- the same
+        // shape `test_reduce_budget_exceeded_errors` uses: two INIT forks
+        // over a 50,001-element source is 100,002 UPDATE evaluations.
+        (
+            "REDUCE_FOREACH_MAX_STEPS/reduce",
+            "reduce range(50001) as $x ((0,1); .+$x)",
+            "reduce: maximum iterations exceeded",
+        ),
+        (
+            "REDUCE_FOREACH_MAX_STEPS/foreach",
+            "foreach range(50001) as $x ((0,1); .+$x; empty)",
+            "foreach: maximum iterations exceeded",
+        ),
+        (
+            "repeat MAX_ITERATIONS",
+            "repeat(.)",
+            "repeat: maximum iterations exceeded",
+        ),
+        (
+            "MAX_EVAL_FRAMES",
+            "def f: f; f",
+            "f/0 exceeded maximum recursion depth",
+        ),
+        (
+            "MAX_EVAL_FRAMES, generator",
+            "def f: 1, f; f",
+            "f/0 exceeded maximum recursion depth",
+        ),
+    ] {
+        for spelling in [
+            format!("[{expr}?] | length"),
+            format!("[try ({expr})] | length"),
+            format!("[try ({expr}) catch \"caught\"] | length"),
+        ] {
+            let (stdout, stderr, code) = run_jq_full(&["-c", &spelling], Some("null"))?;
+            assert_eq!(
+                code, 5,
+                "[{label}] `{spelling}`: the cap must not be caught -- stdout {stdout:?} stderr {stderr:?}"
+            );
+            assert!(
+                stderr.contains(want_err),
+                "[{label}] `{spelling}`: stderr {stderr:?} lacks {want_err:?}"
+            );
+            assert!(
+                !stdout.contains("caught"),
+                "[{label}] `{spelling}`: the handler ran: {stdout:?}"
+            );
+        }
+    }
+
+    Ok(())
+}
+
+/// #2132: the prefix a generator streamed before hitting its cap is still
+/// printed -- the cap is an error that ends the stream, not one that
+/// retroactively discards it. Bare (not inside a `[...]` collector) so the
+/// prefix is observable on stdout, with the cap's error on stderr after it.
+#[test]
+fn test_resource_limit_prefix_still_streams_before_the_cap_2132() -> Result<()> {
+    for (spelling, want_last_line, want_err) in [
+        (
+            "range(100001)?",
+            "99999",
+            "range: maximum iterations exceeded",
+        ),
+        (
+            "try range(100001)",
+            "99999",
+            "range: maximum iterations exceeded",
+        ),
+        (
+            "try range(100001) catch \"caught\"",
+            "99999",
+            "range: maximum iterations exceeded",
+        ),
+        // `reduce` emits its first fork's result before the second exhausts
+        // the shared budget.
+        (
+            "try (reduce range(50001) as $x ((0,1); .+$x)) catch \"caught\"",
+            "1250025000",
+            "reduce: maximum iterations exceeded",
+        ),
+    ] {
+        let (stdout, stderr, code) = run_jq_full(&["-c", spelling], Some("null"))?;
+        assert_eq!(code, 5, "`{spelling}`: stderr {stderr:?}");
+        assert_eq!(
+            stdout.trim_end().lines().last().unwrap_or(""),
+            want_last_line,
+            "`{spelling}`: the prefix must still stream: {}",
+            stdout.len()
+        );
+        assert!(stderr.contains(want_err), "`{spelling}`: stderr {stderr:?}");
+        assert!(!stdout.contains("caught"), "`{spelling}`: {stdout:?}");
+    }
+
+    Ok(())
+}
+
+/// #2132: what the fix must **not** change, each row captured live from jq
+/// 1.7.1.
+///
+/// - An ordinary error under `?`/`try` keeps the prefix and catches the
+///   terminal error -- jq's own semantics, which succinctly already matched.
+///   The issue's broad reading ("discard what already came out") would have
+///   been a divergence, not a fix.
+/// - An early-stopping consumer never reaches the cap, so `?` has nothing
+///   to see: `[limit(5; range(100001))?]` is unaffected.
+/// - A user's own `error(..)` whose *message* happens to match a cap's is
+///   still catchable -- the tag decides, not the text, which is #1660's
+///   lesson and the reason `ErrorKind` exists.
+#[test]
+fn test_resource_limit_tag_leaves_ordinary_errors_catchable_2132() -> Result<()> {
+    for (filter, want) in [
+        (r#"[(1,2,error("x"),3)?]"#, "[1,2]"),
+        (r#"[try (1,2,error("x"),3) catch "c"]"#, r#"[1,2,"c"]"#),
+        ("[limit(5; range(100001))?]", "[0,1,2,3,4]"),
+        ("[limit(3; repeat(.)?)]", "[null,null,null]"),
+        ("first(repeat(1)?)", "1"),
+        (
+            r#"try error("range: maximum iterations exceeded") catch "user""#,
+            r#""user""#,
+        ),
+        (
+            r#"try error("f/0 exceeded maximum recursion depth") catch "user""#,
+            r#""user""#,
+        ),
+        (
+            r#"[error("repeat: maximum iterations exceeded")?] | length"#,
+            "0",
+        ),
+    ] {
+        let (stdout, stderr, code) = run_jq_full(&["-c", filter], Some("null"))?;
+        assert_eq!(code, 0, "`{filter}`: stderr {stderr:?}");
+        assert_eq!(stdout.trim_end(), want, "`{filter}`");
+    }
+
+    Ok(())
+}

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -41758,3 +41758,55 @@ fn test_wrong_arity_special_form_keeps_yq_parse_error_2686() -> Result<()> {
 
     Ok(())
 }
+
+/// #2132 (yq half): the evaluator's resource caps are uncatchable in yq
+/// mode too -- they are not a reference behaviour in either mode, so the
+/// `ErrorKind::ResourceLimit` tag is mode-independent.
+///
+/// `range`/`repeat` are behind `--jq-extensions` here (#1512), so the rows
+/// use the guards yq mode reaches unaided: `while`/`until`'s
+/// `WHILE_UNTIL_MAX_STEPS` and a recursive `def` past `MAX_EVAL_FRAMES`.
+#[test]
+fn test_resource_limit_caps_are_uncatchable_in_yq_mode_2132() -> Result<()> {
+    for (filter, want_err) in [
+        (
+            "[.a | while(true; .+1)?] | length",
+            "while: maximum iterations exceeded",
+        ),
+        (
+            "[.a | try while(true; .+1) catch \"caught\"] | length",
+            "while: maximum iterations exceeded",
+        ),
+        (
+            "[.a | until(false; .+1)?] | length",
+            "until: maximum iterations exceeded",
+        ),
+        (
+            "def f: f; try f catch \"caught\"",
+            "f/0 exceeded maximum recursion depth",
+        ),
+        (
+            "def f: f; [f?] | length",
+            "f/0 exceeded maximum recursion depth",
+        ),
+    ] {
+        let (stdout, stderr, code) = run_yq_stdin_with_stderr(filter, "a: 1\n", &[])?;
+        assert_ne!(
+            code, 0,
+            "`{filter}`: the cap must not be caught: {stdout:?}"
+        );
+        assert!(stderr.contains(want_err), "`{filter}`: stderr {stderr:?}");
+        assert!(
+            !stdout.contains("caught"),
+            "`{filter}`: the handler ran: {stdout:?}"
+        );
+    }
+
+    // And an ordinary error is still caught, so this is the tag, not `try`.
+    let (stdout, _stderr, code) =
+        run_yq_stdin_with_stderr("[.a | try error(\"x\") catch \"c\"]", "a: 1\n", &[])?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout.trim_end(), "- c");
+
+    Ok(())
+}


### PR DESCRIPTION
Fixes #2132

## Summary

Every evaluator resource cap — `MAX_RANGE`, `WHILE_UNTIL_MAX_STEPS`, `REDUCE_FOREACH_MAX_STEPS`, `repeat`'s `MAX_ITERATIONS`, `MAX_EVAL_FRAMES` — raised a plain `EvalError::new`, so `?`/`try` swallowed it and the truncated prefix passed as a clean result:

| filter | jq 1.7.1 | before | after |
|---|---|---|---|
| `[range(100001)?] \| length` | `100001` (no cap) | `100000`, exit 0 | exit 5, `range: maximum iterations exceeded` |
| `[try range(100001) catch "caught"] \| length` | `100001` | `100001` (prefix + handler!) | exit 5 |
| `[while(true;.+1)?] \| length` | (hangs) | `100000`, exit 0 | exit 5 |
| `def f: f; try f catch "caught"` | (stack overflow) | `"caught"`, exit 0 | exit 5, `f/0 exceeded maximum recursion depth` |

That is exactly the silent-wrong-data class #2089 closed for the *un-suppressed* spelling, re-opened one `?` away.

## Decision

The caps are succinctly's own, with no jq counterpart, so a `?`/`try` written against jq semantics cannot have meant "accept a truncated result". Under ADR-0018's decision order this is **rule 4(b)**: matching the reference's catch semantics for an error it cannot raise would corrupt data. Decided identically in both modes — the caps are not a reference behaviour in either.

The issue's broad reading ("should *any* mid-stream error under `?` discard the values already produced?") is answered **no** by the oracle: real jq keeps the prefix and catches the terminal error (`[(1,2,error("x"),3)?]` → `[1,2]`), succinctly already matched, and changing that would be a divergence. Only the caps are different, and not by discarding the prefix — by refusing the catch.

## Mechanism

A new `ErrorKind::ResourceLimit` riding the existing uncatchable machinery (#1840 chose typed tags over message-matching after #1660/#1813). All six value-position `?`/`try` dispatch points in both evaluators already consult `is_uncatchable_at_value_position()` and already have the "emit the prefix, re-raise the tagged error" arm — so **no dispatch site changes**. Only the seven raise sites are touched, each routed through `EvalError::resource_limit` with its message unchanged.

Deliberately *not* `Control::Halt`: a cap is still an ordinary error to the CLI (exit 5), and it must keep flowing through `Partial` so the prefix streamed before it reaches stdout — `range(100001)?` still prints `0`…`99999` and then the error, as #2089 established.

## What does not change (each captured from jq 1.7.1, and pinned)

- Ordinary errors under `?`/`try`: `[(1,2,error("x"),3)?]` → `[1,2]`, `[try (1,2,error("x"),3) catch "c"]` → `[1,2,"c"]`.
- Early-stopping consumers never reach the cap: `[limit(5; range(100001))?]` → `[0,1,2,3,4]`, `first(repeat(1)?)` → `1`.
- A user's own `error("range: maximum iterations exceeded")` is still caught — the tag decides, never the text (#1660's lesson), pinned at the `error.rs` unit level too.
- `EvalError`'s size pin (#1021) holds: a new `Copy` enum variant adds no bytes.
- No existing test pinned a cap being caught — the plan grepped for this and the full suite confirms it (8168 pass, zero changed expectations).

## Provenance

Implements the plan posted on #2132 on 2026-09-06 as written. Its branch reservation had sat idle for five days (zero commits, never pushed, no worktree) and was flagged idle on #235 in two triage rounds; taken over via the atomic worktree-add and rebased onto current `main`, with the premise re-verified there before any edit.

## Test plan

- [x] `cargo build --features cli`
- [x] `cargo test --features cli,simd,regex,serde` — 8168 passed, 0 failed
- [x] both clippy legs `-D warnings`
- [x] `cargo fmt --check`
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features`
- [x] `omni-dev coverage diff` — **100% patch coverage** (30/30)
- [x] Every guard × three spellings (`expr?`, `try expr`, `try expr catch`) asserted uncatchable, jq and yq mode
- [x] Prefix-streams-before-the-cap asserted on the bare form
- [x] Every control row diffed against `/usr/bin/jq` 1.7.1
- [x] `limitations.md` (jq): one shared section, back-linked from all five cap sections; (yq): new entry — its console rows verified against the binary


## Second half (from review)

Review found that `?//`'s destructuring-alternative retry is a catch boundary this PR had missed: every one of its sites still consulted `is_decode_failure()` alone (#1620/#1660's own exclusion) rather than the shared value-position predicate. So a cap raised **inside a `?//` body** read as "this alternative failed, try the next", and the truncated body passed as the next alternative's clean answer — reproduced on this branch's first cut:

| filter | before | after |
|---|---|---|
| `[. as $x ?// $y \| if $x != null then range(100002) else 1 end] \| length` | `100001`, exit 0 | exit 5 |
| `[reduce (1,2) as $x ?// $y (0; if $x != null then range(100002) else 1 end)]` | `[1]`, exit 0 | exit 5 |
| streaming `.[] as [$y] ?// $z` under `limit` | `100001`, exit 0 | exit 5 |

All four `?//` sites, `resolve_as_pattern`'s path-context list, and `suppresses` (the ambient-`?` rule every fold construct shares — the last place still spelling a predicate member out by hand) now use `is_uncatchable_at_value_position()`. That widening also brings the yq negative-index kind under `suppresses`, which its own doc already describes as never suppressed by `optional`; **123 yq-mode programs** over negative indices, slices and every fold construct are byte-identical against a `main` build. Ordinary errors inside a `?//` body still fall through to the next alternative, each row matching jq 1.7.1. Pinned by `test_resource_limit_is_not_a_destructuring_retry_2132`; patch coverage stays at 100%.
