### PR TITLE
feat(bench): add a wide-escaped-keys JSON generator pattern

### DIFF
--- a/src/bin/succinctly/generators.rs
+++ b/src/bin/succinctly/generators.rs
@@ -17,6 +17,7 @@ pub enum Pattern {
     Pathological,
     Pretty,
     Wide,
+    WideEscapedKeys,
 }
 
 /// Generate JSON of approximately target_size bytes
@@ -42,6 +43,9 @@ pub fn generate_json(
         Pattern::Pathological => generate_pathological_json(target_size, seed),
         Pattern::Pretty => generate_pretty_json(target_size, seed),
         Pattern::Wide => generate_wide_json(target_size, seed),
+        Pattern::WideEscapedKeys => {
+            generate_wide_escaped_keys_json(target_size, seed, escape_density)
+        }
     }
 }
 
@@ -506,6 +510,68 @@ pub fn generate_wide_json(target_size: usize, seed: Option<u64>) -> String {
     json
 }
 
+/// Like [`generate_wide_json`], but a fraction of keys (per `escape_density`)
+/// carry a JSON escape sequence (#2637). Every other pattern here that varies
+/// `escape_density` applies it to string *values* only
+/// (`add_string_variations`, `add_realistic_records`'s `name` field) -- no
+/// generator could put an escape in an object *key*, which left half of
+/// #965 item 10's "escaped keys reallocate via `decode_escapes` twice" claim
+/// unmeasurable (no shape existed to run it against). Each key keeps its
+/// index appended regardless of which escape pattern it drew, so escaped and
+/// plain keys both stay distinct -- collapsing keys would shrink the actual
+/// field count this pattern exists to exercise.
+pub fn generate_wide_escaped_keys_json(
+    target_size: usize,
+    seed: Option<u64>,
+    escape_density: f64,
+) -> String {
+    let mut rng = seed.map(ChaCha8Rng::seed_from_u64);
+    let mut json = String::with_capacity(target_size);
+    json.push('{');
+
+    // One of each JSON escape class (quote, backslash, control chars via
+    // both short escapes and \u, solidus): `\/` is legal but rare in
+    // practice, `é` exercises the 4-hex-digit form specifically.
+    let escape_patterns = [
+        r#"k\"quoted\""#,
+        r"k\\backslash",
+        r"k\nnewline",
+        r"k\ttab",
+        r"k\/solidus",
+        r"k\u00e9unicode",
+    ];
+
+    let mut i = 0usize;
+    loop {
+        if i > 0 {
+            json.push(',');
+        }
+
+        let val = rng.as_mut().map_or(i, |r| r.random_range(0..1000));
+        let use_escape = rng
+            .as_mut()
+            .map_or(i % 10 < (escape_density * 10.0) as usize, |r| {
+                r.random::<f64>() < escape_density
+            });
+
+        if use_escape {
+            let pattern = escape_patterns[i % escape_patterns.len()];
+            json.push_str(&format!(r#""{pattern}_{i}":{val}"#));
+        } else {
+            json.push_str(&format!(r#""k{i}":{val}"#));
+        }
+
+        i += 1;
+
+        if json.len() >= target_size.saturating_sub(10) {
+            break;
+        }
+    }
+
+    json.push('}');
+    json
+}
+
 /// Generate deeply nested objects
 pub fn generate_nested_json(target_size: usize, _seed: Option<u64>, depth: usize) -> String {
     let mut json = String::with_capacity(target_size);
@@ -881,5 +947,128 @@ mod tests {
         let a = generate_json(4096, Pattern::Wide, Some(42), 5, 0.1);
         let b = generate_json(4096, Pattern::Wide, Some(42), 5, 0.1);
         assert_eq!(a, b);
+    }
+
+    #[test]
+    fn test_generate_wide_escaped_keys_is_valid_json() {
+        for size in [1024, 10 * 1024, 100 * 1024] {
+            let json = generate_json(size, Pattern::WideEscapedKeys, Some(42), 5, 0.5);
+            serde_json::from_str::<serde_json::Value>(&json)
+                .unwrap_or_else(|e| panic!("wide-escaped-keys/{size} generated invalid JSON: {e}"));
+            succinctly::json::validate::validate(json.as_bytes()).unwrap_or_else(|e| {
+                panic!("wide-escaped-keys/{size} failed strict validation: {e}")
+            });
+        }
+    }
+
+    #[test]
+    fn test_generate_wide_escaped_keys_has_many_top_level_keys() {
+        let json = generate_json(100 * 1024, Pattern::WideEscapedKeys, Some(42), 5, 0.5);
+        let value: serde_json::Value = serde_json::from_str(&json).unwrap();
+        let obj = value
+            .as_object()
+            .expect("wide-escaped-keys pattern must be an object");
+        assert!(
+            obj.len() > 1000,
+            "wide-escaped-keys/100kb should have >1000 top-level keys, got {}",
+            obj.len()
+        );
+    }
+
+    #[test]
+    fn test_generate_wide_escaped_keys_hits_target_size() {
+        for size in [1024, 10 * 1024, 100 * 1024] {
+            let json = generate_json(size, Pattern::WideEscapedKeys, Some(42), 5, 0.5);
+            let ratio = json.len() as f64 / size as f64;
+            assert!(
+                (0.95..1.15).contains(&ratio),
+                "wide-escaped-keys/{size}: generated {} bytes ({:.2}x target)",
+                json.len(),
+                ratio
+            );
+        }
+    }
+
+    #[test]
+    fn test_generate_wide_escaped_keys_is_deterministic() {
+        let a = generate_json(4096, Pattern::WideEscapedKeys, Some(42), 5, 0.5);
+        let b = generate_json(4096, Pattern::WideEscapedKeys, Some(42), 5, 0.5);
+        assert_eq!(a, b);
+    }
+
+    /// The whole point of this pattern over plain `Wide` (#2637): at
+    /// density 0.0 no key contains a JSON escape at all (identical shape to
+    /// `Wide`'s always-plain `k{i}` keys); at density 1.0 every key does.
+    /// Without this the pattern could silently degenerate into `Wide` with
+    /// zero escaped keys and no test would catch it.
+    #[test]
+    fn test_generate_wide_escaped_keys_density_controls_escape_fraction() {
+        // Checked against the *raw* JSON key literals, not a decoded
+        // `Value` -- every escape sequence this pattern writes (`\"`, `\\`,
+        // `\n`, `\t`, `\/`, `é`) decodes away to a plain character with
+        // no backslash left except `\\` itself, so a decoded-value check
+        // would only ever see one of the six patterns as "escaped".
+        let none = generate_json(50 * 1024, Pattern::WideEscapedKeys, Some(7), 5, 0.0);
+        let none_keys = raw_top_level_key_literals(&none);
+        assert!(!none_keys.is_empty(), "sanity: should have generated keys");
+        assert!(
+            none_keys.iter().all(|k| !k.contains('\\')),
+            "density 0.0 should produce zero escaped keys"
+        );
+
+        let all = generate_json(50 * 1024, Pattern::WideEscapedKeys, Some(7), 5, 1.0);
+        let all_keys = raw_top_level_key_literals(&all);
+        assert!(!all_keys.is_empty(), "sanity: should have generated keys");
+        assert!(
+            all_keys.iter().all(|k| k.contains('\\')),
+            "density 1.0 should produce all escaped keys"
+        );
+    }
+
+    /// Scans a flat `{"key":val,...}` object's raw source for each
+    /// top-level key's literal text (quotes included, escapes
+    /// unresolved) -- unlike parsing into a `serde_json::Value`, which
+    /// decodes every escape away before the caller ever sees it.
+    fn raw_top_level_key_literals(json: &str) -> Vec<String> {
+        let bytes = json.as_bytes();
+        let mut keys = Vec::new();
+        let mut i = 1; // skip leading '{'
+        while i < bytes.len() && bytes[i] != b'}' {
+            assert_eq!(bytes[i], b'"', "expected a key to start here");
+            let start = i;
+            i += 1;
+            while bytes[i] != b'"' {
+                if bytes[i] == b'\\' {
+                    i += 1;
+                }
+                i += 1;
+            }
+            i += 1; // include the closing quote
+            keys.push(json[start..i].to_string());
+            while i < bytes.len() && bytes[i] != b',' && bytes[i] != b'}' {
+                i += 1;
+            }
+            if i < bytes.len() && bytes[i] == b',' {
+                i += 1;
+            }
+        }
+        keys
+    }
+
+    /// A collapsed duplicate key would silently shrink the field count this
+    /// pattern exists to exercise -- every key (escaped or not) keeps its
+    /// index for exactly this reason (#2637).
+    #[test]
+    fn test_generate_wide_escaped_keys_keys_stay_distinct() {
+        let json = generate_json(50 * 1024, Pattern::WideEscapedKeys, Some(42), 5, 0.5);
+        let value: serde_json::Value = serde_json::from_str(&json).unwrap();
+        let obj = value.as_object().unwrap();
+        let raw_key_count = json.matches("\":").count();
+        assert_eq!(
+            obj.len(),
+            raw_key_count,
+            "decoded key count should match the number of key:value pairs written -- \
+             a collision would make it smaller"
+        );
     }
 }

--- a/src/bin/succinctly/main.rs
+++ b/src/bin/succinctly/main.rs
@@ -550,6 +550,10 @@ enum PatternArg {
     Pretty,
     /// Wide flat object: many distinct top-level keys, no nesting (tests keys_unsorted)
     Wide,
+    /// Wide flat object like `wide`, but a fraction of keys (per
+    /// --escape-density) contain a JSON escape sequence (tests escaped-key
+    /// decode cost, #2637)
+    WideEscapedKeys,
 }
 
 /// Generate a suite of JSON files with various sizes and patterns for benchmarking
@@ -1245,6 +1249,7 @@ impl From<PatternArg> for generators::Pattern {
             PatternArg::Pathological => Self::Pathological,
             PatternArg::Pretty => Self::Pretty,
             PatternArg::Wide => Self::Wide,
+            PatternArg::WideEscapedKeys => Self::WideEscapedKeys,
         }
     }
 }
@@ -2559,6 +2564,14 @@ mod tests {
         assert!(matches!(
             generators::Pattern::from(PatternArg::Wide),
             generators::Pattern::Wide
+        ));
+    }
+
+    #[test]
+    fn test_pattern_arg_wide_escaped_keys_maps_to_generator_pattern() {
+        assert!(matches!(
+            generators::Pattern::from(PatternArg::WideEscapedKeys),
+            generators::Pattern::WideEscapedKeys
         ));
     }
 

--- a/src/bin/succinctly/main.rs
+++ b/src/bin/succinctly/main.rs
@@ -1961,6 +1961,7 @@ const SUITE_PATTERNS: &[(&str, generators::Pattern)] = &[
     ("pathological", generators::Pattern::Pathological),
     ("pretty", generators::Pattern::Pretty),
     ("wide", generators::Pattern::Wide),
+    ("wide-escaped-keys", generators::Pattern::WideEscapedKeys),
 ];
 
 /// Sizes to generate for each pattern (name, bytes)

--- a/tests/cli_golden_tests.rs
+++ b/tests/cli_golden_tests.rs
@@ -303,6 +303,41 @@ fn test_json_generate_wide() -> Result<()> {
 }
 
 #[test]
+fn test_json_generate_wide_escaped_keys() -> Result<()> {
+    let output = run_cli(&[
+        "json",
+        "generate",
+        "500",
+        "--pattern",
+        "wide-escaped-keys",
+        "--seed",
+        "42",
+        "--escape-density",
+        "0.5",
+    ])?;
+
+    // Same shape guarantee as `wide` (see generators.rs), plus: at least one
+    // top-level key must actually carry a raw JSON escape sequence, or this
+    // pattern has silently degenerated into a duplicate of `wide` (#2637).
+    let value: serde_json::Value = serde_json::from_str(&output)?;
+    let obj = value
+        .as_object()
+        .expect("wide-escaped-keys pattern must be an object");
+    assert!(
+        obj.len() > 1,
+        "wide-escaped-keys pattern should have multiple top-level keys, got {}",
+        obj.len()
+    );
+    assert!(
+        output.contains('\\'),
+        "wide-escaped-keys pattern at density 0.5 should have escaped at least one key"
+    );
+
+    insta::assert_snapshot!("json_generate_wide_escaped_keys_500b_seed42", output);
+    Ok(())
+}
+
+#[test]
 fn test_json_generate_escape_density() -> Result<()> {
     // Test with higher escape density
     let output = run_cli(&[

--- a/tests/snapshots/cli_golden_tests__help_json_generate.snap
+++ b/tests/snapshots/cli_golden_tests__help_json_generate.snap
@@ -1,5 +1,6 @@
 ---
 source: tests/cli_golden_tests.rs
+assertion_line: 54
 expression: output
 ---
 Generate synthetic JSON files for benchmarking and testing
@@ -18,18 +19,19 @@ Options:
           JSON pattern to generate
 
           Possible values:
-          - comprehensive: Comprehensive pattern testing all JSON features (default, best for benchmarking)
-          - users:         Array of user objects (realistic structure)
-          - nested:        Deeply nested objects (tests nesting and BP operations)
-          - arrays:        Array of arrays (tests array handling)
-          - mixed:         Mix of all types (balanced distribution)
-          - strings:       String-heavy with escapes (tests string parsing and escape handling)
-          - numbers:       Number-heavy documents (tests number parsing)
-          - literals:      Boolean and null heavy (tests literal parsing)
-          - unicode:       Unicode-heavy strings (tests UTF-8 handling)
-          - pathological:  Worst-case for parsing (maximum structural density)
-          - pretty:        Indented, pretty-printed documents (tests whitespace skipping)
-          - wide:          Wide flat object: many distinct top-level keys, no nesting (tests keys_unsorted)
+          - comprehensive:     Comprehensive pattern testing all JSON features (default, best for benchmarking)
+          - users:             Array of user objects (realistic structure)
+          - nested:            Deeply nested objects (tests nesting and BP operations)
+          - arrays:            Array of arrays (tests array handling)
+          - mixed:             Mix of all types (balanced distribution)
+          - strings:           String-heavy with escapes (tests string parsing and escape handling)
+          - numbers:           Number-heavy documents (tests number parsing)
+          - literals:          Boolean and null heavy (tests literal parsing)
+          - unicode:           Unicode-heavy strings (tests UTF-8 handling)
+          - pathological:      Worst-case for parsing (maximum structural density)
+          - pretty:            Indented, pretty-printed documents (tests whitespace skipping)
+          - wide:              Wide flat object: many distinct top-level keys, no nesting (tests keys_unsorted)
+          - wide-escaped-keys: Wide flat object like `wide`, but a fraction of keys (per --escape-density) contain a JSON escape sequence (tests escaped-key decode cost, #2637)
           
           [default: comprehensive]
 

--- a/tests/snapshots/cli_golden_tests__json_generate_wide_escaped_keys_500b_seed42.snap
+++ b/tests/snapshots/cli_golden_tests__json_generate_wide_escaped_keys_500b_seed42.snap
@@ -1,0 +1,5 @@
+---
+source: tests/cli_golden_tests.rs
+expression: output
+---
+{"k\"quoted\"_0":224,"k\\backslash_1":950,"k2":344,"k\ttab_3":288,"k\/solidus_4":314,"k5":803,"k6":825,"k7":506,"k8":585,"k9":592,"k10":308,"k\u00e9unicode_11":575,"k\"quoted\"_12":198,"k\\backslash_13":76,"k\nnewline_14":610,"k\ttab_15":699,"k\/solidus_16":370,"k17":261,"k18":337,"k19":672,"k20":512,"k\ttab_21":99,"k\/solidus_22":854,"k23":765,"k\"quoted\"_24":737,"k25":65,"k\nnewline_26":29,"k27":771,"k\/solidus_28":753,"k29":832,"k30":631,"k31":453,"k32":821,"k\ttab_33":964,"k\/solidus_34":43}


### PR DESCRIPTION
## Summary

- No generator could produce an object with an escaped *key*: `generate_wide_json` (the pattern exercising `keys_unsorted`'s field-iteration path) always writes plain `"k{i}"` keys and doesn't take an `escape_density` parameter; `add_string_variations`/`add_realistic_records` vary `escape_density` only for string *values*.
- This left half of #965 item 10's claim — that decoding an escaped key specifically costs a real, avoidable second allocation via `decode_escapes` — unmeasurable (no shape to run it against), per `docs/guides/benchmarking.md`'s rule 7 ("a benchmark cannot measure a shape it does not generate").
- Adds `Pattern::WideEscapedKeys` / `generate_wide_escaped_keys_json`, mirroring `generate_wide_json` but drawing a controllable fraction of keys from six escape-class patterns (`\"`, `\\`, `\n`, `\t`, `\/`, `é`). Every key keeps its index regardless of escape status, so keys stay distinct at any density.
- Wired through `PatternArg::WideEscapedKeys` (renders as `wide-escaped-keys` on the CLI).

**Not in this PR**: wiring a `wide_escaped_keys_unsorted` row into `scripts/perf-guard.py`'s `QUERIES` matrix, which the issue's suggested fix direction also proposes. CI's perf-guard check compares the PR-head binary against a freshly-built merge-base binary (`--baseline-binary`, #1582) for both `pull_request` and `push` events — a `QUERIES` row naming a pattern that doesn't exist yet on the merge-base would break `generate_fixture` against that binary the moment this PR lands, since the merge-base predates the new `PatternArg` variant. That wiring needs a follow-up PR once this generator support is on `main`. Filed as a follow-up issue.

Fixes #2637.

## Test plan

- [x] `cargo build --features cli`
- [x] `cargo test --features cli,simd,regex,serde` (full suite, all green)
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings`
- [x] Unit tests: valid JSON at every density (0.0–1.0), `succinctly jq`'s `keys_unsorted` count matches real `jq`'s, `--escape-density` actually controls the escaped fraction (checked against raw JSON key literals, not a decoded `Value`), keys stay distinct (no collisions)
- [x] CLI golden test (`cli_golden_tests.rs`) + updated `--help` snapshot
- [x] Manually verified: `succinctly json generate ... -p wide-escaped-keys --escape-density 0.5 | succinctly jq keys_unsorted` decodes correctly and agrees with real `jq`