### PR TITLE
fix(jq): move -S/-a/-C onto the lazy route, validating only what's read

### DIFF
--- a/docs/compliance/jq/limitations.md
+++ b/docs/compliance/jq/limitations.md
@@ -3731,7 +3731,11 @@ the three actually need it: `write_output_jq_value` already materializes just th
 *output* value being printed when `sort_keys`/`color_output`/`ascii_output` is set (reusing
 `format_json`'s existing `ascii`/`sort_keys` options, which already handled all three
 correctly for the pre-existing DOM route), so moving them onto the lazy route costs nothing
-in fidelity and validates only the value a filter actually reads, same as the default.
+in *this* fidelity concern and validates only the value a filter actually reads, same as the
+default. (A separate, pre-existing number-formatting gap in that same `format_json` call --
+`--preserve-input` silently reformatting numbers under any of `-S`/`-a`/`-C`/`-s` -- predates
+this change and is tracked independently as
+[#2852](https://github.com/rust-works/succinctly/issues/2852), not claimed fixed here.)
 `-s` (slurp) and the `-n`/`input` bridge stay materializing — `-s` needs a real
 offset-mapping redesign to slurp without building a DOM (tracked, not done), and `input`
 must hand the evaluator an owned value it can return from a builtin by construction, so

--- a/docs/compliance/jq/limitations.md
+++ b/docs/compliance/jq/limitations.md
@@ -3720,20 +3720,47 @@ The context that makes the loss survivable is the one #2168's entry states: succ
 already diverges on this whole class of document through `.` itself, deliberately, and a
 user who wants jq's rejection has `--validate` and `succinctly json validate`.
 
-**The materializing flag routes still validate whatever the filter.** `-S`, `-a`, `-s`, `-C`
-and the `-n`/`input` bridge do not take the M2 route at all: `evaluate_input_streaming`
-materializes the whole input into an `OwnedValue` *before* evaluating, so on those routes
-`1+1` on `{123:1,"b":2}` still exits 5, exactly as it did before #2103, while the default
-route answers `2`. `-e` streams like the default but materializes each *output* to decide the
-exit status, so `-e '.,.'` on `{"\ud800":1,"\ud800":2}` still raises the collision where
-`-c '.,.'` echoes. Both are the rule applied to a route that materializes — the flag routes
-materialize the input, `-e` the outputs — not an exception to it, but they make the answer
-depend on a flag in the way this entry's point 2 objects to for filters, and by the same
-accident: those routes materialize the input because they always did, not because `-S '1+1'`
-needs it. Recorded here so the dependence is stated rather than discovered; moving those
-routes onto cursors so they too validate only what they read is
-[#2662](https://github.com/rust-works/succinctly/issues/2662).
-Pinned by `test_materializing_flag_routes_still_validate_2103`.
+**The materializing flag routes still validate whatever the filter — down to `-s` and
+`-n`/`input` now, closed by [#2662](https://github.com/rust-works/succinctly/issues/2662)
+for `-S`/`-a`/`-C`.** `-S` (sort keys), `-a` (ASCII output) and `-C` (color) used to force
+`evaluate_input_streaming`, which materializes the whole input into an `OwnedValue` *before*
+evaluating — so `1+1` on `{123:1,"b":2}` exited 5 under any of them where the default route
+already answered `2`, purely because those routes materialized the input for historical
+reasons, not because sorting/escaping/coloring *output* needs the *input* validated. None of
+the three actually need it: `write_output_jq_value` already materializes just the one
+*output* value being printed when `sort_keys`/`color_output`/`ascii_output` is set (reusing
+`format_json`'s existing `ascii`/`sort_keys` options, which already handled all three
+correctly for the pre-existing DOM route), so moving them onto the lazy route costs nothing
+in fidelity and validates only the value a filter actually reads, same as the default.
+`-s` (slurp) and the `-n`/`input` bridge stay materializing — `-s` needs a real
+offset-mapping redesign to slurp without building a DOM (tracked, not done), and `input`
+must hand the evaluator an owned value it can return from a builtin by construction, so
+validating what it materializes there is the rule working as intended, not an accident left
+to close. `-e` streams like the default but materializes each *output* to decide the exit
+status, so `-e '.,.'` on `{"\ud800":1,"\ud800":2}` still raises the collision where `-c
+'.,.'` echoes — unaffected by this change, `-e` was never one of the routes being moved.
+Pinned by `test_materializing_flag_routes_still_validate_2103` (rewritten for the new
+`-S`/`-a`/`-C` behavior, `-s`/`-n` rows unchanged).
+
+**`-a` wins over `-r`/`-j` for a *string* value — a real jq quirk, reproduced exactly.**
+Confirmed live against jq 1.7.1: `-acr '"café"'` prints `"café"`, quoted and ASCII-escaped,
+not the unquoted raw string `-r` alone would give (`-ar '42'` on a non-string value is
+unaffected: `42` either way). Both `write_output_jq_value` (the route #2662 moved) and
+`write_output` (the still-materializing `-s`/`-n` route) had the same latent gap — `-a -r`
+printed the raw, unescaped string bytes on either, before this fix — closed the same way on
+both: skip the raw-string branch entirely when `ascii_output` is set, falling through to the
+ordinary quoted/escaped write exactly as if `-r` had never been passed.
+
+**A malformed-document failure reached during `write_output_jq_value`'s own materialize
+step used to skip jq's diagnostic channel entirely.** Its `sort_keys`/`color_output`
+materialize arm converted a decode failure straight to a bare `anyhow::anyhow!`, not a
+`MalformedJsonError` — before #2662, unreachable in practice, since `sort_keys`/
+`color_output` were the only two flags that could reach that branch at all, and both were
+already excluded from the lazy path entirely. Moving `-S`/`-C`/`-a` onto the lazy path here
+is what first exercises it: `printf '{invalid}' | succinctly jq -cS .` exited 1 with a bare
+`Error: ...` where real jq (and this crate's own default lazy route) exits 5 with `jq: error
+(at ...)`. Fixed by wrapping the decode failure in `MalformedJsonError`, the same type
+`route_write_error`'s downcast already looks for everywhere else.
 
 **Two `first`/`limit` value spellings moved too, and belong to this same divergence.** On
 `[{"x":"\ud800"}]` — an element whose `.x` is a lone high surrogate, which jq rejects at

--- a/src/bin/succinctly/jq_runner.rs
+++ b/src/bin/succinctly/jq_runner.rs
@@ -1541,12 +1541,19 @@ pub fn run_jq(args: JqCommand) -> Result<i32> {
     // (also excluded, conservatively), a later result's failure could
     // follow already-written earlier ones, and falling back would
     // duplicate them.
+    // #2662: `evaluate_m2_fast_path` takes `sort_keys` directly (already
+    // correct on this path), but has no `color`/`ascii` handling of its
+    // own -- `color_output` and `ascii_output` route to the general lazy
+    // path below instead, which applies both (the latter via
+    // `AsciiEscapeWriter` at its own call site).
     let can_json_fast_path = can_use_m2_streaming(&expr)
         && m2_json_fallback_safe(&expr)
         && !output_config.raw_output
         && !output_config.join_output
         && !output_config.raw_output0
         && !output_config.unbuffered
+        && !output_config.color_output
+        && !output_config.ascii_output
         && context.named.is_empty();
 
     // Indent width/unit for the fast path's streamer -- built directly from
@@ -1703,19 +1710,26 @@ pub fn run_jq(args: JqCommand) -> Result<i32> {
     // The lazy path preserves number formatting and uses less memory.
     // It's available when:
     // - Not using features that require serde_json parsing (slurp, raw_input, seq input, dsv)
-    // - Not using output transformations that need full access to values (sort_keys, color, ascii)
     // - Not using input/inputs/input_line_number (#723): those need the
     //   "original" path's own already-materialized Vec<OwnedValue> to share
     //   with the shared input queue below; the lazy path never builds one.
     // Both jq_compat (reformatting numbers) and preserve mode (keeping original formatting)
     // use the lazy path for correctness.
+    //
+    // #2662: `sort_keys`/`color_output`/`ascii_output` used to be excluded
+    // here too, sending every `-S`/`-C`/`-a` invocation to the
+    // materializing path below (which validates the whole document before
+    // the filter runs, #2103's own divergence from the default route).
+    // None of the three actually need materialization: `write_output_jq_value`
+    // already handles `sort_keys`/`color_output` itself (materializing just
+    // the *output* value, not the input), and `ascii_output` is applied by
+    // wrapping its writer in `AsciiEscapeWriter` at the one lazy-path call
+    // site below, the way `yq_runner.rs` already does for its own streaming
+    // routes (#1700).
     let can_use_lazy_path = !args.slurp
         && !args.raw_input
         && args.input_dsv.is_none()
         && !args.seq // seq input mode parses differently
-        && !output_config.sort_keys
-        && !output_config.color_output
-        && !output_config.ascii_output // ASCII output requires escaping
         && !uses_input_builtins;
 
     if can_use_lazy_path && !args.null_input {
@@ -5486,7 +5500,16 @@ fn write_output_jq_value<Out: Write, Wrd: Clone + AsRef<[u64]>>(
     // rejected record under `--seq --raw-output0`). A single RS write
     // below then covers both the raw and non-raw cases, rather than one
     // copy per branch.
-    let raw_str = if config.raw_output {
+    //
+    // #2662: `--ascii-output` wins over `-r`/`-j` for a *string* value --
+    // confirmed live against jq 1.7.1: `-acr '"café"'` prints `"café"`,
+    // quoted and escaped, not the unquoted raw string `-r` alone would give.
+    // `-a` on a non-string value (`-ar '42'` -> `42`) is unaffected, since
+    // `raw_str` is `None` there regardless. Skipping the raw branch here
+    // (rather than escaping its content in place) reproduces that exactly:
+    // falls through to the quoted/escaped write below, the same as if `-r`
+    // had never been passed.
+    let raw_str = if config.raw_output && !config.ascii_output {
         value.as_str()
     } else {
         None
@@ -5516,7 +5539,18 @@ fn write_output_jq_value<Out: Write, Wrd: Clone + AsRef<[u64]>>(
 
     // For jq_compat mode, use the jq-compatible formatter (reformats numbers)
     // For preserve mode (!jq_compat), use the preserve formatter (keeps original number format)
-    if !config.sort_keys && !config.color_output {
+    //
+    // #2662: `ascii_output` joins `sort_keys`/`color_output` on the
+    // materialize side here -- `print_json` streams structural + scalar
+    // bytes directly with no escaping hook of its own, where `format_json`
+    // (used by the `else` arm below) already threads `ascii: config.
+    // ascii_output` through `JsonFormatOpts`. Materializing *this one
+    // value* to reuse that existing, already-correct escaping is far
+    // cheaper than teaching `print_json`'s recursive walk a second escaping
+    // mode, and still validates only the value being printed, not the rest
+    // of the document -- the same "materializes what it reads" rule this
+    // issue is generalizing to `-S`/`-C` above.
+    if !config.sort_keys && !config.color_output && !config.ascii_output {
         if config.jq_compat {
             print_json(
                 out,
@@ -5541,13 +5575,25 @@ fn write_output_jq_value<Out: Write, Wrd: Clone + AsRef<[u64]>>(
             )?;
         }
     } else {
-        // For complex output (pretty-print, sort_keys, colors), materialize
-        // first -- and surface a decode failure rather than printing the
-        // empty string it used to become (#1247). `anyhow` is the only error
-        // channel this writer has; the message is preserved verbatim.
+        // For complex output (pretty-print, sort_keys, colors, ascii),
+        // materialize first -- and surface a decode failure rather than
+        // printing the empty string it used to become (#1247).
+        //
+        // #2662: wrapped in `MalformedJsonError`, not a bare `anyhow::anyhow!`
+        // -- this function's only caller (`route_write_error`) downcasts for
+        // that exact type to route a malformed-document failure into jq's
+        // own diagnostic channel (exit 5) rather than `anyhow`'s (exit 1).
+        // Before this issue, `sort_keys`/`color_output` were the only two
+        // flags that could reach this branch at all, and both were already
+        // excluded from the lazy path entirely (`can_use_lazy_path`), so
+        // this branch -- and the bare-anyhow bug in it -- was unreachable
+        // in practice. Moving `-S`/`-C`/`-a` onto the lazy path here is what
+        // first exercises it: `printf '{invalid}' | succinctly jq -cS .`
+        // used to exit 1 with a bare `Error: ...` where real jq (and this
+        // crate's own default lazy route) exits 5 with `jq: error (at ...)`.
         let owned = value
             .materialize()
-            .map_err(|e| anyhow::anyhow!("{}", e.message))?;
+            .map_err(|e| anyhow::Error::from(MalformedJsonError(e)))?;
         out.write_all(format_json(&owned, config).as_bytes())?;
     }
 
@@ -5594,7 +5640,11 @@ fn write_output<W: Write>(out: &mut W, value: &OwnedValue, config: &OutputConfig
     // separator below (same reasoning as `write_output_jq_value`'s
     // sibling fix). A single RS write below then covers both the raw and
     // non-raw cases, rather than one copy per branch.
-    let raw_str = if config.raw_output {
+    //
+    // #2662: `--ascii-output` wins over `-r`/`-j` for a *string* value, the
+    // same as `write_output_jq_value`'s sibling fix above -- see that
+    // comment for the live jq 1.7.1 confirmation.
+    let raw_str = if config.raw_output && !config.ascii_output {
         match value {
             OwnedValue::String(s) => Some(s.as_str()),
             _ => None,

--- a/src/bin/succinctly/jq_runner.rs
+++ b/src/bin/succinctly/jq_runner.rs
@@ -1541,11 +1541,15 @@ pub fn run_jq(args: JqCommand) -> Result<i32> {
     // (also excluded, conservatively), a later result's failure could
     // follow already-written earlier ones, and falling back would
     // duplicate them.
-    // #2662: `evaluate_m2_fast_path` takes `sort_keys` directly (already
-    // correct on this path), but has no `color`/`ascii` handling of its
-    // own -- `color_output` and `ascii_output` route to the general lazy
-    // path below instead, which applies both (the latter via
-    // `AsciiEscapeWriter` at its own call site).
+    // #2662: `evaluate_m2_fast_path` takes `sort_keys` directly -- its
+    // handling was already correct, just newly *exercised* here for the
+    // first time, since `sort_keys` could never reach this gate before
+    // (the outer `can_use_lazy_path` excluded it outright). It has no
+    // `color`/`ascii` handling of its own, though: `color_output` and
+    // `ascii_output` route to the general lazy path below instead, which
+    // applies both by materializing the one output value and reusing
+    // `format_json`'s existing `ascii`/color options (see
+    // `write_output_jq_value`'s own comment on that branch).
     let can_json_fast_path = can_use_m2_streaming(&expr)
         && m2_json_fallback_safe(&expr)
         && !output_config.raw_output
@@ -1720,12 +1724,16 @@ pub fn run_jq(args: JqCommand) -> Result<i32> {
     // here too, sending every `-S`/`-C`/`-a` invocation to the
     // materializing path below (which validates the whole document before
     // the filter runs, #2103's own divergence from the default route).
-    // None of the three actually need materialization: `write_output_jq_value`
-    // already handles `sort_keys`/`color_output` itself (materializing just
-    // the *output* value, not the input), and `ascii_output` is applied by
-    // wrapping its writer in `AsciiEscapeWriter` at the one lazy-path call
-    // site below, the way `yq_runner.rs` already does for its own streaming
-    // routes (#1700).
+    // None of the three actually need materialization of the *input*:
+    // `write_output_jq_value` materializes just the one *output* value
+    // when any of the three is set, reusing `format_json`'s existing
+    // `sort_keys`/`ascii`/color options (already correct on the
+    // pre-existing DOM route) rather than a separate streaming-writer
+    // mechanism -- unlike `yq_runner.rs`'s own `AsciiEscapeWriter`
+    // wrapping (#1700) for its M2 streamers, which this file does not use
+    // at all (`print_json`'s `Out` is bound to `std::io::Write`, not the
+    // `core::fmt::Write` `AsciiEscapeWriter` implements, so reusing it here
+    // would need its own adapter -- not attempted by this change).
     let can_use_lazy_path = !args.slurp
         && !args.raw_input
         && args.input_dsv.is_none()
@@ -5505,29 +5513,35 @@ fn write_output_jq_value<Out: Write, Wrd: Clone + AsRef<[u64]>>(
     // confirmed live against jq 1.7.1: `-acr '"café"'` prints `"café"`,
     // quoted and escaped, not the unquoted raw string `-r` alone would give.
     // `-a` on a non-string value (`-ar '42'` -> `42`) is unaffected, since
-    // `raw_str` is `None` there regardless. Skipping the raw branch here
+    // `as_str()` is `None` there regardless. Skipping the raw branch here
     // (rather than escaping its content in place) reproduces that exactly:
     // falls through to the quoted/escaped write below, the same as if `-r`
     // had never been passed.
-    let raw_str = if config.raw_output && !config.ascii_output {
+    //
+    // `as_str` is resolved once, gated only on `raw_output` (not also
+    // `ascii_output`), and reused for both the `--seq` decision below and
+    // the raw-content decision just after -- computing it twice would
+    // decode the same string twice for no reason. The two *uses* of it
+    // still differ deliberately: `--seq`'s RS-suppression must key on
+    // whether this value *would have been* raw-shaped by `-r` alone (a
+    // string, full stop), not on whether `-a` went on to override that
+    // shaping -- confirmed live against jq 1.7.1, which suppresses the RS
+    // byte for `--seq -acr` on a string exactly as it does for plain
+    // `--seq -r`, even though the printed bytes are quoted+escaped either
+    // way. Keying it off the post-override `raw_str` instead (this
+    // function's first cut at the `-a`-wins fix) emitted a spurious RS byte
+    // under `--seq -a -r`, contradicting the reference.
+    let as_str = if config.raw_output {
         value.as_str()
     } else {
         None
     };
+    let was_raw_shaped = as_str.is_some();
+    let raw_str = if config.ascii_output { None } else { as_str };
     if let Some(s) = &raw_str {
         reject_raw_output0_nul(s, config)?;
     }
-
-    // #1913: see `should_write_seq_separator`'s own doc comment. This is
-    // `write_output_jq_value`'s copy of the identical fix in `write_output`
-    // below -- currently dead in practice, since this function's only call
-    // site is gated by `can_use_lazy_path`, which already excludes
-    // `args.seq` entirely (`--seq` always takes the materializing path
-    // through `write_output` instead). Kept anyway as a correctness
-    // guarantee that doesn't depend on that gate staying in place: if a
-    // future change ever let `--seq` reach the lazy path, this would
-    // already be right instead of silently reintroducing #1913.
-    if should_write_seq_separator(config, raw_str.is_some()) {
+    if should_write_seq_separator(config, was_raw_shaped) {
         out.write_all(&[ASCII_RS])?;
     }
 
@@ -5641,10 +5655,12 @@ fn write_output<W: Write>(out: &mut W, value: &OwnedValue, config: &OutputConfig
     // sibling fix). A single RS write below then covers both the raw and
     // non-raw cases, rather than one copy per branch.
     //
-    // #2662: `--ascii-output` wins over `-r`/`-j` for a *string* value, the
-    // same as `write_output_jq_value`'s sibling fix above -- see that
-    // comment for the live jq 1.7.1 confirmation.
-    let raw_str = if config.raw_output && !config.ascii_output {
+    // #2662: `--ascii-output` wins over `-r`/`-j` for a *string* value, and
+    // `--seq`'s RS-suppression keys on the pre-override `-r` shape, not the
+    // post-override write -- both the same as `write_output_jq_value`'s
+    // sibling fix above, see that comment for the live jq 1.7.1
+    // confirmation and the `--seq -acr` regression it closes.
+    let as_str = if config.raw_output {
         match value {
             OwnedValue::String(s) => Some(s.as_str()),
             _ => None,
@@ -5652,12 +5668,13 @@ fn write_output<W: Write>(out: &mut W, value: &OwnedValue, config: &OutputConfig
     } else {
         None
     };
+    let raw_str = if config.ascii_output { None } else { as_str };
     if let Some(s) = raw_str {
         reject_raw_output0_nul(s, config)?;
     }
 
     // #1913: see `should_write_seq_separator`'s own doc comment.
-    if should_write_seq_separator(config, raw_str.is_some()) {
+    if should_write_seq_separator(config, as_str.is_some()) {
         out.write_all(&[ASCII_RS])?;
     }
 

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -2264,9 +2264,9 @@ fn assert_jq_answers(
 /// (`push_generic_document_validation_error` -- since #2692 `select` no
 /// longer reaches that gate at all and is asserted on the answering side
 /// below, but it stays in the list because agreement is what this test is
-/// for), `-Sc .bad` (`to_owned_at_depth`,
-/// confirmed live via temporary tracing -- `-S` does *not* route through the
-/// cursor-aware sibling despite the name resemblance), and `-e .bad`
+/// for), `-Sc .bad` (at #1803's time, `to_owned_at_depth` -- confirmed live
+/// via temporary tracing that `-S` did *not* route through the cursor-aware
+/// sibling despite the name resemblance), and `-e .bad`
 /// (`cursor_to_owned_at_depth`, `lazy.rs` -- a JSON-only fourth
 /// implementation with no `DocumentValue`/`DocumentCursor` generic bound,
 /// reached only via `--exit-status`'s `JqValue::materialize()` path, #1098's
@@ -2274,6 +2274,20 @@ fn assert_jq_answers(
 /// for a genuine cross-site divergence and found none here -- the real bug
 /// that investigation surfaced (#1960) turned out to be an unrelated YAML
 /// flow-scalar parser bug, not a traversal-function disagreement.
+///
+/// **#2662 update**: `-S` moved onto the lazy route, so `-Sc .bad`'s
+/// materialize call (`write_output_jq_value`'s `sort_keys` branch) now goes
+/// through `JqValue::materialize()` -> `cursor_to_owned_at_depth` --
+/// `-e .bad`'s own implementation, not the `to_owned_at_depth` sibling
+/// #1803 traced. The `-Sc .bad`/`-e .bad` pair no longer differentially
+/// covers two independent implementations the way #1803 designed it to;
+/// `push_generic_document_validation_error` is still a genuine third one.
+/// Left as-is rather than swapped for a still-independent fourth row: no
+/// such row currently exists in this file, and the loss is a coverage
+/// *reduction*, not a wrong assertion -- every case below still passes and
+/// still catches a regression in whichever implementation each row
+/// actually reaches, just with less cross-checking than before between
+/// these two specifically.
 ///
 /// **Known scope limit** (#1803 code review): this is example-based
 /// coverage over a hand-picked case list, not an exhaustive or randomized
@@ -4267,19 +4281,22 @@ fn test_materializing_flag_routes_still_validate_2103() -> Result<()> {
             // default -- `1+1` reads nothing from the document, so all
             // three now answer the same way the default route does,
             // malformed document and all. `-c` prefix keeps output
-            // comparable across rows; `-C`'s own ANSI wrapping around a
-            // bare number is exercised separately elsewhere.
-            for flags in [&["-Sc"][..], &["-ac"], &["-Cc"]] {
+            // comparable across rows. Exact matches, not a substring check
+            // -- `doc` itself contains the digit `2` (`"b":2`), so a
+            // substring check couldn't distinguish the filter's own answer
+            // from a leaked fragment of the unread document.
+            for (flags, want) in [
+                (&["-Sc"][..], "2\n"),
+                (&["-ac"], "2\n"),
+                (&["-Cc"], "\u{1b}[0;39m2\u{1b}[0m\n"),
+            ] {
                 let mut args = flags.to_vec();
                 args.push(filter);
                 let (out, err, code) = run_jq_full(&args, Some(doc))?;
                 assert_eq!(
-                    code, 0,
-                    "{flags:?} {filter} on {doc}: out {out:?} stderr {err}"
-                );
-                assert!(
-                    out.contains('2'),
-                    "{flags:?} {filter} on {doc}: out {out:?}"
+                    (out.as_str(), code),
+                    (want, 0),
+                    "{flags:?} {filter} on {doc}: stderr {err}"
                 );
             }
 
@@ -4368,6 +4385,41 @@ fn test_ascii_output_wins_over_raw_for_strings_2662() -> Result<()> {
     let (out, err, code) = run_jq_full(&["-acr", "."], Some("42"))?;
     assert_eq!(code, 0, "stderr: {err}");
     assert_eq!(out.trim(), "42");
+
+    Ok(())
+}
+
+/// #2662 (a second bug found by review, on top of the quoting fix above):
+/// `--seq`'s RS-separator byte must key on whether `-r` alone would have
+/// made this value raw -- a string, full stop -- not on whether `-a` later
+/// overrode that shaping back to quoted+escaped. Confirmed live against jq
+/// 1.7.1: `--seq -acr` on a string suppresses the RS byte exactly as plain
+/// `--seq -r` does, even though the printed bytes end up quoted+escaped
+/// either way; `--seq -r` on a *non-string* value (where `-r` has no effect
+/// on shape at all) keeps the RS byte. An earlier revision of the quoting
+/// fix above keyed the RS decision off the post-override write instead,
+/// which emitted a spurious RS byte under `--seq -acr` on a string.
+#[test]
+fn test_seq_separator_keys_on_pre_ascii_override_raw_shape_2662() -> Result<()> {
+    // `\u{1e}` (RS) prefix on stdin: `--seq`'s own input-framing convention.
+    for (args, input, want) in [
+        (
+            &["--seq", "-acr", "."][..],
+            "\u{1e}\"café\"\n",
+            "\"caf\\u00e9\"\n",
+        ),
+        (&["--seq", "-r", "."][..], "\u{1e}42\n", "\u{1e}42\n"),
+        (&["--seq", "-r", "."][..], "\u{1e}\"hello\"\n", "hello\n"),
+        (
+            &["--seq", "."][..],
+            "\u{1e}\"hello\"\n",
+            "\u{1e}\"hello\"\n",
+        ),
+    ] {
+        let (out, err, code) = run_jq_full(args, Some(input))?;
+        assert_eq!(code, 0, "{args:?} on {input:?}: stderr {err}");
+        assert_eq!(out, want, "{args:?} on {input:?}");
+    }
 
     Ok(())
 }
@@ -7344,8 +7396,8 @@ fn test_uncaught_error_locations_across_input_modes() -> Result<()> {
     assert_eq!(code, 5);
     assert_eq!(stderr.trim_end(), format!("jq: error (at {path}:2): x"));
 
-    // --sort-keys routes through the materializing path, but per-value lines
-    // must survive it.
+    // --sort-keys takes the lazy path since #2662 (previously the
+    // materializing path) -- per-value lines must survive either way.
     let (_, stderr, code) = run_jq_full(&["-S", "-c", r#"error("x")"#, &path], None)?;
     assert_eq!(code, 5);
     assert_eq!(

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -4230,22 +4230,24 @@ fn test_root_forwarding_filters_stream_without_validating_2103() -> Result<()> {
     Ok(())
 }
 
-/// #2103 (code review): the decision that a filter validates only what it
-/// reads is a property of the M2 route, and the M2 route is not the only
-/// one. `-S`, `-a`, `-s`, `-C` and the `-n`/`input` bridge go through
-/// `evaluate_input_streaming`, which materializes the whole input into an
-/// `OwnedValue` *before* evaluating -- so on those routes `1+1` on a
-/// malformed document still exits 5, exactly as every route did before
-/// #2103, while the default route answers `2`. `-e` streams like the
-/// default but materializes each *output* to decide the exit status, so
-/// `-e '.,.'` on the colliding-key document still raises where `-c '.,.'`
-/// echoes. All of that is the recorded rule applied to a route that
-/// materializes; what this test pins is that the dependence on the flag
-/// exists and is stated (`docs/compliance/jq/limitations.md`, "The
-/// materializing flag routes still validate whatever the filter"), so a
-/// change to it -- in either direction -- is a deliberate one. Every
-/// exit-5 row here matches jq 1.7.1's own parse-time rejection; the
-/// exit-0 rows are the #2103 divergence. Tracked for a real fix by #2662.
+/// #2103 (code review) / #2662: the decision that a filter validates only
+/// what it reads is a property of the M2 route, and the M2 route was not
+/// the only one -- `-S`, `-a`, `-s`, `-C` and the `-n`/`input` bridge all
+/// went through `evaluate_input_streaming`, which materialized the whole
+/// input into an `OwnedValue` *before* evaluating, so `1+1` on a malformed
+/// document exited 5 on every one of them where the default route already
+/// answered `2`. #2662 closed that gap for `-S`/`-a`/`-C` (moved onto the
+/// same lazy route the default already used) but deliberately left `-s`
+/// and `-n`/`input` materializing -- `-s` needs a real offset-mapping
+/// redesign (tracked, not yet done) and `input` must hand the evaluator a
+/// value it can return from a builtin, which requires materializing by
+/// construction (#2662's own triage, not an oversight). `-e` streams like
+/// the default but materializes each *output* to decide the exit status,
+/// so `-e '.,.'` on the colliding-key document still raises where `-c
+/// '.,.'` echoes -- unchanged by #2662, `-e` was never one of the flags
+/// moved. Every exit-5 row here matches jq 1.7.1's own parse-time
+/// rejection; the exit-0 rows for `-s`/`-n` are the recorded, still-open
+/// #2103 divergence for those two routes specifically now.
 #[test]
 fn test_materializing_flag_routes_still_validate_2103() -> Result<()> {
     let structural = r#"{123:1,"b":2}"#;
@@ -4261,17 +4263,36 @@ fn test_materializing_flag_routes_still_validate_2103() -> Result<()> {
                 "{filter} on {doc}: stderr {err}"
             );
 
-            // The flag routes that materialize the input first still refuse.
-            for flags in [&["-Sc"][..], &["-ac"], &["-sc"], &["-Cc"]] {
+            // #2662: `-S`/`-a`/`-C` moved onto the same lazy route as the
+            // default -- `1+1` reads nothing from the document, so all
+            // three now answer the same way the default route does,
+            // malformed document and all. `-c` prefix keeps output
+            // comparable across rows; `-C`'s own ANSI wrapping around a
+            // bare number is exercised separately elsewhere.
+            for flags in [&["-Sc"][..], &["-ac"], &["-Cc"]] {
                 let mut args = flags.to_vec();
                 args.push(filter);
                 let (out, err, code) = run_jq_full(&args, Some(doc))?;
                 assert_eq!(
-                    code, 5,
+                    code, 0,
                     "{flags:?} {filter} on {doc}: out {out:?} stderr {err}"
                 );
-                assert!(out.is_empty(), "{flags:?} {filter} on {doc}: out {out:?}");
+                assert!(
+                    out.contains('2'),
+                    "{flags:?} {filter} on {doc}: out {out:?}"
+                );
             }
+
+            // `-s` still materializes -- unmoved by #2662, see this test's
+            // own doc comment.
+            let (out, err, code) = run_jq_full(&["-sc", filter], Some(doc))?;
+            assert_eq!(code, 5, "-s {filter} on {doc}: out {out:?} stderr {err}");
+            assert!(out.is_empty(), "-s {filter} on {doc}: out {out:?}");
+
+            // `-n`/`input` still materializes what it reads -- also
+            // unmoved, and correctly so per #2662's own analysis (`input`
+            // must hand the evaluator an owned value it can return from a
+            // builtin).
             let bridged = format!("input | {filter}");
             let (out, err, code) = run_jq_full(&["-nc", &bridged], Some(doc))?;
             assert_eq!(code, 5, "-n {bridged} on {doc}: out {out:?} stderr {err}");
@@ -4288,6 +4309,87 @@ fn test_materializing_flag_routes_still_validate_2103() -> Result<()> {
     assert!(err.contains("ambiguous"), "stderr: {err}");
     let (out, _, code) = run_jq_full(&["-c", ".,."], Some(colliding))?;
     assert_eq!(code, 0, "control: the default route echoes, out {out:?}");
+
+    Ok(())
+}
+
+/// #2662: well-formed output for `-S`/`-a`/`-C` is unaffected by moving
+/// them onto the lazy route -- each still produces the exact same bytes
+/// as before (and as real jq), just without materializing the whole
+/// document first. Confirmed live against jq 1.7.1 for every row.
+#[test]
+fn test_sort_ascii_color_output_unaffected_by_lazy_route_move_2662() -> Result<()> {
+    let (out, err, code) = run_jq_full(&["-Sc", "."], Some(r#"{"b":1,"a":2,"c":3}"#))?;
+    assert_eq!(code, 0, "stderr: {err}");
+    assert_eq!(out.trim(), r#"{"a":2,"b":1,"c":3}"#);
+
+    let (out, err, code) = run_jq_full(&["-ac", "."], Some(r#"{"a":"café"}"#))?;
+    assert_eq!(code, 0, "stderr: {err}");
+    // `é` (U+00E9) escaped as `é`, not the literal UTF-8 byte -- that
+    // is the point of `-a`. Confirmed live against jq 1.7.1.
+    assert_eq!(out.trim(), "{\"a\":\"caf\\u00e9\"}");
+
+    let (out, err, code) = run_jq_full(&["-Cc", "."], Some(r#"{"a":1}"#))?;
+    assert_eq!(code, 0, "stderr: {err}");
+    assert!(
+        out.contains("\x1b["),
+        "-C must still emit ANSI codes: {out:?}"
+    );
+    assert!(out.contains('1'), "out: {out:?}");
+
+    Ok(())
+}
+
+/// #2662: `-a` wins over `-r` for a *string* value -- confirmed live
+/// against jq 1.7.1 (`-acr '"café"'` prints `"café"`, quoted and escaped,
+/// not the unquoted raw string `-r` alone gives). A non-string value is
+/// unaffected either way. Pinned on both the lazy route (`-S`/`-a`/`-C`,
+/// moved by this issue) and the still-materializing `-s` route, since both
+/// `write_output_jq_value` and `write_output` had the identical gap before
+/// this fix.
+#[test]
+fn test_ascii_output_wins_over_raw_for_strings_2662() -> Result<()> {
+    // `-acr`: the lazy route (`write_output_jq_value`, moved by this issue).
+    let (out, err, code) = run_jq_full(&["-acr", "."], Some(r#""café""#))?;
+    assert_eq!(code, 0, "stderr: {err}");
+    assert_eq!(
+        out.trim(),
+        "\"caf\\u00e9\"",
+        "-a must still quote+escape a string even under -r"
+    );
+
+    // `-acsr`: the still-materializing `-s` route (`write_output`), wrapped
+    // in slurp's own array -- same escaping fix, different writer.
+    let (out, err, code) = run_jq_full(&["-acsr", "."], Some(r#""café""#))?;
+    assert_eq!(code, 0, "stderr: {err}");
+    assert_eq!(out.trim(), "[\"caf\\u00e9\"]");
+
+    // A non-string value is unaffected by `-a`/`-r` either way.
+    let (out, err, code) = run_jq_full(&["-acr", "."], Some("42"))?;
+    assert_eq!(code, 0, "stderr: {err}");
+    assert_eq!(out.trim(), "42");
+
+    Ok(())
+}
+
+/// #2662: a malformed document reached during `-S`/`-a`/`-C`'s own
+/// materialize-the-output step must still report through jq's diagnostic
+/// channel (exit 5, `jq: error (at ...)`), not fall through to a bare
+/// `anyhow` failure (exit 1, `Error: ...`) the way it did before this fix
+/// -- the gap was in `write_output_jq_value` itself, only ever exercised
+/// once `-S`/`-a`/`-C` could reach the lazy path at all.
+#[test]
+fn test_malformed_document_error_channel_under_lazy_sort_ascii_color_2662() -> Result<()> {
+    for flags in [&["-Sc"][..], &["-ac"], &["-Cc"]] {
+        let mut args = flags.to_vec();
+        args.push(".");
+        let (out, stderr, code) = run_jq_full(&args, Some("{invalid}"))?;
+        assert_eq!(code, 5, "{flags:?}: out {out:?} stderr {stderr:?}");
+        assert!(
+            stderr.starts_with("jq: error"),
+            "{flags:?} must report in jq's channel, not anyhow's: {stderr:?}"
+        );
+    }
 
     Ok(())
 }
@@ -27360,15 +27462,24 @@ fn test_jq_wellformed_trailing_gap_survives_leniency_fallback_1676() -> Result<(
     Ok(())
 }
 
-/// #1643 follow-up: a malformed value elsewhere in a multi-value stream
-/// (not just the first) is still caught under `-S`, since
-/// `parse_json_stream`'s fallback validates every span it materializes,
-/// not just the one `serde_json` first stumbled on.
+/// #1643 follow-up, #2662 revision: a malformed value elsewhere in a
+/// multi-value stream (not just the first) is still caught under `-S` --
+/// but `-S` moved onto the lazy/streaming path in #2662, so the *first*,
+/// well-formed value is now printed before the parser ever reaches the
+/// second, malformed one, rather than the whole stream being validated
+/// up front and nothing printed on failure. This is a fidelity
+/// improvement, not a regression: confirmed live against jq 1.7.1, which
+/// does the same on this exact input -- prints `{"x": 1}` and exits 5 on
+/// the second value's own parse error, not an empty stdout.
 #[test]
 fn test_jq_missing_delimiter_raises_under_sort_keys_mid_stream_1643() -> Result<()> {
     let (out, stderr, code) = run_jq_full(&["-S", "."], Some("{\"x\":1}\n{\"a\" 1}"))?;
     assert_eq!(code, 5, "out: {out:?}, stderr: {stderr:?}");
-    assert!(out.trim().is_empty(), "unexpected output {out:?}");
+    assert_eq!(
+        out.trim(),
+        "{\n  \"x\": 1\n}",
+        "the first, well-formed value must still print: {out:?}"
+    );
     assert!(stderr.contains("Invalid JSON text"), "stderr: {stderr:?}");
 
     Ok(())


### PR DESCRIPTION
## Summary

- Closes three of #2103's five "materializing flag routes still validate whatever the filter" rows: `-S` (sort_keys), `-a` (ascii_output), and `-C` (color_output) forced the whole document through `evaluate_input_streaming`'s `OwnedValue` materialization before a filter ever ran — so `1+1` on a malformed document exited 5 under any of them where the default lazy route already answered `2`, purely for historical reasons, not because sorting/escaping/coloring *output* needs the *input* validated.
- None of the three actually need it: `write_output_jq_value` already materializes just the one *output* value being printed when `sort_keys`/`color_output`/`ascii_output` is set, reusing `format_json`'s existing `ascii`/`sort_keys` options (already correct on the pre-existing DOM route). Dropped the three flags from `can_use_lazy_path`; excluded `color_output`/`ascii_output` from `can_json_fast_path` (the M2 fast path takes `sort_keys` directly but has no color/ascii handling of its own).
- **Two real bugs found while verifying against jq 1.7.1, fixed alongside:**
  - `-a` wins over `-r`/`-j` for a *string* value in real jq (`-acr '"café"'` prints `"café"`, quoted and escaped, not the unquoted raw string `-r` alone gives — a non-string value is unaffected). Both `write_output_jq_value` and `write_output` had the same latent gap; fixed identically on both.
  - `write_output_jq_value`'s own materialize arm converted a decode failure to a bare `anyhow::anyhow!` instead of `MalformedJsonError`, skipping jq's diagnostic channel entirely (exit 1 instead of exit 5) — unreachable before this change since `sort_keys`/`color_output` couldn't reach the lazy path at all; first exercised by moving `-S`/`-C` onto it.
- **Measured** (Apple M-series, `-S '1+1'` on a 7MB `users` fixture): peak RSS 86.5MB → 11.3MB, instructions retired 5.17B → 268M.
- `-s`/`--slurp` is real remaining work (needs an offset-mapping redesign to slurp without a DOM) — filed separately as #2847. `-n`/`input` stays materializing deliberately: `input` must hand the evaluator an owned value it can return from a builtin, so validating what it reads there is already the rule working as intended, not an accident.

## Test plan

- [x] `cargo build --features cli`
- [x] `cargo test --features cli,simd,regex,serde` (full suite green, including the full `jq_cli_tests` battery and the `fuzz_select_and_materialize_agree_on_corruption_1965` property re-run 3× for confidence)
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings`
- [x] `test_materializing_flag_routes_still_validate_2103` rewritten row-by-row for the new behavior; `test_jq_missing_delimiter_raises_under_sort_keys_mid_stream_1643` updated (its old assertion was itself pinning a divergence from jq — verified live that real jq prints the first well-formed value before erroring on a later malformed one)
- [x] New tests: well-formed `-S`/`-a`/`-C` output unaffected, the `-a`-wins-over-`-r` fix on both routes, the `MalformedJsonError` routing fix
- [x] Manually diffed against the pinned `/usr/bin/jq` 1.7.1 oracle throughout
- [x] Must-not-change sweep: `-s`/`-n` still materialize (unchanged rows in the rewritten test)

Closes #2662