### PR TITLE
feat(jq): parse object-construction shorthand {$a}

### DIFF
--- a/docs/compliance/yq/limitations.md
+++ b/docs/compliance/yq/limitations.md
@@ -3594,6 +3594,42 @@ go-yaml's way: first line after the value, each further line as its own comment 
 the key's indent, an empty line left empty, and — top level only — one blank line before
 the continuation (`a: 1 # m` / blank / `# l`, but `  b: 1 # m` / `  # l` when nested).
 
+### Object-construction shorthand (`{x}`, `{$a}`) has no real-yq equivalent at all (#2783)
+
+Real yq's `{...}` object-construction grammar has no shorthand concept whatsoever -- not
+even the plain, non-`$` field shorthand jq accepts. Confirmed live against yq v4.53.3:
+
+```console
+$ printf 'x: 1\n' | yq '{x}'
+Error: 1:2: lexer: invalid input text "x}"
+```
+
+a bare lexer rejection, not a compile or runtime error. `succinctly yq` already diverges
+here -- it accepts `{x}` as sugar for `{x: .x}`, a deliberate (if previously undocumented)
+convenience extension beyond real yq's stricter grammar.
+
+The `$var` case (`{$a}`, jq's variable-shorthand sugar fixed for jq mode by #2724) is left
+unextended: `succinctly yq` still raises its pre-existing "expected identifier, found '$'"
+parse error, matching neither jq's sugar nor real yq's own behavior for the same input,
+which is a third thing again -- not an error at all:
+
+```console
+$ printf 'x: 1\n' | yq '1 as $a | {$a}'
+$ echo $?
+0
+```
+
+Empty stdout, exit 0. `--verbose` shows why: `$a` is evaluated as an ordinary
+`GET_VARIABLE` op and handed to `COLLECT_OBJECT` as a bare, non-`key: value` entry, which
+degrades the whole construction to zero results (`"collectObjectOperation, length of
+rotated is 0"` -> `"no matching results, nothing to print"`) -- an incidental quirk of
+yq's object-collection operator, not a deliberate feature.
+
+Reproducing real yq's exact behavior needs evaluator-level work (an object-construction
+entry that consumes zero pairs and yields nothing), not a parser change, and interacts
+with the pre-existing, separately-undocumented `{x}` extension above -- both tracked
+together in #2783.
+
 ### Other categories
 
 Float and number formatting ([#1071](https://github.com/rust-works/succinctly/issues/1071),

--- a/src/jq/parser.rs
+++ b/src/jq/parser.rs
@@ -1315,6 +1315,30 @@ impl<'a> Parser<'a> {
     }
 
     /// Parse object construction: `{key: value, ...}`
+    /// The shared "peek past `$name`" lookahead behind both `{$a}`/
+    /// `{$a: expr}` (`parse_object_construction`, below, #2724) and
+    /// `{$a}`/`{$a: Pattern}` (`parse_pattern_inner`, #1139/#1204): both
+    /// need to look one token past a `$`-led name to tell the bare-
+    /// shorthand and explicit-colon forms apart before committing to
+    /// either desugaring, and previously each site hand-rolled its own
+    /// copy of exactly that lookahead -- the same "duplicated predicates
+    /// diverge silently" shape #2728 found for identifier-start rules.
+    /// The `$` must already be the current character; consumes the `$`
+    /// and the name, but deliberately does NOT consume a following `:`
+    /// even when present, since what follows it differs completely
+    /// between the two call sites (an `Expr` vs a `Pattern`). Returns the
+    /// name, the 1-based source line the `$` itself started on (only
+    /// object-construction's `$__loc__` case uses it), and whether a `:`
+    /// follows.
+    fn parse_dollar_name(&mut self) -> Result<(String, usize, bool), ParseError> {
+        let line = self.current_line();
+        self.next();
+        let name = self.parse_ident()?;
+        self.skip_ws();
+        let has_colon = self.peek() == Some(':');
+        Ok((name, line, has_colon))
+    }
+
     fn parse_object_construction(&mut self) -> Result<Expr, ParseError> {
         self.expect('{')?;
         self.skip_ws();
@@ -1356,40 +1380,40 @@ impl<'a> Parser<'a> {
             // produces zero output rather than either jq's `{"a":1}` or
             // an error. Reproducing that exactly needs evaluator-level
             // work, not a parser tweak, and is tracked separately (#2783).
-            let mut dollar_shorthand_value: Option<Expr> = None;
-
-            // Parse key
-            let key = if self.peek() == Some('(') {
+            //
+            // Returns the shorthand's already-desugared value alongside
+            // the key when the `$name` form (no `:`) was taken, since
+            // that value is fully known here and the ordinary shorthand
+            // check below (`{foo}` means `{foo: .foo}`) doesn't apply to
+            // it -- `{$a}` means `{a: $a}`, not `{a: .a}`.
+            let (key, dollar_shorthand_value) = if self.peek() == Some('(') {
                 // Dynamic key: (expr)
                 self.next();
                 let key_expr = self.parse_expr()?;
                 self.expect(')')?;
-                ObjectKey::Expr(Box::new(key_expr))
+                (ObjectKey::Expr(Box::new(key_expr)), None)
             } else if self.peek() == Some('"') {
                 // String key
                 let s = self.parse_string_literal()?;
-                ObjectKey::Literal(s)
+                (ObjectKey::Literal(s), None)
             } else if self.mode == ParserMode::Jq && self.peek() == Some('$') {
-                let line = self.current_line();
-                self.next();
-                let name = self.parse_ident()?;
-                self.skip_ws();
-                if self.peek() == Some(':') {
+                let (name, line, has_colon) = self.parse_dollar_name()?;
+                if has_colon {
                     if name == "__loc__" {
                         return Err(ParseError::new(
                             "may need parentheses around object key expression",
                             self.pos,
                         ));
                     }
-                    ObjectKey::Expr(Box::new(dollar_var_expr(name, line)))
+                    (ObjectKey::Expr(Box::new(dollar_var_expr(name, line))), None)
                 } else {
-                    dollar_shorthand_value = Some(dollar_var_expr(name.clone(), line));
-                    ObjectKey::Literal(name)
+                    let value = dollar_var_expr(name.clone(), line);
+                    (ObjectKey::Literal(name), Some(value))
                 }
             } else {
                 // Identifier key
                 let name = self.parse_ident()?;
-                ObjectKey::Literal(name)
+                (ObjectKey::Literal(name), None)
             };
 
             self.skip_ws();
@@ -2584,12 +2608,12 @@ impl<'a> Parser<'a> {
                     // matching jq's own refusal at the second step there.
                     // `PatternEntry.bind` carries the `$a` binding so a single
                     // entry can do both jobs. Peeking past the identifier for
-                    // `:` is required to tell the two `$`-led shapes apart.
+                    // `:` is required to tell the two `$`-led shapes apart --
+                    // shared with `parse_object_construction`'s own `{$a}`/
+                    // `{$a: expr}` lookahead (#2724) via `parse_dollar_name`.
                     if self.peek() == Some('$') {
-                        self.next();
-                        let name = self.parse_ident()?;
-                        self.skip_ws();
-                        if self.peek() == Some(':') {
+                        let (name, _line, has_colon) = self.parse_dollar_name()?;
+                        if has_colon {
                             self.next();
                             self.skip_ws();
                             let nested = self.parse_pattern()?;

--- a/src/jq/parser.rs
+++ b/src/jq/parser.rs
@@ -188,6 +188,26 @@ fn is_ident_start_char(c: char) -> bool {
     c.is_alphabetic() || c == '_'
 }
 
+/// The one definition of what `$name` (the `$` already consumed) desugars
+/// to: jq's two pseudo-variables, `$__loc__`/`$ENV`, get their own
+/// dedicated node; every other name is an ordinary bound-variable
+/// reference. `line` is the 1-based source line the `$` itself started on
+/// (only `$__loc__` uses it, for its own `{file, line}` payload). Shared
+/// by the primary `$var` expression dispatch and the `{$a}`/`{$a: ...}`
+/// object-construction forms (#2724) so the two can't independently drift
+/// on which names get pseudo-variable treatment -- the exact "duplicated
+/// predicates diverge silently" shape #2728 found for identifier-start
+/// rules, per CLAUDE.md's #106 note.
+fn dollar_var_expr(name: String, line: usize) -> Expr {
+    if name == "__loc__" {
+        Expr::Loc { line }
+    } else if name == "ENV" {
+        Expr::Env
+    } else {
+        Expr::Var(name)
+    }
+}
+
 /// #2036 Direction 3: a cheap, deliberately over-approximate scan for every
 /// identifier spelled after a `def` keyword anywhere in `input` -- see
 /// `Parser::shadowable_defs`'s own doc comment for why imprecision here is
@@ -1310,6 +1330,34 @@ impl<'a> Parser<'a> {
         loop {
             self.skip_ws();
 
+            // #2724: `{$a}` and `{$a: expr}` -- captured here rather than
+            // folded into the shorthand check below, because the two
+            // forms diverge in what `$name` means: with no `:` it's sugar
+            // for `{name: $name}` (`dollar_var_expr` -- same desugaring as
+            // the primary `$var` dispatch, so `$__loc__`/`$ENV` still get
+            // their own node); with an explicit `:`, `$name` is an
+            // ordinary *dynamic-key* expression whose bound value becomes
+            // the key (jq 1.7.1 confirmed live: `"x" as $a | {$a: 1}` is
+            // `{"x":1}`, not `{"a":1}`) -- and that holds for `$ENV` too
+            // (`{$ENV: 1}` parses; it only fails at runtime, "Cannot use
+            // object ... as object key", since `$ENV` is an ordinary
+            // bound variable in jq's own grammar, just pre-bound to the
+            // environment). `$__loc__` alone is different: real jq lexes
+            // it as a distinct pseudo-variable token, not a plain `'$'
+            // IDENT`, so `{$__loc__: 1}` is a *compile* error there ("may
+            // need parentheses around object key expression") -- confirmed
+            // live, and confirmed `$ENV` does NOT share that restriction.
+            //
+            // yq mode is deliberately left untouched here (falls through
+            // to the identifier branch below, whose "expected identifier,
+            // found '$'" error is unchanged) -- real yq has no such sugar
+            // at all; `{$a}` there parses via an unrelated mechanism
+            // (`$a` as a bare non-pair COLLECT_OBJECT entry) and silently
+            // produces zero output rather than either jq's `{"a":1}` or
+            // an error. Reproducing that exactly needs evaluator-level
+            // work, not a parser tweak, and is tracked separately (#2783).
+            let mut dollar_shorthand_value: Option<Expr> = None;
+
             // Parse key
             let key = if self.peek() == Some('(') {
                 // Dynamic key: (expr)
@@ -1321,6 +1369,23 @@ impl<'a> Parser<'a> {
                 // String key
                 let s = self.parse_string_literal()?;
                 ObjectKey::Literal(s)
+            } else if self.mode == ParserMode::Jq && self.peek() == Some('$') {
+                let line = self.current_line();
+                self.next();
+                let name = self.parse_ident()?;
+                self.skip_ws();
+                if self.peek() == Some(':') {
+                    if name == "__loc__" {
+                        return Err(ParseError::new(
+                            "may need parentheses around object key expression",
+                            self.pos,
+                        ));
+                    }
+                    ObjectKey::Expr(Box::new(dollar_var_expr(name, line)))
+                } else {
+                    dollar_shorthand_value = Some(dollar_var_expr(name.clone(), line));
+                    ObjectKey::Literal(name)
+                }
             } else {
                 // Identifier key
                 let name = self.parse_ident()?;
@@ -1330,7 +1395,9 @@ impl<'a> Parser<'a> {
             self.skip_ws();
 
             // Check for shorthand: `{foo}` means `{foo: .foo}`
-            let value = if self.peek() == Some(':') {
+            let value = if let Some(v) = dollar_shorthand_value {
+                v
+            } else if self.peek() == Some(':') {
                 self.next();
                 self.skip_ws();
                 // jq's `ExpD`, not `Exp`: the `,` here separates entries, so a
@@ -1666,13 +1733,7 @@ impl<'a> Parser<'a> {
                 let line = self.current_line();
                 self.next();
                 let name = self.parse_ident()?;
-                let expr = if name == "__loc__" {
-                    Expr::Loc { line }
-                } else if name == "ENV" {
-                    Expr::Env
-                } else {
-                    Expr::Var(name)
-                };
+                let expr = dollar_var_expr(name, line);
                 self.parse_postfix(expr)
             }
 

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -18947,6 +18947,114 @@ fn test_object_pattern_var_shorthand_with_alt_patterns_720_1139() -> Result<()> 
 }
 
 // =============================================================================
+// #2724: object *construction* shorthand `{$a}` -- the construction-side
+// mirror of #1139's destructuring-pattern shorthand above. `{$a}` desugars
+// to `{a: $a}` (key inferred from the variable's own name); `$__loc__`/
+// `$ENV` still get their own dedicated Expr via the same `dollar_var_expr`
+// helper the primary `$var` dispatch uses. An explicit `{$a: value}` is a
+// different, unrelated jq feature: `$a` there is an ordinary *dynamic-key*
+// expression (its bound *value* becomes the key), not sugar for `"a"`. All
+// cases live-verified against jq 1.7.1.
+// =============================================================================
+
+#[test]
+fn test_object_construction_var_shorthand_bare_2724() -> Result<()> {
+    let (stdout, _, code) = run_jq_full(&["-c", "1 as $a | {$a}"], Some("null"))?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout.trim_end(), r#"{"a":1}"#);
+    Ok(())
+}
+
+#[test]
+fn test_object_construction_var_shorthand_mixed_with_explicit_2724() -> Result<()> {
+    let (stdout, _, code) = run_jq_full(&["-c", "1 as $a | {$a, \"b\": 2}"], Some("null"))?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout.trim_end(), r#"{"a":1,"b":2}"#);
+    Ok(())
+}
+
+#[test]
+fn test_object_construction_var_shorthand_multiple_2724() -> Result<()> {
+    let (stdout, _, code) = run_jq_full(
+        &["-c", r#""foo" as $a | "bar" as $b | {$a, $b, "c": 3}"#],
+        Some("null"),
+    )?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout.trim_end(), r#"{"a":"foo","b":"bar","c":3}"#);
+    Ok(())
+}
+
+#[test]
+fn test_object_construction_var_shorthand_nested_2724() -> Result<()> {
+    let (stdout, _, code) = run_jq_full(&["-c", "1 as $a | [{$a}]"], Some("null"))?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout.trim_end(), r#"[{"a":1}]"#);
+    Ok(())
+}
+
+/// `$__loc__`/`$ENV` inside the shorthand desugar to their own dedicated
+/// node (matching the primary `$var` dispatch), not a plain variable
+/// lookup -- `{$__loc__}` is `{"__loc__": $__loc__}`, per #2688.
+#[test]
+fn test_object_construction_pseudo_var_shorthand_2724() -> Result<()> {
+    let (stdout, _, code) = run_jq_full(&["-c", "{$__loc__}"], Some("null"))?;
+    assert_eq!(code, 0);
+    assert_eq!(
+        stdout.trim_end(),
+        r#"{"__loc__":{"file":"<top-level>","line":1}}"#
+    );
+    Ok(())
+}
+
+/// `{$a: value}` (with an explicit colon) is a different feature from the
+/// shorthand: `$a`'s own bound *value* becomes the key, not its name --
+/// confirmed jq treats it identically to `{($a): value}`.
+#[test]
+fn test_object_construction_dollar_key_is_dynamic_key_not_shorthand_2724() -> Result<()> {
+    let (stdout, _, code) = run_jq_full(&["-c", r#""foo" as $a | {$a: 99}"#], Some("null"))?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout.trim_end(), r#"{"foo":99}"#);
+    Ok(())
+}
+
+/// `$ENV` is an ordinary bound variable in jq's own grammar (just
+/// pre-bound to the environment), so `{$ENV: value}` parses like any other
+/// `{$var: value}` -- it only fails at *runtime*, because an object can't
+/// be used as a key.
+#[test]
+fn test_object_construction_dollar_env_key_fails_at_runtime_not_parse_2724() -> Result<()> {
+    let (_, stderr, code) = run_jq_full(&["-c", "{$ENV: 5}"], Some("null"))?;
+    assert_eq!(code, 5, "stderr: {stderr:?}");
+    assert!(
+        stderr.contains("Cannot use object") && stderr.contains("as object key"),
+        "stderr: {stderr:?}"
+    );
+    Ok(())
+}
+
+/// `$__loc__` is different: real jq lexes it as a distinct pseudo-variable
+/// token, not a plain `'$' IDENT`, so `{$__loc__: value}` is a *compile*
+/// error there ("may need parentheses around object key expression"), not
+/// a runtime one -- confirmed live, and confirmed `$ENV` does NOT share
+/// this restriction (previous test).
+#[test]
+fn test_object_construction_dollar_loc_key_is_a_parse_error_2724() -> Result<()> {
+    let (_, stderr, code) = run_jq_full(&["-c", "{$__loc__: 5}"], Some("null"))?;
+    assert_eq!(code, 3, "stderr: {stderr:?}");
+    assert!(
+        stderr
+            .to_lowercase()
+            .contains("parentheses around object key expression"),
+        "stderr: {stderr:?}"
+    );
+    Ok(())
+}
+
+// (yq mode's own untouched-by-#2724 behavior is covered in
+// tests/yq_cli_tests.rs, not here -- see
+// test_object_construction_var_shorthand_is_jq_mode_only_2724.)
+
+// =============================================================================
 // #1204: object destructuring pattern entry `{$x: Pattern}` (bind and
 // further destructure). Real jq's `$IDENT: Pattern` entry binds the
 // matched value to `$IDENT` -- same as the `{$x}` shorthand (#1139) --

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -42057,3 +42057,18 @@ fn genuine_yaml_flow_sequences_keep_their_trailing_comma_2279() -> Result<()> {
     }
     Ok(())
 }
+
+/// #2724: jq mode's `{$a}` object-construction shorthand fix is scoped to
+/// jq mode only -- yq mode still raises the same pre-existing parse error
+/// it always has ("expected identifier, found '$'"), not jq's `{"a":1}".
+/// Real yq's own behavior for this shape is a third, unrelated thing
+/// (silently produces zero output, per a `COLLECT_OBJECT` quirk on a bare
+/// non-pair entry) -- reproducing that needs evaluator-level work, tracked
+/// separately as #2783.
+#[test]
+fn test_object_construction_var_shorthand_is_jq_mode_only_2724() -> Result<()> {
+    let (stdout, stderr, code) = run_yq_stdin_with_stderr("1 as $a | {$a}", "x: 1\n", &[])?;
+    assert_ne!(code, 0, "stdout: {stdout:?}");
+    assert!(stderr.contains("expected identifier"), "stderr: {stderr:?}");
+    Ok(())
+}


### PR DESCRIPTION
## Summary

Real jq desugars a bare `$var` entry inside object *construction* to
`{name: $var}`, key inferred from the variable's own name -- e.g.
`1 as $a | {$a}` is sugar for `{a: $a}`. #1139 covered the same shorthand
on the destructuring-*pattern* side (`. as {$a}`); construction was never
covered:

```console
$ echo null | jq -c '1 as $a | {$a}'
{"a":1}
$ echo null | succinctly jq -c '1 as $a | {$a}'   # before
jq: compile error: parse error at position 11: expected identifier, found '$'
```

Also covers the sibling explicit-colon form `{$a: value}`, a different,
unrelated feature discovered live while verifying this fix: `$a` there is
an ordinary *dynamic-key* expression (its bound value becomes the key,
like `($a): value`), not sugar for `"a"` -- `"x" as $a | {$a: 1}` is
`{"x":1}` in real jq, not `{"a":1}`. `$__loc__`/`$ENV` are lexed as
distinct pseudo-variable forms in real jq: both still desugar correctly in
the no-colon shorthand (matching the primary `$var` dispatch, so
`{$__loc__}` is `{"__loc__":{"file":"<top-level>","line":N}}`, per
#2688), but only `$ENV` is valid in the colon form (`{$ENV: v}` parses,
only failing at runtime since an object can't be a key); `{$__loc__: v}`
is a genuine compile error in real jq, reproduced here too.

Extracted `dollar_var_expr` (the "which names are pseudo-variables"
desugaring) as a single shared helper used by both the primary `$var`
dispatch and this new object-construction path, rather than a second
hand-written copy of the same logic -- the exact "duplicated predicates
diverge silently" shape #2728 hit for identifier-start rules earlier this
session.

yq mode is deliberately untouched: real yq has no such sugar at all
(confirmed live -- even the plain non-`$` shorthand `{x}` is a lexer error
there), and its actual behavior for `{$a}` is a third, unrelated thing
(silently produces zero output, a `COLLECT_OBJECT`-on-bare-value quirk)
that needs evaluator-level work, not a parser change -- tracked separately
as #2783.

All cases live-verified against jq 1.7.1.

Fixes #2724

## Test plan

- [x] `cargo build --features cli`
- [x] `cargo test --features cli,simd,regex,serde` (full suite, 0 failures)
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings`
- [x] 8 new jq-mode tests (`tests/jq_cli_tests.rs`): bare shorthand, mixed
      with explicit entries, multiple shorthand entries, nested, the
      `$__loc__`/`$ENV` pseudo-variable shorthand, the explicit-colon
      dynamic-key form for both an ordinary var and `$ENV`, and the
      `$__loc__`-in-colon-position compile error -- each cross-checked
      live against `/usr/bin/jq` 1.7.1
- [x] 1 new yq-mode test (`tests/yq_cli_tests.rs`): confirms `{$a}` still
      raises its pre-existing parse error, unaffected by this jq-mode-only
      change
- [x] `cargo llvm-cov` / `omni-dev coverage diff`: patch coverage 100% (27/27 new lines)