### PR TITLE
fix(jq): $__loc__ inside a module-sourced def names that module's file

### DIFF
--- a/docs/reference/jq-language.md
+++ b/docs/reference/jq-language.md
@@ -179,6 +179,9 @@ below and [ADR-0019](../adrs/adr-0019.md).
 ### I/O & Debug
 - [x] `debug` / `debug(msg)`
 - [x] `$__loc__` - Current source location `{file, line}` where `$__loc__` appears
+      (`file` is `"<top-level>"` for the main filter, #2688; the canonical path of the
+      `include`d module, `import`ed module, or `~/.jq` the enclosing `def` came from
+      otherwise, #2774)
 - [x] Comments in jq expressions (`#` to end of line)
 - [x] `env`, `$ENV.VAR`, `env(VAR)`, `strenv(VAR)`
 - [x] `now` - Current Unix timestamp

--- a/src/bin/succinctly/jq_runner.rs
+++ b/src/bin/succinctly/jq_runner.rs
@@ -19,7 +19,7 @@ use succinctly::jq::eval_generic::{
     to_owned_checked as generic_to_owned_checked, to_owned_cursor, GenericResult, LazyElem,
     MAX_NESTING_DEPTH,
 };
-use succinctly::jq::walk::map_builtin_subexprs;
+use succinctly::jq::walk::{map_builtin_subexprs, stamp_loc_file};
 use succinctly::jq::{
     self, format_number_jq_compat, jq_bare_float_display, nonfinite_display_string, Builtin,
     EvalError, Expr, FuncDefBound, JqSemantics, JqValue, OwnedValue, Param, Program, StreamStats,
@@ -160,7 +160,17 @@ impl ModuleLoader {
                 // Auto-load ~/.jq file - functions defined here are always available
                 if let Ok(contents) = std::fs::read_to_string(&jq_path) {
                     if let Ok(program) = jq::parse_program(&contents) {
-                        auto_loaded_defs = extract_func_defs(&program.expr);
+                        // #2774: same stamping as an `include`d module's
+                        // defs, using `~/.jq`'s own canonical path.
+                        let canonical_path =
+                            std::fs::canonicalize(&jq_path).unwrap_or_else(|_| jq_path.clone());
+                        let loc_file: std::rc::Rc<str> = canonical_path.to_string_lossy().into();
+                        auto_loaded_defs = extract_func_defs(&program.expr)
+                            .into_iter()
+                            .map(|(name, params, body)| {
+                                (name, params, stamp_loc_file(&body, &loc_file))
+                            })
+                            .collect();
                     }
                 }
             } else if jq_path.is_dir() {
@@ -209,8 +219,24 @@ impl ModuleLoader {
                     anyhow::anyhow!("parse error in module '{}': {}", file_path.display(), e)
                 })?;
 
-                // Extract function definitions from the expression
-                Ok(entry.insert(extract_func_defs(&program.expr)))
+                // #2774: jq's own `$__loc__` inside a module-sourced def
+                // names that module's *canonical* (symlink-resolved) path,
+                // not the path as given on `-L`/`include` -- confirmed live
+                // against jq 1.7.1. `canonicalize` can fail (a module
+                // deleted between resolving and reading it, a race no real
+                // program depends on); fall back to the resolved path as-is
+                // rather than failing a load that already succeeded.
+                let canonical_path = std::fs::canonicalize(&file_path).unwrap_or(file_path);
+                let loc_file: std::rc::Rc<str> = canonical_path.to_string_lossy().into();
+
+                // Extract function definitions from the expression, then
+                // stamp every $__loc__ in each def's body with this
+                // module's own path.
+                let defs = extract_func_defs(&program.expr)
+                    .into_iter()
+                    .map(|(name, params, body)| (name, params, stamp_loc_file(&body, &loc_file)))
+                    .collect();
+                Ok(entry.insert(defs))
             }
         }
     }

--- a/src/bin/succinctly/jq_runner.rs
+++ b/src/bin/succinctly/jq_runner.rs
@@ -130,6 +130,29 @@ fn resolve_module_in(search_path: &[PathBuf], module_path: &str) -> Option<PathB
     None
 }
 
+/// Extract a module's function definitions and stamp every `$__loc__` in
+/// each def's body with that module's own canonical (symlink-resolved)
+/// path (#2774) -- confirmed live against jq 1.7.1, and the same shape a
+/// `resolved_path` reaches this function through either way: an
+/// `include`d/`import`ed module (via [`resolve_module_in`]) or `~/.jq`
+/// (found directly, never searched for).
+///
+/// A free function rather than a `ModuleLoader` method for the same reason
+/// [`resolve_module_in`] is: [`ModuleLoader::ensure_module_loaded`] holds a
+/// mutable borrow of the module cache across the call.
+///
+/// `canonicalize` can fail (a module deleted between resolving and reading
+/// it, a race no real program depends on); fall back to `resolved_path`
+/// as-is rather than failing a load that already succeeded.
+fn extract_and_stamp_func_defs(expr: &Expr, resolved_path: PathBuf) -> FuncDefList {
+    let canonical_path = std::fs::canonicalize(&resolved_path).unwrap_or(resolved_path);
+    let loc_file: std::rc::Rc<str> = canonical_path.to_string_lossy().into();
+    extract_func_defs(expr)
+        .into_iter()
+        .map(|(name, params, body)| (name, params, stamp_loc_file(&body, &loc_file)))
+        .collect()
+}
+
 impl ModuleLoader {
     /// Create a new module loader with the given search paths.
     pub fn new(library_paths: &[PathBuf]) -> Self {
@@ -162,15 +185,7 @@ impl ModuleLoader {
                     if let Ok(program) = jq::parse_program(&contents) {
                         // #2774: same stamping as an `include`d module's
                         // defs, using `~/.jq`'s own canonical path.
-                        let canonical_path =
-                            std::fs::canonicalize(&jq_path).unwrap_or_else(|_| jq_path.clone());
-                        let loc_file: std::rc::Rc<str> = canonical_path.to_string_lossy().into();
-                        auto_loaded_defs = extract_func_defs(&program.expr)
-                            .into_iter()
-                            .map(|(name, params, body)| {
-                                (name, params, stamp_loc_file(&body, &loc_file))
-                            })
-                            .collect();
+                        auto_loaded_defs = extract_and_stamp_func_defs(&program.expr, jq_path);
                     }
                 }
             } else if jq_path.is_dir() {
@@ -219,24 +234,7 @@ impl ModuleLoader {
                     anyhow::anyhow!("parse error in module '{}': {}", file_path.display(), e)
                 })?;
 
-                // #2774: jq's own `$__loc__` inside a module-sourced def
-                // names that module's *canonical* (symlink-resolved) path,
-                // not the path as given on `-L`/`include` -- confirmed live
-                // against jq 1.7.1. `canonicalize` can fail (a module
-                // deleted between resolving and reading it, a race no real
-                // program depends on); fall back to the resolved path as-is
-                // rather than failing a load that already succeeded.
-                let canonical_path = std::fs::canonicalize(&file_path).unwrap_or(file_path);
-                let loc_file: std::rc::Rc<str> = canonical_path.to_string_lossy().into();
-
-                // Extract function definitions from the expression, then
-                // stamp every $__loc__ in each def's body with this
-                // module's own path.
-                let defs = extract_func_defs(&program.expr)
-                    .into_iter()
-                    .map(|(name, params, body)| (name, params, stamp_loc_file(&body, &loc_file)))
-                    .collect();
-                Ok(entry.insert(defs))
+                Ok(entry.insert(extract_and_stamp_func_defs(&program.expr, file_path)))
             }
         }
     }

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -2676,7 +2676,7 @@ fn eval_single<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
         // ordinary bound value -- `resolve_node`'s own `Expr::TrackedVar`
         // arm is what actually decides path-trackability.
         Expr::TrackedVar(v) => QueryResult::Owned(v.value.clone()),
-        Expr::Loc { line } => {
+        Expr::Loc { line, file } => {
             // #2688: `$__loc__` names the *program text*, not the input --
             // jq's own `locfile` uses the literal string `<top-level>` for
             // a filter that didn't come from a module (confirmed live
@@ -2685,11 +2685,16 @@ fn eval_single<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
             // `"<stdin>"`: that's jq's distinct *runtime* error prefix
             // (`jq: error (at <stdin>:1): ...`), naming the input, not the
             // filter -- two different strings for two different things.
-            // A def sourced from an `include`d module or `~/.jq` should
-            // report that module's own path instead, per jq 1.7.1
-            // (confirmed live) -- tracked separately, #2774.
+            // #2774: a def sourced from an `include`d module or `~/.jq`
+            // carries that source's own canonical path in `file`, stamped
+            // on by `ModuleLoader` after parsing (the parser itself has no
+            // notion of which file it's reading) -- reported here instead
+            // of `<top-level>` when present.
             let mut obj = IndexMap::new();
-            obj.insert("file".into(), OwnedValue::String("<top-level>".into()));
+            obj.insert(
+                "file".into(),
+                OwnedValue::String(file.as_deref().unwrap_or("<top-level>").into()),
+            );
             obj.insert("line".into(), OwnedValue::Int(*line as i64));
             QueryResult::Owned(OwnedValue::Object(obj))
         }

--- a/src/jq/expr.rs
+++ b/src/jq/expr.rs
@@ -462,12 +462,21 @@ pub enum Expr {
 
     /// Location reference: `$__loc__`
     /// Returns `{"file": "<top-level>", "line": N}` where N is the 1-based line
-    /// number in the jq filter source where `$__loc__` appears (#2688; a def
-    /// sourced from an `include`d module reports that module's own file path
-    /// in real jq instead -- not modeled here, tracked as #2774).
+    /// number in the jq filter source where `$__loc__` appears (#2688). A def
+    /// sourced from an `include`d module or `~/.jq` carries that source's own
+    /// canonical file path in `file` instead (#2774) -- stamped onto every
+    /// `Loc` in a module's parsed body by `ModuleLoader::ensure_module_loaded`
+    /// and `ModuleLoader::new` (`src/bin/succinctly/jq_runner.rs`), since the
+    /// parser itself has no notion of which file it is reading.
     Loc {
         /// 1-based line number in the jq source
         line: usize,
+        /// The source file's canonical path, for a `Loc` sourced from an
+        /// `include`d module or `~/.jq`. `None` for the top-level filter
+        /// (`Rc<str>` rather than `String`: bodies are cloned per inlining
+        /// site, and every clone should share one allocation rather than
+        /// deep-copy the path each time).
+        file: Option<Rc<str>>,
     },
 
     /// Environment variables: `$ENV`

--- a/src/jq/expr.rs
+++ b/src/jq/expr.rs
@@ -461,13 +461,14 @@ pub enum Expr {
     TrackedVar(Rc<Tracked>),
 
     /// Location reference: `$__loc__`
-    /// Returns `{"file": "<top-level>", "line": N}` where N is the 1-based line
-    /// number in the jq filter source where `$__loc__` appears (#2688). A def
-    /// sourced from an `include`d module or `~/.jq` carries that source's own
-    /// canonical file path in `file` instead (#2774) -- stamped onto every
-    /// `Loc` in a module's parsed body by `ModuleLoader::ensure_module_loaded`
-    /// and `ModuleLoader::new` (`src/bin/succinctly/jq_runner.rs`), since the
-    /// parser itself has no notion of which file it is reading.
+    /// Returns `{"file": F, "line": N}`, where `N` is the 1-based line number
+    /// in the jq source where `$__loc__` appears, and `F` is `"<top-level>"`
+    /// for the main filter (#2688) or a module's own canonical file path for
+    /// a def sourced from an `include`d module or `~/.jq` (#2774) -- stamped
+    /// onto every `Loc` in a module's parsed body by
+    /// `ModuleLoader::ensure_module_loaded` and `ModuleLoader::new`
+    /// (`src/bin/succinctly/jq_runner.rs`), since the parser itself has no
+    /// notion of which file it is reading.
     Loc {
         /// 1-based line number in the jq source
         line: usize,

--- a/src/jq/parser.rs
+++ b/src/jq/parser.rs
@@ -200,7 +200,11 @@ fn is_ident_start_char(c: char) -> bool {
 /// rules, per CLAUDE.md's #106 note.
 fn dollar_var_expr(name: String, line: usize) -> Expr {
     if name == "__loc__" {
-        Expr::Loc { line }
+        // #2774: the parser has no notion of which file it is reading (a
+        // module's text arrives here identically to the main filter's), so
+        // `file` always starts `None` -- `ModuleLoader` stamps it in after
+        // the fact for a def sourced from an `include`d module or `~/.jq`.
+        Expr::Loc { line, file: None }
     } else if name == "ENV" {
         Expr::Env
     } else {

--- a/src/jq/walk.rs
+++ b/src/jq/walk.rs
@@ -728,7 +728,10 @@ pub fn map_subexprs(expr: &Expr, mut f: &mut dyn FnMut(&Expr) -> Expr) -> Expr {
         // of the frozen snapshot, so re-inlining a `def` that closes over a
         // large passthrough-bound value on every call stays cheap (#844).
         Expr::TrackedVar(v) => Expr::TrackedVar(v.clone()),
-        Expr::Loc { line } => Expr::Loc { line: *line },
+        Expr::Loc { line, file } => Expr::Loc {
+            line: *line,
+            file: file.clone(),
+        },
         Expr::Env => Expr::Env,
         Expr::Break(name) => Expr::Break(name.clone()),
 
@@ -984,6 +987,28 @@ pub fn map_subexprs(expr: &Expr, mut f: &mut dyn FnMut(&Expr) -> Expr) -> Expr {
             then: Box::new(f(then)),
             bound: FuncDefBound::default(),
         },
+    }
+}
+
+/// Stamp every `Expr::Loc` reachable inside `expr` with `file`.
+///
+/// For a def body sourced from an `include`d module or `~/.jq` (#2774) --
+/// the parser itself has no notion of which file it is reading, so every
+/// `Loc` it builds starts with `file: None`, and `ModuleLoader` (in
+/// `src/bin/succinctly/jq_runner.rs`) calls this once per module-sourced def
+/// body after parsing, with that module's own canonical path.
+///
+/// Built on [`map_subexprs`] rather than a dedicated match, so a future
+/// `Expr` variant needs no update here: `map_subexprs`'s own exhaustive
+/// match already knows how to reach every nested `Expr`, including one
+/// inside a variant that doesn't exist yet.
+pub fn stamp_loc_file(expr: &Expr, file: &Rc<str>) -> Expr {
+    match expr {
+        Expr::Loc { line, .. } => Expr::Loc {
+            line: *line,
+            file: Some(Rc::clone(file)),
+        },
+        _ => map_subexprs(expr, &mut |child| stamp_loc_file(child, file)),
     }
 }
 
@@ -2166,5 +2191,38 @@ mod tests {
         });
         assert_eq!(calls, 2, "expected exactly one call each for body and then");
         assert_eq!(result, expr);
+    }
+
+    /// #2774: `stamp_loc_file` must reach every `Expr::Loc` no matter how
+    /// deeply nested, including through `map_subexprs`'s own `FuncDef`
+    /// clone arm -- the one arm the issue itself flagged as the likeliest
+    /// place to silently drop the new field, since it would still compile
+    /// fine (`{ .. }` covers a new field with no error) while quietly
+    /// losing it.
+    #[test]
+    fn stamp_loc_file_reaches_every_loc_including_through_a_nested_funcdef() {
+        let expr = parse_program("def f: [$__loc__, (def g: $__loc__; g)]; f")
+            .expect("filter should parse")
+            .expr;
+        let file: Rc<str> = Rc::from("/mod/path.jq");
+        let stamped = stamp_loc_file(&expr, &file);
+
+        let mut locs_seen = 0usize;
+        any_subexpr(&stamped, &mut |e| {
+            if let Expr::Loc { file: f, .. } = e {
+                locs_seen += 1;
+                assert_eq!(f.as_deref(), Some("/mod/path.jq"));
+            }
+            false
+        });
+        assert_eq!(locs_seen, 2, "expected both $__loc__ occurrences stamped");
+
+        // The un-stamped original is untouched (stamp_loc_file takes &Expr).
+        any_subexpr(&expr, &mut |e| {
+            if let Expr::Loc { file: f, .. } = e {
+                assert_eq!(f, &None);
+            }
+            false
+        });
     }
 }

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -1517,6 +1517,164 @@ fn test_loc_top_level_2688() -> Result<()> {
     Ok(())
 }
 
+/// #2774: `$__loc__` inside a def sourced from an `include`d module reports
+/// that module's own canonical (symlink-resolved) file path, not
+/// `"<top-level>"`. Line stays module-relative -- already correct before
+/// this fix, since each module is parsed on its own -- so a multi-line def
+/// pins that only `file` was wrong, not `line`.
+///
+/// Expected `file` is computed via `std::fs::canonicalize`, not a literal:
+/// the test's own temp directory differs every run, and on macOS `/tmp` is
+/// itself a symlink to `/private/tmp` -- exactly the realpath case jq
+/// applies, so comparing against the raw `tempdir()` path would spuriously
+/// fail there.
+#[test]
+fn test_loc_include_names_the_modules_own_canonical_file_2774() -> Result<()> {
+    let lib_dir = tempfile::tempdir()?;
+    let module_path = lib_dir.path().join("loc_module.jq");
+    std::fs::write(&module_path, "def f: $__loc__;\ndef g:\n  $__loc__;\n")?;
+    let canonical = std::fs::canonicalize(&module_path)?;
+    let canonical_str = canonical.to_string_lossy();
+
+    for (call, line) in [("f", 1), ("g", 3)] {
+        let (output, code) = spawn_with_signal_retry(
+            || {
+                let mut command = Command::new(succinctly_bin());
+                command
+                    .args(["jq", "-L"])
+                    .arg(lib_dir.path())
+                    .args(["-nc", &format!(r#"include "loc_module"; {call}"#)]);
+                command
+            },
+            None,
+        )?;
+        let stdout = String::from_utf8(output.stdout)?;
+        let stderr = String::from_utf8(output.stderr)?;
+        assert_eq!(code, 0, "{call}: stderr: {stderr:?}");
+        assert_eq!(
+            stdout.trim_end(),
+            format!(r#"{{"file":"{canonical_str}","line":{line}}}"#),
+            "{call}"
+        );
+    }
+    Ok(())
+}
+
+/// #2774 control: the *main filter's* own `$__loc__` still reports
+/// `"<top-level>"` even while a module is loaded alongside it -- the fix
+/// only stamps a module-sourced def's own body, never the filter that
+/// `include`s it.
+#[test]
+fn test_loc_main_filter_stays_top_level_alongside_an_include_2774() -> Result<()> {
+    let lib_dir = tempfile::tempdir()?;
+    std::fs::write(lib_dir.path().join("mod.jq"), "def f: 1;\n")?;
+    let (output, code) = spawn_with_signal_retry(
+        || {
+            let mut command = Command::new(succinctly_bin());
+            command
+                .args(["jq", "-L"])
+                .arg(lib_dir.path())
+                .args(["-nc", r#"include "mod"; $__loc__"#]);
+            command
+        },
+        None,
+    )?;
+    let stdout = String::from_utf8(output.stdout)?;
+    let stderr = String::from_utf8(output.stderr)?;
+    assert_eq!(code, 0, "stderr: {stderr:?}");
+    assert_eq!(stdout.trim_end(), r#"{"file":"<top-level>","line":1}"#);
+    Ok(())
+}
+
+/// #2774: `import "m" as m; m::f` -- a namespaced call into an imported
+/// module -- reports the module's own file too, the same as `include`.
+#[test]
+fn test_loc_import_names_the_modules_own_canonical_file_2774() -> Result<()> {
+    let lib_dir = tempfile::tempdir()?;
+    let module_path = lib_dir.path().join("loc_module.jq");
+    std::fs::write(&module_path, "def f: $__loc__;\n")?;
+    let canonical = std::fs::canonicalize(&module_path)?;
+    let canonical_str = canonical.to_string_lossy();
+
+    let (output, code) = spawn_with_signal_retry(
+        || {
+            let mut command = Command::new(succinctly_bin());
+            command
+                .args(["jq", "-L"])
+                .arg(lib_dir.path())
+                .args(["-nc", r#"import "loc_module" as m; m::f"#]);
+            command
+        },
+        None,
+    )?;
+    let stdout = String::from_utf8(output.stdout)?;
+    let stderr = String::from_utf8(output.stderr)?;
+    assert_eq!(code, 0, "stderr: {stderr:?}");
+    assert_eq!(
+        stdout.trim_end(),
+        format!(r#"{{"file":"{canonical_str}","line":1}}"#)
+    );
+    Ok(())
+}
+
+/// #2774: `~/.jq` gets the same treatment as an `include`d module -- its
+/// own defs' `$__loc__` names `~/.jq`'s own canonical path, not
+/// `"<top-level>"`.
+#[test]
+fn test_loc_home_jq_names_home_jqs_own_canonical_file_2774() -> Result<()> {
+    let temp_home = tempfile::tempdir()?;
+    let jq_path = temp_home.path().join(".jq");
+    std::fs::write(&jq_path, "def g:\n  $__loc__;\n")?;
+    let canonical = std::fs::canonicalize(&jq_path)?;
+    let canonical_str = canonical.to_string_lossy();
+
+    let (output, code) = spawn_jq_with_env(&["-nc", "g"], "HOME", temp_home.path(), None)?;
+    let stdout = String::from_utf8(output.stdout)?;
+    let stderr = String::from_utf8(output.stderr)?;
+    assert_eq!(code, 0, "stderr: {stderr:?}");
+    assert_eq!(
+        stdout.trim_end(),
+        format!(r#"{{"file":"{canonical_str}","line":2}}"#)
+    );
+    Ok(())
+}
+
+/// #2774: a module reached through a symlink reports the symlink's
+/// *target* path (jq's own realpath behavior), not the symlink path it was
+/// `-L`'d through.
+#[test]
+#[cfg(unix)]
+fn test_loc_symlinked_module_names_the_canonical_target_2774() -> Result<()> {
+    let real_dir = tempfile::tempdir()?;
+    let real_path = real_dir.path().join("real.jq");
+    std::fs::write(&real_path, "def real_target_fn: $__loc__;\n")?;
+    let canonical = std::fs::canonicalize(&real_path)?;
+    let canonical_str = canonical.to_string_lossy();
+
+    let symlink_dir = tempfile::tempdir()?;
+    std::os::unix::fs::symlink(&real_path, symlink_dir.path().join("real.jq"))?;
+
+    let (output, code) = spawn_with_signal_retry(
+        || {
+            let mut command = Command::new(succinctly_bin());
+            command
+                .args(["jq", "-L"])
+                .arg(symlink_dir.path())
+                .args(["-nc", r#"include "real"; real_target_fn"#]);
+            command
+        },
+        None,
+    )?;
+    let stdout = String::from_utf8(output.stdout)?;
+    let stderr = String::from_utf8(output.stderr)?;
+    assert_eq!(code, 0, "stderr: {stderr:?}");
+    assert_eq!(
+        stdout.trim_end(),
+        format!(r#"{{"file":"{canonical_str}","line":1}}"#)
+    );
+    Ok(())
+}
+
 // =============================================================================
 // Exit Status Tests
 // =============================================================================


### PR DESCRIPTION
## Summary
- `\$__loc__` inside a def sourced from an `include`d module or `~/.jq` reported `"<top-level>"` (the main filter's own placeholder) instead of that module's own file path, since the parser has no notion of which file it is reading and there was previously nowhere on the AST to record one.
- `Expr::Loc` gains an `Option<Rc<str>>` `file` field (`None` for the top-level filter). `ModuleLoader::ensure_module_loaded` and `ModuleLoader::new` now stamp every `Loc` in a module-sourced def's body with that module's canonical (symlink-resolved) path via a new `walk::stamp_loc_file` helper, built on `map_subexprs` so no per-variant match needs updating when a future `Expr` variant is added.
- Confirmed live against jq 1.7.1 for: `include`, `import` (namespaced calls), `~/.jq`, a relative `-L` path, a symlinked module (resolves to the symlink's *target*), and a multi-line def (line stays module-relative, already correct -- only `file` was wrong).
- `test_expr_size_is_pinned_1401` re-verified: the new field grows `Expr` by 16 bytes, still well under its 96-byte pin.

Fixes #2774

## Two adjacent gaps filed separately, out of scope here
Found while probing this issue (both confirmed live, neither touched by this PR):
- #2865 -- a module's own `include` directive is silently ignored (transitive includes not processed at all).
- #2866 -- the unresolved-call diagnostic has the same provenance gap for a module-sourced call (names `<top-level>` instead of the module).

## Test plan
- [x] `test_loc_include_names_the_modules_own_canonical_file_2774` (line 1 and line 3, multi-line def)
- [x] `test_loc_main_filter_stays_top_level_alongside_an_include_2774` (control)
- [x] `test_loc_import_names_the_modules_own_canonical_file_2774`
- [x] `test_loc_home_jq_names_home_jqs_own_canonical_file_2774`
- [x] `test_loc_symlinked_module_names_the_canonical_target_2774`
- [x] `walk::tests::stamp_loc_file_reaches_every_loc_including_through_a_nested_funcdef` (unit test pinning the field survives `map_subexprs`'s `FuncDef` clone arm, the site most likely to silently drop it)
- [x] Re-ran `test_loc_top_level_2688` -- unaffected
- [x] `cargo test --features cli` -- full suite passes, 0 failures
- [x] `cargo clippy --all-targets --all-features -- -D warnings` -- clean
- [x] Patch coverage: 100% (55/55 new lines covered)