### PR TITLE
fix(jq): make // a transparent construct so it agrees with the bare spelling

### DIFF
--- a/docs/adrs/adr-0021.md
+++ b/docs/adrs/adr-0021.md
@@ -420,6 +420,48 @@ rejected: the only *safe* allowlist of "cannot read a node" was the one enumerat
 benchmarked queries. [#2789](https://github.com/rust-works/succinctly/issues/2789) carries
 the two remaining shapes a real fix could take.
 
+### Amendment (#2782, implemented 2026-09-12): `//` is a transparent construct
+
+`needs_path_context` (`src/jq/eval.rs`) had no `Expr::Alternative` arm, so a pipe whose
+only read sat inside a `//` was never routed anywhere: `.a | to_entries | .[] | (key //
+99)` answered `99` where the bare `.[] | key` is `0` (#2665 item 1). Adding the arm alone
+traded that gap for several (#2782), because the identity pass had given `//` an
+*operand-shaped* arm on the owned identity route: it answered one output per side,
+rewrote a read inside either side to a detached literal before evaluating it, stamped a
+multi-output left side with the identity of its first output (re-evaluated), and forced
+`optional = true` onto the left side — a rule its own comment attributed to jq, which jq
+does not have (`5 | (.a // 1)` is an error in 1.7.1).
+
+**`//` has no placement rule; it is run like `,` and `if`.** `owned_identity_rule` answers
+`None` for it, so a pipe that *starts* with one enters the identity route whole
+(`owned_identity_pipe_entry_stage`, the door #2563 opened for `as`), and
+`eval_owned_identity_alternative` runs the left side as stages of the pipe, continues
+`rest` from every truthy output standing exactly where it was produced — a `key` at its
+key node, a `file_index` where the node stood, each output of a comma at its own — and
+splices the right side only when nothing truthy came out. Errors, `break` and laziness
+follow `eval_single`'s cursor-native arm: a falsy output is dropped, a truthy one before an
+error survives it, the right side never runs after one, and a bounded consumer stops the
+left side early. The gate (`owned_identity_pipe_supported`) asks of each side what it asks
+of a comma branch.
+
+**A `//` at a live cursor that nothing reads after stays on the cursor route**
+(`alternative_stays_cursor_native`). There the identity route has nothing to answer that
+the cursor-native arm does not, and materializing would re-render the node `parent`
+landed on: `.a | (parent // 1)` keeps its flow style, anchor and trailing comment, as it
+did before the arm and as yq prints it. Only a read *after* the operator needs to know
+which operand produced the output, and only the identity route tracks that.
+
+The non-sink route's gate (`owned_identity_pipe_applies`) learned the same door for a
+stage with no rule reached *after* a navigational head, so the yq CLI's DOM path and the
+jq CLI's sink pipeline answer `. | (null // .b) | key` alike. `path_context_single_native`
+gained the matching `Expr::Alternative` entry.
+
+Two divergences this surfaced are not this amendment's: real yq's `//` maps *per left
+output* and passes a falsy left value through when the right side is empty (#2817, recorded
+in the sweep's manifest), and the vivified `parent` at an absent position (#2435) decides
+which side `.a | (parent // .)` takes on a `null` document. The sweep's alphabet gained
+`alt_l`/`alt_r` wrappers so a leaf on either side of `//` is part of the claim.
+
 ## Consequences
 
 - **Fidelity moved toward the reference where the two models disagree.** `key`/`parent`

--- a/docs/compliance/yq/limitations.md
+++ b/docs/compliance/yq/limitations.md
@@ -2259,6 +2259,30 @@ comment for the full call-site list and `tests/yq_cli_tests.rs`'s
 unaffected (it keeps its own separate, unconditional-null rule), and a real container
 target keeps its own structural error.
 
+### `//` maps per left output and keeps a falsy left value when the right side is empty — not chased ([#2817](https://github.com/rust-works/succinctly/issues/2817) discovered by #2782, not fixed)
+
+succinctly evaluates `L // R` with jq's rule in both modes: collect `L`'s outputs, keep the
+truthy ones, run `R` only if none survived. Real yq v4.53.3 differs on two axes, captured
+live when [#2782](https://github.com/rust-works/succinctly/issues/2782) added `//` to
+`scripts/jq-path-context-oracle-sweep.sh`'s alphabet:
+
+| filter (`yq -n -o=json`)            | yq v4.53.3    | succinctly yq (= jq 1.7.1) |
+|-------------------------------------|---------------|----------------------------|
+| `(1, null) // 2`                    | `1` `2`       | `1`                        |
+| `(null, 1) // 2`                    | `2` `1`       | `1`                        |
+| `(null, 1, null) // 2`              | `2` `1` `2`   | `1`                        |
+| `(false, null) // (3, 4)`           | `3` `4` `3` `4` | `3` `4`                  |
+| `{} \| (null // .[])`               | `null`        | *(nothing)*                |
+| `{"a":1} \| (null // key)` (root)   | `null`        | *(nothing)*                |
+
+Each falsy output of `L` is replaced *in place* by `R`'s outputs, and where `R` yields
+nothing the falsy output itself is emitted. The twelve sweep rows this produces (`(null //
+key)`/`(null // parent)` at the document root, where both tools' `key`/`parent` are
+empty) are recorded in `tests/data/jq-path-context-sweep-known-divergences.txt` under
+#2817. Not a path-context question — it is *which* outputs `//` produces, an
+`EvalSemantics`-level rule for yq mode — and pre-existing: identical on `main` before
+#2782, whose change is *where* an output of `//` stands.
+
 ### An `and`/`or` operand's evaluation context — resolved for `and`/`or` (#2540); `=`'s right side remains open
 
 A literal or constructor is not really "empty" against a read-only, zero-node context in

--- a/scripts/jq-path-context-oracle-sweep.sh
+++ b/scripts/jq-path-context-oracle-sweep.sh
@@ -39,7 +39,7 @@
 # `key`/`parent`/bare `path`/`file_index` at all), and the wrappers are every
 # construct #2416 names: `limit`, `first`, `last`, `foreach`, `reduce`,
 # `getpath`, object construction, `select`, comma, `if`, `try`, `label`/`break`,
-# plus `path(...)` and `?` as outer forms. `--self-test` asserts every
+# either side of `//` (#2782), plus `path(...)` and `?` as outer forms. `--self-test` asserts every
 # combination class is present, so a future alphabet shrink fails loudly.
 #
 # **yq comma/pipe precedence (#2420).** Real yq v4.53.3 parses `a, b | c` as
@@ -148,7 +148,15 @@ YQ_LEAF_TPL=('key' 'parent' 'path' 'file_index')
 # input text"), which is itself an oracle fact worth sweeping — succinctly yq
 # accepting them is a divergence, tracked as a category below rather than
 # quietly dropped from the alphabet.
-WRAP_IDS=(bare limit first last foreach reduce getpath object select comma if try label)
+#
+# `alt_l`/`alt_r` (#2782): the leaf on either side of `//`. Real yq has `//`,
+# so both are oracle-backed in both modes. Added when `needs_path_context`
+# gained its `Expr::Alternative` arm: until then a leaf inside a `//` was never
+# routed to path-context evaluation at all, and the owned identity route's own
+# `//` arm spelled it as a detached literal -- neither of which this sweep
+# could see without the wrapper. The right-hand form uses `null // ...` so the
+# leaf is what the operator answers with, not the fallback that never runs.
+WRAP_IDS=(bare limit first last foreach reduce getpath object select comma if try label alt_l alt_r)
 WRAP_TPL=(
   '__I__'
   'limit(2; __I__)'
@@ -163,6 +171,8 @@ WRAP_TPL=(
   'if (__I__) then 1 else 2 end'
   'try (__I__) catch "e"'
   'label $o | ((__I__), break $o)'
+  '((__I__) // 9)'
+  '(null // (__I__))'
 )
 
 # Outer forms. `__W__` is the wrapped leaf.

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -36815,12 +36815,14 @@ pub(crate) fn stop_with_escape(slot: &mut Option<Control>, control: Control) -> 
 ///
 /// [`stop_with_escape`], [`stop_with_escape_cell`] and
 /// [`stop_with_downstream`] cover every driver whose slot holds a `Control`
-/// or a whole `Flow`; four drivers keep a shape none of those fit -- a
-/// [`Flow`] in [`foreach_forks`], and `eval_generic.rs`'s three
-/// owned-identity stages, which answer `Flow::Stopped` directly rather than
-/// `Demand::Stop` -- and call this beside their own store instead of growing
-/// an adapter each. The *rule* is still in one place, which is what drifted
-/// twice before (#1313, #1457).
+/// or a whole `Flow`; five drivers keep a shape none of those fit -- a
+/// [`Flow`] in [`foreach_forks`], and `eval_generic.rs`'s four
+/// owned-identity stages (`eval_owned_identity_scoped`,
+/// `eval_owned_identity_try`, `eval_owned_identity_bounded`, and
+/// `eval_owned_identity_alternative` since #2782), which answer
+/// `Flow::Stopped` directly rather than `Demand::Stop` -- and call this
+/// beside their own store instead of growing an adapter each. The *rule* is
+/// still in one place, which is what drifted twice before (#1313, #1457).
 pub(crate) fn mark_nonretryable_escape(control: &Control) {
     if !is_retryable_control(control, false) {
         nonretryable_stop::set();

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -2115,6 +2115,18 @@ pub(crate) fn needs_path_context(expr: &Expr) -> bool {
         Expr::And(left, right) | Expr::Or(left, right) => {
             needs_path_context(left) || needs_path_context(right)
         }
+        // `//` (#2782, #2665 item 1): the same reasoning as `and`/`or` just
+        // above -- a `key`/`parent`/`file_index` can sit in either operand,
+        // and without this arm a pipe whose only read is inside a `//` was
+        // never routed to path-context evaluation at all: `.a | to_entries |
+        // .[] | (key // 99)` answered `99` where the bare `.[] | key` is
+        // `0` (yq v4.53.3 answers `0` for both). #2782 found that adding the
+        // arm alone traded that gap for several -- the owned identity
+        // route's own `//` arm spelled a read inside either side as a
+        // detached literal and truncated a multi-output left side to its
+        // first output -- so it lands together with that arm's rewrite
+        // (`eval_generic::eval_owned_identity_alternative`).
+        Expr::Alternative(left, right) => needs_path_context(left) || needs_path_context(right),
         // Same reasoning as `Arithmetic` above: a `key`/`file_index` can
         // hide inside unary minus's single operand too, e.g.
         // `-(file_index)` (#1100). Without this arm the whole pipe reports

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -10061,9 +10061,7 @@ fn eval_each_pipe_generic<S: EvalSemantics, V: DocumentValue>(
         // `c: [10, 20]`), which is what the eager route answered and what
         // the staged fallback below would lose.
         if let Some(root) = cursor {
-            if exprs.first().is_some_and(owned_identity_pipe_entry_stage)
-                && owned_identity_pipe_supported(exprs)
-            {
+            if owned_identity_pipe_enters_at_first(exprs) {
                 // STYLE-0012: an undecodable node is the decode failure the
                 // whole query answers with (#1755), not something this
                 // route's ambient `?` may swallow -- the same rule the
@@ -17281,6 +17279,15 @@ fn path_context_single_native(expr: &Expr) -> bool {
         Expr::And(left, right) | Expr::Or(left, right) => {
             path_context_single_native(left) && path_context_single_native(right)
         }
+        // #2782: `eval_single`'s own `Expr::Alternative` arm (#2476) evaluates
+        // both sides through `eval_single` *with the cursor*, so `//` is native
+        // on the same terms as `and`/`or` just above. Until `needs_path_context`
+        // gained its `Alternative` arm this entry was moot -- a `//` was never
+        // seen as reading path context -- and the `_` arm below would now
+        // call it non-native for exactly the shapes it answers natively.
+        Expr::Alternative(left, right) => {
+            path_context_single_native(left) && path_context_single_native(right)
+        }
         Expr::Try { expr, catch } => {
             path_context_single_native(expr)
                 && catch
@@ -20470,8 +20477,6 @@ enum OwnedIdentityRule {
     /// `min`/`max`: the output *is* one of the input's children, at its own
     /// position.
     Extremum,
-    /// `a // b`: the output stands where whichever side produced it stood.
-    Alternative,
     /// A literal slice. Mode decides (ADR-0018): real yq keeps the
     /// container's position (`.a | .[0:3] | .[0] | path` is `["a",0]`,
     /// `parent | parent` the root), while jq mode follows jq's own
@@ -20515,8 +20520,7 @@ enum OwnedIdentityRule {
 
 fn owned_identity_rule(stage: &Expr) -> Option<OwnedIdentityRule> {
     use OwnedIdentityRule::{
-        Alternative, Bound, Detaches, DetachesContainer, Extremum, Keeps, KeyNode, LeftOperand,
-        Slice,
+        Bound, Detaches, DetachesContainer, Extremum, Keeps, KeyNode, LeftOperand, Slice,
     };
     Some(match strip_parens(stage) {
         Expr::Slice { .. } => Slice,
@@ -20568,7 +20572,16 @@ fn owned_identity_rule(stage: &Expr) -> Option<OwnedIdentityRule> {
         // `.a.b | (false or parent) | key` print nothing, `.a.b | (parent or
         // false) | path` is `["a"]`.
         Expr::And(..) | Expr::Or(..) => LeftOperand,
-        Expr::Alternative(..) => Alternative,
+        // #2782: `//` has no rule. Its outputs are its operands' outputs,
+        // each standing where *that* output stood, and a rule places one
+        // output at a time from the stage's input -- which is how a
+        // multi-output left side (`(.a, .b) // 9 | key`) came out stamped
+        // with the first output's position. It is a transparent construct
+        // now, like `,` and `if`: `eval_owned_identity_stages`'s own arm
+        // runs each side as stages of this pipe, and a pipe that *starts*
+        // with one enters the identity route whole
+        // (`owned_identity_pipe_entry_stage`).
+        Expr::Alternative(..) => return None,
         // The builtin match is exhaustive on purpose (spine 2416, walk
         // residue): a new builtin is a compile error here, not a silent
         // hand-over to an evaluator that no longer exists to answer it.
@@ -21027,18 +21040,15 @@ fn owned_identity_pipe_supported_at(stages: &[Expr], unfolded: u8) -> bool {
                     return false;
                 }
             }
-            // spine 2416 (identity pass): a read inside either side of `//`
-            // is resolved at this position before the alternative is taken
-            // (the rewrite spells it as a literal, which
-            // `owned_identity_operand` places as one).
+            // #2782: each side of `//` runs as stages of this pipe (see
+            // `eval_owned_identity_alternative`), so the gate is the one
+            // `,` and `if` apply to their branches. Until #2782 a side with
+            // a read in it was admitted only through the constant rewrite,
+            // which spelled `key`/`file_index` as detached literals -- the
+            // position `(key // 9) | parent` and `(file_index // 9) | key`
+            // then had nothing to answer from.
             Expr::Alternative(left, right) => {
-                if needs_path_context(stage) {
-                    if !owned_identity_stage_resolvable(stage) {
-                        return false;
-                    }
-                } else if !owned_identity_operand_supported(left)
-                    || !owned_identity_operand_supported(right)
-                {
+                if !body(left) || !body(right) {
                     return false;
                 }
             }
@@ -21219,10 +21229,7 @@ fn owned_identity_pipe_applies(exprs: &[Expr]) -> bool {
     // sends such a pipe to `collect_each_generic`, which is what puts it on
     // `eval_each_pipe_generic`'s own entry for the same shape, so the two
     // routes share one definition instead of gaining a second.
-    if exprs.iter().any(needs_path_context)
-        && exprs.first().is_some_and(owned_identity_pipe_entry_stage)
-        && owned_identity_pipe_supported(exprs)
-    {
+    if exprs.iter().any(needs_path_context) && owned_identity_pipe_enters_at_first(exprs) {
         return true;
     }
     for (i, stage) in exprs.iter().enumerate() {
@@ -21230,9 +21237,20 @@ fn owned_identity_pipe_applies(exprs: &[Expr]) -> bool {
             continue;
         }
         let rest = &exprs[i + 1..];
-        return rest.iter().any(needs_path_context)
-            && owned_identity_leaving_stage_supported(stage)
-            && owned_identity_pipe_supported(rest);
+        if !rest.iter().any(needs_path_context) {
+            return false;
+        }
+        // #2782: the leaving stage may also be an entry stage -- `//`, `as`
+        // -- reached after a navigational head (`. | (null // .b) | key`).
+        // `eval_each_pipe_generic` already runs that shape: its staged driver
+        // hands each navigated node's `rest` back to itself, where the
+        // entry-stage door takes it. This is the non-sink route's gate, so
+        // without this arm the yq CLI's DOM path answered nothing where the
+        // jq CLI's sink pipeline answered `"b"`.
+        return (owned_identity_leaving_stage_supported(stage)
+            && owned_identity_pipe_supported(rest))
+            || (owned_identity_pipe_entry_stage(stage)
+                && owned_identity_pipe_supported(&exprs[i..]));
     }
     false
 }
@@ -21257,6 +21275,41 @@ fn owned_identity_pipe_entry_stage(stage: &Expr) -> bool {
     !path_context_is_navigational(stage)
         && !path_context_stage_preserves_node(stage)
         && owned_identity_rule(stage).is_none()
+}
+
+/// Whether a pipe enters the owned identity route at its *first* stage: the
+/// stage is an [`owned_identity_pipe_entry_stage`] and the whole pipe is
+/// [`owned_identity_pipe_supported`] -- except for a `//` that nothing reads
+/// after (#2782). `eval_each_pipe_generic`'s door and
+/// [`owned_identity_pipe_applies`] (the non-sink route's gate) share it so the
+/// two routes cannot disagree about where such a pipe runs.
+///
+/// The exception: `//` became an entry stage in #2782 (it has no placement
+/// rule, see [`owned_identity_rule`]), and the identity route materializes
+/// its input. At a live cursor with no path-context read after it there is
+/// nothing for that route to answer that `eval_single`'s own cursor-native
+/// `Expr::Alternative` arm does not -- both operands run with the cursor
+/// there (#2476), so `.a | (parent // 1)` is the *node* `parent` landed on,
+/// flow style, anchor and trailing comment intact, where the identity route
+/// would print a re-rendered copy (`a: {b: 1} # c` came out as a block
+/// mapping without the comment). A read *after* the operator still enters
+/// here: its answer depends on which operand produced the output, which only
+/// the identity route tracks (`eval_owned_identity_alternative`).
+fn owned_identity_pipe_enters_at_first(exprs: &[Expr]) -> bool {
+    let Some((first, rest)) = exprs.split_first() else {
+        return false;
+    };
+    owned_identity_pipe_entry_stage(first)
+        && owned_identity_pipe_supported(exprs)
+        && !alternative_stays_cursor_native(first, rest)
+}
+
+/// A `//` stage that stays on the cursor route (#2782): cursor-native in
+/// `eval_single`, with nothing after it reading path context.
+fn alternative_stays_cursor_native(first: &Expr, rest: &[Expr]) -> bool {
+    matches!(strip_parens(first), Expr::Alternative(..))
+        && path_context_stage_native(first)
+        && !rest.iter().any(needs_path_context)
 }
 
 /// Whether `stage` can be the one a pipe leaves the cursor domain at: it
@@ -21878,8 +21931,8 @@ fn owned_identity_operand<S: EvalSemantics, V: DocumentValue>(
 
 /// The identity of `output`, an output of `stage` evaluated over `value`
 /// (whose identity is `id`), per the stage's [`OwnedIdentityRule`].
-/// `Alternative` is not answered here: its output is chosen by
-/// [`eval_owned_identity_alternative`], which knows which side produced it.
+/// `//` has no rule and is not answered here: its outputs are its operands'
+/// own, placed by [`eval_owned_identity_alternative`] as it runs them.
 fn owned_identity_after_stage<S: EvalSemantics, V: DocumentValue>(
     stage: &Expr,
     rule: OwnedIdentityRule,
@@ -22029,9 +22082,6 @@ fn owned_identity_placed_by<S: EvalSemantics, V: DocumentValue>(
                 _ => None,
             };
             component.map(|component| id.child(&parent, component))
-        }
-        OwnedIdentityRule::Alternative => {
-            unreachable!("Alternative is evaluated by eval_owned_identity_alternative")
         }
     })
 }
@@ -22212,21 +22262,73 @@ fn continue_owned_identity_ancestor<S: EvalSemantics, V: DocumentValue>(
     }
 }
 
-/// `a // b` over an owned value with identity: the left operand's value if
-/// it is truthy (errors in it suppressed, as `//` does), else the right's.
+/// `left // right` over an owned value with identity (#2782): `left` runs as
+/// stages of this pipe from `(value, id)`, every truthy output continues
+/// into `rest` standing exactly where it was produced -- a `key` at its key
+/// node, a `file_index` where the node stood, a `parent` at the ancestor,
+/// each output of a comma at its own position -- and `right` runs the same
+/// way only when nothing truthy came out. The rule is `eval_single`'s own
+/// `Expr::Alternative` arm's, captured from jq 1.7.1: a falsy output is
+/// dropped, a truthy one is kept, an error on the left propagates after the
+/// truthy outputs before it (`(1, error("x")) // 2` prints `1`, exits 5)
+/// and the right side then never runs, a `break` escapes the operator.
+/// `optional` reaches both sides unchanged, as it does on that arm and on
+/// `eval::eval_alternative`.
+///
+/// This replaces an operand-shaped arm that answered one output per side and
+/// stamped it with the identity of the side's *first* output, evaluated a
+/// second time (`(.a, .b) // 9 | key` was `"a"`, `"a"`; yq v4.53.3 answers
+/// `"a"`, `"b"`), rewrote a read inside either side to a detached literal
+/// first (`(key // 9) | parent` printed nothing where the bare `key | parent`
+/// is the enclosing map), and forced `optional = true` onto the left side
+/// (`.a | tostring | (.x // 1) | key` swallowed the `Cannot index string`
+/// that `.a | tostring | (.x // 1)` raises).
+///
+/// An escape raised in `rest` is kept apart from one raised by `left` and
+/// reported as the pipe's, the same split [`eval_owned_identity_scoped`]
+/// makes -- otherwise a downstream error would read as "the left side
+/// failed" and be indistinguishable from one that should stop the right
+/// side from running.
 fn eval_owned_identity_alternative<S: EvalSemantics, V: DocumentValue>(
     left: &Expr,
     right: &Expr,
-    value: &OwnedValue,
-    id: &OwnedIdentity<V>,
+    rest: &[Expr],
+    value: OwnedValue,
+    id: OwnedIdentity<V>,
     optional: bool,
-) -> Result<Option<(OwnedValue, OwnedIdentity<V>)>, EvalError> {
-    if let Some((v, vid)) = owned_identity_operand::<S, V>(left, value, id, true)? {
-        if v.is_truthy() {
-            return Ok(Some((v, vid)));
-        }
+    mut tail: OwnedIdentityTail<'_, V>,
+) -> Flow {
+    let mut any_truthy = false;
+    let mut rest_escape: Option<Control> = None;
+    let left_flow = eval_owned_identity_stages::<S, V>(
+        owned_identity_body_stages(left),
+        value.clone(),
+        id.clone(),
+        optional,
+        OwnedIdentityTail::Pairs(&mut |v, vid| {
+            if !v.is_truthy() {
+                return Flow::Exhausted;
+            }
+            any_truthy = true;
+            match eval_owned_identity_stages::<S, V>(rest, v, vid, optional, tail.reborrow()) {
+                Flow::Escaped(control) => {
+                    mark_nonretryable_escape(&control);
+                    rest_escape = Some(control);
+                    Flow::Stopped { pending: None }
+                }
+                other => other,
+            }
+        }),
+    );
+    if let Some(control) = rest_escape {
+        return Flow::Escaped(control);
     }
-    owned_identity_operand::<S, V>(right, value, id, optional)
+    match left_flow {
+        Flow::Exhausted if !any_truthy => {
+            eval_owned_identity_spliced::<S, V>(right, rest, value, id, optional, tail)
+        }
+        other => other,
+    }
 }
 
 /// Which map-family builtin a stage is (#2471, gate reason 1 of spine 2416).
@@ -23086,35 +23188,11 @@ fn eval_owned_identity_stages<S: EvalSemantics, V: DocumentValue>(
                 None => Flow::Exhausted,
             }
         }
+        // #2782: a transparent construct, like `,` and `if` -- each side runs
+        // as stages of this pipe, so its outputs keep the positions they were
+        // produced at. See [`eval_owned_identity_alternative`].
         Expr::Alternative(left, right) => {
-            // spine 2416 (identity pass): a read inside either side is
-            // resolved at this position first; the rewrite spells it as a
-            // literal, which `owned_identity_operand` places as one.
-            let escaped = core::cell::RefCell::new(None);
-            let resolved;
-            let (left, right) = if needs_path_context(stage) {
-                resolved =
-                    match owned_identity_resolve_at::<S, V>(stage, &value, &id, optional, &escaped)
-                    {
-                        Ok(e) => e,
-                        Err(e) => return Flow::Escaped(Control::Error(e)),
-                    };
-                let Expr::Alternative(l, r) = strip_parens(&resolved) else {
-                    unreachable!("the rewrite keeps a node's own kind")
-                };
-                (&**l, &**r)
-            } else {
-                (&**left, &**right)
-            };
-            let flow =
-                match eval_owned_identity_alternative::<S, V>(left, right, &value, &id, optional) {
-                    Ok(Some((v, vid))) => {
-                        eval_owned_identity_stages::<S, V>(rest, v, vid, optional, tail)
-                    }
-                    Ok(None) => Flow::Exhausted,
-                    Err(e) => Flow::Escaped(Control::Error(e)),
-                };
-            owned_identity_after_prefetch(flow, escaped)
+            eval_owned_identity_alternative::<S, V>(left, right, rest, value, id, optional, tail)
         }
         // spine 2416 (#2563): the binding keeps this stage's identity for
         // its body -- see [`eval_owned_identity_as`].
@@ -23547,17 +23625,6 @@ fn owned_identity_leaving_cursor<S: EvalSemantics, V: DocumentValue>(
             // internal invariant it is.
             let input = to_owned_cursor(&cursor)?;
             owned_identity_after_stage::<S, V>(stage, rule, &input, &id, output, optional)
-        }
-        OwnedIdentityRule::Alternative => {
-            let Expr::Alternative(left, right) = strip_parens(stage) else {
-                unreachable!("Alternative is assigned to Expr::Alternative only")
-            };
-            // STYLE-0012: same invariant as the arm above.
-            let input = to_owned_cursor(&cursor)?;
-            Ok(
-                eval_owned_identity_alternative::<S, V>(left, right, &input, &id, optional)?
-                    .map(|(_, oid)| oid),
-            )
         }
     }
 }

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -21247,10 +21247,20 @@ fn owned_identity_pipe_applies(exprs: &[Expr]) -> bool {
         // entry-stage door takes it. This is the non-sink route's gate, so
         // without this arm the yq CLI's DOM path answered nothing where the
         // jq CLI's sink pipeline answered `"b"`.
+        //
+        // Delegates to `owned_identity_pipe_enters_at_first` on the suffix
+        // rather than hand-spelling `owned_identity_pipe_entry_stage(stage)
+        // && owned_identity_pipe_supported(&exprs[i..])`, so this door and
+        // `eval_each_pipe_generic`'s own runtime dispatch cannot silently
+        // diverge about where such a pipe runs -- the exact drift #2782
+        // fixed for the sink-vs-DOM disagreement above. Sound to add the
+        // helper's `alternative_stays_cursor_native` exclusion here: this
+        // arm is reached only when `rest.iter().any(needs_path_context)`
+        // (the early return two lines up), which is precisely the negation
+        // of that exclusion's own trailing condition.
         return (owned_identity_leaving_stage_supported(stage)
             && owned_identity_pipe_supported(rest))
-            || (owned_identity_pipe_entry_stage(stage)
-                && owned_identity_pipe_supported(&exprs[i..]));
+            || owned_identity_pipe_enters_at_first(&exprs[i..]);
     }
     false
 }

--- a/tests/data/jq-path-context-sweep-known-divergences.txt
+++ b/tests/data/jq-path-context-sweep-known-divergences.txt
@@ -73,6 +73,19 @@ yq/*/first/*/*        yq_first        real yq's first(f) ignores its argument an
 # `test_bound_variable_carries_node_identity_2072` and recorded in
 # `docs/compliance/yq/limitations.md`.
 
+# Real yq's `//` is not jq's either (#2817, found when #2782 added the
+# `alt_l`/`alt_r` wrappers): it maps *per left output*, and a falsy left
+# output whose right side yields nothing is emitted as itself. `(null // key)`
+# and `(null // parent)` at the document root -- where `key`/`parent` emit
+# nothing in both tools -- therefore print `null` in yq and nothing here, on
+# the `root`, `bind_root` and `descend` (whose first output is the root)
+# prefixes. Every other prefix agrees. succinctly yq follows jq's
+# collect-then-fallback rule; identical on `main` before #2782, whose change
+# is where a `//` output *stands*, not which outputs it produces.
+yq/*/alt_r/plain/root        yq_alt_empty_rhs  yq's `//` emits a falsy left value when the right side is empty; root `key`/`parent` are empty — #2817
+yq/*/alt_r/plain/bind_root   yq_alt_empty_rhs  same, through an `as`-bound root — #2817
+yq/*/alt_r/plain/descend     yq_alt_empty_rhs  same, at `..`'s first output (the root) — #2817
+
 # --- jq mode ----------------------------------------------------------------
 
 # `path(foreach (getpath(...)) as $x (null; $x))` raises "Invalid path

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -46799,13 +46799,19 @@ fn test_alternative_control_flow_2476() -> Result<()> {
 /// mode (real jq 1.7.1 errors on all three), so there is no jq oracle here.
 /// yq mode is the oracle-backed sibling, and the two now agree.
 ///
-/// Two shapes deliberately left alone, both unchanged by this commit and both
-/// matching what the yq test records: an *absent* position
-/// (`.a.missing | (key // 1)`) still answers the fallback rather than
-/// `"missing"`, and a `//` after `to_entries` has left the cursor domain
-/// before the `//` is reached, so `needs_path_context`'s lack of an
-/// `Expr::Alternative` arm still keeps that pipe off path-context evaluation
-/// (#715/#1405's recursion table, pinned by #2416, not this arm's).
+/// Two shapes #2692 left unreached are fixed as a side effect of #2782's
+/// rewrite (`//` became a fully transparent construct -- see
+/// `eval_owned_identity_alternative` -- rather than an operand-shaped rule
+/// evaluated at the pipe's outer position): `.a.missing | key` answers
+/// `"missing"` (a pre-existing, unrelated quirk of the bare `key` extension
+/// on a synthesized/absent node -- not this issue's concern), and `(key //
+/// 1)` now agrees with it instead of falling through to `1`; a `//` reached
+/// after `to_entries | .[]` now sees each iteration's own position instead of
+/// leaving the cursor domain beforehand, so `(key // 99)` agrees with bare
+/// `key` (`0`, `1`) instead of always answering the fallback `99`. Asserted
+/// against the bare spelling rather than a hardcoded literal, matching
+/// #2782's own acceptance rule: the `//` spelling must agree with the bare
+/// spelling, whatever that bare spelling itself answers.
 #[test]
 fn test_alternative_operands_read_the_real_position_in_jq_mode_2692() -> Result<()> {
     let doc = r#"{"a":{"b":1,"e":2}}"#;
@@ -46827,15 +46833,23 @@ fn test_alternative_operands_read_the_real_position_in_jq_mode_2692() -> Result<
         assert_eq!(stdout.trim(), want, "`{filter}` -- stderr: {stderr:?}");
     }
 
-    // The two shapes this does not reach, pinned so the table above is not
-    // read as "position reading through `//` is now generally correct".
-    for (filter, want) in [
-        (".a.missing | (key // 1)", "1"),
-        (".a | to_entries | .[] | (key // 99)", "99\n99"),
+    // #2782: two shapes #2692 could not reach, now agreeing with bare `key`.
+    for (filter, bare) in [
+        (".a.missing | (key // 1)", ".a.missing | key"),
+        (
+            ".a | to_entries | .[] | (key // 99)",
+            ".a | to_entries | .[] | key",
+        ),
     ] {
+        let (want, want_stderr, want_code) = run_jq_full(&["-c", bare], Some(doc))?;
+        assert_eq!(want_code, 0, "`{bare}` -- stderr: {want_stderr:?}");
         let (stdout, stderr, code) = run_jq_full(&["-c", filter], Some(doc))?;
         assert_eq!(code, 0, "`{filter}` -- stderr: {stderr:?}");
-        assert_eq!(stdout.trim(), want, "`{filter}` -- stderr: {stderr:?}");
+        assert_eq!(
+            stdout.trim(),
+            want.trim(),
+            "`{filter}` should agree with `{bare}` -- stderr: {stderr:?}"
+        );
     }
 
     Ok(())
@@ -48556,6 +48570,72 @@ fn test_nth_result_twin_forces_skipped_elements_2666() -> Result<()> {
     assert_eq!(code, 5, "stdout: {out:?} stderr: {err:?}");
     assert!(out.trim().is_empty(), "nothing may be emitted, got {out:?}");
     assert!(err.contains("cannot be divided"), "stderr: {err:?}");
+    Ok(())
+}
+
+/// #2782: the owned identity route's `//` arm forced `optional = true` onto
+/// its left operand -- its own comment said "errors in it suppressed, as `//`
+/// does", which jq's `//` does not do: `jq -n '5 | (.a // 1)'` is `Cannot
+/// index number with "a"`, exit 5, and `(1, error("x")) // 2` prints `1`
+/// then exits 5 with the right side never run (both captured live from
+/// 1.7.1). So a pipe that reached that arm -- one with a path-context read
+/// after the `//`, here the extension builtins `key`/`parent` -- swallowed an
+/// error the same pipe without the read raised. The arm runs each side as
+/// stages of the pipe now, with `optional` passed through as `eval_single`'s
+/// and `eval.rs`'s `//` arms already do, so the two spellings agree: the
+/// oracle-checkable spelling (no read) pins the rule, the read spelling pins
+/// the route.
+#[test]
+fn test_alternative_left_error_is_not_swallowed_on_the_identity_route_2782() -> Result<()> {
+    let doc = r#"{"a":{"b":1,"c":2}}"#;
+    // `.a | tostring` is a string, so `.x` on it is an error in jq -- with and
+    // without the trailing read.
+    for filter in [
+        ".a | tostring | (.x // 1)",
+        ".a | tostring | (.x // 1) | key",
+    ] {
+        let (out, err, code) = run_jq_full(&["-c", filter], Some(doc))?;
+        assert_eq!(
+            code, 5,
+            "#2782: `{filter}` -- stdout: {out:?} stderr: {err:?}"
+        );
+        assert!(
+            out.trim().is_empty(),
+            "#2782: `{filter}` -- stdout: {out:?}"
+        );
+        assert!(
+            err.contains(r#"Cannot index string with string "x""#),
+            "#2782: `{filter}` -- stderr: {err:?}"
+        );
+    }
+    // A truthy output before the error survives; the right side never runs.
+    for (filter, want) in [
+        (".a | ((.b, error(\"x\")) // 2)", "1"),
+        (".a | ((.b, error(\"x\")) // 2) | key", "\"b\""),
+    ] {
+        let (out, err, code) = run_jq_full(&["-c", filter], Some(doc))?;
+        assert_eq!(
+            code, 5,
+            "#2782: `{filter}` -- stdout: {out:?} stderr: {err:?}"
+        );
+        assert_eq!(out.trim(), want, "#2782: `{filter}` -- stderr: {err:?}");
+        assert!(err.contains('x'), "#2782: `{filter}` -- stderr: {err:?}");
+    }
+    // Each output of a multi-output left side stands at its own node, in jq
+    // mode as in yq mode (`(.a, .b) // 9 | key` was `"a"`, `"a"` before).
+    let (out, err, code) = run_jq_full(&["-c", ".a | ((.b, .c) // 9) | key"], Some(doc))?;
+    assert_eq!(
+        (out.trim(), code),
+        ("\"b\"\n\"c\"", 0),
+        "#2782 -- stderr: {err:?}"
+    );
+    // And the operator stays lazy under a bounded consumer: `first` pulls one
+    // output and the `error` behind it is never evaluated.
+    let (out, err, code) = run_jq_full(
+        &["-c", ".a | first((.b, error(\"never\")) // 9) | key"],
+        Some(doc),
+    )?;
+    assert_eq!((out.trim(), code), ("\"b\"", 0), "#2782 -- stderr: {err:?}");
     Ok(())
 }
 

--- a/tests/jq_path_context_alphabet_tests.rs
+++ b/tests/jq_path_context_alphabet_tests.rs
@@ -21,8 +21,8 @@
 //!    appears in the generated corpus, per mode — `key`/`parent`/`path`/
 //!    `file_index` in yq mode and the path-expression family in jq mode, each
 //!    under `limit`/`first`/`last`/`foreach`/`reduce`/`getpath`/object
-//!    construction/`select`/comma/`if`/`try`/`label`, and each of those again
-//!    under `path(...)` and `?`.
+//!    construction/`select`/comma/`if`/`try`/`label`/either side of `//`
+//!    (#2782), and each of those again under `path(...)` and `?`.
 //! 2. **yq comma/pipe precedence (#2420).** Real yq v4.53.3 groups `a, b | c`
 //!    as `a, (b | c)` where jq groups it as `(a, b) | c`. succinctly used to
 //!    apply jq's grouping in both modes; since #2420 `succinctly yq` follows
@@ -61,7 +61,7 @@ const YQ_LEAVES: &[&str] = &["key", "parent", "path", "file_index"];
 /// Every consumer construct #2416's phase-0 checklist names.
 const WRAPPERS: &[&str] = &[
     "bare", "limit", "first", "last", "foreach", "reduce", "getpath", "object", "select", "comma",
-    "if", "try", "label",
+    "if", "try", "label", "alt_l", "alt_r",
 ];
 
 /// `path(...)` over each of the above, plus `?`.

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -41790,9 +41790,12 @@ fn test_alternative_output_stands_where_its_operand_stood_2782() -> Result<()> {
 /// is correctly attributed to `rest`, not swallowed or misreported as the
 /// left operand's own failure (`eval_owned_identity_alternative`'s
 /// `rest_escape` split, mirroring `eval_owned_identity_scoped`'s existing
-/// pattern): `key` resolves truthy (`"a"`), then `rest` (`error(...)`)
-/// raises -- the escape must survive, not be swallowed as if the left
-/// operand itself had failed.
+/// pattern). `rest` must itself need path context (`(path, error(...))`,
+/// not a bare `error(...)`) to force the materializing identity route at
+/// all -- a `rest` with no path-context read stays on `eval_single`'s
+/// cursor-native `//` arm instead (`alternative_stays_cursor_native`),
+/// which never reaches `eval_owned_identity_alternative`'s escape-stash
+/// path and would leave this row not actually exercising it.
 #[test]
 fn test_alternative_review_gaps_2782() -> Result<()> {
     let doc = "a: {b: 1, e: 2}\n";
@@ -41806,13 +41809,13 @@ fn test_alternative_review_gaps_2782() -> Result<()> {
     assert_eq!(stdout.trim(), "[\"a\",\"z\"]", "stderr: {stderr:?}");
 
     let (stdout, stderr, code) = run_yq_stdin_with_stderr(
-        ".a | (key // 9) | error(\"boom-\" + .)",
+        ".a | (key // 9) | (path, error(\"boom\"))",
         doc,
         &["-o=json", "-I=0"],
     )?;
     assert_eq!(code, 1, "stdout: {stdout:?} stderr: {stderr:?}");
     assert!(
-        stderr.contains("boom-a"),
+        stderr.contains("boom"),
         "stdout: {stdout:?} stderr: {stderr:?}"
     );
 

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -41774,6 +41774,51 @@ fn test_alternative_output_stands_where_its_operand_stood_2782() -> Result<()> {
     Ok(())
 }
 
+/// #2782 review: two shapes verified correct during review but left
+/// untested by the sweep and the tests above.
+///
+/// `needs_path_context`'s new `Expr::Alternative` arm also tightens
+/// `owned_identity_operand_resolvable`'s `//`-nested-inside-another-operator
+/// gate (`src/jq/eval_generic.rs`'s `Expr::Alternative` arm in
+/// `path_context_resolvable`, unchanged by this PR): before the arm existed,
+/// `needs_path_context(a // b)` was unconditionally `false`, so a `//`
+/// nested inside an arithmetic/and/or operand was silently treated as
+/// contentless. `(path // ["x"]) + ["z"]` pins the fix: `path` must resolve
+/// to `["a"]` before `+` runs, matching real yq v4.53.3.
+///
+/// The second row pins that a `rest`-side error after a truthy `//` output
+/// is correctly attributed to `rest`, not swallowed or misreported as the
+/// left operand's own failure (`eval_owned_identity_alternative`'s
+/// `rest_escape` split, mirroring `eval_owned_identity_scoped`'s existing
+/// pattern): `key` resolves truthy (`"a"`), then `rest` (`error(...)`)
+/// raises -- the escape must survive, not be swallowed as if the left
+/// operand itself had failed.
+#[test]
+fn test_alternative_review_gaps_2782() -> Result<()> {
+    let doc = "a: {b: 1, e: 2}\n";
+
+    let (stdout, stderr, code) = run_yq_stdin_with_stderr(
+        ".a | (path // [\"x\"]) + [\"z\"]",
+        doc,
+        &["-o=json", "-I=0"],
+    )?;
+    assert_eq!(code, 0, "stderr: {stderr:?}");
+    assert_eq!(stdout.trim(), "[\"a\",\"z\"]", "stderr: {stderr:?}");
+
+    let (stdout, stderr, code) = run_yq_stdin_with_stderr(
+        ".a | (key // 9) | error(\"boom-\" + .)",
+        doc,
+        &["-o=json", "-I=0"],
+    )?;
+    assert_eq!(code, 1, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert!(
+        stderr.contains("boom-a"),
+        "stdout: {stdout:?} stderr: {stderr:?}"
+    );
+
+    Ok(())
+}
+
 /// #2476's `//` sibling of
 /// `test_not_no_longer_raises_through_a_container_alias_2476` just above.
 /// The native arm's `ambient_validation_error` call is

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -41634,23 +41634,12 @@ fn test_alternative_keeps_the_cursor_it_hands_on_2476() -> Result<()> {
 /// | `.a \| (parent // 1)`     | `a: {b: 1, e: 2}` | `1`     |
 /// | `.a \| (.missing // key)` | `a`               | (empty) |
 ///
-/// One shape this does *not* reach, unchanged in either direction:
-/// `.a | to_entries | .[] | (key // 99)` is `0`, `1` in yq and `99`, `99`
-/// here, before and after. `needs_path_context` has no `Expr::Alternative`
-/// arm at all (it falls to that function's `_ => false`), so a pipe whose
-/// only path-context read is inside a `//` is never routed to path-context
-/// evaluation, and `to_entries` has already left the cursor domain by then.
-/// That is #715/#1405's recursion list, not this arm's, and deliberately not
-/// touched here -- #2416 pins that table.
-///
-/// A second, distinct gap: this arm's position-reading fix above is for a
-/// *present* left/ambient position. An *absent* one is still wrong in both
-/// directions -- `.a.missing | (key // 1)` is `1` here (should be `missing`,
-/// yq v4.53.3's own answer) on this branch, and identically `1` on `main`
-/// pre-#2476 (`//` still bridging there) -- so this is not a regression this
-/// arm introduced, just one it does not close. Root cause not chased down
-/// here; flagged so this table is not read as "position-reading through `//`
-/// is now generally correct."
+/// Two shapes this arm did *not* reach, both closed by #2782 and pinned in
+/// `test_alternative_is_routed_to_path_context_2782` below: `.a | to_entries
+/// | .[] | (key // 99)` (`99`, `99` here until `needs_path_context` gained
+/// its `Expr::Alternative` arm -- a pipe whose only read sat inside a `//`
+/// was never routed at all) and `.a.missing | (key // 1)` at an *absent*
+/// position (`1` here; yq's `"missing"`).
 #[test]
 fn test_alternative_operands_read_the_real_position_2476() -> Result<()> {
     let doc = "a: {b: 1, e: 2}\n";
@@ -41668,6 +41657,120 @@ fn test_alternative_operands_read_the_real_position_2476() -> Result<()> {
         assert_eq!(stdout.trim(), want, "`{filter}` -- stderr: {stderr:?}");
     }
 
+    Ok(())
+}
+
+/// #2782 (#2665 item 1): `needs_path_context` has an `Expr::Alternative` arm,
+/// so a pipe whose only path-context read sits inside a `//` is routed to
+/// path-context evaluation like one whose read sits inside `and`/`or`
+/// (#1405). Every row is captured live from yq v4.53.3 on `a: {b: 1, e: 2}`
+/// and fails on `main` before #2782, where the pipe was never routed and
+/// the read answered nothing -- which is falsy, so `//` took the other side.
+///
+/// | filter                                   | yq v4.53.3          | before      |
+/// |------------------------------------------|---------------------|-------------|
+/// | `.a \| to_entries \| .[] \| (key // 99)`  | `0`, `1`            | `99`, `99`  |
+/// | `.a.missing \| (key // 1)`               | `"missing"`         | `1`         |
+/// | `.a.missing \| (path // 1)`              | `["a","missing"]`   | `[]`        |
+/// | `.a \| tostring \| (key // 9)`           | `"a"`               | `9`         |
+/// | `.a \| map_values(key // 9)`             | `{"b":"b","e":"e"}` | all `9`     |
+/// | `.a \| with_entries(.value = (key // 9))`| `{"b":0,"e":1}`     | all `9`     |
+///
+/// The `before` column is the silent-fallback class ADR-0021 exists to end:
+/// no error, a plausible value, and the wrong one.
+#[test]
+fn test_alternative_is_routed_to_path_context_2782() -> Result<()> {
+    let doc = "a: {b: 1, e: 2}\n";
+    for (filter, want) in [
+        (".a | to_entries | .[] | (key // 99)", "0\n1"),
+        (".a.missing | (key // 1)", "\"missing\""),
+        (".a.missing | (path // 1)", "[\"a\",\"missing\"]"),
+        (".a | tostring | (key // 9)", "\"a\""),
+        (".a | map_values(key // 9)", "{\"b\":\"b\",\"e\":\"e\"}"),
+        (
+            ".a | with_entries(.value = (key // 9))",
+            "{\"b\":0,\"e\":1}",
+        ),
+    ] {
+        let (stdout, stderr, code) = run_yq_stdin_with_stderr(filter, doc, &["-o=json", "-I=0"])?;
+        assert_eq!(code, 0, "#2782: `{filter}` -- stderr: {stderr:?}");
+        assert_eq!(
+            stdout.trim(),
+            want,
+            "#2782: `{filter}` -- stderr: {stderr:?}"
+        );
+    }
+    Ok(())
+}
+
+/// #2782's second half: an output of `//` stands where the operand that
+/// produced it stood, so a read *after* the operator answers from that
+/// position. Real yq's rule, captured live from v4.53.3 on `a: {b: 1}`, and
+/// the one the bare spellings already followed: `key`'s output is the key
+/// node (`path` is `["a"]`, `parent` the enclosing map, a second `key` is
+/// nothing), `path`/`file_index` keep the input node, `parent` stands at the
+/// ancestor, and each output of a comma stands at its own node.
+///
+/// Adding `needs_path_context`'s arm alone regressed the first block: the
+/// owned identity route's `//` arm rewrote `key`/`file_index` to *detached*
+/// literals before evaluating (so `(key // 9) | parent` printed nothing where
+/// `key | parent` is the map) and stamped every output of a multi-output
+/// left side with the identity of the side's first output, re-evaluated
+/// (`(.a, .b) // 9 | key` was `"a"`, `"a"`). `//` is a transparent construct
+/// on that route now -- each side runs as stages of the pipe, like `,` and
+/// `if` -- which is what `eval_owned_identity_alternative` documents. The
+/// rows marked `route` also fail on `main` for the yq CLI's DOM path alone,
+/// where `owned_identity_pipe_applies` had to learn that a stage with no
+/// placement rule can follow a navigational head.
+#[test]
+fn test_alternative_output_stands_where_its_operand_stood_2782() -> Result<()> {
+    let doc = "a: {b: 1}\n";
+    for (filter, want) in [
+        // The operand's position survives the operator.
+        (".a | (key // 9) | path", "[\"a\"]"),
+        (".a | (key // 9) | parent", "{\"a\":{\"b\":1}}"),
+        (".a | (key // 9) | key", ""),
+        (".a | (file_index // 9) | key", "\"a\""),
+        (".a | (file_index // 9) | path", "[\"a\"]"),
+        (".a | (file_index // 9) | parent", "{\"a\":{\"b\":1}}"),
+        (".a | (null // key) | parent", "{\"a\":{\"b\":1}}"),
+        (".a | (null // file_index) | key", "\"a\""),
+        (".a | (path // 9) | key", "\"a\""),
+        (".a | (parent // 9) | path", "[]"),
+        // route: a stage with no placement rule after a navigational head.
+        (". | (null // .b) | key", "\"b\""),
+        (". | (key // .b) | path", "[\"b\"]"),
+        (".a | . | (null // .x) | key", "\"x\""),
+    ] {
+        let (stdout, stderr, code) = run_yq_stdin_with_stderr(filter, doc, &["-o=json", "-I=0"])?;
+        assert_eq!(code, 0, "#2782: `{filter}` -- stderr: {stderr:?}");
+        assert_eq!(
+            stdout.trim(),
+            want,
+            "#2782: `{filter}` -- stderr: {stderr:?}"
+        );
+    }
+
+    // Each output of a multi-output left side keeps its own position.
+    let doc = "x: {a: 1, b: 2}\n";
+    for (filter, want) in [
+        (".x | ((.a, .b) // 9) | key", "\"a\"\n\"b\""),
+        (
+            ".x | ((.a, .b) // 9) | path",
+            "[\"x\",\"a\"]\n[\"x\",\"b\"]",
+        ),
+        // A falsy output is dropped, not replaced (jq's rule, which succinctly
+        // yq follows; real yq's per-output rule is #2817).
+        (".x | ((.a, null, .b) // 9) | key", "\"a\"\n\"b\""),
+    ] {
+        let (stdout, stderr, code) = run_yq_stdin_with_stderr(filter, doc, &["-o=json", "-I=0"])?;
+        assert_eq!(code, 0, "#2782: `{filter}` -- stderr: {stderr:?}");
+        assert_eq!(
+            stdout.trim(),
+            want,
+            "#2782: `{filter}` -- stderr: {stderr:?}"
+        );
+    }
     Ok(())
 }
 


### PR DESCRIPTION
## Summary

- `needs_path_context` had no `Expr::Alternative` arm, so a pipe whose only path-context read sat inside a `//` was never routed to path-context evaluation at all (`.a | to_entries | .[] | (key // 99)` answered `99` where bare `.[] | key` is `0`).
- Adding the arm alone traded that gap for several: the owned-identity route's own `//` arm rewrote a read inside either operand into a detached literal, stamped a multi-output left side with its first output's (re-evaluated) identity, and forced `optional = true` onto the left operand.
- `//` is now a fully transparent construct on that route (like `,` and `if`): `eval_owned_identity_alternative` runs the left operand as stages of the pipe, continuing `rest` from every truthy output at the position it was actually produced, splicing the right side only when nothing truthy came out.
- A `//` at a live cursor with nothing reading after it stays on the cursor-native route (`alternative_stays_cursor_native`) so yq's flow style/anchor/comments survive (`.a | (parent // 1)`).
- `owned_identity_pipe_applies` (the non-sink gate) learned that a stage with no placement rule can also be a leaving stage reached after a navigational head, so the yq CLI's DOM path and the jq CLI's sink pipeline now agree on `. | (null // .b) | key`.

Two divergences the fix's own oracle sweep surfaced are filed separately rather than chased here:
- #2817 — real yq's `//` maps per left output and keeps a falsy left value when the right side is empty (succinctly follows jq's collect-then-fallback rule in both modes).
- #2435 (pre-existing) — the null-document `parent` autovivification question, orthogonal to where a `//` output stands.

Fixes #2782 (#2665 item 1).

## Test plan

- [x] `cargo build --features cli`
- [x] `cargo test --features cli,simd,regex,serde` (full suite, 3688+ tests, all green)
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings`
- [x] `scripts/jq-path-context-oracle-sweep.sh --self-test` (alphabet coverage, extended with `alt_l`/`alt_r` wrappers)
- [x] `scripts/jq-path-context-oracle-sweep.sh --summary` against pinned jq 1.7.1 / yq v4.53.3: 6300 cases, 0 unexpected divergences, every known divergence still accounted for
- [x] New CLI tests pinning both defects and their fix in `tests/jq_cli_tests.rs` and `tests/yq_cli_tests.rs`
- [x] `docs/adrs/adr-0021.md` amendment and `docs/compliance/yq/limitations.md` entry for the #2817 divergence