### PR TITLE
fix(jq): make reverse follow jq's own definition on non-arrays

### DIFF
--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -12692,14 +12692,17 @@ fn builtin_nth<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
 /// and answers `[]`; a boolean fails inside `length` ("boolean (true) has no
 /// length"); everything else with a positive length reaches `.[n]` and fails
 /// there ("Cannot index object with number"). Captured against jq 1.7.1 and
-/// 1.8.2, which agree on every cell. This arm used to decide by type: `{}`,
-/// `null`, `0`, `""` raised the index error, booleans raised it too, and a
-/// string was *reversed* -- a guess from the first implementation that no
-/// pinned jq has ever done. `reverse_length_is_empty` is the shared rule;
-/// `eval_generic.rs`'s own arm asks it too.
+/// 1.8.2, which agree on every cell. This arm used to decide by type, in
+/// both modes: `null` answered `[]`, a string was *reversed* (so `""` came
+/// back as `""`) -- both guesses from the first implementation that no
+/// pinned jq or yq has ever made -- and everything else, `{}`, `0` and the
+/// booleans included, raised the index error. `reverse_length_is_empty` is
+/// the shared rule; `eval_generic.rs`'s own arm asks it too.
 ///
-/// yq mode is untouched: real yq (v4.53.3) rejects every non-array with
-/// "node at path [] is not an array", `{}`/`null`/`""` included.
+/// yq mode takes the fall-through only: real yq (v4.53.3) rejects every
+/// non-array with "node at path [] is not an array", `{}`/`null`/`""`
+/// included, so dropping the `null`/string arms moved this route toward yq
+/// as well (`.a |= reverse` on `{}` used to write `{"a":[]}`; yq errors).
 fn builtin_reverse<W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     value: StandardJson<'_, W>,
     optional: bool,
@@ -64715,6 +64718,32 @@ mod tests {
                 assert_eq!(e.message, "boolean (true) has no length");
             }
         );
+    }
+
+    /// #2730: `builtin_reverse`'s jq-mode arm forwards `length`'s own
+    /// `optional` suppression (`QueryResult::None`) rather than turning it
+    /// into an index error. No real syntax reaches a builtin with
+    /// `optional = true` (`reverse?` parses to `Expr::Optional`, whose catch
+    /// evaluates the inner builtin at the ambient `optional` -- see
+    /// `test_generic_plain_map_optional_on_non_container_is_unreachable_via_parser_725`
+    /// in `eval_generic.rs`), so pin the arm by calling the dispatcher
+    /// directly, as that test does.
+    #[test]
+    fn test_builtin_reverse_forwards_lengths_optional_suppression_2730() {
+        let json_bytes: &[u8] = br"true";
+        let index = JsonIndex::build(json_bytes);
+        let cursor = index.root(json_bytes);
+        let expr = Expr::Builtin(Builtin::Reverse);
+        assert!(matches!(
+            eval_single::<Vec<u64>, JqSemantics>(&expr, cursor.value(), true),
+            QueryResult::None
+        ));
+        // The positive control: the same input un-suppressed is `length`'s
+        // own error, not the fall-through index error.
+        match eval_single::<Vec<u64>, JqSemantics>(&expr, cursor.value(), false) {
+            QueryResult::Error(e) => assert_eq!(e.message, "boolean (true) has no length"),
+            other => panic!("expected length's error, got: {other:?}"),
+        }
     }
 
     #[test]

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -9935,7 +9935,7 @@ fn eval_builtin<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
         Builtin::First => builtin_first::<W>(value, optional),
         Builtin::Last => builtin_last::<W>(value, optional),
         Builtin::Nth(n) => builtin_nth::<W, S>(n, value, optional),
-        Builtin::Reverse => builtin_reverse::<W>(value, optional),
+        Builtin::Reverse => builtin_reverse::<W, S>(value, optional),
         Builtin::Flatten => builtin_flatten::<W, S>(value, optional, 1),
         Builtin::FlattenDepth(depth) => builtin_flatten_depth::<W, S>(depth, value, optional),
         Builtin::GroupBy(f) => builtin_group_by::<W, S>(f, value, optional),
@@ -12680,7 +12680,27 @@ fn builtin_nth<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
 }
 
 /// Builtin: reverse - reverse array
-fn builtin_reverse<W: Clone + AsRef<[u64]>>(
+///
+/// jq defines it, it does not implement it:
+///
+/// ```jq
+/// def reverse: [.[length - 1 - range(0;length)]];
+/// ```
+///
+/// so the non-array answer is decided by **`length`**, not by type (#2730).
+/// Anything whose `length` is `0` -- `{}`, `null`, `""`, `0` -- never indexes
+/// and answers `[]`; a boolean fails inside `length` ("boolean (true) has no
+/// length"); everything else with a positive length reaches `.[n]` and fails
+/// there ("Cannot index object with number"). Captured against jq 1.7.1 and
+/// 1.8.2, which agree on every cell. This arm used to decide by type: `{}`,
+/// `null`, `0`, `""` raised the index error, booleans raised it too, and a
+/// string was *reversed* -- a guess from the first implementation that no
+/// pinned jq has ever done. `reverse_length_is_empty` is the shared rule;
+/// `eval_generic.rs`'s own arm asks it too.
+///
+/// yq mode is untouched: real yq (v4.53.3) rejects every non-array with
+/// "node at path [] is not an array", `{}`/`null`/`""` included.
+fn builtin_reverse<W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     value: StandardJson<'_, W>,
     optional: bool,
 ) -> QueryResult<'_, W> {
@@ -12694,23 +12714,35 @@ fn builtin_reverse<W: Clone + AsRef<[u64]>>(
             items.reverse();
             QueryResult::Owned(OwnedValue::Array(items))
         }
-        // reverse also works on strings. #1620/#1660: an undecodable string
-        // must raise, not silently substitute an empty string.
-        StandardJson::String(s) => match s.as_str() {
-            Ok(cow) => {
-                let reversed: String = cow.chars().rev().collect();
-                QueryResult::Owned(OwnedValue::String(reversed))
+        _ if S::TAG == EvalTag::Jq => match builtin_length::<W, S>(value.clone(), optional) {
+            QueryResult::Owned(len) if reverse_length_is_empty(&len) => {
+                QueryResult::Owned(OwnedValue::Array(Vec::new()))
             }
-            Err(e) => QueryResult::Error(EvalError::decode_failure(e.message())),
+            QueryResult::Error(e) => QueryResult::Error(e),
+            // `optional` already suppressed `length`'s own error.
+            QueryResult::None => QueryResult::None,
+            _ => QueryResult::Error(EvalError::cannot_index_with_type(
+                type_name(&value),
+                "number",
+            )),
         },
-        // jq: null | reverse => []
-        StandardJson::Null => QueryResult::Owned(OwnedValue::Array(Vec::new())),
         _ if optional => QueryResult::None,
         _ => QueryResult::Error(EvalError::cannot_index_with_type(
             type_name(&value),
             "number",
         )),
     }
+}
+
+/// The one rule in jq's `def reverse: [.[length - 1 - range(0;length)]]`
+/// that decides a non-array's fate (#2730): a `length` of `0` makes
+/// `range(0;0)` empty, so the comprehension is `[]` and the value's type is
+/// never consulted. Anything else runs `.[n]` and fails there. Shared by both
+/// evaluators' `Reverse` arms -- each asks its own `length`, then asks this --
+/// so the two cannot drift on what "empty" means (`0` and `0.0` both are;
+/// jq's `length` of a number is its absolute value, so `-0` is too).
+pub(crate) fn reverse_length_is_empty(length: &OwnedValue) -> bool {
+    matches!(length, OwnedValue::Int(0)) || matches!(length, OwnedValue::Float(f) if *f == 0.0)
 }
 
 /// Builtin: flatten - flatten nested arrays (1 level)
@@ -64651,10 +64683,36 @@ mod tests {
             }
         );
 
-        // Reverse also works on strings
+        // #2730: `reverse` does NOT work on strings in any pinned jq -- this
+        // test used to assert `"olleh"`, a guess from the first
+        // implementation that neither jq 1.7.1 nor 1.8.2 has ever made
+        // (`"hello" | reverse` is `Cannot index string with number` in
+        // both, captured live). jq's own `def reverse:
+        // [.[length - 1 - range(0;length)]]` indexes the string and fails.
         query!(br#""hello""#, "reverse",
-            QueryResult::Owned(OwnedValue::String(s)) => {
-                assert_eq!(s, "olleh");
+            QueryResult::Error(e) => {
+                assert_eq!(e.message, "Cannot index string with number");
+            }
+        );
+
+        // #2730: the same def makes anything of `length` 0 answer `[]` --
+        // `range(0;0)` is empty, so the type is never consulted.
+        query!(br"{}", "reverse",
+            QueryResult::Owned(OwnedValue::Array(arr)) => assert!(arr.is_empty())
+        );
+        query!(br"null", "reverse",
+            QueryResult::Owned(OwnedValue::Array(arr)) => assert!(arr.is_empty())
+        );
+        query!(br"0", "reverse",
+            QueryResult::Owned(OwnedValue::Array(arr)) => assert!(arr.is_empty())
+        );
+        query!(br#""""#, "reverse",
+            QueryResult::Owned(OwnedValue::Array(arr)) => assert!(arr.is_empty())
+        );
+        // ..and a boolean fails inside `length`, not at the index.
+        query!(br"true", "reverse",
+            QueryResult::Error(e) => {
+                assert_eq!(e.message, "boolean (true) has no length");
             }
         );
     }

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -19638,7 +19638,12 @@ fn eval_builtin<S: EvalSemantics, V: DocumentValue>(
                         GenericResult::Owned(OwnedValue::Array(Vec::new()))
                     }
                     GenericResult::Error(e) => GenericResult::Error(e),
-                    GenericResult::None => GenericResult::None,
+                    // `length` only answers `None` under `optional = true`,
+                    // which `eval_single`'s #2368 pin keeps from ever
+                    // reaching `Builtin::Reverse`; forwarded so the day a
+                    // dispatch path does grant it, the suppression is
+                    // `length`'s, not an index error.
+                    GenericResult::None => GenericResult::None, // omni-dev: coverage tolerate-line reason="unreachable by design -- eval_single's #2368 debug_assert forbids optional=true on Builtin::Reverse, so length never answers None here (#2730)"
                     _ => GenericResult::Error(index_error()),
                 }
             } else if optional {

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -64,15 +64,16 @@ use super::eval::{
     mark_nonretryable_escape, needs_path_context, numeric_key_to_array_index, numeric_key_to_index,
     numeric_length_owned, owned_bound_to_i64, owned_to_expr, owned_to_string,
     pattern_alternatives_var_names, prefer_pending_control, range_max_exceeded_error, range_num,
-    range_values_f64, range_values_int, resume_from_escape, select_emits, slice_component_value,
-    slice_object_as_yq_children, slice_owned_value_read, stop_with_downstream, stop_with_error,
-    stop_with_escape, stop_with_escape_cell, streams_escaped_generator_prefix, streams_unbounded,
-    substitute_bound_var_from, substitute_vars, suppress_or_raise, suppresses, tonumber_from_str,
-    vec_with_capacity, yq_absent_key_read_is_empty, yq_assign_rhs_document,
-    yq_empty_operand_output, yq_field_index_on_scalar_is_empty, yq_negative_index_check,
-    yq_numeric_index_on_object_is_null, yq_object_key_stringify, yq_read_only_context,
-    BinaryFanoutRules, Control, Demand, EmptyOperandOp, EvalError, EvalSemantics, EvalTag, Flow,
-    ForeachElementSink, JqSemantics, LimitN, PathTrail, QueryResult, RangeNum, YqSemantics,
+    range_values_f64, range_values_int, resume_from_escape, reverse_length_is_empty, select_emits,
+    slice_component_value, slice_object_as_yq_children, slice_owned_value_read,
+    stop_with_downstream, stop_with_error, stop_with_escape, stop_with_escape_cell,
+    streams_escaped_generator_prefix, streams_unbounded, substitute_bound_var_from,
+    substitute_vars, suppress_or_raise, suppresses, tonumber_from_str, vec_with_capacity,
+    yq_absent_key_read_is_empty, yq_assign_rhs_document, yq_empty_operand_output,
+    yq_field_index_on_scalar_is_empty, yq_negative_index_check, yq_numeric_index_on_object_is_null,
+    yq_object_key_stringify, yq_read_only_context, BinaryFanoutRules, Control, Demand,
+    EmptyOperandOp, EvalError, EvalSemantics, EvalTag, Flow, ForeachElementSink, JqSemantics,
+    LimitN, PathTrail, QueryResult, RangeNum, YqSemantics,
 };
 #[cfg(test)]
 use super::expr::FuncDefBound;
@@ -19614,6 +19615,32 @@ fn eval_builtin<S: EvalSemantics, V: DocumentValue>(
                 let mut cursors = owned_or_suppress!(elements.collect_cursors_checked(), optional);
                 cursors.reverse();
                 GenericResult::LazySeq(Box::new(LazySeq::from_cursors(cursors)))
+            } else if S::TAG == EvalTag::Jq {
+                // #2730: jq defines `reverse` as `[.[length - 1 -
+                // range(0;length)]]`, so a non-array is decided by its
+                // `length`, not its type -- `{}`/`null`/`""`/`0` are `[]`,
+                // a boolean fails in `length`, the rest fail at `.[n]`.
+                // Ask this evaluator's own `Length` arm (gap checks, yq
+                // numeric rendering and the `has no length` wording all
+                // ride along) and ask `eval.rs`'s `reverse_length_is_empty` what
+                // counts as empty, so the two arms cannot drift on this again.
+                let length = eval_single::<S, V>(
+                    &Expr::Builtin(Builtin::Length),
+                    value.clone(),
+                    optional,
+                    cursor,
+                );
+                let index_error = || {
+                    EvalError::cannot_index_with_type(tagged_type_name(&value, cursor), "number")
+                };
+                match length {
+                    GenericResult::Owned(len) if reverse_length_is_empty(&len) => {
+                        GenericResult::Owned(OwnedValue::Array(Vec::new()))
+                    }
+                    GenericResult::Error(e) => GenericResult::Error(e),
+                    GenericResult::None => GenericResult::None,
+                    _ => GenericResult::Error(index_error()),
+                }
             } else if optional {
                 GenericResult::None
             } else {

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -48473,6 +48473,13 @@ fn test_reverse_follows_jqs_own_definition_2730() -> Result<()> {
         ("null", "[]", 0, ""),
         ("0", "[]", 0, ""),
         ("-0", "[]", 0, ""),
+        // Float zeros: `length` of a number is its `fabs`, so these are the
+        // `Float(0.0)` half of `reverse_length_is_empty` as *documents* --
+        // stdin `-0` parses to `Int(0)`, and only the owned route's unary
+        // minus reaches the float arm through that row.
+        ("0.0", "[]", 0, ""),
+        ("-0.0", "[]", 0, ""),
+        ("1e-400", "[]", 0, ""),
         (r#""""#, "[]", 0, ""),
         ("[]", "[]", 0, ""),
         ("[1,2]", "[2,1]", 0, ""),
@@ -48515,6 +48522,21 @@ fn test_reverse_follows_jqs_own_definition_2730() -> Result<()> {
     for input in [r#"{"a":1}"#, "true", r#""ab""#] {
         let (out, _, code) = run_jq_full(&["-c", "reverse?"], Some(input))?;
         assert_eq!((out.trim(), code), ("", 0), "#2730: `{input} | reverse?`");
+    }
+    // An undecodable string root now fails in `length` (a decode failure,
+    // which `?` never suppresses) instead of at the type check, where the
+    // old arm raised a plain index error that `?` *did* swallow -- exit 0 on
+    // a document jq refuses to parse at all (`parse error: Invalid escape`,
+    // exit 5). Both routes through `length` (`length?`, the hand-desugared
+    // def) already behaved this way; `reverse` now agrees with them.
+    for filter in ["reverse", "reverse?", "try reverse catch ."] {
+        let (out, err, code) = run_jq_full(&["-c", filter], Some(r#""bad\x""#))?;
+        assert_eq!(
+            (out.trim(), code),
+            ("", 5),
+            "#2730: `{filter}` on an undecodable string -- stderr: {err:?}"
+        );
+        assert!(err.contains("invalid escape"), "stderr: {err:?}");
     }
     Ok(())
 }

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -48455,3 +48455,66 @@ fn test_nth_result_twin_forces_skipped_elements_2666() -> Result<()> {
     assert!(err.contains("cannot be divided"), "stderr: {err:?}");
     Ok(())
 }
+
+/// #2730: `reverse` is jq-defined, not built in --
+/// `def reverse: [.[length - 1 - range(0;length)]]` -- so a non-array's fate
+/// is decided by its `length`, not its type. Anything whose length is `0`
+/// never indexes and answers `[]`; a boolean fails inside `length`; the rest
+/// reach `.[n]` and fail there. The issue found one cell (`{}`); the sweep
+/// found seven, plus a string that was being *reversed* on the owned route
+/// (`-n`), which no pinned jq does. Every cell captured against jq 1.7.1
+/// (1.8.2 agrees), on both routes: the cursor route via stdin and the owned
+/// route via `-n`.
+#[test]
+fn test_reverse_follows_jqs_own_definition_2730() -> Result<()> {
+    // (input, expected stdout, expected exit, stderr fragment)
+    let rows: &[(&str, &str, i32, &str)] = &[
+        ("{}", "[]", 0, ""),
+        ("null", "[]", 0, ""),
+        ("0", "[]", 0, ""),
+        ("-0", "[]", 0, ""),
+        (r#""""#, "[]", 0, ""),
+        ("[]", "[]", 0, ""),
+        ("[1,2]", "[2,1]", 0, ""),
+        ("[[1],[2]]", "[[2],[1]]", 0, ""),
+        (r#"{"a":1}"#, "", 5, "Cannot index object with number"),
+        ("5", "", 5, "Cannot index number with number"),
+        ("-3", "", 5, "Cannot index number with number"),
+        ("0.5", "", 5, "Cannot index number with number"),
+        // The row that used to answer "ba" on the owned route.
+        (r#""ab""#, "", 5, "Cannot index string with number"),
+        ("false", "", 5, "boolean (false) has no length"),
+        ("true", "", 5, "boolean (true) has no length"),
+    ];
+    for (input, want_out, want_code, want_err) in rows {
+        // cursor route
+        let (out, err, code) = run_jq_full(&["-c", "reverse"], Some(input))?;
+        assert_eq!(
+            (out.trim(), code),
+            (*want_out, *want_code),
+            "#2730 cursor route: `{input} | reverse` -- stderr: {err:?}"
+        );
+        assert!(
+            err.contains(want_err),
+            "#2730 cursor route: `{input}` -- stderr: {err:?}"
+        );
+        // owned route -- parenthesised so a negative literal is an expression,
+        // not a flag, and so `-0` is unary minus on 0 (length 0) as in jq.
+        let (out, err, code) = run_jq_full(&["-nc", &format!("({input}) | reverse")], None)?;
+        assert_eq!(
+            (out.trim(), code),
+            (*want_out, *want_code),
+            "#2730 owned route: `-n '{input} | reverse'` -- stderr: {err:?}"
+        );
+        assert!(
+            err.contains(want_err),
+            "#2730 owned route: `{input}` -- stderr: {err:?}"
+        );
+    }
+    // `?` suppresses the index error and the `length` error alike, as in jq.
+    for input in [r#"{"a":1}"#, "true", r#""ab""#] {
+        let (out, _, code) = run_jq_full(&["-c", "reverse?"], Some(input))?;
+        assert_eq!((out.trim(), code), ("", 0), "#2730: `{input} | reverse?`");
+    }
+    Ok(())
+}

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -42661,6 +42661,13 @@ fn range_bounds_validate_only_what_they_read_2698() -> Result<()> {
 /// `reverse` input -- `{}`, `null`, `""`, `0` included -- with "node at path
 /// [] is not an array", so the jq-mode `length`-decided rule must NOT reach
 /// here. Pins that every non-array still errors and every array still works.
+///
+/// The second loop is the owned route (`-n`, and `.a |= reverse`, which
+/// materializes), where the pre-#2730 `eval.rs` arm answered `[]` for
+/// `null` and *reversed* a string in every mode -- `.a |= reverse` on `{}`
+/// wrote `{"a":[]}`, `"ab" | reverse` gave `"ba"`. Real yq errors on both
+/// (`node at path [a] is not an array (it's a !!null)`), so dropping those
+/// arms moved this route toward yq too; these rows fail on the old binary.
 #[test]
 fn reverse_still_rejects_every_non_array_in_yq_mode_2730() -> Result<()> {
     for input in ["{}", "a: 1", "null", r#""""#, "0", r#""ab""#, "true"] {
@@ -42668,6 +42675,20 @@ fn reverse_still_rejects_every_non_array_in_yq_mode_2730() -> Result<()> {
         assert_ne!(
             code, 0,
             "#2730 yq: `{input} | reverse` must error like real yq, got {out:?}"
+        );
+    }
+    for (filter, input, args) in [
+        (".a |= reverse", "{}", &["-o=json", "-I=0"][..]),
+        (".a | reverse", "{}", &["-o=json", "-I=0"][..]),
+        (".a |= reverse", "a: ab", &["-o=json", "-I=0"][..]),
+        ("null | reverse", "", &["-n", "-o=json", "-I=0"][..]),
+        (r#""ab" | reverse"#, "", &["-n", "-o=json", "-I=0"][..]),
+        (r#""" | reverse"#, "", &["-n", "-o=json", "-I=0"][..]),
+    ] {
+        let (out, code) = run_yq_stdin(filter, input, args)?;
+        assert_ne!(
+            code, 0,
+            "#2730 yq owned route: `{filter}` on {input:?} must error like real yq, got {out:?}"
         );
     }
     for (input, want) in [("[]", "[]"), ("[1, 2]", "[2,1]")] {

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -42656,3 +42656,27 @@ fn range_bounds_validate_only_what_they_read_2698() -> Result<()> {
     }
     Ok(())
 }
+
+/// #2730's yq-mode gate: real yq (v4.53.3) rejects every non-array
+/// `reverse` input -- `{}`, `null`, `""`, `0` included -- with "node at path
+/// [] is not an array", so the jq-mode `length`-decided rule must NOT reach
+/// here. Pins that every non-array still errors and every array still works.
+#[test]
+fn reverse_still_rejects_every_non_array_in_yq_mode_2730() -> Result<()> {
+    for input in ["{}", "a: 1", "null", r#""""#, "0", r#""ab""#, "true"] {
+        let (out, code) = run_yq_stdin("reverse", input, &["-o=json", "-I=0"])?;
+        assert_ne!(
+            code, 0,
+            "#2730 yq: `{input} | reverse` must error like real yq, got {out:?}"
+        );
+    }
+    for (input, want) in [("[]", "[]"), ("[1, 2]", "[2,1]")] {
+        let (out, code) = run_yq_stdin("reverse", input, &["-o=json", "-I=0"])?;
+        assert_eq!(
+            (out.trim(), code),
+            (want, 0),
+            "#2730 yq: `{input} | reverse`"
+        );
+    }
+    Ok(())
+}


### PR DESCRIPTION
Fixes #2730

## What

jq 1.7.1 defines `reverse` as `def reverse: [.[length - 1 - range(0;length)]];`, so a non-array is decided by its `length`, not its type. `succinctly jq` previously rejected most non-arrays outright, and the owned evaluator (`-n`, anything materialized) answered `[]` for `null` and *reversed strings* — neither of which any jq release does (verified against 1.7.1 and 1.8.2).

Captured live from `/usr/bin/jq` 1.7.1, matched on both routes (cursor: `-c reverse` over stdin; owned: `-nc '(<doc>) | reverse'`):

| input | jq 1.7.1 → succinctly jq now | was (cursor / owned) |
|---|---|---|
| `{}` `0` `-0` `0.0` `-0.0` `1e-400` | `[]` | `Cannot index <type> with number` |
| `null` | `[]` | error / `[]` |
| `""` | `[]` | error / `""` |
| `"ab"` | `Cannot index string with number` (exit 5) | error / `"ba"` |
| `true` / `false` | `boolean (true) has no length` (exit 5) | `Cannot index boolean with number` |
| `{"a":1}` `5` `-3` `1.5` | `Cannot index <type> with number` (exit 5) | same |
| `[]` `[1,2]` | `[]` / `[2,1]` | same |

`?` suppression works on the erroring rows as before (`{"a":1} \| reverse?` → nothing; `{} \| reverse?` → `[]`).

## How

Both `src/jq/eval.rs::builtin_reverse` and the `Builtin::Reverse` arm in `src/jq/eval_generic.rs` now, in jq mode, ask their own `Length` arm and route the answer through a shared `reverse_length_is_empty` (`Int(0)` or `Float(0.0)`), so the two evaluators cannot drift on this again. Any `length` error propagates verbatim (that is where jq's `boolean (true) has no length` comes from); a non-zero length falls through to the original `Cannot index <type> with number`.

The `null => []` and string-reversal arms in `eval.rs` are removed — original-implementation guesses with no reference behind them in either mode.

## Effects beyond the jq-mode cells (all toward the reference)

- **yq mode, owned route.** Those removed `eval.rs` arms served every mode, so `succinctly yq` moved too: `.a |= reverse` on `{}` used to write `{"a":[]}`, `-n '"ab" | reverse'` gave `"ba"`. Real yq v4.53.3 errors on every one (`node at path [a] is not an array (it's a !!null)`). 28 yq cells change in the sweep below, all to an error where yq errors. The jq-mode `length` rule itself is gated (`S::TAG == EvalTag::Jq`) — yq's cursor route is unchanged. Pinned in `reverse_still_rejects_every_non_array_in_yq_mode_2730`, which now has owned-route rows that fail on `main`.
- **Undecodable string root.** `printf '"bad\x"' | sjq 'reverse?'` used to exit 0 with nothing (index error, swallowed); it now fails inside `length` with `invalid escape sequence in string`, exit 5, which `?`/`try` never suppress. jq refuses the document at parse (exit 5). `length?` and the hand-desugared def already behaved this way on `main`. Pinned in the jq test. Object-leaf faults are unaffected (object `length` never decodes the leaf).
- yq's `first(f)` ignores `f` (a succinctly extension, recorded under #2377), so `-n 'null | first(reverse)'` moving from `[]` to an error is the extension agreeing with its own cursor route, not a fidelity change.

## Verification

- `test_reverse_follows_jqs_own_definition_2730` (`tests/jq_cli_tests.rs`): 18-row table of `(input, stdout, exit, stderr fragment)` run on both routes, `?` suppression rows, and the undecodable-string rows.
- `test_builtin_reverse` (unit) flipped to the jq-defined expectations; `test_builtin_reverse_forwards_lengths_optional_suppression_2730` pins the `optional` forwarding arm by direct call (no syntax reaches a builtin with `optional = true`; #725/#1953 precedent). The generic evaluator's twin arm is unreachable by its own #2368 `eval_single` pin and is marked so.
- Differential sweep vs a `main` build, both modes × both routes: **jq: 71/1088 cells change, every one to jq 1.7.1's output** (`reverse`, `reverse?`, `[reverse]`, `first(reverse)`, `reverse|length`, `map(reverse)?`, `.a |= reverse`, `.a | reverse`; controls `sort`/`unique`/`min`/`max`/`add`/`flatten`/`length`/`to_entries`/`keys` unchanged). **yq: 28/448 change**, as above. The first version of this PR claimed zero yq changes — that sweep was vacuous (zsh passed the yq flags as one argument, so every yq cell errored identically on both binaries); the second commit's message records this.
- No new divergence recorded: this closes unrecorded ones. The `path(reverse)` row under #2744 in `docs/compliance/jq/limitations.md` is about path tracking, not values, and is unaffected.
- Full local gate green after the review fixes: fmt, both clippy legs, rustdoc `-D warnings`, `--no-default-features`, full `cargo test --features cli,simd,regex,serde`, commit lint. Adversarial review's findings (false `-3` row, unclaimed yq owned-route change, unclaimed undecodable-string change, doc-comment inaccuracy, float-zero rows) all addressed in the second commit.
