### PR TITLE
test(jq): pin the undecodable-key spelling boundary, and answer #2710's fork

### DIFF
--- a/docs/compliance/jq/limitations.md
+++ b/docs/compliance/jq/limitations.md
@@ -3706,6 +3706,31 @@ escape sequence` on `keys_unsorted[]` — was a bug, not a candidate:
 `eval_each_pipe_generic`'s empty-stages arm dropped the cursor and decoded the key. Fixed in
 the same change.
 
+**#2710 checked the rule against a route that changed under it, and the rule held.**
+`scripts/jq-m2-streaming-sweep.expected` recorded the *doubled* spelling for
+`. as $x | $x` while the binary emitted the raw one. The binary is right: a plain `$x`
+reference forwards the cursor rather than materializing, so raw is exactly what the rule
+above prescribes — the wording needs no narrowing, and what went stale was the golden,
+against a route that became a passthrough. Measured across the boundary on
+`{"a\q":1,"b":2}`:
+
+| raw (never materialized) | doubled (materialized) |
+|---|---|
+| `.`, `. \| .`, `first(.)`, `getpath([])` | `[.] \| .[0]`, `[.] as [$x] \| $x` |
+| `. as $x \| $x`, `. as {a:$v} \| .` | `. as $x \| [$x] \| .[0]`, `. as $x \| $x + {}` |
+| `if . then . else . end` | `tojson`, `to_entries`, `keys`, `with_entries(.)` |
+
+Every raw row forwards a cursor; every doubled row builds an `OwnedValue`. No filter on
+either side contradicts the rule, which is what makes "the golden was stale" the answer
+rather than "the rule is too broad". jq 1.7.1 has no opinion to appeal to — it rejects both
+documents at parse time — so this is succinctly's own rule throughout.
+
+The sweep is a verification tool, not a CI gate, which is how the drift went unnoticed;
+`test_undecodable_key_spelling_follows_materialization_2710` (`tests/jq_cli_tests.rs`) now
+pins both halves of the boundary where CI runs them. The sweep's own `FILTERS` grouping
+("materializing eager twin") is a historical label from the two-route era and no longer
+describes which routes materialize — several rows in that group forward a cursor today.
+
 Six further cells move off jq's exit 5 as a consequence of that rule, beyond the 19 rows
 above: `limit(1; keys_unsorted[])` and `limit(2; keys_unsorted[])` on each of
 `{"\ud800":1,"\ud800":2}`, `{"\ud800":1,"b":2}` and `{"a\q":1,"b":2}` now echo the key raw

--- a/docs/compliance/jq/limitations.md
+++ b/docs/compliance/jq/limitations.md
@@ -3710,8 +3710,11 @@ the same change.
 `scripts/jq-m2-streaming-sweep.expected` recorded the *doubled* spelling for
 `. as $x | $x` while the binary emitted the raw one. The binary is right: a plain `$x`
 reference forwards the cursor rather than materializing, so raw is exactly what the rule
-above prescribes — the wording needs no narrowing, and what went stale was the golden,
-against a route that became a passthrough. Measured across the boundary on
+above prescribes — the wording needs no narrowing, and what had gone stale was the golden,
+against a route that became a passthrough. (The mismatch is no longer observable: #2692
+regenerated the golden as a side effect of adding filters, and recorded the drift as
+pre-existing rather than absorbing it silently. Running the sweep today shows a clean
+table — the rows below, not the sweep, are what now holds the answer.) Measured across the boundary on
 `{"a\q":1,"b":2}`:
 
 | raw (never materialized) | doubled (materialized) |
@@ -3725,7 +3728,8 @@ either side contradicts the rule, which is what makes "the golden was stale" the
 rather than "the rule is too broad". jq 1.7.1 has no opinion to appeal to — it rejects both
 documents at parse time — so this is succinctly's own rule throughout.
 
-The sweep is a verification tool, not a CI gate, which is how the drift went unnoticed;
+The sweep is a verification tool, not a CI gate, which is how the drift survived long
+enough to be absorbed by an unrelated `--update`;
 `test_undecodable_key_spelling_follows_materialization_2710` (`tests/jq_cli_tests.rs`) now
 pins both halves of the boundary where CI runs them. The sweep's own `FILTERS` grouping
 ("materializing eager twin") is a historical label from the two-route era and no longer

--- a/scripts/jq-m2-streaming-sweep.sh
+++ b/scripts/jq-m2-streaming-sweep.sh
@@ -144,7 +144,16 @@ FILTERS=(
   'map(.x) | .[]'
   'first(map(.x) | .[])'
   'limit(1; map(.x) | .[])'
-  # materializing eager twin / native streaming arm
+  # materializing eager twin / native streaming arm.
+  #
+  # #2710: a historical label. It classifies each shape by what the *eager*
+  # route did when there were two routes to compare; that route is gone, and
+  # several rows here forward a cursor today rather than materializing --
+  # `. as $x | $x`, `if . then . else . end`, `. | .` and `first(.)` among
+  # them, which is why they echo an undecodable key's raw source bytes. Do
+  # not read the grouping as a live statement about materialization; the
+  # boundary that still holds is pinned by
+  # `test_undecodable_key_spelling_follows_materialization_2710`.
   '.,.'
   'if . then . else . end'
   'try .'

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -47651,7 +47651,9 @@ fn test_resource_limit_is_not_a_destructuring_retry_2132() -> Result<()> {
 /// is succinctly's own documented rule, not a fidelity question.
 ///
 /// The sweep is a verification tool, not a CI gate — which is how the drift
-/// went unnoticed. These rows are.
+/// went unnoticed until #2692 regenerated the golden over it. These rows are
+/// the CI-gated half, so the next such drift fails a build rather than
+/// waiting for someone to run the sweep and read a 154-row `--update`.
 #[test]
 fn test_undecodable_key_spelling_follows_materialization_2710() -> Result<()> {
     for doc in [r#"{"a\q":1,"b":2}"#, r#"{"\ud800":1,"b":2}"#] {

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -47616,3 +47616,93 @@ fn test_resource_limit_is_not_a_destructuring_retry_2132() -> Result<()> {
 
     Ok(())
 }
+
+/// #2710: which spelling an undecodable key echoes is decided by **whether
+/// the value is materialized**, and nothing else — so the boundary is worth
+/// pinning in CI rather than only in the sweep.
+///
+/// `docs/compliance/jq/limitations.md` has stated the rule since #2103: raw
+/// source bytes wherever the value is never materialized,
+/// `key_display_string`'s fallback (the source `\` doubled) wherever it is.
+/// #2710 found `scripts/jq-m2-streaming-sweep.expected` recording the
+/// *doubled* spelling for `. as $x | $x` while the binary emitted the raw
+/// one, and asked which side was right.
+///
+/// **The binary is.** A plain `$x` reference forwards the cursor rather than
+/// materializing, so the raw spelling is what the rule already prescribes —
+/// the rule needs no narrowing, and the drift was the golden going stale
+/// against a route that became a passthrough. Measured across the boundary,
+/// input `{"a\q":1,"b":2}`:
+///
+/// | raw (never materialized) | doubled (materialized) |
+/// |---|---|
+/// | `.`, `. \| .`, `first(.)` | `[.] \| .[0]`, `[.] as [$x] \| $x` |
+/// | `. as $x \| $x`, `. as {a:$v} \| .` | `. as $x \| [$x] \| .[0]` |
+/// | `if . then . else . end` | `. as $x \| $x + {}`, `tojson` |
+/// | `getpath([])`, `(., .) \| first(.)` | `to_entries`, `keys`, `with_entries(.)` |
+///
+/// Every raw row forwards a cursor; every doubled row builds an
+/// `OwnedValue`. There is no filter on either side that contradicts the
+/// rule, which is what makes "the rule stands, the golden was stale" the
+/// answer rather than "the wording needs narrowing".
+///
+/// jq 1.7.1 has no opinion to appeal to: it rejects both documents at parse
+/// time (`Invalid \uXXXX\uXXXX surrogate pair`, `Invalid escape`), so this
+/// is succinctly's own documented rule, not a fidelity question.
+///
+/// The sweep is a verification tool, not a CI gate — which is how the drift
+/// went unnoticed. These rows are.
+#[test]
+fn test_undecodable_key_spelling_follows_materialization_2710() -> Result<()> {
+    for doc in [r#"{"a\q":1,"b":2}"#, r#"{"\ud800":1,"b":2}"#] {
+        // The raw spelling is the document's own bytes back. Asserted per
+        // output line, not on the whole stdout: a multi-output row like
+        // `(., .) | first(.)` legitimately emits it twice, and the claim
+        // here is about the spelling, not the cardinality.
+        for filter in [
+            ".",
+            ". | .",
+            ". as $x | $x",
+            ". as $x | $x | .",
+            ". as {a:$v} | .",
+            "if . then . else . end",
+            "getpath([])",
+            "first(.)",
+            "(., .) | first(.)",
+        ] {
+            let (out, err, code) = run_jq_full(&["-c", filter], Some(doc))?;
+            assert_eq!(code, 0, "`{filter}` on {doc}: stderr {err:?}");
+            let lines: Vec<&str> = out.lines().collect();
+            assert!(!lines.is_empty(), "`{filter}` produced nothing");
+            for line in lines {
+                assert_eq!(
+                    line, doc,
+                    "`{filter}` forwards a cursor, so it must echo the raw source bytes"
+                );
+            }
+        }
+
+        // ... and a materializing route doubles the source `\`.
+        let doubled = doc.replace('\\', "\\\\");
+        for filter in [
+            "[.] | .[0]",
+            "[.] as [$x] | $x",
+            ". as $x | [$x] | .[0]",
+            ". as $x | $x + {}",
+            "with_entries(.)",
+        ] {
+            let (out, err, code) = run_jq_full(&["-c", filter], Some(doc))?;
+            assert_eq!(code, 0, "`{filter}` on {doc}: stderr {err:?}");
+            let lines: Vec<&str> = out.lines().collect();
+            assert!(!lines.is_empty(), "`{filter}` produced nothing");
+            for line in lines {
+                assert_eq!(
+                    line, doubled,
+                    "`{filter}` materializes, so it must use key_display_string's fallback"
+                );
+            }
+        }
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
Fixes #2710

## The question, and the answer

#2710 found `scripts/jq-m2-streaming-sweep.expected` recording the **doubled** spelling for `. as $x | $x` while the binary emits the **raw** one, and asked which side is right.

**The binary is, and the documented rule needs no narrowing.** A plain `$x` reference forwards the cursor rather than materializing, so raw is exactly what the rule already prescribes — "raw source bytes wherever the value is never materialized, `key_display_string`'s fallback (the source `\` doubled) wherever it is". The issue's own **first** option was correct: the binding route stopped materializing. What went stale is the golden, against a route that became a passthrough; #2692 already regenerated it, so the sweep passes today (744 cases).

## Measured, not argued

Across the boundary on `{"a\q":1,"b":2}` (and the `\ud800` twin):

| raw — never materialized | doubled — materialized |
|---|---|
| `.`, `. \| .`, `first(.)`, `getpath([])` | `[.] \| .[0]`, `[.] as [$x] \| $x` |
| `. as $x \| $x`, `. as {a:$v} \| .` | `. as $x \| [$x] \| .[0]`, `. as $x \| $x + {}` |
| `if . then . else . end`, `(., .) \| first(.)` | `tojson`, `to_entries`, `keys`, `with_entries(.)` |

Every raw row forwards a cursor; every doubled row builds an `OwnedValue`. **No filter on either side contradicts the rule** — which is what makes "the golden was stale" the answer rather than "the wording is too broad". Had even one cursor-forwarding route doubled, the rule would have needed the narrowing the issue suspected.

jq 1.7.1 has no opinion to appeal to: it rejects both documents at parse time (`Invalid \uXXXX\uXXXX surrogate pair`, `Invalid escape`), so this is succinctly's own rule throughout, not a fidelity question.

## What changes

Nothing in `src/`. The issue is a decision, and the decision is "the rule stands" — so the deliverable is making it hold in future:

- **`test_undecodable_key_spelling_follows_materialization_2710`** pins both halves of the boundary. The sweep is a verification tool, not a CI gate, which is exactly how this drift went unnoticed; these rows run where CI does.
- **`limitations.md`** records the check and its table beside the rule.
- The sweep's **`materializing eager twin`** grouping is a historical label from the two-route era. Several rows in it (`. as $x | $x`, `if . then . else . end`, `. | .`, `first(.)`) forward a cursor today, so it now says so rather than reading as a live claim about materialization — the thing that made the golden look authoritative about a classification it no longer describes.

## Test plan

- [x] `cargo test --features cli,simd,regex,serde` — 8189 passed, 0 failed
- [x] `./scripts/jq-m2-streaming-sweep.sh` — 744 cases match
- [x] both clippy legs `-D warnings`
- [x] `cargo fmt --check`
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features`
- [x] Boundary measured on both undecodable-key documents, raw and doubled halves
- [x] jq 1.7.1 consulted and found to reject both documents (no oracle)