### PR TITLE
fix(jq): let a def error: shadow break $label, matching jq's own desugaring

### DIFF
--- a/docs/compliance/jq/limitations.md
+++ b/docs/compliance/jq/limitations.md
@@ -5431,6 +5431,64 @@ whole document that a streaming arm never read, and the M2 path was gated to kee
 from disagreeing. The gate is gone; the entry under "Real-time stdout/stderr interleaving"
 records the 19 rows that moved away from jq and the spelling rule it left in place.
 
+### `break $x` shadowed by a `def error:` observes the ambient input, not jq's own `{"__jq":N}` sentinel (#2687)
+
+[#2687](https://github.com/rust-works/succinctly/issues/2687): real jq does not treat `break`
+as a primitive — its parser desugars `break $x` into a named call to `error/0`
+(`gen_call("error", gen_noop())` in `parser.y`), applied to a synthetic sentinel value
+(`{"__jq":N}`, `N` the label's compile-time index) as `.`. Name resolution then runs as it
+would for any other call, so a `def error:` (arity 0) in scope at the break's own position
+shadows it: the label stops catching it, the def's own value becomes an ordinary output, and
+evaluation continues past the break instead of unwinding.
+
+succinctly reproduces this (`src/jq/parser.rs`'s `parse_break_expr` wraps `break $x` as a
+shadowable `error` call the same way `error`, `limit`, `until`, ... already are, per
+`Parser::shadowable_defs`/`wrap_shadowable_call`, #2036), but does **not** carry jq's
+`{"__jq":N}` sentinel as the wrapped call's input — the shadowing def instead sees the ambient
+`.` the break itself was reached with:
+
+```console
+$ jq            -nc 'def error: .; label $out | break $out'
+{"__jq":0}
+$ succinctly jq -nc 'def error: .; label $out | break $out'
+null
+```
+
+**Why not carried.** The sentinel is observable only through a `def error:` whose body reads
+`.` — `def error: "S";` (the shape #2687 was actually filed over, and every case in its own
+repro table) is unaffected, since a literal body never looks at its input. Carrying it would
+mean the break can no longer fall back to a bare `Expr::Break` node when nothing shadows it —
+the overwhelmingly common case, and the one this fix's whole design (`Parser::shadowable_defs`'s
+text-only fast-reject) keeps at zero cost and byte-identical AST. It would instead need
+`Expr::Pipe(vec![Expr::Literal(<sentinel>), <the wrapped call>])`, widening the shape every
+break-aware evaluator arm has to recognize (`needs_path_context`, `owned_identity_step`,
+`path_context_step_generic`, `step_can_yield_absent`, `path_context_stage_preserves_node`, …)
+for a construction with no purpose outside probing this one divergence. Per ADR-0018's decision
+order: the reference behavior here is readable and nothing is corrupted, discarded, or takes the
+process down (no rule-4 condition), so the order reaches step 2 (closer match) — but the cost
+this row would add to every break site, shadowed or not, makes the narrower fix (#2687 itself,
+closing the *shadowing* gap) the one taken, with this payload detail recorded rather than chased.
+
+A second, related gap is **not** covered by #2687 or this entry: `label`'s own error re-raise
+(when a caught escape isn't a matching `Control::Break`) is *also* `gen_call("error",
+gen_noop())` in jq, resolved at the **label's** lexical position — so a shadowing `def error:`
+also intercepts an uncaught `error(...)`/division-by-zero/etc. escaping through a `label` block,
+which succinctly does not reproduce at all:
+
+```console
+$ jq            -nc 'def error: "S"; label $out | (1, error("x"), 2)'
+1
+"S"
+$ succinctly jq -nc 'def error: "S"; label $out | (1, error("x"), 2)'
+1
+jq: error (at <unknown>): x
+```
+
+Filed as [#2840](https://github.com/rust-works/succinctly/issues/2840) — a materially larger
+change (`eval_label`/`each_label`/`each_label_generic` and both owned-identity/path-context
+`Label` arms would each need their non-matching-escape fallthrough routed through a resolvable
+call), out of #2687's stated scope.
+
 ## Provenance
 
 | Artifact           | Path                                                                                                       |

--- a/docs/compliance/jq/limitations.md
+++ b/docs/compliance/jq/limitations.md
@@ -5431,7 +5431,7 @@ whole document that a streaming arm never read, and the M2 path was gated to kee
 from disagreeing. The gate is gone; the entry under "Real-time stdout/stderr interleaving"
 records the 19 rows that moved away from jq and the spelling rule it left in place.
 
-### `break $x` shadowed by a `def error:` observes the ambient input, not jq's own `{"__jq":N}` sentinel (#2687)
+### `break $x` shadowed by a `def error:` observes arbitrary ambient pipe state, not jq's own context-independent `{"__jq":N}` sentinel (#2687)
 
 [#2687](https://github.com/rust-works/succinctly/issues/2687): real jq does not treat `break`
 as a primitive — its parser desugars `break $x` into a named call to `error/0`
@@ -5445,14 +5445,29 @@ succinctly reproduces this (`src/jq/parser.rs`'s `parse_break_expr` wraps `break
 shadowable `error` call the same way `error`, `limit`, `until`, ... already are, per
 `Parser::shadowable_defs`/`wrap_shadowable_call`, #2036), but does **not** carry jq's
 `{"__jq":N}` sentinel as the wrapped call's input — the shadowing def instead sees the ambient
-`.` the break itself was reached with:
+`.` the break itself was reached with. jq's sentinel is **fixed and context-independent**
+(tied only to the label's own compile-time index, never to any pipeline value), where
+succinctly's substitute is **unbounded**: whatever `.` happens to be at the break's textual
+position, however unrelated to the label:
 
 ```console
 $ jq            -nc 'def error: .; label $out | break $out'
 {"__jq":0}
 $ succinctly jq -nc 'def error: .; label $out | break $out'
 null
+
+$ jq            -nc 'def error: {seen: .}; 5 as $x | label $out | ($x | break $out)'
+{"seen":{"__jq":0}}
+$ succinctly jq -nc 'def error: {seen: .}; 5 as $x | label $out | ($x | break $out)'
+{"seen":5}
 ```
+
+The second row is not "sentinel vs. null" — it is jq's own fixed marker vs. an arbitrary,
+unrelated upstream value (`5`, bound three pipe stages earlier) leaking through a construct
+whose entire premise is "produce a value with no real connection to the input in scope."
+`test_break_shadowed_by_def_error_sees_ambient_input_not_jqs_sentinel_2687`
+(`tests/jq_cli_tests.rs`) pins this specific shape so a future change to the mechanism can't
+silently make it worse than documented here.
 
 **Why not carried.** The sentinel is observable only through a `def error:` whose body reads
 `.` — `def error: "S";` (the shape #2687 was actually filed over, and every case in its own

--- a/src/jq/parser.rs
+++ b/src/jq/parser.rs
@@ -2878,6 +2878,39 @@ impl<'a> Parser<'a> {
 
     /// Parse a break expression.
     /// Syntax: break $name
+    /// #2687: real jq does not treat `break` as a primitive -- its parser
+    /// desugars `break $x` into a *named call* to `error/0` (`gen_call("error",
+    /// gen_noop())` in `parser.y`), resolved through ordinary lexical scope
+    /// exactly like any other call. That means a `def error:` in scope at the
+    /// break's own position intercepts it: the label stops catching it, the
+    /// def's value becomes an ordinary extra output, and evaluation continues
+    /// past the break instead of unwinding. succinctly's own `Expr::Break` is
+    /// evaluated directly with no name lookup, so a shadowing `def error:` had
+    /// no effect on it -- a silently wrong *number* of outputs, not just a
+    /// wrong value, per ADR-0018 (real jq's own inconsistency, reproduced
+    /// bug-for-bug).
+    ///
+    /// Mirrors `parse_shadowable_special_form`'s wrap step directly rather
+    /// than going through it: that helper's failure path
+    /// (`retry_shadow_candidate_as_generic_call`) re-parses the fallback as an
+    /// ordinary call *named after the keyword itself* (`break(...)`), which is
+    /// not the shape being desugared to here -- `break $x` never fails to
+    /// parse once the `$name` is read, so there is no failure path to share.
+    /// `shadowable_defs.contains("error")` is the same fast-reject the other
+    /// special forms use: on a program with no `def error` anywhere, this
+    /// parses to the exact `Expr::Break` node it always has, byte-identical
+    /// AST, zero evaluator cost.
+    ///
+    /// Deliberately does not carry jq's own `{"__jq":N}` sentinel value as the
+    /// wrapped call's (nonexistent) input -- a genuinely shadowing `def
+    /// error: .;` observes the ambient `.` here instead of that sentinel.
+    /// Recorded as a divergence in `docs/compliance/jq/limitations.md` rather
+    /// than chased: carrying it would mean *not* falling back to a bare
+    /// `Expr::Break` when nothing shadows it (the overwhelmingly common case),
+    /// widening the shape every break-aware evaluator arm
+    /// (`needs_path_context`, `owned_identity_step`, `path_context_step_generic`,
+    /// ...) has to recognize for no observable benefit outside that one
+    /// `def error: .;` construction.
     fn parse_break_expr(&mut self) -> Result<Expr, ParseError> {
         self.consume_keyword("break");
         self.skip_ws();
@@ -2889,7 +2922,12 @@ impl<'a> Parser<'a> {
         self.next();
         let name = self.parse_ident()?;
 
-        Ok(Expr::Break(name))
+        let node = Expr::Break(name);
+        if self.shadowable_defs.contains("error") {
+            Ok(Self::wrap_shadowable_call("error", node))
+        } else {
+            Ok(node)
+        }
     }
 
     /// Parse a `def`'s optional `(PARAMS)` parameter list, one [`Param`]
@@ -3607,6 +3645,7 @@ impl<'a> Parser<'a> {
                 | Expr::Range { .. }
                 | Expr::Error(_)
                 | Expr::Builtin(_)
+                | Expr::Break(_)
         ) || matches!(&original, Expr::Paren(inner) if matches!(**inner, Expr::Range { .. }));
         if !is_recognized_special_form_shape {
             return original;

--- a/src/jq/resolve.rs
+++ b/src/jq/resolve.rs
@@ -405,6 +405,11 @@ fn builtin_fallback_arity(fallback: &Expr) -> usize {
         Expr::Paren(inner) if matches!(**inner, Expr::Range { .. }) => 1,
         Expr::Range { to, step, .. } => 1 + usize::from(to.is_some()) + usize::from(step.is_some()),
         Expr::Error(msg) => usize::from(msg.is_some()),
+        // #2687: `break $x` desugars to a call to `error/0` -- see
+        // `parser.rs`'s `parse_break_expr`. The label name is not an
+        // argument (it's not even in scope as a call argument would be),
+        // so this is arity 0, same as a bare `error`.
+        Expr::Break(_) => 0,
         Expr::Builtin(builtin) => match builtin_kids(builtin) {
             BuiltinKids::None => 0,
             BuiltinKids::One(_) => 1,
@@ -464,6 +469,13 @@ fn builtin_fallback_into_args(fallback: Expr) -> Vec<Expr> {
             args
         }
         Expr::Error(msg) => msg.into_iter().map(|b| *b).collect(),
+        // #2687: `break $x`'s label name is not surfaced as an `error/0`
+        // argument -- see `builtin_fallback_arity`'s matching arm. Once this
+        // arm is reached, the shadowing `def error:` has already won (`check`
+        // only calls this after confirming `in_scope`), so the original
+        // `Expr::Break` -- label name included -- is simply discarded; it was
+        // never going to reach the label-catching machinery either way.
+        Expr::Break(_) => Vec::new(),
         // `builtin_kids` only ever borrows -- there is no by-value
         // counterpart, so this one case clones rather than moves. Bounded
         // even so: it can only fire once per node that check() has just
@@ -1076,6 +1088,86 @@ mod tests {
                 name: "nosuchfn".into(),
                 arity: 0,
             }]
+        );
+    }
+
+    /// #2687: `break $x` desugars to a resolvable `error/0` call -- a
+    /// same-name, same-arity `def error:` in scope at the break's own
+    /// position shadows it, same as any other call. Oracle: `jq-1.7.1`
+    /// answers `1`, `"S"`, `3` for
+    /// `def error: "S"; label $out | (1, break $out, 3)`.
+    #[test]
+    fn break_with_a_shadowing_arity_0_def_error_resolves_clean() {
+        assert_eq!(
+            resolve("def error: \"S\"; label $out | (1, break $out, 3)"),
+            Ok(())
+        );
+    }
+
+    /// #2687: an arity-1 `def error(m):` does not shadow a bare `break $x`
+    /// (arity 0) -- real jq's own `is_jq_builtin`-style arity distinction
+    /// applies here exactly as it does to a plain `error` call. Confirmed
+    /// live: `def error(m): "S1"; label $out | 1, break $out` still answers
+    /// `1` in jq 1.7.1.
+    #[test]
+    fn break_is_not_shadowed_by_a_different_arity_def_error() {
+        assert_eq!(
+            resolve("def error(m): \"S1\"; label $out | 1, break $out"),
+            Ok(())
+        );
+    }
+
+    /// #2687: with no `def error` anywhere in the program, `break $x` must
+    /// parse to the exact same `Expr::Break` node it always has -- not a
+    /// `FuncCall` that then falls back at resolve time. This is what keeps
+    /// every existing break/label test byte-for-byte unaffected by this
+    /// fix's parser change (`Parser::shadowable_defs`'s fast-reject, the
+    /// same one every other shadowable special form already relies on).
+    #[test]
+    fn break_with_no_def_error_anywhere_stays_a_bare_break_node() {
+        let mut expr = parse("label $out | break $out").expect("filter must parse");
+        assert!(
+            resolve_func_calls(&mut expr).is_ok(),
+            "must resolve with no unresolved calls"
+        );
+        assert!(
+            crate::jq::walk::any_subexpr(
+                &expr,
+                &mut |e| matches!(e, Expr::Break(name) if name == "out")
+            ),
+            "expected a bare Expr::Break(\"out\") node, found: {expr:?}"
+        );
+        assert!(
+            !crate::jq::walk::any_subexpr(&expr, &mut |e| matches!(
+                e,
+                Expr::FuncCall { name, .. } if name == "error"
+            )),
+            "must not have been wrapped as a FuncCall when nothing shadows it: {expr:?}"
+        );
+    }
+
+    /// #2687: the flip side of the above -- once a shadowing `def error:` is
+    /// genuinely in scope, the break site must resolve to a real call
+    /// (`DefCall`, after `eval::install_def_calls` runs) rather than staying
+    /// an `Expr::Break`. `resolve_func_calls` alone leaves a shadowed site as
+    /// an ordinary zero-arg `Expr::FuncCall { name: "error", .. }` -- the
+    /// `DefCall` rewrite is a separate, later eval-time pass -- so this
+    /// checks that intermediate shape directly.
+    #[test]
+    fn break_with_a_shadowing_def_error_becomes_an_error_call_node() {
+        let mut expr =
+            parse("def error: \"S\"; label $out | break $out").expect("filter must parse");
+        assert!(resolve_func_calls(&mut expr).is_ok());
+        assert!(
+            crate::jq::walk::any_subexpr(&expr, &mut |e| matches!(
+                e,
+                Expr::FuncCall { name, args, .. } if name == "error" && args.is_empty()
+            )),
+            "expected a resolved zero-arg `error` FuncCall node, found: {expr:?}"
+        );
+        assert!(
+            !crate::jq::walk::any_subexpr(&expr, &mut |e| matches!(e, Expr::Break(_))),
+            "the original Expr::Break must not survive once shadowed: {expr:?}"
         );
     }
 }

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -7316,6 +7316,59 @@ fn test_uncaught_break_after_output_keeps_the_prefix() -> Result<()> {
     Ok(())
 }
 
+/// #2687: real jq does not treat `break` as a primitive -- it desugars
+/// `break $x` into a *named call* to `error/0`, resolved through ordinary
+/// lexical scope. A `def error:` (arity 0) in scope at the break's own
+/// position therefore shadows it: the label stops catching it, the def's
+/// value becomes an ordinary extra output, and evaluation continues past
+/// the break instead of unwinding. Every row verified live against jq
+/// 1.7.1.
+#[test]
+fn test_break_desugars_to_a_shadowable_error_call_2687() -> Result<()> {
+    for (filter, want_stdout) in [
+        // Basic shadowing: the def's value replaces the break, evaluation
+        // continues past it.
+        (
+            r#"def error: "S"; label $out | (1, break $out, 3)"#,
+            "1\n\"S\"\n3\n",
+        ),
+        // An arity-1 `def error(m):` does not shadow a bare (arity-0) break.
+        (r#"def error(m): "S1"; label $out | 1, break $out"#, "1\n"),
+        // Scope is resolved at the break's own position, not the label's --
+        // a def declared only inside the label body shadows.
+        (r#"label $out | (def error: "S"; break $out)"#, "\"S\"\n"),
+        // The shadowing def's value is an ordinary output, not an error --
+        // nothing here for `try`/`catch` to catch.
+        (
+            r#"def error: "S"; try (label $out | break $out) catch "C""#,
+            "\"S\"\n",
+        ),
+        // Shadowing reaches a break wherever it's reached from, including
+        // through `repeat`/`limit`.
+        (
+            r#"def error: "S"; label $out | [limit(3; repeat(break $out))]"#,
+            "[\"S\",\"S\",\"S\"]\n",
+        ),
+        // With no `def error` anywhere in the program, behavior is
+        // unchanged from before this fix.
+        (r"label $out | (1, break $out, 3)", "1\n"),
+    ] {
+        let (stdout, stderr, code) = run_jq_full(&["-c", filter], Some("null"))?;
+        assert_eq!(code, 0, "`{filter}` -- stderr: {stderr:?}");
+        assert_eq!(stdout, want_stdout, "`{filter}` -- stderr: {stderr:?}");
+    }
+
+    // `error/1` (a def taking an argument) is unaffected -- jq's desugaring
+    // is specifically to the zero-arg call.
+    let (stdout, stderr, code) =
+        run_jq_full(&["-c", r#"def error: "S"; error("x")"#], Some("null"))?;
+    assert_eq!(stdout, "");
+    assert!(stderr.contains('x'), "stderr: {stderr:?}");
+    assert_eq!(code, 5);
+
+    Ok(())
+}
+
 #[test]
 fn regression_issue_575_break_in_loop_constructs_reaches_label() -> Result<()> {
     // A `break $label` raised from inside `while`/`foreach`/`repeat`'s

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -7369,6 +7369,32 @@ fn test_break_desugars_to_a_shadowable_error_call_2687() -> Result<()> {
     Ok(())
 }
 
+/// #2687 review: the sentinel-payload divergence
+/// `docs/compliance/jq/limitations.md` records is not merely "sees null
+/// instead of `{"__jq":N}`" -- a shadowing `def error:` observes whatever
+/// `.` happens to be at the break's own textual position, however unrelated
+/// to the label, where jq's own sentinel is fixed and never depends on any
+/// pipeline value. Pinned here (not just in a doc's console block) so a
+/// future change to this mechanism can't silently make the substitute value
+/// worse without a test catching it. `succinctly`'s answer is intentionally
+/// *not* asserted to match jq's -- this row exists to keep the *shape* of
+/// the known divergence from drifting, not to claim fidelity here.
+#[test]
+fn test_break_shadowed_by_def_error_sees_ambient_input_not_jqs_sentinel_2687() -> Result<()> {
+    let (stdout, stderr, code) = run_jq_full(
+        &[
+            "-c",
+            r"def error: {seen: .}; 5 as $x | label $out | ($x | break $out)",
+        ],
+        Some("null"),
+    )?;
+    assert_eq!(code, 0, "stderr: {stderr:?}");
+    // jq 1.7.1: {"seen":{"__jq":0}} -- the fixed, label-indexed sentinel,
+    // never the unrelated `5` bound three stages earlier.
+    assert_eq!(stdout, "{\"seen\":5}\n", "stderr: {stderr:?}");
+    Ok(())
+}
+
 #[test]
 fn regression_issue_575_break_in_loop_constructs_reaches_label() -> Result<()> {
     // A `break $label` raised from inside `while`/`foreach`/`repeat`'s

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -18486,6 +18486,34 @@ fn test_bare_break_outside_label_reports_error() -> Result<()> {
     Ok(())
 }
 
+/// #2687: `label`/`break`/`def` are all ungated succinctly extensions in yq
+/// mode (real yq v4.53.3 rejects all three at its lexer) -- extension-on-
+/// extension, no oracle, but the same fix applies here since `yq_runner`
+/// runs the identical `resolve_func_calls` pass. Mirrors
+/// `test_break_desugars_to_a_shadowable_error_call_2687` in
+/// `jq_cli_tests.rs`.
+#[test]
+fn test_yq_break_desugars_to_a_shadowable_error_call_2687() -> Result<()> {
+    let doc = "a: 1\n";
+    for (filter, want) in [
+        (
+            r#"def error: "S"; label $out | (1, break $out, 3)"#,
+            "1\n\"S\"\n3",
+        ),
+        (r#"def error(m): "S1"; label $out | 1, break $out"#, "1"),
+        (r"label $out | (1, break $out, 3)", "1"),
+    ] {
+        let (stdout, stderr, code) = run_yq_stdin_with_stderr(filter, doc, &["-o=json", "-I=0"])?;
+        assert_eq!(code, 0, "#2687: `{filter}` -- stderr: {stderr:?}");
+        assert_eq!(
+            stdout.trim(),
+            want,
+            "#2687: `{filter}` -- stderr: {stderr:?}"
+        );
+    }
+    Ok(())
+}
+
 // ============================================================================
 // --split-exp Tests (#715)
 // ============================================================================


### PR DESCRIPTION
## Summary

Real jq does not treat `break` as a primitive — its parser desugars `break $x` into a named call to `error/0` (`gen_call("error", gen_noop())` in `parser.y`), resolved through ordinary lexical scope. A `def error:` (arity 0) in scope at the break's own position therefore shadows it: the label stops catching it, the def's own value becomes an ordinary extra output, and evaluation continues past the break instead of unwinding.

succinctly represented `break` as a dedicated `Expr` node evaluated directly with no name lookup, so a shadowing `def error:` had no effect — a silently wrong *number* of outputs, not just a wrong value. Per ADR-0018, this is the reference tool's own inconsistency, in the category the rule says to reproduce bug-for-bug.

`parse_break_expr` now inlines the same shadow-gate every other special form (`error`, `limit`, `until`, ...) already goes through: on `Parser::shadowable_defs.contains("error")`, the freshly-built `Expr::Break(name)` is wrapped via `wrap_shadowable_call("error", ..)` into a `FuncCall{name: "error", args: [], builtin_fallback: Some(Break(name))}` that `resolve.rs`'s existing three-stage mechanism already knows how to unwrap. Three small additions to `resolve.rs`'s existing match arms: arity 0 in `builtin_fallback_arity`, an empty `Vec` in `builtin_fallback_into_args`, and `Expr::Break` added to `wrap_shadowable_call`'s recognized-shape allowlist.

On a program with no `def error` anywhere — the overwhelming majority — `Parser::shadowable_defs`'s fast-reject means `break` parses to the exact same `Expr::Break` node it always has: confirmed by the full existing test suite (99 break-touching tests in `jq_cli_tests.rs` alone) passing completely unmodified.

Deliberately does not carry jq's own `{"__jq":N}` sentinel value as the wrapped call's input — a shadowing `def error: .;` observes the ambient `.` instead. Recorded in `docs/compliance/jq/limitations.md` rather than chased.

Also documents and defers a second, related gap found during investigation: `label`'s own error re-raise is *also* `gen_call(error)` in real jq, resolved at the label's own position — filed separately as #2840 (a materially larger change spanning both evaluators' label-catching arms).

Fixes #2687.

## Test plan

- [x] `cargo build --features cli`
- [x] `cargo test --features cli,simd,regex,serde` (full suite, 1848 jq_cli_tests + all others, all green — every existing break/label test passes unmodified)
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings`
- [x] Verified against pinned jq 1.7.1 for every case in the issue's own repro table, plus position-dependent-scope, try/catch-doesn't-catch-the-value, and repeat/limit cases
- [x] New `resolve.rs` unit tests pinning both the shadowed and not-shadowed AST shapes directly
- [x] New CLI tests in `jq_cli_tests.rs` and `yq_cli_tests.rs` (yq mode picks up the fix for free — `label`/`break`/`def` are all ungated succinctly extensions there)