### PR TITLE
fix(jq): check, not assume, that only a ?// retry re-drives resolve_terminal's sink

### DIFF
--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -34203,6 +34203,10 @@ fn resolve_terminal<'a, S: EvalSemantics>(
 ) -> PathResolveResult<'a> {
     let mut kept: Vec<PathBranch<'a>> = Vec::new();
     let mut violation: Option<EvalEscape> = None;
+    // The retry generation current when this sink last refused a branch,
+    // `Some` only between that refusal and the next invocation -- see the
+    // `debug_assert!` below and `terminal_retry` (#2691).
+    let mut refused_at: Option<u64> = None;
     // `input` is the call's own fresh document root — never itself a
     // frozen `$x` snapshot, so ambient `snapshot` starts `false` (#1591),
     // and the document `path()`/`=`/`|=`/`del()` were actually called on is
@@ -34216,6 +34220,23 @@ fn resolve_terminal<'a, S: EvalSemantics>(
         &Frame::enter(expr),
         Keep::First,
         &mut |branch| {
+            // #2691: the reset just below discards a violation this sink
+            // already recorded. That is correct for exactly one caller -- a
+            // `?//` alternative that stopped on the refusal and is now
+            // trying the next alternative through this same sink -- and
+            // would be a silent false success for any other producer that
+            // kept driving past `Demand::Stop` (the refused write would go
+            // through). So a re-invocation after a refusal must have seen a
+            // retry begin. Checked, not assumed: the full suite plus 10,400
+            // generated `path`/`del`/`=`/`|=` shapes without a `?//` never
+            // re-invoke here, and the one `?//` retry that does is the
+            // shape this admits.
+            if let Some(generation) = refused_at.take() {
+                debug_assert!(
+                    terminal_retry::began_since(generation),
+                    "resolve_terminal's sink was re-invoked after refusing a branch, but no                      `?//` alternative retry began in between -- a producer drove past                      `Demand::Stop`, and the refusal it just cleared would have been a                      false success (#2691): expr={expr:?}"
+                );
+            }
             violation = None;
             if !branch.trackable {
                 if skip_untracked {
@@ -34226,6 +34247,7 @@ fn resolve_terminal<'a, S: EvalSemantics>(
                 } else {
                     EvalError::invalid_path_expression(&branch.value).into()
                 });
+                refused_at = Some(terminal_retry::current());
                 return Demand::Stop;
             }
             kept.push(branch);
@@ -36529,6 +36551,74 @@ mod nonretryable_stop {
     }
 }
 
+/// The `?//` retry generation [`resolve_terminal`]'s sink checks before it
+/// discards a refusal it already recorded (#2691).
+///
+/// That sink resets its captured violation on every invocation. The reset
+/// exists for one kind of caller: a `?//` alternative loop that stopped on
+/// the refusal and then drives the *next* alternative through the same
+/// sink, at which point the earlier alternative's refusal must not stand.
+/// The loop is not always the resolver's own [`resolve_as_pattern`] -- when
+/// the `?//` sits in a demand-pulled `foreach`/`reduce` source, the sink's
+/// `Demand::Stop` unwinds into the *value-mode* loop, which retries and
+/// feeds the sink again (see [`clear_nonretryable_stop`]). Any other
+/// producer that re-invoked the sink after `Demand::Stop` would clear a
+/// real refusal and let `del`/`=`/`|=` write where jq refuses -- a false
+/// success, not a wrong message. Nothing at the sink can tell the two apart
+/// from the branch alone, so the retry announces itself here:
+/// [`begin_attempt`] bumps a generation on entry to every alternative
+/// attempt (from [`clear_nonretryable_stop`], which every such loop already
+/// calls), the sink records the generation when it refuses, and a
+/// re-invocation asserts the generation moved.
+///
+/// The check is a `debug_assert!`: it fires in the suite and every debug
+/// build, which is where the invariant is exercised, and costs a release
+/// build nothing beyond the `Option<u64>` the sink already keeps. Sound in
+/// the direction that matters -- a legitimate retry always bumps before it
+/// re-invokes, so it can never fire spuriously; a rogue re-invocation
+/// *inside* a nested `?//` that happened to bump first would be missed, not
+/// misreported.
+///
+/// Rides beside the stack the way [`nonretryable_stop`] does, with the same
+/// `#[cfg(feature = "std")]` split for the same reason.
+#[cfg(feature = "std")]
+mod terminal_retry {
+    use std::cell::Cell;
+
+    thread_local! {
+        static GENERATION: Cell<u64> = const { Cell::new(0) };
+    }
+
+    pub(crate) fn begin_attempt() {
+        GENERATION.with(|g| g.set(g.get().wrapping_add(1)));
+    }
+
+    pub(crate) fn current() -> u64 {
+        GENERATION.with(Cell::get)
+    }
+
+    /// Whether an attempt began since `generation` was read.
+    pub(crate) fn began_since(generation: u64) -> bool {
+        current() != generation
+    }
+}
+
+/// `no_std` has no `thread_local!`, so the generation never moves and the
+/// assertion answers vacuously -- unchecked there, exactly as it was before
+/// #2691, never falsely failing.
+#[cfg(not(feature = "std"))]
+mod terminal_retry {
+    pub(crate) fn begin_attempt() {}
+
+    pub(crate) fn current() -> u64 {
+        0
+    }
+
+    pub(crate) fn began_since(_generation: u64) -> bool {
+        true
+    }
+}
+
 /// `no_std` has no `thread_local!`, so the side channel is never set and
 /// every escape-backed stop stays retryable there -- exactly as it was
 /// before #2180 WP3, not worse. Same trade-off, and the same reasoning, as
@@ -36637,8 +36727,26 @@ pub(crate) fn resume_from_escape(slot: Option<Control>, flow: Flow) -> Flow {
 /// Clear the non-retryable-stop side channel on entry to one `?//`
 /// alternative's attempt. See [`nonretryable_stop`] for why the clear lives
 /// here rather than at whoever set the flag.
+///
+/// Also the one place a `?//` attempt announces itself to
+/// [`resolve_terminal`]'s sink ([`terminal_retry::begin_attempt`], #2691).
+/// Every `?//` attempt loop in both evaluators -- value-mode
+/// [`each_pattern_alternatives`]/[`try_pattern_alternatives`], the fold
+/// forms, `eval_generic`'s twin, and the resolver's own
+/// [`resolve_as_pattern`] -- already calls this on entry, so putting the
+/// bump here rather than at any retry site makes "a retry began since the
+/// refusal" true by construction for every retry form, including the one
+/// that is easy to miss: a refusal at the resolver's terminal sink inside a
+/// `foreach`/`reduce` whose *source* holds the `?//`. That source is pulled
+/// by demand (#2235), so the sink's `Demand::Stop` crosses the value/path
+/// boundary and it is the **value-mode** retry that drives the next source
+/// value back into the same sink -- `path(foreach (1 as $x ?// $y | ..) as
+/// $v (.; .; if $v == 1 then 1 else . end))` is jq's `[]` only because of
+/// it. A first cut of #2691 bumped at `resolve_as_pattern` alone and fired
+/// on exactly that row.
 pub(crate) fn clear_nonretryable_stop() {
     nonretryable_stop::clear();
+    terminal_retry::begin_attempt();
 }
 
 /// Try each `?//`-separated pattern alternative (#1365) for one `foreach`
@@ -69485,6 +69593,33 @@ mod tests {
             ),
             ["3"]
         );
+    }
+
+    /// #2691: the retry-generation predicate `resolve_terminal`'s
+    /// `debug_assert!` relies on genuinely discriminates -- read a
+    /// generation, and `began_since` is `false` until an attempt begins and
+    /// `true` after. Without this the assertion could be vacuously true
+    /// (the `no_std` half *is*, by design, and says so); with it, the one
+    /// way the check can pass in a `std` build is a real
+    /// `terminal_retry::begin_attempt()` between the refusal and the
+    /// re-invocation, which only `resolve_as_pattern`'s alternative loop
+    /// performs.
+    #[test]
+    #[cfg(feature = "std")]
+    fn terminal_retry_generation_discriminates_2691() {
+        let before = terminal_retry::current();
+        assert!(
+            !terminal_retry::began_since(before),
+            "no attempt began, so nothing may claim one did"
+        );
+        terminal_retry::begin_attempt();
+        assert!(terminal_retry::began_since(before));
+        // And it keeps moving: a second refusal reads a fresh generation
+        // that the *previous* attempt does not satisfy.
+        let after = terminal_retry::current();
+        assert!(!terminal_retry::began_since(after));
+        terminal_retry::begin_attempt();
+        assert!(terminal_retry::began_since(after));
     }
 
     #[test]

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -30071,7 +30071,12 @@ fn drive_fold_source_by_value<S: EvalSemantics>(
 /// the same way [`resume_from_escape`] does for a [`Flow`]-shaped reclaim.
 fn reclaim_fold_escape(aborted: Option<Control>, source: Option<Control>) -> Option<Control> {
     if aborted.is_some() {
-        clear_nonretryable_stop();
+        // `nonretryable_stop::clear()` directly, as `resume_from_escape`
+        // does -- not `clear_nonretryable_stop()`, which since #2691 also
+        // announces a `?//` attempt to `resolve_terminal`'s sink. A reclaim
+        // is not an attempt, and bumping here would let a producer that
+        // drove past `Demand::Stop` after a fold-step escape slip the check.
+        nonretryable_stop::clear();
     }
     aborted.or(source)
 }
@@ -34234,7 +34239,13 @@ fn resolve_terminal<'a, S: EvalSemantics>(
             if let Some(generation) = refused_at.take() {
                 debug_assert!(
                     terminal_retry::began_since(generation),
-                    "resolve_terminal's sink was re-invoked after refusing a branch, but no                      `?//` alternative retry began in between -- a producer drove past                      `Demand::Stop`, and the refusal it just cleared would have been a                      false success (#2691): expr={expr:?}"
+                    concat!(
+                        "resolve_terminal's sink was re-invoked after refusing a branch, but no ",
+                        "`?//` alternative retry began in between -- a producer drove past ",
+                        "`Demand::Stop`, and the refusal it just cleared would have been a ",
+                        "false success (#2691): expr={:?}"
+                    ),
+                    expr
                 );
             }
             violation = None;
@@ -36730,13 +36741,13 @@ pub(crate) fn resume_from_escape(slot: Option<Control>, flow: Flow) -> Flow {
 ///
 /// Also the one place a `?//` attempt announces itself to
 /// [`resolve_terminal`]'s sink ([`terminal_retry::begin_attempt`], #2691).
-/// Every `?//` attempt loop in both evaluators -- value-mode
-/// [`each_pattern_alternatives`]/[`try_pattern_alternatives`], the fold
-/// forms, `eval_generic`'s twin, and the resolver's own
-/// [`resolve_as_pattern`] -- already calls this on entry, so putting the
-/// bump here rather than at any retry site makes "a retry began since the
-/// refusal" true by construction for every retry form, including the one
-/// that is easy to miss: a refusal at the resolver's terminal sink inside a
+/// Every `?//` attempt loop that can re-drive a *sink* after a
+/// `Demand::Stop` calls this on entry -- [`each_pattern_alternatives`], its
+/// `eval_generic` twin, [`try_foreach_step_alternatives`], and the
+/// resolver's own [`resolve_as_pattern`] -- so putting the bump here rather
+/// than at any retry site makes "a retry began since the refusal" true by
+/// construction for every retry form, including the one that is easy to
+/// miss: a refusal at the resolver's terminal sink inside a
 /// `foreach`/`reduce` whose *source* holds the `?//`. That source is pulled
 /// by demand (#2235), so the sink's `Demand::Stop` crosses the value/path
 /// boundary and it is the **value-mode** retry that drives the next source
@@ -36744,6 +36755,15 @@ pub(crate) fn resume_from_escape(slot: Option<Control>, flow: Flow) -> Flow {
 /// $v (.; .; if $v == 1 then 1 else . end))` is jq's `[]` only because of
 /// it. A first cut of #2691 bumped at `resolve_as_pattern` alone and fired
 /// on exactly that row.
+///
+/// The eager loops ([`try_pattern_alternatives`],
+/// [`try_reduce_step_alternatives`]) do not call this, and need not: they
+/// collect their alternative's outputs before anything downstream sees
+/// them, so no sink can have stopped on a refusal mid-attempt for them to
+/// retry past. Path-mode `resolve_reduce`/`resolve_foreach` admit only a
+/// bare `$var` pattern and cannot retry at all. A reclaim of a fold-step
+/// escape ([`reclaim_fold_escape`]) is not an attempt either, and clears
+/// the flag directly rather than through here.
 pub(crate) fn clear_nonretryable_stop() {
     nonretryable_stop::clear();
     terminal_retry::begin_attempt();


### PR DESCRIPTION
Fixes #2691

## Summary

`resolve_terminal`'s sink resets its captured violation on every invocation. That is correct for exactly one kind of caller — a `?//` alternative loop that stopped on the refusal and then drives the next alternative through the same sink — and would be a **silent false success** for any other producer that kept driving past `Demand::Stop`: the refusal it just cleared would let `del`/`=`/`|=` write where jq refuses. The issue asked for either a repro or an enforced invariant.

## Settled empirically first

Instrumented the sink to panic on any re-invocation after a refusal in an expression containing no `?//`, then ran:

- the full suite — 8,184 tests: **zero**
- 10,400 generated `path`/`del`/`=`/`|=` shapes over untracked/tracked branch mixes: **zero**

So no producer drives past `Stop` today, and the reset is sound — but only because of a discipline nothing checked. No repro; the invariant holds.

## Now checked

A `terminal_retry` generation counter rides beside the stack the way `nonretryable_stop` already does, with the same `std`/`no_std` split. It is bumped from `clear_nonretryable_stop()` — which every `?//` attempt loop in both evaluators already calls on entry — and the sink records it when it refuses. A re-invocation `debug_assert!`s that the generation moved. Zero release cost beyond the `Option<u64>` the sink keeps.

## The retry is not always the resolver's own — the finding worth recording

A first cut bumped only at `resolve_as_pattern` and **fired** on a row the suite already pins:

```
path(foreach (1 as $x ?// $y | if $x == 1 then 1 else 2 end) as $v (.; .; if $v == 1 then 1 else . end))   # jq: []
```

The `?//` there is in a `foreach` **source**, which is pulled by demand (#2235). The terminal refusal's `Demand::Stop` crosses the value/path boundary and it is the **value-mode** `each_pattern_alternatives` that retries and feeds the sink again. The issue's "only ever re-invoked after Stop in one documented case — a `?//` alternative retry" was right about the *kind* of caller and wrong about there being one site. Bumping at the shared attempt-entry point makes the property hold by construction for every retry form, enumerated or not.

## Soundness, in the direction that matters

The assertion must never fire on a legitimate retry. 14,310 generated pairs — 1,530 of them `?//` shapes across as-patterns, `reduce`/`foreach` patterns, and demand-pulled fold sources — never fire it. A unit test pins that `began_since` genuinely discriminates (false until an attempt begins, true after), so the check is not vacuously true. A rogue re-invocation *nested inside* a `?//` that happened to bump first would be missed, not misreported.

## Test plan

- [x] `cargo build --features cli` and `--no-default-features` (the `cfg` split)
- [x] `cargo test --features cli,simd,regex,serde` — 8184 passed, 0 failed (assertion live in debug)
- [x] both clippy legs `-D warnings`
- [x] `cargo fmt --check`
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features`
- [x] `omni-dev coverage diff` — **100% patch coverage** (27/27)
- [x] Instrumented negative sweep (suite + 10,400 shapes, no `?//`): 0 rogue re-invocations
- [x] Positive sweep (14,310 pairs incl. 1,530 `?//` shapes): 0 spurious fires