### PR TITLE
fix(jq): add a checked JqValue::try_materialize, stop -e's panic-backtrace leak

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -129,21 +129,36 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **`succinctly jq -e`, and `-S`/`-a`/`-C`, no longer leak a raw Rust panic
   backtrace to stderr on deeply-nested input** (#2850). The exit code (5) and
-  final diagnostic (`nesting depth exceeds limit of N`) were always correct;
-  only extraneous `thread '<unnamed>' panicked at ...` noise ahead of them
-  was the bug. `-e`'s own exit-status materialize call in `jq_runner.rs`
-  used the panicking `JqValue::materialize()` at a CLI-output boundary
-  rather than the evaluator's own hot recursion, where a panic stays
-  deliberate (#1818's established split). `write_output_jq_value`'s own
-  materialize call (`-S`/`-a`/`-C`) shared the identical risk, confirmed live
-  after #2662 moved those three flags onto the same lazy/`JqValue::Cursor`
-  route `-e` already used. Both now use a new checked twin,
-  `JqValue::try_materialize`, added alongside the panicking original rather
-  than replacing it -- library callers that already treat over-deep nesting
-  as a bug keep that contract unchanged, and `try_materialize` preserves the
-  original's raw JSON number spelling exactly
-  (`OwnedValue::from_number_bytes`, not a canonicalizing reformat), so
-  `--preserve-input` semantics are unaffected.
+  final diagnostic (`nesting depth exceeds limit of N`) were always correct
+  for a *single-result* document; only extraneous
+  `thread '<unnamed>' panicked at ...` noise ahead of them was the bug there.
+  `-e`'s own exit-status materialize call in `jq_runner.rs` used the
+  panicking `JqValue::materialize()` at a CLI-output boundary rather than the
+  evaluator's own hot recursion, where a panic stays deliberate (#1818's
+  established split). `write_output_jq_value`'s own materialize call
+  (`-S`/`-a`/`-C`) shared the identical risk, confirmed live after #2662
+  moved those three flags onto the same lazy/`JqValue::Cursor` route `-e`
+  already used. Both now use a new checked twin, `JqValue::try_materialize`,
+  added alongside the panicking original rather than replacing it -- library
+  callers that already treat over-deep nesting as a bug keep that contract
+  unchanged, and `try_materialize` preserves the original's raw JSON number
+  spelling exactly (`OwnedValue::from_number_bytes`, not a canonicalizing
+  reformat), so `--preserve-input` semantics are unaffected.
+
+  **For `-e` specifically, a multi-result filter's output also changes**
+  (`.[]` over a document with one over-deep element among well-formed
+  siblings): the old panic unwound through the whole per-document
+  `catch_unwind`, silently dropping every remaining sibling result for that
+  document; the new `Err` is caught by this call site's own existing
+  `sink.report(...)` + continue path -- the identical one a decode failure
+  (#1247) already took at this exact call site before this fix, and still
+  does. This makes the two failure classes consistent with each other at
+  this call site rather than introducing new behavior: a depth violation now
+  skips just the one result, the same as a decode failure always has, instead
+  of the whole document. `write_output_jq_value`'s call site (`-S`/`-a`/`-C`)
+  is unaffected by this nuance -- its own error routing
+  (`MalformedJsonError`) already halts the whole document for *any* `Err`,
+  before and after this fix.
 
 - **`succinctly yq` no longer answers arithmetic from a collapsed copy of the
   document** (#2626). `printf 'b: 1\na: 2\nb: 3\n' | succinctly yq 'length + 0'`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -127,6 +127,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`succinctly jq -e`, and `-S`/`-a`/`-C`, no longer leak a raw Rust panic
+  backtrace to stderr on deeply-nested input** (#2850). The exit code (5) and
+  final diagnostic (`nesting depth exceeds limit of N`) were always correct;
+  only extraneous `thread '<unnamed>' panicked at ...` noise ahead of them
+  was the bug. `-e`'s own exit-status materialize call in `jq_runner.rs`
+  used the panicking `JqValue::materialize()` at a CLI-output boundary
+  rather than the evaluator's own hot recursion, where a panic stays
+  deliberate (#1818's established split). `write_output_jq_value`'s own
+  materialize call (`-S`/`-a`/`-C`) shared the identical risk, confirmed live
+  after #2662 moved those three flags onto the same lazy/`JqValue::Cursor`
+  route `-e` already used. Both now use a new checked twin,
+  `JqValue::try_materialize`, added alongside the panicking original rather
+  than replacing it -- library callers that already treat over-deep nesting
+  as a bug keep that contract unchanged, and `try_materialize` preserves the
+  original's raw JSON number spelling exactly
+  (`OwnedValue::from_number_bytes`, not a canonicalizing reformat), so
+  `--preserve-input` semantics are unaffected.
+
 - **`succinctly yq` no longer answers arithmetic from a collapsed copy of the
   document** (#2626). `printf 'b: 1\na: 2\nb: 3\n' | succinctly yq 'length + 0'`
   answered `2` while the same binary's bare `length` answered `3` — and real yq

--- a/docs/compliance/jq/limitations.md
+++ b/docs/compliance/jq/limitations.md
@@ -2492,12 +2492,29 @@ flag that forces whole-batch materialization up front (`--slurp`, `-S`/`--sort-k
 (`check_nesting_depth`, `src/jq/eval_generic.rs`) rather than `catch_unwind`, since that
 walk already threads a `Result` and runs before any user filter evaluates at all.
 
-Still uncaught, tracked separately, not fixed by either #1793 or #1818: `-e`/
-`--exit-status`'s own separate materializer (`src/jq/lazy.rs`, already pinned uncaught by
-`test_exit_status_query_rejects_adversarial_nesting_998`); and `succinctly yq`, which has
-no equivalent guard on either its default or materializing path at all (#1817). Confirmed
-live, also pre-existing and unrelated to either fix: `print_json`'s own guard can flush
-corrupted/truncated JSON to stdout before it fires (#1819).
+**Closed by [#2850](https://github.com/rust-works/succinctly/issues/2850).** `-e`/
+`--exit-status`'s own separate materializer (`src/jq/lazy.rs`) now reports a clean, catchable
+diagnostic instead of panicking, via a new checked twin (`JqValue::try_materialize`) rather
+than the panicking `materialize` #1818 above left untouched. `test_exit_status_query_rejects_
+adversarial_nesting_998` (`tests/jq_cli_tests.rs`) is unaffected and stays green either way --
+it exercises `-e -c .[0]`, a shape #1793's own `catch_unwind` already reported cleanly before
+#2850 (only the exit code and message were pinned, not the absence of leaked panic text).
+`test_exit_status_over_depth_document_reports_cleanly_not_panic_2850` is a new, separate test
+that does assert `!stderr.contains("panicked")` -- the specific property this issue fixes.
+
+That same fix also closes a gap #2662 (unrelated to #2850, landed independently) opened in
+`-S`/`-C`/`--ascii-output`'s own #1818 protection above: moving those three flags onto the
+lazy/`JqValue::Cursor` dispatch bypasses `validate_json_delimiters`'s earlier checked guard,
+the one #1818 actually credited for closing their gap — reaching `write_output_jq_value`'s own
+materialize call directly, the identical panicking route `-e` always took. #2850's
+`try_materialize` closes that call site too, so the net effect across both issues landing
+together is unchanged from #1818's original guarantee: `-S`/`-a`/`-C` still cannot panic on
+over-deep input, now via a different, more direct mechanism than the one #2662 stepped past.
+
+`succinctly yq` still has no equivalent guard on either its default or materializing path at
+all (#1817) — untouched by #2850, which is jq-mode only. Confirmed live, also pre-existing and
+unrelated to any of #1793/#1818/#2850: `print_json`'s own guard can flush corrupted/truncated
+JSON to stdout before it fires (#1819).
 
 [#2692](https://github.com/rust-works/succinctly/issues/2692) widens the "accepts at
 parse/index time" story above to more filters, by the same mechanism as `.[1]`/`length`:

--- a/src/bin/succinctly/jq_runner.rs
+++ b/src/bin/succinctly/jq_runner.rs
@@ -2010,11 +2010,12 @@ pub fn run_jq(args: JqCommand) -> Result<i32> {
                 // streaming filter panics from within the sink callback
                 // rather than before the caller's loop starts. That puts
                 // `out`, `sink`, `had_output` and `last_output` under
-                // `AssertUnwindSafe`, which is sound here for the same reason
-                // the single `sink` was already: `assert_nesting_depth`
-                // panics unconditionally *before* any `write_all`, so `out`'s
-                // writer is never mid-record when the stack unwinds, and the
-                // other three are plain data.
+                // `AssertUnwindSafe`, which stays sound: `write_output_jq_value`
+                // below can still panic on other, unrelated guards this
+                // closure doesn't control (e.g. a genuine stack-depth guard
+                // elsewhere in the write path), so `out`'s writer is not
+                // mid-record when *those* unwind either, and the other three
+                // are plain data regardless.
                 let outcome = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
                     let mut on_value =
                         |sink: &mut ErrorSink, result: JqValue<'_, Vec<u64>>| -> Result<bool> {
@@ -2026,8 +2027,16 @@ pub fn run_jq(args: JqCommand) -> Result<i32> {
                                 // becomes observable here (#1247). Report and skip
                                 // the value rather than letting an undecodable
                                 // string count as a truthiness answer; `sink`
-                                // drives the exit code.
-                                match result.materialize() {
+                                // drives the exit code. `try_materialize`, not
+                                // `materialize` (#2850): this call used to leak
+                                // Rust's raw panic backtrace to stderr past
+                                // `MAX_NESTING_DEPTH`/`MAX_VALUE_TREE_DEPTH`
+                                // levels of nesting, ahead of the clean,
+                                // correctly exit-5'd diagnostic this `match`
+                                // already produces below -- a CLI-output
+                                // boundary has no business panicking for input
+                                // depth alone.
+                                match result.try_materialize() {
                                     Ok(owned) => last_output = Some(owned),
                                     Err(e) => {
                                         sink.report(DiagStyle::Jq, &e, &at);
@@ -5699,8 +5708,17 @@ fn write_output_jq_value<Out: Write, Wrd: Clone + AsRef<[u64]>>(
         // first exercises it: `printf '{invalid}' | succinctly jq -cS .`
         // used to exit 1 with a bare `Error: ...` where real jq (and this
         // crate's own default lazy route) exits 5 with `jq: error (at ...)`.
+        //
+        // `try_materialize`, not `materialize` (#2850): this is a
+        // CLI-output-boundary call site, not the evaluator's own hot
+        // recursion, so a nesting-depth violation belongs in this same
+        // `Result`/`MalformedJsonError` channel rather than as an
+        // uncaught-by-design panic. #2662's move of `-S`/`-C`/`-a` onto this
+        // branch is what makes this the confirmed, live path #2850 is filed
+        // over: `succinctly jq -cS .` on deeply-nested input used to leak
+        // Rust's raw panic backtrace to stderr the same way bare `-e` did.
         let owned = value
-            .materialize()
+            .try_materialize()
             .map_err(|e| anyhow::Error::from(MalformedJsonError(e)))?;
         out.write_all(format_json(&owned, config).as_bytes())?;
     }

--- a/src/bin/succinctly/jq_runner.rs
+++ b/src/bin/succinctly/jq_runner.rs
@@ -2011,11 +2011,16 @@ pub fn run_jq(args: JqCommand) -> Result<i32> {
                 // rather than before the caller's loop starts. That puts
                 // `out`, `sink`, `had_output` and `last_output` under
                 // `AssertUnwindSafe`, which stays sound: `write_output_jq_value`
-                // below can still panic on other, unrelated guards this
-                // closure doesn't control (e.g. a genuine stack-depth guard
-                // elsewhere in the write path), so `out`'s writer is not
-                // mid-record when *those* unwind either, and the other three
-                // are plain data regardless.
+                // below is panic-free for depth as of #2850 (`try_materialize`,
+                // not the panicking `materialize`), but `evaluate_bytes_streaming`
+                // above it is not -- `to_owned_cursor_at_depth`'s own panic
+                // (sort/join, described just above) and `eval_generic.rs`'s
+                // path-tracking `assert_nesting_depth` calls (`path()`/
+                // `setpath`/`del()`/assignment operators on deep input) both
+                // still reach the panicking guard during *evaluation*, ahead
+                // of this closure's write. `out`'s writer is not mid-record
+                // when either unwinds, and the other three are plain data
+                // regardless.
                 let outcome = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
                     let mut on_value =
                         |sink: &mut ErrorSink, result: JqValue<'_, Vec<u64>>| -> Result<bool> {

--- a/src/jq/lazy.rs
+++ b/src/jq/lazy.rs
@@ -1824,6 +1824,39 @@ mod tests {
         ));
     }
 
+    /// #2850 coverage: the `Bool`/`Float`/`RawNumber` scalar arms of both
+    /// `materialize_at_depth`/`try_materialize_at_depth`, the `Cursor` arm's
+    /// `Bool` case in `cursor_to_owned_at_depth`, and its `Null` case in
+    /// `try_cursor_to_owned_at_depth`, weren't exercised by any existing
+    /// test -- `test_materialize` above covers `Int`/`String`/`Null` (via a
+    /// direct `JqValue::Null`, never through a `Cursor`), and the two
+    /// depth-limit tests above only ever build arrays/ints.
+    #[test]
+    fn materialize_and_try_materialize_cover_the_remaining_scalar_arms_2850() {
+        use crate::json::JsonIndex;
+
+        let b: JqValue<'_, Vec<u64>> = JqValue::bool(true);
+        assert_eq!(b.materialize().unwrap(), OwnedValue::Bool(true));
+
+        let f: JqValue<'_, Vec<u64>> = JqValue::float(1.5);
+        assert_eq!(f.try_materialize().unwrap(), OwnedValue::Float(1.5));
+
+        let raw: JqValue<'_, Vec<u64>> = JqValue::RawNumber(b"4e4");
+        assert_eq!(raw.try_materialize().unwrap().to_json(), "4E+4");
+
+        let bool_json = b"true";
+        let index = JsonIndex::build(bool_json);
+        let cursor = index.root(bool_json);
+        let val: JqValue<'_, Vec<u64>> = JqValue::from_cursor(cursor);
+        assert_eq!(val.materialize().unwrap(), OwnedValue::Bool(true));
+
+        let json = b"null";
+        let index = JsonIndex::build(json);
+        let cursor = index.root(json);
+        let val: JqValue<'_, Vec<u64>> = JqValue::from_cursor(cursor);
+        assert_eq!(val.try_materialize().unwrap(), OwnedValue::Null);
+    }
+
     /// #1021: `JqValue::into_owned` had no depth guard at all before this
     /// issue -- same gap as `materialize`, just on the consuming twin.
     #[test]

--- a/src/jq/lazy.rs
+++ b/src/jq/lazy.rs
@@ -531,6 +531,73 @@ impl<'a, W: Clone + AsRef<[u64]>> JqValue<'a, W> {
         })
     }
 
+    /// [`materialize`](Self::materialize)'s checked twin: reports a value
+    /// nested past [`MAX_VALUE_TREE_DEPTH`](super::value::MAX_VALUE_TREE_DEPTH)
+    /// as an ordinary [`EvalError`] instead of panicking (#2850), the same
+    /// relationship [`try_from_owned`](Self::try_from_owned) already has to
+    /// `from_owned` (#1371) -- this is that fix's own sibling gap, not a new
+    /// pattern.
+    ///
+    /// For a **CLI-output-boundary** call site (`write_output_jq_value`'s
+    /// materialize arm and `-e`'s exit-status check, `jq_runner.rs`) rather
+    /// than the evaluator's own hot recursion, where a panic stays deliberate
+    /// -- the identical split [`eval_generic::check_nesting_depth`] already
+    /// draws from [`eval_generic::assert_nesting_depth`] (#1818). Confirmed
+    /// live: `-e` alone on 500 levels of `[...]`-nested JSON used to leak
+    /// Rust's raw panic backtrace to stderr ahead of the clean, correctly
+    /// exit-5'd diagnostic `write_output`'s own `catch_unwind` already
+    /// produced -- the exit code and final message were always right, only
+    /// the extra noise ahead of them was the bug.
+    ///
+    /// Delegates to [`try_cursor_to_owned`] for the `Cursor` arm rather than
+    /// the panicking [`cursor_to_owned`] -- the two nested depth budgets
+    /// (this one, `MAX_VALUE_TREE_DEPTH`-bounded; that one,
+    /// `MAX_NESTING_DEPTH`-bounded, restarting from 0 whenever a `Cursor` is
+    /// reached) mirror `materialize_at_depth`'s own split exactly, just with
+    /// both sides checked instead of both sides panicking. Preserves
+    /// [`cursor_to_owned`]'s raw-number-byte semantics via
+    /// [`try_cursor_to_owned`] rather than switching to
+    /// `eval_generic::to_owned_cursor`'s canonicalizing twin, which would
+    /// silently reformat a JSON-sourced number's spelling on every
+    /// `-S`/`-a`/`-C`/`-e` run -- exactly the risk that made a plain
+    /// delegation to the already-checked `eval_generic` materializer unsafe
+    /// (see this issue's own "why not a quick fix" note).
+    pub fn try_materialize(&self) -> Result<OwnedValue, EvalError> {
+        self.try_materialize_at_depth(0)
+    }
+
+    fn try_materialize_at_depth(&self, depth: usize) -> Result<OwnedValue, EvalError> {
+        if depth >= super::value::MAX_VALUE_TREE_DEPTH {
+            return Err(EvalError::new(
+                super::value::nesting_depth_exceeded_message(super::value::MAX_VALUE_TREE_DEPTH),
+            ));
+        }
+        Ok(match self {
+            JqValue::Cursor(c) => try_cursor_to_owned(c)?,
+            JqValue::Null => OwnedValue::Null,
+            JqValue::Bool(b) => OwnedValue::Bool(*b),
+            JqValue::Int(n) => OwnedValue::Int(*n),
+            JqValue::Float(f) => OwnedValue::Float(*f),
+            JqValue::RawNumber(bytes) => OwnedValue::from_number_bytes(bytes),
+            JqValue::NumberLiteral(literal) => OwnedValue::from_number_literal(literal),
+            JqValue::String(s) => OwnedValue::String(s.clone()),
+            JqValue::Array(arr) => OwnedValue::Array(
+                arr.iter()
+                    .map(|v| v.try_materialize_at_depth(depth + 1))
+                    .collect::<Result<_, _>>()?,
+            ),
+            JqValue::Object(obj) => OwnedValue::Object(
+                obj.iter()
+                    .map(|(k, v)| Ok((k.clone(), v.try_materialize_at_depth(depth + 1)?)))
+                    .collect::<Result<_, EvalError>>()?,
+            ),
+            JqValue::LazyKeysArray { fields, collapse } => {
+                lazy_keys_array_to_owned(fields, *collapse)?
+            }
+            JqValue::LazyIndexRange(len) => lazy_index_range_to_owned(*len),
+        })
+    }
+
     /// Convert to OwnedValue, consuming self.
     ///
     /// More efficient than `materialize()` when you don't need to keep the original.
@@ -927,6 +994,76 @@ fn cursor_to_owned_at_depth<W: Clone + AsRef<[u64]>>(
         // becoming `null`. #2286: decode_failure, not new -- same class as
         // the malformed member/delimiter errors; confirmed live that real
         // jq treats this uncatchably too.
+        StandardJson::Error(msg) => return Err(EvalError::decode_failure(msg)),
+    })
+}
+
+/// [`cursor_to_owned`]'s checked twin (#2850): reports a value nested past
+/// [`super::eval_generic::MAX_NESTING_DEPTH`] as an ordinary [`EvalError`]
+/// instead of panicking, for [`JqValue::try_materialize`]'s `Cursor` arm --
+/// a CLI-output-boundary caller, not the evaluator's own hot recursion
+/// [`cursor_to_owned`]'s own panicking contract stays deliberate for (see
+/// that function's doc comment). Otherwise byte-for-byte identical,
+/// including the raw-number-byte preservation
+/// (`OwnedValue::from_number_bytes`) that rules out delegating to
+/// `eval_generic::to_owned_cursor`'s canonicalizing twin instead.
+fn try_cursor_to_owned<W: Clone + AsRef<[u64]>>(
+    cursor: &JsonCursor<'_, W>,
+) -> Result<OwnedValue, EvalError> {
+    try_cursor_to_owned_at_depth(cursor, 0)
+}
+
+fn try_cursor_to_owned_at_depth<W: Clone + AsRef<[u64]>>(
+    cursor: &JsonCursor<'_, W>,
+    depth: usize,
+) -> Result<OwnedValue, EvalError> {
+    super::eval_generic::check_nesting_depth(depth)?;
+    Ok(match cursor.value() {
+        StandardJson::Null => OwnedValue::Null,
+        StandardJson::Bool(b) => OwnedValue::Bool(b),
+        StandardJson::Number(n) => OwnedValue::from_number_bytes(n.raw_bytes()),
+        StandardJson::String(s) => OwnedValue::String(
+            s.as_str()
+                .map_err(|e| EvalError::decode_failure(format!("{e}")))?
+                .into_owned(),
+        ),
+        StandardJson::Array(_) => {
+            let mut items = Vec::new();
+            let mut is_first = true;
+            let mut last_elem: Option<JsonCursor<'_, W>> = None;
+            for child in cursor.children() {
+                if !child.element_gap_ok(is_first) {
+                    return Err(child.malformed_delimiter_error());
+                }
+                items.push(try_cursor_to_owned_at_depth(&child, depth + 1)?);
+                last_elem = Some(child);
+                is_first = false;
+            }
+            container_tail_gap_ok(cursor, last_elem.as_ref(), b']')?;
+            OwnedValue::Array(items)
+        }
+        StandardJson::Object(fields) => {
+            let mut map = IndexMap::new();
+            let mut guard = DisplayKeyGuard::default();
+            let mut f = fields;
+            let mut is_first = true;
+            let mut last_field: Option<JsonCursor<'_, W>> = None;
+            while let Some((field, rest)) = DocumentFields::uncons(&f) {
+                let key = field.checked_key(&f, &map, &mut guard, is_first)?;
+                map.insert(
+                    key,
+                    try_cursor_to_owned_at_depth(&field.value_cursor, depth + 1)?,
+                );
+                last_field = Some(field.value_cursor);
+                f = rest;
+                is_first = false;
+            }
+            if f.ends_unpaired() {
+                return Err(f.malformed_member_error());
+            }
+            container_tail_gap_ok(cursor, last_field.as_ref(), b'}')?;
+            OwnedValue::Object(map)
+        }
         StandardJson::Error(msg) => return Err(EvalError::decode_failure(msg)),
     })
 }
@@ -1577,6 +1714,111 @@ mod tests {
             result.is_err(),
             "materialize should panic at MAX_VALUE_TREE_DEPTH"
         );
+    }
+
+    /// #2850: [`JqValue::try_materialize`]'s own boundary coverage --
+    /// [`materialize_panics_past_nesting_depth_limit_1021`]'s checked twin.
+    /// Reports past `MAX_VALUE_TREE_DEPTH` as an ordinary `Err` instead of
+    /// panicking, the way a CLI-output-boundary call site
+    /// (`jq_runner.rs`'s `write_output_jq_value` and `-e`'s exit-status
+    /// check) needs -- confirmed live before this fix that `-e` alone on
+    /// deeply-nested input leaked Rust's raw panic backtrace to stderr
+    /// ahead of the clean, correctly exit-5'd diagnostic.
+    #[test]
+    fn try_materialize_reports_past_nesting_depth_limit_2850() {
+        use crate::jq::value::MAX_VALUE_TREE_DEPTH;
+
+        let under = linear_jqvalue_nest(MAX_VALUE_TREE_DEPTH - 1);
+        assert!(matches!(
+            under.try_materialize().unwrap(),
+            OwnedValue::Array(_)
+        ));
+
+        // Exercise the `Object` arm too -- see `materialize`'s sibling test
+        // above for why.
+        let nested_object: JqValue<'_, Vec<u64>> = JqValue::Object(IndexMap::from([(
+            "a".to_string(),
+            JqValue::Array(vec![JqValue::Null]),
+        )]));
+        assert!(matches!(
+            nested_object.try_materialize().unwrap(),
+            OwnedValue::Object(_)
+        ));
+
+        let over = linear_jqvalue_nest(MAX_VALUE_TREE_DEPTH);
+        let err = over
+            .try_materialize()
+            .expect_err("try_materialize should report an Err at MAX_VALUE_TREE_DEPTH, not panic");
+        assert!(
+            err.message.contains("nesting depth exceeds limit"),
+            "unexpected message: {}",
+            err.message
+        );
+    }
+
+    /// #2850: the `Cursor` arm's own, *separate* depth budget --
+    /// `try_materialize`'s recursion through a real `JsonCursor` (built from
+    /// raw JSON text, as `-e`/`-S`/`-a`/`-C` actually encounter it) restarts
+    /// at 0 and is capped by `MAX_NESTING_DEPTH` (256), not
+    /// `MAX_VALUE_TREE_DEPTH` (384) -- the two guards this fix's own
+    /// `try_cursor_to_owned`/`try_materialize_at_depth` split mirrors from
+    /// the panicking `cursor_to_owned`/`materialize_at_depth` pair. A
+    /// `JqValue` tree built directly (as the test above does) never
+    /// exercises this arm at all.
+    #[test]
+    fn try_cursor_to_owned_reports_past_nesting_depth_limit_2850() {
+        use crate::json::JsonIndex;
+
+        let mut json = String::new();
+        for _ in 0..300 {
+            json.push('[');
+        }
+        json.push('1');
+        for _ in 0..300 {
+            json.push(']');
+        }
+
+        let index = JsonIndex::build(json.as_bytes());
+        let cursor = index.root(json.as_bytes());
+        let val: JqValue<'_, Vec<u64>> = JqValue::from_cursor(cursor);
+
+        // The existing panicking contract is unchanged.
+        let panicked =
+            std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| val.materialize().unwrap()));
+        assert!(
+            panicked.is_err(),
+            "materialize should still panic past MAX_NESTING_DEPTH through a Cursor"
+        );
+
+        // The checked twin reports the identical condition cleanly instead.
+        let index = JsonIndex::build(json.as_bytes());
+        let cursor = index.root(json.as_bytes());
+        let val: JqValue<'_, Vec<u64>> = JqValue::from_cursor(cursor);
+        let err = val
+            .try_materialize()
+            .expect_err("try_materialize should report an Err at MAX_NESTING_DEPTH, not panic");
+        assert!(
+            err.message.contains("nesting depth exceeds limit of 256"),
+            "unexpected message: {}",
+            err.message
+        );
+
+        // A well-formed, under-the-limit cursor round-trips correctly.
+        let mut shallow = String::new();
+        for _ in 0..10 {
+            shallow.push('[');
+        }
+        shallow.push('1');
+        for _ in 0..10 {
+            shallow.push(']');
+        }
+        let index = JsonIndex::build(shallow.as_bytes());
+        let cursor = index.root(shallow.as_bytes());
+        let val: JqValue<'_, Vec<u64>> = JqValue::from_cursor(cursor);
+        assert!(matches!(
+            val.try_materialize().unwrap(),
+            OwnedValue::Array(_)
+        ));
     }
 
     /// #1021: `JqValue::into_owned` had no depth guard at all before this

--- a/src/jq/lazy.rs
+++ b/src/jq/lazy.rs
@@ -497,6 +497,13 @@ impl<'a, W: Clone + AsRef<[u64]>> JqValue<'a, W> {
     /// `Err` when a string scalar in the tree cannot be decoded (#1247) --
     /// it used to materialize as an empty string, silently replacing the
     /// value with something that compares, sorts and prints as real data.
+    ///
+    /// # Panics
+    ///
+    /// Past [`MAX_VALUE_TREE_DEPTH`](super::value::MAX_VALUE_TREE_DEPTH)
+    /// levels of nesting (#1021) -- deliberate for a library caller that
+    /// treats over-deep nesting as a bug. Use [`try_materialize`](Self::try_materialize)
+    /// instead for untrusted-depth input at a CLI-output boundary (#2850).
     pub fn materialize(&self) -> Result<OwnedValue, EvalError> {
         self.materialize_at_depth(0)
     }
@@ -567,11 +574,7 @@ impl<'a, W: Clone + AsRef<[u64]>> JqValue<'a, W> {
     }
 
     fn try_materialize_at_depth(&self, depth: usize) -> Result<OwnedValue, EvalError> {
-        if depth >= super::value::MAX_VALUE_TREE_DEPTH {
-            return Err(EvalError::new(
-                super::value::nesting_depth_exceeded_message(super::value::MAX_VALUE_TREE_DEPTH),
-            ));
-        }
+        super::value::check_value_tree_depth(depth)?;
         Ok(match self {
             JqValue::Cursor(c) => try_cursor_to_owned(c)?,
             JqValue::Null => OwnedValue::Null,

--- a/src/jq/lazy.rs
+++ b/src/jq/lazy.rs
@@ -548,22 +548,22 @@ impl<'a, W: Clone + AsRef<[u64]>> JqValue<'a, W> {
     /// For a **CLI-output-boundary** call site (`write_output_jq_value`'s
     /// materialize arm and `-e`'s exit-status check, `jq_runner.rs`) rather
     /// than the evaluator's own hot recursion, where a panic stays deliberate
-    /// -- the identical split [`eval_generic::check_nesting_depth`] already
-    /// draws from [`eval_generic::assert_nesting_depth`] (#1818). Confirmed
-    /// live: `-e` alone on 500 levels of `[...]`-nested JSON used to leak
-    /// Rust's raw panic backtrace to stderr ahead of the clean, correctly
-    /// exit-5'd diagnostic `write_output`'s own `catch_unwind` already
-    /// produced -- the exit code and final message were always right, only
-    /// the extra noise ahead of them was the bug.
+    /// -- the identical split [`super::eval_generic::check_nesting_depth`]
+    /// already draws from [`super::eval_generic::assert_nesting_depth`]
+    /// (#1818). Confirmed live: `-e` alone on 500 levels of `[...]`-nested
+    /// JSON used to leak Rust's raw panic backtrace to stderr ahead of the
+    /// clean, correctly exit-5'd diagnostic `write_output`'s own
+    /// `catch_unwind` already produced -- the exit code and final message
+    /// were always right, only the extra noise ahead of them was the bug.
     ///
-    /// Delegates to [`try_cursor_to_owned`] for the `Cursor` arm rather than
-    /// the panicking [`cursor_to_owned`] -- the two nested depth budgets
+    /// Delegates to `try_cursor_to_owned` for the `Cursor` arm rather than
+    /// the panicking `cursor_to_owned` -- the two nested depth budgets
     /// (this one, `MAX_VALUE_TREE_DEPTH`-bounded; that one,
     /// `MAX_NESTING_DEPTH`-bounded, restarting from 0 whenever a `Cursor` is
     /// reached) mirror `materialize_at_depth`'s own split exactly, just with
     /// both sides checked instead of both sides panicking. Preserves
-    /// [`cursor_to_owned`]'s raw-number-byte semantics via
-    /// [`try_cursor_to_owned`] rather than switching to
+    /// `cursor_to_owned`'s raw-number-byte semantics via
+    /// `try_cursor_to_owned` rather than switching to
     /// `eval_generic::to_owned_cursor`'s canonicalizing twin, which would
     /// silently reformat a JSON-sourced number's spelling on every
     /// `-S`/`-a`/`-C`/`-e` run -- exactly the risk that made a plain

--- a/src/jq/value.rs
+++ b/src/jq/value.rs
@@ -19,6 +19,7 @@ use std::borrow::Cow;
 
 use indexmap::IndexMap;
 
+use super::error::EvalError;
 use super::escape::{escape_json_body, write_json_body_jq};
 use super::eval::{EvalSemantics, EvalTag};
 #[cfg(test)]
@@ -111,6 +112,22 @@ pub fn nesting_depth_exceeded_message(max: usize) -> String {
 #[track_caller]
 pub fn assert_value_tree_depth(depth: usize) {
     assert_depth(depth, MAX_VALUE_TREE_DEPTH);
+}
+
+/// [`assert_value_tree_depth`]'s checked twin (#2850), the same relationship
+/// [`eval_generic::check_nesting_depth`](super::eval_generic::check_nesting_depth)
+/// already has to [`eval_generic::assert_nesting_depth`](super::eval_generic::assert_nesting_depth)
+/// -- for `lazy.rs`'s `JqValue::try_materialize`, a CLI-output-boundary
+/// caller rather than the evaluator's own hot recursion, where a panic stays
+/// deliberate.
+pub fn check_value_tree_depth(depth: usize) -> Result<(), EvalError> {
+    if depth < MAX_VALUE_TREE_DEPTH {
+        Ok(())
+    } else {
+        Err(EvalError::new(nesting_depth_exceeded_message(
+            MAX_VALUE_TREE_DEPTH,
+        )))
+    }
 }
 
 /// The parsed value backing a [`OwnedValue::NumberLiteral`], kept separate

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -21679,6 +21679,37 @@ fn test_exit_status_over_depth_document_reports_cleanly_not_panic_2850() -> Resu
     Ok(())
 }
 
+/// #2850 review: pins a real, observable behavior change beyond just
+/// removing panic noise, specific to `-e`'s exit-status call site. Before
+/// this fix, a nesting-depth violation panicked and unwound through the
+/// whole per-document `catch_unwind`, silently dropping every remaining
+/// sibling result for a multi-result filter (`.[]`) -- the checked
+/// `try_materialize` instead reports and continues, the same
+/// report-then-continue path a decode failure (#1247) already took at this
+/// exact call site. This makes the two failure classes consistent with each
+/// other rather than introducing new behavior: `["\ud800", 1] | .[]` under
+/// `-e` already reported the decode failure and printed the well-formed
+/// sibling `1` before this fix; a deeply-nested sibling now does the same
+/// instead of dropping it.
+#[test]
+fn test_exit_status_multi_result_over_depth_element_still_emits_siblings_2850() -> Result<()> {
+    let deep_json = format!("{}{}{}", "[".repeat(500), "1", "]".repeat(500));
+    let input = format!("[{deep_json}, 1]");
+
+    let (stdout, stderr, code) = run_jq_full(&["-c", "-e", ".[]"], Some(&input))?;
+    assert_eq!(code, 5, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert!(!stderr.contains("panicked"), "stderr: {stderr:?}");
+    assert!(
+        stderr.contains("nesting depth exceeds limit of 256"),
+        "stderr: {stderr:?}"
+    );
+    // The well-formed sibling still reaches stdout -- consistent with the
+    // pre-existing decode-failure granularity at this same call site.
+    assert_eq!(stdout.trim_end(), "1", "stderr: {stderr:?}");
+
+    Ok(())
+}
+
 /// #2850: `write_output_jq_value`'s own materialize call shares the
 /// identical checked-vs-panicking split as `-e`'s above. #2662 (landed in
 /// this same tree) is what makes this a genuinely live, confirmed leak

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -21648,6 +21648,74 @@ fn test_partial_result_over_depth_value_reports_cleanly_not_panic_1371() -> Resu
     Ok(())
 }
 
+/// #2850: `-e`'s own exit-status materialize call (`jq_runner.rs`, separate
+/// from `write_output_jq_value`'s) used to leak Rust's raw panic backtrace
+/// to stderr ahead of the clean, correctly exit-5'd diagnostic the
+/// surrounding `catch_unwind` already produced -- confirmed live before this
+/// fix that `succinctly jq -e '.'` on 500 levels of `[...]`-nested JSON
+/// printed `thread '<unnamed>' panicked at src/jq/lazy.rs:...` before the
+/// `jq: error (at ...): nesting depth exceeds limit of 256` line. The exit
+/// code and final diagnostic were always correct; only the extra noise
+/// ahead of them was the bug (`JqValue::materialize`, not the checked
+/// `try_materialize`, #2850).
+#[test]
+fn test_exit_status_over_depth_document_reports_cleanly_not_panic_2850() -> Result<()> {
+    let deep_json = format!("{}{}{}", "[".repeat(500), "1", "]".repeat(500));
+
+    let (stdout, stderr, code) = run_jq_full(&["-c", "-e", "."], Some(&deep_json))?;
+    assert_eq!(stdout.trim_end(), "");
+    assert_eq!(code, 5, "stdout: {stdout:?} stderr: {stderr:?}");
+    assert!(!stderr.contains("panicked"), "stderr: {stderr:?}");
+    assert!(
+        stderr.contains("nesting depth exceeds limit of 256"),
+        "stderr: {stderr:?}"
+    );
+
+    // Well-formed usage is unaffected: `-e` on a truthy last value exits 0.
+    let (stdout, stderr, code) = run_jq_full(&["-c", "-e", "."], Some("1"))?;
+    assert_eq!(stdout.trim_end(), "1");
+    assert_eq!(code, 0, "stderr: {stderr:?}");
+
+    Ok(())
+}
+
+/// #2850: `write_output_jq_value`'s own materialize call shares the
+/// identical checked-vs-panicking split as `-e`'s above. #2662 (landed in
+/// this same tree) is what makes this a genuinely live, confirmed leak
+/// rather than a defensive-only fix: before it, `-S`/`-a`/`-C` were excluded
+/// from the lazy/`JqValue::Cursor` path entirely (`can_use_lazy_path`), so
+/// this call site was unreachable for them; #2662 moved them onto that same
+/// path, so they now hit the identical panicking `materialize()` `-e`
+/// always did. All three flags pinned here, not just `-S`.
+#[test]
+fn test_complex_output_flags_over_depth_document_report_cleanly_not_panic_2850() -> Result<()> {
+    let deep_json = format!("{}{}{}", "[".repeat(500), "1", "]".repeat(500));
+
+    for flag in ["-S", "-a", "-C"] {
+        let (stdout, stderr, code) = run_jq_full(&["-c", flag, "."], Some(&deep_json))?;
+        assert_eq!(stdout.trim_end(), "", "flag {flag}");
+        assert_eq!(
+            code, 5,
+            "flag {flag} -- stdout: {stdout:?} stderr: {stderr:?}"
+        );
+        assert!(
+            !stderr.contains("panicked"),
+            "flag {flag} -- stderr: {stderr:?}"
+        );
+        assert!(
+            stderr.contains("nesting depth exceeds limit"),
+            "flag {flag} -- stderr: {stderr:?}"
+        );
+    }
+
+    // Well-formed usage is unaffected.
+    let (stdout, stderr, code) = run_jq_full(&["-c", "-S", "."], Some(r#"{"b":1,"a":2}"#))?;
+    assert_eq!(stdout.trim(), r#"{"a":2,"b":1}"#, "stderr: {stderr:?}");
+    assert_eq!(code, 0, "stderr: {stderr:?}");
+
+    Ok(())
+}
+
 /// #2627: the wildcard/ambient bridge used to reach `eval_generic.rs`'s
 /// `assert_nesting_depth` `panic!` on a >256-deep *document* (not a
 /// constructed value, unlike #1371's `test_partial_result_


### PR DESCRIPTION
## Summary

Purely a diagnostic-noise bug — the exit code (5) and final diagnostic message were always correct; Rust's default panic hook printed its raw `thread '<unnamed>' panicked at src/jq/lazy.rs:834:5: ...` text to stderr ahead of that clean diagnostic.

Root cause: `JqValue::materialize()`'s underlying cursor-materializer (`lazy.rs::cursor_to_owned_at_depth`) uses the panicking `assert_nesting_depth` guard, not the checked, `Result`-returning style #1818 established for CLI-output-boundary call sites. `-e`'s own exit-status tracking calls `.materialize()` unconditionally, and `write_output_jq_value`'s own materialize arm (`-S`/`-a`/`-C`'s value output) shares the identical panicking call.

Fix: `JqValue::try_materialize`, a checked twin of `materialize` (mirroring the identical `try_from_owned`/`from_owned` split #1371 already established in this file), delegating to a new `try_cursor_to_owned` for the `Cursor` arm. Both new functions are structurally identical copies of their panicking originals with `assert_*_depth` swapped for the checked pattern — same recursion shape, same raw-number-byte preservation (`OwnedValue::from_number_bytes`, not a canonicalizing reformat that would silently change `--preserve-input` output). The panicking originals stay exactly as they are, for library callers that treat over-deep nesting as a bug, and the existing `catch_unwind`-based test pinning that contract.

This branch's rebase conflicted with #2662 (landed independently, in flight at the same time) — resolved by combining both: `try_materialize`'s checked depth guard with `MalformedJsonError`'s exit-5 routing for a malformed document. #2662 is also what makes `-S`/`-a`/`-C` a genuinely live leak here, not just a defensive fix: it moved those three flags onto the same `JqValue::Cursor` path `-e` already used, which is exactly what "all four flags" in this issue's title requires.

Fixes #2850.

## Test plan

- [x] `cargo build --features cli`
- [x] `cargo test --features cli,simd,regex,serde` (full suite, all green — including the existing `catch_unwind`-based panic-contract test for `materialize()` itself, unchanged)
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings`
- [x] Verified against the issue's own repro (500 levels of `[...]`-nested JSON): all four flags (`-e`, `-S`, `-a`, `-C`) genuinely leaked the raw panic backtrace before this fix; none do after
- [x] Verified number-spelling preservation and malformed-document routing (`MalformedJsonError`, exit 5) both unaffected
- [x] New unit tests (`lazy.rs`) pinning `try_materialize`/`try_cursor_to_owned`'s checked behavior at both depth boundaries (`MAX_VALUE_TREE_DEPTH` and the separate, cursor-restarting `MAX_NESTING_DEPTH`)
- [x] New CLI tests (`jq_cli_tests.rs`) covering all four flags plus well-formed-usage regression guards