### PR TITLE
fix(yq): answer metadata builtins after key from the key node

### DIFF
--- a/docs/adrs/adr-0021.md
+++ b/docs/adrs/adr-0021.md
@@ -343,6 +343,60 @@ recorded in `docs/compliance/yq/limitations.md`: a variable bound from an absent
 yq binds a candidate *list*, and a key lookup that finds nothing contributes no candidate),
 and the flow style of an anchor node read through an alias binding.
 
+### Amendment (#2763, implemented 2026-09-11): the key `key` emits is a document node
+
+Decision 2 made path context a *cursor property* and `cursor_key` a sibling scan of the
+parent's members. That scan looked only for the member **value**, returned the key's
+display string and discarded the key's own cursor — so every getter that reads nothing but
+a cursor (`line_comment`, `head_comment`, `foot_comment`, `line`, `column`, `style`,
+`anchor`) answered its no-cursor default after a `key` stage, where real yq answers the
+key's own. The same node is where a mapping entry's comments live, which is why #765 and
+#798 both ended at this wall.
+
+**A mapping key is a position, not just a string.** `cursor_slot` (`src/jq/eval_generic.rs`)
+replaces `cursor_key`'s scan and recognises *both* halves of a member — `Value { key,
+key_cursor }`, `Key(key)`, `Element(i)` — and `cursor_path_and_ancestors` climbs from a key
+exactly as from the value beside it, so a key node's `path` is its member's path and
+`parent` is the mapping. `key` then emits that node (`GenericItem::OneCursor`) on all three
+routes that can carry one: the walk (`path_context_emitting_value`, which also carries a
+new `PathContextPos::at_key` so a second `key` emits nothing), `eval_builtin`'s cursor arm,
+and the owned identity pipe, which hands the rest of the pipe back to the cursor pipe from
+the key node exactly as `continue_owned_identity_ancestor` already does for `parent`.
+
+The node is reached by one **`DocumentCursor::prev_sibling`** hop, not a second scan: both
+indexed formats lay a member out as key-then-value siblings (`uncons` is defined that way),
+so `[.[] | key | line]` stays linear. `key_node_spells` is the guard on that hop — the
+emitted node must be a plain string spelling exactly the member's own display key — and
+every other case (a typed key, an explicitly tagged key, a complex `? [a, b]` key, an
+undecodable one) keeps the display string byte-for-byte.
+
+**Three properties this amendment preserves.**
+
+1. **A key has no key; a value standing at one does.** `cursor_key` answers `None` for a
+   live key cursor (`.a.b | key | key` prints nothing in yq v4.53.3) while
+   `OwnedIdentity::key` answers the member's key for an owned value positioned there
+   (`.a.b | key | tostring | key` is `"b"`). The two designs #2763 records as wrong both
+   collapse that distinction.
+2. **`path`/`parent` after `key` are unchanged.** Returning the key cursor *without*
+   decision 2's climb knowing what a key node is was the first of those designs: it makes
+   `.a.b | key | path` answer `[]`. Teaching `cursor_path_and_ancestors` the `Key` slot is
+   what makes the emission safe, and `jq_evaluator_parity_tests`/
+   `jq_path_context_alphabet_tests` are the net.
+3. **One route cannot answer differently from another.** The non-sink walk route collapses
+   its items to one `GenericResult` before folding the rest, and that collapse keeps cursors
+   only when *every* item is one — so a document mixing string and typed keys would have
+   answered `0` there while the sink route answered from the node. It now drives the sink
+   route whenever there is a rest, which is also what removes its own duplicate
+   `fold_pipe_stages` call.
+
+The library's `QueryResult` shape for `.[] | key` moves from `ManyOwned` to `Many`
+accordingly (a batch of cursors renders as its borrowed values); the values are unchanged,
+and the CLI output is byte-identical. Residuals are recorded in
+`docs/compliance/yq/limitations.md`: a typed key, a `key | <metadata>` nested inside a
+bounded consumer or an `as` source *when a later stage also reads path context*, metadata
+through a constructed container, and the wider question of whether an ordinary kept owned
+value answers metadata from its base at all.
+
 ## Consequences
 
 - **Fidelity moved toward the reference where the two models disagree.** `key`/`parent`
@@ -450,6 +504,12 @@ and the flow style of an anchor node read through an alias binding.
   binding carries the node it was bound from ·
   [#2042](https://github.com/rust-works/succinctly/issues/2042) — the jq-mode half, still
   open, which the origin gives a node to work from
+- [#2763](https://github.com/rust-works/succinctly/issues/2763) — the amendment above: the
+  key `key` emits is a document node, which is where a mapping entry's metadata lives ·
+  [#765](https://github.com/rust-works/succinctly/issues/765),
+  [#798](https://github.com/rust-works/succinctly/issues/798),
+  [#2758](https://github.com/rust-works/succinctly/issues/2758) — the three getters that hit
+  this wall before it was named
 - [ADR-0018](adr-0018.md) — mode, not format, decides fidelity; every divergence above is
   recorded under it
 - [`docs/compliance/yq/limitations.md`](../compliance/yq/limitations.md) — the yq-mode

--- a/docs/adrs/adr-0021.md
+++ b/docs/adrs/adr-0021.md
@@ -397,6 +397,29 @@ bounded consumer or an `as` source *when a later stage also reads path context*,
 through a constructed container, and the wider question of whether an ordinary kept owned
 value answers metadata from its base at all.
 
+**What the node costs.** Measured against the merge-base, interleaved per repetition,
+min-of-9, on 100k/200k-key flat mappings (M4 Pro / 7950X):
+
+| query | M4 Pro | 7950X |
+|---|---|---|
+| `[.[] \| key \| line]` — the shape the node exists for | −1% | +9% |
+| `[.[] \| key]` — emitted, then materialized straight back to its string | +17% | +19% |
+| `[.[] \| key \| tostring]` | +45% | +50% |
+| `keys_unsorted`, `[.[] \| path]`, `.` | neutral | neutral |
+
+The first cut read +49-59% on `[.[] | key]` and +58-72% on `| tostring`; a binary with the
+emission disabled landed exactly on the baseline, and one with only the type check
+disabled split the cost in half. Three changes brought it here, each measured: a spelling
+prefilter (`key_spelling_may_retype`) that keeps the `as_i64`/`as_f64` parse attempts off
+a key that cannot be a number, materializing the emitted `OneCursorValue` from the string
+it already holds rather than re-deciding its type, and resolving each key's value once. The
+remainder is a sibling hop plus one decode per key against a `String::clone`, and — for
+`tostring` — the loss of the `Owned`-arm format bypass (#2543) now that the item is
+cursor-backed. Gating the emission on what the rest of the pipe does with it was tried and
+rejected: the only *safe* allowlist of "cannot read a node" was the one enumerated from the
+benchmarked queries. [#2789](https://github.com/rust-works/succinctly/issues/2789) carries
+the two remaining shapes a real fix could take.
+
 ## Consequences
 
 - **Fidelity moved toward the reference where the two models disagree.** `key`/`parent`

--- a/docs/compliance/yq/limitations.md
+++ b/docs/compliance/yq/limitations.md
@@ -3508,40 +3508,42 @@ Two rendering divergences, both readable back and both pinned:
   tagged scalar whose cursor reports a quoted style (`a: !!int "5"`, #747) keeps its
   current (already divergent, pre-#798) rendering.
 
-### Metadata getters answer from the wrong node after `key` (#2763)
+### A typed mapping key is not emitted as a node by `key` (#2763 residual)
 
-A mapping entry's metadata lives on its **key** node, and succinctly loses the key node's
-cursor at a `key` stage, so every metadata builtin after `key` answers from a no-cursor
-default. Measured against pinned yq v4.53.3 on `a: # keyc\n  b: 1\n` (and `"qk": 1` for
-`style`):
+`key` emits the key **node** of a string-keyed member since #2763, so `line_comment`,
+`head_comment`, `foot_comment`, `line`, `column`, `style` and `anchor` after it read the
+key's own metadata, matching yq v4.53.3. A *typed* (non-string) key does not: `1: x`,
+`true: y` and `null: z` keep the display string `key` always emitted, so their metadata
+still reads the no-cursor default (`.["1"] | key | line` is `0`; yq answers `1`), and
+`[.[] | key]` prints `["1", "true", "null"]` where yq prints `[1, true, null]`.
 
-| `.a \| key \| …` | yq | succinctly |
-|---|---|---|
-| `line_comment` | `keyc` | `""` |
-| `line` / `column` | `1` / `1` | `0` / `0` |
-| `style` (quoted key) | `double` | `""` |
-| `head_comment` / `foot_comment` | the comment | `""` |
-| `tag`, `kind` | `!!str`, `scalar` | same — already correct |
+Deliberate, and blocked on a different divergence rather than on this mechanism: real yq's
+scalar `==` is stringly (`1 == "1"` is `true` there, `false` here), so it can emit an
+`!!int` key node and still answer `select(key == "1")`. succinctly's `==` is typed, so
+emitting one would break `select(key == "1")` — which matches yq today — to fix a metadata
+read that nothing else depends on. The key-node hop therefore takes the string case only
+(`key_node_spells`, `src/jq/eval_generic.rs`), and every other key falls back to the
+display string byte-for-byte: a complex `? [a, b]` key, an explicitly tagged key, a key
+whose bytes do not decode, and a node that is not the raw member value.
 
-This is not specific to comments, and it is older than #798: `line_comment` has had it
-since #765's capture side landed, and `line`/`column`/`style` were never recorded at all.
-`head_comment`/`foot_comment` (#2758) inherit exactly the same gap rather than introducing
-a different one — deliberately, so one fix closes all six. The natural spelling is
-unaffected and correct: `.b | head_comment` is `""` in both tools, because the comment
-genuinely belongs to the key; only the explicit `| key |` step diverges.
+Pinned by `key_node_metadata_2763::a_typed_key_keeps_its_display_string_2763`
+(`tests/yq_cli_tests.rs`), so closing the typing gap has to update this together.
 
-The cause is routing, not a missing read. `cursor_key` (`src/jq/eval_generic.rs`) already
-holds `field.key_cursor` and discards it, but a `... | key | <metadata>` pipe never reaches
-the position-carrying evaluator: `owned_identity_pipe_applies` gates on
-`rest.iter().any(needs_path_context)` and these builtins do not need path context, while
-widening that gate still loses to the walk route, which `path_context_walk_split` leaves a
-non-empty rest for and which evaluates the tail from a materialized node. #2763 records two
-designs that look right and are not — returning the key's cursor from `key` regresses
-`.a.b | key | path`, which is currently correct.
+Three narrower residuals of the same fix, each captured live from v4.53.3:
 
-Pinned by `head_foot_comment_798::key_node_head_comment_is_not_reachable_yet_798`
-(`tests/yq_cli_tests.rs`), which asserts the current wrong answers for both `head_comment`
-and `line_comment` so the fix updates them together.
+- A `key | <metadata>` nested inside a bounded consumer (`first`/`limit`/`last`) or an `as`
+  *source* still answers the default when a later stage also reads path context
+  (`.a.b | first(key | line) | path`). The bounded consumers are not real yq builtins
+  anyway — its lexer rejects `limit`, `last` and `try`, and its own `first(f)` ignores `f`
+  (#2377) — so these shapes are succinctly extensions.
+- Metadata through a *constructed* container is the container's, not the key's:
+  `map_values(key | line)` is `a: 1` in yq and `a: 0` here, as are
+  `to_entries[0].key | line` and `[.a | key] | .[0] | line`.
+- The wider question this issue does not settle: whether an ordinary owned value that
+  *kept* its position answers metadata from it. On `a:\n  b: 1\n`, `.a | del(.b) | line`,
+  `.a | .b = 3 | line` and `.a | key as $k | . | line` are all `2` in yq (the line `.a`
+  itself stands on) and `0` here. Only the key-node case is answered, because only it is
+  what `key` emits.
 
 ### Standalone comments are dropped from every YAML output route (#798)
 

--- a/src/jq/document.rs
+++ b/src/jq/document.rs
@@ -232,6 +232,15 @@ pub trait DocumentCursor: Sized + Copy + Clone {
     /// Navigate to the next sibling.
     fn next_sibling(&self) -> Option<Self>;
 
+    /// Navigate to the previous sibling; `None` at a first child.
+    ///
+    /// Both indexed formats lay an object member out as two consecutive
+    /// siblings, key then value (`uncons` is defined that way), so the key
+    /// node of a member *value* is exactly its previous sibling -- the O(1)
+    /// answer that `eval_generic`'s `cursor_slot` would otherwise need a scan
+    /// of the parent's members for (#2763).
+    fn prev_sibling(&self) -> Option<Self>;
+
     /// Navigate to the parent container.
     fn parent(&self) -> Option<Self>;
 

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -78361,16 +78361,21 @@ mod tests {
 
     #[test]
     fn test_key_object() {
-        // Test key on object iteration
+        // Test key on object iteration.
+        //
+        // `Many`, not `ManyOwned`: a string key is emitted as its own
+        // document node since #2763 (so the metadata getters after it read
+        // the key's line/column/comments), and `generic_to_query_result`
+        // renders a batch of cursors as their borrowed values. Unchanged
+        // keys.
         query!(br#"{"a": 1, "b": 2, "c": 3}"#, ".[] | key",
-            QueryResult::ManyOwned(results) => {
+            QueryResult::Many(results) => {
                 assert_eq!(results.len(), 3);
                 // Check that all results are string keys
                 let keys: Vec<String> = results.iter().filter_map(|v| {
-                    if let OwnedValue::String(s) = v {
-                        Some(s.clone())
-                    } else {
-                        None
+                    match to_owned_lossy(v) {
+                        OwnedValue::String(s) => Some(s),
+                        _ => None,
                     }
                 }).collect();
                 assert!(keys.contains(&"a".to_string()));
@@ -78414,10 +78419,14 @@ mod tests {
 
     #[test]
     fn test_key_nested() {
-        // Test key on nested access
+        // Test key on nested access. `OneCursor`, not `Owned`: see
+        // `test_key_object` above (#2763).
         query!(br#"{"outer": {"inner": 42}}"#, ".outer | .[] | key",
-            QueryResult::Owned(OwnedValue::String(s)) => {
-                assert_eq!(s, "inner");
+            QueryResult::OneCursor(c) => {
+                assert_eq!(
+                    crate::jq::eval_generic::to_owned_cursor(&c).expect("decodes"),
+                    OwnedValue::String("inner".to_string())
+                );
             }
         );
     }

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -14701,15 +14701,31 @@ fn path_context_item_to_owned<V: DocumentValue>(
 ) -> Result<OwnedValue, EvalError> {
     match item {
         GenericItem::OneCursor(c) => to_owned_cursor(&c),
-        // #2763: a key node carries its own already-decoded value, so this
-        // is the one shape here that does not re-derive it -- the second
-        // `value()` plus the tag and number-canonicalization lookups
-        // `to_owned_cursor` makes are what `[.[] | key]` was paying twice.
-        // Dropping the cursor is sound *because* of the emission's own gate:
-        // `key_node_spells` refuses a node with an explicit tag and one that
-        // is not a plain string, which are exactly the two things
-        // `to_owned_cursor` consults a cursor for.
-        GenericItem::OneCursorValue(_, v) => to_owned(&v),
+        // #2763: the *key node* shape, and the one item here that is already
+        // known to be a plain, untagged string -- `key_node_spells` proved
+        // exactly that before emitting it, which is why this can take the
+        // string straight out of the value instead of re-deciding its type.
+        //
+        // That matters because deciding it is the expensive part: `to_owned`
+        // would run the same `as_i64`/`as_f64` parse attempts the emission
+        // gate was restructured to avoid, and `to_owned_cursor` would add a
+        // second `value()` plus the tag and canonicalization lookups the gate
+        // already ruled out. `[.[] | key]` materializes every key it emits,
+        // so it pays this per key.
+        GenericItem::OneCursorValue(c, v) => match v.as_str() {
+            Some(s) => {
+                debug_assert!(
+                    plain_string_value(&v) && c.explicit_tag().is_none(),
+                    "the walk emits OneCursorValue only for a key node \
+                     `key_node_spells` proved is a plain untagged string"
+                );
+                Ok(OwnedValue::String(s.into_owned()))
+            }
+            // Unreachable through the gate above; materialized the ordinary
+            // way rather than asserted, so a future walk arm emitting this
+            // shape for something else is merely slower, never wrong.
+            None => to_owned_with_cursor(&v, Some(c)),
+        },
         GenericItem::Owned(o) => Ok(o),
         GenericItem::One(_)
         | GenericItem::LazyKeys { .. }
@@ -16414,6 +16430,10 @@ fn key_spelling_may_retype(key: &str) -> bool {
 /// the owned path, where `key` echoes the raw-byte fallback spelling rather
 /// than raising the decode failure materializing its node would.
 fn key_node_spells<C: DocumentCursor>(kc: &C, expected: &str) -> bool {
+    // Unconditional: an explicit tag can change what the node *materializes
+    // as* regardless of how the key is spelled (`!!null anything` resolves to
+    // null), so this cannot ride the rare branch below the way the type
+    // ladder can.
     if kc.explicit_tag().is_some() {
         return false;
     }

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -9856,12 +9856,25 @@ fn eval_each_pipe_generic<S: EvalSemantics, V: DocumentValue>(
             && owned_identity_leaving_stage_supported(first)
             && owned_identity_pipe_supported(rest)
     });
+    // #2763: `key` on a string-keyed member emits the key *node* -- a live
+    // cursor whose position is its own (`cursor_path_and_ancestors` climbs
+    // from it), so it never left the cursor domain and needs no owned
+    // identity. The rest continues as the ordinary cursor pipe from that
+    // node, which is what gives `key | select(line == 2) | path` and
+    // `key | (line, path)` the key's metadata. Only `key`: a `keys[]` item
+    // is a key cursor too, but at a *constructed* position (`.a | keys[] |
+    // path` is `[0]` in yq v4.53.3), which the identity route models.
+    let key_stage =
+        identity_from_first.is_some() && matches!(strip_parens(first), Expr::Builtin(Builtin::Key));
     // Same once-per-driver cache as `drive_pipe_elements_generic` (#1598):
     // this closure also runs once per item stage 1 produces.
     let mut rest = RestPipe::new(rest);
     let upstream = {
         let mut driver = |item: GenericItem<V>| -> Demand {
             let flow = match identity_from_first {
+                Some(_) if key_stage && matches!(item, GenericItem::OneCursor(_)) => {
+                    continue_pipe_element_generic::<S, V>(item, &mut rest, optional, &mut *sink)
+                }
                 Some(c) => match owned_identity_materialize::<V>(item) {
                     Ok(o) => match owned_identity_leaving_cursor::<S, V>(first, c, &o, optional) {
                         Ok(id) => eval_owned_identity_pipe::<S, V>(
@@ -14646,6 +14659,14 @@ struct PathContextPos<V: DocumentValue> {
     node: PathNode<V>,
     path: Vec<OwnedValue>,
     ancestors: Vec<PathNode<V>>,
+    /// `node` is a member's *key* node (#2763): the walk was seeded from the
+    /// cursor `key` emitted. It stands at its member's position -- `path`
+    /// and a `parent` hop answer as they would for the value -- but a key has
+    /// no key of its own, so `key` here emits nothing. Only
+    /// `path_context_root` (from `cursor_path_and_ancestors`) and a zero hop
+    /// (`parent(0)`) can produce a position with this set; every step lands
+    /// on an ordinary node.
+    at_key: bool,
 }
 
 impl<V: DocumentValue> Clone for PathContextPos<V> {
@@ -14654,6 +14675,7 @@ impl<V: DocumentValue> Clone for PathContextPos<V> {
             node: self.node.clone(),
             path: self.path.clone(),
             ancestors: self.ancestors.clone(),
+            at_key: self.at_key,
         }
     }
 }
@@ -14751,7 +14773,8 @@ fn path_context_hop<V: DocumentValue>(
     n: usize,
 ) -> Option<PathContextPos<V>> {
     let len = pos.path.len().checked_sub(n)?;
-    let node = if len == pos.path.len() {
+    let stays = len == pos.path.len();
+    let node = if stays {
         pos.node.clone()
     } else {
         pos.ancestors[len].clone()
@@ -14760,6 +14783,10 @@ fn path_context_hop<V: DocumentValue>(
         node,
         path: pos.path[..len].to_vec(),
         ancestors: pos.ancestors[..len].to_vec(),
+        // `parent(0)` is the node itself, key node included (`[.a | key |
+        // parent(0) | key]` is `[]` in yq v4.53.3); any real hop lands on a
+        // container.
+        at_key: stays && pos.at_key,
     })
 }
 
@@ -14796,6 +14823,7 @@ fn path_context_step_generic<S: EvalSemantics, V: DocumentValue>(
                     node: PathNode::Owned(Rc::new(var.value.clone())),
                     path: Vec::new(),
                     ancestors: Vec::new(),
+                    at_key: false,
                 }),
             }
             Ok(())
@@ -14829,6 +14857,7 @@ fn path_context_step_generic<S: EvalSemantics, V: DocumentValue>(
                     node,
                     path,
                     ancestors,
+                    at_key: false,
                 });
             }
             stepped.map_err(Control::Error)
@@ -15037,6 +15066,7 @@ fn path_context_step_generic<S: EvalSemantics, V: DocumentValue>(
                     node: PathNode::Owned(Rc::new(OwnedValue::Null)),
                     path: pos.path.clone(),
                     ancestors: pos.ancestors.clone(),
+                    at_key: false,
                 }),
             }
             Ok(())
@@ -15053,6 +15083,7 @@ fn path_context_step_generic<S: EvalSemantics, V: DocumentValue>(
                     node: PathNode::Owned(Rc::new(v)),
                     path: pos.path.clone(),
                     ancestors: pos.ancestors.clone(),
+                    at_key: false,
                 });
             }
             control.map_or(Ok(()), Err)
@@ -15108,12 +15139,14 @@ fn path_context_push_owned_children<V: DocumentValue>(
                     node,
                     path,
                     ancestors,
+                    at_key: false,
                 });
             }
             None => out.push(PathContextPos {
                 node,
                 path: pos.path.clone(),
                 ancestors: pos.ancestors.clone(),
+                at_key: false,
             }),
         }
     }
@@ -15547,6 +15580,7 @@ fn path_context_step_try<S: EvalSemantics, V: DocumentValue>(
             node: PathNode::Owned(Rc::new(v)),
             path: pos.path.clone(),
             ancestors: pos.ancestors.clone(),
+            at_key: false,
         });
     }
     control.map_or(Ok(()), Err)
@@ -15675,6 +15709,7 @@ fn path_context_step_target<S: EvalSemantics, V: DocumentValue>(
             node: PathNode::Owned(Rc::new(value)),
             path: Vec::new(),
             ancestors: Vec::new(),
+            at_key: false,
         });
     }
     control.map_or(Ok(()), Err)
@@ -15808,23 +15843,43 @@ fn path_component_step_expr(component: &OwnedValue) -> Option<Expr> {
     })
 }
 
-/// `key`/`path` (no arg)'s value at `pos` -- the sole caller is
+/// `key`/`path` (no arg)'s output at `pos` -- the sole caller is
 /// `path_context_walk_generic`'s own terminal arm, extracted only to keep
 /// that arm's body short once `PathNoArg`/`Key` were merged into one match
-/// arm (#2149). `Ok(None)` only for `key` at the document root, which
-/// emits nothing (see the caller's own doc comment for why).
+/// arm (#2149). `Ok(None)` only for `key` where there is none: at the
+/// document root, which emits nothing (see the caller's own doc comment for
+/// why), and at a key node (`key | key`, #2763).
+///
+/// `key` on the value of a string-keyed member emits the **key node itself**
+/// (#2763): a live cursor, so `line_comment`/`head_comment`/`line`/`column`/
+/// `style`/`anchor` after it read the key's own metadata, as they do in real
+/// yq. The node is the value's previous sibling ([`member_key_node`]), an O(1)
+/// hop that keeps `[.[] | key | line]` linear; a mismatch there, an index
+/// component and an absent or owned node keep the trail's spelling, as
+/// before.
 fn path_context_emitting_value<V: DocumentValue>(
     expr: &Expr,
     pos: &PathContextPos<V>,
-) -> Result<Option<OwnedValue>, EvalError> {
+) -> Result<Option<GenericItem<V>>, EvalError> {
+    let owned = |v: OwnedValue| Some(GenericItem::Owned(v));
     match expr {
-        Expr::Builtin(Builtin::PathNoArg) => Ok(Some(OwnedValue::Array(pos.path.clone()))),
+        Expr::Builtin(Builtin::PathNoArg) => Ok(owned(OwnedValue::Array(pos.path.clone()))),
+        Expr::Builtin(Builtin::Key) if pos.at_key => Ok(None),
         Expr::Builtin(Builtin::Key) => match pos.path.last() {
             Some(OwnedValue::Int(i)) if *i < 0 => match &pos.node {
-                PathNode::At(c) => cursor_key(c),
-                _ => Ok(Some(OwnedValue::Int(*i))),
+                PathNode::At(c) => Ok(cursor_key(c)?.and_then(owned)),
+                _ => Ok(owned(OwnedValue::Int(*i))),
             },
-            Some(key) => Ok(Some(key.clone())),
+            Some(OwnedValue::String(key)) => Ok(Some(match &pos.node {
+                PathNode::At(c) => match member_key_node(c, key) {
+                    Some(kc) => GenericItem::OneCursor(kc),
+                    None => GenericItem::Owned(OwnedValue::String(key.clone())),
+                },
+                PathNode::Absent | PathNode::Owned(_) => {
+                    GenericItem::Owned(OwnedValue::String(key.clone()))
+                }
+            })),
+            Some(key) => Ok(owned(key.clone())),
             None => Ok(None),
         },
         // Unreachable: the sole caller (path_context_walk_generic's merged
@@ -15898,10 +15953,13 @@ fn path_context_walk_generic<S: EvalSemantics, V: DocumentValue>(
         // `c: [10, 20]` (captured live; `[20,1]`, and `[10,0]` for `-2`).
         // Only then is the sibling scan paid, so `[.[] | key]` keeps its
         // per-element constant. Shared with `path_context_walk_pipe`'s own
-        // `Key`/`PathNoArg`-then-more-stages case (#2149).
+        // `Key`/`PathNoArg`-then-more-stages case (#2149). Since #2763 a
+        // string key on a live node is emitted as the key *node* (one
+        // sibling hop, still constant) so the metadata builtins after it
+        // answer from the key -- see `path_context_emitting_value`.
         Expr::Builtin(Builtin::PathNoArg | Builtin::Key) => {
             match path_context_emitting_value(expr, pos) {
-                Ok(Some(v)) => Ok(sink(GenericItem::Owned(v))),
+                Ok(Some(item)) => Ok(sink(item)),
                 Ok(None) => Ok(Demand::Continue),
                 // `cursor_key`'s malformed-member-key error path, pre-existing
                 // before this refactor merged this arm with `PathNoArg`'s.
@@ -16067,6 +16125,16 @@ fn collect_each_generic<S: EvalSemantics, V: DocumentValue>(
         items.push(item);
         Demand::Continue
     });
+    collected_items_result(items, flow)
+}
+
+/// The `GenericResult` of a sink evaluation that collected `items` and ended
+/// in `flow`: the items themselves when the sink ran out, else the prefix
+/// delivered before the escape, carrying it.
+fn collected_items_result<V: DocumentValue>(
+    items: Vec<GenericItem<V>>,
+    flow: Flow,
+) -> GenericResult<V> {
     let control = match flow {
         Flow::Exhausted | Flow::Stopped { pending: None } => {
             return match items_to_generic_result(items) {
@@ -16191,6 +16259,35 @@ fn build_object_entries_generic<S: EvalSemantics, V: DocumentValue>(
 /// `select(key == "a")`, `{k: key}` and every other construct evaluate
 /// path-context builtins in the generic evaluator with no dedicated arm.
 fn cursor_key<C: DocumentCursor>(c: &C) -> Result<Option<OwnedValue>, EvalError> {
+    Ok(match cursor_slot(c)? {
+        Some(CursorSlot::Value { key, .. }) => Some(key),
+        Some(CursorSlot::Element(index)) => Some(OwnedValue::Int(index)),
+        // A live key node has no key of its own: `.a.b | key | key` prints
+        // nothing in yq v4.53.3 (#2471).
+        Some(CursorSlot::Key(_)) | None => None,
+    })
+}
+
+/// Where `c` sits in its parent (#2763): the value of an object member, the
+/// **key** of one, or an element of an array. `None` at the document root.
+///
+/// The key node is a position of its own, not just a string `key` spells:
+/// its metadata (`line_comment`, `head_comment`, `line`, `column`, `style`,
+/// `anchor`) is what real yq answers after `key`, and it is a live cursor in
+/// both indexed formats -- the sibling *before* the member value. This is the
+/// one scan that recognises both halves of a member, so `cursor_key`,
+/// `cursor_path_and_ancestors` and the `key` emissions cannot disagree about
+/// which node is which.
+enum CursorSlot<C> {
+    /// `c` is the value of a member whose key is `key`, standing at `key_cursor`.
+    Value { key: OwnedValue, key_cursor: C },
+    /// `c` is itself the key node of a member spelled `key`.
+    Key(OwnedValue),
+    /// `c` is the element at this index of a sequence.
+    Element(i64),
+}
+
+fn cursor_slot<C: DocumentCursor>(c: &C) -> Result<Option<CursorSlot<C>>, EvalError> {
     let Some(parent) = c.document_parent() else {
         return Ok(None);
     };
@@ -16198,11 +16295,20 @@ fn cursor_key<C: DocumentCursor>(c: &C) -> Result<Option<OwnedValue>, EvalError>
     if let Some(fields) = parent_value.as_object() {
         let mut f = fields.clone();
         while let Some((field, rest)) = f.uncons() {
-            if field.value_cursor.same_node(c) {
+            let is_value = field.value_cursor.same_node(c);
+            if is_value || field.key_cursor.same_node(c) {
                 let Some(key) = key_display_string(&field.key) else {
                     return Err(fields.malformed_member_error());
                 };
-                return Ok(Some(OwnedValue::String(key.into_owned())));
+                let key = OwnedValue::String(key.into_owned());
+                return Ok(Some(if is_value {
+                    CursorSlot::Value {
+                        key,
+                        key_cursor: field.key_cursor,
+                    }
+                } else {
+                    CursorSlot::Key(key)
+                }));
             }
             f = rest;
         }
@@ -16212,7 +16318,7 @@ fn cursor_key<C: DocumentCursor>(c: &C) -> Result<Option<OwnedValue>, EvalError>
         let mut e = elements;
         while let Some((elem, rest)) = e.uncons_cursor() {
             if elem.same_node(c) {
-                return Ok(Some(OwnedValue::Int(index)));
+                return Ok(Some(CursorSlot::Element(index)));
             }
             index += 1;
             e = rest;
@@ -16223,26 +16329,74 @@ fn cursor_key<C: DocumentCursor>(c: &C) -> Result<Option<OwnedValue>, EvalError>
     }
 }
 
-/// The path from the document root to `c`, and the node at every proper
-/// prefix of it -- `(path, ancestors)` in the shape [`PathContextPos`] holds
-/// them. Empty at the root.
+/// The key node `key` emits for the member value `c` -- its previous sibling
+/// -- when that node is a plain string spelling exactly `expected`, the
+/// display string the caller already holds for the member (#2763).
+///
+/// The equality is the self-check that makes the O(1) sibling hop safe to
+/// take without a scan: a node that is not the raw member value, a complex
+/// (`? [a, b]`) key, a key whose bytes do not decode, an explicitly tagged
+/// key, and a *typed* key (`1: x`, `true: y`, `null: z`) all answer `None`,
+/// and `key` then keeps emitting the owned display string it always has.
+/// Typed keys are excluded on purpose: real yq's `key` there is an `!!int`/
+/// `!!bool`/`!!null` node, but its scalar `==` is stringly (`1 == "1"` is
+/// `true`) where succinctly's is typed, so a typed key node would break
+/// `select(key == "1")`, which matches yq today -- recorded in
+/// `docs/compliance/yq/limitations.md`.
+fn member_key_node<C: DocumentCursor>(c: &C, expected: &str) -> Option<C> {
+    let kc = c.prev_sibling()?;
+    key_node_spells(&kc, expected).then_some(kc)
+}
+
+/// Whether the key node `kc` is a plain string that materializes as exactly
+/// `expected` -- the scalar order [`to_owned_at_depth`] applies, without the
+/// allocation.
+fn key_node_spells<C: DocumentCursor>(kc: &C, expected: &str) -> bool {
+    if kc.explicit_tag().is_some() {
+        return false;
+    }
+    let v = kc.value();
+    !v.is_null()
+        && v.as_bool().is_none()
+        && v.number_literal().is_none()
+        && v.as_i64().is_none()
+        && v.as_f64().is_none()
+        && v.as_str().is_some_and(|s| s == expected)
+}
+
+/// The path from the document root to `c`, the node at every proper prefix
+/// of it -- `(path, ancestors)` in the shape [`PathContextPos`] holds them --
+/// and whether `c` is itself a member's key node. Empty at the root.
+///
+/// A key node's path is its member's path: `.a.b | key | path` is
+/// `["a","b"]` in yq v4.53.3, and `parent` from it is the mapping, so the
+/// climb treats a `Key` slot exactly as the `Value` slot beside it (#2763).
 fn cursor_path_and_ancestors<C: DocumentCursor>(
     c: &C,
-) -> Result<(Vec<OwnedValue>, Vec<C>), EvalError> {
+) -> Result<(Vec<OwnedValue>, Vec<C>, bool), EvalError> {
     let mut path = Vec::new();
     let mut ancestors = Vec::new();
+    let mut at_key = false;
     let mut cur = *c;
+    let mut first = true;
     while let Some(parent) = cur.document_parent() {
-        let Some(key) = cursor_key(&cur)? else {
-            break;
+        let key = match cursor_slot(&cur)? {
+            Some(CursorSlot::Value { key, .. }) => key,
+            Some(CursorSlot::Key(key)) => {
+                at_key |= first;
+                key
+            }
+            Some(CursorSlot::Element(index)) => OwnedValue::Int(index),
+            None => break,
         };
+        first = false;
         path.push(key);
         ancestors.push(parent);
         cur = parent;
     }
     path.reverse();
     ancestors.reverse();
-    Ok((path, ancestors))
+    Ok((path, ancestors, at_key))
 }
 
 /// `n` levels up from `c`, or `None` at or above the document root.
@@ -16754,7 +16908,7 @@ fn path_context_root<V: DocumentValue>(root: V::Cursor) -> Result<PathContextPos
     // stage handed it (#2416 phase 3). `path`/`parent` are absolute, so the
     // position starts from the input's real path and ancestors, climbed
     // from the cursor itself.
-    let (path, ancestors) = match cursor_path_and_ancestors(&root) {
+    let (path, ancestors, at_key) = match cursor_path_and_ancestors(&root) {
         Ok(found) => found,
         Err(e) => return Err(Control::Error(e)),
     };
@@ -16762,6 +16916,7 @@ fn path_context_root<V: DocumentValue>(root: V::Cursor) -> Result<PathContextPos
         node: PathNode::At(root),
         path,
         ancestors: ancestors.into_iter().map(PathNode::At).collect(),
+        at_key,
     })
 }
 
@@ -16771,10 +16926,11 @@ fn path_context_root<V: DocumentValue>(root: V::Cursor) -> Result<PathContextPos
 /// `first(.[] | key)` stops after one element instead of materializing the
 /// document into a `Vec` and then taking its head.
 ///
-/// `optional` is deliberately `false` for `rest`, for the same reason the
-/// non-sink route passes `false` to `fold_pipe_stages`: the bridge this
-/// replaces restarts every evaluation at `false` regardless of what its
-/// caller passed, so `false` is what it actually delivered.
+/// `optional` is deliberately `false` for `rest`: the bridge this replaces
+/// restarted every evaluation at `false` regardless of what its caller
+/// passed, so `false` is what it actually delivered. Since #2763 the non-sink
+/// route drives this same function whenever there is a `rest`, so the two
+/// cannot disagree about that either.
 fn try_path_context_walk_sink<S: EvalSemantics, V: DocumentValue>(
     exprs: &[Expr],
     root: V::Cursor,
@@ -16821,6 +16977,23 @@ fn try_path_context_cursor_walk<S: EvalSemantics, V: DocumentValue>(
     root: V::Cursor,
 ) -> Option<GenericResult<V>> {
     let (walked, rest) = path_context_walk_split(exprs)?;
+    if !rest.is_empty() {
+        // #2763: `rest` is folded per walked item, through the sink route,
+        // rather than after collapsing the items into one result. The
+        // collapse (`path_context_items_to_result`) keeps cursors only when
+        // *every* item is one, and a `key` walk over a document mixing
+        // string keys (emitted as key nodes) with sequence indices or typed
+        // keys (emitted owned) would hand `rest` a cursorless copy of the
+        // key nodes too -- `.. | key | line` answering `0` for every key of
+        // a document with one sequence in it, where `[.[] | key | line]`
+        // already answered from the nodes. One driver for both routes.
+        let mut items: Vec<GenericItem<V>> = Vec::new();
+        let flow = try_path_context_walk_sink::<S, V>(exprs, root, &mut |item| {
+            items.push(item);
+            Demand::Continue
+        })?;
+        return Some(collected_items_result(items, flow));
+    }
     let root_pos = match path_context_root::<V>(root) {
         Ok(pos) => pos,
         Err(control) => {
@@ -16836,7 +17009,7 @@ fn try_path_context_cursor_walk<S: EvalSemantics, V: DocumentValue>(
         items.push(item);
         Demand::Continue
     });
-    let resolved = match walked_result {
+    Some(match walked_result {
         Ok(_) => path_context_items_to_result(items),
         // Whatever resolved before the failure still stands: jq's generator
         // never un-emits an output it already produced. A decode failure
@@ -16846,15 +17019,6 @@ fn try_path_context_cursor_walk<S: EvalSemantics, V: DocumentValue>(
             let (prefix, failure) = path_context_items_to_owned(items);
             partial_generic(prefix, failure.map_or(control, Control::Error))
         }
-    };
-    Some(if rest.is_empty() {
-        resolved
-    } else {
-        // `false`, not the caller's `optional`, for the same reason the
-        // bridge this replaces passes `false`: that entry point restarts
-        // every evaluation at `false` regardless of what its caller passed,
-        // so `false` is what it actually delivered.
-        fold_pipe_stages::<S, V>(resolved, rest, false)
     })
 }
 
@@ -18103,17 +18267,10 @@ fn eval_builtin<S: EvalSemantics, V: DocumentValue>(
         // newline-joined -- real yq returns one string, not a list, and ""
         // when there are none.
         //
-        // Answered from whatever cursor the pipe stands on, which reaches
-        // a sequence item and the document root but *not* a mapping
-        // entry's: those comments live on the entry's **key** node, and a
-        // `key` stage leaves the cursor domain, so `.b | key | head_comment`
-        // is still `""` where real yq answers the comment. That is the same
-        // gap `line_comment` has had since #765 -- `.a | key | line_comment`
-        // is `""` here and `keyc` in yq -- and closing it means routing a
-        // `... | key | <metadata>` pipe to a position-carrying evaluator,
-        // which the walk route currently intercepts. Tracked separately;
-        // these two builtins deliberately inherit the existing gap rather
-        // than inventing a second, different one.
+        // Answered from whatever cursor the pipe stands on. A mapping
+        // entry's comments live on its **key** node, which `key` emits as a
+        // live cursor since #2763, so `.b | key | head_comment` answers the
+        // comment the same way `.a | key | line_comment` does.
         Builtin::HeadComment => GenericResult::Owned(OwnedValue::String(
             cursor
                 .map(|c| c.head_comment().join("\n"))
@@ -19386,14 +19543,25 @@ fn eval_builtin<S: EvalSemantics, V: DocumentValue>(
         // value with no cursor still goes to the eager evaluator below,
         // which is the one place owned-domain path tracking lives
         // (`[1,2] | .[0] | key` is `0` in real yq).
-        Builtin::Key if cursor.is_some() => match cursor_key(&cursor.expect("guarded")) {
-            Ok(Some(key)) => GenericResult::Owned(key),
-            Ok(None) => GenericResult::None,
+        // #2763: the key of a string-keyed member is emitted as its key
+        // *node*, so `first(key) | line`, `(key // .) | line_comment` and
+        // every other construct that threads this result on reads the key's
+        // own metadata. `cursor_slot`'s scan already holds the key cursor;
+        // `key_node_spells` is the same string/tag check the walk applies.
+        Builtin::Key if cursor.is_some() => match cursor_slot(&cursor.expect("guarded")) {
+            Ok(Some(CursorSlot::Value { key, key_cursor })) => match &key {
+                OwnedValue::String(s) if key_node_spells(&key_cursor, s) => {
+                    GenericResult::OneCursor(key_cursor)
+                }
+                _ => GenericResult::Owned(key),
+            },
+            Ok(Some(CursorSlot::Element(index))) => GenericResult::Owned(OwnedValue::Int(index)),
+            Ok(Some(CursorSlot::Key(_)) | None) => GenericResult::None,
             Err(e) => GenericResult::Error(e),
         },
         Builtin::PathNoArg if cursor.is_some() => {
             match cursor_path_and_ancestors(&cursor.expect("guarded")) {
-                Ok((path, _)) => GenericResult::Owned(OwnedValue::Array(path)),
+                Ok((path, _, _)) => GenericResult::Owned(OwnedValue::Array(path)),
                 Err(e) => GenericResult::Error(e),
             }
         }
@@ -19407,7 +19575,7 @@ fn eval_builtin<S: EvalSemantics, V: DocumentValue>(
         Builtin::ParentN(n_expr) if cursor.is_some() => {
             let c = cursor.expect("guarded");
             let depth = match cursor_path_and_ancestors(&c) {
-                Ok((path, _)) => path.len(),
+                Ok((path, _, _)) => path.len(),
                 Err(e) => return GenericResult::Error(e),
             };
             let (counts, control) =
@@ -19454,7 +19622,9 @@ fn eval_builtin<S: EvalSemantics, V: DocumentValue>(
         // else, since no other caller installs a table.
         Builtin::FileIndex if cursor.is_some() => {
             match cursor_path_and_ancestors(&cursor.expect("guarded")) {
-                Ok((path, _)) => GenericResult::Owned(OwnedValue::Int(file_index_for_path(&path))),
+                Ok((path, _, _)) => {
+                    GenericResult::Owned(OwnedValue::Int(file_index_for_path(&path)))
+                }
                 Err(e) => GenericResult::Error(e),
             }
         }
@@ -19597,6 +19767,12 @@ impl<V: DocumentValue> OwnedIdentity<V> {
 
     /// `key`: the last component taken, else the base node's own key, else
     /// nothing (a detached root, or the document root -- #2421).
+    ///
+    /// A base that is itself a key node (#2763: `key | tostring` hands the
+    /// key cursor on) answers the member's key, not nothing: an owned value
+    /// *positioned at* the key node has that key (`.a.b | key | tostring |
+    /// key` is `"b"` in yq v4.53.3), whereas the live key node itself has
+    /// none -- that is `key_node` above, and `cursor_key`'s own answer.
     fn key(&self) -> Result<Option<OwnedValue>, EvalError> {
         if self.key_node {
             return Ok(None);
@@ -19604,7 +19780,11 @@ impl<V: DocumentValue> OwnedIdentity<V> {
         match self.ancestors.last() {
             Some((_, component)) => Ok(Some(component.clone())),
             None => match self.base {
-                Some(c) => cursor_key(&c),
+                Some(c) => Ok(match cursor_slot(&c)? {
+                    Some(CursorSlot::Value { key, .. } | CursorSlot::Key(key)) => Some(key),
+                    Some(CursorSlot::Element(index)) => Some(OwnedValue::Int(index)),
+                    None => None,
+                }),
                 None => Ok(None),
             },
         }
@@ -22091,17 +22271,114 @@ fn eval_owned_identity_stages<S: EvalSemantics, V: DocumentValue>(
         // #2471: the emitted key keeps the node's position, flagged so a
         // second `key` emits nothing -- `id.key()` answers `None` for a key
         // node, which is exactly yq's own `.a.b | key | key`.
-        Expr::Builtin(Builtin::Key) => match id.key() {
-            Ok(Some(key)) => eval_owned_identity_stages::<S, V>(
-                rest,
-                key,
-                id.with_key_node(true),
-                optional,
-                tail,
-            ),
-            Ok(None) => Flow::Exhausted,
-            Err(e) => Flow::Escaped(Control::Error(e)),
-        },
+        //
+        // #2763: at a live document node the key is a *node* too -- the
+        // member's key cursor (or the base itself, when `key | tostring`
+        // already handed the key cursor on) -- and real yq answers the key's
+        // own metadata after it (`.a | tostring | key | line` is `1`). With a
+        // sink to emit to, the rest of the pipe is handed back to the cursor
+        // pipe from that node, exactly as `continue_owned_identity_ancestor`
+        // hands `parent` back; a `Pairs` tail keeps the owned position.
+        Expr::Builtin(Builtin::Key) => {
+            let key_node = match (id.key_node, id.ancestors.as_slice(), id.base) {
+                (false, [], Some(c)) => match cursor_slot(&c) {
+                    Ok(Some(CursorSlot::Value { key, key_cursor })) => match &key {
+                        OwnedValue::String(s) if key_node_spells(&key_cursor, s) => {
+                            Some(key_cursor)
+                        }
+                        _ => None,
+                    },
+                    Ok(Some(CursorSlot::Key(_))) => Some(c),
+                    Ok(Some(CursorSlot::Element(_)) | None) => None,
+                    Err(e) => return Flow::Escaped(Control::Error(e)),
+                },
+                _ => None,
+            };
+            if let Some(kc) = key_node {
+                if let OwnedIdentityTail::Sink(sink) = tail.reborrow() {
+                    return eval_each_pipe_generic::<S, V>(
+                        rest,
+                        kc.value(),
+                        optional,
+                        Some(kc),
+                        sink,
+                    );
+                }
+                // An enclosing stage wants pairs, so the pipe stays in the
+                // owned domain -- but it stays at the *key* node, which is
+                // what lets the metadata arm below answer from it and what
+                // a binding's `BindOrigin` then carries (`key as $k | $k |
+                // line`).
+                let key = match id.key() {
+                    Ok(Some(key)) => key,
+                    Ok(None) => return Flow::Exhausted,
+                    Err(e) => return Flow::Escaped(Control::Error(e)),
+                };
+                return eval_owned_identity_stages::<S, V>(
+                    rest,
+                    key,
+                    OwnedIdentity::kept(kc).with_key_node(true),
+                    optional,
+                    tail,
+                );
+            }
+            match id.key() {
+                Ok(Some(key)) => eval_owned_identity_stages::<S, V>(
+                    rest,
+                    key,
+                    id.with_key_node(true),
+                    optional,
+                    tail,
+                ),
+                Ok(None) => Flow::Exhausted,
+                Err(e) => Flow::Escaped(Control::Error(e)),
+            }
+        }
+        // #2763: the node-metadata getters at a key-node position. Every
+        // other stage in this route is evaluated by `eval_each_owned`, which
+        // has no cursor and answers these with their `""`/`0` defaults --
+        // correct for a value the query *built*, wrong for the key `key`
+        // just emitted, which is a document node real yq reads the entry's
+        // comments, line, column, style and anchor from. Narrowed to a key
+        // node deliberately: whether an *ordinary* kept owned value should
+        // answer metadata from its base is the wider question this issue
+        // does not settle (`.a | del(.b) | line` is `2` in yq, `0` here).
+        Expr::Builtin(
+            builtin @ (Builtin::Line
+            | Builtin::Column
+            | Builtin::Style
+            | Builtin::Anchor
+            | Builtin::LineComment
+            | Builtin::HeadComment
+            | Builtin::FootComment),
+        ) if id.key_node && id.ancestors.is_empty() && id.base.is_some() => {
+            let c = id.base.expect("guarded");
+            let outputs = eval_builtin::<S, V>(builtin, c.value(), optional, Some(c));
+            let mut downstream: Option<Flow> = None;
+            let flow = drain_result_generic::<V>(outputs, &mut |item| {
+                let output = match owned_identity_materialize::<V>(item) {
+                    Ok(o) => o,
+                    Err(control) => {
+                        return stop_with_downstream(&mut downstream, Flow::Escaped(control))
+                    }
+                };
+                // Every one of these is `OwnedIdentityRule::Keeps`, so the
+                // output stands where its input did -- at the key node, no
+                // longer *as* the key (`.a.b | key | line | key` is `"b"` in
+                // yq v4.53.3).
+                match eval_owned_identity_stages::<S, V>(
+                    rest,
+                    output,
+                    id.clone().with_key_node(false),
+                    optional,
+                    tail.reborrow(),
+                ) {
+                    Flow::Exhausted => Demand::Continue,
+                    other => stop_with_downstream(&mut downstream, other),
+                }
+            });
+            downstream.unwrap_or(flow)
+        }
         Expr::Builtin(Builtin::PathNoArg) => match id.path() {
             Ok(path) => eval_owned_identity_stages::<S, V>(
                 rest,
@@ -32602,6 +32879,7 @@ mod tests {
                 OwnedValue::String("x".to_string()),
             ],
             ancestors: vec![PathNode::At(root), PathNode::Absent],
+            at_key: false,
         };
         for filter in [
             "key",
@@ -32874,7 +33152,8 @@ mod tests {
             cursor_key(&at(".a.b[1]")).unwrap(),
             Some(OwnedValue::Int(1))
         );
-        let (path, ancestors) = cursor_path_and_ancestors(&at(".a.b[1]")).unwrap();
+        let (path, ancestors, at_key) = cursor_path_and_ancestors(&at(".a.b[1]")).unwrap();
+        assert!(!at_key);
         assert_eq!(
             path,
             vec![
@@ -32891,6 +33170,69 @@ mod tests {
         assert!(
             cursor_ancestor(&at(".a.b[1]"), 4).is_none(),
             "above the root"
+        );
+    }
+
+    /// #2763: the key node is a slot of its own, and it is the member
+    /// value's previous sibling in the tree -- so `key` can emit it without
+    /// a second scan, and the climb from it answers the member's own path.
+    #[test]
+    fn the_key_node_is_a_slot_of_its_own_2763() {
+        let json = br#"{"a":{"b":[10,20]},"c":1}"#;
+        let index = JsonIndex::build(json);
+        let root = index.root(json);
+        let at = |f: &str| {
+            let expr = parse(f).unwrap();
+            match eval_with_cursor(&expr, root) {
+                GenericResult::OneCursor(c) => c,
+                other => panic!("`{f}` is not one cursor: {other:?}"),
+            }
+        };
+
+        let value = at(".a.b");
+        let key_cursor = match cursor_slot(&value).unwrap() {
+            Some(CursorSlot::Value { key, key_cursor }) => {
+                assert_eq!(key, OwnedValue::String("b".into()));
+                key_cursor
+            }
+            other => panic!("a member value is a Value slot, got {:?}", other.is_none()),
+        };
+        // The O(1) hop the emission takes, and the check that guards it.
+        assert!(value.prev_sibling().unwrap().same_node(&key_cursor));
+        assert!(member_key_node(&value, "b").unwrap().same_node(&key_cursor));
+        assert!(
+            member_key_node(&value, "elsewhere").is_none(),
+            "the spelling has to match the member's own key"
+        );
+        assert!(value.first_child().unwrap().prev_sibling().is_none());
+
+        // From the key node: its own slot is `Key`, so `key` emits nothing
+        // there, while its path and ancestors are the member's.
+        assert!(matches!(
+            cursor_slot(&key_cursor).unwrap(),
+            Some(CursorSlot::Key(_))
+        ));
+        assert_eq!(cursor_key(&key_cursor).unwrap(), None);
+        let (path, ancestors, at_key) = cursor_path_and_ancestors(&key_cursor).unwrap();
+        assert!(at_key);
+        assert_eq!(
+            path,
+            vec![
+                OwnedValue::String("a".into()),
+                OwnedValue::String("b".into())
+            ]
+        );
+        assert_eq!(ancestors.len(), 2);
+        assert!(ancestors[1].same_node(&at(".a")));
+
+        // An array element is an index, with no key node to hop to.
+        assert!(matches!(
+            cursor_slot(&at(".a.b[1]")).unwrap(),
+            Some(CursorSlot::Element(1))
+        ));
+        assert!(
+            cursor_slot(&root).unwrap().is_none(),
+            "the root has no slot"
         );
     }
 

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -14701,9 +14701,17 @@ fn path_context_item_to_owned<V: DocumentValue>(
 ) -> Result<OwnedValue, EvalError> {
     match item {
         GenericItem::OneCursor(c) => to_owned_cursor(&c),
+        // #2763: a key node carries its own already-decoded value, so this
+        // is the one shape here that does not re-derive it -- the second
+        // `value()` plus the tag and number-canonicalization lookups
+        // `to_owned_cursor` makes are what `[.[] | key]` was paying twice.
+        // Dropping the cursor is sound *because* of the emission's own gate:
+        // `key_node_spells` refuses a node with an explicit tag and one that
+        // is not a plain string, which are exactly the two things
+        // `to_owned_cursor` consults a cursor for.
+        GenericItem::OneCursorValue(_, v) => to_owned(&v),
         GenericItem::Owned(o) => Ok(o),
         GenericItem::One(_)
-        | GenericItem::OneCursorValue(..)
         | GenericItem::LazyKeys { .. }
         | GenericItem::LazyIndexRange(_)
         | GenericItem::LazySeq(_) => {
@@ -14734,14 +14742,20 @@ fn path_context_items_to_owned<V: DocumentValue>(
 /// `path`, an absent node's `null`, a constructed array -- makes the whole
 /// result owned, exactly as #2061's walk produced.
 fn path_context_items_to_result<V: DocumentValue>(items: Vec<GenericItem<V>>) -> GenericResult<V> {
-    if items
-        .iter()
-        .all(|item| matches!(item, GenericItem::OneCursor(_)))
-    {
+    if items.iter().all(|item| {
+        matches!(
+            item,
+            GenericItem::OneCursor(_) | GenericItem::OneCursorValue(..)
+        )
+    }) {
         let mut cursors = vec_with_capacity(items.len());
         for item in items {
-            if let GenericItem::OneCursor(c) = item {
-                cursors.push(c);
+            match item {
+                // #2763: a key node carries its decoded value alongside its
+                // cursor; either shape is a node, so neither forces the
+                // whole result owned.
+                GenericItem::OneCursor(c) | GenericItem::OneCursorValue(c, _) => cursors.push(c),
+                _ => unreachable!("the loop above admitted only cursor-bearing items"),
             }
         }
         return match cursors.len() {
@@ -15871,8 +15885,14 @@ fn path_context_emitting_value<V: DocumentValue>(
                 _ => Ok(owned(OwnedValue::Int(*i))),
             },
             Some(OwnedValue::String(key)) => Ok(Some(match &pos.node {
+                // `OneCursorValue`, not `OneCursor`: the key's value is
+                // already decoded here, and re-deriving it downstream costs
+                // a second `value()` plus the tag and number-canonicalization
+                // lookups `to_owned_cursor` makes -- half of what this
+                // emission originally added on `[.[] | key]`, where the node
+                // is materialized straight back into the string it came from.
                 PathNode::At(c) => match member_key_node(c, key) {
-                    Some(kc) => GenericItem::OneCursor(kc),
+                    Some(kc) => GenericItem::OneCursorValue(kc, kc.value()),
                     None => GenericItem::Owned(OwnedValue::String(key.clone())),
                 },
                 PathNode::Absent | PathNode::Owned(_) => {
@@ -16348,20 +16368,70 @@ fn member_key_node<C: DocumentCursor>(c: &C, expected: &str) -> Option<C> {
     key_node_spells(&kc, expected).then_some(kc)
 }
 
+/// Whether a key *spelled* like this could be resolved to something other
+/// than a string -- the prefilter that keeps [`key_node_spells`]'s type
+/// ladder off the common key.
+///
+/// Conservative in the only safe direction: `true` means "ask the node",
+/// never "this is not a string". The listed first bytes are every one a
+/// YAML `null`, bool or number can begin with (the core schema plus YAML
+/// 1.1's `y`/`n`/`on`/`off` spellings, which go-yaml still resolves), so a
+/// spelling this rejects cannot be retyped by any of them and the ladder
+/// would only confirm what the text already says.
+///
+/// Worth a function because the ladder is not free: `as_i64`/`as_f64`
+/// *parse* the scalar to prove it is not a number, and that is charged to
+/// every key. Measured on an M4 Pro over a 100k-key mapping,
+/// `[.[] | key] | length`: 19 ms of the 37 ms this emission originally
+/// added.
+fn key_spelling_may_retype(key: &str) -> bool {
+    matches!(
+        key.as_bytes().first(),
+        None | Some(
+            b'-' | b'+' | b'.' | b'0'
+                ..=b'9'
+                    | b't'
+                    | b'T'
+                    | b'f'
+                    | b'F'
+                    | b'n'
+                    | b'N'
+                    | b'y'
+                    | b'Y'
+                    | b'o'
+                    | b'O'
+                    | b'~'
+        )
+    )
+}
+
 /// Whether the key node `kc` is a plain string that materializes as exactly
 /// `expected` -- the scalar order [`to_owned_at_depth`] applies, without the
 /// allocation.
+///
+/// The `as_str` comparison is not redundant with the sibling hop and is
+/// never skipped: it is what keeps an **undecodable** key (#1247/#1642) on
+/// the owned path, where `key` echoes the raw-byte fallback spelling rather
+/// than raising the decode failure materializing its node would.
 fn key_node_spells<C: DocumentCursor>(kc: &C, expected: &str) -> bool {
     if kc.explicit_tag().is_some() {
         return false;
     }
     let v = kc.value();
+    if key_spelling_may_retype(expected) && !plain_string_value(&v) {
+        return false;
+    }
+    v.as_str().is_some_and(|s| s == expected)
+}
+
+/// The scalar-classification ladder [`to_owned_at_depth`] applies, asked as
+/// a yes/no: is this value a string rather than a `null`, a bool or a number?
+fn plain_string_value<V: DocumentValue>(v: &V) -> bool {
     !v.is_null()
         && v.as_bool().is_none()
         && v.number_literal().is_none()
         && v.as_i64().is_none()
         && v.as_f64().is_none()
-        && v.as_str().is_some_and(|s| s == expected)
 }
 
 /// The path from the document root to `c`, the node at every proper prefix

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -15908,7 +15908,7 @@ fn path_context_emitting_value<V: DocumentValue>(
                 // emission originally added on `[.[] | key]`, where the node
                 // is materialized straight back into the string it came from.
                 PathNode::At(c) => match member_key_node(c, key) {
-                    Some(kc) => GenericItem::OneCursorValue(kc, kc.value()),
+                    Some((kc, v)) => GenericItem::OneCursorValue(kc, v),
                     None => GenericItem::Owned(OwnedValue::String(key.clone())),
                 },
                 PathNode::Absent | PathNode::Owned(_) => {
@@ -16379,9 +16379,13 @@ fn cursor_slot<C: DocumentCursor>(c: &C) -> Result<Option<CursorSlot<C>>, EvalEr
 /// `true`) where succinctly's is typed, so a typed key node would break
 /// `select(key == "1")`, which matches yq today -- recorded in
 /// `docs/compliance/yq/limitations.md`.
-fn member_key_node<C: DocumentCursor>(c: &C, expected: &str) -> Option<C> {
+/// Returns the node *and the value it was checked against*: the check has to
+/// resolve the key's value anyway and the emitted item carries it, so handing
+/// it back is what keeps `value()` to one call per key.
+fn member_key_node<C: DocumentCursor>(c: &C, expected: &str) -> Option<(C, C::Value)> {
     let kc = c.prev_sibling()?;
-    key_node_spells(&kc, expected).then_some(kc)
+    let v = kc.value();
+    key_node_spells(&kc, &v, expected).then_some((kc, v))
 }
 
 /// Whether a key *spelled* like this could be resolved to something other
@@ -16429,7 +16433,7 @@ fn key_spelling_may_retype(key: &str) -> bool {
 /// never skipped: it is what keeps an **undecodable** key (#1247/#1642) on
 /// the owned path, where `key` echoes the raw-byte fallback spelling rather
 /// than raising the decode failure materializing its node would.
-fn key_node_spells<C: DocumentCursor>(kc: &C, expected: &str) -> bool {
+fn key_node_spells<C: DocumentCursor>(kc: &C, v: &C::Value, expected: &str) -> bool {
     // Unconditional: an explicit tag can change what the node *materializes
     // as* regardless of how the key is spelled (`!!null anything` resolves to
     // null), so this cannot ride the rare branch below the way the type
@@ -16437,8 +16441,7 @@ fn key_node_spells<C: DocumentCursor>(kc: &C, expected: &str) -> bool {
     if kc.explicit_tag().is_some() {
         return false;
     }
-    let v = kc.value();
-    if key_spelling_may_retype(expected) && !plain_string_value(&v) {
+    if key_spelling_may_retype(expected) && !plain_string_value(v) {
         return false;
     }
     v.as_str().is_some_and(|s| s == expected)
@@ -19640,7 +19643,7 @@ fn eval_builtin<S: EvalSemantics, V: DocumentValue>(
         // `key_node_spells` is the same string/tag check the walk applies.
         Builtin::Key if cursor.is_some() => match cursor_slot(&cursor.expect("guarded")) {
             Ok(Some(CursorSlot::Value { key, key_cursor })) => match &key {
-                OwnedValue::String(s) if key_node_spells(&key_cursor, s) => {
+                OwnedValue::String(s) if key_node_spells(&key_cursor, &key_cursor.value(), s) => {
                     GenericResult::OneCursor(key_cursor)
                 }
                 _ => GenericResult::Owned(key),
@@ -22373,7 +22376,9 @@ fn eval_owned_identity_stages<S: EvalSemantics, V: DocumentValue>(
             let key_node = match (id.key_node, id.ancestors.as_slice(), id.base) {
                 (false, [], Some(c)) => match cursor_slot(&c) {
                     Ok(Some(CursorSlot::Value { key, key_cursor })) => match &key {
-                        OwnedValue::String(s) if key_node_spells(&key_cursor, s) => {
+                        OwnedValue::String(s)
+                            if key_node_spells(&key_cursor, &key_cursor.value(), s) =>
+                        {
                             Some(key_cursor)
                         }
                         _ => None,
@@ -33289,7 +33294,10 @@ mod tests {
         };
         // The O(1) hop the emission takes, and the check that guards it.
         assert!(value.prev_sibling().unwrap().same_node(&key_cursor));
-        assert!(member_key_node(&value, "b").unwrap().same_node(&key_cursor));
+        assert!(member_key_node(&value, "b")
+            .unwrap()
+            .0
+            .same_node(&key_cursor));
         assert!(
             member_key_node(&value, "elsewhere").is_none(),
             "the spelling has to match the member's own key"

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -22329,6 +22329,45 @@ fn owned_identity_after_prefetch(
     }
 }
 
+/// The live key-node cursor `id` stands at, if any (#2763) -- re-derived
+/// rather than trusted from `id.key_node` alone. The `Key` arm of
+/// [`eval_owned_identity_stages`] sets that flag for an array index and for
+/// a key that is not a string node too, because a second `key` must emit
+/// nothing there as well (yq v4.53.3: `.x[0] | key | key` prints nothing);
+/// but `id.base` in those cases is the *value's* cursor, carried for
+/// `path`/`parent`, and reading metadata from it leaked the element's own
+/// line (`.x[0] | tostring | key | line` answered `4`, yq `0`). Only a base
+/// that `cursor_slot` itself reports as a key node is one.
+///
+/// `Ok` is assumed: whichever branch of the `Key` arm produced this `id`
+/// already ran the identical `cursor_slot(&c)` and would have returned its
+/// error itself, before `key_node` was ever set.
+/// The node-metadata getter `stage` is, if it is one: the builtins that read
+/// nothing but a cursor and so answer their `""`/`0` defaults over an owned
+/// value (#2763).
+fn node_metadata_getter(stage: &Expr) -> Option<&Builtin> {
+    match strip_parens(stage) {
+        Expr::Builtin(
+            builtin @ (Builtin::Line
+            | Builtin::Column
+            | Builtin::Style
+            | Builtin::Anchor
+            | Builtin::LineComment
+            | Builtin::HeadComment
+            | Builtin::FootComment),
+        ) => Some(builtin),
+        _ => None,
+    }
+}
+
+fn owned_identity_live_key_node<V: DocumentValue>(id: &OwnedIdentity<V>) -> Option<V::Cursor> {
+    if !id.key_node || !id.ancestors.is_empty() {
+        return None;
+    }
+    let c = id.base?;
+    matches!(cursor_slot(&c), Ok(Some(CursorSlot::Key(_)))).then_some(c)
+}
+
 /// The stages of an owned identity pipe, run from `(value, id)` and ending
 /// in `tail` (spine 2416 step 3; the transparent constructs and the tail
 /// since the identity pass).
@@ -22359,6 +22398,45 @@ fn eval_owned_identity_stages<S: EvalSemantics, V: DocumentValue>(
             Ok(()) => Flow::Exhausted,
             Err(control) => Flow::Escaped(control),
         };
+    }
+    // #2763: the node-metadata getters at a key-node position. Every other
+    // stage in this route is evaluated by `eval_each_owned`, which has no
+    // cursor and answers these with their `""`/`0` defaults -- correct for a
+    // value the query *built*, wrong for the key `key` just emitted, which is
+    // a document node real yq reads the entry's comments, line, column, style
+    // and anchor from. Narrowed to a key node deliberately: whether an
+    // *ordinary* kept owned value should answer metadata from its base is the
+    // wider question this issue does not settle (`.a | del(.b) | line` is `2`
+    // in yq, `0` here). Decided before the match so the key-node check --
+    // a member scan -- runs once, and only for a metadata stage.
+    if let Some(builtin) = node_metadata_getter(stage) {
+        if let Some(c) = owned_identity_live_key_node(&id) {
+            let outputs = eval_builtin::<S, V>(builtin, c.value(), optional, Some(c));
+            let mut downstream: Option<Flow> = None;
+            let flow = drain_result_generic::<V>(outputs, &mut |item| {
+                let output = match owned_identity_materialize::<V>(item) {
+                    Ok(o) => o,
+                    Err(control) => {
+                        return stop_with_downstream(&mut downstream, Flow::Escaped(control))
+                    }
+                };
+                // Every one of these is `OwnedIdentityRule::Keeps`, so the
+                // output stands where its input did -- at the key node, no
+                // longer *as* the key (`.a.b | key | line | key` is `"b"` in
+                // yq v4.53.3).
+                match eval_owned_identity_stages::<S, V>(
+                    rest,
+                    output,
+                    id.clone().with_key_node(false),
+                    optional,
+                    tail.reborrow(),
+                ) {
+                    Flow::Exhausted => Demand::Continue,
+                    other => stop_with_downstream(&mut downstream, other),
+                }
+            });
+            return downstream.unwrap_or(flow);
+        }
     }
     match strip_parens(stage) {
         // #2471: the emitted key keeps the node's position, flagged so a
@@ -22428,51 +22506,6 @@ fn eval_owned_identity_stages<S: EvalSemantics, V: DocumentValue>(
                 Ok(None) => Flow::Exhausted,
                 Err(e) => Flow::Escaped(Control::Error(e)),
             }
-        }
-        // #2763: the node-metadata getters at a key-node position. Every
-        // other stage in this route is evaluated by `eval_each_owned`, which
-        // has no cursor and answers these with their `""`/`0` defaults --
-        // correct for a value the query *built*, wrong for the key `key`
-        // just emitted, which is a document node real yq reads the entry's
-        // comments, line, column, style and anchor from. Narrowed to a key
-        // node deliberately: whether an *ordinary* kept owned value should
-        // answer metadata from its base is the wider question this issue
-        // does not settle (`.a | del(.b) | line` is `2` in yq, `0` here).
-        Expr::Builtin(
-            builtin @ (Builtin::Line
-            | Builtin::Column
-            | Builtin::Style
-            | Builtin::Anchor
-            | Builtin::LineComment
-            | Builtin::HeadComment
-            | Builtin::FootComment),
-        ) if id.key_node && id.ancestors.is_empty() && id.base.is_some() => {
-            let c = id.base.expect("guarded");
-            let outputs = eval_builtin::<S, V>(builtin, c.value(), optional, Some(c));
-            let mut downstream: Option<Flow> = None;
-            let flow = drain_result_generic::<V>(outputs, &mut |item| {
-                let output = match owned_identity_materialize::<V>(item) {
-                    Ok(o) => o,
-                    Err(control) => {
-                        return stop_with_downstream(&mut downstream, Flow::Escaped(control))
-                    }
-                };
-                // Every one of these is `OwnedIdentityRule::Keeps`, so the
-                // output stands where its input did -- at the key node, no
-                // longer *as* the key (`.a.b | key | line | key` is `"b"` in
-                // yq v4.53.3).
-                match eval_owned_identity_stages::<S, V>(
-                    rest,
-                    output,
-                    id.clone().with_key_node(false),
-                    optional,
-                    tail.reborrow(),
-                ) {
-                    Flow::Exhausted => Demand::Continue,
-                    other => stop_with_downstream(&mut downstream, other),
-                }
-            });
-            downstream.unwrap_or(flow)
         }
         Expr::Builtin(Builtin::PathNoArg) => match id.path() {
             Ok(path) => eval_owned_identity_stages::<S, V>(

--- a/src/json/light.rs
+++ b/src/json/light.rs
@@ -760,6 +760,19 @@ impl<'a, W: AsRef<[u64]>> JsonCursor<'a, W> {
         })
     }
 
+    /// Navigate to the previous sibling.
+    ///
+    /// Returns `None` if this is the first sibling.
+    #[inline]
+    pub fn prev_sibling(&self) -> Option<Self> {
+        let new_pos = self.index.bp().prev_sibling(self.bp_pos)?;
+        Some(JsonCursor {
+            text: self.text,
+            index: self.index,
+            bp_pos: new_pos,
+        })
+    }
+
     /// Navigate to the parent.
     ///
     /// Returns `None` if this is the root.
@@ -2392,6 +2405,11 @@ impl<'a, W: AsRef<[u64]> + Clone> DocumentCursor for JsonCursor<'a, W> {
     #[inline]
     fn next_sibling(&self) -> Option<Self> {
         JsonCursor::next_sibling(self)
+    }
+
+    #[inline]
+    fn prev_sibling(&self) -> Option<Self> {
+        JsonCursor::prev_sibling(self)
     }
 
     #[inline]

--- a/src/trees/bp.rs
+++ b/src/trees/bp.rs
@@ -2739,6 +2739,17 @@ impl<W: AsRef<[u64]>, S: SelectSupport> BalancedParens<W, S> {
         }
     }
 
+    /// Navigate to the previous sibling in the tree.
+    ///
+    /// `None` for a first child (the position before it is the parent's
+    /// open) and for the root.
+    pub fn prev_sibling(&self, p: usize) -> Option<usize> {
+        if p == 0 || !self.is_open(p) || !self.is_close(p - 1) {
+            return None;
+        }
+        self.find_open(p - 1)
+    }
+
     /// Navigate to first child.
     pub fn first_child(&self, p: usize) -> Option<usize> {
         if !self.is_open(p) || p + 1 >= self.len {
@@ -3072,10 +3083,27 @@ mod tests {
         // No next sibling for second child
         assert_eq!(bp.next_sibling(3), None);
 
+        // Previous sibling: the inverse, `None` at a first child and the root
+        assert_eq!(bp.prev_sibling(3), Some(1));
+        assert_eq!(bp.prev_sibling(1), None);
+        assert_eq!(bp.prev_sibling(0), None);
+        // A close position is not a node
+        assert_eq!(bp.prev_sibling(2), None);
+
         // Parent navigation
         assert_eq!(bp.parent(1), Some(0));
         assert_eq!(bp.parent(3), Some(0));
         assert_eq!(bp.parent(0), None);
+    }
+
+    #[test]
+    fn test_prev_sibling_skips_a_subtree() {
+        // "((())())" : root, first child with one grandchild, second child
+        //  positions: 0=( 1=( 2=( 3=) 4=) 5=( 6=) 7=)
+        let bp = BalancedParens::new(vec![0b00100111u64], 8);
+        assert_eq!(bp.next_sibling(1), Some(5));
+        assert_eq!(bp.prev_sibling(5), Some(1));
+        assert_eq!(bp.prev_sibling(2), None);
     }
 
     #[test]

--- a/src/yaml/light.rs
+++ b/src/yaml/light.rs
@@ -124,6 +124,17 @@ impl<'a, W: AsRef<[u64]>> YamlCursor<'a, W> {
         })
     }
 
+    /// Navigate to the previous sibling.
+    #[inline]
+    pub fn prev_sibling(&self) -> Option<Self> {
+        let new_pos = self.index.bp().prev_sibling(self.bp_pos)?;
+        Some(YamlCursor {
+            text: self.text,
+            index: self.index,
+            bp_pos: new_pos,
+        })
+    }
+
     /// Navigate to the parent.
     #[inline]
     pub fn parent(&self) -> Option<Self> {
@@ -6610,6 +6621,11 @@ impl<'a, W: AsRef<[u64]> + Clone> DocumentCursor for YamlCursor<'a, W> {
     #[inline]
     fn next_sibling(&self) -> Option<Self> {
         YamlCursor::next_sibling(self)
+    }
+
+    #[inline]
+    fn prev_sibling(&self) -> Option<Self> {
+        YamlCursor::prev_sibling(self)
     }
 
     #[inline]

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -42222,6 +42222,11 @@ mod key_node_metadata_2763 {
             (".ek | key | line", DOC, "8\n"),
             // A sequence element has an index, not a key node: 0 in yq too.
             (".x[0] | key | line", MIXED, "0\n"),
+            // An owned value standing on the element (reached via `tostring`,
+            // so `key` sees an already-owned position rather than a live
+            // cursor) still has no key node -- the element's own line must
+            // not leak through, matching the direct case above.
+            (".x[0] | tostring | key | line", MIXED, "0\n"),
             // An absent node likewise.
             (".zz | key | line", KEYC, "0\n"),
         ])
@@ -42239,6 +42244,8 @@ mod key_node_metadata_2763 {
         const TYPED: &str = "1: x\ntrue: y\n";
         check(&[
             (".[\"1\"] | key | line", TYPED, "0\n"),
+            // Same through a `tostring` detour into the owned domain first.
+            (".[\"1\"] | tostring | key | line", TYPED, "0\n"),
             ("[.[] | key | select(. == \"1\")]", TYPED, "- \"1\"\n"),
             (".[] | select(key == \"1\")", TYPED, "x\n"),
             // A string key beside a typed one still answers, on both the

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -13852,21 +13852,20 @@ mod head_foot_comment_798 {
         Ok(())
     }
 
-    /// Known gap, deliberately inherited rather than newly invented: a
-    /// mapping entry's head/foot live on its **key** node, and a `key` stage
-    /// leaves the cursor domain, so this is `""` where real yq answers
-    /// `mid`. `line_comment` has had exactly this gap since #765
-    /// (`.a | key | line_comment` is `""` here, `keyc` in yq) — pinned so
-    /// the follow-up that closes it updates both together, deliberately.
+    /// The gap this used to pin, now closed by #2763: a mapping entry's
+    /// head/foot (and its line comment, and its line/column/style/anchor)
+    /// live on the entry's **key** node, and `key` emits that node.
+    /// `line_comment` had the same gap from #765 onwards, which is why the
+    /// two are asserted together here — one cause, one fix.
     #[test]
-    fn key_node_head_comment_is_not_reachable_yet_798() -> Result<()> {
+    fn key_node_metadata_is_the_keys_own_2763() -> Result<()> {
         let (out, code) = run_yq_stdin(".b | key | head_comment", "a: 1\n# mid\nb: 2\n", &[])?;
         assert_eq!(code, 0);
-        assert_eq!(out, "\n");
+        assert_eq!(out, "mid\n");
 
         let (out, code) = run_yq_stdin(".a | key | line_comment", "a: # keyc\n  b: 1\n", &[])?;
         assert_eq!(code, 0);
-        assert_eq!(out, "\n");
+        assert_eq!(out, "keyc\n");
         Ok(())
     }
 
@@ -42071,4 +42070,254 @@ fn test_object_construction_var_shorthand_is_jq_mode_only_2724() -> Result<()> {
     assert_ne!(code, 0, "stdout: {stdout:?}");
     assert!(stderr.contains("expected identifier"), "stderr: {stderr:?}");
     Ok(())
+}
+
+/// #2763: a mapping entry's metadata lives on its **key** node, and `key`
+/// emits that node -- so `line_comment`, `head_comment`, `foot_comment`,
+/// `line`, `column`, `style` and `anchor` after a `key` stage read the key's
+/// own, as real yq does. Before this they all answered the no-cursor default
+/// (`""`/`0`), which is exactly what an "asserts absent" test accepts, so
+/// every row here asserts a *non-empty* value through a full pipe.
+///
+/// Every expectation was captured from pinned `yq` v4.53.3 before being
+/// written here.
+mod key_node_metadata_2763 {
+    use super::{run_jq_stdin, run_yq_stdin};
+    use anyhow::Result;
+
+    /// `a: # keyc` -- the comment is the key's, and `.a` is the mapping under it.
+    const KEYC: &str = "a: # keyc\n  b: 1\n";
+    /// Four entries at known lines, one of them a sequence (whose *items*
+    /// have no key), one quoted, one a block scalar.
+    const MIXED: &str =
+        "a: &anc # keyc\n  b: 1\nx:\n  - 1 # e0\n  - 2\n\"qk\": 1\nk2: |\n  block\n";
+
+    fn yq(filter: &str, input: &str) -> Result<String> {
+        let (out, code) = run_yq_stdin(filter, input, &[])?;
+        assert_eq!(code, 0, "`{filter}` exited {code}: {out:?}");
+        Ok(out)
+    }
+
+    fn check(rows: &[(&str, &str, &str)]) -> Result<()> {
+        for (filter, input, want) in rows {
+            assert_eq!(yq(filter, input)?, *want, "`{filter}`");
+        }
+        Ok(())
+    }
+
+    /// The issue's own table, row for row.
+    #[test]
+    fn the_six_getters_answer_from_the_key_2763() -> Result<()> {
+        check(&[
+            (".a | key | line_comment", KEYC, "keyc\n"),
+            (".a | key | line", KEYC, "1\n"),
+            (".a | key | column", KEYC, "1\n"),
+            (".b | key | head_comment", "a: 1\n# mid\nb: 2\n", "mid\n"),
+            (".b | key | foot_comment", "a: 1\nb: 2\n# foot\n", "foot\n"),
+            (".qk | key | style", "\"qk\": 1\n", "double\n"),
+            (".a | key | anchor", "&ka a: 1\n", "ka\n"),
+            // Already correct before the fix, because both are computed from
+            // the value rather than read from a cursor.
+            (".a | key | tag", KEYC, "!!str\n"),
+            (".a | key | kind", KEYC, "scalar\n"),
+        ])
+    }
+
+    /// The iterating shape routes differently from direct navigation -- it
+    /// was the walk route that intercepted `... | key | <metadata>` and
+    /// evaluated the tail from a materialized node.
+    #[test]
+    fn the_iterating_shapes_answer_too_2763() -> Result<()> {
+        check(&[
+            ("[.[] | key | line]", MIXED, "- 1\n- 3\n- 6\n- 7\n"),
+            (".[] | key | line", MIXED, "1\n3\n6\n7\n"),
+            ("[.[] | key | line_comment]", KEYC, "- keyc\n"),
+            // Recursive descent reaches the sequence *items* too, which have
+            // no key of their own and so answer 0 -- as in yq.
+            (
+                "[.. | key | line]",
+                MIXED,
+                "- 1\n- 2\n- 3\n- 0\n- 0\n- 6\n- 7\n",
+            ),
+        ])
+    }
+
+    /// Key-as-a-node must not disturb what `key` already answered. Every row
+    /// here was correct before #2763 and is pinned against the two designs
+    /// the issue records as wrong -- returning the key cursor without giving
+    /// the key node a path of its own regresses all of them.
+    #[test]
+    fn path_parent_and_a_second_key_are_unchanged_2763() -> Result<()> {
+        check(&[
+            (".a.b | key | path", KEYC, "- a\n- b\n"),
+            (".a.b | key | parent | key", KEYC, "a\n"),
+            // A key has no key of its own.
+            (".a.b | key | key", KEYC, ""),
+            ("[.a | key | parent(0) | key]", KEYC, "[]\n"),
+            // ... but a value merely *standing* at the key node does.
+            (".a.b | key | tostring | key", KEYC, "b\n"),
+            (".a | key | tostring | path", KEYC, "- a\n"),
+            (".a.b | key | line | key", KEYC, "b\n"),
+            (".a.b | key | line | path", KEYC, "- a\n- b\n"),
+        ])
+    }
+
+    /// The key node survives the constructs that carry a position: a
+    /// `select` filter, a comma, an `as` binding, a bounded consumer, and a
+    /// second navigation out of it.
+    #[test]
+    fn the_key_node_survives_the_carrying_constructs_2763() -> Result<()> {
+        check(&[
+            (".a.b | key | select(line == 2) | path", KEYC, "- a\n- b\n"),
+            (".a.b | key | select(line == 2) | parent | key", KEYC, "a\n"),
+            (".a | key | select(line_comment == \"keyc\")", KEYC, "a\n"),
+            (
+                ".[] | select((key | line_comment) == \"keyc\") | key",
+                KEYC,
+                "a\n",
+            ),
+            (".a | key | (line, path)", KEYC, "1\n- a\n"),
+            (
+                ".a | key | [line, column, line_comment]",
+                KEYC,
+                "- 1\n- 1\n- keyc\n",
+            ),
+            (".a | key | . as $k | $k | line", KEYC, "1\n"),
+            ("(.a | key) as $k | $k | line", KEYC, "1\n"),
+            (".a | key as $k | $k | line_comment", KEYC, "keyc\n"),
+            (".a | first(key | line)", KEYC, "1\n"),
+            (".a | key | parent | .a | key | line", KEYC, "1\n"),
+            (".a.b | key | parent | key | line", KEYC, "1\n"),
+            // `(key, .)`: the key's own metadata, then the value's.
+            (".a | (key, .) | line", KEYC, "1\n2\n"),
+        ])
+    }
+
+    /// An owned value that stands *at* a node reaches its key the same way.
+    #[test]
+    fn a_positioned_owned_value_reaches_the_key_node_2763() -> Result<()> {
+        check(&[
+            (".a | tostring | key | line", KEYC, "1\n"),
+            (".a | key | tostring | key | line", KEYC, "1\n"),
+            (".a | key | tostring | key | line_comment", KEYC, "keyc\n"),
+            (".a | tostring | key", KEYC, "a\n"),
+        ])
+    }
+
+    /// The YAML shapes where "the key node" is not simply the token before
+    /// the value: an alias value, a merge-key-resolved entry, a flow
+    /// mapping, an explicit `? k` key, and a sequence item (which has none).
+    #[test]
+    fn the_awkward_yaml_shapes_2763() -> Result<()> {
+        const DOC: &str =
+            "a: &x\n  q: 1\nb: *x\nm:\n  <<: *x\n  r: 2\nf: {fa: 1, fb: 2}\n? ek\n: ev\n";
+        check(&[
+            // An alias value's key is its own, not the anchor's.
+            (".b | key | line", DOC, "3\n"),
+            (".b | key", DOC, "b\n"),
+            // A merged entry's key belongs to the merge *source*.
+            (".m.q | key | line", DOC, "2\n"),
+            (".f.fb | key | column", DOC, "12\n"),
+            ("[.f[] | key | column]", DOC, "- 5\n- 12\n"),
+            (".ek | key | line", DOC, "8\n"),
+            // A sequence element has an index, not a key node: 0 in yq too.
+            (".x[0] | key | line", MIXED, "0\n"),
+            // An absent node likewise.
+            (".zz | key | line", KEYC, "0\n"),
+        ])
+    }
+
+    /// A *typed* (non-string) mapping key keeps the display string real yq
+    /// renders as an `!!int`/`!!bool`/`!!null` node, so its metadata still
+    /// reads the no-cursor default. Deliberate and recorded in
+    /// `docs/compliance/yq/limitations.md`: yq's scalar `==` is stringly
+    /// (`1 == "1"` is `true`) where succinctly's is typed, so emitting a
+    /// typed key node would break `select(key == "1")`, which matches yq
+    /// today. Pinned so closing that gap has to update this together.
+    #[test]
+    fn a_typed_key_keeps_its_display_string_2763() -> Result<()> {
+        const TYPED: &str = "1: x\ntrue: y\n";
+        check(&[
+            (".[\"1\"] | key | line", TYPED, "0\n"),
+            ("[.[] | key | select(. == \"1\")]", TYPED, "- \"1\"\n"),
+            (".[] | select(key == \"1\")", TYPED, "x\n"),
+            // A string key beside a typed one still answers, on both the
+            // sink route and the collecting one.
+            (".[] | key | line", "a: 1\n1: 2\n", "1\n0\n"),
+            ("[.[] | key | line]", "a: 1\n1: 2\n", "- 1\n- 0\n"),
+        ])
+    }
+
+    /// The key node is a node, but it is still printed as the plain key it
+    /// always was -- no anchor, tag or style leaks into the output, and the
+    /// write paths are untouched. Every row is byte-identical to what this
+    /// binary printed before #2763; two of them (`[.[] | key]` and `keys`,
+    /// where real yq re-emits the key's own `"qk"` quoting and its `&ka`
+    /// anchor) diverge from yq exactly as they did before, which is a
+    /// rendering question this issue does not touch.
+    #[test]
+    fn the_rendering_and_write_paths_are_unchanged_2763() -> Result<()> {
+        check(&[
+            (".a | key", MIXED, "a\n"),
+            (".[] | key", MIXED, "a\nx\nqk\nk2\n"),
+            ("[.[] | key]", MIXED, "- a\n- x\n- qk\n- k2\n"),
+            ("keys", MIXED, "- a\n- x\n- qk\n- k2\n"),
+            (".a | key | tostring | key", KEYC, "a\n"),
+            // A write *through* a key is still positional, unchanged.
+            ("(.a | key) = \"z\"", KEYC, "a: # keyc\n  b: 1\n"),
+            (
+                "(.a | key | line_comment) = \"x\"",
+                KEYC,
+                "a: # keyc\n  b: 1\n",
+            ),
+        ])?;
+        let (out, code) = run_yq_stdin("[.[] | key]", MIXED, &["-o", "json"])?;
+        assert_eq!(code, 0);
+        assert_eq!(out, "[\n  \"a\",\n  \"x\",\n  \"qk\",\n  \"k2\"\n]\n");
+        Ok(())
+    }
+
+    /// The DOM-forcing flags take a different output route and must answer
+    /// the same (`-P` and `--arg` both build a `CommentTree`).
+    #[test]
+    fn the_dom_forcing_flags_answer_the_same_2763() -> Result<()> {
+        for args in [
+            vec!["-P"],
+            vec!["--arg", "x", "1"],
+            vec!["-r"],
+            vec!["--sort-keys"],
+        ] {
+            let (out, code) = run_yq_stdin(".a | key | line_comment", KEYC, &args)?;
+            assert_eq!(code, 0, "{args:?}");
+            assert_eq!(out, "keyc\n", "{args:?}");
+
+            let (out, code) = run_yq_stdin(".a | key | line", KEYC, &args)?;
+            assert_eq!(code, 0, "{args:?}");
+            assert_eq!(out, "1\n", "{args:?}");
+        }
+        Ok(())
+    }
+
+    /// jq 1.7.1 has no `key`/`line`/`column` at all (`key/0 is not
+    /// defined`), so these are succinctly extensions in jq mode with no
+    /// oracle to capture from -- modelled on yq, as ADR-0018 rule 5 says an
+    /// extension is. They answer from the key node there too: JSON has no
+    /// comments, but it does have positions.
+    #[test]
+    fn jq_mode_answers_from_the_key_node_too_2763() -> Result<()> {
+        let doc = "{\"a\": {\"b\": 1},\n \"c\": 2}";
+        for (filter, want) in [
+            (".c | key | line", "2\n"),
+            (".c | key | column", "2\n"),
+            ("[.[] | key | line]", "[\n  1,\n  2\n]\n"),
+            // Unchanged: the key's path and a second `key`.
+            (".a.b | key | path", "[\n  \"a\",\n  \"b\"\n]\n"),
+            (".a.b | key | key", ""),
+        ] {
+            let (out, code) = run_jq_stdin(filter, doc, &[])?;
+            assert_eq!(code, 0, "`{filter}`");
+            assert_eq!(out, want, "`{filter}`");
+        }
+        Ok(())
+    }
 }


### PR DESCRIPTION
Closes #2763.

## Summary

A mapping entry's metadata lives on its **key** node, but `key` emitted an owned display string, so every cursor-only getter after it -- `line_comment`, `head_comment`, `foot_comment`, `line`, `column`, `style`, `anchor` -- answered its no-cursor default (`""`/`0`) where real yq answers the key's own.

`key` now emits the key **node** for a string-keyed member, and the key node becomes a position of its own:

- `cursor_slot` (replacing `cursor_key`'s scan) recognises both halves of a member -- `Value { key, key_cursor }`, `Key`, `Element` -- and `cursor_path_and_ancestors` climbs from a key exactly as from the value beside it, so a key node's `path` is its member's path and `parent` is the mapping. That is what keeps `.a.b | key | path`, `| parent | key`, `| key` and `| tostring | key` unchanged -- the two designs #2763 records as wrong both skipped this step.
- The node is the member value's previous sibling in both indexed formats (new `DocumentCursor::prev_sibling`), an O(1) hop rather than a scan, so `[.[] | key | line]` stays linear.
- It is emitted on every route that can carry one: the walk, `eval_builtin`'s cursor arm, and the owned-identity pipe (which hands the rest of the pipe back to the cursor pipe from the key node, as it already does for `parent`). The non-sink walk route now folds its rest per item, so a document mixing string and typed keys cannot answer `0` on one route and from the node on the other.

Typed (non-string) keys deliberately keep the display string: real yq's scalar `==` is stringly where succinctly's is typed, so a typed key node would break `select(key == "1")`, which matches yq today. Recorded with the other residuals in `docs/compliance/yq/limitations.md`; ADR-0021 gains an amendment.

Every expectation captured from pinned yq v4.53.3. Before/after on `a: # keyc\n  b: 1`:

| `.a \| key \| …` | yq | before | after |
|---|---|---|---|
| `line_comment` | `keyc` | `""` | `keyc` |
| `line` / `column` | `1` / `1` | `0` / `0` | `1` / `1` |
| `style` (`"qk": 1`) | `double` | `""` | `double` |
| `head_comment` (`.b`, `a: 1\n# mid\nb: 2`) | `mid` | `""` | `mid` |
| `[.[] \| key \| line]` | `[1]` | `[0]` | `[1]` |
| `.a.b \| key \| path` | `["a","b"]` | same | same |

## Performance

The first cut cost +49-59% on `[.[] | key]` and +58-72% on `[.[] | key | tostring]` (M4 Pro and 7950X). A binary with the emission disabled landed exactly on the baseline, and one with only the type check disabled split the cost in half -- so three follow-up commits each target a measured term: a spelling prefilter that keeps `as_i64`/`as_f64` off keys that cannot be numbers, materializing the emitted node from the string it already holds, and one `value()` per key. Final, against the merge-base, interleaved per repetition, min-of-9, 100k/200k-key mappings:

| query | M4 Pro | 7950X |
|---|---|---|
| `[.[] \| key \| line]` -- the shape the node exists for | -1% | +9% |
| `[.[] \| key]` | +17% | +19% |
| `[.[] \| key \| tostring]` | +45% | +50% |
| `keys_unsorted`, `[.[] \| path]`, `.` | neutral | neutral |

Gating the emission on what the rest of the pipe does was tried and rejected: the only *safe* allowlist of "cannot read a node" was the one enumerated from the benchmarked queries. #2789 carries the two remaining shapes a real fix could take. The library's `QueryResult` for `.[] | key` moves from `ManyOwned` to `Many`; values and CLI output are byte-identical.

## Follow-ups filed

- #2784 -- `cursor_key`'s sibling scan is O(fields) per call (pre-existing; `[.[] | key | path]` is quadratic)
- #2785 -- typed key nodes, blocked on yq's stringly scalar `==`
- #2786 -- an owned value that kept its position answers no node metadata
- #2789 -- the residual `key | tostring` cost above

## Test plan

- [x] `cargo test --features cli` -- 62 binaries green, on the rebased tree
- [x] `cargo clippy --all-targets --all-features -- -D warnings` + the two other CI clippy legs, `cargo fmt --check`, `cargo doc -D warnings`, `cargo test --no-default-features`
- [x] `scripts/jq-path-context-oracle-sweep.sh` -- 5508 cases, 0 unexpected, known-divergence counts identical to a merge-base run
- [x] New `key_node_metadata_2763` module (10 tests, every row yq-captured), plus jq-mode rows; `head_foot_comment_798`'s pin of the old wrong answers updated to the correct ones
- [x] A/B on both pinned bench boxes as above, output-identity gated