### PR TITLE
perf(jq): stop isempty/any(gen;cond)/all(gen;cond) materializing closed input

### DIFF
--- a/docs/compliance/jq/limitations.md
+++ b/docs/compliance/jq/limitations.md
@@ -3845,6 +3845,40 @@ documents, plus 5 reading spellings that must still raise), the split probe list
 if it calls a filter closed, the filter's output must not depend on the document — is
 `tests/jq_closed_term_tests.rs`.
 
+**Widened again by [#2794](https://github.com/rust-works/succinctly/issues/2794): `isempty(f)`,
+`any(gen; cond)` and `all(gen; cond)` are argument-transparent, so a closed argument closes
+the whole builtin.** `node_reads_ambient`'s `Builtin` arm was a negative allowlist that
+forced `true` for every builtin except ten, regardless of its arguments — right for a
+builtin that reads `.` itself (`length`, `add`, ...), wrong for one whose whole answer comes
+from a generator it consumes. `isempty(f)`'s argument sees the true ambient, so it joins the
+allowlist directly; `any(gen; cond)`/`all(gen; cond)` desugar to `gen | cond` (confirmed
+live: `any(1,2,3; .a > 1)` on `{"a":99}` errors "Cannot index number with string \"a\"",
+naming gen's own numeric output, not the document), the same rebinding `reduce`'s `update`
+and `foreach`'s `extract` already get, so they need a dedicated `reads_ambient_value` arm
+rather than the flat allowlist. On the same `{123: 1, "b": 2}`:
+
+| filter                          | jq 1.7.1 | succinctly before | succinctly now |
+|----------------------------------|----------|--------------------|-----------------|
+| `isempty(1)`, `isempty(empty)`  | error    | error              | `false`, `true` |
+| `any(range(3); . > 1)`          | error    | error              | `true`          |
+| `all(range(3); . >= 0)`         | error    | error              | `true`          |
+| `isempty(1 \| .)`                | error    | error              | `false`         |
+
+The last row is its own instance of the #2699 widening, one level in: `isempty`'s own arm
+recurses through `reads_ambient_value` rather than the flat allowlist specifically so a
+rebinding construct nested inside its argument (a pipe, a `reduce`, a `foreach`) gets the
+same refinement a top-level filter would, not just a bare `.`.
+
+Measured on a 96 MB `json generate` document (Apple M4 Pro, release build; the baseline for
+a filter that reads nothing is ~110 MB): `isempty(empty)` 2020 MB → 110 MB,
+`isempty(range(9))` 2020 MB → 110 MB, `isempty(1 | .)` 2118 MB → 110 MB,
+`any(range(3); . > 1)` 3763 MB → 110 MB, `all(range(3); . >= 0)` 3764 MB → 110 MB.
+
+`any`/`all`'s arity-0/1 forms (`any`, `all`, `any(cond)`, `all(cond)`) are deliberately
+unaffected: those desugar to an implicit `.[]` generator and genuinely read `.` on their own
+account. Pinned by the same `test_closed_terms_do_not_validate_2173` and
+`tests/jq_closed_term_tests.rs` the #2699 rows above are.
+
 ### Arithmetic and unary minus validate only what they read (#2626)
 
 [#2173](https://github.com/rust-works/succinctly/issues/2173) above stopped the wildcard

--- a/src/jq/walk.rs
+++ b/src/jq/walk.rs
@@ -1357,6 +1357,20 @@ pub fn reads_ambient_value(expr: &Expr) -> bool {
             reads_ambient_value(gen) || stage_escapes_own_input(cond)
         }
 
+        // `isempty(f)`'s argument sees the true ambient `.`, not a rebound
+        // value (unlike `cond` above), so a plain `reads_ambient_value(f)`
+        // is sound -- and strictly more precise than falling through to the
+        // flat allowlist entry below, which loses the recursive refinement
+        // this function gives Pipe/Reduce/Foreach/Comma: `isempty(1 | .)`
+        // is closed (the `.` reads the rebound `1` from the first pipe
+        // stage, matching `1 | .`'s own row in this function's Pipe arm
+        // above), but the flat `any_subexpr` walk cannot tell that nested
+        // `.` apart from a real document read. Measured: fixing this arm
+        // took `isempty(1 | .)` from 2.1 GB to the ~110 MB baseline on a
+        // 96 MB document, the same class of gap #2794's `AnyCond`/`AllCond`
+        // arm above closes for their own rebound stage.
+        Expr::Builtin(Builtin::IsEmpty(f)) => reads_ambient_value(f),
+
         // Everything else keeps the flat whole-tree answer. That is still
         // sound -- `any_subexpr` reaches every descendant, so a `.` anywhere
         // reports `true` -- just less precise than it could be: a `Pipe`

--- a/src/jq/walk.rs
+++ b/src/jq/walk.rs
@@ -1341,6 +1341,22 @@ pub fn reads_ambient_value(expr: &Expr) -> bool {
         }
         Expr::Comma(branches) => branches.iter().any(reads_ambient_value),
 
+        // #2794: `any(gen; cond)`/`all(gen; cond)` evaluate `cond` with `.`
+        // rebound to each output of `gen` -- real jq desugars both to
+        // `generator | condition` (confirmed live: `any(1,2,3; .a > 1)` on
+        // `{"a":99}` errors "Cannot index number with string \"a\"", naming
+        // gen's own numeric output, not the document) -- the same rebinding
+        // `Expr::Reduce`'s `update` and `Expr::Foreach`'s `extract` get
+        // above. Without this arm, the flat fallback below finds `.` inside
+        // `cond` (e.g. `any(range(3); . > 1)`) and blames the document for
+        // a read that is actually gen's rebound value, which is *safe*
+        // (over-materializes) but defeats the fix this issue is about --
+        // `gen` itself is still ordinary ambient-reading, only `cond` is
+        // rebound.
+        Expr::Builtin(Builtin::AnyCond(gen, cond) | Builtin::AllCond(gen, cond)) => {
+            reads_ambient_value(gen) || stage_escapes_own_input(cond)
+        }
+
         // Everything else keeps the flat whole-tree answer. That is still
         // sound -- `any_subexpr` reaches every descendant, so a `.` anywhere
         // reports `true` -- just less precise than it could be: a `Pipe`
@@ -1486,6 +1502,17 @@ fn node_reads_ambient(node: &Expr) -> bool {
         // variable name), not an `Expr`, so there is no child for
         // `any_subexpr` to miss either. Verified against their `eval.rs`
         // arms, each of which takes `_value` or no value parameter at all.
+        //
+        // #2794: `IsEmpty`/`AnyCond`/`AllCond` (the 2-arg `isempty(f)`,
+        // `any(gen; cond)`, `all(gen; cond)` forms) join the allowlist too --
+        // they consume a *generator* argument rather than reading `.`
+        // themselves, and `any_subexpr` already visits that argument
+        // separately, so the node's own contribution is nothing. Their
+        // arity-0/1 siblings (`Any`, `AnyF`, `All`, `AllF` -- `any`, `all`,
+        // `any(cond)`, `all(cond)`) are deliberately NOT here: those desugar
+        // to an implicit `.[]` generator (jq: "true if cond is truthy for
+        // any/every element of `.[]`"), so they read `.` on their own
+        // account and must keep the default "reads" answer.
         Expr::Builtin(builtin) => !matches!(
             builtin,
             Builtin::Empty
@@ -1498,6 +1525,9 @@ fn node_reads_ambient(node: &Expr) -> bool {
                 | Builtin::StrEnv(_)
                 | Builtin::Builtins
                 | Builtin::Halt
+                | Builtin::IsEmpty(_)
+                | Builtin::AnyCond(_, _)
+                | Builtin::AllCond(_, _)
         ),
 
         // Everything below contributes nothing of its own: whether it reads

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -46016,6 +46016,13 @@ fn test_closed_terms_do_not_validate_2173() -> Result<()> {
         // outcome deterministic across environments.
         ("[env(NONEXISTENT_VAR_XYZ_2173)?]", "[]"),
         ("[strenv(NONEXISTENT_VAR_XYZ_2173)?]", "[]"),
+        // #2794: `isempty(f)`/`any(gen; cond)`/`all(gen; cond)` contribute
+        // nothing of their own -- `bridge_ambient_input` sees only their
+        // (closed) argument(s), same as every other row here.
+        ("isempty(empty)", "true"),
+        ("isempty(1)", "false"),
+        ("any(range(3); . > 1)", "true"),
+        ("all(range(3); . >= 0)", "true"),
     ];
     for doc in docs {
         for (filter, want) in closed {

--- a/tests/jq_closed_term_tests.rs
+++ b/tests/jq_closed_term_tests.rs
@@ -120,6 +120,24 @@ const CLOSED: &[&str] = &[
     "1 | keys",
     "[1,2] | .a",
     "[foreach (1,2) as $x (0; . + $x; .a)]",
+    // #2794: `isempty(f)`'s argument is evaluated against the true ambient,
+    // so it is closed exactly when `f` is.
+    "isempty(1)",
+    "isempty(empty)",
+    "isempty(range(9))",
+    // #2794: `any(gen; cond)`/`all(gen; cond)` desugar to `gen | cond`, so
+    // `cond` sees gen's *output*, not the document -- closed when `gen` is,
+    // whatever `cond` looks like.
+    "any(range(3); . > 1)",
+    "any(range(3); . > 5)",
+    "all(range(3); . >= 0)",
+    "all(range(3); . > 5)",
+    "any(1,2,3; . == 2)",
+    "all(1,2,3; . > 0)",
+    // Closed *and* ill-typed, mirroring `[foreach ...; .a]` above: `.a`
+    // applies to gen's own `1`, not the document.
+    "any(1; .a)",
+    "all(1; .a)",
 ];
 
 /// Filters that read the input. These must be reported as reading — a
@@ -210,6 +228,19 @@ const READING: &[&str] = &[
     ".a //= 1",
     "del(.a)",
     "setpath([\"a\"]; 1)",
+    // #2794: a reading `isempty`/`any`/`all` argument keeps the whole node
+    // reading.
+    "isempty(.[])",
+    "isempty(.a)",
+    "any(.[]; . > 1)",
+    "all(.[]; . > 0)",
+    // #2794: `gen` closed but `cond` escapes through a channel that
+    // bypasses gen's rebound value entirely -- the same rule
+    // `stage_escapes_own_input` already enforces for `reduce`/`foreach`.
+    "any(1; key)",
+    "any(1; input)",
+    "any(1; path(.))",
+    "all(1; key)",
 ];
 
 /// yq's metadata-assignment grammar (#798), which only the yq-mode parser

--- a/tests/jq_closed_term_tests.rs
+++ b/tests/jq_closed_term_tests.rs
@@ -125,6 +125,14 @@ const CLOSED: &[&str] = &[
     "isempty(1)",
     "isempty(empty)",
     "isempty(range(9))",
+    // #2794 review: `isempty(f)` gets its own `reads_ambient_value` arm
+    // (not just the flat allowlist) so a rebinding construct nested inside
+    // `f` still gets the same Pipe/Reduce/Foreach refinement a top-level
+    // filter would -- `1 | .` reads the rebound `1`, not the document,
+    // whether or not it sits inside `isempty(...)`.
+    "isempty(1 | .)",
+    "isempty([1,2,3] | .[])",
+    "isempty(reduce (1,2,3) as $x (0; . + $x) | empty)",
     // #2794: `any(gen; cond)`/`all(gen; cond)` desugar to `gen | cond`, so
     // `cond` sees gen's *output*, not the document -- closed when `gen` is,
     // whatever `cond` looks like.


### PR DESCRIPTION
## Summary

\`isempty(f)\`, \`any(gen; cond)\` and \`all(gen; cond)\` materialized the whole
document into an \`OwnedValue\` even when their arguments are closed --
provably unable to read \`.\` -- costing 2-3.7 GB of peak RSS on a 77 MB
document for filters that read nothing:

\`\`\`console
$ succinctly json generate 96mb -o big.json
$ /usr/bin/time -l succinctly jq -c 'isempty(empty)' big.json
true
     2118000640  maximum resident set size
$ /usr/bin/time -l succinctly jq -c '[1+1]' big.json
[2]
      110182400  maximum resident set size
\`\`\`

\`node_reads_ambient\`'s \`Builtin\` arm was a negative allowlist that defaulted
every builtin except ten to "reads \`.\`", regardless of its arguments.
\`IsEmpty\` joins that allowlist directly -- its argument is evaluated
against the true ambient, so \`any_subexpr\`'s ordinary recursion already
judges it correctly once the outer node stops forcing \`true\`.

\`AnyCond\`/\`AllCond\` needed a dedicated arm in \`reads_ambient_value\` itself,
not just the allowlist: real jq desugars \`any(gen; cond)\` to \`gen | cond\`,
so \`cond\` is evaluated with \`.\` rebound to gen's output, the same
rebinding \`Reduce\`'s \`update\` and \`Foreach\`'s \`extract\` already get.
Confirmed live: \`any(1,2,3; .a > 1)\` on \`{"a":99}\` errors "Cannot index
number with string \\"a\\"", naming gen's own numeric output, not the
document. Adding \`AnyCond\`/\`AllCond\` to the flat \`Builtin\` allowlist alone
left \`cond\`'s ordinary \`.\` misattributed to the document by the fallback
whole-tree walk -- safe (over-materializes) but ineffective, which is why
\`isempty(empty)\` measured fixed at 110MB while \`any(range(3); . > 1)\`
stayed at ~3.9GB until this arm was added.

Measured after the full fix (Apple M4 Pro, 77MB generated JSON, release
build, baseline for a filter that reads nothing is ~110MB):

| filter | before | after |
|---|--:|--:|
| \`isempty(empty)\` | 2020 MB | 110 MB |
| \`isempty(range(9))\` | 2020 MB | 110 MB |
| \`any(range(3); . > 1)\` | 3763 MB | 110 MB |
| \`all(range(3); . >= 0)\` | 3764 MB | 110 MB |

\`isempty\`/\`any\`/\`all\`'s arity-0/1 forms (\`Any\`, \`AnyF\`, \`All\`, \`AllF\` --
\`any\`, \`all\`, \`any(cond)\`, \`all(cond)\`) are deliberately untouched: those
desugar to an implicit \`.[]\` generator and genuinely read \`.\` on their own
account.

Refs #2173, #2699, #2698, #2476.

Fixes #2794

## Test plan

- [x] \`cargo build --features cli\`
- [x] \`cargo test --features cli,simd,regex,serde\` (full suite, 0 failures)
- [x] \`cargo clippy --all-targets --all-features -- -D warnings\`
- [x] \`cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings\`
- [x] Extended the #2173 soundness corpus (\`tests/jq_closed_term_tests.rs\`)
      with CLOSED rows for all three builtins (including the
      closed-and-ill-typed \`any(1; .a)\` mirror of the existing
      \`[foreach ...; .a]\` row) and READING rows for a reading \`gen\` and for
      \`cond\` escaping through \`key\`/\`input\`/\`path(.)\`
- [x] Added rows to \`test_closed_terms_do_not_validate_2173\`
      (\`tests/jq_cli_tests.rs\`) confirming the new closed terms also stop
      validating malformed documents
- [x] Manually reproduced the issue's own memory measurements before and
      after the fix (table above)
- [x] \`cargo llvm-cov\` / \`omni-dev coverage diff\`: patch coverage 100% (2/2 new lines)