### PR TITLE
jq: dedupe //|and|or|not truthy check, drop Expr::Not's Vec round-trip (#2665 items 2-4)

### DIFF
--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -7139,11 +7139,9 @@ fn eval_single<S: EvalSemantics, V: DocumentValue>(
         // operand for a `needs_path_context` gate to key on, so it fell to
         // the wildcard bridge below unconditionally, paying the same
         // alias-fan-out cost as the ungated `and`/`or` above (#2476). `not`
-        // is exactly the truthiness of `.`, negated, and
-        // `push_generic_truthiness` already computes that truthiness for
-        // the identity result -- so this arm has never needed a validation
-        // call of its own, and since #2692 there is none to make: that
-        // function's `OneCursor` arm reads `is_falsy` and nothing else.
+        // is exactly the truthiness of `.`, negated -- so this arm has never
+        // needed a validation call of its own, and since #2692 there is none
+        // to make.
         //
         // `eval::eval_not`'s own comment argues a container that merely
         // *holds* an undecodable string should answer `false` rather than
@@ -7152,13 +7150,38 @@ fn eval_single<S: EvalSemantics, V: DocumentValue>(
         // still raises now (via the same decode, run as a walk instead of
         // a materialization), so this is a faster route to the same
         // raise-set, not a behaviour change.
+        //
+        // The identity result is always exactly one output (`cursor.map_or`
+        // never produces a stream), so this used to route through
+        // `push_generic_truthiness` -- built for genuinely multi-output
+        // streams -- via a `vec_with_capacity(1)`/push/index round-trip to
+        // extract one guaranteed bit. Inlined directly here instead (#2665
+        // item 4): [`cursor_is_truthy`] for the cursor case is the exact
+        // same rule that function's `OneCursor` arm uses, and the `None`
+        // case is the exact same `to_owned`-then-`is_truthy` its `One` arm
+        // uses, with the identical error surfaced the same way
+        // (`partial_generic` on an empty prefix collapses to
+        // `GenericResult::Error` -- see `partial_generic` above).
         Expr::Not => {
-            let identity = cursor.map_or(GenericResult::One(value), GenericResult::OneCursor);
-            let mut bits = vec_with_capacity(1);
-            if let Some(control) = push_generic_truthiness(identity, &mut bits) {
-                return partial_generic(Vec::new(), control);
-            }
-            GenericResult::Owned(OwnedValue::Bool(!bits[0]))
+            let truthy = match cursor {
+                Some(c) => cursor_is_truthy(&c),
+                // STYLE-0012: raises regardless of `optional`, and must --
+                // `not` has never consulted it. Two reasons, either
+                // sufficient. (1) `to_owned` raises only decode failures,
+                // which `suppresses` never suppresses -- routing this would
+                // be a guaranteed no-op, same as the `sort_by`/`unique_by`
+                // family's own `STYLE-0012` note above. (2) Before this
+                // refactor (#2665 item 4) this exact call lived inside
+                // `push_generic_truthiness`, a function with no `optional`
+                // parameter at all to route through; relocating it into this
+                // match does not change what it does with `optional` --
+                // still nothing, then and now.
+                None => match to_owned(&value) {
+                    Ok(v) => v.is_truthy(),
+                    Err(e) => return GenericResult::Error(e),
+                },
+            };
+            GenericResult::Owned(OwnedValue::Bool(!truthy))
         }
 
         // `//` had no native arm at all, so like `Expr::Not` above it fell to

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -3231,6 +3231,15 @@ fn push_generic_document_validation_error<C: DocumentCursor>(
     }
 }
 
+/// The one rule every cursor-backed truthiness check in this file answers
+/// by: `is_falsy(Preserve)`, negated. Pulled out so `//`/`and`/`or`/`not`
+/// structurally cannot drift on what "truthy" means — previously enforced
+/// only by [`push_generic_truthiness`] and [`retain_truthy_generic`]'s
+/// matching doc comments (#2665 item 3).
+fn cursor_is_truthy<C: DocumentCursor>(c: &C) -> bool {
+    !c.is_falsy(JsonConvention::Preserve)
+}
+
 /// Append one truthiness bit per output of a `GenericResult` stream to
 /// `out`. Mirrors [`super::eval::push_truthiness`] for the generic
 /// evaluator's cursor-aware result type — used to fan `select`'s condition
@@ -3265,7 +3274,7 @@ fn push_generic_truthiness<V: DocumentValue>(
             // it to -- `Preserve` keeps a malformed number truthy here the
             // same way it always has (see `StreamableValue::is_falsy`'s own
             // doc comment for the convention this parameter selects).
-            out.push(!c.is_falsy(JsonConvention::Preserve));
+            out.push(cursor_is_truthy(&c));
         }
         GenericResult::Many(vs) => {
             for v in &vs {
@@ -3274,7 +3283,7 @@ fn push_generic_truthiness<V: DocumentValue>(
         }
         GenericResult::ManyCursor(cs) => {
             for c in &cs {
-                out.push(!c.is_falsy(JsonConvention::Preserve));
+                out.push(cursor_is_truthy(c));
             }
         }
         // A lazy keys array, materialized or not, sorted or not, is
@@ -3361,8 +3370,8 @@ fn owned_prefix_partial<V: DocumentValue, T>(
 ///
 /// Every arm answers truthiness by exactly the rule its
 /// `push_generic_truthiness` counterpart uses, so `//` and `and`/`or`/`not`
-/// cannot drift apart on what "truthy" means: `OneCursor`/`ManyCursor` read
-/// `is_falsy(Preserve)` and nothing else, validating nothing (#2692 -- see
+/// cannot drift apart on what "truthy" means: `OneCursor`/`ManyCursor` share
+/// [`cursor_is_truthy`] and nothing else, validating nothing (#2692 -- see
 /// that function's `OneCursor` arm for why reading truthiness decodes
 /// nothing and so raises nothing, and a malformed *number* stays truthy);
 /// `LazyKeys`/`LazyIndexRange` are array-shaped and therefore always truthy
@@ -3390,10 +3399,10 @@ fn retain_truthy_generic<V: DocumentValue>(result: GenericResult<V>) -> GenericR
             Err(e) => GenericResult::Error(e),
         },
         GenericResult::OneCursor(c) => {
-            if c.is_falsy(JsonConvention::Preserve) {
-                GenericResult::None
-            } else {
+            if cursor_is_truthy(&c) {
                 GenericResult::OneCursor(c)
+            } else {
+                GenericResult::None
             }
         }
         GenericResult::Many(vs) => {
@@ -3418,7 +3427,7 @@ fn retain_truthy_generic<V: DocumentValue>(result: GenericResult<V>) -> GenericR
         GenericResult::ManyCursor(cs) => {
             let mut kept: Vec<V::Cursor> = Vec::new();
             for c in cs {
-                if !c.is_falsy(JsonConvention::Preserve) {
+                if cursor_is_truthy(&c) {
                     kept.push(c);
                 }
             }


### PR DESCRIPTION
## Summary

Addresses items 2-4 of #2665. Item 1 (missing `needs_path_context` arms for `Expr::Alternative`/`Expr::Not`/`Builtin::Any`/`All`) was already investigated on this branch and moved to #2782 (blocked) — untouched here.

The codebase moved since #2665 was filed: #2692 already deleted the `ambient_validation_error` walk entirely, which resolves **item 2 as moot** — the "redundant double validation walk" it described no longer exists, since there's no walk left to run twice. No code change for it; recording the finding here instead.

- **Item 3**: `push_generic_truthiness` and `retain_truthy_generic` each independently spelled out `!c.is_falsy(JsonConvention::Preserve)` in their `OneCursor`/`ManyCursor` arms — `retain_truthy_generic`'s own doc comment already said these "cannot drift apart," enforced only by matching comments. Extracted a `cursor_is_truthy` helper used at all 4 sites, making that claim structural.
- **Item 4**: `Expr::Not`'s identity result is always exactly one output, but it routed through `push_generic_truthiness` (built for multi-output streams) via a `vec_with_capacity(1)`/push/index round-trip to extract one guaranteed bit. Inlined directly using `cursor_is_truthy` for the cursor case and the same `to_owned`-then-`is_truthy` for the no-cursor case, with the identical error path (`partial_generic` on an empty prefix collapses to `GenericResult::Error`).

Both changes are pure refactors — behavior is unchanged and pinned by existing tests (`test_not_truthiness_table_2476`, `test_alternative_truthiness_table_2476`, `test_alternative_operands_read_the_real_position_2476`/`_in_jq_mode_2692`, `test_any_all_truthiness_table_2476`, etc.).

Relocating the `to_owned` call into `Expr::Not`'s arm (which lives in a function with a live `optional`) tripped the STYLE-0012 optional-suppression audit (#2334); added a `// STYLE-0012:` exemption comment explaining why this site must raise regardless of `optional`, matching the existing `sort_by`/`unique_by` precedent.

## Test plan

- [x] `cargo build --features cli`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test --features cli,simd,regex,serde` (full suite, including `jq_optional_suppression_audit`)
- [x] Targeted regression tests: `test_not_truthiness_table_2476`, `test_alternative_truthiness_table_2476`, `test_alternative_control_flow_2476`, `test_alternative_operands_read_the_real_position_2476`, `test_alternative_operands_read_the_real_position_in_jq_mode_2692`, `test_any_all_truthiness_table_2476`, `test_any_all_validate_only_the_keys_they_resolve_2476_2692`

Closes #2665 items 3-4 (items 1 blocked on #2782, item 2 moot per above).