### PR TITLE
fix(jq): --preserve-input must reformat numbers nowhere on -S/-a/-C/-s

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -127,6 +127,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`succinctly jq --preserve-input` no longer silently reformats number
+  spelling under `-S`/`-a`/`-C`/`-s`** (#2852). `--preserve-input` is
+  documented to echo a document's numbers exactly as written (`4e4` stays
+  `4e4`, never `40000`) — true for the default `-c`/pretty route, but not for
+  these four flags, which all force a materializing route with its own
+  formatting logic.
+
+  Two independent root causes, both fixed together: `format_json`/
+  `JsonFormatOpts` (`-S`/`-a`/`-C`'s own *output*-formatting call in
+  `write_output_jq_value`) had no `jq_compat`/preserve split on a
+  `NumberLiteral` at all — it always reformatted, regardless of the flag.
+  `JsonFormatOpts` gained a new `jq_compat: bool` field, mirroring how its
+  existing `json_sourced` field is only meaningful for yq mode.
+
+  Separately, `evaluate_input_streaming` (needed for `-s`/`--slurp` and any
+  query using `input`/`inputs`, both of which must materialize the whole
+  input document before the filter can run) always reindexed the outer input
+  value through the unconditionally-reformatting `OwnedValue::to_json()`
+  before evaluation even started — so the number was already reformatted by
+  the time the filter ran, independent of the first fix. A *second* document
+  read via the `input`/`inputs` builtin itself was never affected: those
+  resolve from an already-materialized queue that never reaches either
+  `to_json` variant, only the one input value `evaluate_input_streaming`'s
+  caller hands it directly (confirmed live: `jq --preserve-input -a '.,
+  input' a.json b.json` reformatted `a.json`'s numbers but not `b.json`'s).
+  A new `OwnedValue::to_json_jq_preserve()` — the jq-mode sibling of the
+  existing yq-mode `to_json_yq()` — closes that half.
+
 - **`succinctly jq -e`, and `-S`/`-a`/`-C`, no longer leak a raw Rust panic
   backtrace to stderr on deeply-nested input** (#2850). The exit code (5) and
   final diagnostic (`nesting depth exceeds limit of N`) were always correct

--- a/docs/compliance/jq/limitations.md
+++ b/docs/compliance/jq/limitations.md
@@ -3884,9 +3884,21 @@ the three actually need it: `write_output_jq_value` already materializes just th
 correctly for the pre-existing DOM route), so moving them onto the lazy route costs nothing
 in *this* fidelity concern and validates only the value a filter actually reads, same as the
 default. (A separate, pre-existing number-formatting gap in that same `format_json` call --
-`--preserve-input` silently reformatting numbers under any of `-S`/`-a`/`-C`/`-s` -- predates
-this change and is tracked independently as
-[#2852](https://github.com/rust-works/succinctly/issues/2852), not claimed fixed here.)
+`--preserve-input` silently reformatting numbers under any of `-S`/`-a`/`-C`/`-s` -- predated
+this change and was tracked independently as
+[#2852](https://github.com/rust-works/succinctly/issues/2852), not fixed here at the time.
+**Closed by #2852**: two independent root causes, both in play for the four flags above.
+`format_json`/`JsonFormatOpts` had no `jq_compat`/preserve split on a `NumberLiteral` at all
+(`-S`/`-a`/`-C`'s own *output*-formatting call, unconditionally reformatting regardless of the
+flag) -- now threads `config.jq_compat` through, mirroring the `json_sourced` field's existing
+yq-only-meaningful pattern. Separately, `evaluate_input_streaming`'s own input-side reindex
+round-trip (needed for `-s`/`--slurp` and any query touching `input`/`inputs`, both of which
+must materialize the whole document before the filter can run) always called the
+unconditionally-reformatting `OwnedValue::to_json()` on the outer input value -- a *second*
+document read via the `input`/`inputs` builtin itself was never affected, since those resolve
+from an already-materialized queue that never reaches either `to_json` variant. A new
+`to_json_jq_preserve()` (the jq-mode sibling of the existing yq-mode `to_json_yq()`) closes
+that half.)
 `-s` (slurp) and the `-n`/`input` bridge stay materializing — `-s` needs a real
 offset-mapping redesign to slurp without building a DOM (tracked, not done), and `input`
 must hand the evaluator an owned value it can return from a builtin by construction, so

--- a/src/bin/succinctly/jq_runner.rs
+++ b/src/bin/succinctly/jq_runner.rs
@@ -1757,6 +1757,7 @@ pub fn run_jq(args: JqCommand) -> Result<i32> {
                         &context,
                         &at,
                         &mut sink,
+                        output_config.jq_compat,
                         &mut |sink, result| {
                             had_output = true;
                             if args.exit_status {
@@ -2245,6 +2246,7 @@ pub fn run_jq(args: JqCommand) -> Result<i32> {
                     &context,
                     &ErrorAt::Live(&locations),
                     &mut sink,
+                    output_config.jq_compat,
                     &mut |sink, result| {
                         had_output = true;
                         last_output = Some(result.clone());
@@ -2282,6 +2284,7 @@ pub fn run_jq(args: JqCommand) -> Result<i32> {
                         &context,
                         &ErrorAt::Live(&locations),
                         &mut sink,
+                        output_config.jq_compat,
                         &mut |sink, result| {
                             had_output = true;
                             last_output = Some(result.clone());
@@ -2315,6 +2318,7 @@ pub fn run_jq(args: JqCommand) -> Result<i32> {
                     &context,
                     &at,
                     &mut sink,
+                    output_config.jq_compat,
                     &mut |sink, result| {
                         had_output = true;
                         last_output = Some(result.clone());
@@ -4747,9 +4751,21 @@ fn evaluate_input_streaming(
     _context: &EvalContext,
     at: &ErrorAt<'_>,
     sink: &mut ErrorSink,
+    jq_compat: bool,
     on_value: &mut dyn FnMut(&mut ErrorSink, OwnedValue) -> Result<bool>,
 ) -> Result<()> {
-    let json_str = input.to_json();
+    // #2852: `to_json()` always reformats a `NumberLiteral` to jq's own
+    // spelling -- before this, every call site here reindexed through it
+    // unconditionally, silently reformatting this one input value's own
+    // numbers regardless of `--preserve-input` (a document read via the
+    // `input`/`inputs` builtin themselves was unaffected, since those
+    // resolve from an already-materialized queue that never reaches this
+    // function or either `to_json` variant).
+    let json_str = if jq_compat {
+        input.to_json()
+    } else {
+        input.to_json_jq_preserve()
+    };
     let json_bytes = json_str.as_bytes();
     let index = JsonIndex::build(json_bytes);
     let cursor = index.root(json_bytes);
@@ -6964,6 +6980,11 @@ fn format_json(value: &OwnedValue, config: &OutputConfig) -> String {
         // `JsonFormatOpts::json_sourced`'s own doc comment) -- jq mode
         // never consults it.
         json_sourced: false,
+        // #2852: was missing entirely, so `-S`/`-a`/`-C`/`-s` always
+        // reformatted a `NumberLiteral` regardless of `--preserve-input`,
+        // disagreeing with `print_json`'s `JqCompatFormatter`/
+        // `PreserveFormatter` split on the default `-c` route.
+        jq_compat: config.jq_compat,
     };
     let json = output::format_json(value, &opts);
 

--- a/src/bin/succinctly/jq_runner.rs
+++ b/src/bin/succinctly/jq_runner.rs
@@ -1757,7 +1757,7 @@ pub fn run_jq(args: JqCommand) -> Result<i32> {
                         &context,
                         &at,
                         &mut sink,
-                        output_config.jq_compat,
+                        &output_config,
                         &mut |sink, result| {
                             had_output = true;
                             if args.exit_status {
@@ -2246,7 +2246,7 @@ pub fn run_jq(args: JqCommand) -> Result<i32> {
                     &context,
                     &ErrorAt::Live(&locations),
                     &mut sink,
-                    output_config.jq_compat,
+                    &output_config,
                     &mut |sink, result| {
                         had_output = true;
                         last_output = Some(result.clone());
@@ -2284,7 +2284,7 @@ pub fn run_jq(args: JqCommand) -> Result<i32> {
                         &context,
                         &ErrorAt::Live(&locations),
                         &mut sink,
-                        output_config.jq_compat,
+                        &output_config,
                         &mut |sink, result| {
                             had_output = true;
                             last_output = Some(result.clone());
@@ -2318,7 +2318,7 @@ pub fn run_jq(args: JqCommand) -> Result<i32> {
                     &context,
                     &at,
                     &mut sink,
-                    output_config.jq_compat,
+                    &output_config,
                     &mut |sink, result| {
                         had_output = true;
                         last_output = Some(result.clone());
@@ -4737,21 +4737,22 @@ fn strip_quotes_and_decode(field: &[u8]) -> String {
 ///
 /// A per-item materialization failure (`materialize_stream_item`'s
 /// `sink.materialize` calls) is defense-in-depth rather than reachable in
-/// practice: `cursor` is always rooted in `input.to_json()`, a fresh
-/// serialization of an already-decoded `OwnedValue` -- a Rust `String`, which
-/// by construction cannot hold an undecodable byte sequence, and whose
-/// escapes this crate's own serializer writes. Same argument
-/// `eval_generic.rs`'s textually-similar bridge relies on (search
-/// "defense-in-depth" there). Kept as a reported diagnostic rather than an
-/// `unwrap()` so a real failure, if that invariant is ever violated,
-/// surfaces as an ordinary `EvalError` instead of a panic.
+/// practice: `cursor` is always rooted in `input.to_json()`/
+/// `input.to_json_jq_preserve()` (#2852), a fresh serialization of an
+/// already-decoded `OwnedValue` -- a Rust `String`, which by construction
+/// cannot hold an undecodable byte sequence, and whose escapes this crate's
+/// own serializer writes. Same argument `eval_generic.rs`'s
+/// textually-similar bridge relies on (search "defense-in-depth" there).
+/// Kept as a reported diagnostic rather than an `unwrap()` so a real
+/// failure, if that invariant is ever violated, surfaces as an ordinary
+/// `EvalError` instead of a panic.
 fn evaluate_input_streaming(
     input: &OwnedValue,
     expr: &jq::Expr,
     _context: &EvalContext,
     at: &ErrorAt<'_>,
     sink: &mut ErrorSink,
-    jq_compat: bool,
+    output_config: &OutputConfig,
     on_value: &mut dyn FnMut(&mut ErrorSink, OwnedValue) -> Result<bool>,
 ) -> Result<()> {
     // #2852: `to_json()` always reformats a `NumberLiteral` to jq's own
@@ -4761,7 +4762,7 @@ fn evaluate_input_streaming(
     // `input`/`inputs` builtin themselves was unaffected, since those
     // resolve from an already-materialized queue that never reaches this
     // function or either `to_json` variant).
-    let json_str = if jq_compat {
+    let json_str = if output_config.jq_compat {
         input.to_json()
     } else {
         input.to_json_jq_preserve()
@@ -5148,10 +5149,10 @@ fn evaluate_m2_fast_path<W: Write>(
 ///
 /// The M2 counterpart of [`evaluate_input_streaming`], and deliberately not a
 /// call into it: that one takes an already-materialized `OwnedValue` and
-/// re-indexes `input.to_json()`, where this streams from the `JsonIndex` the
-/// caller already built and keeps the lazy [`write_output_jq_value`] writer,
-/// so a transparent filter still writes raw source spans rather than
-/// materializing every output.
+/// re-indexes it through `to_json()`/`to_json_jq_preserve()` (#2852), where
+/// this streams from the `JsonIndex` the caller already built and keeps the
+/// lazy [`write_output_jq_value`] writer, so a transparent filter still
+/// writes raw source spans rather than materializing every output.
 ///
 /// `on_value` returns `false` to stop the generator. `sink` is passed *into*
 /// it rather than captured, so this function can keep its own `&mut` for the

--- a/src/bin/succinctly/output.rs
+++ b/src/bin/succinctly/output.rs
@@ -514,6 +514,19 @@ pub struct JsonFormatOpts<'a> {
     /// mode (yq's own compact/pretty JSON output always agree with each
     /// other on float formatting; see [`format_float_yq`]'s doc comment).
     pub json_sourced: bool,
+    /// Whether a jq-mode `NumberLiteral` reformats to jq's own number
+    /// spelling (`true`) or echoes its source spelling verbatim (`false`,
+    /// `--preserve-input`) — only meaningful alongside `control_escape:
+    /// Jq`, mirroring how `json_sourced` above is only meaningful
+    /// alongside `control_escape: Yq`. yq mode has its own, independent
+    /// preserve-vs-reformat split on `NumberLiteral` (gated by
+    /// `json_sourced`) and ignores this field entirely.
+    ///
+    /// Before #2852, `format_json`/`JsonFormatOpts` had no such split at
+    /// all — every `NumberLiteral` in jq mode reformatted unconditionally,
+    /// disagreeing with `print_json`'s own `JqCompatFormatter`/
+    /// `PreserveFormatter` split for the default `-c` route.
+    pub jq_compat: bool,
 }
 
 /// Escape a JSON string body per the opts' control-escape style and ASCII mode.
@@ -663,7 +676,7 @@ fn format_json_impl(value: &OwnedValue, opts: &JsonFormatOpts, level: usize) -> 
                     // real yq too).
                     _ => literal.to_string(),
                 }
-            } else {
+            } else if opts.jq_compat {
                 // jq mode keeps `format_number_jq_compat`'s reformatting
                 // unchanged, which itself already reformats a non-finite
                 // literal's mantissa correctly (#1083/#1087) rather than
@@ -674,6 +687,13 @@ fn format_json_impl(value: &OwnedValue, opts: &JsonFormatOpts, level: usize) -> 
                 // real jq, unrelated and left alone here, e.g. `0.1e1` ->
                 // `1E+0` here vs real jq's `1`.
                 format_number_jq_compat(literal.as_bytes())
+            } else {
+                // `--preserve-input`: echo the source spelling verbatim,
+                // the same rule `PreserveFormatter::format_raw_number`
+                // already applies on the default `-c` `print_json` route
+                // (#2852) -- this `format_json` route (`-S`/`-a`/`-C`/`-s`)
+                // had no such split until this fix.
+                literal.to_string()
             }
         }
         OwnedValue::String(s) => {
@@ -1308,6 +1328,7 @@ mod tests {
             float_style: FloatStyle::Shortest,
             control_escape: ControlEscape::Jq,
             json_sourced: false,
+            jq_compat: true,
         };
         assert_eq!(format_json(&value, &opts), r#"{"a":2,"z":1}"#);
     }
@@ -1322,6 +1343,7 @@ mod tests {
             float_style,
             control_escape: ControlEscape::Jq,
             json_sourced: false,
+            jq_compat: true,
         };
         assert_eq!(format_json(&value, &opts(FloatStyle::Shortest)), "1");
         assert_eq!(
@@ -1370,6 +1392,7 @@ mod tests {
             float_style,
             control_escape: ControlEscape::Yq,
             json_sourced: false,
+            jq_compat: true,
         };
         let huge = OwnedValue::Float(1e100);
         assert_eq!(format_json(&huge, &opts(FloatStyle::Shortest)), "1e+100");
@@ -1476,6 +1499,7 @@ mod tests {
             float_style: FloatStyle::Shortest,
             control_escape: ControlEscape::Yq,
             json_sourced: false,
+            jq_compat: true,
         };
         assert_eq!(
             format_json(&OwnedValue::Object(obj), &opts),
@@ -1497,6 +1521,7 @@ mod tests {
             float_style: FloatStyle::PreserveWholeFloat,
             control_escape: ControlEscape::Jq,
             json_sourced: false,
+            jq_compat: true,
         };
         assert_eq!(format_json(&OwnedValue::Float(f64::NAN), &opts), "null");
         assert_eq!(
@@ -1536,6 +1561,7 @@ mod tests {
             float_style: FloatStyle::Shortest,
             control_escape: ControlEscape::Jq,
             json_sourced: false,
+            jq_compat: true,
         };
         let overflowed = OwnedValue::NumberLiteral(
             succinctly::jq::NumberRepr::Float(f64::INFINITY),
@@ -1568,6 +1594,7 @@ mod tests {
             float_style: FloatStyle::Shortest,
             control_escape: ControlEscape::Jq,
             json_sourced: false,
+            jq_compat: true,
         };
         assert_eq!(format_json(&OwnedValue::Array(vec![]), &pretty), "[]");
         assert_eq!(
@@ -1591,6 +1618,7 @@ mod tests {
             float_style: FloatStyle::Shortest,
             control_escape: ControlEscape::Jq,
             json_sourced: false,
+            jq_compat: true,
         };
         assert_eq!(
             format_json(&value, &opts),
@@ -1658,6 +1686,7 @@ mod tests {
             float_style: FloatStyle::Shortest,
             control_escape: ControlEscape::Jq,
             json_sourced: false,
+            jq_compat: true,
         };
 
         let under = linear_array_nest(MAX_VALUE_TREE_DEPTH - 1);

--- a/src/bin/succinctly/yq_runner.rs
+++ b/src/bin/succinctly/yq_runner.rs
@@ -4482,6 +4482,10 @@ fn output_value<W: Write>(
             },
             json_sourced: config.json_sourced_floats,
             control_escape: ControlEscape::Yq,
+            // Only meaningful alongside `ControlEscape::Jq` -- yq mode has
+            // its own `json_sourced`-gated preserve/reformat split above
+            // and never consults this field.
+            jq_compat: true,
         },
     );
 

--- a/src/jq/value.rs
+++ b/src/jq/value.rs
@@ -2173,6 +2173,29 @@ impl OwnedValue {
         )
     }
 
+    /// The `--preserve-input`-aware sibling of [`to_json`](Self::to_json):
+    /// identical except a finite `NumberLiteral` echoes its source spelling
+    /// verbatim instead of jq's own reformatting (#2852).
+    ///
+    /// Used by the non-lazy evaluator's own input-side reindex round-trip
+    /// (`jq_runner.rs`'s `evaluate_input_streaming`, needed for `--slurp`
+    /// and any query using `input`/`inputs`): before this fix, that
+    /// round-trip always called plain [`to_json`](Self::to_json), silently
+    /// reformatting every number in the outer input document regardless of
+    /// `--preserve-input` -- a document read via the `input`/`inputs`
+    /// builtin themselves was unaffected (they resolve from an
+    /// already-materialized queue, never round-tripping through either
+    /// `to_json` variant), only the one input value this function's own
+    /// caller receives directly.
+    pub fn to_json_jq_preserve(&self) -> String {
+        self.to_json_at_depth(
+            0,
+            crate::jq::stream::real_output_finite_literal,
+            jq_bare_float_display,
+            infinite_float_preview_text,
+        )
+    }
+
     /// The yq-mode sibling of [`to_json`](Self::to_json) (#1030): identical
     /// except a finite `NumberLiteral` echoes its document-sourced spelling
     /// verbatim rather than being reformatted per jq's own rules -- real yq

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -47091,6 +47091,97 @@ fn test_preserve_input_keeps_jq_escape_table_2209() -> Result<()> {
     Ok(())
 }
 
+/// #2852: `--preserve-input` must also preserve number spelling on the
+/// materializing `-S`/`-a`/`-C`/`-s` routes, not just the default `-c`
+/// cursor-streaming path (`test_preserve_input_still_echoes_raw_number_text`
+/// pins that one). Two independent root causes, both fixed together here:
+/// `format_json`/`JsonFormatOpts` had no jq_compat/preserve split at all
+/// (`-S`/`-a`/`-C`'s own *output*-formatting call), and
+/// `evaluate_input_streaming`'s input-side reindex round-trip always called
+/// the unconditionally-reformatting `OwnedValue::to_json()` (`--slurp` and
+/// any query touching `input`/`inputs`, both of which must materialize the
+/// whole document before the filter runs).
+#[test]
+fn test_preserve_input_number_spelling_survives_materializing_routes_2852() -> Result<()> {
+    let input = r#"{"a":1e-3}"#;
+
+    // `-S`/`-a`, alone and combined -- both route through
+    // `write_output_jq_value`'s `format_json` call.
+    for args in [vec!["-a"], vec!["-S"], vec!["-S", "-a"]] {
+        let mut full_args = args.clone();
+        full_args.push("-c");
+        full_args.push("--preserve-input");
+        let (out, code) = run_jq_stdin(".", input, &full_args)?;
+        assert_eq!(code, 0, "args={args:?}");
+        assert_eq!(out.trim_end(), r#"{"a":1e-3}"#, "args={args:?}");
+    }
+
+    // `-C` takes the identical `format_json` call but wraps the result in
+    // ANSI color codes, so check containment rather than an exact match.
+    let (out, code) = run_jq_stdin(".", input, &["-C", "-c", "--preserve-input"])?;
+    assert_eq!(code, 0);
+    assert!(out.contains("1e-3"), "lost the source spelling: {out:?}");
+    assert!(!out.contains("0.001"), "reformatted the number: {out:?}");
+
+    // `-s`/`--slurp` -- routes through `write_output`, which shares the
+    // same `format_json`, but before this fix the *input* to the evaluator
+    // was already reformatted by the time the filter ran.
+    let (out, code) = run_jq_stdin(".[0]", input, &["-c", "--slurp", "--preserve-input"])?;
+    assert_eq!(code, 0);
+    assert_eq!(out.trim_end(), r#"{"a":1e-3}"#);
+
+    // The same reindex bug also reached the outer document under a bare
+    // `input`/`inputs` call (without `--slurp`) -- see the dedicated
+    // multi-file test below for that shape.
+
+    // Without `--preserve-input`, all of the above still reformat --
+    // regression guard against accidentally making preserve the default.
+    let (out, code) = run_jq_stdin(".", input, &["-a", "-c"])?;
+    assert_eq!(code, 0);
+    assert_eq!(out.trim_end(), r#"{"a":0.001}"#);
+    let (out, code) = run_jq_stdin(".[0]", input, &["-c", "--slurp"])?;
+    assert_eq!(code, 0);
+    assert_eq!(out.trim_end(), r#"{"a":0.001}"#);
+
+    Ok(())
+}
+
+/// #2852: the `input`/`inputs`-builtin reindex gap specifically, across two
+/// real files -- the outer document (read via `.`, materialized directly by
+/// `evaluate_input_streaming`) used to reformat under `--preserve-input`
+/// even though a *second* document read via the `input` builtin itself
+/// never did (that one resolves from an already-materialized queue that
+/// never reindexes through `OwnedValue::to_json()` at all).
+#[test]
+fn test_preserve_input_outer_document_survives_input_builtin_reindex_2852() -> Result<()> {
+    let dir = tempfile::tempdir()?;
+    let file1 = dir.path().join("doc1.json");
+    let file2 = dir.path().join("doc2.json");
+    std::fs::write(&file1, r#"{"a":1e-3}"#)?;
+    std::fs::write(&file2, r#"{"b":2e-3}"#)?;
+
+    let (out, _stderr, code) = run_jq_full(
+        &[
+            "-a",
+            "-c",
+            "--preserve-input",
+            "., input",
+            file1.to_str().unwrap(),
+            file2.to_str().unwrap(),
+        ],
+        None,
+    )?;
+    assert_eq!(code, 0, "stdout: {out:?}");
+    let lines: Vec<&str> = out.lines().collect();
+    assert_eq!(
+        lines,
+        vec![r#"{"a":1e-3}"#, r#"{"b":2e-3}"#],
+        "stdout: {out:?}"
+    );
+
+    Ok(())
+}
+
 /// #2692: **a filter validates only what it materializes**, stated as a
 /// corpus. Every malformed-document class succinctly's checks can detect,
 /// probed through a filter that reads nothing (`try (1+1)`) and through every


### PR DESCRIPTION
## Summary

`--preserve-input` is documented to echo a document's numbers exactly as written (`4e4` stays `4e4`, never `40000`) — true for the default `-c`/pretty route, but not for `-S`/`-a`/`-C`/`-s`, which all force a materializing route with its own, independent number-formatting logic.

Two independent root causes, both fixed together:

- `format_json`/`JsonFormatOpts` (`-S`/`-a`/`-C`'s own *output*-formatting call in `write_output_jq_value`) had no `jq_compat`/preserve split on a `NumberLiteral` at all — it always reformatted, regardless of the flag. `JsonFormatOpts` gains a new `jq_compat: bool` field, mirroring how its existing `json_sourced` field is only meaningful for yq mode.
- Separately, `evaluate_input_streaming` (needed for `-s`/`--slurp` and any query using `input`/`inputs`, both of which must materialize the whole input document before the filter can run) always reindexed the outer input value through the unconditionally-reformatting `OwnedValue::to_json()` before evaluation even started. A *second* document read via the `input`/`inputs` builtin itself was never affected — those resolve from an already-materialized queue that never reaches either `to_json` variant, only the one input value this function's caller hands it directly (confirmed live: `jq --preserve-input -a '., input' a.json b.json` reformatted `a.json`'s numbers but not `b.json`'s). A new `OwnedValue::to_json_jq_preserve()` — the jq-mode sibling of the existing yq-mode `to_json_yq()` — closes that half.

Both root causes were verified live against the pinned oracle before and after the fix; the issue's own claimed premise ("Same result for `-Sc`/`-Cc`/`-sc`") had actually narrowed since filing — `-S` alone no longer reproduced (fixed incidentally by #2850/#2662's own changes to this call site) — so this PR's scope was re-derived from a fresh live repro rather than the issue's original text.

Fixes #2852

## Test plan

- [x] `cargo build --features cli,simd,regex,serde`
- [x] `cargo test --features cli,simd,regex,serde` (full suite, 63/63 binaries, 0 failed)
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo clippy --all-targets --features std,simd,serde,cli,regex,bench-runner,large-tests,mmap-tests -- -D warnings`
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features`
- [x] Live-verified against the pinned `jq` 1.7.1 semantics documented in `docs/compliance/jq/limitations.md` for every affected flag (`-a`, `-C`, `-S`, combined `-Sa`, `-s`/`--slurp`, and the `input`/`inputs`-builtin case), both with and without `--preserve-input`
- [x] New CLI tests: `test_preserve_input_number_spelling_survives_materializing_routes_2852`, `test_preserve_input_outer_document_survives_input_builtin_reindex_2852`
- [x] Local `cargo llvm-cov` confirms every new/changed line is exercised