### PR TITLE
fix(jq): a nested zero-arg def is in scope inside its own recursive body

### DIFF
--- a/docs/compliance/jq/limitations.md
+++ b/docs/compliance/jq/limitations.md
@@ -2752,7 +2752,13 @@ Three differences remain, all in the direction of erroring rather than aborting:
 - **A non-terminating `def` errors; jq dies.** `def deep: [deep]; deep` and `def f: [f, f];
   f` exceed `MAX_EVAL_FRAMES` and raise a catchable error, exit 5. Real jq aborts on both
   with `cannot allocate memory` and exit 134 (confirmed live). Divergence in the only
-  direction ADR-0018 permits: matching would take the process down.
+  direction ADR-0018 permits: matching would take the process down. [#2737](https://github.com/rust-works/succinctly/issues/2737)
+  fixed a shadow bug (a nested zero-arg `def` sharing a name with an enclosing
+  parameter wasn't in scope inside its own body, so it silently resolved to the
+  stale parameter instead of recursing) that had been keeping some of these shapes
+  terminating with a wrong answer instead of reaching this same divergence:
+  `def f(a): def a: a+1; a; f(1)` now hits `MAX_EVAL_FRAMES` where it used to answer
+  `2`.
 - **A heavy body runs out of depth sooner than jq's does.** jq evaluates on a
   heap-allocated VM stack (confirmed against jq 1.7.1's source: `exec_stack.h`'s
   `struct stack` grows via `realloc` through `jv_mem_realloc`, and `execute.c`'s

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -50054,19 +50054,20 @@ struct SubstScope {
     /// Bare `param` (`Expr::FuncCall { args: [] }`) still resolves to this
     /// call's own argument. Only a *filter*-namespace binder clears it: a
     /// nested `def`'s matching parameter (of either spelling, since both
-    /// bind the bare name), or -- in that def's `then` -- a nested
-    /// zero-argument `def` of the name. An `as`/`reduce`/`foreach` binder
-    /// never does, however it is spelled: confirmed live against jq 1.7.1,
-    /// `def f(g): 1 as $g | $g + g; 10 as $g | f($g)` is `11` -- the inner
-    /// `1 as $g` shadows the inner `$g` (evaluating to `1`) and never the
-    /// bare `g` (still the caller's `$g`, `10`).
+    /// bind the bare name), or a nested zero-argument `def` of the name --
+    /// in **both** its `body` and its `then` (#2737: `def` is recursive in
+    /// jq, so a zero-argument `def` of `param`'s own name is in scope inside
+    /// its own body too, not just after it). An `as`/`reduce`/`foreach`
+    /// binder never clears this, however it is spelled: confirmed live
+    /// against jq 1.7.1, `def f(g): 1 as $g | $g + g; 10 as $g | f($g)` is
+    /// `11` -- the inner `1 as $g` shadows the inner `$g` (evaluating to `1`)
+    /// and never the bare `g` (still the caller's `$g`, `10`).
     ///
-    /// A nested zero-argument `def` does **not** clear this inside its own
-    /// `body`, where jq also has it in scope (`def` is recursive there).
-    /// That gap predates #2555 and is deliberately left alone: closing it
-    /// makes `def f(a): def a: a+1; a; f(1)` recurse forever, as jq does,
-    /// so it is a behaviour change that needs its own oracle matrix rather
-    /// than a drive-by. Tracked as #2737.
+    /// Closing the `body` gap (#2737) can turn a terminating program into a
+    /// non-terminating one, matching jq: `def f(a): def a: a+1; a; f(1)` now
+    /// hits `MAX_EVAL_FRAMES` and errors cleanly (exit 5) where jq itself
+    /// aborts with `cannot allocate memory` -- see the "non-terminating def"
+    /// divergence in `docs/compliance/jq/limitations.md`.
     bare: bool,
 }
 
@@ -50292,7 +50293,19 @@ fn substitute_func_param_impl(expr: &Expr, param: &str, arg: &Expr, scope: Subst
             // here. So the bare namespace is shadowed by a matching
             // parameter of *either* spelling, while the `$` namespace is
             // shadowed only when the binding one is `$`-style.
-            let mut body_scope = scope;
+            // #2737: `def` is recursive in jq -- a nested zero-argument
+            // `def` of `param`'s own name is in scope inside its *own*
+            // `body` too, exactly as it is in `then` above, so the same
+            // `name == param && params.is_empty()` condition applies here.
+            // Before this fix only `then_scope` cleared it, so a bare
+            // self-reference inside the nested def's own body kept
+            // resolving to the outer parameter's substituted argument
+            // instead of recursing.
+            let mut body_scope = if name == param && params.is_empty() {
+                scope.without_bare()
+            } else {
+                scope
+            };
             if params.iter().any(|p| p.name() == param) {
                 body_scope = body_scope.without_bare();
             }
@@ -70087,6 +70100,25 @@ mod tests {
         // `body` (the pre-existing `body_shadowed` check) -- confirmed
         // against jq 1.7.1: `1` (h's own g=1), not `2` (f's outer g).
         assert_eq!(outputs(b"null", "def f(g): def h(g): g; h(1); f(2)"), ["1"]);
+    }
+
+    #[test]
+    fn test_func_arg_nested_zero_arg_def_of_params_own_name_is_in_scope_in_its_own_body_2737() {
+        // #2737: `def` is recursive in jq -- a nested zero-argument `def` of
+        // the enclosing parameter's own name is in scope inside its own
+        // `body`, not just in `then` (the pre-existing `then_scope` check
+        // from #2077). Before this fix `body_scope` never cleared `bare` for
+        // this case, so the recursive self-reference resolved to `f`'s own
+        // substituted argument (`1`) on the very first step instead of
+        // recursing -- confirmed against jq 1.7.1: `100` (recursing
+        // `3 -> 2 -> 1 -> 0`), not `1`.
+        assert_eq!(
+            outputs(
+                b"null",
+                "def f(a): def a: if . > 0 then (.-1|a) else 100 end; (3|a); f(1)"
+            ),
+            ["100"]
+        );
     }
 
     #[test]

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -50262,11 +50262,18 @@ fn substitute_func_param_impl(expr: &Expr, param: &str, arg: &Expr, scope: Subst
             // one -- confirmed live against jq 1.7.1, `def f($a): def a: 99;
             // $a; f(2)` is `2` (this used to block both namespaces and
             // answered "undefined variable: $a").
-            let then_scope = if name == param && params.is_empty() {
+            // #2737 review: `then_scope` and `body_scope` both start from
+            // this same self-shadow check -- computed once here so a future
+            // edit to the condition (or to a new namespace rule) cannot be
+            // applied to one and not the other the way #2737 itself
+            // happened (the check below was added to `then_scope` alone by
+            // #2077 and stayed missing from `body_scope` for years).
+            let self_shadow_scope = if name == param && params.is_empty() {
                 scope.without_bare()
             } else {
                 scope
             };
+            let then_scope = self_shadow_scope;
             // #2283 review: this blanket "any matching param name shadows,
             // bare or `$`-style alike" is correct as-is for the *bare*
             // `param`-reference substitution this arm mostly exists for --
@@ -50295,17 +50302,20 @@ fn substitute_func_param_impl(expr: &Expr, param: &str, arg: &Expr, scope: Subst
             // shadowed only when the binding one is `$`-style.
             // #2737: `def` is recursive in jq -- a nested zero-argument
             // `def` of `param`'s own name is in scope inside its *own*
-            // `body` too, exactly as it is in `then` above, so the same
-            // `name == param && params.is_empty()` condition applies here.
-            // Before this fix only `then_scope` cleared it, so a bare
-            // self-reference inside the nested def's own body kept
-            // resolving to the outer parameter's substituted argument
-            // instead of recursing.
-            let mut body_scope = if name == param && params.is_empty() {
-                scope.without_bare()
-            } else {
-                scope
-            };
+            // `body` too, exactly as it is in `then` above, so `body_scope`
+            // starts from the identical `self_shadow_scope` computed above
+            // rather than plain `scope`. Before this fix `body_scope` never
+            // narrowed for this case, so a bare self-reference inside the
+            // nested def's own body kept resolving to the outer parameter's
+            // substituted argument instead of recursing.
+            //
+            // The two `if`s below are mutually exclusive with
+            // `self_shadow_scope`'s own condition: they fire only when
+            // `params` is non-empty, which `self_shadow_scope`'s
+            // `params.is_empty()` rules out -- so there is no double-clear
+            // to reason about, only three independent ways to reach
+            // `without_bare()`/`without_dollar()` (idempotent either way).
+            let mut body_scope = self_shadow_scope;
             if params.iter().any(|p| p.name() == param) {
                 body_scope = body_scope.without_bare();
             }

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -21153,6 +21153,47 @@ fn test_composed_recursion_across_two_defs_errors_not_aborts_1371() -> Result<()
     Ok(())
 }
 
+/// #2737: `substitute_func_param_impl`'s `Expr::FuncDef` arm cleared the
+/// bare namespace for a nested zero-argument `def` of the enclosing
+/// parameter's own name in that def's `then` but not in its `body` -- so a
+/// self-recursive reference inside the nested def's own body resolved to
+/// the outer parameter's substituted argument instead of recursing. Oracle-
+/// verified against jq 1.7.1: `100` (recursing `3 -> 2 -> 1 -> 0`), not `1`.
+#[test]
+fn test_nested_zero_arg_def_of_params_own_name_recurses_in_its_own_body_2737() -> Result<()> {
+    let (stdout, stderr, code) = run_jq_full(
+        &[
+            "-nc",
+            "def f(a): def a: if . > 0 then (.-1|a) else 100 end; (3|a); f(1)",
+        ],
+        None,
+    )?;
+    assert_eq!(code, 0, "stderr: {stderr:?}");
+    assert_eq!(stdout.trim_end(), "100");
+    Ok(())
+}
+
+/// #2737 control: closing the body-scope gap above can turn a terminating
+/// (wrong) answer into jq's own non-terminating one -- `def f(a): def a:
+/// a+1; a; f(1)` used to answer `2` (one substitution, no recursion); it now
+/// recurses for real and hits `MAX_EVAL_FRAMES`, erroring cleanly (exit 5)
+/// rather than hanging or overflowing the native stack, matching the
+/// documented "non-terminating def" divergence in
+/// docs/compliance/jq/limitations.md -- real jq aborts the process with
+/// `cannot allocate memory` on this same program (confirmed live).
+#[test]
+fn test_nested_zero_arg_def_self_recursion_hits_the_frame_guard_not_a_wrong_answer_2737(
+) -> Result<()> {
+    let (stdout, stderr, code) = run_jq_full(&["-nc", "def f(a): def a: a+1; a; f(1)"], None)?;
+    assert_eq!(stdout.trim_end(), "");
+    assert_eq!(code, 5, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert!(
+        stderr.contains("exceeded maximum recursion depth"),
+        "stderr: {stderr:?}"
+    );
+    Ok(())
+}
+
 /// #1371 follow-up code-review: end-to-end companion to
 /// `jq::eval::tests::test_bind_def_seeds_defcall_frames_from_ambient_depth_1371`
 /// (a fast, white-box pin of the same mechanism -- see its own doc comment


### PR DESCRIPTION
## Summary
- `substitute_func_param_impl`'s `Expr::FuncDef` arm cleared the bare namespace for a nested zero-argument `def` of the enclosing parameter's own name in that def's `then` (the `then_scope` check, from #2077), but not in its `body` -- even though `def` is recursive in jq, so the name is in scope in both.
- `def f(a): def a: if . > 0 then (.-1|a) else 100 end; (3|a); f(1)` resolved the recursive self-reference to `f`'s own substituted argument on the first step and answered `1`; it now recurses `3 -> 2 -> 1 -> 0` and answers `100`, matching jq 1.7.1.
- Fixed by applying the same `name == param && params.is_empty()` condition to `body_scope`, mirroring the existing `then_scope` check (the issue's own suggested fix direction).
- This can turn a terminating (wrong) program into jq's own non-terminating one: `def f(a): def a: a+1; a; f(1)` now hits `MAX_EVAL_FRAMES` and errors cleanly (exit 5) instead of answering `2`, matching the already-documented "non-terminating def" divergence in `docs/compliance/jq/limitations.md` (real jq aborts the process with `cannot allocate memory` on this same program).
- Related to, but distinct from, #2738 (already merged): that issue was about `install_def_calls` (an *earlier* def's install pass not checking whether a *later* def's own parameters shadow it); this one is about `substitute_func_param_impl` (an enclosing parameter's substitution not stopping at a nested def's own recursive body).

Fixes #2737

## Test plan
- [x] New regression tests: `test_func_arg_nested_zero_arg_def_of_params_own_name_is_in_scope_in_its_own_body_2737` (`src/jq/eval.rs`), `test_nested_zero_arg_def_of_params_own_name_recurses_in_its_own_body_2737` and `test_nested_zero_arg_def_self_recursion_hits_the_frame_guard_not_a_wrong_answer_2737` (`tests/jq_cli_tests.rs`), oracle-verified against jq 1.7.1
- [x] Both of the issue's own repro cases verified live against the fix
- [x] Regression-checked adjacent #2077/#2555 shadow scenarios against jq 1.7.1 -- all match
- [x] `cargo test --features cli` -- full suite passes, 0 failures
- [x] `cargo clippy --all-targets --all-features -- -D warnings` -- clean
- [x] Patch coverage: 100% (9/9 new lines covered)