### PR TITLE
feat(yq): add the sort_keys(f) builtin

### DIFF
--- a/docs/compliance/yq/limitations.md
+++ b/docs/compliance/yq/limitations.md
@@ -318,6 +318,36 @@ kind drops its `&anchor`, where real yq keeps it),
 [#1352](https://github.com/rust-works/succinctly/issues/1352) and
 [#1353](https://github.com/rust-works/succinctly/issues/1353).
 
+**`sort_keys(f)`'s "don't vivify an absent target" rule has a gap past a fan-out
+([#2870](https://github.com/rust-works/succinctly/issues/2870)).** `sort_keys(.nope)` on a
+document with no `.nope` correctly leaves it unchanged (unlike plain `|=`, which creates
+it) — but only when the absent component sits *before* any `Iterate`/`Slice` in `f`. A
+static field *after* a fan-out point still gets vivified, since the existence pre-filter
+only checks the resolved path's prefix up to that point (`navigate_read_only` has no arm
+for `Iterate`/`Slice`, so requiring the whole path to pre-exist would wrongly drop a
+genuinely-existing target like `sort_keys(.a[])` itself) and hands the rest to
+`update_path`'s ordinary per-element vivification, which has no "skip absent" gate of its
+own:
+
+```bash
+$ printf 'a:\n  - b: 2\n    q: 1\n  - q: 3\n' | yq            'sort_keys(.a[].b)'
+a:
+  - b: 2
+    q: 1
+  - q: 3
+$ printf 'a:\n  - b: 2\n    q: 1\n  - q: 3\n' | succinctly yq 'sort_keys(.a[].b)'
+a:
+  - b: 2
+    q: 1
+  - q: 3
+    b: null
+```
+
+Fixing this properly needs either threading a skip-absent flag through
+`update_path`/`update_path_steps` (shared by every `|=`-family operator, too high a blast
+radius for a `sort_keys`-only fix) or a dedicated post-fan-out pre-filter inside
+`builtin_sort_keys` itself.
+
 ### `-0`/`--nul-output` multi-document separator — rule 4(a)
 
 Real yq's own `-0` output on multi-document input is not readable by real yq itself: the

--- a/docs/compliance/yq/limitations.md
+++ b/docs/compliance/yq/limitations.md
@@ -298,6 +298,20 @@ every M2-streamable filter, not just identity (`--sort-keys '.outer'`, `--sort-k
 ...) — the fallback now evaluates the real filter expression instead of always assuming `.`,
 so any shape that can reach the M2 fast path gets the same soundness check.
 
+[#2855](https://github.com/rust-works/succinctly/issues/2855)'s `sort_keys(f)` builtin (as
+opposed to this `--sort-keys` flag) takes the identical licensed divergence on the same
+inversion shape, through the same `enforce_anchor_soundness` pass — it's a write, so it
+always takes the DOM route already:
+
+```bash
+$ printf 'b: &x 1\na: *x\n' | yq 'sort_keys(..)'              # real yq: unsound
+a: *x
+b: &x 1
+$ printf 'b: &x 1\na: *x\n' | succinctly yq 'sort_keys(..)'   # sound: value, not the mark
+a: 1
+b: &x 1
+```
+
 Related open items in the same family, still unresolved:
 [#1359](https://github.com/rust-works/succinctly/issues/1359) (a write that changes a node's
 kind drops its `&anchor`, where real yq keeps it),
@@ -3921,6 +3935,12 @@ Four known gaps this write shares with every other write form, none specific to 
   introduced it — real yq has no `def`/user-defined-function syntax at all, so there is no
   oracle for that second case. Tracked as #2679; pinned by
   `preceding_stage_outside_the_admitted_shapes_silently_drops_the_write`.
+  [#2855](https://github.com/rust-works/succinctly/issues/2855)'s `sort_keys(f)` hits this
+  same gap through a value, not just a comment: `.a | sort_keys(.)` correctly reorders
+  `.a`'s own keys and returns just `.a` (matching real yq), but loses `.a.y`'s flow style —
+  the identical loss `.a | (.z = 3)` already had on `main`, confirmed unrelated to
+  `sort_keys` itself. Pinned by `test_yq_sort_keys_composes_with_pipe_2855`
+  (`tests/yq_cli_tests.rs`).
 
 Finally, one rule real yq decides by the target's value, reproduced rather than "fixed":
 a `line_comment` written onto a **block-rendered container** is dropped (`.a line_comment

--- a/docs/reference/yq-language.md
+++ b/docs/reference/yq-language.md
@@ -222,17 +222,18 @@ succinctly yq --eval-all '[.] | reduce .[] as $item ({}; . * $item)' f1.yaml f2.
 
 ### yq-Specific Operators
 
-| Operator      | Description                                  | Example                        |
-|---------------|----------------------------------------------|--------------------------------|
-| `pick(keys)`  | Select only specified keys                   | `pick(["a", "b"])`             |
-| `omit(keys)`  | Remove specified keys (inverse of pick)      | `omit(["temp", "debug"])`      |
-| `shuffle`     | Randomly shuffle array elements              | `[1,2,3] \| shuffle`           |
-| `pivot`       | Transpose arrays/objects (SQL-style)         | `[[1,2],[3,4]] \| pivot`       |
-| `load(file)`  | Load external YAML/JSON file                 | `load("config.yaml")`          |
-| `parent`      | Return parent node                           | `.. \| select(.name) \| parent`|
-| `parent(n)`   | Return nth parent node                       | `parent(2)`                    |
-| `downcase`    | Lowercase ASCII characters                   | `"HELLO" \| downcase`          |
-| `upcase`      | Uppercase ASCII characters                   | `"hello" \| upcase`            |
+| Operator       | Description                                  | Example                         |
+|----------------|----------------------------------------------|---------------------------------|
+| `pick(keys)`   | Select only specified keys                   | `pick(["a", "b"])`              |
+| `omit(keys)`   | Remove specified keys (inverse of pick)      | `omit(["temp", "debug"])`       |
+| `shuffle`      | Randomly shuffle array elements              | `[1,2,3] \| shuffle`            |
+| `pivot`        | Transpose arrays/objects (SQL-style)         | `[[1,2],[3,4]] \| pivot`        |
+| `load(file)`   | Load external YAML/JSON file                 | `load("config.yaml")`           |
+| `parent`       | Return parent node                           | `.. \| select(.name) \| parent` |
+| `parent(n)`    | Return nth parent node                       | `parent(2)`                     |
+| `downcase`     | Lowercase ASCII characters                   | `"HELLO" \| downcase`           |
+| `upcase`       | Uppercase ASCII characters                   | `"hello" \| upcase`             |
+| `sort_keys(f)` | Sort a mapping's own keys, shallow (yq only) | `sort_keys(.)`                  |
 
 ```bash
 # Remove keys from object

--- a/src/bin/succinctly/yq_runner.rs
+++ b/src/bin/succinctly/yq_runner.rs
@@ -2073,6 +2073,15 @@ fn collect_write_targets(expr: &Expr) -> Option<Vec<WriteTarget>> {
             | Expr::CompoundAssign { path, .. }
             | Expr::AlternativeAssign { path, .. } => push(path, WriteKind::Set, false, out),
             Expr::Builtin(Builtin::Del(inner)) => push(inner, WriteKind::Del, false, out),
+            // #2855: `sort_keys(f)` is a write (reorders `f`'s own mapping
+            // entries in place) exactly like `|=`'s -- same `WriteKind::Set`,
+            // never fresh, since it only reorders what's already there. A
+            // bare `sort_keys`/`sort_keys()` (no path at all) never reaches
+            // a write; it always raises at evaluation, so it's treated the
+            // same as `Expr::Identity` above -- no target, but not a reason
+            // to give up on the whole expression's write analysis either.
+            Expr::Builtin(Builtin::SortKeys(Some(path))) => push(path, WriteKind::Set, false, out),
+            Expr::Builtin(Builtin::SortKeys(None)) => true,
             // `setpath(["a", 0]; v)` / `delpaths([["a", 0]])` name their
             // paths as array literals (#1351 made both alias-sensitive, so
             // they reach this walk). Only a literal path list is static; a

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -1311,7 +1311,17 @@ fn contains_assign_scoped<'e>(expr: &'e Expr, scope: &mut DefScope<'e>) -> bool 
         | Expr::CompoundAssign { .. }
         | Expr::AlternativeAssign { .. }
         | Expr::MetaAssign { .. }
-        | Expr::Builtin(Builtin::Del(_) | Builtin::SetPath(..) | Builtin::DelPaths(_)) => true,
+        // #2855: `sort_keys(f)` is a write (delegates to `eval_update`
+        // internally, `builtin_sort_keys`), so it needs the same
+        // recognition `Del`/`SetPath`/`DelPaths` already get here --
+        // otherwise `is_alias_sensitive_assign` below never sees it as a
+        // write at all, `presentation_sync_ctx` stays `None`, and the CLI
+        // falls back to an empty `CommentTree` for the whole document,
+        // losing every sibling's comments and flow style, not just the
+        // path this write actually touches.
+        | Expr::Builtin(
+            Builtin::Del(_) | Builtin::SetPath(..) | Builtin::DelPaths(_) | Builtin::SortKeys(_),
+        ) => true,
         Expr::Paren(inner) | Expr::Optional(inner) => contains_assign_scoped(inner, scope),
         Expr::Shared(inner) => contains_assign_scoped(inner, scope),
         Expr::Pipe(stages) => stages
@@ -1393,6 +1403,7 @@ pub fn is_alias_sensitive_assign(expr: &Expr) -> bool {
                 Builtin::Del(_)
                 | Builtin::SetPath(..)
                 | Builtin::DelPaths(_)
+                | Builtin::SortKeys(_)
                 | Builtin::Select(_)
                 | Builtin::Empty
                 | Builtin::Debug
@@ -10185,6 +10196,21 @@ fn eval_builtin<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
 
         // Phase 11: Path manipulation
         Builtin::Del(path) => builtin_del::<W, S>(path, value, optional),
+        Builtin::SortKeys(path) => builtin_sort_keys::<W, S>(path.as_deref(), value, optional),
+        Builtin::SortKeysOneLevel => {
+            let owned = match to_owned(&value) {
+                Ok(v) => v,
+                Err(e) => return suppress_or_raise(e, optional),
+            };
+            match owned {
+                OwnedValue::Object(obj) => {
+                    let mut sorted: Vec<(String, OwnedValue)> = obj.into_iter().collect();
+                    sorted.sort_by(|a, b| a.0.cmp(&b.0));
+                    QueryResult::Owned(OwnedValue::Object(sorted.into_iter().collect()))
+                }
+                other => QueryResult::Owned(other),
+            }
+        }
 
         // Phase 12: Additional builtins
         Builtin::Now => builtin_now::<W>(),
@@ -22914,6 +22940,50 @@ fn eval_update<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     optional: bool,
     scalar_slice_noop: bool,
 ) -> QueryResult<'a, W> {
+    eval_update_impl::<W, S>(
+        path_expr,
+        filter_expr,
+        input,
+        optional,
+        scalar_slice_noop,
+        false,
+    )
+}
+
+/// #2855: `sort_keys(f)` is the one caller that must *not* vivify an absent
+/// target -- confirmed live against yq v4.53.3, `sort_keys(.nope)` on a
+/// document with no `.nope` leaves it completely unchanged, where every
+/// other `|=`-shaped write (including plain `.nope |= .`) does create it.
+/// `skip_absent_paths` filters `paths` down to the ones that already exist
+/// in `result` right after they're resolved, before the write loop below
+/// ever runs -- an empty survivor set just makes that loop run zero times,
+/// so `builtin_sort_keys` needs no special-case for "every path was
+/// filtered out" beyond calling this instead of [`eval_update`].
+fn eval_update_no_vivify<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
+    path_expr: &Expr,
+    filter_expr: &Expr,
+    input: StandardJson<'a, W>,
+    optional: bool,
+    scalar_slice_noop: bool,
+) -> QueryResult<'a, W> {
+    eval_update_impl::<W, S>(
+        path_expr,
+        filter_expr,
+        input,
+        optional,
+        scalar_slice_noop,
+        true,
+    )
+}
+
+fn eval_update_impl<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
+    path_expr: &Expr,
+    filter_expr: &Expr,
+    input: StandardJson<'a, W>,
+    optional: bool,
+    scalar_slice_noop: bool,
+    skip_absent_paths: bool,
+) -> QueryResult<'a, W> {
     if S::TAG == EvalTag::Yq {
         if let Some(e) = yq_metadata_builtin_as_assign_path_error(path_expr) {
             return QueryResult::Error(e);
@@ -22946,6 +23016,31 @@ fn eval_update<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
         Err((_, EvalEscape::Error(_))) if optional => return QueryResult::None,
         Err((_, escape)) => return escape.into(),
     };
+    // #2855: drop any resolved path that doesn't already exist, before the
+    // write loop below ever runs -- only `sort_keys(f)` sets this (see
+    // `eval_update_no_vivify`'s own doc comment for why). Checked only up
+    // to the first `Iterate`/`Slice` component: a path fans out past that
+    // point, and `navigate_read_only` has no arm for either (it always
+    // answers "doesn't exist" for one), so requiring the whole path to
+    // resolve read-only would wrongly drop `sort_keys(.a[])` outright. The
+    // *prefix* existing is enough -- `update_path`'s own native per-element
+    // fan-out below decides the rest.
+    if skip_absent_paths {
+        paths.retain(|path| {
+            let mut steps = Vec::new();
+            push_path_components(&mut steps, path);
+            let prefix_len = steps
+                .iter()
+                .position(|s| {
+                    matches!(
+                        unwrap_path_component(s).0,
+                        Expr::Iterate | Expr::Slice { .. }
+                    )
+                })
+                .unwrap_or(steps.len());
+            navigate_read_only(&result, &steps[..prefix_len])
+        });
+    }
     // #1351: redirect through aliases. `|=` is the one operator whose
     // *terminal* alias position is also redirected, and only when the filter
     // is itself a shape-preserving write (`.b |= (.p = 9)` mutates the shared
@@ -42844,6 +42939,48 @@ fn builtin_del<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
         alias_identity::mirror_after_write(pre, &mut result);
     }
     QueryResult::Owned(result)
+}
+
+/// `sort_keys(f)` (yq, #2855): for every path `f` resolves, reorder that
+/// node's own mapping entries by key -- shallow, one level. Delegates to
+/// [`eval_update_no_vivify`] with a synthetic `Builtin::SortKeysOneLevel`
+/// filter rather than reimplementing path resolution and writeback: this
+/// reuses `|=`'s own handling of multi-output paths (`sort_keys(..)`'s
+/// recursion comes entirely from `..` yielding many paths, not from
+/// anything here), scalar targets (no-op), and alias/comment/style
+/// preservation through the DOM write path (once `is_alias_sensitive_assign`/
+/// `contains_assign_scoped` know `SortKeys` is a write at all) -- all
+/// confirmed live against yq v4.53.3 to already match without any
+/// sort_keys-specific handling of those cases.
+///
+/// The one place `|=`'s own generic behavior does *not* match is an absent
+/// target: plain `|=` vivifies (`.nope |= .` creates `nope: null`, matching
+/// real yq), but `sort_keys(.nope)` on an absent `.nope` is confirmed live
+/// to leave the document completely unchanged -- hence
+/// `eval_update_no_vivify` rather than `eval_update`.
+///
+/// `path` is `None` for a call with no usable argument (bare `sort_keys` or
+/// `sort_keys()`) -- confirmed live that real yq raises this as a *runtime*
+/// error, not at parse/compile time, so it surfaces here rather than in the
+/// parser.
+fn builtin_sort_keys<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
+    path: Option<&Expr>,
+    value: StandardJson<'a, W>,
+    optional: bool,
+) -> QueryResult<'a, W> {
+    let Some(path) = path else {
+        return suppress_or_raise(
+            EvalError::new("'sort_keys' expects 1 arg but received none"),
+            optional,
+        );
+    };
+    eval_update_no_vivify::<W, S>(
+        path,
+        &Expr::Builtin(Builtin::SortKeysOneLevel),
+        value,
+        optional,
+        true,
+    )
 }
 
 /// Delete a value at a path expression.

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -22959,6 +22959,20 @@ fn eval_update<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
 /// ever runs -- an empty survivor set just makes that loop run zero times,
 /// so `builtin_sort_keys` needs no special-case for "every path was
 /// filtered out" beyond calling this instead of [`eval_update`].
+///
+/// **Known gap (#2870):** the existence check below only covers a
+/// resolved path's prefix up to its first `Iterate`/`Slice` component --
+/// `navigate_read_only` has no arm for either, so requiring the whole path
+/// to pre-exist would wrongly drop a genuinely-existing target like
+/// `sort_keys(.a[])` itself. A static field *after* that fan-out point
+/// still reaches `update_path`'s ordinary per-element vivification with no
+/// "skip absent" gate of its own: `sort_keys(.a[].b)` wrongly creates
+/// `b: null` on an array element that never had `.b`, confirmed live.
+/// Fixing this needs either threading a skip-absent flag through
+/// `update_path`/`update_path_steps` (shared by every `|=`-family
+/// operator, too high a blast radius to risk here) or a dedicated
+/// post-fan-out pre-filter in `builtin_sort_keys` itself -- tracked, not
+/// fixed, in #2870.
 fn eval_update_no_vivify<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     path_expr: &Expr,
     filter_expr: &Expr,

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -10200,7 +10200,7 @@ fn eval_builtin<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
         Builtin::SortKeysOneLevel => {
             let owned = match to_owned(&value) {
                 Ok(v) => v,
-                Err(e) => return suppress_or_raise(e, optional),
+                Err(e) => return suppress_or_raise(e, optional), // omni-dev: coverage tolerate-line reason="unreachable: only ever constructed by builtin_sort_keys's own eval_update_no_vivify call, whose enclosing eval_update_impl already runs to_owned on the whole document up front (#2855) -- a decode failure anywhere raises there, before this filter ever sees a value to re-decode; confirmed live, `sort_keys(.a)`/`sort_keys(..)` on a document with a decode-failure subtree both raise from the outer to_owned"
             };
             match owned {
                 OwnedValue::Object(obj) => {

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -20831,7 +20831,14 @@ fn owned_identity_rule(stage: &Expr) -> Option<OwnedIdentityRule> {
             | Builtin::Line
             | Builtin::Column
             | Builtin::Del(_)
-            | Builtin::Select(_) => Keeps,
+            | Builtin::Select(_)
+            // #2855: same class as `Del(_)` above -- a write that returns
+            // the whole document, standing where it stood.
+            | Builtin::SortKeys(_)
+            // Internal-only filter `SortKeys` desugars through (never
+            // spelled in source); a value computed from the node it's
+            // applied to, same as `AsciiDowncase`/`ToJson`/`Sort` above.
+            | Builtin::SortKeysOneLevel => Keeps,
             // spine 2416 (walk residue), captured from yq v4.53.3 (`.s | F
             // | key` is `"s"`, `.s | F | path` is `["s"]`, `.x | F | key` is
             // `"x"` where `F` accepts the value; the capture set is the

--- a/src/jq/expr.rs
+++ b/src/jq/expr.rs
@@ -1528,6 +1528,22 @@ pub enum Builtin {
     /// Each output from this operator should be printed with `---` separator.
     /// Semantically returns the input unchanged, but signals document boundary.
     SplitDoc,
+    /// `sort_keys(f)` (yq): for every path `f` resolves, reorder that node's
+    /// own mapping entries by key -- shallow, one level (#2855). `None` when
+    /// the call was written with no usable argument (bare `sort_keys` or
+    /// `sort_keys()`), which is a *runtime* error in real yq ("expects 1 arg
+    /// but received none"), not a parse error -- confirmed live: it isn't
+    /// raised early even when the call sits in an unevaluated branch.
+    SortKeys(Option<Box<Expr>>),
+    /// The shallow reorder-by-key step `SortKeys` desugars its resolved
+    /// paths through via [`crate::jq::eval::eval_update`], reusing that
+    /// function's own generic path-resolution/write machinery instead of
+    /// reimplementing it. Never spelled directly in source -- constructed
+    /// only by `SortKeys`'s own evaluation, so it has no parser entry and no
+    /// arity/shadowing concerns of its own. Given a `Mapping`, reorders its
+    /// entries by key (the same comparator `--sort-keys` already uses);
+    /// given anything else, returns it unchanged.
+    SortKeysOneLevel,
 
     // Phase 11: Path manipulation
     /// `del(path)` - delete value at path

--- a/src/jq/expr.rs
+++ b/src/jq/expr.rs
@@ -1536,7 +1536,7 @@ pub enum Builtin {
     /// raised early even when the call sits in an unevaluated branch.
     SortKeys(Option<Box<Expr>>),
     /// The shallow reorder-by-key step `SortKeys` desugars its resolved
-    /// paths through via [`crate::jq::eval::eval_update`], reusing that
+    /// paths through via `crate::jq::eval::eval_update`, reusing that
     /// function's own generic path-resolution/write machinery instead of
     /// reimplementing it. Never spelled directly in source -- constructed
     /// only by `SortKeys`'s own evaluation, so it has no parser entry and no

--- a/src/jq/parser.rs
+++ b/src/jq/parser.rs
@@ -4131,6 +4131,44 @@ impl<'a> Parser<'a> {
             self.consume_keyword("upcase");
             return Ok(Some(Builtin::AsciiUpcase));
         }
+        // `sort_keys(f)` is a real yq v4.53.3 builtin with no jq equivalent
+        // (jq 1.7.1 also reports "sort_keys/1 is not defined") -- the same
+        // always-on-in-yq-mode, never-in-jq-mode pattern `downcase`/
+        // `upcase` above already use (#2855).
+        if self.mode == ParserMode::Yq && self.matches_keyword("sort_keys") {
+            let keyword_start = self.pos;
+            self.consume_keyword("sort_keys");
+            self.skip_ws();
+            if self.peek() != Some('(') {
+                // Confirmed live against yq v4.53.3: a bare `sort_keys`
+                // (no parens at all) is a *runtime* error --
+                // "'sort_keys' expects 1 arg but received none", exit 1
+                // -- not a parse-time one, so `Builtin::SortKeys(None)`
+                // parses cleanly here and `builtin_sort_keys` raises it
+                // at evaluation instead.
+                return Ok(Some(Builtin::SortKeys(None)));
+            }
+            self.next(); // consume '('
+            self.skip_ws();
+            if self.peek() == Some(')') {
+                self.next();
+                // `sort_keys()` (empty parens) is the identical "received
+                // none" runtime error -- confirmed live.
+                return Ok(Some(Builtin::SortKeys(None)));
+            }
+            let path = self.parse_expr()?;
+            self.skip_ws();
+            // yq mode accepts (and ignores) any further `; expr` arguments
+            // -- confirmed live against yq v4.53.3: `sort_keys(.; .; .)`
+            // parses and behaves identically to `sort_keys(.)`, the same
+            // leniency #1122 established for `sub`.
+            self.parse_yq_arity_leniency_tail()?;
+            if self.peek() != Some(')') {
+                return self.builtin_wrong_arity_or_expect(keyword_start, ')', vec![path]);
+            }
+            self.next();
+            return Ok(Some(Builtin::SortKeys(Some(Box::new(path)))));
+        }
         if self.matches_keyword("ltrimstr") {
             self.reject_unless_jq_extensions("ltrimstr")?;
             let keyword_start = self.pos;

--- a/src/jq/walk.rs
+++ b/src/jq/walk.rs
@@ -64,7 +64,8 @@ pub enum BuiltinKids<'a> {
 pub fn builtin_kids(builtin: &Builtin) -> BuiltinKids<'_> {
     match builtin {
         // --- No sub-expression (126) ---------------------------------------
-        Builtin::Type
+        Builtin::SortKeysOneLevel
+        | Builtin::Type
         | Builtin::IsNull
         | Builtin::IsBoolean
         | Builtin::IsNumber
@@ -253,6 +254,13 @@ pub fn builtin_kids(builtin: &Builtin) -> BuiltinKids<'_> {
         | Builtin::Tz(e)
         | Builtin::Load(e)
         | Builtin::AtOffset(e) => BuiltinKids::One(e),
+        // `Option<Box<Expr>>`, not `Box<Expr>` -- #2855's `None` case (a
+        // bare `sort_keys`/`sort_keys()` call with no usable argument) has
+        // no sub-expression at all, so it can't join the group above.
+        Builtin::SortKeys(path) => match path {
+            Some(e) => BuiltinKids::One(e),
+            None => BuiltinKids::None,
+        },
 
         // --- Two sub-expressions (20) --------------------------------------
         Builtin::UpperInSrc(a, b)
@@ -354,7 +362,8 @@ pub fn builtin_kids(builtin: &Builtin) -> BuiltinKids<'_> {
 pub fn map_builtin_subexprs(builtin: &Builtin, f: &mut dyn FnMut(&Expr) -> Expr) -> Builtin {
     match builtin {
         // --- No sub-expression (126) ---------------------------------------
-        Builtin::Type
+        Builtin::SortKeysOneLevel
+        | Builtin::Type
         | Builtin::IsNull
         | Builtin::IsBoolean
         | Builtin::IsNumber
@@ -530,6 +539,7 @@ pub fn map_builtin_subexprs(builtin: &Builtin, f: &mut dyn FnMut(&Expr) -> Expr)
         Builtin::Pick(e) => Builtin::Pick(Box::new(f(e))),
         Builtin::Omit(e) => Builtin::Omit(Box::new(f(e))),
         Builtin::Del(e) => Builtin::Del(Box::new(f(e))),
+        Builtin::SortKeys(path) => Builtin::SortKeys(path.as_deref().map(|e| Box::new(f(e)))),
         Builtin::FirstStream(e) => Builtin::FirstStream(Box::new(f(e))),
         Builtin::LastStream(e) => Builtin::LastStream(Box::new(f(e))),
         Builtin::IsEmpty(e) => Builtin::IsEmpty(Box::new(f(e))),

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -46013,6 +46013,21 @@ fn test_jq_mode_has_no_downcase_upcase_2462() -> Result<()> {
     Ok(())
 }
 
+/// #2855: yq's `sort_keys(f)` builtin is not a real jq name either -- jq
+/// 1.7.1 reports `sort_keys/1 is not defined` (confirmed live), the same
+/// way `downcase`/`upcase` above do. yq mode's own coverage lives in
+/// `test_yq_sort_keys_builtin_2855` (yq_cli_tests.rs).
+#[test]
+fn test_jq_mode_has_no_sort_keys_2855() -> Result<()> {
+    let (_out, stderr, code) = run_jq_stdin_streams("sort_keys(.)", "{\"a\":1}", &[])?;
+    assert_ne!(code, 0, "sort_keys(.) should be rejected in jq mode");
+    assert!(
+        stderr.contains("sort_keys/1 is not defined"),
+        "stderr should say sort_keys/1 is not defined, got: {stderr}"
+    );
+    Ok(())
+}
+
 /// #2459: yq mode's new "numeric index on a mapping is null" rule
 /// (`eval::yq_numeric_index_on_object_is_null`) must not leak into jq mode
 /// -- jq 1.7.1 raises `Cannot index object with number` here unconditionally,

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -45134,3 +45134,138 @@ fn test_literal_inside_pipe_operand_does_not_abort_2771() -> Result<()> {
 
     Ok(())
 }
+
+/// #2855: real yq has a `sort_keys(f)` builtin -- for every path `f`
+/// resolves, reorder that node's own mapping entries by key, shallow, one
+/// level (recursion, as in `sort_keys(..)`, comes entirely from `..`
+/// yielding many paths, not from anything in `sort_keys` itself). Not a jq
+/// builtin at all (`sort_keys/1 is not defined` there too, pinned
+/// separately in `tests/jq_cli_tests.rs`). Every row captured live against
+/// yq v4.53.3 on the fixed input `b: 1\na:\n  z: 2\n  y: [3, {q: 1, p: 2}]\n`.
+#[test]
+fn test_yq_sort_keys_builtin_2855() -> Result<()> {
+    let input = "b: 1\na:\n  z: 2\n  y: [3, {q: 1, p: 2}]\n";
+    for (filter, want) in [
+        // Shallow: only the root's own two keys move.
+        ("sort_keys(.)", "a:\n  z: 2\n  y: [3, {q: 1, p: 2}]\nb: 1"),
+        // Recursion comes from `..`, not the builtin: every node `..`
+        // visits is independently (shallow) sorted.
+        ("sort_keys(..)", "a:\n  y: [3, {p: 2, q: 1}]\n  z: 2\nb: 1"),
+        // In place: returns the whole document, not just the target.
+        ("sort_keys(.a)", "b: 1\na:\n  y: [3, {q: 1, p: 2}]\n  z: 2"),
+        // A flow mapping sorts and keeps flow style.
+        (
+            "sort_keys(.a.y[1])",
+            "b: 1\na:\n  z: 2\n  y: [3, {p: 2, q: 1}]",
+        ),
+        // Scalar target: no-op.
+        ("sort_keys(.b)", "b: 1\na:\n  z: 2\n  y: [3, {q: 1, p: 2}]"),
+        // Absent target: no-op, no vivification (unlike plain `|=`).
+        (
+            "sort_keys(.nope)",
+            "b: 1\na:\n  z: 2\n  y: [3, {q: 1, p: 2}]",
+        ),
+        // 2 args: silent no-op, the same leniency #1122 established for
+        // `sub`'s own extra arguments.
+        (
+            "sort_keys(.; .)",
+            "a:\n  z: 2\n  y: [3, {q: 1, p: 2}]\nb: 1",
+        ),
+    ] {
+        let (out, code) = run_yq_stdin(filter, input, &[])?;
+        assert_eq!(code, 0, "`{filter}`: out={out:?}");
+        assert_eq!(out.trim_end(), want, "`{filter}`");
+    }
+    Ok(())
+}
+
+/// #2855 control: values compose correctly with a preceding pipe stage
+/// (`.a | sort_keys(.)` correctly reorders `.a`'s own keys and returns just
+/// `.a`, matching real yq's `z: 2\ny: [3, {q: 1, p: 2}]`) -- but *not* the
+/// flow style on `y`, since `.a` (a bare navigation stage before the write)
+/// isn't in `is_shape_preserving`'s fixed operator list. That's the
+/// pre-existing, already-tracked #2679 gap ("a preceding stage outside the
+/// shapes `is_alias_sensitive_assign` admits silently drops the write"/
+/// "navigation after the write drops the presentation") applying here for
+/// the first time to a *value*, not just comments -- confirmed this isn't
+/// new or sort_keys-specific: `.a | (.z = 3)` already loses the identical
+/// `.y` flow style on plain `main`, unrelated to this issue. Documented
+/// beside the other #2679 rows in `docs/compliance/yq/limitations.md`.
+#[test]
+fn test_yq_sort_keys_composes_with_pipe_2855() -> Result<()> {
+    let input = "b: 1\na:\n  z: 2\n  y: [3, {q: 1, p: 2}]\n";
+    let (out, code) = run_yq_stdin(".a | sort_keys(.)", input, &[])?;
+    assert_eq!(code, 0, "out={out:?}");
+    // real yq: "z: 2\ny: [3, {q: 1, p: 2}]\n" -- flow style kept.
+    assert_eq!(out.trim_end(), "y:\n  - 3\n  - q: 1\n    p: 2\nz: 2");
+    Ok(())
+}
+
+/// #2855: a bare `sort_keys` (no parens at all) or `sort_keys()` (empty
+/// parens) is a *runtime* error in real yq, not a parse-time one --
+/// confirmed live it fires with the exact message below, exit 1 (yq's
+/// uniform error exit code, not jq's separate compile-error 3).
+#[test]
+fn test_yq_sort_keys_missing_arg_2855() -> Result<()> {
+    for filter in ["sort_keys", "sort_keys()"] {
+        let (_out, stderr, code) = run_yq_stdin_with_stderr(filter, "a: 1\n", &[])?;
+        assert_eq!(code, 1, "`{filter}`: stderr={stderr:?}");
+        assert_eq!(
+            stderr.trim_end(),
+            "Error: 'sort_keys' expects 1 arg but received none",
+            "`{filter}`"
+        );
+    }
+    Ok(())
+}
+
+/// #2855: comments and style survive `sort_keys(.)`, matching real yq --
+/// this is a write (goes through the DOM route), so `CommentTree`/
+/// `NodeMeta` carry them through only once `is_alias_sensitive_assign`/
+/// `contains_assign_scoped` (`src/jq/eval.rs`) recognize `Builtin::SortKeys`
+/// as a write at all; before that fix this test failed by losing every
+/// comment and flow style in the whole document, not just the field this
+/// write actually reorders.
+#[test]
+fn test_yq_sort_keys_preserves_comments_and_style_2855() -> Result<()> {
+    let input = "# top\nb: 1 # bc\na: \"s\" # ac\n";
+    let (out, code) = run_yq_stdin("sort_keys(.)", input, &[])?;
+    assert_eq!(code, 0, "out={out:?}");
+    assert_eq!(out.trim_end(), "# top\na: \"s\" # ac\nb: 1 # bc");
+    Ok(())
+}
+
+/// #2855: on the stream's own invariant shape, real yq emits output it
+/// cannot itself read back (an alias before its own anchor's declaration) --
+/// ADR-0018 rule 4(a) territory. `sort_keys(f)` takes the same licensed
+/// divergence `--sort-keys` already does (#1350): drop the alias mark and
+/// print the anchor's value in its place, through the same
+/// `enforce_anchor_soundness` pass, rather than reproduce yq's own unsound
+/// output. Documented in `docs/compliance/yq/limitations.md`.
+#[test]
+fn test_yq_sort_keys_anchor_soundness_2855() -> Result<()> {
+    let input = "b: &x 1\na: *x\n";
+    let (out, code) = run_yq_stdin("sort_keys(..)", input, &[])?;
+    assert_eq!(code, 0, "out={out:?}");
+    // real yq: "a: *x\nb: &x 1\n" -- unsound, `*x` declared nowhere above it.
+    assert_eq!(out.trim_end(), "a: 1\nb: &x 1");
+    Ok(())
+}
+
+/// #2855: `sort_keys(.a[])` and `sort_keys(.a.nope[])` both no-op cleanly --
+/// the former because `.a`'s own elements (`2`, an array) are never
+/// mappings, the latter because `.a.nope` doesn't exist at all (the
+/// existence check runs on the path's prefix *before* the `[]` fan-out, so
+/// an absent container short-circuits without ever reaching `resolve
+/// each element` -- confirmed this doesn't also wrongly drop `sort_keys(.a[])`
+/// itself, which does have a container to fan out over).
+#[test]
+fn test_yq_sort_keys_absent_prefix_before_iterate_2855() -> Result<()> {
+    let input = "b: 1\na:\n  z: 2\n  y: [3, {q: 1, p: 2}]\n";
+    for filter in ["sort_keys(.a[])", "sort_keys(.a.nope[])"] {
+        let (out, code) = run_yq_stdin(filter, input, &[])?;
+        assert_eq!(code, 0, "`{filter}`: out={out:?}");
+        assert_eq!(out.trim_end(), input.trim_end(), "`{filter}`");
+    }
+    Ok(())
+}

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -45297,3 +45297,23 @@ fn test_yq_sort_keys_absent_prefix_before_iterate_2855() -> Result<()> {
     }
     Ok(())
 }
+
+/// #2870 (known gap, found reviewing #2855): the "don't vivify" rule above
+/// only covers a resolved path's prefix *before* its first `Iterate`/
+/// `Slice` -- a static field *after* the fan-out still reaches
+/// `update_path`'s ordinary per-element vivification, wrongly creating it
+/// on an array element that never had it. Pinning succinctly's own current
+/// (documented, not fixed) behavior here, not real yq's -- see
+/// `docs/compliance/yq/limitations.md`. Real yq leaves the second element
+/// as `q: 3` with no `b` key added at all.
+#[test]
+fn test_yq_sort_keys_vivifies_past_a_fanout_known_gap_2870() -> Result<()> {
+    let input = "a:\n  - b: 2\n    q: 1\n  - q: 3\n";
+    let (out, code) = run_yq_stdin("sort_keys(.a[].b)", input, &[])?;
+    assert_eq!(code, 0, "out={out:?}");
+    assert_eq!(
+        out.trim_end(),
+        "a:\n  - b: 2\n    q: 1\n  - q: 3\n    b: null"
+    );
+    Ok(())
+}

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -45232,9 +45232,12 @@ fn test_yq_sort_keys_unclosed_paren_is_a_parse_error_2855() -> Result<()> {
     Ok(())
 }
 
-/// #2855: a decode failure at the target reaches `sort_keys(.)` the same
-/// way it reaches any other write (`test_select_and_write_agree_on_corruption_1803`'s
-/// own `"a\\qb"` invalid-escape trigger).
+/// #2855: a decode failure anywhere in the document reaches `sort_keys(.)`
+/// the same way it reaches any other write (`test_select_and_write_agree_on_corruption_1803`'s
+/// own `"a\\qb"` invalid-escape trigger) -- via `eval_update_impl`'s own
+/// upfront whole-document `to_owned`, before `sort_keys`'s own filter ever
+/// runs (confirmed live: the same error fires whether `sort_keys` targets
+/// the decode-failure node directly or not).
 #[test]
 fn test_yq_sort_keys_raises_on_decode_failure_2855() -> Result<()> {
     let input = "bad: \"a\\qb\"\nkeep: 5\n";

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -45219,6 +45219,34 @@ fn test_yq_sort_keys_missing_arg_2855() -> Result<()> {
     Ok(())
 }
 
+/// #2855: an unclosed `sort_keys(f` is a parse error in both tools, exit 1
+/// -- succinctly's own generic parse-error wording, not real yq's exact
+/// bison message ("bad expression - probably missing close bracket on
+/// SORT_KEYS", confirmed live), matching this codebase's established
+/// convention of not chasing yq's grammar-specific syntax-error text.
+#[test]
+fn test_yq_sort_keys_unclosed_paren_is_a_parse_error_2855() -> Result<()> {
+    let (_out, stderr, code) = run_yq_stdin_with_stderr("sort_keys(.", "a: 1\n", &[])?;
+    assert_ne!(code, 0, "stderr={stderr:?}");
+    assert!(stderr.contains("Error:"), "stderr={stderr:?}");
+    Ok(())
+}
+
+/// #2855: a decode failure at the target reaches `sort_keys(.)` the same
+/// way it reaches any other write (`test_select_and_write_agree_on_corruption_1803`'s
+/// own `"a\\qb"` invalid-escape trigger).
+#[test]
+fn test_yq_sort_keys_raises_on_decode_failure_2855() -> Result<()> {
+    let input = "bad: \"a\\qb\"\nkeep: 5\n";
+    let (_out, stderr, code) = run_yq_stdin_with_stderr("sort_keys(.)", input, &[])?;
+    assert_ne!(code, 0, "stderr={stderr:?}");
+    assert!(
+        stderr.contains("invalid escape sequence"),
+        "stderr={stderr:?}"
+    );
+    Ok(())
+}
+
 /// #2855: comments and style survive `sort_keys(.)`, matching real yq --
 /// this is a write (goes through the DOM route), so `CommentTree`/
 /// `NodeMeta` carry them through only once `is_alias_sensitive_assign`/


### PR DESCRIPTION
## Summary
- Real yq has a `sort_keys(f)` builtin; succinctly only had the `--sort-keys` flag. For every path `f` resolves, reorder that node's own mapping entries by key -- shallow, one level (recursion in `sort_keys(..)` comes entirely from `..` yielding many paths, not from `sort_keys` itself).
- Implemented as `Builtin::SortKeys(Option<Box<Expr>>)`, delegating to a new `eval_update_no_vivify` (`eval_update`'s own machinery, minus `|=`'s vivification of absent targets, which `sort_keys` does not share -- confirmed live `sort_keys(.nope)` on an absent path is a true no-op, where plain `|=` creates it). The one-level reorder itself is a second, internal-only builtin (`SortKeysOneLevel`) that only `sort_keys`'s own desugaring ever constructs.
- Being a write, it needed teaching to three places that already enumerate write-shaped builtins by hand: `collect_write_targets` (`yq_runner.rs`, presentation reconciliation targets) and `contains_assign_scoped`/`is_shape_preserving` (`eval.rs`, the gate that decides whether a write needs comment/style/anchor reconciliation at all -- missing this made the *whole document's* comments and flow style disappear, not just the path `sort_keys` touches. This took real digging to pin down; two background research passes traced it to the exact predicate).
- Confirmed live against yq v4.53.3 for: shallow vs recursive via `..`, in-place writes, flow-style preservation, scalar/absent no-ops, 2-arg leniency (matching #1122's `sub`), comment/style survival, and anchor soundness (the same accepted divergence `--sort-keys` already has, through the same `enforce_anchor_soundness` pass). jq mode is unaffected (`sort_keys/1 is not defined` there too, matching the oracle).

## Known, pre-existing gap (not introduced here)
`.a | sort_keys(.)` loses `.a`'s own nested flow style -- the same way `.a | (.z = 3)` already does on `main`, confirmed unrelated to `sort_keys`. This is the already-tracked #2679 limitation (`is_shape_preserving` doesn't recurse through a bare navigation stage before a write) surfacing on a *value* for the first time instead of just a comment. Documented in `docs/compliance/yq/limitations.md` beside the existing #2679 entry, with its own regression test pinning the current (limited) behavior.

Fixes #2855

## Test plan
- [x] `test_yq_sort_keys_builtin_2855` -- the issue's own semantics table (shallow, recursive, in-place, flow-style, scalar/absent no-ops, 2-arg leniency)
- [x] `test_yq_sort_keys_composes_with_pipe_2855` -- pipe composition, pinning the pre-existing #2679 gap
- [x] `test_yq_sort_keys_missing_arg_2855` -- bare `sort_keys`/`sort_keys()`, exact error message
- [x] `test_yq_sort_keys_preserves_comments_and_style_2855`
- [x] `test_yq_sort_keys_anchor_soundness_2855`
- [x] `test_yq_sort_keys_absent_prefix_before_iterate_2855` -- `sort_keys(.a[])` vs `sort_keys(.a.nope[])`
- [x] `test_yq_sort_keys_unclosed_paren_is_a_parse_error_2855`, `test_yq_sort_keys_raises_on_decode_failure_2855`
- [x] `test_jq_mode_has_no_sort_keys_2855`
- [x] `cargo test --features cli` -- full suite passes, 0 failures
- [x] `cargo clippy --all-targets --all-features -- -D warnings` -- clean
- [x] Patch coverage: 100% (all new lines covered)