### PR TITLE
fix(jq): let a postfix chain apply to a string or number literal

### DIFF
--- a/src/jq/parser.rs
+++ b/src/jq/parser.rs
@@ -1666,37 +1666,36 @@ impl<'a> Parser<'a> {
                 self.parse_postfix(object)
             }
 
-            // String literal or interpolation. #2741, jq mode only: same
-            // `Term` rule #2667 fixed for collection literals --
-            // `"abc"[0:1]`/`"abc"[0]`/`"abc"[]` are all valid jq 1.7.1 and
-            // were parse errors here, since only `(...)`/`[...]`/`{...}`
-            // routed through `parse_postfix`. This covers plain and
-            // interpolated strings alike (`parse_string_or_interpolation`
-            // returns one `Expr` either way); confirmed live that jq
-            // applies the same postfix chain to an interpolated string
-            // (`"\(1)"[0:1]` is `"1"`). yq mode is excluded: real yq
-            // rejects every one of these at parse time too (`bad
-            // expression, please check expression syntax`, confirmed live
-            // against v4.53.3 for both `"abc"[0:1]` and `"abc".x`) --
-            // unlike #2667's own array-literal case, where real yq
-            // happens to accept the same postfix shape (`[1,2][0]`
-            // succeeds there), there is no reachable yq behaviour here to
-            // match, so widening this arm unconditionally would introduce
-            // a brand new divergence rather than close one.
-            Some('"') if self.mode == ParserMode::Jq => {
+            // String literal or interpolation. #2741: same `Term` rule
+            // #2667 fixed for collection literals -- `"abc"[0:1]`/
+            // `"abc"[0]`/`"abc"[]` are all valid jq 1.7.1 and were parse
+            // errors here, since only `(...)`/`[...]`/`{...}` routed
+            // through `parse_postfix`. This covers plain and interpolated
+            // strings alike (`parse_string_or_interpolation` returns one
+            // `Expr` either way); confirmed live that jq applies the same
+            // postfix chain to an interpolated string (`"\(1)"[0:1]` is
+            // `"1"`). See `postfix_if_jq`'s own doc comment for the
+            // jq-mode gate.
+            Some('"') => {
                 let string = self.parse_string_or_interpolation()?;
-                self.parse_postfix(string)
+                self.postfix_if_jq(string)
             }
-            Some('"') => self.parse_string_or_interpolation(),
 
-            // Format strings: @text, @json, @uri, etc.
-            Some('@') => self.parse_format_string(),
+            // Format strings: @text, @json, @uri, etc. #2741 review: the
+            // same `Term` rule applies here too -- `@base64[0]` is a valid
+            // (if always-erroring at runtime, "Cannot index string with
+            // number") jq 1.7.1 program, confirmed live, and real yq
+            // rejects it at parse time the same way it rejects the string/
+            // number cases (confirmed live against v4.53.3).
+            Some('@') => {
+                let format = self.parse_format_string()?;
+                self.postfix_if_jq(format)
+            }
 
-            // Number literal (starts with digit). #2741, jq mode only,
-            // same reasoning as the string arm above -- `1[0]` is a valid
-            // (if always-erroring at runtime, "Cannot index number with
-            // number") jq 1.7.1 program and was a parse error here; real
-            // yq rejects it at parse time too (confirmed live). Also
+            // Number literal (starts with digit). #2741, same reasoning as
+            // the string arm above -- `1[0]` is a valid (if
+            // always-erroring at runtime, "Cannot index number with
+            // number") jq 1.7.1 program and was a parse error here. Also
             // deliberately not extended to the unary-minus arm below: real
             // jq's `-1[0]` parses as `-(1[0])` (confirmed live: errors
             // "Cannot index number with number", naming the *positive*
@@ -1705,13 +1704,9 @@ impl<'a> Parser<'a> {
             // postfix could follow -- a materially larger restructure of
             // the #1035 negative-literal-preservation logic there, out of
             // this issue's scope.
-            Some(c) if c.is_ascii_digit() && self.mode == ParserMode::Jq => {
-                let lit = self.parse_number_literal()?;
-                self.parse_postfix(Expr::Literal(lit))
-            }
             Some(c) if c.is_ascii_digit() => {
                 let lit = self.parse_number_literal()?;
-                Ok(Expr::Literal(lit))
+                self.postfix_if_jq(Expr::Literal(lit))
             }
 
             // Unary minus: either a negative number literal or negation of an expression
@@ -5233,6 +5228,24 @@ impl<'a> Parser<'a> {
             }
             Some('c') if self.matches_keyword("catch") => true,
             _ => false,
+        }
+    }
+
+    /// #2741: applies `parse_postfix` in jq mode, leaves `expr` untouched in
+    /// yq mode. Shared by the string, `@format`, and number-literal arms of
+    /// `parse_primary_inner` -- unlike #2667's own array/object-literal
+    /// fix (which real yq happens to accept the identical postfix shape
+    /// for, `[1,2][0]`/`{"a":1}.a`), real yq rejects a postfix chain
+    /// applied directly to any of these three literal kinds at parse time
+    /// (`bad expression, please check expression syntax`, confirmed live
+    /// against v4.53.3 for `"abc"[0:1]`, `1[0]` and `@base64[0]`), so
+    /// widening unconditionally would introduce a new divergence rather
+    /// than close one.
+    fn postfix_if_jq(&mut self, expr: Expr) -> Result<Expr, ParseError> {
+        if self.mode == ParserMode::Jq {
+            self.parse_postfix(expr)
+        } else {
+            Ok(expr)
         }
     }
 

--- a/src/jq/parser.rs
+++ b/src/jq/parser.rs
@@ -1666,13 +1666,49 @@ impl<'a> Parser<'a> {
                 self.parse_postfix(object)
             }
 
-            // String literal or interpolation
+            // String literal or interpolation. #2741, jq mode only: same
+            // `Term` rule #2667 fixed for collection literals --
+            // `"abc"[0:1]`/`"abc"[0]`/`"abc"[]` are all valid jq 1.7.1 and
+            // were parse errors here, since only `(...)`/`[...]`/`{...}`
+            // routed through `parse_postfix`. This covers plain and
+            // interpolated strings alike (`parse_string_or_interpolation`
+            // returns one `Expr` either way); confirmed live that jq
+            // applies the same postfix chain to an interpolated string
+            // (`"\(1)"[0:1]` is `"1"`). yq mode is excluded: real yq
+            // rejects every one of these at parse time too (`bad
+            // expression, please check expression syntax`, confirmed live
+            // against v4.53.3 for both `"abc"[0:1]` and `"abc".x`) --
+            // unlike #2667's own array-literal case, where real yq
+            // happens to accept the same postfix shape (`[1,2][0]`
+            // succeeds there), there is no reachable yq behaviour here to
+            // match, so widening this arm unconditionally would introduce
+            // a brand new divergence rather than close one.
+            Some('"') if self.mode == ParserMode::Jq => {
+                let string = self.parse_string_or_interpolation()?;
+                self.parse_postfix(string)
+            }
             Some('"') => self.parse_string_or_interpolation(),
 
             // Format strings: @text, @json, @uri, etc.
             Some('@') => self.parse_format_string(),
 
-            // Number literal (starts with digit)
+            // Number literal (starts with digit). #2741, jq mode only,
+            // same reasoning as the string arm above -- `1[0]` is a valid
+            // (if always-erroring at runtime, "Cannot index number with
+            // number") jq 1.7.1 program and was a parse error here; real
+            // yq rejects it at parse time too (confirmed live). Also
+            // deliberately not extended to the unary-minus arm below: real
+            // jq's `-1[0]` parses as `-(1[0])` (confirmed live: errors
+            // "Cannot index number with number", naming the *positive*
+            // operand), which would need that arm to stop eagerly folding
+            // `-`+digits into one negative-literal token whenever a
+            // postfix could follow -- a materially larger restructure of
+            // the #1035 negative-literal-preservation logic there, out of
+            // this issue's scope.
+            Some(c) if c.is_ascii_digit() && self.mode == ParserMode::Jq => {
+                let lit = self.parse_number_literal()?;
+                self.parse_postfix(Expr::Literal(lit))
+            }
             Some(c) if c.is_ascii_digit() => {
                 let lit = self.parse_number_literal()?;
                 Ok(Expr::Literal(lit))

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -47577,6 +47577,12 @@ fn test_postfix_applies_directly_to_a_string_or_number_literal_2741() -> Result<
         ),
         (r#""\(1)"[0:1]"#, "\"1\"", 0),
         (r#""abc"[]?"#, "", 0),
+        // #2741 review: `@format` shares the same `Term` rule.
+        (
+            r#""AAAA" | @base64[0]"#,
+            "jq: error (at <unknown>): Cannot index string with number",
+            5,
+        ),
     ] {
         let (stdout, stderr, code) = run_jq_full(&["-cn", filter], None)?;
         assert_eq!(

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -47545,6 +47545,53 @@ fn test_postfix_applies_directly_to_a_collection_literal_2667() -> Result<()> {
     Ok(())
 }
 
+/// #2741: same `Term` rule as #2667 above, for the two literal kinds that
+/// issue's own repro table and title left out -- string and number. Every
+/// row captured live from jq 1.7.1; the error-shaped rows still parse (jq
+/// accepts the program) and only fail at evaluation, which is the point --
+/// they were parse errors here before this fix.
+#[test]
+fn test_postfix_applies_directly_to_a_string_or_number_literal_2741() -> Result<()> {
+    for (filter, want, want_code) in [
+        (r#""abc"[0:1]"#, "\"a\"", 0),
+        (r#""abc"[1:]"#, "\"bc\"", 0),
+        (
+            "1[0]",
+            "jq: error (at <unknown>): Cannot index number with number",
+            5,
+        ),
+        (
+            r#""abc"[0]"#,
+            "jq: error (at <unknown>): Cannot index string with number",
+            5,
+        ),
+        (
+            r#""abc".x"#,
+            "jq: error (at <unknown>): Cannot index string with string \"x\"",
+            5,
+        ),
+        (
+            r#""abc"["x"]"#,
+            "jq: error (at <unknown>): Cannot index string with string \"x\"",
+            5,
+        ),
+        (r#""\(1)"[0:1]"#, "\"1\"", 0),
+        (r#""abc"[]?"#, "", 0),
+    ] {
+        let (stdout, stderr, code) = run_jq_full(&["-cn", filter], None)?;
+        assert_eq!(
+            code, want_code,
+            "`{filter}` -- stdout: {stdout:?} stderr: {stderr:?}"
+        );
+        if want_code == 0 {
+            assert_eq!(stdout.trim(), want, "`{filter}`");
+        } else {
+            assert!(stderr.contains(want), "`{filter}` -- stderr: {stderr:?}");
+        }
+    }
+    Ok(())
+}
+
 /// #2667: making a collection literal a postfix target must not swallow the
 /// `[`/`{` that opens a **destructuring pattern** after `as`, which is the
 /// one place the same two characters follow a term and mean something else.

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -41961,20 +41961,33 @@ fn test_flatten_depth_widening_is_jq_mode_only_2755() -> Result<()> {
 
 /// #2741: unlike #2667's own collection-literal postfix fix (which real yq
 /// happens to accept for the same shapes -- `[1,2][0]`, `{"a":1}.a`), real
-/// yq rejects a postfix chain applied directly to a string or number
-/// literal at parse time (`bad expression, please check expression
-/// syntax`, confirmed live against v4.53.3). Per ADR-0018 the mode
-/// decides: jq mode gets the #2741 fix
+/// yq rejects a postfix chain applied directly to a string, number or
+/// `@format` literal at parse time (`bad expression, please check
+/// expression syntax`, confirmed live against v4.53.3). Per ADR-0018 the
+/// mode decides: jq mode gets the #2741 fix
 /// (`test_postfix_applies_directly_to_a_string_or_number_literal_2741` in
 /// `tests/jq_cli_tests.rs`), yq mode keeps its pre-existing rejection
-/// unchanged.
+/// unchanged -- pinned by the specific (unrelated-wording, succinctly's
+/// own) error text below, not just a nonzero exit code, so a future
+/// regression that let these start *parsing* in yq mode (even if they then
+/// failed at evaluation instead, the way jq mode's own runtime errors do)
+/// would still be caught here.
 #[test]
 fn test_postfix_on_string_or_number_literal_is_jq_mode_only_2741() -> Result<()> {
-    for filter in [r#""abc"[0:1]"#, "1[0]", r#""abc".x"#] {
+    for (filter, want_err) in [
+        (r#""abc"[0:1]"#, "unexpected character '['"),
+        ("1[0]", "unexpected character '['"),
+        (r#""abc".x"#, "unexpected character '.'"),
+        (r#""AAAA"|@base64d[0]"#, "unexpected character '['"),
+    ] {
         let (_stdout, stderr, code) = run_yq_stdin_with_stderr(filter, "null\n", &[])?;
-        assert_ne!(
-            code, 0,
+        assert_eq!(
+            code, 1,
             "`{filter}` unexpectedly compiled: stderr {stderr:?}"
+        );
+        assert!(
+            stderr.contains(want_err),
+            "`{filter}` -- stderr: {stderr:?}"
         );
     }
     Ok(())

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -41959,6 +41959,27 @@ fn test_flatten_depth_widening_is_jq_mode_only_2755() -> Result<()> {
     Ok(())
 }
 
+/// #2741: unlike #2667's own collection-literal postfix fix (which real yq
+/// happens to accept for the same shapes -- `[1,2][0]`, `{"a":1}.a`), real
+/// yq rejects a postfix chain applied directly to a string or number
+/// literal at parse time (`bad expression, please check expression
+/// syntax`, confirmed live against v4.53.3). Per ADR-0018 the mode
+/// decides: jq mode gets the #2741 fix
+/// (`test_postfix_applies_directly_to_a_string_or_number_literal_2741` in
+/// `tests/jq_cli_tests.rs`), yq mode keeps its pre-existing rejection
+/// unchanged.
+#[test]
+fn test_postfix_on_string_or_number_literal_is_jq_mode_only_2741() -> Result<()> {
+    for filter in [r#""abc"[0:1]"#, "1[0]", r#""abc".x"#] {
+        let (_stdout, stderr, code) = run_yq_stdin_with_stderr(filter, "null\n", &[])?;
+        assert_ne!(
+            code, 0,
+            "`{filter}` unexpectedly compiled: stderr {stderr:?}"
+        );
+    }
+    Ok(())
+}
+
 /// #2692, yq twin of `test_truthiness_probes_validate_nothing_2692` in
 /// `tests/jq_cli_tests.rs`: the same corpus through the YAML cursor (and, for
 /// the JSON-syntax rows, through yq's own reading of them -- most of the JSON


### PR DESCRIPTION
## Summary
- #2667 made an array/object literal a postfix target; jq's `Term` rule allows the same suffix chain on string and number literals, and those were still parse errors: `"abc"[0:1]`, `"abc"[0]` and `1[0]` are all valid jq 1.7.1 programs that succinctly rejected before evaluation.
- `parse_primary_inner`'s string arm now routes through `parse_postfix` the same way #2667's array/object arms do (plain and interpolated strings alike), and the digit-literal arm does the same.
- Not extended to the unary-minus arm: real jq's `-1[0]` parses as `-(1[0])` (confirmed live, errors naming the *positive* operand), which would need that arm to stop eagerly folding `-`+digits into one negative-literal token whenever a postfix could follow — a materially larger restructure of the #1035 negative-literal-preservation logic there, out of this issue's scope.
- **jq mode only**: unlike #2667's own collection-literal fix (which real yq happens to accept for the same shapes), real yq rejects a postfix chain on a string or number literal at parse time (confirmed live against v4.53.3), so widening this arm unconditionally would introduce a new divergence rather than close one.

## Test plan
- [x] `cargo build --features cli`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test --features cli` (full suite, 0 failures)
- [x] Live-verified every repro against `/usr/bin/jq` 1.7.1 and yq v4.53.3
- [x] Local patch coverage: 100% (6/6 new lines)

Fixes #2741