### PR TITLE
fix(jq): $__loc__.file reports "<top-level>", not "<stdin>"

### DIFF
--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -2650,10 +2650,19 @@ fn eval_single<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
         // arm is what actually decides path-trackability.
         Expr::TrackedVar(v) => QueryResult::Owned(v.value.clone()),
         Expr::Loc { line } => {
-            // $__loc__ returns {"file": "<stdin>", "line": N}
-            // where N is the 1-based line number in the jq filter source
+            // #2688: `$__loc__` names the *program text*, not the input --
+            // jq's own `locfile` uses the literal string `<top-level>` for
+            // a filter that didn't come from a module (confirmed live
+            // against jq 1.7.1; the runner's own unresolved-call diagnostic
+            // already uses this same string, so the two now agree). Not
+            // `"<stdin>"`: that's jq's distinct *runtime* error prefix
+            // (`jq: error (at <stdin>:1): ...`), naming the input, not the
+            // filter -- two different strings for two different things.
+            // A def sourced from an `include`d module or `~/.jq` should
+            // report that module's own path instead, per jq 1.7.1
+            // (confirmed live) -- tracked separately, #2774.
             let mut obj = IndexMap::new();
-            obj.insert("file".into(), OwnedValue::String("<stdin>".into()));
+            obj.insert("file".into(), OwnedValue::String("<top-level>".into()));
             obj.insert("line".into(), OwnedValue::Int(*line as i64));
             QueryResult::Owned(OwnedValue::Object(obj))
         }
@@ -79681,10 +79690,11 @@ mod tests {
 
     #[test]
     fn test_loc_basic() {
-        // $__loc__ returns {"file": "<stdin>", "line": N}
+        // #2688: $__loc__ returns {"file": "<top-level>", "line": N} for a
+        // filter that isn't sourced from a module (matches jq 1.7.1)
         query!(b"null", "$__loc__",
             QueryResult::Owned(OwnedValue::Object(obj)) => {
-                assert_eq!(obj.get("file"), Some(&OwnedValue::String("<stdin>".into())));
+                assert_eq!(obj.get("file"), Some(&OwnedValue::String("<top-level>".into())));
                 assert_eq!(obj.get("line"), Some(&OwnedValue::Int(1)));
             }
         );
@@ -79702,10 +79712,10 @@ mod tests {
 
     #[test]
     fn test_loc_file() {
-        // $__loc__.file should be "<stdin>"
+        // #2688: $__loc__.file should be "<top-level>" (matches jq 1.7.1)
         query!(b"null", "$__loc__.file",
             QueryResult::Owned(OwnedValue::String(s)) => {
-                assert_eq!(s, "<stdin>");
+                assert_eq!(s, "<top-level>");
             }
         );
     }

--- a/src/jq/expr.rs
+++ b/src/jq/expr.rs
@@ -461,8 +461,10 @@ pub enum Expr {
     TrackedVar(Rc<Tracked>),
 
     /// Location reference: `$__loc__`
-    /// Returns `{"file": "<stdin>", "line": N}` where N is the 1-based line number
-    /// in the jq filter source where `$__loc__` appears.
+    /// Returns `{"file": "<top-level>", "line": N}` where N is the 1-based line
+    /// number in the jq filter source where `$__loc__` appears (#2688; a def
+    /// sourced from an `include`d module reports that module's own file path
+    /// in real jq instead -- not modeled here, tracked as #2774).
     Loc {
         /// 1-based line number in the jq source
         line: usize,

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -1507,15 +1507,11 @@ fn test_loc_top_level_2688() -> Result<()> {
 
     let mut filter_file = NamedTempFile::new()?;
     writeln!(filter_file, "$__loc__")?;
-    let (output, _code) = spawn_with_signal_retry(
-        || {
-            let mut cmd = Command::new(succinctly_bin());
-            cmd.arg("jq").arg("-c").arg("-f").arg(filter_file.path());
-            cmd
-        },
-        Some(b"null"),
+    let (stdout, stderr, code) = run_jq_full(
+        &["-c", "-f", filter_file.path().to_str().unwrap()],
+        Some("null"),
     )?;
-    let stdout = String::from_utf8(output.stdout)?;
+    assert_eq!(code, 0, "stderr: {stderr:?}");
     assert_eq!(stdout.trim(), r#"{"file":"<top-level>","line":1}"#);
 
     Ok(())

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -1488,6 +1488,39 @@ fn test_from_file() -> Result<()> {
     Ok(())
 }
 
+// #2688: `$__loc__` names the *program text* as `"<top-level>"` for a
+// filter that isn't sourced from a module -- across the inline form, `-f`
+// file form, and nested inside another filter (`map(...)`) -- each row
+// cross-checked live against jq 1.7.1.
+#[test]
+fn test_loc_top_level_2688() -> Result<()> {
+    let (stdout, code) = run_jq_null("$__loc__", &["-c"])?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout.trim(), r#"{"file":"<top-level>","line":1}"#);
+
+    let (stdout, code) = run_jq_stdin("map($__loc__)", "[1,2]", &["-c"])?;
+    assert_eq!(code, 0);
+    assert_eq!(
+        stdout.trim(),
+        r#"[{"file":"<top-level>","line":1},{"file":"<top-level>","line":1}]"#
+    );
+
+    let mut filter_file = NamedTempFile::new()?;
+    writeln!(filter_file, "$__loc__")?;
+    let (output, _code) = spawn_with_signal_retry(
+        || {
+            let mut cmd = Command::new(succinctly_bin());
+            cmd.arg("jq").arg("-c").arg("-f").arg(filter_file.path());
+            cmd
+        },
+        Some(b"null"),
+    )?;
+    let stdout = String::from_utf8(output.stdout)?;
+    assert_eq!(stdout.trim(), r#"{"file":"<top-level>","line":1}"#);
+
+    Ok(())
+}
+
 // =============================================================================
 // Exit Status Tests
 // =============================================================================


### PR DESCRIPTION
## Summary

Real jq's `locfile` uses the literal string `"<top-level>"` for a filter
that wasn't sourced from an `include`d module -- `succinctly jq` was using
`"<stdin>"` instead, which is jq's distinct *runtime* error-location prefix
(`jq: error (at <stdin>:1): ...`, naming the *input document*, not the
filter program) -- the two got conflated at the one `Expr::Loc`
value-construction site in `src/jq/eval.rs`.

```console
$ echo null | jq -c '$__loc__'
{"file":"<top-level>","line":1}
$ echo null | succinctly jq -c '$__loc__'   # before
{"file":"<stdin>","line":1}
```

Confirmed live against jq 1.7.1 (the pinned oracle) across the inline,
`-f` file, and nested (`map($__loc__)`) forms -- all three now byte-for-byte
match.

The module-sourced case (`$__loc__` inside a `def` reached via `include`,
which real jq reports as that module's own file path) needs real AST
source-provenance plumbing that doesn't exist yet, and is out of scope for
this one-line fix -- filed separately as #2774.

Fixes #2688

## Test plan

- [x] `cargo build --features cli`
- [x] `cargo test --features cli,simd,regex,serde` (full suite, 0 failures)
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings`
- [x] Updated existing `test_loc_basic`/`test_loc_file` (src/jq/eval.rs) to
      expect `"<top-level>"`
- [x] New `test_loc_top_level_2688` (tests/jq_cli_tests.rs) covering the
      inline, `-f`, and nested forms -- each cross-checked live against
      `/usr/bin/jq` 1.7.1
- [x] `cargo llvm-cov` / `omni-dev coverage diff`: patch coverage 100% (3/3 new lines)