### PR TITLE
fix(jq): thread flatten's depth argument lazily, matching jq

### DIFF
--- a/docs/compliance/jq/limitations.md
+++ b/docs/compliance/jq/limitations.md
@@ -417,17 +417,30 @@ have to be recorded here.
 |--------------------|---------|-------------------------------------|-----------------------------------|
 | `@uri`             | `[1,2]` | `"%5B1%2C2%5D"`                     | `expected string, got array`      |
 | `@base64`          | `5`     | `"NQ=="`                            | `expected string, got number`     |
-| `flatten("x")`     | `[1,2]` | `[1,2]` (ignores non-integer depth) | `expected number, got non-number` |
 
-[#929](https://github.com/rust-works/succinctly/issues/929) found these while auditing
-`EvalError::type_error` wording: real jq's `@uri`/`@base64` (and every other format string
-except `@csv`/`@tsv`/`@sh`) auto-`tostring`s a non-string argument before formatting rather
-than refusing it outright, and `flatten`'s depth argument is silently ignored if it isn't a
-number rather than validated. `@base64d` is a related but distinct case — jq *does* still
-error on `5 | @base64d` (`string ("5") trailing base64 byte found`), just from attempting to
-base64-decode the auto-stringified `"5"` rather than refusing the number up front, so it
-isn't purely a "jq doesn't error" gap; matching it needs the same underlying
-auto-`tostring`-first change `@uri`/`@base64` do, not just a different error message.
+[#929](https://github.com/rust-works/succinctly/issues/929) found these (a third row,
+`flatten("x")` on `[1,2]`, is below) while auditing `EvalError::type_error` wording: real
+jq's `@uri`/`@base64` (and every other format string except `@csv`/`@tsv`/`@sh`)
+auto-`tostring`s a non-string argument before formatting rather than refusing it outright.
+`@base64d` is a related but distinct case — jq *does* still error on `5 | @base64d`
+(`string ("5") trailing base64 byte found`), just from attempting to base64-decode the
+auto-stringified `"5"` rather than refusing the number up front, so it isn't purely a "jq
+doesn't error" gap; matching it needs the same underlying auto-`tostring`-first change
+`@uri`/`@base64` do, not just a different error message.
+
+`flatten("x")` on `[1,2]` (`[1,2]` in jq, `expected number, got non-number` here) was the
+third #929 row: jq's own `flatten` never validates its depth argument up front, only ever
+inspecting it lazily (`!= 0`, `- 1`) once per recursion level, so a non-numeric depth is
+silent whenever the input has no nesting deep enough to actually reach a real `- 1`
+attempt. [#2755](https://github.com/rust-works/succinctly/issues/2755) closed it:
+`flatten`'s depth argument now threads through as the raw value (`OwnedValue`) rather than
+an eagerly-converted count, reusing the same `compare_values`/`arith_sub` machinery real
+subtraction and comparison already use, so it only ever errors — with jq's own
+subtraction-type wording, not a generic message — once nesting deep enough to reach it is
+actually present. jq mode only; real yq's own grammar accepts nothing but a bare
+non-negative integer literal for `flatten`'s argument, so there is no reachable yq
+behaviour for this widening to match, and yq mode keeps its exact pre-#2755 eager
+rejection.
 
 Both rows are a slice write walking a path *in place*, and the gap is the same
 auto-vivification jq performs everywhere else it writes through a path: `null` grows into

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -9936,7 +9936,7 @@ fn eval_builtin<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
         Builtin::Last => builtin_last::<W>(value, optional),
         Builtin::Nth(n) => builtin_nth::<W, S>(n, value, optional),
         Builtin::Reverse => builtin_reverse::<W, S>(value, optional),
-        Builtin::Flatten => builtin_flatten::<W, S>(value, optional, 1),
+        Builtin::Flatten => builtin_flatten::<W, S>(value, optional, OwnedValue::Int(1)),
         Builtin::FlattenDepth(depth) => builtin_flatten_depth::<W, S>(depth, value, optional),
         Builtin::GroupBy(f) => builtin_group_by::<W, S>(f, value, optional),
         Builtin::Unique => builtin_unique::<W, S>(value, optional),
@@ -12755,7 +12755,7 @@ pub(crate) fn reverse_length_is_empty(length: &OwnedValue) -> bool {
 fn builtin_flatten<W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     value: StandardJson<'_, W>,
     optional: bool,
-    depth: usize,
+    depth: OwnedValue,
 ) -> QueryResult<'_, W> {
     // #1755: to_owned, not to_owned_lossy -- an undecodable element must
     // raise, not silently flatten in as "".
@@ -12793,13 +12793,44 @@ fn builtin_flatten<W: Clone + AsRef<[u64]>, S: EvalSemantics>(
         Ok(items) => items,
         Err(e) => return suppress_or_raise(e, optional),
     };
-    let flattened = flatten_owned(items, depth);
-    QueryResult::Owned(OwnedValue::Array(flattened))
+    match flatten_owned::<S>(items, depth) {
+        Ok(flattened) => QueryResult::Owned(OwnedValue::Array(flattened)),
+        Err(e) => suppress_or_raise(e, optional),
+    }
 }
 
 /// Flatten owned values to a specific depth.
-fn flatten_owned(items: Vec<OwnedValue>, depth: usize) -> Vec<OwnedValue> {
-    flatten_owned_at_depth(items, depth, 0)
+///
+/// #2755: `depth` is `$x` itself, jq's own definition's parameter --
+/// threaded through recursion and only ever inspected via `!= 0`
+/// (`compare_values`) and decremented via `- 1` (`arith_sub`), never
+/// eagerly converted to an integer count up front. This matters because
+/// jq's own reference definition is lazy about both:
+///
+/// ```jq
+/// def flatten($x): if $x < 0 then error("flatten depth must not be negative") else _flatten($x) end;
+/// def _flatten($x):
+///   reduce .[] as $i
+///     ([]; if ($i|type) == "array" and $x != 0
+///          then . + ($i | _flatten($x - 1))
+///          else . + [$i]
+///          end);
+/// ```
+///
+/// A non-numeric or non-integer `$x` is never rejected up front -- only if
+/// and when a genuinely nested array item is actually reached does `$x - 1`
+/// get attempted, and only then can it raise a type error. Confirmed live
+/// against jq 1.7.1: `[[1,[2]],3] | flatten(2.0)` is `[1,2,3]` (an
+/// integral float works fine, decrementing to exactly `0.0` which compares
+/// equal to `0`), and `[1,2,3] | flatten("a")` (no nesting to nest into)
+/// is `[1,2,3]` with no error at all, while `[[1,[2]],3] | flatten("a")`
+/// errors only once the recursion actually reaches a nested array and
+/// tries `"a" - 1`.
+fn flatten_owned<S: EvalSemantics>(
+    items: Vec<OwnedValue>,
+    depth: OwnedValue,
+) -> Result<Vec<OwnedValue>, EvalError> {
+    flatten_owned_at_depth::<S>(items, depth, 0)
 }
 
 /// `depth` (the *remaining flatten levels* the caller asked for, e.g. from
@@ -12815,26 +12846,30 @@ fn flatten_owned(items: Vec<OwnedValue>, depth: usize) -> Vec<OwnedValue> {
 /// (#1005's `to_owned_lossy`/reindex-bridge), so this is defense-in-depth
 /// against that invariant changing, not a currently-live independent
 /// crash path.
-fn flatten_owned_at_depth(
+fn flatten_owned_at_depth<S: EvalSemantics>(
     items: Vec<OwnedValue>,
-    depth: usize,
+    depth: OwnedValue,
     tree_depth: usize,
-) -> Vec<OwnedValue> {
-    if depth == 0 {
-        return items;
-    }
+) -> Result<Vec<OwnedValue>, EvalError> {
     assert_value_tree_depth(tree_depth);
 
     let mut result = Vec::new();
     for item in items {
         match item {
-            OwnedValue::Array(inner) => {
-                result.extend(flatten_owned_at_depth(inner, depth - 1, tree_depth + 1));
+            OwnedValue::Array(inner)
+                if compare_values(&depth, &OwnedValue::Int(0)) != core::cmp::Ordering::Equal =>
+            {
+                let next_depth = arith_sub::<S>(depth.clone(), OwnedValue::Int(1))?;
+                result.extend(flatten_owned_at_depth::<S>(
+                    inner,
+                    next_depth,
+                    tree_depth + 1,
+                )?);
             }
             other => result.push(other),
         }
     }
-    result
+    Ok(result)
 }
 
 /// Builtin: flatten(depth) - flatten to specific depth
@@ -12854,9 +12889,6 @@ fn builtin_flatten_depth<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
         ArgFanout::All,
         |depth_value| {
             let depth = match depth_value {
-                OwnedValue::Int(d) | OwnedValue::NumberLiteral(NumberRepr::Int(d), _) if d >= 0 => {
-                    d as usize
-                }
                 // #2747: jq defines this as `if $x < 0 then error(...) else
                 // _flatten($x) end`, where `$x < 0` is jq's own total
                 // ordering (`compare_values`), not a plain integer sign
@@ -12865,8 +12897,6 @@ fn builtin_flatten_depth<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
                 // and `true` all rank below every number in that ordering;
                 // `nan` orders as less than every other number, including
                 // itself -- see `compare_values`'s own doc comment).
-                // Checked *after* the non-negative-int arm above so that
-                // arm still owns the success path unchanged.
                 //
                 // jq mode only: real yq's own grammar rejects every one of
                 // those shapes at *parse* time -- `flatten(null)`,
@@ -12887,8 +12917,37 @@ fn builtin_flatten_depth<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
                         "flatten depth must not be negative",
                     ));
                 }
-                OwnedValue::Int(_) | OwnedValue::NumberLiteral(NumberRepr::Int(_), _) => {
+                OwnedValue::Int(d) | OwnedValue::NumberLiteral(NumberRepr::Int(d), _) if d < 0 => {
                     return QueryResult::Error(EvalError::new("depth must be non-negative"));
+                }
+                // #2755, jq mode only: everything else -- including a
+                // non-integer number, and (past the guard above) a
+                // non-number -- is passed through unconverted rather than
+                // rejected here. jq's own `_flatten($x)` never eagerly
+                // requires `$x` to be a non-negative integer; it only ever
+                // inspects `$x` via `!= 0` and `$x - 1`, both applied
+                // lazily, once per recursion level, only when a genuinely
+                // nested array item is actually reached -- see
+                // `flatten_owned`'s own doc comment for the live-verified
+                // consequences (an integral float depth succeeds; a
+                // non-numeric depth only errors if the input actually has
+                // nesting deep enough to reach a real `- 1` attempt).
+                other if S::TAG == EvalTag::Jq => other,
+                // yq mode: preserve the exact pre-#2755 eager behavior.
+                // Real yq's own grammar only ever accepts a bare
+                // non-negative integer literal token for `flatten`'s
+                // argument -- a float, `null`, `false`, a string, ... are
+                // all rejected at *parse* time (`bad expression, please
+                // check expression syntax`, live-verified against
+                // v4.53.3), so there is no reachable yq behaviour for
+                // #2755's own widening to match, mirroring #2747's
+                // identical yq-mode gate immediately above. Reusing
+                // `arith_sub`'s yq-only `null - x = x` identity (#1198)
+                // inside `flatten_owned` for a shape real yq can never
+                // even parse would be an accidental behavior change with
+                // no oracle behind it, not a fix.
+                OwnedValue::Int(d) | OwnedValue::NumberLiteral(NumberRepr::Int(d), _) => {
+                    OwnedValue::Int(d)
                 }
                 _ => return QueryResult::Error(EvalError::type_error("number", "non-number")),
             };
@@ -84555,22 +84614,26 @@ mod tests {
 
     /// #1017: `flatten` had no guard on its own tree-recursion depth,
     /// distinct from the pre-existing `depth` parameter (remaining flatten
-    /// levels) it already threads. Passes `usize::MAX` for that parameter
-    /// so it can never be the thing that stops recursion first -- with a
+    /// levels) it already threads. Passes `i64::MAX` for that parameter so
+    /// it can never be the thing that stops recursion first -- with a
     /// flatten-level count matched to the actual nesting instead, `depth`
-    /// and the tree-depth counter reach zero on the same call, and the
-    /// early `if depth == 0` return happens *before* the assert, masking
-    /// it entirely.
+    /// and the tree-depth counter would reach zero on the same call
+    /// otherwise, masking the assert entirely.
+    ///
+    /// #2755: `depth` is now `OwnedValue`, not `usize` -- `flatten_owned`
+    /// needs a concrete `EvalSemantics` for its own `arith_sub` call, and
+    /// `JqSemantics` is as good as `YqSemantics` here since `i64::MAX - 1`
+    /// never overflows either mode's integer subtraction.
     #[test]
     fn flatten_owned_panics_past_nesting_depth_limit_1017() {
         use crate::jq::value::MAX_VALUE_TREE_DEPTH;
 
         let under = vec![linear_array_nest(MAX_VALUE_TREE_DEPTH - 1)];
-        let _ = flatten_owned(under, usize::MAX);
+        let _ = flatten_owned::<JqSemantics>(under, OwnedValue::Int(i64::MAX));
 
         let over = vec![linear_array_nest(MAX_VALUE_TREE_DEPTH)];
         let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-            flatten_owned(over, usize::MAX)
+            flatten_owned::<JqSemantics>(over, OwnedValue::Int(i64::MAX))
         }));
         assert!(
             result.is_err(),

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -12835,11 +12835,11 @@ fn flatten_owned<S: EvalSemantics>(
 
 /// `depth` (the *remaining flatten levels* the caller asked for, e.g. from
 /// `flatten(depth)`) and `tree_depth` (this recursion's own descent so
-/// far) are two independent counters: `depth` already self-terminates
-/// (`depth == 0` stops), but a user-supplied `flatten(N)` for a large `N`
-/// places no ceiling of its own on how deep the *array's own structure*
-/// (not the flatten count) can be walked before that termination kicks
-/// in. Panics past
+/// far) are two independent counters: `depth` already self-terminates (the
+/// `Array` match arm's own guard below only recurses while `depth != 0`),
+/// but a user-supplied `flatten(N)` for a large `N` places no ceiling of
+/// its own on how deep the *array's own structure* (not the flatten
+/// count) can be walked before that termination kicks in. Panics past
 /// [`MAX_VALUE_TREE_DEPTH`](super::value::MAX_VALUE_TREE_DEPTH) levels of
 /// `tree_depth` (#1017) -- currently only reachable at a `tree_depth`
 /// this deep via a value already capped there by an upstream guard

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -28512,6 +28512,56 @@ fn test_flatten_negative_depth_errors_even_with_trailing_break_1164() -> Result<
     Ok(())
 }
 
+/// #2755: `flatten`'s success path used to eagerly require a literal
+/// non-negative integer depth, rejecting everything else outright with a
+/// generic "expected number, got non-number" -- but jq's own reference
+/// definition (`_flatten($x): reduce .[] as $i ([]; if ($i|type) ==
+/// "array" and $x != 0 then . + ($i | _flatten($x - 1)) else . + [$i]
+/// end)`) never converts `$x` up front. It only ever compares `$x != 0`
+/// and computes `$x - 1`, both lazily, once per recursion level, only when
+/// a genuinely nested array item is actually reached. All values below
+/// are live jq 1.7.1 captures.
+#[test]
+fn test_flatten_depth_argument_is_not_eagerly_converted_2755() -> Result<()> {
+    for (filter, input, expected) in [
+        // An integral float depth decrements to exactly `0.0`, which
+        // compares equal to `0` -- succeeds exactly like the same
+        // integer depth would.
+        ("flatten(2.0)", "[[1,[2]],3]", "[1,2,3]"),
+        // A non-numeric depth with no nesting deep enough to ever reach
+        // `$x - 1` never errors at all.
+        (r#"flatten("a")"#, "[1,2,3]", "[1,2,3]"),
+    ] {
+        let (stdout, stderr, code) = run_jq_full(&["-c", filter], Some(input))?;
+        assert_eq!(
+            code, 0,
+            "`{filter}` on {input}: stdout {stdout:?} stderr {stderr:?}"
+        );
+        assert_eq!(stdout.trim_end(), expected, "`{filter}` on {input}");
+    }
+    Ok(())
+}
+
+/// #2755: the flip side of the test above -- a non-numeric depth errors
+/// only once the recursion actually reaches a nested array and attempts a
+/// real `$x - 1`, with the exact type-error wording real subtraction
+/// raises (not a generic "expected number" message), and that error is
+/// suppressible by `?` like any other evaluation error, matching jq.
+#[test]
+fn test_flatten_depth_argument_errors_lazily_on_real_nesting_2755() -> Result<()> {
+    let (stdout, stderr, code) = run_jq_full(&["-c", r#"flatten("a")"#], Some("[[1,[2]],3]"))?;
+    assert_eq!(code, 5, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert!(
+        stderr.contains(r#"string ("a") and number (1) cannot be subtracted"#),
+        "stderr: {stderr:?}"
+    );
+
+    let (stdout, stderr, code) = run_jq_full(&["-c", r#"flatten("a")?"#], Some("[[1,[2]],3]"))?;
+    assert_eq!(code, 0, "stderr: {stderr:?}");
+    assert_eq!(stdout.trim_end(), "");
+    Ok(())
+}
+
 /// `combinations(n)` uses `n` inside a nested `range(n)` that an array
 /// construction then collects, so its escape semantics differ from every
 /// other builtin in this block: a trailing break in `n`'s own generator
@@ -29168,15 +29218,22 @@ fn test_compound_assign_optional_swallowed_rhs_error_produces_no_output_1313() -
     Ok(())
 }
 
-/// #1045 coverage: `flatten(depth)`'s `Ok(Some(_)) => ...type_error("number",
-/// "non-number")` arm -- a non-number depth argument, unconditional (no
-/// `optional` gate), unlike the negative-depth arm covered by
-/// `test_flatten_negative_depth_errors_even_with_trailing_break_1164` above.
+/// #1045 coverage: a non-number depth argument, unconditional (no
+/// `optional` gate) once the input actually nests deep enough to reach a
+/// real `$x - 1` attempt, unlike the negative-depth arm covered by
+/// `test_flatten_negative_depth_errors_even_with_trailing_break_1164`
+/// above. #2755 replaced this arm's generic, eager "expected number, got
+/// non-number" with jq's own lazy subtraction-type-error wording --
+/// confirmed live against jq 1.7.1, which raises the identical message for
+/// this exact filter (`[[1]]` has one level of real nesting to reach).
 #[test]
 fn test_flatten_depth_non_number_argument_errors_1045() -> Result<()> {
     let (out, err, code) = run_jq_full(&["-cn", r#"[[1]] | flatten("x")"#], None)?;
-    assert_ne!(code, 0);
-    assert!(err.contains("non-number"), "err={err}");
+    assert_eq!(code, 5, "err={err}");
+    assert!(
+        err.contains(r#"string ("x") and number (1) cannot be subtracted"#),
+        "err={err}"
+    );
     let _ = out;
     Ok(())
 }

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -40374,6 +40374,39 @@ fn test_flatten_negative_depth_widening_is_jq_mode_only_2747() -> Result<()> {
     Ok(())
 }
 
+/// #2755's own yq-mode gate, on the exact same terms as #2747's above: jq
+/// mode's fix widened `flatten`'s success path to accept a non-integer or
+/// non-numeric depth, threading it lazily through `arith_sub`/
+/// `compare_values` instead of eagerly requiring a non-negative integer --
+/// but real yq's own grammar only ever accepts a bare non-negative integer
+/// literal token for `flatten`'s argument, rejecting a float (or anything
+/// else) at *parse* time (live-verified against v4.53.3). So yq mode must
+/// keep the exact pre-#2755 eager rejection here too, unaffected by jq
+/// mode's own widening -- confirmed during this PR's own review, which
+/// found a first draft had reused `arith_sub`'s yq-only `null - x = x`
+/// identity (#1198) unconditionally, letting `flatten(null)` silently
+/// succeed in yq mode instead of erroring.
+#[test]
+fn test_flatten_depth_widening_is_jq_mode_only_2755() -> Result<()> {
+    let (_stdout, stderr, code) =
+        run_yq_stdin_with_stderr("[[1,[2]],3] | flatten(2.0)", "null\n", &[])?;
+    assert_eq!(code, 1, "stderr: {stderr:?}");
+    assert!(
+        stderr.contains("expected number, got non-number"),
+        "stderr: {stderr:?}"
+    );
+
+    // The ordinary, still-supported shape -- a literal non-negative
+    // integer depth -- is unaffected by #2755's jq-only widening and
+    // still succeeds exactly as before, now threaded through the same
+    // `OwnedValue`-based `flatten_owned` jq mode uses.
+    let (stdout, stderr, code) =
+        run_yq_stdin_with_stderr("[[1,[2]],3] | flatten(1)", "null\n", &["-o=json", "-I=0"])?;
+    assert_eq!(code, 0, "stderr: {stderr:?}");
+    assert_eq!(stdout.trim_end(), "[1,[2],3]");
+    Ok(())
+}
+
 /// #2692, yq twin of `test_truthiness_probes_validate_nothing_2692` in
 /// `tests/jq_cli_tests.rs`: the same corpus through the YAML cursor (and, for
 /// the JSON-syntax rows, through yq's own reading of them -- most of the JSON


### PR DESCRIPTION
## Summary
- `flatten(depth)`'s success path eagerly required a literal non-negative integer, rejecting everything else with a generic "expected number, got non-number" — but jq's own reference definition (`_flatten($x): reduce .[] as $i ([]; if ($i|type)=="array" and $x!=0 then . + ($i|_flatten($x-1)) else . + [$i] end)`) never converts `$x` up front. It only ever inspects `$x` via `!= 0` and `$x - 1`, both lazily, once per recursion level, only when a genuinely nested array item is reached.
- `flatten_owned`/`flatten_owned_at_depth` now thread `depth` as `OwnedValue` instead of `usize`, reusing the existing `compare_values`/`arith_sub` machinery for those two operations. An integral float depth now succeeds (`flatten(2.0)` decrements to exactly `0.0`, which compares equal to `0`), and a non-numeric depth only errors once real nesting is reached, with jq's own subtraction-type error wording.
- Gated to **jq mode only**: real yq's own grammar accepts only a bare non-negative integer literal for `flatten`'s argument, rejecting everything this widens for at parse time — so yq mode keeps its exact pre-existing eager rejection unchanged (confirmed during review, which caught a first draft accidentally letting yq's `null - x = x` identity, #1198, leak into `flatten(null)`).
- Filed #2818 separately for an unrelated pre-existing bug found along the way: bare `flatten` (no args) is wired to `flatten(1)` instead of unlimited depth.

## Test plan
- [x] `cargo build --features cli`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test --features cli` (full suite, 0 failures)
- [x] Live-verified every repro against `/usr/bin/jq` 1.7.1 and yq v4.53.3
- [x] Local patch coverage: 100% (28/28 new lines)

Fixes #2755