### PR TITLE
perf(jq): evaluate range()'s bounds from the cursor, not a materialized document

### DIFF
--- a/docs/compliance/jq/limitations.md
+++ b/docs/compliance/jq/limitations.md
@@ -3913,6 +3913,44 @@ Sanctioned by ADR-0018's #2103 amendment, like the two entries above. Pinned by
 duplicate-key half of #2626 is also pinned) and by the arithmetic rows added to
 `test_closed_terms_do_not_validate_2173`'s closed-probe lists in both suites.
 
+### `range` bounds validate only what they read (#2698)
+
+The same mechanism as the [#2626](https://github.com/rust-works/succinctly/issues/2626) entry
+above, one construct over. Both of `range`'s dispatch sites reached the eager evaluator
+through `bridge_ambient_input`, so a bound that reads the document — `range(length)`,
+`range(0; .b)` — materialized a full `OwnedValue` copy of it, and that walk validated every
+byte. [#2698](https://github.com/rust-works/succinctly/issues/2698) gives both sites a native,
+cursor-threaded arm (`each_range_generic`), so the bound now reads exactly what it reads and
+nothing else is validated.
+
+On `{"a": "bad\x", "b": 5}`, which jq 1.7.1 rejects at parse time for every filter:
+
+| filter                                | jq 1.7.1 | succinctly before | succinctly now |
+|---------------------------------------|----------|-------------------|----------------|
+| `length`                              | error    | `2` (exit 0)      | `2` — unchanged |
+| `[range(3)]`                          | error    | `[0,1,2]`         | `[0,1,2]` — unchanged |
+| `[range(length)]`                     | error    | error             | `[0,1]`        |
+| `first(range(length))`                | error    | error             | `0`            |
+| `[range(.b)]`                         | error    | error             | `[0,1,2,3,4]`  |
+| `reduce range(length) as $x (0;.+$x)` | error    | error             | `1`            |
+| `[range(.a \| length)]`               | error    | error — unchanged | error — unchanged |
+
+The last row is the rule stated positively: a bound that *does* read the malformed scalar
+still raises, exactly as bare `.a` does. Only the validation the bridge performed as a side
+effect of building an input it never needed is gone — the accident #2173's own entry
+describes, arrived at from a fifth direction. Same in yq mode (`--jq-extensions`), where
+real yq rejects the document at read time and succinctly now answers.
+
+**This entry exists because the first version of the PR claimed the opposite.** It was
+checked against `{123: 1, "b": 2}` — a *structural* fault at the root, which `length` itself
+reads and so still raises on both binaries — and that was taken as "unchanged in both
+directions". A fault the bound does *not* read is the case that moves, and the check has to
+be built from one. The #2797 review caught it with a bad escape inside a leaf value.
+
+Sanctioned by ADR-0018's #2103 amendment, like the entries above. Pinned by the `range`
+rows in `test_closed_terms_do_not_validate_2173` (jq) and
+`range_bounds_validate_only_what_they_read_2698` (yq).
+
 ### A fault found by walking to it leaves the prefix on stdout
 
 succinctly is a semi-index and finds a malformed document only when the walk reaches the

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -38197,13 +38197,13 @@ fn eval_repeat<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
 /// A numeric argument to `range()`: kept as `i64` when exact so all-integer
 /// ranges emit `Int` values, promoted to `f64` when any argument is a float.
 #[derive(Clone, Copy)]
-enum RangeNum {
+pub(crate) enum RangeNum {
     Int(i64),
     Float(f64),
 }
 
 impl RangeNum {
-    fn as_f64(self) -> f64 {
+    pub(crate) fn as_f64(self) -> f64 {
         match self {
             Self::Int(i) => i as f64,
             Self::Float(f) => f,
@@ -38216,7 +38216,7 @@ impl RangeNum {
 /// Was a `QueryResult` matcher with its own `Halt`/`Break`/`Partial` arms;
 /// since #1279 gave `range` a real fan-out, [`stream_outputs_lossy`] owns those and
 /// this is left as a pure per-value classifier.
-fn range_num(value: &OwnedValue) -> Result<RangeNum, EvalError> {
+pub(crate) fn range_num(value: &OwnedValue) -> Result<RangeNum, EvalError> {
     match value {
         OwnedValue::Int(i) | OwnedValue::NumberLiteral(NumberRepr::Int(i), _) => {
             Ok(RangeNum::Int(*i))
@@ -38294,7 +38294,7 @@ const MAX_RANGE: usize = 100000;
 /// The error [`each_range`]'s `emit` raises once a caller that actually
 /// wanted every value (its sink kept answering [`Demand::Continue`]) hits a
 /// [`MAX_RANGE`]-truncated batch -- shared so callers can't drift in wording.
-fn range_max_exceeded_error() -> EvalError {
+pub(crate) fn range_max_exceeded_error() -> EvalError {
     // #2132: uncatchable -- `[range(100001)?] | length` answered `100000`
     // at exit 0 with a plain `new`, the silent truncation #2089 closed for
     // the un-suppressed spelling. See `EvalError::resource_limit`.
@@ -38421,6 +38421,19 @@ fn eval_range_values<'a, W: Clone + AsRef<[u64]>>(
     to: i64,
     step: i64,
 ) -> (QueryResult<'a, W>, bool) {
+    let (values, truncated) = range_values_int(from, to, step);
+    (owned_vec_to_result(values), truncated)
+}
+
+/// [`eval_range_values`]'s body, stopping at the `Vec` (#2698).
+///
+/// `eval_generic.rs`'s own `each_range_generic` needs these values as owned
+/// numbers to hand its `GenericItem` sink, not wrapped in a `QueryResult` it
+/// would have to unwrap again -- and duplicating the `MAX_RANGE` cap and its
+/// two overflow proofs into a second copy is exactly the drift the
+/// `MAX_RANGE` doc comment above already warns about. One definition, two
+/// wrappers.
+pub(crate) fn range_values_int(from: i64, to: i64, step: i64) -> (Vec<OwnedValue>, bool) {
     let mut values: Vec<OwnedValue> = Vec::new();
     let mut truncated = false;
 
@@ -38480,7 +38493,7 @@ fn eval_range_values<'a, W: Clone + AsRef<[u64]>>(
         }
     }
 
-    (owned_vec_to_result(values), truncated)
+    (values, truncated)
 }
 
 /// Helper to generate range values over floats, capped at [`MAX_RANGE`] per
@@ -38495,6 +38508,13 @@ fn eval_range_values_f64<'a, W: Clone + AsRef<[u64]>>(
     to: f64,
     step: f64,
 ) -> (QueryResult<'a, W>, bool) {
+    let (values, truncated) = range_values_f64(from, to, step);
+    (owned_vec_to_result(values), truncated)
+}
+
+/// [`eval_range_values_f64`]'s body, stopping at the `Vec` -- the float twin
+/// of [`range_values_int`], same reasoning (#2698).
+pub(crate) fn range_values_f64(from: f64, to: f64, step: f64) -> (Vec<OwnedValue>, bool) {
     let mut values: Vec<OwnedValue> = Vec::new();
     let mut truncated = false;
 
@@ -38519,7 +38539,7 @@ fn eval_range_values_f64<'a, W: Clone + AsRef<[u64]>>(
         truncated = i > to;
     }
 
-    (owned_vec_to_result(values), truncated)
+    (values, truncated)
 }
 
 /// Builtin: recurse (recurse(.[]))

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -2122,6 +2122,21 @@ pub(crate) fn needs_path_context(expr: &Expr) -> bool {
         // `eval_single`'s 0-stub `file_index` instead of erroring or
         // resolving correctly.
         Expr::Negate(inner) => needs_path_context(inner),
+        // #2698: a `range` bound reads position exactly as a `Negate` operand
+        // does, and `eval_single` now evaluates all three bounds natively
+        // from the cursor (`each_range_generic`). Without this arm a `key`
+        // or `line` inside a bound was invisible here, so the live-cursor
+        // routes resolved it while every other route still stubbed it --
+        // the #2797 review's "spelling-dependent" finding, ADR-0021's
+        // silent-fallback class one construct over. Registering it here is
+        // necessary but not sufficient: the routes that reach `eval.rs`'s
+        // own `each_range` still stub, because *that* function's bounds
+        // carry no position frame -- tracked as #2803.
+        Expr::Range { from, to, step } => {
+            needs_path_context(from)
+                || to.as_deref().is_some_and(needs_path_context)
+                || step.as_deref().is_some_and(needs_path_context)
+        }
         Expr::Builtin(Builtin::Select(cond)) => needs_path_context(cond),
         // `map(f)` needs the same recursion as `Select` above -- e.g.
         // `map(select(file_index == 0))`, previously silently stubbed to 0

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -7049,7 +7049,19 @@ fn eval_single<S: EvalSemantics, V: DocumentValue>(
         // 105 MB on a 77 MB input, for a root whose `length` is 9. The
         // demand-driven spellings (`first`, `limit`, `reduce`) already reach
         // the native arm directly through `eval_each_generic`.
-        Expr::Range { .. } => collect_each_generic::<S, V>(expr, value, optional, cursor),
+        //
+        // `stream_owned_outputs_generic`, not `collect_each_generic`: `range`
+        // only ever emits `GenericItem::Owned` numbers, and the latter
+        // buffers every output as an 80-byte `GenericItem<V>` before copying
+        // into a `Vec<OwnedValue>` -- which the #2797 review measured at
+        // +66% peak and +27% time on a large-output `[range(..)]` against
+        // the bridge it replaced, undoing the win for the closed shape. The
+        // `Negate` arm above collects the same way for the same reason.
+        Expr::Range { .. } => {
+            let (values, control) =
+                stream_owned_outputs_generic::<S, V>(expr, value, optional, cursor);
+            finish_fork_generic(values, control, optional)
+        }
 
         // Spine 2416 (the exit): unary minus over a path-context operand.
         // The eager evaluator carried this as `eval_negate_with_path_context`
@@ -16974,6 +16986,15 @@ fn path_context_single_native(expr: &Expr) -> bool {
         // arm, above): unary minus over a path-context operand is evaluated
         // with the cursor, like the binary arithmetic just above.
         Expr::Negate(inner) => path_context_single_native(inner),
+        // #2698: `eval_single`'s own `Expr::Range` arm evaluates every bound
+        // through `each_range_generic`, cursor threaded, so a range is native
+        // exactly when each of its bounds is -- the same shape as
+        // `Arithmetic`'s two operands just above.
+        Expr::Range { from, to, step } => {
+            path_context_single_native(from)
+                && to.as_deref().map_or(true, path_context_single_native)
+                && step.as_deref().map_or(true, path_context_single_native)
+        }
         // Native since spine 2416 gate reason 3 (#2473): `eval_single`'s own
         // `Expr::And`/`Expr::Or` arms, above, over `eval_boolean_generic`.
         // Those arms lost their `needs_path_context` gate in #2476, and the

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -63,15 +63,16 @@ use super::eval::{
     index_one_owned as index_owned_by_key, is_pure_chain_link, is_retryable_stop, literal_to_owned,
     mark_nonretryable_escape, needs_path_context, numeric_key_to_array_index, numeric_key_to_index,
     numeric_length_owned, owned_bound_to_i64, owned_to_expr, owned_to_string,
-    pattern_alternatives_var_names, prefer_pending_control, resume_from_escape, select_emits,
-    slice_component_value, slice_object_as_yq_children, slice_owned_value_read,
-    stop_with_downstream, stop_with_error, stop_with_escape, streams_escaped_generator_prefix,
-    streams_unbounded, substitute_bound_var_from, substitute_vars, suppress_or_raise, suppresses,
-    tonumber_from_str, vec_with_capacity, yq_absent_key_read_is_empty, yq_assign_rhs_document,
+    pattern_alternatives_var_names, prefer_pending_control, range_max_exceeded_error, range_num,
+    range_values_f64, range_values_int, resume_from_escape, select_emits, slice_component_value,
+    slice_object_as_yq_children, slice_owned_value_read, stop_with_downstream, stop_with_error,
+    stop_with_escape, stop_with_escape_cell, streams_escaped_generator_prefix, streams_unbounded,
+    substitute_bound_var_from, substitute_vars, suppress_or_raise, suppresses, tonumber_from_str,
+    vec_with_capacity, yq_absent_key_read_is_empty, yq_assign_rhs_document,
     yq_empty_operand_output, yq_field_index_on_scalar_is_empty, yq_negative_index_check,
     yq_numeric_index_on_object_is_null, yq_object_key_stringify, yq_read_only_context,
     BinaryFanoutRules, Control, Demand, EmptyOperandOp, EvalError, EvalSemantics, EvalTag, Flow,
-    ForeachElementSink, JqSemantics, LimitN, PathTrail, QueryResult, YqSemantics,
+    ForeachElementSink, JqSemantics, LimitN, PathTrail, QueryResult, RangeNum, YqSemantics,
 };
 #[cfg(test)]
 use super::expr::FuncDefBound;
@@ -7041,6 +7042,15 @@ fn eval_single<S: EvalSemantics, V: DocumentValue>(
         // `test_arithmetic_validates_only_what_it_reads_2626`.
         Expr::Arithmetic { .. } => collect_each_generic::<S, V>(expr, value, optional, cursor),
 
+        // #2698: `range`'s bounds are evaluated by `each_range_generic` from
+        // the cursor, so collecting that arm keeps the whole-collection
+        // spellings (`[range(length)]`, `last(range(length))`) off the
+        // wildcard bridge's whole-document materialization -- 2022 MB to
+        // 105 MB on a 77 MB input, for a root whose `length` is 9. The
+        // demand-driven spellings (`first`, `limit`, `reduce`) already reach
+        // the native arm directly through `eval_each_generic`.
+        Expr::Range { .. } => collect_each_generic::<S, V>(expr, value, optional, cursor),
+
         // Spine 2416 (the exit): unary minus over a path-context operand.
         // The eager evaluator carried this as `eval_negate_with_path_context`
         // (#1100) so `-file_index` mid-pipe read at the node; with that
@@ -8168,9 +8178,24 @@ fn eval_each_generic<S: EvalSemantics, V: DocumentValue>(
         // doc comment gives. Captured live against jq 1.7.1, input `1`:
         // `[first(range((1 as $x ?// $y | 1); 3))]` is `[1,1]`, where the
         // eager fallback answered `[1]`.
-        Expr::Range { .. } => {
-            bridge_to_each_owned_flow::<S, V>(expr, value, cursor, optional, sink)
-        }
+        //
+        // #2698: native since the bridge's `bridge_ambient_input` cost a
+        // whole-document `OwnedValue` copy whenever a *bound* reads the
+        // document -- `range(length; 3)` measured 2032 MB peak on a 77 MB
+        // input against 105 MB for `length` alone. `each_range_generic`
+        // keeps this arm's demand forwarding and its `?//` fan-out row by
+        // mirroring `each_range`'s nesting rather than replacing it; only
+        // where the bounds are *evaluated* changes, from the eager
+        // evaluator over a materialized ambient to this one over the cursor.
+        Expr::Range { from, to, step } => each_range_generic::<S, V>(
+            from,
+            to.as_deref(),
+            step.as_deref(),
+            value,
+            optional,
+            cursor,
+            sink,
+        ),
 
         // #2180 WP3: `foreach`'s own demand-forwarding arm, native rather
         // than bridged for the same reason this file's eager `Expr::Foreach`
@@ -11243,6 +11268,136 @@ fn each_boolean_generic<S: EvalSemantics, V: DocumentValue>(
         binary_fanout_rules::<S>(EmptyOperandOp::Boolean),
         &mut |bit| sink(GenericItem::Owned(OwnedValue::Bool(bit))),
     )
+}
+
+/// `range(from; to; step)` with the cursor threaded into its bound
+/// expressions (#2698) -- the generic twin of [`super::eval::each_range`],
+/// loop for loop.
+///
+/// `eval_each_generic`'s `Expr::Range` arm went to `bridge_to_each_owned_flow`
+/// (#2180 WP2b), whose first act is `bridge_ambient_input`. That buys the
+/// demand forwarding and the jq-matching `?//` fan-out the arm's comment
+/// records, but for a bound that *reads the document* it also buys a whole
+/// `OwnedValue` copy of it. `range(length; 3)` measured 2032 MB peak on a
+/// 77 MB document against 105 MB for `length` alone -- ~19x, for a filter
+/// whose outputs are three numbers. `range(0; length)` is the idiomatic
+/// index-iteration spelling, so this is not an exotic shape.
+///
+/// Evaluating the bounds through *this* evaluator instead reads them from
+/// the cursor, and the demand forwarding the bridge provided is kept because
+/// this mirrors `each_range`'s own nesting rather than replacing it: each of
+/// `from`/`to`/`step` drives the one inside it, and a `Demand::Stop` from the
+/// sink unwinds all three. The values themselves come from
+/// [`super::eval::range_values_int`]/[`super::eval::range_values_f64`], the
+/// same `MAX_RANGE`-capped definitions `each_range` uses -- one cap, not a
+/// second copy to drift.
+fn each_range_generic<S: EvalSemantics, V: DocumentValue>(
+    from: &Expr,
+    to: Option<&Expr>,
+    step: Option<&Expr>,
+    value: V,
+    optional: bool,
+    cursor: Option<V::Cursor>,
+    sink: &mut dyn FnMut(GenericItem<V>) -> Demand,
+) -> Flow {
+    // `Cell` for the same reason `each_range` uses one: `emit` and the three
+    // operand closures are live simultaneously and each must be able to
+    // record an escape it discovers on its own.
+    let escape: core::cell::Cell<Option<Control>> = core::cell::Cell::new(None);
+    let mut sink_stopped = false;
+
+    let mut emit = |from_val: RangeNum, to_val: RangeNum, step_val: RangeNum| -> Demand {
+        let (values, truncated) = match (from_val, to_val, step_val) {
+            (RangeNum::Int(f), RangeNum::Int(t), RangeNum::Int(st)) => range_values_int(f, t, st),
+            (f, t, st) => range_values_f64(f.as_f64(), t.as_f64(), st.as_f64()),
+        };
+        for v in values {
+            if sink(GenericItem::Owned(v)) == Demand::Stop {
+                sink_stopped = true;
+                return Demand::Stop;
+            }
+        }
+        // Truncation only raises once the sink has taken everything the
+        // capped batch held and still wants more -- `each_range`'s #2089
+        // rule, unchanged: `first(range(1e18))` stops early and never sees
+        // this, `[range(1e18)]` does.
+        if truncated {
+            return stop_with_escape_cell(&escape, Control::Error(range_max_exceeded_error()));
+        }
+        Demand::Continue
+    };
+
+    let from_flow = eval_each_generic::<S, V>(from, value.clone(), optional, cursor, &mut |item| {
+        let from_val = match generic_item_into_owned(item)
+            .and_then(|v| range_num(&v).map_err(Control::Error))
+        {
+            Ok(n) => n,
+            Err(control) => return stop_with_escape_cell(&escape, control),
+        };
+
+        let Some(to_expr) = to else {
+            // `range(n)` -- unreachable from any query today, mirroring
+            // `each_range`'s own note on this branch.
+            return match from_val {
+                RangeNum::Int(t) => emit(RangeNum::Int(0), RangeNum::Int(t), RangeNum::Int(1)),
+                RangeNum::Float(t) => emit(
+                    RangeNum::Float(0.0),
+                    RangeNum::Float(t),
+                    RangeNum::Float(1.0),
+                ),
+            };
+        };
+
+        let to_flow =
+            eval_each_generic::<S, V>(to_expr, value.clone(), optional, cursor, &mut |to_item| {
+                let to_val = match generic_item_into_owned(to_item)
+                    .and_then(|v| range_num(&v).map_err(Control::Error))
+                {
+                    Ok(n) => n,
+                    Err(control) => return stop_with_escape_cell(&escape, control),
+                };
+
+                match step {
+                    None => emit(from_val, to_val, RangeNum::Int(1)),
+                    Some(step_expr) => {
+                        let step_flow = eval_each_generic::<S, V>(
+                            step_expr,
+                            value.clone(),
+                            optional,
+                            cursor,
+                            &mut |step_item| {
+                                let step_val = match generic_item_into_owned(step_item)
+                                    .and_then(|v| range_num(&v).map_err(Control::Error))
+                                {
+                                    Ok(n) => n,
+                                    Err(control) => return stop_with_escape_cell(&escape, control),
+                                };
+                                emit(from_val, to_val, step_val)
+                            },
+                        );
+                        match step_flow {
+                            Flow::Exhausted => Demand::Continue,
+                            Flow::Stopped { .. } => Demand::Stop,
+                            Flow::Escaped(control) => stop_with_escape_cell(&escape, control),
+                        }
+                    }
+                }
+            });
+
+        match to_flow {
+            Flow::Exhausted => Demand::Continue,
+            Flow::Stopped { .. } => Demand::Stop,
+            Flow::Escaped(control) => stop_with_escape_cell(&escape, control),
+        }
+    });
+
+    if sink_stopped {
+        return Flow::Stopped { pending: None };
+    }
+    match escape.into_inner() {
+        Some(control) => Flow::Escaped(control),
+        None => from_flow,
+    }
 }
 
 /// Unary minus with the cursor threaded into its operand (#2626) -- the

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -47896,3 +47896,83 @@ fn test_undecodable_key_spelling_follows_materialization_2710() -> Result<()> {
 
     Ok(())
 }
+
+/// #2698: `range`'s bounds are evaluated from the cursor, not from a
+/// materialized copy of the document.
+///
+/// The win is memory (2022 MB -> 105 MB on a 77 MB input, for a root whose
+/// `length` is 9), which a CLI test cannot assert cheaply. What it *can*
+/// assert is the half that would silently break if the native arm got the
+/// semantics wrong: `range` is a fan-out generator whose bounds are
+/// themselves generators, and the arm it replaced was chosen (#2180 WP2b)
+/// precisely for that behaviour. Every row is captured from jq 1.7.1.
+#[test]
+fn range_bounds_keep_their_fanout_semantics_2698() -> Result<()> {
+    // (filter, input, expected stdout)
+    let rows = [
+        // The row #2180 WP2b's own comment records -- a `?//` alternative in
+        // the `from` position. The eager fallback answered `[1]` here.
+        ("[first(range((1 as $x ?// $y | 1); 3))]", "1", "[1,1]"),
+        // Each bound position fans out, and the nesting order is
+        // from-major, then to, then step.
+        ("[range((1,2);4)]", "null", "[1,2,3,2,3]"),
+        ("[range(1;(3,5))]", "null", "[1,2,1,2,3,4]"),
+        ("[range(1;5;(1,2))]", "null", "[1,2,3,4,1,3]"),
+        // A bound that reads the document -- the shape this change is about.
+        ("[range(length)]", "[7,8,9]", "[0,1,2]"),
+        ("[first(range(length;3))]", "[7,8,9]", "[]"),
+        ("last(range(length))", "[7,8,9]", "2"),
+        ("[range(0;length)]", "[7,8,9]", "[0,1,2]"),
+        ("reduce range(length) as $x (0; .+$x)", "[7,8,9]", "3"),
+        ("[limit(2; range(length))]", "[7,8,9,10,11]", "[0,1]"),
+        // Float and descending paths through the same arm.
+        ("[range(0;1;0.3)]", "null", "[0,0.3,0.6,0.8999999999999999]"),
+        ("[range(5;0;-1)]", "null", "[5,4,3,2,1]"),
+        // Degenerate bounds still produce nothing rather than erroring.
+        ("[range(0;0)]", "null", "[]"),
+        ("[range(3;1)]", "null", "[]"),
+        ("[range(0;3;0)]", "null", "[]"),
+    ];
+    for (filter, input, want) in rows {
+        let (out, err, code) = run_jq_full(&["-c", filter], Some(input))?;
+        assert_eq!(
+            (out.trim(), code),
+            (want, 0),
+            "#2698: `{filter}` on {input} -- stderr: {err:?}"
+        );
+    }
+    Ok(())
+}
+
+/// #2698 keeps #2089's `MAX_RANGE` rule: truncation raises only once a
+/// consumer has taken the whole capped batch and still wants more.
+///
+/// This is the rule most at risk from moving where the bounds are evaluated,
+/// because it depends on what the *sink* does, not on the bounds -- and the
+/// native arm now owns both sides of that conversation. Real jq has no cap
+/// and would try to build 10^18 elements here, so there is no oracle row:
+/// these pin succinctly's own documented divergence.
+#[test]
+fn range_max_iterations_rule_survives_the_native_arm_2698() -> Result<()> {
+    // A demand-driven consumer stops inside the capped batch and never sees
+    // the truncation.
+    let (out, _, code) = run_jq_full(&["-c", "first(range(1e18))"], Some("null"))?;
+    assert_eq!((out.trim(), code), ("0", 0));
+    let (out, _, code) = run_jq_full(&["-c", "[limit(3; range(1e18))]"], Some("null"))?;
+    assert_eq!((out.trim(), code), ("[0,1,2]", 0));
+
+    // An unbounded one takes everything and must raise rather than silently
+    // return a 100000-element prefix.
+    for filter in ["[range(1e18)]", "reduce range(1e18) as $x (0;.+$x)"] {
+        let (_, err, code) = run_jq_full(&["-c", filter], Some("null"))?;
+        assert_ne!(
+            code, 0,
+            "#2698: `{filter}` must raise, not truncate silently"
+        );
+        assert!(
+            err.contains("maximum iterations exceeded"),
+            "#2698: `{filter}` -- stderr: {err:?}"
+        );
+    }
+    Ok(())
+}

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -46023,6 +46023,12 @@ fn test_closed_terms_do_not_validate_2173() -> Result<()> {
         ("isempty(1)", "false"),
         ("any(range(3); . > 1)", "true"),
         ("all(range(3); . >= 0)", "true"),
+        // #2698: `range` with a *closed* bound was already here in spirit
+        // (`[range(3)]` above); these pin that the native arm keeps it so on
+        // every route, including the ones that used to bridge.
+        ("last(range(3))", "2"),
+        ("[range(0;3)]", "[0,1,2]"),
+        ("reduce range(3) as $x (0; .+$x)", "3"),
     ];
     for doc in docs {
         for (filter, want) in closed {
@@ -47963,6 +47969,60 @@ fn range_rejects_a_non_numeric_bound_in_every_position_2698() -> Result<()> {
         assert_ne!(code, 0, "#2698: `{filter}` must raise");
         assert!(
             err.contains("Range bounds must be numeric"),
+            "#2698: `{filter}` -- stderr: {err:?}"
+        );
+    }
+    Ok(())
+}
+
+/// #2698: a `range` bound validates only what it reads -- the #2103/#2173
+/// divergence, one construct over, recorded in `limitations.md`.
+///
+/// The fault is a bad escape inside a *leaf value*, which `length` and `.b`
+/// never decode. That choice is the whole test: a structural fault at the
+/// root (`{123:1}`) is read by `length` itself and raises on every route,
+/// which is exactly what the first version of this PR checked and then
+/// wrongly reported as "malformed documents unchanged". Real jq 1.7.1
+/// rejects this document at parse time for every filter.
+#[test]
+fn range_bounds_validate_only_what_they_read_2698() -> Result<()> {
+    let doc = r#"{"a": "bad\x", "b": 5}"#;
+
+    // Reads the key count / a good sibling, never the bad scalar: answers.
+    for (filter, want) in [
+        ("[range(length)]", "[0,1]"),
+        ("first(range(length))", "0"),
+        ("[range(.b)]", "[0,1,2,3,4]"),
+        ("reduce range(length) as $x (0;.+$x)", "1"),
+        ("last(range(0;.b))", "4"),
+    ] {
+        let (out, err, code) = run_jq_full(&["-c", filter], Some(doc))?;
+        assert_eq!(
+            (out.trim(), code),
+            (want, 0),
+            "#2698: `{filter}` -- stderr: {err:?}"
+        );
+    }
+
+    // The other half, which keeps this from being a hole: a bound that DOES
+    // read the malformed scalar still raises, exactly as `.a | length` does.
+    // (Not bare `.a`: in jq mode that streams the raw bytes through as
+    // `"bad\x"` without decoding them -- the M2 passthrough, pre-existing
+    // and identical on both binaries -- so it is not a "reads the scalar"
+    // control here the way it is in yq mode's #2626 twin.)
+    for filter in [
+        ".a | length",
+        "[.a]",
+        "[range(.a|length)]",
+        "first(range(.a|length))",
+    ] {
+        let (_, err, code) = run_jq_full(&["-c", filter], Some(doc))?;
+        assert_ne!(
+            code, 0,
+            "#2698: `{filter}` must still raise -- stderr: {err:?}"
+        );
+        assert!(
+            err.contains("invalid escape"),
             "#2698: `{filter}` -- stderr: {err:?}"
         );
     }

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -47944,6 +47944,31 @@ fn range_bounds_keep_their_fanout_semantics_2698() -> Result<()> {
     Ok(())
 }
 
+/// #2698: a non-numeric bound raises, in each of the three positions -- the
+/// `step` position is the one no other test reached (it is the innermost
+/// closure of `each_range_generic`, so a bad `from` or `to` never gets
+/// there).
+///
+/// The `from`/`to` message matches jq 1.7.1 ("Range bounds must be
+/// numeric"). The `step` one does not: jq adds the step first and reports
+/// `number (0) and string ("a") cannot be added`, while succinctly's
+/// `range_num` rejects all three positions with the same bounds message.
+/// That divergence predates this change -- the old bridge route answered
+/// identically -- so this row pins succinctly's existing behaviour rather
+/// than jq's, and is not a claim of fidelity.
+#[test]
+fn range_rejects_a_non_numeric_bound_in_every_position_2698() -> Result<()> {
+    for filter in ["[range(\"a\";3)]", "[range(0;\"b\")]", "[range(0;3;\"c\")]"] {
+        let (_, err, code) = run_jq_full(&["-c", filter], Some("null"))?;
+        assert_ne!(code, 0, "#2698: `{filter}` must raise");
+        assert!(
+            err.contains("Range bounds must be numeric"),
+            "#2698: `{filter}` -- stderr: {err:?}"
+        );
+    }
+    Ok(())
+}
+
 /// #2698 keeps #2089's `MAX_RANGE` rule: truncation raises only once a
 /// consumer has taken the whole capped batch and still wants more.
 ///

--- a/tests/jq_range_native_arm_tests.rs
+++ b/tests/jq_range_native_arm_tests.rs
@@ -1,0 +1,45 @@
+//! #2698: `each_range_generic`'s two branches the parser cannot reach.
+//!
+//! The parser desugars `range(n)` to `range(0; n)` (every `Expr::Range` it
+//! builds carries `to: Some(..)`), so the `to == None` arm is unreachable
+//! from any query text. But `Expr` is public, so a library caller can build
+//! one directly -- which is what these tests do, rather than marking the arm
+//! tolerated and leaving its behaviour unasserted.
+
+use succinctly::jq::{eval_generic, Expr, Literal};
+use succinctly::json::JsonIndex;
+
+fn run(expr: &Expr, doc: &str) -> Vec<String> {
+    let bytes = doc.as_bytes();
+    let index = JsonIndex::build(bytes);
+    let cursor = index.root(bytes);
+    eval_generic::eval_with_cursor(expr, cursor)
+        .collect_owned()
+        .expect("evaluates")
+        .iter()
+        .map(succinctly::jq::OwnedValue::to_json)
+        .collect()
+}
+
+fn range_to_none(from: Literal) -> Expr {
+    Expr::Range {
+        from: Box::new(Expr::Literal(from)),
+        to: None,
+        step: None,
+    }
+}
+
+/// A hand-built `Range { to: None }` behaves as `range(0; n)`, exactly as
+/// `eval.rs`'s own `each_range` treats that shape -- integer path.
+#[test]
+fn range_with_no_upper_bound_counts_from_zero_int_2698() {
+    let expr = Expr::Array(Box::new(range_to_none(Literal::Int(3))));
+    assert_eq!(run(&expr, "null"), vec!["[0,1,2]"]);
+}
+
+/// Same arm, float path: `range(2.5)` as a bare bound is `range(0.0; 2.5)`.
+#[test]
+fn range_with_no_upper_bound_counts_from_zero_float_2698() {
+    let expr = Expr::Array(Box::new(range_to_none(Literal::Float(2.5))));
+    assert_eq!(run(&expr, "null"), vec!["[0,1,2]"]);
+}

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -42345,3 +42345,51 @@ mod key_node_metadata_2763 {
         Ok(())
     }
 }
+
+/// #2698: `range`'s bounds see the document the cursor sees, not a
+/// materialized copy with its duplicate mapping keys already collapsed.
+///
+/// This is the #2626 bug class, one construct over: the owned bridge's first
+/// act is to build an `OwnedValue` of the ambient, and that collapses
+/// duplicate keys *before* the bound expression runs. So the same binary
+/// disagreed with itself -- `length` answered `3` (real yq v4.53.3 agrees,
+/// it keeps duplicates) while `[range(length)]` produced only two values,
+/// because the bound had been evaluated against a 2-key copy.
+///
+/// `range` is jq-only surface in yq mode (#1512), hence `--jq-extensions`;
+/// the duplicate-key document is the point, and yq mode is where duplicates
+/// survive to be seen.
+#[test]
+fn range_bounds_see_uncollapsed_duplicate_keys_2698() -> Result<()> {
+    let dir = tempfile::tempdir()?;
+    let path = dir.path().join("dup.yaml");
+    std::fs::write(&path, "b: 1\na: 2\nb: 3\n")?;
+    let file = path.to_str().expect("utf-8 path");
+    let args = ["-o=json", "-I=0", "--jq-extensions"];
+
+    // The premise: three keys, duplicates kept.
+    let (out, code) = run_yq_file("length", file, &args)?;
+    assert_eq!(
+        (out.trim(), code),
+        ("3", 0),
+        "#2698: premise -- yq keeps duplicate keys"
+    );
+
+    // Therefore a bound reading `length` must fan out three times, not two.
+    for (filter, want) in [
+        ("[range(length)]", "[0,1,2]"),
+        ("[range(0;length)]", "[0,1,2]"),
+        ("last(range(length))", "2"),
+        ("[range(length)]|length", "3"),
+        ("[limit(9; range(length))]", "[0,1,2]"),
+    ] {
+        let (out, code) = run_yq_file(filter, file, &args)?;
+        assert_eq!(
+            (out.trim(), code),
+            (want, 0),
+            "#2698: `{filter}` must agree with `length` == 3; a bridged bound \
+             sees the collapsed 2-key copy and answers as if length were 2"
+        );
+    }
+    Ok(())
+}

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -42393,3 +42393,32 @@ fn range_bounds_see_uncollapsed_duplicate_keys_2698() -> Result<()> {
     }
     Ok(())
 }
+
+/// #2698's yq twin of `range_bounds_validate_only_what_they_read_2698`:
+/// same fault (a bad escape in a leaf value `length` never decodes), same
+/// rule. Real yq v4.53.3 rejects the document at read time for every
+/// filter; `range` is `--jq-extensions` surface here (#1512).
+#[test]
+fn range_bounds_validate_only_what_they_read_2698() -> Result<()> {
+    let doc = "a: \"bad\\q\"\nb: 5\n";
+    let args = ["-o=json", "-I=0", "--jq-extensions"];
+    for (filter, want) in [
+        ("[range(length)]", "[0,1]"),
+        ("[limit(2; range(length))]", "[0,1]"),
+    ] {
+        let (stdout, stderr, code) = run_yq_stdin_with_stderr(filter, doc, &args)?;
+        assert_eq!(
+            (stdout.trim(), code),
+            (want, 0),
+            "#2698: `{filter}` -- stderr: {stderr:?}"
+        );
+    }
+    for filter in [".a", "[range(.a|length)]"] {
+        let (_, stderr, code) = run_yq_stdin_with_stderr(filter, doc, &args)?;
+        assert_ne!(
+            code, 0,
+            "#2698: `{filter}` must still raise -- stderr: {stderr:?}"
+        );
+    }
+    Ok(())
+}


### PR DESCRIPTION
## What

`range`'s bound expressions are now evaluated from the cursor instead of from a materialized copy of the document. Both dispatch sites are covered: the streaming arm (`eval_each_generic`) natively, and `eval_single` via `collect_each_generic`.

Refs #2698 (see below — this closes the `Range` half; the issue as filed is broader and partly stale).

## Measured

Release, interleaved, 77 MB generated JSON whose root `length` is **9**:

| filter | base | this branch |
|---|--:|--:|
| `[limit(1; range(length))]` | 2020 MB / 2.10 s | **105 MB / 0.15 s** |
| `first(range(length; 3))` | 2020 MB | 105 MB |
| `[range(length)]` | 2022 MB | 105 MB |
| `last(range(length))` | 2021 MB | 105 MB |
| `[range(9)]` (control) | 105 MB | 105 MB |
| `length` (the bound alone) | 105 MB | 105 MB |

~19x, for a filter whose outputs are three numbers. `range(0; length)` is the idiomatic index-iteration spelling, so this is not an exotic shape.

## It is also a correctness fix

This was not obvious until mutation testing forced the question — my first set of tests passed with *either* arm reverted, so they proved nothing.

The bridge's first act is to build an `OwnedValue` of the ambient, and that **collapses duplicate mapping keys before the bound runs**. So on `b: 1 / a: 2 / b: 3` the same binary disagreed with itself:

| | before | after |
|---|---|---|
| `length` | `3` | `3` |
| `[range(length)]` | `[0,1]` | `[0,1,2]` |

Real yq v4.53.3 keeps duplicates and answers `length == 3`, so `[0,1]` was wrong. This is #2626's bug class one construct over — that issue fixed exactly the same thing for `Negate`. The new yq test pins it and was verified to fail with either arm reverted, independently.

## Fidelity

- **8448 (filter, document) pairs byte-identical to `main` on well-formed input** — 11 bound expressions × 16 consumer shapes × 8 documents, stdout and exit code. Re-run after every review fix.
- **28 range rows agree with jq 1.7.1**, including the `?//` fan-out row the replaced arm's own comment records (`[first(range((1 as $x ?// $y | 1); 3))]` == `[1,1]`).
- **#2089's `MAX_RANGE` rule preserved**: `[range(1e18)]` and `reduce range(1e18) ...` still raise; `first(range(1e18))` still answers `0` instantly.

## It widens a sanctioned divergence — and the first version of this PR denied it

**Retraction.** The first PR body said *"malformed documents unchanged in both directions … checked explicitly rather than assumed."* That was false, and it was the same false claim #2790 made. The check used `{123:1,"b":2}` — a *structural* fault at the root, which `length` itself reads and so raises on every route no matter what. A fault the bound does **not** read is the case that moves:

On `{"a": "bad\x", "b": 5}` (jq 1.7.1 rejects it at parse time for every filter):

| filter | before | now |
|---|---|---|
| `length` | `2` | `2` — unchanged |
| `[range(length)]` | error | `[0,1]` |
| `first(range(length))` | error | `0` |
| `[range(.b)]` | error | `[0,1,2,3,4]` |
| `[range(.a \| length)]` | error | error — unchanged (reads the bad scalar) |

The review measured 3,597 flipping pairs. This is the #2103/#2173/#2626 divergence — a bound validates what it reads and nothing else — and it is now recorded in `limitations.md` (a section modelled on #2626's, on the same document) and pinned in both suites. The behaviour is the sanctioned rule; the defect was the claim.

## Other review findings, all acted on

- **Memory regression on `[range(..)]`.** `collect_each_generic` buffers 80-byte `GenericItem`s before copying — +66% peak / +27% time on a large-output range versus the bridge. Switched to `stream_owned_outputs_generic`, as the `Negate` arm does. Now **1.00× memory**; time 1.03–1.05× on common shapes, **1.14× on a pathological nested range** (`[range(range(200); range(200;400))]`) — disclosed, not hidden.
- **Positional builtins inside a bound now answer spelling-dependently.** `key`/`line`/`file_index` in a bound resolve on the generic route (this arm reads the cursor) but still stub on `eval.rs` routes — assignment RHS, string interpolation, `map_values`, `isempty`. Before this PR all routes stubbed (wrong but uniform). Registered `Expr::Range` in `needs_path_context` and `path_context_single_native` per their protocol, **verified live that it does not unify the `eval.rs` routes** (the stub is inside `each_range`'s own bound evaluation), and filed **#2803** with the full table rather than claiming it fixed.
- **yq `length` of a float/hex scalar in a bound** now follows yq's text-length semantics (`n: 2.0` → `[range(.n|length)]` is `[0,1,2]`, matching bare `length`) instead of the JSON reindex's numeric answer. An improvement the first version did not know it had made.
- **Coverage** closed to 100% with real tests rather than tolerate annotations.

## The issue is partly stale — worth reading before scoping follow-ups

I re-measured #2698's premise before implementing:

- **`. and true`, its headline case at 3515 MB, is already fixed** — 105 MB now, on both routes.
- **`Alternative` is not a gap at all.** `[limit(1; . // 1)]` looks expensive (1704 MB) but that is *inherent*: the filter's output is the document. `first((. // 1) | type)` is 105 MB.
- `Expr::Range` was the real remaining target, and worse than filed.

## Filed separately

**#2794** — `isempty(f)`, `any(gen; cond)` and `all(gen; cond)` materialize the whole document even for a **closed** argument: `isempty(empty)` costs 2020 MB to answer `true`, and `any(range(3); .>1)` costs 3763 MB. Cause is `node_reads_ambient`'s `Builtin` arm defaulting every unlisted builtin to "reads" regardless of its arguments. Same class as #2699, different axis.

## Verification

Full suite (63 binaries), both clippy legs (one caught an MSRV violation — `is_none_or` is 1.82, MSRV is 1.73), fmt, `--no-default-features`, rustdoc with `-D warnings`, 100% patch coverage — all on current `main`.
