### PR TITLE
fix(jq): recurse into error()'s message during substitution (#2095)

### DIFF
--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -34793,10 +34793,13 @@ fn substitute_var_impl(
             Some(marker) => Expr::TrackedVar(marker.get()),
             None => owned_to_expr(replacement),
         },
-        // #2095: does not recurse into `msg` -- see `map_subexprs`'s own doc
-        // comment (`src/jq/walk.rs`) on its `Expr::Error` arm for why this is
-        // preserved as a likely latent gap rather than fixed here.
-        Expr::Error(msg) => Expr::Error(msg.clone()),
+        // #2727: `Expr::Error` used to stop here with `msg.clone()`,
+        // unconditionally opaque, so a bound variable referenced inside
+        // `error(...)`'s message was never substituted (#2095's own review
+        // flagged this as a likely latent gap rather than a deliberate
+        // invariant like `Shared`'s). No longer special-cased: it now falls
+        // through to the catch-all below, reaching `map_subexprs`'s own
+        // `Expr::Error` arm, which already recurses into the message.
         Expr::Builtin(b) => {
             Expr::Builtin(substitute_var_in_builtin(b, var_name, replacement, mark))
         }
@@ -34909,10 +34912,10 @@ fn substitute_var_impl(
         // `Expr`-typed child and rebuild the node, nothing else -- so it
         // lives once in `map_subexprs` (`src/jq/walk.rs`) instead of being
         // hand-repeated in all three. See that function's own doc comment
-        // for the full variant-by-variant justification, including the five
-        // arms (`Shared`, `Error`, `Builtin`, `FuncDef`, and
-        // `install_def_calls`'s own `DefCall` policy) that stay explicit
-        // above/in each caller instead of ever reaching it.
+        // for the full variant-by-variant justification, including the four
+        // arms (`Shared`, `Builtin`, `FuncDef`, and `install_def_calls`'s own
+        // `DefCall` policy) that stay explicit above/in each caller instead
+        // of ever reaching it -- `Expr::Error` used to be a fifth (#2727).
         _ => map_subexprs(expr, &mut |sub| {
             substitute_var_impl(sub, var_name, replacement, mark)
         }),
@@ -49317,10 +49320,12 @@ pub(crate) fn install_def_calls(
                 bound: BoundBody::default(),
             }
         }
-        // #2095: does not recurse into `msg` -- see `map_subexprs`'s own doc
-        // comment (`src/jq/walk.rs`) on its `Expr::Error` arm for why this is
-        // preserved as a likely latent gap rather than fixed here.
-        Expr::Error(msg) => Expr::Error(msg.clone()),
+        // #2727: `Expr::Error` used to stop here with `msg.clone()`,
+        // unconditionally opaque, so a recursive call inside `error(...)`'s
+        // message (e.g. `error("...\(f(n-1))...")`) was never bound to its
+        // `DefCall` wrapper. No longer special-cased: it now falls through
+        // to the catch-all below, reaching `map_subexprs`'s own
+        // `Expr::Error` arm, which already recurses into the message.
         Expr::Builtin(b) => Expr::Builtin(install_def_calls_in_builtin(
             b,
             def,
@@ -49843,10 +49848,12 @@ fn substitute_func_param_impl(expr: &Expr, param: &str, arg: &Expr, scope: Subst
         // `FuncCall` arm below reads `scope.bare` instead, and the two
         // narrow on different binders (#2555).
         Expr::Var(name) if scope.dollar && name == param => arg.clone(),
-        // #2095: does not recurse into `msg` -- see `map_subexprs`'s own doc
-        // comment (`src/jq/walk.rs`) on its `Expr::Error` arm for why this is
-        // preserved as a likely latent gap rather than fixed here.
-        Expr::Error(msg) => Expr::Error(msg.clone()),
+        // #2727: `Expr::Error` used to stop here with `msg.clone()`,
+        // unconditionally opaque, so a `def` parameter referenced inside
+        // `error(...)`'s message was never substituted. No longer
+        // special-cased: it now falls through to the catch-all below,
+        // reaching `map_subexprs`'s own `Expr::Error` arm, which already
+        // recurses into the message.
         Expr::Builtin(b) => Expr::Builtin(substitute_func_param_in_builtin(b, param, arg, scope)),
         // #2141: `expr`/`input`/`init` (evaluated in the *outer* scope)
         // always keep the ambient scope, and `body`/`update`/`extract` (the

--- a/src/jq/walk.rs
+++ b/src/jq/walk.rs
@@ -640,14 +640,14 @@ pub fn map_builtin_subexprs(builtin: &Builtin, f: &mut dyn FnMut(&Expr) -> Expr)
 ///   Kept explicit in all three rather than folded here, despite being
 ///   identical across them, because each function's own comment on this arm
 ///   documents a different concrete hazard worth reading in place.
-/// - `Expr::Error`: also identical across all three (`msg.clone()`, no
-///   recursion into the message) -- and also kept explicit in all three
-///   rather than folded, but for the opposite reason from `Shared`: unlike
-///   `Shared`'s opacity, this one is not obviously a deliberate invariant.
-///   `error($x)` referencing a variable, parameter, or def-call the
-///   enclosing pass is substituting would not get substituted by any of the
-///   three today. Preserved as-is (behavior-preserving refactor, not a
-///   bugfix) but flagged here for follow-up.
+/// - `Expr::Error`: **no longer** kept explicit in any of the three (#2727)
+///   -- it used to be, identically, an unconditional `msg.clone()` with no
+///   recursion into the message, which meant `error($x)` referencing a
+///   variable, parameter, or def-call the enclosing pass was substituting
+///   never got substituted by any of the three. Unlike `Shared`'s opacity,
+///   that was never a deliberate invariant (flagged as a likely latent gap
+///   when this function was introduced), so all three now fall through to
+///   this function's own arm below, which does recurse into the message.
 /// - `Expr::Builtin`: always delegates to [`map_builtin_subexprs`], but
 ///   `install_def_calls_in_builtin` charges its own sub-expressions an extra
 ///   frame relative to every other structural descent (see its own doc
@@ -671,14 +671,17 @@ pub fn map_builtin_subexprs(builtin: &Builtin, f: &mut dyn FnMut(&Expr) -> Expr)
 ///   unconditional shape exists to fall back to, so all three keep their own
 ///   complete arm and never reach this function's own arm for it.
 ///
-/// The five arms named above (`Shared`, `Error`, `Builtin`, `FuncDef`, and
+/// The four arms named above (`Shared`, `Builtin`, `FuncDef`, and
 /// `install_def_calls`'s own `DefCall` policy) are therefore never actually
 /// exercised by any of today's three callers -- but this function still
 /// implements them, with a reasoned default, rather than reaching for a
 /// wildcard: the whole point of matching exhaustively is that a *future*
 /// `Expr` variant is a compile error here until it is categorized, and a
-/// wildcard on these five would quietly extend to that future variant too,
+/// wildcard on these four would quietly extend to that future variant too,
 /// recreating exactly the silent-drop risk this function exists to close.
+/// `Expr::Error` no longer joins them (#2727): all three now genuinely reach
+/// this function's own `Expr::Error` arm below, rather than shadowing it
+/// with their own copy first.
 ///
 /// **Deliberately has no wildcard arm**, for the same reason
 /// [`map_builtin_subexprs`] doesn't.
@@ -1862,11 +1865,11 @@ mod tests {
         assert_eq!(result, expr);
     }
 
-    /// `Expr::Error`'s default arm recurses into the message (unlike any of
-    /// today's three `eval.rs` callers, which all keep their own
-    /// non-recursing `Expr::Error(msg) => Expr::Error(msg.clone())` arm
-    /// instead of reaching this one -- see this function's own doc comment
-    /// for why). Confirms both the `Some` and `None` message shapes.
+    /// `Expr::Error`'s arm recurses into the message -- since #2727, all
+    /// three `eval.rs` callers now actually reach this one instead of
+    /// shadowing it with their own non-recursing copy (see this function's
+    /// own doc comment for the pre-#2727 history). Confirms both the `Some`
+    /// and `None` message shapes.
     #[test]
     fn map_subexprs_error_default_recurses_into_message() {
         let with_msg = parse("error(.a)").expect("filter should parse");

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -27952,6 +27952,53 @@ fn test_error_message_arg_break_semantics_unaffected_by_1164() -> Result<()> {
     Ok(())
 }
 
+/// #2727: `error(...)`'s message sub-expression used to be cloned rather
+/// than recursed into by all three tree rewriters (`substitute_func_param_impl`,
+/// `substitute_var_impl`, `install_def_calls`), so a `def` parameter, a bound
+/// variable, or a recursive call referenced inside it was never substituted
+/// -- surfacing as a confusing "undefined function"/wrong-message error
+/// instead of the program's own. All four shapes below are live jq 1.7.1
+/// captures.
+#[test]
+fn test_error_message_substitution_reaches_bound_names_2727() -> Result<()> {
+    // A `def` parameter referenced inside `error(...)`'s message.
+    let (out, _err, code) =
+        run_jq_full(&["-cn", r#"def f(a): try error(a) catch .; f("x")"#], None)?;
+    assert_eq!(code, 0, "out={out:?}");
+    assert_eq!(out, "\"x\"\n", "out={out:?}");
+
+    // An `as`-bound variable referenced inside `error(...)`'s message --
+    // not parameter-specific, per the issue's own "why this is separate"
+    // note.
+    let (out, _err, code) = run_jq_full(&["-cn", r#""x" as $a | try error($a) catch ."#], None)?;
+    assert_eq!(code, 0, "out={out:?}");
+    assert_eq!(out, "\"x\"\n", "out={out:?}");
+
+    // A `$`-style def parameter referenced inside `error(...)`'s message --
+    // the other substitution namespace `substitute_func_param_impl` handles.
+    let (out, _err, code) = run_jq_full(
+        &["-cn", r#"def f($a): try error($a) catch .; f("x")"#],
+        None,
+    )?;
+    assert_eq!(code, 0, "out={out:?}");
+    assert_eq!(out, "\"x\"\n", "out={out:?}");
+
+    // A recursive def call inside error(...)'s own message string --
+    // exercises `install_def_calls`'s copy of the same arm, which binds
+    // `Expr::FuncCall` to `Expr::DefCall` before evaluation ever runs.
+    let (out, _err, code) = run_jq_full(
+        &[
+            "-cn",
+            r#"def f(n): if n == 0 then "done" else error("depth \(f(n-1))") end; try f(2) catch ."#,
+        ],
+        None,
+    )?;
+    assert_eq!(code, 0, "out={out:?}");
+    assert_eq!(out, "\"depth done\"\n", "out={out:?}");
+
+    Ok(())
+}
+
 /// #1164 coverage: the `optional` (`?`) arm of a wrong-typed argument is a
 /// separate branch from the non-optional error arm every other test above
 /// already exercises -- `?` suppresses the type mismatch to no output


### PR DESCRIPTION
## Summary

`Expr::Error`'s message sub-expression was cloned rather than recursed into by all
three tree rewriters (`substitute_func_param_impl`, `substitute_var_impl`,
`install_def_calls`) — each carried its own non-recursing
`Expr::Error(msg) => Expr::Error(msg.clone())` arm that shadowed `map_subexprs`'s
own already-correct default arm, so a `def` parameter, a bound variable, or a
recursive call referenced inside `error(...)` was never substituted. It survived to
evaluation as an unresolved call and surfaced as a fabricated
`"undefined function: a/0"` instead of the error the program actually asked for.

```console
$ echo null | jq -c 'def f(a): try error(a) catch .; f("x")'
"x"
$ echo null | succinctly jq -c 'def f(a): try error(a) catch .; f("x")'   # before
"undefined function: a/0"
```

All three non-recursing arms were already tagged with `#2095` code comments
explicitly flagging this as "preserved as a likely latent gap rather than fixed
here" — this closes that gap. Fixed by removing the three shadowing arms so they
fall through to their own existing `_ => map_subexprs(expr, &mut |sub| ...)`
catch-all, which already recurses into the message correctly (confirmed by
`map_subexprs`'s own pre-existing test, whose doc comment explicitly noted the
three callers weren't reaching it).

Fixes #2727

## Test plan

- [x] `cargo build --features cli`
- [x] `cargo test --features cli,simd,regex,serde` (full suite, 0 failures)
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings`
- [x] New `test_error_message_substitution_reaches_bound_names_2727` covering all
      four substitution shapes (bare `def` parameter, `as`-bound variable, `$`-style
      `def` parameter, and a recursive `def` call inside the message) — each
      cross-checked live against `/usr/bin/jq` 1.7.1
- [x] Updated `map_subexprs`'s own doc comment and test, both of which had
      explicitly documented the pre-fix gap
- [x] No new executable lines (the diff removes dead-end arms and updates
      comments), so `omni-dev coverage diff` reports nothing new to cover
