### PR TITLE
fix(jq): stop label $x from shadowing a same-named variable

### DIFF
--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -34963,8 +34963,11 @@ fn substitute_var_impl(
         // a break target, not a variable), so a same-named label must
         // never block a variable substitution from reaching into its
         // body -- confirmed live against jq 1.7.1 across the bare case,
-        // nested same-named labels, and a `break $x` inside a rebound
-        // `$x` scope. `map_subexprs`'s own `Expr::Label` arm already
+        // nested same-named labels, an unrelated rebinding inside the
+        // label body, and `break` still escaping to the right label
+        // afterward (each its own row in `test_label_does_not_shadow_
+        // same_named_variable_2739`, `tests/jq_cli_tests.rs`, not one
+        // combined case). `map_subexprs`'s own `Expr::Label` arm already
         // recurses into `body` unconditionally and leaves `name` (a plain
         // `String`, not an `Expr`) untouched, which is exactly right here.
         _ => map_subexprs(expr, &mut |sub| {

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -34948,10 +34948,6 @@ fn substitute_var_impl(
                 bound: FuncDefBound::default(),
             }
         }
-        // Label-break
-        // Don't substitute if the label shadows our variable
-        Expr::Label { name, .. } if name == var_name => expr.clone(),
-
         // #2095: every remaining variant's recursive-structural-child
         // handling here is identical to `install_def_calls`'s and
         // `substitute_func_param`'s own -- apply this substitution to each
@@ -34961,7 +34957,16 @@ fn substitute_var_impl(
         // for the full variant-by-variant justification, including the four
         // arms (`Shared`, `Builtin`, `FuncDef`, and `install_def_calls`'s own
         // `DefCall` policy) that stay explicit above/in each caller instead
-        // of ever reaching it -- `Expr::Error` used to be a fifth (#2727).
+        // of ever reaching it -- `Expr::Error` used to be a fifth (#2727),
+        // and `Expr::Label` a sixth (#2739): a label name and a variable
+        // name live in different namespaces in jq (`label $x | ...` binds
+        // a break target, not a variable), so a same-named label must
+        // never block a variable substitution from reaching into its
+        // body -- confirmed live against jq 1.7.1 across the bare case,
+        // nested same-named labels, and a `break $x` inside a rebound
+        // `$x` scope. `map_subexprs`'s own `Expr::Label` arm already
+        // recurses into `body` unconditionally and leaves `name` (a plain
+        // `String`, not an `Expr`) untouched, which is exactly right here.
         _ => map_subexprs(expr, &mut |sub| {
             substitute_var_impl(sub, var_name, replacement, mark)
         }),

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -28153,7 +28153,7 @@ fn test_label_does_not_shadow_same_named_variable_2739() -> Result<()> {
         ("1 as $x | label $x | (label $x | $x)", "1\n"),
         ("label $x | (2 as $x | $x)", "2\n"),
         ("1 as $x | label $x | (2, break $x, 3)", "2\n"),
-        (r#"def f: label $x | (1, break $x, 2); [f]"#, "[1]\n"),
+        (r"def f: label $x | (1, break $x, 2); [f]", "[1]\n"),
         ("def f($x): label $x | $x; f(1)", "1\n"),
     ] {
         let (out, err, code) = run_jq_full(&["-cn", filter], None)?;

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -28136,6 +28136,33 @@ fn test_error_message_substitution_reaches_bound_names_2727() -> Result<()> {
     Ok(())
 }
 
+/// #2739: a label name and a variable name live in different namespaces in
+/// jq -- `label $x | ...` binds a break target, not a variable -- but
+/// `substitute_var_impl`'s `Expr::Label` arm treated a matching label as
+/// shadowing the variable, blocking substitution from reaching an in-scope
+/// `$x` read inside the label's body. Covers the bare case, a nested
+/// same-named label, an unrelated rebinding inside the label body (already
+/// correct, unaffected by this fix), `break` still escaping to the right
+/// label afterward, and the `$`-style def-parameter sibling case
+/// (`substitute_func_param_impl` has no such arm and stays correct). All
+/// rows are live jq 1.7.1 captures.
+#[test]
+fn test_label_does_not_shadow_same_named_variable_2739() -> Result<()> {
+    for (filter, expected) in [
+        ("1 as $x | label $x | $x", "1\n"),
+        ("1 as $x | label $x | (label $x | $x)", "1\n"),
+        ("label $x | (2 as $x | $x)", "2\n"),
+        ("1 as $x | label $x | (2, break $x, 3)", "2\n"),
+        (r#"def f: label $x | (1, break $x, 2); [f]"#, "[1]\n"),
+        ("def f($x): label $x | $x; f(1)", "1\n"),
+    ] {
+        let (out, err, code) = run_jq_full(&["-cn", filter], None)?;
+        assert_eq!(code, 0, "`{filter}` -- out={out:?} err={err:?}");
+        assert_eq!(out, expected, "`{filter}`");
+    }
+    Ok(())
+}
+
 /// #2728: a leading underscore is a valid identifier-start character
 /// throughout jq (`def _walk: ...` is a common real-jq library convention),
 /// but the bare-name/call dispatch gate in `parse_primary` only checked

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -12722,6 +12722,18 @@ fn test_yq_halt_not_caught_by_try_catch_or_label() -> Result<()> {
     Ok(())
 }
 
+/// #2739: the label/variable namespace fix applies uniformly (not gated by
+/// `S: EvalSemantics`, since `substitute_var_impl` is shared), so a
+/// same-named `label $x | ... $x ...` must resolve the variable correctly
+/// in yq mode too, not just jq mode.
+#[test]
+fn test_label_does_not_shadow_same_named_variable_yq_2739() -> Result<()> {
+    let (stdout, code) = run_yq_stdin("1 as $x | label $x | $x", "x: 1\n", &[])?;
+    assert_eq!(code, 0);
+    assert_eq!(stdout.trim_end(), "1");
+    Ok(())
+}
+
 /// #791 follow-up: `map(f)`'s path-context evaluator (only reachable via
 /// `--eval-all` when `f` references `file_index`/`key`/`path`/`parent`, which
 /// routes through the deleted eager path-context evaluator instead of the

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -12728,6 +12728,11 @@ fn test_yq_halt_not_caught_by_try_catch_or_label() -> Result<()> {
 /// in yq mode too, not just jq mode.
 #[test]
 fn test_label_does_not_shadow_same_named_variable_yq_2739() -> Result<()> {
+    // The filter never reads the input document, so its content is
+    // irrelevant here -- "x: 1" matches this file's local convention for
+    // the surrounding block of tests, not a deliberate YAML-key-vs-jq-
+    // variable interaction (the `$x` above is a jq variable, entirely
+    // unrelated to the YAML key `x` below).
     let (stdout, code) = run_yq_stdin("1 as $x | label $x | $x", "x: 1\n", &[])?;
     assert_eq!(code, 0);
     assert_eq!(stdout.trim_end(), "1");


### PR DESCRIPTION
## Summary

A label name and a variable name live in different namespaces in jq --
`label \$x | ...` binds a break target, not a variable -- but
`substitute_var_impl`'s `Expr::Label { name, .. } if name == var_name =>
expr.clone()` arm treated a matching label as shadowing the variable,
blocking substitution from reaching an in-scope `\$x` read inside the
label's body:

```console
$ echo null | jq -c '1 as $x | label $x | $x'
1
$ echo null | succinctly jq -c '1 as $x | label $x | $x'
jq: error (at <stdin>:1): undefined variable: $x
```

Dropped the arm, letting it fall through to the shared `_ =>
map_subexprs(...)` default (which already recurses into `Expr::Label`'s
`body` unconditionally, per #2095, and never touches `name` -- a plain
`String`, not an `Expr`, so a variable substitution was never at risk of
corrupting a label/break target either way).

Confirmed against jq 1.7.1 across the bare case, nested same-named labels,
an unrelated rebinding inside the label body, `break` still escaping to
the right label afterward, and the `\$`-style def-parameter sibling case
(`substitute_func_param_impl` has no such arm and stays correct, per the
issue's own note). Applies uniformly to yq mode too, since
`substitute_var_impl` is shared and unconditional -- verified there as
well.

Fixes #2739

## Test plan

- [x] `cargo build --features cli`
- [x] `cargo test --features cli,simd,regex,serde` (full suite, 0 failures)
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings`
- [x] New `test_label_does_not_shadow_same_named_variable_2739`
      (`tests/jq_cli_tests.rs`) covering 6 shapes -- each cross-checked
      live against `/usr/bin/jq` 1.7.1
- [x] New `test_label_does_not_shadow_same_named_variable_yq_2739`
      (`tests/yq_cli_tests.rs`) confirming the fix applies in yq mode too
- [x] `cargo llvm-cov` / `omni-dev coverage diff`: no new executable lines
      added (the fix is a pure arm removal)