### PR TITLE
fix(jq): accept a trailing comma in object construction

### DIFF
--- a/docs/reference/jq-language.md
+++ b/docs/reference/jq-language.md
@@ -90,7 +90,7 @@ below and [ADR-0019](../adrs/adr-0019.md).
 - [x] `to_entries` / `from_entries` / `with_entries(f)`
 - [x] `pick(keys)` - select only specified keys (yq)
 - [x] `omit(keys)` - remove specified keys (inverse of pick, yq)
-- [x] Object construction: `{foo: .bar}`, `{(expr): value}`, shorthand `{foo}`
+- [x] Object construction: `{foo: .bar}`, `{(expr): value}`, shorthand `{foo}` -- a single trailing comma before `}` is accepted in jq mode only (`{foo: 1,}`, #2788), matching real jq; real yq rejects it
 
 ### Array Operations
 - [x] `length`

--- a/src/jq/parser.rs
+++ b/src/jq/parser.rs
@@ -1531,6 +1531,20 @@ impl<'a> Parser<'a> {
             match self.peek() {
                 Some(',') => {
                     self.next();
+                    self.skip_ws();
+                    // #2788: jq's object-construction production alone
+                    // accepts a trailing comma (`{a:1,}`) -- array
+                    // construction and destructuring patterns don't, and
+                    // neither does real yq (`',' expects 2 args but there
+                    // is 1`), so this is jq-mode only. A doubled comma
+                    // (`{a:1,,}`) still re-enters key parsing below and
+                    // hits its existing "expected identifier" error --
+                    // this only short-circuits the single-trailing-comma
+                    // shape.
+                    if self.mode == ParserMode::Jq && self.peek() == Some('}') {
+                        self.next();
+                        break;
+                    }
                     continue;
                 }
                 Some('}') => {
@@ -7270,6 +7284,47 @@ mod tests {
             }
             _ => panic!("expected Object"),
         }
+    }
+
+    /// #2788: real jq's object-construction production alone accepts a
+    /// single trailing comma before the closing `}` -- `{a:1,}` parses
+    /// identically to `{a:1}`. Every trailing-comma shape here must parse
+    /// to the exact same `Expr` its comma-free equivalent does (jq mode
+    /// only; confirmed live that real yq rejects every one of them, `','
+    /// expects 2 args but there is 1`).
+    #[test]
+    #[allow(clippy::literal_string_with_formatting_args)]
+    fn test_object_construction_trailing_comma_2788() {
+        for (with_comma, without_comma) in [
+            ("{a:1,}", "{a:1}"),
+            ("{a,}", "{a}"),
+            (r#"{"a":1,}"#, r#"{"a":1}"#),
+            ("{(.x):1,}", "{(.x):1}"),
+            ("{a:1, }", "{a:1}"),
+            ("{a:1,\n}", "{a:1}"),
+        ] {
+            assert_eq!(
+                parse(with_comma).unwrap(),
+                parse(without_comma).unwrap(),
+                "`{with_comma}` should parse identically to `{without_comma}`"
+            );
+        }
+
+        // A doubled comma still re-enters key parsing and hits the
+        // existing error unchanged -- this fix only short-circuits a
+        // single trailing comma, not "skip any run of commas".
+        for src in ["{,}", "{a:1,,}", "{,a:1}"] {
+            let err = parse(src).unwrap_err();
+            assert!(
+                err.to_string().contains("expected identifier"),
+                "`{src}`: {err}"
+            );
+        }
+
+        // yq mode: the same trailing comma stays rejected, matching real
+        // yq (`',' expects 2 args but there is 1`) -- this extension is
+        // jq-mode only.
+        assert!(parse_with_mode(r#"{"a":1,}"#, ParserMode::Yq).is_err());
     }
 
     #[test]

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -19054,6 +19054,52 @@ fn test_object_construction_dollar_loc_key_is_a_parse_error_2724() -> Result<()>
 // tests/yq_cli_tests.rs, not here -- see
 // test_object_construction_var_shorthand_is_jq_mode_only_2724.)
 
+/// #2788: real jq's object-construction production alone accepts a single
+/// trailing comma before the closing `}` -- confirmed live against jq
+/// 1.7.1. `{$a,}` is the shape that surfaced this during #2724's own
+/// review; the rest round-trip through the evaluator too, not just the
+/// parser.
+#[test]
+fn test_object_construction_trailing_comma_2788() -> Result<()> {
+    for (filter, input, want) in [
+        ("{a:1,}", "null", "{\"a\":1}"),
+        ("{a,}", "{\"a\":2}", "{\"a\":2}"),
+        ("1 as $a | {$a,}", "null", "{\"a\":1}"),
+        ("{a:1,} | keys", "null", "[\"a\"]"),
+    ] {
+        let (stdout, stderr, code) = run_jq_full(&["-c", filter], Some(input))?;
+        assert_eq!(code, 0, "`{filter}`: stderr {stderr:?}");
+        assert_eq!(stdout.trim_end(), want, "`{filter}`");
+    }
+    Ok(())
+}
+
+/// #2788 review: a doubled or leading comma stays rejected exactly as
+/// before -- this fix only short-circuits a *single* trailing comma, not
+/// "skip any run of commas". A future "trailing comma everywhere" change
+/// has to consciously break these two rows, not accidentally widen into
+/// them.
+#[test]
+fn test_object_construction_trailing_comma_does_not_widen_2788() -> Result<()> {
+    for filter in ["{a:1,,}", "{,}"] {
+        let (_, stderr, code) = run_jq_full(&["-c", filter], Some("null"))?;
+        assert_eq!(code, 3, "`{filter}`: stderr {stderr:?}");
+        assert!(
+            stderr.contains("expected identifier"),
+            "`{filter}`: stderr {stderr:?}"
+        );
+    }
+
+    // Array construction and destructuring patterns don't share this
+    // allowance in real jq either -- confirmed live, both are syntax
+    // errors there too.
+    for filter in ["[1,2,]", ". as {$a,} | $a"] {
+        let (_, stderr, code) = run_jq_full(&["-c", filter], Some("null"))?;
+        assert_eq!(code, 3, "`{filter}`: stderr {stderr:?}");
+    }
+    Ok(())
+}
+
 // =============================================================================
 // #1204: object destructuring pattern entry `{$x: Pattern}` (bind and
 // further destructure). Real jq's `$IDENT: Pattern` entry binds the

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -42804,6 +42804,20 @@ fn test_object_construction_var_shorthand_is_jq_mode_only_2724() -> Result<()> {
     Ok(())
 }
 
+/// #2788: jq mode's object-construction trailing-comma allowance
+/// (`{a:1,}`) is likewise jq-mode only -- real yq rejects it too, just for
+/// an unrelated reason of its own (`',' expects 2 args but there is 1`,
+/// live-verified against v4.53.3), so this stays the same pre-existing
+/// parse error succinctly yq always raised for a trailing comma, not jq's
+/// `{"a":1}`.
+#[test]
+fn test_object_construction_trailing_comma_is_jq_mode_only_2788() -> Result<()> {
+    let (stdout, stderr, code) = run_yq_stdin_with_stderr(r#"{"a":1,}"#, "x: 1\n", &[])?;
+    assert_ne!(code, 0, "stdout: {stdout:?}");
+    assert!(stderr.contains("expected identifier"), "stderr: {stderr:?}");
+    Ok(())
+}
+
 /// #2763: a mapping entry's metadata lives on its **key** node, and `key`
 /// emits that node -- so `line_comment`, `head_comment`, `foot_comment`,
 /// `line`, `column`, `style` and `anchor` after a `key` stage read the key's


### PR DESCRIPTION
## Summary
- Real jq's object-construction production alone accepts a single trailing comma before the closing `}` — `{a:1,}` parses and evaluates identically to `{a:1}`. `parse_object_construction`'s loop always re-entered key parsing after consuming a comma, so a trailing one hit `expected identifier, found '}'` instead.
- jq mode only: real yq rejects the same shape too, just for an unrelated reason of its own (`',' expects 2 args but there is 1`), and array construction / destructuring patterns don't share this allowance in real jq either. A doubled comma still re-enters key parsing and hits the existing error unchanged.
- Surfaced during #2724's code review (independently confirmed by two review passes); pre-existing on `main`, unrelated to #2724's own mechanism.

## Test plan
- [x] `cargo build --features cli`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test --features cli` (full suite, 0 failures)
- [x] Live-verified every repro and must-not-widen row against `/usr/bin/jq` 1.7.1 and yq v4.53.3
- [x] Local patch coverage: 100% (23/23 new lines)

Fixes #2788