### PR TITLE
fix(jq): resolve a multi-arg builtin's wrong-arity call in place, not via the retry budget

### DIFF
--- a/src/jq/parser.rs
+++ b/src/jq/parser.rs
@@ -404,9 +404,41 @@ struct Parser<'a> {
     /// reparse can fire across this whole parse, so a deeply nested,
     /// arity-mismatched shadow candidate degrades to "stops shadowing past
     /// this depth" instead of the `O(2^depth)` blowup that function's own
-    /// doc comment describes. An ordinary, non-adversarial program never
-    /// comes close to this; the exact constant is not load-bearing.
+    /// doc comment describes.
+    ///
+    /// **"An ordinary, non-adversarial program never comes close to this"
+    /// was false until #2807.** Every one of `try_parse_builtin`'s 27
+    /// multi-argument and optional-arity arms used to reach that fallback
+    /// for a wrong-arity call under a shadowing `def`, so 65 flat
+    /// `def test(a;b;c): a; test(1;2;3)` calls -- or 7 nested ones,
+    /// the budget being spent `2^depth` times -- exhausted it and turned a
+    /// program jq 1.7.1 accepts into a raw `expected ')', found ';'` parse
+    /// error. Those arms now resolve the call in place
+    /// ([`Self::builtin_wrong_arity_or_expect`]) and draw nothing from this
+    /// budget, which is what makes the claim true again rather than a
+    /// larger constant would have: the nested shape is exponential, so
+    /// every constant is reachable at some small depth.
+    ///
+    /// What can still draw on it: a shadow candidate whose *dedicated*
+    /// parser fails for a reason that is not an argument boundary -- a
+    /// genuine syntax error inside an argument, which the generic reparse
+    /// rejects too. The constant is not load-bearing for those.
     shadow_retry_budget: usize,
+    /// #2807: the wrong-arity call a [`Self::try_parse_builtin`] arm
+    /// resolved in place, handed to its one caller alongside `Ok(None)`.
+    ///
+    /// That function answers `Result<Option<Builtin>, ParseError>`, and a
+    /// wrong-arity call is an `Expr::FuncCall` -- no `Builtin` at all -- so
+    /// an arm that has already parsed its arguments and then finds the
+    /// boundary wrong ([`Self::builtin_wrong_arity_or_expect`]) has nowhere
+    /// to return it. It parks it here and answers `Ok(None)`, the same "not
+    /// this builtin after all" signal [`Self::parse_required_single_arg`]'s
+    /// rewind already uses; `parse_primary_inner`'s `Ok(None)` arm takes it
+    /// instead of re-parsing the call from source.
+    ///
+    /// Always `None` between calls: the arm returns immediately after
+    /// parking, and the sole caller takes it as the first thing it does.
+    wrong_arity_call: Option<Expr>,
 }
 
 /// Where one ordinary function call's identifier begins in the filter source
@@ -531,6 +563,7 @@ impl<'a> Parser<'a> {
             call_sites: Vec::new(),
             shadowable_defs,
             shadow_retry_budget: SHADOW_RETRY_BUDGET,
+            wrong_arity_call: None,
         }
     }
 
@@ -2057,6 +2090,14 @@ impl<'a> Parser<'a> {
                         // only fails later at name resolution), so jq mode
                         // keeps the postfix fix.
                         Ok(None) => {
+                            // #2807: an arm that had already parsed its
+                            // arguments when it found the boundary wrong
+                            // resolved the call itself (postfix included)
+                            // and parked it -- take it rather than
+                            // re-parsing the same text.
+                            if let Some(call) = self.wrong_arity_call.take() {
+                                return Ok(call);
+                            }
                             let call = self.parse_func_call_or_error()?;
                             if self.mode == ParserMode::Jq {
                                 self.parse_postfix(call)
@@ -3215,6 +3256,45 @@ impl<'a> Parser<'a> {
         self.expect(expected).map(|()| unreachable!())
     }
 
+    /// [`Self::wrong_arity_or_expect`] for a [`Self::try_parse_builtin`]
+    /// arm, whose answer is a `Builtin` rather than an `Expr` (#2807).
+    ///
+    /// The 27 multi-argument and optional-arity arms in that function
+    /// checked their argument boundaries with a bare `self.expect(';')?` /
+    /// `self.expect(')')?`, so a wrong-arity call under a shadowing `def`
+    /// reached `parse_primary_inner`'s `Err` arm and was recovered only by
+    /// [`Self::retry_shadow_candidate_as_generic_call`]'s re-parse -- which
+    /// re-scans the whole argument text from the keyword (`O(2^depth)` when
+    /// nested, #2686's shape) and spends one unit of the process-wide
+    /// [`SHADOW_RETRY_BUDGET`]. 65 flat `def test(a;b;c): a; test(1;2;3)`
+    /// calls, or 7 nested ones, exhausted that budget and turned a program
+    /// jq 1.7.1 accepts into a raw `expected ')', found ';'` parse error.
+    /// Handing the already-parsed arguments over instead reaches the same
+    /// generic call with no re-parse and no budget draw -- and, for an
+    /// *unshadowed* spelling, replaces that parse error with jq's own
+    /// `test/3 is not defined` (#2573's MULTI-ARG remainder).
+    ///
+    /// The parked `Expr` is collected by `parse_primary_inner`; see
+    /// [`Self::wrong_arity_call`] for why it travels in a field. Shaped as
+    /// "check, else return" like its sibling, so `args` moves only on the
+    /// diverging branch and the caller keeps using its own bindings on the
+    /// success path. yq mode raises `expect`'s own natural error, the same
+    /// carve-out every member of this family applies.
+    fn builtin_wrong_arity_or_expect(
+        &mut self,
+        start_pos: usize,
+        expected: char,
+        args: Vec<Expr>,
+    ) -> Result<Option<Builtin>, ParseError> {
+        let call = self.wrong_arity_or_expect(start_pos, expected, args)?;
+        debug_assert!(
+            self.wrong_arity_call.is_none(),
+            "a parked wrong-arity call was not collected by parse_primary_inner (#2807)"
+        );
+        self.wrong_arity_call = Some(call);
+        Ok(None)
+    }
+
     /// One shared definition of the 7-line argument-boundary checkpoint
     /// hand-copied at ~15 sites (#2391) across the eight dedicated
     /// special-form parsers that resolve a mismatch via
@@ -3555,8 +3635,22 @@ impl<'a> Parser<'a> {
     ///   reparses across the whole program to a small constant, keeping the
     ///   worst case linear instead of exponential -- past the budget,
     ///   `original_err` is propagated instead, the same as if `name` had
-    ///   never been a shadow candidate at all. Ordinary, non-adversarial
-    ///   programs never come close to exhausting it.
+    ///   never been a shadow candidate at all.
+    ///
+    ///   **#2807 corrected "ordinary, non-adversarial programs never come
+    ///   close to exhausting it."** They did: every wrong-arity call to one
+    ///   of `try_parse_builtin`'s 27 multi-argument and optional-arity
+    ///   builtins under a shadowing `def` arrived here, so 65 flat
+    ///   `def test(a;b;c): a; test(1;2;3)` calls, or 7 nested ones, spent
+    ///   the whole budget and rejected a program jq 1.7.1 accepts. Those
+    ///   arms resolve their own wrong-arity calls now
+    ///   ([`Self::builtin_wrong_arity_or_expect`]) and never reach this
+    ///   function; what is left here is a shadow candidate whose dedicated
+    ///   parser failed for a reason that is *not* an argument boundary --
+    ///   a genuine syntax error inside an argument, which this fallback's
+    ///   own reparse rejects as well. For those the retry only re-reports
+    ///   the same error, so exhausting the budget cannot change a
+    ///   program's verdict, only which error text it carries.
     fn retry_shadow_candidate_as_generic_call(
         &mut self,
         start_pos: usize,
@@ -3805,6 +3899,7 @@ impl<'a> Parser<'a> {
         if self.matches_keyword("halt_error") {
             // Check halt_error before halt so "halt_error" isn't parsed as
             // "halt" followed by a stray "_error".
+            let keyword_start = self.pos;
             self.consume_keyword("halt_error");
             self.skip_ws();
             if self.peek() == Some('(') {
@@ -3812,7 +3907,10 @@ impl<'a> Parser<'a> {
                 self.skip_ws();
                 let code = self.parse_expr()?;
                 self.skip_ws();
-                self.expect(')')?;
+                if self.peek() != Some(')') {
+                    return self.builtin_wrong_arity_or_expect(keyword_start, ')', vec![code]);
+                }
+                self.next();
                 return Ok(Some(Builtin::HaltErrorCode(Box::new(code))));
             }
             return Ok(Some(Builtin::HaltError));
@@ -3852,6 +3950,7 @@ impl<'a> Parser<'a> {
         }
         // any, any(cond), any(gen; cond)
         if self.matches_keyword("any") {
+            let keyword_start = self.pos;
             self.consume_keyword("any");
             self.skip_ws();
             if self.peek() == Some('(') {
@@ -3864,16 +3963,27 @@ impl<'a> Parser<'a> {
                     self.skip_ws();
                     let cond = self.parse_expr()?;
                     self.skip_ws();
-                    self.expect(')')?;
+                    if self.peek() != Some(')') {
+                        return self.builtin_wrong_arity_or_expect(
+                            keyword_start,
+                            ')',
+                            vec![f, cond],
+                        );
+                    }
+                    self.next();
                     return Ok(Some(Builtin::AnyCond(Box::new(f), Box::new(cond))));
                 }
-                self.expect(')')?;
+                if self.peek() != Some(')') {
+                    return self.builtin_wrong_arity_or_expect(keyword_start, ')', vec![f]);
+                }
+                self.next();
                 return Ok(Some(Builtin::AnyF(Box::new(f))));
             }
             return Ok(Some(Builtin::Any));
         }
         // all, all(cond), all(gen; cond)
         if self.matches_keyword("all") {
+            let keyword_start = self.pos;
             self.consume_keyword("all");
             self.skip_ws();
             if self.peek() == Some('(') {
@@ -3886,10 +3996,20 @@ impl<'a> Parser<'a> {
                     self.skip_ws();
                     let cond = self.parse_expr()?;
                     self.skip_ws();
-                    self.expect(')')?;
+                    if self.peek() != Some(')') {
+                        return self.builtin_wrong_arity_or_expect(
+                            keyword_start,
+                            ')',
+                            vec![f, cond],
+                        );
+                    }
+                    self.next();
                     return Ok(Some(Builtin::AllCond(Box::new(f), Box::new(cond))));
                 }
-                self.expect(')')?;
+                if self.peek() != Some(')') {
+                    return self.builtin_wrong_arity_or_expect(keyword_start, ')', vec![f]);
+                }
+                self.next();
                 return Ok(Some(Builtin::AllF(Box::new(f))));
             }
             return Ok(Some(Builtin::All));
@@ -3935,9 +4055,19 @@ impl<'a> Parser<'a> {
         // IN(src; s) - true if any output of src equals any output of s
         if self.matches_keyword("IN") {
             self.reject_unless_jq_extensions("IN")?;
+            let keyword_start = self.pos;
             self.consume_keyword("IN");
             self.skip_ws();
-            self.expect('(')?;
+            // #2807: no `(` at all is a wrong-arity call before any
+            // argument exists -- rewind and let the generic fallback
+            // resolve it (`IN` alone is `IN/0 is not defined` in jq
+            // 1.7.1, not a syntax error). The reparse is arity-0, so the
+            // #2686 exponent this function's other checkpoints avoid does
+            // not arise here.
+            if let Err(early) = self.expect_or_none('(', keyword_start) {
+                return early;
+            }
+            self.next();
             self.skip_ws();
             let first = self.parse_expr()?;
             self.skip_ws();
@@ -3946,10 +4076,16 @@ impl<'a> Parser<'a> {
                 self.skip_ws();
                 let s = self.parse_expr()?;
                 self.skip_ws();
-                self.expect(')')?;
+                if self.peek() != Some(')') {
+                    return self.builtin_wrong_arity_or_expect(keyword_start, ')', vec![first, s]);
+                }
+                self.next();
                 return Ok(Some(Builtin::UpperInSrc(Box::new(first), Box::new(s))));
             }
-            self.expect(')')?;
+            if self.peek() != Some(')') {
+                return self.builtin_wrong_arity_or_expect(keyword_start, ')', vec![first]);
+            }
+            self.next();
             return Ok(Some(Builtin::UpperIn(Box::new(first))));
         }
 
@@ -4015,9 +4151,19 @@ impl<'a> Parser<'a> {
         // Check splits before split since split is a prefix of splits
         if self.matches_keyword("splits") {
             self.reject_unless_jq_extensions("splits")?;
+            let keyword_start = self.pos;
             self.consume_keyword("splits");
             self.skip_ws();
-            self.expect('(')?;
+            // #2807: no `(` at all is a wrong-arity call before any
+            // argument exists -- rewind and let the generic fallback
+            // resolve it (`splits` alone is `splits/0 is not defined` in jq
+            // 1.7.1, not a syntax error). The reparse is arity-0, so the
+            // #2686 exponent this function's other checkpoints avoid does
+            // not arise here.
+            if let Err(early) = self.expect_or_none('(', keyword_start) {
+                return early;
+            }
+            self.next();
             self.skip_ws();
             let re = self.parse_expr()?;
             self.skip_ws();
@@ -4026,16 +4172,32 @@ impl<'a> Parser<'a> {
                 self.skip_ws();
                 let flags = self.parse_expr()?;
                 self.skip_ws();
-                self.expect(')')?;
+                if self.peek() != Some(')') {
+                    return self.builtin_wrong_arity_or_expect(keyword_start, ')', vec![re, flags]);
+                }
+                self.next();
                 return Ok(Some(Builtin::SplitsFlags(Box::new(re), Box::new(flags))));
             }
-            self.expect(')')?;
+            if self.peek() != Some(')') {
+                return self.builtin_wrong_arity_or_expect(keyword_start, ')', vec![re]);
+            }
+            self.next();
             return Ok(Some(Builtin::Splits(Box::new(re))));
         }
         if self.matches_keyword("split") {
+            let keyword_start = self.pos;
             self.consume_keyword("split");
             self.skip_ws();
-            self.expect('(')?;
+            // #2807: no `(` at all is a wrong-arity call before any
+            // argument exists -- rewind and let the generic fallback
+            // resolve it (`split` alone is `split/0 is not defined` in jq
+            // 1.7.1, not a syntax error). The reparse is arity-0, so the
+            // #2686 exponent this function's other checkpoints avoid does
+            // not arise here.
+            if let Err(early) = self.expect_or_none('(', keyword_start) {
+                return early;
+            }
+            self.next();
             self.skip_ws();
             let s = self.parse_expr()?;
             self.skip_ws();
@@ -4052,17 +4214,33 @@ impl<'a> Parser<'a> {
                 // this is shared with `sub` below rather than a second
                 // hand-copied loop.
                 self.parse_yq_arity_leniency_tail()?;
-                self.expect(')')?;
+                if self.peek() != Some(')') {
+                    return self.builtin_wrong_arity_or_expect(keyword_start, ')', vec![s, flags]);
+                }
+                self.next();
                 return Ok(Some(Builtin::SplitRegex(Box::new(s), Box::new(flags))));
             }
-            self.expect(')')?;
+            if self.peek() != Some(')') {
+                return self.builtin_wrong_arity_or_expect(keyword_start, ')', vec![s]);
+            }
+            self.next();
             return Ok(Some(Builtin::Split(Box::new(s))));
         }
         // match function - regex matching
         if self.matches_keyword("match") {
+            let keyword_start = self.pos;
             self.consume_keyword("match");
             self.skip_ws();
-            self.expect('(')?;
+            // #2807: no `(` at all is a wrong-arity call before any
+            // argument exists -- rewind and let the generic fallback
+            // resolve it (`match` alone is `match/0 is not defined` in jq
+            // 1.7.1, not a syntax error). The reparse is arity-0, so the
+            // #2686 exponent this function's other checkpoints avoid does
+            // not arise here.
+            if let Err(early) = self.expect_or_none('(', keyword_start) {
+                return early;
+            }
+            self.next();
             self.skip_ws();
             let re = self.parse_expr()?;
             self.skip_ws();
@@ -4071,17 +4249,33 @@ impl<'a> Parser<'a> {
                 self.skip_ws();
                 let flags = self.parse_expr()?;
                 self.skip_ws();
-                self.expect(')')?;
+                if self.peek() != Some(')') {
+                    return self.builtin_wrong_arity_or_expect(keyword_start, ')', vec![re, flags]);
+                }
+                self.next();
                 return Ok(Some(Builtin::MatchFlags(Box::new(re), Box::new(flags))));
             }
-            self.expect(')')?;
+            if self.peek() != Some(')') {
+                return self.builtin_wrong_arity_or_expect(keyword_start, ')', vec![re]);
+            }
+            self.next();
             return Ok(Some(Builtin::Match(Box::new(re))));
         }
         // capture function - named capture groups
         if self.matches_keyword("capture") {
+            let keyword_start = self.pos;
             self.consume_keyword("capture");
             self.skip_ws();
-            self.expect('(')?;
+            // #2807: no `(` at all is a wrong-arity call before any
+            // argument exists -- rewind and let the generic fallback
+            // resolve it (`capture` alone is `capture/0 is not defined` in jq
+            // 1.7.1, not a syntax error). The reparse is arity-0, so the
+            // #2686 exponent this function's other checkpoints avoid does
+            // not arise here.
+            if let Err(early) = self.expect_or_none('(', keyword_start) {
+                return early;
+            }
+            self.next();
             self.skip_ws();
             let re = self.parse_expr()?;
             self.skip_ws();
@@ -4090,21 +4284,40 @@ impl<'a> Parser<'a> {
                 self.skip_ws();
                 let flags = self.parse_expr()?;
                 self.skip_ws();
-                self.expect(')')?;
+                if self.peek() != Some(')') {
+                    return self.builtin_wrong_arity_or_expect(keyword_start, ')', vec![re, flags]);
+                }
+                self.next();
                 return Ok(Some(Builtin::CaptureFlags(Box::new(re), Box::new(flags))));
             }
-            self.expect(')')?;
+            if self.peek() != Some(')') {
+                return self.builtin_wrong_arity_or_expect(keyword_start, ')', vec![re]);
+            }
+            self.next();
             return Ok(Some(Builtin::Capture(Box::new(re))));
         }
         // sub function - replace first match
         if self.matches_keyword("sub") {
+            let keyword_start = self.pos;
             self.consume_keyword("sub");
             self.skip_ws();
-            self.expect('(')?;
+            // #2807: no `(` at all is a wrong-arity call before any
+            // argument exists -- rewind and let the generic fallback
+            // resolve it (`sub` alone is `sub/0 is not defined` in jq
+            // 1.7.1, not a syntax error). The reparse is arity-0, so the
+            // #2686 exponent this function's other checkpoints avoid does
+            // not arise here.
+            if let Err(early) = self.expect_or_none('(', keyword_start) {
+                return early;
+            }
+            self.next();
             self.skip_ws();
             let re = self.parse_expr()?;
             self.skip_ws();
-            self.expect(';')?;
+            if self.peek() != Some(';') {
+                return self.builtin_wrong_arity_or_expect(keyword_start, ';', vec![re]);
+            }
+            self.next();
             self.skip_ws();
             let replacement = self.parse_expr()?;
             self.skip_ws();
@@ -4121,26 +4334,53 @@ impl<'a> Parser<'a> {
                 // why this is shared with `split` above rather than a
                 // second hand-copied loop (#1439 review).
                 self.parse_yq_arity_leniency_tail()?;
-                self.expect(')')?;
+                if self.peek() != Some(')') {
+                    return self.builtin_wrong_arity_or_expect(
+                        keyword_start,
+                        ')',
+                        vec![re, replacement, flags],
+                    );
+                }
+                self.next();
                 return Ok(Some(Builtin::SubFlags(
                     Box::new(re),
                     Box::new(replacement),
                     Box::new(flags),
                 )));
             }
-            self.expect(')')?;
+            if self.peek() != Some(')') {
+                return self.builtin_wrong_arity_or_expect(
+                    keyword_start,
+                    ')',
+                    vec![re, replacement],
+                );
+            }
+            self.next();
             return Ok(Some(Builtin::Sub(Box::new(re), Box::new(replacement))));
         }
         // gsub function - replace all matches
         if self.matches_keyword("gsub") {
             self.reject_unless_jq_extensions("gsub")?;
+            let keyword_start = self.pos;
             self.consume_keyword("gsub");
             self.skip_ws();
-            self.expect('(')?;
+            // #2807: no `(` at all is a wrong-arity call before any
+            // argument exists -- rewind and let the generic fallback
+            // resolve it (`gsub` alone is `gsub/0 is not defined` in jq
+            // 1.7.1, not a syntax error). The reparse is arity-0, so the
+            // #2686 exponent this function's other checkpoints avoid does
+            // not arise here.
+            if let Err(early) = self.expect_or_none('(', keyword_start) {
+                return early;
+            }
+            self.next();
             self.skip_ws();
             let re = self.parse_expr()?;
             self.skip_ws();
-            self.expect(';')?;
+            if self.peek() != Some(';') {
+                return self.builtin_wrong_arity_or_expect(keyword_start, ';', vec![re]);
+            }
+            self.next();
             self.skip_ws();
             let replacement = self.parse_expr()?;
             self.skip_ws();
@@ -4149,22 +4389,46 @@ impl<'a> Parser<'a> {
                 self.skip_ws();
                 let flags = self.parse_expr()?;
                 self.skip_ws();
-                self.expect(')')?;
+                if self.peek() != Some(')') {
+                    return self.builtin_wrong_arity_or_expect(
+                        keyword_start,
+                        ')',
+                        vec![re, replacement, flags],
+                    );
+                }
+                self.next();
                 return Ok(Some(Builtin::GsubFlags(
                     Box::new(re),
                     Box::new(replacement),
                     Box::new(flags),
                 )));
             }
-            self.expect(')')?;
+            if self.peek() != Some(')') {
+                return self.builtin_wrong_arity_or_expect(
+                    keyword_start,
+                    ')',
+                    vec![re, replacement],
+                );
+            }
+            self.next();
             return Ok(Some(Builtin::Gsub(Box::new(re), Box::new(replacement))));
         }
         // scan function - find all matches
         if self.matches_keyword("scan") {
             self.reject_unless_jq_extensions("scan")?;
+            let keyword_start = self.pos;
             self.consume_keyword("scan");
             self.skip_ws();
-            self.expect('(')?;
+            // #2807: no `(` at all is a wrong-arity call before any
+            // argument exists -- rewind and let the generic fallback
+            // resolve it (`scan` alone is `scan/0 is not defined` in jq
+            // 1.7.1, not a syntax error). The reparse is arity-0, so the
+            // #2686 exponent this function's other checkpoints avoid does
+            // not arise here.
+            if let Err(early) = self.expect_or_none('(', keyword_start) {
+                return early;
+            }
+            self.next();
             self.skip_ws();
             let re = self.parse_expr()?;
             self.skip_ws();
@@ -4173,10 +4437,16 @@ impl<'a> Parser<'a> {
                 self.skip_ws();
                 let flags = self.parse_expr()?;
                 self.skip_ws();
-                self.expect(')')?;
+                if self.peek() != Some(')') {
+                    return self.builtin_wrong_arity_or_expect(keyword_start, ')', vec![re, flags]);
+                }
+                self.next();
                 return Ok(Some(Builtin::ScanFlags(Box::new(re), Box::new(flags))));
             }
-            self.expect(')')?;
+            if self.peek() != Some(')') {
+                return self.builtin_wrong_arity_or_expect(keyword_start, ')', vec![re]);
+            }
+            self.next();
             return Ok(Some(Builtin::Scan(Box::new(re))));
         }
         if self.matches_keyword("join") {
@@ -4212,6 +4482,7 @@ impl<'a> Parser<'a> {
         }
         // Check flatten with depth before plain flatten
         if self.matches_keyword("flatten") {
+            let keyword_start = self.pos;
             self.consume_keyword("flatten");
             self.skip_ws();
             if self.peek() == Some('(') {
@@ -4219,7 +4490,10 @@ impl<'a> Parser<'a> {
                 self.skip_ws();
                 let depth = self.parse_expr()?;
                 self.skip_ws();
-                self.expect(')')?;
+                if self.peek() != Some(')') {
+                    return self.builtin_wrong_arity_or_expect(keyword_start, ')', vec![depth]);
+                }
+                self.next();
                 return Ok(Some(Builtin::FlattenDepth(Box::new(depth))));
             }
             return Ok(Some(Builtin::Flatten));
@@ -4302,9 +4576,19 @@ impl<'a> Parser<'a> {
             return Ok(Some(Builtin::Implode));
         }
         if self.matches_keyword("test") {
+            let keyword_start = self.pos;
             self.consume_keyword("test");
             self.skip_ws();
-            self.expect('(')?;
+            // #2807: no `(` at all is a wrong-arity call before any
+            // argument exists -- rewind and let the generic fallback
+            // resolve it (`test` alone is `test/0 is not defined` in jq
+            // 1.7.1, not a syntax error). The reparse is arity-0, so the
+            // #2686 exponent this function's other checkpoints avoid does
+            // not arise here.
+            if let Err(early) = self.expect_or_none('(', keyword_start) {
+                return early;
+            }
+            self.next();
             self.skip_ws();
             let re = self.parse_expr()?;
             self.skip_ws();
@@ -4313,10 +4597,16 @@ impl<'a> Parser<'a> {
                 self.skip_ws();
                 let flags = self.parse_expr()?;
                 self.skip_ws();
-                self.expect(')')?;
+                if self.peek() != Some(')') {
+                    return self.builtin_wrong_arity_or_expect(keyword_start, ')', vec![re, flags]);
+                }
+                self.next();
                 return Ok(Some(Builtin::TestFlags(Box::new(re), Box::new(flags))));
             }
-            self.expect(')')?;
+            if self.peek() != Some(')') {
+                return self.builtin_wrong_arity_or_expect(keyword_start, ')', vec![re]);
+            }
+            self.next();
             return Ok(Some(Builtin::Test(Box::new(re))));
         }
         if self.matches_keyword("indices") {
@@ -4348,9 +4638,19 @@ impl<'a> Parser<'a> {
         // INDEX(stream; idx_expr) - build an object keyed by idx_expr from stream
         if self.matches_keyword("INDEX") {
             self.reject_unless_jq_extensions("INDEX")?;
+            let keyword_start = self.pos;
             self.consume_keyword("INDEX");
             self.skip_ws();
-            self.expect('(')?;
+            // #2807: no `(` at all is a wrong-arity call before any
+            // argument exists -- rewind and let the generic fallback
+            // resolve it (`INDEX` alone is `INDEX/0 is not defined` in jq
+            // 1.7.1, not a syntax error). The reparse is arity-0, so the
+            // #2686 exponent this function's other checkpoints avoid does
+            // not arise here.
+            if let Err(early) = self.expect_or_none('(', keyword_start) {
+                return early;
+            }
+            self.next();
             self.skip_ws();
             let first = self.parse_expr()?;
             self.skip_ws();
@@ -4359,13 +4659,23 @@ impl<'a> Parser<'a> {
                 self.skip_ws();
                 let idx_expr = self.parse_expr()?;
                 self.skip_ws();
-                self.expect(')')?;
+                if self.peek() != Some(')') {
+                    return self.builtin_wrong_arity_or_expect(
+                        keyword_start,
+                        ')',
+                        vec![first, idx_expr],
+                    );
+                }
+                self.next();
                 return Ok(Some(Builtin::UpperIndexStream(
                     Box::new(first),
                     Box::new(idx_expr),
                 )));
             }
-            self.expect(')')?;
+            if self.peek() != Some(')') {
+                return self.builtin_wrong_arity_or_expect(keyword_start, ')', vec![first]);
+            }
+            self.next();
             return Ok(Some(Builtin::UpperIndex(Box::new(first))));
         }
         if self.matches_keyword("tojsonstream") {
@@ -4409,6 +4719,7 @@ impl<'a> Parser<'a> {
         // Phase 8: Advanced Control Flow Builtins
         // recurse, recurse(f), recurse(f; cond)
         if self.matches_keyword("recurse") {
+            let keyword_start = self.pos;
             self.consume_keyword("recurse");
             self.skip_ws();
             if self.peek() == Some('(') {
@@ -4421,10 +4732,20 @@ impl<'a> Parser<'a> {
                     self.skip_ws();
                     let cond = self.parse_expr()?;
                     self.skip_ws();
-                    self.expect(')')?;
+                    if self.peek() != Some(')') {
+                        return self.builtin_wrong_arity_or_expect(
+                            keyword_start,
+                            ')',
+                            vec![f, cond],
+                        );
+                    }
+                    self.next();
                     return Ok(Some(Builtin::RecurseCond(Box::new(f), Box::new(cond))));
                 }
-                self.expect(')')?;
+                if self.peek() != Some(')') {
+                    return self.builtin_wrong_arity_or_expect(keyword_start, ')', vec![f]);
+                }
+                self.next();
                 return Ok(Some(Builtin::RecurseF(Box::new(f))));
             }
             return Ok(Some(Builtin::Recurse));
@@ -4466,7 +4787,10 @@ impl<'a> Parser<'a> {
                 self.skip_ws();
                 let expr = self.parse_expr()?;
                 self.skip_ws();
-                self.expect(')')?;
+                if self.peek() != Some(')') {
+                    return self.builtin_wrong_arity_or_expect(keyword_start, ')', vec![expr]);
+                }
+                self.next();
                 return Ok(Some(Builtin::Path(Box::new(expr))));
             }
             // path (no-arg) - yq style
@@ -4475,6 +4799,7 @@ impl<'a> Parser<'a> {
         // parent (no-arg, yq) - return the parent node
         // parent(n) (yq) - return the nth parent node
         if self.matches_keyword("parent") {
+            let keyword_start = self.pos;
             self.consume_keyword("parent");
             self.skip_ws();
             if self.peek() == Some('(') {
@@ -4483,7 +4808,10 @@ impl<'a> Parser<'a> {
                 self.skip_ws();
                 let n = self.parse_expr()?;
                 self.skip_ws();
-                self.expect(')')?;
+                if self.peek() != Some(')') {
+                    return self.builtin_wrong_arity_or_expect(keyword_start, ')', vec![n]);
+                }
+                self.next();
                 return Ok(Some(Builtin::ParentN(Box::new(n))));
             }
             // parent (no-arg) - immediate parent
@@ -4498,6 +4826,7 @@ impl<'a> Parser<'a> {
         // paths or paths(filter)
         if self.matches_keyword("paths") {
             self.reject_unless_jq_extensions("paths")?;
+            let keyword_start = self.pos;
             self.consume_keyword("paths");
             self.skip_ws();
             if self.peek() == Some('(') {
@@ -4505,24 +4834,43 @@ impl<'a> Parser<'a> {
                 self.skip_ws();
                 let filter = self.parse_expr()?;
                 self.skip_ws();
-                self.expect(')')?;
+                if self.peek() != Some(')') {
+                    return self.builtin_wrong_arity_or_expect(keyword_start, ')', vec![filter]);
+                }
+                self.next();
                 return Ok(Some(Builtin::PathsFilter(Box::new(filter))));
             }
             return Ok(Some(Builtin::Paths));
         }
         // setpath(path; value)
         if self.matches_keyword("setpath") {
+            let keyword_start = self.pos;
             self.consume_keyword("setpath");
             self.skip_ws();
-            self.expect('(')?;
+            // #2807: no `(` at all is a wrong-arity call before any
+            // argument exists -- rewind and let the generic fallback
+            // resolve it (`setpath` alone is `setpath/0 is not defined` in jq
+            // 1.7.1, not a syntax error). The reparse is arity-0, so the
+            // #2686 exponent this function's other checkpoints avoid does
+            // not arise here.
+            if let Err(early) = self.expect_or_none('(', keyword_start) {
+                return early;
+            }
+            self.next();
             self.skip_ws();
             let path = self.parse_expr()?;
             self.skip_ws();
-            self.expect(';')?;
+            if self.peek() != Some(';') {
+                return self.builtin_wrong_arity_or_expect(keyword_start, ';', vec![path]);
+            }
+            self.next();
             self.skip_ws();
             let value = self.parse_expr()?;
             self.skip_ws();
-            self.expect(')')?;
+            if self.peek() != Some(')') {
+                return self.builtin_wrong_arity_or_expect(keyword_start, ')', vec![path, value]);
+            }
+            self.next();
             return Ok(Some(Builtin::SetPath(Box::new(path), Box::new(value))));
         }
         // delpaths(paths)
@@ -4603,17 +4951,33 @@ impl<'a> Parser<'a> {
         // pow(base; exp)
         if self.matches_keyword("pow") {
             self.reject_unless_jq_extensions("pow")?;
+            let keyword_start = self.pos;
             self.consume_keyword("pow");
             self.skip_ws();
-            self.expect('(')?;
+            // #2807: no `(` at all is a wrong-arity call before any
+            // argument exists -- rewind and let the generic fallback
+            // resolve it (`pow` alone is `pow/0 is not defined` in jq
+            // 1.7.1, not a syntax error). The reparse is arity-0, so the
+            // #2686 exponent this function's other checkpoints avoid does
+            // not arise here.
+            if let Err(early) = self.expect_or_none('(', keyword_start) {
+                return early;
+            }
+            self.next();
             self.skip_ws();
             let base = self.parse_expr()?;
             self.skip_ws();
-            self.expect(';')?;
+            if self.peek() != Some(';') {
+                return self.builtin_wrong_arity_or_expect(keyword_start, ';', vec![base]);
+            }
+            self.next();
             self.skip_ws();
             let exp = self.parse_expr()?;
             self.skip_ws();
-            self.expect(')')?;
+            if self.peek() != Some(')') {
+                return self.builtin_wrong_arity_or_expect(keyword_start, ')', vec![base, exp]);
+            }
+            self.next();
             return Ok(Some(Builtin::Pow(Box::new(base), Box::new(exp))));
         }
         // Trigonometric functions - check longer names first
@@ -4650,17 +5014,33 @@ impl<'a> Parser<'a> {
         // atan2(y; x) - must check before atan
         if self.matches_keyword("atan2") {
             self.reject_unless_jq_extensions("atan2")?;
+            let keyword_start = self.pos;
             self.consume_keyword("atan2");
             self.skip_ws();
-            self.expect('(')?;
+            // #2807: no `(` at all is a wrong-arity call before any
+            // argument exists -- rewind and let the generic fallback
+            // resolve it (`atan2` alone is `atan2/0 is not defined` in jq
+            // 1.7.1, not a syntax error). The reparse is arity-0, so the
+            // #2686 exponent this function's other checkpoints avoid does
+            // not arise here.
+            if let Err(early) = self.expect_or_none('(', keyword_start) {
+                return early;
+            }
+            self.next();
             self.skip_ws();
             let y = self.parse_expr()?;
             self.skip_ws();
-            self.expect(';')?;
+            if self.peek() != Some(';') {
+                return self.builtin_wrong_arity_or_expect(keyword_start, ';', vec![y]);
+            }
+            self.next();
             self.skip_ws();
             let x = self.parse_expr()?;
             self.skip_ws();
-            self.expect(')')?;
+            if self.peek() != Some(')') {
+                return self.builtin_wrong_arity_or_expect(keyword_start, ')', vec![y, x]);
+            }
+            self.next();
             return Ok(Some(Builtin::Atan2(Box::new(y), Box::new(x))));
         }
         if self.matches_keyword("asin") {
@@ -4730,6 +5110,7 @@ impl<'a> Parser<'a> {
         // Phase 10: Debug
         if self.matches_keyword("debug") {
             self.reject_unless_jq_extensions("debug")?;
+            let keyword_start = self.pos;
             self.consume_keyword("debug");
             self.skip_ws();
             if self.peek() == Some('(') {
@@ -4737,7 +5118,10 @@ impl<'a> Parser<'a> {
                 self.skip_ws();
                 let msg = self.parse_expr()?;
                 self.skip_ws();
-                self.expect(')')?;
+                if self.peek() != Some(')') {
+                    return self.builtin_wrong_arity_or_expect(keyword_start, ')', vec![msg]);
+                }
+                self.next();
                 return Ok(Some(Builtin::DebugMsg(Box::new(msg))));
             }
             return Ok(Some(Builtin::Debug));
@@ -4806,13 +5190,45 @@ impl<'a> Parser<'a> {
 
         // strenv(VAR) - get environment variable as string (yq specific)
         if self.matches_keyword("strenv") {
+            let keyword_start = self.pos;
             self.consume_keyword("strenv");
             self.skip_ws();
-            self.expect('(')?;
+            // #2807: no `(` at all is a wrong-arity call before any
+            // argument exists -- rewind and let the generic fallback
+            // resolve it (`strenv` alone is `strenv/0 is not defined` in jq
+            // 1.7.1, not a syntax error). The reparse is arity-0, so the
+            // #2686 exponent this function's other checkpoints avoid does
+            // not arise here.
+            if let Err(early) = self.expect_or_none('(', keyword_start) {
+                return early;
+            }
+            self.next();
             self.skip_ws();
-            let var_name = self.parse_ident()?;
+            // #2807: `strenv`'s argument is a bare identifier, not an
+            // `Expr`, so there is nothing to hand
+            // `builtin_wrong_arity_or_expect` at either checkpoint --
+            // rewind instead and let the generic fallback re-parse the
+            // call. That covers both an argument that is not an identifier
+            // at all (`strenv(1)`) and a second one (`strenv(a;b)`), which
+            // jq 1.7.1 reports as `strenv/1 is not defined` and
+            // `strenv/2 is not defined`. No exponential exposure: the
+            // re-scanned text is one identifier, never a nested expression.
+            // yq mode keeps the raw parse error, as everywhere else in this
+            // family -- `strenv` is a real yq builtin there, and real yq's
+            // own leniency for these shapes (both answer `""` in v4.53.3)
+            // is a separate, pre-existing divergence.
+            let Ok(var_name) = self.parse_ident() else {
+                if self.mode == ParserMode::Jq {
+                    self.pos = keyword_start;
+                    return Ok(None);
+                }
+                return self.parse_ident().map(|_| unreachable!());
+            };
             self.skip_ws();
-            self.expect(')')?;
+            if let Err(early) = self.expect_or_none(')', keyword_start) {
+                return early;
+            }
+            self.next();
             return Ok(Some(Builtin::StrEnv(var_name)));
         }
 
@@ -5030,20 +5446,36 @@ impl<'a> Parser<'a> {
         // skip(n; expr) - skip first n outputs from expr
         if self.matches_keyword("skip") {
             self.reject_unless_jq_extensions("skip")?;
+            let keyword_start = self.pos;
             self.consume_keyword("skip");
             self.skip_ws();
-            self.expect('(')?;
+            // #2807: no `(` at all is a wrong-arity call before any
+            // argument exists -- rewind and let the generic fallback
+            // resolve it (`skip` alone is `skip/0 is not defined` in jq
+            // 1.7.1, not a syntax error). The reparse is arity-0, so the
+            // #2686 exponent this function's other checkpoints avoid does
+            // not arise here.
+            if let Err(early) = self.expect_or_none('(', keyword_start) {
+                return early;
+            }
+            self.next();
             self.skip_ws();
             // `n` deliberately stays restricted to non-comma — same rationale
             // as `parse_limit_expr`'s own `n`: real jq's `$n` parameter
             // convention isn't implemented here.
             let n = self.parse_pipe_no_comma_with_booleans()?;
             self.skip_ws();
-            self.expect(';')?;
+            if self.peek() != Some(';') {
+                return self.builtin_wrong_arity_or_expect(keyword_start, ';', vec![n]);
+            }
+            self.next();
             self.skip_ws();
             let expr = self.parse_expr()?;
             self.skip_ws();
-            self.expect(')')?;
+            if self.peek() != Some(')') {
+                return self.builtin_wrong_arity_or_expect(keyword_start, ')', vec![n, expr]);
+            }
+            self.next();
             return Ok(Some(Builtin::Skip(Box::new(n), Box::new(expr))));
         }
 
@@ -5051,9 +5483,19 @@ impl<'a> Parser<'a> {
         // nth(n) without second arg is already handled by Phase 5 Builtin::Nth
         if self.matches_keyword("nth") {
             self.reject_unless_jq_extensions("nth")?;
+            let keyword_start = self.pos;
             self.consume_keyword("nth");
             self.skip_ws();
-            self.expect('(')?;
+            // #2807: no `(` at all is a wrong-arity call before any
+            // argument exists -- rewind and let the generic fallback
+            // resolve it (`nth` alone is `nth/0 is not defined` in jq
+            // 1.7.1, not a syntax error). The reparse is arity-0, so the
+            // #2686 exponent this function's other checkpoints avoid does
+            // not arise here.
+            if let Err(early) = self.expect_or_none('(', keyword_start) {
+                return early;
+            }
+            self.next();
             self.skip_ws();
             // `n` deliberately stays restricted to non-comma — same rationale
             // as `parse_limit_expr`'s own `n` above: real jq's `$n` parameter
@@ -5065,10 +5507,16 @@ impl<'a> Parser<'a> {
                 self.skip_ws();
                 let expr = self.parse_expr()?;
                 self.skip_ws();
-                self.expect(')')?;
+                if self.peek() != Some(')') {
+                    return self.builtin_wrong_arity_or_expect(keyword_start, ')', vec![n, expr]);
+                }
+                self.next();
                 return Ok(Some(Builtin::NthStream(Box::new(n), Box::new(expr))));
             }
-            self.expect(')')?;
+            if self.peek() != Some(')') {
+                return self.builtin_wrong_arity_or_expect(keyword_start, ')', vec![n]);
+            }
+            self.next();
             // No-arg nth(n) is already handled by Phase 5 Builtin::Nth
             return Ok(Some(Builtin::Nth(Box::new(n))));
         }
@@ -5176,6 +5624,7 @@ impl<'a> Parser<'a> {
         // Phase 17: Combinations
         if self.matches_keyword("combinations") {
             self.reject_unless_jq_extensions("combinations")?;
+            let keyword_start = self.pos;
             self.consume_keyword("combinations");
             self.skip_ws();
             if self.peek() == Some('(') {
@@ -5183,7 +5632,10 @@ impl<'a> Parser<'a> {
                 self.skip_ws();
                 let n = self.parse_expr()?;
                 self.skip_ws();
-                self.expect(')')?;
+                if self.peek() != Some(')') {
+                    return self.builtin_wrong_arity_or_expect(keyword_start, ')', vec![n]);
+                }
+                self.next();
                 return Ok(Some(Builtin::CombinationsN(Box::new(n))));
             }
             return Ok(Some(Builtin::Combinations));
@@ -5223,17 +5675,37 @@ impl<'a> Parser<'a> {
 
         // at_position(line; col) - jump to node at line/column (1-indexed)
         if self.matches_keyword("at_position") {
+            let keyword_start = self.pos;
             self.consume_keyword("at_position");
             self.skip_ws();
-            self.expect('(')?;
+            // #2807: no `(` at all is a wrong-arity call before any
+            // argument exists -- rewind and let the generic fallback
+            // resolve it (`at_position` alone is `at_position/0 is not defined` in jq
+            // 1.7.1, not a syntax error). The reparse is arity-0, so the
+            // #2686 exponent this function's other checkpoints avoid does
+            // not arise here.
+            if let Err(early) = self.expect_or_none('(', keyword_start) {
+                return early;
+            }
+            self.next();
             self.skip_ws();
             let line_expr = self.parse_expr()?;
             self.skip_ws();
-            self.expect(';')?;
+            if self.peek() != Some(';') {
+                return self.builtin_wrong_arity_or_expect(keyword_start, ';', vec![line_expr]);
+            }
+            self.next();
             self.skip_ws();
             let col_expr = self.parse_expr()?;
             self.skip_ws();
-            self.expect(')')?;
+            if self.peek() != Some(')') {
+                return self.builtin_wrong_arity_or_expect(
+                    keyword_start,
+                    ')',
+                    vec![line_expr, col_expr],
+                );
+            }
+            self.next();
             return Ok(Some(Builtin::AtPosition(
                 Box::new(line_expr),
                 Box::new(col_expr),

--- a/src/jq/parser.rs
+++ b/src/jq/parser.rs
@@ -420,9 +420,17 @@ struct Parser<'a> {
     /// every constant is reachable at some small depth.
     ///
     /// What can still draw on it: a shadow candidate whose *dedicated*
-    /// parser fails for a reason that is not an argument boundary -- a
-    /// genuine syntax error inside an argument, which the generic reparse
-    /// rejects too. The constant is not load-bearing for those.
+    /// parser fails for a reason that is not an argument boundary it can
+    /// resolve in place. Two shapes reach that today -- a genuine syntax
+    /// error inside an argument, which the generic reparse rejects too, and
+    /// the comma-restricted first argument of `limit`/`nth`/`skip`
+    /// (`parse_pipe_no_comma_with_booleans` stops at the comma, so the
+    /// already-parsed prefix no longer lines up with the real argument
+    /// text and cannot be handed over). Only the second can still change a
+    /// program's verdict: `def nth(a;b): a; nth(1,2;3)` x65 is `130` in jq
+    /// 1.7.1 and a parse error here once the budget runs out. Tracked
+    /// separately; it is a residual of this class, not a regression -- the
+    /// pre-#2807 parser rejected it at every count. Tracked as #2863.
     shadow_retry_budget: usize,
     /// #2807: the wrong-arity call a [`Self::try_parse_builtin`] arm
     /// resolved in place, handed to its one caller alongside `Ok(None)`.
@@ -3645,12 +3653,15 @@ impl<'a> Parser<'a> {
     ///   the whole budget and rejected a program jq 1.7.1 accepts. Those
     ///   arms resolve their own wrong-arity calls now
     ///   ([`Self::builtin_wrong_arity_or_expect`]) and never reach this
-    ///   function; what is left here is a shadow candidate whose dedicated
-    ///   parser failed for a reason that is *not* an argument boundary --
-    ///   a genuine syntax error inside an argument, which this fallback's
-    ///   own reparse rejects as well. For those the retry only re-reports
-    ///   the same error, so exhausting the budget cannot change a
-    ///   program's verdict, only which error text it carries.
+    ///   function unless their own argument parse fails first. What is
+    ///   left here is a shadow candidate whose dedicated parser failed for
+    ///   a reason that is *not* an argument boundary it can resolve in
+    ///   place: a genuine syntax error inside an argument, where the retry
+    ///   only re-reports the same error and exhausting the budget changes
+    ///   nothing but the error text -- and the comma-restricted first
+    ///   argument of `limit`/`nth`/`skip`, where it still changes the
+    ///   verdict (#2863). See [`Self::shadow_retry_budget`]'s own doc
+    ///   comment for that residual.
     fn retry_shadow_candidate_as_generic_call(
         &mut self,
         start_pos: usize,
@@ -5211,14 +5222,24 @@ impl<'a> Parser<'a> {
             // call. That covers both an argument that is not an identifier
             // at all (`strenv(1)`) and a second one (`strenv(a;b)`), which
             // jq 1.7.1 reports as `strenv/1 is not defined` and
-            // `strenv/2 is not defined`. No exponential exposure: the
-            // re-scanned text is one identifier, never a nested expression.
-            // yq mode keeps the raw parse error, as everywhere else in this
-            // family -- `strenv` is a real yq builtin there, and real yq's
-            // own leniency for these shapes (both answer `""` in v4.53.3)
-            // is a separate, pre-existing divergence.
+            // `strenv/2 is not defined`. yq mode keeps the raw parse error,
+            // as everywhere else in this family -- `strenv` is a real yq
+            // builtin there, and real yq's own leniency for these shapes
+            // (both answer `""` in v4.53.3) is a separate, pre-existing
+            // divergence.
+            //
+            // **Empty parens are excluded** (review): a rewind hands
+            // `strenv()` to `parse_func_call_or_error`, which reads it as a
+            // legitimate arity-0 call, so `def strenv: 1; strenv()` would
+            // answer `1` where jq 1.7.1 -- and every other builtin here --
+            // rejects empty parens as a syntax error. That is exactly the
+            // guard [`Self::retry_shadow_candidate_as_generic_call`] applies
+            // with `peek_after_keyword_at_is_empty_parens` before its own
+            // reparse; this rewind bypasses that function, so it repeats the
+            // check itself rather than inheriting it.
+            let empty_parens = self.peek_after_keyword_at_is_empty_parens(keyword_start);
             let Ok(var_name) = self.parse_ident() else {
-                if self.mode == ParserMode::Jq {
+                if self.mode == ParserMode::Jq && !empty_parens {
                     self.pos = keyword_start;
                     return Ok(None);
                 }
@@ -5517,7 +5538,9 @@ impl<'a> Parser<'a> {
                 return self.builtin_wrong_arity_or_expect(keyword_start, ')', vec![n]);
             }
             self.next();
-            // No-arg nth(n) is already handled by Phase 5 Builtin::Nth
+            // The single-argument form. (A "Phase 5 `Builtin::Nth`" arm this
+            // comment used to defer to no longer exists -- this is the only
+            // `nth` arm in the function; review, #2807.)
             return Ok(Some(Builtin::Nth(Box::new(n))));
         }
 

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -48842,6 +48842,15 @@ fn test_every_arm_checkpoint_matches_jq_under_a_shadow_2807() -> Result<()> {
         ("def strenv(a;b): 1; strenv", 3, ""),
         ("def strenv(a;b): 1; strenv(1)", 3, ""),
         ("def strenv(a;b): 1; strenv(1;2)", 0, "1"),
+        // `strenv`'s trailing-`)` checkpoint: reached only with a genuine
+        // identifier argument (a non-identifier fails the arm's own
+        // `parse_ident` first and rewinds from there instead).
+        ("strenv(a;b)", 3, ""),
+        (
+            "def strenv(a;b): 1; def x: 7; def y: 8; strenv(x;y)",
+            0,
+            "1",
+        ),
     ] {
         let (stdout, stderr, code) = run_jq_full(&["-c", filter], Some("null"))?;
         assert_eq!(

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -48660,6 +48660,78 @@ fn test_shadowed_wrong_arity_calls_do_not_exhaust_the_retry_budget_2807() -> Res
     Ok(())
 }
 
+/// #2807: every converted arm, in the shape the issue is actually about --
+/// a wrong-arity call to a builtin name that a `def` in scope shadows at
+/// that arity. Each row must resolve to the `def` and answer `1`, which is
+/// what jq 1.7.1 answers for all of them; before the fix each one failed its
+/// arm and was recovered only by the budget-consuming reparse, so the answer
+/// was right only while the budget lasted.
+///
+/// One row per arm rather than a spot check: the arms differ in shape (fixed
+/// multi-arg, optional-arity, `;`-checkpoint, `parse_pipe_no_comma_with_booleans`
+/// first argument), and #2389 records two earlier regressions from
+/// conversions that "looked like a copy but weren't".
+#[test]
+fn test_every_converted_arm_resolves_a_shadowed_wrong_arity_call_2807() -> Result<()> {
+    // (keyword, the `def`'s parameter list, the call's arguments)
+    for (kw, params, args) in [
+        ("test", "a;b;c", "1;2;3"),
+        ("match", "a;b;c", "1;2;3"),
+        ("capture", "a;b;c", "1;2;3"),
+        ("scan", "a;b;c", "1;2;3"),
+        ("splits", "a;b;c", "1;2;3"),
+        ("split", "a;b;c", "1;2;3"),
+        ("sub", "a;b;c;d", "1;2;3;4"),
+        ("gsub", "a;b;c;d", "1;2;3;4"),
+        ("IN", "a;b;c", "1;2;3"),
+        ("INDEX", "a;b;c", "1;2;3"),
+        ("any", "a;b;c", "1;2;3"),
+        ("all", "a;b;c", "1;2;3"),
+        ("recurse", "a;b;c", "1;2;3"),
+        ("nth", "a;b;c", "1;2;3"),
+        ("skip", "a;b;c", "1;2;3"),
+        ("flatten", "a;b", "1;2"),
+        ("path", "a;b", "1;2"),
+        ("paths", "a;b", "1;2"),
+        ("debug", "a;b", "1;2"),
+        ("parent", "a;b", "1;2"),
+        ("combinations", "a;b", "1;2"),
+        ("halt_error", "a;b", "1;2"),
+        // `1` rather than an identifier: `strenv`'s own argument parse
+        // wants an identifier, but a bare `x` there is an undefined
+        // *function* call to both parsers (jq 1.7.1 says `x/0 is not
+        // defined` too), which would test name resolution rather than this
+        // arm's rewind.
+        ("strenv", "a;b", "1;2"),
+        // The `;`-checkpoint arms, reached by giving one argument where the
+        // builtin's own parser requires two.
+        ("setpath", "a", "1"),
+        ("pow", "a", "1"),
+        ("atan2", "a", "1"),
+        ("at_position", "a", "1"),
+        // The before-any-argument checkpoint: no parentheses at all.
+        ("test", "", ""),
+        ("split", "", ""),
+        ("setpath", "", ""),
+    ] {
+        let call = if args.is_empty() {
+            kw.to_string()
+        } else {
+            format!("{kw}({args})")
+        };
+        let def = if params.is_empty() {
+            format!("def {kw}: 1;")
+        } else {
+            format!("def {kw}({params}): 1;")
+        };
+        let filter = format!("{def} {call}");
+        let (stdout, stderr, code) = run_jq_full(&["-c", &filter], Some("null"))?;
+        assert_eq!(code, 0, "{filter}: stdout: {stdout:?} stderr: {stderr:?}");
+        assert_eq!(stdout.trim_end(), "1", "{filter}");
+    }
+    Ok(())
+}
+
 /// #2807 (review): empty parens stay a syntax error, even for the one arm
 /// whose recovery is a rewind rather than a hand-over.
 ///

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -48628,6 +48628,130 @@ fn test_wrong_arity_deep_nesting_does_not_blow_up_2686() -> Result<()> {
     Ok(())
 }
 
+/// #2807: the two programs the shared `SHADOW_RETRY_BUDGET` used to reject.
+///
+/// Every wrong-arity call to one of `try_parse_builtin`'s multi-argument or
+/// optional-arity builtins under a shadowing `def` used to reach
+/// `retry_shadow_candidate_as_generic_call`, which re-parses the call and
+/// spends one unit of a single process-wide 64-unit budget. 65 flat calls
+/// exhaust it outright; nested, each level's reparse walks every level below
+/// it, so depth 7 spends 128. Past the budget the raw `expected ')', found
+/// ';'` parse error propagates and the program is rejected. Both of these are
+/// accepted by jq 1.7.1 (`65` and `1`), and both are legitimate, non-
+/// adversarial code -- a `def` that shadows a builtin name at its own arity.
+#[test]
+fn test_shadowed_wrong_arity_calls_do_not_exhaust_the_retry_budget_2807() -> Result<()> {
+    let flat = format!(
+        "def test(a;b;c): a; [{}] | length",
+        vec!["test(1;2;3)"; 65].join(",")
+    );
+    let (stdout, stderr, code) = run_jq_full(&["-c", &flat], Some("null"))?;
+    assert_eq!(code, 0, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert_eq!(stdout.trim_end(), "65");
+
+    let mut nested = String::from("1");
+    for _ in 0..7 {
+        nested = format!("test({nested};2;3)");
+    }
+    let nested = format!("def test(a;b;c): a; {nested}");
+    let (stdout, stderr, code) = run_jq_full(&["-c", &nested], Some("null"))?;
+    assert_eq!(code, 0, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert_eq!(stdout.trim_end(), "1");
+    Ok(())
+}
+
+/// #2807: an *unshadowed* wrong-arity call to one of the converted builtins
+/// now reaches jq's own name/arity resolver instead of stopping at the
+/// parser's argument-boundary check -- #2573's MULTI-ARG remainder, the same
+/// direction #2110/#2237/#2686 already took for the zero-arity,
+/// single-argument and special-form families.
+///
+/// Every expectation captured from `/usr/bin/jq` 1.7.1. The `strenv` rows
+/// cover the one arm whose argument is a bare identifier rather than an
+/// expression, so it rewinds rather than handing parsed arguments over; the
+/// `test`/`split` no-parens rows cover the before-any-argument checkpoint.
+#[test]
+fn test_wrong_arity_multi_arg_builtins_resolve_by_name_and_arity_2807() -> Result<()> {
+    for (filter, expected) in [
+        ("test(1;2;3)", "test/3 is not defined"),
+        ("match(1;2;3)", "match/3 is not defined"),
+        ("capture(1;2;3)", "capture/3 is not defined"),
+        ("sub(1;2;3;4)", "sub/4 is not defined"),
+        ("gsub(1;2;3;4)", "gsub/4 is not defined"),
+        ("scan(1;2;3)", "scan/3 is not defined"),
+        ("splits(1;2;3)", "splits/3 is not defined"),
+        ("split(1;2;3)", "split/3 is not defined"),
+        ("IN(1;2;3)", "IN/3 is not defined"),
+        ("INDEX(1;2;3)", "INDEX/3 is not defined"),
+        ("setpath(1)", "setpath/1 is not defined"),
+        ("pow(1)", "pow/1 is not defined"),
+        ("atan2(1)", "atan2/1 is not defined"),
+        ("skip(1)", "skip/1 is not defined"),
+        ("nth(1;2;3)", "nth/3 is not defined"),
+        ("at_position(1)", "at_position/1 is not defined"),
+        ("strenv(1;2)", "strenv/2 is not defined"),
+        ("strenv(1)", "strenv/1 is not defined"),
+        ("all(1;2;3)", "all/3 is not defined"),
+        ("any(1;2;3)", "any/3 is not defined"),
+        ("flatten(1;2)", "flatten/2 is not defined"),
+        ("path(1;2)", "path/2 is not defined"),
+        ("paths(1;2)", "paths/2 is not defined"),
+        ("recurse(1;2;3)", "recurse/3 is not defined"),
+        ("combinations(1;2)", "combinations/2 is not defined"),
+        ("debug(1;2)", "debug/2 is not defined"),
+        ("halt_error(1;2)", "halt_error/2 is not defined"),
+        ("parent(1;2)", "parent/2 is not defined"),
+        ("test", "test/0 is not defined"),
+        ("split", "split/0 is not defined"),
+    ] {
+        let (stdout, stderr, code) = run_jq_full(&["-c", filter], Some("null"))?;
+        assert_eq!(code, 3, "{filter}: stdout: {stdout:?} stderr: {stderr:?}");
+        assert!(stderr.contains(expected), "{filter}: stderr: {stderr:?}");
+    }
+    Ok(())
+}
+
+/// #2807: a shadowed wrong-arity call nested to depth 30 must stay flat.
+///
+/// The budget bounded the `O(2^depth)` reparse rather than removing it, so
+/// before this fix these rejected the program once the budget ran out
+/// instead of taking exponential time; with the arms resolving their calls
+/// in place there is no reparse to bound and every row answers jq's own `1`.
+/// Same generous margin and reasoning as
+/// `test_wrong_arity_deep_nesting_does_not_blow_up_2686`'s table.
+#[test]
+fn test_shadowed_multi_arg_deep_nesting_stays_flat_2807() -> Result<()> {
+    for (kw, params, tail) in [
+        ("test", "a;b;c", ";2;3"),
+        ("match", "a;b;c", ";2;3"),
+        ("setpath", "a;b;c", ";2;3"),
+        ("any", "a;b;c", ";2;3"),
+        ("sub", "a;b;c;d", ";2;3;4"),
+        ("nth", "a;b;c", ";2;3"),
+        ("recurse", "a;b;c", ";2;3"),
+    ] {
+        let depth = 30;
+        let mut nested = String::from("1");
+        for _ in 0..depth {
+            nested = format!("{kw}({nested}{tail})");
+        }
+        let filter = format!("def {kw}({params}): a; {nested}");
+        let start = std::time::Instant::now();
+        let (stdout, stderr, code) = run_jq_full(&["-c", &filter], Some("null"))?;
+        let elapsed = start.elapsed();
+        assert_eq!(
+            code, 0,
+            "`{kw}` at {depth} levels: stdout: {stdout:?} stderr: {stderr:?}"
+        );
+        assert_eq!(stdout.trim_end(), "1", "`{kw}` at {depth} levels");
+        assert!(
+            elapsed < std::time::Duration::from_secs(15),
+            "`{kw}` at {depth} levels took {elapsed:?} -- exponential parse blowup regressed"
+        );
+    }
+    Ok(())
+}
+
 /// #2686: the no-re-parse path must resolve a wrong-arity call to exactly
 /// what the rewinding path did — same message, same shadow resolution, same
 /// postfix handling.

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -48732,6 +48732,127 @@ fn test_every_converted_arm_resolves_a_shadowed_wrong_arity_call_2807() -> Resul
     Ok(())
 }
 
+/// #2807: every argument-boundary checkpoint of every converted arm, under a
+/// shadowing `def`, against jq 1.7.1's own `(exit code, stdout)`.
+///
+/// One row per checkpoint rather than one per keyword: an arm has up to four
+/// -- no parentheses at all (the `expect_or_none` rewind), a mismatch after
+/// the first argument (`kw(1 2)`), after the second (`kw(1;2 3)`), and the
+/// wrong-arity call that is otherwise well formed (`kw(1;2;3)`) -- and they
+/// take different branches. #2389 records two earlier regressions from
+/// conversions that "looked like a copy but weren't", so each is pinned
+/// rather than sampled.
+///
+/// Every expectation was captured live from `/usr/bin/jq` 1.7.1; all 91 rows
+/// agreed with it when this test was written, which is the property being
+/// pinned -- a future change that makes one of these a parse error again is
+/// the #2807 regression.
+#[test]
+fn test_every_arm_checkpoint_matches_jq_under_a_shadow_2807() -> Result<()> {
+    // (program, jq's exit code, jq's stdout)
+    for (filter, expected_code, expected_stdout) in [
+        ("def test(a;b;c): 1; test", 3, ""),
+        ("def test(a;b;c): 1; test(1 2)", 3, ""),
+        ("def test(a;b;c): 1; test(1;2 3)", 3, ""),
+        ("def test(a;b;c): 1; test(1;2;3)", 0, "1"),
+        ("def match(a;b;c): 1; match", 3, ""),
+        ("def match(a;b;c): 1; match(1 2)", 3, ""),
+        ("def match(a;b;c): 1; match(1;2 3)", 3, ""),
+        ("def match(a;b;c): 1; match(1;2;3)", 0, "1"),
+        ("def capture(a;b;c): 1; capture", 3, ""),
+        ("def capture(a;b;c): 1; capture(1 2)", 3, ""),
+        ("def capture(a;b;c): 1; capture(1;2 3)", 3, ""),
+        ("def capture(a;b;c): 1; capture(1;2;3)", 0, "1"),
+        ("def scan(a;b;c): 1; scan", 3, ""),
+        ("def scan(a;b;c): 1; scan(1 2)", 3, ""),
+        ("def scan(a;b;c): 1; scan(1;2 3)", 3, ""),
+        ("def scan(a;b;c): 1; scan(1;2;3)", 0, "1"),
+        ("def splits(a;b;c): 1; splits", 3, ""),
+        ("def splits(a;b;c): 1; splits(1 2)", 3, ""),
+        ("def splits(a;b;c): 1; splits(1;2 3)", 3, ""),
+        ("def splits(a;b;c): 1; splits(1;2;3)", 0, "1"),
+        ("def split(a;b;c): 1; split", 3, ""),
+        ("def split(a;b;c): 1; split(1 2)", 3, ""),
+        ("def split(a;b;c): 1; split(1;2 3)", 3, ""),
+        ("def split(a;b;c): 1; split(1;2;3)", 0, "1"),
+        ("def sub(a;b;c;d): 1; sub", 3, ""),
+        ("def sub(a;b;c;d): 1; sub(1)", 3, ""),
+        ("def sub(a;b;c;d): 1; sub(1;2 3)", 3, ""),
+        ("def sub(a;b;c;d): 1; sub(1;2;3 4)", 3, ""),
+        ("def sub(a;b;c;d): 1; sub(1;2;3;4)", 0, "1"),
+        ("def gsub(a;b;c;d): 1; gsub", 3, ""),
+        ("def gsub(a;b;c;d): 1; gsub(1)", 3, ""),
+        ("def gsub(a;b;c;d): 1; gsub(1;2 3)", 3, ""),
+        ("def gsub(a;b;c;d): 1; gsub(1;2;3 4)", 3, ""),
+        ("def gsub(a;b;c;d): 1; gsub(1;2;3;4)", 0, "1"),
+        ("def IN(a;b;c): 1; IN", 3, ""),
+        ("def IN(a;b;c): 1; IN(1 2)", 3, ""),
+        ("def IN(a;b;c): 1; IN(1;2 3)", 3, ""),
+        ("def IN(a;b;c): 1; IN(1;2;3)", 0, "1"),
+        ("def INDEX(a;b;c): 1; INDEX", 3, ""),
+        ("def INDEX(a;b;c): 1; INDEX(1 2)", 3, ""),
+        ("def INDEX(a;b;c): 1; INDEX(1;2 3)", 3, ""),
+        ("def INDEX(a;b;c): 1; INDEX(1;2;3)", 0, "1"),
+        ("def any(a;b;c): 1; any(1 2)", 3, ""),
+        ("def any(a;b;c): 1; any(1;2 3)", 3, ""),
+        ("def any(a;b;c): 1; any(1;2;3)", 0, "1"),
+        ("def all(a;b;c): 1; all(1 2)", 3, ""),
+        ("def all(a;b;c): 1; all(1;2 3)", 3, ""),
+        ("def all(a;b;c): 1; all(1;2;3)", 0, "1"),
+        ("def recurse(a;b;c): 1; recurse(1 2)", 3, ""),
+        ("def recurse(a;b;c): 1; recurse(1;2 3)", 3, ""),
+        ("def recurse(a;b;c): 1; recurse(1;2;3)", 0, "1"),
+        ("def nth(a;b;c): 1; nth", 3, ""),
+        ("def nth(a;b;c): 1; nth(1;2 3)", 3, ""),
+        ("def nth(a;b;c): 1; nth(1;2;3)", 0, "1"),
+        ("def skip(a;b;c): 1; skip", 3, ""),
+        ("def skip(a;b;c): 1; skip(1)", 3, ""),
+        ("def skip(a;b;c): 1; skip(1;2 3)", 3, ""),
+        ("def skip(a;b;c): 1; skip(1;2;3)", 0, "1"),
+        ("def setpath(a;b;c): 1; setpath", 3, ""),
+        ("def setpath(a;b;c): 1; setpath(1)", 3, ""),
+        ("def setpath(a;b;c): 1; setpath(1;2 3)", 3, ""),
+        ("def setpath(a;b;c): 1; setpath(1;2;3)", 0, "1"),
+        ("def pow(a;b;c): 1; pow", 3, ""),
+        ("def pow(a;b;c): 1; pow(1)", 3, ""),
+        ("def pow(a;b;c): 1; pow(1;2 3)", 3, ""),
+        ("def pow(a;b;c): 1; pow(1;2;3)", 0, "1"),
+        ("def atan2(a;b;c): 1; atan2", 3, ""),
+        ("def atan2(a;b;c): 1; atan2(1)", 3, ""),
+        ("def atan2(a;b;c): 1; atan2(1;2 3)", 3, ""),
+        ("def atan2(a;b;c): 1; atan2(1;2;3)", 0, "1"),
+        ("def at_position(a;b;c): 1; at_position", 3, ""),
+        ("def at_position(a;b;c): 1; at_position(1)", 3, ""),
+        ("def at_position(a;b;c): 1; at_position(1;2 3)", 3, ""),
+        ("def at_position(a;b;c): 1; at_position(1;2;3)", 0, "1"),
+        ("def flatten(a;b): 1; flatten(1 2)", 3, ""),
+        ("def flatten(a;b): 1; flatten(1;2)", 0, "1"),
+        ("def path(a;b): 1; path(1 2)", 3, ""),
+        ("def path(a;b): 1; path(1;2)", 0, "1"),
+        ("def paths(a;b): 1; paths(1 2)", 3, ""),
+        ("def paths(a;b): 1; paths(1;2)", 0, "1"),
+        ("def debug(a;b): 1; debug(1 2)", 3, ""),
+        ("def debug(a;b): 1; debug(1;2)", 0, "1"),
+        ("def parent(a;b): 1; parent(1 2)", 3, ""),
+        ("def parent(a;b): 1; parent(1;2)", 0, "1"),
+        ("def combinations(a;b): 1; combinations(1 2)", 3, ""),
+        ("def combinations(a;b): 1; combinations(1;2)", 0, "1"),
+        ("def halt_error(a;b): 1; halt_error(1 2)", 3, ""),
+        ("def halt_error(a;b): 1; halt_error(1;2)", 0, "1"),
+        ("def strenv(a;b): 1; strenv", 3, ""),
+        ("def strenv(a;b): 1; strenv(1)", 3, ""),
+        ("def strenv(a;b): 1; strenv(1;2)", 0, "1"),
+    ] {
+        let (stdout, stderr, code) = run_jq_full(&["-c", filter], Some("null"))?;
+        assert_eq!(
+            code, expected_code,
+            "{filter}: stdout: {stdout:?} stderr: {stderr:?}"
+        );
+        assert_eq!(stdout.trim_end(), expected_stdout, "{filter}");
+    }
+    Ok(())
+}
+
 /// #2807 (review): empty parens stay a syntax error, even for the one arm
 /// whose recovery is a rewind rather than a hand-over.
 ///

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -48660,6 +48660,74 @@ fn test_shadowed_wrong_arity_calls_do_not_exhaust_the_retry_budget_2807() -> Res
     Ok(())
 }
 
+/// #2807 (review): empty parens stay a syntax error, even for the one arm
+/// whose recovery is a rewind rather than a hand-over.
+///
+/// `retry_shadow_candidate_as_generic_call` guards its own reparse with
+/// `peek_after_keyword_at_is_empty_parens` precisely so `def f: 1; f()`
+/// cannot be re-read as a legitimate arity-0 call; `strenv`'s rewind bypasses
+/// that function, so it repeats the check. Without it
+/// `def strenv: 1; strenv()` answered `1`, where jq 1.7.1 (and the pre-#2807
+/// parser) both reject it. `strenv(1)`/`strenv(1;2)` -- the shapes the rewind
+/// exists for -- must still reach the resolver.
+#[test]
+fn test_strenv_rewind_keeps_empty_parens_a_syntax_error_2807() -> Result<()> {
+    for filter in [
+        "def strenv: 1; strenv()",
+        "def strenv: 1; strenv( )",
+        "strenv()",
+    ] {
+        let (stdout, stderr, code) = run_jq_full(&["-c", filter], Some("null"))?;
+        assert_ne!(code, 0, "{filter}: stdout: {stdout:?} stderr: {stderr:?}");
+        assert_eq!(stdout, "", "{filter}");
+    }
+    let (stdout, stderr, code) = run_jq_full(&["-c", "def strenv(a): a; strenv(1)"], Some("null"))?;
+    assert_eq!(code, 0, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert_eq!(stdout.trim_end(), "1");
+    Ok(())
+}
+
+/// #2807 (review): the residual this fix does **not** close -- `limit`, `nth`
+/// and `skip` parse their first argument with the comma-restricted
+/// `parse_pipe_no_comma_with_booleans`, so a comma there leaves the
+/// already-parsed prefix out of step with the real argument text and nothing
+/// can be handed over. Those calls still reach
+/// `retry_shadow_candidate_as_generic_call` and still spend the budget, so 65
+/// of them are still rejected where jq 1.7.1 answers `130`.
+///
+/// Characterization, not an endorsement: this is a residual of #2807's class,
+/// not a regression -- the pre-#2807 parser rejected these at every count, and
+/// 64 still pass here. Tracked as #2863; when that lands these rows flip to
+/// jq's answers.
+#[test]
+fn test_comma_restricted_first_arg_still_spends_the_retry_budget_2807() -> Result<()> {
+    for kw in ["nth", "limit", "skip"] {
+        let within = format!(
+            "def {kw}(a;b): a; [{}] | length",
+            vec![format!("{kw}(1,2;3)"); 64].join(",")
+        );
+        let (stdout, stderr, code) = run_jq_full(&["-c", &within], Some("null"))?;
+        assert_eq!(code, 0, "{kw} x64: stdout: {stdout:?} stderr: {stderr:?}");
+        assert_eq!(stdout.trim_end(), "128", "{kw} x64");
+
+        let past = format!(
+            "def {kw}(a;b): a; [{}] | length",
+            vec![format!("{kw}(1,2;3)"); 65].join(",")
+        );
+        let (stdout, stderr, code) = run_jq_full(&["-c", &past], Some("null"))?;
+        assert_eq!(code, 3, "{kw} x65: stdout: {stdout:?} stderr: {stderr:?}");
+        // `nth`/`skip` report the hand-over helper's own separator
+        // complaint, `limit` its dedicated parser's -- both are the raw
+        // `original_err` the exhausted budget lets through, which is the
+        // property under test, not the wording.
+        assert!(
+            stderr.contains("parse error"),
+            "{kw} x65: stderr: {stderr:?}"
+        );
+    }
+    Ok(())
+}
+
 /// #2807: an *unshadowed* wrong-arity call to one of the converted builtins
 /// now reaches jq's own name/arity resolver instead of stopping at the
 /// parser's argument-boundary check -- #2573's MULTI-ARG remainder, the same


### PR DESCRIPTION
## Summary

The issue was filed as an *unconfirmed* risk against #2723's parameter-name widening. The triage re-probe confirmed it, and found the widening is not the cause — a plain `def` name does it, and the budget is reachable by ordinary code:

```console
# 65 flat wrong-arity calls of a def-shadowed builtin name
$ P="def test(a;b;c): a; [$(printf 'test(1;2;3),%.0s' $(seq 65) | sed 's/,$//')] | length"
$ echo null | jq -c "$P"                  # 65
$ echo null | succinctly jq -c "$P"       # jq: compile error: parse error at position 797: expected ')', found ';'

# nested: each level's reparse walks every level below it, so depth 7 spends 2^7 = 128
$ echo null | jq -c 'def test(a;b;c): a; test(test(test(test(test(test(test(1;2;3);2;3);2;3);2;3);2;3);2;3);2;3)'   # 1
$ echo null | succinctly jq -c '<same>'    # jq: compile error: parse error at position 58: expected ')', found ';'
```

**Root cause.** `try_parse_builtin`'s 27 multi-argument and optional-arity arms checked their argument boundaries with a bare `self.expect(';')?` / `self.expect(')')?`. A wrong-arity call under a shadowing `def` therefore failed the arm outright and was recovered only by `retry_shadow_candidate_as_generic_call`, which re-parses the call from the keyword and spends one unit of a single process-wide 64-unit `SHADOW_RETRY_BUDGET`. Past the budget the raw parse error propagates. #2573/#2686/#2750 converted the zero-arity, single-argument and special-form families away from this; the MULTI-ARG arms were the unfiled remainder.

**Fix.** Each arm hands its already-parsed arguments to a new `builtin_wrong_arity_or_expect`, which resolves the same generic call through #2686's `wrong_arity_call_from_parsed` — no re-parse, no budget draw. Since `try_parse_builtin` answers a `Builtin` and a wrong-arity call is an `Expr::FuncCall`, the resolved node travels to `parse_primary_inner` in a new `Parser::wrong_arity_call` field alongside `Ok(None)` (the same "not this builtin after all" signal `parse_required_single_arg`'s rewind already uses). A missing `(` (`test`, `split`) rewinds through `expect_or_none` instead — that reparse is arity-0, so no exponent.

Not a larger constant: the nested shape is exponential, so any constant is reachable at a small depth. The budget stays, correctly scoped — what can still draw on it is a genuine syntax error inside an argument, which the generic reparse rejects too, so exhausting it can no longer change a program's verdict, only its error text. Both doc comments that claimed "an ordinary, non-adversarial program never comes close" are corrected.

**Also fixes #2573's MULTI-ARG remainder.** For an *unshadowed* spelling these arms now reach jq's name/arity resolver: `test(1;2;3)` is `test/3 is not defined` rather than `expected ')', found ';'`, matching jq 1.7.1. 30 such rows are pinned. This is user-visible and intentional, the same direction #2110/#2237/#2686 took for the other three families.

**yq mode is untouched** — every member of this helper family raises `expect`'s own error there, and `strenv`, whose argument is a bare identifier rather than an expression, rewinds rather than handing arguments over (its own jq-mode rows, `strenv(1)`/`strenv(1;2)`, now match jq too).

Closes #2807

## Test plan

- [x] `cargo build --features cli`
- [x] `cargo test --features cli,simd,regex,serde` (full suite, 8421 tests)
- [x] New: `test_shadowed_wrong_arity_calls_do_not_exhaust_the_retry_budget_2807` (both repros), `test_wrong_arity_multi_arg_builtins_resolve_by_name_and_arity_2807` (30 rows, every expectation from `/usr/bin/jq` 1.7.1), `test_shadowed_multi_arg_deep_nesting_stays_flat_2807` (7 keywords at depth 30, answer + timing guard)
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings`
- [x] `cargo fmt --all --check`; `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features`
- [x] Measured old vs new vs jq on shadowed nesting at depths 7/12/18 for `test`/`match`/`setpath`/`any`: old rejects every row, new answers jq's `1` at every depth, both flat
- [x] Differential sweep, 1320 programs (44 names x 10 arg shapes x 3 shadow spellings), branch vs merge-base binary vs jq 1.7.1, both modes: **0 regressions** (no program that matched jq before differs now), **0 yq-mode changes**, 101 programs newly byte-identical to jq
- [x] Review round (`/code-review high`) plus an independent ~15k-program sweep: one real regression found and fixed (`strenv`'s rewind bypassed the empty-parens guard, so `def strenv: 1; strenv()` answered `1`), and one over-broad doc claim corrected — `limit`/`nth`/`skip`'s comma-restricted first argument still spends the budget and still changes a verdict, now filed as #2863 and pinned as characterization
- [x] `cargo llvm-cov --features cli,simd,regex,serde --workspace --lcov`: the first run left 41 of the converted branches unexercised (chiefly each arm's no-parentheses rewind and its smaller-arity trailing-`)` checkpoint), so every arm/checkpoint shape was probed against jq 1.7.1 — all 91 already agreed — and pinned in `test_every_arm_checkpoint_matches_jq_under_a_shadow_2807`. Every instrumented added line in `parser.rs` is now covered; CI reports `src/jq/parser.rs` 93.97% → **94.54%** (+0.57 pp), total +0.03 pp