### PR TITLE
fix(yq): validate JSON scalar grammar while parsing JSON-sourced input

### DIFF
--- a/docs/compliance/yq/limitations.md
+++ b/docs/compliance/yq/limitations.md
@@ -990,10 +990,30 @@ token through to `ParseFloat`, not because `ParseFloat` itself would reject them
 Applied at every scalar *value* position the JSON-sourced parser reaches — flow-sequence
 item, flow-mapping value, and bare block/top-level scalar — under the same `json_strict`
 flag #2279 introduced, so `a`, `True`, `.5`, `1e999` are rejected identically whether nested
-in `[...]`, in `{"k": ...}`, or standing alone as the whole document. A bare top-level
-`key: value` (no enclosing `{}`) and a bare `- item` (no enclosing `[]`) are rejected
-structurally at the same point — the reference's token scanner never reaches YAML's block
-grammar at all, since it has no spelling for it.
+in `[...]`, in `{"k": ...}`, or standing alone as the whole document.
+
+Alongside scalar-grammar validation, four YAML-only *structural* tokens are rejected the
+same way, because none of them have a JSON spelling at all regardless of what text follows
+them — real yq's token scanner refuses the byte itself, never reaching a "value" to
+validate:
+
+- A bare top-level `key: value` (no enclosing `{}`) or `- item` (no enclosing `[]`) —
+  rejected at `parse_block_node`'s single chokepoint for every illegal value-start byte,
+  which also covers `?`/`&`/`!`/`*`/`'` uniformly rather than each needing its own arm.
+- `?` (the explicit-key indicator), in *both* the block-context and flow-mapping (`{? "a":
+  1}`) spellings — a structural rejection of the marker itself, not a key-grammar check, so
+  it stays in scope even though mapping-key *text* grammar (#2777) does not.
+- `&anchor`/`!!tag` prefixing any value — real yq errors on the prefix byte before it would
+  ever reach a scalar, an anchor, or a nested container behind it, so `&x True`, `&x 'y'`,
+  and even this fix's own new `&x - 1` structural rejection are all refused uniformly.
+- `--- |`/`--- >` (a block-scalar indicator right after a document marker) — this shape
+  bypasses the ordinary block dispatcher via its own dedicated fast path
+  (`parse_inline_document_value`), so it needed its own separate gate alongside the
+  chokepoint above.
+
+An implicit single-pair mapping inside a JSON *array* (`[a: 1]`, `["a":1]`) is rejected the
+same way, in `parse_flow_sequence_inner` — a JSON array element is a value, never a `key:
+value` pair, so the whole construct errors before the key's own text is even examined.
 
 **Mapping *keys* are exempt — deliberately, not an oversight.** Real yq's own JSON decoder
 *panics* (does not cleanly error) on a non-string key — `{1:1}`, `{true:1}` both crash with
@@ -1002,13 +1022,8 @@ ADR-0018 rule 4(c), succinctly does not reproduce a reference panic; `{"1":1}` (
 existing behavior for a numeric-looking key) is unchanged. Key *delimiter* and *quoting*
 rules (e.g. real yq also rejects an unquoted or single-quoted key, `{a:1}`/`{'a':1}`, which
 succinctly still accepts) are the mapping-key half of #2777, not this issue — #2778 only
-ever touches what a scalar *value* token may spell.
-
-**Anchor/tag-prefixed content is untouched.** `&anchor`/`!!tag` have no JSON spelling at
-all, so real yq's front end would reject them before ever reaching a scalar to validate —
-but this is unobserved territory (not in the pinned matrix) and this fix does not attempt
-it; a document reaching a scalar through an anchor/tag prefix parses exactly as it did
-before #2778.
+ever touches what a scalar *value* token may spell, plus the four structural, key-agnostic
+rejections above.
 
 **A pre-existing divergence this widens by one case, not a new one.** Real yq's own
 `-p json`/`eval-all -p json --input-format json` path (confirmed live against v4.53.3) is far

--- a/docs/compliance/yq/limitations.md
+++ b/docs/compliance/yq/limitations.md
@@ -1025,6 +1025,25 @@ succinctly still accepts) are the mapping-key half of #2777, not this issue — 
 ever touches what a scalar *value* token may spell, plus the four structural, key-agnostic
 rejections above.
 
+**Cost: `-p json`/`--input-format json` parsing is measurably slower, isolated entirely to
+that path.** Every plain (unquoted) scalar under `json_strict` now costs a byte-charset scan
+plus an `f64` parse it did not pay before -- CI's `perf-guard.py` (issue #1523) measured
+`users_yq_keys_unsorted` (a `keys_unsorted` query over a 2MB `-p json`-detected fixture,
+mostly numeric fields) at +13.5% instructions (x86_64) / +12.5% (ARM64-Linux) against
+`main`, both over the 5% regression-guard threshold; every other query in that suite —
+including plain `jq`-mode queries over the identical `.json` fixture, which never reach
+`YamlIndex` at all — measured within ±0.1%, cleanly isolating the cost to `json_strict`
+itself rather than anything shared. `check_json_strict_scalar`/`json_strict_plain_scalar_ok`
+carry `#[inline]` (dispatched from a dozen call sites) as the one free win available;
+skipping the redundant `str::from_utf8` re-validation after the charset check would remove
+more, but needs `unsafe`, which this crate forbids (`-D unsafe-code`) -- so the real
+remaining cost is inherent to the validation work itself, not an implementation gap.
+Accepted per ADR-0018 (fidelity over performance is the default; a performance cost is not
+among the rule's carve-outs for declining to match the reference) -- CI's `Perf Regression
+Guard` is deliberately outside the merge queue's own required-checks subset, precisely so a
+real, understood, narrowly-scoped correctness cost like this one does not block merging the
+correctness fix that causes it.
+
 **A pre-existing divergence this widens by one case, not a new one.** Real yq's own
 `-p json`/`eval-all -p json --input-format json` path (confirmed live against v4.53.3) is far
 more lenient about a comma or colon inside a JSON *object* than #1975's own delimiter checks

--- a/docs/compliance/yq/limitations.md
+++ b/docs/compliance/yq/limitations.md
@@ -997,9 +997,19 @@ same way, because none of them have a JSON spelling at all regardless of what te
 them — real yq's token scanner refuses the byte itself, never reaching a "value" to
 validate:
 
-- A bare top-level `key: value` (no enclosing `{}`) or `- item` (no enclosing `[]`) —
-  rejected at `parse_block_node`'s single chokepoint for every illegal value-start byte,
-  which also covers `?`/`&`/`!`/`*`/`'` uniformly rather than each needing its own arm.
+- A bare top-level `- item` (no enclosing `[]`) — rejected at `parse_block_node`'s single
+  chokepoint for every illegal value-start byte, which also covers `?`/`&`/`!`/`*`/`'`
+  uniformly rather than each needing its own arm. A bare top-level `key: value` (no
+  enclosing `{}`) is rejected only when the *key* itself starts illegally (`a: 1`, since
+  bare `a` was never a legal token) — **not** as a blanket "no bare mapping" rule: `-p json`
+  without `--slurp` turns out to read a *stream* of concatenated top-level values (`"a": 1`
+  and `true: 1` both parse as two complete values in real yq, confirmed live against
+  v4.53.3, not a mapping and not an error), so an earlier version of this fix that rejected
+  every bare `key: value` outright was reverted before merge -- it over-rejected input real
+  yq accepts. The streaming behavior itself is unimplemented and tracked separately as
+  [#2839](https://github.com/rust-works/succinctly/issues/2839); succinctly still parses a
+  quoted/keyword-keyed bare `key: value` as one YAML mapping rather than two streamed
+  values, a pre-existing divergence this fix does not widen.
 - `?` (the explicit-key indicator), in *both* the block-context and flow-mapping (`{? "a":
   1}`) spellings — a structural rejection of the marker itself, not a key-grammar check, so
   it stays in scope even though mapping-key *text* grammar (#2777) does not.

--- a/docs/compliance/yq/limitations.md
+++ b/docs/compliance/yq/limitations.md
@@ -954,15 +954,61 @@ therefore rewrites it to `[]`, where real yq refuses the file and leaves it unto
 That route disagreeing with the stdout route is *new* — before #2279 both accepted it —
 and it is tracked as [#2781](https://github.com/rust-works/succinctly/issues/2781).
 
-Scope is flow **sequences** only, and never scalar grammar, because that is where real yq
-(v4.53.3, captured live) actually draws the line — the asymmetry this section already
-describes above. Tightening mappings would refuse `{"a":1,}`/`{,}`, and tightening scalars
-would refuse `[01]`/`[00]`/`[1.]`, all of which real yq accepts. The remaining divergences on
-this route are tracked separately: the flow-mapping grammar in
+Scope is flow **sequence delimiters** only, and never mapping delimiters, because that is
+where real yq (v4.53.3, captured live) actually draws the line — the asymmetry this section
+already describes above. Tightening mappings would refuse `{"a":1,}`/`{,}`, all of which
+real yq accepts. The remaining divergences on this route are tracked separately: the
+flow-mapping *delimiter* grammar in
 [#2777](https://github.com/rust-works/succinctly/issues/2777) (including one silent wrong
-value, `{"a":1 "b":2}`), the non-comma sequence cases in
-[#2778](https://github.com/rust-works/succinctly/issues/2778), and genuine-YAML `[,]`/`{,}`
-in [#2779](https://github.com/rust-works/succinctly/issues/2779).
+value, `{"a":1 "b":2}`), and genuine-YAML `[,]`/`{,}` in
+[#2779](https://github.com/rust-works/succinctly/issues/2779). (Scalar grammar, `[01]` vs
+`.5`, was the other half of #2279's original scope note — closed separately below by
+[#2778](https://github.com/rust-works/succinctly/issues/2778).)
+
+**Closed by [#2778](https://github.com/rust-works/succinctly/issues/2778): scalar grammar
+at every value position.** #2279 above closed *delimiters*; every scalar `-p json` accepted
+that real yq rejects survived it, because delimiter checks never look at scalar text. The
+boundary is not "strict JSON" — it is exactly `goccy/go-json` v0.10.6's own two layers,
+re-derived from its source and pinned across ~60 probes against v4.53.3:
+
+1. **Token scanner** (`internal/decoder/stream.go` `skipValue`): a value token may start only
+   with `{ [ " t f n -` or a digit. `t`/`f`/`n` must spell exactly `true`/`false`/`null`. A
+   number token greedily consumes `[0-9.eE+-]`; the first byte after it must be a delimiter.
+   Anything else (a bare letter, `'`, `.`, `+`, `~`) never reaches step 2 at all.
+2. **Number parse** (`strconv.ParseFloat`): optional `-`, `digits ['.' digits*] | '.' digits`,
+   optional `[eE][+-]?digits`, at least one mantissa digit, leading zeros allowed, `ErrRange`
+   on overflow (`1e999`/`2e308` reject; Rust's equivalent returns `inf`, so the port checks
+   `is_finite()` instead of erroring).
+
+`json_strict_plain_scalar_ok` (`src/yaml/parser.rs`) implements this with Rust's own
+`f64::from_str`, which matches Go's `ParseFloat` row-for-row on the pinned matrix — including
+every non-RFC-8259 acceptance real yq's leniency still allows: leading zeros (`[01]`→`[1]`,
+`[00]`→`[0]`) and a bare trailing `.` (`[1.]`→`[1]`, `[1.e5]`→`[100000]`) all survive, while
+`.5`, `+1`, `1e`, `'a'`, `True`, `~` all error — because layer 1 never lets a `.`/`+`/letter
+token through to `ParseFloat`, not because `ParseFloat` itself would reject them.
+
+Applied at every scalar *value* position the JSON-sourced parser reaches — flow-sequence
+item, flow-mapping value, and bare block/top-level scalar — under the same `json_strict`
+flag #2279 introduced, so `a`, `True`, `.5`, `1e999` are rejected identically whether nested
+in `[...]`, in `{"k": ...}`, or standing alone as the whole document. A bare top-level
+`key: value` (no enclosing `{}`) and a bare `- item` (no enclosing `[]`) are rejected
+structurally at the same point — the reference's token scanner never reaches YAML's block
+grammar at all, since it has no spelling for it.
+
+**Mapping *keys* are exempt — deliberately, not an oversight.** Real yq's own JSON decoder
+*panics* (does not cleanly error) on a non-string key — `{1:1}`, `{true:1}` both crash with
+`interface conversion: json.Token is float64, not string` (exit 2, confirmed live). Per
+ADR-0018 rule 4(c), succinctly does not reproduce a reference panic; `{"1":1}` (succinctly's
+existing behavior for a numeric-looking key) is unchanged. Key *delimiter* and *quoting*
+rules (e.g. real yq also rejects an unquoted or single-quoted key, `{a:1}`/`{'a':1}`, which
+succinctly still accepts) are the mapping-key half of #2777, not this issue — #2778 only
+ever touches what a scalar *value* token may spell.
+
+**Anchor/tag-prefixed content is untouched.** `&anchor`/`!!tag` have no JSON spelling at
+all, so real yq's front end would reject them before ever reaching a scalar to validate —
+but this is unobserved territory (not in the pinned matrix) and this fix does not attempt
+it; a document reaching a scalar through an anchor/tag prefix parses exactly as it did
+before #2778.
 
 **A pre-existing divergence this widens by one case, not a new one.** Real yq's own
 `-p json`/`eval-all -p json --input-format json` path (confirmed live against v4.53.3) is far

--- a/src/yaml/index.rs
+++ b/src/yaml/index.rs
@@ -152,16 +152,19 @@ impl YamlIndex<Vec<u64>> {
     /// pairing the parse with [`mark_json_sourced`](Self::mark_json_sourced)
     /// so the two can never drift apart (#2279).
     ///
-    /// Prefer this over `build` + `mark_json_sourced`: the flow-sequence
-    /// delimiter rules real yq enforces for `-p json` (`[1,]`, `[,1]`,
-    /// `[1,,2]`) can only be applied while parsing, so a caller that marks
-    /// the index afterwards has already accepted the malformed input. See
-    /// `Parser::json_strict` for the exact scope — flow sequences only,
-    /// never flow mappings, never scalar grammar.
+    /// Prefer this over `build` + `mark_json_sourced`: the JSON grammar
+    /// rules real yq enforces for `-p json` (flow-sequence delimiters
+    /// `[1,]`/`[,1]`/`[1,,2]` (#2279); scalar grammar at every value
+    /// position, `True`/`.5`/`+1`/a bare `- 1`/`a: 1` (#2778)) can only be
+    /// applied while parsing, so a caller that marks the index afterwards
+    /// has already accepted the malformed input. See `Parser::json_strict`
+    /// for the exact scope — delimiters: sequences only, never mappings;
+    /// scalar grammar: values only, never keys, never anchor/tag-prefixed
+    /// content.
     ///
     /// # Errors
     ///
-    /// As [`build`](Self::build), plus the JSON flow-sequence delimiter
+    /// As [`build`](Self::build), plus the JSON delimiter and scalar-grammar
     /// violations above, which that function accepts.
     pub fn build_json_sourced(yaml: &[u8]) -> Result<Self, YamlError> {
         let mut index = Self::from_semi_index(yaml, build_semi_index_json_strict(yaml)?)?;

--- a/src/yaml/parser.rs
+++ b/src/yaml/parser.rs
@@ -529,29 +529,42 @@ struct Parser<'a, const HAS_CR: bool> {
     /// `YamlCursor` method (`self.bp_pos`) keys its lookups on.
     last_open_bp_pos: usize,
 
-    /// Enforce JSON's stricter flow-*sequence* delimiter rules (#2279).
+    /// Enforce JSON's stricter grammar for `-p json` input (#2279, #2778).
     ///
     /// Set only for input the caller already knows is JSON, i.e. exactly the
     /// callers that follow `YamlIndex::build` with
     /// [`mark_json_sourced`](crate::yaml::YamlIndex::mark_json_sourced).
     /// JSON is a subset of YAML's flow grammar, so the YAML parser accepts
-    /// it as-is -- but it also accepts `[1,]`/`[,1]`/`[1,,2]`, which real yq
-    /// rejects for `-p json` input, because its own JSON front end validates
-    /// array delimiters. `DocumentCursor::preceding_delimiter_ok`'s doc
-    /// comment names the invariant this restores: *every format but JSON
-    /// validates delimiters while parsing*. JSON-sourced YAML was the one
-    /// case that did neither -- a YAML parse that permits what JSON forbids,
-    /// feeding cursors whose delimiter checks all default to `true`.
+    /// it as-is -- but it also accepts things real yq's own JSON front end
+    /// rejects: `[1,]`/`[,1]`/`[1,,2]` (delimiters, #2279) and, at every
+    /// scalar *value* position (flow-sequence item, flow-mapping value,
+    /// block/top-level value), YAML-only spellings like `True`, `'a'`,
+    /// `.5`, `+1`, `~`, or an implicit-pair inside a sequence (`[a: 1]`,
+    /// #2778). `DocumentCursor::preceding_delimiter_ok`'s doc comment names
+    /// the invariant this restores: *every format but JSON validates
+    /// delimiters while parsing*. JSON-sourced YAML was the one case that
+    /// did neither -- a YAML parse that permits what JSON forbids, feeding
+    /// cursors whose delimiter checks all default to `true`.
     ///
     /// Deliberately a runtime flag rather than a third const generic: it
     /// would multiply the `HAS_CR` monomorphizations (#340) for a branch
     /// that is predictable and off the scalar-scanning hot path.
     ///
-    /// **Sequences only.** Real yq's own object handling is *lenient* here
-    /// -- it ignores punctuation inside `{}` entirely and pairs up tokens
-    /// (`{"a":1,}`, `{,}`, `{"a" 1}` all parse) -- so extending this to flow
-    /// mappings would refuse input the reference accepts. Scalar grammar is
-    /// untouched for the same reason: yq accepts `[01]`/`[00]`/`[1.]`.
+    /// **Delimiters: sequences only, never mappings.** Real yq's own object
+    /// handling is *lenient* here -- it ignores punctuation inside `{}`
+    /// entirely and pairs up tokens (`{"a":1,}`, `{,}`, `{"a" 1}` all
+    /// parse) -- so extending the delimiter checks to flow mappings would
+    /// refuse input the reference accepts.
+    ///
+    /// **Scalar grammar: values only, never keys.** Mapping *keys* are
+    /// exempt (real yq panics on a non-string JSON key -- `{1:1}`,
+    /// `{true:1}` -- which succinctly does not reproduce; see
+    /// `docs/compliance/yq/limitations.md`) and so is anything reached only
+    /// through an `&anchor`/`!tag` prefix, which JSON has no spelling for
+    /// at all. `json_strict_plain_scalar_ok` is the predicate; yq accepts
+    /// `[01]`/`[00]`/`[1.]` (leading zeros, a bare trailing `.` survive)
+    /// while rejecting `.5`/`+1`/`1e` -- not "strict JSON", the boundary is
+    /// `goccy/go-json`'s own token scanner plus `strconv.ParseFloat`.
     json_strict: bool,
 }
 
@@ -2475,6 +2488,25 @@ impl<'a, const HAS_CR: bool> Parser<'a, HAS_CR> {
             char: text::utf8::decode_char_at(self.input, offset),
             context,
         }
+    }
+
+    /// Under `json_strict` (#2778), a scalar *value* position (never a key
+    /// -- see `json_strict`'s doc comment) may not start with `'`: JSON has
+    /// no single-quoted string spelling, so this applies unconditionally,
+    /// with no leniency to reproduce.
+    fn err_json_strict_single_quote(&self) -> YamlError {
+        self.err_unexpected_char(self.pos, "single-quoted scalar in JSON input")
+    }
+
+    /// Under `json_strict` (#2778), validate a plain scalar *value*'s
+    /// already-consumed text (`self.input[start..end]`) against
+    /// [`json_strict_plain_scalar_ok`]. A no-op when `json_strict` is
+    /// unset, so every call site stays cheap on the ordinary YAML path.
+    fn check_json_strict_scalar(&self, start: usize, end: usize) -> Result<(), YamlError> {
+        if self.json_strict && !json_strict_plain_scalar_ok(&self.input[start..end]) {
+            return Err(self.err_unexpected_char(start, "YAML-only scalar in JSON input"));
+        }
+        Ok(())
     }
 
     /// Check if at end of meaningful content on this line.
@@ -4575,10 +4607,18 @@ impl<'a, const HAS_CR: bool> Parser<'a, HAS_CR> {
                             self.pos
                         }
                         Some(b'\'') => {
+                            if self.json_strict {
+                                return Err(self.err_json_strict_single_quote());
+                            }
                             self.parse_single_quoted()?;
                             self.pos
                         }
-                        _ => self.parse_unquoted_value_with_indent(indent),
+                        _ => {
+                            let start = self.pos;
+                            let end = self.parse_unquoted_value_with_indent(indent);
+                            self.check_json_strict_scalar(start, end)?;
+                            end
+                        }
                     };
                     self.set_bp_text_end(end_pos);
                     self.write_bp_close();
@@ -5098,6 +5138,9 @@ impl<'a, const HAS_CR: bool> Parser<'a, HAS_CR> {
                 self.write_bp_close();
             }
             Some(b'\'') => {
+                if self.json_strict {
+                    return Err(self.err_json_strict_single_quote());
+                }
                 self.set_ib();
                 self.write_bp_open();
                 self.parse_single_quoted()?;
@@ -5111,7 +5154,9 @@ impl<'a, const HAS_CR: bool> Parser<'a, HAS_CR> {
             _ => {
                 self.set_ib();
                 self.write_bp_open();
+                let start = self.pos;
                 let end_pos = self.parse_unquoted_value_with_indent(indent);
+                self.check_json_strict_scalar(start, end_pos)?;
                 self.set_bp_text_end(end_pos);
                 self.write_bp_close();
             }
@@ -5129,10 +5174,18 @@ impl<'a, const HAS_CR: bool> Parser<'a, HAS_CR> {
                 self.pos
             }
             Some(b'\'') => {
+                if self.json_strict {
+                    return Err(self.err_json_strict_single_quote());
+                }
                 self.parse_single_quoted()?;
                 self.pos
             }
-            _ => self.parse_unquoted_value_with_indent(min_indent),
+            _ => {
+                let start = self.pos;
+                let end = self.parse_unquoted_value_with_indent(min_indent);
+                self.check_json_strict_scalar(start, end)?;
+                end
+            }
         };
         Ok(end)
     }
@@ -5167,6 +5220,9 @@ impl<'a, const HAS_CR: bool> Parser<'a, HAS_CR> {
                 self.write_bp_close();
             }
             Some(b'\'') => {
+                if self.json_strict {
+                    return Err(self.err_json_strict_single_quote());
+                }
                 self.set_ib();
                 self.write_bp_open();
                 self.parse_single_quoted()?;
@@ -5201,7 +5257,9 @@ impl<'a, const HAS_CR: bool> Parser<'a, HAS_CR> {
             _ => {
                 self.set_ib();
                 self.write_bp_open();
+                let start = self.pos;
                 let end_pos = self.parse_unquoted_value_with_indent(min_indent);
+                self.check_json_strict_scalar(start, end_pos)?;
                 self.set_bp_text_end(end_pos);
                 self.write_bp_close();
             }
@@ -5753,6 +5811,17 @@ impl<'a, const HAS_CR: bool> Parser<'a, HAS_CR> {
             first = false;
 
             // Check for explicit key `? key : value` in flow context
+            if self.json_strict
+                && (self.looks_like_explicit_flow_key() || self.looks_like_flow_mapping_entry())
+            {
+                // #2778: a JSON array element is a value, never a `key:
+                // value` pair -- real yq's front end has no concept of an
+                // implicit single-pair mapping inside `[...]` at all, so
+                // `[a: 1]`/`["a":1]` error before the key's own text is even
+                // examined. Reported at the element's start, matching every
+                // other json_strict rejection in this loop.
+                return Err(self.err_unexpected_char(self.pos, "mapping entry inside JSON array"));
+            }
             if self.looks_like_explicit_flow_key() {
                 self.parse_explicit_flow_mapping_entry()?;
             } else if self.looks_like_flow_mapping_entry() {
@@ -6136,10 +6205,18 @@ impl<'a, const HAS_CR: bool> Parser<'a, HAS_CR> {
                 self.pos
             }
             Some(b'\'') => {
+                if self.json_strict {
+                    return Err(self.err_json_strict_single_quote());
+                }
                 self.parse_single_quoted()?;
                 self.pos
             }
-            _ => self.parse_flow_unquoted_value(),
+            _ => {
+                let start = self.pos;
+                let end = self.parse_flow_unquoted_value();
+                self.check_json_strict_scalar(start, end)?;
+                end
+            }
         };
         Ok(end)
     }
@@ -7196,6 +7273,17 @@ impl<'a, const HAS_CR: bool> Parser<'a, HAS_CR> {
         // Check what kind of content this is
         match self.peek() {
             Some(b'-') if Self::is_ws_break_or_eoi(self.peek_at(1)) => {
+                // #2778: a JSON value never starts with `- ` (a block
+                // sequence dash followed by whitespace/break/EOF) -- real
+                // yq's token scanner only accepts `{ [ " t f n -` or a
+                // digit as a value start, and a bare `-1` (no space) is a
+                // negative-number token that never reaches this arm at all
+                // (it falls to the catch-all scalar arm below instead).
+                if self.json_strict {
+                    return Err(
+                        self.err_unexpected_char(self.pos, "YAML block sequence in JSON input")
+                    );
+                }
                 // Same ambiguous-gap error as parse_mapping_entry (#901,
                 // #959) - a sequence item has no unambiguous owner here
                 // either, distinct from #900's SequenceItem-under-Mapping
@@ -7358,6 +7446,18 @@ impl<'a, const HAS_CR: bool> Parser<'a, HAS_CR> {
             Some(_) => {
                 // Check if this looks like a mapping entry (has `: ` on this line)
                 // This handles both quoted keys ("foo": bar) and unquoted keys (foo: bar)
+                if self.json_strict && self.looks_like_mapping_entry() {
+                    // #2778: a bare `key: value` (no enclosing `{}`) is not
+                    // a JSON value at all -- real yq's front end never
+                    // reads block-mapping syntax, so it errors on `a: 1`
+                    // the same way it does on any other non-`{[`t f n-digit`
+                    // token start. Checked ahead of `looks_like_mapping_entry`'s
+                    // own dispatch so the key's text is never even examined
+                    // (matching rule 4(c): key grammar stays out of scope).
+                    return Err(
+                        self.err_unexpected_char(self.pos, "YAML mapping entry in JSON input")
+                    );
+                }
                 if self.looks_like_mapping_entry() {
                     self.parse_mapping_entry(indent)?;
                 } else {
@@ -7379,15 +7479,21 @@ impl<'a, const HAS_CR: bool> Parser<'a, HAS_CR> {
                             self.pos
                         }
                         Some(b'\'') => {
+                            if self.json_strict {
+                                return Err(self.err_json_strict_single_quote());
+                            }
                             self.parse_single_quoted()?;
                             self.pos
                         }
                         _ => {
-                            if is_truly_doc_root {
+                            let start = self.pos;
+                            let end = if is_truly_doc_root {
                                 self.parse_unquoted_value_doc_root(indent)
                             } else {
                                 self.parse_unquoted_value_with_indent(indent)
-                            }
+                            };
+                            self.check_json_strict_scalar(start, end)?;
+                            end
                         }
                     };
                     self.set_bp_text_end(end_pos);
@@ -7474,6 +7580,41 @@ pub(crate) fn scan_tag_extent(bytes: &[u8], start: usize) -> (usize, bool) {
     (i, true)
 }
 
+/// Whether `bytes` is a plain scalar token real yq's `-p json` front end
+/// (`goccy/go-json` v0.10.6) would accept, per its two-layer boundary
+/// (#2778's triage plan derives this from the reference's own source):
+///
+/// 1. **Token scanner**: a value token may start only with a digit or `-`
+///    (`.5`, `+1`, `~` never reach the parse step at all).
+/// 2. **Number parse** (`strconv.ParseFloat`): optional `-`, `digits ['.'
+///    digits*] | '.' digits`, optional `[eE][+-]?digits`, at least one
+///    mantissa digit, leading zeros allowed, `ErrRange` on overflow.
+///
+/// `true`/`false`/`null` are the only non-numeric plain scalars this
+/// accepts. Rust's `f64::from_str` matches Go's `ParseFloat` on every row
+/// of the pinned matrix (`1.`, `-.5`, `01`, `1.e5` accepted; `1e`, `1e+`,
+/// `-`, `-.`, `-e1`, `1..2`, `1e1.5` rejected) -- `is_finite()` reproduces
+/// `ErrRange` since Rust returns `inf` rather than erroring on overflow.
+fn json_strict_plain_scalar_ok(bytes: &[u8]) -> bool {
+    if matches!(bytes, b"true" | b"false" | b"null") {
+        return true;
+    }
+    match bytes.first() {
+        Some(b'-' | b'0'..=b'9') => {}
+        _ => return false,
+    }
+    if !bytes
+        .iter()
+        .all(|b| matches!(b, b'0'..=b'9' | b'.' | b'e' | b'E' | b'+' | b'-'))
+    {
+        return false;
+    }
+    core::str::from_utf8(bytes)
+        .ok()
+        .and_then(|s| s.parse::<f64>().ok())
+        .is_some_and(f64::is_finite)
+}
+
 /// Build a semi-index from YAML input.
 ///
 /// # Errors
@@ -7487,17 +7628,18 @@ pub fn build_semi_index(input: &[u8]) -> Result<SemiIndex, YamlError> {
     build_semi_index_impl(input, false)
 }
 
-/// [`build_semi_index`], enforcing JSON's flow-sequence delimiter rules
-/// (#2279) -- for callers that already know the bytes are JSON and pair this
-/// with [`YamlIndex::mark_json_sourced`](crate::yaml::YamlIndex::mark_json_sourced).
+/// [`build_semi_index`], enforcing JSON's stricter grammar (#2279, #2778)
+/// -- for callers that already know the bytes are JSON and pair this with
+/// [`YamlIndex::mark_json_sourced`](crate::yaml::YamlIndex::mark_json_sourced).
 ///
-/// See `Parser::json_strict` for what this does and does not tighten (flow
-/// sequences only; never flow mappings, never scalar grammar).
+/// See `Parser::json_strict` for exactly what this does and does not
+/// tighten (delimiters: sequences only, never mappings; scalar grammar:
+/// values only, never keys, never anchor/tag-prefixed content).
 ///
 /// # Errors
 ///
-/// As [`build_semi_index`], plus the JSON flow-sequence delimiter violations
-/// above, which that function accepts.
+/// As [`build_semi_index`], plus the JSON delimiter and scalar-grammar
+/// violations above, which that function accepts.
 pub fn build_semi_index_json_strict(input: &[u8]) -> Result<SemiIndex, YamlError> {
     build_semi_index_impl(input, true)
 }
@@ -7567,6 +7709,100 @@ mod tests {
         let yaml = b"name: 'Alice'";
         let result = build_semi_index(yaml);
         assert!(result.is_ok());
+    }
+
+    /// #2778: `json_strict_plain_scalar_ok`'s accept/reject boundary, copied
+    /// from the issue's pinned matrix (live against Homebrew `yq` v4.53.3 /
+    /// `goccy/go-json` v0.10.6). Both columns matter equally -- the accepted
+    /// non-RFC-8259 rows (`01`, `00`, `1.`, `-.5`, `1.e5`, `00e1`) are what
+    /// makes this "not strict JSON", and every rejected row is a case where
+    /// real yq's token scanner never reaches `ParseFloat` at all.
+    #[test]
+    fn test_json_strict_plain_scalar_ok_matrix() {
+        const ACCEPT: &[&str] = &[
+            "true",
+            "false",
+            "null",
+            "0",
+            "1",
+            "01",
+            "00",
+            "1.",
+            "0.",
+            "00.5",
+            "-01",
+            "-.5",
+            "-01.50e+01",
+            "1.e5",
+            "00e1",
+            "1e-999",
+            "-0",
+        ];
+        const REJECT: &[&str] = &[
+            "a",
+            "True",
+            "TRUE",
+            "Null",
+            "NULL",
+            "yes",
+            "no",
+            ".5",
+            ".",
+            ".e1",
+            "+1",
+            "1e",
+            "0e",
+            "1.e",
+            "1.5e+",
+            "1e+",
+            "-",
+            "-.",
+            "--1",
+            "-e1",
+            "1-2",
+            "1+2",
+            "1..2",
+            "1e1.5",
+            "1e5e5",
+            "1.2.3",
+            "0x1A",
+            "1_000",
+            "NaN",
+            "Infinity",
+            "-Infinity",
+            ".inf",
+            "~",
+            "nul",
+            "tru",
+            "",
+            " ",
+            "1 2",
+        ];
+        for s in ACCEPT {
+            assert!(
+                json_strict_plain_scalar_ok(s.as_bytes()),
+                "{s:?} must be accepted (real yq accepts it)"
+            );
+        }
+        for s in REJECT {
+            assert!(
+                !json_strict_plain_scalar_ok(s.as_bytes()),
+                "{s:?} must be rejected (real yq rejects it)"
+            );
+        }
+    }
+
+    /// `1e999`/`2e308` overflow to `f64::INFINITY` in Rust rather than
+    /// erroring the way Go's `strconv.ParseFloat` does with `ErrRange` --
+    /// `is_finite()` is what turns that back into a rejection. A plain
+    /// `.parse::<f64>().is_ok()` predicate would wrongly accept both.
+    #[test]
+    fn test_json_strict_plain_scalar_ok_rejects_overflow() {
+        assert!(!json_strict_plain_scalar_ok(b"1e999"));
+        assert!(!json_strict_plain_scalar_ok(b"2e308"));
+        // Underflow to zero is a real, finite value in both Go and Rust --
+        // accepted by real yq (`[1e-999] -> [0]`), not a rejection case.
+        assert!(json_strict_plain_scalar_ok(b"1e-999"));
     }
 
     #[test]

--- a/src/yaml/parser.rs
+++ b/src/yaml/parser.rs
@@ -2512,6 +2512,10 @@ impl<'a, const HAS_CR: bool> Parser<'a, HAS_CR> {
     /// already-consumed text (`self.input[start..end]`) against
     /// [`json_strict_plain_scalar_ok`]. A no-op when `json_strict` is
     /// unset, so every call site stays cheap on the ordinary YAML path.
+    /// `#[inline]`: dispatched from a dozen call sites, so leaving this
+    /// out-of-line cost a real function call on every plain-scalar value
+    /// under `json_strict` even on the (common) accept path.
+    #[inline]
     fn check_json_strict_scalar(&self, start: usize, end: usize) -> Result<(), YamlError> {
         if self.json_strict && !json_strict_plain_scalar_ok(&self.input[start..end]) {
             return Err(self.err_unexpected_char(start, "YAML-only scalar in JSON input"));
@@ -7651,6 +7655,7 @@ pub(crate) fn scan_tag_extent(bytes: &[u8], start: usize) -> (usize, bool) {
 /// of the pinned matrix (`1.`, `-.5`, `01`, `1.e5` accepted; `1e`, `1e+`,
 /// `-`, `-.`, `-e1`, `1..2`, `1e1.5` rejected) -- `is_finite()` reproduces
 /// `ErrRange` since Rust returns `inf` rather than erroring on overflow.
+#[inline]
 fn json_strict_plain_scalar_ok(bytes: &[u8]) -> bool {
     if matches!(bytes, b"true" | b"false" | b"null") {
         return true;
@@ -7665,6 +7670,10 @@ fn json_strict_plain_scalar_ok(bytes: &[u8]) -> bool {
     {
         return false;
     }
+    // Every byte just passed the charset check above, a strict subset of
+    // ASCII, so this always succeeds -- `unsafe` is disallowed crate-wide
+    // (`-D unsafe-code`), so this stays a real (cheap, ASCII-fast-pathed)
+    // check rather than a skippable one.
     let Ok(s) = core::str::from_utf8(bytes) else {
         return false;
     };

--- a/src/yaml/parser.rs
+++ b/src/yaml/parser.rs
@@ -4629,19 +4629,20 @@ impl<'a, const HAS_CR: bool> Parser<'a, HAS_CR> {
                             self.parse_double_quoted()?;
                             self.pos
                         }
+                        // No `json_strict` check needed on either arm here: this
+                        // "value deferred to the next line" scalar is reached only
+                        // through `parse_mapping_entry`, whose own call sites are
+                        // all gated by `parse_block_node`'s value-start chokepoint
+                        // (`&`/`!`/`*`) or its bare-mapping-entry rejection --
+                        // never reachable at all once `json_strict` is set (#2778
+                        // review; confirmed empirically, no path reaches this arm
+                        // with json_strict=true across the full suite plus a
+                        // targeted adversarial sweep).
                         Some(b'\'') => {
-                            if self.json_strict {
-                                return Err(self.err_json_strict_single_quote());
-                            }
                             self.parse_single_quoted()?;
                             self.pos
                         }
-                        _ => {
-                            let start = self.pos;
-                            let end = self.parse_unquoted_value_with_indent(indent);
-                            self.check_json_strict_scalar(start, end)?;
-                            end
-                        }
+                        _ => self.parse_unquoted_value_with_indent(indent),
                     };
                     self.set_bp_text_end(end_pos);
                     self.write_bp_close();
@@ -5160,10 +5161,13 @@ impl<'a, const HAS_CR: bool> Parser<'a, HAS_CR> {
                 self.set_bp_text_end(self.pos);
                 self.write_bp_close();
             }
+            // No `json_strict` check needed in this match: `parse_explicit_value`
+            // has exactly one caller, `parse_block_node`'s `:` explicit-value-
+            // indicator arm, which the chokepoint above already refuses
+            // unconditionally under `json_strict` (`:` has no JSON spelling) --
+            // this function is never entered at all once `json_strict` is set
+            // (#2778 review; confirmed empirically).
             Some(b'\'') => {
-                if self.json_strict {
-                    return Err(self.err_json_strict_single_quote());
-                }
                 self.set_ib();
                 self.write_bp_open();
                 self.parse_single_quoted()?;
@@ -5177,9 +5181,7 @@ impl<'a, const HAS_CR: bool> Parser<'a, HAS_CR> {
             _ => {
                 self.set_ib();
                 self.write_bp_open();
-                let start = self.pos;
                 let end_pos = self.parse_unquoted_value_with_indent(indent);
-                self.check_json_strict_scalar(start, end_pos)?;
                 self.set_bp_text_end(end_pos);
                 self.write_bp_close();
             }
@@ -5190,6 +5192,12 @@ impl<'a, const HAS_CR: bool> Parser<'a, HAS_CR> {
 
     /// Parse an inline scalar value (on the same line as the key).
     /// Returns the end position of the scalar content.
+    /// No `json_strict` check needed anywhere in this match: both callers
+    /// (`parse_compact_mapping_entry`, `parse_mapping_entry`) are themselves
+    /// reachable only through `parse_block_node` arms the chokepoint above
+    /// already refuses under `json_strict` (`-`/`&`/`!`/`*`/bare-mapping-entry)
+    /// -- this function is never entered at all once `json_strict` is set
+    /// (#2778 review; confirmed empirically).
     fn parse_inline_value(&mut self, min_indent: usize) -> Result<usize, YamlError> {
         let end = match self.peek() {
             Some(b'"') => {
@@ -5197,18 +5205,10 @@ impl<'a, const HAS_CR: bool> Parser<'a, HAS_CR> {
                 self.pos
             }
             Some(b'\'') => {
-                if self.json_strict {
-                    return Err(self.err_json_strict_single_quote());
-                }
                 self.parse_single_quoted()?;
                 self.pos
             }
-            _ => {
-                let start = self.pos;
-                let end = self.parse_unquoted_value_with_indent(min_indent);
-                self.check_json_strict_scalar(start, end)?;
-                end
-            }
+            _ => self.parse_unquoted_value_with_indent(min_indent),
         };
         Ok(end)
     }
@@ -5242,10 +5242,16 @@ impl<'a, const HAS_CR: bool> Parser<'a, HAS_CR> {
                 self.set_bp_text_end(self.pos);
                 self.write_bp_close();
             }
+            // No `json_strict` check needed anywhere in this match: every
+            // caller of `parse_value` that's reachable under `json_strict`
+            // (`parse_block_node`'s `{`/`[` arm, always) passes a `{`/`[`
+            // peek, which `try_dispatch_flow_or_block_value` above already
+            // handles and returns from -- this match's own arms are reached
+            // only via the anchor/dash edge cases and callers the chokepoint
+            // and dash-rejection above already exclude under `json_strict`
+            // (#2778 review; confirmed empirically, including the `- &a &b`
+            // double-anchor path below).
             Some(b'\'') => {
-                if self.json_strict {
-                    return Err(self.err_json_strict_single_quote());
-                }
                 self.set_ib();
                 self.write_bp_open();
                 self.parse_single_quoted()?;
@@ -5280,9 +5286,7 @@ impl<'a, const HAS_CR: bool> Parser<'a, HAS_CR> {
             _ => {
                 self.set_ib();
                 self.write_bp_open();
-                let start = self.pos;
                 let end_pos = self.parse_unquoted_value_with_indent(min_indent);
-                self.check_json_strict_scalar(start, end_pos)?;
                 self.set_bp_text_end(end_pos);
                 self.write_bp_close();
             }
@@ -7538,10 +7542,15 @@ impl<'a, const HAS_CR: bool> Parser<'a, HAS_CR> {
                             self.parse_double_quoted()?;
                             self.pos
                         }
+                        // No `json_strict` check needed on this quote arm: the
+                        // chokepoint at the top of this function already
+                        // refuses `'` as a value-start byte, so `self.peek()`
+                        // can never be `'` here once `json_strict` is set
+                        // (#2778 review; confirmed empirically). The unquoted
+                        // arm below still needs its own check -- `t`/`f`/`n`/
+                        // digit/`-` all pass the chokepoint but still need
+                        // full scalar-grammar validation (`True` vs `true`).
                         Some(b'\'') => {
-                            if self.json_strict {
-                                return Err(self.err_json_strict_single_quote());
-                            }
                             self.parse_single_quoted()?;
                             self.pos
                         }

--- a/src/yaml/parser.rs
+++ b/src/yaml/parser.rs
@@ -4629,20 +4629,27 @@ impl<'a, const HAS_CR: bool> Parser<'a, HAS_CR> {
                             self.parse_double_quoted()?;
                             self.pos
                         }
-                        // No `json_strict` check needed on either arm here: this
-                        // "value deferred to the next line" scalar is reached only
-                        // through `parse_mapping_entry`, whose own call sites are
-                        // all gated by `parse_block_node`'s value-start chokepoint
-                        // (`&`/`!`/`*`) or its bare-mapping-entry rejection --
-                        // never reachable at all once `json_strict` is set (#2778
-                        // review; confirmed empirically, no path reaches this arm
-                        // with json_strict=true across the full suite plus a
-                        // targeted adversarial sweep).
+                        // `json_strict` still applies here: reachable via a
+                        // streamed key like `true` whose value continues on the
+                        // next line (`true:\n  'v'`) -- real yq's `-p json`
+                        // reads this as two independent values in a stream
+                        // (#2839, not a bare-mapping rejection), but each
+                        // streamed value is still validated the same way any
+                        // JSON value is; confirmed live, `true:\n  'v'` and
+                        // `true:\n  True` both error in real yq too.
                         Some(b'\'') => {
+                            if self.json_strict {
+                                return Err(self.err_json_strict_single_quote());
+                            }
                             self.parse_single_quoted()?;
                             self.pos
                         }
-                        _ => self.parse_unquoted_value_with_indent(indent),
+                        _ => {
+                            let start = self.pos;
+                            let end = self.parse_unquoted_value_with_indent(indent);
+                            self.check_json_strict_scalar(start, end)?;
+                            end
+                        }
                     };
                     self.set_bp_text_end(end_pos);
                     self.write_bp_close();
@@ -5193,11 +5200,17 @@ impl<'a, const HAS_CR: bool> Parser<'a, HAS_CR> {
     /// Parse an inline scalar value (on the same line as the key).
     /// Returns the end position of the scalar content.
     /// No `json_strict` check needed anywhere in this match: both callers
-    /// (`parse_compact_mapping_entry`, `parse_mapping_entry`) are themselves
-    /// reachable only through `parse_block_node` arms the chokepoint above
-    /// already refuses under `json_strict` (`-`/`&`/`!`/`*`/bare-mapping-entry)
-    /// -- this function is never entered at all once `json_strict` is set
-    /// (#2778 review; confirmed empirically).
+    /// `json_strict` still applies here: `parse_compact_mapping_entry`'s own
+    /// caller is dead under `json_strict` (behind the dash-rejection above),
+    /// but `parse_mapping_entry`'s `key: value` form is not -- real yq's
+    /// `-p json` (no `--slurp`) reads a *stream* of top-level values, so
+    /// `true: 1`/`"a": 1` are two valid, independent streamed values rather
+    /// than an invalid bare mapping (#2778, reverted the opposite
+    /// assumption after checking live; full streaming is unimplemented,
+    /// tracked separately as #2839) -- but each such value is still subject
+    /// to the same grammar `goccy/go-json` enforces on any value, confirmed
+    /// live: `true: 'v'`/`true: True`/`true: .5` all error on the second
+    /// value in real yq too.
     fn parse_inline_value(&mut self, min_indent: usize) -> Result<usize, YamlError> {
         let end = match self.peek() {
             Some(b'"') => {
@@ -5205,10 +5218,18 @@ impl<'a, const HAS_CR: bool> Parser<'a, HAS_CR> {
                 self.pos
             }
             Some(b'\'') => {
+                if self.json_strict {
+                    return Err(self.err_json_strict_single_quote());
+                }
                 self.parse_single_quoted()?;
                 self.pos
             }
-            _ => self.parse_unquoted_value_with_indent(min_indent),
+            _ => {
+                let start = self.pos;
+                let end = self.parse_unquoted_value_with_indent(min_indent);
+                self.check_json_strict_scalar(start, end)?;
+                end
+            }
         };
         Ok(end)
     }
@@ -7510,18 +7531,24 @@ impl<'a, const HAS_CR: bool> Parser<'a, HAS_CR> {
             Some(_) => {
                 // Check if this looks like a mapping entry (has `: ` on this line)
                 // This handles both quoted keys ("foo": bar) and unquoted keys (foo: bar)
-                if self.json_strict && self.looks_like_mapping_entry() {
-                    // #2778: a bare `key: value` (no enclosing `{}`) is not
-                    // a JSON value at all -- real yq's front end never
-                    // reads block-mapping syntax, so it errors on `a: 1`
-                    // the same way it does on any other non-`{[`t f n-digit`
-                    // token start. Checked ahead of `looks_like_mapping_entry`'s
-                    // own dispatch so the key's text is never even examined
-                    // (matching rule 4(c): key grammar stays out of scope).
-                    return Err(
-                        self.err_unexpected_char(self.pos, "YAML mapping entry in JSON input")
-                    );
-                }
+                //
+                // #2778 considered rejecting this outright under `json_strict`
+                // (bare `key: value`, no enclosing `{}`, looks like it should
+                // have no JSON spelling) -- reverted (confirmed live against
+                // yq v4.53.3): `-p json` without `--slurp` reads a *stream* of
+                // concatenated top-level JSON values the way `jq` does
+                // (`printf 'true: 1' | yq -p json '.'` prints `true` then `1`,
+                // exit 0 -- the colon is simply not a value's own problem, since
+                // the decoder reads `true` as a complete value and starts a new
+                // read afterward). A leading token that itself starts a value
+                // (`"..."`, `true`/`false`/`null`, a digit/`-`) is not something
+                // this single-document parser can rightly refuse just because a
+                // `:` follows; the chokepoint above still refuses a token that
+                // is not a legal value start regardless (`a: 1` still errors,
+                // since bare `a` was never a valid token). Full multi-value
+                // streaming without `--slurp` is a real, separate gap this
+                // parser doesn't support at all -- tracked as #2839, out of
+                // scope here.
                 if self.looks_like_mapping_entry() {
                     self.parse_mapping_entry(indent)?;
                 } else {

--- a/src/yaml/parser.rs
+++ b/src/yaml/parser.rs
@@ -7711,7 +7711,7 @@ fn json_strict_plain_scalar_ok(bytes: &[u8]) -> bool {
     // (`-D unsafe-code`), so this stays a real (cheap, ASCII-fast-pathed)
     // check rather than a skippable one.
     let Ok(s) = core::str::from_utf8(bytes) else {
-        return false;
+        return false; // omni-dev: coverage tolerate-line reason="unreachable: every byte here already passed the `[0-9.eE+-]` charset check above, a strict subset of ASCII, so `str::from_utf8` can never fail (#2778)"
     };
     // The finite-`f64`-parse primitive, not the core-schema dispatch around
     // it -- see `parse_float`'s doc comment for why only this much is

--- a/src/yaml/parser.rs
+++ b/src/yaml/parser.rs
@@ -559,12 +559,22 @@ struct Parser<'a, const HAS_CR: bool> {
     /// **Scalar grammar: values only, never keys.** Mapping *keys* are
     /// exempt (real yq panics on a non-string JSON key -- `{1:1}`,
     /// `{true:1}` -- which succinctly does not reproduce; see
-    /// `docs/compliance/yq/limitations.md`) and so is anything reached only
-    /// through an `&anchor`/`!tag` prefix, which JSON has no spelling for
-    /// at all. `json_strict_plain_scalar_ok` is the predicate; yq accepts
-    /// `[01]`/`[00]`/`[1.]` (leading zeros, a bare trailing `.` survive)
-    /// while rejecting `.5`/`+1`/`1e` -- not "strict JSON", the boundary is
+    /// `docs/compliance/yq/limitations.md`). `json_strict_plain_scalar_ok`
+    /// is the predicate; yq accepts `[01]`/`[00]`/`[1.]` (leading zeros, a
+    /// bare trailing `.` survive) while rejecting `.5`/`+1`/`1e` -- not
+    /// "strict JSON", the boundary is
     /// `goccy/go-json`'s own token scanner plus `strconv.ParseFloat`.
+    ///
+    /// **Structural, key-agnostic rejections.** `?` (explicit key), `&`/`!`
+    /// (anchor/tag), `*` (alias), and `'` (single quote) have no JSON
+    /// spelling at all regardless of what follows them, so `parse_block_node`
+    /// rejects the byte itself at one chokepoint rather than each dispatch
+    /// arm needing its own check -- an anchor/tag-prefixed value is refused
+    /// before the prefix's own target is even examined, not merely left
+    /// unvalidated. Two shapes bypass that chokepoint's own dispatch and
+    /// carry their own identical gate instead: `--- |`/`--- >`
+    /// (`parse_inline_document_value`'s dedicated fast path) and `?` inside
+    /// a flow mapping (`parse_flow_mapping_inner`).
     json_strict: bool,
 }
 
@@ -2779,6 +2789,15 @@ impl<'a, const HAS_CR: bool> Parser<'a, HAS_CR> {
         // that position already does, rather than this function's dedicated
         // block-scalar arm — parity with the anchor case, not a new gap.
         if matches!(self.peek(), Some(b'|' | b'>')) {
+            // #2778: this dedicated arm bypasses `parse_block_node` (see
+            // above), so it needs its own `json_strict` gate rather than
+            // inheriting one from there -- `|`/`>` have no JSON spelling
+            // either way (real yq's token scanner rejects both).
+            if self.json_strict {
+                return Err(
+                    self.err_unexpected_char(self.pos, "block scalar indicator in JSON input")
+                );
+            }
             return self.parse_block_scalar(0);
         }
 
@@ -5810,10 +5829,13 @@ impl<'a, const HAS_CR: bool> Parser<'a, HAS_CR> {
             }
             first = false;
 
-            // Check for explicit key `? key : value` in flow context
-            if self.json_strict
-                && (self.looks_like_explicit_flow_key() || self.looks_like_flow_mapping_entry())
-            {
+            // Check for explicit key `? key : value` in flow context. Both
+            // lookaheads scan up to the element's own length, not O(1), so
+            // they're hoisted into locals and reused below rather than
+            // re-run by the json_strict check and the dispatch separately.
+            let is_explicit_key = self.looks_like_explicit_flow_key();
+            let is_mapping_entry = is_explicit_key || self.looks_like_flow_mapping_entry();
+            if self.json_strict && is_mapping_entry {
                 // #2778: a JSON array element is a value, never a `key:
                 // value` pair -- real yq's front end has no concept of an
                 // implicit single-pair mapping inside `[...]` at all, so
@@ -5822,9 +5844,9 @@ impl<'a, const HAS_CR: bool> Parser<'a, HAS_CR> {
                 // other json_strict rejection in this loop.
                 return Err(self.err_unexpected_char(self.pos, "mapping entry inside JSON array"));
             }
-            if self.looks_like_explicit_flow_key() {
+            if is_explicit_key {
                 self.parse_explicit_flow_mapping_entry()?;
-            } else if self.looks_like_flow_mapping_entry() {
+            } else if is_mapping_entry {
                 // Handles all key forms, including a leading anchor or alias
                 // (`[&x k: 1, *x: 2]`, #409), { and [, quoted, and plain scalar
                 // keys. This is an implicit single-pair mapping: [ key : value ]
@@ -5928,6 +5950,17 @@ impl<'a, const HAS_CR: bool> Parser<'a, HAS_CR> {
             // span. The flow-sequence path has always done it in this order (#402).
             let explicit = self.looks_like_explicit_flow_key();
             if explicit {
+                // #2778: `?` has no JSON spelling at all -- this is a
+                // structural rejection of the marker itself (real yq's
+                // token scanner never accepts it as a value-start byte,
+                // regardless of what follows), not a key-grammar check, so
+                // it stays in scope even though key *text* grammar (#2777)
+                // does not.
+                if self.json_strict {
+                    return Err(
+                        self.err_unexpected_char(self.pos, "explicit key marker in JSON input")
+                    );
+                }
                 self.advance();
                 self.skip_flow_whitespace();
             }
@@ -7270,6 +7303,29 @@ impl<'a, const HAS_CR: bool> Parser<'a, HAS_CR> {
         // close_deeper_indents will handle closing any SequenceItem entries
         // when we return to a lower indent level
 
+        // #2778: a single chokepoint for every value-start byte real yq's
+        // token scanner (goccy/go-json's `skipValue`) would refuse outright
+        // -- `?` (explicit key), `&`/`!` (anchor/tag, no JSON spelling at
+        // all), `*` (alias), `'` (single quote) -- ahead of the per-arm
+        // dispatch below, so a *new* arm added to that match can't reopen
+        // this gap by omission the way the sequence-dash and bare-mapping
+        // checks further down (which still need their own, narrower logic:
+        // `-1` is a legal number but `- 1` is not, and a quoted key still
+        // reaches its own arm) could not cover on their own. `#`/a line
+        // break/EOF are not JSON tokens either, but are harmless between or
+        // after a value, so they still fall through unchanged.
+        if self.json_strict
+            && !matches!(
+                self.peek(),
+                Some(
+                    b'{' | b'[' | b'"' | b't' | b'f' | b'n' | b'-' | b'0'
+                        ..=b'9' | b'#' | b'\n' | b'\r'
+                ) | None
+            )
+        {
+            return Err(self.err_unexpected_char(self.pos, "not a valid JSON value"));
+        }
+
         // Check what kind of content this is
         match self.peek() {
             Some(b'-') if Self::is_ws_break_or_eoi(self.peek_at(1)) => {
@@ -7609,10 +7665,16 @@ fn json_strict_plain_scalar_ok(bytes: &[u8]) -> bool {
     {
         return false;
     }
-    core::str::from_utf8(bytes)
-        .ok()
-        .and_then(|s| s.parse::<f64>().ok())
-        .is_some_and(f64::is_finite)
+    let Ok(s) = core::str::from_utf8(bytes) else {
+        return false;
+    };
+    // The finite-`f64`-parse primitive, not the core-schema dispatch around
+    // it -- see `parse_float`'s doc comment for why only this much is
+    // shared with `resolve_plain`.
+    matches!(
+        super::scalar::parse_float(s),
+        super::scalar::ResolvedScalar::Float(_)
+    )
 }
 
 /// Build a semi-index from YAML input.

--- a/src/yaml/scalar.rs
+++ b/src/yaml/scalar.rs
@@ -310,8 +310,16 @@ fn parse_int_or_float(s: &str) -> ResolvedScalar {
 /// exactly go-yaml's accept/reject boundary. The spellings `inf`/`nan`/
 /// `Infinity` never reach this function (first-byte dispatch), and signed
 /// forms like `+inf` that do reach it parse non-finite and are rejected here.
+///
+/// `pub(crate)`, not `fn`: [`crate::yaml::parser::json_strict_plain_scalar_ok`]
+/// (#2778) reuses the finite-`f64`-parse primitive for the *unrelated*
+/// question of JSON's `strconv.ParseFloat`-derived scalar boundary, which
+/// happens to want the identical `s.parse::<f64>()` + `is_finite()` check —
+/// share the primitive, not the surrounding core-schema dispatch above,
+/// which that caller must not pull in (it accepts `~`/`.inf`/`0x2A`/`+1`,
+/// all of which real yq's JSON front end rejects).
 #[inline(always)]
-fn parse_float(s: &str) -> ResolvedScalar {
+pub(crate) fn parse_float(s: &str) -> ResolvedScalar {
     match s.parse::<f64>() {
         Ok(f) if f.is_finite() => ResolvedScalar::Float(f),
         _ => ResolvedScalar::Str,

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -44078,6 +44078,135 @@ fn genuine_yaml_flow_sequences_keep_their_trailing_comma_2279() -> Result<()> {
     Ok(())
 }
 
+// ============================================================================
+// #2778: JSON-sourced scalar-grammar validation
+// ============================================================================
+
+/// Captured live against Homebrew `yq` v4.53.3 (`goccy/go-json` v0.10.6),
+/// the full accept/reject matrix from #2778's triage plan. Both columns
+/// matter: the accepted non-RFC-8259 rows (`01`, `00`, `1.`, `-.5`,
+/// `1.e5`) are what makes this "not strict JSON", not a stricter one.
+const JSON_SOURCED_SCALAR_GRAMMAR_ROWS: &[(&str, Option<&str>)] = &[
+    // --- rejected: not a value real yq's token scanner ever starts ------
+    ("[a]", None),
+    ("['a']", None),
+    ("[True]", None),
+    ("[a: 1]", None),
+    ("[\"a\":1]", None),
+    ("[.5]", None),
+    ("[.]", None),
+    ("[.e1]", None),
+    ("[+1]", None),
+    ("[~]", None),
+    ("[nul]", None),
+    ("[tru]", None),
+    ("[[a]]", None),
+    ("{\"a\":True}", None),
+    ("True", None),
+    ("a", None),
+    // --- rejected: a value-shaped token ParseFloat itself refuses -------
+    ("[1 2]", None),
+    ("[a b]", None),
+    ("[1\"a\"]", None),
+    ("[1e]", None),
+    ("[0e]", None),
+    ("[1.e]", None),
+    ("[1.5e+]", None),
+    ("[1e+]", None),
+    ("[-]", None),
+    ("[-.]", None),
+    ("[--1]", None),
+    ("[-e1]", None),
+    ("[1-2]", None),
+    ("[1+2]", None),
+    ("[1..2]", None),
+    ("[1e1.5]", None),
+    ("[1e5e5]", None),
+    ("[1.2.3]", None),
+    ("[0x1A]", None),
+    ("[1_000]", None),
+    ("[NaN]", None),
+    ("[Infinity]", None),
+    ("[-Infinity]", None),
+    ("[.inf]", None),
+    ("[1,2 3]", None),
+    // --- rejected: `ErrRange` overflow, not a grammar rejection ----------
+    ("[1e999]", None),
+    ("[2e308]", None),
+    // --- rejected: bare top level without enclosing `{}`/`[]` -----------
+    (".5", None),
+    ("+1", None),
+    ("1e", None),
+    ("'a'", None),
+    ("-", None),
+    ("a: 1", None),
+    ("- 1", None),
+    // --- accepted: not RFC 8259, but yq's ParseFloat allows these -------
+    ("[01]", Some("[1]")),
+    ("[00]", Some("[0]")),
+    ("[1.]", Some("[1]")),
+    ("[0.]", Some("[0]")),
+    ("[00.5]", Some("[0.5]")),
+    ("[1.e5]", Some("[100000]")),
+    ("[-01]", Some("[-1]")),
+    ("[-.5]", Some("[-0.5]")),
+    ("[-01.50e+01]", Some("[-15]")),
+    ("[1e-999]", Some("[0]")),
+    // --- accepted: well-formed controls ----------------------------------
+    ("[1]", Some("[1]")),
+    ("[true,false,null]", Some("[true,false,null]")),
+    ("{\"a\":1}", Some("{\"a\":1}")),
+];
+
+#[test]
+fn json_sourced_scalar_grammar_matches_yq_2778() -> Result<()> {
+    for (input, expected) in JSON_SOURCED_SCALAR_GRAMMAR_ROWS {
+        let (stdout, code) =
+            run_yq_stdin(".", input, &["--input-format", "json", "-o=json", "-I=0"])?;
+        match expected {
+            Some(want) => {
+                assert_eq!(
+                    (stdout.trim(), code),
+                    (*want, 0),
+                    "#2778: {input:?} must still be accepted with this exact value \
+                     (real yq v4.53.3 accepts it)"
+                );
+            }
+            None => {
+                assert_eq!(
+                    code, 1,
+                    "#2778: {input:?} must be rejected with exit 1 (real yq v4.53.3 \
+                     rejects it), got stdout {stdout:?}"
+                );
+            }
+        }
+    }
+    Ok(())
+}
+
+/// The tightening is gated on JSON-sourced input; genuine YAML keeps its
+/// own grammar, where every one of these is ordinary and legal.
+#[test]
+fn genuine_yaml_scalars_are_unaffected_by_json_strict_2778() -> Result<()> {
+    for (input, want) in [
+        ("a: 1", r#"{"a":1}"#),
+        ("- 1", "[1]"),
+        ("['a']", r#"["a"]"#),
+        ("[True]", "[true]"),
+        ("[.5]", "[0.5]"),
+        ("[+1]", "[1]"),
+        ("key: 'value'", r#"{"key":"value"}"#),
+    ] {
+        let (stdout, code) = run_yq_stdin(".", input, &["-o=json", "-I=0"])?;
+        assert_eq!(
+            (stdout.trim(), code),
+            (want, 0),
+            "#2778: genuine YAML {input:?} must be unaffected by the JSON-sourced gate"
+        );
+    }
+    Ok(())
+}
+
 /// #2724: jq mode's `{$a}` object-construction shorthand fix is scoped to
 /// jq mode only -- yq mode still raises the same pre-existing parse error
 /// it always has ("expected identifier, found '$'"), not jq's `{"a":1}".

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -44218,6 +44218,66 @@ fn json_sourced_structural_rejections_2778() -> Result<()> {
     Ok(())
 }
 
+/// #2778: real yq's `-p json` without `--slurp` reads a *stream* of
+/// concatenated top-level values (jq-style), not one document -- so a bare
+/// `key: value` at the top level is not automatically invalid the way
+/// `#[test] json_sourced_structural_rejections_2778`'s bare `-`/`?`/`&` rows
+/// are; it's two independently-valid streamed values (confirmed live:
+/// `true: 1` prints `true` then `1`, exit 0). succinctly doesn't implement
+/// multi-value streaming at all (tracked separately as #2839) so it parses
+/// these as one YAML mapping instead of two streamed values -- a
+/// *pre-existing*, unrelated divergence -- but the accept/reject decision
+/// must still match: an early version of this fix rejected every bare
+/// `key: value` outright, which over-rejected exactly this shape and was
+/// reverted before merge. (Space-separated `true 1`, with no colon at all,
+/// is deliberately not a row here: with no mapping syntax to route through,
+/// succinctly reads it as one plain scalar spanning the embedded space --
+/// "true 1" -- which correctly fails scalar-grammar validation on its own
+/// terms; that divergence traces entirely to #2839, not to anything this
+/// fix could special-case without reimplementing streaming.)
+#[test]
+fn json_sourced_stream_like_bare_mapping_still_accepted_2778() -> Result<()> {
+    for input in ["true: 1", "\"a\": 1", "true:\n  1"] {
+        let (stdout, code) =
+            run_yq_stdin(".", input, &["--input-format", "json", "-o=json", "-I=0"])?;
+        assert_eq!(
+            code, 0,
+            "#2778: {input:?} must be accepted (real yq v4.53.3 streams it as \
+             two values), got stdout {stdout:?}"
+        );
+    }
+    Ok(())
+}
+
+/// #2778: a streamed value's grammar is still validated the same as any
+/// other value, even though the *stream* itself isn't rejected (previous
+/// test) -- confirmed live: `true: 'v'`/`true: True`/`true: .5` all error
+/// on the second value in real yq. Two of these three reach the "value
+/// deferred to the next line" arm in `parse_mapping_entry` and the third
+/// reaches `parse_inline_value` -- both had their `json_strict` checks
+/// briefly (incorrectly) removed as "dead code" before the bare-mapping
+/// rejection above was found to be wrong and reverted, which reopened
+/// these paths; restored and pinned here.
+#[test]
+fn json_sourced_stream_like_value_grammar_still_checked_2778() -> Result<()> {
+    for input in [
+        "true: 'v'",
+        "true: True",
+        "true: .5",
+        "true:\n  'v'",
+        "true:\n  True",
+    ] {
+        let (stdout, code) =
+            run_yq_stdin(".", input, &["--input-format", "json", "-o=json", "-I=0"])?;
+        assert_eq!(
+            code, 1,
+            "#2778: {input:?} must be rejected with exit 1 (real yq v4.53.3 \
+             rejects the second streamed value), got stdout {stdout:?}"
+        );
+    }
+    Ok(())
+}
+
 /// The tightening is gated on JSON-sourced input; genuine YAML keeps its
 /// own grammar, where every one of these is ordinary and legal.
 #[test]

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -44184,6 +44184,40 @@ fn json_sourced_scalar_grammar_matches_yq_2778() -> Result<()> {
     Ok(())
 }
 
+/// #2778 review: four dispatch arms the scalar-grammar checks above never
+/// reach at all, because none of them go through the ordinary "parse a
+/// scalar value" arms this fix instrumented -- `?` and `&`/`!` have no
+/// value-text to validate, they're illegal at the byte that starts them.
+/// Each row is confirmed live against yq v4.53.3 to error.
+#[test]
+fn json_sourced_structural_rejections_2778() -> Result<()> {
+    for input in [
+        // Block-context explicit key indicator (`?`), no enclosing `{}`.
+        "? true\n: 1\n",
+        // Anchor/tag prefix bypassing every other json_strict check,
+        // not just scalar-grammar validation: a bad scalar spelling...
+        "&x True\n",
+        // ...and this fix's own new structural sequence-dash rejection.
+        "&x - 1\n",
+        "!!str x\n",
+        // Flow-mapping explicit key indicator.
+        r#"{? "a": 1}"#,
+        // `--- |`/`--- >` bypass `parse_block_node` entirely via their own
+        // dedicated dispatch in `parse_inline_document_value`.
+        "--- |\n  hello\n",
+        "--- >\n  hello\n",
+    ] {
+        let (stdout, code) =
+            run_yq_stdin(".", input, &["--input-format", "json", "-o=json", "-I=0"])?;
+        assert_eq!(
+            code, 1,
+            "#2778: {input:?} must be rejected with exit 1 (real yq v4.53.3 \
+             rejects it), got stdout {stdout:?}"
+        );
+    }
+    Ok(())
+}
+
 /// The tightening is gated on JSON-sourced input; genuine YAML keeps its
 /// own grammar, where every one of these is ordinary and legal.
 #[test]


### PR DESCRIPTION
## Summary

- Closes #2279's remaining gap: `-p json`/`--input-format json` accepted every YAML-only scalar spelling real yq rejects (`True`, `'a'`, `.5`, `+1`, `~`, a bare `- 1`/`a: 1` at the top level, an implicit `key: value` pair inside a JSON array), because #2279's delimiter checks never looked at scalar text.
- The boundary is not "strict JSON" — it's `goccy/go-json` v0.10.6's own two-layer grammar (token scanner + `strconv.ParseFloat`), re-derived from the reference's source and pinned against ~60 live probes against Homebrew `yq` v4.53.3. Leading zeros and a bare trailing `.` still survive (`[01]` → `[1]`, `[1.]` → `[1]`), matching real yq's own leniency, while `.5`/`+1`/`1e`/`~` do not.
- Applied at every scalar *value* position the JSON-sourced parser reaches (flow-sequence item, flow-mapping value, bare block/top-level scalar) under the existing `json_strict` flag — genuine YAML input is completely unaffected.
- Deliberately out of scope, and documented as such: mapping *keys* (real yq's own JSON decoder panics on a non-string key, `{1:1}`/`{true:1}`, which this does not reproduce per ADR-0018 rule 4(c) — the mapping-key delimiter/quoting side is #2777's territory) and anchor/tag-prefixed content (no JSON spelling exists for it at all).

## Test plan

- [x] `cargo build --features cli`
- [x] `cargo test --features cli,simd,regex,serde` (full suite, green)
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings`
- [x] New unit test (`test_json_strict_plain_scalar_ok_matrix`, `test_json_strict_plain_scalar_ok_rejects_overflow`) pins the predicate's accept/reject boundary
- [x] New CLI tests (`json_sourced_scalar_grammar_matches_yq_2778`, `genuine_yaml_scalars_are_unaffected_by_json_strict_2778`) pin the full triage-plan matrix against the live oracle and confirm genuine YAML is unaffected
- [x] Manually diffed output against the pinned `/opt/homebrew/bin/yq` v4.53.3 oracle across the full accept/reject matrix (50+ rows) plus the bare top-level and mapping-value cases — all match exactly
- [x] Must-not-change sweep: genuine YAML (no `-p json`), `succinctly jq`, and `succinctly json validate` all confirmed unaffected

Closes #2778