### PR TITLE
fix(jq): include outranks ~/.jq, and later include beats earlier one

### DIFF
--- a/src/bin/succinctly/jq_runner.rs
+++ b/src/bin/succinctly/jq_runner.rs
@@ -260,19 +260,28 @@ impl ModuleLoader {
     pub fn process_program(&mut self, program: &Program) -> Result<Expr, ModuleLoadError> {
         let mut expr = program.expr.clone();
 
-        // First, prepend auto-loaded ~/.jq definitions (lowest priority, can be overridden)
-        for (name, params, body) in self.auto_loaded_defs.clone().into_iter().rev() {
-            expr = Expr::FuncDef {
-                name,
-                params,
-                body: Box::new(body),
-                then: Box::new(expr),
-                bound: FuncDefBound::default(),
-            };
-        }
-
-        // Process includes (definitions merged into current scope)
-        for include in &program.includes {
+        // #2682: each `expr = FuncDef { .., then: expr }` wraps the *previous*
+        // `expr` one layer further in, so whichever source is processed
+        // FIRST ends up nearest the original body -- the innermost def, and
+        // therefore the one jq's own innermost-first scoping resolves a
+        // name to. The two facts this loop order has to get right, both
+        // confirmed live against jq 1.7.1:
+        //
+        // - `include` outranks `~/.jq`: a name defined in both resolves to
+        //   the `include`d one (`~/.jq`'s own def is still visible, and
+        //   still outranks the same name in a module that was never
+        //   included -- just not one that was).
+        // - among multiple `include`s defining the same name, the *last*
+        //   declared one wins, not the first -- `include "pa"; include
+        //   "pb"; foo` answers `pb`'s `foo`, and reversing the two
+        //   `include`s reverses the answer.
+        //
+        // So `program.includes` is walked in reverse (declaration order
+        // last-to-first) so the last-declared include is processed first
+        // and ends up innermost, and the whole includes block runs before
+        // the `~/.jq` block below so every include ends up nested inside
+        // `~/.jq`'s own defs, not the other way around.
+        for include in program.includes.iter().rev() {
             let defs = self.load_module(&include.path)?;
             // Wrap expression with function definitions from the included module
             for (name, params, body) in defs.into_iter().rev() {
@@ -284,6 +293,19 @@ impl ModuleLoader {
                     bound: FuncDefBound::default(),
                 };
             }
+        }
+
+        // `~/.jq`'s own defs: lowest priority of the two unqualified
+        // sources (loses to any `include`d module of the same name, but
+        // still beats a name that was never `include`d at all).
+        for (name, params, body) in self.auto_loaded_defs.clone().into_iter().rev() {
+            expr = Expr::FuncDef {
+                name,
+                params,
+                body: Box::new(body),
+                then: Box::new(expr),
+                bound: FuncDefBound::default(),
+            };
         }
 
         // Process imports (definitions available under namespace::)

--- a/src/bin/succinctly/jq_runner.rs
+++ b/src/bin/succinctly/jq_runner.rs
@@ -276,11 +276,9 @@ impl ModuleLoader {
         //   "pb"; foo` answers `pb`'s `foo`, and reversing the two
         //   `include`s reverses the answer.
         //
-        // So `program.includes` is walked in reverse (declaration order
-        // last-to-first) so the last-declared include is processed first
-        // and ends up innermost, and the whole includes block runs before
-        // the `~/.jq` block below so every include ends up nested inside
-        // `~/.jq`'s own defs, not the other way around.
+        // Hence `.rev()` below (last-declared include processed first, so
+        // it ends up innermost) and the whole includes block running before
+        // the `~/.jq` block that follows it.
         for include in program.includes.iter().rev() {
             let defs = self.load_module(&include.path)?;
             // Wrap expression with function definitions from the included module

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -23337,6 +23337,127 @@ fn test_home_jq_def_shadows_builtin_2395() -> Result<()> {
     Ok(())
 }
 
+/// #2682: `process_program` wraps `~/.jq`'s defs before an `include`d
+/// module's, which makes `~/.jq` the *innermost* `Expr::FuncDef` and
+/// therefore the one that wins a same-name collision -- the reverse of what
+/// jq actually does. Confirmed live against jq 1.7.1: an `include`d module's
+/// def always outranks a same-named `~/.jq` def.
+#[test]
+fn test_include_outranks_home_jq_on_a_name_collision_2682() -> Result<()> {
+    let temp_home = tempfile::tempdir()?;
+    std::fs::write(temp_home.path().join(".jq"), "def myfn: \"dotjq-myfn\";\n")?;
+    let lib_dir = tempfile::tempdir()?;
+    std::fs::write(
+        lib_dir.path().join("pfn.jq"),
+        "def myfn: \"include-myfn\";\n",
+    )?;
+
+    let lib_arg = lib_dir.path().to_string_lossy().into_owned();
+    let (output, code) = spawn_jq_with_env(
+        &["-L", &lib_arg, "-nc", r#"include "pfn"; myfn"#],
+        "HOME",
+        temp_home.path(),
+        None,
+    )?;
+    let stdout = String::from_utf8(output.stdout)?;
+    let stderr = String::from_utf8(output.stderr)?;
+    assert_eq!(code, 0, "stderr: {stderr:?}");
+    assert_eq!(stdout.trim_end(), r#""include-myfn""#);
+    Ok(())
+}
+
+/// #2682 control: `~/.jq` still wins when nothing `include`d defines the
+/// same name -- the bug is specifically about `include` vs `~/.jq`
+/// priority on a genuine collision, not about `~/.jq` losing outright.
+#[test]
+fn test_home_jq_still_wins_without_a_colliding_include_2682() -> Result<()> {
+    let temp_home = tempfile::tempdir()?;
+    std::fs::write(temp_home.path().join(".jq"), "def myfn: \"dotjq-myfn\";\n")?;
+    let lib_dir = tempfile::tempdir()?;
+    std::fs::write(lib_dir.path().join("pfn.jq"), "def other: 1;\n")?;
+
+    let lib_arg = lib_dir.path().to_string_lossy().into_owned();
+    let (output, code) = spawn_jq_with_env(
+        &["-L", &lib_arg, "-nc", r#"include "pfn"; myfn"#],
+        "HOME",
+        temp_home.path(),
+        None,
+    )?;
+    let stdout = String::from_utf8(output.stdout)?;
+    let stderr = String::from_utf8(output.stderr)?;
+    assert_eq!(code, 0, "stderr: {stderr:?}");
+    assert_eq!(stdout.trim_end(), r#""dotjq-myfn""#);
+    Ok(())
+}
+
+/// #2682 (filed via a comment on the issue by the repo owner): among
+/// multiple `include`s defining the same name, the *last*-declared one
+/// wins, not the first -- `program.includes` was walked in declaration
+/// order, making the first-declared include the innermost `Expr::FuncDef`
+/// and therefore the winner, backwards from jq's own rule. Both directions
+/// confirmed live against jq 1.7.1.
+#[test]
+fn test_last_declared_include_wins_on_a_name_collision_2682() -> Result<()> {
+    let lib_dir = tempfile::tempdir()?;
+    std::fs::write(lib_dir.path().join("pa.jq"), "def foo: \"from-A\";\n")?;
+    std::fs::write(lib_dir.path().join("pb.jq"), "def foo: \"from-B\";\n")?;
+
+    for (filter, want) in [
+        (r#"include "pa"; include "pb"; foo"#, r#""from-B""#),
+        (r#"include "pb"; include "pa"; foo"#, r#""from-A""#),
+    ] {
+        let (output, code) = spawn_with_signal_retry(
+            || {
+                let mut command = Command::new(succinctly_bin());
+                command
+                    .args(["jq", "-L"])
+                    .arg(lib_dir.path())
+                    .args(["-nc", filter]);
+                command
+            },
+            None,
+        )?;
+        let stdout = String::from_utf8(output.stdout)?;
+        let stderr = String::from_utf8(output.stderr)?;
+        assert_eq!(code, 0, "{filter}: stderr: {stderr:?}");
+        assert_eq!(stdout.trim_end(), want, "{filter}");
+    }
+    Ok(())
+}
+
+/// #2682, the three-way case the issue's own author flagged worth checking:
+/// a main-filter `def` still outranks both an `include`d module's and
+/// `~/.jq`'s same-named def, since it's the innermost of all three (jq
+/// agrees: confirmed live).
+#[test]
+fn test_main_filter_def_outranks_both_include_and_home_jq_2682() -> Result<()> {
+    let temp_home = tempfile::tempdir()?;
+    std::fs::write(temp_home.path().join(".jq"), "def myfn: \"dotjq-myfn\";\n")?;
+    let lib_dir = tempfile::tempdir()?;
+    std::fs::write(
+        lib_dir.path().join("pfn.jq"),
+        "def myfn: \"include-myfn\";\n",
+    )?;
+
+    let lib_arg = lib_dir.path().to_string_lossy().into_owned();
+    let (output, code) = spawn_jq_with_env(
+        &[
+            "-L",
+            &lib_arg,
+            "-nc",
+            r#"include "pfn"; def myfn: "main-filter"; myfn"#,
+        ],
+        "HOME",
+        temp_home.path(),
+        None,
+    )?;
+    let stdout = String::from_utf8(output.stdout)?;
+    let stderr = String::from_utf8(output.stderr)?;
+    assert_eq!(code, 0, "stderr: {stderr:?}");
+    assert_eq!(stdout.trim_end(), r#""main-filter""#);
+    Ok(())
+}
+
 /// #2395: `import "m" as ns` must *not* shadow, and the exclusion is
 /// deliberate rather than an oversight -- jq puts an imported module's defs in
 /// scope only as `ns::name`, so a bare `length` there is still the builtin


### PR DESCRIPTION
## Summary
- `ModuleLoader::process_program` builds scope by wrapping outward (`expr = FuncDef { .., then: expr }`), and jq resolves names innermost-first, so whichever source is wrapped *first* ends up nearest the original body and wins a same-name collision. The loop order had this backwards in two ways:
  - `~/.jq` was wrapped before `include`, making `~/.jq` the innermost source and letting it win over a same-named `include`d def; real jq gives `include` the higher priority.
  - `program.includes` was walked in declaration order, making the *first* `include` innermost; real jq gives the *last*-declared `include` the win on a same-name collision between two includes (found via a follow-up comment from the repo owner on the issue itself).
- Fixed by walking `includes` in reverse (so the last-declared one is wrapped first, ending up innermost) and running the whole includes block before `~/.jq`'s.
- Confirmed live against jq 1.7.1 for all four combinations: `include` vs `~/.jq`, both `include` orderings, and the three-way case with a main-filter `def` on top (already correct, confirmed it stays that way).

Fixes #2682

## Test plan
- [x] `test_include_outranks_home_jq_on_a_name_collision_2682`
- [x] `test_home_jq_still_wins_without_a_colliding_include_2682` (control: `~/.jq` still applies when nothing `include`d collides)
- [x] `test_last_declared_include_wins_on_a_name_collision_2682` (both orderings)
- [x] `test_main_filter_def_outranks_both_include_and_home_jq_2682` (the three-way case the issue's own author flagged worth checking)
- [x] All oracle-verified against jq 1.7.1
- [x] Re-ran the full #2395/module/include/import test cluster -- no regressions
- [x] `cargo test --features cli` -- full suite passes, 0 failures
- [x] `cargo clippy --all-targets --all-features -- -D warnings` -- clean
- [x] Patch coverage: 100% (11/11 new lines covered)