### PR TITLE
fix(yq): validate JSON array delimiters while parsing JSON-sourced input

### DIFF
--- a/docs/compliance/yq/limitations.md
+++ b/docs/compliance/yq/limitations.md
@@ -928,6 +928,31 @@ the fast path here would cost M2's performance for JSON input with no correctnes
 is a real, broader, non-destructive sibling gap — tracked as a further follow-up rather than
 folded into #2276.
 
+**Closed by [#2279](https://github.com/rust-works/succinctly/issues/2279), in the parser
+rather than on either route.** Declining the fast path was indeed no help, and neither was
+the obvious alternative of giving `YamlCursor` the `DocumentCursor` delimiter overrides
+(`container_gap_ok`/`trailing_element_gap_ok`/`preceding_delimiter_ok`): those methods are
+never called on this path at all — JSON's own validation lives in `json::light`'s
+module-private walk functions, so overriding the trait for `YamlCursor` installs code nothing
+calls (verified by instrumenting it). The giveaway is that `length` on `[1,]` also answered
+`1`: that count comes from the BP structure, so no output-side check could have reached it.
+
+The fix restores the invariant `preceding_delimiter_ok`'s own doc comment states — *every
+format but JSON validates delimiters while parsing*. JSON-sourced YAML was the one case that
+did neither. `YamlIndex::build_json_sourced` now parses with `Parser::json_strict` set and
+marks the index in one step (a post-build `mark_json_sourced()` has already accepted the bad
+input), so `[1,]`, `[,1]`, `[1,,2]`, `[,]` and their nested forms error on every route.
+
+Scope is flow **sequences** only, and never scalar grammar, because that is where real yq
+(v4.53.3, captured live) actually draws the line — the asymmetry this section already
+describes above. Tightening mappings would refuse `{"a":1,}`/`{,}`, and tightening scalars
+would refuse `[01]`/`[00]`/`[1.]`, all of which real yq accepts. The remaining divergences on
+this route are tracked separately: the flow-mapping grammar in
+[#2777](https://github.com/rust-works/succinctly/issues/2777) (including one silent wrong
+value, `{"a":1 "b":2}`), the non-comma sequence cases in
+[#2778](https://github.com/rust-works/succinctly/issues/2778), and genuine-YAML `[,]`/`{,}`
+in [#2779](https://github.com/rust-works/succinctly/issues/2779).
+
 **A pre-existing divergence this widens by one case, not a new one.** Real yq's own
 `-p json`/`eval-all -p json --input-format json` path (confirmed live against v4.53.3) is far
 more lenient about a comma or colon inside a JSON *object* than #1975's own delimiter checks

--- a/docs/compliance/yq/limitations.md
+++ b/docs/compliance/yq/limitations.md
@@ -941,7 +941,18 @@ The fix restores the invariant `preceding_delimiter_ok`'s own doc comment states
 format but JSON validates delimiters while parsing*. JSON-sourced YAML was the one case that
 did neither. `YamlIndex::build_json_sourced` now parses with `Parser::json_strict` set and
 marks the index in one step (a post-build `mark_json_sourced()` has already accepted the bad
-input), so `[1,]`, `[,1]`, `[1,,2]`, `[,]` and their nested forms error on every route.
+input), so `[1,]`, `[,1]`, `[1,,2]`, `[,]` and their nested forms error on every route that
+parses through `YamlIndex` — the plain stdout path this issue was filed about, for every
+filter.
+
+**One shape is still accepted, and it is on the other family of routes**: a *top-level*
+`[,]` (only `[,]` itself — `[[,]]` and `{"a":[,]}` are refused) still passes on
+`--slurp`/`--eval-all`/`--inplace`, which materialize through `JsonIndex`'s DOM bridge
+rather than this parser, and whose check needs a cursor for the outermost container that
+the bridge does not have. `succinctly yq -p json -i '.'` on a file containing `[,]`
+therefore rewrites it to `[]`, where real yq refuses the file and leaves it untouched.
+That route disagreeing with the stdout route is *new* — before #2279 both accepted it —
+and it is tracked as [#2781](https://github.com/rust-works/succinctly/issues/2781).
 
 Scope is flow **sequences** only, and never scalar grammar, because that is where real yq
 (v4.53.3, captured live) actually draws the line — the asymmetry this section already

--- a/src/bin/succinctly/yq_runner.rs
+++ b/src/bin/succinctly/yq_runner.rs
@@ -1468,11 +1468,15 @@ fn evaluate_yaml_direct_filtered(
         sort_keys,
         mark_json_sourced,
     } = opts;
-    let mut index =
-        YamlIndex::build(bytes).map_err(|e| anyhow::anyhow!("YAML parse error: {e}"))?;
-    if mark_json_sourced {
-        index.mark_json_sourced();
+    // #2279: build_json_sourced parses with JSON's flow-sequence delimiter
+    // rules *and* marks the index; the two cannot be applied separately,
+    // since `[1,]` is already accepted by the time a post-build mark runs.
+    let index = if mark_json_sourced {
+        YamlIndex::build_json_sourced(bytes)
+    } else {
+        YamlIndex::build(bytes)
     }
+    .map_err(|e| anyhow::anyhow!("YAML parse error: {e}"))?;
     let root = index.root(bytes);
 
     // YAML documents are wrapped in a sequence at the root
@@ -6405,11 +6409,13 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
             if let Some(code) = yaml_validate_guard(&yaml_bytes, fmt, args.validate, None) {
                 return Ok(code);
             }
-            let mut index = YamlIndex::build(&yaml_bytes)
-                .map_err(|e| anyhow::anyhow!("YAML parse error: {e}"))?;
-            if fmt == InputFormat::Json {
-                index.mark_json_sourced();
+            let index = if fmt == InputFormat::Json {
+                // #2279: see `evaluate_yaml_direct_filtered`'s own call.
+                YamlIndex::build_json_sourced(&yaml_bytes)
+            } else {
+                YamlIndex::build(&yaml_bytes)
             }
+            .map_err(|e| anyhow::anyhow!("YAML parse error: {e}"))?;
 
             // #1350/#2486: `--sort-keys` has no soundness pass on the M2
             // fast path below -- fall back to the DOM evaluator (via
@@ -6585,16 +6591,19 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
                     writer.flush()?;
                     return Ok(code);
                 }
-                let mut index = match YamlIndex::build(&yaml_bytes) {
+                // #2279: see `evaluate_yaml_direct_filtered`'s own call.
+                let built = if fmt == InputFormat::Json {
+                    YamlIndex::build_json_sourced(&yaml_bytes)
+                } else {
+                    YamlIndex::build(&yaml_bytes)
+                };
+                let index = match built {
                     Ok(index) => index,
                     Err(e) => {
                         let e = anyhow::anyhow!("YAML parse error in {file_path}: {e}");
                         return flush_then_err(&mut writer, e);
                     }
                 };
-                if fmt == InputFormat::Json {
-                    index.mark_json_sourced();
-                }
 
                 // #1350/#2486: see the stdin branch's identical check above
                 // for the full rationale.

--- a/src/yaml/index.rs
+++ b/src/yaml/index.rs
@@ -126,6 +126,10 @@ impl YamlIndex<Vec<u64>> {
     /// Returns [`YamlError::InputTooLarge`] for inputs over `u32::MAX` bytes
     /// (just under 4 GiB): the semi-index stores text positions as `u32`
     /// (#188). Other variants report malformed YAML.
+    pub fn build(yaml: &[u8]) -> Result<Self, YamlError> {
+        Self::from_semi_index(yaml, build_semi_index(yaml)?)
+    }
+
     /// [`build`](Self::build) for input the caller already knows is JSON,
     /// pairing the parse with [`mark_json_sourced`](Self::mark_json_sourced)
     /// so the two can never drift apart (#2279).
@@ -134,15 +138,17 @@ impl YamlIndex<Vec<u64>> {
     /// delimiter rules real yq enforces for `-p json` (`[1,]`, `[,1]`,
     /// `[1,,2]`) can only be applied while parsing, so a caller that marks
     /// the index afterwards has already accepted the malformed input. See
-    /// `Parser::json_strict` for the exact scope.
+    /// `Parser::json_strict` for the exact scope — flow sequences only,
+    /// never flow mappings, never scalar grammar.
+    ///
+    /// # Errors
+    ///
+    /// As [`build`](Self::build), plus the JSON flow-sequence delimiter
+    /// violations above, which that function accepts.
     pub fn build_json_sourced(yaml: &[u8]) -> Result<Self, YamlError> {
         let mut index = Self::from_semi_index(yaml, build_semi_index_json_strict(yaml)?)?;
         index.mark_json_sourced();
         Ok(index)
-    }
-
-    pub fn build(yaml: &[u8]) -> Result<Self, YamlError> {
-        Self::from_semi_index(yaml, build_semi_index(yaml)?)
     }
 
     fn from_semi_index(yaml: &[u8], semi: SemiIndex) -> Result<Self, YamlError> {

--- a/src/yaml/index.rs
+++ b/src/yaml/index.rs
@@ -20,7 +20,7 @@ use super::advance_positions::{build_cumulative_rank, OpenPositions};
 use super::end_positions::EndPositions;
 use super::error::YamlError;
 use super::light::YamlCursor;
-use super::parser::{build_semi_index, NodeComments};
+use super::parser::{build_semi_index, build_semi_index_json_strict, NodeComments, SemiIndex};
 use super::starts_seq_entry;
 
 /// Index structures for navigating YAML.
@@ -126,9 +126,26 @@ impl YamlIndex<Vec<u64>> {
     /// Returns [`YamlError::InputTooLarge`] for inputs over `u32::MAX` bytes
     /// (just under 4 GiB): the semi-index stores text positions as `u32`
     /// (#188). Other variants report malformed YAML.
-    pub fn build(yaml: &[u8]) -> Result<Self, YamlError> {
-        let semi = build_semi_index(yaml)?;
+    /// [`build`](Self::build) for input the caller already knows is JSON,
+    /// pairing the parse with [`mark_json_sourced`](Self::mark_json_sourced)
+    /// so the two can never drift apart (#2279).
+    ///
+    /// Prefer this over `build` + `mark_json_sourced`: the flow-sequence
+    /// delimiter rules real yq enforces for `-p json` (`[1,]`, `[,1]`,
+    /// `[1,,2]`) can only be applied while parsing, so a caller that marks
+    /// the index afterwards has already accepted the malformed input. See
+    /// `Parser::json_strict` for the exact scope.
+    pub fn build_json_sourced(yaml: &[u8]) -> Result<Self, YamlError> {
+        let mut index = Self::from_semi_index(yaml, build_semi_index_json_strict(yaml)?)?;
+        index.mark_json_sourced();
+        Ok(index)
+    }
 
+    pub fn build(yaml: &[u8]) -> Result<Self, YamlError> {
+        Self::from_semi_index(yaml, build_semi_index(yaml)?)
+    }
+
+    fn from_semi_index(yaml: &[u8], semi: SemiIndex) -> Result<Self, YamlError> {
         let ib_len = yaml.len();
         let ib_rank = build_ib_rank(&semi.ib);
         let containers_rank = build_containers_rank(&semi.containers);

--- a/src/yaml/parser.rs
+++ b/src/yaml/parser.rs
@@ -4565,6 +4565,7 @@ impl<'a, const HAS_CR: bool> Parser<'a, HAS_CR> {
                         self.err_unexpected_char(self.pos, "expected ',' or ']' in flow sequence")
                     );
                 }
+                let comma_pos = self.pos;
                 self.advance(); // Skip `,`
                 self.skip_flow_whitespace();
 
@@ -4577,10 +4578,13 @@ impl<'a, const HAS_CR: bool> Parser<'a, HAS_CR> {
 
                 // Allow trailing comma -- except for JSON-sourced input
                 // (#2279), where `[1,]` is exactly what real yq rejects.
+                // Reported against the offending `,`, not the `]` that
+                // merely revealed it.
                 if self.peek() == Some(b']') {
                     if self.json_strict {
-                        return Err(self
-                            .err_unexpected_char(self.pos, "trailing ',' in JSON array (#2279)"));
+                        return Err(
+                            self.err_unexpected_char(comma_pos, "trailing ',' in JSON array")
+                        );
                     }
                     break;
                 }
@@ -6304,18 +6308,23 @@ pub(crate) fn scan_tag_extent(bytes: &[u8], start: usize) -> (usize, bool) {
 /// Other variants report malformed YAML. (Pathological YAML can also push the
 /// BP bit count past `u32::MAX` before the text does; `BalancedParens`
 /// asserts its own ceiling as a loud backstop.)
+pub fn build_semi_index(input: &[u8]) -> Result<SemiIndex, YamlError> {
+    build_semi_index_impl(input, false)
+}
+
 /// [`build_semi_index`], enforcing JSON's flow-sequence delimiter rules
 /// (#2279) -- for callers that already know the bytes are JSON and pair this
 /// with [`YamlIndex::mark_json_sourced`](crate::yaml::YamlIndex::mark_json_sourced).
 ///
 /// See `Parser::json_strict` for what this does and does not tighten (flow
 /// sequences only; never flow mappings, never scalar grammar).
+///
+/// # Errors
+///
+/// As [`build_semi_index`], plus the JSON flow-sequence delimiter violations
+/// above, which that function accepts.
 pub fn build_semi_index_json_strict(input: &[u8]) -> Result<SemiIndex, YamlError> {
     build_semi_index_impl(input, true)
-}
-
-pub fn build_semi_index(input: &[u8]) -> Result<SemiIndex, YamlError> {
-    build_semi_index_impl(input, false)
 }
 
 fn build_semi_index_impl(input: &[u8], json_strict: bool) -> Result<SemiIndex, YamlError> {

--- a/src/yaml/parser.rs
+++ b/src/yaml/parser.rs
@@ -353,6 +353,31 @@ struct Parser<'a, const HAS_CR: bool> {
     /// (#710) needs the real bit position, since that's what every
     /// `YamlCursor` method (`self.bp_pos`) keys its lookups on.
     last_open_bp_pos: usize,
+
+    /// Enforce JSON's stricter flow-*sequence* delimiter rules (#2279).
+    ///
+    /// Set only for input the caller already knows is JSON, i.e. exactly the
+    /// callers that follow `YamlIndex::build` with
+    /// [`mark_json_sourced`](crate::yaml::YamlIndex::mark_json_sourced).
+    /// JSON is a subset of YAML's flow grammar, so the YAML parser accepts
+    /// it as-is -- but it also accepts `[1,]`/`[,1]`/`[1,,2]`, which real yq
+    /// rejects for `-p json` input, because its own JSON front end validates
+    /// array delimiters. `DocumentCursor::preceding_delimiter_ok`'s doc
+    /// comment names the invariant this restores: *every format but JSON
+    /// validates delimiters while parsing*. JSON-sourced YAML was the one
+    /// case that did neither -- a YAML parse that permits what JSON forbids,
+    /// feeding cursors whose delimiter checks all default to `true`.
+    ///
+    /// Deliberately a runtime flag rather than a third const generic: it
+    /// would multiply the `HAS_CR` monomorphizations (#340) for a branch
+    /// that is predictable and off the scalar-scanning hot path.
+    ///
+    /// **Sequences only.** Real yq's own object handling is *lenient* here
+    /// -- it ignores punctuation inside `{}` entirely and pairs up tokens
+    /// (`{"a":1,}`, `{,}`, `{"a" 1}` all parse) -- so extending this to flow
+    /// mappings would refuse input the reference accepts. Scalar grammar is
+    /// untouched for the same reason: yq accepts `[01]`/`[00]`/`[1.]`.
+    json_strict: bool,
 }
 
 impl<'a, const HAS_CR: bool> Parser<'a, HAS_CR> {
@@ -405,6 +430,7 @@ impl<'a, const HAS_CR: bool> Parser<'a, HAS_CR> {
             document_start_bp_pos: 0,
             pending_explicit_key: None,
             nesting_depth: 0,
+            json_strict: false,
             #[cfg(debug_assertions)]
             wrapper_slots: Vec::with_capacity(estimated_opens),
             #[cfg(debug_assertions)]
@@ -4523,6 +4549,15 @@ impl<'a, const HAS_CR: bool> Parser<'a, HAS_CR> {
                 });
             }
 
+            // #2279: a leading `,` (`[,1]`, and `[,]`'s first pass) is an
+            // element YAML reads as an empty scalar and JSON has no spelling
+            // for at all.
+            if first && self.json_strict && self.peek() == Some(b',') {
+                return Err(
+                    self.err_unexpected_char(self.pos, "expected value or ']' in flow sequence")
+                );
+            }
+
             if !first {
                 // Expect comma
                 if self.peek() != Some(b',') {
@@ -4533,8 +4568,20 @@ impl<'a, const HAS_CR: bool> Parser<'a, HAS_CR> {
                 self.advance(); // Skip `,`
                 self.skip_flow_whitespace();
 
-                // Allow trailing comma
+                // #2279: `[1,,2]` -- a second `,` where an element belongs.
+                if self.json_strict && self.peek() == Some(b',') {
+                    return Err(
+                        self.err_unexpected_char(self.pos, "expected value in flow sequence")
+                    );
+                }
+
+                // Allow trailing comma -- except for JSON-sourced input
+                // (#2279), where `[1,]` is exactly what real yq rejects.
                 if self.peek() == Some(b']') {
+                    if self.json_strict {
+                        return Err(self
+                            .err_unexpected_char(self.pos, "trailing ',' in JSON array (#2279)"));
+                    }
                     break;
                 }
             }
@@ -6257,7 +6304,21 @@ pub(crate) fn scan_tag_extent(bytes: &[u8], start: usize) -> (usize, bool) {
 /// Other variants report malformed YAML. (Pathological YAML can also push the
 /// BP bit count past `u32::MAX` before the text does; `BalancedParens`
 /// asserts its own ceiling as a loud backstop.)
+/// [`build_semi_index`], enforcing JSON's flow-sequence delimiter rules
+/// (#2279) -- for callers that already know the bytes are JSON and pair this
+/// with [`YamlIndex::mark_json_sourced`](crate::yaml::YamlIndex::mark_json_sourced).
+///
+/// See `Parser::json_strict` for what this does and does not tighten (flow
+/// sequences only; never flow mappings, never scalar grammar).
+pub fn build_semi_index_json_strict(input: &[u8]) -> Result<SemiIndex, YamlError> {
+    build_semi_index_impl(input, true)
+}
+
 pub fn build_semi_index(input: &[u8]) -> Result<SemiIndex, YamlError> {
+    build_semi_index_impl(input, false)
+}
+
+fn build_semi_index_impl(input: &[u8], json_strict: bool) -> Result<SemiIndex, YamlError> {
     // Text positions (bp_to_text/bp_to_text_end and the select samples and
     // rank arrays derived from them) are stored as u32, so inputs past
     // u32::MAX bytes would silently truncate offsets (#188). Every position
@@ -6273,9 +6334,13 @@ pub fn build_semi_index(input: &[u8]) -> Result<SemiIndex, YamlError> {
     // through at 16-32 bytes per iteration and leaves it warm in cache for the
     // parse that follows.
     if crate::util::simd::escape::contains_cr(input) {
-        Parser::<true>::new(input).parse()
+        let mut p = Parser::<true>::new(input);
+        p.json_strict = json_strict;
+        p.parse()
     } else {
-        Parser::<false>::new(input).parse()
+        let mut p = Parser::<false>::new(input);
+        p.json_strict = json_strict;
+        p.parse()
     }
 }
 

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -41934,3 +41934,119 @@ fn test_resource_limit_caps_are_uncatchable_in_yq_mode_2132() -> Result<()> {
 
     Ok(())
 }
+
+// ============================================================================
+// #2279: JSON-sourced flow-sequence delimiter validation
+// ============================================================================
+
+/// Every row below was captured live from Homebrew `yq` v4.53.3, comparing
+/// `(exit code, stdout)` rather than the exit code alone -- the object rows
+/// agree on "accepted" while disagreeing on the *value*, so an exit-code-only
+/// comparison scores them as matching when they are not.
+///
+/// The table is deliberately two-sided. Half of it pins shapes this fix
+/// *changes* (`[1,]` and friends now error); the other half pins shapes it
+/// must **not** change -- the object rows real yq accepts, and the array
+/// scalars whose grammar JSON rejects but yq allows (`[01]`, `[00]`, `[1.]`).
+/// Routing a leaf through stricter machinery is exactly how a fidelity fix
+/// over-reaches, so the must-not-change rows are the load-bearing ones.
+const JSON_SOURCED_DELIMITER_ROWS: &[(&str, Option<&str>)] = &[
+    // --- flow sequences: real yq rejects, and now so do we -------------
+    ("[1,]", None),
+    ("[1,2,]", None),
+    ("[,]", None),
+    ("[,1]", None),
+    ("[1,,2]", None),
+    ("[1,2,,]", None),
+    ("[[1,],2]", None),
+    (r#"{"a":[1,]}"#, None),
+    // --- flow mappings: real yq ACCEPTS these; we must not start -------
+    // refusing them. yq ignores punctuation inside `{}` and pairs up
+    // tokens, so a trailing/stray comma there is simply dropped.
+    (r#"{"a":1,}"#, Some(r#"{"a":1}"#)),
+    (r#"{"a":1,"b":2,}"#, Some(r#"{"a":1,"b":2}"#)),
+    (r#"[{"a":1,}]"#, Some(r#"[{"a":1}]"#)),
+    (r#"{"a":{"b":1,}}"#, Some(r#"{"a":{"b":1}}"#)),
+    // --- scalar grammar is NOT tightened: yq accepts all three --------
+    ("[01]", Some("[1]")),
+    ("[00]", Some("[0]")),
+    ("[1.]", Some("[1]")),
+    // --- well-formed controls ----------------------------------------
+    ("[1]", Some("[1]")),
+    ("[]", Some("[]")),
+    ("{}", Some("{}")),
+    ("[[]]", Some("[[]]")),
+    ("[1 ,2]", Some("[1,2]")),
+    ("[1, 2]", Some("[1,2]")),
+    ("[1,\n2]", Some("[1,2]")),
+    ("[1,\r\n2]", Some("[1,2]")),
+    (r#"[{"a":1},{"b":2}]"#, Some(r#"[{"a":1},{"b":2}]"#)),
+];
+
+#[test]
+fn json_sourced_flow_sequence_delimiters_match_yq_2279() -> Result<()> {
+    for (input, expected) in JSON_SOURCED_DELIMITER_ROWS {
+        let (stdout, code) = run_yq_stdin(
+            ".",
+            input,
+            &["--input-format", "json", "-o=json", "-I=0"],
+        )?;
+        match expected {
+            Some(want) => {
+                assert_eq!(
+                    (stdout.trim(), code),
+                    (*want, 0),
+                    "#2279: {input:?} must still be accepted with this exact value \
+                     (real yq v4.53.3 accepts it)"
+                );
+            }
+            None => {
+                assert_ne!(
+                    code, 0,
+                    "#2279: {input:?} must be rejected (real yq v4.53.3 rejects it), \
+                     got stdout {stdout:?}"
+                );
+            }
+        }
+    }
+    Ok(())
+}
+
+/// The gap was never output-shaped: `length` and `keys` answer from the BP
+/// structure, so they diverged too and no serializer-side check could have
+/// caught them. Parsing is the only place that fixes every route at once.
+#[test]
+fn json_sourced_delimiter_check_covers_every_route_2279() -> Result<()> {
+    for filter in [".", ".[0]", ".[]", "length", "keys"] {
+        let (stdout, code) = run_yq_stdin(
+            filter,
+            "[1,]",
+            &["--input-format", "json", "-o=json", "-I=0"],
+        )?;
+        assert_ne!(
+            code, 0,
+            "#2279: `{filter}` on `[1,]` must be rejected, got stdout {stdout:?}"
+        );
+    }
+    Ok(())
+}
+
+/// The tightening is gated on JSON-sourced input. Genuine YAML keeps YAML's
+/// own flow rules, where a trailing comma is legal -- and real yq agrees.
+#[test]
+fn genuine_yaml_flow_sequences_keep_their_trailing_comma_2279() -> Result<()> {
+    for (input, want) in [
+        ("[1,]", "[1]"),
+        ("[1, 2,]", "[1,2]"),
+        ("a: [1,]", r#"{"a":[1]}"#),
+        ("{a: 1,}", r#"{"a":1}"#),
+    ] {
+        let (stdout, code) = run_yq_stdin(".", input, &["-o=json", "-I=0"])?;
+        assert_eq!(
+            (stdout.trim(), code),
+            (want, 0),
+            "#2279: genuine YAML {input:?} must be unaffected by the JSON-sourced gate"
+        );
+    }
+    Ok(())
+}

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -41959,6 +41959,13 @@ const JSON_SOURCED_DELIMITER_ROWS: &[(&str, Option<&str>)] = &[
     ("[1,,2]", None),
     ("[1,2,,]", None),
     ("[[1,],2]", None),
+    // CRLF rejection rows, deliberately alongside the accepting `[1,\r\n2]`
+    // below: the flag is threaded into *both* `HAS_CR` monomorphizations
+    // (#340), and only a `\r`-bearing row that must REJECT can tell whether
+    // `Parser::<true>` still carries it -- an accepting row passes either way,
+    // since a valid document never reaches the check.
+    ("[1,\r\n]", None),
+    ("[\r\n,1]", None),
     (r#"{"a":[1,]}"#, None),
     // --- flow mappings: real yq ACCEPTS these; we must not start -------
     // refusing them. yq ignores punctuation inside `{}` and pairs up
@@ -41998,10 +42005,13 @@ fn json_sourced_flow_sequence_delimiters_match_yq_2279() -> Result<()> {
                 );
             }
             None => {
-                assert_ne!(
-                    code, 0,
-                    "#2279: {input:?} must be rejected (real yq v4.53.3 rejects it), \
-                     got stdout {stdout:?}"
+                // Exactly 1, not merely non-zero: a panic (101) or abort
+                // (134) would satisfy `assert_ne!` just as well, and real yq
+                // exits 1 here.
+                assert_eq!(
+                    code, 1,
+                    "#2279: {input:?} must be rejected with exit 1 (real yq v4.53.3 \
+                     rejects it), got stdout {stdout:?}"
                 );
             }
         }
@@ -42020,9 +42030,9 @@ fn json_sourced_delimiter_check_covers_every_route_2279() -> Result<()> {
             "[1,]",
             &["--input-format", "json", "-o=json", "-I=0"],
         )?;
-        assert_ne!(
-            code, 0,
-            "#2279: `{filter}` on `[1,]` must be rejected, got stdout {stdout:?}"
+        assert_eq!(
+            code, 1,
+            "#2279: `{filter}` on `[1,]` must be rejected with exit 1, got stdout {stdout:?}"
         );
     }
     Ok(())

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -41986,11 +41986,8 @@ const JSON_SOURCED_DELIMITER_ROWS: &[(&str, Option<&str>)] = &[
 #[test]
 fn json_sourced_flow_sequence_delimiters_match_yq_2279() -> Result<()> {
     for (input, expected) in JSON_SOURCED_DELIMITER_ROWS {
-        let (stdout, code) = run_yq_stdin(
-            ".",
-            input,
-            &["--input-format", "json", "-o=json", "-I=0"],
-        )?;
+        let (stdout, code) =
+            run_yq_stdin(".", input, &["--input-format", "json", "-o=json", "-I=0"])?;
         match expected {
             Some(want) => {
                 assert_eq!(


### PR DESCRIPTION
## What

`succinctly yq --input-format json` accepted every malformed-comma array real yq rejects — `[1,]`, `[,1]`, `[1,,2]`, `[,]` and their nested forms — on **every** route:

| filter on `[1,]` | real yq | before | after |
|---|---|---|---|
| `.` | `<ERROR>` | `[1]` | `<ERROR>` |
| `.[0]` | `<ERROR>` | `1` | `<ERROR>` |
| `.[]` | `<ERROR>` | `1` | `<ERROR>` |
| `length` | `<ERROR>` | `1` | `<ERROR>` |
| `keys` | `<ERROR>` | `[0]` | `<ERROR>` |

Fixes #2279.

## Two corrections to the issue's plan, both verified rather than assumed

**1. The planned mechanism is dead code on this route.** The issue (and its costed follow-up plan) proposed giving `YamlCursor` the `DocumentCursor` delimiter overrides. I spiked the cheapest half of that — `container_gap_ok`, which needs no new hook and covers `[,]` — and nothing changed. An `eprintln!` in the override confirmed it is **never called**, for any filter. JSON's validation lives in `json::light`'s module-private walk functions, not behind those trait methods, so overriding them for `YamlCursor` installs code nothing calls. The giveaway was `length` on `[1,]` also answering `1`: that count comes from the BP structure, so no output-side check could ever have reached it.

**2. Both costed options would have broken fidelity in the other direction.** Re-capturing real yq (v4.53.3) across the whole malformed space, comparing `(exit, stdout)` rather than exit codes alone, shows it treats arrays and objects completely differently — it **ignores punctuation inside `{}` entirely** and pairs up tokens (`{"a":1,}` → `{"a":1}`, `{,}` → `{}`, `{"a" 1}` → `{"a":1}`). Applying JSON-strict checks document-wide would start rejecting input real yq accepts. Option A (whole-file RFC 8259 validation) is dominated outright: the previously measured +40% *and* worse fidelity.

## The fix

Parse time, which is where `DocumentCursor::preceding_delimiter_ok`'s own doc comment says this belongs:

> The default answers `true` unconditionally: **every format but JSON validates delimiters while parsing**, so this costs them nothing.

JSON-sourced YAML was the one case that did neither — parsed by YAML's flow grammar, which permits what JSON forbids, then read through cursors whose checks default to permissive.

`YamlIndex::build_json_sourced` parses with `Parser::json_strict` set and marks the index in one step, so the two can't drift apart (a post-build `mark_json_sourced()` has already accepted the bad input). All three JSON-sourced build sites in `yq_runner.rs` use it.

## Scope, and why it is drawn here

Flow **sequences** only, and never scalar grammar — because that is where real yq actually draws the line:

| | real yq | kept working |
|---|---|---|
| `[01]`, `[00]`, `[1.]` | accepted (invalid RFC 8259) | ✅ delimiter checks never read scalar text |
| `{"a":1,}`, `{,}` | accepted | ✅ mappings untouched |

So this adds **zero** new over-rejections. Every row of the captured table is pinned as a test, in both directions — the must-not-change rows are the load-bearing ones.

## Verification

- Full suite green; both clippy legs; fmt; `--no-default-features`; rustdoc with `-D warnings` (two new `pub fn`s).
- Genuine YAML unaffected (flag off) and jq mode unaffected (`JsonIndex`, already correct) — both pinned.
- LF and CRLF both covered, so the flag reaches both `HAS_CR` monomorphizations.

## Left standing, filed not folded in

#2777 (flow-mapping grammar, including one silent wrong value `{"a":1 "b":2}`), #2778 (non-comma sequence cases), #2779 (genuine-YAML `[,]`/`{,}`). `limitations.md` is updated with the fix, the dead-mechanism finding, and these three.

Note #2777 carries a correction: part of the object-side strictness is a **deliberate** prior decision (#1975), recorded in `limitations.md` — flagged so nobody "fixes" it by accident.

## Perf

The change is a couple of comparisons on bytes the parser already reads, gated off for genuine YAML — no second pass. It does land in the YAML parser, so `yaml_bench`/perf-guard is the relevant gate rather than a query-side A/B; happy to run it if the CI perf leg flags anything.
