### PR TITLE
ci: add the two map(f)|.[] perf-guard rows #2666 needs, refresh both baselines

### DIFF
--- a/scripts/perf-guard.py
+++ b/scripts/perf-guard.py
@@ -114,6 +114,23 @@ QUERIES = [
     ("users_identity", "users", "2mb", "jq", "."),
     ("arrays_identity", "arrays", "2mb", "jq", "."),
     ("users_yq_keys_unsorted", "users", "2mb", "yq", "keys_unsorted"),
+    # #2666: the two sides of the `map(f) | .[]` atomicity boundary, on the
+    # one fixture where `map` applies at the root (a top-level array of
+    # arrays). The first is #1565's win -- a truncating consumer over a
+    # `LazySeq` pulls one element and stops -- and is the row that must NOT
+    # move when #2666 lands. The second is the shape #2666 makes atomic: it
+    # goes from streaming to the O(n) buffer jq itself pays for the array
+    # `map` builds, so it is *expected* to move. Its `QUERY_THRESHOLDS`
+    # entry arrives with the fix PR, sized from that PR's own merge-base
+    # delta (`--baseline-binary`, #1582) -- the one measurement that can be
+    # attributed to the fix. It is deliberately absent here: an override
+    # committed before the fix is a permanent loosening on a row whose only
+    # job is to be watched, during a window in which nothing has moved.
+    # Neither row existed before, which is how #2042's +21-33% resolver
+    # regression passed at -0.0% (#2655) -- this guard cannot see a shape
+    # it does not run.
+    ("arrays_first_map_iterate", "arrays", "2mb", "jq", "first(map(length) | .[])"),
+    ("arrays_map_iterate", "arrays", "2mb", "jq", "map(length) | .[]"),
 ]
 
 IR_PATTERN = re.compile(r"I\s+refs:\s+([\d,]+)")

--- a/tests/data/perf-guard-baseline.json
+++ b/tests/data/perf-guard-baseline.json
@@ -1,18 +1,22 @@
 {
   "ARM64-Linux": {
-    "arrays_identity": 594207638,
-    "users_identity": 289261734,
-    "users_keys_unsorted": 44367858,
-    "users_yq_keys_unsorted": 73041061,
-    "wide_identity": 467108181,
-    "wide_keys_unsorted": 291360706
+    "arrays_first_map_iterate": 111093246,
+    "arrays_identity": 594206439,
+    "arrays_map_iterate": 1119002742,
+    "users_identity": 289260562,
+    "users_keys_unsorted": 44366766,
+    "users_yq_keys_unsorted": 73403543,
+    "wide_identity": 467107189,
+    "wide_keys_unsorted": 290310316
   },
   "x86_64": {
-    "arrays_identity": 659508283,
-    "users_identity": 354088795,
-    "users_keys_unsorted": 66351190,
-    "users_yq_keys_unsorted": 80986986,
-    "wide_identity": 578685455,
-    "wide_keys_unsorted": 346886468
+    "arrays_first_map_iterate": 121074952,
+    "arrays_identity": 659510931,
+    "arrays_map_iterate": 1161373631,
+    "users_identity": 354091314,
+    "users_keys_unsorted": 66354067,
+    "users_yq_keys_unsorted": 81210364,
+    "wide_identity": 578688312,
+    "wide_keys_unsorted": 345792588
   }
 }


### PR DESCRIPTION
## What

PR A of #2666's two-PR sequence: two new `perf-guard` rows on the `arrays` fixture, and both CI legs' baselines regenerated.

| row | query | role |
|---|---|---|
| `arrays_first_map_iterate` | `first(map(length) \| .[])` | #1565's win — the row #2666's fix must **not** move |
| `arrays_map_iterate` | `map(length) \| .[]` | the shape the fix makes atomic — **expected** to move |

Neither had a row before, which is how #2042's +21–33% resolver regression passed at −0.0% (#2655): the guard cannot see a shape it does not run.

Refs #2666, #2655.

## Why a separate PR, first

So the fix's own CI run measures its effect on both rows against **its merge-base** (#1582's `--baseline-binary` mode) — an isolated, attributable delta — rather than against a baseline that never saw the shape.

## One deviation from the plan in #2666 — corrected after review

The plan proposed a `QUERY_THRESHOLDS` override for `arrays_map_iterate` sized against `ce691ca85` (the pre-#2103 merge-base). This PR sets **none**. The first version of this body justified that with a "wrong direction" argument that was **false** — the guard is `abs(drift)`, direction-blind, and a threshold has no direction. The review caught it. The decision stands on the two reasons that are actually valid:

1. **The number is unattributable.** Measured on terminus, cachegrind, both built release from the same script:

   | query | `ce691ca85` | `main` | drift |
   |---|--:|--:|--:|
   | `arrays_map_iterate` | 685,988,106 | 1,161,373,631 | +69.3% |
   | `arrays_first_map_iterate` | 125,747,846 | 121,074,952 | −3.7% |
   | `arrays_identity` (control) | 650,891,692 | 659,510,931 | +1.3% |

   60 commits touched `eval_generic.rs` in that window, and PR B's implementation need not land at the old buffered cost anyway. It is not a number to size anything from.

2. **An override committed now is a permanent loosening.** With `--baseline-binary` on every PR and push run (#1582), the checked-in file is never consulted, so a `QUERY_THRESHOLDS` entry is the only mechanism — and it never expires. Adding one before anything has moved would blind the row for the PR A → PR B window for no reason.

PR B will see its own isolated delta on this row and add the override then, with a number it can attribute. **Stated so it isn't read as an accident:** PR B's first perf-guard run will fail on this row (non-blocking) until that same PR adds the override — and that override should be removed once `main` has moved past it, or a future +40% regression on `map(f) | .[]` passes forever.

Also from review: the guard row is `first(map(length) | .[])` with an empty tail, while #1565's measured shape was `first(map(.+1) | .[] | .+1)`. The row catches a drain-before-`first` regression (121M → ~1,000M, ~8×), but a regression confined to the non-empty-tail branch would need the plan's manual A/B — don't read this row as covering #1565's exact shape.

## Baselines

Regenerated for both legs with the new script, then re-checked at 0.0% on all eight rows:

- **x86_64** — terminus (7950X, valgrind 3.18.1), release + `cli`. Six pre-existing rows moved at most 0.32% (`wide_keys_unsorted`, −0.315%).
- **ARM64-Linux** — native `linux/arm64` `ubuntu:24.04` container, valgrind 3.22.0 on aarch64, matching the `ubuntu-24.04-arm` CI image (#2116's procedure; valgrind has no Apple Silicon support). Six pre-existing rows moved at most 0.50%.

Both new queries verified to produce jq-identical output on the fixture before measuring.
