### PR TITLE
fix(yaml): float an absent bare item's comment the way yq does (#1079)

### DIFF
--- a/docs/compliance/yq/limitations.md
+++ b/docs/compliance/yq/limitations.md
@@ -3626,18 +3626,22 @@ the sequence is nested straight inside an item) while the rest go forward, or at
 document all of them become the root's `foot_comment`. The parser now attributes these
 the way yq reports them, so the getters agree (`- # c\n- 2\n` answers `c` for
 `.[1] | head_comment` and nothing for `.[0] | line_comment`), but the identity output
-still drops them until this entry's emitter work lands. Three placements are recorded
-divergences, not gaps: real yq *drops* every floated comment but the last when a
+still drops them until this entry's emitter work lands. One placement is a recorded
+divergence, not a gap: real yq *drops* every floated comment but the last when a
 sequence holding several closes to an outer item or to end of input inside a mapping
 (`- k:\n  - # c\n  - # d\n- 2\n` keeps only `d`), which ADR-0018 rule 4 forbids
-matching — the rest go forward as the next node's head; a tag with no value on the
-item's next line (`- # c\n  !!str\n- 2\n`) drops both tag and comment here where yq
-keeps the tag and floats the comment; and a floated comment whose next sibling is a
-compact mapping or a nested sequence attaches to that item's first key / inner item
-rather than the item itself, the attribution #798's standalone-line capture already has
+matching — the rest go forward as the next node's head instead of being discarded to
+match. Two more are separate, pre-existing gaps, not divergences licensed by that
+rule: a tag with no value on the item's next line (`- # c\n  !!str\n- 2\n`) drops both
+tag and comment here where yq keeps the tag and floats the comment; and a floated
+comment whose next sibling is a compact mapping or a nested sequence attaches to that
+item's first key / inner item rather than the item itself — the same misattribution
+#798's standalone-line capture already has for an ordinary (non-floated) comment
 (`- 1\n# h\n- b: 1\n` is `.[1] | head_comment` in real yq, `.[1].b | key |
-head_comment` here — [#2811](https://github.com/rust-works/succinctly/issues/2811)). Blank lines in any of these shapes are unmodelled on both sides
-(yq keeps a `\n` inside the slot value and reorders).
+head_comment` here), neither introduced by nor fixable within this entry, tracked as a
+follow-up in [#2811](https://github.com/rust-works/succinctly/issues/2811). Blank
+lines in any of these shapes are unmodelled on both sides (yq keeps a `\n` inside the
+slot value and reorders).
 
 Four known gaps this write shares with every other write form, none specific to #798:
 

--- a/docs/compliance/yq/limitations.md
+++ b/docs/compliance/yq/limitations.md
@@ -3616,6 +3616,29 @@ reads comments straight off the live cursor at ~9 sites and never consults `Node
 plain `yq '.'` goes through here — while the DOM emitter (`emit_yaml_value_at_depth`,
 `yq_runner.rs`) does consult `NodeMeta` but is never given head/foot to print.
 
+The same gap covers a bare sequence item's own trailing comment when its value is
+*absent* (`- # c` followed by a sibling item, a dedent, or end of input — #1079's
+deferred half). Real yq has no node for that comment and floats it: forward onto the
+next item of the same sequence as its `head_comment` (accumulating across consecutive
+absent items), or — when the sequence closes past a dedent first — the last one becomes
+a `foot_comment` (of the key whose value the sequence is, or of the next outer item when
+the sequence is nested straight inside an item) while the rest go forward, or at end of
+document all of them become the root's `foot_comment`. The parser now attributes these
+the way yq reports them, so the getters agree (`- # c\n- 2\n` answers `c` for
+`.[1] | head_comment` and nothing for `.[0] | line_comment`), but the identity output
+still drops them until this entry's emitter work lands. Three placements are recorded
+divergences, not gaps: real yq *drops* every floated comment but the last when a
+sequence holding several closes to an outer item or to end of input inside a mapping
+(`- k:\n  - # c\n  - # d\n- 2\n` keeps only `d`), which ADR-0018 rule 4 forbids
+matching — the rest go forward as the next node's head; a tag with no value on the
+item's next line (`- # c\n  !!str\n- 2\n`) drops both tag and comment here where yq
+keeps the tag and floats the comment; and a floated comment whose next sibling is a
+compact mapping or a nested sequence attaches to that item's first key / inner item
+rather than the item itself, the attribution #798's standalone-line capture already has
+(`- 1\n# h\n- b: 1\n` is `.[1] | head_comment` in real yq, `.[1].b | key |
+head_comment` here — [#2811](https://github.com/rust-works/succinctly/issues/2811)). Blank lines in any of these shapes are unmodelled on both sides
+(yq keeps a `\n` inside the slot value and reorders).
+
 Four known gaps this write shares with every other write form, none specific to #798:
 
 - **No read-after-write within one pipe.** The `line_comment`/`style`/`anchor` GET-forms

--- a/src/yaml/light.rs
+++ b/src/yaml/light.rs
@@ -2237,14 +2237,14 @@ impl<'a, W: AsRef<[u64]>> YamlCursor<'a, W> {
                             if let Some(comment) = wrapper_comment {
                                 // #1079: real yq attaches a bare item's own
                                 // comment to the scalar node it defers to
-                                // (case C) -- an absent (null) value has no
-                                // node to attach it to and instead floats
-                                // it forward onto the next sibling item
-                                // (case D), which needs a multi-valued
-                                // head/line/foot comment slot this codebase
-                                // doesn't have yet (#798 PR2); only write
-                                // it here when the value actually
-                                // materializes. Gated on
+                                // (case C). The parser only parks a comment
+                                // on the wrapper when a child node follows,
+                                // but that child can still render as
+                                // absent -- a tag with no value (`- # c\n
+                                // !!str`), where real yq floats the comment
+                                // forward instead; leave that shape alone
+                                // rather than write a comment line above
+                                // an empty item. Gated on
                                 // `wrapper_comment.is_some()` (rare), so
                                 // this second `.value()` resolve -- on top
                                 // of the one `write_deferred_value` below
@@ -2267,21 +2267,20 @@ impl<'a, W: AsRef<[u64]>> YamlCursor<'a, W> {
                                 sort_keys,
                             )?;
                             // A bare `- # c` item with nothing at all after
-                            // it (no key, no nested value) shares its bp
-                            // with the wrapper -- same as a genuine compact
-                            // scalar (`- foo # own`), since neither opens a
-                            // separate child node. `raw == cursor` covers
-                            // both shapes; only the absent one is a comment
-                            // `maybe_capture_line_comment` stashed here
-                            // earlier in this branch as a head-comment
-                            // slot (#1079), not a real same-line trailing
-                            // comment on a materialized node -- and real yq
-                            // never renders that inline either way (it
-                            // relocates or floats forward, #798 PR2), so
-                            // suppress it here instead of misrendering it.
-                            // A compact scalar's own genuine comment
-                            // (`is_deferred_value_absent_at` false there)
-                            // is unaffected.
+                            // it shares its bp with the wrapper -- same as
+                            // a genuine compact scalar (`- foo # own`),
+                            // since neither opens a separate child node.
+                            // The parser floats such a comment onto another
+                            // node's head/foot rather than parking it here
+                            // (#1079), with one gap: a deeper line that
+                            // writes no node (`- # c\n  !!str`, a tag with
+                            // no value, dropped along with its tag today)
+                            // reads as a present value at capture time, so
+                            // the wrapper still holds `c`. Real yq floats
+                            // that one too, so suppress it rather than
+                            // render it inline. A compact scalar's own
+                            // genuine comment (`is_deferred_value_absent_at`
+                            // false there) is unaffected.
                             let own_comment = cursor.line_comment_raw();
                             let own_comment = if own_comment.is_some()
                                 && raw.bp_position() == cursor.bp_position()

--- a/src/yaml/parser.rs
+++ b/src/yaml/parser.rs
@@ -1131,6 +1131,23 @@ impl<'a, const HAS_CR: bool> Parser<'a, HAS_CR> {
     /// `old_root_bp` is `None` for the very first document (nothing to
     /// reach back to), in which case this always defers to the ordinary
     /// path.
+    ///
+    /// #1079 state (a floated comment, or the plain "an absent item was
+    /// seen" flag) is settled first, against the *closing* document, and
+    /// takes priority over the ordinary blank-line-adjacency rule above --
+    /// measured against pinned yq v4.53.3, a document boundary always fully
+    /// closes any open block sequence, so unlike an in-document dedent
+    /// there is no "still at the sequence's own column" case for
+    /// [`Self::settle_float_if_sequence_closed`]'s column check to apply to
+    /// the node opening in the *next* document; passing `next: None` skips
+    /// straight to its `owner_key_bp` fallback. A floated comment still
+    /// becomes that key's foot when there is one (`a:\n  - # c\n---\nb: 2\n`
+    /// puts `c` on `.a`'s foot, whether or not a blank line separates it
+    /// from the marker -- unlike true end of input, which collapses this
+    /// same shape onto the *root*'s foot instead, `a:\n  - # c\n` measured
+    /// against `.a | key | foot_comment` empty vs. `. | foot_comment` = `c`).
+    /// With no owner key, or after an absent item with no comment of its
+    /// own, whatever is left is the closing document's own root foot.
     fn flush_pending_head_lines_at_boundary(
         &mut self,
         next: Option<(usize, usize)>,
@@ -1140,6 +1157,18 @@ impl<'a, const HAS_CR: bool> Parser<'a, HAS_CR> {
             return;
         }
         if let Some(old_root) = old_root_bp {
+            if let Some(floated) = self.floated_item_comment.take() {
+                self.settle_float_if_sequence_closed(floated, None);
+            }
+            if core::mem::take(&mut self.block_passed_absent_item) {
+                if !self.pending_head_lines.is_empty() {
+                    self.drain_pending_into_foot(old_root);
+                }
+                return;
+            }
+            if self.pending_head_lines.is_empty() {
+                return;
+            }
             let block_end = self.pending_head_lines[self.pending_head_lines.len() - 1].1 as usize;
             let adjacent_to_marker = !self.blank_line_between(block_end, self.pos);
             if adjacent_to_marker {
@@ -2097,6 +2126,17 @@ impl<'a, const HAS_CR: bool> Parser<'a, HAS_CR> {
         let root_bp = self.document_start_bp_pos;
         self.flush_pending_head_lines_at_boundary(Some((root_bp, 0)), old_root_bp);
         self.last_head_foot_bp = None;
+        // #1079: `block_passed_absent_item` belongs to whichever document set
+        // it. `flush_pending_head_lines_at_boundary` above already clears it
+        // when it drains a pending block, but it early-returns without
+        // touching any state when nothing is pending -- which is exactly the
+        // case an absent bare item with no comment of its own leaves behind
+        // (`end_float` sets the flag without ever pushing into
+        // `pending_head_lines`). Left set, it would wrongly force a later,
+        // unrelated comment in *this* document onto its own root foot at end
+        // of input, the same way it correctly does for the document that
+        // actually saw the absent item.
+        self.block_passed_absent_item = false;
         // Primes the no-`PREV` fallback for whatever comes next in the new
         // document -- see [`Self::document_boundary_fallback_bp`].
         self.document_boundary_fallback_bp = old_root_bp;

--- a/src/yaml/parser.rs
+++ b/src/yaml/parser.rs
@@ -8009,4 +8009,84 @@ mod tests {
             other => panic!("expected string 'v' value, got {other:?}"),
         }
     }
+
+    /// The #106 guard for #1079's fast path: [`Parser::next_line_settles_value_is_null`]
+    /// restates part of [`Parser::following_value_is_null`]'s answer with its own
+    /// byte scan rather than calling it, for the measured performance reason on
+    /// its own doc comment. Its doc comment argues the two cannot disagree, by
+    /// inspection; this pins that claim the way `skip_line_break_agrees` pins
+    /// `skip_line_break` against `break_len_at` -- whenever the fast path
+    /// commits to an answer (`Some`), the full lookahead must agree. A `None`
+    /// makes no claim and is not checked here; the caller falls back to the
+    /// full lookahead in that case regardless.
+    #[test]
+    fn next_line_settles_value_is_null_agrees_with_following_value_is_null() {
+        let cases: &[(&[u8], usize)] = &[
+            (b"x", 1),        // no trailing break at all (last line, EOF)
+            (b"x\n", 1),      // break then immediate EOF
+            (b"x\n  y\n", 1), // deeper indent: value continues
+            (b"x\n  y\n", 2), // same indent: value settles null
+            (b"x\n  y\n", 3), // shallower-than-content indent
+            (b"x\ny\n", 0),   // next line at indent 0
+            (b"x\ny\n", 1),   // dedent past indent 1
+            (b"x\n    deep\n", 0),
+            (b"x\n    deep\n", 4),
+            (b"x\n    deep\n", 5),
+        ];
+        for &(input, indent) in cases {
+            // `self.pos` must sit on the current line's own break, per both
+            // functions' contracts -- that's `x`'s length here in every case.
+            let pos = input
+                .iter()
+                .position(|&b| is_line_break(b))
+                .unwrap_or(input.len());
+
+            let fast = {
+                let mut p = Parser::<false>::new(input);
+                p.pos = pos;
+                p.next_line_settles_value_is_null(indent)
+            };
+            if let Some(fast) = fast {
+                let mut full = Parser::<false>::new(input);
+                full.pos = pos;
+                let slow = full.following_value_is_null(indent);
+                assert_eq!(
+                    fast, slow,
+                    "{input:?} @ pos {pos}, indent {indent}: fast path and full \
+                     lookahead disagree"
+                );
+                assert_eq!(full.pos, pos, "following_value_is_null must restore pos");
+            }
+        }
+
+        // The CRLF-carrying `HAS_CR == true` monomorphization has its own `\r`
+        // arm in the fast path (`next_line_settles_value_is_null` steps over
+        // `\r\n` as one break); pin it the same way.
+        let crlf_cases: &[(&[u8], usize)] = &[
+            (b"x\r\n  y\r\n", 1),
+            (b"x\r\n  y\r\n", 2),
+            (b"x\r\ny\r\n", 0),
+        ];
+        for &(input, indent) in crlf_cases {
+            let pos = input
+                .iter()
+                .position(|&b| is_line_break(b))
+                .unwrap_or(input.len());
+            let fast = {
+                let mut p = Parser::<true>::new(input);
+                p.pos = pos;
+                p.next_line_settles_value_is_null(indent)
+            };
+            if let Some(fast) = fast {
+                let mut full = Parser::<true>::new(input);
+                full.pos = pos;
+                let slow = full.following_value_is_null(indent);
+                assert_eq!(
+                    fast, slow,
+                    "{input:?} @ pos {pos}, indent {indent}: fast path and full \
+                     lookahead disagree (CRLF)"
+                );
+            }
+        }
+    }
 }

--- a/src/yaml/parser.rs
+++ b/src/yaml/parser.rs
@@ -4167,8 +4167,16 @@ impl<'a, const HAS_CR: bool> Parser<'a, HAS_CR> {
                 self.write_ty(true); // sequence
                 self.indent_stack.push(indent + 2); // Indent for sequence content
                 self.push_type(NodeType::Sequence);
-                // A key is nobody's value, so no owner key (#1079).
-                self.register_seq_frame(indent + 2, None, false);
+                // This sequence *is* the key, not any key's value -- but a
+                // comment floated off one of its own absent items still
+                // lands on the key's own foot when the sequence closes past
+                // a dedent, the same as an ordinary mapping value's would
+                // (measured against pinned yq v4.53.3: `? - a\n  - # c\n:
+                // v\nb: 2\n` puts `c` on the explicit key's own foot, not
+                // `.b`'s head). `last_head_foot_bp` still holds this key's
+                // own bp, set by `attach_head_foot_at` above, unchanged
+                // since (#1079).
+                self.register_seq_frame(indent + 2, self.last_head_foot_bp, true);
 
                 // Parse first sequence item inline
                 self.write_bp_open_seq_item(); // item node

--- a/src/yaml/parser.rs
+++ b/src/yaml/parser.rs
@@ -117,6 +117,22 @@ pub struct NodeComments {
 }
 
 /// An open block sequence, as [`Parser::seq_frames`] tracks it (#1079).
+///
+/// This is a second stack, parallel to (not folded into) `indent_stack`/
+/// `type_stack` -- tempting to simplify by widening `NodeType::Sequence`
+/// into a payload-carrying variant and dropping `serial`/`frame_len`
+/// instead, reading a sequence's identity straight off those two. That
+/// simplification is unsound: `serial` is load-bearing, not redundant with
+/// depth. Two sibling items nested inline (`- - # c1\n- - # c2\n`) each open
+/// an inner sequence at the *same* stack depth with no settle checkpoint in
+/// between -- an inline `- - x` item never calls `attach_head_foot_at` for
+/// its own dash, it recurses straight into the nested sequence -- so by the
+/// time item 1's inner sequence registers, it has already replaced item 0's
+/// at that identical depth. A depth-only check reads that as "still open"
+/// and never settles item 0's floated comment at all
+/// (`test_seq_frame_serial_distinguishes_sibling_frames_at_the_same_depth_1079_float`
+/// pins the diverging case this produces against real yq; confirmed by a
+/// throwaway experimental patch during #1079's review).
 #[derive(Debug, Clone, Copy)]
 struct SeqFrame {
     /// Identity that survives the frame's depth being reused by a later

--- a/src/yaml/parser.rs
+++ b/src/yaml/parser.rs
@@ -116,6 +116,47 @@ pub struct NodeComments {
     pub foot: Vec<(u32, u32)>,
 }
 
+/// An open block sequence, as [`Parser::seq_frames`] tracks it (#1079).
+#[derive(Debug, Clone, Copy)]
+struct SeqFrame {
+    /// Identity that survives the frame's depth being reused by a later
+    /// sequence -- see [`Parser::next_seq_serial`].
+    serial: u32,
+    /// `indent_stack.len()` while this sequence is the top frame; only
+    /// used to drop entries whose frame has since been popped.
+    frame_len: usize,
+    /// The column of the sequence's `-` markers: a later node at a lower
+    /// column is a dedent out of it, which is when a floated comment can
+    /// become a foot at all.
+    indent: usize,
+    /// The nearest enclosing mapping key -- the key this sequence is the
+    /// value of, or the enclosing sequence's own when this one is nested in
+    /// an item: the node real yq gives a floated comment to as its `foot`
+    /// when the sequence closes to a following key.
+    owner_key_bp: Option<usize>,
+    /// Whether that key is this sequence's *own* (parent frame a mapping)
+    /// rather than inherited through an item. A directly-owned sequence's
+    /// floated comment is always the key's foot; an inherited one's is the
+    /// next outer item's when that is what opens next.
+    direct_key_value: bool,
+}
+
+/// A comment floated off an absent bare sequence item -- see
+/// [`Parser::floated_item_comment`] (#1079).
+#[derive(Debug, Clone, Copy)]
+struct FloatedItemComment {
+    /// Its byte range, as also held in [`Parser::pending_head_lines`].
+    range: (u32, u32),
+    /// The sequence the item belonged to, by [`SeqFrame::serial`].
+    seq_serial: u32,
+    /// That sequence's [`SeqFrame::indent`].
+    seq_indent: usize,
+    /// That sequence's [`SeqFrame::owner_key_bp`].
+    owner_key_bp: Option<usize>,
+    /// That sequence's [`SeqFrame::direct_key_value`].
+    direct_key_value: bool,
+}
+
 /// Output from parsing: the semi-index structures.
 #[derive(Debug)]
 pub struct SemiIndex {
@@ -304,6 +345,34 @@ struct Parser<'a, const HAS_CR: bool> {
     /// reach back across the boundary a second time. Consulted only by
     /// [`Self::flush_pending_head_lines`]'s no-`PREV` fallback.
     document_boundary_fallback_bp: Option<usize>,
+    /// One entry per open block sequence, innermost last (#1079). Not
+    /// popped where the frame closes -- several paths pop `indent_stack`
+    /// -- but trimmed lazily against `indent_stack.len()` wherever it is
+    /// read, which is only when a floated comment is being placed.
+    seq_frames: Vec<SeqFrame>,
+    /// Source of [`SeqFrame::serial`]; never reused, so a sequence that
+    /// closed and had another opened at the same depth is told apart from
+    /// one that is still open.
+    next_seq_serial: u32,
+    /// The most recent comment floated off a bare `- # c` item whose value
+    /// turned out absent (#1079), still sitting in
+    /// [`Self::pending_head_lines`] with the standalone lines. Real yq has
+    /// no node for such a comment and moves it: forward onto the next item
+    /// of the same sequence as its `head` (accumulating), or -- when the
+    /// sequence closes past a dedent first -- the *last* one becomes a
+    /// `foot` (see [`Self::settle_float_if_sequence_closed`] for whose)
+    /// while the rest go forward, or at end of document all of them become
+    /// the root's `foot`. The first of those is what the ordinary forward
+    /// attach already does; this records what
+    /// [`Self::flush_pending_head_lines`] needs for the other two.
+    floated_item_comment: Option<FloatedItemComment>,
+    /// Whether an absent bare `-` item, with or without a comment of its
+    /// own, has been seen since the last node that owns head/foot comments
+    /// opened (#1079). At end of document the pending block is then the
+    /// root's foot in real yq, not `PREV`'s (`- 1\n# c\n-\n` and
+    /// `- 1\n-\n# c\n` alike), whether or not a floated comment is still
+    /// in it.
+    block_passed_absent_item: bool,
 
     // Document tracking
     /// Whether we're currently inside a document
@@ -432,6 +501,10 @@ impl<'a, const HAS_CR: bool> Parser<'a, HAS_CR> {
             saw_head_foot_node: false,
             seen_any_document: false,
             document_boundary_fallback_bp: None,
+            seq_frames: Vec::new(),
+            next_seq_serial: 0,
+            floated_item_comment: None,
+            block_passed_absent_item: false,
             in_document: false,
             document_start_bp_pos: 0,
             pending_explicit_key: None,
@@ -732,16 +805,59 @@ impl<'a, const HAS_CR: bool> Parser<'a, HAS_CR> {
     /// Attach the pending standalone-comment block (#798), applying the
     /// measured rule in [`Self::record_standalone_comment`]'s doc comment.
     ///
-    /// `next_bp` is the node that just opened and would own the block as its
-    /// `head`, or `None` at end of input. Called at every point a node that
-    /// can own a head comment opens — a mapping key, a sequence item's
-    /// content, and a document's content node — plus once at end of parse.
-    /// A no-op when nothing is pending, which is the overwhelmingly common
-    /// case, so the hooks cost one `Vec::is_empty` each.
-    fn flush_pending_head_lines(&mut self, next_bp: Option<usize>) {
+    /// `next` is the node that just opened and would own the block as its
+    /// `head`, with the column its line starts at, or `None` at end of
+    /// input. Called at every point a node that can own a head comment
+    /// opens — a mapping key, a sequence item's content, and a document's
+    /// content node — plus once at end of parse. A no-op when nothing is
+    /// pending, which is the overwhelmingly common case, so the hooks cost
+    /// one `Vec::is_empty` each.
+    fn flush_pending_head_lines(&mut self, next: Option<(usize, usize)>) {
         if self.pending_head_lines.is_empty() {
             return;
         }
+        // The block passed through an absent bare `-` item (#1079): a
+        // comment floated off one may be in it, and real yq's placements
+        // for such a block differ from the rule below in two ways settled
+        // here. The third -- forward onto the next item of the same
+        // sequence, accumulating -- is the ordinary `NEXT.head` path and
+        // falls through to it.
+        let floated = self.floated_item_comment.take();
+        let passed_absent_item = core::mem::take(&mut self.block_passed_absent_item);
+        let Some((bp, column)) = next else {
+            if floated.is_some() || passed_absent_item {
+                // End of document: everything still pending is the root's
+                // foot, whatever `PREV` is -- `a:\n  - # c\n` answers
+                // `. | foot_comment`, not `.a | key | foot_comment`; `- # c\n`
+                // alone has no `PREV` at all yet is a foot, not a
+                // comment-only document's head; and `- 1\n# c\n-\n` is the
+                // root's, not `.[0]`'s (all measured).
+                let root = self.document_start_bp_pos;
+                self.drain_pending_into_foot(root);
+                return;
+            }
+            return self.flush_pending_head_lines_by_rule(None);
+        };
+        if let Some(floated) = floated {
+            // The sequence may have closed before this node opened: then
+            // the last floated comment becomes a foot -- of this node when
+            // it is an item of an outer sequence (`-\n  - # c\n- 2\n` is
+            // `.[1]`'s foot, measured), otherwise of the nearest enclosing
+            // key (`a:\n  - # c\n  - # d\nb: 2\n` gives `.a`'s key `d` and
+            // `.b`'s key `c`) -- and whatever else is pending goes forward
+            // as usual.
+            let is_item = self.current_type == Some(NodeType::SequenceItem);
+            self.settle_float_if_sequence_closed(floated, Some((bp, column, is_item)));
+            if self.pending_head_lines.is_empty() {
+                return;
+            }
+        }
+        self.flush_pending_head_lines_by_rule(Some(bp));
+    }
+
+    /// The #798 rule proper -- see [`Self::flush_pending_head_lines`],
+    /// which handles the floated-comment cases first.
+    fn flush_pending_head_lines_by_rule(&mut self, next_bp: Option<usize>) {
         // A blank line between the block and whatever follows detaches it
         // forward; so does having nothing follow at all. Either way it falls
         // back onto `PREV` — which `record_standalone_comment` has already
@@ -750,8 +866,7 @@ impl<'a, const HAS_CR: bool> Parser<'a, HAS_CR> {
         let detached_forward = next_bp.is_none() || self.blank_line_between(block_end, self.pos);
         if detached_forward {
             if let Some(prev) = self.last_head_foot_bp {
-                let pending = &mut self.pending_head_lines;
-                self.comments.entry(prev).or_default().foot.append(pending);
+                self.drain_pending_into_foot(prev);
                 return;
             }
             // No `PREV` in *this* document -- if nothing has opened here yet
@@ -761,29 +876,198 @@ impl<'a, const HAS_CR: bool> Parser<'a, HAS_CR> {
             // v4.53.3: `a: 1\n---\n# mid\n\nb: 2\n` puts `mid` on the first
             // document's own foot, not `.b`'s head, #798).
             if let Some(old_root) = self.document_boundary_fallback_bp {
-                let pending = &mut self.pending_head_lines;
-                self.comments
-                    .entry(old_root)
-                    .or_default()
-                    .foot
-                    .append(pending);
+                self.drain_pending_into_foot(old_root);
                 return;
             }
         }
         let root = self.document_start_bp_pos;
-        let pending = &mut self.pending_head_lines;
         match next_bp {
-            Some(bp) => self.comments.entry(bp).or_default().head.append(pending),
+            Some(bp) => {
+                let pending = &mut self.pending_head_lines;
+                self.comments.entry(bp).or_default().head.append(pending);
+            }
             // Nothing follows and nothing precedes it closely enough, so the
             // block belongs to the document root -- as its *foot* normally,
             // but as its *head* when the document never opened a node at all
             // (a comment-only document, where real yq answers
             // `. | head_comment`, not `foot_comment`).
-            None if self.saw_head_foot_node => {
-                self.comments.entry(root).or_default().foot.append(pending);
+            None if self.saw_head_foot_node => self.drain_pending_into_foot(root),
+            None => {
+                let pending = &mut self.pending_head_lines;
+                self.comments.entry(root).or_default().head.append(pending);
             }
-            None => self.comments.entry(root).or_default().head.append(pending),
         }
+    }
+
+    /// Move the whole pending block onto `bp`'s `foot`. The one place a
+    /// pending block leaves for a foot, so it is also where a floated item
+    /// comment (#1079) that was part of that block stops being pending --
+    /// left set, it would claim some later, unrelated block at end of
+    /// document.
+    fn drain_pending_into_foot(&mut self, bp: usize) {
+        self.floated_item_comment = None;
+        self.block_passed_absent_item = false;
+        let pending = &mut self.pending_head_lines;
+        self.comments.entry(bp).or_default().foot.append(pending);
+    }
+
+    /// Whether the block sequence [`SeqFrame::serial`] names is still on the
+    /// stack (#1079). Entries whose frame has been popped are dropped here;
+    /// a sequence that closed and had another opened at the same depth has
+    /// a different serial, so it correctly reads as closed.
+    fn sequence_still_open(&mut self, serial: u32) -> bool {
+        self.trim_seq_frames_to(self.indent_stack.len());
+        self.seq_frames.iter().any(|frame| frame.serial == serial)
+    }
+
+    /// Drop [`Self::seq_frames`] entries deeper than `max_frame_len`: their
+    /// frames were popped by one of the paths that don't touch this stack.
+    fn trim_seq_frames_to(&mut self, max_frame_len: usize) {
+        while self
+            .seq_frames
+            .last()
+            .is_some_and(|frame| frame.frame_len > max_frame_len)
+        {
+            self.seq_frames.pop();
+        }
+    }
+
+    /// The entry for the sequence just below the item frame on top of the
+    /// stack, if that sequence was registered (#1079).
+    fn enclosing_seq_frame(&mut self) -> Option<SeqFrame> {
+        let seq_frame_len = self.indent_stack.len() - 1;
+        self.trim_seq_frames_to(seq_frame_len);
+        self.seq_frames
+            .last()
+            .copied()
+            .filter(|frame| frame.frame_len == seq_frame_len)
+    }
+
+    /// A floated comment whose sequence has since closed becomes a foot
+    /// (#1079), leaving the rest of the pending block to go forward. `next`
+    /// is the node opening now, as (bp, column, is a sequence item), or
+    /// `None` when the trigger is another absent item.
+    ///
+    /// Real yq's placement, measured: a node at or past the sequence's own
+    /// column is not a dedent out of it, and the comment goes forward as
+    /// that node's head like any other (`a:\n- # c\nb: 2\n` heads `b`);
+    /// past a real dedent, the comment is the foot of the nearest enclosing
+    /// key when the sequence was that key's own value (`a:\n  - # c\nb: 2\n`,
+    /// and `k:\n- # c\n-\n` closing to an outer item alike), else -- the
+    /// sequence nested in an item -- of the outer item opening now
+    /// (`-\n  - # c\n- 2\n` is `.[1]`'s foot), or of the inherited key when
+    /// a key opens instead. A no-op while the sequence is still open, or
+    /// with no target at all (a root-level sequence nested in a sequence
+    /// closing to nothing: real yq drops the comment outright, and keeping
+    /// it pending, to go forward, is the ADR-0018 rule 4 answer to that).
+    fn settle_float_if_sequence_closed(
+        &mut self,
+        floated: FloatedItemComment,
+        next: Option<(usize, usize, bool)>,
+    ) {
+        if self.sequence_still_open(floated.seq_serial) {
+            return;
+        }
+        let target = match next {
+            Some((_, column, _)) if column >= floated.seq_indent => return,
+            Some((bp, _, true)) if !floated.direct_key_value => Some(bp),
+            _ => floated.owner_key_bp,
+        };
+        let Some(target) = target else {
+            return;
+        };
+        if let Some(idx) = self
+            .pending_head_lines
+            .iter()
+            .position(|&range| range == floated.range)
+        {
+            let range = self.pending_head_lines.remove(idx);
+            self.comments.entry(target).or_default().foot.push(range);
+        }
+    }
+
+    /// An absent item with no comment of its own (#1079): a comment
+    /// floated earlier in the *same* sequence can no longer become a foot
+    /// -- real yq heads the next key with it (`a:\n  - # c\n  -\nb: 2\n`).
+    /// One from a nested sequence that has already closed stays pending
+    /// for the next node to place (`a:\n  - b:\n      - # c\n  -\nz: 1\n`
+    /// is `.a[0].b`'s key's foot, measured). The pending lines themselves
+    /// stay to go forward -- and at end of document, lines pending after
+    /// any absent item are the root's foot (`- 1\n-\n# c\n`, measured).
+    fn end_float(&mut self) {
+        if let Some(previous) = self.floated_item_comment {
+            if self.sequence_still_open(previous.seq_serial) {
+                self.floated_item_comment = None;
+            }
+        }
+        self.block_passed_absent_item = true;
+    }
+
+    /// The owner key of the innermost open block sequence, for a sequence
+    /// about to open inside one of its items (#1079). Called before the new
+    /// sequence's own push, with the item frame on top.
+    fn enclosing_seq_owner_key(&mut self) -> Option<usize> {
+        self.enclosing_seq_frame()
+            .and_then(|frame| frame.owner_key_bp)
+    }
+
+    /// Record the block sequence that just became the top frame (#1079).
+    /// Called right after its `indent_stack`/`type_stack` push. Entries at
+    /// this depth or deeper belong to sequences that have since closed
+    /// through one of the paths that don't touch this stack, so they go
+    /// first.
+    fn register_seq_frame(
+        &mut self,
+        indent: usize,
+        owner_key_bp: Option<usize>,
+        direct_key_value: bool,
+    ) {
+        let frame_len = self.indent_stack.len();
+        self.trim_seq_frames_to(frame_len - 1);
+        let serial = self.next_seq_serial;
+        self.next_seq_serial += 1;
+        self.seq_frames.push(SeqFrame {
+            serial,
+            frame_len,
+            indent,
+            owner_key_bp,
+            direct_key_value,
+        });
+    }
+
+    /// A bare `- # c` item's trailing comment whose value turned out absent
+    /// (#1079): there is no node to attach it to, so real yq moves it -- see
+    /// [`Self::floated_item_comment`]. It joins the pending standalone
+    /// block, which is what carries it forward, in source order: the
+    /// absence lookahead has already recorded any comment-only lines that
+    /// follow it (`- # c\n# h\n- 2\n` reads `c\nh` on `.[1]`).
+    ///
+    /// Called with the item frame on top of the stack, so the sequence is
+    /// the frame below it.
+    fn float_absent_item_comment(&mut self, range: (u32, u32)) {
+        // An earlier float whose own sequence has closed since (this item
+        // is in an outer sequence: `a:\n  - b:\n      - # c\n  - # d\n`)
+        // settles onto its key's foot now, before this one takes its place
+        // as the pending float -- real yq gives `.a[0].b`'s key `c` there.
+        // One from this same sequence simply goes forward with the block.
+        if let Some(previous) = self.floated_item_comment.take() {
+            self.settle_float_if_sequence_closed(previous, None);
+        }
+        let Some(frame) = self.enclosing_seq_frame() else {
+            return; // omni-dev: coverage tolerate-line reason="unreachable: every block-sequence open registers a frame at its own depth before any item of it can be parsed (#1079)"
+        };
+        let idx = self
+            .pending_head_lines
+            .partition_point(|&(start, _)| start < range.0);
+        self.pending_head_lines.insert(idx, range);
+        self.block_passed_absent_item = true;
+        self.floated_item_comment = Some(FloatedItemComment {
+            range,
+            seq_serial: frame.serial,
+            seq_indent: frame.indent,
+            owner_key_bp: frame.owner_key_bp,
+            direct_key_value: frame.direct_key_value,
+        });
     }
 
     /// Settle a pending block whose forward attachment is already disproven
@@ -795,8 +1079,7 @@ impl<'a, const HAS_CR: bool> Parser<'a, HAS_CR> {
             return; // omni-dev: coverage tolerate-line reason="unreachable: this function's sole caller (record_standalone_comment) only invokes it from inside a match on `pending_head_lines.last()`, so pending_head_lines is already known non-empty here (#798)"
         }
         if let Some(prev) = self.last_head_foot_bp {
-            let pending = &mut self.pending_head_lines;
-            self.comments.entry(prev).or_default().foot.append(pending);
+            self.drain_pending_into_foot(prev);
         }
     }
 
@@ -810,17 +1093,18 @@ impl<'a, const HAS_CR: bool> Parser<'a, HAS_CR> {
     /// standalone comment of their own (a comment above a nested mapping's
     /// first key belongs to that key, measured), and not for an inline
     /// `k: v`'s value node.
-    fn attach_head_foot_to_key(&mut self) {
-        self.attach_head_foot_at(self.last_open_bp_pos);
+    fn attach_head_foot_to_key(&mut self, column: usize) {
+        self.attach_head_foot_at(self.last_open_bp_pos, column);
     }
 
     /// [`Self::attach_head_foot_to_key`] for a node whose bp is known but
     /// which has not opened yet — a sequence item's content, flushed *before*
     /// `parse_value` runs so [`Self::flush_pending_head_lines`] still sees
     /// `self.pos` at the content's own line rather than past the whole value.
-    fn attach_head_foot_at(&mut self, bp: usize) {
-        self.flush_pending_head_lines(Some(bp));
+    fn attach_head_foot_at(&mut self, bp: usize, column: usize) {
+        self.flush_pending_head_lines(Some((bp, column)));
         self.last_head_foot_bp = Some(bp);
+        self.block_passed_absent_item = false;
         self.saw_head_foot_node = true;
         // A real node has now opened in this document, so a later blank
         // line detaching *its own* `PREV` must fall forward as usual, not
@@ -849,7 +1133,7 @@ impl<'a, const HAS_CR: bool> Parser<'a, HAS_CR> {
     /// path.
     fn flush_pending_head_lines_at_boundary(
         &mut self,
-        next_bp: Option<usize>,
+        next: Option<(usize, usize)>,
         old_root_bp: Option<usize>,
     ) {
         if self.pending_head_lines.is_empty() {
@@ -859,36 +1143,42 @@ impl<'a, const HAS_CR: bool> Parser<'a, HAS_CR> {
             let block_end = self.pending_head_lines[self.pending_head_lines.len() - 1].1 as usize;
             let adjacent_to_marker = !self.blank_line_between(block_end, self.pos);
             if adjacent_to_marker {
-                let pending = &mut self.pending_head_lines;
-                self.comments
-                    .entry(old_root)
-                    .or_default()
-                    .foot
-                    .append(pending);
+                self.drain_pending_into_foot(old_root);
                 return;
             }
         }
-        self.flush_pending_head_lines(next_bp);
+        self.flush_pending_head_lines(next);
     }
 
-    /// Whether a wholly blank line lies in `[from, to)` — i.e. whether the
-    /// text there holds two or more line breaks (`\r\n` counting once). One
-    /// break is just the end of the earlier line; a second means an empty
-    /// line came between.
+    /// Whether a wholly blank line (empty or inline whitespace only) lies in
+    /// `[from, to)`.
+    ///
+    /// Every caller passes `from` at the end of a comment line's text, so
+    /// the first break scanned is that line's own; `to` is always mid-line
+    /// (a key, a value, or just past a `---`), so a trailing partial line is
+    /// never counted. Lines with content in between are not blank: an
+    /// empty `-` item or a bare `-` whose value is deferred sits between a
+    /// comment block and the node it heads without attaching anything
+    /// itself, and counting its line break as a blank line sent the block
+    /// backwards onto `PREV`'s foot (`- 1\n# h\n-\n- 3\n` is `.[2]`'s head
+    /// in real yq, #1079).
     fn blank_line_between(&self, from: usize, to: usize) -> bool {
-        let mut breaks = 0usize;
+        let mut seen_content = true;
         let mut p = from;
         let end = to.min(self.input.len());
         while p < end {
-            if is_line_break(self.input[p]) {
-                breaks += 1;
-                if breaks >= 2 {
+            let byte = self.input[p];
+            if is_line_break(byte) {
+                if !seen_content {
                     return true;
                 }
+                seen_content = false;
                 // CRLF is one break.
-                if self.input[p] == b'\r' && p + 1 < end && self.input[p + 1] == b'\n' {
+                if byte == b'\r' && p + 1 < end && self.input[p + 1] == b'\n' {
                     p += 1;
                 }
+            } else if !Self::is_inline_whitespace(byte) {
+                seen_content = true;
             }
             p += 1;
         }
@@ -1805,7 +2095,7 @@ impl<'a, const HAS_CR: bool> Parser<'a, HAS_CR> {
         // a block still pending here may belong to the *closing* document
         // instead (see [`Self::flush_pending_head_lines_at_boundary`]).
         let root_bp = self.document_start_bp_pos;
-        self.flush_pending_head_lines_at_boundary(Some(root_bp), old_root_bp);
+        self.flush_pending_head_lines_at_boundary(Some((root_bp, 0)), old_root_bp);
         self.last_head_foot_bp = None;
         // Primes the no-`PREV` fallback for whatever comes next in the new
         // document -- see [`Self::document_boundary_fallback_bp`].
@@ -2797,11 +3087,24 @@ impl<'a, const HAS_CR: bool> Parser<'a, HAS_CR> {
             || !self.sequence_frame_reaches(self.indent_stack.len() - 1, indent);
 
         if need_new_sequence {
+            // The nearest enclosing mapping key is where real yq puts a
+            // comment floated off an absent item of this sequence when the
+            // sequence closes past a dedent (#1079): the key whose value
+            // this sequence is -- the key whose line just ended -- or, for
+            // a sequence nested in a sequence item, the enclosing
+            // sequence's own. Read before the push below changes
+            // `current_type`. See `settle_float_if_sequence_closed`.
+            let (owner_key_bp, direct_key_value) = match self.current_type {
+                Some(NodeType::Mapping) => (self.last_head_foot_bp, true),
+                Some(NodeType::SequenceItem) => (self.enclosing_seq_owner_key(), false),
+                _ => (None, false),
+            };
             // Open new sequence
             self.write_bp_open();
             self.write_ty(true); // 1 = sequence
             self.indent_stack.push(indent);
             self.push_type(NodeType::Sequence);
+            self.register_seq_frame(indent, owner_key_bp, direct_key_value);
         }
 
         // Normalize to the sequence's own recorded indent for everything below:
@@ -2826,9 +3129,9 @@ impl<'a, const HAS_CR: bool> Parser<'a, HAS_CR> {
         // fresh line dispatch) claims it at its own, already-instrumented
         // key/wrapper-open site instead. The wrapper's own bp *is* read for
         // a bare item's (`had_property == false`) trailing comment when its
-        // value is deferred to the next line (#1079, below) — that comment
-        // has no node of its own yet, so the wrapper is the only bp
-        // available to key it against.
+        // value is deferred to a node on a later line (#1079, below) — that
+        // node hasn't opened yet, so the wrapper is the only bp available
+        // to key the comment against.
         let wrapper_bp = self.last_open_bp_pos;
 
         // Skip `- `
@@ -2867,19 +3170,60 @@ impl<'a, const HAS_CR: bool> Parser<'a, HAS_CR> {
             // value, not to the item's dash line (#784, same shape as
             // `parse_mapping_entry`'s anchor case). A property-prefixed
             // item defers it past the property (`defer_line_comment`,
-            // #784); a bare item has no property to defer past, so it's
-            // captured against the item wrapper's own bp instead (#1079) —
-            // the emitter only renders it when the deferred value
-            // materializes into a real node (a mapping, nested sequence, or
-            // scalar). An absent (null) value has nothing to attach it to
-            // and the comment is dropped here, matching current behavior —
-            // real yq floats it forward onto the next sibling item instead,
-            // which needs a multi-valued head/line/foot comment slot this
-            // codebase doesn't have yet (#798 PR2).
+            // #784). A bare item has no property to defer past, and where
+            // the comment goes depends on whether a value follows at all
+            // (#1079):
+            //
+            // - deferred to a node on a later line (a mapping, nested
+            //   sequence, or scalar): captured against the item wrapper's
+            //   own bp, which the emitter renders on the dash line (or, for
+            //   a scalar, above it) -- and that node, opening next at
+            //   `self.bp_pos`, is the one `.[i]` resolves to and real yq
+            //   answers `head_comment` from (`# h\n-\n  x\n` is `.[1]`'s
+            //   head, not `.[0]`'s foot), so any pending standalone block
+            //   attaches to it here, exactly as the plain-scalar arm below
+            //   does for `- x`;
+            // - absent (the next content is a sibling item, a dedent, or
+            //   end of input): there is no node, and real yq floats the
+            //   comment -- see `float_absent_item_comment`. An absent item
+            //   with no comment attaches nothing either, so a block above
+            //   it reaches the next item that does exist -- and it ends an
+            //   earlier floated comment's claim on the enclosing key's foot
+            //   (`a:\n  - # c\n  -\nb: 2\n` heads `b`, measured).
             if had_property {
                 self.defer_line_comment();
             } else {
-                self.maybe_capture_line_comment(wrapper_bp);
+                let trailing = self.scan_trailing_comment();
+                // The lookahead also records comment-only lines between
+                // this dash and the following content. Those sit *inside*
+                // the deferred value and belong to its first node
+                // (`-\n  # c\n  - x\n` heads `.[0][0]`, measured), so only
+                // the lines already pending here are this value's own head.
+                let above_dash = self.pending_head_lines.len();
+                if self.following_value_is_null(indent) {
+                    match trailing {
+                        Some(range) => self.float_absent_item_comment(range),
+                        None => self.end_float(),
+                    }
+                    // A null item is still content: a block after it at end
+                    // of document is the root's foot, not a comment-only
+                    // document's head (`-\n# c\n`, measured).
+                    self.saw_head_foot_node = true;
+                } else {
+                    // The lookahead can also have *settled* the block (a
+                    // blank line after it resolves it backwards), so clamp.
+                    let above_dash = above_dash.min(self.pending_head_lines.len());
+                    let below_dash = self.pending_head_lines.split_off(above_dash);
+                    self.attach_head_foot_at(self.bp_pos, indent);
+                    self.pending_head_lines = below_dash;
+                    if let Some(range) = trailing {
+                        self.comments
+                            .entry(wrapper_bp)
+                            .or_default()
+                            .line
+                            .get_or_insert(range);
+                    }
+                }
             }
 
             // An anchor records the *next* BP position as its target, and a
@@ -2968,7 +3312,7 @@ impl<'a, const HAS_CR: bool> Parser<'a, HAS_CR> {
             // directly for one, with no `key` step (#798). Flushed before
             // `parse_value` so the blank-line check still sees `self.pos` on
             // the item's own line.
-            self.attach_head_foot_at(bp_pos_before_value);
+            self.attach_head_foot_at(bp_pos_before_value, indent);
             self.parse_value(indent)?;
             // Claim a comment deferred by an earlier anchor's deferred value
             // (#784): a plain-scalar item's own trailing comment lives on
@@ -3035,7 +3379,7 @@ impl<'a, const HAS_CR: bool> Parser<'a, HAS_CR> {
         // Open key node
         self.write_bp_open();
         // Standalone comments attach to a mapping entry's *key* (#798).
-        self.attach_head_foot_to_key();
+        self.attach_head_foot_to_key(indent);
 
         // Check for a property on the key (`- &a k: v` / `- !!str k: v`) -
         // record it pointing to this key.
@@ -3281,7 +3625,7 @@ impl<'a, const HAS_CR: bool> Parser<'a, HAS_CR> {
         // Open key node
         self.write_bp_open();
         // Standalone comments attach to a mapping entry's *key* (#798).
-        self.attach_head_foot_to_key();
+        self.attach_head_foot_to_key(indent);
 
         // Check for a property on the key - record it pointing to this key BP
         self.record_key_properties()?;
@@ -3662,6 +4006,14 @@ impl<'a, const HAS_CR: bool> Parser<'a, HAS_CR> {
         // Check for a property before the key
         self.parse_node_properties()?;
 
+        // Standalone comments attach to the key node (#798), which every
+        // arm below opens at `self.bp_pos` -- inline, on a later line, or
+        // synthesized empty -- so attach before the dispatch, as
+        // `parse_mapping_entry` does at its key open. Also makes this key
+        // the owner of a same-indent sequence value's floated item comment
+        // (`? a\n:\n  - # c\nb: 2\n` is `.a`'s key's foot, #1079).
+        self.attach_head_foot_at(self.bp_pos, indent);
+
         // Check what the key is
         if self.at_line_end() {
             // Key content might be on next line(s), or this could be an empty key
@@ -3745,6 +4097,8 @@ impl<'a, const HAS_CR: bool> Parser<'a, HAS_CR> {
                 self.write_ty(true); // sequence
                 self.indent_stack.push(indent + 2); // Indent for sequence content
                 self.push_type(NodeType::Sequence);
+                // A key is nobody's value, so no owner key (#1079).
+                self.register_seq_frame(indent + 2, None, false);
 
                 // Parse first sequence item inline
                 self.write_bp_open_seq_item(); // item node

--- a/src/yaml/parser.rs
+++ b/src/yaml/parser.rs
@@ -3220,11 +3220,7 @@ impl<'a, const HAS_CR: bool> Parser<'a, HAS_CR> {
                     self.attach_head_foot_at(self.bp_pos, indent);
                     self.pending_head_lines = below_dash;
                     if let Some(range) = trailing {
-                        self.comments
-                            .entry(wrapper_bp)
-                            .or_default()
-                            .line
-                            .get_or_insert(range);
+                        self.push_line_comment(wrapper_bp, range);
                     }
                 }
             }

--- a/src/yaml/parser.rs
+++ b/src/yaml/parser.rs
@@ -3200,7 +3200,10 @@ impl<'a, const HAS_CR: bool> Parser<'a, HAS_CR> {
                 // (`-\n  # c\n  - x\n` heads `.[0][0]`, measured), so only
                 // the lines already pending here are this value's own head.
                 let above_dash = self.pending_head_lines.len();
-                if self.following_value_is_null(indent) {
+                let value_is_null = self
+                    .next_line_settles_value_is_null(indent)
+                    .unwrap_or_else(|| self.following_value_is_null(indent));
+                if value_is_null {
                     match trailing {
                         Some(range) => self.float_absent_item_comment(range),
                         None => self.end_float(),
@@ -3362,6 +3365,37 @@ impl<'a, const HAS_CR: bool> Parser<'a, HAS_CR> {
         let is_null = self.peek().is_none() || self.count_indent().unwrap_or(0) <= indent;
         self.pos = saved_pos;
         is_null
+    }
+
+    /// [`Self::following_value_is_null`]'s answer read straight off the
+    /// next line when that line settles it by itself: ordinary content at
+    /// some indent, or end of input. `None` when the next line is blank,
+    /// comment-only, or tab-led -- anything `skip_newlines` has an opinion
+    /// about -- so the caller falls back to the full lookahead and the two
+    /// cannot disagree. Called with `self.pos` on the current line's break.
+    ///
+    /// Exists for the bare `-` item, the common shape in record-style
+    /// documents (`-\n  name: ...` per record, #1079): the full lookahead
+    /// measured +0.9% on that shape, this reads a handful of bytes.
+    #[inline]
+    fn next_line_settles_value_is_null(&self, indent: usize) -> Option<bool> {
+        let mut p = self.pos;
+        let Some(&b) = self.input.get(p) else {
+            return Some(true);
+        };
+        if !Self::is_break(b) {
+            return None;
+        }
+        p += 1;
+        if b == b'\r' && self.input.get(p) == Some(&b'\n') {
+            p += 1;
+        }
+        let spaces = super::simd::count_leading_spaces(self.input, p);
+        match self.input.get(p + spaces) {
+            Some(&b) if !Self::is_break(b) && b != b'#' && b != b'\t' => Some(spaces <= indent),
+            None if spaces == 0 => Some(true),
+            _ => None,
+        }
     }
 
     /// Parse a compact mapping entry within a sequence item.

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -16316,6 +16316,49 @@ fn test_absent_item_comment_settles_when_inner_sequence_closes_1079_float() -> R
     assert_yq_getter(input, ".a | key | foot_comment", "c\nd\n")
 }
 
+/// A node's `foot` can accumulate from two different code paths: a floated
+/// comment settling via `settle_float_if_sequence_closed` when its sequence
+/// closes onto an outer item, and a later, wholly separate standalone block
+/// falling backward onto that same item as `PREV` (the ordinary #798 rule).
+/// Both must land in source order -- `.[1]`'s own inner float first, the
+/// later detached block second -- not the reverse.
+#[test]
+fn test_floated_and_ordinary_foot_entries_on_the_same_node_stay_in_order_1079_float() -> Result<()>
+{
+    assert_yq_getter(
+        "- - 1\n  - # c\n- 2\n# f\n\n- 3\n",
+        ".[1] | foot_comment",
+        "c\nf\n",
+    )
+}
+
+/// `SeqFrame::serial` (`Parser::seq_frames`) exists to tell a still-open
+/// sequence apart from a *different* one that has since opened at the same
+/// stack depth -- pins that this identity tracking is load-bearing, not
+/// redundant with the depth (`indent_stack.len()`) it also carries.
+///
+/// `k`'s two inline-nested-sequence items (`- - # c1`, `- - # c2`) each open
+/// their own inner sequence at the same depth, back to back, with no
+/// intervening node open (an inline `- - x` item never calls
+/// `attach_head_foot_at` for its own dash -- it recurses straight into the
+/// nested sequence) to settle `c1` in between. By the time `c2`'s own
+/// absent item registers its float, item 1's inner sequence has already
+/// replaced item 0's at that same depth: a depth-only check (matching a
+/// hypothetical simplification that reads a sequence's identity off
+/// `type_stack`/`indent_stack` alone, dropping `serial`) would wrongly read
+/// this as "still open" and never settle `c1` onto `k`'s foot at all --
+/// confirmed by a throwaway experimental patch during #1079's review that
+/// this exact input diverges from real yq (empty instead of `c1`) with that
+/// simplification and matches with `serial` intact.
+#[test]
+fn test_seq_frame_serial_distinguishes_sibling_frames_at_the_same_depth_1079_float() -> Result<()> {
+    assert_yq_getter(
+        "k:\n  - - # c1\n  - - # c2\n",
+        ".k | key | foot_comment",
+        "c1\n",
+    )
+}
+
 /// Real yq *drops* the first of two floated comments in a nested sequence
 /// that closes to an outer absent item (`c1` here appears in no slot and
 /// is not printed). Discarding it to match is exactly what ADR-0018 rule 4

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -16139,13 +16139,72 @@ fn test_absent_item_comment_at_end_is_root_foot_1079_float() -> Result<()> {
     assert_yq_getter("a:\n- # c\n", ". | foot_comment", "c\n")
 }
 
-/// A document marker ends the document the same way end of input does.
+/// A document marker ends a root-level sequence's floated comment the same
+/// way end of input does -- with no owner key, there's nowhere else for it
+/// to go either way. A blank line before the marker doesn't change this,
+/// unlike the ordinary (non-floated) #798 rule for a ROOT-level float:
+/// document-boundary settling runs before the blank-line-adjacency check
+/// (see [`Parser::flush_pending_head_lines_at_boundary`]).
 #[test]
 fn test_absent_item_comment_before_document_marker_is_root_foot_1079_float() -> Result<()> {
     let (out, code) = run_yq_stdin(". | foot_comment", "- # c\n---\n- 2\n", &[])?;
     assert_eq!(code, 0);
     assert_eq!(out.lines().next(), Some("c"));
-    Ok(())
+
+    assert_yq_getter(
+        "- 1\n- # c\n\n---\n- 2\n",
+        "select(document_index==0) | foot_comment",
+        "c\n",
+    )?;
+    // Not the previous sibling item -- the whole first document's own foot.
+    assert_yq_getter(
+        "- 1\n- # c\n\n---\n- 2\n",
+        "select(document_index==0) | .[0] | foot_comment",
+        "\n",
+    )
+}
+
+/// Unlike true end of input (which collapses a floated comment's owner key
+/// onto the document *root*'s foot regardless -- see
+/// [`test_absent_item_comment_at_end_is_root_foot_1079_float`]), a document
+/// boundary still respects the owner key: measured against pinned yq
+/// v4.53.3, `a:\n  - # c\n---\nb: 2\n` puts `c` on `.a`'s foot, not the
+/// document's own root foot -- whether or not a blank line separates the
+/// comment from the `---` marker.
+#[test]
+fn test_absent_item_comment_before_document_marker_is_owner_key_foot_1079_float() -> Result<()> {
+    assert_yq_getter(
+        "a:\n  - # c\n---\nb: 2\n",
+        "select(document_index==0) | .a | key | foot_comment",
+        "c\n",
+    )?;
+    assert_yq_getter(
+        "a:\n  - # c\n---\nb: 2\n",
+        "select(document_index==0) | foot_comment",
+        "\n",
+    )?;
+    assert_yq_getter(
+        "a:\n  - # c\n\n---\nb: 2\n",
+        "select(document_index==0) | .a | key | foot_comment",
+        "c\n",
+    )?;
+    assert_yq_getter(
+        "a:\n  - # c\n\n---\nb: 2\n",
+        "select(document_index==0) | foot_comment",
+        "\n",
+    )
+}
+
+/// An uncommented absent item (`block_passed_absent_item`, set without ever
+/// pushing into `pending_head_lines`) must not survive past the document it
+/// was seen in: a later, unrelated comment in the *next* document is that
+/// document's own concern, not a second "everything pending is the root's
+/// foot" trigger left over from the one before it.
+#[test]
+fn test_absent_item_flag_does_not_leak_across_document_boundary_1079_float() -> Result<()> {
+    let input = "- 1\n-\n---\n# c\n";
+    assert_yq_getter(input, "select(document_index==0) | foot_comment", "c\n")?;
+    assert_yq_getter(input, "select(document_index==1) | foot_comment", "\n")
 }
 
 /// The sequence closes to a mapping key: the comment is the foot of the key

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -16298,7 +16298,12 @@ fn test_absent_item_comment_residuals_1079_float() -> Result<()> {
 
     let input = "- k:\n  - # c\n  - # d\n- 2\n";
     assert_yq_getter(input, ".[0].k | key | foot_comment", "d\n")?;
-    assert_yq_getter(input, ".[1] | head_comment", "c\n")
+    assert_yq_getter(input, ".[1] | head_comment", "c\n")?;
+    // A root-level nested sequence has no key to settle onto and the next
+    // outer item is itself absent: real yq keeps only `c5` on `.[2]`.
+    let input = "-\n  - # c3\n- # c5\n- 6\n";
+    assert_yq_getter(input, ".[2] | head_comment", "c3\nc5\n")?;
+    assert_yq_getter(input, ".[1] | foot_comment", "\n")
 }
 
 /// A standalone block above a bare `-` whose value is deferred to the next

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -16439,6 +16439,23 @@ fn test_explicit_key_owns_head_and_foot_comments_1079_float() -> Result<()> {
     assert_yq_getter("? a\n: 1\n# h\nb: 2\n", ".b | key | head_comment", "h\n")
 }
 
+/// A sequence used as an explicit key is nobody's *value* -- but a comment
+/// floated off one of its own absent items still lands on this key's own
+/// foot when the sequence closes past a dedent, the same as it would for
+/// an ordinary mapping value's sequence (measured against pinned yq
+/// v4.53.3: `to_entries` shows `c` right after the entry's `value: v`, not
+/// floating forward onto the next key's head the way a truly keyless
+/// sequence's float would, #1079). Read via `keys | .[0]` rather than
+/// `.[""]`: addressing a non-scalar mapping key by its JSON-collapsed `""`
+/// form is a separate, pre-existing gap in succinctly's complex-key path
+/// resolution, unrelated to comment placement.
+#[test]
+fn test_sequence_as_explicit_key_owns_its_own_foot_1079_float() -> Result<()> {
+    let input = "? - a\n  - # c\n: v\nb: 2\n";
+    assert_yq_getter(input, ". | keys | .[0] | foot_comment", "c\n")?;
+    assert_yq_getter(input, ".b | key | head_comment", "\n")
+}
+
 // ============================================================================
 // Explicit-key (`? k ... : v`) trailing comment (#795)
 // ============================================================================

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -15934,16 +15934,26 @@ fn test_defer_line_comment_does_not_overwrite_already_pending_784() -> Result<()
 //
 // #784 (above) fixed this shape for a *property-prefixed* item (`- &x # c`);
 // this is the sibling gap for a *bare* item (`- # c`), same as #765 fixed
-// the mapping-key equivalent. Scoped to the three shapes where the deferred
-// value materializes into a real node - a mapping, a nested sequence, or a
-// scalar - since the comment is a `head_comment` on whichever node the
-// value contributes, per the issue's own oracle triage. An *absent* (null)
-// deferred value has no node to attach to; real yq instead floats the
-// comment forward onto the next sibling item that does exist, which needs a
-// multi-valued head/line/foot comment slot this codebase doesn't have yet
-// (#798 PR2) - that family stays exactly as it was (comment dropped), not a
-// regression, just not fixed here. Every expected string below was verified
-// byte-for-byte against the pinned real `yq` binary before being pinned.
+// the mapping-key equivalent. Two families, by whether the deferred value
+// exists at all:
+//
+// - it materializes into a real node (a mapping, a nested sequence, or a
+//   scalar): the comment is rendered with that node, and the tests below
+//   pin the identity output;
+// - it is *absent* (a sibling item, a dedent, or end of input follows):
+//   there is no node to attach to, and real yq *floats* the comment --
+//   forward onto the next item of the same sequence as its `head_comment`
+//   (accumulating across consecutive absent items), or, when the sequence
+//   closes to a mapping key first, the last one becomes the enclosing key's
+//   `foot_comment` while the rest go forward, or at end of document all of
+//   them become the root's `foot_comment`. The parser now attributes these
+//   exactly as yq reports them through the getters (the `_1079_float` tests
+//   below), but the streaming emitter does not yet print any head/foot
+//   comment (#2795), so the identity output for this family still drops
+//   them -- pinned as such so #2795 has to update those pins deliberately.
+//
+// Every expected value below was captured from the pinned real `yq` binary
+// before being pinned.
 
 /// The issue's own repro: a bare item's trailing comment, value deferred to
 /// a nested mapping.
@@ -16036,19 +16046,333 @@ fn test_bare_item_comment_not_exposed_via_line_comment_getter_1079() -> Result<(
     Ok(())
 }
 
-/// Known residual, out of scope for this fix: when the deferred value is
-/// *absent* (null - a sibling item follows at the same or lower indent),
-/// real yq floats the comment forward onto that sibling instead of
-/// attaching it here, which needs #798 PR2's multi-valued comment slot.
-/// Pinned as still-dropped (not the corrupted `- # c` inline rendering an
-/// earlier version of this fix produced) so a future #798 PR2 change has to
-/// deliberately update this test rather than silently drift.
+/// Run `filter` over `input` and compare its stdout (a getter's one-line
+/// answer, `\n`-terminated) against what the pinned real `yq` prints for
+/// the same pair; the message names both so a failing row is identifiable.
+fn assert_yq_getter(input: &str, filter: &str, expected: &str) -> Result<()> {
+    let (out, code) = run_yq_stdin(filter, input, &[])?;
+    assert_eq!(code, 0, "{filter} on {input:?} failed");
+    assert_eq!(out, expected, "{filter} on {input:?}");
+    Ok(())
+}
+
+/// The absent family's identity output: the comment is attributed (see the
+/// getter tests below) but not yet printed, because no emitter renders a
+/// head/foot comment at all (#2795). Real yq prints `-\n# comment\n- 2\n`.
+/// Pinned as still-dropped -- not the corrupted `- # c` inline rendering an
+/// earlier version of the A/B/C fix produced -- so #2795 has to update this
+/// deliberately rather than drift.
 #[test]
 fn test_bare_item_comment_still_dropped_when_value_absent_1079() -> Result<()> {
     let (out, code) = run_yq_stdin(".", "- # comment\n- 2\n", &[])?;
     assert_eq!(code, 0);
     assert_eq!(out, "-\n- 2\n");
+
+    let (out, code) = run_yq_stdin(".", "a:\n  - # c\n  - # d\nb: 2\n", &[])?;
+    assert_eq!(code, 0);
+    assert_eq!(out, "a:\n  -\n  -\nb: 2\n");
     Ok(())
+}
+
+/// A sibling item follows: the comment is that item's head, whatever kind
+/// of node it is, and never the absent item's own line comment.
+#[test]
+fn test_absent_item_comment_floats_onto_next_sibling_head_1079_float() -> Result<()> {
+    assert_yq_getter("- # c\n- 2\n", ".[1] | head_comment", "c\n")?;
+    assert_yq_getter("- # c\n- 2\n", ".[0] | line_comment", "\n")?;
+    assert_yq_getter("- # c\n- 2\n", ".[0] | head_comment", "\n")?;
+    assert_yq_getter("- # c\n- 2 # own\n", ".[1] | head_comment", "c\n")?;
+    assert_yq_getter("- # c\n- 2 # own\n", ".[1] | line_comment", "own\n")?;
+    assert_yq_getter("- # c\n- &x 2\n", ".[1] | head_comment", "c\n")?;
+    assert_yq_getter("a:\n  - # c\n  - 2\n", ".a[1] | head_comment", "c\n")?;
+    assert_yq_getter("a:\n- # c\n- 2\n", ".a[1] | head_comment", "c\n")
+}
+
+/// Consecutive absent items accumulate onto the first item that exists, in
+/// source order, with any standalone comment lines in between -- `.[1]`
+/// gets nothing of its own.
+#[test]
+fn test_absent_item_comments_accumulate_forward_1079_float() -> Result<()> {
+    assert_yq_getter("- # c1\n- # c2\n- 3\n", ".[2] | head_comment", "c1\nc2\n")?;
+    assert_yq_getter("- # c1\n- # c2\n- 3\n", ".[1] | head_comment", "\n")?;
+    assert_yq_getter("- # c1\n- # c2\n- 3\n", ".[1] | line_comment", "\n")?;
+    assert_yq_getter("- # c\n# h\n- 2\n", ".[1] | head_comment", "c\nh\n")?;
+    assert_yq_getter("- # c\n  # h\n- 2\n", ".[1] | head_comment", "c\nh\n")?;
+    assert_yq_getter("- 1\n# h\n- # c\n- 3\n", ".[2] | head_comment", "h\nc\n")?;
+    assert_yq_getter("- 1\n# h\n- # c\n- 3\n", ".[0] | foot_comment", "\n")?;
+    assert_yq_getter("- # c\n-\n- 3\n", ".[2] | head_comment", "c\n")
+}
+
+/// The next item's own deferred scalar (case C above) keeps its comment in
+/// the item wrapper's slot, so the head getter answers only the floated
+/// one -- real yq joins both (`c1\nc2`). Once #2795 prints heads the
+/// rendering is identical (`-\n# c1\n# c2\n- x`), so this is pinned rather
+/// than fixed.
+#[test]
+fn test_absent_item_comment_before_deferred_scalar_item_1079_float() -> Result<()> {
+    assert_yq_getter("- # c1\n- # c2\n  x\n", ".[1] | head_comment", "c1\n")?;
+    let (out, code) = run_yq_stdin(".", "- # c1\n- # c2\n  x\n", &[])?;
+    assert_eq!(code, 0);
+    assert_eq!(out, "-\n# c2\n- x\n");
+    Ok(())
+}
+
+/// Nothing follows in the document: everything pending is the root's foot,
+/// at any nesting depth and regardless of which node opened last -- not
+/// the previous item's foot and not the enclosing key's.
+#[test]
+fn test_absent_item_comment_at_end_is_root_foot_1079_float() -> Result<()> {
+    assert_yq_getter("- # c\n", ". | foot_comment", "c\n")?;
+    assert_yq_getter("- # c\n", ". | head_comment", "\n")?;
+    assert_yq_getter("- # c\n", ".[0] | line_comment", "\n")?;
+    assert_yq_getter("- 1\n- # c\n", ". | foot_comment", "c\n")?;
+    assert_yq_getter("- 1\n- # c\n", ".[0] | foot_comment", "\n")?;
+    assert_yq_getter("- 1\n- # c\n", ".[1] | foot_comment", "\n")?;
+    assert_yq_getter("- # c\n# h\n", ". | foot_comment", "c\nh\n")?;
+    assert_yq_getter("- # c1\n- # c2\n", ". | foot_comment", "c1\nc2\n")?;
+    assert_yq_getter("- 1\n-\n# c\n", ". | foot_comment", "c\n")?;
+    assert_yq_getter("- 1\n-\n# c\n", ".[0] | foot_comment", "\n")?;
+    assert_yq_getter("- 1\n-\n- 2\n# c\n", ".[2] | foot_comment", "c\n")?;
+    assert_yq_getter("a:\n  - # c\n", ". | foot_comment", "c\n")?;
+    assert_yq_getter("a:\n  - # c\n", ".a | key | foot_comment", "\n")?;
+    assert_yq_getter("a:\n  b:\n    - # c\n", ". | foot_comment", "c\n")?;
+    assert_yq_getter("a:\n- # c\n", ". | foot_comment", "c\n")
+}
+
+/// A document marker ends the document the same way end of input does.
+#[test]
+fn test_absent_item_comment_before_document_marker_is_root_foot_1079_float() -> Result<()> {
+    let (out, code) = run_yq_stdin(". | foot_comment", "- # c\n---\n- 2\n", &[])?;
+    assert_eq!(code, 0);
+    assert_eq!(out.lines().next(), Some("c"));
+    Ok(())
+}
+
+/// The sequence closes to a mapping key: the comment is the foot of the key
+/// the sequence was the value of -- the enclosing key, not the most recent
+/// one and not the previous item -- however deep, and whatever kind of key.
+#[test]
+fn test_absent_item_comment_before_dedent_is_enclosing_key_foot_1079_float() -> Result<()> {
+    assert_yq_getter("a:\n  - # c\nb: 2\n", ".a | key | foot_comment", "c\n")?;
+    assert_yq_getter("a:\n  - # c\nb: 2\n", ".b | key | head_comment", "\n")?;
+    assert_yq_getter(
+        "a:\n  - 1\n  - # c\nb: 2\n",
+        ".a | key | foot_comment",
+        "c\n",
+    )?;
+    assert_yq_getter("a:\n  - 1\n  - # c\nb: 2\n", ".a[0] | foot_comment", "\n")?;
+    assert_yq_getter(
+        "a:\n  - b: 1\n  - # c\nd: 2\n",
+        ".a | key | foot_comment",
+        "c\n",
+    )?;
+    assert_yq_getter(
+        "a:\n  - b: 1\n  - # c\nd: 2\n",
+        ".a[0].b | key | foot_comment",
+        "\n",
+    )?;
+    assert_yq_getter(
+        "a:\n  x: 1\n  y:\n    - # c\nb: 2\n",
+        ".a.y | key | foot_comment",
+        "c\n",
+    )?;
+    assert_yq_getter(
+        "a:\n  x: 1\n  y:\n    - # c\nb: 2\n",
+        ".a | key | foot_comment",
+        "\n",
+    )?;
+    assert_yq_getter(
+        "- a: 1\n  b:\n    - # c\n  d: 2\n",
+        ".[0].b | key | foot_comment",
+        "c\n",
+    )?;
+    assert_yq_getter("? a\n:\n  - # c\nb: 2\n", ".a | key | foot_comment", "c\n")?;
+    // A sequence at its key's own indent is not "closed to" that key in
+    // real yq's model: the comment goes forward onto the next key instead.
+    assert_yq_getter("a:\n- # c\nb: 2\n", ".a | key | foot_comment", "\n")?;
+    assert_yq_getter("a:\n- # c\nb: 2\n", ".b | key | head_comment", "c\n")
+}
+
+/// Several absent items before the dedent: only the *last* floated comment
+/// becomes the enclosing key's foot; the earlier ones, and any standalone
+/// lines, go forward onto the next key's head.
+#[test]
+fn test_last_of_several_absent_item_comments_is_the_foot_1079_float() -> Result<()> {
+    assert_yq_getter(
+        "a:\n  - # c\n  - # d\nb: 2\n",
+        ".a | key | foot_comment",
+        "d\n",
+    )?;
+    assert_yq_getter(
+        "a:\n  - # c\n  - # d\nb: 2\n",
+        ".b | key | head_comment",
+        "c\n",
+    )?;
+    assert_yq_getter(
+        "a:\n  - # c\n  - # d\n  - # e\nb: 2\n",
+        ".a | key | foot_comment",
+        "e\n",
+    )?;
+    assert_yq_getter(
+        "a:\n  - # c\n  - # d\n  - # e\nb: 2\n",
+        ".b | key | head_comment",
+        "c\nd\n",
+    )?;
+    assert_yq_getter("a:\n  - # c\n# d\nb: 2\n", ".a | key | foot_comment", "c\n")?;
+    assert_yq_getter("a:\n  - # c\n# d\nb: 2\n", ".b | key | head_comment", "d\n")
+}
+
+/// The sequence closes to an *outer item* rather than a key. A sequence
+/// that is a key's own value keeps that key as the target (`.a[0].b`, a
+/// same-indent `k:\n- # c` alike); one nested straight inside an item has
+/// no key of its own and the comment becomes the outer item's foot
+/// instead -- unless a key opens next, when it is the inherited key's.
+#[test]
+fn test_absent_item_comment_settles_when_inner_sequence_closes_1079_float() -> Result<()> {
+    let input = "a:\n  - b:\n      - # c\n  - # d\nz: 1\n";
+    assert_yq_getter(input, ".a[0].b | key | foot_comment", "c\n")?;
+    assert_yq_getter(input, ".a | key | foot_comment", "d\n")?;
+    assert_yq_getter(input, ".a[1] | head_comment", "\n")?;
+    assert_yq_getter(input, ".z | key | head_comment", "\n")?;
+    let input = "a:\n  - b:\n      - # c\n  - 2\nz: 1\n";
+    assert_yq_getter(input, ".a[0].b | key | foot_comment", "c\n")?;
+    assert_yq_getter(input, ".a[1] | head_comment", "\n")?;
+    let input = "a:\n  - b:\n      - # c\n  -\nz: 1\n";
+    assert_yq_getter(input, ".a[0].b | key | foot_comment", "c\n")?;
+    assert_yq_getter(input, ".z | key | head_comment", "\n")?;
+    let input = "- k:\n  - # c\n- 2\n";
+    assert_yq_getter(input, ".[0].k | key | foot_comment", "c\n")?;
+    assert_yq_getter(input, ".[1] | foot_comment", "\n")?;
+
+    assert_yq_getter("- - 1\n  - # c\n- 2\n", ".[1] | foot_comment", "c\n")?;
+    assert_yq_getter("- - 1\n  - # c\n- 2\n", ".[1] | head_comment", "\n")?;
+    assert_yq_getter("- - 1\n  - # c\n- 2\n", ".[0][1] | foot_comment", "\n")?;
+    let input = "a:\n  -\n    - # c\n  - 2\nb: 1\n";
+    assert_yq_getter(input, ".a[1] | foot_comment", "c\n")?;
+    assert_yq_getter(input, ".a | key | foot_comment", "\n")?;
+    let input = "a:\n  -\n    - # c\nb: 1\n";
+    assert_yq_getter(input, ".a | key | foot_comment", "c\n")?;
+    assert_yq_getter(input, ".b | key | head_comment", "\n")?;
+    let input = "a:\n  -\n    - # c\n  - # d\nb: 1\n";
+    assert_yq_getter(input, ".a | key | foot_comment", "c\nd\n")
+}
+
+/// Real yq *drops* the first of two floated comments in a nested sequence
+/// that closes to an outer absent item (`c1` here appears in no slot and
+/// is not printed). Discarding it to match is exactly what ADR-0018 rule 4
+/// forbids, so it goes forward onto the next key like any other pending
+/// comment -- a recorded divergence, not an oversight.
+#[test]
+fn test_nested_double_float_keeps_the_comment_yq_drops_1079_float() -> Result<()> {
+    let input = "a:\n  - b:\n      - # c1\n      - # c2\n  - # d\nz: 1\n";
+    assert_yq_getter(input, ".a[0].b | key | foot_comment", "c2\n")?;
+    assert_yq_getter(input, ".a | key | foot_comment", "d\n")?;
+    assert_yq_getter(input, ".z | key | head_comment", "c1\n")
+}
+
+/// Known residuals, pinned with real yq's answer in the comment so a change
+/// is deliberate:
+///
+/// - a sibling item that is a compact mapping or a nested sequence -- real
+///   yq answers `.[1] | head_comment` directly; here the comment attaches
+///   to the first key / inner item instead, the same attribution #798's
+///   standalone-line capture already has for `- 1\n# h\n- b: 1\n` (#2811);
+/// - a tag with no value on the item's next line (`- # c\n  !!str`) --
+///   real yq keeps the tag and floats the comment (`- !!str\n# c\n- 2`);
+///   here the tag is dropped (a pre-existing gap) and the comment with it;
+/// - several floated comments in a sequence that closes to an outer item
+///   or to end of input: real yq keeps only the last (`- k:\n  - # c\n
+///   - # d\n- 2\n` has `d` on `.[0].k`'s foot and `c` nowhere); here the
+///   rest go forward as the next node's head, per ADR-0018 rule 4.
+#[test]
+fn test_absent_item_comment_residuals_1079_float() -> Result<()> {
+    assert_yq_getter("- # c\n- b: 1\n", ".[1] | head_comment", "\n")?;
+    assert_yq_getter("- # c\n- b: 1\n", ".[1].b | key | head_comment", "c\n")?;
+    assert_yq_getter("- # c\n- - 1\n", ".[1] | head_comment", "\n")?;
+    assert_yq_getter("- # c\n- - 1\n", ".[1][0] | head_comment", "c\n")?;
+
+    assert_yq_getter("- # c\n  !!str\n- 2\n", ".[1] | head_comment", "\n")?;
+    let (out, code) = run_yq_stdin(".", "- # c\n  !!str\n- 2\n", &[])?;
+    assert_eq!(code, 0);
+    assert_eq!(out, "-\n- 2\n");
+
+    let input = "- k:\n  - # c\n  - # d\n- 2\n";
+    assert_yq_getter(input, ".[0].k | key | foot_comment", "d\n")?;
+    assert_yq_getter(input, ".[1] | head_comment", "c\n")
+}
+
+/// A standalone block above a bare `-` whose value is deferred to the next
+/// line is that value's head -- the node `.[1]` resolves to -- not the
+/// previous item's foot. Before this fix the bare item attached nothing,
+/// and its own line break was then miscounted as a blank line that
+/// "detached" the block backwards onto `.[0]`. Same for an empty `-` item
+/// with no value at all, which real yq skips over entirely.
+#[test]
+fn test_standalone_block_above_bare_deferred_item_is_its_head_1079_float() -> Result<()> {
+    assert_yq_getter("- 1\n# h\n-\n  x\n", ".[1] | head_comment", "h\n")?;
+    assert_yq_getter("- 1\n# h\n-\n  x\n", ".[0] | foot_comment", "\n")?;
+    assert_yq_getter("- 1\n# h\n-\n  b: 1\n", ".[1] | head_comment", "h\n")?;
+    assert_yq_getter("- 1\n# h\n-\n  - 2\n", ".[1] | head_comment", "h\n")?;
+    assert_yq_getter("- 1\n# h\n-\n- 3\n", ".[2] | head_comment", "h\n")?;
+    assert_yq_getter("- 1\n# h\n-\n- 3\n", ".[0] | foot_comment", "\n")?;
+    // The deferred value is now `PREV` for a later detached block.
+    assert_yq_getter("-\n  x\n# f\n\n- 2\n", ".[0] | foot_comment", "f\n")?;
+    assert_yq_getter("-\n  x\n# f\n\n- 2\n", ".[1] | head_comment", "\n")?;
+    // A property-prefixed item keeps deferring to its first key, which is
+    // where real yq puts the block for a mapping value.
+    assert_yq_getter(
+        "- 1\n# h\n- &x\n  b: 1\n",
+        ".[1].b | key | head_comment",
+        "h\n",
+    )?;
+    assert_yq_getter("- 1\n# h\n- &x\n  b: 1\n", ".[0] | foot_comment", "\n")
+}
+
+/// A blank line inside the absence lookahead's gap settles the pending
+/// block backwards while the bare item is still deciding what to do with
+/// it -- the split around that lookahead must not assume the block is
+/// still there (this panicked with `split index should be <= len` when
+/// found by differential fuzzing). Blank-line placement itself is a
+/// residual (real yq: `.[2] | head_comment` is `c\n\nh`, blank preserved
+/// inside the value); only the exit code and shape are pinned.
+#[test]
+fn test_blank_line_in_absence_lookahead_gap_does_not_panic_1079_float() -> Result<()> {
+    let (out, code) = run_yq_stdin(".", "- 1\n- # c\n\n-\n  # h\n  x\n", &[])?;
+    assert_eq!(code, 0);
+    assert_eq!(out, "- 1\n-\n- x\n");
+    Ok(())
+}
+
+/// Residual: a property-prefixed item whose deferred value is a *scalar*
+/// still attaches nothing (real yq: `.[1] | head_comment` is `h`), so the
+/// block now travels on to the next item that does -- previously it was
+/// misfiled as `.[0]`'s foot. Pinned so the shape changes deliberately.
+#[test]
+fn test_standalone_block_above_anchored_deferred_scalar_item_residual_1079_float() -> Result<()> {
+    assert_yq_getter("- 1\n# h\n- &x\n  2\n- 3\n", ".[1] | head_comment", "\n")?;
+    assert_yq_getter("- 1\n# h\n- &x\n  2\n- 3\n", ".[2] | head_comment", "h\n")?;
+    assert_yq_getter("- 1\n# h\n- &x\n  2\n- 3\n", ".[0] | foot_comment", "\n")
+}
+
+/// An explicit key owns head/foot comments like any other key (real yq
+/// answers `.a | key | head_comment`), which `parse_explicit_key` never
+/// hooked up -- the block fell back onto the previous key's foot.
+#[test]
+fn test_explicit_key_owns_head_and_foot_comments_1079_float() -> Result<()> {
+    assert_yq_getter(
+        "x: 0\n# h\n? a\n: 1\nb: 2\n",
+        ".a | key | head_comment",
+        "h\n",
+    )?;
+    assert_yq_getter(
+        "x: 0\n# h\n? a\n: 1\nb: 2\n",
+        ".x | key | foot_comment",
+        "\n",
+    )?;
+    assert_yq_getter("x: 0\n# h\n?\n  a\n: 1\n", ".a | key | head_comment", "h\n")?;
+    assert_yq_getter("? a\n: 1\n# f\n\nb: 2\n", ".a | key | foot_comment", "f\n")?;
+    assert_yq_getter("? a\n: 1\n# f\n\nb: 2\n", ".b | key | head_comment", "\n")?;
+    assert_yq_getter("? a\n: 1\n# h\nb: 2\n", ".b | key | head_comment", "h\n")
 }
 
 // ============================================================================


### PR DESCRIPTION
## Summary

The remaining half of #1079: a bare `- # c` whose value turns out *absent* (a sibling item, a dedent, or end of input follows). A/B/C (deferred mapping / nested sequence / scalar) landed in #2673; this attributes the absent family the way real yq does, so the `head_comment`/`foot_comment` getters agree with yq v4.53.3 on every shape below. The identity output still drops these comments until #2795 gives the streaming emitter a head/foot printer at all — that is now the only thing between #1079 and done, and needs no further #1079-specific work.

Scope was agreed as attribution-only (the 2026-09-08 plan's "blocked on #798 PR2" is stale: the `NodeComments { head, line, foot }` storage, standalone-line capture and getters are all on `main`; only the emitter isn't, tracked by #2795).

**yq's rule, measured live:** the comment goes forward onto the next item of the same sequence as its `head` (accumulating across consecutive absent items and any standalone lines between); when the sequence closes past a *dedent* first, the last one becomes a `foot` — of the key whose value the sequence is, or of the next outer item when the sequence is nested straight inside an item — and the rest go forward; at end of document everything pending is the root's `foot`, whatever `PREV` is. `.[i] | line_comment` is empty on every absent item.

| Input | yq slot | value | before |
|---|---|---|---|
| `- # c` / `- 2` | `.[1] \| head` | `c` | dropped; `.[0] \| line` leaked `c` |
| `- # c1` / `- # c2` / `- 3` | `.[2] \| head` | `c1\nc2` | dropped |
| `- # c` / `# h` / `- 2` | `.[1] \| head` | `c\nh` | dropped |
| `- # c` | `. \| foot` | `c` | dropped |
| `a:` / `  - # c` | `. \| foot` (not `.a`'s key) | `c` | dropped |
| `a:` / `  - # c` / `b: 2` | `.a \| key \| foot` | `c` | dropped |
| `a:` / `  - # c` / `  - # d` / `  - # e` / `b: 2` | `.a \| key \| foot` = `e`, `.b \| key \| head` = `c\nd` | | dropped |
| `a:` / `- # c` / `b: 2` (same column: not a dedent) | `.b \| key \| head` | `c` | dropped |
| `a:` / `  - b: 1` / `  - # c` / `d: 2` | `.a \| key \| foot` (enclosing, not most recent) | `c` | dropped |
| `? a` / `:` / `  - # c` / `b: 2` | `.a \| key \| foot` | `c` | dropped |
| `- - 1` / `  - # c` / `- 2` | `.[1] \| foot` | `c` | dropped |
| `a:` / `  - b:` / `      - # c` / `  - # d` / `z: 1` | `.a[0].b \| key \| foot` = `c`, `.a \| key \| foot` = `d` | | dropped |

Mechanism (`src/yaml/parser.rs`): the floated comment joins `pending_head_lines` in source order, so the forward/accumulate case is the ordinary #798 attach; a `SeqFrame` stack (serial + column + nearest enclosing key) lets `flush_pending_head_lines` tell a closed sequence from a reopened one at the same depth and settle the last float onto the right foot; the EOF flush routes a block that passed an absent item to the root.

### Also fixed — three #798 attribution gaps the float tests tripped over

- A standalone block above a bare `-` whose value is deferred (`# h` / `-` / `  x`, `-`/`  b: 1`, `-`/`  - 2`, or an empty `-`) landed on `PREV.foot` instead of `.[1] | head` (yq). Two causes: the bare item never called `attach_head_foot_at`, and `blank_line_between` counted *line breaks*, so the content-bearing `-` line between the block and its node read as a blank line that "detached" the block backwards. Now it counts blank lines.
- `parse_explicit_key` never called `attach_head_foot_to_key` (`x: 0` / `# h` / `? a` / `: 1` is `.a | key | head` in yq).
- `-` / `# c` at end of document read as a comment-only document's head; it is the root's foot.

### Recorded divergences (ADR-0018 rule 4), in `docs/compliance/yq/limitations.md`

- yq **drops** every floated comment but the last when several close to an outer item or to end of input inside a mapping (`- k:` / `  - # c` / `  - # d` / `- 2` keeps only `d`); we keep them, forward as the next node's head.
- A tag-only child (`- # c` / `  !!str` / `- 2`): yq keeps the tag and floats the comment; we drop both (the tag loss is pre-existing).
- The compact-item head attribution (`- 1` / `# h` / `- b: 1` heads `.[1]` in yq, `.[1].b`'s key here) is a pre-existing #798 gap the floated shape inherits — filed as **#2811** together with the column-sensitive EOF/dedent placement the fuzz surfaced. Blank-line shapes are unmodelled on both sides.

## Verification

- `tests/yq_cli_tests.rs`, `_1079_float` block: one getter assertion per oracle row above (every value re-captured from `yq` at test-writing time), the #798 fixes, residual pins with yq's answer in the doc comment, and a no-panic pin for a blank-line shape the fuzz crashed (`split_off` past a block the lookahead had settled).
- Differential fuzz against pinned yq (small docs over `-`, `- # c`, `- N`, `- N # own`, `# h`, `k:` dedents, 2–3 levels; every path's `head/line/foot_comment` compared): 0 crashes over 2,800 docs incl. blank lines; remaining mismatches are all in the three classes above plus #2811. Script attached below.
- `cargo test --features cli` (all CI test targets), default, `simd,scalar-yaml` and `--no-default-features` legs, both clippy legs, fmt, rustdoc `-D warnings`: green. Patch coverage 99.5% locally (the one line is a `tolerate-line` unreachable).
- Perf, interleaved A/B on `johns-mac-mini` (M4 Pro, idle), `yq -o json -I0` `.`/`.[]` over 2 MB `sequences`/`users`/`comprehensive`/`nested`, 21 reps, identity gate clean: median of medians **+0.12%** (range −0.3%..+0.5%) vs a control floor of −0.34% (−1.1%..−0.1%, same uniform sign) — neutral within the harness's own bias. The first cut read +0.9% on `users` (a bare `-` per record); the second commit reads the absence off the next line when it is unambiguous and only falls back to the full lookahead otherwise, which took that row to +0.1%.

<details><summary>fuzz_float.py</summary>

```python
#!/usr/bin/env python3
"""Differential fuzz: comment getters, succinctly vs pinned yq (#1079)."""
import json, os, random, subprocess, sys

SUCC = sys.argv[1]
N = int(sys.argv[2]) if len(sys.argv) > 2 else 300
SEED = int(sys.argv[3]) if len(sys.argv) > 3 else 1
BLANKS = "--blanks" in sys.argv
NOABC = "--no-abc" in sys.argv
rng = random.Random(SEED)
counter = [0]

def fresh():
    counter[0] += 1
    return f"c{counter[0]}"

def gen_seq(indent, depth, lines):
    n = rng.randint(1, 3)
    for _ in range(n):
        gen_item(indent, depth, lines)

def gen_item(indent, depth, lines):
    pad = " " * indent
    r = rng.random()
    if rng.random() < 0.15:
        lines.append(pad + "# " + fresh())
    if r < 0.30:
        lines.append(pad + "- # " + fresh())          # absent, floated
    elif r < 0.40:
        lines.append(pad + "-")                          # absent, no comment
    elif r < 0.55:
        v = fresh()
        own = " # " + fresh() if rng.random() < 0.3 else ""
        lines.append(pad + "- " + v + own)              # compact scalar
    elif r < 0.65 and depth < 2:
        lines.append(pad + "- # " + fresh() if (rng.random() < 0.5 and not NOABC) else pad + "-")
        lines.append(pad + "  " + fresh())              # deferred scalar
    elif r < 0.80 and depth < 2:
        lines.append(pad + "- # " + fresh() if (rng.random() < 0.5 and not NOABC) else pad + "-")
        gen_map(indent + 2, depth + 1, lines)           # deferred mapping
    elif depth < 2:
        lines.append(pad + "- # " + fresh() if (rng.random() < 0.5 and not NOABC) else pad + "-")
        gen_seq(indent + 2, depth + 1, lines)           # deferred sequence
    else:
        lines.append(pad + "- " + fresh())
    if BLANKS and rng.random() < 0.1:
        lines.append("")

def gen_map(indent, depth, lines):
    pad = " " * indent
    n = rng.randint(1, 3)
    for i in range(n):
        if rng.random() < 0.15:
            lines.append(pad + "# " + fresh())
        k = f"k{counter[0]}_{i}"
        r = rng.random()
        if r < 0.4:
            own = " # " + fresh() if rng.random() < 0.3 else ""
            lines.append(pad + k + ": " + fresh() + own)
        elif r < 0.75 and depth < 2:
            lines.append(pad + k + ":")
            gen_seq(indent + 2 if rng.random() < 0.8 else indent, depth + 1, lines)
        elif depth < 2:
            lines.append(pad + k + ":")
            gen_map(indent + 2, depth + 1, lines)
        else:
            lines.append(pad + k + ": " + fresh())
        if BLANKS and rng.random() < 0.1:
            lines.append("")

def gen_doc():
    counter[0] = 0
    lines = []
    if rng.random() < 0.5:
        gen_seq(0, 0, lines)
    else:
        gen_map(0, 0, lines)
    if rng.random() < 0.2:
        lines.append("# " + fresh())
    return "\n".join(lines) + "\n"

def run(binary, args, doc):
    p = subprocess.run([binary] + args, input=doc.encode(), capture_output=True)
    return p.returncode, p.stdout.decode(errors="replace"), p.stderr.decode(errors="replace")

def paths(node, prefix, out):
    out.append((prefix, False))
    if isinstance(node, dict):
        for k, v in node.items():
            p = prefix + f".{json.dumps(k)}" if prefix != "." else f".{json.dumps(k)}"
            out.append((p, True))
            paths(v, p, out)
    elif isinstance(node, list):
        for i, v in enumerate(node):
            p = (prefix if prefix != "." else "") + f".[{i}]"
            paths(v, p, out)

mismatches = 0
errors = 0
for i in range(N):
    doc = gen_doc()
    code, js, err = run("yq", ["-o=json", "-I0", "."], doc)
    if code != 0:
        continue  # yq rejects; not our concern here
    try:
        tree = json.loads(js.splitlines()[0]) if js.strip() else None
    except Exception:
        continue
    ps = []
    paths(tree, ".", ps)
    probes = []
    for p, is_key in ps:
        base = p if p != "." else "."
        for g in ("head_comment", "line_comment", "foot_comment"):
            probes.append(f"({base} | {g})")
            if is_key:
                probes.append(f"({base} | key | {g})")
    flt = "[" + ", ".join(probes) + "] | @json"
    yc, yo, ye = run("yq", [flt], doc)
    sc, so, se = run(SUCC, ["yq", flt], doc)
    if yc != 0 or sc != 0:
        errors += 1
        print(f"--- ERROR doc {i} (yq={yc}, succ={sc})\n{doc}{ye}{se}")
        continue
    if yo != so:
        mismatches += 1
        ya = json.loads(yo); sa = json.loads(so)
        print(f"--- MISMATCH doc {i}\n{doc}", end="")
        for pr, a, b in zip(probes, ya, sa):
            if a != b:
                print(f"   {pr}: yq={a!r} succ={b!r}")
print(f"docs={N} mismatches={mismatches} errors={errors}")
```
</details>
