### PR TITLE
test(jq): audit group (c)'s Expr-dispatch catch-alls and pin what closes them

### DIFF
--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -25765,6 +25765,10 @@ fn wrap_fresh(steps: &[Expr], value: OwnedValue) -> Result<OwnedValue, EvalError
                 OwnedValue::Array(arr)
             }
             // `fresh_run_len` only ever collects `Field`/`Index` components.
+            // #2549: closed by construction, not by a predicate -- the caller
+            // passes the slice that `take_while` measured, so any other shape
+            // ends the run instead of arriving here. Pinned by
+            // `fresh_run_stops_at_a_non_field_index_step_2549`.
             _ => unreachable!("wrap_fresh only ever walks a fresh Field/Index run"),
         };
     }
@@ -88958,5 +88962,33 @@ mod tests {
         assert_eq!(meta_slot_keyword(MetaSlot::HeadComment), "head_comment");
         assert_eq!(meta_slot_keyword(MetaSlot::FootComment), "foot_comment");
         assert_eq!(meta_slot_keyword(MetaSlot::Comments), "comments");
+    }
+
+    /// #2549: `wrap_fresh`'s `unreachable!` catch-all is closed by
+    /// construction, not by a predicate -- its caller hands it
+    /// `&fresh[1..]`, and `fresh` is the slice `fresh_run_len`'s
+    /// `take_while(Field | Index)` measured. So the run stops at the first
+    /// step of any other shape, and a new `Expr` variant shortens the run
+    /// rather than reaching the dispatch.
+    ///
+    /// See `eval_generic`'s
+    /// `expr_dispatch_catchall_guards_default_conservatively_2549` for the
+    /// other five sites and the audit table.
+    #[test]
+    fn fresh_run_stops_at_a_non_field_index_step_2549() {
+        let steps = |f: &str| match parse(f).unwrap() {
+            Expr::Pipe(stages) => stages,
+            other => vec![other],
+        };
+        // A pure `Field`/`Index` run is measured whole ...
+        assert_eq!(fresh_run_len(&steps(".a | .b | .c")), 3);
+        assert_eq!(fresh_run_len(&steps(".a | .[0] | .b")), 3);
+        // ... and stops at the first step of any other shape, so `wrap_fresh`
+        // never walks one.
+        assert_eq!(fresh_run_len(&steps(".a | tostring | .b")), 1);
+        assert_eq!(fresh_run_len(&steps("tostring | .a")), 0);
+        assert_eq!(fresh_run_len(&steps(".a | .[] | .b")), 1);
+        assert_eq!(fresh_run_len(&steps(".a | .[1:2] | .b")), 1);
+        assert_eq!(fresh_run_len(&steps("length")), 0);
     }
 }

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -20633,9 +20633,13 @@ fn owned_identity_step<S: EvalSemantics, V: DocumentValue>(
             owned_identity_recurse_step::<S, V>(value, id, out);
             Ok(())
         }
-        // #2549: closed by that predicate's own `_ => false` -- a shape it
-        // has never heard of is not admitted, so it never reaches here. Pinned
-        // by `expr_dispatch_catchall_guards_default_conservatively_2549`.
+        // #2549 audit: `owned_identity_nav_supported`'s own `_ => false` keeps
+        // the *pipe/stages* route from reaching here. It is **not** the only
+        // gate: `owned_identity_operand` reaches this same dispatch under
+        // `owned_identity_operand_supported`, which admits `Expr::Literal` --
+        // a shape with no arm below. `.a | ((.b | 1) + 2) | key` aborts the
+        // process today; tracked as #2771, pinned by
+        // `expr_dispatch_catchall_guards_default_conservatively_2549`.
         _ => unreachable!("owned_identity_nav_supported admits no other shape"),
     }
 }
@@ -33319,11 +33323,13 @@ mod tests {
     /// add ~60 arms per site and move where the compile error lands without
     /// changing what a *new* variant does today.
     ///
-    /// Audited at #2549 pickup -- all closed, none a live gap:
+    /// Audited at #2549 pickup. Seven of the eight are closed; the eighth is
+    /// a live process abort, filed as #2771 (see the row below and the
+    /// divergence pinned at the end of this test):
     ///
     /// | catch-all | closed by |
     /// |---|---|
-    /// | `owned_identity_step` | `owned_identity_nav_supported`, `_ => false` |
+    /// | `owned_identity_step` | **NOT closed -- #2771** (two call sites, two guards) |
     /// | `owned_identity_computed_step` | its caller's arm pattern, syntactic |
     /// | `path_context_step_generic` | `path_context_is_navigational`, `_ => false` |
     /// | its two `Optional(..)` let-elses | the same arm's own `matches!` guard |
@@ -33337,6 +33343,16 @@ mod tests {
     /// edit that flips one of those defaults to `true` -- the only way a new
     /// variant could start reaching an `unreachable!` -- fails here instead
     /// of aborting a user's process.
+    ///
+    /// **A conservative default is necessary but not sufficient**, which is
+    /// what #2771 turned out to be: a dispatch reached from *two* call sites
+    /// under *two* guards is only as closed as the weaker one, however
+    /// conservative each is on its own. `owned_identity_step` is gated on
+    /// `owned_identity_nav_supported` from the pipe/stages route and on
+    /// `owned_identity_operand_supported` from `owned_identity_operand`, and
+    /// the two disagree on `Expr::Literal` -- which the dispatch has no arm
+    /// for. The first draft of this audit checked one call site, found its
+    /// guard conservative, and recorded the site as closed.
     #[test]
     fn expr_dispatch_catchall_guards_default_conservatively_2549() {
         // Guards `owned_identity_step`'s catch-all.
@@ -33355,14 +33371,14 @@ mod tests {
             assert!(!owned_identity_nav_supported(&e), "nav admitted `{src}`");
         }
 
-        // The *operand* guard, consulted by `owned_identity_nav_supported`'s
-        // own `IndexExpr`/`SliceExpr` arms for a computed bracket's target.
-        // Its sibling `owned_identity_component_supported` delegates to
+        // The *operand* guard: `owned_identity_step`'s second gate, via
+        // `owned_identity_operand`. Its sibling
+        // `owned_identity_component_supported` delegates to
         // `path_context_absent_resolvable`, a deliberately broader predicate
         // that admits folds and `if`: it decides whether a component can be
         // *resolved*, not whether a stage may be stepped, and guards no
         // `unreachable!`. A first draft of this test asserted against it and
-        // failed -- recorded here rather than quietly corrected, since
+        // failed -- recorded rather than quietly corrected, since
         // mis-attributing which guard closes a catch-all is exactly what
         // #2549 asked to check.
         for src in [
@@ -33410,5 +33426,22 @@ mod tests {
                 "binary stage not selected for `{src}`"
             );
         }
+
+        // #2771, the one gap this audit found: `owned_identity_step`'s two
+        // guards disagree on `Expr::Literal`, and the dispatch has no arm
+        // for it -- so `.a | ((.b | 1) + 2) | key` aborts the process.
+        // Pinned as the divergence it is, so the day `Expr::Literal` gets an
+        // arm this fails and the row above can move back to "closed".
+        let literal = parse("1").unwrap();
+        assert!(
+            owned_identity_operand_supported(&literal),
+            "a literal is a legitimate operand of a ruled stage"
+        );
+        assert!(
+            !owned_identity_nav_supported(&literal),
+            "a literal is not navigation"
+        );
+        // The two together are the gap: admitted by one gate, unhandled by
+        // the dispatch both gates share.
     }
 }

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -10439,6 +10439,10 @@ fn cross_together<S: EvalSemantics, V: DocumentValue>(
             |left_val, right_val| arith_combine::<S>(*op, left_val, right_val),
             &mut collect,
         ),
+        // #2549: closed by `yq_list_stage`'s own `_ => {}` -- a stage it does
+        // not recognise selects nothing, so `YqListStage::Binary` (the only
+        // kind routed here) is reached for `Arithmetic`/`Compare` alone. Pinned
+        // by `expr_dispatch_catchall_guards_default_conservatively_2549`.
         _ => unreachable!("yq_list_stage selects only Compare/Arithmetic as a binary stage"),
     };
     if let Some(control) = stray {
@@ -15053,6 +15057,11 @@ fn path_context_step_generic<S: EvalSemantics, V: DocumentValue>(
             }
             control.map_or(Ok(()), Err)
         }
+        // #2549: closed by that predicate's own `_ => false`, same shape as
+        // `owned_identity_step`'s. Its two `Optional(..)` let-elses just
+        // above are closed more tightly still, by their own arm's `matches!`
+        // guard. Pinned by
+        // `expr_dispatch_catchall_guards_default_conservatively_2549`.
         other => unreachable!(
             "path_context_is_navigational admitted a stage the walk cannot step: {other:?}"
         ),
@@ -20624,6 +20633,9 @@ fn owned_identity_step<S: EvalSemantics, V: DocumentValue>(
             owned_identity_recurse_step::<S, V>(value, id, out);
             Ok(())
         }
+        // #2549: closed by that predicate's own `_ => false` -- a shape it
+        // has never heard of is not admitted, so it never reaches here. Pinned
+        // by `expr_dispatch_catchall_guards_default_conservatively_2549`.
         _ => unreachable!("owned_identity_nav_supported admits no other shape"),
     }
 }
@@ -20846,6 +20858,9 @@ fn owned_identity_computed_step<S: EvalSemantics, V: DocumentValue>(
             );
             control.map_or(Ok(()), Err)
         }
+        // #2549: closed syntactically -- the only caller routes here from an
+        // `Expr::IndexExpr { .. } | Expr::SliceExpr { .. }` arm, the two shapes
+        // this match handles. No predicate involved, nothing to pin.
         other => unreachable!("not a computed navigation step: {other:?}"),
     }
 }
@@ -33292,6 +33307,108 @@ mod tests {
                     )
                 }
             }
+        }
+    }
+
+    /// #2549: the `Expr`-dispatch `unreachable!` catch-alls in this file are
+    /// closed because each one's **guard defaults conservatively** -- a shape
+    /// the guard has never heard of answers "not admitted" and never reaches
+    /// the dispatch. That is the property that makes adding a new `Expr`
+    /// variant safe here, and the one worth pinning: spelling every dispatch
+    /// out per-variant (#2182's group (a) treatment, #1401's option 3) would
+    /// add ~60 arms per site and move where the compile error lands without
+    /// changing what a *new* variant does today.
+    ///
+    /// Audited at #2549 pickup -- all closed, none a live gap:
+    ///
+    /// | catch-all | closed by |
+    /// |---|---|
+    /// | `owned_identity_step` | `owned_identity_nav_supported`, `_ => false` |
+    /// | `owned_identity_computed_step` | its caller's arm pattern, syntactic |
+    /// | `path_context_step_generic` | `path_context_is_navigational`, `_ => false` |
+    /// | its two `Optional(..)` let-elses | the same arm's own `matches!` guard |
+    /// | `cross_together` | `yq_list_stage` picks `Binary` for arith/compare only |
+    /// | `eval::wrap_fresh` | the slice `fresh_run_len`'s `take_while` built |
+    ///
+    /// The issue listed five sites and counted six; the sixth is the second
+    /// `Optional(..)` let-else (`SliceExpr`, beside the `IndexExpr` one).
+    ///
+    /// Each row below drives a shape the guard does not admit, so a future
+    /// edit that flips one of those defaults to `true` -- the only way a new
+    /// variant could start reaching an `unreachable!` -- fails here instead
+    /// of aborting a user's process.
+    #[test]
+    fn expr_dispatch_catchall_guards_default_conservatively_2549() {
+        // Guards `owned_identity_step`'s catch-all.
+        for src in [
+            "tostring",
+            "length",
+            "(1, 2)",
+            "if . then . else . end",
+            "reduce .[] as $x (0; .)",
+            "{a: 1}",
+            "[.[]]",
+            "def f: .; f",
+            "error",
+        ] {
+            let e = parse(src).unwrap();
+            assert!(!owned_identity_nav_supported(&e), "nav admitted `{src}`");
+        }
+
+        // The *operand* guard, consulted by `owned_identity_nav_supported`'s
+        // own `IndexExpr`/`SliceExpr` arms for a computed bracket's target.
+        // Its sibling `owned_identity_component_supported` delegates to
+        // `path_context_absent_resolvable`, a deliberately broader predicate
+        // that admits folds and `if`: it decides whether a component can be
+        // *resolved*, not whether a stage may be stepped, and guards no
+        // `unreachable!`. A first draft of this test asserted against it and
+        // failed -- recorded here rather than quietly corrected, since
+        // mis-attributing which guard closes a catch-all is exactly what
+        // #2549 asked to check.
+        for src in [
+            "reduce .[] as $x (0; .)",
+            "if . then 1 else 2 end",
+            "(1, 2)",
+            "tostring",
+        ] {
+            let e = parse(src).unwrap();
+            assert!(
+                !owned_identity_operand_supported(&e),
+                "operand admitted `{src}`"
+            );
+        }
+
+        // Guards `path_context_step_generic`'s catch-all.
+        for src in ["tostring", "length", "to_entries", "[.[]]", "{a: .}"] {
+            let e = parse(src).unwrap();
+            assert!(
+                !path_context_is_navigational(&e),
+                "nav-walk admitted `{src}`"
+            );
+        }
+
+        // `yq_list_stage` routes to `cross_together` only for `Binary`.
+        fn stages_of(f: &str) -> Vec<Expr> {
+            let parsed = parse(f).unwrap();
+            let mut out = Vec::new();
+            yq_flatten_pipe_stages(core::slice::from_ref(&parsed), &mut out);
+            out
+        }
+        for src in ["tostring", "length", "[.[]]", ".a"] {
+            let picked = yq_list_stage(&stages_of(src), true);
+            assert!(
+                !matches!(picked, Some((_, YqListStage::Binary))),
+                "binary stage selected for `{src}`"
+            );
+        }
+        // ... and does pick it for the two it admits, so the above is not
+        // vacuous.
+        for src in [".a == 1", ".a + 1"] {
+            let picked = yq_list_stage(&stages_of(src), true);
+            assert!(
+                matches!(picked, Some((_, YqListStage::Binary))),
+                "binary stage not selected for `{src}`"
+            );
         }
     }
 }


### PR DESCRIPTION
Fixes #2549

## Summary

Re-derived group (c)'s current membership rather than trusting the issue's list — which it asked for, warning its own line numbers and names had drifted (two had). **Eight sites, all closed, none a live gap**, so nothing to file separately under the issue's step 3.

| catch-all | closed by |
|---|---|
| `owned_identity_step` | `owned_identity_nav_supported`, `_ => false` |
| `owned_identity_computed_step` | its caller's arm pattern, syntactic |
| `path_context_step_generic` | `path_context_is_navigational`, `_ => false` |
| its two `Optional(..)` let-elses | the same arm's own `matches!` guard |
| `cross_together` | `yq_list_stage` picks `Binary` for arith/compare only |
| `eval::wrap_fresh` | the slice `fresh_run_len`'s `take_while` built |
| `via_cursor` | a `#[cfg(test)]` helper, unchanged since #2182 |

## The finding

**What closes these is not "the guard enumerates the right variants" but "the guard's own default is conservative".** Every one answers *not admitted* / *not selected* for a shape it has never heard of, or is closed by a pattern or by slice construction. So a **new `Expr` variant is already safe by default**: it lands on `false` and never reaches an `unreachable!`.

That reframes the issue's step 2. Spelling each dispatch out per-variant (#2182's group (a) treatment, #1401's option 3) would add ~60 arms per site and move where the compile error lands **without changing what a new variant does today** — the hazard would be a guard defaulting to `true`, and none does.

So this takes the third option the issue offered: pin the property instead. Two tests drive shapes each guard does not admit, so an edit that flips one of those defaults to `true` — the only way a new variant could start reaching an `unreachable!` — fails there rather than aborting a user's process. The `yq_list_stage` half also asserts the *positive* direction (`.a == 1`, `.a + 1` **are** selected), so the negative rows are not vacuous. Each site's comment now names its guard and why it is conservative.

## Corrections to the issue's own text

- It listed five sites and counted six. The sixth is the second `Optional(..)` let-else (`SliceExpr`, beside the `IndexExpr` one).
- `yq_list_stage`'s catch-all actually lives in `cross_together`; the two entries it could not name are `wrap_fresh` (`eval.rs`) and `path_context_step_generic`'s `Optional` pair — which is in `eval_generic.rs`, not `eval.rs` as listed.

## An attribution error worth recording

A first draft of the test attributed `owned_identity_computed_step` to `owned_identity_component_supported` and **failed**. That predicate delegates to `path_context_absent_resolvable`, which deliberately admits folds and `if` because it decides whether a component can be *resolved*, not whether a stage may be stepped — and it guards no `unreachable!` at all. The real guard is the caller's arm pattern. Left in the test's comment rather than quietly corrected: mis-attributing which guard closes a catch-all is precisely what this audit was asked to check.

## Test plan

- [x] `cargo test --features cli,simd,regex,serde` — 8187 passed, 0 failed
- [x] both clippy legs `-D warnings`
- [x] `cargo fmt --check`
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features`
- [x] `omni-dev coverage diff` — no new executable lines (tests and comments only)
- [x] Each guard's conservatism verified by reading the predicate, then pinned by a test


## Correction (from review): one site is NOT closed — #2771

Review found the audit's first row wrong, and it is a **live process abort**.

`owned_identity_step` has **two** call sites under **two** guards — `owned_identity_nav_supported` (pipe/stages route) and `owned_identity_operand_supported` (`owned_identity_operand`). They disagree on `Expr::Literal`, which the dispatch has no arm for:

```console
$ printf 'a: {b: 1}\n' | succinctly yq '.a | ((.b | 1) + 2) | key'
internal error: entered unreachable code: owned_identity_nav_supported admits no other shape   # exit 101
$ echo '{"a":{"b":1}}' | jq -c '.a | ((.b | 1) + 2) | path'
jq: error (at <stdin>:1): Invalid path expression with result 3                                 # jq refuses, does not crash
```

Pre-existing (reproduced on `main` @ `c0a442806`), filed as **#2771** per this issue's own step 3 — "if NOT closed, file it as its own separate correctness issue". The audit now reads **seven closed, one open**.

**The lesson the audit itself missed, now recorded in it: a conservative default is necessary but not sufficient.** A dispatch reached from two call sites is only as closed as the weaker guard, however conservative each is on its own. The first draft checked one call site, found its guard conservative, and recorded the site as closed — the same shape of mistake #2182 made when it counted this group as "effectively 2", which is what #2549 exists to correct.

The test now pins the divergence (`Expr::Literal` is admitted as an operand and is not navigation) rather than asserting a closure that does not hold, so the day it gets an arm the pin fails and the row moves back.
