### PR TITLE
fix(yq): pass the root cursor into the JSON DOM bridge, close #2781's top-level [,] leak

### DIFF
--- a/docs/compliance/jq/limitations.md
+++ b/docs/compliance/jq/limitations.md
@@ -1642,8 +1642,21 @@ practice #2243's own issue text cites for not folding into #2211):
   before the tail check -- and now thread it through the same way, via a shared
   `tail_gap_ok` helper (`document.rs`) extracted in review rather than a third and fourth
   hand-copy of the `container_tail_gap_ok`/`child_tail_gap_ok` dispatch. Only the true top
-  level (`to_owned`'s and `to_owned_canonicalizing_numbers`'s own depth-0 entry points, no
-  cursor to give) keeps the gap, matching `eval_generic.rs`'s own residual scope above.
+  level (`to_owned`'s own depth-0 entry point, no cursor to give) keeps the gap, matching
+  `eval_generic.rs`'s own residual scope above.
+
+  **Update (#2781, yq mode)**: `to_owned_canonicalizing_numbers`'s own depth-0 entry point
+  -- the true-top-level exception this note originally named alongside `to_owned`'s -- is
+  closed. `parse_input`'s JSON arm (`yq_runner.rs`, the only caller reaching this
+  materializer, for `--slurp`/`--eval-all`/`--inplace --input-format json`) already held the
+  root cursor and simply was not threading it through; `to_owned_canonicalizing_numbers`
+  is now folded into `to_owned_canonicalizing_numbers_at_depth`, whose `cursor` parameter is
+  a bare `&V::Cursor` (no longer `Option`) since every call site in that file has one.
+  `to_owned`'s own top-level gap (jq mode, `eval.rs`/`eval_generic.rs`) is untouched by
+  #2781 -- currently not independently reachable there (parser-level validation intercepts
+  a top-level `[,]`/`{,}` before `to_owned` runs on every route probed), but that is
+  incidental protection from a different layer, not a guarantee `to_owned_at_depth`'s own
+  signature enforces the way `to_owned_canonicalizing_numbers_at_depth`'s now does.
 - **#2263**: `jq_runner.rs` still carries its own independent, hand-copied
   `trailing_gap_ok`/`scalar_end_pos` pair rather than the new trait methods --
   a cleanup, not a behavior gap, but the same "duplicated predicates diverge

--- a/docs/compliance/yq/limitations.md
+++ b/docs/compliance/yq/limitations.md
@@ -945,14 +945,25 @@ input), so `[1,]`, `[,1]`, `[1,,2]`, `[,]` and their nested forms error on every
 parses through `YamlIndex` — the plain stdout path this issue was filed about, for every
 filter.
 
-**One shape is still accepted, and it is on the other family of routes**: a *top-level*
-`[,]` (only `[,]` itself — `[[,]]` and `{"a":[,]}` are refused) still passes on
-`--slurp`/`--eval-all`/`--inplace`, which materialize through `JsonIndex`'s DOM bridge
-rather than this parser, and whose check needs a cursor for the outermost container that
-the bridge does not have. `succinctly yq -p json -i '.'` on a file containing `[,]`
-therefore rewrites it to `[]`, where real yq refuses the file and leaves it untouched.
-That route disagreeing with the stdout route is *new* — before #2279 both accepted it —
-and it is tracked as [#2781](https://github.com/rust-works/succinctly/issues/2781).
+**Closed on the other family of routes by [#2781](https://github.com/rust-works/succinctly/issues/2781).**
+A *top-level* `[,]` (only `[,]` itself — `[[,]]` and `{"a":[,]}` were already refused)
+still passed on `--slurp`/`--eval-all`/`--inplace`, which materialize through `JsonIndex`'s
+DOM bridge rather than this parser. The premise that the bridge's check "needs a cursor for
+the outermost container it does not have" was false: `yq_runner.rs`'s `parse_input` already
+holds the root cursor when it builds the initial `OwnedValue`, it simply was not threading it
+down to `to_owned_canonicalizing_numbers_at_depth` — every *nested* container already got its
+own cursor this same way (#2403). Passing the root cursor through closes the top-level gap
+the identical way. `succinctly yq -p json -i '.'` on a file containing `[,]` used to rewrite
+it to `[]`; it now raises and leaves the file untouched, matching real yq's own refusal.
+
+Passing the root cursor also makes the DOM-bridge route's **top-level `{,}`** consistent
+with its own nested rejection — before #2781 the top level accepted `{,}` (agreeing with real
+yq only by construction, since the check simply could not reach it) while `{"a":{,}}` was
+already refused one level down. #2781 chose consistency with the route's own nested behaviour
+over preserving that accidental top-level agreement; the resulting divergence from real yq
+(which does accept top-level and nested `{,}`) is not new to this fix and is recorded with
+the DOM bridge's other flow-mapping delimiter gaps in #2777 below, not carved out as a
+special case here.
 
 Scope is flow **sequence delimiters** only, and never mapping delimiters, because that is
 where real yq (v4.53.3, captured live) actually draws the line — the asymmetry this section

--- a/src/bin/succinctly/yq_runner.rs
+++ b/src/bin/succinctly/yq_runner.rs
@@ -1137,13 +1137,14 @@ fn gather_input_sources(
 /// to have no cursor for the container itself to close `[,]`/`{,}` with, but
 /// that premise was false -- `parse_input`'s JSON arm already holds the root
 /// cursor when it calls this function, it simply was not being passed down.
-/// `cursor` below is `None` only for a handful of direct unit-test callers
-/// that intentionally probe this function without a container cursor in
-/// scope; every real call site (`parse_input`, and every recursive call this
-/// function makes for a child) always has one.
+/// `cursor` is a bare reference, not an `Option`, unlike its
+/// `eval_generic::to_owned_at_depth` sibling (which still has genuine `None`
+/// callers -- `to_owned`'s own top-level entry point among them): every call
+/// site in this file, `parse_input` and every recursive call this function
+/// makes for a child alike, always has one now.
 fn to_owned_canonicalizing_numbers_at_depth<V: DocumentValue>(
     value: &V,
-    cursor: Option<&V::Cursor>,
+    cursor: &V::Cursor,
     depth: usize,
 ) -> Result<OwnedValue, EvalError> {
     // `check_nesting_depth` (256, matching `eval_generic::to_owned_at_depth`
@@ -1159,9 +1160,9 @@ fn to_owned_canonicalizing_numbers_at_depth<V: DocumentValue>(
     //
     // #2282: `check_nesting_depth`, the catchable sibling of
     // `assert_nesting_depth` (#1818), not the panicking guard itself --
-    // this function's only two callers (`to_owned_canonicalizing_numbers`,
-    // reached from `parse_input`'s JSON arm) sit ahead of any user filter
-    // evaluation, parsing raw external JSON text for `--slurp`/
+    // this function's only non-recursive caller (`parse_input`'s JSON arm,
+    // #2781) sits ahead of any user filter evaluation, parsing raw external
+    // JSON text for `--slurp`/
     // `--eval-all`/`--inplace`. That's CLI-level input parsing, not the
     // evaluator's own hot recursion over an already-parsed value -- the
     // same distinction `jq_runner.rs`'s `json_bytes_to_owned_value_checked`
@@ -1203,7 +1204,7 @@ fn to_owned_canonicalizing_numbers_at_depth<V: DocumentValue>(
                 key,
                 to_owned_canonicalizing_numbers_at_depth(
                     &field.value,
-                    Some(&field.value_cursor),
+                    &field.value_cursor,
                     depth + 1,
                 )?,
             );
@@ -1218,13 +1219,11 @@ fn to_owned_canonicalizing_numbers_at_depth<V: DocumentValue>(
         if f.ends_unpaired() {
             return Err(f.malformed_member_error());
         }
-        // #2403: with `cursor` in hand (every level but the true top),
-        // `tail_gap_ok` closes #2211's `{,}` gap the same way
-        // `eval_generic::to_owned_at_depth` does since #2358 -- its own
-        // `None` fallback (only ever hit at the true top level) still
-        // can't, for the reason this function's own doc comment above
-        // explains.
-        tail_gap_ok(cursor, last_field.as_ref(), b'}')?;
+        // #2403/#2781: `cursor` is always in hand now (see this function's
+        // own doc comment above), so `tail_gap_ok` always takes its
+        // `container_tail_gap_ok` arm here, closing #2211's `{,}` gap the
+        // same way `eval_generic::to_owned_at_depth` does since #2358.
+        tail_gap_ok(Some(cursor), last_field.as_ref(), b'}')?;
         OwnedValue::Object(map)
     } else if let Some(elements) = value.as_array() {
         let mut items = Vec::new();
@@ -1244,7 +1243,7 @@ fn to_owned_canonicalizing_numbers_at_depth<V: DocumentValue>(
             }
             items.push(to_owned_canonicalizing_numbers_at_depth(
                 &elem_cursor.value(),
-                Some(&elem_cursor),
+                &elem_cursor,
                 depth + 1,
             )?);
             last_elem = Some(elem_cursor);
@@ -1252,7 +1251,7 @@ fn to_owned_canonicalizing_numbers_at_depth<V: DocumentValue>(
             is_first = false;
         }
         // #2403: same reasoning as the object arm's own check above.
-        tail_gap_ok(cursor, last_elem.as_ref(), b']')?;
+        tail_gap_ok(Some(cursor), last_elem.as_ref(), b']')?;
         OwnedValue::Array(items)
     } else if value.is_null() {
         OwnedValue::Null
@@ -1399,7 +1398,7 @@ fn parse_input(bytes: &[u8], format: InputFormat) -> Result<Vec<OwnedValue>> {
             // an empty top-level container (`[,]`/`{,}`) -- every *nested*
             // level already gets `Some(cursor)` (#2403) and closes the same
             // gap via `container_tail_gap_ok`.
-            let value = to_owned_canonicalizing_numbers_at_depth(&cursor.value(), Some(&cursor), 0)
+            let value = to_owned_canonicalizing_numbers_at_depth(&cursor.value(), &cursor, 0)
                 .map_err(|e| anyhow::anyhow!("{e}"))?;
             Ok(vec![value])
         }
@@ -8776,14 +8775,13 @@ mod tests {
         let json = linear_json_nest(255);
         let index = JsonIndex::build(json.as_bytes());
         let cursor = index.root(json.as_bytes());
-        let owned =
-            to_owned_canonicalizing_numbers_at_depth(&cursor.value(), Some(&cursor), 0).unwrap();
+        let owned = to_owned_canonicalizing_numbers_at_depth(&cursor.value(), &cursor, 0).unwrap();
         assert!(matches!(owned, OwnedValue::Object(_)));
 
         let json = linear_json_nest(256);
         let index = JsonIndex::build(json.as_bytes());
         let cursor = index.root(json.as_bytes());
-        let result = to_owned_canonicalizing_numbers_at_depth(&cursor.value(), Some(&cursor), 0);
+        let result = to_owned_canonicalizing_numbers_at_depth(&cursor.value(), &cursor, 0);
         assert!(
             result.is_err(),
             "to_owned_canonicalizing_numbers should raise a catchable error at depth 256"
@@ -8801,8 +8799,7 @@ mod tests {
         let json = br#"{"int": 1, "float": 1.50, "exp": 1e2, "neg": -3, "arr": [1.0, 2], "s": "x", "b": true, "n": null}"#;
         let index = JsonIndex::build(json);
         let cursor = index.root(json);
-        let owned =
-            to_owned_canonicalizing_numbers_at_depth(&cursor.value(), Some(&cursor), 0).unwrap();
+        let owned = to_owned_canonicalizing_numbers_at_depth(&cursor.value(), &cursor, 0).unwrap();
         let OwnedValue::Object(map) = owned else {
             panic!("expected an object")
         };
@@ -8853,8 +8850,8 @@ mod tests {
         for json in [br#"{"n": 5.}"#.as_slice(), br#"{"n": .5}"#.as_slice()] {
             let index = JsonIndex::build(json);
             let cursor = index.root(json);
-            let owned = to_owned_canonicalizing_numbers_at_depth(&cursor.value(), Some(&cursor), 0)
-                .unwrap();
+            let owned =
+                to_owned_canonicalizing_numbers_at_depth(&cursor.value(), &cursor, 0).unwrap();
             let OwnedValue::Object(map) = owned else {
                 panic!("expected an object for {json:?}")
             };
@@ -8881,8 +8878,8 @@ mod tests {
         ] {
             let index = JsonIndex::build(json);
             let cursor = index.root(json);
-            let owned = to_owned_canonicalizing_numbers_at_depth(&cursor.value(), Some(&cursor), 0)
-                .unwrap();
+            let owned =
+                to_owned_canonicalizing_numbers_at_depth(&cursor.value(), &cursor, 0).unwrap();
             let OwnedValue::Object(map) = owned else {
                 panic!("expected an object for {json:?}")
             };
@@ -8914,7 +8911,7 @@ mod tests {
         ] {
             let index = JsonIndex::build(json);
             let cursor = index.root(json);
-            to_owned_canonicalizing_numbers_at_depth(&cursor.value(), Some(&cursor), 0)
+            to_owned_canonicalizing_numbers_at_depth(&cursor.value(), &cursor, 0)
                 .expect_err(&format!("{json:?} is not well-formed JSON"));
         }
 
@@ -8922,8 +8919,7 @@ mod tests {
         let json = br#"{"a": 1, "b": 2}"#;
         let index = JsonIndex::build(json);
         let cursor = index.root(json);
-        let owned =
-            to_owned_canonicalizing_numbers_at_depth(&cursor.value(), Some(&cursor), 0).unwrap();
+        let owned = to_owned_canonicalizing_numbers_at_depth(&cursor.value(), &cursor, 0).unwrap();
         assert_eq!(
             owned,
             OwnedValue::Object(IndexMap::from([
@@ -8936,7 +8932,7 @@ mod tests {
         let json = br"[1 2, 3]";
         let index = JsonIndex::build(json);
         let cursor = index.root(json);
-        to_owned_canonicalizing_numbers_at_depth(&cursor.value(), Some(&cursor), 0)
+        to_owned_canonicalizing_numbers_at_depth(&cursor.value(), &cursor, 0)
             .expect_err("a missing ',' between array elements is not well-formed JSON");
     }
 
@@ -8955,7 +8951,7 @@ mod tests {
         let json = br#"{"a": 1, 123: 2, "b": 3}"#;
         let index = JsonIndex::build(json);
         let cursor = index.root(json);
-        to_owned_canonicalizing_numbers_at_depth(&cursor.value(), Some(&cursor), 0)
+        to_owned_canonicalizing_numbers_at_depth(&cursor.value(), &cursor, 0)
             .expect_err("a non-string key is not well-formed JSON");
 
         // A structurally malformed value token (not a decode failure -- a
@@ -8964,7 +8960,7 @@ mod tests {
         let json = br"[xyz123]";
         let index = JsonIndex::build(json);
         let cursor = index.root(json);
-        to_owned_canonicalizing_numbers_at_depth(&cursor.value(), Some(&cursor), 0)
+        to_owned_canonicalizing_numbers_at_depth(&cursor.value(), &cursor, 0)
             .expect_err("an unclassifiable value token is not well-formed JSON");
     }
 
@@ -8981,7 +8977,7 @@ mod tests {
         for json in [&br"[1,]"[..], &br#"{"a":1,}"#[..]] {
             let index = JsonIndex::build(json);
             let cursor = index.root(json);
-            to_owned_canonicalizing_numbers_at_depth(&cursor.value(), Some(&cursor), 0).expect_err(
+            to_owned_canonicalizing_numbers_at_depth(&cursor.value(), &cursor, 0).expect_err(
                 &format!("{json:?}: a trailing comma after a real last child is not JSON"),
             );
         }
@@ -8990,8 +8986,7 @@ mod tests {
         let json = br#"{"a":1,"b":2}"#;
         let index = JsonIndex::build(json);
         let cursor = index.root(json);
-        let owned =
-            to_owned_canonicalizing_numbers_at_depth(&cursor.value(), Some(&cursor), 0).unwrap();
+        let owned = to_owned_canonicalizing_numbers_at_depth(&cursor.value(), &cursor, 0).unwrap();
         assert_eq!(
             owned,
             OwnedValue::Object(IndexMap::from([
@@ -9003,7 +8998,7 @@ mod tests {
         let index = JsonIndex::build(json);
         let cursor = index.root(json);
         assert_eq!(
-            to_owned_canonicalizing_numbers_at_depth(&cursor.value(), Some(&cursor), 0).unwrap(),
+            to_owned_canonicalizing_numbers_at_depth(&cursor.value(), &cursor, 0).unwrap(),
             OwnedValue::Array(vec![
                 OwnedValue::Int(1),
                 OwnedValue::Int(2),
@@ -9033,7 +9028,7 @@ mod tests {
         for json in [&br"[,]"[..], &br"{,}"[..]] {
             let index = JsonIndex::build(json);
             let cursor = index.root(json);
-            let err = to_owned_canonicalizing_numbers_at_depth(&cursor.value(), Some(&cursor), 0)
+            let err = to_owned_canonicalizing_numbers_at_depth(&cursor.value(), &cursor, 0)
                 .expect_err("a stray comma in a top-level empty container is not JSON");
             assert!(
                 err.message.contains("Invalid JSON text"),
@@ -9051,7 +9046,7 @@ mod tests {
         for json in [&br"[]"[..], &br"[ ]"[..], &br"{}"[..], &br"{ }"[..]] {
             let index = JsonIndex::build(json);
             let cursor = index.root(json);
-            let owned = to_owned_canonicalizing_numbers_at_depth(&cursor.value(), Some(&cursor), 0)
+            let owned = to_owned_canonicalizing_numbers_at_depth(&cursor.value(), &cursor, 0)
                 .unwrap_or_else(|e| panic!("{json:?}: expected Ok, got {e:?}"));
             assert!(
                 matches!(&owned, OwnedValue::Array(v) if v.is_empty())
@@ -9077,7 +9072,7 @@ mod tests {
         for json in [&br#"{"a": {,}}"#[..], &br#"{"a": [,]}"#[..]] {
             let index = JsonIndex::build(json);
             let cursor = index.root(json);
-            let err = to_owned_canonicalizing_numbers_at_depth(&cursor.value(), Some(&cursor), 0)
+            let err = to_owned_canonicalizing_numbers_at_depth(&cursor.value(), &cursor, 0)
                 .expect_err("a stray comma in a nested empty container is not JSON");
             assert!(
                 err.message.contains("Invalid JSON text"),
@@ -9097,7 +9092,7 @@ mod tests {
         for json in [&br#"{"a": {"b":1,}}"#[..], &br#"{"a": [1,]}"#[..]] {
             let index = JsonIndex::build(json);
             let cursor = index.root(json);
-            let err = to_owned_canonicalizing_numbers_at_depth(&cursor.value(), Some(&cursor), 0)
+            let err = to_owned_canonicalizing_numbers_at_depth(&cursor.value(), &cursor, 0)
                 .expect_err("a stray trailing comma after a real nested child is not JSON");
             assert!(
                 err.message.contains("Invalid JSON text"),
@@ -9128,7 +9123,7 @@ mod tests {
             ("d".to_string(), OwnedValue::Array(vec![])),
         ]));
         assert_eq!(
-            to_owned_canonicalizing_numbers_at_depth(&cursor.value(), Some(&cursor), 0).unwrap(),
+            to_owned_canonicalizing_numbers_at_depth(&cursor.value(), &cursor, 0).unwrap(),
             expected
         );
     }

--- a/src/bin/succinctly/yq_runner.rs
+++ b/src/bin/succinctly/yq_runner.rs
@@ -1129,20 +1129,18 @@ fn gather_input_sources(
 /// `echo '[1,]' | succinctly yq --slurp --input-format json -o json '.[0]'`
 /// used to exit 0 with `1`, where real yq rejects it.
 ///
-/// `[,]`/`{,}` remain unchecked only at the *true top level*: the bare
-/// `value: &V` this function's own public entry point receives has no
-/// cursor for the container itself, so once a container's child walk is
-/// exhausted there is no cursor left to find its opening bracket from.
-/// `eval_generic::to_owned_at_depth` had the identical shape, and #2358
-/// closed it there by threading each recursive call's already-resolved
-/// child cursor through as the next level's container cursor -- #2403
-/// applies the same fix here (`to_owned_canonicalizing_numbers_at_depth`'s
-/// own `cursor` parameter below), closing the gap for every *nested*
-/// container the same way.
-fn to_owned_canonicalizing_numbers<V: DocumentValue>(value: &V) -> Result<OwnedValue, EvalError> {
-    to_owned_canonicalizing_numbers_at_depth(value, None, 0)
-}
-
+/// `eval_generic::to_owned_at_depth` had the identical shape at every level
+/// before #2358 closed it there by threading each recursive call's
+/// already-resolved child cursor through as the next level's container
+/// cursor; #2403 applied the same fix here for every *nested* container.
+/// #2781 closed the one case #2403 left: the *true top level* was believed
+/// to have no cursor for the container itself to close `[,]`/`{,}` with, but
+/// that premise was false -- `parse_input`'s JSON arm already holds the root
+/// cursor when it calls this function, it simply was not being passed down.
+/// `cursor` below is `None` only for a handful of direct unit-test callers
+/// that intentionally probe this function without a container cursor in
+/// scope; every real call site (`parse_input`, and every recursive call this
+/// function makes for a child) always has one.
 fn to_owned_canonicalizing_numbers_at_depth<V: DocumentValue>(
     value: &V,
     cursor: Option<&V::Cursor>,
@@ -1391,7 +1389,17 @@ fn parse_input(bytes: &[u8], format: InputFormat) -> Result<Vec<OwnedValue>> {
         InputFormat::Json => {
             let index = JsonIndex::build(bytes);
             let cursor = index.root(bytes);
-            let value = to_owned_canonicalizing_numbers(&cursor.value())
+            // #2781: pass the root cursor through rather than going via the
+            // cursor-less `to_owned_canonicalizing_numbers` wrapper -- the
+            // premise that "there is no cursor for the true top-level
+            // container" was false at this call site all along; the root
+            // cursor is already in hand here, it just was not threaded down.
+            // Without it, `tail_gap_ok` falls back to `child_tail_gap_ok`,
+            // which can only see a last child and so misses a stray `,` in
+            // an empty top-level container (`[,]`/`{,}`) -- every *nested*
+            // level already gets `Some(cursor)` (#2403) and closes the same
+            // gap via `container_tail_gap_ok`.
+            let value = to_owned_canonicalizing_numbers_at_depth(&cursor.value(), Some(&cursor), 0)
                 .map_err(|e| anyhow::anyhow!("{e}"))?;
             Ok(vec![value])
         }
@@ -8768,13 +8776,14 @@ mod tests {
         let json = linear_json_nest(255);
         let index = JsonIndex::build(json.as_bytes());
         let cursor = index.root(json.as_bytes());
-        let owned = to_owned_canonicalizing_numbers(&cursor.value()).unwrap();
+        let owned =
+            to_owned_canonicalizing_numbers_at_depth(&cursor.value(), Some(&cursor), 0).unwrap();
         assert!(matches!(owned, OwnedValue::Object(_)));
 
         let json = linear_json_nest(256);
         let index = JsonIndex::build(json.as_bytes());
         let cursor = index.root(json.as_bytes());
-        let result = to_owned_canonicalizing_numbers(&cursor.value());
+        let result = to_owned_canonicalizing_numbers_at_depth(&cursor.value(), Some(&cursor), 0);
         assert!(
             result.is_err(),
             "to_owned_canonicalizing_numbers should raise a catchable error at depth 256"
@@ -8792,7 +8801,8 @@ mod tests {
         let json = br#"{"int": 1, "float": 1.50, "exp": 1e2, "neg": -3, "arr": [1.0, 2], "s": "x", "b": true, "n": null}"#;
         let index = JsonIndex::build(json);
         let cursor = index.root(json);
-        let owned = to_owned_canonicalizing_numbers(&cursor.value()).unwrap();
+        let owned =
+            to_owned_canonicalizing_numbers_at_depth(&cursor.value(), Some(&cursor), 0).unwrap();
         let OwnedValue::Object(map) = owned else {
             panic!("expected an object")
         };
@@ -8843,7 +8853,8 @@ mod tests {
         for json in [br#"{"n": 5.}"#.as_slice(), br#"{"n": .5}"#.as_slice()] {
             let index = JsonIndex::build(json);
             let cursor = index.root(json);
-            let owned = to_owned_canonicalizing_numbers(&cursor.value()).unwrap();
+            let owned = to_owned_canonicalizing_numbers_at_depth(&cursor.value(), Some(&cursor), 0)
+                .unwrap();
             let OwnedValue::Object(map) = owned else {
                 panic!("expected an object for {json:?}")
             };
@@ -8870,7 +8881,8 @@ mod tests {
         ] {
             let index = JsonIndex::build(json);
             let cursor = index.root(json);
-            let owned = to_owned_canonicalizing_numbers(&cursor.value()).unwrap();
+            let owned = to_owned_canonicalizing_numbers_at_depth(&cursor.value(), Some(&cursor), 0)
+                .unwrap();
             let OwnedValue::Object(map) = owned else {
                 panic!("expected an object for {json:?}")
             };
@@ -8902,7 +8914,7 @@ mod tests {
         ] {
             let index = JsonIndex::build(json);
             let cursor = index.root(json);
-            to_owned_canonicalizing_numbers(&cursor.value())
+            to_owned_canonicalizing_numbers_at_depth(&cursor.value(), Some(&cursor), 0)
                 .expect_err(&format!("{json:?} is not well-formed JSON"));
         }
 
@@ -8910,7 +8922,8 @@ mod tests {
         let json = br#"{"a": 1, "b": 2}"#;
         let index = JsonIndex::build(json);
         let cursor = index.root(json);
-        let owned = to_owned_canonicalizing_numbers(&cursor.value()).unwrap();
+        let owned =
+            to_owned_canonicalizing_numbers_at_depth(&cursor.value(), Some(&cursor), 0).unwrap();
         assert_eq!(
             owned,
             OwnedValue::Object(IndexMap::from([
@@ -8923,7 +8936,7 @@ mod tests {
         let json = br"[1 2, 3]";
         let index = JsonIndex::build(json);
         let cursor = index.root(json);
-        to_owned_canonicalizing_numbers(&cursor.value())
+        to_owned_canonicalizing_numbers_at_depth(&cursor.value(), Some(&cursor), 0)
             .expect_err("a missing ',' between array elements is not well-formed JSON");
     }
 
@@ -8942,7 +8955,7 @@ mod tests {
         let json = br#"{"a": 1, 123: 2, "b": 3}"#;
         let index = JsonIndex::build(json);
         let cursor = index.root(json);
-        to_owned_canonicalizing_numbers(&cursor.value())
+        to_owned_canonicalizing_numbers_at_depth(&cursor.value(), Some(&cursor), 0)
             .expect_err("a non-string key is not well-formed JSON");
 
         // A structurally malformed value token (not a decode failure -- a
@@ -8951,7 +8964,7 @@ mod tests {
         let json = br"[xyz123]";
         let index = JsonIndex::build(json);
         let cursor = index.root(json);
-        to_owned_canonicalizing_numbers(&cursor.value())
+        to_owned_canonicalizing_numbers_at_depth(&cursor.value(), Some(&cursor), 0)
             .expect_err("an unclassifiable value token is not well-formed JSON");
     }
 
@@ -8968,16 +8981,17 @@ mod tests {
         for json in [&br"[1,]"[..], &br#"{"a":1,}"#[..]] {
             let index = JsonIndex::build(json);
             let cursor = index.root(json);
-            to_owned_canonicalizing_numbers(&cursor.value()).expect_err(&format!(
-                "{json:?}: a trailing comma after a real last child is not JSON"
-            ));
+            to_owned_canonicalizing_numbers_at_depth(&cursor.value(), Some(&cursor), 0).expect_err(
+                &format!("{json:?}: a trailing comma after a real last child is not JSON"),
+            );
         }
 
         // Well-formed data is unaffected.
         let json = br#"{"a":1,"b":2}"#;
         let index = JsonIndex::build(json);
         let cursor = index.root(json);
-        let owned = to_owned_canonicalizing_numbers(&cursor.value()).unwrap();
+        let owned =
+            to_owned_canonicalizing_numbers_at_depth(&cursor.value(), Some(&cursor), 0).unwrap();
         assert_eq!(
             owned,
             OwnedValue::Object(IndexMap::from([
@@ -8989,7 +9003,7 @@ mod tests {
         let index = JsonIndex::build(json);
         let cursor = index.root(json);
         assert_eq!(
-            to_owned_canonicalizing_numbers(&cursor.value()).unwrap(),
+            to_owned_canonicalizing_numbers_at_depth(&cursor.value(), Some(&cursor), 0).unwrap(),
             OwnedValue::Array(vec![
                 OwnedValue::Int(1),
                 OwnedValue::Int(2),
@@ -8998,27 +9012,52 @@ mod tests {
         );
     }
 
-    /// #2262: unlike the trailing-comma case above, a stray `,` with *zero*
-    /// real children (`[,]`, `{,}`) remains a known, deliberately unclosed
-    /// gap here -- #2211's `container_gap_ok` needs a cursor to the
-    /// *container itself* to find its opening bracket, and this function is
-    /// only ever given a bare `value: &V` (never a cursor for the container,
-    /// unlike `eval_generic::to_owned_cursor_at_depth`'s own `cursor`
-    /// parameter). Once the child walk is exhausted there is nothing left
-    /// to check against. `eval_generic::to_owned_at_depth` had the
-    /// identical value-only shape, but #2358 closed it there by threading
-    /// each recursive call's already-resolved child cursor through as the
-    /// next level's container cursor -- untouched here, out of #2358's own
-    /// scope (tracked as #2403). Pinned rather than left silently
-    /// uncovered.
+    /// #2781: a stray `,` with *zero* real children (`[,]`, `{,}`) at the
+    /// *true top level* now raises, closing the one case #2403 left --
+    /// `parse_input`'s JSON arm always holds the root cursor, it just was
+    /// not being passed through to this function, so `tail_gap_ok` fell back
+    /// to the cursor-less `child_tail_gap_ok`, which can only see a last
+    /// child and so missed an empty container's own stray comma. With the
+    /// root cursor threaded down, `container_tail_gap_ok` closes it exactly
+    /// as it already did for every nested container (#2403). The `{,}` row
+    /// is a deliberate behavior change beyond `[,]`, not a side effect:
+    /// real yq accepts top-level `{,}` (`{}`), but this function's nested
+    /// arm already rejected `{"a":{,}}` before this fix (`{,}` remains
+    /// accepted only at the top level) -- passing the root cursor makes the
+    /// top level consistent with every level below it rather than carving
+    /// out an exception to preserve an accidental agreement with the
+    /// reference. That mapping-grammar divergence is recorded under #2777,
+    /// not reintroduced here as a special case.
     #[test]
-    fn to_owned_canonicalizing_numbers_stray_comma_in_empty_container_remains_a_known_gap_2262() {
+    fn to_owned_canonicalizing_numbers_raises_on_top_level_stray_comma_in_empty_container_2781() {
         for json in [&br"[,]"[..], &br"{,}"[..]] {
             let index = JsonIndex::build(json);
             let cursor = index.root(json);
-            if let Err(e) = to_owned_canonicalizing_numbers(&cursor.value()) {
-                panic!("{json:?}: known gap -- silently accepted, got error {e:?}");
-            }
+            let err = to_owned_canonicalizing_numbers_at_depth(&cursor.value(), Some(&cursor), 0)
+                .expect_err("a stray comma in a top-level empty container is not JSON");
+            assert!(
+                err.message.contains("Invalid JSON text"),
+                "{json:?}: message: {}",
+                err.message
+            );
+        }
+    }
+
+    /// #2781 regression guard: a well-formed top-level empty container
+    /// (`[]`, `{}`) -- including with inner whitespace, the shape most
+    /// likely to false-positive against the check above -- is unaffected.
+    #[test]
+    fn to_owned_canonicalizing_numbers_wellformed_top_level_empty_container_unaffected_2781() {
+        for json in [&br"[]"[..], &br"[ ]"[..], &br"{}"[..], &br"{ }"[..]] {
+            let index = JsonIndex::build(json);
+            let cursor = index.root(json);
+            let owned = to_owned_canonicalizing_numbers_at_depth(&cursor.value(), Some(&cursor), 0)
+                .unwrap_or_else(|e| panic!("{json:?}: expected Ok, got {e:?}"));
+            assert!(
+                matches!(&owned, OwnedValue::Array(v) if v.is_empty())
+                    || matches!(&owned, OwnedValue::Object(m) if m.is_empty()),
+                "{json:?}: expected an empty container, got {owned:?}"
+            );
         }
     }
 
@@ -9038,7 +9077,7 @@ mod tests {
         for json in [&br#"{"a": {,}}"#[..], &br#"{"a": [,]}"#[..]] {
             let index = JsonIndex::build(json);
             let cursor = index.root(json);
-            let err = to_owned_canonicalizing_numbers(&cursor.value())
+            let err = to_owned_canonicalizing_numbers_at_depth(&cursor.value(), Some(&cursor), 0)
                 .expect_err("a stray comma in a nested empty container is not JSON");
             assert!(
                 err.message.contains("Invalid JSON text"),
@@ -9058,7 +9097,7 @@ mod tests {
         for json in [&br#"{"a": {"b":1,}}"#[..], &br#"{"a": [1,]}"#[..]] {
             let index = JsonIndex::build(json);
             let cursor = index.root(json);
-            let err = to_owned_canonicalizing_numbers(&cursor.value())
+            let err = to_owned_canonicalizing_numbers_at_depth(&cursor.value(), Some(&cursor), 0)
                 .expect_err("a stray trailing comma after a real nested child is not JSON");
             assert!(
                 err.message.contains("Invalid JSON text"),
@@ -9089,7 +9128,7 @@ mod tests {
             ("d".to_string(), OwnedValue::Array(vec![])),
         ]));
         assert_eq!(
-            to_owned_canonicalizing_numbers(&cursor.value()).unwrap(),
+            to_owned_canonicalizing_numbers_at_depth(&cursor.value(), Some(&cursor), 0).unwrap(),
             expected
         );
     }

--- a/src/jq/document.rs
+++ b/src/jq/document.rs
@@ -1933,14 +1933,20 @@ pub fn container_tail_gap_ok<C: DocumentCursor>(
 ///
 /// Used by a recursive value-domain materializer (`eval::to_owned_at_depth`,
 /// `eval_generic::to_owned_at_depth`, `yq_runner::
-/// to_owned_canonicalizing_numbers_at_depth`) whose public entry point
-/// starts at `cursor: None` (no container cursor exists yet) and whose own
-/// recursive calls pass `Some` (the child cursor each already resolved for
-/// an unrelated reason, per #2358/#2403). Delegates to
+/// to_owned_canonicalizing_numbers_at_depth`). All three pass `Some` (the
+/// child cursor each recursive call already resolved for an unrelated
+/// reason, per #2358/#2403) at every nested level. `eval::to_owned_at_depth`
+/// and `eval_generic::to_owned_at_depth` still start their own public entry
+/// point at `cursor: None` (the true top level, where the gap remains open
+/// by construction -- see those two functions' own doc comments for why,
+/// and #2846 for whether that premise still holds). `yq_runner::
+/// to_owned_canonicalizing_numbers_at_depth` no longer takes `Option` at
+/// all: #2781 found its own "no cursor at the top level" premise false --
+/// its one real call site already held the root cursor -- so every call
+/// there passes `Some` unconditionally now. Delegates to
 /// [`container_tail_gap_ok`] when a cursor is available (closing #2211's
 /// `{,}`/`[,]` check) or [`child_tail_gap_ok`]'s weaker fallback when it
-/// isn't (the true top level, where the gap remains open by construction --
-/// see those two functions' own doc comments for why).
+/// isn't.
 ///
 /// Extracted (#2403 review) after the identical 4-line `match cursor { ... }`
 /// was hand-copied into three separate files -- one call this instead of a

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -2320,6 +2320,91 @@ fn test_yq_inplace_fast_path_rejects_trailing_comma_leaves_file_untouched_2276()
     Ok(())
 }
 
+/// #2781: a top-level `[,]` -- a stray comma with *zero* real children --
+/// still leaked through `--slurp`/`--eval-all`/`--inplace`'s DOM-bridge
+/// route after #2279 closed the plain-route parser and #2403 closed every
+/// *nested* occurrence on this route. Confirmed live before this fix:
+/// `--slurp`/`--eval-all` answered `[[]]`/`[]` at exit 0, and `--inplace`
+/// rewrote the file to `[]` -- for input real yq v4.53.3 refuses to read at
+/// all (`bad file ...: json: null unexpected end of JSON input`, exit 1,
+/// file untouched).
+#[test]
+fn test_yq_top_level_stray_comma_in_empty_container_rejected_on_dom_bridge_routes_2781(
+) -> Result<()> {
+    // --slurp
+    let (_output, stderr, code) = run_yq_stdin_with_stderr(
+        ".",
+        "[,]",
+        &["--slurp", "--input-format", "json", "-o", "json"],
+    )?;
+    assert_eq!(code, 1, "stderr: {stderr}");
+    assert!(
+        stderr.contains("Invalid JSON text"),
+        "expected an 'Invalid JSON text' error, got: {stderr}"
+    );
+
+    // --eval-all
+    let (_output, stderr, code) = run_yq_stdin_with_stderr(
+        ".",
+        "[,]",
+        &["--eval-all", "--input-format", "json", "-o", "json"],
+    )?;
+    assert_eq!(code, 1, "stderr: {stderr}");
+    assert!(
+        stderr.contains("Invalid JSON text"),
+        "expected an 'Invalid JSON text' error, got: {stderr}"
+    );
+
+    // --inplace -- the destructive one: must raise *and* leave the file
+    // byte-for-byte untouched, not "heal" it to `[]` on disk.
+    let json = "[,]";
+    let mut input_file = NamedTempFile::new()?;
+    write!(input_file, "{json}")?;
+    let output = Command::new(env!("CARGO_BIN_EXE_succinctly"))
+        .arg("yq")
+        .arg("-i")
+        .args(["--input-format", "json"])
+        .arg(".")
+        .arg(input_file.path())
+        .stdin(Stdio::null())
+        .output()?;
+    let stderr = String::from_utf8(output.stderr)?;
+    assert!(
+        !output.status.success(),
+        "--inplace should raise, stderr: {stderr}"
+    );
+    assert!(
+        stderr.contains("Invalid JSON text"),
+        "expected an 'Invalid JSON text' error, got: {stderr}"
+    );
+    let file_contents = std::fs::read_to_string(input_file.path())?;
+    assert_eq!(
+        file_contents, json,
+        "a raised --inplace write must leave the file byte-for-byte untouched"
+    );
+
+    // Positive control: a well-formed empty container still round-trips on
+    // all three routes -- the fix must not have turned `[]`/`{}` into false
+    // positives.
+    let (output, code) = run_yq_stdin(
+        ".",
+        "[]",
+        &["--slurp", "--input-format", "json", "-o", "json", "-I=0"],
+    )?;
+    assert_eq!(code, 0);
+    assert_eq!(output.trim(), "[[]]");
+
+    let (output, code) = run_yq_stdin(
+        ".",
+        "{}",
+        &["--eval-all", "--input-format", "json", "-o", "json", "-I=0"],
+    )?;
+    assert_eq!(code, 0);
+    assert_eq!(output.trim(), "{}");
+
+    Ok(())
+}
+
 /// #2276 review: `any_input_is_json` is one run-wide boolean, not a
 /// per-file switch (see its own doc comment in `yq_runner.rs` for why a
 /// per-file version wasn't attempted here) -- so a single JSON-sourced


### PR DESCRIPTION
## Summary

`--slurp`/`--eval-all`/`--inplace`'s `--input-format json` route materializes through `JsonIndex`'s DOM bridge (`yq_runner.rs`'s `to_owned_canonicalizing_numbers`), not the `YamlIndex` parser #2279 fixed. A stray comma with zero real children at the *true top level* (`[,]`, `{,}`) still leaked through: `parse_input`'s JSON arm called the cursor-less wrapper, so `tail_gap_ok` fell back to `child_tail_gap_ok`, which can only see a last child. Every nested level already got a real cursor this same way (#2403), so the "no cursor for the outermost container" premise the old doc comments stated was false — `parse_input` already holds the root cursor, it was simply never threaded down.

`--inplace` is the destructive case: it rewrote a file containing `[,]` to `[]` on disk, where real yq v4.53.3 refuses to read `[,]` at all and leaves the file untouched.

Fix: pass `Some(&cursor)` from `parse_input`'s JSON arm into `to_owned_canonicalizing_numbers_at_depth` instead of the depth-0 `None` wrapper, which is now removed (no real caller left) so the gap can't be silently reintroduced by a future call reaching for the wrong entry point.

Also makes top-level `{,}` consistent with the DOM bridge's own nested `{,}` rejection (already refused since #2403) rather than carving out a top-level exception to preserve an accidental agreement with real yq — recorded under #2777's existing flow-mapping delimiter tracking, not a new special case.

This issue already carried a detailed triage plan from the repo owner, posted the same day — followed closely, with every claim re-verified live against the pinned yq v4.53.3 binary before implementing.

Fixes #2781.

## Test plan

- [x] `cargo build --features cli`
- [x] `cargo test --features cli,simd,regex,serde` (full suite, 1854 yq/jq CLI tests + all others, all green)
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings`
- [x] Verified against pinned yq v4.53.3 for every case in the issue's own repro table, plus the `{,}` consistency claim
- [x] Flipped the "known gap" unit test into one asserting the fix; added a well-formed-empty-container regression guard
- [x] New CLI tests covering `--slurp`/`--eval-all`/`--inplace`, including `--inplace`'s file-untouched-on-error assertion