### PR TITLE
fix(jq): let a def parameter shadow a same-named builtin

### DIFF
--- a/src/jq/parser.rs
+++ b/src/jq/parser.rs
@@ -209,7 +209,8 @@ fn dollar_var_expr(name: String, line: usize) -> Expr {
 }
 
 /// #2036 Direction 3: a cheap, deliberately over-approximate scan for every
-/// identifier spelled after a `def` keyword anywhere in `input` -- see
+/// identifier spelled after a `def` keyword anywhere in `input`, plus (#2723)
+/// every identifier spelled in that `def`'s own parameter list -- see
 /// `Parser::shadowable_defs`'s own doc comment for why imprecision here is
 /// safe (a false positive costs one wasted double-parse at one call site; a
 /// false negative is impossible to turn into a wrong *answer* either, since
@@ -225,6 +226,23 @@ fn collect_def_names(input: &str) -> BTreeSet<String> {
     // only ever widens the (already-imprecise) set, never narrows it.
     fn is_ident_continue(c: char) -> bool {
         c.is_alphanumeric() || c == '_' || c == '-'
+    }
+
+    // #2036 review round 2's comment-skip loop, factored out so the
+    // parameter-list scan below (#2723) can reuse it verbatim instead of
+    // hand-duplicating it -- real jq's own `skip_ws` skips both whitespace
+    // and comments, repeatedly, wherever it appears in a `def` header.
+    fn skip_ws_and_comments(mut rest: &str) -> &str {
+        loop {
+            let trimmed = rest.trim_start();
+            let Some(after_hash) = trimmed.strip_prefix('#') else {
+                return trimmed;
+            };
+            rest = match after_hash.find('\n') {
+                Some(i) => &after_hash[i..],
+                None => "",
+            };
+        }
     }
 
     let mut names = BTreeSet::new();
@@ -249,18 +267,7 @@ fn collect_def_names(input: &str) -> BTreeSet<String> {
         // shadow it should have enabled silently never fires. Confirmed
         // live: `def #c\nlength: 99; length` returned `0` (the real
         // builtin) instead of `99` before this fix.
-        let mut rest = &input[end..];
-        loop {
-            let trimmed = rest.trim_start();
-            let Some(after_hash) = trimmed.strip_prefix('#') else {
-                rest = trimmed;
-                break;
-            };
-            rest = match after_hash.find('\n') {
-                Some(i) => &after_hash[i..],
-                None => "",
-            };
-        }
+        let rest = skip_ws_and_comments(&input[end..]);
         let mut chars = rest.char_indices();
         let Some((_, first)) = chars.next() else {
             continue;
@@ -272,6 +279,47 @@ fn collect_def_names(input: &str) -> BTreeSet<String> {
             .find(|&(_, c)| !is_ident_continue(c))
             .map_or(rest.len(), |(i, _)| i);
         names.insert(rest[..ident_end].to_string());
+
+        // #2723: a def's *parameters* can shadow a zero-arity (or
+        // wrong-arity-shadowable) builtin inside the def's own body
+        // exactly the way the def's own name can -- confirmed live against
+        // jq 1.7.1, `def f(length): length; f(1)` answers `1`, not the
+        // real `length` builtin's `0`. `resolve.rs::check`'s `FuncDef` arm
+        // already pushes every parameter into scope at arity 0, identically
+        // to the def's own name, so once a bare `length` reference reaches
+        // it as a shadow candidate it resolves correctly -- the only gap
+        // was here: this prescan used to collect only the def's own name,
+        // so the parser committed a parameter-shadowed builtin straight to
+        // `Expr::Builtin(Length)` with no shadow-candidate wrapping at all,
+        // and `resolve.rs`'s scope-aware check never got a chance to see
+        // it. Scanning the parameter list on the same "cheap, deliberately
+        // over-approximate" terms as the rest of this function closes that
+        // gap: a `$`-style parameter is stripped of its leading `$` before
+        // being recorded, since it binds a *variable* (`$name`), never the
+        // bare-identifier builtin spelling this set exists to catch --
+        // recording it anyway would only cost a harmless extra wasted
+        // double-parse at any call site spelled with that bare name, never
+        // a wrong answer.
+        let after_name = skip_ws_and_comments(&rest[ident_end..]);
+        if let Some(params) = after_name.strip_prefix('(') {
+            if let Some(close) = params.find(')') {
+                for part in params[..close].split(';') {
+                    let part = skip_ws_and_comments(part);
+                    let part = part.strip_prefix('$').unwrap_or(part);
+                    let mut pchars = part.char_indices();
+                    let Some((_, pfirst)) = pchars.next() else {
+                        continue;
+                    };
+                    if !is_ident_start_char(pfirst) {
+                        continue;
+                    }
+                    let pend = pchars
+                        .find(|&(_, c)| !is_ident_continue(c))
+                        .map_or(part.len(), |(i, _)| i);
+                    names.insert(part[..pend].to_string());
+                }
+            }
+        }
     }
     names
 }

--- a/src/jq/parser.rs
+++ b/src/jq/parser.rs
@@ -245,6 +245,24 @@ fn collect_def_names(input: &str) -> BTreeSet<String> {
         }
     }
 
+    // Scans one identifier off the front of `s` (whitespace/comments
+    // already skipped by the caller), returning it and everything after
+    // it. Shared by the def-name extraction and the parameter-list walk
+    // below (#2805 review) rather than hand-duplicated between them, per
+    // this codebase's own "duplicated predicates diverge silently" lesson
+    // (#106, #2728) that `is_ident_start_char`'s own doc comment cites.
+    fn scan_leading_ident(s: &str) -> Option<(&str, &str)> {
+        let mut chars = s.char_indices();
+        let (_, first) = chars.next()?;
+        if !is_ident_start_char(first) {
+            return None;
+        }
+        let end = chars
+            .find(|&(_, c)| !is_ident_continue(c))
+            .map_or(s.len(), |(i, _)| i);
+        Some((&s[..end], &s[end..]))
+    }
+
     let mut names = BTreeSet::new();
     for (start, _) in input.match_indices("def") {
         let end = start + 3;
@@ -268,17 +286,10 @@ fn collect_def_names(input: &str) -> BTreeSet<String> {
         // live: `def #c\nlength: 99; length` returned `0` (the real
         // builtin) instead of `99` before this fix.
         let rest = skip_ws_and_comments(&input[end..]);
-        let mut chars = rest.char_indices();
-        let Some((_, first)) = chars.next() else {
+        let Some((name, after_name_start)) = scan_leading_ident(rest) else {
             continue;
         };
-        if !is_ident_start_char(first) {
-            continue;
-        }
-        let ident_end = chars
-            .find(|&(_, c)| !is_ident_continue(c))
-            .map_or(rest.len(), |(i, _)| i);
-        names.insert(rest[..ident_end].to_string());
+        names.insert(name.to_string());
 
         // #2723: a def's *parameters* can shadow a zero-arity (or
         // wrong-arity-shadowable) builtin inside the def's own body
@@ -292,31 +303,53 @@ fn collect_def_names(input: &str) -> BTreeSet<String> {
         // so the parser committed a parameter-shadowed builtin straight to
         // `Expr::Builtin(Length)` with no shadow-candidate wrapping at all,
         // and `resolve.rs`'s scope-aware check never got a chance to see
-        // it. Scanning the parameter list on the same "cheap, deliberately
-        // over-approximate" terms as the rest of this function closes that
-        // gap: a `$`-style parameter is stripped of its leading `$` before
-        // being recorded, since it binds a *variable* (`$name`), never the
-        // bare-identifier builtin spelling this set exists to catch --
-        // recording it anyway would only cost a harmless extra wasted
-        // double-parse at any call site spelled with that bare name, never
-        // a wrong answer.
-        let after_name = skip_ws_and_comments(&rest[ident_end..]);
-        if let Some(params) = after_name.strip_prefix('(') {
-            if let Some(close) = params.find(')') {
-                for part in params[..close].split(';') {
-                    let part = skip_ws_and_comments(part);
-                    let part = part.strip_prefix('$').unwrap_or(part);
-                    let mut pchars = part.char_indices();
-                    let Some((_, pfirst)) = pchars.next() else {
-                        continue;
-                    };
-                    if !is_ident_start_char(pfirst) {
-                        continue;
-                    }
-                    let pend = pchars
-                        .find(|&(_, c)| !is_ident_continue(c))
-                        .map_or(part.len(), |(i, _)| i);
-                    names.insert(part[..pend].to_string());
+        // it. `$`-style parameters are stripped of their leading `$` before
+        // being recorded, since they bind a *variable* (`$name`), but a
+        // `$`-style parameter *also* binds the bare namespace to the same
+        // argument per jq's own `def f($x): body` == `def f(x): x as $x |
+        // body` desugaring, so the bare spelling still needs to be in this
+        // set to shadow the builtin (confirmed live: `[1,2,3] | def
+        // f($length): length; f(1)` is `1` in jq, not `3`).
+        //
+        // #2805 review: a plain `find(')')`/`split(';')` over the raw
+        // remaining text -- this function's first cut at this scan -- is
+        // fooled by a `#`-comment inside the parameter list containing
+        // either character, silently reopening the exact bug this issue
+        // fixes for a comment-containing header (confirmed live: `def
+        // f(#c)\nlength): length; f(1)` mistook the comment's own `)` for
+        // the list's close and left `length` out of `names` entirely,
+        // still answering `0`), and the unbounded forward `find(')')` scan
+        // is O(n) *per `def` occurrence* even when the paren is never
+        // closed, making a file with many such occurrences O(n^2) overall
+        // (confirmed live: doubling a crafted `"def a(".repeat(n)` input
+        // roughly quadrupled prescan time). Walking the list one token at
+        // a time instead -- skipping whitespace/comments before every
+        // token via `skip_ws_and_comments`, the same helper the def name
+        // above already uses -- fixes both: a comment's `)`/`;` is
+        // invisible to this walk because the whole comment is skipped
+        // before the walk inspects what follows it, and the walk bails
+        // (keeping whatever it already collected) the moment a token isn't
+        // `IDENT` followed by `;`/`,`/`)`, so an unclosed list costs at
+        // most its own length, never a scan of everything after it. `,` is
+        // accepted alongside `;` to match `Parser::parse_func_params`'s own
+        // separator set -- this dialect's grammar, not real jq's (real jq
+        // rejects a comma-separated def parameter list outright, confirmed
+        // live) -- since a comma-separated parameter is otherwise silently
+        // dropped from the shadow set the exact same way (confirmed live:
+        // `def f(a, length): length; f(1;2)` answered `0`, not `2`).
+        let after_name = skip_ws_and_comments(after_name_start);
+        if let Some(mut rest_params) = after_name.strip_prefix('(') {
+            loop {
+                rest_params = skip_ws_and_comments(rest_params);
+                let unprefixed = rest_params.strip_prefix('$').unwrap_or(rest_params);
+                let Some((pname, after_pname)) = scan_leading_ident(unprefixed) else {
+                    break;
+                };
+                names.insert(pname.to_string());
+                rest_params = skip_ws_and_comments(after_pname);
+                match rest_params.chars().next() {
+                    Some(';' | ',') => rest_params = &rest_params[1..],
+                    _ => break,
                 }
             }
         }

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -23718,9 +23718,17 @@ fn test_def_param_shadow_scoping_2723() -> Result<()> {
 /// noise rather than a tight benchmark.
 #[test]
 fn test_def_param_scan_unclosed_list_does_not_blow_up_2805() -> Result<()> {
+    // Via a `-f` file, not a `-nc <filter>` argument: a 300,000-byte
+    // filter exceeds Linux CI's ARG_MAX for a single exec'd argument
+    // ("Argument list too long", os error 7) -- confirmed live on this
+    // PR's own CI run, matching the codebase's established large-filter
+    // test pattern (`test_wide_non_recursive_literals_and_pipes_unaffected_2135`).
     let filter = "def a(".repeat(50_000);
+    let mut filter_file = NamedTempFile::new()?;
+    write!(filter_file, "{filter}")?;
     let start = std::time::Instant::now();
-    let (_, stderr, code) = run_jq_full(&["-nc", &filter], None)?;
+    let (_, stderr, code) =
+        run_jq_full(&["-nc", "-f", filter_file.path().to_str().unwrap()], None)?;
     let elapsed = start.elapsed();
     assert_ne!(code, 0, "stderr: {stderr:?}");
     assert!(!stderr.contains("panicked"), "stderr: {stderr:?}");

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -23616,28 +23616,30 @@ fn test_def_param_shadows_zero_arity_builtin_2723() -> Result<()> {
     Ok(())
 }
 
-/// #2723: `collect_def_names`'s new parameter-list scan is, like the rest
-/// of that function, a cheap *and deliberately not lexically aware* text
-/// scan -- it does not know a `#`-comment can itself contain a `)`
-/// character, so a comment inside a parameter list can trick it into
-/// treating that in-comment `)` as the list's real close. A malformed `def`
-/// header exercising that gap (and the sibling "first parameter character
-/// isn't an identifier start" gap, from a raw non-identifier token in
-/// parameter position) must still fail as an ordinary compile error --
-/// never panic -- since this scan runs on every filter's raw source text
-/// unconditionally, valid or not, before the real parser ever sees it.
+/// #2723: `collect_def_names`'s parameter-list scan is, like the rest of
+/// that function, a cheap and deliberately over-approximate text scan --
+/// it walks the list one token at a time (identifier, then a `;`/`,`/`)`)
+/// and simply stops, keeping whatever it already collected, the moment a
+/// token doesn't fit that shape. A malformed `def` header exercising that
+/// bail-out (a non-identifier token in parameter position, and a `(` with
+/// no closing `)` anywhere in the rest of the input) must still fail as an
+/// ordinary compile error -- never panic -- since this scan runs on every
+/// filter's raw source text unconditionally, valid or not, before the real
+/// parser ever sees it.
 #[test]
 fn test_def_param_scan_malformed_headers_do_not_panic_2723() -> Result<()> {
     for filter in [
-        // A comment's own `)` short-circuits the naive `find(')')`, so the
-        // scan treats the comment body as the entire parameter list.
-        "def f(#c) 0: 1; f",
         // A non-identifier token in parameter position.
         "def f(1): 5; f",
         // An opening paren with no closing paren anywhere in the rest of
-        // the input at all -- `params.find(')')` answers `None`, so the
-        // scan never enters the parameter-splitting loop for this `def`.
+        // the input at all -- the token walk bails on the first thing
+        // that isn't `IDENT` followed by `;`/`,`/`)`, here immediately
+        // (nothing follows the lone parameter `a`).
         "def f(a",
+        // A comment with no trailing newline anywhere, consuming the rest
+        // of the input -- the leading-identifier scan sees only `""` and
+        // bails with nothing collected for this def's parameter list.
+        "def f(#c) 0: 1; f",
     ] {
         let (_, stderr, code) = run_jq_full(&["-nc", filter], None)?;
         assert_ne!(code, 0, "filter: {filter:?} unexpectedly compiled");
@@ -23673,11 +23675,59 @@ fn test_def_param_shadow_scoping_2723() -> Result<()> {
         ("def f(a; length; b): [a,length,b]; f(1;2;3)", "[1,2,3]"),
         // A comment between the parameter name and `)` still counts.
         ("def f(#c\nlength): length; f(1)", "1"),
+        // `,` is accepted as a parameter separator alongside `;`, matching
+        // `Parser::parse_func_params`'s own grammar (a succinctly
+        // extension -- real jq rejects a comma-separated def parameter
+        // list outright, confirmed live). A first cut of this scan split
+        // only on `;`, silently dropping a comma-separated parameter from
+        // the shadow set the same way the original #2723 bug dropped an
+        // unscanned one (#2805 review; confirmed live pre-fix: `def f(a,
+        // length): length; f(1;2)` answered `0`, not `2`).
+        ("def f(a, length): length; f(1;2)", "2"),
+        // #2805 review: a `#`-comment *inside* the parameter list can
+        // contain a `)` or `;` of its own -- a naive `find(')')`/
+        // `split(';')` over the raw text is fooled by either, mistaking
+        // the comment's own character for the list's real delimiter and
+        // losing the real parameter that follows. All three confirmed
+        // live pre-fix to answer `0`/`[1,true]` (falling through to the
+        // real builtin) instead of the values below.
+        ("def f(#c)\nlength): length; f(1)", "1"),
+        ("def f(#comment; more comment\nlength): length; f(1)", "1"),
+        ("def f(a; #comment; junk\nnot): [a, not]; f(1;2)", "[1,2]"),
     ] {
         let (stdout, stderr, code) = run_jq_full(&["-nc", filter], None)?;
         assert_eq!(code, 0, "filter: {filter:?}, stderr: {stderr:?}");
         assert_eq!(stdout.trim_end(), expected, "filter: {filter:?}");
     }
+    Ok(())
+}
+
+/// #2805 review: a first cut of `collect_def_names`'s parameter-list scan
+/// located the list's close with an unbounded `params.find(')')` -- a scan
+/// across *the rest of the entire remaining input*, repeated for every
+/// `def NAME(` occurrence. A file with many such occurrences and no nearby
+/// `)` made every occurrence re-scan an ever-shrinking-but-still-huge
+/// remaining suffix, an `O(n^2)` blowup confirmed live pre-fix (doubling a
+/// crafted `"def a(".repeat(n)` input roughly quadrupled prescan time, e.g.
+/// ~2.7s at 128,000 reps). The token-by-token walk this issue's own fix
+/// replaced it with instead bails the moment a token doesn't look like
+/// `IDENT` followed by `;`/`,`/`)`, so an unclosed list costs at most its
+/// own length, never a scan of everything after it -- pinned here the same
+/// way `test_def_shadow_deep_nesting_does_not_blow_up_2036` pins its own
+/// parser-level denial-of-service fix, with a generous margin against CI
+/// noise rather than a tight benchmark.
+#[test]
+fn test_def_param_scan_unclosed_list_does_not_blow_up_2805() -> Result<()> {
+    let filter = "def a(".repeat(50_000);
+    let start = std::time::Instant::now();
+    let (_, stderr, code) = run_jq_full(&["-nc", &filter], None)?;
+    let elapsed = start.elapsed();
+    assert_ne!(code, 0, "stderr: {stderr:?}");
+    assert!(!stderr.contains("panicked"), "stderr: {stderr:?}");
+    assert!(
+        elapsed < std::time::Duration::from_secs(15),
+        "50,000 unclosed \"def a(\" reps took {elapsed:?} -- quadratic blowup regressed"
+    );
     Ok(())
 }
 

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -23590,6 +23590,97 @@ fn test_bare_param_does_not_bind_dollar_leaves_outer_binding_2726() -> Result<()
     Ok(())
 }
 
+/// #2723: a `def` parameter whose name collides with a zero-arity builtin
+/// must shadow it -- `substitute_func_param_impl`'s bare-parameter
+/// substitution never runs on these because the parser used to commit a
+/// builtin-named identifier straight to its dedicated `Expr` variant
+/// (`Expr::Builtin(Length)`, `Expr::Not`, ...) without ever routing it
+/// through the `#2036` shadow-candidate machinery -- that machinery only
+/// ever knew about a `def`'s own name, not its *parameters*. All four rows
+/// confirmed live against jq 1.7.1; `empty` is the most consequential
+/// misresolution, since a shadowed reference to it silently discards the
+/// substituted argument's output rather than merely computing the wrong
+/// value.
+#[test]
+fn test_def_param_shadows_zero_arity_builtin_2723() -> Result<()> {
+    for (filter, expected) in [
+        ("def f(length): length; f(1)", "1"),
+        ("def f(not): not; f(1)", "1"),
+        ("def f(empty): [empty]; f(1)", "[1]"),
+        ("def f(recurse): recurse; f(1)", "1"),
+    ] {
+        let (stdout, stderr, code) = run_jq_full(&["-nc", filter], None)?;
+        assert_eq!(code, 0, "filter: {filter:?}, stderr: {stderr:?}");
+        assert_eq!(stdout.trim_end(), expected, "filter: {filter:?}");
+    }
+    Ok(())
+}
+
+/// #2723: `collect_def_names`'s new parameter-list scan is, like the rest
+/// of that function, a cheap *and deliberately not lexically aware* text
+/// scan -- it does not know a `#`-comment can itself contain a `)`
+/// character, so a comment inside a parameter list can trick it into
+/// treating that in-comment `)` as the list's real close. A malformed `def`
+/// header exercising that gap (and the sibling "first parameter character
+/// isn't an identifier start" gap, from a raw non-identifier token in
+/// parameter position) must still fail as an ordinary compile error --
+/// never panic -- since this scan runs on every filter's raw source text
+/// unconditionally, valid or not, before the real parser ever sees it.
+#[test]
+fn test_def_param_scan_malformed_headers_do_not_panic_2723() -> Result<()> {
+    for filter in [
+        // A comment's own `)` short-circuits the naive `find(')')`, so the
+        // scan treats the comment body as the entire parameter list.
+        "def f(#c) 0: 1; f",
+        // A non-identifier token in parameter position.
+        "def f(1): 5; f",
+        // An opening paren with no closing paren anywhere in the rest of
+        // the input at all -- `params.find(')')` answers `None`, so the
+        // scan never enters the parameter-splitting loop for this `def`.
+        "def f(a",
+    ] {
+        let (_, stderr, code) = run_jq_full(&["-nc", filter], None)?;
+        assert_ne!(code, 0, "filter: {filter:?} unexpectedly compiled");
+        assert!(
+            !stderr.contains("panicked"),
+            "filter: {filter:?}, stderr: {stderr:?}"
+        );
+    }
+    Ok(())
+}
+
+/// #2723 review: the shadow must actually be scoped like any other
+/// parameter -- unrelated to the builtin's own name, a real (non-shadowed)
+/// use of the same builtin elsewhere in the program stays a real builtin
+/// call, and a comment sitting between the parameter name and the closing
+/// `)` doesn't hide it from the parser's own prescan. All confirmed live
+/// against jq 1.7.1.
+#[test]
+fn test_def_param_shadow_scoping_2723() -> Result<()> {
+    for (filter, expected) in [
+        // The real builtin is untouched outside the shadowing def.
+        ("[1,2,3] | length", "3"),
+        ("def f(length): length; [f(1), ([1,2,3]|length)]", "[1,3]"),
+        // A `$`-style parameter shadows the bare namespace too, not just
+        // its own `$name` -- real jq desugars `def f($x): body` to
+        // `def f(x): x as $x | body`, so `$length` also binds bare
+        // `length` to the same argument (confirmed live: `[1,2,3] | def
+        // f($length): length; f(1)` is `1` in jq, not `3` -- this is why
+        // `collect_def_names`'s parameter scan strips a leading `$` before
+        // recording the name, rather than skipping `$`-style parameters).
+        ("[1,2,3] | def f($length): length; f(1)", "1"),
+        // Multiple params, only one of which shadows a builtin.
+        ("def f(a; length; b): [a,length,b]; f(1;2;3)", "[1,2,3]"),
+        // A comment between the parameter name and `)` still counts.
+        ("def f(#c\nlength): length; f(1)", "1"),
+    ] {
+        let (stdout, stderr, code) = run_jq_full(&["-nc", filter], None)?;
+        assert_eq!(code, 0, "filter: {filter:?}, stderr: {stderr:?}");
+        assert_eq!(stdout.trim_end(), expected, "filter: {filter:?}");
+    }
+    Ok(())
+}
+
 /// #2560: `bind_def_call`'s own argument-binding for a duplicate parameter
 /// name now resolves by jq's ordinary later-wins parameter shadowing, the
 /// same rule `test_duplicate_named_param_shadow_resolves_by_last_occurrence_2283`


### PR DESCRIPTION
## Summary
- A `def` parameter named after a zero-arity builtin (`length`, `not`, `empty`, `recurse`, ...) was never substituted at the call site — the builtin won instead, silently producing a wrong answer (`def f(empty): [empty]; f(1)` was `[]`, not `[1]`).
- Root cause: the #2036 shadow-candidate prescan (`collect_def_names`) only ever collected a `def`'s own name, not its parameters, so a bare reference to a builtin-shadowing parameter committed straight to the builtin's dedicated `Expr` variant and never reached `resolve.rs`'s scope-aware check — even though that check already pushes every parameter into scope exactly like a `def`.
- Fix: extend the same prescan to also collect parameter names (stripping a leading `$`, since a `$`-style parameter binds the bare namespace too per jq's own desugaring). This routes every affected builtin through the existing, already-tested shadow-candidate machinery instead of adding a new mechanism.

## Test plan
- [x] `cargo build --features cli`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test --features cli` (full suite, 0 failures)
- [x] Live-verified every repro and edge case against `/usr/bin/jq` 1.7.1 (oracle)
- [x] Local patch coverage: 100% (27/27 new lines)

Fixes #2723