### PR TITLE
perf(jq): teach reads_ambient_value that a pipe stage rebinds `.`

### DIFF
--- a/docs/compliance/jq/limitations.md
+++ b/docs/compliance/jq/limitations.md
@@ -3797,6 +3797,27 @@ its input; `to_owned_with_cursor` validated because it needed a value to bridge 
 `1+1` escaped only because someone had written it a native arm. Sanctioned by ADR-0018's
 #2103 amendment, and now listed there as its own instance.
 
+**Widened by [#2699](https://github.com/rust-works/succinctly/issues/2699): a pipe stage
+rebinds `.`, so more filters are closed than the predicate used to admit.** `1 | .`,
+`[1,2,3] | length`, `reduce (1,2,3) as $x (0; . + $x)` and friends read the previous stage's
+output, never the document, and are now recognised as such. Where that reaches a bridge, the
+rows above gain siblings — `repeat` bridges its *inner* `f`, so on the same
+`{123: 1, "b": 2}`:
+
+| filter                                                   | jq 1.7.1 | before #2699 | now         |
+|----------------------------------------------------------|----------|--------------|-------------|
+| `[limit(1; repeat(1))]`                                  | error    | `[1]`        | `[1]` — unchanged |
+| `[limit(1; repeat(1 \| .))]`                             | error    | error        | `[1]`       |
+| `[limit(1; repeat([1,2,3] \| length))]`                   | error    | error        | `[3]`       |
+| `[limit(1; repeat(reduce (1,2,3) as $x (0; . + $x)))]`   | error    | error        | `[6]`       |
+| `[limit(1; repeat([foreach (1,2) as $x (0; . + $x)]))]`  | error    | error        | `[[1,3]]`   |
+| `[limit(1; repeat(.))]` (control, reads)                 | error    | error        | error — unchanged |
+
+Same sanction, same reasoning: which spelling kept the rejection was still an accident, now
+one level further in. Pinned by the corresponding rows in
+`test_closed_terms_do_not_validate_2173`. The materialization this skips is not small —
+on a 13 MB document that filter goes from 354 MB peak and 8.9 s to 30 MB and 1.1 s.
+
 **It also cost what #2103's own point 3 costs.** On a 16 MB `json generate` document,
 indicative single runs: `[1+1]` 443 MB / 0.75 s → 29 MB / 0.03 s; `[range(3)]` 446 MB /
 0.89 s → 29 MB; `false // 1` 445 MB / 0.86 s → 29 MB. In yq mode, where every filter takes

--- a/src/jq/walk.rs
+++ b/src/jq/walk.rs
@@ -1265,16 +1265,167 @@ pub fn uses_cursor_metadata_builtins(expr: &Expr) -> bool {
 /// against `null`. Only the first is acceptable, so anything unclear is
 /// `true`.
 ///
-/// **Deliberately imprecise about pipes.** `1 | .` reads `1`, not the
-/// document, but this walk sees an `Expr::Identity` node and reports
-/// `true`. Teaching it that a pipe stage's ambient value is the previous
-/// stage's output is a refinement, not a correction — it would widen what
-/// counts as closed, never narrow it.
+/// **Structure-aware for the three binders that rebind `.`** (#2699).
+/// A pipe stage's ambient value is the *previous stage's output*, so
+/// `Expr::Pipe` is closed when its first stage is closed — `1 | .`,
+/// `[1,2,3] | length`, `"abc" | ascii_upcase` all read `1`/`[1,2,3]`/`"abc"`,
+/// never the document. `Expr::Reduce`/`Expr::Foreach` rebind `.` the same
+/// way in their `update`/`extract` arms, where `.` is the accumulator
+/// (verified against jq 1.7.1: `reduce (1,2,3) as $x (0; . + $x + (.zz|length))`
+/// fails with *Cannot index number*, naming the accumulator, not the
+/// document).
+///
+/// Every other variant still takes the whole-tree
+/// [`any_subexpr`] answer, so this widens what counts as closed and never
+/// narrows it. In particular `Expr::As` is **not** one of these: `1 as $x | .`
+/// binds `$x` but leaves `.` pointing at the *outer* ambient, so its body
+/// must keep reading through to the document.
+///
+/// A later stage still reaches the document if it uses a channel that does
+/// not flow through the ambient *value* — `input`, cursor metadata, `key`,
+/// `parent`, path tracking, or an unresolved call whose body cannot be
+/// inspected. `stage_escapes_own_input` is that gate, and any stage
+/// tripping it forces the whole pipe back to `true`.
 ///
 /// Same expanded-program requirement as [`uses_input_builtins`]: a call
 /// reachable only through an imported module body still counts.
 pub fn reads_ambient_value(expr: &Expr) -> bool {
-    any_subexpr(expr, &mut node_reads_ambient)
+    match expr {
+        // `stages[0]` sees the document; every later stage sees the stage
+        // before it. An empty `Pipe` is not something the parser produces,
+        // but `false` would be the wrong way to guess if it ever did.
+        Expr::Pipe(stages) => match stages.split_first() {
+            Some((first, rest)) => {
+                reads_ambient_value(first) || rest.iter().any(stage_escapes_own_input)
+            }
+            None => true,
+        },
+
+        // `input` and `init` are evaluated against the document; `update`
+        // (and `foreach`'s `extract`) against the accumulator.
+        // `patterns` is not consulted: `PatternEntry::key` is a `String`,
+        // so a pattern holds no `Expr` to reach the document with. #2677
+        // would change that by widening it to a computed key -- if it lands,
+        // the new key expression is evaluated against the *document* and
+        // belongs on the `reads_ambient_value` side of these arms.
+        Expr::Reduce {
+            input,
+            init,
+            update,
+            ..
+        } => {
+            reads_ambient_value(input)
+                || reads_ambient_value(init)
+                || stage_escapes_own_input(update)
+        }
+        Expr::Foreach {
+            input,
+            init,
+            update,
+            extract,
+            ..
+        } => {
+            reads_ambient_value(input)
+                || reads_ambient_value(init)
+                || stage_escapes_own_input(update)
+                || extract.as_deref().is_some_and(stage_escapes_own_input)
+        }
+
+        // Ambient-transparent wrappers: each child is evaluated against the
+        // very same `.` this node received, so the refinement above has to
+        // survive being wrapped in one -- `[foreach (1,2) as $x (0; . + $x)]`
+        // and `(1 | .) | .a` are closed for exactly the reasons their
+        // unwrapped forms are.
+        Expr::Paren(inner) | Expr::Array(inner) | Expr::Optional(inner) => {
+            reads_ambient_value(inner)
+        }
+        Expr::Comma(branches) => branches.iter().any(reads_ambient_value),
+
+        // Everything else keeps the flat whole-tree answer. That is still
+        // sound -- `any_subexpr` reaches every descendant, so a `.` anywhere
+        // reports `true` -- just less precise than it could be: a `Pipe`
+        // nested under a variant not listed above is judged by its parts
+        // rather than by its first stage. Widening this list is a further
+        // refinement in the same safe direction, never a correction.
+        _ => any_subexpr(expr, &mut node_reads_ambient),
+    }
+}
+
+/// Whether a subtree evaluated against a *rebound* `.` (a later pipe stage, a
+/// `reduce`/`foreach` update) could still reach the document (#2699).
+///
+/// Its own `.` is safe by construction — that is the previous stage's output.
+/// What is not safe is a channel that bypasses the ambient value entirely, so
+/// this lists those channels, and it is deliberately broader than "reads the
+/// document": `1 | key` and `1 | path(.)` answer from cursor and
+/// path-tracking context that [`reads_ambient_value`]'s caller
+/// (`eval_generic::bridge_ambient_input`) is not deciding about, so they keep
+/// their materialization rather than have this predicate reason about them.
+///
+/// **This list is fail-open, which is the opposite of the discipline the rest
+/// of this module uses, and that is a known weakness rather than a choice.**
+/// `node_reads_ambient` is exhaustive over `Expr` with no wildcard so a new
+/// variant is a compile error, and its `Builtin` arm is a negative allowlist
+/// so a new builtin defaults to "reads" — both fail *safe*. Here a builtin
+/// nobody adds to this list defaults to "does not escape", i.e. to the
+/// wrong-answer direction. `Builtin` has 209 variants, so the fail-closed
+/// reshape (an exhaustive match, one decision per variant) is its own change
+/// with its own review; it is tracked as #2791.
+///
+/// The concrete cost of the fail-open shape is already on record: an
+/// adversarial review of #2790 found five siblings of listed entries missing
+/// from the first version of this list — `path` (the no-argument, yq-native
+/// spelling of `path(f)`), `paths(f)`, `file_index`, `tag` and `kind` — none
+/// of which could be turned into a wrong answer, but all of which were
+/// omitted on day one. They are listed below now.
+///
+/// `needs_path_context` in `eval.rs` answers a related question and is
+/// deliberately *not* reused: it is superlinear on recursive definitions, and
+/// `bridge_ambient_input` runs per evaluation.
+///
+/// One walk, not four: the four separate whole-subtree scans this started as
+/// measured 2.7-4.2x slower than the single walk it replaced, on a predicate
+/// that runs per evaluation.
+fn stage_escapes_own_input(expr: &Expr) -> bool {
+    any_subexpr(expr, &mut |e| match e {
+        // An unresolved call carries no body to inspect, exactly as
+        // `node_reads_ambient` treats it.
+        Expr::FuncCall { .. } | Expr::NamespacedCall { .. } => true,
+        Expr::Builtin(b) => matches!(
+            b,
+            // `input`/`inputs`/`input_line_number` (`uses_input_builtins`).
+            Builtin::Input
+                | Builtin::Inputs
+                | Builtin::InputLineNumber
+                // Cursor metadata (`uses_cursor_metadata_builtins`).
+                | Builtin::Line
+                | Builtin::Column
+                | Builtin::DocumentIndex
+                | Builtin::Anchor
+                | Builtin::Style
+                | Builtin::LineComment
+                | Builtin::HeadComment
+                | Builtin::FootComment
+                | Builtin::AtOffset(_)
+                | Builtin::AtPosition(_, _)
+                // Path tracking and traversal context.
+                | Builtin::Key
+                | Builtin::Parent
+                | Builtin::ParentN(_)
+                | Builtin::Path(_)
+                | Builtin::PathNoArg
+                | Builtin::Paths
+                | Builtin::PathsFilter(_)
+                | Builtin::LeafPaths
+                | Builtin::GetPath(_)
+                // Invocation context (which file, which node), not a value
+                // read -- the #2790 review's remaining three.
+                | Builtin::FileIndex
+                | Builtin::Tag
+                | Builtin::Kind
+        ),
+        _ => false,
+    })
 }
 
 /// One node's own answer for [`reads_ambient_value`], ignoring its children —

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -45966,6 +45966,23 @@ fn test_closed_terms_do_not_validate_2173() -> Result<()> {
         // `bridge_ambient_input`, so a closed `repeat(f)` kept validating
         // the whole document after #2173 landed everywhere else.
         ("[limit(1; repeat(1))]", "[1]"),
+        // #2699: `repeat`'s bridge takes the *inner* `f`, so once a pipe /
+        // `reduce` / `foreach` counts as closed, these stop validating too.
+        // This is the same sanctioned divergence the rows above are, but it
+        // is a NEW instance of it and it is the one #2790 nearly shipped
+        // unrecorded: `[limit(1; repeat(1))]` above cannot flip (it was
+        // already closed), so the pre-existing row proved nothing about the
+        // change. Real jq 1.7.1 exits 5 on every cell, as with every row here.
+        ("[limit(1; repeat(1 | .))]", "[1]"),
+        ("[limit(1; repeat([1,2,3] | length))]", "[3]"),
+        (
+            "[limit(1; repeat(reduce (1,2,3) as $x (0; . + $x)))]",
+            "[6]",
+        ),
+        (
+            "[limit(1; repeat([foreach (1,2) as $x (0; . + $x)]))]",
+            "[[1,3]]",
+        ),
         // `env(NAME)`/`strenv(NAME)` (`Builtin::EnvObject`/`Builtin::StrEnv`)
         // take no `value` parameter at all, but `node_reads_ambient`'s
         // allowlist omitted both -- a var guaranteed absent makes the `?`

--- a/tests/jq_closed_term_tests.rs
+++ b/tests/jq_closed_term_tests.rs
@@ -75,6 +75,51 @@ const CLOSED: &[&str] = &[
     // absent keeps the `?` outcome document-independent.
     "[env(NONEXISTENT_VAR_XYZ_2173)?]",
     "[strenv(NONEXISTENT_VAR_XYZ_2173)?]",
+    // #2699: a pipe stage's ambient value is the previous stage's output,
+    // so a closed first stage closes the whole pipe.
+    "1 | .",
+    "now | type",
+    "[1,2,3] | length",
+    r#""abc" | ascii_upcase"#,
+    "2 | . + 1",
+    "[1] | .[0]",
+    "1 | length",
+    "[1,2,3] | .[1:2]",
+    "[1,2] | add",
+    "{} | keys",
+    "1 | if . then 2 else 3 end",
+    "[1,2] | map(. + 1)",
+    "1 | 2 | 3 | .",
+    "[1,2,3] | .[] | . + 1",
+    // `reduce`/`foreach` rebind `.` to the accumulator in `update`.
+    "reduce (1,2,3) as $x (0; . + $x)",
+    "[foreach (1,2) as $x (0; . + $x)]",
+    "[foreach (1,2) as $x (0; . + $x; . * 10)]",
+    // The ambient-transparent wrappers carry the refinement through.
+    "(1 | .) | .a?",
+    "[1 | .]",
+    "[[1,2] | length]",
+    "((1 | .))",
+    // The `Expr::Optional` arm's only witness. Every other `?` in this
+    // corpus sits in a *later* stage, which `stage_escapes_own_input`
+    // judges -- so removing the `Optional` arm broke no test at all until
+    // this row existed (found by the #2790 review's arm-by-arm mutation).
+    "(1 | .)?",
+    "[(1 | .), (2 | .)]",
+    // Closed *and* ill-typed: `.a` applies to the previous stage's `1`, so
+    // the outcome is the same whatever the document is -- which is the
+    // property under test. Note these raise on the CLI ("Cannot index
+    // number with string \"a\"", matching jq 1.7.1) but reach this
+    // library harness as no output, because `collect_owned` stops at the
+    // failure rather than propagating it. Either way: document-independent.
+    // `[foreach ...; .a]` is here for the same reason, and is the row that
+    // proves `extract` sees the accumulator rather than the document.
+    "1 | .a",
+    "1 | .[0]",
+    r#""abc" | .a"#,
+    "1 | keys",
+    "[1,2] | .a",
+    "[foreach (1,2) as $x (0; . + $x; .a)]",
 ];
 
 /// Filters that read the input. These must be reported as reading — a
@@ -118,6 +163,49 @@ const READING: &[&str] = &[
     "(1, 2) = 5",
     ".a = 5",
     "1 |= . + 1",
+    // #2699: the refinement must NOT reach these.
+    //
+    // `as` binds a variable but leaves `.` on the OUTER ambient, so the
+    // body still reads the document. This is the row that makes the pipe
+    // rule safe: it parses as `Expr::As`, never `Expr::Pipe`.
+    "1 as $x | .",
+    "1 as $x | .a",
+    "[1,2] as [$a,$b] | .",
+    "{} as {a:$a} | .",
+    // A closed first stage does not help if a later stage reaches the
+    // document through a channel that bypasses the ambient value.
+    "1 | input",
+    "1 | [inputs]",
+    "1 | key",
+    "1 | parent",
+    "1 | path(.)",
+    "1 | [paths]",
+    "1 | [leaf_paths]",
+    "1 | getpath([\"a\"])",
+    "1 | line",
+    "1 | column",
+    // The five siblings missing from `stage_escapes_own_input` on day one
+    // (#2790 review). None could be turned into a wrong answer, but the
+    // omissions are what a fail-open list looks like in practice.
+    "1 | path",
+    "1 | [paths(numbers)]",
+    "1 | file_index",
+    "1 | tag",
+    "1 | kind",
+    // An unresolved call carries no body to inspect.
+    "1 | f",
+    // A reading first stage keeps the whole pipe reading, at any depth.
+    ". | 1",
+    ".a | 1",
+    "(. | 1) | 2",
+    "[. | 1]",
+    ". | . | .",
+    "(.a, 1) | 1",
+    // `reduce`/`foreach` read the document through `input` and `init`.
+    "reduce .[] as $x (0; . + $x)",
+    "reduce (1,2) as $x (.; . + $x)",
+    "[foreach .[] as $x (0; . + $x)]",
+    "[foreach (1,2) as $x (.; . + $x)]",
     ".a += 1",
     ".a //= 1",
     "del(.a)",
@@ -251,4 +339,19 @@ fn input_independent_builtins_are_closed_2173() {
             "`{filter}` consults `.` however closed its argument is"
         );
     }
+}
+
+/// The defensive arm: an empty `Expr::Pipe` answers `true` (#2699).
+///
+/// The parser never builds one — a pipe always has at least the stage before
+/// its `|` — but `reads_ambient_value` is `pub`, so a library caller can
+/// construct one directly, which is what this test does. `true` is the only
+/// safe guess: `false` would tell `bridge_ambient_input` to hand `null` to an
+/// expression nobody has inspected.
+#[test]
+fn an_empty_pipe_is_conservatively_reading_2699() {
+    assert!(
+        reads_ambient_value(&succinctly::jq::Expr::Pipe(vec![])),
+        "an empty pipe has no first stage to judge, so it must not be called closed"
+    );
 }


### PR DESCRIPTION
## What

`jq::walk::reads_ambient_value` was `any_subexpr` plus a leaf classifier, so any tree containing an `Identity`-shaped node reported "reads the document" — even when that `.` meant a previous pipe stage's output. Where that verdict reaches a bridge, it costs a full `OwnedValue` copy of the document.

Three binders actually rebind `.`, and are now structural arms:

- **`Pipe`** — stage *n+1* sees stage *n*'s output, so a closed first stage closes the pipe.
- **`Reduce` / `Foreach`** — `update` and `extract` see the accumulator.
- Plus four ambient-transparent wrappers (`Paren`/`Array`/`Optional`/`Comma`) so the refinement survives being wrapped.

Fixes #2699.

## Measured

On the `repeat` route, where `each_repeat_generic` bridges the **inner** `f`. Release builds, interleaved, 5 reps, 13 MB document:

| filter | base | this branch | |
|---|--:|--:|---|
| `[limit(1; repeat(1 \| .))]` | 0.351 s / 349 MB | 0.031 s / 25 MB | **11.3x faster, 14.1x smaller peak** |
| `[limit(1; repeat(1))]` | 0.030 s / 25 MB | 0.030 s / 25 MB | control, already closed — unchanged |
| `[limit(1; repeat(.))]` | 0.404 s / 478 MB | 0.404 s / 477 MB | control, genuinely reads — unchanged |

Same order as the 443 MB → 29 MB #2173 itself recorded.

## It also widens a sanctioned divergence — recorded, not shipped quietly

The skipped materialization is a skipped *validation*, which is ADR-0018's #2103/#2173 divergence. This adds new instances of it, so both places the project pins that family are updated: a table in `docs/compliance/jq/limitations.md` and rows in `test_closed_terms_do_not_validate_2173`.

On `{123:1,"b":2}`, `[limit(1; repeat(1 | .))]` goes from exit 5 to `[1]`. Real jq exits 5 on every cell of that grid, as it does for every row already in that table.

## Why it is safe

A wrong "reads" costs a materialization; a wrong "closed" evaluates a user's filter against `null`. Only the second matters:

- **5400 (filter, document) pairs byte-identical to `main`** on well-formed input — 900 generated pipe/reduce/foreach/wrapper filters × 6 documents, stdout and exit code.
- The existing soundness property — each closed filter run against five structurally unrelated documents, outputs must agree — extended with the new shapes.
- The must-not-change direction pinned directly, led by **`1 as $x | .`**: it binds `$x` but leaves `.` on the *outer* ambient. It parses as `Expr::As`, never `Expr::Pipe`, so the rule never sees it — but that distinction is exactly what makes the rule safe, so it is a test.

A later stage can still reach the document through channels that bypass the ambient value — `input`, cursor metadata, `key`, `parent`, path tracking, `file_index`/`tag`/`kind`, or an unresolved call with no body. `stage_escapes_own_input` gates those.

## Corrections made after adversarial review

The first version of this PR was wrong in two significant ways, both caught by review:

1. **It claimed "malformed documents unchanged".** False — the `repeat` route flips, as shown above. My sweep was run at the wrong altitude: bare pipes never reach a bridge from the CLI, so testing them proved nothing about the change. Now pinned in the compliance doc and the CLI test.
2. **It claimed "no measured payoff" and offered to close itself.** Also false — that rested on `sort_by(1 | .)`, which reports `READS` at top level on this branch too, so it was never a probe of this change; its flat number was `sort_by`'s own array materialization. The real route is `repeat`, at 11.3x/14.1x.

Also fixed from the same review:

3. `Expr::Optional` had **no** discriminating test — every `?` in the corpus sat in a later stage, judged by a different function. `(1 | .)?` added; verified it fails without the arm.
4. `stage_escapes_own_input` ran **four** whole-subtree walks per later stage, measuring 2.7–4.2x slower than the single walk it replaced, on a predicate that runs per evaluation. Fused into one walk: now **1.00–1.13x**.
5. The escape list was missing five siblings of entries it already had — `path` (the no-arg yq spelling), `paths(f)`, `file_index`, `tag`, `kind`. All added and pinned. The list is **fail-open** where the rest of `walk.rs` fails safe; that is now stated at the function and tracked as #2791, since the fail-closed reshape is ~210 arms over `Builtin` and deserves its own review.

## Verification

Full suite (62 binaries), both clippy legs, fmt, `--no-default-features`, rustdoc with `-D warnings`, 100% patch coverage. Rebased onto current `main` (#2724) and re-verified there.
