### PR TITLE
fix(jq): a nested def's own params shadow a zero-arity def being installed

### DIFF
--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -49649,15 +49649,33 @@ pub(crate) fn install_def_calls(
                 // Don't expand in the body or then - this is a new definition
                 expr.clone()
             } else {
-                Expr::FuncDef {
-                    name: inner_name.clone(),
-                    params: inner_params.clone(),
-                    body: Box::new(install_def_calls(
+                // #2738: a nested def's own *parameters* also shadow `def`
+                // within that def's body when `def` is zero-arity -- a
+                // parameter is referenced as a bare zero-argument call, so it
+                // occupies the same namespace slot as a zero-arity def. This
+                // mirrors `substitute_func_param_impl`'s own `body_scope`
+                // check for the same reason: `def b: 8; def h(b): b; h(6)`
+                // must resolve `b` inside `h`'s body to the parameter, not to
+                // the outer `def b`, even though `h`'s own name/arity don't
+                // match `b`/0 at all. The shadowing is scoped to `inner_body`
+                // only -- jq's parameter scope never extends past the def's
+                // own body, so `then` still gets `def` installed normally.
+                let body_shadowed =
+                    def.params.is_empty() && inner_params.iter().any(|p| p.name() == def.name);
+                let new_body = if body_shadowed {
+                    inner_body.clone()
+                } else {
+                    Box::new(install_def_calls(
                         inner_body,
                         def,
                         frames + 1,
                         in_recursive_body,
-                    )),
+                    ))
+                };
+                Expr::FuncDef {
+                    name: inner_name.clone(),
+                    params: inner_params.clone(),
+                    body: new_body,
                     then: Box::new(install_def_calls(then, def, frames + 1, in_recursive_body)),
                     // Rebuilt above, so any cache from the pre-install node
                     // is stale (#2094) -- the shadowed branch above instead

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -22425,12 +22425,17 @@ fn test_def_shadows_builtin_2036() -> Result<()> {
 /// installed straight through `h`'s body, ignoring `h`'s own parameter
 /// named `b`) and row 2 overflowed the recursion guard (the outer `def a`'s
 /// installation loop never terminated once it also got installed inside the
-/// nested nested-recursive `def a(a): a`). Oracle-verified against jq 1.7.1.
+/// nested nested-recursive `def a(a): a`). Row 3 is the same shape as row 1
+/// but with a `$`-parameter: the shadow check reads a parameter's name via
+/// `Param::name()`, which deliberately unifies `Bare`/`Dollar`, so a
+/// `$`-parameter must shadow exactly like a bare one does. Oracle-verified
+/// against jq 1.7.1.
 #[test]
 fn test_nested_def_own_param_shadows_zero_arity_def_being_installed_2738() -> Result<()> {
     for (filter, want) in [
         ("def b: 8; def h(b): b; h(6)", "6"),
         ("def a: (def a(a): a; a(4)); a", "4"),
+        ("def b: 8; def h($b): b; h(99)", "99"),
     ] {
         let (stdout, stderr, code) = run_jq_full(&["-nc", filter], None)?;
         assert_eq!(code, 0, "{filter}: stderr {stderr:?}");

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -22416,6 +22416,52 @@ fn test_def_shadows_builtin_2036() -> Result<()> {
     Ok(())
 }
 
+/// #2738: `install_def_calls`'s `Expr::FuncDef` arm only checked whether a
+/// nested `def` was a full name+arity *redefinition* of the def being
+/// installed -- it never checked whether a nested def's own *parameter*
+/// list shadows a zero-arity def being installed (a parameter is referenced
+/// as a bare zero-argument call, the same namespace slot a zero-arity def
+/// occupies). Before this fix, row 1 answered `8` (the outer `def b`
+/// installed straight through `h`'s body, ignoring `h`'s own parameter
+/// named `b`) and row 2 overflowed the recursion guard (the outer `def a`'s
+/// installation loop never terminated once it also got installed inside the
+/// nested nested-recursive `def a(a): a`). Oracle-verified against jq 1.7.1.
+#[test]
+fn test_nested_def_own_param_shadows_zero_arity_def_being_installed_2738() -> Result<()> {
+    for (filter, want) in [
+        ("def b: 8; def h(b): b; h(6)", "6"),
+        ("def a: (def a(a): a; a(4)); a", "4"),
+    ] {
+        let (stdout, stderr, code) = run_jq_full(&["-nc", filter], None)?;
+        assert_eq!(code, 0, "{filter}: stderr {stderr:?}");
+        assert_eq!(stdout.trim_end(), want, "{filter}");
+    }
+    Ok(())
+}
+
+/// #2738 controls: the shadowing above must stay scoped to the nested def's
+/// own `body` only, per jq's parameter-scope rules -- it must not leak into
+/// `then` (row 1: the outer `def b` is still installed after `h`'s
+/// definition ends), and a nested def's parameter must not shadow an
+/// installed def of a *different* name (row 2), nor must this new check
+/// disturb the pre-existing same-name-and-arity redefinition guard (row 3:
+/// a nested `def b: 99` with the *same* zero arity as the outer `def b`
+/// still shadows it for the rest of that def's body, unrelated to this fix).
+/// Oracle-verified against jq 1.7.1.
+#[test]
+fn test_nested_def_param_shadow_scoped_to_body_only_2738() -> Result<()> {
+    for (filter, want) in [
+        ("def b: 8; def h(x): x; h(1), b", "1\n8"),
+        ("def b: 8; def h(x): x + b; h(1)", "9"),
+        ("def b: 8; def h: (def b: 99; b); h", "99"),
+    ] {
+        let (stdout, stderr, code) = run_jq_full(&["-nc", filter], None)?;
+        assert_eq!(code, 0, "{filter}: stderr {stderr:?}");
+        assert_eq!(stdout.trim_end(), want, "{filter}");
+    }
+    Ok(())
+}
+
 /// #2237 sibling: the same fix for the "dedicated parse function" family
 /// (`range`/`limit`/`until`/`while`/`repeat`/`first`/`last`), which returns
 /// `Expr` directly rather than going through `try_parse_builtin`'s


### PR DESCRIPTION
## Summary
- `install_def_calls`'s `Expr::FuncDef` arm only checked whether a nested `def` was a full name+arity redefinition of the def being installed; it never checked whether a nested def's own parameter list (referenced as a bare zero-argument call) shadows a zero-arity def within that def's own body.
- `def b: 8; def h(b): b; h(6)` installed the outer `def b` straight through `h`'s body, giving `8` instead of `6`. The self-recursive-parameter variant (`def a: (def a(a): a; a(4)); a`) overflowed the recursion guard instead of returning `4`.
- Fixed by adding a `body_shadowed` check mirroring `substitute_func_param_impl`'s own `body_scope` logic: when the def being installed is zero-arity and a nested def's own parameter list contains that name, skip installing into that nested def's `body` (but still process `then` normally, since jq's parameter scope never extends past the def's own body).

Fixes #2738

## Test plan
- [x] New regression tests `test_nested_def_own_param_shadows_zero_arity_def_being_installed_2738` and `test_nested_def_param_shadow_scoped_to_body_only_2738` in `tests/jq_cli_tests.rs`, oracle-verified against jq 1.7.1
- [x] Both of the issue's own repro cases verified live against the fix
- [x] Regression-checked adjacent shadowing scenarios (#1376 arity overloading, `then`-scope leak, same-arity redefinition) against jq 1.7.1 — all match
- [x] `cargo test --features cli` — full suite passes, 0 failures
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean
- [x] Patch coverage: 100% (9/9 new lines covered)