### PR TITLE
fix(jq): make map(f) | .[] atomic outside a truncating consumer, as in jq

### DIFF
--- a/docs/adrs/README.md
+++ b/docs/adrs/README.md
@@ -48,6 +48,7 @@ by Michael Nygard.
 | [ADR-0019](adr-0019.md) | ✅ Accepted | 2026-08-22 | Reject Regex-Engine Swap for jq's l/n Flag Gaps (#920, #922)  |
 | [ADR-0020](adr-0020.md) | ✅ Accepted | 2026-09-01 | Evaluate User-Defined `def`s as Runtime Calls (#1371)         |
 | [ADR-0021](adr-0021.md) | ✅ Accepted | 2026-09-05 | Path Context as a Cursor Property, Not Walk State (#2416)     |
+| [ADR-0022](adr-0022.md) | ✅ Accepted | 2026-09-12 | Demand Budgets Ride the Sink (#2666)                          |
 
 The inventory is maintained by the [`update-adr-inventory`](../../.claude/skills/update-adr-inventory/SKILL.md)
 skill, which scans `adr-*.md` for the title and status and derives the date from git history.

--- a/docs/adrs/adr-0022.md
+++ b/docs/adrs/adr-0022.md
@@ -32,7 +32,7 @@ consumer *of* the consumer: the truncating builtins all interpose their own clos
 ## Decision
 
 1. **The sink boundary is a trait, not a bare closure.** Every
-   `sink: &mut dyn FnMut(GenericItem<V>) -> Demand` in `eval_generic.rs` (54 signatures, 31
+   `sink: &mut dyn FnMut(GenericItem<V>) -> Demand` in `eval_generic.rs` (53 signatures, 30
    direct calls) is `&mut dyn Sink<V>`, with `push(item) -> Demand` as the old call and a new
    `budget() -> Budget`. A blanket `impl<F: FnMut(GenericItem<V>) -> Demand> Sink<V> for F`
    keeps the ~60 `&mut |item| ..` closure sites unchanged.
@@ -56,15 +56,28 @@ consumer *of* the consumer: the truncating builtins all interpose their own clos
    jq itself pays for the array). `AtMost(1)` pulls one and pushes it: bit-for-bit #1565's
    work. Past the window the tail streams as before.
 
-5. **No forwarding wrapper.** The design admits a `forward(inner, f)` that would let a
-   pass-through closure — `try`, `//`, `?//`, `as`-pattern — *inherit* an inner bound rather
-   than reset it to `Unbounded`. It is deliberately not built. A missing forwarder can only
-   make a shape *more* atomic, i.e. closer to jq: `first(try (map(f)|.[]) catch c)` answers `c`
-   exactly as jq does *because* `try` resets. ADR-0018's decision order puts that fidelity
-   ahead of the O(n) it costs on those shapes, and the one shape whose laziness the project
-   promised — #1565's bare `first(map(f) | .[])` — has no wrapper in its way (0.047 s on 2M
-   elements before and after). Adding a forwarder is a fidelity regression on every shape it
-   touches and needs its own recorded divergence.
+5. **A forwarder exists, and is applied at exactly one kind of site: syntax.**
+   `forward(inner, f)` lets a closure that stands between a bounded consumer and the producer
+   *inherit* the bound instead of resetting it to `Unbounded`. It is applied to
+   `eval_each_pipe_generic`'s driver — the closure that routes a parenthesised pipe's items
+   through the remaining stages — because `(a | b) | c` and `a | b | c` are the same jq program
+   and must answer alike and run alike. Without it, `first((map(f) | .[]) | g)` drained 2M
+   elements (0.575 s against the flat spelling's 0.043 s) *and* answered differently on a
+   failing element; the divergence boundary would have been syntactic. Found by #2815's review
+   after this ADR's first draft claimed, having measured only `try` and `//`, that no forwarder
+   was ever needed.
+
+   It is deliberately **not** applied at semantic boundaries — `try`, `//`, `?//`, `as`-pattern
+   — where a reset to `Unbounded` is what buys jq's answer: `first(try (map(f)|.[]) catch c)`
+   answers `c` exactly as jq does *because* `try` resets. ADR-0018's decision order puts that
+   fidelity ahead of the cost, and the cost is real and named: those shapes take ~0.58 s on 2M
+   elements where the flat `first(map(f) | .[])` takes 0.047 s — roughly jq's own 0.48 s,
+   rather than the 11× lead the divergence used to buy. Adding `forward` at any of them is a
+   fidelity regression on that shape and needs its own recorded divergence.
+
+   `label $o | (map(f) | .[] | ., break $o)` — jq's own definition of `first` — pays the same
+   ~0.58 s and cannot be budgeted: `break` is dynamic truncation, invisible to a static budget.
+   That is inherent to the design, and the shape is jq-correct (atomic) where it used to leak.
 
 ### Why a trait rather than a second parameter
 
@@ -81,7 +94,9 @@ did not costs a materialization on one shape; it cannot cost a wrong answer.
 
 - **Sixteen spellings now match jq**, no output and exit 5 where a prefix used to leak. Two
   more that the plan expected to stay divergent match too (`first(try ..)`,
-  `first(.. // 0)`), for the reason in decision 5.
+  `first(.. // 0)`), for the reason in decision 5. And the two spellings of one program,
+  `first(map(f) | .[] | g)` and `first((map(f) | .[]) | g)`, agree — on the answer and on
+  the 0.04 s.
 - **The recorded divergence is now a statement, not an observation**: "the first `n` elements
   of `map(f)` are validated before the first output, where `n` is the truncating consumer's
   count." `first`/`limit(1)`/`.[0]`/`nth(0)` keep yielding where jq errors (#725, #1565),
@@ -90,12 +105,17 @@ did not costs a materialization on one shape; it cannot cost a wrong answer.
   Bare `map(f) | .[]` pays the buffer jq pays — 29 MB → 168 MB on 2M elements, still under
   the 272 MB `[map(f) | .[]]` already paid — and is marginally faster (1.29 s → 1.22 s;
   buffering then draining is friendlier to the cache than interleaved pull/push).
-- **Perf-guard watches both sides.** #2808 landed `arrays_first_map_iterate` (the guard row
-  for #1565) and `arrays_map_iterate` (the shape this makes atomic) ahead of this change, so
-  its CI run measured both against the merge-base. The second row's threshold override is
-  sized from that measured delta, and should be removed once `main` has moved past it: with
-  `--baseline-binary` on every PR run, an override is a permanent loosening of a row whose only
-  job is to be watched.
-- **`fold_lazy_seq_stage`'s own `Expr::Iterate` arm** implemented the drain-first behaviour
-  this now reproduces at the consumer. If coverage shows it dead, delete it rather than
-  tolerate it — it will then be genuinely duplicate code.
+- **Perf-guard watches both sides, and needed no override.** #2808 landed
+  `arrays_first_map_iterate` (the guard row for #1565) and `arrays_map_iterate` (the shape this
+  makes atomic) ahead of this change, so its CI run measured both against the merge-base:
+  **+0.0%** and **+0.9% / +0.6%** (x86_64 / ARM64-Linux). The plan expected the second row to
+  move by tens of percent and proposed pre-sizing a threshold override from the pre-#2103
+  merge-base; it moved by under one. The buffer changes *when* each element's work runs and how
+  much *memory* is live, not how many instructions execute, and cachegrind counts instructions.
+  No override was added, so none has to be removed later, and the row keeps its full 5%
+  sensitivity — which a pre-sized 40–70% loosening would have destroyed for a sub-1% change.
+- **`fold_lazy_seq_stage`'s own `Expr::Iterate` arm is not dead.** It implemented drain-first
+  atomicity for the collecting route (`[map(f) | .[]]`, `map(map(f) | .[])`,
+  `sort_by(map(f) | .[])` via `eval_single` → `fold_pipe_stages`) and still serves it; the
+  window here reproduces that behaviour for the *sink* route. Coverage on #2815 showed no
+  per-file change against `main`. Two arms, two routes, one rule.

--- a/docs/adrs/adr-0022.md
+++ b/docs/adrs/adr-0022.md
@@ -1,0 +1,101 @@
+# ADR-0022: Demand Budgets Ride the Sink (#2666)
+
+## Status
+
+✅ Accepted (2026-09-12)
+
+## Context
+
+`succinctly jq` evaluates `map(f)` as a lazy sequence (#724, #725) so a truncating consumer
+— `first`, `limit(n; ..)`, `nth`, `.[0]` — can pull one element and stop, never running the
+rest. #1565 extended that to `first(map(f) | .[] | g)`: the `.[]` consumer of a `LazySeq`
+pushes one element at a time to its sink, so a 2M-element `first(map(.+1) | .[] | .+1)`
+went from ~1.8 s to ~0.04 s. The deliberate divergence from jq — where `map` builds the whole
+array before `.[]` can observe it, so a failing element fails the expression even when only
+the first output was wanted — is recorded in `limitations.md` under "a truncating consumer of
+`map(f)` skips the elements it never needed".
+
+#2666 found the divergence was not bounded to truncating consumers. `[1,"x",3] | map(.+1) |
+.[]` — no truncating consumer anywhere — leaked `2` to stdout before raising, because the
+`.[]` consumer streamed one element at a time *regardless of who was downstream*. So did the
+same shape under `try`/`?`/`//`, in a `def` body, as a `foreach` source, under `limit(n)` with
+`n` at least the array's length: sixteen spellings, every one of them reaching the same
+consumer, `each_lazy_seq_iterate_sink`.
+
+The tempting fix cannot work. `map(f) | .[]` and `first(map(f) | .[])` arrive at that
+consumer in a bit-identical state — same `GenericResult::LazySeq`, same `rest == []` — because
+`first` *wraps* the expression rather than following it in the pipe. There is nothing in the
+consumer's own arguments to tell them apart. The information lives one level up, in the
+consumer *of* the consumer: the truncating builtins all interpose their own closure and return
+`Demand::Stop` from it after `n` outputs. That closure is the sink. The sink knows.
+
+## Decision
+
+1. **The sink boundary is a trait, not a bare closure.** Every
+   `sink: &mut dyn FnMut(GenericItem<V>) -> Demand` in `eval_generic.rs` (54 signatures, 31
+   direct calls) is `&mut dyn Sink<V>`, with `push(item) -> Demand` as the old call and a new
+   `budget() -> Budget`. A blanket `impl<F: FnMut(GenericItem<V>) -> Demand> Sink<V> for F`
+   keeps the ~60 `&mut |item| ..` closure sites unchanged.
+
+2. **The default is atomic.** `Sink::budget()` defaults to `Budget::Unbounded`. A closure that
+   names no budget — every one of them, before this change — *is* unbounded, and an unbounded
+   consumer gets jq's semantics: the whole `map(f)` is validated before the first output.
+
+3. **Laziness is opt-in, at the consumer that truncates.** `bounded(n, inner, f)` wraps a
+   truncating consumer's closure with `Budget::AtMost(n)`, composed with the budget of the
+   sink it feeds (`first(limit(3; ..))` is `AtMost(1)`; `[limit(3; ..)]` is `AtMost(3)`). Five
+   sites: `take_at_index_generic` (`skip + 1`), `each_take_first_generic` (1),
+   `each_limit_with_n_generic` and `limit_with_n_generic` (`n`), `nth_with_n_generic`
+   (`n + 1`). `isempty`/`any`/`all`/`IN` are *not* wrapped: they were already atomic, and
+   wrapping would widen a divergence for no fidelity gain.
+
+4. **The consumer pulls a validation window.** `each_lazy_seq_iterate_sink` reads
+   `sink.budget()`, pulls `min(budget, len)` elements before pushing the first, and returns
+   through the same escape path a mid-sequence failure takes if any of them fails — with
+   nothing emitted. `Unbounded` drains the whole sequence (jq's atomicity, at the O(n) buffer
+   jq itself pays for the array). `AtMost(1)` pulls one and pushes it: bit-for-bit #1565's
+   work. Past the window the tail streams as before.
+
+5. **No forwarding wrapper.** The design admits a `forward(inner, f)` that would let a
+   pass-through closure — `try`, `//`, `?//`, `as`-pattern — *inherit* an inner bound rather
+   than reset it to `Unbounded`. It is deliberately not built. A missing forwarder can only
+   make a shape *more* atomic, i.e. closer to jq: `first(try (map(f)|.[]) catch c)` answers `c`
+   exactly as jq does *because* `try` resets. ADR-0018's decision order puts that fidelity
+   ahead of the O(n) it costs on those shapes, and the one shape whose laziness the project
+   promised — #1565's bare `first(map(f) | .[])` — has no wrapper in its way (0.047 s on 2M
+   elements before and after). Adding a forwarder is a fidelity regression on every shape it
+   touches and needs its own recorded divergence.
+
+### Why a trait rather than a second parameter
+
+The parallel-parameter shape — `budget: Budget` threaded alongside every sink — was the
+plan's first draft and was rejected for its default. Roughly forty closures interpose between
+a truncating consumer and the producer. With a parallel parameter, each of them chooses
+whether to pass the budget through or reset it, and "inherit" typed where "reset" was needed
+re-opens exactly the leak this fixes, silently, under `try`/`reduce`/function bodies. With the
+trait, a closure that says nothing is `Unbounded`, and the only way to get laziness is to opt
+in with `bounded` at the site that actually truncates. A site that *should* have opted in and
+did not costs a materialization on one shape; it cannot cost a wrong answer.
+
+## Consequences
+
+- **Sixteen spellings now match jq**, no output and exit 5 where a prefix used to leak. Two
+  more that the plan expected to stay divergent match too (`first(try ..)`,
+  `first(.. // 0)`), for the reason in decision 5.
+- **The recorded divergence is now a statement, not an observation**: "the first `n` elements
+  of `map(f)` are validated before the first output, where `n` is the truncating consumer's
+  count." `first`/`limit(1)`/`.[0]`/`nth(0)` keep yielding where jq errors (#725, #1565),
+  pinned with the divergent literal on purpose so the boundary is held from both sides.
+- **#1565's win is untouched**: 0.048 s → 0.047 s, 29 MB → 29 MB on the 2M-element case.
+  Bare `map(f) | .[]` pays the buffer jq pays — 29 MB → 168 MB on 2M elements, still under
+  the 272 MB `[map(f) | .[]]` already paid — and is marginally faster (1.29 s → 1.22 s;
+  buffering then draining is friendlier to the cache than interleaved pull/push).
+- **Perf-guard watches both sides.** #2808 landed `arrays_first_map_iterate` (the guard row
+  for #1565) and `arrays_map_iterate` (the shape this makes atomic) ahead of this change, so
+  its CI run measured both against the merge-base. The second row's threshold override is
+  sized from that measured delta, and should be removed once `main` has moved past it: with
+  `--baseline-binary` on every PR run, an override is a permanent loosening of a row whose only
+  job is to be watched.
+- **`fold_lazy_seq_stage`'s own `Expr::Iterate` arm** implemented the drain-first behaviour
+  this now reproduces at the consumer. If coverage shows it dead, delete it rather than
+  tolerate it — it will then be genuinely duplicate code.

--- a/docs/compliance/jq/limitations.md
+++ b/docs/compliance/jq/limitations.md
@@ -2890,16 +2890,46 @@ sequence before emitting anything — reinstating exactly the O(n) cost
 [#1565](https://github.com/rust-works/succinctly/issues/1565) removed (a 2M-element
 `first(map(.+1) | .[] | .+1)` went from ~1.8 s to ~0.04 s).
 
-The divergence is bounded to consumers that genuinely truncate. Anything that has to see
-the whole array still errors, in both tools:
+**The bound is enforced, not accidental (#2666).** Before #2666 the bound was wherever the
+consumer happened to stop, and `map(f) | .[]` with *no* truncating consumer at all — bare, in
+a pipe, under `try`/`?`/`//`, in a `def` body, as a `foreach` source — leaked the prefix
+`2` to stdout before raising, because the iterate consumer streamed one element at a time
+regardless of who was downstream. It now asks: every sink carries a
+[`Budget`](../../../src/jq/eval_generic.rs) (`Unbounded` unless a truncating consumer says
+`AtMost(n)`), and `each_lazy_seq_iterate_sink` validates the first `n` elements of `map(f)`
+*before* the first output leaves — all of them when unbounded. So the divergence is exactly:
+
+> the first `n` elements of `map(f)` are validated before the first output, where `n` is the
+> truncating consumer's count; an element past that window is never run if the consumer
+> stops before reaching it.
+
+`limit(2; ..)` on `[1,2,"x"]` is the worked example of what still diverges — two elements
+are pulled, both good, the consumer stops, the third is never run — while `limit(2; ..)` on
+`[1,"x",3]` now errors like jq because the failing element is inside the window. Anything
+that has to see the whole array still errors, in both tools, and bare `map(f) | .[]` has
+moved into this block:
 
 ```
-$ echo '[1,"x",3]' | succinctly jq -c 'map(.+1)'         # error, exit 5
-$ echo '[1,"x",3]' | succinctly jq -c 'map(.+1) | last'  # error, exit 5
-$ echo '[1,"x",3]' | succinctly jq -c '[map(.+1) | .[]]' # error, exit 5
+$ echo '[1,"x",3]' | succinctly jq -c 'map(.+1)'                    # error, exit 5
+$ echo '[1,"x",3]' | succinctly jq -c 'map(.+1) | .[]'              # error, exit 5, no output
+$ echo '[1,"x",3]' | succinctly jq -c 'try (map(.+1)|.[]) catch "c"' # "c"
+$ echo '[1,"x",3]' | succinctly jq -c 'map(.+1) | last'             # error, exit 5
+$ echo '[1,"x",3]' | succinctly jq -c '[map(.+1) | .[]]'            # error, exit 5
+$ echo '[1,"x",3]' | succinctly jq -c 'limit(3; map(.+1) | .[])'    # error, exit 5
 ```
 
-Pinned by [`test_generic_lazy_seq_first_after_map_skips_later_error_725`](../../../tests/jq_cli_tests.rs)
+Two shapes that used to diverge now match jq for free: `first(try (map(f)|.[]) catch c)`
+and `first((map(f)|.[]) // 0)`. A `try`/`//` interposes its own closure between `first` and
+the producer, and that closure carries the `Unbounded` default — so `map` is atomic inside
+it, and `try` sees an error and no output, as in jq. The design allows a forwarding wrapper
+that would let such closures inherit `first`'s bound for speed; it is deliberately not
+built, because it can only make a shape *less* jq-like, and ADR-0018 puts fidelity ahead of
+that O(n). See [ADR-0022](../../adrs/adr-0022.md).
+
+Pinned by [`test_map_iterate_atomicity_outside_truncators_2666`](../../../tests/jq_cli_tests.rs)
+(every row above, both directions, one assertion each — the preserved rows carry the
+divergent literal on purpose so the boundary is pinned from both sides),
+[`test_generic_lazy_seq_first_after_map_skips_later_error_725`](../../../tests/jq_cli_tests.rs)
 (the `map(f) | first` / `map(f) | .[0]` spelling) and
 [`test_first_over_lazy_seq_iterate_skips_later_error_1565`](../../../tests/jq_cli_tests.rs)
 (the `first(map(f) | .[] | g)` spelling, plus the draining counter-cases above).

--- a/docs/compliance/jq/limitations.md
+++ b/docs/compliance/jq/limitations.md
@@ -2897,11 +2897,19 @@ a pipe, under `try`/`?`/`//`, in a `def` body, as a `foreach` source — leaked 
 regardless of who was downstream. It now asks: every sink carries a
 [`Budget`](../../../src/jq/eval_generic.rs) (`Unbounded` unless a truncating consumer says
 `AtMost(n)`), and `each_lazy_seq_iterate_sink` validates the first `n` elements of `map(f)`
-*before* the first output leaves — all of them when unbounded. So the divergence is exactly:
+*before* the first output leaves — all of them when unbounded. So the divergence is bounded
+by:
 
-> the first `n` elements of `map(f)` are validated before the first output, where `n` is the
-> truncating consumer's count; an element past that window is never run if the consumer
-> stops before reaching it.
+> **at least** the first `n` elements of `map(f)` are validated before the first output, where
+> `n` is the truncating consumer's count; an element past that window is run only if the
+> consumer's remaining stages pull it.
+
+"At least", not "exactly": a stage after `.[]` that *expands* an element (`(.,.)`) or that a
+`try`/`//`/`as` closure interposes resets the count upward, so more may be validated than the
+consumer strictly needed — the safe direction. `nth(k; ..)` and `.[k]` validate `k + 1`
+elements whatever bound the consumer behind them carries, because that is how many they must
+examine; `limit(n; ..)` composes with the consumer behind it (`first(limit(3; ..))` validates
+one).
 
 `limit(2; ..)` on `[1,2,"x"]` is the worked example of what still diverges — two elements
 are pulled, both good, the consumer stops, the third is never run — while `limit(2; ..)` on
@@ -2921,10 +2929,14 @@ $ echo '[1,"x",3]' | succinctly jq -c 'limit(3; map(.+1) | .[])'    # error, exi
 Two shapes that used to diverge now match jq for free: `first(try (map(f)|.[]) catch c)`
 and `first((map(f)|.[]) // 0)`. A `try`/`//` interposes its own closure between `first` and
 the producer, and that closure carries the `Unbounded` default — so `map` is atomic inside
-it, and `try` sees an error and no output, as in jq. The design allows a forwarding wrapper
-that would let such closures inherit `first`'s bound for speed; it is deliberately not
-built, because it can only make a shape *less* jq-like, and ADR-0018 puts fidelity ahead of
-that O(n). See [ADR-0022](../../adrs/adr-0022.md).
+it, and `try` sees an error and no output, as in jq. The cost is real and accepted under
+ADR-0018's decision order: those shapes, and `label $o | (map(f) | .[] | ., break $o)` (jq's
+own `first`, whose `break` no static budget can see), run in ~0.58 s on 2M elements against
+the flat `first(map(f) | .[])`'s 0.047 s — roughly jq's own 0.48 s, rather than the 11× lead
+the divergence used to buy them. A forwarding wrapper *is* applied at one place, for the
+opposite reason: the parenthesised `first((map(f) | .[]) | g)` is the same program as the flat
+spelling and must answer and run alike, which it now does. See
+[ADR-0022](../../adrs/adr-0022.md).
 
 Pinned by [`test_map_iterate_atomicity_outside_truncators_2666`](../../../tests/jq_cli_tests.rs)
 (every row above, both directions, one assertion each — the preserved rows carry the

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -5777,16 +5777,24 @@ fn drive_pipe_elements_generic<S: EvalSemantics, V: DocumentValue>(
                     other => return other,
                 }
             }
-            Err(Control::Error(e)) => return drain_result_generic(GenericResult::Error(e), sink),
-            Err(Control::Break(label)) => {
-                return drain_result_generic(GenericResult::Break(label), sink);
-            }
-            Err(Control::Halt(code)) => {
-                return drain_result_generic(GenericResult::Halt(code), sink)
-            }
+            Err(control) => return escape_via_sink(control, sink),
         }
     }
     Flow::Exhausted
+}
+
+/// A `Control` that ended a generator before its next element, delivered
+/// the way [`drive_pipe_elements_generic`] always has: as the matching
+/// `GenericResult` through `drain_result_generic`, so `sink` sees the same
+/// terminal shape it would for any other escape. Factored out (#2666) so the
+/// validation window in [`each_lazy_seq_iterate_sink`] takes the identical
+/// path when the failure is inside the window and nothing has been emitted.
+fn escape_via_sink<V: DocumentValue>(control: Control, sink: &mut dyn Sink<V>) -> Flow {
+    match control {
+        Control::Error(e) => drain_result_generic(GenericResult::Error(e), sink),
+        Control::Break(label) => drain_result_generic(GenericResult::Break(label), sink),
+        Control::Halt(code) => drain_result_generic(GenericResult::Halt(code), sink),
+    }
 }
 
 /// Demand-aware `Expr::Iterate` fan-out for a `LazyIndexRange` (#1565): no
@@ -5991,18 +5999,47 @@ fn each_lazy_keys_iterate_sink<S: EvalSemantics, V: DocumentValue>(
 /// `test_first_over_lazy_seq_iterate_skips_later_error_1565`; recorded in
 /// `docs/compliance/jq/limitations.md`.
 fn each_lazy_seq_iterate_sink<S: EvalSemantics, V: DocumentValue>(
-    seq: LazySeq<V>,
+    mut seq: LazySeq<V>,
     rest: &[Expr],
     optional: bool,
     sink: &mut dyn Sink<V>,
 ) -> Flow {
+    // #2666: the validation window. Pull as many elements as the consumer
+    // will ever accept *before* pushing the first one, so a failure inside
+    // that window raises with nothing emitted -- the atomicity `map` has in
+    // jq, where the whole array is built before `.[]` can observe it.
+    //
+    // `Unbounded` (top level, `[..]`, `reduce`, `try`, `def` bodies, ..)
+    // pulls the whole `seq`: exactly `fold_lazy_seq_stage`'s `Expr::Iterate`
+    // arm's atomicity, at the O(n) buffer jq itself pays for the array.
+    // `AtMost(1)` (`first`, `.[0]`, `nth(0)`) pulls one element and pushes
+    // it -- bit-for-bit #1565's work, the 2M-element win untouched.
+    // `AtMost(n)` pulls `min(n, len)` first, so `limit(3; map(.+1) | .[])`
+    // on a 3-element array errors like jq, while `limit(1; ..)` still pulls
+    // one. Past the window the tail streams one element at a time exactly
+    // as before, so the remaining divergence is bounded to "an element past
+    // the window, when the consumer stopped before reaching it".
+    let window = match sink.budget() {
+        Budget::Unbounded => usize::MAX,
+        Budget::AtMost(n) => n,
+    };
+    let (lower, _) = seq.size_hint();
+    let mut head: Vec<LazyElem<V>> = vec_with_capacity(lower.min(window));
+    for item in seq.by_ref().take(window) {
+        match item {
+            Ok(elem) => head.push(elem),
+            // Nothing has reached `sink` yet, so this is the whole answer.
+            Err(control) => return escape_via_sink(control, sink),
+        }
+    }
+    let to_item = |elem: LazyElem<V>| match elem {
+        LazyElem::Cursor(c) => GenericItem::OneCursor(c),
+        LazyElem::Owned(o) => GenericItem::Owned(o),
+    };
     drive_pipe_elements_generic::<S, V>(
-        seq.map(|item| {
-            item.map(|elem| match elem {
-                LazyElem::Cursor(c) => GenericItem::OneCursor(c),
-                LazyElem::Owned(o) => GenericItem::Owned(o),
-            })
-        }),
+        head.into_iter()
+            .map(|elem| Ok(to_item(elem)))
+            .chain(seq.map(move |item| item.map(to_item))),
         rest,
         optional,
         sink,
@@ -7676,18 +7713,110 @@ enum GenericItem<V: DocumentValue> {
     LazySeq(Box<LazySeq<V>>),
 }
 
+/// How many outputs the consumer behind a [`Sink`] will accept before it
+/// stops (#2666).
+///
+/// `Unbounded` unless a *truncating* consumer -- `first`, `limit(n; ..)`,
+/// `nth`, `.[0]` -- says otherwise. A producer that has to choose between
+/// streaming its outputs one at a time and validating them as a batch
+/// before the first one leaves reads this to decide: with a bound it may
+/// stream (nothing past the bound can be observed anyway), without one it
+/// must not (see `each_lazy_seq_iterate_sink`).
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum Budget {
+    Unbounded,
+    AtMost(usize),
+}
+
+impl Budget {
+    /// The tighter of two budgets -- a bounded consumer inside another
+    /// bounded consumer accepts at most the smaller count.
+    fn min(self, other: Self) -> Self {
+        match (self, other) {
+            (Self::Unbounded, b) | (b, Self::Unbounded) => b,
+            (Self::AtMost(a), Self::AtMost(b)) => Self::AtMost(a.min(b)),
+        }
+    }
+}
+
 /// The push boundary between a producer and whatever consumes its outputs
 /// (#2666) -- what every `sink: &mut dyn FnMut(GenericItem<V>) -> Demand`
-/// parameter in this module used to be, as a trait.
+/// parameter in this module used to be, as a trait so the consumer can
+/// also *describe itself*.
 ///
-/// [`push`](Self::push) is the old closure call, and this commit changes
-/// nothing else: the trait exists so the consumer can later *describe
-/// itself* to the producer (how many outputs it will accept), which a bare
-/// closure cannot. That method, and why a trait rather than a second
-/// parameter threaded alongside the closure, arrive with the behaviour
-/// change that needs them.
+/// [`push`](Self::push) is the old closure call. [`budget`](Self::budget)
+/// is why this is a trait rather than a second parameter threaded alongside
+/// the closure: with a parallel `budget` argument the default at each of
+/// the ~60 closures that interpose between producer and consumer is
+/// whatever their author typed, and "inherit" typed where "reset" was
+/// needed silently re-opens the very leak #2666 closes. With the trait, a
+/// closure that names no budget *is* `Unbounded` -- atomic, jq-matching,
+/// correct -- through the blanket impl below. Laziness is opt-in via
+/// [`bounded`] and nothing else: a closure that interposes between a
+/// bounded consumer and the producer resets the budget, which costs a
+/// materialization on that shape and buys jq's atomicity for it. It
+/// cannot cost a wrong answer.
 trait Sink<V: DocumentValue> {
     fn push(&mut self, item: GenericItem<V>) -> Demand;
+
+    /// How many more outputs the consumer will accept. `Unbounded` unless a
+    /// truncating consumer says otherwise -- see [`Budget`].
+    fn budget(&self) -> Budget {
+        Budget::Unbounded
+    }
+}
+
+/// A sink with an explicit [`Budget`]: the only way a consumer opts *out*
+/// of the atomic default (#2666).
+///
+/// [`bounded`] is a truncating consumer (`first`, `limit(n; ..)`, `nth`,
+/// `.[0]`) announcing how many outputs it will take -- composed with
+/// whatever budget the sink *it* feeds already carries, so
+/// `first(limit(3; ..))` is `AtMost(1)` and `[limit(3; ..)]` is `AtMost(3)`.
+///
+/// There is deliberately no `forward` -- a pass-through wrapper that would
+/// let `try`/`//`/`?//`/`as` *inherit* an inner bound instead of resetting
+/// it to `Unbounded`. The design allows one, and #2666's plan sketched it as
+/// a perf-only opt-in "applied where measured". Measured, it has no case:
+/// every interposing closure that resets the budget makes its shape *more*
+/// atomic, i.e. closer to jq -- `first(try (map(f)|.[]) catch c)` answers
+/// `c` exactly as jq does precisely because `try` resets -- and ADR-0018's
+/// decision order puts that fidelity ahead of the O(n) it costs on those
+/// shapes. The one shape whose laziness matters, #1565's bare
+/// `first(map(f) | .[])`, has no wrapper in the way (0.047 s on 2M elements
+/// before and after). Re-introducing a forwarder is a fidelity regression
+/// on every shape it touches and needs its own recorded divergence.
+///
+/// Takes the inner budget as a value rather than holding `&dyn Sink`: the
+/// closure it wraps already borrows that sink mutably to push into it, and
+/// `Budget` is `Copy`, so reading it once up front is both the
+/// borrow-checker's answer and the cheaper one.
+struct WithBudget<F> {
+    budget: Budget,
+    f: F,
+}
+
+impl<V: DocumentValue, F: FnMut(GenericItem<V>) -> Demand> Sink<V> for WithBudget<F> {
+    fn push(&mut self, item: GenericItem<V>) -> Demand {
+        (self.f)(item)
+    }
+    fn budget(&self) -> Budget {
+        self.budget
+    }
+}
+
+/// See [`WithBudget`]: a consumer that will take at most `n` outputs,
+/// composed with `inner` (the budget of the sink `f` pushes into, or
+/// `Unbounded` for a result-returning consumer with no sink behind it).
+fn bounded<V: DocumentValue, F: FnMut(GenericItem<V>) -> Demand>(
+    n: usize,
+    inner: Budget,
+    f: F,
+) -> WithBudget<F> {
+    WithBudget {
+        budget: Budget::AtMost(n).min(inner),
+        f,
+    }
 }
 
 /// Every existing `&mut |item| ..` closure is a `Sink` with the default
@@ -9235,17 +9364,24 @@ fn each_limit_with_n_generic<S: EvalSemantics, V: DocumentValue>(
 
     let mut count = 0usize;
     let mut outer_stopped = false;
-    let flow = eval_each_generic::<S, V>(expr, value, optional, cursor, &mut |item| {
-        count += 1;
-        if sink.push(item) == Demand::Stop {
-            outer_stopped = true;
-            Demand::Stop
-        } else if count >= n {
-            Demand::Stop
-        } else {
-            Demand::Continue
-        }
-    });
+    let outer_budget = sink.budget();
+    let flow = eval_each_generic::<S, V>(
+        expr,
+        value,
+        optional,
+        cursor,
+        &mut bounded(n, outer_budget, |item| {
+            count += 1;
+            if sink.push(item) == Demand::Stop {
+                outer_stopped = true;
+                Demand::Stop
+            } else if count >= n {
+                Demand::Stop
+            } else {
+                Demand::Continue
+            }
+        }),
+    );
 
     // The wrapping consumer, not our own `n` cap, is why the generator
     // stopped -- propagate its verdict (and whatever `pending` came with it)
@@ -9306,29 +9442,36 @@ fn take_at_index_generic<S: EvalSemantics, V: DocumentValue>(
     let mut outer_stopped = false;
     let mut kept_any = false;
     let mut skipped_err: Option<Control> = None;
-    let flow = eval_each_generic::<S, V>(expr, value, optional, cursor, &mut |item| {
-        let at_or_past = seen >= skip;
-        seen += 1;
-        if at_or_past {
-            let item = if kept_any {
-                match generic_item_into_owned(item) {
-                    Ok(v) => GenericItem::Owned(v),
-                    Err(control) => return stop_with_escape(&mut skipped_err, control),
+    let outer_budget = sink.budget();
+    let flow = eval_each_generic::<S, V>(
+        expr,
+        value,
+        optional,
+        cursor,
+        &mut bounded(skip + 1, outer_budget, |item| {
+            let at_or_past = seen >= skip;
+            seen += 1;
+            if at_or_past {
+                let item = if kept_any {
+                    match generic_item_into_owned(item) {
+                        Ok(v) => GenericItem::Owned(v),
+                        Err(control) => return stop_with_escape(&mut skipped_err, control),
+                    }
+                } else {
+                    item
+                };
+                kept_any = true;
+                if sink.push(item) == Demand::Stop {
+                    outer_stopped = true;
                 }
-            } else {
-                item
-            };
-            kept_any = true;
-            if sink.push(item) == Demand::Stop {
-                outer_stopped = true;
+                return Demand::Stop;
             }
-            return Demand::Stop;
-        }
-        if let Err(control) = generic_item_into_owned(item) {
-            return stop_with_escape(&mut skipped_err, control);
-        }
-        Demand::Continue
-    });
+            if let Err(control) = generic_item_into_owned(item) {
+                return stop_with_escape(&mut skipped_err, control);
+            }
+            Demand::Continue
+        }),
+    );
     if let Some(control) = skipped_err {
         return Flow::Escaped(control);
     }
@@ -10671,10 +10814,16 @@ fn each_take_first_generic<S: EvalSemantics, V: DocumentValue>(
     // alternative. Under a single alternative this is still entered exactly
     // once and returns exactly one item.
     let mut taken: Vec<GenericItem<V>> = Vec::new();
-    let flow = eval_each_generic::<S, V>(inner, value, optional, cursor, &mut |item| {
-        taken.push(item);
-        Demand::Stop
-    });
+    let flow = eval_each_generic::<S, V>(
+        inner,
+        value,
+        optional,
+        cursor,
+        &mut bounded(1, Budget::Unbounded, |item| {
+            taken.push(item);
+            Demand::Stop
+        }),
+    );
     (taken, flow)
 }
 
@@ -12038,14 +12187,20 @@ fn limit_with_n_generic<S: EvalSemantics, V: DocumentValue>(
     // too (`limit(2; .[])` on a sequence of duplicate-keyed mappings), not
     // only across the `limit`/`nth` walk itself.
     let mut out: Vec<GenericItem<V>> = Vec::new();
-    let flow = eval_each_generic::<S, V>(expr, value, optional, cursor, &mut |item| {
-        out.push(item);
-        if out.len() >= n {
-            Demand::Stop
-        } else {
-            Demand::Continue
-        }
-    });
+    let flow = eval_each_generic::<S, V>(
+        expr,
+        value,
+        optional,
+        cursor,
+        &mut bounded(n, Budget::Unbounded, |item| {
+            out.push(item);
+            if out.len() >= n {
+                Demand::Stop
+            } else {
+                Demand::Continue
+            }
+        }),
+    );
     match flow {
         // The sink returns `Demand::Stop` the instant `out.len() >= n`, and
         // every `eval_each_generic` arm stops pulling as soon as `Demand`
@@ -12138,36 +12293,42 @@ fn nth_with_n_generic<S: EvalSemantics, V: DocumentValue>(
     let mut seen = 0usize;
     let mut wanted: Vec<GenericItem<V>> = Vec::new();
     let mut skipped_err: Option<Control> = None;
-    let flow = eval_each_generic::<S, V>(expr, value, optional, cursor, &mut |item| {
-        // #1519: `>=`, not `==`, and a `Vec` rather than a latch -- see
-        // `eval::each_take_nth`'s doc comment for why jq's own counter keeps
-        // rising across a `?//` retry and emits again
-        // (`[nth(1; 1 as $x ?// $y | 5, 6)]` is `[6,5]`). Outside a `?//`
-        // chain the sink is never re-entered after its stop, so this is
-        // exactly the previous behaviour.
-        let at_or_past = seen >= n;
-        seen += 1;
-        if at_or_past {
-            wanted.push(item);
-            return Demand::Stop;
-        }
-        // jq defines `nth($n; f)` as `last(limit($n + 1; f))`: every output
-        // of `f` up to index `n` is genuinely produced, not just the one
-        // ultimately kept -- a *skipped* item's own lazy computation (a
-        // buffered `map`/`select` chain, `GenericItem::LazySeq`, #724/#725)
-        // must still run for its side effects/errors even though its value
-        // is discarded here. `each_take_nth` in `eval.rs` gets this for
-        // free (its `Item`s are never themselves lazy, only ever borrowed
-        // or already-owned); this sink has to force it explicitly, or
-        // `nth(2; .[] | map(10/.))` over `[[1],[0],[2]]` would silently
-        // skip the division-by-zero `map` never ran on `[0]` and answer
-        // from `[2]` instead of erroring. The item *at* index `n` is
-        // deliberately exempted from this force -- see below.
-        if let Err(control) = generic_item_into_owned(item) {
-            return stop_with_escape(&mut skipped_err, control);
-        }
-        Demand::Continue
-    });
+    let flow = eval_each_generic::<S, V>(
+        expr,
+        value,
+        optional,
+        cursor,
+        &mut bounded(n + 1, Budget::Unbounded, |item| {
+            // #1519: `>=`, not `==`, and a `Vec` rather than a latch -- see
+            // `eval::each_take_nth`'s doc comment for why jq's own counter keeps
+            // rising across a `?//` retry and emits again
+            // (`[nth(1; 1 as $x ?// $y | 5, 6)]` is `[6,5]`). Outside a `?//`
+            // chain the sink is never re-entered after its stop, so this is
+            // exactly the previous behaviour.
+            let at_or_past = seen >= n;
+            seen += 1;
+            if at_or_past {
+                wanted.push(item);
+                return Demand::Stop;
+            }
+            // jq defines `nth($n; f)` as `last(limit($n + 1; f))`: every output
+            // of `f` up to index `n` is genuinely produced, not just the one
+            // ultimately kept -- a *skipped* item's own lazy computation (a
+            // buffered `map`/`select` chain, `GenericItem::LazySeq`, #724/#725)
+            // must still run for its side effects/errors even though its value
+            // is discarded here. `each_take_nth` in `eval.rs` gets this for
+            // free (its `Item`s are never themselves lazy, only ever borrowed
+            // or already-owned); this sink has to force it explicitly, or
+            // `nth(2; .[] | map(10/.))` over `[[1],[0],[2]]` would silently
+            // skip the division-by-zero `map` never ran on `[0]` and answer
+            // from `[2]` instead of erroring. The item *at* index `n` is
+            // deliberately exempted from this force -- see below.
+            if let Err(control) = generic_item_into_owned(item) {
+                return stop_with_escape(&mut skipped_err, control);
+            }
+            Demand::Continue
+        }),
+    );
     // #2199: `skipped_err` is checked *before* `wanted`, reversing this
     // function's own prior order -- the comment that used to sit here
     // claimed "by construction, over `skipped_err` too -- once `wanted` is
@@ -23270,6 +23431,117 @@ mod tests {
     use super::super::expr::{CompareOp, FormatType, Literal};
     use super::super::value::NumberRepr;
     use super::*;
+
+    // ---- #2666: Budget composition and the validation window ----
+
+    #[test]
+    fn budget_min_is_the_tighter_bound_2666() {
+        use Budget::{AtMost, Unbounded};
+        assert_eq!(Unbounded.min(Unbounded), Unbounded);
+        assert_eq!(Unbounded.min(AtMost(3)), AtMost(3));
+        assert_eq!(AtMost(3).min(Unbounded), AtMost(3));
+        assert_eq!(AtMost(3).min(AtMost(1)), AtMost(1));
+        assert_eq!(AtMost(1).min(AtMost(3)), AtMost(1));
+    }
+
+    /// `bounded(n, inner, f)` composes: `first(limit(3; ..))` is `AtMost(1)`,
+    /// `[limit(3; ..)]` is `AtMost(3)`; a bare closure is `Unbounded` -- the
+    /// default that makes the design safe.
+    #[test]
+    fn bounded_composes_as_documented_2666() {
+        use Budget::{AtMost, Unbounded};
+        type V<'a> = crate::json::light::StandardJson<'a, Vec<u64>>;
+        let noop = |_: GenericItem<V<'_>>| Demand::Continue;
+        assert_eq!(Sink::<V<'_>>::budget(&noop), Unbounded);
+        assert_eq!(
+            Sink::<V<'_>>::budget(&bounded(3, Unbounded, noop)),
+            AtMost(3)
+        );
+        assert_eq!(
+            Sink::<V<'_>>::budget(&bounded(3, AtMost(1), noop)),
+            AtMost(1)
+        );
+        assert_eq!(
+            Sink::<V<'_>>::budget(&bounded(1, AtMost(3), noop)),
+            AtMost(1)
+        );
+    }
+
+    /// The window on `[1,2,"x"] | map(.+1) | .[]`, driven straight through
+    /// `each_lazy_seq_iterate_sink` with a sink of each budget. `AtMost(2)`
+    /// yields `2, 3` and never reaches the failing third element -- the new,
+    /// stated bound of the divergence. `AtMost(3)` and `Unbounded` pull the
+    /// failing element into the window and raise with nothing emitted.
+    #[test]
+    fn lazy_seq_iterate_window_follows_the_sink_budget_2666() {
+        use Budget::{AtMost, Unbounded};
+        let doc = br#"[1,2,"x"]"#;
+        let index = crate::json::JsonIndex::build(doc);
+        let root = index.root(doc);
+        let map_expr = super::super::parse("map(.+1)").expect("parses");
+
+        let run = |budget: Budget| -> (Vec<String>, Option<String>) {
+            let seq = match eval_with_cursor(&map_expr, root) {
+                GenericResult::LazySeq(seq) => seq,
+                other => panic!("map(.+1) should be a LazySeq here, got {other:?}"),
+            };
+            // A real truncating consumer stops once it has its `n`; a sink that
+            // kept answering `Continue` past its own budget would pull the tail
+            // and see the failing element regardless of the window.
+            let take = match budget {
+                AtMost(n) => n,
+                Unbounded => usize::MAX,
+            };
+            let mut got: Vec<String> = Vec::new();
+            let mut sink = WithBudget {
+                budget,
+                f: |item: GenericItem<_>| {
+                    got.push(
+                        generic_item_into_owned(item)
+                            .expect("element decodes")
+                            .to_json(),
+                    );
+                    if got.len() >= take {
+                        Demand::Stop
+                    } else {
+                        Demand::Continue
+                    }
+                },
+            };
+            let flow = each_lazy_seq_iterate_sink::<JqSemantics, _>(*seq, &[], false, &mut sink);
+            let err = match flow {
+                Flow::Escaped(Control::Error(e)) => Some(e.to_string()),
+                Flow::Escaped(other) => panic!("unexpected escape {other:?}"),
+                Flow::Exhausted | Flow::Stopped { .. } => None,
+            };
+            (got, err)
+        };
+
+        let (got, err) = run(AtMost(2));
+        assert_eq!(
+            got,
+            ["2", "3"],
+            "AtMost(2): the failing element is past the window"
+        );
+        assert!(err.is_none(), "AtMost(2): {err:?}");
+
+        let (got, err) = run(AtMost(3));
+        assert!(
+            got.is_empty(),
+            "AtMost(3): nothing may be emitted, got {got:?}"
+        );
+        assert!(
+            err.is_some(),
+            "AtMost(3): the failing element is inside the window"
+        );
+
+        let (got, err) = run(Unbounded);
+        assert!(
+            got.is_empty(),
+            "Unbounded: nothing may be emitted, got {got:?}"
+        );
+        assert!(err.is_some(), "Unbounded: atomic, like jq");
+    }
 
     /// #1909: [`reindex_bridge_is_identity`] claims to describe exactly when
     /// `eval_on_owned`'s serialize + `JsonIndex::build` +

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -5993,11 +5993,20 @@ fn each_lazy_keys_iterate_sink<S: EvalSemantics, V: DocumentValue>(
 /// `test_generic_lazy_seq_first_after_map_skips_later_error_725`), widened
 /// from `first`/`.[0]` to `.[]`-under-demand: the point of a lazy `first` is
 /// to skip elements that cannot affect the requested output, and an element
-/// that errors is one such element. Restoring atomicity would mean draining
+/// that errors is one such element.
+///
+/// **Since #2666 the trade applies only under a truncating consumer.** The
+/// body below reads `sink.budget()` and drains exactly that many elements
+/// before pushing the first -- all of them when the consumer is
+/// `Unbounded`, which is jq's atomicity at the O(n) buffer jq itself pays;
+/// one when it is `first`, which is bit-for-bit the #1565 pull. The
+/// paragraph this replaced said restoring atomicity "would mean draining
 /// the whole `seq` before emitting anything, which is exactly the O(n) cost
-/// #1565 exists to remove. Pinned by
-/// `test_first_over_lazy_seq_iterate_skips_later_error_1565`; recorded in
-/// `docs/compliance/jq/limitations.md`.
+/// #1565 exists to remove" -- true of an unconditional drain, and exactly
+/// what a *budgeted* one avoids. Pinned by
+/// `test_first_over_lazy_seq_iterate_skips_later_error_1565` and
+/// `test_map_iterate_atomicity_outside_truncators_2666`; recorded in
+/// `docs/compliance/jq/limitations.md` and ADR-0022.
 fn each_lazy_seq_iterate_sink<S: EvalSemantics, V: DocumentValue>(
     mut seq: LazySeq<V>,
     rest: &[Expr],
@@ -6023,8 +6032,13 @@ fn each_lazy_seq_iterate_sink<S: EvalSemantics, V: DocumentValue>(
         Budget::Unbounded => usize::MAX,
         Budget::AtMost(n) => n,
     };
-    let (lower, _) = seq.size_hint();
-    let mut head: Vec<LazyElem<V>> = vec_with_capacity(lower.min(window));
+    // No capacity pre-size: `LazySeq` has no `size_hint` (its source is an
+    // iterator over an index it has not walked yet), so `lower` is always
+    // 0 and `with_capacity(0)` is what the plan's `min(window, hint)` would
+    // have computed. The `Unbounded` buffer grows by doubling; measured on
+    // 2M elements that is 168 MB peak against the 272 MB the already-atomic
+    // `[map(f) | .[]]` pays, so nothing to tune here.
+    let mut head: Vec<LazyElem<V>> = Vec::new();
     for item in seq.by_ref().take(window) {
         match item {
             Ok(elem) => head.push(elem),
@@ -7819,6 +7833,24 @@ fn bounded<V: DocumentValue, F: FnMut(GenericItem<V>) -> Demand>(
     }
 }
 
+/// See [`WithBudget`]: a forwarder that inherits `inner`'s budget instead of
+/// resetting it to `Unbounded` -- for a closure that stands between a bounded
+/// consumer and the producer purely to route items (run the remaining pipe
+/// stages on each, then push), where `(a | b) | c` and `a | b | c` must
+/// answer alike.
+///
+/// Inheriting is safe in both directions. If the stages this closure runs
+/// *expand* an item (a `.[]` in `rest`), the producer may pull more than
+/// the consumer strictly needed -- more validation, more atomic, the safe
+/// side. If they *filter* (a `select`), the window is "at least `n`
+/// validated" and the tail streams exactly as before.
+fn forward<V: DocumentValue, F: FnMut(GenericItem<V>) -> Demand>(
+    inner: Budget,
+    f: F,
+) -> WithBudget<F> {
+    WithBudget { budget: inner, f }
+}
+
 /// Every existing `&mut |item| ..` closure is a `Sink` with the default
 /// `Unbounded` budget -- which is what makes the default safe. Nothing
 /// about the 60-odd closure sites in this module changed to adopt the trait.
@@ -9442,13 +9474,18 @@ fn take_at_index_generic<S: EvalSemantics, V: DocumentValue>(
     let mut outer_stopped = false;
     let mut kept_any = false;
     let mut skipped_err: Option<Control> = None;
-    let outer_budget = sink.budget();
+    // #2666: `skip + 1` inputs are what this consumer needs to produce its
+    // one output, whatever bound the sink behind it carries -- an outer
+    // `first` limits how many outputs leave, not how many elements must be
+    // examined to find the (skip+1)th. So this does NOT compose with
+    // `sink.budget()` the way `limit` does: `first(nth(1; ..))` must still
+    // validate two elements, not `min(2, 1)`. Found by #2815's review.
     let flow = eval_each_generic::<S, V>(
         expr,
         value,
         optional,
         cursor,
-        &mut bounded(skip + 1, outer_budget, |item| {
+        &mut bounded(skip + 1, Budget::Unbounded, |item| {
             let at_or_past = seen >= skip;
             seen += 1;
             if at_or_past {
@@ -10069,8 +10106,16 @@ fn eval_each_pipe_generic<S: EvalSemantics, V: DocumentValue>(
     // Same once-per-driver cache as `drive_pipe_elements_generic` (#1598):
     // this closure also runs once per item stage 1 produces.
     let mut rest = RestPipe::new(rest);
+    // #2666: the budget the consumer behind `sink` announced, read before
+    // `driver` borrows `sink` mutably. `driver` is a forwarder -- it runs
+    // `rest` on each item and pushes -- so it must carry that budget, or
+    // `first((map(f) | .[]) | g)` drains where `first(map(f) | .[] | g)`
+    // pulls one: same jq program, 13x apart, and a different answer on a
+    // failing element. Found by #2815's review after this file's first
+    // version claimed no forwarder was ever needed.
+    let outer_budget = sink.budget();
     let upstream = {
-        let mut driver = |item: GenericItem<V>| -> Demand {
+        let mut driver = forward(outer_budget, |item: GenericItem<V>| -> Demand {
             let flow = match identity_from_first {
                 Some(_) if key_stage && matches!(item, GenericItem::OneCursor(_)) => {
                     continue_pipe_element_generic::<S, V>(item, &mut rest, optional, &mut *sink)
@@ -10096,7 +10141,7 @@ fn eval_each_pipe_generic<S: EvalSemantics, V: DocumentValue>(
                 Flow::Exhausted => Demand::Continue,
                 other => stop_with_downstream(&mut downstream, other),
             }
-        };
+        });
         eval_each_generic::<S, V>(first, value, optional, cursor, &mut driver)
     };
 

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -2401,7 +2401,7 @@ fn bridge_to_full_evaluator_flow<S: EvalSemantics, V: DocumentValue>(
     value: V,
     cursor: Option<V::Cursor>,
     optional: bool,
-    sink: &mut dyn FnMut(GenericItem<V>) -> Demand,
+    sink: &mut dyn Sink<V>,
 ) -> Flow {
     // #2327: consults `optional` via `suppresses`, matching
     // `bridge_to_full_evaluator`'s own sibling fix above -- a suppressed
@@ -2444,12 +2444,12 @@ fn bridge_to_each_owned_flow<S: EvalSemantics, V: DocumentValue>(
     value: V,
     cursor: Option<V::Cursor>,
     optional: bool,
-    sink: &mut dyn FnMut(GenericItem<V>) -> Demand,
+    sink: &mut dyn Sink<V>,
 ) -> Flow {
     match bridge_ambient_input(expr, &value, cursor) {
-        Ok(owned) => {
-            eval_each_owned::<S>(expr, &owned, optional, &mut |v| sink(GenericItem::Owned(v)))
-        }
+        Ok(owned) => eval_each_owned::<S>(expr, &owned, optional, &mut |v| {
+            sink.push(GenericItem::Owned(v))
+        }),
         Err(e) if suppresses(&e, optional) => Flow::Exhausted,
         Err(e) => Flow::Escaped(Control::Error(e)),
     }
@@ -5764,7 +5764,7 @@ fn drive_pipe_elements_generic<S: EvalSemantics, V: DocumentValue>(
     elements: impl Iterator<Item = Result<GenericItem<V>, Control>>,
     rest: &[Expr],
     optional: bool,
-    sink: &mut dyn FnMut(GenericItem<V>) -> Demand,
+    sink: &mut dyn Sink<V>,
 ) -> Flow {
     // One `RestPipe` for the whole drive, so an owned copy is built on the
     // first `Owned` element and reused by every element after it (#1598).
@@ -5798,7 +5798,7 @@ fn each_lazy_index_range_iterate_sink<S: EvalSemantics, V: DocumentValue>(
     len: usize,
     rest: &[Expr],
     optional: bool,
-    sink: &mut dyn FnMut(GenericItem<V>) -> Demand,
+    sink: &mut dyn Sink<V>,
 ) -> Flow {
     drive_pipe_elements_generic::<S, V>(
         (0..len).map(|i| Ok(GenericItem::Owned(OwnedValue::Int(i as i64)))),
@@ -5900,7 +5900,7 @@ fn each_lazy_keys_iterate_sink<S: EvalSemantics, V: DocumentValue>(
     collapse: bool,
     rest: &[Expr],
     optional: bool,
-    sink: &mut dyn FnMut(GenericItem<V>) -> Demand,
+    sink: &mut dyn Sink<V>,
 ) -> Flow {
     if !sorted {
         // Held by `by_ref` rather than moved into the `map` closure so the
@@ -5994,7 +5994,7 @@ fn each_lazy_seq_iterate_sink<S: EvalSemantics, V: DocumentValue>(
     seq: LazySeq<V>,
     rest: &[Expr],
     optional: bool,
-    sink: &mut dyn FnMut(GenericItem<V>) -> Demand,
+    sink: &mut dyn Sink<V>,
 ) -> Flow {
     drive_pipe_elements_generic::<S, V>(
         seq.map(|item| {
@@ -6048,7 +6048,7 @@ fn each_lazy_seq_iterate_sink<S: EvalSemantics, V: DocumentValue>(
 /// the early-exit trade. Recorded in `docs/compliance/jq/limitations.md`.
 fn each_lazy_array_iterate_sink<V: DocumentValue>(
     elements: V::Elements,
-    sink: &mut dyn FnMut(GenericItem<V>) -> Demand,
+    sink: &mut dyn Sink<V>,
 ) -> Flow {
     let mut elems = elements;
     let mut is_first = true;
@@ -6073,7 +6073,7 @@ fn each_lazy_array_iterate_sink<V: DocumentValue>(
         is_first = false;
         elems = next;
         last_cursor = Some(cursor);
-        if sink(GenericItem::OneCursor(cursor)) == Demand::Stop {
+        if sink.push(GenericItem::OneCursor(cursor)) == Demand::Stop {
             return Flow::Stopped { pending: None };
         }
     }
@@ -6137,7 +6137,7 @@ fn try_owned_format_or_tostring_bypass<S: EvalSemantics, V: DocumentValue>(
     remaining: &[Expr],
     o: OwnedValue,
     optional: bool,
-    sink: &mut dyn FnMut(GenericItem<V>) -> Demand,
+    sink: &mut dyn Sink<V>,
 ) -> Result<Flow, OwnedValue> {
     match remaining {
         [stage @ (Expr::Format(_) | Expr::Builtin(Builtin::ToString))] => Ok(drain_result_generic(
@@ -6152,7 +6152,7 @@ fn fold_pipe_stages_sink<S: EvalSemantics, V: DocumentValue>(
     mut current: GenericResult<V>,
     stages: &[Expr],
     optional: bool,
-    sink: &mut dyn FnMut(GenericItem<V>) -> Demand,
+    sink: &mut dyn Sink<V>,
 ) -> Flow {
     let mut j = 0usize;
     loop {
@@ -6225,7 +6225,7 @@ fn fold_pipe_stages_sink<S: EvalSemantics, V: DocumentValue>(
                 };
                 let rest_pipe = Expr::Pipe(stages[j..].to_vec());
                 return eval_each_owned::<S>(&rest_pipe, &o, optional, &mut |o| {
-                    sink(GenericItem::Owned(o))
+                    sink.push(GenericItem::Owned(o))
                 });
             }
             // Nothing further to fold; push (or don't) and stop, same as
@@ -7676,12 +7676,32 @@ enum GenericItem<V: DocumentValue> {
     LazySeq(Box<LazySeq<V>>),
 }
 
+/// The push boundary between a producer and whatever consumes its outputs
+/// (#2666) -- what every `sink: &mut dyn FnMut(GenericItem<V>) -> Demand`
+/// parameter in this module used to be, as a trait.
+///
+/// [`push`](Self::push) is the old closure call, and this commit changes
+/// nothing else: the trait exists so the consumer can later *describe
+/// itself* to the producer (how many outputs it will accept), which a bare
+/// closure cannot. That method, and why a trait rather than a second
+/// parameter threaded alongside the closure, arrive with the behaviour
+/// change that needs them.
+trait Sink<V: DocumentValue> {
+    fn push(&mut self, item: GenericItem<V>) -> Demand;
+}
+
+/// Every existing `&mut |item| ..` closure is a `Sink` with the default
+/// `Unbounded` budget -- which is what makes the default safe. Nothing
+/// about the 60-odd closure sites in this module changed to adopt the trait.
+impl<V: DocumentValue, F: FnMut(GenericItem<V>) -> Demand> Sink<V> for F {
+    fn push(&mut self, item: GenericItem<V>) -> Demand {
+        self(item)
+    }
+}
+
 /// Push one item to `sink`, translating its `Demand` into a terminal `Flow`.
-fn push_one_generic<V: DocumentValue>(
-    item: GenericItem<V>,
-    sink: &mut dyn FnMut(GenericItem<V>) -> Demand,
-) -> Flow {
-    match sink(item) {
+fn push_one_generic<V: DocumentValue>(item: GenericItem<V>, sink: &mut dyn Sink<V>) -> Flow {
+    match sink.push(item) {
         Demand::Continue => Flow::Exhausted,
         Demand::Stop => Flow::Stopped { pending: None },
     }
@@ -7693,10 +7713,10 @@ fn push_one_generic<V: DocumentValue>(
 /// already hold gets wrapped into a `GenericItem`.
 fn push_many_generic<V: DocumentValue>(
     items: impl Iterator<Item = GenericItem<V>>,
-    sink: &mut dyn FnMut(GenericItem<V>) -> Demand,
+    sink: &mut dyn Sink<V>,
 ) -> Flow {
     for item in items {
-        if sink(item) == Demand::Stop {
+        if sink.push(item) == Demand::Stop {
             return Flow::Stopped { pending: None };
         }
     }
@@ -7718,7 +7738,7 @@ fn push_many_generic<V: DocumentValue>(
 /// never decomposed here -- see [`GenericItem`]'s own doc comment for why.
 fn drain_result_generic<V: DocumentValue>(
     result: GenericResult<V>,
-    sink: &mut dyn FnMut(GenericItem<V>) -> Demand,
+    sink: &mut dyn Sink<V>,
 ) -> Flow {
     match result {
         GenericResult::None => Flow::Exhausted,
@@ -7818,7 +7838,7 @@ fn eval_positioned_stage_generic<S: EvalSemantics, V: DocumentValue>(
     expr: &Expr,
     cursor: V::Cursor,
     optional: bool,
-    sink: &mut dyn FnMut(GenericItem<V>) -> Demand,
+    sink: &mut dyn Sink<V>,
 ) -> Flow {
     // STYLE-0012: the decode failure of the node this stage stands on is
     // raised or suppressed as `optional` says -- the same choice the bridge
@@ -7841,7 +7861,7 @@ fn eval_each_generic<S: EvalSemantics, V: DocumentValue>(
     value: V,
     optional: bool,
     cursor: Option<V::Cursor>,
-    sink: &mut dyn FnMut(GenericItem<V>) -> Demand,
+    sink: &mut dyn Sink<V>,
 ) -> Flow {
     match expr {
         // Mirrors `eval::eval_each`'s own `Comma` arm exactly: the sink *is*
@@ -8314,7 +8334,7 @@ fn each_foreach_generic<S: EvalSemantics, V: DocumentValue>(
     value: V,
     optional: bool,
     cursor: Option<V::Cursor>,
-    sink: &mut dyn FnMut(GenericItem<V>) -> Demand,
+    sink: &mut dyn Sink<V>,
 ) -> Flow {
     // INIT first, source second (#2440), same as the eager arm above it.
     let (init_values, init_control) =
@@ -8330,7 +8350,7 @@ fn each_foreach_generic<S: EvalSemantics, V: DocumentValue>(
         &mut |per_element| {
             drive_foreach_source_generic::<S, V>(input, &value, optional, cursor, per_element)
         },
-        &mut |v| sink(GenericItem::Owned(v)),
+        &mut |v| sink.push(GenericItem::Owned(v)),
     )
 }
 
@@ -8341,9 +8361,9 @@ fn each_foreach_generic<S: EvalSemantics, V: DocumentValue>(
 /// (#1620), which escapes.
 fn each_recurse_cursor_generic<S: EvalSemantics, V: DocumentValue>(
     cursor: V::Cursor,
-    sink: &mut dyn FnMut(GenericItem<V>) -> Demand,
+    sink: &mut dyn Sink<V>,
 ) -> Flow {
-    if matches!(sink(GenericItem::OneCursor(cursor)), Demand::Stop) {
+    if matches!(sink.push(GenericItem::OneCursor(cursor)), Demand::Stop) {
         return Flow::Stopped { pending: None };
     }
     let mut children: Vec<(Rc<PathTrail>, PathNode<V>)> = Vec::new();
@@ -8410,7 +8430,7 @@ fn each_repeat_generic<S: EvalSemantics, V: DocumentValue>(
     value: V,
     optional: bool,
     cursor: Option<V::Cursor>,
-    sink: &mut dyn FnMut(GenericItem<V>) -> Demand,
+    sink: &mut dyn Sink<V>,
 ) -> Flow {
     // `f` is `Repeat`'s only child and the wrapper contributes nothing of
     // its own (`walk.rs`'s `node_reads_ambient` leaves `Expr::Repeat` to the
@@ -8434,7 +8454,7 @@ fn each_repeat_generic<S: EvalSemantics, V: DocumentValue>(
                 stopped = true;
                 return stop_with_escape(&mut budget_control, control);
             }
-            match sink(GenericItem::Owned(v)) {
+            match sink.push(GenericItem::Owned(v)) {
                 Demand::Continue => Demand::Continue,
                 Demand::Stop => {
                     stopped = true;
@@ -8525,7 +8545,7 @@ fn continue_pipe_element_generic<S: EvalSemantics, V: DocumentValue>(
     item: GenericItem<V>,
     rest: &mut RestPipe<'_>,
     optional: bool,
-    sink: &mut dyn FnMut(GenericItem<V>) -> Demand,
+    sink: &mut dyn Sink<V>,
 ) -> Flow {
     match item {
         GenericItem::One(v) => {
@@ -8554,7 +8574,7 @@ fn continue_pipe_element_generic<S: EvalSemantics, V: DocumentValue>(
                     Err(o) => o,
                 };
             eval_each_owned::<S>(rest.owned(), &o, optional, &mut |o| {
-                sink(GenericItem::Owned(o))
+                sink.push(GenericItem::Owned(o))
             })
         }
         item @ (GenericItem::LazyKeys { .. }
@@ -8599,7 +8619,7 @@ fn each_if_generic<S: EvalSemantics, V: DocumentValue>(
     value: V,
     optional: bool,
     cursor: Option<V::Cursor>,
-    sink: &mut dyn FnMut(GenericItem<V>) -> Demand,
+    sink: &mut dyn Sink<V>,
 ) -> Flow {
     let mut outer_stopped = false;
     let mut escape: Option<Control> = None;
@@ -8662,12 +8682,12 @@ fn each_try_generic<S: EvalSemantics, V: DocumentValue>(
     value: V,
     optional: bool,
     cursor: Option<V::Cursor>,
-    sink: &mut dyn FnMut(GenericItem<V>) -> Demand,
+    sink: &mut dyn Sink<V>,
 ) -> Flow {
     let mut lazy_fault: Option<Control> = None;
     let flow = eval_each_generic::<S, V>(expr, value, optional, cursor, &mut |item| {
         match check_lazy_item_for_try(item) {
-            Ok(item) => sink(item),
+            Ok(item) => sink.push(item),
             Err(control) => stop_with_escape(&mut lazy_fault, control),
         }
     });
@@ -8715,7 +8735,7 @@ fn run_try_handler_generic<S: EvalSemantics, V: DocumentValue>(
     payload: OwnedValue,
     optional: bool,
     cursor: Option<V::Cursor>,
-    sink: &mut dyn FnMut(GenericItem<V>) -> Demand,
+    sink: &mut dyn Sink<V>,
 ) -> Flow {
     if let Some(c) = cursor {
         let stages = owned_identity_body_stages(handler);
@@ -8730,7 +8750,7 @@ fn run_try_handler_generic<S: EvalSemantics, V: DocumentValue>(
         }
     }
     eval_each_owned::<S>(handler, &payload, optional, &mut |o| {
-        sink(GenericItem::Owned(o))
+        sink.push(GenericItem::Owned(o))
     })
 }
 
@@ -8794,7 +8814,7 @@ fn each_label_generic<S: EvalSemantics, V: DocumentValue>(
     value: V,
     optional: bool,
     cursor: Option<V::Cursor>,
-    sink: &mut dyn FnMut(GenericItem<V>) -> Demand,
+    sink: &mut dyn Sink<V>,
 ) -> Flow {
     match eval_each_generic::<S, V>(body, value, optional, cursor, sink) {
         Flow::Escaped(Control::Break(label)) if label == name => Flow::Exhausted,
@@ -8932,7 +8952,7 @@ fn each_as_generic<S: EvalSemantics, V: DocumentValue>(
     value: V,
     optional: bool,
     cursor: Option<V::Cursor>,
-    sink: &mut dyn FnMut(GenericItem<V>) -> Demand,
+    sink: &mut dyn Sink<V>,
 ) -> Flow {
     fanout_arg_each_generic_with_origin::<S, V, _>(
         expr,
@@ -8961,7 +8981,7 @@ fn each_as_pattern_generic<S: EvalSemantics, V: DocumentValue>(
     value: V,
     optional: bool,
     cursor: Option<V::Cursor>,
-    sink: &mut dyn FnMut(GenericItem<V>) -> Demand,
+    sink: &mut dyn Sink<V>,
 ) -> Flow {
     let all_var_names = pattern_alternatives_var_names(patterns);
 
@@ -9021,7 +9041,7 @@ fn each_pattern_alternatives_generic<S: EvalSemantics, V: DocumentValue>(
     value: &V,
     optional: bool,
     cursor: Option<V::Cursor>,
-    sink: &mut dyn FnMut(GenericItem<V>) -> Demand,
+    sink: &mut dyn Sink<V>,
 ) -> Flow {
     let last_idx = patterns.len() - 1;
     // #1366: a genuine `?//`-chain (2+ patterns) inverts real jq's
@@ -9064,7 +9084,7 @@ fn each_pattern_alternatives_generic<S: EvalSemantics, V: DocumentValue>(
             optional,
             cursor,
             &mut |item| match check_lazy_item_for_try(item) {
-                Ok(item) => sink(item),
+                Ok(item) => sink.push(item),
                 Err(control) => stop_with_escape(&mut lazy_fault, control),
             },
         );
@@ -9172,7 +9192,7 @@ fn each_limit_generic<S: EvalSemantics, V: DocumentValue>(
     value: V,
     optional: bool,
     cursor: Option<V::Cursor>,
-    sink: &mut dyn FnMut(GenericItem<V>) -> Demand,
+    sink: &mut dyn Sink<V>,
 ) -> Flow {
     // Rebuilt once, up front: all three deferral points below hand the same
     // node to the same bridge (#1687 item 4).
@@ -9199,7 +9219,7 @@ fn each_limit_with_n_generic<S: EvalSemantics, V: DocumentValue>(
     value: V,
     optional: bool,
     cursor: Option<V::Cursor>,
-    sink: &mut dyn FnMut(GenericItem<V>) -> Demand,
+    sink: &mut dyn Sink<V>,
 ) -> Flow {
     let n = match classify_limit_n(n_value) {
         Ok(LimitN::Unlimited) => {
@@ -9217,7 +9237,7 @@ fn each_limit_with_n_generic<S: EvalSemantics, V: DocumentValue>(
     let mut outer_stopped = false;
     let flow = eval_each_generic::<S, V>(expr, value, optional, cursor, &mut |item| {
         count += 1;
-        if sink(item) == Demand::Stop {
+        if sink.push(item) == Demand::Stop {
             outer_stopped = true;
             Demand::Stop
         } else if count >= n {
@@ -9280,7 +9300,7 @@ fn take_at_index_generic<S: EvalSemantics, V: DocumentValue>(
     optional: bool,
     cursor: Option<V::Cursor>,
     skip: usize,
-    sink: &mut dyn FnMut(GenericItem<V>) -> Demand,
+    sink: &mut dyn Sink<V>,
 ) -> Flow {
     let mut seen = 0usize;
     let mut outer_stopped = false;
@@ -9299,7 +9319,7 @@ fn take_at_index_generic<S: EvalSemantics, V: DocumentValue>(
                 item
             };
             kept_any = true;
-            if sink(item) == Demand::Stop {
+            if sink.push(item) == Demand::Stop {
                 outer_stopped = true;
             }
             return Demand::Stop;
@@ -9340,7 +9360,7 @@ fn each_first_generic<S: EvalSemantics, V: DocumentValue>(
     value: V,
     optional: bool,
     cursor: Option<V::Cursor>,
-    sink: &mut dyn FnMut(GenericItem<V>) -> Demand,
+    sink: &mut dyn Sink<V>,
 ) -> Flow {
     if crate::jq::input_queue_is_active() && crate::jq::walk::uses_input_builtins(inner) {
         return bridge_to_each_owned_flow::<S, V>(
@@ -9385,7 +9405,7 @@ fn each_nth_generic<S: EvalSemantics, V: DocumentValue>(
     value: V,
     optional: bool,
     cursor: Option<V::Cursor>,
-    sink: &mut dyn FnMut(GenericItem<V>) -> Demand,
+    sink: &mut dyn Sink<V>,
 ) -> Flow {
     if limit_or_nth_uses_live_input_queue(n_expr, expr) {
         return bridge_to_each_owned_flow::<S, V>(
@@ -9441,7 +9461,7 @@ fn each_select_generic<S: EvalSemantics, V: DocumentValue>(
     cond: &Expr,
     value: V,
     cursor: Option<V::Cursor>,
-    sink: &mut dyn FnMut(GenericItem<V>) -> Demand,
+    sink: &mut dyn Sink<V>,
 ) -> Flow {
     let mut already_emitted = false;
     let mut escape: Option<Control> = None;
@@ -9454,8 +9474,8 @@ fn each_select_generic<S: EvalSemantics, V: DocumentValue>(
             return Demand::Continue;
         }
         match cursor {
-            Some(c) => sink(GenericItem::OneCursor(c)),
-            None => sink(GenericItem::One(value.clone())),
+            Some(c) => sink.push(GenericItem::OneCursor(c)),
+            None => sink.push(GenericItem::One(value.clone())),
         }
     });
     resume_from_escape(escape, flow)
@@ -9491,7 +9511,7 @@ fn each_index_expr_generic<S: EvalSemantics, V: DocumentValue>(
     value: V,
     optional: bool,
     cursor: Option<V::Cursor>,
-    sink: &mut dyn FnMut(GenericItem<V>) -> Demand,
+    sink: &mut dyn Sink<V>,
 ) -> Flow {
     let mut escape: Option<Control> = None;
 
@@ -9586,7 +9606,7 @@ fn process_index_key<S: EvalSemantics, V: DocumentValue>(
     value: V,
     optional: bool,
     cursor: Option<V::Cursor>,
-    sink: &mut dyn FnMut(GenericItem<V>) -> Demand,
+    sink: &mut dyn Sink<V>,
     escape: &mut Option<Control>,
 ) -> bool {
     let literal_key = owned_to_expr(k);
@@ -9645,11 +9665,11 @@ fn each_object_entries_generic<S: EvalSemantics, V: DocumentValue>(
     optional: bool,
     cursor: Option<V::Cursor>,
     acc: &mut Vec<(String, OwnedValue)>,
-    sink: &mut dyn FnMut(GenericItem<V>) -> Demand,
+    sink: &mut dyn Sink<V>,
 ) -> Flow {
     let Some((entry, rest)) = entries.split_first() else {
         let object: IndexMap<String, OwnedValue> = acc.iter().cloned().collect();
-        return match sink(GenericItem::Owned(OwnedValue::Object(object))) {
+        return match sink.push(GenericItem::Owned(OwnedValue::Object(object))) {
             Demand::Continue => Flow::Exhausted,
             Demand::Stop => Flow::Stopped { pending: None },
         };
@@ -9718,7 +9738,7 @@ fn each_object_value_generic<S: EvalSemantics, V: DocumentValue>(
     optional: bool,
     cursor: Option<V::Cursor>,
     acc: &mut Vec<(String, OwnedValue)>,
-    sink: &mut dyn FnMut(GenericItem<V>) -> Demand,
+    sink: &mut dyn Sink<V>,
 ) -> Flow {
     let mut escape: Option<Control> = None;
     let flow =
@@ -9793,7 +9813,7 @@ fn eval_each_pipe_generic<S: EvalSemantics, V: DocumentValue>(
     value: V,
     optional: bool,
     cursor: Option<V::Cursor>,
-    sink: &mut dyn FnMut(GenericItem<V>) -> Demand,
+    sink: &mut dyn Sink<V>,
 ) -> Flow {
     // #2451 rule 1: in yq mode a pipe with a union in it is evaluated over a
     // whole context list, branch-major, by `eval_yq_context_pipe` -- ahead of
@@ -10100,7 +10120,7 @@ fn run_yq_stages_over_item<S: EvalSemantics, V: DocumentValue>(
     stages: &[Expr],
     item: &YqContextItem<V>,
     optional: bool,
-    sink: &mut dyn FnMut(GenericItem<V>) -> Demand,
+    sink: &mut dyn Sink<V>,
 ) -> Flow {
     match item.tag.origin {
         Some(origin) => with_node_origin(origin, || {
@@ -10114,7 +10134,7 @@ fn run_yq_stages_bare<S: EvalSemantics, V: DocumentValue>(
     stages: &[Expr],
     item: &YqContextItem<V>,
     optional: bool,
-    sink: &mut dyn FnMut(GenericItem<V>) -> Demand,
+    sink: &mut dyn Sink<V>,
 ) -> Flow {
     if stages.is_empty() {
         return push_one_generic(item.to_generic_item(), sink);
@@ -10294,7 +10314,7 @@ fn eval_yq_context_pipe<S: EvalSemantics, V: DocumentValue>(
     inputs: &[YqContextItem<V>],
     optional: bool,
     cur: &core::cell::Cell<YqContextTag>,
-    sink: &mut dyn FnMut(GenericItem<V>) -> Demand,
+    sink: &mut dyn Sink<V>,
 ) -> Flow {
     // `collectOperator`'s own `evaluateAllTogether` fold
     // (`operator_collect.go:33-38`): every node must carry the flag, and an
@@ -10449,7 +10469,7 @@ fn cross_together<S: EvalSemantics, V: DocumentValue>(
     optional: bool,
     cur: &core::cell::Cell<YqContextTag>,
 ) -> Result<Vec<YqContextItem<V>>, Flow> {
-    let each_operand = |operand: &Expr, operand_sink: &mut dyn FnMut(GenericItem<V>) -> Demand| {
+    let each_operand = |operand: &Expr, operand_sink: &mut dyn Sink<V>| {
         let mut flat: Vec<Expr> = Vec::new();
         yq_flatten_pipe_stages(core::slice::from_ref(operand), &mut flat);
         eval_yq_context_pipe::<S, V>(&flat, context, false, cur, operand_sink)
@@ -10534,7 +10554,7 @@ fn try_yq_context_pipe<S: EvalSemantics, V: DocumentValue>(
     value: V,
     optional: bool,
     cursor: Option<V::Cursor>,
-    sink: &mut dyn FnMut(GenericItem<V>) -> Demand,
+    sink: &mut dyn Sink<V>,
 ) -> Option<Flow> {
     if !yq_context_pipe_applies::<S>(exprs) {
         return None;
@@ -10776,13 +10796,13 @@ fn generic_item_into_owned_with_origin<V: DocumentValue>(
 /// `eval.rs`'s `binary_fanout_each` gives: the per-right-value call on `left`
 /// happens while the call on `right` is still on the stack.
 fn binary_fanout_each_generic<V: DocumentValue>(
-    each_operand: impl Fn(&Expr, &mut dyn FnMut(GenericItem<V>) -> Demand) -> Flow,
+    each_operand: impl Fn(&Expr, &mut dyn Sink<V>) -> Flow,
     left: &Expr,
     right: &Expr,
     optional: bool,
     rules: BinaryFanoutRules,
     mut combine: impl FnMut(OwnedValue, OwnedValue) -> Result<OwnedValue, EvalError>,
-    sink: &mut dyn FnMut(GenericItem<V>) -> Demand,
+    sink: &mut dyn Sink<V>,
 ) -> Flow {
     // #2470: same wrapper, same rule, same `BinaryFanoutRules::read_only`
     // flag as `eval::binary_fanout_each` -- see
@@ -10824,7 +10844,7 @@ fn binary_fanout_each_generic<V: DocumentValue>(
                 (inner_val, outer_val.clone())
             };
             match combine(left_val, right_val) {
-                Ok(v) => sink(GenericItem::Owned(v)),
+                Ok(v) => sink.push(GenericItem::Owned(v)),
                 // Reached by the `Expr::Arithmetic` caller only: the two
                 // `Expr::Compare` call sites wrap the infallible
                 // `apply_compare_op` in `Ok(...)` (`CompareOp` has no failure
@@ -10856,7 +10876,7 @@ fn binary_fanout_each_generic<V: DocumentValue>(
         if inner_seen == 0 && matches!(inner, Flow::Exhausted) {
             if let Some(op) = rules.empty {
                 if let Some(v) = yq_empty_operand_output(op, Some(&outer_val)) {
-                    if matches!(sink(GenericItem::Owned(v)), Demand::Stop) {
+                    if matches!(sink.push(GenericItem::Owned(v)), Demand::Stop) {
                         return stop_with_downstream(&mut abort, Flow::Stopped { pending: None });
                     }
                 }
@@ -10885,16 +10905,16 @@ fn binary_fanout_each_generic<V: DocumentValue>(
 /// `rules.read_only`.
 fn read_only_operand_strategy_generic<V: DocumentValue>(
     rules: BinaryFanoutRules,
-    each_operand: impl Fn(&Expr, &mut dyn FnMut(GenericItem<V>) -> Demand) -> Flow,
-) -> impl Fn(&Expr, &mut dyn FnMut(GenericItem<V>) -> Demand) -> Flow {
-    move |expr: &Expr, sink: &mut dyn FnMut(GenericItem<V>) -> Demand| {
+    each_operand: impl Fn(&Expr, &mut dyn Sink<V>) -> Flow,
+) -> impl Fn(&Expr, &mut dyn Sink<V>) -> Flow {
+    move |expr: &Expr, sink: &mut dyn Sink<V>| {
         if !rules.read_only {
             return each_operand(expr, sink);
         }
         let _scope = yq_read_only_context::enter();
         each_operand(expr, &mut |item| {
             let _suspended = yq_read_only_context::suspend();
-            sink(item)
+            sink.push(item)
         })
     }
 }
@@ -10904,10 +10924,10 @@ fn read_only_operand_strategy_generic<V: DocumentValue>(
 /// of `eval::empty_outer_operand_pass`, split out for the same reason (one
 /// `return` shape in the loop above).
 fn empty_outer_operand_pass_generic<V: DocumentValue>(
-    each_operand: &impl Fn(&Expr, &mut dyn FnMut(GenericItem<V>) -> Demand) -> Flow,
+    each_operand: &impl Fn(&Expr, &mut dyn Sink<V>) -> Flow,
     other: &Expr,
     op: EmptyOperandOp,
-    sink: &mut dyn FnMut(GenericItem<V>) -> Demand,
+    sink: &mut dyn Sink<V>,
 ) -> Flow {
     let mut abort: Option<Flow> = None;
     let mut other_seen = 0usize;
@@ -10918,7 +10938,7 @@ fn empty_outer_operand_pass_generic<V: DocumentValue>(
             Err(control) => return stop_with_downstream(&mut abort, Flow::Escaped(control)),
         };
         match yq_empty_operand_output(op, Some(&other_val)) {
-            Some(v) => sink(GenericItem::Owned(v)),
+            Some(v) => sink.push(GenericItem::Owned(v)),
             None => Demand::Continue,
         }
     });
@@ -11134,7 +11154,7 @@ fn each_alternative_generic<S: EvalSemantics, V: DocumentValue>(
     value: V,
     optional: bool,
     cursor: Option<V::Cursor>,
-    sink: &mut dyn FnMut(GenericItem<V>) -> Demand,
+    sink: &mut dyn Sink<V>,
 ) -> Flow {
     let mut forwarded = 0usize;
     let mut outer_stopped = false;
@@ -11158,34 +11178,40 @@ fn each_alternative_generic<S: EvalSemantics, V: DocumentValue>(
             Flow::Escaped(control) => stop_with_escape(&mut escape, control),
         }
     };
-    let left_flow = eval_each_generic::<S, V>(left, value.clone(), optional, cursor, &mut |item| {
-        // Fast path: `OneCursorValue` carries an already-decoded value
-        // (#1599/#1606/#1609, e.g. a `keys_unsorted` iteration) that routing
-        // through `generic_item_to_result` would otherwise collapse to a
-        // bare `OneCursor`, discarding it and forcing a second cursor
-        // `.value()` resolve on every item this forwards. Truthiness only
-        // needs the cursor, so answer it directly and keep the pair intact.
-        if let GenericItem::OneCursorValue(ref c, _) = item {
-            if c.is_falsy(JsonConvention::Preserve) {
-                return Demand::Continue;
-            }
-            forwarded += 1;
-            return handle_flow(push_one_generic(item, sink));
-        }
-        match retain_truthy_generic(generic_item_to_result(item)) {
-            // Falsy: dropped, and the left operand keeps producing. A
-            // genuine `Error`/`Break`/`Halt` falls to the `kept` arm below
-            // rather than getting its own -- `drain_result_generic` already
-            // converts each straight to `Flow::Escaped` with no sink call,
-            // the same conversion every other call site in this file relies
-            // on (#106: no second copy of that mapping to drift from it).
-            GenericResult::None => Demand::Continue,
-            kept => {
+    let left_flow = eval_each_generic::<S, V>(
+        left,
+        value.clone(),
+        optional,
+        cursor,
+        &mut |item: GenericItem<V>| {
+            // Fast path: `OneCursorValue` carries an already-decoded value
+            // (#1599/#1606/#1609, e.g. a `keys_unsorted` iteration) that routing
+            // through `generic_item_to_result` would otherwise collapse to a
+            // bare `OneCursor`, discarding it and forcing a second cursor
+            // `.value()` resolve on every item this forwards. Truthiness only
+            // needs the cursor, so answer it directly and keep the pair intact.
+            if let GenericItem::OneCursorValue(ref c, _) = item {
+                if c.is_falsy(JsonConvention::Preserve) {
+                    return Demand::Continue;
+                }
                 forwarded += 1;
-                handle_flow(drain_result_generic(kept, sink))
+                return handle_flow(push_one_generic(item, sink));
             }
-        }
-    });
+            match retain_truthy_generic(generic_item_to_result(item)) {
+                // Falsy: dropped, and the left operand keeps producing. A
+                // genuine `Error`/`Break`/`Halt` falls to the `kept` arm below
+                // rather than getting its own -- `drain_result_generic` already
+                // converts each straight to `Flow::Escaped` with no sink call,
+                // the same conversion every other call site in this file relies
+                // on (#106: no second copy of that mapping to drift from it).
+                GenericResult::None => Demand::Continue,
+                kept => {
+                    forwarded += 1;
+                    handle_flow(drain_result_generic(kept, sink))
+                }
+            }
+        },
+    );
 
     if outer_stopped || escape.is_some() {
         return resume_from_escape(escape, left_flow);
@@ -11268,7 +11294,7 @@ fn each_boolean_generic<S: EvalSemantics, V: DocumentValue>(
     value: V,
     optional: bool,
     cursor: Option<V::Cursor>,
-    sink: &mut dyn FnMut(GenericItem<V>) -> Demand,
+    sink: &mut dyn Sink<V>,
 ) -> Flow {
     boolean_fanout_each(
         |operand, bit_sink| {
@@ -11278,7 +11304,7 @@ fn each_boolean_generic<S: EvalSemantics, V: DocumentValue>(
         right,
         short_circuit,
         binary_fanout_rules::<S>(EmptyOperandOp::Boolean),
-        &mut |bit| sink(GenericItem::Owned(OwnedValue::Bool(bit))),
+        &mut |bit| sink.push(GenericItem::Owned(OwnedValue::Bool(bit))),
     )
 }
 
@@ -11310,7 +11336,7 @@ fn each_range_generic<S: EvalSemantics, V: DocumentValue>(
     value: V,
     optional: bool,
     cursor: Option<V::Cursor>,
-    sink: &mut dyn FnMut(GenericItem<V>) -> Demand,
+    sink: &mut dyn Sink<V>,
 ) -> Flow {
     // `Cell` for the same reason `each_range` uses one: `emit` and the three
     // operand closures are live simultaneously and each must be able to
@@ -11324,7 +11350,7 @@ fn each_range_generic<S: EvalSemantics, V: DocumentValue>(
             (f, t, st) => range_values_f64(f.as_f64(), t.as_f64(), st.as_f64()),
         };
         for v in values {
-            if sink(GenericItem::Owned(v)) == Demand::Stop {
+            if sink.push(GenericItem::Owned(v)) == Demand::Stop {
                 sink_stopped = true;
                 return Demand::Stop;
             }
@@ -11432,7 +11458,7 @@ fn each_negate_generic<S: EvalSemantics, V: DocumentValue>(
     value: V,
     optional: bool,
     cursor: Option<V::Cursor>,
-    sink: &mut dyn FnMut(GenericItem<V>) -> Demand,
+    sink: &mut dyn Sink<V>,
 ) -> Flow {
     let mut outer_stopped = false;
     let mut escape: Option<Control> = None;
@@ -11443,7 +11469,7 @@ fn each_negate_generic<S: EvalSemantics, V: DocumentValue>(
         };
         match crate::jq::eval::arith_negate::<S>(owned) {
             Ok(negated) => {
-                if sink(GenericItem::Owned(negated)) == Demand::Stop {
+                if sink.push(GenericItem::Owned(negated)) == Demand::Stop {
                     outer_stopped = true;
                     Demand::Stop
                 } else {
@@ -16103,7 +16129,7 @@ fn path_context_emitting_value<V: DocumentValue>(
 fn path_context_walk_generic<S: EvalSemantics, V: DocumentValue>(
     expr: &Expr,
     pos: &PathContextPos<V>,
-    sink: &mut dyn FnMut(GenericItem<V>) -> Demand,
+    sink: &mut dyn Sink<V>,
 ) -> Result<Demand, Control> {
     match expr {
         Expr::Paren(inner) => path_context_walk_generic::<S, V>(inner, pos, sink),
@@ -16138,7 +16164,7 @@ fn path_context_walk_generic<S: EvalSemantics, V: DocumentValue>(
                 return Err(Control::Error(e));
             }
             walked?;
-            Ok(sink(GenericItem::Owned(OwnedValue::Array(items))))
+            Ok(sink.push(GenericItem::Owned(OwnedValue::Array(items))))
         }
         // `key` at the document root emits nothing: real yq prints nothing
         // there (#2421, captured live from v4.53.3), and jq has no `key` at
@@ -16162,7 +16188,7 @@ fn path_context_walk_generic<S: EvalSemantics, V: DocumentValue>(
         // answer from the key -- see `path_context_emitting_value`.
         Expr::Builtin(Builtin::PathNoArg | Builtin::Key) => {
             match path_context_emitting_value(expr, pos) {
-                Ok(Some(item)) => Ok(sink(item)),
+                Ok(Some(item)) => Ok(sink.push(item)),
                 Ok(None) => Ok(Demand::Continue),
                 // `cursor_key`'s malformed-member-key error path, pre-existing
                 // before this refactor merged this arm with `PathNoArg`'s.
@@ -16173,7 +16199,7 @@ fn path_context_walk_generic<S: EvalSemantics, V: DocumentValue>(
             let mut heads = Vec::new();
             let stepped = path_context_step_generic::<S, V>(expr, pos, &mut heads);
             for head in heads {
-                if matches!(sink(path_context_emit_node(&head.node)), Demand::Stop) {
+                if matches!(sink.push(path_context_emit_node(&head.node)), Demand::Stop) {
                     return Ok(Demand::Stop);
                 }
             }
@@ -16187,10 +16213,10 @@ fn path_context_walk_generic<S: EvalSemantics, V: DocumentValue>(
 fn path_context_walk_pipe<S: EvalSemantics, V: DocumentValue>(
     exprs: &[Expr],
     pos: &PathContextPos<V>,
-    sink: &mut dyn FnMut(GenericItem<V>) -> Demand,
+    sink: &mut dyn Sink<V>,
 ) -> Result<Demand, Control> {
     match exprs.split_first() {
-        None => Ok(sink(path_context_emit_node(&pos.node))),
+        None => Ok(sink.push(path_context_emit_node(&pos.node))),
         Some((first, [])) => path_context_walk_generic::<S, V>(first, pos, sink),
         Some((first, rest)) => {
             let mut heads = Vec::new();
@@ -17203,7 +17229,7 @@ fn path_context_root<V: DocumentValue>(root: V::Cursor) -> Result<PathContextPos
 fn try_path_context_walk_sink<S: EvalSemantics, V: DocumentValue>(
     exprs: &[Expr],
     root: V::Cursor,
-    sink: &mut dyn FnMut(GenericItem<V>) -> Demand,
+    sink: &mut dyn Sink<V>,
 ) -> Option<Flow> {
     let (walked, rest) = path_context_walk_split(exprs)?;
     let root_pos = match path_context_root::<V>(root) {
@@ -17214,7 +17240,7 @@ fn try_path_context_walk_sink<S: EvalSemantics, V: DocumentValue>(
     let mut rest_pipe = RestPipe::new(rest);
     let walked_result = path_context_walk_pipe::<S, V>(walked, &root_pos, &mut |item| {
         if rest.is_empty() {
-            return sink(item);
+            return sink.push(item);
         }
         // Same driver shape as `eval_each_pipe_generic`'s own: a downstream
         // stop or escape ends the walk, and is what the caller sees.
@@ -18210,7 +18236,7 @@ fn path_context_resolve_parent(at: &PathContextAt<'_>, n: usize) -> Result<Expr,
 fn try_path_context_absent_sink<S: EvalSemantics, V: DocumentValue>(
     exprs: &[Expr],
     root: V::Cursor,
-    sink: &mut dyn FnMut(GenericItem<V>) -> Demand,
+    sink: &mut dyn Sink<V>,
 ) -> Option<Flow> {
     let (head, rest, route) = path_context_absent_split(exprs)?;
     let root_pos = match path_context_root::<V>(root) {
@@ -18257,7 +18283,7 @@ fn try_path_context_absent_sink<S: EvalSemantics, V: DocumentValue>(
                         match path_context_resolve_absent_stages::<S, V>(rest, pos) {
                             Ok(resolved) => {
                                 eval_each_owned::<S>(&resolved, &owned, false, &mut |v| {
-                                    sink(GenericItem::Owned(v))
+                                    sink.push(GenericItem::Owned(v))
                                 })
                             }
                             Err(e) => Flow::Escaped(Control::Error(e)),
@@ -22196,7 +22222,7 @@ fn eval_owned_identity_pipe<S: EvalSemantics, V: DocumentValue>(
     value: OwnedValue,
     id: OwnedIdentity<V>,
     optional: bool,
-    sink: &mut dyn FnMut(GenericItem<V>) -> Demand,
+    sink: &mut dyn Sink<V>,
 ) -> Flow {
     eval_owned_identity_stages::<S, V>(stages, value, id, optional, OwnedIdentityTail::Sink(sink))
 }
@@ -22205,7 +22231,7 @@ fn eval_owned_identity_pipe<S: EvalSemantics, V: DocumentValue>(
 /// (spine 2416, identity pass).
 enum OwnedIdentityTail<'a, V: DocumentValue> {
     /// The pipe's outputs are values: the identity has done its work.
-    Sink(&'a mut dyn FnMut(GenericItem<V>) -> Demand),
+    Sink(&'a mut dyn Sink<V>),
     /// An enclosing stage continues from each `(value, identity)` pair --
     /// a bounded consumer counting its body's outputs, a `try` that has to
     /// tell its body's errors from the rest of the pipe's, a map-family

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -23528,7 +23528,7 @@ mod tests {
         let run = |budget: Budget| -> (Vec<String>, Option<String>) {
             let seq = match eval_with_cursor(&map_expr, root) {
                 GenericResult::LazySeq(seq) => seq,
-                other => panic!("map(.+1) should be a LazySeq here, got {other:?}"),
+                other => panic!("map(.+1) should be a LazySeq here, got {other:?}"), // omni-dev: coverage tolerate-line reason="unreachable in a passing suite by design -- the fixture's map(.+1) is always a LazySeq; this arm is the test's own diagnostic (#2666)"
             };
             // A real truncating consumer stops once it has its `n`; a sink that
             // kept answering `Continue` past its own budget would pull the tail
@@ -23556,7 +23556,7 @@ mod tests {
             let flow = each_lazy_seq_iterate_sink::<JqSemantics, _>(*seq, &[], false, &mut sink);
             let err = match flow {
                 Flow::Escaped(Control::Error(e)) => Some(e.to_string()),
-                Flow::Escaped(other) => panic!("unexpected escape {other:?}"),
+                Flow::Escaped(other) => panic!("unexpected escape {other:?}"), // omni-dev: coverage tolerate-line reason="unreachable in a passing suite by design -- the fixture's only escape is Control::Error; this arm is the test's own diagnostic (#2666)"
                 Flow::Exhausted | Flow::Stopped { .. } => None,
             };
             (got, err)

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -48210,3 +48210,120 @@ fn range_max_iterations_rule_survives_the_native_arm_2698() -> Result<()> {
     }
     Ok(())
 }
+
+/// #2666: `map(f) | .[]` is atomic outside a truncating consumer, exactly as
+/// in jq -- a failing element discards every element `map` already
+/// produced, because real jq builds the whole array before `.[]` can
+/// observe it. Before this, every spelling that reached
+/// `each_lazy_seq_iterate_sink` through the generic evaluator leaked the
+/// prefix `2` to stdout before raising.
+///
+/// The table is the whole of #2666's §0, in three blocks, and every row is
+/// one assertion on `(stdout, exit code)`. The **must-preserve** block carries
+/// the *divergent* literal on purpose: `first`/`limit(1)`/`.[0]`/`nth(0)`
+/// over a `LazySeq` pull one element and stop (#725, #1565), and that is
+/// the deliberate, recorded trade this fix keeps -- so the boundary is
+/// pinned in both directions, not just the direction that moved. Real jq
+/// 1.7.1 exits 5 with no output on every one of those.
+///
+/// Two rows the plan listed as must-preserve now match jq instead --
+/// `first(try (map(.+1)|.[]) catch "c")` and `first((map(.+1)|.[]) // 0)`
+/// -- because the atomic default applies inside `try`/`//` before any
+/// `forward` opt-in. That is fidelity gained for free, so they sit in the
+/// first block.
+#[test]
+fn test_map_iterate_atomicity_outside_truncators_2666() -> Result<()> {
+    let input = r#"[1,"x",3]"#;
+
+    // Block 1 -- matches jq: no output, and the exit code jq gives.
+    let match_jq: &[(&str, &str, i32)] = &[
+        ("map(.+1) | .[]", "", 5),
+        ("map(.+1)[]", "", 5),
+        (". as $a | $a | map(.+1) | .[]", "", 5),
+        ("map(.+1) | .[] | select(.>1)", "", 5),
+        ("map(.+1) | .[] | tostring", "", 5),
+        ("map(.+1) | map(.+1) | .[]", "", 5),
+        // The comma's own left branch still emits; only the leak is gone.
+        ("99, (map(.+1) | .[])", "99", 5),
+        ("foreach (map(.+1)|.[]) as $x (0; .+$x)", "", 5),
+        // The escape happens before anything is emitted, so `try` sees an
+        // error and no output -- jq's own answer.
+        (r#"try (map(.+1)|.[]) catch "caught""#, r#""caught""#, 0),
+        ("(map(.+1)|.[])?", "", 0),
+        ("(map(.+1) | .[]) as $x | $x", "", 5),
+        ("def f: map(.+1) | .[]; f", "", 5),
+        ("if true then (map(.+1)|.[]) else 0 end", "", 5),
+        ("(map(.+1)|.[]) // 0", "", 5),
+        // `limit(n)` with n >= the array's length pulls the whole window, so
+        // the failing third element is inside it -- the row a boolean flag
+        // could never get right.
+        ("limit(2; map(.+1) | .[])", "", 5),
+        ("limit(3; map(.+1) | .[])", "", 5),
+        // Gained for free (see the doc comment).
+        (r#"first(try (map(.+1)|.[]) catch "c")"#, r#""c""#, 0),
+        ("first((map(.+1)|.[]) // 0)", "", 5),
+        // Already atomic before this change; must not regress.
+        ("[map(.+1)|.[]]", "", 5),
+        ("map(.+1)|last", "", 5),
+        ("map(.+1)|length", "", 5),
+        ("reduce (map(.+1)|.[]) as $x (0;.+$x)", "", 5),
+        ("isempty(map(.+1)|.[])", "", 5),
+        ("any(map(.+1)|.[]; .>1)", "", 5),
+        ("first(map(.+1) | .[] | select(.>2))", "", 5),
+        ("first(map(.+1) | .[] , 9)", "", 5),
+        ("{a: .} | .a | map(.+1) | .[]", "", 5),
+        ("{a: .} | .a | first(map(.+1) | .[])", "", 5),
+    ];
+    for (filter, want_out, want_code) in match_jq {
+        let (out, err, code) = run_jq_full(&["-c", filter], Some(input))?;
+        assert_eq!(
+            (out.trim(), code),
+            (*want_out, *want_code),
+            "#2666: `{filter}` must match jq 1.7.1 -- stderr: {err:?}"
+        );
+    }
+
+    // Block 2 -- the deliberate divergence, pinned as such: one element is
+    // pulled and the consumer stops before the failing one is ever reached.
+    // jq: exit 5, no output, on every row.
+    let preserved: &[(&str, &str)] = &[
+        ("first(map(.+1) | .[])", "2"),
+        ("limit(1; map(.+1) | .[])", "2"),
+        ("map(.+1) | .[0]", "2"),
+        ("nth(0; map(.+1)|.[])", "2"),
+    ];
+    for (filter, want_out) in preserved {
+        let (out, err, code) = run_jq_full(&["-c", filter], Some(input))?;
+        assert_eq!(
+            (out.trim(), code),
+            (*want_out, 0),
+            "#2666: `{filter}` is the #725/#1565 trade and must keep yielding -- stderr: {err:?}"
+        );
+    }
+    Ok(())
+}
+
+/// #2666's table again, through the owned route (`-n --argjson`), for the
+/// rows that changed: the owned evaluator was already atomic here, and the
+/// point of the fix is that the two routes now agree.
+#[test]
+fn test_map_iterate_atomicity_owned_and_generic_agree_2666() -> Result<()> {
+    for filter in [
+        "$d | map(.+1) | .[]",
+        "$d | (map(.+1)|.[])?",
+        r#"$d | try (map(.+1)|.[]) catch "caught""#,
+        "$d | limit(3; map(.+1) | .[])",
+    ] {
+        let (owned_out, _, owned_code) =
+            run_jq_full(&["-nc", "--argjson", "d", r#"[1,"x",3]"#, filter], None)?;
+        let generic_filter = filter.replacen("$d | ", "", 1);
+        let (generic_out, _, generic_code) =
+            run_jq_full(&["-c", &generic_filter], Some(r#"[1,"x",3]"#))?;
+        assert_eq!(
+            (owned_out.trim(), owned_code),
+            (generic_out.trim(), generic_code),
+            "#2666: owned vs generic route disagree on `{generic_filter}`"
+        );
+    }
+    Ok(())
+}

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -48402,3 +48402,56 @@ fn test_parenthesised_pipe_agrees_with_flat_pipe_under_first_2666() -> Result<()
     assert_eq!((flat.0.trim(), flat.2), ("3", 0));
     Ok(())
 }
+
+/// #2666: a `break` or `halt` raised by a `map` body is delivered from
+/// inside the validation window through `escape_via_sink` -- the same path a
+/// mid-sequence escape took before the window existed -- with nothing
+/// emitted. jq agrees on every row: `map` is atomic, so a `break` on the
+/// second element discards the first, and the enclosing `label` then yields
+/// nothing.
+#[test]
+fn test_break_and_halt_inside_the_map_window_2666() -> Result<()> {
+    let input = "[1,2,3]";
+    for (filter, want_out, want_code) in [
+        (
+            "label $o | map(if . == 2 then break $o else . end) | .[]",
+            "",
+            0,
+        ),
+        (
+            "[label $o | map(if . == 2 then break $o else . end) | .[]]",
+            "[]",
+            0,
+        ),
+        (
+            "label $o | map(if . == 2 then halt_error else . end) | .[]",
+            "",
+            5,
+        ),
+    ] {
+        let (out, err, code) = run_jq_full(&["-c", filter], Some(input))?;
+        assert_eq!(
+            (out.trim(), code),
+            (want_out, want_code),
+            "#2666: `{filter}` -- stderr: {err:?}"
+        );
+    }
+    Ok(())
+}
+
+/// `nth_with_n_generic`'s skipped-element force, reached through the
+/// result-returning twin (`map(nth(..))`): an element `nth` skips is still
+/// decoded, so a `map(10/.)` that divides by zero on a skipped `[0]` raises
+/// rather than being silently stepped over. The doc comment on that force
+/// gives this exact shape; it had no test on this route. Matches jq 1.7.1.
+#[test]
+fn test_nth_result_twin_forces_skipped_elements_2666() -> Result<()> {
+    let (out, err, code) = run_jq_full(
+        &["-c", "map(nth(2; .[] | map(10/.)))"],
+        Some("[[[1],[0],[2]]]"),
+    )?;
+    assert_eq!(code, 5, "stdout: {out:?} stderr: {err:?}");
+    assert!(out.trim().is_empty(), "nothing may be emitted, got {out:?}");
+    assert!(err.contains("cannot be divided"), "stderr: {err:?}");
+    Ok(())
+}

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -48327,3 +48327,78 @@ fn test_map_iterate_atomicity_owned_and_generic_agree_2666() -> Result<()> {
     }
     Ok(())
 }
+
+/// #2666: the two `bounded` sites the §0 table never reached, and the two
+/// off-by-ones no §0 row could see -- found by #2815's review, which
+/// mutation-tested each site and each `n` and watched the whole suite stay
+/// green.
+///
+/// `limit_with_n_generic` and `nth_with_n_generic` are the *result-returning*
+/// twins of the sink-driven consumers, reached only when the truncating
+/// builtin's output is consumed by something that collects (`map(..)`, `+`),
+/// not by the top-level driver. Their `n` is only observable through a `rest`
+/// that *expands* an element into several outputs: `nth(1; .. | (.,.))` on
+/// `[1,"x"]` needs two outputs, both of which come from the first element,
+/// so a window of `n` (one element) yields `2` while jq's atomic `map` errors
+/// -- and a window of `n + 1` reaches the failing element and errors like jq.
+///
+/// The `first(nth(1; ..))` row pins the composition rule: `nth` needs
+/// `skip + 1` *inputs* whatever the outer bound accepts as *outputs*, so it
+/// must not take `min(skip + 1, outer)`. The first version of this PR did,
+/// and answered `2` there.
+#[test]
+fn test_bounded_result_returning_twins_and_their_n_2666() -> Result<()> {
+    // (input, filter, stdout, exit) -- all captured against jq 1.7.1, which
+    // is atomic on every row (exit 5, no output); the rows that yield are
+    // the #725/#1565 divergence reached through the result-returning twins.
+    let rows: &[(&str, &str, &str, i32)] = &[
+        // limit_with_n_generic -- would error like jq with its bound removed.
+        (r#"[[1,"x"]]"#, "map(limit(1; map(.+1) | .[]))", "[2]", 0),
+        (r#"[1,"x"]"#, "[limit(1; map(.+1)|.[])] + [1]", "[2,1]", 0),
+        // nth_with_n_generic -- same.
+        (r#"[[1,"x"]]"#, "map(nth(0; map(.+1) | .[]))", "[2]", 0),
+        // nth's `n + 1`: an expanding rest is the only way to see it. Top-level
+        // `nth` takes the sink-driven `take_at_index_generic`; it is the
+        // `map(..)`-wrapped spelling that reaches `nth_with_n_generic`, so
+        // both are here.
+        (r#"[1,"x"]"#, "nth(1; map(.+1)|.[] | (.,.))", "", 5),
+        (r#"[[1,"x"]]"#, "map(nth(1; map(.+1)|.[] | (.,.)))", "", 5),
+        // take_at_index's `skip + 1`, NOT min'd with the outer `first`.
+        (r#"[1,"x"]"#, "first(nth(1; map(.+1) | .[] | (.,.)))", "", 5),
+        // limit DOES compose with an outer bound: first(limit(3; ..)) pulls 1.
+        (r#"[1,"x",3]"#, "first(limit(3; map(.+1)|.[]))", "2", 0),
+        (r#"[1,"x",3]"#, "[limit(3; map(.+1)|.[])]", "", 5),
+    ];
+    for (input, filter, want_out, want_code) in rows {
+        let (out, err, code) = run_jq_full(&["-c", filter], Some(input))?;
+        assert_eq!(
+            (out.trim(), code),
+            (*want_out, *want_code),
+            "#2666: `{filter}` on {input} -- stderr: {err:?}"
+        );
+    }
+    Ok(())
+}
+
+/// #2666: `(a | b) | c` and `a | b | c` are the same jq program and must
+/// answer alike -- and run alike. The parenthesised spelling routes its
+/// inner pipe through `eval_each_pipe_generic`'s driver closure, which is a
+/// forwarder; #2815's first version left that closure on the `Unbounded`
+/// default, so `first((map(.+1) | .[]) | .+1)` drained 2M elements (13x
+/// slower than the flat spelling) and answered differently on a failing
+/// element. The driver now carries the outer budget via `forward`. Pinned
+/// here by the answer; the timing lives in the PR's A/B table.
+#[test]
+fn test_parenthesised_pipe_agrees_with_flat_pipe_under_first_2666() -> Result<()> {
+    let input = r#"[1,"x",3]"#;
+    let flat = run_jq_full(&["-c", "first(map(.+1) | .[] | .+1)"], Some(input))?;
+    let parens = run_jq_full(&["-c", "first((map(.+1) | .[]) | .+1)"], Some(input))?;
+    assert_eq!(
+        (flat.0.trim(), flat.2),
+        (parens.0.trim(), parens.2),
+        "#2666: the two spellings of one program disagree -- flat: {flat:?}, parens: {parens:?}"
+    );
+    // And they agree on the deliberately-divergent literal, not on an error:
+    assert_eq!((flat.0.trim(), flat.2), ("3", 0));
+    Ok(())
+}


### PR DESCRIPTION
## What

`[1,"x",3] | map(.+1) | .[]` leaked `2` to stdout before raising. Real jq builds the whole array before `.[]` can observe it, so a failing element fails the expression with no output. Sixteen spellings leaked — bare, piped, under `try`/`?`/`//`, in a `def`, as a `foreach` source, under `limit(n)` with `n` ≥ the array's length. All match jq now.

Fixes #2666. PR B of the two-PR sequence; PR A (#2808) landed the perf-guard rows first.

## Three commits, each reviewable alone

1. **`refactor`** — the sink boundary becomes a trait. 54 signatures, 31 direct calls, one closure annotation. Full suite green, **zero behaviour change** (verified before the next commit was written).
2. **`fix`** — `Sink::budget()`, `bounded(n, inner, f)` at the five sites that count outputs, and a validation window in `each_lazy_seq_iterate_sink` that pulls `min(budget, len)` elements before the first push. A failure inside the window returns through the same escape path a mid-sequence failure takes, with nothing emitted.
3. **`docs`** — ADR-0022, and `limitations.md`'s entry restated as an enforced bound.

## Why a trait, not a parallel parameter

`map(f) | .[]` and `first(map(f) | .[])` reach the consumer in a bit-identical state — same `LazySeq`, same empty `rest` — because `first` *wraps* rather than follows. The information lives in the consumer of the consumer. With a parallel `budget` parameter, each of ~40 interposing closures chooses inherit-or-reset, and one wrong choice re-opens the leak silently. With the trait, a closure that says nothing is `Unbounded` — atomic, jq-matching — and laziness is opt-in at the site that truncates. A missed opt-in costs a materialization; it cannot cost a wrong answer.

## `forward` — where it is applied, where it is withheld, and a correction

The first version of this PR said no forwarding wrapper was needed, "measured." It had measured `try` and `//` only. The review found the one closure that is *pure syntax*: the driver for a parenthesised pipe. `first((map(.+1) | .[]) | .+1)` drained 2M elements — **0.575 s vs the flat spelling's 0.043 s, 13×** — and answered differently on a failing element. Same jq program; the divergence boundary had become syntactic.

`forward(inner, f)` now exists and is applied at exactly that driver. Both spellings agree, on the answer and on the 0.04 s.

It is still **withheld** at the semantic boundaries — `try`, `//`, `?//`, `as` — because there the reset *is* the behaviour: `first(try (map(.+1)|.[]) catch "c")` answers `"c"` exactly as jq does because `try` resets. The cost is real and now stated with numbers rather than waved away:

| shape (2M elements) | base | head | jq 1.7.1 |
|---|--:|--:|--:|
| `first(map(.+1) \| .[] \| .+1)` — flat | 0.045 s | 0.047 s | 0.48 s |
| `first((map(.+1) \| .[]) \| .+1)` — parens | 0.043 s | **0.043 s** (was 0.575 s) | 0.48 s |
| `first(try (map(.+1) \| .[]) catch "c")` | 0.046 s | 0.577 s | 0.48 s |
| `first((map(.+1) \| .[]) // 0)` | 0.044 s | 0.584 s | 0.48 s |
| `label $o \| (map(.+1) \| .[] \| ., break $o)` — jq's own `first` | 0.045 s | 0.589 s | 0.48 s |

The withheld shapes run at roughly jq's own speed instead of 11× ahead of it, and they answer as jq does. `label`/`break` cannot be budgeted at all — `break` is dynamic truncation — so that cost is inherent. ADR-0022 decision 5 records all of this.

## Other review findings, all acted on

- **`first(nth(1; ..))` under-validated.** `take_at_index_generic` took `min(skip+1, outer)`; an outer `first` bounds *outputs*, not the inputs `nth` must examine. Now `AtMost(skip+1)` regardless. `limitations.md`'s "the divergence is exactly …" corrected to "at least …", which is what the window guarantees.
- **Two `bounded` sites and both off-by-ones were undiscriminated** — the result-returning twins (`limit_with_n_generic`, `nth_with_n_generic`, reached only under a collecting consumer like `map(..)`) and `n+1`/`skip+1`. Rows added; every mutation re-run and now fails exactly one test each.
- **ADR slips**: it described a perf-guard override that was never added (and isn't needed — see below); claimed `fold_lazy_seq_stage`'s Iterate arm might be dead (it serves the collecting route); `LazySeq` has no `size_hint`, so the capacity pre-size was `with_capacity(0)` — removed; a stale doc paragraph above the consumer described the pre-#2666 trade as unconditional.

## Measured — release, interleaved, 5 reps, 2M-element array

| shape | base | head |
|---|---|---|
| `first(map(.+1) \| .[] \| .+1)` — **#1565's win** | 0.048 s / 29 MB | **0.047 s / 29 MB** |
| `[limit(1; map(.+1) \| .[])]` | 0.048 s / 29 MB | 0.047 s / 29 MB |
| `map(.+1) \| .[] \| length` — now atomic | 1.293 s / 29 MB | 1.217 s / **168 MB** |
| `[map(.+1) \| .[]] \| length` — control | 0.723 s / 272 MB | 0.715 s / 272 MB |

The atomic shape pays the O(n) buffer jq itself pays (still under the `[..]` form's 272 MB) and is marginally faster — buffer-then-drain is friendlier to the cache than interleaved pull/push.

## Verification

- **3,000 pairs** (12 sources × 25 consumers × 10 docs): 5 differ, all now matching jq. **Plus 1,848 pairs** built from the review's attack surface — parenthesised pipes, result-returning twins, expanding tails, failing element first/last/only: **24 differ, all 24 now match jq, zero move away.**
- Every row of #2666's §0 table pinned, one assertion each on `(stdout, exit)`, in `test_map_iterate_atomicity_outside_truncators_2666` — including the four **must-preserve** rows carrying the divergent literal on purpose, so the boundary is pinned from both sides.
- Owned and generic routes agree on the changed rows (`test_map_iterate_atomicity_owned_and_generic_agree_2666`).
- Unit tests: `Budget::min` composition; `bounded` composes (`first(limit(3;..))` → `AtMost(1)`); the window on `[1,2,"x"]` — `AtMost(2)` yields `2, 3`, `AtMost(3)` and `Unbounded` raise with nothing emitted.
- The existing #725/#1565 pins pass unchanged.
- Full suite (63 binaries), both clippy legs, fmt, `--no-default-features`, rustdoc `-D warnings`, commit lint on all five commits.
- **Patch coverage 97.66% (292/299)**, and the seven lines are accounted for rather than annotated away: two are `panic!` diagnostics in the window unit test, unreachable in a passing suite by design (annotated with the established reason); five existed on `main` uncovered and appear "new" only because the `sink(..)` → `sink.push(..)` rename touched their line — the `//` operand's `OneCursorValue`-falsy branch (provably unreachable: its only constructor yields key strings, never falsy) and an empty path-context pipe's `None` arm (parser-unreachable). `omni-dev`'s `tolerate` keeps lines in the percentage by design — it stabilises the delta — so those five were left un-annotated rather than mis-attributed to this change. The `nth` skipped-element force, also re-attributed, got the test its own doc comment describes instead.

## perf-guard — measured, and no override is needed

CI's merge-base comparison on this PR, both legs:

| row | x86_64 | ARM64-Linux |
|---|--:|--:|
| `arrays_first_map_iterate` (#1565's guard) | **+0.0%** | **+0.0%** |
| `arrays_map_iterate` (the shape made atomic) | **+0.9%** | **+0.6%** |

Both inside the default 5%. The plan expected the second row to move substantially — "back to the O(n) buffer pre-#2103 always paid" — and proposed pre-sizing a `QUERY_THRESHOLDS` override from the `ce691ca85` comparison (which reads +69%). It moved by under 1%. The buffer changes *when* each element's work happens and how much *memory* is live (29 → 168 MB on 2M elements), not how many instructions run, and cachegrind counts instructions. The +69% between `ce691ca85` and `main` was, as #2808 suspected, the other 60 `eval_generic.rs` commits in that window.

So: no override added, none to remove later, and the row keeps its full 5% sensitivity. Had one been pre-sized as proposed, it would have been a permanent 40–70% loosening for a sub-1% change.

## Still to check from the plan

`fold_lazy_seq_stage`'s own `Expr::Iterate` arm implemented drain-first behaviour this now reproduces at the consumer. If coverage shows it dead, it gets deleted, not tolerated.
