### PR TITLE
jq: route //'s OneCursorValue fast path through cursor_is_truthy

### DIFF
--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -11416,9 +11416,13 @@ fn each_alternative_generic<S: EvalSemantics, V: DocumentValue>(
             // through `generic_item_to_result` would otherwise collapse to a
             // bare `OneCursor`, discarding it and forcing a second cursor
             // `.value()` resolve on every item this forwards. Truthiness only
-            // needs the cursor, so answer it directly and keep the pair intact.
+            // needs the cursor, so answer it directly via `cursor_is_truthy`
+            // and keep the pair intact -- the same shared rule, not a second
+            // inlined copy of it (#2665 item 3 follow-up: this site was the one
+            // cursor-backed truthiness check `cursor_is_truthy`'s doc comment
+            // claimed to cover but didn't actually reach).
             if let GenericItem::OneCursorValue(ref c, _) = item {
-                if c.is_falsy(JsonConvention::Preserve) {
+                if !cursor_is_truthy(c) {
                     return Demand::Continue;
                 }
                 forwarded += 1;


### PR DESCRIPTION
## Summary

Follow-up to #2813 (#2665 item 3). `each_alternative_generic`'s `OneCursorValue` fast path (the `keys_unsorted` iteration case, #1599/#1606/#1609) still inlined `c.is_falsy(JsonConvention::Preserve)` directly instead of calling `cursor_is_truthy` -- the one cursor-backed truthiness site `cursor_is_truthy`'s own doc comment claimed to cover ("so `//`/`and`/`or`/`not` structurally cannot drift") but didn't actually reach.

No behavior change -- closes the gap between that doc comment's claim and the code.

## Test plan

- [x] `cargo build --features cli`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test --features cli,simd,regex,serde` (full suite)
- [x] Targeted: tests referencing #1599/#1606/#1609 (the `keys_unsorted` lazy-keys fast path)