### PR TITLE
feat(yaml): print standalone comments on the DOM yq route (#2795)

### DIFF
--- a/docs/compliance/yq/limitations.md
+++ b/docs/compliance/yq/limitations.md
@@ -3756,12 +3756,15 @@ navigated distinction for a bare *scalar* result (a container keeps its head/foo
 regardless of navigation, matching the streaming route's rule below, but a navigated-away
 scalar drops both even though its own cursor may still carry them structurally — e.g. a
 sequence item's scalar value keys head/foot off its own position the same way whether or
-not it's ever reached by navigation). `evaluate_yaml_cursor`'s `owned_with_comments`
-clears them immediately for a non-root scalar cursor (new `DocumentCursor::is_document_content`,
-mirroring `light.rs`'s private method of the same name), and the pre-existing #852
-style/anchor-clearing pass for a bare scalar result now preserves whatever head survives
-that gate while always dropping foot (matching the streaming route's own root-only
-asymmetry below). Pinned by `dom_standalone_comments_2795`
+not it's ever reached by navigation). The document-root/first-document/scalar-vs-collection
+gating for a bare result's standalone head/foot lives in `to_owned_with_comments` itself
+(`src/jq/eval_generic.rs`, #2795 PR B review) — not in `evaluate_yaml_cursor`'s
+`owned_with_comments` closure (`yq_runner.rs`), which only consumes the already-gated
+result — clearing them immediately for a non-root or non-first-document scalar cursor (new
+`DocumentCursor::is_document_content`, mirroring `light.rs`'s private method of the same
+name), and the pre-existing #852 style/anchor-clearing pass for a bare scalar result now
+preserves whatever head survives that gate while always dropping foot (matching the
+streaming route's own root-only asymmetry below). Pinned by `dom_standalone_comments_2795`
 (`tests/yq_cli_tests.rs`).
 
 What the streaming route reproduces, all measured against pinned v4.53.3:
@@ -3770,7 +3773,14 @@ What the streaming route reproduces, all measured against pinned v4.53.3:
   by a sibling in the same collection is followed by one blank line (`a: 1\n# mid\n\nb: 2`
   round-trips as-is), a foot that ends its collection by none (`b: 2\n\n# trail` loses
   its blank); a blank line *inside* a head block is reproduced, a blank *after* one is not
-  (`a: 1\n# f\n\n# g\n\nb: 2` prints `# f`, blank, `# g`, `b: 2`);
+  (`a: 1\n# f\n\n# g\n\nb: 2` prints `# f`, blank, `# g`, `b: 2`). The DOM route reproduces
+  the interior-blank-line half of this too (#2795 review): `head_comment_raw`'s `YamlCursor`
+  impl derives it from the raw text the same way `write_head_comment_lines` does
+  (`head_comment_lines_with_blanks`, `src/yaml/light.rs`), rather than the plain decoded-line
+  iterator it started with, which had no way to represent a blank at all
+  (`a:\n  # h1\n\n  # h2\n  b: 1` lost the blank under `-P '.'` until this fix, live-verified
+  against pinned v4.53.3). The **header**'s own blank-line handling remains streaming-only —
+  see the next bullet;
 - the leading **header** real yq's default `--header-preprocess` slurps — every line before
   the first content line that is blank, a `#` comment at any indent, a `%YA..` directive or
   a `---` marker — is re-emitted verbatim in front of the first document whenever the

--- a/docs/compliance/yq/limitations.md
+++ b/docs/compliance/yq/limitations.md
@@ -3654,15 +3654,13 @@ ruled out), even though real yq supports every one of them:
 - **`tag =`, `head_comment =`, `foot_comment =`, `comments =`** raise `<slot> = ... is not
   yet supported`. Real yq's `.a tag = "!!str"` coerces the value's type, `.a head_comment
   = "hi"`/`.a foot_comment = "bye"` insert standalone comment lines, and `.a comments =
-  "x"` sets head, line and foot together. None has a write mechanism here yet, though the
-  reason has changed since this entry was written: `NodeMeta` (`src/jq/eval_generic.rs`)
-  still has no tag slot (#747), but head/foot comments *do* now have a backing field —
-  `NodeComments { head, line, foot }` (#2690), which the parser populates (#2704, #2718)
-  and the `head_comment`/`foot_comment` getters read (#2758). What is still missing on the
-  write side is the other half of that pipeline: `NodeMeta.head_foot_comment` is `None` at
-  every construction site and the DOM emitter renders no head/foot lines (the streaming
-  emitter does since #2795), so a write would have nowhere to land and nothing to print
-  it. See the identity-round-trip entry below.
+  "x"` sets head, line and foot together. None has a write mechanism here yet: `NodeMeta`
+  (`src/jq/eval_generic.rs`) still has no tag slot (#747), and — though #2795 PR B (below)
+  closed the *read-and-print* half, `NodeMeta.head_foot_comment` is now populated from the
+  parsed document and both emitters print it — there is still no way for a filter to
+  *write* a new head/foot value that didn't already exist in the source: `head_comment =`/
+  `foot_comment =`/`comments =` would need their own write mechanism into `CommentTree`,
+  which this issue didn't add. See the identity-round-trip entry below.
   Remaining: the write forms (`comments =`/`comments |=`) and `...` recursive descent in yq
   mode; cross-link #1079/#1080/#1085 above.
 - **`style = "literal"`/`"folded"`/`"tagged"`** raise `style = "<name>" is not yet
@@ -3735,17 +3733,36 @@ Three narrower residuals of the same fix, each captured live from v4.53.3:
   itself stands on) and `0` here. Only the key-node case is answered, because only it is
   what `key` emits.
 
-### Standalone comments print on the streaming route only, so far (#2795, #798)
+### Standalone comments print on both routes now (#2795, #798)
 
-The parser captures head/foot comments and the getters read them (#2758); since #2795 the
-*streaming* emitter (`stream_yaml_value_at`/`stream_yaml_as_document`, `src/yaml/light.rs`)
-prints them too — the route plain `yq '.'`, `select(true)` and every other cursor-forwarded
-result take. On `# lead\na: 1\n# mid\nb: 2\n\n# trail\n`, real yq and succinctly now
-agree byte-for-byte on `.` and `select(true)`; `-o=json` drops them in both, correctly.
-The **DOM** emitter (`emit_yaml_value_at_depth`, `yq_runner.rs`) is the other half and is
-still never given head/foot to print, so `-P '.'`, `.a = 5` and `del(.b)` keep dropping
-every standalone comment (real yq keeps them, minus `# mid`, which belongs to the deleted
-key). `NodeMeta.head_foot_comment` is `None` at every construction site until that lands.
+The parser captures head/foot comments and the getters read them (#2758); the *streaming*
+emitter (`stream_yaml_value_at`/`stream_yaml_as_document`, `src/yaml/light.rs`, PR A) and
+the **DOM** emitter (`emit_yaml_value_at_depth`, `yq_runner.rs`, PR B) both print them now.
+On `# lead\na: 1\n# mid\nb: 2\n\n# trail\n`, real yq and succinctly agree byte-for-byte on
+`.`, `select(true)`, `-P '.'`, `.a = 5` and `del(.b)` (which keeps `# lead`/`# trail` but
+drops `# mid`, owned by the deleted key); `-o=json` drops them on both routes, correctly.
+
+`NodeMeta.head_foot_comment` (`src/jq/eval_generic.rs`) is populated by
+`to_owned_with_comments_at_depth`, reading `DocumentCursor::head_comment_raw`/
+`foot_comment_raw` (new trait methods, empty-by-default so JSON pays nothing) off the
+node the parser actually keys head/foot to — the *key* cursor for a mapping entry, not the
+value cursor `to_owned_with_comments_at_depth` otherwise recurses with (`.b | key |
+head_comment` is non-empty, `.b | head_comment` is `""`) — and both
+`reconcile_presentation_at_depth` and `strip_presentation_style_at_depth` already carried
+it through a write for free, via their existing whole-`NodeMeta` clones.
+
+One DOM-route-only residual, not shared with the streaming route: real yq's own root-vs-
+navigated distinction for a bare *scalar* result (a container keeps its head/foot
+regardless of navigation, matching the streaming route's rule below, but a navigated-away
+scalar drops both even though its own cursor may still carry them structurally — e.g. a
+sequence item's scalar value keys head/foot off its own position the same way whether or
+not it's ever reached by navigation). `evaluate_yaml_cursor`'s `owned_with_comments`
+clears them immediately for a non-root scalar cursor (new `DocumentCursor::is_document_content`,
+mirroring `light.rs`'s private method of the same name), and the pre-existing #852
+style/anchor-clearing pass for a bare scalar result now preserves whatever head survives
+that gate while always dropping foot (matching the streaming route's own root-only
+asymmetry below). Pinned by `dom_standalone_comments_2795`
+(`tests/yq_cli_tests.rs`).
 
 What the streaming route reproduces, all measured against pinned v4.53.3:
 
@@ -3759,10 +3776,19 @@ What the streaming route reproduces, all measured against pinned v4.53.3:
   a `---` marker — is re-emitted verbatim in front of the first document whenever the
   result is that document itself (`# lead\n\na: 1` keeps its blank; `---\na: 1` and
   `%YAML 1.2\n---\na: 1` keep their markers; `-N` drops the markers, as in yq; `.a` prints
-  no header). `--header-preprocess=false` itself is not implemented;
+  no header). `--header-preprocess=false` itself is not implemented. **DOM-route-only
+  gap (#2795 PR B):** this verbatim byte-range mechanism is streaming-only — the DOM route
+  only carries structured head/foot *comment lines* through `CommentTree`, not the raw
+  header text, so a blank line or a `---`/`%YAML` marker in the header block does not
+  survive `-P`/a write (`# lead\n\na: 1\n` under `-P '.'` prints `# lead\na: 1\n`, dropping
+  the blank; a bare `---\na: 1\n` drops the marker entirely). Plain leading `#` comment
+  lines with no blank line or marker between them are unaffected. Pinned by
+  `header_verbatim_reproduction_is_streaming_only_2795`
+  (`tests/yq_cli_tests.rs`), so a future header-unification fix has a test to flip rather
+  than a silent behavior change to notice;
 - a scalar root prints its head and *drops* its foot, a flow or block collection root
   prints both (`# lead\n42\n# foot` is `# lead\n42` in yq; the getter still answers
-  `foot`).
+  `foot`). The DOM route reproduces this asymmetry too (#2795 PR B).
 
 Divergences, each classified by `scripts/yq-comment-oracle-fuzz.py`:
 
@@ -3796,8 +3822,13 @@ a `foot_comment` (of the key whose value the sequence is, or of the next outer i
 the sequence is nested straight inside an item) while the rest go forward, or at end of
 document all of them become the root's `foot_comment`. The parser now attributes these
 the way yq reports them, so the getters agree (`- # c\n- 2\n` answers `c` for
-`.[1] | head_comment` and nothing for `.[0] | line_comment`), but the identity output
-still drops them until this entry's emitter work lands. One placement is a recorded
+`.[1] | head_comment` and nothing for `.[0] | line_comment`), and both emitters now print
+the floated comment itself in the right place (#2795 PR A/B) — `- # c\n- 2\n` prints its
+`# c` between the two items on both routes. A separate, pre-existing, unrelated gap
+remains on the item's own *value*: real yq prints a bare `-` for the absent item (`-\n#
+c\n- 2\n`), while succinctly's DOM route materializes it as an explicit `null` (`- null\n#
+c\n- 2\n`) — an `OwnedValue` representation gap, nothing to do with comment placement, out
+of scope here. One placement is a recorded
 divergence, not a gap: real yq *drops* every floated comment but the last when a
 sequence holding several closes to an outer item or to end of input inside a mapping
 (`- k:\n  - # c\n  - # d\n- 2\n` keeps only `d`), which ADR-0018 rule 4 forbids

--- a/docs/compliance/yq/limitations.md
+++ b/docs/compliance/yq/limitations.md
@@ -3801,6 +3801,19 @@ Divergences, each classified by `scripts/yq-comment-oracle-fuzz.py`:
   which yq cannot read back); succinctly prints `---` and drops the marker's comment. A
   whitespace-only line ahead of the first comment makes yq print a bare `#   ` line;
   succinctly ends the header there and prints nothing for it.
+- **A genuinely blank CRLF line near a standalone comment, in the header or not,** is
+  turned by yq into a literal `# \r\n` comment line, or a spurious extra blank line is
+  inserted after the comment that the CRLF source never had at all (go-yaml's scanner
+  appears to special-case a blank line only for `\n`, not `\r\n`, in more than one place)
+  -- confirmed round-trips through yq itself, so this is accepted as an unreplicated
+  fidelity gap rather than a data-loss exception (#2795 review), in the header
+  (`# lead\r\n\r\na: 1\r\n` prints `# lead\r\n\r\na: 1\n` in succinctly, not yq's
+  `# lead\r\n# \r\na: 1\n`) and mid-document alike (`a: 1\r\n# mid\r\nb: 2\r\n` prints
+  `a: 1\n# mid\nb: 2\n` in succinctly, where yq inserts a blank line it never had:
+  `a: 1\n# mid\n\nb: 2\n` -- pinned by the CRLF/CR exemptions in
+  `tests/yq_golden_tests.rs`'s `KNOWN_CRLF_DIVERGENCES`, not the usual known-failures
+  manifest, since these cases pass under LF). The header's line breaks are otherwise reproduced
+  verbatim (not normalized to `\n` like the rest of a document's content), matching yq.
 
 [#2811](https://github.com/rust-works/succinctly/issues/2811) closed the placement gap
 this section used to record here: a comment above a compact `- k: v` item or a nested

--- a/docs/reference/yq-language.md
+++ b/docs/reference/yq-language.md
@@ -636,7 +636,7 @@ See [yq Remaining Work](../plan/yq-remaining.md) for incomplete features.
 ### Intentionally Not Implemented
 
 1. **XML/TOML input/output** - Out of scope (separate tools)
-2. **Comment preservation on the DOM route** - trailing (`# c`) comments, anchors and style survive every YAML route; standalone head/foot comment lines print on the streaming route (`.`, `select(...)`, any cursor-forwarded result -- #2795) but not yet through `-P` or a write (`.a = 5`, `del(.b)`), and `--header-preprocess=false` is not implemented (the default header slurping is)
+2. **Comment preservation** - trailing (`# c`) comments, anchors, style and standalone head/foot comment lines all survive every YAML route now (the streaming route, `-P`, and a write like `.a = 5`/`del(.b)` -- #2795 PR A/B); `--header-preprocess=false` is not implemented (the default header slurping is), and the DOM route's verbatim header reproduction has known gaps -- see [limitations.md](../compliance/yq/limitations.md)
 3. **Merge keys** (`<<: *alias`) - Rarely used, complex semantics
 4. **Schema validation** - Separate tool concern
 

--- a/src/bin/succinctly/yq_runner.rs
+++ b/src/bin/succinctly/yq_runner.rs
@@ -3814,24 +3814,12 @@ fn evaluate_yaml_cursor<W: AsRef<[u64]> + Clone>(
     // YAML output, which already went through the cursor-aware path.
     let owned_with_comments = |c: &YamlCursor<'_, W>| {
         if need_comments {
-            // A bare scalar result's standalone head/foot only survives
-            // when `c` is the document's own content node (#2795 PR B) --
-            // real yq drops both for a navigated-away scalar (`.a`,
-            // `.items[0]` when item 0 is a scalar) even though a navigated
-            // *container* keeps its own (`.items[0]` when item 0 is a
-            // mapping still prints its head). `to_owned_with_comments`
-            // can't see this by itself: a sequence item's head/foot keys off
-            // its own cursor the same way whether or not that cursor is
-            // ever reached via navigation, so this clears it right after,
-            // before the later unconditional style/anchor-clearing pass
-            // (#852) decides what to keep for a bare scalar.
-            let is_document_root = DocumentCursor::is_document_content(c);
-            to_owned_with_comments(&c.value(), Some(c)).map(|(v, mut comments)| {
-                if !is_document_root && !matches!(v, OwnedValue::Object(_) | OwnedValue::Array(_)) {
-                    *comments.meta_mut() = comments.meta().with_head_foot(Vec::new(), Vec::new());
-                }
-                (v, comments)
-            })
+            // The document-root/first-document/scalar-vs-collection gating
+            // for a bare result's standalone head/foot now lives in
+            // `to_owned_with_comments` itself (#2795 PR B review), since
+            // the write path's pristine snapshot (`presentation_sync_ctx`
+            // above) needs the exact same rule and was missing it.
+            to_owned_with_comments(&c.value(), Some(c))
         } else {
             generic_to_owned_cursor(c).map(&no_comments)
         }

--- a/src/bin/succinctly/yq_runner.rs
+++ b/src/bin/succinctly/yq_runner.rs
@@ -3814,7 +3814,24 @@ fn evaluate_yaml_cursor<W: AsRef<[u64]> + Clone>(
     // YAML output, which already went through the cursor-aware path.
     let owned_with_comments = |c: &YamlCursor<'_, W>| {
         if need_comments {
-            to_owned_with_comments(&c.value(), Some(c))
+            // A bare scalar result's standalone head/foot only survives
+            // when `c` is the document's own content node (#2795 PR B) --
+            // real yq drops both for a navigated-away scalar (`.a`,
+            // `.items[0]` when item 0 is a scalar) even though a navigated
+            // *container* keeps its own (`.items[0]` when item 0 is a
+            // mapping still prints its head). `to_owned_with_comments`
+            // can't see this by itself: a sequence item's head/foot keys off
+            // its own cursor the same way whether or not that cursor is
+            // ever reached via navigation, so this clears it right after,
+            // before the later unconditional style/anchor-clearing pass
+            // (#852) decides what to keep for a bare scalar.
+            let is_document_root = DocumentCursor::is_document_content(c);
+            to_owned_with_comments(&c.value(), Some(c)).map(|(v, mut comments)| {
+                if !is_document_root && !matches!(v, OwnedValue::Object(_) | OwnedValue::Array(_)) {
+                    *comments.meta_mut() = comments.meta().with_head_foot(Vec::new(), Vec::new());
+                }
+                (v, comments)
+            })
         } else {
             generic_to_owned_cursor(c).map(&no_comments)
         }
@@ -4017,13 +4034,24 @@ fn evaluate_yaml_cursor<W: AsRef<[u64]> + Clone>(
     // the whole `NodeMeta` here covers an alias mark too, which
     // `enforce_anchor_soundness` below would drop regardless (see
     // `output_value`'s own note on why a root `*name` is never emittable).
+    //
+    // The standalone *head* comment is the one exception (#2795 PR B): real
+    // `yq` keeps it for the true, unnavigated document root (`. ` on
+    // `# h\n42\n` prints `# h`), even though it drops style and anchor there
+    // too. `owned_with_comments` above already cleared `comments`' head/foot
+    // for every navigated-away scalar, so whatever survives to here is
+    // exactly the root case -- `.with_head_foot` carries it through this
+    // rebuild unchanged. The *foot* is dropped unconditionally instead,
+    // root included (`# h\n42\n# f\n` prints `# h\n42`, live-verified) --
+    // real yq's own asymmetry, not a succinctly gap.
     if let Ok(docs) = &mut docs {
         for (value, comments) in docs.iter_mut() {
             if !matches!(value, OwnedValue::Object(_) | OwnedValue::Array(_)) {
-                *comments = CommentTree::Leaf(NodeMeta::from_comment_and_style(
-                    comments.own().map(str::to_string),
-                    "",
-                ));
+                let head = comments.meta().head_comment().to_vec();
+                *comments = CommentTree::Leaf(
+                    NodeMeta::from_comment_and_style(comments.own().map(str::to_string), "")
+                        .with_head_foot(head, Vec::new()),
+                );
             }
         }
     }
@@ -4378,6 +4406,14 @@ fn output_value<W: Write>(
                 _ => rendered,
             }
         };
+        // A root's own standalone head comment (#798 PR2, #2795 PR B) has no
+        // parent call site either, same reasoning as the trailing comment
+        // below — append it here. Unlike the trailing comment, this applies
+        // to every root kind including a bare scalar: verified against the
+        // pinned real `yq` binary, `# lead\n42\n` keeps `# lead` on both the
+        // streaming and DOM routes (the streaming route's own `foot` root
+        // exclusion just below is scalar-only).
+        let body = prepend_head_comment_lines(body, comments.meta().head_comment(), "");
         // Every non-root node's own trailing comment is appended by its
         // *parent* during `emit_yaml_value`'s recursion (see its Array/Object
         // arms), but the root has no parent call site to do that for it —
@@ -4401,11 +4437,17 @@ fn output_value<W: Write>(
         // `yq`'s flow-preserving output, before `CommentTree` carried style
         // data to tell the two cases apart.
         let output = if matches!(value, OwnedValue::Array(_) | OwnedValue::Object(_)) {
-            if is_flow_safe(value, comments) {
+            let with_own_comment = if is_flow_safe(value, comments) {
                 format!("{body}{}", trailing_comment_suffix(comments, ""))
             } else {
                 append_own_comment_line(body, comments.own(), "")
-            }
+            };
+            // A root's own standalone foot comment (#798 PR2, #2795 PR B),
+            // same "no parent call site" reasoning as above -- collection
+            // roots only, matching the streaming route's own scalar-root
+            // exclusion (`# lead\n42\n# foot` keeps `# lead`, drops `# foot`,
+            // live-verified against pinned yq; the getter still answers it).
+            append_foot_comment_lines(with_own_comment, comments.meta().foot_comment(), "").0
         } else {
             body
         };
@@ -4603,6 +4645,65 @@ fn append_own_comment_line(body: String, own_comment: Option<&str>, indent: &str
     }
 }
 
+/// Prepend a node's standalone head comment lines (#798 PR2, #2795 PR B) at
+/// `indent`, one per source line, before `body` — the DOM twin of
+/// `write_head_comments_at`/`write_head_comment_lines` in `light.rs`'s
+/// streaming route. `head` is already raw (`#` and all); an empty entry is a
+/// blank line *within* the head block and is written bare (no indent),
+/// matching [`append_own_comment_line`]'s same per-line convention and the
+/// streaming route's own reproduction of an interior blank line.
+fn prepend_head_comment_lines(body: String, head: &[String], indent: &str) -> String {
+    if head.is_empty() {
+        return body;
+    }
+    let mut out = String::with_capacity(body.len());
+    for line in head {
+        if !line.is_empty() {
+            out.push_str(indent);
+            out.push_str(line);
+        }
+        out.push('\n');
+    }
+    out.push_str(&body);
+    out
+}
+
+/// Append a node's standalone foot comment lines (#798 PR2, #2795 PR B) at
+/// `indent`, one per source line, after `body` — the DOM twin of
+/// `write_foot_comments_at`/`write_foot_comment_lines` in `light.rs`'s
+/// streaming route. Returns whether anything was appended, so a caller can
+/// reproduce that route's rule of a blank line between a foot and a
+/// following sibling in the same collection.
+fn append_foot_comment_lines(body: String, foot: &[String], indent: &str) -> (String, bool) {
+    let out = foot.iter().fold(body, |mut acc, line| {
+        acc.push('\n');
+        if !line.is_empty() {
+            acc.push_str(indent);
+            acc.push_str(line);
+        }
+        acc
+    });
+    (out, !foot.is_empty())
+}
+
+/// Join block-mapping/-sequence entries with `"\n"`, inserting one extra
+/// blank line before an entry whose predecessor ended in a foot comment
+/// (#2795 PR B) — the DOM twin of `stream_yaml_value`'s `prev_had_foot`
+/// handling in `light.rs` for the same rule.
+fn join_block_entries(entries: Vec<(String, bool)>) -> String {
+    let mut out = String::new();
+    for (i, (entry, _)) in entries.iter().enumerate() {
+        if i > 0 {
+            if entries[i - 1].1 {
+                out.push('\n');
+            }
+            out.push('\n');
+        }
+        out.push_str(entry);
+    }
+    out
+}
+
 /// Emit a YAML value as a string, appending each node's trailing same-line
 /// comment from the parallel `comments` tree (issue #710). Flow-style
 /// (`in_flow`) contexts never append one — flow items are comma-joined on
@@ -4729,12 +4830,12 @@ fn emit_yaml_value_at_depth(
                 format!("[{}]", items.join(", "))
             } else {
                 // Block style sequence
-                let items: Vec<_> = arr
+                let items: Vec<(String, bool)> = arr
                     .iter()
                     .enumerate()
                     .map(|(i, v)| {
                         let elem_comments = comments.at_index(i);
-                        if defers_to_own_block(v, elem_comments) {
+                        let rendered = if defers_to_own_block(v, elem_comments) {
                             // Both arms below share this same 2-column
                             // "compact" offset — the `- ` prefix's own
                             // width, not a full `config.indent_str` step
@@ -4781,54 +4882,55 @@ fn emit_yaml_value_at_depth(
                                 );
                                 let val =
                                     append_own_comment_line(val, elem_comments.own(), &val_indent);
-                                return format!("{indent}- &{anchor}\n{val}");
+                                format!("{indent}- &{anchor}\n{val}")
+                            } else {
+                                // A non-empty mapping/sequence element renders
+                                // in real yq's "compact" form: `- ` shares its
+                                // line with the value's own first field/
+                                // element, and the rest of the value's own
+                                // content aligns under that first line's
+                                // content (`indent` plus the 2-character width
+                                // of `- `), not under `indent` plus a full
+                                // `config.indent_str` step like an ordinary
+                                // nested block (#785).
+                                //
+                                // `emit_yaml_value` derives every line's own
+                                // indent purely from the `indent` string it's
+                                // handed, so rendering the element at
+                                // `compact_indent` and then stripping that
+                                // exact prefix from just the start of the
+                                // result (leaving every subsequent line's own
+                                // copy of the prefix untouched) reproduces the
+                                // "no separate indent for the first line"
+                                // effect `stream_yaml_value`'s cursor-based
+                                // sibling gets for free from its per-field/
+                                // per-element loop only indenting 2nd+ items.
+                                // #1485 (code review): `recursion_base` is
+                                // *this invocation's own* `recursion_base`,
+                                // forwarded unchanged -- see the anchor branch
+                                // above for the full rationale.
+                                let inner = emit_yaml_value_at_depth(
+                                    v,
+                                    elem_comments,
+                                    config,
+                                    &compact_indent,
+                                    false,
+                                    depth + 1,
+                                    recursion_base,
+                                );
+                                // The element's own comment goes on its own
+                                // line rather than glued onto its last
+                                // grandchild's line (#793).
+                                let inner = append_own_comment_line(
+                                    inner,
+                                    elem_comments.own(),
+                                    &compact_indent,
+                                );
+                                let first_line = inner
+                                    .strip_prefix(compact_indent.as_str())
+                                    .unwrap_or(&inner);
+                                format!("{indent}- {first_line}")
                             }
-                            // A non-empty mapping/sequence element renders
-                            // in real yq's "compact" form: `- ` shares its
-                            // line with the value's own first field/
-                            // element, and the rest of the value's own
-                            // content aligns under that first line's
-                            // content (`indent` plus the 2-character width
-                            // of `- `), not under `indent` plus a full
-                            // `config.indent_str` step like an ordinary
-                            // nested block (#785).
-                            //
-                            // `emit_yaml_value` derives every line's own
-                            // indent purely from the `indent` string it's
-                            // handed, so rendering the element at
-                            // `compact_indent` and then stripping that
-                            // exact prefix from just the start of the
-                            // result (leaving every subsequent line's own
-                            // copy of the prefix untouched) reproduces the
-                            // "no separate indent for the first line"
-                            // effect `stream_yaml_value`'s cursor-based
-                            // sibling gets for free from its per-field/
-                            // per-element loop only indenting 2nd+ items.
-                            // #1485 (code review): `recursion_base` is
-                            // *this invocation's own* `recursion_base`,
-                            // forwarded unchanged -- see the anchor branch
-                            // above for the full rationale.
-                            let rendered = emit_yaml_value_at_depth(
-                                v,
-                                elem_comments,
-                                config,
-                                &compact_indent,
-                                false,
-                                depth + 1,
-                                recursion_base,
-                            );
-                            // The element's own comment goes on its own
-                            // line rather than glued onto its last
-                            // grandchild's line (#793).
-                            let rendered = append_own_comment_line(
-                                rendered,
-                                elem_comments.own(),
-                                &compact_indent,
-                            );
-                            let first_line = rendered
-                                .strip_prefix(compact_indent.as_str())
-                                .unwrap_or(&rendered);
-                            format!("{indent}- {first_line}")
                         } else {
                             let val_indent = format!("{indent}{}", config.indent_str);
                             let item = emit_yaml_value_at_depth(
@@ -4843,10 +4945,20 @@ fn emit_yaml_value_at_depth(
                             let comment_suffix = trailing_comment_suffix(elem_comments, indent);
                             let anchor = anchor_decl_prefix(elem_comments);
                             format!("{indent}-{anchor} {item}{comment_suffix}")
-                        }
+                        };
+                        let rendered = prepend_head_comment_lines(
+                            rendered,
+                            elem_comments.meta().head_comment(),
+                            indent,
+                        );
+                        append_foot_comment_lines(
+                            rendered,
+                            elem_comments.meta().foot_comment(),
+                            indent,
+                        )
                     })
                     .collect();
-                items.join("\n")
+                join_block_entries(items)
             }
         }
         OwnedValue::Object(obj) => {
@@ -4884,7 +4996,7 @@ fn emit_yaml_value_at_depth(
                     obj.iter().collect()
                 };
 
-                let items: Vec<_> = entries
+                let items: Vec<(String, bool)> = entries
                     .iter()
                     .map(|(k, v)| {
                         let key = yaml_quote_key(k);
@@ -4899,7 +5011,7 @@ fn emit_yaml_value_at_depth(
                         // flow-styled container stays on the key's own line
                         // instead, the same as a scalar (#739), and so does
                         // an alias, however large its target (#763).
-                        if defers_to_own_block(v, field_comments) {
+                        let rendered = if defers_to_own_block(v, field_comments) {
                             // A comment trailing the key's own line, when the
                             // value is deferred to the next line, belongs to
                             // the key, not the value (#765).
@@ -4962,10 +5074,20 @@ fn emit_yaml_value_at_depth(
                                 comment_suffix
                             };
                             format!("{indent}{key}:{anchor} {val}{comment_suffix}")
-                        }
+                        };
+                        let rendered = prepend_head_comment_lines(
+                            rendered,
+                            field_comments.meta().head_comment(),
+                            indent,
+                        );
+                        append_foot_comment_lines(
+                            rendered,
+                            field_comments.meta().foot_comment(),
+                            indent,
+                        )
                     })
                     .collect();
-                items.join("\n")
+                join_block_entries(items)
             }
         }
     }

--- a/src/bin/succinctly/yq_runner.rs
+++ b/src/bin/succinctly/yq_runner.rs
@@ -6306,7 +6306,15 @@ pub fn run_yq(args: YqCommand) -> Result<i32> {
                         report_stream_decode_failure(&mut sink, &e);
                         stream_truncated.set(true);
                     } else {
-                        terminator.write_io($writer)?;
+                        // #2795 review: a header-only document's own
+                        // verbatim header already ends in its own captured
+                        // line break -- see `is_header_only_document`'s doc
+                        // comment -- so adding this terminator on top would
+                        // double-terminate it, printing a spurious blank
+                        // line real yq never has.
+                        if !$cursor.is_header_only_document() {
+                            terminator.write_io($writer)?;
+                        }
                         // Streaming skips evaluation, so inspect the document
                         // value directly to keep `-e` falsy tracking (#178).
                         if args.exit_status {

--- a/src/jq/document.rs
+++ b/src/jq/document.rs
@@ -629,6 +629,27 @@ pub trait DocumentCursor: Sized + Copy + Clone {
         false
     }
 
+    /// Whether this cursor's *document* has any standalone head/foot
+    /// comment at all.
+    ///
+    /// A whole-document property, not a property of this node, and O(1) --
+    /// `YamlIndex::has_standalone_comments` is an emptiness check on an
+    /// already-built map, mirroring [`Self::document_has_aliases`]'s own
+    /// shape. `false` for formats with no standalone-comment concept
+    /// (JSON), where it monomorphizes away entirely.
+    ///
+    /// Lets a DOM materializer skip a per-node comment lookup on a document
+    /// that has none at all (#2795 PR B review): the streaming route
+    /// already gates its own per-node head/foot reads on this exact check
+    /// (`write_head_comments_at`/`write_foot_comments_at`,
+    /// `src/yaml/light.rs`) after measuring a real regression from paying
+    /// two `BTreeMap` probes per node on comment-free input; the DOM route
+    /// (`to_owned_with_comments_at_depth`, `src/jq/eval_generic.rs`) reads
+    /// the same two maps per node with no equivalent short-circuit.
+    fn document_has_standalone_comments(&self) -> bool {
+        false
+    }
+
     /// Get the explicit YAML tag at this node, if any (e.g. `"!!str"`).
     ///
     /// Returns `None` when the node has no explicit tag, and for formats

--- a/src/jq/document.rs
+++ b/src/jq/document.rs
@@ -580,6 +580,26 @@ pub trait DocumentCursor: Sized + Copy + Clone {
         false
     }
 
+    /// Whether this cursor stands on a document's own content node -- a
+    /// direct child of the document stream, the node the parser keys a
+    /// document's own head/foot comments on (#2795 PR B).
+    ///
+    /// `false` for formats with no document-stream concept (JSON), where it
+    /// monomorphizes away entirely. Only YAML cursors override this.
+    ///
+    /// Needed to reproduce real yq's own root-vs-navigated distinction for a
+    /// bare scalar result's standalone comments: `. ` on `# h\n42\n` keeps
+    /// `# h` (this cursor *is* the document's content node), but `.a` on
+    /// `# h\na: 1\n` and `.items[0]` on `items:\n  # h\n  - 1\n` both drop it
+    /// (navigated away from that node) -- live-verified against pinned yq
+    /// v4.53.3. A navigated-to *container* keeps its own head/foot
+    /// regardless (`.items[0]` on a mapping item does print `# h`), which is
+    /// why this only needs consulting where a bare scalar result's own
+    /// metadata gets cleared, not generally.
+    fn is_document_content(&self) -> bool {
+        false
+    }
+
     /// Whether this cursor's *document* declares any `*name` alias at all.
     ///
     /// A whole-document property, not a property of this node, and O(1) --
@@ -716,6 +736,25 @@ pub trait DocumentCursor: Sized + Copy + Clone {
     /// The standalone comment lines directly below this node — its *foot*
     /// comment (#798). See [`head_comment`](Self::head_comment).
     fn foot_comment(&self) -> Vec<String> {
+        Vec::new()
+    }
+
+    /// This node's standalone head comment lines, `#` and all, exactly as
+    /// they appear in the source (#798 PR2) — the raw counterpart of
+    /// [`head_comment`](Self::head_comment), used by the write path
+    /// ([`crate::jq::eval_generic::to_owned_with_comments`]) to re-emit them
+    /// verbatim. See [`line_comment_raw`](Self::line_comment_raw) for why
+    /// the raw and stripped forms intentionally differ, and
+    /// [`head_comment`](Self::head_comment) for the key-vs-value attribution
+    /// rule on a mapping entry.
+    fn head_comment_raw(&self) -> Vec<String> {
+        Vec::new()
+    }
+
+    /// This node's standalone foot comment lines, `#` and all, exactly as
+    /// they appear in the source (#798 PR2). See
+    /// [`head_comment_raw`](Self::head_comment_raw).
+    fn foot_comment_raw(&self) -> Vec<String> {
         Vec::new()
     }
 

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -1389,7 +1389,8 @@ pub fn to_owned_with_comments<V: DocumentValue>(
     value: &V,
     cursor: Option<&V::Cursor>,
 ) -> Result<(OwnedValue, CommentTree), EvalError> {
-    let (v, mut comments) = to_owned_with_comments_at_depth(value, cursor, 0, false, false)?;
+    let (v, mut comments) =
+        to_owned_with_comments_at_depth(value, cursor, 0, false, HeadFootRead::Own)?;
     if let Some(c) = cursor {
         let is_collection = matches!(v, OwnedValue::Object(_) | OwnedValue::Array(_));
         if !is_collection {
@@ -1401,6 +1402,29 @@ pub fn to_owned_with_comments<V: DocumentValue>(
         }
     }
     Ok((v, comments))
+}
+
+/// Whether [`to_owned_with_comments_at_depth`] should read this node's own
+/// standalone head/foot off its own cursor, or skip that read outright
+/// because the caller already knows it will be discarded -- a mapping
+/// field's value cursor is never the node the parser attaches head/foot to
+/// (see `DocumentCursor::head_comment`'s own doc comment), so the object arm
+/// always overwrites this generic read with `field.key_cursor`'s own once it
+/// has one. A two-variant enum rather than a second `bool` parameter next to
+/// `under_alias` (#2795 PR B review): both are same-typed and adjacent in
+/// the signature, so a transposed call-site argument order would still
+/// compile silently with a plain `bool` -- this makes a mis-ordered call a
+/// type error instead.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum HeadFootRead {
+    /// Read this node's own head/foot normally (the top-level and array-
+    /// element callers).
+    Own,
+    /// Skip the read: a mapping field's value cursor never carries its own
+    /// head/foot (the key cursor does), so reading here would only be
+    /// immediately overwritten -- skipping it saves two wasted `BTreeMap`
+    /// probes per field, comment or not.
+    SkippedForMappingValue,
 }
 
 /// `under_alias`: whether some ancestor on the path from the root is itself
@@ -1423,7 +1447,7 @@ fn to_owned_with_comments_at_depth<V: DocumentValue>(
     cursor: Option<&V::Cursor>,
     depth: usize,
     under_alias: bool,
-    skip_own_head_foot: bool,
+    head_foot_read: HeadFootRead,
 ) -> Result<(OwnedValue, CommentTree), EvalError> {
     assert_nesting_depth(depth);
     // The raw (`#`-prefixed) form, not the stripped `line_comment` builtin
@@ -1462,14 +1486,15 @@ fn to_owned_with_comments_at_depth<V: DocumentValue>(
     // for a mapping field, whose head/foot instead lives on the *key* node
     // (see `head_comment`'s own doc comment) -- the object arm below
     // overrides this empty read with `field.key_cursor`'s once it has one,
-    // so it passes `skip_own_head_foot` rather than pay for a read it will
-    // discard on every field of every object, comment or not (#2795 PR B
-    // review). Also skipped, via `document_has_standalone_comments`, when
-    // the whole document has no standalone comment at all -- mirrors the
-    // streaming route's own `write_head_comments_at`/`write_foot_comments_at`
-    // gate (`src/yaml/light.rs`), added there after measuring a real
-    // regression from these same two lookups on comment-free input.
-    let (own_head, own_foot) = if !skip_own_head_foot
+    // so it passes `HeadFootRead::SkippedForMappingValue` rather than pay
+    // for a read it will discard on every field of every object, comment or
+    // not (#2795 PR B review). Also skipped, via
+    // `document_has_standalone_comments`, when the whole document has no
+    // standalone comment at all -- mirrors the streaming route's own
+    // `write_head_comments_at`/`write_foot_comments_at` gate
+    // (`src/yaml/light.rs`), added there after measuring a real regression
+    // from these same two lookups on comment-free input.
+    let (own_head, own_foot) = if head_foot_read == HeadFootRead::Own
         && cursor.is_some_and(DocumentCursor::document_has_standalone_comments)
     {
         (
@@ -1523,7 +1548,7 @@ fn to_owned_with_comments_at_depth<V: DocumentValue>(
                 Some(&field.value_cursor),
                 depth + 1,
                 child_under_alias,
-                true,
+                HeadFootRead::SkippedForMappingValue,
             )?;
             if field.key_cursor.document_has_standalone_comments() {
                 let field_head = field.key_cursor.head_comment_raw();
@@ -1588,7 +1613,7 @@ fn to_owned_with_comments_at_depth<V: DocumentValue>(
                 Some(&elem_cursor),
                 depth + 1,
                 child_under_alias,
-                false,
+                HeadFootRead::Own,
             )?;
             items.push(v);
             comment_items.push(c);

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -1368,11 +1368,39 @@ static EMPTY_COMMENT_TREE: CommentTree = CommentTree::Leaf(NodeMeta::empty());
 /// See [`to_owned`] for the value-only conversion this mirrors and
 /// delegates scalar handling to. Panics past [`MAX_NESTING_DEPTH`] levels of
 /// nesting (#998), same as `to_owned`.
+///
+/// A bare scalar result's standalone head/foot only survives at the root
+/// (`depth` 0, this function's own level -- nested nodes are untouched)
+/// when `cursor` is the document's own content node *and* that document is
+/// the first in the stream (#2795 PR B): real yq drops both for a
+/// navigated-away scalar (`.a`, `.items[0]` when item 0 is a scalar) even
+/// though a navigated *container* keeps its own (`.items[0]` when item 0 is
+/// a mapping still prints its head), and a *later* document's scalar root
+/// drops its head too, not just its foot -- verified against pinned yq:
+/// `1\n---\n# lead\n42\n# foot\n` prints `1\n---\n42` under both `.` and
+/// `-P '.'`/a write. `to_owned_with_comments_at_depth` can't see any of this
+/// by itself: a node's head/foot keys off its own cursor the same way
+/// whether or not that cursor is ever reached via navigation or which
+/// document it belongs to, so this clears it right after, before the later
+/// unconditional style/anchor-clearing pass (#852) decides what to keep for
+/// a bare scalar. A no-op for JSON, where `is_document_content`/
+/// `document_index` monomorphize to `false`/`None`.
 pub fn to_owned_with_comments<V: DocumentValue>(
     value: &V,
     cursor: Option<&V::Cursor>,
 ) -> Result<(OwnedValue, CommentTree), EvalError> {
-    to_owned_with_comments_at_depth(value, cursor, 0, false)
+    let (v, mut comments) = to_owned_with_comments_at_depth(value, cursor, 0, false, false)?;
+    if let Some(c) = cursor {
+        let is_collection = matches!(v, OwnedValue::Object(_) | OwnedValue::Array(_));
+        if !is_collection {
+            let is_document_root = DocumentCursor::is_document_content(c);
+            let is_first_document = DocumentCursor::document_index(c) == Some(0);
+            if !is_document_root || !is_first_document {
+                *comments.meta_mut() = comments.meta().with_head_foot(Vec::new(), Vec::new());
+            }
+        }
+    }
+    Ok((v, comments))
 }
 
 /// `under_alias`: whether some ancestor on the path from the root is itself
@@ -1395,6 +1423,7 @@ fn to_owned_with_comments_at_depth<V: DocumentValue>(
     cursor: Option<&V::Cursor>,
     depth: usize,
     under_alias: bool,
+    skip_own_head_foot: bool,
 ) -> Result<(OwnedValue, CommentTree), EvalError> {
     assert_nesting_depth(depth);
     // The raw (`#`-prefixed) form, not the stripped `line_comment` builtin
@@ -1432,13 +1461,28 @@ fn to_owned_with_comments_at_depth<V: DocumentValue>(
     // cursor is exactly the node the parser attaches head/foot to. Wrong
     // for a mapping field, whose head/foot instead lives on the *key* node
     // (see `head_comment`'s own doc comment) -- the object arm below
-    // overrides this empty read with `field.key_cursor`'s once it has one.
-    let own_head = cursor
-        .map(DocumentCursor::head_comment_raw)
-        .unwrap_or_default();
-    let own_foot = cursor
-        .map(DocumentCursor::foot_comment_raw)
-        .unwrap_or_default();
+    // overrides this empty read with `field.key_cursor`'s once it has one,
+    // so it passes `skip_own_head_foot` rather than pay for a read it will
+    // discard on every field of every object, comment or not (#2795 PR B
+    // review). Also skipped, via `document_has_standalone_comments`, when
+    // the whole document has no standalone comment at all -- mirrors the
+    // streaming route's own `write_head_comments_at`/`write_foot_comments_at`
+    // gate (`src/yaml/light.rs`), added there after measuring a real
+    // regression from these same two lookups on comment-free input.
+    let (own_head, own_foot) = if !skip_own_head_foot
+        && cursor.is_some_and(DocumentCursor::document_has_standalone_comments)
+    {
+        (
+            cursor
+                .map(DocumentCursor::head_comment_raw)
+                .unwrap_or_default(),
+            cursor
+                .map(DocumentCursor::foot_comment_raw)
+                .unwrap_or_default(),
+        )
+    } else {
+        (Vec::new(), Vec::new())
+    };
     let own_meta = NodeMeta {
         comment: own_comment,
         style: own_style,
@@ -1467,21 +1511,26 @@ fn to_owned_with_comments_at_depth<V: DocumentValue>(
             // is `pub`, so a future JSON-typed caller silently inherited a
             // walk that accepted `{"a" 1}` -- closing that latent gap.
             let key = field.checked_key(&f, &map, &mut guard, is_first)?;
+            // `skip_own_head_foot: true` -- standalone head/foot comments on
+            // a mapping entry live on its *key* node, not its value (#798
+            // PR2, #2795 PR B review) -- see `DocumentCursor::head_comment`'s
+            // own doc comment. The generic read the recursive call would
+            // otherwise do against `field.value_cursor` is guaranteed empty
+            // here and immediately overwritten by the key's own read below,
+            // so skipping it saves two wasted `BTreeMap` probes per field.
             let (v, mut c) = to_owned_with_comments_at_depth(
                 &field.value,
                 Some(&field.value_cursor),
                 depth + 1,
                 child_under_alias,
+                true,
             )?;
-            // Standalone head/foot comments on a mapping entry live on its
-            // *key* node, not its value (#798 PR2, #2795 PR B) -- see
-            // `DocumentCursor::head_comment`'s own doc comment. The generic
-            // read above used `field.value_cursor`, which has none, so this
-            // replaces that (already-empty) read with the key's.
-            let field_head = field.key_cursor.head_comment_raw();
-            let field_foot = field.key_cursor.foot_comment_raw();
-            if !field_head.is_empty() || !field_foot.is_empty() {
-                *c.meta_mut() = c.meta().with_head_foot(field_head, field_foot);
+            if field.key_cursor.document_has_standalone_comments() {
+                let field_head = field.key_cursor.head_comment_raw();
+                let field_foot = field.key_cursor.foot_comment_raw();
+                if !field_head.is_empty() || !field_foot.is_empty() {
+                    *c.meta_mut() = c.meta().with_head_foot(field_head, field_foot);
+                }
             }
             map.insert(key.clone(), v);
             comment_map.insert(key.clone(), c);
@@ -1539,6 +1588,7 @@ fn to_owned_with_comments_at_depth<V: DocumentValue>(
                 Some(&elem_cursor),
                 depth + 1,
                 child_under_alias,
+                false,
             )?;
             items.push(v);
             comment_items.push(c);

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -1051,16 +1051,16 @@ pub struct NodeMeta {
     /// This node's `&anchor`/`*alias` syntax (issue #763), or `None` if it
     /// carried neither.
     pub anchor: Option<AnchorMark>,
-    /// Standalone head/foot comment lines (#798 PR2), boxed behind a single
-    /// `Option` rather than kept as two inline `Vec<String>` fields: a
-    /// review of this widening found that the extra ~48 stack bytes of two
-    /// always-empty `Vec`s was enough to make `reconcile_presentation_at_depth`
-    /// overflow the real stack *before* its own `MAX_VALUE_TREE_DEPTH` guard
-    /// could fire (`reconcile_presentation_panics_past_nesting_depth_limit_1005`).
-    /// `None` here costs one pointer and no allocation — exactly the
-    /// "always empty today" state every construction site below sets — and
-    /// only the (still unimplemented) capture work that fills these in pays
-    /// for the `Box`.
+    /// Standalone head/foot comment lines (#798 PR2, populated by #2795 PR
+    /// B), boxed behind a single `Option` rather than kept as two inline
+    /// `Vec<String>` fields: a review of this widening found that the extra
+    /// ~48 stack bytes of two always-empty `Vec`s was enough to make
+    /// `reconcile_presentation_at_depth` overflow the real stack *before*
+    /// its own `MAX_VALUE_TREE_DEPTH` guard could fire
+    /// (`reconcile_presentation_panics_past_nesting_depth_limit_1005`).
+    /// `None` here costs one pointer and no allocation — the shape the
+    /// overwhelmingly common no-standalone-comment node still gets, via
+    /// [`Self::with_head_foot`].
     head_foot_comment: Option<Box<HeadFootComment>>,
 }
 
@@ -1068,14 +1068,27 @@ pub struct NodeMeta {
 /// One entry per standalone `#` line, in source order; consecutive lines
 /// join into one logical block (real yq treats them as one comment either
 /// way, and #1085 needs more than one comment associated with a single node
-/// at all). Always empty today -- capturing these is separate, follow-up
-/// work; this type only prepares a place for that work to write into.
+/// at all).
 #[derive(Debug, Clone, Default)]
 struct HeadFootComment {
     /// Standalone `#` lines directly above the node.
     head: Vec<String>,
     /// Standalone `#` lines directly below the node.
     foot: Vec<String>,
+}
+
+impl HeadFootComment {
+    /// `None` when both `head` and `foot` are empty, else boxed -- the one
+    /// place this "only allocate when there's something to say" rule is
+    /// defined, shared by every [`NodeMeta`] construction site that can
+    /// produce head/foot data (#2795 PR B).
+    fn boxed_if_any(head: Vec<String>, foot: Vec<String>) -> Option<Box<Self>> {
+        if head.is_empty() && foot.is_empty() {
+            None
+        } else {
+            Some(Box::new(Self { head, foot }))
+        }
+    }
 }
 
 impl NodeMeta {
@@ -1104,13 +1117,14 @@ impl NodeMeta {
     }
 
     /// Standalone comment lines directly above this node, in source order
-    /// (#798 PR2). Always empty today -- capturing these is follow-up work.
+    /// (#798 PR2). Populated by [`Self::with_head_foot`]; empty for a node
+    /// with no head comment.
     pub fn head_comment(&self) -> &[String] {
         self.head_foot_comment.as_deref().map_or(&[], |hf| &hf.head)
     }
 
-    /// Standalone comment lines directly below this node (#798 PR2). Always
-    /// empty today -- see [`Self::head_comment`].
+    /// Standalone comment lines directly below this node (#798 PR2). See
+    /// [`Self::head_comment`].
     pub fn foot_comment(&self) -> &[String] {
         self.head_foot_comment.as_deref().map_or(&[], |hf| &hf.foot)
     }
@@ -1139,6 +1153,23 @@ impl NodeMeta {
     pub fn with_style(&self, style: &'static str) -> Self {
         Self {
             style,
+            ..self.clone()
+        }
+    }
+
+    /// This node's own metadata with standalone head/foot comment lines
+    /// replaced, everything else (comment, style, anchor) kept as-is (#798
+    /// PR2). `head_foot_comment` stays private across the bin/lib crate
+    /// boundary for the same reason [`Self::empty_with_anchor`] is a method
+    /// rather than a struct-update literal — see that doc comment.
+    ///
+    /// Boxes only when at least one of `head`/`foot` is non-empty, so the
+    /// (still overwhelmingly common) no-standalone-comment case stays the
+    /// same "one pointer, no allocation" shape every other construction site
+    /// already gets — see the field's own doc comment for why that matters.
+    pub fn with_head_foot(&self, head: Vec<String>, foot: Vec<String>) -> Self {
+        Self {
+            head_foot_comment: HeadFootComment::boxed_if_any(head, foot),
             ..self.clone()
         }
     }
@@ -1396,11 +1427,23 @@ fn to_owned_with_comments_at_depth<V: DocumentValue>(
     } else {
         own_anchor
     };
+    // Standalone head/foot comments (#798 PR2, #2795 PR B): correct as-is
+    // for a scalar, an array element, or the document root, whose own
+    // cursor is exactly the node the parser attaches head/foot to. Wrong
+    // for a mapping field, whose head/foot instead lives on the *key* node
+    // (see `head_comment`'s own doc comment) -- the object arm below
+    // overrides this empty read with `field.key_cursor`'s once it has one.
+    let own_head = cursor
+        .map(DocumentCursor::head_comment_raw)
+        .unwrap_or_default();
+    let own_foot = cursor
+        .map(DocumentCursor::foot_comment_raw)
+        .unwrap_or_default();
     let own_meta = NodeMeta {
         comment: own_comment,
         style: own_style,
         anchor: own_anchor,
-        head_foot_comment: None,
+        head_foot_comment: HeadFootComment::boxed_if_any(own_head, own_foot),
     };
     if let Some(fields) = value.as_object() {
         let mut map = IndexMap::new();
@@ -1424,12 +1467,22 @@ fn to_owned_with_comments_at_depth<V: DocumentValue>(
             // is `pub`, so a future JSON-typed caller silently inherited a
             // walk that accepted `{"a" 1}` -- closing that latent gap.
             let key = field.checked_key(&f, &map, &mut guard, is_first)?;
-            let (v, c) = to_owned_with_comments_at_depth(
+            let (v, mut c) = to_owned_with_comments_at_depth(
                 &field.value,
                 Some(&field.value_cursor),
                 depth + 1,
                 child_under_alias,
             )?;
+            // Standalone head/foot comments on a mapping entry live on its
+            // *key* node, not its value (#798 PR2, #2795 PR B) -- see
+            // `DocumentCursor::head_comment`'s own doc comment. The generic
+            // read above used `field.value_cursor`, which has none, so this
+            // replaces that (already-empty) read with the key's.
+            let field_head = field.key_cursor.head_comment_raw();
+            let field_foot = field.key_cursor.foot_comment_raw();
+            if !field_head.is_empty() || !field_foot.is_empty() {
+                *c.meta_mut() = c.meta().with_head_foot(field_head, field_foot);
+            }
             map.insert(key.clone(), v);
             comment_map.insert(key.clone(), c);
             // A comment trailing the key's own line, when the value is

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -27189,6 +27189,28 @@ mod tests {
         assert_eq!(comments.field("a").own(), None);
     }
 
+    /// `to_owned_with_comments`'s #2795 PR B document-root/first-document
+    /// gate (the `if let Some(c) = cursor { .. }` block) only ever runs with
+    /// a cursor -- every production caller (`yq_runner.rs`) and every other
+    /// test in this module passes `Some(&cursor)`. But the parameter is a
+    /// genuine `Option`, and a cursorless call is a real, reachable shape
+    /// (mirrors `to_owned`'s own cursor-optional contract): with no cursor
+    /// there is nothing to gate on, so the whole block is skipped and a bare
+    /// scalar keeps whatever `to_owned_with_comments_at_depth` already
+    /// produced -- this is the only test in the module that ever passes
+    /// `None` here.
+    #[test]
+    fn test_to_owned_with_comments_with_no_cursor_skips_the_document_root_gate() {
+        let json = b"42";
+        let index = JsonIndex::build(json);
+        let cursor = index.root(json);
+        let value = cursor.value();
+
+        let (owned, comments) = to_owned_with_comments(&value, None).unwrap();
+        assert_eq!(owned, OwnedValue::Int(42));
+        assert_eq!(comments.own(), None);
+    }
+
     /// #2405: `to_owned_with_comments`'s object arm now runs the same
     /// #1677 key/value delimiter check `to_owned_at_depth` does, via
     /// `DocumentField::checked_key` -- a missing `:` between key and value

--- a/src/json/light.rs
+++ b/src/json/light.rs
@@ -4117,6 +4117,40 @@ mod tests {
         assert_eq!(DocumentCursor::line_comment(&root), None);
     }
 
+    /// `DocumentCursor::is_document_content`'s default (`document.rs`,
+    /// unconditionally `false`) is what every JSON cursor uses -- JSON has no
+    /// document-stream concept (no `---`/`...` boundaries), so `JsonCursor`
+    /// never overrides it. Its only production caller
+    /// (`to_owned_with_comments`, #2795 PR B) is only ever invoked with a
+    /// `YamlCursor` in practice (`yq_runner.rs`), so this pins the default
+    /// directly, mirroring `test_document_cursor_line_comment_default_is_none_for_json`
+    /// just above.
+    #[test]
+    fn test_document_cursor_is_document_content_default_is_false_for_json() {
+        let json = br#"{"a": 1}"#;
+        let index = JsonIndex::build(json);
+        let root = index.root(json);
+        assert!(!DocumentCursor::is_document_content(&root));
+    }
+
+    /// `DocumentCursor::head_comment_raw`/`foot_comment_raw`'s defaults
+    /// (`document.rs`, unconditionally empty) are what every JSON cursor
+    /// uses -- JSON has no standalone-comment concept, so `JsonCursor` never
+    /// overrides either. Both production call sites
+    /// (`to_owned_with_comments_at_depth`, #2795 PR B review) gate on
+    /// `document_has_standalone_comments`, whose own JSON default is
+    /// `false`, so neither is ever reached for JSON in practice -- this pins
+    /// both defaults directly, same rationale as the `is_document_content`
+    /// test just above.
+    #[test]
+    fn test_document_cursor_head_and_foot_comment_raw_defaults_are_empty_for_json() {
+        let json = br#"{"a": 1}"#;
+        let index = JsonIndex::build(json);
+        let root = index.root(json);
+        assert!(DocumentCursor::head_comment_raw(&root).is_empty());
+        assert!(DocumentCursor::foot_comment_raw(&root).is_empty());
+    }
+
     /// `key_raw_source_span`'s non-`String` arm is unreachable via any real
     /// evaluation path -- `key_display_string_kind` only calls it once
     /// `string_decode_error()` is `Some`, which for this type is itself

--- a/src/yaml/index.rs
+++ b/src/yaml/index.rs
@@ -1425,18 +1425,6 @@ mod tests {
         panic!("nested key {outer}.{inner} not found"); // omni-dev: coverage tolerate-line reason="unreachable: every call to nested_key_head_foot in this test module passes an outer.inner pair that the fixture actually has (#798)"
     }
 
-    /// `head`/`foot` of the virtual root sequence itself — where a
-    /// comment-only document's block lands, since such a document opens no
-    /// content node of its own.
-    fn virtual_root_head_foot(yaml: &[u8]) -> (Vec<String>, Vec<String>) {
-        let index = YamlIndex::build(yaml).expect("valid YAML");
-        let bp = index.root(yaml).bp_position();
-        (
-            raw_lines(yaml, index.get_head_comments(bp)),
-            raw_lines(yaml, index.get_foot_comments(bp)),
-        )
-    }
-
     /// A block sticks to whatever it is *not* separated from by a blank
     /// line, preferring forward. Every expectation here was captured from
     /// pinned `yq` v4.53.3 before being written down; the triage note that
@@ -1677,9 +1665,13 @@ mod tests {
 
     #[test]
     fn a_comment_only_document_keeps_its_block_as_a_head_798() {
-        // Measured: `. | head_comment` == "only", foot empty. succinctly has
-        // no document content node here, so it lands on the virtual root.
-        let (head, foot) = virtual_root_head_foot(b"# only\n");
+        // Measured: `. | head_comment` == "only", foot empty. A comment-only
+        // (or whitespace-only) input still synthesizes one null document, the
+        // same way an explicit `---`/`...` boundary with nothing before it
+        // does (#2795 review) -- real yq answers `1` for a literal `1`
+        // filter here, not zero results, so the comment attaches to that
+        // document's own content node rather than the virtual root.
+        let (head, foot) = doc_head_foot(b"# only\n");
         assert_eq!(head, ["# only"]);
         assert!(foot.is_empty(), "{foot:?}");
     }

--- a/src/yaml/index.rs
+++ b/src/yaml/index.rs
@@ -1761,6 +1761,29 @@ mod tests {
         assert!(doc0_foot.is_empty(), "{doc0_foot:?}");
     }
 
+    /// A *second* blank-detached block after the boundary, before the new
+    /// document's first key opens, splits from the first instead of merging
+    /// onto it: the earlier block (`c1`) still reaches back across the
+    /// boundary onto the closing document's root foot the moment the second
+    /// block (`c2`) is recorded, and only `c2` goes forward -- exercising
+    /// `resolve_pending_block_backward`'s own boundary-fallback arm
+    /// (`src/yaml/parser.rs`), distinct from the single-block case above
+    /// which never calls it (the block settles once `.b`'s key opens, not
+    /// when a second comment line is recorded). Measured against pinned yq
+    /// v4.53.3: `select(di==0) | . | foot_comment` == "c1", document 1's own
+    /// root head is empty, and `.b | key | head_comment` == "c2".
+    #[test]
+    fn two_blank_separated_blocks_after_a_boundary_split_between_the_closing_document_and_the_next_key_2795(
+    ) {
+        let yaml = b"a: 1\n---\n# c1\n\n# c2\nb: 2\n";
+        let (_, doc0_foot) = doc_head_foot_at(yaml, 0);
+        assert_eq!(doc0_foot, ["# c1"]);
+        let (doc1_head, _) = doc_head_foot_at(yaml, 1);
+        assert!(doc1_head.is_empty(), "{doc1_head:?}");
+        let (b_head, _) = field_key_head_foot_in_doc(yaml, 1, "b");
+        assert_eq!(b_head, ["# c2"]);
+    }
+
     /// A leading block before the very first document's own `---` has no
     /// closing document to reach back to, so it must take the ordinary path
     /// (document 0's own head) rather than being silently dropped by the

--- a/src/yaml/light.rs
+++ b/src/yaml/light.rs
@@ -1637,7 +1637,22 @@ impl<'a, W: AsRef<[u64]>> YamlCursor<'a, W> {
                 }
             }
             out.write_str(&str_val)?;
-        } else {
+        } else if !matches!(value, YamlValue::Null) {
+            // #2795 review: a `Null` reaching this point is never an
+            // explicit `null`/`~` keyword (those decode as `YamlValue::String`
+            // and take the arm above, preserving their raw spelling) -- per
+            // `YamlCursor::value`'s own doc comment, `Null` is produced only
+            // when there is genuinely no source text at this position
+            // (`text_pos >= self.text.len()`), i.e. a synthesized-absent
+            // document root: `end_document`'s null for a bare `---`/comment-
+            // only stream with nothing after it. Real yq's printer omits the
+            // value line entirely for that document (`# c\n` under `.` prints
+            // just `# c`, `---\n` prints just `---`), never the literal text
+            // `null` -- confirmed live against v4.53.3. A `Null` nested
+            // *inside* a container (`a: [null, 1]`) never reaches this
+            // function at all (it streams through `stream_yaml_value`'s own
+            // block/flow loops), so this only ever suppresses a whole-result
+            // synthesized absence, not a real nested null.
             self_.stream_yaml_value(out, "", indent.width, indent.unit, sort_keys, false, "")?;
         }
         if is_collection_root {
@@ -1652,6 +1667,33 @@ impl<'a, W: AsRef<[u64]>> YamlCursor<'a, W> {
             }
         }
         Ok(())
+    }
+
+    /// True when [`Self::stream_yaml_as_document`]'s entire identity output
+    /// for this cursor is exactly its verbatim-header reproduction, with no
+    /// value line following it: the first document's own root has genuinely
+    /// no source text (comment-only/blank-only input, or a bare `---`/`...`
+    /// marker with nothing after it, both of which parse to a synthesized
+    /// `YamlValue::Null`, per `value`'s own doc comment). The header's own
+    /// captured line break already supplies this document's trailing
+    /// newline in that case, so the identity streaming path's own
+    /// per-document terminator (`stream_cursor!` in `yq_runner.rs`) must be
+    /// skipped -- adding it on top double-terminates, printing a spurious
+    /// blank line real yq never has (confirmed live: `# c\n` and `---\n`
+    /// both round-trip through `.` byte-for-byte only when the terminator is
+    /// skipped here). A later document's own empty `---` has no such header
+    /// to fold into and keeps the ordinary terminator (verified: `a: 1\n---\n`
+    /// prints `a: 1\n---\n\n` in real yq, the blank line coming from the
+    /// terminator alone) -- `bp_pos == FIRST_DOCUMENT_BP` is what tells the
+    /// two apart.
+    pub fn is_header_only_document(&self) -> bool {
+        let self_ = self.resolve_bare_seq_item();
+        self_.is_document_content()
+            && self_.bp_pos == FIRST_DOCUMENT_BP
+            && matches!(
+                self_.resolve_alias_target_cursor().unwrap_or(self_).value(),
+                YamlValue::Null
+            )
     }
 
     /// Stream YAML, unwrapping single documents (matches yq behavior).
@@ -7060,9 +7102,14 @@ impl<'a, W: AsRef<[u64]> + Clone> DocumentCursor for YamlCursor<'a, W> {
 
     #[inline]
     fn head_comment_raw(&self) -> Vec<String> {
-        YamlCursor::head_comment_raw(self)
-            .map(ToString::to_string)
-            .collect()
+        // Not a plain `YamlCursor::head_comment_raw(self).collect()` (unlike
+        // `foot_comment_raw` just below): that inherent iterator only ever
+        // yields the stored `#` lines themselves, with no way to tell the
+        // DOM route's `NodeMeta` seed (`to_owned_with_comments_at_depth`)
+        // about an interior blank line the block also had -- see
+        // `head_comment_lines_with_blanks`'s own doc comment for the bug
+        // this closes.
+        head_comment_lines_with_blanks(self.text, self.index.get_head_comments(self.bp_pos))
     }
 
     #[inline]
@@ -8174,6 +8221,51 @@ fn blank_line_between(text: &[u8], from: usize, to: usize) -> bool {
         }
     }
     false
+}
+
+/// Build a node's standalone head comment lines as owned strings, inserting
+/// an empty (`""`) entry wherever [`blank_line_between`] finds a blank line
+/// separating two lines of the block -- the DOM route's own analogue of
+/// [`write_head_comment_lines`]'s live text scan (#2795 review). Consumed by
+/// `DocumentCursor::head_comment_raw`'s `YamlCursor` impl, which is what
+/// actually seeds `NodeMeta::head_comment` in `to_owned_with_comments_at_depth`
+/// (`eval_generic.rs`); `yq_runner.rs`'s `prepend_head_comment_lines` already
+/// treats an empty entry as a bare blank line (matching
+/// `append_own_comment_line`'s same convention), so without this the DOM
+/// route silently dropped every interior blank line a head block had
+/// (`a:\n  # h1\n\n  # h2\n  b: 1` lost the blank under `-P`, kept it under
+/// plain streaming -- confirmed live against pinned yq v4.53.3, undocumented
+/// until this fix).
+///
+/// No `skip_before` parameter, unlike [`write_head_comment_lines`]: the DOM
+/// route never reproduces the verbatim header (`write_yq_header` is
+/// streaming-only, a separate documented gap), so it has nothing to skip --
+/// every head line, including the first document's leading block, goes
+/// through this same structured path.
+fn head_comment_lines_with_blanks(text: &[u8], ranges: &[(u32, u32)]) -> Vec<String> {
+    let mut out = Vec::with_capacity(ranges.len());
+    let mut prev_end: Option<usize> = None;
+    for &(start, end) in ranges {
+        let (start, end) = (start as usize, end as usize);
+        let Ok(line) = core::str::from_utf8(&text[start..end]) else {
+            // Same rationale as `write_head_comment_lines`'s identical
+            // guard: still advance `prev_end` past this skipped line's own
+            // break, or the next real line's blank-line check would count
+            // both the gap before and after this line as one combined span.
+            if prev_end.is_some() {
+                prev_end = Some(end + line_break_len(text, end));
+            }
+            continue;
+        };
+        if let Some(pe) = prev_end {
+            if blank_line_between(text, pe, start) {
+                out.push(String::new());
+            }
+        }
+        out.push(line.to_string());
+        prev_end = Some(end);
+    }
+    out
 }
 
 /// Write a node's standalone *head* comment lines (#2795) so that the node

--- a/src/yaml/light.rs
+++ b/src/yaml/light.rs
@@ -1547,11 +1547,29 @@ impl<'a, W: AsRef<[u64]>> YamlCursor<'a, W> {
         // (`-p json`) never has a header: real yq only preprocesses one
         // for its YAML decoder.
         let is_document = self_.is_document_content();
+        let is_first_document = self_.bp_pos == FIRST_DOCUMENT_BP;
+        // A scalar/null/alias root's head is only kept on the *first*
+        // document -- the `--header-preprocess` header covers that case
+        // regardless of kind. A later document's scalar root drops its
+        // head entirely, not just its foot (verified against pinned yq:
+        // `1\n---\n# lead\n42\n# foot\n` prints `1\n---\n42`, dropping
+        // `# lead` too, where a first-document scalar root keeps its head
+        // -- `# lead\n1\n# foot\n` prints `# lead\n1`). A collection root
+        // keeps both on every document (see the `is_collection_root` guard
+        // on the foot below). Resolving the alias target here (rather than
+        // after printing the value, as before) just moves an existing,
+        // side-effect-free computation earlier so its kind is known before
+        // deciding whether to print the head at all.
+        let resolved = self_.resolve_alias_target_cursor().unwrap_or(self_);
+        let value = resolved.value();
+        let is_collection_root = matches!(value, YamlValue::Mapping(_) | YamlValue::Sequence(_));
         if is_document {
-            if self_.bp_pos == FIRST_DOCUMENT_BP {
+            if is_first_document {
                 write_yq_header(out, self_.text, self_.index)?;
             }
-            self_.write_head_comments_at(out, "", self_.bp_pos)?;
+            if is_first_document || is_collection_root {
+                self_.write_head_comments_at(out, "", self_.bp_pos)?;
+            }
         }
         // #1350 code review: `write_leading_anchor` must run *before*
         // resolving a root alias below, not after -- the target's own
@@ -1577,13 +1595,14 @@ impl<'a, W: AsRef<[u64]>> YamlCursor<'a, W> {
         // target instead of printing the mark, and this streaming path
         // should too. `resolve_alias_target_cursor` is a no-op (single
         // `.value()` check, no chain walk) when `self_` isn't an alias.
+        // Already resolved above (`resolved`/`value`) to decide whether to
+        // print the head comment; reused here rather than resolved twice.
         //
         // Known gap, not a new regression (confirmed against pre-#1350
         // `main`, which dropped it too): the alias's *own* trailing comment
         // (e.g. `b: *x # kept`) is not carried over here, only the target's.
         // Same family as #1085 (a node can carry only one comment slot).
-        let self_ = self_.resolve_alias_target_cursor().unwrap_or(self_);
-        let value = self_.value();
+        let self_ = resolved;
         if let YamlValue::String(s) = &value {
             // #1615: this root-scalar shortcut bypasses `stream_yaml_value`/
             // `stream_yaml_string_value` entirely (see this function's own doc
@@ -1621,7 +1640,7 @@ impl<'a, W: AsRef<[u64]>> YamlCursor<'a, W> {
         } else {
             self_.stream_yaml_value(out, "", indent.width, indent.unit, sort_keys, false, "")?;
         }
-        if matches!(value, YamlValue::Mapping(_) | YamlValue::Sequence(_)) {
+        if is_collection_root {
             write_line_comment(out, self_.line_comment_raw())?;
             // The document's own foot comment (#2795): a block at the end
             // of the document that a blank line detached from its last
@@ -6984,6 +7003,11 @@ impl<'a, W: AsRef<[u64]> + Clone> DocumentCursor for YamlCursor<'a, W> {
     }
 
     #[inline]
+    fn document_has_standalone_comments(&self) -> bool {
+        self.index.has_standalone_comments()
+    }
+
+    #[inline]
     fn explicit_tag(&self) -> Option<&str> {
         YamlCursor::explicit_tag(self)
     }
@@ -8353,11 +8377,17 @@ fn write_yq_header<W: AsRef<[u64]>, Out: core::fmt::Write>(
         let line = &rest[..line_end];
         if doc_markers || !line.starts_with("---") {
             out.write_str(line)?;
-            // The break itself is normalized to `\n`, as every other line
-            // break in the output is (#324): a CRLF/CR source header prints
-            // the same as its LF spelling, matching yq.
+            // The break itself is reproduced verbatim, unlike every other
+            // line break in the output, which is normalized to `\n` (#324):
+            // measured against pinned yq, a CRLF/CR source header keeps its
+            // own spelling (`# lead\r\n# lead2\r\na: 1\r\n` prints back with
+            // `\r\n` intact), not normalized like a document's ordinary
+            // content lines are. `rest[line_end..line_end + brk]` is always
+            // a valid `str` slice boundary: `brk` bytes are CR/LF, one byte
+            // each, so slicing there can never land inside a multi-byte
+            // UTF-8 sequence.
             if brk > 0 {
-                out.write_char('\n')?;
+                out.write_str(&rest[line_end..line_end + brk])?;
             }
         }
         pos += line_end + brk;
@@ -15649,12 +15679,15 @@ plain: hello
         }
 
         #[test]
-        fn header_line_breaks_are_normalized() {
+        fn header_line_breaks_are_reproduced_verbatim() {
+            // Measured against pinned yq (#2795 review): a CRLF/CR source
+            // header keeps its own break spelling, unlike every other line
+            // break in the output, which is normalized to `\n` (#324).
             assert_eq!(
                 stream(b"# lead\r\n\r\n---\r\na: 1\r\n"),
-                "# lead\n\n---\na: 1"
+                "# lead\r\n\r\n---\r\na: 1"
             );
-            assert_eq!(stream(b"# lead\r\ra: 1\r"), "# lead\n\na: 1");
+            assert_eq!(stream(b"# lead\r\ra: 1\r"), "# lead\r\ra: 1");
         }
 
         #[test]

--- a/src/yaml/light.rs
+++ b/src/yaml/light.rs
@@ -6974,6 +6974,11 @@ impl<'a, W: AsRef<[u64]> + Clone> DocumentCursor for YamlCursor<'a, W> {
     }
 
     #[inline]
+    fn is_document_content(&self) -> bool {
+        YamlCursor::is_document_content(self)
+    }
+
+    #[inline]
     fn document_has_aliases(&self) -> bool {
         self.index.has_aliases()
     }
@@ -7025,6 +7030,20 @@ impl<'a, W: AsRef<[u64]> + Clone> DocumentCursor for YamlCursor<'a, W> {
     #[inline]
     fn foot_comment(&self) -> Vec<String> {
         YamlCursor::foot_comment(self)
+            .map(ToString::to_string)
+            .collect()
+    }
+
+    #[inline]
+    fn head_comment_raw(&self) -> Vec<String> {
+        YamlCursor::head_comment_raw(self)
+            .map(ToString::to_string)
+            .collect()
+    }
+
+    #[inline]
+    fn foot_comment_raw(&self) -> Vec<String> {
+        YamlCursor::foot_comment_raw(self)
             .map(ToString::to_string)
             .collect()
     }

--- a/src/yaml/parser.rs
+++ b/src/yaml/parser.rs
@@ -948,8 +948,21 @@ impl<'a, const HAS_CR: bool> Parser<'a, HAS_CR> {
         // before starting a new one. Without this, `a: 1 / # m1 / <blank> /
         // # m2 / b: 2` would merge both blocks onto `b`, where real yq
         // splits them `m1` -> `.a`'s foot, `m2` -> `.b`'s head.
+        //
+        // Only when the pending block is not *deeper* than `PREV`'s own
+        // block, though (`pending_block.column <= pending_block.prev_indent`,
+        // the same signal the column-change split below gates on): a block
+        // already sitting inside a not-yet-opened nested block (`a:` /
+        // `  # h1` / blank / `  # h2` / `  b: 1`) is still working out which
+        // forward node will own it, so an internal blank line does not yet
+        // mean "settle onto `PREV`" -- real yq keeps `h1`/`h2` together as
+        // one block (blank line preserved) attached to `.a.b`'s key, not
+        // split with `h1` misrouted onto `.a`'s own foot (measured; #2795
+        // review).
         if let Some(&(_, last_end)) = self.pending_head_lines.last() {
-            if self.blank_line_between(last_end as usize, start as usize) {
+            if self.blank_line_between(last_end as usize, start as usize)
+                && self.pending_block.column <= self.pending_block.prev_indent
+            {
                 self.resolve_pending_block_backward();
             }
         }
@@ -1239,20 +1252,8 @@ impl<'a, const HAS_CR: bool> Parser<'a, HAS_CR> {
             .rposition(|frame| frame.indent == column && closing(frame))
             .or_else(|| next_column.is_none().then_some(0));
         if let Some(start) = start {
-            let claimed = frames[..=start]
-                .iter()
-                .rev()
-                .take_while(|frame| closing(frame))
-                .find(|frame| frame.is_mapping)
-                .and_then(|frame| frame.last_key_bp)
-                // A mapping frame with no key yet records the
-                // `open_frame_key_slot` sentinel rather than `None` (its
-                // `last_key_bp` is only ever cleared to `None` for a
-                // non-mapping frame); filter it out here the same way the
-                // fallback arm below already does, so a mapping that opened
-                // without ever yet completing a key doesn't hand a dedented
-                // comment to a bp no cursor resolves to (#2811 review).
-                .filter(|&bp| bp != usize::MAX);
+            let claimed =
+                Self::last_mapping_key(frames[..=start].iter().rev().take_while(|f| closing(f)));
             if claimed.is_some() {
                 return claimed;
             }
@@ -1308,13 +1309,26 @@ impl<'a, const HAS_CR: bool> Parser<'a, HAS_CR> {
         if start == 0 {
             return None;
         }
-        frames[1..=start]
-            .iter()
-            .rev()
+        Self::last_mapping_key(frames[1..=start].iter().rev()).or_else(|| self.attached_prev())
+    }
+
+    /// The last mapping frame's key bp among `frames`, filtering the
+    /// `open_frame_key_slot` sentinel (#2811 review) -- shared by
+    /// [`Self::positional_foot_target`] and
+    /// [`Self::positional_boundary_foot_target`], whose own backward scans
+    /// differ only in which frames are in range to begin with (one takes
+    /// `closing` into account and starts at index 0, the other doesn't and
+    /// starts past index 0) -- everything after that range is picked is this
+    /// one rule in both. A mapping frame with no key yet records the
+    /// `open_frame_key_slot` sentinel rather than `None` (`last_key_bp` is
+    /// only ever cleared to `None` for a non-mapping frame); filtering it out
+    /// here keeps a mapping that opened without ever completing a key from
+    /// handing a dedented comment to a bp no cursor resolves to.
+    fn last_mapping_key<'f>(mut frames: impl Iterator<Item = &'f CommentFrame>) -> Option<usize> {
+        frames
             .find(|frame| frame.is_mapping)
             .and_then(|frame| frame.last_key_bp)
             .filter(|&bp| bp != usize::MAX)
-            .or_else(|| self.attached_prev())
     }
 
     /// Real yq never makes a detached block the foot of the stream's very
@@ -1564,15 +1578,25 @@ impl<'a, const HAS_CR: bool> Parser<'a, HAS_CR> {
     }
 
     /// Settle a pending block whose forward attachment is already disproven
-    /// (a blank line follows it) onto `PREV`'s foot. A no-op when `PREV` is
-    /// unset, which means a blank line detached the block backwards too —
-    /// it stays pending and goes forward to whatever opens next.
+    /// (a blank line follows it) onto `PREV`'s foot -- or, with no `PREV` in
+    /// the *current* document yet, onto the document that just closed
+    /// across a `---`/`...` boundary (mirrors
+    /// [`Self::flush_pending_head_lines_with_root`]'s own no-`PREV`
+    /// fallback, #2795 review): `a: 1\n---\n# c1\n\n# c2\nb: 2\n` gives `c1`
+    /// to the first document's foot and only `c2` goes forward to `.b`'s
+    /// head, not both merged onto `.b` (measured against pinned yq). A
+    /// genuine no-op only when neither is set, which means a blank line
+    /// detached the block backwards *and* this is still the very first
+    /// document -- it stays pending and goes forward to whatever opens
+    /// next.
     fn resolve_pending_block_backward(&mut self) {
         if self.pending_head_lines.is_empty() {
             return; // omni-dev: coverage tolerate-line reason="unreachable: this function's sole caller (record_standalone_comment) only invokes it from inside a match on `pending_head_lines.last()`, so pending_head_lines is already known non-empty here (#798)"
         }
         if let Some(prev) = self.attached_prev() {
             self.drain_pending_into_foot(prev);
+        } else if let Some(old_root) = self.document_boundary_fallback_bp {
+            self.drain_pending_into_foot(old_root);
         }
     }
 
@@ -7069,6 +7093,39 @@ impl<'a, const HAS_CR: bool> Parser<'a, HAS_CR> {
         // Parse all documents (may be empty for comment-only files)
         if self.peek().is_some() {
             self.parse_documents()?;
+        } else {
+            // The whole input is comments and/or blank lines, with no
+            // `---`/`...` marker anywhere (#2795 review): real yq still
+            // yields exactly one (null) document for this, e.g. a lone
+            // `# c1` line prints back verbatim under `.` and answers `1`
+            // under a literal filter, rather than the stream producing no
+            // documents at all (verified against pinned yq). Synthesizing
+            // one here, rather than leaving `pending_head_lines` to attach
+            // to the virtual root sequence itself, gives the comment(s) a
+            // real document node to be this document's own head -- exactly
+            // `start_document`'s own "a leading `# lead` belongs to the
+            // document's own node" rule, and `end_document` synthesizes the
+            // null value since nothing gets written for it. Distinct from
+            // the genuinely-zero-document case `parse_documents` still
+            // handles on its own (#225's HWV9/QT73: an explicit marker with
+            // nothing before it) -- that case requires a marker to exist at
+            // all, which this branch's `peek().is_none()` guard already
+            // rules out.
+            //
+            // Known residual, confirmed live and unfixed here: real yq's
+            // YAML-target printer suppresses the value line entirely for a
+            // document with no explicit content (`# c\n` under `.` prints
+            // just `# c`, no `null`), where succinctly still prints the
+            // synthesized `null` (`# c\nnull`) -- both tools agree it's
+            // `!!null` under `. | type`, and JSON output already agrees
+            // (`null` on both). This is not new here: an explicit `---`
+            // alone with nothing after it has the identical gap already
+            // (`---\n` under `.` prints `---` in yq, `---\nnull` here),
+            // unrelated to comments -- this synthesis just reaches the same
+            // pre-existing emitter gap from a new angle, not a regression
+            // this change introduces.
+            self.start_document();
+            self.end_document();
         }
 
         // A standalone comment block still pending at EOF has no following

--- a/src/yaml/parser.rs
+++ b/src/yaml/parser.rs
@@ -7112,18 +7112,24 @@ impl<'a, const HAS_CR: bool> Parser<'a, HAS_CR> {
             // all, which this branch's `peek().is_none()` guard already
             // rules out.
             //
-            // Known residual, confirmed live and unfixed here: real yq's
-            // YAML-target printer suppresses the value line entirely for a
-            // document with no explicit content (`# c\n` under `.` prints
-            // just `# c`, no `null`), where succinctly still prints the
-            // synthesized `null` (`# c\nnull`) -- both tools agree it's
-            // `!!null` under `. | type`, and JSON output already agrees
-            // (`null` on both). This is not new here: an explicit `---`
-            // alone with nothing after it has the identical gap already
-            // (`---\n` under `.` prints `---` in yq, `---\nnull` here),
-            // unrelated to comments -- this synthesis just reaches the same
-            // pre-existing emitter gap from a new angle, not a regression
-            // this change introduces.
+            // Real yq's YAML-target printer suppresses the value line
+            // entirely for a document with no explicit content (`# c\n`
+            // under `.` prints just `# c`, no `null`) -- both tools agree
+            // it's `!!null` under `. | type`, and JSON output already
+            // agrees (`null` on both). This was a pre-existing emitter gap,
+            // not new here (an explicit `---` alone with nothing after it
+            // had the identical `---\nnull` bug already, unrelated to
+            // comments), now closed on the streaming route by
+            // `YamlCursor::is_header_only_document` (`src/yaml/light.rs`)
+            // gating the identity path's own per-document terminator in
+            // `yq_runner.rs`'s `stream_cursor!` macro (#2795 review) --
+            // `# c\n`/`---\n` now round-trip through `.` byte-for-byte.
+            // Still open on the DOM route (`-P`/a write): `OwnedValue` has
+            // no signal distinguishing this synthesized absence from a
+            // genuine `null`/`~` keyword or a literal `null` filter result
+            // once evaluation has materialized it, so the same fix can't
+            // safely land there without new plumbing -- tracked, not
+            // fixed, as of this comment.
             self.start_document();
             self.end_document();
         }

--- a/tests/data/yaml-test-suite-known-failures.txt
+++ b/tests/data/yaml-test-suite-known-failures.txt
@@ -41,7 +41,9 @@
 2SXE      structure         document/block structure differs from spec
 4JVG      lax:anchors       anchor/alias rules not validated — #223
 5LLU      lax:indentation   indentation not validated — #223
+8G76      structure         comment-only stream: spec wants zero documents, succinctly now synthesizes one null document to match real yq's CLI decode loop (`yq '1'` on `# c` answers `1`, not zero) — deliberate #2795 review fidelity choice (ADR-0018), not a regression
 8XDJ      lax:comments      comment placement not validated — #223
+98YD      structure         same shape and reason as 8G76 — #2795 review
 9C9N      lax:indentation   indentation not validated — #223
 9HCY      lax:documents     mid-stream `%TAG` directive (no `...` footer before it) absorbed as scalar text rather than rejected — #223 (surfaced by #224: previously masked by tags erroring at column 0 before the directive was ever reached)
 9KBC      lax:mapping       mapping/key rules not validated — #223

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -15013,8 +15013,9 @@ mod standalone_comment_attribution_2811_review {
 /// #2795: standalone (head/foot) comments print on the streaming YAML
 /// route. Every expected string was captured from pinned yq v4.53.3 on the
 /// same input and arguments. Shapes whose *attribution* the parser still
-/// diverges on (#2811) are left to that fix; the DOM route (`-P`, writes)
-/// is the second half of #2795 and not asserted here.
+/// diverges on (#2811) are left to that fix; the DOM route (`-P`, writes) is
+/// the second half of #2795, covered separately by `dom_standalone_comments_2795`
+/// below.
 mod standalone_comments_2795 {
     use super::run_yq_stdin;
     use anyhow::Result;
@@ -15152,6 +15153,165 @@ mod standalone_comments_2795 {
         // a scalar root, but prints both around a flow-collection root.
         assert_eq!(yq(".", "# lead\n42\n", &[])?, "# lead\n42\n");
         assert_eq!(yq(".", "# lead\n[1]\n", &[])?, "# lead\n[1]\n");
+        Ok(())
+    }
+}
+
+/// #2795 PR B: standalone (head/foot) comments print on the DOM route too --
+/// `-P`, `.a = 5`, `del(...)` and every other write, previously the
+/// documented gap left by `standalone_comments_2795` above. Every expected
+/// string was captured from pinned yq v4.53.3 on the same input and
+/// arguments (`-P` forces the DOM route for a plain read the same way
+/// `--arg` does elsewhere in this file). Shapes whose *attribution* the
+/// parser still diverges on (#2811) are out of scope here too, same as the
+/// streaming module.
+mod dom_standalone_comments_2795 {
+    use super::run_yq_stdin;
+    use anyhow::Result;
+
+    fn yq_p(filter: &str, input: &str, args: &[&str]) -> Result<String> {
+        let mut full_args = vec!["-P"];
+        full_args.extend_from_slice(args);
+        let (out, code) = run_yq_stdin(filter, input, &full_args)?;
+        assert_eq!(code, 0, "{out}");
+        Ok(out)
+    }
+
+    const ISSUE_DOC: &str = "# lead\na: 1\n# mid\nb: 2\n\n# trail\n";
+
+    #[test]
+    fn identity_keeps_every_standalone_comment_2795() -> Result<()> {
+        assert_eq!(
+            yq_p(".", ISSUE_DOC, &[])?,
+            "# lead\na: 1\n# mid\nb: 2\n# trail\n"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn a_write_keeps_unrelated_standalone_comments_2795() -> Result<()> {
+        assert_eq!(
+            yq_p(".a = 5", ISSUE_DOC, &[])?,
+            "# lead\na: 5\n# mid\nb: 2\n# trail\n"
+        );
+        Ok(())
+    }
+
+    /// `del(.b)` drops `# mid` (owned by `b`'s key) but keeps `# lead`/
+    /// `# trail` (the root's own head/foot) -- the issue's own ownership-
+    /// model confirmation, now on the write route that actually needs it.
+    #[test]
+    fn delete_drops_only_the_deleted_keys_own_head_2795() -> Result<()> {
+        assert_eq!(yq_p("del(.b)", ISSUE_DOC, &[])?, "# lead\na: 1\n# trail\n");
+        Ok(())
+    }
+
+    #[test]
+    fn json_output_still_drops_them_2795() -> Result<()> {
+        assert_eq!(
+            yq_p(".", ISSUE_DOC, &["-o=json", "-I=0"])?,
+            "{\"a\":1,\"b\":2}\n"
+        );
+        Ok(())
+    }
+
+    /// A bare scalar field navigated to directly drops its comment, same as
+    /// the streaming route -- it belongs to the mapping entry (its key),
+    /// never to the bare extracted value.
+    #[test]
+    fn a_navigated_scalar_field_prints_bare_2795() -> Result<()> {
+        assert_eq!(yq_p(".a", "# lead\na: 1\n# foot\n", &[])?, "1\n");
+        Ok(())
+    }
+
+    /// A navigated sequence-item *scalar* also drops it (same reasoning),
+    /// but a navigated sequence-item *container* keeps its own -- real yq's
+    /// root-vs-navigated distinction only ever applies to a bare scalar
+    /// result, live-verified against pinned v4.53.3.
+    #[test]
+    fn a_navigated_sequence_item_head_follows_its_own_kind_2795() -> Result<()> {
+        assert_eq!(
+            yq_p(".items[0]", "items:\n  # h\n  - 1\n  - 2\n", &[])?,
+            "1\n"
+        );
+        assert_eq!(
+            yq_p(".items[0]", "items:\n  # h\n  - a: 1\n  - b: 2\n", &[])?,
+            "# h\na: 1\n"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn nested_and_sequence_placement_2795() -> Result<()> {
+        assert_eq!(
+            yq_p(".", "a:\n  # inner\n  b: 1\n  c: 2\nd: 3\n", &[])?,
+            "a:\n  # inner\n  b: 1\n  c: 2\nd: 3\n"
+        );
+        assert_eq!(
+            yq_p(".", "- 1\n# mid\n- 2\n# foot\n", &[])?,
+            "- 1\n# mid\n- 2\n# foot\n"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn a_foot_followed_by_a_sibling_gets_one_blank_line_2795() -> Result<()> {
+        assert_eq!(
+            yq_p(".", "a: 1\n# mid\n\nb: 2\n", &[])?,
+            "a: 1\n# mid\n\nb: 2\n"
+        );
+        assert_eq!(
+            yq_p(".", "a: 1\n# f\n\n# g\n\nb: 2\n", &[])?,
+            "a: 1\n# f\n\n# g\nb: 2\n"
+        );
+        Ok(())
+    }
+
+    /// `-P` forces block/plain style regardless of source (#705) -- in both
+    /// tools, so the quoted style from the streaming module's equivalent
+    /// test is gone here (`&x q`, not `&x "q"`), live-verified against
+    /// pinned yq. The head-line-before-anchor ordering is unaffected.
+    #[test]
+    fn head_lines_precede_anchor_style_and_line_comment_2795() -> Result<()> {
+        assert_eq!(
+            yq_p(".", "# h\na: &x \"q\" # line\n", &[])?,
+            "# h\na: &x q # line\n"
+        );
+        Ok(())
+    }
+
+    /// A scalar root prints its head and drops its foot; a flow-collection
+    /// root prints both -- same asymmetry the streaming route documents,
+    /// now confirmed through the DOM route's own root-vs-navigated pass in
+    /// `evaluate_yaml_cursor` (`owned_with_comments`/the `#852` rebuild).
+    /// `-P` also forces the flow collection to block style (`- 1`, not
+    /// `[1]`, same reasoning as the anchor/style test above).
+    #[test]
+    fn a_scalar_root_prints_its_head_and_drops_its_foot_2795() -> Result<()> {
+        assert_eq!(yq_p(".", "# lead\n42\n", &[])?, "# lead\n42\n");
+        assert_eq!(yq_p(".", "# lead\n42\n# foot\n", &[])?, "# lead\n42\n");
+        assert_eq!(yq_p(".", "# lead\n[1]\n", &[])?, "# lead\n- 1\n");
+        assert_eq!(
+            yq_p(".", "# lead\n[1]\n# foot\n", &[])?,
+            "# lead\n- 1\n# foot\n"
+        );
+        Ok(())
+    }
+
+    /// Known, recorded residual: real yq's `--header-preprocess` slurps a
+    /// leading blank line / `%YAML`/`---` marker verbatim ahead of the first
+    /// document (the streaming route's own `write_yq_header`, #2795 PR A) --
+    /// the DOM route only carries structured head/foot *comment lines*, not
+    /// that raw verbatim header, so a marker or an interior blank line in
+    /// the header block does not survive a write. Plain leading `#` comment
+    /// lines (no blank line, no marker) are unaffected -- see the tests
+    /// above. Pinned here so a future header-unification fix has a failing
+    /// test to flip, not a silent behavior change.
+    #[test]
+    fn header_verbatim_reproduction_is_streaming_only_2795() -> Result<()> {
+        // Real yq: "# lead\n\na: 1\n" (keeps the blank line and the marker).
+        assert_eq!(yq_p(".", "# lead\n\na: 1\n", &[])?, "# lead\na: 1\n");
+        assert_eq!(yq_p(".", "---\na: 1\n", &[])?, "a: 1\n");
         Ok(())
     }
 }

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -14932,7 +14932,15 @@ mod standalone_comment_attribution_2811_review {
         let input = "---\n---\n# c\nb: 2\n";
         let (out, code) = run_yq_stdin(".", input, &["--doc", "0"])?;
         assert_eq!(code, 0);
-        assert_eq!(out, "---\nnull\n");
+        // Was `"---\nnull\n"` before the #2795 review fix to
+        // `is_header_only_document`: document 0 here is a bare `---` with
+        // nothing before the next marker, the same synthesized-absent shape
+        // as a lone `---\n` file, which real yq always prints as just
+        // `---\n` -- confirmed live in isolation (`printf -- '---\n' | yq
+        // '.'`) and by real yq's own combined rendering of this exact input
+        // (`yq '.'` with no `--doc` filter prints `---\n---\n# c\nb: 2\n`,
+        // whose first line is this document's whole contribution).
+        assert_eq!(out, "---\n");
         let (out, code) = run_yq_stdin(".", input, &["--doc", "1"])?;
         assert_eq!(code, 0);
         assert_eq!(out, "# c\nb: 2\n");
@@ -15078,6 +15086,31 @@ mod standalone_comments_2795 {
             yq(".", "# lead\n---\na: 1\n---\nb: 2\n", &[])?,
             "# lead\n---\na: 1\n---\nb: 2\n"
         );
+        Ok(())
+    }
+
+    /// A document whose whole identity output is its own verbatim header
+    /// (comment-only or blank-only input, or a bare `---`/`...` marker with
+    /// nothing after it) prints no `null` for its synthesized-absent value
+    /// -- `YamlCursor::is_header_only_document` (#2795 review) gates the
+    /// identity path's own per-document terminator so it doesn't
+    /// double-terminate a header that already ends in its own captured line
+    /// break. Live-verified against pinned yq v4.53.3; a later document's
+    /// own empty `---` is unaffected (still gets the ordinary terminator,
+    /// same as real yq).
+    #[test]
+    fn a_header_only_document_prints_no_synthesized_null_2795() -> Result<()> {
+        assert_eq!(yq(".", "# c\n", &[])?, "# c\n");
+        assert_eq!(yq(".", "\n\n\n", &[])?, "\n\n\n");
+        assert_eq!(yq(".", "---\n", &[])?, "---\n");
+        // Sanity: an explicit `null`/`~` keyword, and a `null` nested inside
+        // a container, are unaffected -- only a whole-result synthesized
+        // absence is ever suppressed.
+        assert_eq!(yq(".", "null\n", &[])?, "null\n");
+        assert_eq!(yq(".", "a: [null, 1]\n", &[])?, "a: [null, 1]\n");
+        // A later document's own empty `---` keeps the ordinary terminator
+        // (no header to fold into).
+        assert_eq!(yq(".", "a: 1\n---\n", &[])?, "a: 1\n---\n\n");
         Ok(())
     }
 
@@ -15312,6 +15345,28 @@ mod dom_standalone_comments_2795 {
         // Real yq: "# lead\n\na: 1\n" (keeps the blank line and the marker).
         assert_eq!(yq_p(".", "# lead\n\na: 1\n", &[])?, "# lead\na: 1\n");
         assert_eq!(yq_p(".", "---\na: 1\n", &[])?, "a: 1\n");
+        Ok(())
+    }
+
+    /// A blank line *inside* an ordinary (non-header) head-comment block --
+    /// distinct from the header-verbatim residual just above, which is about
+    /// the *first document's leading* block only -- is now reproduced on the
+    /// DOM route too (#2795 review): `DocumentCursor::head_comment_raw`'s
+    /// `YamlCursor` impl used to just decode the stored `#` ranges with no
+    /// way to represent a blank between them, silently dropping it under
+    /// `-P`/a write while the streaming route already kept it. Live-verified
+    /// against pinned yq v4.53.3.
+    #[test]
+    fn interior_blank_line_in_a_head_block_survives_the_dom_route_2795() -> Result<()> {
+        assert_eq!(
+            yq_p(".", "a:\n  # h1\n\n  # h2\n  b: 1\n", &[])?,
+            "a:\n  # h1\n\n  # h2\n  b: 1\n"
+        );
+        // A write forcing the DOM route keeps it too, not just plain `-P`.
+        assert_eq!(
+            yq_p(".c = 2", "a:\n  # h1\n\n  # h2\n  b: 1\n", &[])?,
+            "a:\n  # h1\n\n  # h2\n  b: 1\nc: 2\n"
+        );
         Ok(())
     }
 }

--- a/tests/yq_golden_tests.rs
+++ b/tests/yq_golden_tests.rs
@@ -272,6 +272,33 @@ fn yq_golden_conformance() {
     assert!(report.is_empty(), "{report}");
 }
 
+/// Golden cases whose *input* carries a standalone comment and which real yq
+/// itself does not render output-invariantly across line-break forms for —
+/// confirmed live against pinned yq v4.53.3, not assumed (#2795 review).
+///
+/// Two distinct, unreplicated go-yaml quirks are responsible, both pre-existing
+/// and unrelated to comment *placement* — see
+/// `docs/compliance/yq/limitations.md`'s "genuinely blank CRLF line" entry:
+///
+/// - Under CRLF, a comment's header is reproduced verbatim (`\r\n` kept, matching
+///   this branch's own header fix) but yq additionally inserts a blank line after
+///   a standalone comment, or a blank CRLF line turns into a literal `# ` comment
+///   line, that the source never had at all.
+/// - Under a lone CR, yq preserves `\r` as the output's own line break through
+///   the *entire* document (not just a header) whenever a standalone comment is
+///   present anywhere in it — a much larger, separately-confirmed gap neither
+///   succinctly's old nor new behavior replicates.
+///
+/// Neither quirk is triggered by ordinary (comment-free) content, which is why
+/// every other golden case still passes this test's invariance check unmodified.
+const KNOWN_CRLF_DIVERGENCES: &[&str] = &[
+    "standalone_comments_cursor_result_2795",
+    "standalone_comments_head_anchor_style_2795",
+    "standalone_comments_header_2795",
+    "standalone_comments_header_no_doc_2795",
+    "standalone_comments_identity_2795",
+];
+
 /// The same goldens, with the input's line breaks rewritten to CRLF and to a
 /// lone CR (#324).
 ///
@@ -281,6 +308,12 @@ fn yq_golden_conformance() {
 /// oracle for every variant. Rewriting `\n` is sound because a raw LF in YAML is
 /// always a line break; the `\n` inside a double-quoted scalar is the two
 /// characters `\` and `n`, which `str::replace` leaves alone.
+///
+/// That premise turns out false for a comment-bearing document specifically
+/// (real yq is not fully line-break-invariant there either — see
+/// [`KNOWN_CRLF_DIVERGENCES`]), so those cases are exempted from the invariance
+/// assertion below rather than silently asserted against; every other case
+/// keeps the original, tighter guarantee this test's doc comment describes.
 ///
 /// The assertion is invariance: each variant must fail on exactly the cases the
 /// LF run fails on, so this stays honest without a second manifest.
@@ -303,7 +336,10 @@ fn yq_golden_conformance_under_crlf_and_lone_cr() {
         }
 
         let actual: BTreeSet<String> = failures.keys().cloned().collect();
-        let regressed: Vec<_> = actual.difference(&baseline).collect();
+        let regressed: Vec<_> = actual
+            .difference(&baseline)
+            .filter(|name| !KNOWN_CRLF_DIVERGENCES.contains(&name.as_str()))
+            .collect();
         let inverted: Vec<_> = baseline.difference(&actual).collect();
 
         let mut report = String::new();


### PR DESCRIPTION
## Description

PR A (#2795, merged) printed standalone (`#`) head/foot comments on the
streaming route only — plain `yq '.'`, `select(true)`, and every other
cursor-forwarded result. The DOM emitter (`emit_yaml_value_at_depth`,
`src/bin/succinctly/yq_runner.rs`), used by `-P`, `.a = 5`, `del(.b)` and
every other write, still dropped every standalone comment. This closes
that second half.

## What changes

- **`NodeMeta.head_foot_comment` is populated.** It was a prepared-but-
  always-`None` field. `to_owned_with_comments_at_depth`
  (`src/jq/eval_generic.rs`) now reads it via two new `DocumentCursor`
  trait methods, `head_comment_raw`/`foot_comment_raw` (empty-by-default,
  so JSON pays nothing), off the node the parser actually keys head/foot
  to — a mapping entry's *key* cursor, not the value cursor the function
  otherwise recurses with (`.b | key | head_comment` is non-empty, `.b |
  head_comment` is `""`).
- **The DOM emitter prints it.** New `prepend_head_comment_lines`/
  `append_foot_comment_lines`/`join_block_entries` helpers in
  `yq_runner.rs` mirror `light.rs`'s `write_head_comments_at`/
  `write_foot_comments_at`/`prev_had_foot` placement rules (indent, one
  blank line after a foot before a sibling) for the block mapping/sequence
  loops and the root wrapper in `output_value`.
- **`reconcile_presentation_at_depth`/`strip_presentation_style_at_depth`
  needed no changes** — both already clone/copy `NodeMeta` wholesale, so
  head/foot survives `.a = 5`/`del(.b)`/`-P`'s style-strip for free once
  populated.
- **Root-vs-navigated fix (`#852`).** A pre-existing pass that strips
  style/anchor from a bare scalar result was also wiping the newly-
  populated root head comment. Real yq keeps a document root's head (not
  its foot) while dropping both for any navigated-away scalar, even
  though a navigated *container* keeps its own — fixed via a new
  `DocumentCursor::is_document_content` (mirroring `light.rs`'s private
  method of the same name), later folded into `to_owned_with_comments`
  itself so the write path's pristine snapshot picks up the same rule,
  and extended to also drop head for a scalar root past the first
  document in a multi-doc stream.
- **Review pass**, included in this PR: perf short-circuit
  (`DocumentCursor::document_has_standalone_comments`, skipping two
  `BTreeMap` probes per node on a document with none at all, matching the
  streaming route's existing gate), a comment-only input (`# c`, no
  `---` anywhere) now synthesizing one null document instead of zero
  (matching real yq's CLI decode loop), CRLF header line breaks now
  reproduced verbatim instead of normalized, and a parser dedup
  (`last_mapping_key`).

## Known residuals (recorded, not silently mismatched)

- The streaming route's verbatim **header** re-emission (blank lines,
  `---`/`%YAML` markers ahead of the first document) has no DOM-route
  equivalent — the DOM route only carries structured head/foot *comment
  lines* through `CommentTree`, not the raw header bytes. Plain leading
  `#` lines with no blank line or marker between them are unaffected.
  Pinned by `header_verbatim_reproduction_is_streaming_only_2795`.
- A content-less document (`# c` alone, or an explicit `---` alone) still
  prints a spurious `null` value line where real yq's YAML printer
  suppresses it entirely — both tools already agree it's `!!null` via
  `. | type` and via `-o=json`, just not the YAML-target print. Pre-
  existing (also affects `---` alone, unrelated to comments); documented
  at the parser's new comment-only-document synthesis site rather than
  fixed here, since a proper fix needs the emitter to distinguish
  "genuinely no content" from "explicit null" more broadly than this PR's
  scope.
- A few narrower CRLF-only quirks in go-yaml's own comment scanner (an
  extra blank line yq inserts that the CRLF source never had, or a blank
  CRLF line yq turns into a literal `# ` comment) are recorded as an
  accepted, unreplicated fidelity gap (`KNOWN_CRLF_DIVERGENCES` in
  `tests/yq_golden_tests.rs`), not chased.

`docs/compliance/yq/limitations.md` and `docs/reference/yq-language.md`
are updated to match.

## Testing

**Automated:**
- [x] Full workspace suite green (`cargo test --features cli,regex,serde`
  and the default/`--no-default-features` legs) — thousands of tests
  across unit, integration, golden, doc.
- [x] New tests added: `dom_standalone_comments_2795` module in
  `tests/yq_cli_tests.rs` (identity, write, `del()`, JSON output,
  navigated scalar-vs-container, blank-line-after-foot, anchor/style
  ordering, root scalar-vs-flow, header residual).
- [x] Depth-guard regression tests re-verified
  (`reconcile_presentation_panics_past_nesting_depth_limit_1005`,
  `emit_yaml_value_panics_past_nesting_depth_limit_1017`,
  `strip_presentation_style_panics_past_nesting_depth_limit_1017`).

**Manual (live-verified against pinned yq v4.53.3):**
- [x] The issue's own probe table: `-P '.'`, `.a = 5`, `del(.b)`,
  `-o=json`, byte-identical.
- [x] Root-vs-navigated/scalar-vs-container matrix that the `#852` fix
  required.
- [x] Multi-document scalar root head/foot.
- [x] Comment-only input, CRLF header verbatim reproduction.

```bash
cargo test --features cli,regex,serde
cargo clippy --all-targets --all-features -- -D warnings
cargo fmt --check
```

## Performance Impact
- [x] No performance impact expected on the primary streaming hot path
  (this PR touches only the DOM/write route); a new perf short-circuit
  (`document_has_standalone_comments`) is a net improvement on the DOM
  materialization path for comment-free documents.

## Related Issue
Closes #2795 (the DOM half; the streaming half was PR A, already merged).