### PR TITLE
fix(jq): module-not-found compile error matches jq exactly

### DIFF
--- a/docs/compliance/jq/limitations.md
+++ b/docs/compliance/jq/limitations.md
@@ -2742,6 +2742,40 @@ yq has no `def` at all — its lexer rejects `def f: 42; f` outright — so succ
 support there is an extension (ADR-0018 rule 5) rather than a behaviour with a reference to
 match.
 
+### The other three compile-error paths — one closed, two still open (#2703)
+
+[#2703](https://github.com/rust-works/succinctly/issues/2703) found that the shape above
+(`jq: error: … at <top-level>, line N:`, the echoed source, and the `jq: N compile error(s)`
+trailer) was reproduced only on the undefined-name/arity path this section describes — three
+sibling compile-error paths used a flat `jq: compile error: {e}` or `jq: module error: {e}`
+instead, disagreeing with the runner's own correct sibling.
+
+**Closed: an unresolvable `include`/`import` (`module not found`).** Fully deterministic —
+no source position to compute, so nothing blocks matching jq byte for byte:
+`jq: error: module not found: {name}`, a blank line (jq's own stand-in for the missing source
+echo), then the trailer. `ModuleLoader::ensure_module_loaded`'s not-found case now reports
+this exactly; verified against jq 1.7.1 for both `include` and `import`.
+
+**Still open: a syntax error in the main filter, and a syntax error inside an `include`d
+module.** Unlike the deterministic not-found case, jq's trailing padding for a *syntax*
+error is not the same fixed rule as the undefined-name case above — probing several shapes
+(`1 +`, `.foo[`, `{a:`, `1,,`, `.foo | 1,, | .bar`) all echoed the line plus `len - 1` trailing
+spaces, but `if 1 then` breaks that pattern: it produces *two* separate compile errors from
+one parse, one padded per the `len - 1` rule and the second with none at all. jq's real rule
+depends on the specific diagnostic's own token span, which is bison/lexer internals this
+codebase has no access to; reproducing it needs either reading jq's C parser source
+(`parser.y`/`scanner.l`) or a much wider oracle sweep than #2703 did. Also unresolved: jq's
+parser can report *multiple* compile errors from a single malformed filter (again, `if 1 then`
+→ 2 errors); succinctly's parser returns a single `Result<_, ParseError>` and has no
+architecture for accumulating more than one, which is a separate, larger gap than the message
+wording alone.
+
+Until that lands, these two paths keep their pre-#2703 shape: `jq: compile error: parse error
+at position N: …` for the main filter, `jq: module error: parse error in module '{path}': …`
+for a module (naming the path as given on the command line, not jq's resolved absolute path).
+Both still exit 3, matching jq, and neither corrupts output or crashes — the two conditions
+that would otherwise make this an accepted ADR-0018 divergence rather than an open gap.
+
 ## Recursive `def`s: what a native call stack costs that jq's own does not — #1371
 
 > The `MAX_EVAL_FRAMES` raise is uncatchable by `?`/`try`/`catch` since #2132 -- see "Every resource cap is uncatchable" below.

--- a/docs/compliance/jq/limitations.md
+++ b/docs/compliance/jq/limitations.md
@@ -2750,11 +2750,31 @@ trailer) was reproduced only on the undefined-name/arity path this section descr
 sibling compile-error paths used a flat `jq: compile error: {e}` or `jq: module error: {e}`
 instead, disagreeing with the runner's own correct sibling.
 
-**Closed: an unresolvable `include`/`import` (`module not found`).** Fully deterministic —
-no source position to compute, so nothing blocks matching jq byte for byte:
-`jq: error: module not found: {name}`, a blank line (jq's own stand-in for the missing source
-echo), then the trailer. `ModuleLoader::ensure_module_loaded`'s not-found case now reports
-this exactly; verified against jq 1.7.1 for both `include` and `import`.
+**Closed for a single unresolvable `include`/`import` (`module not found`).** Fully
+deterministic when only one module fails to resolve — no source position to compute, so
+nothing blocks matching jq byte for byte: `jq: error: module not found: {name}`, a blank
+line (jq's own stand-in for the missing source echo), then the trailer.
+`ModuleLoader::ensure_module_loaded`'s not-found case now reports this exactly; verified
+against jq 1.7.1 for both `include` and `import`.
+
+**Residual gap: which module is named when *more than one* is unresolvable.** jq reports
+the last failing declaration in true source order, regardless of `include`/`import` kind
+or how many resolvable declarations sit between the failures (confirmed live: `include
+"AAA"; include "BBB"; include "CCC"; 1` names `CCC`; interleaving kinds --
+`include "CCC"; import "AAA" as a; 1` names `AAA`, and reversing the two names `CCC` --
+always whichever comes last in the source, not last within its own directive kind). Two
+architectural reasons this codebase can't reproduce that: `Program` stores `includes` and
+`imports` as two separate `Vec`s with no shared position or interleaving order between
+them (unlike `Expr::FuncCall`'s own well-known missing-position problem elsewhere in this
+document, extending `Import`/`Include` the same way is unexplored, not deliberately
+declined); and `ModuleLoader::unqualified_def_names` (#2395) resolves every `include`
+*before* `process_program` ever looks at an `import`, so a failing `import` is never even
+reached when an earlier-declared `include` also fails, regardless of which one jq itself
+would report. Succinctly instead reports the first `include` failure it encounters, or (if
+every `include` resolves) the first failing declaration in whichever of the two
+`process_program` loops runs into one -- includes, then imports, each in their own list
+order. This is a gap #2703's own single-module repro never exercised; tracked separately
+as [#2857](https://github.com/rust-works/succinctly/issues/2857).
 
 **Still open: a syntax error in the main filter, and a syntax error inside an `include`d
 module.** Unlike the deterministic not-found case, jq's trailing padding for a *syntax*

--- a/src/bin/succinctly/jq_runner.rs
+++ b/src/bin/succinctly/jq_runner.rs
@@ -46,15 +46,59 @@ pub struct EvalContext {
     pub positional: Vec<OwnedValue>,
 }
 
+/// A module or filter's function definitions, as extracted from its parsed
+/// `Expr`: name, parameters, body. Named (#2703) so the two-parameter
+/// `Result<_, ModuleLoadError>` signatures this module needs don't also
+/// spell out this tuple-of-a-tuple inline, which clippy's `type_complexity`
+/// lint flags once it stops being folded into `anyhow::Result`'s single-
+/// parameter alias.
+type FuncDefList = Vec<(String, Vec<Param>, Expr)>;
+
 /// Module loader for resolving and loading jq modules.
 #[derive(Debug)]
 pub struct ModuleLoader {
     /// Search path for modules (in order of priority)
     search_path: Vec<PathBuf>,
     /// Loaded modules (path -> function definitions: name, params, body)
-    loaded_modules: BTreeMap<String, Vec<(String, Vec<Param>, Expr)>>,
+    loaded_modules: BTreeMap<String, FuncDefList>,
     /// Auto-loaded ~/.jq file definitions (if file exists): name, params, body
-    auto_loaded_defs: Vec<(String, Vec<Param>, Expr)>,
+    auto_loaded_defs: FuncDefList,
+}
+
+/// A [`ModuleLoader`] failure, structured enough to report in jq's own
+/// per-case shape (#2703) -- unlike a flattened `anyhow::Error`, which loses
+/// the distinction [`report_module_load_error`] needs.
+pub(crate) enum ModuleLoadError {
+    /// No `{module_path}.jq` was found anywhere in the search path. jq's own
+    /// shape has no source location to show for this case: `module not
+    /// found: {module_path}`, a blank line standing in for the missing echo,
+    /// then the usual `jq: 1 compile error` trailer. Confirmed live against
+    /// jq 1.7.1, byte-for-byte.
+    NotFound { module_path: String },
+    /// The module could not be read, or its own contents failed to parse.
+    /// jq's shape for this case additionally names the resolved *absolute*
+    /// path and echoes the module's own source line -- #2703's fix does not
+    /// yet extend this far (see the issue's own follow-up note on the
+    /// syntax-error padding rule, which isn't a fixed formula), so this
+    /// stays an opaque `anyhow::Error`, reported the same way as before.
+    Other(anyhow::Error),
+}
+
+/// Print a [`ModuleLoadError`] the way `run_jq`'s two call sites both need
+/// to (#2703): one shared place so the not-found case's jq-matching shape
+/// can't drift between them the way the two `eprintln!("jq: module error:
+/// {e}")` sites used to have to be kept in step by hand.
+fn report_module_load_error(e: &ModuleLoadError) {
+    match e {
+        ModuleLoadError::NotFound { module_path } => {
+            eprintln!("jq: error: module not found: {module_path}");
+            eprintln!();
+            eprintln!("jq: 1 compile error");
+        }
+        ModuleLoadError::Other(inner) => {
+            eprintln!("jq: module error: {inner}");
+        }
+    }
 }
 
 /// Resolve a module path to a file path within `search_path`.
@@ -136,7 +180,7 @@ impl ModuleLoader {
     fn ensure_module_loaded(
         &mut self,
         module_path: &str,
-    ) -> Result<&Vec<(String, Vec<Param>, Expr)>> {
+    ) -> Result<&FuncDefList, ModuleLoadError> {
         // `entry` rather than `get`-then-insert: the borrow checker cannot
         // see that an early `return` of `get`'s borrow ends it, so the
         // `contains_key` spelling would need an unreachable `expect` on the
@@ -148,16 +192,21 @@ impl ModuleLoader {
                 // Resolve the module path
                 let file_path =
                     resolve_module_in(&self.search_path, module_path).ok_or_else(|| {
-                        anyhow::anyhow!("module '{module_path}' not found in search path")
+                        ModuleLoadError::NotFound {
+                            module_path: module_path.to_string(),
+                        }
                     })?;
 
                 // Read and parse the module
                 let contents = std::fs::read_to_string(&file_path)
-                    .with_context(|| format!("failed to read module: {}", file_path.display()))?;
+                    .with_context(|| format!("failed to read module: {}", file_path.display()))
+                    .map_err(ModuleLoadError::Other)?;
 
-                let program = jq::parse_program(&contents).map_err(|e| {
-                    anyhow::anyhow!("parse error in module '{}': {}", file_path.display(), e)
-                })?;
+                let program = jq::parse_program(&contents)
+                    .map_err(|e| {
+                        anyhow::anyhow!("parse error in module '{}': {}", file_path.display(), e)
+                    })
+                    .map_err(ModuleLoadError::Other)?;
 
                 // Extract function definitions from the expression
                 Ok(entry.insert(extract_func_defs(&program.expr)))
@@ -167,7 +216,10 @@ impl ModuleLoader {
 
     /// Load a module and return an owned copy of its function definitions
     /// (name, params, body).
-    pub fn load_module(&mut self, module_path: &str) -> Result<Vec<(String, Vec<Param>, Expr)>> {
+    pub fn load_module(
+        &mut self,
+        module_path: &str,
+    ) -> Result<FuncDefList, ModuleLoadError> {
         self.ensure_module_loaded(module_path).cloned()
     }
 
@@ -188,7 +240,10 @@ impl ModuleLoader {
     /// re-reads and re-parses nothing. A module that cannot be resolved fails
     /// here instead of there, one step earlier but still after the main filter
     /// has parsed, so the caller's error and exit code are unchanged.
-    pub fn unqualified_def_names(&mut self, program: &Program) -> Result<BTreeSet<String>> {
+    pub fn unqualified_def_names(
+        &mut self,
+        program: &Program,
+    ) -> Result<BTreeSet<String>, ModuleLoadError> {
         let mut names: BTreeSet<String> = self
             .auto_loaded_defs
             .iter()
@@ -204,7 +259,7 @@ impl ModuleLoader {
     }
 
     /// Process imports and includes, returning the modified expression with all functions defined.
-    pub fn process_program(&mut self, program: &Program) -> Result<Expr> {
+    pub fn process_program(&mut self, program: &Program) -> Result<Expr, ModuleLoadError> {
         let mut expr = program.expr.clone();
 
         // First, prepend auto-loaded ~/.jq definitions (lowest priority, can be overridden)
@@ -551,10 +606,10 @@ fn rewrite_namespaced_calls(expr: Expr) -> Expr {
 }
 
 /// Extract function definitions from an expression, preserving parameters.
-fn extract_func_defs(expr: &Expr) -> Vec<(String, Vec<Param>, Expr)> {
+fn extract_func_defs(expr: &Expr) -> FuncDefList {
     let mut defs = Vec::new();
 
-    fn extract_inner(expr: &Expr, defs: &mut Vec<(String, Vec<Param>, Expr)>) {
+    fn extract_inner(expr: &Expr, defs: &mut FuncDefList) {
         if let Expr::FuncDef {
             name,
             params,
@@ -1413,7 +1468,7 @@ pub fn run_jq(args: JqCommand) -> Result<i32> {
     let module_def_names = match module_loader.unqualified_def_names(&program) {
         Ok(names) => names,
         Err(e) => {
-            eprintln!("jq: module error: {e}");
+            report_module_load_error(&e);
             return Ok(exit_codes::COMPILE_ERROR);
         }
     };
@@ -1445,7 +1500,7 @@ pub fn run_jq(args: JqCommand) -> Result<i32> {
     let expr = match module_loader.process_program(&program) {
         Ok(expr) => expr,
         Err(e) => {
-            eprintln!("jq: module error: {e}");
+            report_module_load_error(&e);
             return Ok(exit_codes::COMPILE_ERROR);
         }
     };

--- a/src/bin/succinctly/jq_runner.rs
+++ b/src/bin/succinctly/jq_runner.rs
@@ -68,6 +68,7 @@ pub struct ModuleLoader {
 /// A [`ModuleLoader`] failure, structured enough to report in jq's own
 /// per-case shape (#2703) -- unlike a flattened `anyhow::Error`, which loses
 /// the distinction [`report_module_load_error`] needs.
+#[derive(Debug)]
 pub(crate) enum ModuleLoadError {
     /// No `{module_path}.jq` was found anywhere in the search path. jq's own
     /// shape has no source location to show for this case: `module not
@@ -82,6 +83,12 @@ pub(crate) enum ModuleLoadError {
     /// syntax-error padding rule, which isn't a fixed formula), so this
     /// stays an opaque `anyhow::Error`, reported the same way as before.
     Other(anyhow::Error),
+}
+
+impl From<anyhow::Error> for ModuleLoadError {
+    fn from(e: anyhow::Error) -> Self {
+        Self::Other(e)
+    }
 }
 
 /// Print a [`ModuleLoadError`] the way `run_jq`'s two call sites both need
@@ -177,10 +184,7 @@ impl ModuleLoader {
     /// does not pay for a deep clone of every def body it is about to drop
     /// (#2395). [`Self::load_module`] is this plus that clone, for callers
     /// that need an owned copy.
-    fn ensure_module_loaded(
-        &mut self,
-        module_path: &str,
-    ) -> Result<&FuncDefList, ModuleLoadError> {
+    fn ensure_module_loaded(&mut self, module_path: &str) -> Result<&FuncDefList, ModuleLoadError> {
         // `entry` rather than `get`-then-insert: the borrow checker cannot
         // see that an early `return` of `get`'s borrow ends it, so the
         // `contains_key` spelling would need an unreachable `expect` on the
@@ -199,14 +203,11 @@ impl ModuleLoader {
 
                 // Read and parse the module
                 let contents = std::fs::read_to_string(&file_path)
-                    .with_context(|| format!("failed to read module: {}", file_path.display()))
-                    .map_err(ModuleLoadError::Other)?;
+                    .with_context(|| format!("failed to read module: {}", file_path.display()))?;
 
-                let program = jq::parse_program(&contents)
-                    .map_err(|e| {
-                        anyhow::anyhow!("parse error in module '{}': {}", file_path.display(), e)
-                    })
-                    .map_err(ModuleLoadError::Other)?;
+                let program = jq::parse_program(&contents).map_err(|e| {
+                    anyhow::anyhow!("parse error in module '{}': {}", file_path.display(), e)
+                })?;
 
                 // Extract function definitions from the expression
                 Ok(entry.insert(extract_func_defs(&program.expr)))
@@ -216,10 +217,7 @@ impl ModuleLoader {
 
     /// Load a module and return an owned copy of its function definitions
     /// (name, params, body).
-    pub fn load_module(
-        &mut self,
-        module_path: &str,
-    ) -> Result<FuncDefList, ModuleLoadError> {
+    pub fn load_module(&mut self, module_path: &str) -> Result<FuncDefList, ModuleLoadError> {
         self.ensure_module_loaded(module_path).cloned()
     }
 

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -23425,18 +23425,44 @@ fn test_module_shadow_scope_boundaries_unchanged_2395() -> Result<()> {
     Ok(())
 }
 
-/// #2395 regression guard: an unresolvable module is still the same compile
-/// error with the same exit code, now that the loader runs one step earlier
-/// (the shadow-name collection resolves every `include` before the re-parse,
-/// where previously `process_program` was the first to touch them).
+/// #2395 regression guard, updated for #2703: an unresolvable module is
+/// still the same compile error with the same exit code, now that the
+/// loader runs one step earlier (the shadow-name collection resolves every
+/// `include` before the re-parse, where previously `process_program` was
+/// the first to touch them).
+///
+/// #2703 fixed this specific case's *wording* to match jq exactly -- see
+/// `test_module_not_found_matches_jq_exactly_2703` below for the full
+/// byte-for-byte pin; this test only re-asserts the exit code and message
+/// content the #2395 guard originally existed to protect.
 #[test]
 fn test_module_not_found_still_reports_module_error_2395() -> Result<()> {
     let (stdout, stderr, code) = run_jq_full(&["-nc", r#"include "nosuchmod"; 1"#], None)?;
     assert_eq!(code, 3, "stdout: {stdout:?} stderr: {stderr:?}");
-    assert!(
-        stderr.contains("module error") && stderr.contains("nosuchmod"),
-        "stderr: {stderr:?}"
-    );
+    assert!(stderr.contains("nosuchmod"), "stderr: {stderr:?}");
+    Ok(())
+}
+
+/// #2703: `include`/`import`'s module-not-found error now matches jq 1.7.1
+/// byte-for-byte, not just in exit code -- `jq: error: module not found:
+/// {name}`, a blank line standing in for the missing source echo (jq has no
+/// location to show for a module it never found), then the usual `jq: 1
+/// compile error` trailer. Both directives share the same underlying
+/// `ModuleLoader::ensure_module_loaded`, so both are pinned here. Oracle-
+/// verified against jq 1.7.1.
+///
+/// Before this fix: `jq: module error: module 'nosuchmod' not found in
+/// search path\n` -- wrong prefix, wrong wording, no trailer.
+#[test]
+fn test_module_not_found_matches_jq_exactly_2703() -> Result<()> {
+    for filter in [r#"include "nosuchmod"; 1"#, r#"import "nosuchmod" as m; 1"#] {
+        let (stdout, stderr, code) = run_jq_full(&["-nc", filter], None)?;
+        assert_eq!(code, 3, "{filter}: stdout {stdout:?} stderr {stderr:?}");
+        assert_eq!(
+            stderr, "jq: error: module not found: nosuchmod\n\njq: 1 compile error\n",
+            "{filter}"
+        );
+    }
     Ok(())
 }
 
@@ -23506,9 +23532,13 @@ fn test_module_search_path_falls_through_to_a_later_dir_2395() -> Result<()> {
 
 /// #2395: a module whose own text does not parse is a compile error, exit 3 --
 /// not a panic, and not a silently ignored module. jq 1.7.1 also exits 3 here
-/// (its wording names the file and line, where succinctly reports the module
-/// path and a byte position -- the same pre-existing wording gap already
-/// recorded for `module not found`).
+/// (its wording names the file by *absolute* resolved path and reports a
+/// line + echoed source, where succinctly reports the module path as given
+/// on the command line and a byte position -- unlike the sibling
+/// `module not found` wording gap, #2703 does not close this one: jq's own
+/// source-echo padding for a syntax error is not a fixed formula -- see
+/// #2703's own follow-up note -- so it stays a documented, unfixed
+/// divergence for now).
 #[test]
 fn test_module_with_a_syntax_error_is_a_compile_error_2395() -> Result<()> {
     let temp_dir = tempfile::tempdir()?;


### PR DESCRIPTION
## Summary

Partial fix for #2703 -- see "Scope" below for what's deliberately left open.

- Three of jq's four compile-error paths used a flat `jq: compile error: {e}`/`jq: module error: {e}` wrapper instead of the `jq: error: ... at LOCATION, line N:` shape plus `jq: N compile error(s)` trailer the runner already reproduces correctly for undefined-name/arity resolution (#1473).
- Of those three, an unresolvable `include`/`import` (module not found) is fully deterministic -- no source position to compute -- so this closes it completely: `jq: error: module not found: {name}`, a blank line standing in for the missing source echo, then the trailer. Matches jq 1.7.1 byte for byte, verified for both `include` and `import`.
- Introduced `ModuleLoadError` so the not-found case can be distinguished and reported in its own shape without disturbing the two still-unfixed module-error cases sharing the same call sites (`unqualified_def_names`, `process_program`).

## Scope: two of #2703's four paths are NOT fixed here

- A syntax error in the main filter, and a syntax error inside an `include`d module, both keep their pre-existing (wrong) shape.
- Investigated jq's trailing-padding rule for a syntax error and found it is **not** the same fixed formula as the undefined-name case: probing several shapes (`1 +`, `.foo[`, `{a:`, `1,,`, `.foo | 1,, | .bar`) all echoed the line plus `len - 1` trailing spaces, but `if 1 then` breaks that pattern -- it produces **two** separate compile errors from one parse, one padded per the `len - 1` rule and the second with none at all.
- jq's real rule depends on the specific diagnostic's own token span (bison/lexer internals), and jq's parser can report multiple compile errors from a single filter, which succinctly's parser architecture (`Result<_, ParseError>`, single error) has no way to represent at all. Both need real jq C-source study (`parser.y`/`scanner.l`) or a much wider oracle sweep than this PR did -- left as #2703's remaining scope, documented in `docs/compliance/jq/limitations.md`.
- I'll leave a comment on #2703 explaining this split; the issue stays open rather than closing, since two of its four paths remain.

## Test plan
- [x] New regression test `test_module_not_found_matches_jq_exactly_2703` (both `include` and `import`), byte-for-byte pin against jq 1.7.1
- [x] Updated the pre-existing `test_module_not_found_still_reports_module_error_2395` (its old `"module error"` assertion no longer holds) and a stale doc comment on `test_module_with_a_syntax_error_is_a_compile_error_2395`
- [x] Confirmed the still-open syntax-error paths are genuinely unaffected (byte-for-byte identical output before/after)
- [x] `cargo test --features cli` -- full suite passes, 0 failures
- [x] `cargo clippy --all-targets --all-features -- -D warnings` -- clean
- [x] Patch coverage: 100% (34/34 new lines covered)