### PR TITLE
fix(jq): include appends .jq unconditionally, matching real jq

### DIFF
--- a/src/bin/succinctly/jq_runner.rs
+++ b/src/bin/succinctly/jq_runner.rs
@@ -64,12 +64,9 @@ pub struct ModuleLoader {
 /// the module cache across the call, which an `&self` method could not
 /// coexist with. It reads nothing but the search path either way.
 fn resolve_module_in(search_path: &[PathBuf], module_path: &str) -> Option<PathBuf> {
-    // Add .jq extension if not present
-    let module_file = if module_path.ends_with(".jq") {
-        module_path.to_string()
-    } else {
-        format!("{module_path}.jq")
-    };
+    // #2702: real jq appends `.jq` unconditionally -- `include "m.jq"` looks
+    // for `m.jq.jq`, never `m.jq` itself. Confirmed live against jq 1.7.1.
+    let module_file = format!("{module_path}.jq");
 
     // Search in each path
     for base in search_path {

--- a/src/jq/expr.rs
+++ b/src/jq/expr.rs
@@ -1031,7 +1031,9 @@ pub enum MetaValue {
 /// Import directive: `import "path" as name;` or `import "path" as name { meta };`
 #[derive(Debug, Clone, PartialEq)]
 pub struct Import {
-    /// The module path (relative, without .jq extension)
+    /// The module path, exactly as written -- `.jq` is appended
+    /// unconditionally when resolving it to a file (#2702), so a path that
+    /// already ends in `.jq` is not stripped or treated specially here.
     pub path: String,
     /// The namespace alias
     pub alias: String,
@@ -1042,7 +1044,9 @@ pub struct Import {
 /// Include directive: `include "path";` or `include "path" { meta };`
 #[derive(Debug, Clone, PartialEq)]
 pub struct Include {
-    /// The module path (relative, without .jq extension)
+    /// The module path, exactly as written -- `.jq` is appended
+    /// unconditionally when resolving it to a file (#2702), so a path that
+    /// already ends in `.jq` is not stripped or treated specially here.
     pub path: String,
     /// Optional metadata overrides
     pub metadata: Option<BTreeMap<String, MetaValue>>,

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -23379,26 +23379,49 @@ fn test_module_with_a_syntax_error_is_a_compile_error_2395() -> Result<()> {
     Ok(())
 }
 
-/// Characterization test, **pinning a known divergence from jq**: succinctly
-/// resolves `include "m.jq"` to the file `m.jq`, where real jq appends `.jq`
-/// unconditionally and therefore looks for `m.jq.jq` -- so jq rejects this
-/// program with `module not found: m.jq` (exit 3) while succinctly runs it.
+/// #2702: real jq appends `.jq` to a module path unconditionally, even when
+/// the path already ends in `.jq` -- `include "mod.jq"` looks for
+/// `mod.jq.jq`, never `mod.jq` itself. Confirmed live against jq 1.7.1:
+/// with only `mod.jq` present, jq rejects the program with
+/// `module not found: mod.jq` (exit 3); succinctly used to resolve `mod.jq`
+/// directly and run it (`ends_with(".jq")` special-cased the suffix away).
 ///
-/// Verified live against jq 1.7.1 both ways: with only `m.jq` present jq errors
-/// and succinctly returns the module's def, and with `m.jq.jq` also present jq
-/// reads *that* file while succinctly still reads `m.jq`.
+/// Row 2 confirms the mechanism rather than just the rejection: with
+/// `mod.jq.jq` also present, `include "mod.jq"` resolves to *that* file's
+/// definition, not `mod.jq`'s -- pinning that the fix is "append `.jq`
+/// unconditionally," not merely "reject an already-suffixed path."
 ///
-/// Pre-existing and unrelated to #2395, which only relocated the `ends_with(".jq")`
-/// arm responsible; tracked as issue 2702. This test exists so that arm is
-/// covered rather than silently untested, and **is expected to flip** when 2702
-/// is fixed -- at which point it should assert jq's `module not found` and exit
-/// 3 instead.
+/// Pre-existing and unrelated to #2395, which only relocated the
+/// `ends_with(".jq")` arm responsible.
 #[test]
-fn test_include_with_explicit_jq_suffix_diverges_from_jq_2702() -> Result<()> {
+fn test_include_appends_jq_suffix_unconditionally_2702() -> Result<()> {
     let temp_dir = tempfile::tempdir()?;
     std::fs::write(
         temp_dir.path().join("mod.jq"),
         "def length: \"s-length\";\n",
+    )?;
+
+    let (output, code) = spawn_with_signal_retry(
+        || {
+            let mut command = Command::new(succinctly_bin());
+            command
+                .args(["jq", "-L"])
+                .arg(temp_dir.path())
+                .args(["-nc", r#"include "mod.jq"; length"#]);
+            command
+        },
+        None,
+    )?;
+    let stderr = String::from_utf8(output.stderr)?;
+    assert_eq!(code, 3, "stderr: {stderr:?}");
+    assert!(
+        stderr.contains("mod.jq") && stderr.to_lowercase().contains("not found"),
+        "stderr: {stderr:?}"
+    );
+
+    std::fs::write(
+        temp_dir.path().join("mod.jq.jq"),
+        "def length: \"double-suffix\";\n",
     )?;
     let (output, code) = spawn_with_signal_retry(
         || {
@@ -23416,9 +23439,10 @@ fn test_include_with_explicit_jq_suffix_diverges_from_jq_2702() -> Result<()> {
     assert_eq!(code, 0, "stderr: {stderr:?}");
     assert_eq!(
         stdout.trim_end(),
-        r#""s-length""#,
-        "succinctly resolves the explicit .jq suffix; real jq would error here (issue 2702)"
+        r#""double-suffix""#,
+        "stderr: {stderr:?}"
     );
+
     Ok(())
 }
 

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -23401,17 +23401,21 @@ fn test_include_appends_jq_suffix_unconditionally_2702() -> Result<()> {
         "def length: \"s-length\";\n",
     )?;
 
-    let (output, code) = spawn_with_signal_retry(
-        || {
-            let mut command = Command::new(succinctly_bin());
-            command
-                .args(["jq", "-L"])
-                .arg(temp_dir.path())
-                .args(["-nc", r#"include "mod.jq"; length"#]);
-            command
-        },
-        None,
-    )?;
+    let run = || {
+        spawn_with_signal_retry(
+            || {
+                let mut command = Command::new(succinctly_bin());
+                command
+                    .args(["jq", "-L"])
+                    .arg(temp_dir.path())
+                    .args(["-nc", r#"include "mod.jq"; length"#]);
+                command
+            },
+            None,
+        )
+    };
+
+    let (output, code) = run()?;
     let stderr = String::from_utf8(output.stderr)?;
     assert_eq!(code, 3, "stderr: {stderr:?}");
     assert!(
@@ -23423,17 +23427,7 @@ fn test_include_appends_jq_suffix_unconditionally_2702() -> Result<()> {
         temp_dir.path().join("mod.jq.jq"),
         "def length: \"double-suffix\";\n",
     )?;
-    let (output, code) = spawn_with_signal_retry(
-        || {
-            let mut command = Command::new(succinctly_bin());
-            command
-                .args(["jq", "-L"])
-                .arg(temp_dir.path())
-                .args(["-nc", r#"include "mod.jq"; length"#]);
-            command
-        },
-        None,
-    )?;
+    let (output, code) = run()?;
     let stdout = String::from_utf8(output.stdout)?;
     let stderr = String::from_utf8(output.stderr)?;
     assert_eq!(code, 0, "stderr: {stderr:?}");


### PR DESCRIPTION
## Summary
- `resolve_module_in` special-cased a module path already ending in `.jq` and resolved it as-is; real jq appends `.jq` unconditionally regardless of the path's own suffix, so `include "m.jq"` looks for `m.jq.jq`, never `m.jq` itself.
- Confirmed live against jq 1.7.1: with only `m.jq` present, jq rejects the program (`module not found: m.jq`, exit 3) where succinctly ran it successfully; with `m.jq.jq` also present, jq reads *that* file, not `m.jq` -- pinning that the fix is "append `.jq` unconditionally," not merely "reject an already-suffixed path."
- Fixed by dropping the `ends_with(".jq")` special case, per ADR-0018 rule 3 (bug-for-bug fidelity is the default; no documentation records the lenient behavior as intended).
- Updated the pre-existing characterization test from PR #2684/#2395 (`test_include_with_explicit_jq_suffix_diverges_from_jq_2702`), which explicitly documented itself as "expected to flip when 2702 is fixed" -- now `test_include_appends_jq_suffix_unconditionally_2702`, asserting both directions.

Fixes #2702

## Test plan
- [x] New/updated regression test covering both directions (rejection when only `m.jq` exists; reads `m.jq.jq` when both exist), oracle-verified against jq 1.7.1
- [x] Confirmed no other test relies on the old lenient `.jq`-suffix resolution
- [x] `cargo test --features cli` -- full suite passes, 0 failures
- [x] `cargo clippy --all-targets --all-features -- -D warnings` -- clean
- [x] Patch coverage: 100% (1/1 new lines covered)