### PR TITLE
fix(jq): accept and evaluate a computed key in a destructuring pattern (#2677)

### DIFF
--- a/docs/compliance/jq/limitations.md
+++ b/docs/compliance/jq/limitations.md
@@ -976,23 +976,32 @@ a plain `String` to `ObjectKey` (the same type object construction already used)
 `extract_pattern_bindings` (value mode)/`walk_pattern` (path mode) resolve the key expression
 against the pattern's own current node, using the same "Cannot index `<type>` with `<type>`"
 wording jq's own `INDEX` bytecode gives for any key, computed or literal — confirmed live in
-both positions, including nested computed keys and through `|=`/`del()`. **Scoped to a key
-expression that yields exactly one string** — the common case (`{(.k): $q}`, a string
-interpolation, which by construction can only ever yield one value). A key expression that is
-itself a multi-output *generator* (`{("a","b"): $q}` — real jq fans out one full pattern-match,
-and one full run of the surrounding body, per key it yields: `{"a":1,"b":2} \| . as
-{("a","b"):$q} \| $q` is `1` then `2`) refuses clearly instead — `extract_pattern_bindings`
-itself models the full cartesian-fold generator semantics real jq has, but every one of its
-eight call sites (across both evaluators, plus `reduce`/`foreach`'s own pre-loop substitution-
-matrix builders) collapses back to a single result via `extract_single_pattern_binding`, since
-fanning out correctly needs each call site's own `?//`-alternative-retry/fold-matrix machinery
-threaded through, not just the core function — not yet done. The same refusal covers a key
-expression producing **zero** outputs (`{(empty): $q}`, where real jq legitimately binds
-nothing and the body never runs, `[. as {(empty):$q} \| $q]` is `[]`) and one interrupted by
-`break`/`halt`, rather than risking a silently wrong answer at any of the eight sites
-individually. `test_pattern_computed_key_evaluates_2677`/
-`test_pattern_computed_key_multi_output_refuses_cleanly_2677` (`tests/jq_cli_tests.rs`) pin both
-halves.
+both positions, including nested computed keys and through `|=`/`del()`. A key expression that
+is itself a multi-output *generator* (`{("a","b"): $q}` — real jq fans out one full pattern-
+match, and one full run of the surrounding body, per key it yields: `{"a":1,"b":2} \| . as
+{("a","b"):$q} \| $q` is `1` then `2`) or a **zero**-output one (`{(empty): $q}`, where real jq
+legitimately binds nothing and the body never runs, `[. as {(empty):$q} \| $q]` is `[]`) now
+**fans out correctly in value position**: `each_pattern_alternatives`/
+`each_pattern_alternatives_generic` (the `?//`-alternative loops both evaluators route a bare,
+non-`?//` pattern through too) run `body` once per binding-set `extract_pattern_bindings`
+yields, applying the pre-#2677 match-failure retry rule only to the key generator's own
+trailing error/break/halt once every binding-set's body has run — including the two hardest
+interaction cases: a body error partway through a fan-out abandons the *remaining* key outputs
+and retries the next `?//` alternative, keeping whatever already ran (`[. as {("a","b"):$q} ?//
+$z \| if $q==2 then error("boom") else $q end]` on `{"a":1,"b":2}` is `[1,null]`), and a
+zero-output key still *wins* inside a `?//` chain (no fallthrough) even though it contributes
+nothing. `test_pattern_computed_key_fans_out_in_value_position_2677` (`tests/jq_cli_tests.rs`)
+pins both.
+
+**Path position does not fan out yet** — `walk_pattern`/`resolve_as_pattern`/
+`try_pattern_alternatives` still collapse to a single result via
+`extract_single_pattern_binding` and refuse a multi- or zero-output computed key cleanly
+(`test_pattern_computed_key_multi_output_refuses_in_path_position_2677`), the same reasoning
+that motivated `extract_single_pattern_binding` in the first place: fanning out correctly needs
+each call site's own retry/register machinery threaded through, not just the core function.
+`reduce`/`foreach`'s own pattern (`eval_reduce_with_values`/`substitute_foreach_steps`'s
+pre-loop substitution-matrix builders) is unaffected either way — a multi-output computed key
+there still refuses in both value and path position.
 
 A related, narrower gap the fix surfaced and closed along the way: `map_subexprs`
 (`src/jq/walk.rs`) — the shared tree-rewrite primitive `install_def_calls`/`bind_def` and

--- a/docs/compliance/jq/limitations.md
+++ b/docs/compliance/jq/limitations.md
@@ -969,6 +969,46 @@ key as a genuine, null-valued navigation — `path({} \| .foo)` is `["foo"]` —
 resolver's own carried-register fallback does not appear to model correctly), which is a
 separate, pre-existing investigation from this issue's own scope.
 
+A destructuring pattern's own **computed key** (`{(EXPR): P}`, or an interpolated string
+`{"\(EXPR)": P}`) parses and evaluates since
+[#2677](https://github.com/rust-works/succinctly/issues/2677) — `PatternEntry.key` widened from
+a plain `String` to `ObjectKey` (the same type object construction already used), and
+`extract_pattern_bindings` (value mode)/`walk_pattern` (path mode) resolve the key expression
+against the pattern's own current node, using the same "Cannot index `<type>` with `<type>`"
+wording jq's own `INDEX` bytecode gives for any key, computed or literal — confirmed live in
+both positions, including nested computed keys and through `|=`/`del()`. **Scoped to a key
+expression that yields exactly one string** — the common case (`{(.k): $q}`, a string
+interpolation, which by construction can only ever yield one value). A key expression that is
+itself a multi-output *generator* (`{("a","b"): $q}` — real jq fans out one full pattern-match,
+and one full run of the surrounding body, per key it yields: `{"a":1,"b":2} \| . as
+{("a","b"):$q} \| $q` is `1` then `2`) refuses clearly instead — `extract_pattern_bindings`
+itself models the full cartesian-fold generator semantics real jq has, but every one of its
+eight call sites (across both evaluators, plus `reduce`/`foreach`'s own pre-loop substitution-
+matrix builders) collapses back to a single result via `extract_single_pattern_binding`, since
+fanning out correctly needs each call site's own `?//`-alternative-retry/fold-matrix machinery
+threaded through, not just the core function — not yet done. The same refusal covers a key
+expression producing **zero** outputs (`{(empty): $q}`, where real jq legitimately binds
+nothing and the body never runs, `[. as {(empty):$q} \| $q]` is `[]`) and one interrupted by
+`break`/`halt`, rather than risking a silently wrong answer at any of the eight sites
+individually. `test_pattern_computed_key_evaluates_2677`/
+`test_pattern_computed_key_multi_output_refuses_cleanly_2677` (`tests/jq_cli_tests.rs`) pin both
+halves.
+
+A related, narrower gap the fix surfaced and closed along the way: `map_subexprs`
+(`src/jq/walk.rs`) — the shared tree-rewrite primitive `install_def_calls`/`bind_def` and
+`substitute_var_impl` both build on — cloned a pattern's own `patterns` field verbatim in its
+`Reduce`/`Foreach`/`AsPattern` arms rather than descending into it, a premise ("a pattern holds
+only destructuring names, never an `Expr`") that held before #2677 and silently broke once a
+computed key gave a pattern entry a real `Expr` to hold. Concretely, `def f: "a"; . as {(f):$q}
+\| $q` wrongly raised "undefined function: f/0" even though `f` *is* defined, and an outer
+`$var` referenced inside a computed key was left unsubstituted — both fixed by a new
+`map_pattern_subexprs` helper. Three siblings with the analogous gap — `any_subexpr`,
+`node_reads_ambient`, and `resolve::check` (`src/jq/resolve.rs`) not descending into a computed
+key either — are, confirmed live, in the safe direction only (a missed static-analysis
+optimization, or jq's own compile-time "undefined function" check surfacing one stage later as
+a runtime error instead of at parse time) and are left for #2677's own remaining
+walker-invariant audit.
+
 **Fixed by [#1467](https://github.com/rust-works/succinctly/issues/1467),
 [#1872](https://github.com/rust-works/succinctly/issues/1872),
 [#2031](https://github.com/rust-works/succinctly/issues/2031) and

--- a/docs/compliance/jq/limitations.md
+++ b/docs/compliance/jq/limitations.md
@@ -974,24 +974,36 @@ A destructuring pattern's own **computed key** (`{(EXPR): P}`, or an interpolate
 [#2677](https://github.com/rust-works/succinctly/issues/2677) — `PatternEntry.key` widened from
 a plain `String` to `ObjectKey` (the same type object construction already used), and
 `extract_pattern_bindings` (value mode)/`walk_pattern` (path mode) resolve the key expression
-against the pattern's own current node, using the same "Cannot index `<type>` with `<type>`"
-wording jq's own `INDEX` bytecode gives for any key, computed or literal — confirmed live in
-both positions, including nested computed keys and through `|=`/`del()`. A key expression that
-is itself a multi-output *generator* (`{("a","b"): $q}` — real jq fans out one full pattern-
-match, and one full run of the surrounding body, per key it yields: `{"a":1,"b":2} \| . as
-{("a","b"):$q} \| $q` is `1` then `2`) or a **zero**-output one (`{(empty): $q}`, where real jq
-legitimately binds nothing and the body never runs, `[. as {(empty):$q} \| $q]` is `[]`) now
-**fans out correctly in value position**: `each_pattern_alternatives`/
-`each_pattern_alternatives_generic` (the `?//`-alternative loops both evaluators route a bare,
-non-`?//` pattern through too) run `body` once per binding-set `extract_pattern_bindings`
-yields, applying the pre-#2677 match-failure retry rule only to the key generator's own
-trailing error/break/halt once every binding-set's body has run — including the two hardest
-interaction cases: a body error partway through a fan-out abandons the *remaining* key outputs
-and retries the next `?//` alternative, keeping whatever already ran (`[. as {("a","b"):$q} ?//
-$z \| if $q==2 then error("boom") else $q end]` on `{"a":1,"b":2}` is `[1,null]`), and a
-zero-output key still *wins* inside a `?//` chain (no fallthrough) even though it contributes
-nothing. `test_pattern_computed_key_fans_out_in_value_position_2677` (`tests/jq_cli_tests.rs`)
-pins both.
+against the pattern's own current node via `index_one_owned`, the same generic `.[EXPR]`
+operator used elsewhere (`nth`, `(.a\|tostring)[$k]`) — so a computed key can resolve to a
+*string* (indexing an object) or a *number* (indexing an array, with jq's own float-truncation
+and negative-index wraparound, `path(.arr as {(-1):$q}\|$q)` on an array giving `[-1]`, the raw
+key, matching `path(.arr[-1])`) exactly like `.[EXPR]` does, in both value and path position,
+using the same "Cannot index `<type>` with `<type>`" wording jq's own `INDEX` bytecode gives for
+any key, computed or literal — confirmed live in both positions, including nested computed keys
+and through `\|=`/`del()`. (PR #2873 review caught and fixed an initial version of this that
+unconditionally required a string key, wrongly rejecting a numeric key against an array.)
+
+A key expression that is itself a multi-output *generator* (`{("a","b"): $q}` — real jq fans out
+one full pattern-match, and one full run of the surrounding body, per key it yields:
+`{"a":1,"b":2} \| . as {("a","b"):$q} \| $q` is `1` then `2`) or a **zero**-output one
+(`{(empty): $q}`, where real jq legitimately binds nothing and the body never runs, `[. as
+{(empty):$q} \| $q]` is `[]`) now **fans out correctly in value position**:
+`each_pattern_alternatives`/`each_pattern_alternatives_generic` (the `?//`-alternative loops both
+evaluators route a bare, non-`?//` pattern through too) run `body` once per binding-set
+`extract_pattern_bindings` yields, applying the pre-#2677 match-failure retry rule only to the
+key generator's own trailing error/break/halt once every binding-set's body has run — including
+the two hardest interaction cases: a body error partway through a fan-out abandons the
+*remaining* key outputs and retries the next `?//` alternative, keeping whatever already ran
+(`[. as {("a","b"):$q} ?// $z \| if $q==2 then error("boom") else $q end]` on `{"a":1,"b":2}` is
+`[1,null]`), and a zero-output key still *wins* inside a `?//` chain (no fallthrough) even though
+it contributes nothing. `test_pattern_computed_key_fans_out_in_value_position_2677`
+(`tests/jq_cli_tests.rs`) pins both. A third interaction case PR #2873 review found and fixed:
+`key_control` (the key generator's own trailing control, e.g. a `Halt` its *last*, never-bound
+output raised) is computed eagerly, before any binding-set's body runs — an earlier binding-set's
+body already deciding to retry the next `?//` alternative must not silently drop a pending
+`Halt`/uncatchable `Error` that trailing control carries; both evaluators now check it first,
+with priority over any retry decision (`test_pattern_computed_key_review_fixes_2873`).
 
 **Path position does not fan out yet** — `walk_pattern`/`resolve_as_pattern`/
 `try_pattern_alternatives` still collapse to a single result via
@@ -1001,7 +1013,14 @@ that motivated `extract_single_pattern_binding` in the first place: fanning out 
 each call site's own retry/register machinery threaded through, not just the core function.
 `reduce`/`foreach`'s own pattern (`eval_reduce_with_values`/`substitute_foreach_steps`'s
 pre-loop substitution-matrix builders) is unaffected either way — a multi-output computed key
-there still refuses in both value and path position.
+there still refuses in both value and path position. Tracked as follow-up
+[#2872](https://github.com/rust-works/succinctly/issues/2872), alongside `walk_pattern`'s own
+narrower gap that a `Halt`/`Break` interrupting a computed key's generator in path position (or
+in `reduce`/`foreach`'s own pattern) currently downgrades to an ordinary, catchable refusal
+rather than true uncatchable/unwind semantics — a real, but bounded, fidelity gap (still a clean
+refusal, never a wrong value), left for that same follow-up rather than the deeper
+`Result<_, EvalError>` → `Result<_, EvalEscape>` signature change `walk_pattern` would need to
+carry a real `Halt`/`Break` through path-tracking's register machinery.
 
 A related, narrower gap the fix surfaced and closed along the way: `map_subexprs`
 (`src/jq/walk.rs`) — the shared tree-rewrite primitive `install_def_calls`/`bind_def` and
@@ -1011,12 +1030,20 @@ only destructuring names, never an `Expr`") that held before #2677 and silently 
 computed key gave a pattern entry a real `Expr` to hold. Concretely, `def f: "a"; . as {(f):$q}
 \| $q` wrongly raised "undefined function: f/0" even though `f` *is* defined, and an outer
 `$var` referenced inside a computed key was left unsubstituted — both fixed by a new
-`map_pattern_subexprs` helper. Three siblings with the analogous gap — `any_subexpr`,
-`node_reads_ambient`, and `resolve::check` (`src/jq/resolve.rs`) not descending into a computed
-key either — are, confirmed live, in the safe direction only (a missed static-analysis
-optimization, or jq's own compile-time "undefined function" check surfacing one stage later as
-a runtime error instead of at parse time) and are left for #2677's own remaining
-walker-invariant audit.
+`map_pattern_subexprs` helper. PR #2873 review found the identical gap in two more,
+separate hand-written traversals `map_subexprs` does not cover: `substitute_func_param_impl`
+(a `$`-style `def` parameter referenced inside a computed key was never substituted, `def
+f($x): . as {($x): $y} \| $y; f("a")` wrongly raised "undefined variable: $x") and
+`substitute_var_impl`'s own shadow-guarded `Reduce`/`Foreach`/`AsPattern` arms (when the
+pattern's *own* binding shadows the outer variable for its body, the computed key — which
+resolves *before* that shadow takes effect — must still see the outer value, `"a" as $x \| (.
+as {($x): $x} \| $x)` wrongly raised the same "undefined variable" error). Both fixed the same
+way, with `map_pattern_subexprs` wired into their own `Reduce`/`Foreach`/`AsPattern` arms.
+Three siblings with the analogous gap — `any_subexpr`, `node_reads_ambient`, and
+`resolve::check` (`src/jq/resolve.rs`) not descending into a computed key either — are,
+confirmed live, in the safe direction only (a missed static-analysis optimization, or jq's own
+compile-time "undefined function" check surfacing one stage later as a runtime error instead of
+at parse time) and are left for the same #2872 follow-up's walker-invariant audit.
 
 **Fixed by [#1467](https://github.com/rust-works/succinctly/issues/1467),
 [#1872](https://github.com/rust-works/succinctly/issues/1872),

--- a/docs/reference/jq-language.md
+++ b/docs/reference/jq-language.md
@@ -142,14 +142,17 @@ below and [ADR-0019](../adrs/adr-0019.md).
 - [x] `as $var | expr` - Variable binding
 - [x] Object/array destructuring patterns
 - [x] A computed or interpolated key in an object destructuring pattern --
-      `{(EXPR): $var}`, `{"\(EXPR)": $var}` (#2677) -- for the common case, a
-      key expression yielding exactly one string, in both value position and
-      inside `path()`/`del()`/an assignment target, including nested
-      computed keys. A key expression that is itself a multi-output
-      *generator* (`{("a","b"): $var}`, which real jq fans out into one full
-      pattern-match per key it yields) is not yet supported and refuses
-      clearly rather than keeping only the first output or dropping the
-      rest -- see [docs/compliance/jq/limitations.md](../compliance/jq/limitations.md).
+      `{(EXPR): $var}`, `{"\(EXPR)": $var}` (#2677) -- for a key expression
+      yielding exactly one string, in both value position and inside
+      `path()`/`del()`/an assignment target, including nested computed keys.
+      A key expression that is itself a multi-output *generator*
+      (`{("a","b"): $var}`, which real jq fans out into one full
+      pattern-match per key it yields, including through `?//` retry) is
+      also supported in value position (`. as PATTERN | body`); the same
+      fan-out inside `path()`/an assignment target, and inside `reduce`/
+      `foreach`'s own pattern, is not yet supported and refuses clearly
+      rather than keeping only the first output or dropping the rest --
+      see [docs/compliance/jq/limitations.md](../compliance/jq/limitations.md).
 - [x] `reduce expr as $x (init; update)`
 - [x] `foreach expr as $x (init; update)` / `foreach ... (init; update; extract)`
 - [x] A full destructuring pattern in `reduce`/`foreach`'s own `as` clause —

--- a/docs/reference/jq-language.md
+++ b/docs/reference/jq-language.md
@@ -141,6 +141,15 @@ below and [ADR-0019](../adrs/adr-0019.md).
 ### Variables & Control Flow
 - [x] `as $var | expr` - Variable binding
 - [x] Object/array destructuring patterns
+- [x] A computed or interpolated key in an object destructuring pattern --
+      `{(EXPR): $var}`, `{"\(EXPR)": $var}` (#2677) -- for the common case, a
+      key expression yielding exactly one string, in both value position and
+      inside `path()`/`del()`/an assignment target, including nested
+      computed keys. A key expression that is itself a multi-output
+      *generator* (`{("a","b"): $var}`, which real jq fans out into one full
+      pattern-match per key it yields) is not yet supported and refuses
+      clearly rather than keeping only the first output or dropping the
+      rest -- see [docs/compliance/jq/limitations.md](../compliance/jq/limitations.md).
 - [x] `reduce expr as $x (init; update)`
 - [x] `foreach expr as $x (init; update)` / `foreach ... (init; update; extract)`
 - [x] A full destructuring pattern in `reduce`/`foreach`'s own `as` clause —

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -5864,73 +5864,117 @@ fn each_pattern_alternatives<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     for (i, pattern) in patterns.iter().enumerate() {
         let is_last = i == last_idx;
 
-        let bindings = match extract_single_pattern_binding::<S>(pattern, bound_val, invert_dedup) {
-            Ok(b) => b,
-            Err(e) => {
-                if is_last {
+        // #2677: a computed key's own generator can yield more than one
+        // binding-set (`{("a","b"):$q}` fans out one full run of `body` per
+        // key it yields, jq's own nested-fork compilation of
+        // `gen_object_matcher`) -- every binding-set here runs `body` in
+        // turn, *not* a try-until-one-succeeds loop like the alternatives
+        // loop itself; only once every binding-set's own body has run does
+        // this alternative's own trailing `control` (the key generator's
+        // own error/break/halt, or a structural mismatch) get the *same*
+        // is_last/continue retry treatment the pre-#2677 single-binding-set
+        // shape already gave a match failure. A body failure partway
+        // through the fan-out abandons the *remaining* binding-sets of
+        // this same alternative (jq's single-threaded generator model) and
+        // retries the next `?//` alternative from there -- confirmed live:
+        // `[. as {("a","b"):$q} ?// $z | if $q==2 then error("boom") else
+        // $q end]` on `{"a":1,"b":2}` is `[1,null]` (the first output
+        // survives, "b"'s own binding-set is never tried, and the retried
+        // `$z` alternative's own `$q` is unbound -> null).
+        let (binding_sets, key_control) =
+            extract_pattern_bindings::<S>(pattern, bound_val, invert_dedup);
+
+        let mut retry_next_alternative = false;
+        for bindings in &binding_sets {
+            let null_value = OwnedValue::Null;
+            let substituted_body = substitute_vars(
+                body,
+                as_var_refs(bindings).chain(
+                    all_var_names
+                        .iter()
+                        .filter(|name| !bindings.iter().any(|(n, _)| n == *name))
+                        .map(|name| (name.as_str(), &null_value)),
+                ),
+            );
+
+            // #2180 WP3 review: cleared per attempt, so what the retry
+            // decision below reads is exactly "did this attempt's own
+            // evaluation end in a `Halt`/decode failure a driver had to
+            // stash out-of-band" -- see [`nonretryable_stop`].
+            clear_nonretryable_stop();
+            match eval_each::<W, S>(&substituted_body, value.clone(), optional, sink) {
+                Flow::Exhausted => {}
+                // #1519: a satisfied consumer is jq's escaping `break`, so
+                // it retries the next alternative just like `Control::Break`
+                // below. `pending` is dropped on the retry rather than
+                // carried: it is only ever `Some` when an eager fallback had
+                // already raised a trailing control before the stop, and
+                // real jq -- which would never have evaluated that far --
+                // ignores it, the same reasoning `builtin_isempty` records
+                // at its own `Flow::Stopped` arm.
+                Flow::Stopped { pending } => {
+                    if is_retryable_stop(is_last) {
+                        retry_next_alternative = true;
+                        break;
+                    }
+                    return Flow::Stopped { pending };
+                }
+                // #1620/#1660: same uncatchable exclusion as
+                // `try_pattern_alternatives` -- always propagates, `is_last`
+                // or not. #2132 widened it from `is_decode_failure()` to the
+                // shared value-position predicate: a resource cap raised
+                // inside a `?//` body was read as "this alternative failed,
+                // try the next", and the truncated body passed as the next
+                // alternative's clean answer.
+                Flow::Escaped(Control::Error(e)) if e.is_uncatchable_at_value_position() => {
                     return Flow::Escaped(Control::Error(e));
                 }
-                continue;
-            }
-        };
-
-        let null_value = OwnedValue::Null;
-        let substituted_body = substitute_vars(
-            body,
-            as_var_refs(&bindings).chain(
-                all_var_names
-                    .iter()
-                    .filter(|name| !bindings.iter().any(|(n, _)| n == *name))
-                    .map(|name| (name.as_str(), &null_value)),
-            ),
-        );
-
-        // #2180 WP3 review: cleared per attempt, so what the retry decision
-        // below reads is exactly "did this attempt's own evaluation end in a
-        // `Halt`/decode failure a driver had to stash out-of-band" -- see
-        // [`nonretryable_stop`].
-        clear_nonretryable_stop();
-        match eval_each::<W, S>(&substituted_body, value.clone(), optional, sink) {
-            Flow::Exhausted => return Flow::Exhausted,
-            // #1519: a satisfied consumer is jq's escaping `break`, so it
-            // retries the next alternative just like `Control::Break` below.
-            // `pending` is dropped on the retry rather than carried: it is
-            // only ever `Some` when an eager fallback had already raised a
-            // trailing control before the stop, and real jq -- which would
-            // never have evaluated that far -- ignores it, the same reasoning
-            // `builtin_isempty` records at its own `Flow::Stopped` arm.
-            Flow::Stopped { pending } => {
-                if is_retryable_stop(is_last) {
-                    continue;
+                // #1457: `Break` falls through like `Error`, not immediately
+                // like `Halt` -- same live-verified correction
+                // `try_pattern_alternatives` itself documents.
+                Flow::Escaped(Control::Error(e)) => {
+                    if is_last {
+                        return Flow::Escaped(Control::Error(e));
+                    }
+                    retry_next_alternative = true;
+                    break;
                 }
-                return Flow::Stopped { pending };
+                Flow::Escaped(Control::Break(label)) => {
+                    if is_last {
+                        return Flow::Escaped(Control::Break(label));
+                    }
+                    retry_next_alternative = true;
+                    break;
+                }
+                Flow::Escaped(Control::Halt(code)) => return Flow::Escaped(Control::Halt(code)),
             }
-            // #1620/#1660: same uncatchable exclusion as
-            // `try_pattern_alternatives` -- always propagates, `is_last` or
-            // not. #2132 widened it from `is_decode_failure()` to the shared
-            // value-position predicate: a resource cap raised inside a `?//`
-            // body was read as "this alternative failed, try the next", and
-            // the truncated body passed as the next alternative's clean
-            // answer.
-            Flow::Escaped(Control::Error(e)) if e.is_uncatchable_at_value_position() => {
+        }
+        if retry_next_alternative {
+            continue;
+        }
+
+        // Every binding-set's own body ran to completion. Now the key
+        // generator's *own* trailing control (if it stopped early rather
+        // than exhausting) gets the same is_last/continue treatment a
+        // pre-#2677 match failure already had.
+        match key_control {
+            None => return Flow::Exhausted,
+            Some(Control::Error(e)) if e.is_uncatchable_at_value_position() => {
                 return Flow::Escaped(Control::Error(e));
             }
-            // #1457: `Break` falls through like `Error`, not immediately
-            // like `Halt` -- same live-verified correction
-            // `try_pattern_alternatives` itself documents.
-            Flow::Escaped(Control::Error(e)) => {
+            Some(Control::Error(e)) => {
                 if is_last {
                     return Flow::Escaped(Control::Error(e));
                 }
                 continue;
             }
-            Flow::Escaped(Control::Break(label)) => {
+            Some(Control::Break(label)) => {
                 if is_last {
                     return Flow::Escaped(Control::Break(label));
                 }
                 continue;
             }
-            Flow::Escaped(Control::Halt(code)) => return Flow::Escaped(Control::Halt(code)),
+            Some(Control::Halt(code)) => return Flow::Escaped(Control::Halt(code)),
         }
     }
 

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -44,7 +44,7 @@ use super::document::{
     DocumentElements, DocumentFields,
 };
 use super::slice::{self, SliceBounds};
-use super::walk::{any_subexpr, map_builtin_subexprs, map_subexprs};
+use super::walk::{any_subexpr, map_builtin_subexprs, map_pattern_subexprs, map_subexprs};
 
 /// Which `EvalSemantics` implementor a value carries, as a runtime tag.
 ///
@@ -5949,6 +5949,25 @@ fn each_pattern_alternatives<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
                 Flow::Escaped(Control::Halt(code)) => return Flow::Escaped(Control::Halt(code)),
             }
         }
+        // #2873 review: `key_control` was computed eagerly, before any
+        // binding-set's body ran, so a `Halt` (or an uncatchable `Error`) it
+        // carries already happened -- real jq's own uncatchability rule
+        // (`Control`'s own doc comment) means it must win regardless of
+        // whatever an *earlier* binding-set's body already decided about
+        // retrying the next `?//` alternative. Dropping it here (behind the
+        // `retry_next_alternative` check below) silently turned a real
+        // `halt`/`halt_error` into an ordinary alternative fallthrough --
+        // confirmed live: `. as {("a", halt_error(7)):$q} ?// $z | if
+        // $q==1 then error("boom") else ($q // $z) end` on `{"a":1}` must
+        // halt (exit 7), not fall through to `$z`.
+        match &key_control {
+            Some(Control::Halt(code)) => return Flow::Escaped(Control::Halt(*code)),
+            Some(Control::Error(e)) if e.is_uncatchable_at_value_position() => {
+                return Flow::Escaped(Control::Error(e.clone()));
+            }
+            _ => {}
+        }
+
         if retry_next_alternative {
             continue;
         }
@@ -5956,12 +5975,10 @@ fn each_pattern_alternatives<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
         // Every binding-set's own body ran to completion. Now the key
         // generator's *own* trailing control (if it stopped early rather
         // than exhausting) gets the same is_last/continue treatment a
-        // pre-#2677 match failure already had.
+        // pre-#2677 match failure already had. `Halt` and an uncatchable
+        // `Error` were already handled above.
         match key_control {
             None => return Flow::Exhausted,
-            Some(Control::Error(e)) if e.is_uncatchable_at_value_position() => {
-                return Flow::Escaped(Control::Error(e));
-            }
             Some(Control::Error(e)) => {
                 if is_last {
                     return Flow::Escaped(Control::Error(e));
@@ -5974,7 +5991,7 @@ fn each_pattern_alternatives<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
                 }
                 continue;
             }
-            Some(Control::Halt(code)) => return Flow::Escaped(Control::Halt(code)),
+            Some(Control::Halt(_)) => unreachable!("handled above"),
         }
     }
 
@@ -30601,7 +30618,16 @@ struct PatternBinding {
 /// [`walk_pattern_step`]).
 enum PatternStep<'a> {
     Field(&'a str),
-    Index(usize),
+    /// A signed array index, matching `.[EXPR]`'s own path-recording rule:
+    /// `path(.[-1])` on real jq is `[-1]`, the *raw* key, not the
+    /// wraparound-resolved position -- `child()` below resolves the
+    /// wraparound only when actually reading the element, same as
+    /// `index_one_owned`. Every pre-#2873 call site (array-pattern
+    /// positional matching, `[$a,$b]`) only ever builds this from a small
+    /// non-negative `usize` position, so widening from `usize` to `i64`
+    /// (#2873, to carry a computed key's own possibly-negative/out-of-range
+    /// numeric value) changes nothing for that existing caller.
+    Index(i64),
 }
 
 impl PatternStep<'_> {
@@ -30609,10 +30635,7 @@ impl PatternStep<'_> {
     fn component(&self) -> Expr {
         match self {
             Self::Field(key) => Expr::Field((*key).to_string()),
-            Self::Index(i) => Expr::Index {
-                idx: *i as i64,
-                key: None,
-            },
+            Self::Index(i) => Expr::Index { idx: *i, key: None },
         }
     }
 
@@ -30635,7 +30658,16 @@ impl PatternStep<'_> {
                 key,
             )),
             (Self::Index(i), OwnedValue::Array(arr)) => {
-                Ok(arr.get(*i).cloned().unwrap_or(OwnedValue::Null))
+                // #2873: wraparound-resolve a negative index the same way
+                // `index_one_owned` does -- a pre-#2873 caller always passes
+                // a non-negative position, so this is a no-op there.
+                let resolved = if *i < 0 { arr.len() as i64 + *i } else { *i };
+                let element = usize::try_from(resolved)
+                    .ok()
+                    .and_then(|idx| arr.get(idx))
+                    .cloned()
+                    .unwrap_or(OwnedValue::Null);
+                Ok(element)
             }
             (Self::Index(_), _) => Err(EvalError::cannot_index_with_type(
                 owned_type_name(input),
@@ -30643,6 +30675,19 @@ impl PatternStep<'_> {
             )),
         }
     }
+}
+
+/// A computed key's resolved value, ahead of building the [`PatternStep`]
+/// it drives (#2873): a string indexes an object by field, a number indexes
+/// an array by position -- jq's generic `INDEX` bytecode, not an
+/// object-only special case. Kept separate from `PatternStep` itself
+/// because the two live at different points in `walk_pattern`'s Object
+/// arm: this is resolved once per entry (from either a literal or a
+/// computed key expression), `PatternStep` is built from it fresh right
+/// before each step.
+enum ResolvedPatternKey<'a> {
+    Field(Cow<'a, str>),
+    Index(i64),
 }
 
 /// Perform one tracked pattern step from `input`, returning the child value
@@ -30755,14 +30800,32 @@ fn walk_pattern<S: EvalSemantics>(
                 // -- see `extract_single_pattern_binding`'s own doc comment
                 // for why 0/2+/break/halt refuse clearly here too rather
                 // than being modelled.
-                let key: Cow<'_, str> = match &entry.key {
-                    ObjectKey::Literal(key) => Cow::Borrowed(key.as_str()),
+                let key: ResolvedPatternKey = match &entry.key {
+                    ObjectKey::Literal(key) => {
+                        ResolvedPatternKey::Field(Cow::Borrowed(key.as_str()))
+                    }
                     ObjectKey::Expr(key_expr) => {
                         let (mut key_values, control) =
                             eval_owned_expr_fork::<S>(key_expr, input, false);
                         match (key_values.len(), control) {
                             (1, None) => match key_values.pop().unwrap() {
-                                OwnedValue::String(s) => Cow::Owned(s),
+                                OwnedValue::String(s) => ResolvedPatternKey::Field(Cow::Owned(s)),
+                                // #2873 review: real jq's `INDEX` bytecode is
+                                // generic, not object-only -- a numeric
+                                // computed key indexes an array target
+                                // exactly like `.[EXPR]` does in value mode
+                                // (`fold_object_pattern_entry`'s identical
+                                // fix and doc comment). A NaN key has no
+                                // index, matching `numeric_key_to_index`'s
+                                // own contract -- `i64::MAX` is a plain
+                                // guaranteed-out-of-range sentinel `child()`
+                                // resolves to `null`, not a real path
+                                // position.
+                                v @ (OwnedValue::Int(_)
+                                | OwnedValue::Float(_)
+                                | OwnedValue::NumberLiteral(..)) => ResolvedPatternKey::Index(
+                                    numeric_key_to_index(&v).unwrap_or(i64::MAX),
+                                ),
                                 other => {
                                     return Err(EvalError::cannot_index_with_type(
                                         owned_type_name(input),
@@ -30782,7 +30845,10 @@ fn walk_pattern<S: EvalSemantics>(
                         }
                     }
                 };
-                let step = PatternStep::Field(&key);
+                let step = match &key {
+                    ResolvedPatternKey::Field(s) => PatternStep::Field(s),
+                    ResolvedPatternKey::Index(i) => PatternStep::Index(*i),
+                };
                 let (child, moved) = walk_pattern_step(&step, input, &reg)?;
                 // `{$b: P}`: the bind names the node the register just moved
                 // to, so it carries that position's marker, and is pushed
@@ -30809,7 +30875,7 @@ fn walk_pattern<S: EvalSemantics>(
                     reg.is_input = false;
                 }
                 first = false;
-                let step = PatternStep::Index(i);
+                let step = PatternStep::Index(i as i64);
                 let (child, moved) = walk_pattern_step(&step, input, &reg)?;
                 reg = walk_pattern::<S>(pat, &child, moved, frame, out)?;
             }
@@ -35443,7 +35509,23 @@ fn substitute_var_impl(
             update,
         } if patterns.iter().any(|p| pattern_binds_var(p, var_name)) => Expr::Reduce {
             input: Box::new(substitute_var_impl(input, var_name, replacement, mark)),
-            patterns: patterns.clone(),
+            // #2873 review: the pattern's *own* binding shadows `var_name`
+            // for `update`, which stays unsubstituted below -- but a
+            // computed key inside the pattern resolves against the
+            // pattern's current node *before* that shadow takes effect
+            // (jq evaluates the key ahead of binding), so an outer
+            // `var_name` reference inside it must still be substituted.
+            // Same gap class `map_subexprs` itself fixed (#2677's own
+            // `c15aa1287`), missed here because this is a separate,
+            // hand-written traversal.
+            patterns: patterns
+                .iter()
+                .map(|p| {
+                    map_pattern_subexprs(p, &mut |e| {
+                        substitute_var_impl(e, var_name, replacement, mark)
+                    })
+                })
+                .collect(),
             init: Box::new(substitute_var_impl(init, var_name, replacement, mark)),
             update: update.clone(), // shadowed
         },
@@ -35455,7 +35537,16 @@ fn substitute_var_impl(
             extract,
         } if patterns.iter().any(|p| pattern_binds_var(p, var_name)) => Expr::Foreach {
             input: Box::new(substitute_var_impl(input, var_name, replacement, mark)),
-            patterns: patterns.clone(),
+            // #2873 review: see the identical `Expr::Reduce` arm's comment
+            // just above.
+            patterns: patterns
+                .iter()
+                .map(|p| {
+                    map_pattern_subexprs(p, &mut |e| {
+                        substitute_var_impl(e, var_name, replacement, mark)
+                    })
+                })
+                .collect(),
             init: Box::new(substitute_var_impl(init, var_name, replacement, mark)),
             update: update.clone(),
             extract: extract.clone(),
@@ -35470,7 +35561,15 @@ fn substitute_var_impl(
             body,
         } if patterns.iter().any(|p| pattern_binds_var(p, var_name)) => Expr::AsPattern {
             expr: Box::new(substitute_var_impl(expr, var_name, replacement, mark)),
-            patterns: patterns.clone(),
+            // #2873 review: see `Expr::Reduce`'s identical comment above.
+            patterns: patterns
+                .iter()
+                .map(|p| {
+                    map_pattern_subexprs(p, &mut |e| {
+                        substitute_var_impl(e, var_name, replacement, mark)
+                    })
+                })
+                .collect(),
             body: body.clone(),
         },
         Expr::FuncDef {
@@ -49526,40 +49625,83 @@ fn fold_object_pattern_entry<S: EvalSemantics>(
         ObjectKey::Expr(key_expr) => eval_owned_expr_fork::<S>(key_expr, value, false),
     };
 
-    let mut new_frontier = Vec::new();
-    for key_value in &key_values {
-        let key = match key_value {
-            OwnedValue::String(s) => s,
-            other => {
-                // #2677: a computed key evaluating to a non-string is the
-                // pattern's own `INDEX`-shaped refusal, not construction's
-                // "Cannot use ... as object key" (that's a different jq
-                // bytecode op) -- confirmed live: `. as {(.n):$q} | $q` on
-                // `{"a":1,"n":1}` raises "Cannot index object with number".
-                // A bare non-string *literal* key (`{(1):$q}`) is a
-                // compile-time check in real jq, not modelled here --
-                // matching object construction's own pre-existing,
-                // out-of-scope gap for the identical shape (`{(1): 1}`,
-                // #2677's own triage explicitly scopes this out).
-                let err = EvalError::cannot_index_with_type(
-                    owned_type_name(value),
-                    owned_type_name(other),
-                );
-                return (new_frontier, Some(Control::Error(err)));
-            }
+    // #2873 perf review: the overwhelmingly common pattern -- literal keys
+    // only, nowhere in this entry or its sub-pattern -- always keeps
+    // `key_values`/`frontier`/`sub_results` at length 1, so the general
+    // `frontier × key_values × sub_results` cartesian fold below (needed
+    // once a computed key can fan out to 2+ outputs) would still pay an
+    // extra `partial.clone()` per pattern entry, turning what used to be an
+    // O(1)-amortized `Vec::extend` per entry back into an O(entries) clone
+    // per entry -- on the hot `.[] as {...}` path. `key_values.len() == 1`
+    // is known up front and guarantees the loop below runs exactly once,
+    // so this fast path is handled entirely outside it (letting the
+    // borrow checker see `frontier` is moved at most once), consuming
+    // `frontier`/`sub_results` in place instead of cloning.
+    if key_values.len() == 1 {
+        let key_value = &key_values[0];
+        let field_value = match index_one_owned(value, key_value, false) {
+            Ok(Some(v)) => v,
+            Ok(None) => unreachable!("index_one_owned(.., optional: false) never suppresses"),
+            Err(err) => return (Vec::new(), Some(Control::Error(err))),
         };
-        // jq destructures by indexing once per key, so a non-object target
-        // reports exactly what `.<key>` would.
-        let obj = match value {
-            OwnedValue::Object(o) => o,
-            _ => {
-                let err = EvalError::cannot_index_with_field(owned_type_name(value), key);
-                return (new_frontier, Some(Control::Error(err)));
-            }
-        };
-        let field_value = obj.get(key).cloned().unwrap_or(OwnedValue::Null);
         let (sub_results, sub_control) =
             extract_pattern_bindings::<S>(&entry.pattern, &field_value, invert);
+        // `sub_control` (the sub-pattern's own trailing control) takes
+        // priority when present, matching the general loop's immediate
+        // `return` on a `Some(control)`; when it's `None`, the single
+        // key_value's processing has run to completion, so this is exactly
+        // the "loop finished normally" case the general path falls through
+        // to `(new_frontier, key_control)` for -- `key_control` is the
+        // *key generator's own* trailing control (e.g. `Some(Halt(_))` from
+        // `{("a", halt_error(7)):$q}`'s second output) and must not be
+        // dropped here (#2873 review: an earlier version of this fast path
+        // did exactly that).
+        if frontier.len() == 1 && sub_results.len() == 1 {
+            let mut combined = frontier.into_iter().next().unwrap();
+            if let Some(bind) = &entry.bind {
+                combined.push((bind.clone(), field_value.clone()));
+            }
+            combined.extend(sub_results.into_iter().next().unwrap());
+            return (vec![combined], sub_control.or(key_control));
+        }
+        let mut new_frontier = Vec::new();
+        for partial in &frontier {
+            for sub in &sub_results {
+                let mut combined = partial.clone();
+                if let Some(bind) = &entry.bind {
+                    combined.push((bind.clone(), field_value.clone()));
+                }
+                combined.extend(sub.iter().cloned());
+                new_frontier.push(combined);
+            }
+        }
+        return (new_frontier, sub_control.or(key_control));
+    }
+
+    let mut new_frontier = Vec::new();
+    for key_value in &key_values {
+        // real jq's `INDEX` bytecode is generic, not object-only -- a
+        // computed key can resolve to a *number* and index into an *array*
+        // target exactly like `.[EXPR]` does (confirmed live: `def one: 1;
+        // [10,20,30] as {(one):$q} | $q` is `20` in real jq; a bare
+        // non-string *literal* key like `{(1):$q}` is instead a
+        // compile-time check in real jq, not modelled here, matching object
+        // construction's own pre-existing, out-of-scope gap for the
+        // identical shape). [`index_one_owned`] is the same generic
+        // `.[EXPR]` operator's owned-value implementation used elsewhere
+        // (`nth`, `(.a|tostring)[$k]`), so reusing it here gets jq's own
+        // object/array/null dispatch, key-type errors ("Cannot index
+        // <type> with <type>"/"Cannot index <type> with string \"...\""),
+        // float truncation and negative-index wraparound for free instead
+        // of a narrower, string-only special case.
+        let field_value = match index_one_owned(value, key_value, false) {
+            Ok(Some(v)) => v,
+            Ok(None) => unreachable!("index_one_owned(.., optional: false) never suppresses"),
+            Err(err) => return (new_frontier, Some(Control::Error(err))),
+        };
+        let (sub_results, sub_control) =
+            extract_pattern_bindings::<S>(&entry.pattern, &field_value, invert);
+
         for partial in &frontier {
             for sub in &sub_results {
                 let mut combined = partial.clone();
@@ -50828,7 +50970,21 @@ fn substitute_func_param_impl(expr: &Expr, param: &str, arg: &Expr, scope: Subst
             };
             Expr::Reduce {
                 input: Box::new(substitute_func_param_impl(input, param, arg, scope)),
-                patterns: patterns.clone(),
+                // #2873 review: a computed key runs against the pattern's
+                // own current node *before* the pattern's bindings take
+                // effect, so it sees `scope` (the outer, unbound scope),
+                // same as `input`/`init` above -- not `bound_scope`. Same
+                // gap class `map_subexprs` itself fixed for def/`$var`
+                // resolution (#2677's own `c15aa1287`), missed here because
+                // this is a separate, hand-written traversal.
+                patterns: patterns
+                    .iter()
+                    .map(|p| {
+                        map_pattern_subexprs(p, &mut |e| {
+                            substitute_func_param_impl(e, param, arg, scope)
+                        })
+                    })
+                    .collect(),
                 init: Box::new(substitute_func_param_impl(init, param, arg, scope)),
                 update: Box::new(substitute_func_param_impl(update, param, arg, bound_scope)),
             }
@@ -50847,7 +51003,16 @@ fn substitute_func_param_impl(expr: &Expr, param: &str, arg: &Expr, scope: Subst
             };
             Expr::Foreach {
                 input: Box::new(substitute_func_param_impl(input, param, arg, scope)),
-                patterns: patterns.clone(),
+                // #2873 review: see the identical `Expr::Reduce` arm's
+                // comment just above.
+                patterns: patterns
+                    .iter()
+                    .map(|p| {
+                        map_pattern_subexprs(p, &mut |e| {
+                            substitute_func_param_impl(e, param, arg, scope)
+                        })
+                    })
+                    .collect(),
                 init: Box::new(substitute_func_param_impl(init, param, arg, scope)),
                 update: Box::new(substitute_func_param_impl(update, param, arg, bound_scope)),
                 extract: extract
@@ -50867,7 +51032,15 @@ fn substitute_func_param_impl(expr: &Expr, param: &str, arg: &Expr, scope: Subst
             };
             Expr::AsPattern {
                 expr: Box::new(substitute_func_param_impl(expr, param, arg, scope)),
-                patterns: patterns.clone(),
+                // #2873 review: see `Expr::Reduce`'s identical comment above.
+                patterns: patterns
+                    .iter()
+                    .map(|p| {
+                        map_pattern_subexprs(p, &mut |e| {
+                            substitute_func_param_impl(e, param, arg, scope)
+                        })
+                    })
+                    .collect(),
                 body: Box::new(substitute_func_param_impl(body, param, arg, bound_scope)),
             }
         }

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -365,7 +365,7 @@ use crate::json::light::{JsonCursor, JsonElements, JsonFields, StandardJson};
 use super::expr::{
     ArithOp, AssignOp, BindOrigin, BoundBody, Builtin, CompareOp, Expr, FormatType, FuncDefBound,
     FuncDefData, Literal, MergeFlags, MetaSlot, NumberKey, ObjectEntry, ObjectKey, Origin, Param,
-    Pattern, StringPart, Tracked,
+    Pattern, PatternEntry, StringPart, Tracked,
 };
 use super::value::{
     assert_value_tree_depth, cmp_f64, infinite_float_preview_text, is_infinity_sentinel,
@@ -5864,7 +5864,7 @@ fn each_pattern_alternatives<'a, W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     for (i, pattern) in patterns.iter().enumerate() {
         let is_last = i == last_idx;
 
-        let bindings = match extract_pattern_bindings(pattern, bound_val, invert_dedup) {
+        let bindings = match extract_single_pattern_binding::<S>(pattern, bound_val, invert_dedup) {
             Ok(b) => b,
             Err(e) => {
                 if is_last {
@@ -30662,7 +30662,7 @@ fn walk_pattern_step(
 /// - **a bare `$x` performs no step**: it binds the current input and leaves
 ///   the register alone, marked with [`Frame::origin_at`] exactly when that
 ///   input *is* the register's node.
-fn walk_pattern(
+fn walk_pattern<S: EvalSemantics>(
     pattern: &Pattern,
     input: &OwnedValue,
     reg: PatternRegister,
@@ -30697,18 +30697,48 @@ fn walk_pattern(
                     reg.is_input = false;
                 }
                 first = false;
-                // #2677: a computed key (`{(EXPR): P}`, or an interpolated
-                // string) is not yet walked in path position -- landing
-                // separately from the parse-acceptance half so each is
-                // independently testable (see this repo's own issue #2677
-                // triage). `extract_pattern_bindings`'s value-mode arm below
-                // carries the identical stub.
-                let ObjectKey::Literal(key) = &entry.key else {
-                    return Err(EvalError::new(
-                        "computed keys in a destructuring pattern are not yet supported in path position (#2677)",
-                    ));
+                // #2677: a computed key is resolved against `input` -- the
+                // pattern's own current node -- exactly like value mode's
+                // identical resolution in `fold_object_pattern_entry`
+                // (this function's own doc comment there has the full
+                // derivation, oracle-verified against jq 1.7.1 in *both*
+                // positions: the "Cannot index X with Y" wording is the
+                // same in path mode as value mode, since it comes from the
+                // key-resolution step, not from `walk_pattern_step`'s own
+                // *separate* register-tracking check below, whose "near
+                // attempt to access" wording is unrelated). Scoped down to
+                // exactly one valid string output for this first increment
+                // -- see `extract_single_pattern_binding`'s own doc comment
+                // for why 0/2+/break/halt refuse clearly here too rather
+                // than being modelled.
+                let key: Cow<'_, str> = match &entry.key {
+                    ObjectKey::Literal(key) => Cow::Borrowed(key.as_str()),
+                    ObjectKey::Expr(key_expr) => {
+                        let (mut key_values, control) =
+                            eval_owned_expr_fork::<S>(key_expr, input, false);
+                        match (key_values.len(), control) {
+                            (1, None) => match key_values.pop().unwrap() {
+                                OwnedValue::String(s) => Cow::Owned(s),
+                                other => {
+                                    return Err(EvalError::cannot_index_with_type(
+                                        owned_type_name(input),
+                                        owned_type_name(&other),
+                                    ));
+                                }
+                            },
+                            (0, Some(Control::Error(e))) => return Err(e),
+                            _ => {
+                                return Err(EvalError::new(
+                                    "a computed key in a destructuring pattern produced zero \
+                                     outputs, more than one output, or was interrupted by \
+                                     break/halt, none of which are yet supported in path \
+                                     position (#2677)",
+                                ));
+                            }
+                        }
+                    }
                 };
-                let step = PatternStep::Field(key);
+                let step = PatternStep::Field(&key);
                 let (child, moved) = walk_pattern_step(&step, input, &reg)?;
                 // `{$b: P}`: the bind names the node the register just moved
                 // to, so it carries that position's marker, and is pushed
@@ -30720,7 +30750,7 @@ fn walk_pattern(
                         origin: frame.origin_at(&moved.path),
                     });
                 }
-                reg = walk_pattern(&entry.pattern, &child, moved, frame, out)?;
+                reg = walk_pattern::<S>(&entry.pattern, &child, moved, frame, out)?;
             }
             Ok(reg)
         }
@@ -30737,7 +30767,7 @@ fn walk_pattern(
                 first = false;
                 let step = PatternStep::Index(i);
                 let (child, moved) = walk_pattern_step(&step, input, &reg)?;
-                reg = walk_pattern(pat, &child, moved, frame, out)?;
+                reg = walk_pattern::<S>(pat, &child, moved, frame, out)?;
             }
             Ok(reg)
         }
@@ -30831,7 +30861,7 @@ fn resolve_as_pattern<'a, S: EvalSemantics>(
                 value: value.clone(),
                 is_input: identical,
             };
-            let reg = match walk_pattern(pattern, bound, seed, frame, &mut bindings) {
+            let reg = match walk_pattern::<S>(pattern, bound, seed, frame, &mut bindings) {
                 Ok(reg) => reg,
                 Err(e) => {
                     if is_last {
@@ -31506,7 +31536,7 @@ fn resolve_reduce<'a, S: EvalSemantics>(
                 Pattern::Object(_) | Pattern::Array(_) => {
                     let seed = fold_pattern_seed(&elem, &reg);
                     let mut bindings = Vec::new();
-                    match walk_pattern(pattern, &elem.value, seed, frame, &mut bindings) {
+                    match walk_pattern::<S>(pattern, &elem.value, seed, frame, &mut bindings) {
                         // `reduce` substitutes every binding *untracked*
                         // (`origin` cleared) regardless of what the walk
                         // computed — see this arm's own doc comment above:
@@ -31523,13 +31553,15 @@ fn resolve_reduce<'a, S: EvalSemantics>(
                         Err(e) => return stop_with_escape(&mut aborted, Control::Error(e)),
                     }
                 }
-                Pattern::Var(_) => match extract_pattern_bindings(pattern, &elem.value, false) {
-                    Ok(b) if elem.register_path.is_some() => {
-                        substitute_var_tracked(update, &b[0].0, &b[0].1)
+                Pattern::Var(_) => {
+                    match extract_single_pattern_binding::<S>(pattern, &elem.value, false) {
+                        Ok(b) if elem.register_path.is_some() => {
+                            substitute_var_tracked(update, &b[0].0, &b[0].1)
+                        }
+                        Ok(b) => substitute_vars(update, as_var_refs(&b)),
+                        Err(e) => return stop_with_escape(&mut aborted, Control::Error(e)),
                     }
-                    Ok(b) => substitute_vars(update, as_var_refs(&b)),
-                    Err(e) => return stop_with_escape(&mut aborted, Control::Error(e)),
-                },
+                }
             };
             // **#2632**: mirrors `resolve_foreach`'s own `None`-arm widening
             // (#2161) — `acc_at_register` alone is the previous step's
@@ -31810,7 +31842,7 @@ fn resolve_foreach<'a, S: EvalSemantics>(
                 Pattern::Object(_) | Pattern::Array(_) => {
                     let seed = fold_pattern_seed(&elem, &reg);
                     let mut bindings = Vec::new();
-                    match walk_pattern(pattern, &elem.value, seed, frame, &mut bindings) {
+                    match walk_pattern::<S>(pattern, &elem.value, seed, frame, &mut bindings) {
                         Ok(w) => Some((w, dedup_pattern_bindings(pattern, bindings, false))),
                         Err(e) => return stop_with_escape(&mut aborted, Control::Error(e)),
                     }
@@ -31823,7 +31855,7 @@ fn resolve_foreach<'a, S: EvalSemantics>(
                     extract.map(|ext| apply_pattern_bindings(ext, bindings)),
                 )
             } else {
-                match extract_pattern_bindings(pattern, &elem.value, false) {
+                match extract_single_pattern_binding::<S>(pattern, &elem.value, false) {
                     Ok(b) if elem.register_path.is_some() => (
                         substitute_var_tracked(update, &b[0].0, &b[0].1),
                         extract.map(|ext| substitute_var_tracked(ext, &b[0].0, &b[0].1)),
@@ -35937,7 +35969,8 @@ where
             patterns
                 .iter()
                 .map(|pattern| {
-                    let bindings = extract_pattern_bindings(pattern, input_val, invert_dedup)?;
+                    let bindings =
+                        extract_single_pattern_binding::<S>(pattern, input_val, invert_dedup)?;
                     // #1368: bound and null-filled names never overlap (the
                     // filter below excludes anything `bindings` already
                     // covers), so fold order between the two groups can't
@@ -37717,7 +37750,7 @@ pub(crate) fn pattern_alternatives_var_names(patterns: &[Pattern]) -> Vec<String
 /// therefore never hoist a whole matrix, could share it (#768/#822). WP3's
 /// review then drove the eager path the same way, so the matrix form is gone
 /// entirely and this is the only spelling left.
-pub(crate) fn substitute_foreach_steps(
+pub(crate) fn substitute_foreach_steps<S: EvalSemantics>(
     patterns: &[Pattern],
     all_var_names: &[String],
     update: &Expr,
@@ -37728,7 +37761,7 @@ pub(crate) fn substitute_foreach_steps(
     patterns
         .iter()
         .map(|pattern| {
-            let bindings = extract_pattern_bindings(pattern, input_val, invert_dedup)?;
+            let bindings = extract_single_pattern_binding::<S>(pattern, input_val, invert_dedup)?;
             // #1368: bound and null-filled names never overlap (the
             // filter below excludes anything `bindings` already
             // covers), so fold order between the two groups can't
@@ -37844,7 +37877,7 @@ pub(crate) fn foreach_forks<S: EvalSemantics>(
             // the way the pre-review eager path did (#695), and with the
             // eager path now driven the same way there is no matrix left to
             // hoist anywhere.
-            let row = substitute_foreach_steps(
+            let row = substitute_foreach_steps::<S>(
                 patterns,
                 &all_var_names,
                 update,
@@ -49095,7 +49128,7 @@ fn try_pattern_alternatives<W: Clone + AsRef<[u64]>, S: EvalSemantics>(
     for (i, pattern) in patterns.iter().enumerate() {
         let is_last = i == last_idx;
 
-        let bindings = match extract_pattern_bindings(pattern, bound_val, invert_dedup) {
+        let bindings = match extract_single_pattern_binding::<S>(pattern, bound_val, invert_dedup) {
             Ok(b) => b,
             Err(e) => {
                 if is_last {
@@ -49266,13 +49299,36 @@ pub(crate) fn collect_pattern_var_names(pattern: &Pattern, names: &mut Vec<Strin
 /// inverted for the *inner* array sub-pattern too, not just the outermost
 /// container -- so `invert` threads through every recursive call
 /// unchanged, it is not computed once and only applied at the top.
-pub(crate) fn extract_pattern_bindings(
+///
+/// **#2677**: returns every alternative binding-set a computed key's own
+/// generator can produce, plus whatever [`Control`] stopped generation
+/// early (a key expression's own error/break/halt, or a structural
+/// mismatch) -- [`eval_owned_expr_fork`]'s own `(Vec<T>, Option<Control>)`
+/// shape, reused here rather than inventing a sink/stream abstraction. A
+/// pattern with no computed key anywhere in it still produces exactly one
+/// binding-set on success, matching this function's pre-#2677
+/// single-`Result` shape byte-for-byte. jq compiles multiple entries (and a
+/// multi-output computed key within one entry) as nested generator forks
+/// (`gen_object_matcher`), so entries run left to right and, within one
+/// entry, its own key outputs run in the order its expression yields them --
+/// confirmed live: `{"a":1,"b":2} | . as {("a","b"):$q} | $q` prints `1`
+/// then `2`. The very first failure anywhere -- a key expression's own
+/// error, a non-string key value, an `INDEX` against a non-object, or a
+/// recursive sub-pattern failure -- stops the whole pipeline immediately
+/// (jq's own single-threaded generator model), keeping every combination
+/// already completed before that point (confirmed live:
+/// `[. as {("a",1,"b"):$q} ?// $q | $q]` on `{"a":1,"b":2}` is
+/// `[1,{"a":1,"b":2}]` -- the `1` key output already succeeded and its
+/// binding was consumed by the body *before* the `1` (number) key output's
+/// own type error aborted the rest of that alternative, retrying `?//`'s
+/// own next alternative from there).
+pub(crate) fn extract_pattern_bindings<S: EvalSemantics>(
     pattern: &Pattern,
     value: &OwnedValue,
     invert: bool,
-) -> Result<Vec<(String, OwnedValue)>, EvalError> {
+) -> (Vec<Vec<(String, OwnedValue)>>, Option<Control>) {
     match pattern {
-        Pattern::Var(name) => Ok(vec![(name.clone(), value.clone())]),
+        Pattern::Var(name) => (vec![vec![(name.clone(), value.clone())]], None),
         Pattern::Object(entries) => {
             // Real jq lets `null` absorb any further field access the same
             // way plain `.foo` on `null` does (`null | .foo` is `null`) --
@@ -49283,51 +49339,36 @@ pub(crate) fn extract_pattern_bindings(
             // code review) so this path upholds the same "no duplicate
             // names in the result" invariant every other path does, rather
             // than relying on "every value happens to be Null anyway" to
-            // paper over a skipped step.
+            // paper over a skipped step. No entry's own key expression is
+            // evaluated here either -- confirmed live,
+            // `null | . as {(error("x")):$q} | $q` is `null`, not a raised
+            // `"x"`, so `null` short-circuits before any key expression
+            // (computed or not) ever runs, same as it already did for a
+            // literal key.
             if matches!(value, OwnedValue::Null) {
                 let mut names = Vec::new();
                 collect_pattern_var_names(pattern, &mut names);
                 let bindings = names.into_iter().map(|n| (n, OwnedValue::Null)).collect();
-                return Ok(dedup_object_bindings(bindings, invert));
+                return (vec![dedup_object_bindings(bindings, invert)], None);
             }
-            let mut bindings = Vec::new();
+            let mut frontier: Vec<Vec<(String, OwnedValue)>> = vec![Vec::new()];
             for entry in entries {
-                // #2677: a computed key is not yet evaluated in value
-                // position either -- see `walk_pattern`'s identical stub
-                // (path position) for the shared rationale. Checked before
-                // the non-object-target check just below, matching real
-                // jq's own order (the key expression's own error, or a
-                // `Cannot index ... with ...` naming its actual type, would
-                // otherwise be masked by a generic non-object refusal here).
-                let ObjectKey::Literal(key) = &entry.key else {
-                    return Err(EvalError::new(
-                        "computed keys in a destructuring pattern are not yet supported (#2677)",
-                    ));
-                };
-                // jq destructures by indexing once per key, so a non-object
-                // reports exactly what `.<key>` would — and a pattern with no
-                // keys never indexes, so it cannot fail.
-                let obj = match value {
-                    OwnedValue::Object(o) => o,
-                    _ => {
-                        return Err(EvalError::cannot_index_with_field(
-                            owned_type_name(value),
-                            key,
-                        ))
-                    }
-                };
-                let field_value = obj.get(key).cloned().unwrap_or(OwnedValue::Null);
-                // `{$b: P}` binds `$b` to the matched value *before* running
-                // `P` against that same value (one `INDEX` step in jq's own
-                // compilation, #2649) -- pushed ahead of the sub-pattern's
-                // own bindings so this preserves today's order (and hence
-                // `dedup_object_bindings`'s first/last-wins result) exactly
-                // as when this was desugared into two separate entries.
-                if let Some(bind) = &entry.bind {
-                    bindings.push((bind.clone(), field_value.clone()));
+                let (next, control) =
+                    fold_object_pattern_entry::<S>(entry, value, frontier, invert);
+                frontier = next;
+                if let Some(control) = control {
+                    // A later entry never runs once an earlier one has
+                    // stopped generation -- jq's own sequential generator
+                    // model, and the reason this doesn't also dedup+return
+                    // the partial `frontier` through the loop's normal exit
+                    // below (which still applies the `#1366` dedup rule to
+                    // whatever combinations already completed).
+                    let deduped = frontier
+                        .into_iter()
+                        .map(|b| dedup_object_bindings(b, invert))
+                        .collect();
+                    return (deduped, Some(control));
                 }
-                let sub_bindings = extract_pattern_bindings(&entry.pattern, &field_value, invert)?;
-                bindings.extend(sub_bindings);
             }
             // #1366: an object pattern binding the same variable name from
             // more than one field (`{x:$a,y:$a}`) keeps the *first* field's
@@ -49339,42 +49380,195 @@ pub(crate) fn extract_pattern_bindings(
             // the value's. Opposite of the Array arm below, and inverted
             // again under `?//` -- see `extract_pattern_bindings`'s own doc
             // comment and `dedup_object_bindings`'s for why.
-            Ok(dedup_object_bindings(bindings, invert))
+            let deduped = frontier
+                .into_iter()
+                .map(|b| dedup_object_bindings(b, invert))
+                .collect();
+            (deduped, None)
         }
         Pattern::Array(patterns) => {
             // Same `null`-absorbs-further-access tolerance as the Object arm
             // above, for array-shaped destructuring (#1239); same "route
-            // through the real dedup step anyway" reasoning too.
+            // through the real dedup step anyway" reasoning too. Array
+            // patterns have no computed keys of their own (positional), but
+            // a nested `Pattern::Object` element can still carry one.
             if matches!(value, OwnedValue::Null) {
                 let mut names = Vec::new();
                 collect_pattern_var_names(pattern, &mut names);
                 let bindings = names.into_iter().map(|n| (n, OwnedValue::Null)).collect();
-                return Ok(dedup_array_bindings(bindings, invert));
+                return (vec![dedup_array_bindings(bindings, invert)], None);
             }
-            let mut bindings = Vec::new();
+            let arr = match value {
+                OwnedValue::Array(a) => a,
+                _ => {
+                    let err = EvalError::cannot_index_with_type(owned_type_name(value), "number");
+                    return (Vec::new(), Some(Control::Error(err)));
+                }
+            };
+            let mut frontier: Vec<Vec<(String, OwnedValue)>> = vec![Vec::new()];
             for (i, pat) in patterns.iter().enumerate() {
-                // As above: one index per element position, so the error is
-                // the one `.[i]` would raise.
-                let arr = match value {
-                    OwnedValue::Array(a) => a,
-                    _ => {
-                        return Err(EvalError::cannot_index_with_type(
-                            owned_type_name(value),
-                            "number",
-                        ))
-                    }
-                };
                 let elem_value = arr.get(i).cloned().unwrap_or(OwnedValue::Null);
-                let sub_bindings = extract_pattern_bindings(pat, &elem_value, invert)?;
-                bindings.extend(sub_bindings);
+                let (sub_results, sub_control) =
+                    extract_pattern_bindings::<S>(pat, &elem_value, invert);
+                // No pre-sized capacity hint: `frontier.len() *
+                // sub_results.len()` is a product of two generator fan-outs
+                // an attacker-controlled query could grow arbitrarily
+                // large, and `Vec::with_capacity` on that product risks an
+                // uncatchable allocation panic/abort rather than jq's own
+                // "stream one output at a time" behavior for a cross
+                // product this size (#1669/#1721's own guard exists for
+                // exactly this class) -- an unsized `Vec::new()` growing by
+                // ordinary amortized `push` is the safe default here.
+                let mut next = Vec::new();
+                for partial in &frontier {
+                    for sub in &sub_results {
+                        let mut combined = partial.clone();
+                        combined.extend(sub.iter().cloned());
+                        next.push(combined);
+                    }
+                }
+                frontier = next;
+                if let Some(control) = sub_control {
+                    let deduped = frontier
+                        .into_iter()
+                        .map(|b| dedup_array_bindings(b, invert))
+                        .collect();
+                    return (deduped, Some(control));
+                }
             }
             // #1366: an array pattern binding the same variable name at more
             // than one position (`[$a,$a]`) keeps the *last* position's
             // value in real jq -- confirmed live: `[1,2] | . as [$a,$a] |
             // $a` is `2`. Opposite of the Object arm above, and inverted
             // again under `?//`.
-            Ok(dedup_array_bindings(bindings, invert))
+            let deduped = frontier
+                .into_iter()
+                .map(|b| dedup_array_bindings(b, invert))
+                .collect();
+            (deduped, None)
         }
+    }
+}
+
+/// One [`Pattern::Object`] entry's own contribution to
+/// [`extract_pattern_bindings`]'s cartesian fold (#2677): for every key
+/// value `entry.key` yields against `value` (one for a
+/// [`ObjectKey::Literal`], possibly many for an [`ObjectKey::Expr`]
+/// generator) and every already-accumulated partial binding-set in
+/// `frontier`, extends that partial set with the entry's own `{$bind}`
+/// marker (if any) and every binding its sub-pattern produces against the
+/// matched field -- the full `frontier × keys × sub_pattern_bindings`
+/// cross product, in that nesting order (matches jq's own left-to-right,
+/// outer-to-inner generator compilation). Stops at the first failure
+/// anywhere in that generation, keeping whatever combinations already
+/// completed.
+fn fold_object_pattern_entry<S: EvalSemantics>(
+    entry: &PatternEntry,
+    value: &OwnedValue,
+    frontier: Vec<Vec<(String, OwnedValue)>>,
+    invert: bool,
+) -> (Vec<Vec<(String, OwnedValue)>>, Option<Control>) {
+    // The key expression runs against `value` -- the pattern's own current
+    // node -- regardless of whether `value` even is an object: real jq's
+    // `INDEX` bytecode needs the key *value* in hand before it can raise
+    // its own "Cannot index <type> with <type>" (confirmed live: `{("a"):
+    // $q}` on `[1,2,3]` raises "Cannot index array with string \"a\"" --
+    // the literal key evaluates fine, and only the *subsequent* indexing
+    // attempt fails; `{(.a):$q}` on `5` raises "Cannot index number with
+    // string \"a\"" too, but via the key expression's *own* `.a` navigation
+    // failing on `5`, a different mechanism landing on the same wording).
+    let (key_values, key_control): (Vec<OwnedValue>, Option<Control>) = match &entry.key {
+        ObjectKey::Literal(key) => (vec![OwnedValue::String(key.clone())], None),
+        ObjectKey::Expr(key_expr) => eval_owned_expr_fork::<S>(key_expr, value, false),
+    };
+
+    let mut new_frontier = Vec::new();
+    for key_value in &key_values {
+        let key = match key_value {
+            OwnedValue::String(s) => s,
+            other => {
+                // #2677: a computed key evaluating to a non-string is the
+                // pattern's own `INDEX`-shaped refusal, not construction's
+                // "Cannot use ... as object key" (that's a different jq
+                // bytecode op) -- confirmed live: `. as {(.n):$q} | $q` on
+                // `{"a":1,"n":1}` raises "Cannot index object with number".
+                // A bare non-string *literal* key (`{(1):$q}`) is a
+                // compile-time check in real jq, not modelled here --
+                // matching object construction's own pre-existing,
+                // out-of-scope gap for the identical shape (`{(1): 1}`,
+                // #2677's own triage explicitly scopes this out).
+                let err = EvalError::cannot_index_with_type(
+                    owned_type_name(value),
+                    owned_type_name(other),
+                );
+                return (new_frontier, Some(Control::Error(err)));
+            }
+        };
+        // jq destructures by indexing once per key, so a non-object target
+        // reports exactly what `.<key>` would.
+        let obj = match value {
+            OwnedValue::Object(o) => o,
+            _ => {
+                let err = EvalError::cannot_index_with_field(owned_type_name(value), key);
+                return (new_frontier, Some(Control::Error(err)));
+            }
+        };
+        let field_value = obj.get(key).cloned().unwrap_or(OwnedValue::Null);
+        let (sub_results, sub_control) =
+            extract_pattern_bindings::<S>(&entry.pattern, &field_value, invert);
+        for partial in &frontier {
+            for sub in &sub_results {
+                let mut combined = partial.clone();
+                // `{$b: P}` binds `$b` to the matched value *before* running
+                // `P` against that same value (one `INDEX` step in jq's own
+                // compilation, #2649) -- pushed ahead of the sub-pattern's
+                // own bindings so this preserves the existing order (and
+                // hence `dedup_object_bindings`'s first/last-wins result)
+                // exactly as when this was desugared into two separate
+                // entries.
+                if let Some(bind) = &entry.bind {
+                    combined.push((bind.clone(), field_value.clone()));
+                }
+                combined.extend(sub.iter().cloned());
+                new_frontier.push(combined);
+            }
+        }
+        if let Some(control) = sub_control {
+            return (new_frontier, Some(control));
+        }
+    }
+    (new_frontier, key_control)
+}
+
+/// [`extract_pattern_bindings`], collapsed back to its pre-#2677
+/// single-`Result` shape (#2677 step 3, first increment): a pattern with no
+/// computed key anywhere still produces exactly one binding-set with no
+/// trailing control, so every existing call site is unaffected byte-for-
+/// byte, and so does a computed key whose own expression yields exactly one
+/// valid string (the common real-world shape -- `{(.key): $q}`, `{"\(.k)":
+/// $q}`). A computed key that is itself a *generator* (`{("a","b"):$q}`,
+/// jq's own multi-output fan-out per key) needs each call site's own
+/// alternative-retry/fold-matrix machinery threaded through to fan out
+/// correctly rather than silently keeping one output or dropping the rest
+/// -- not yet done (tracked on #2677 itself), so it -- along with the rarer
+/// zero-output (`{(empty):$q}`) and `break`/`halt`-inside-a-key-expression
+/// shapes -- refuses clearly here instead, at every one of this adapter's
+/// call sites uniformly, rather than risking a wrong answer at any one of
+/// them individually.
+pub(crate) fn extract_single_pattern_binding<S: EvalSemantics>(
+    pattern: &Pattern,
+    value: &OwnedValue,
+    invert: bool,
+) -> Result<Vec<(String, OwnedValue)>, EvalError> {
+    let (mut binding_sets, control) = extract_pattern_bindings::<S>(pattern, value, invert);
+    match (binding_sets.len(), control) {
+        (1, None) => Ok(binding_sets.pop().unwrap()),
+        (0, Some(Control::Error(e))) => Err(e),
+        _ => Err(EvalError::new(
+            "a computed key in a destructuring pattern produced zero outputs, more than \
+             one output, or was interrupted by break/halt, none of which are yet \
+             supported at this call site (#2677)",
+        )),
     }
 }
 
@@ -86086,7 +86280,7 @@ mod tests {
             is_input,
         };
         let mut out = Vec::new();
-        let result = walk_pattern(&patterns[alt], input, seed, &frame, &mut out);
+        let result = walk_pattern::<JqSemantics>(&patterns[alt], input, seed, &frame, &mut out);
         (frame, result, out)
     }
 

--- a/src/jq/eval.rs
+++ b/src/jq/eval.rs
@@ -30697,7 +30697,18 @@ fn walk_pattern(
                     reg.is_input = false;
                 }
                 first = false;
-                let step = PatternStep::Field(&entry.key);
+                // #2677: a computed key (`{(EXPR): P}`, or an interpolated
+                // string) is not yet walked in path position -- landing
+                // separately from the parse-acceptance half so each is
+                // independently testable (see this repo's own issue #2677
+                // triage). `extract_pattern_bindings`'s value-mode arm below
+                // carries the identical stub.
+                let ObjectKey::Literal(key) = &entry.key else {
+                    return Err(EvalError::new(
+                        "computed keys in a destructuring pattern are not yet supported in path position (#2677)",
+                    ));
+                };
+                let step = PatternStep::Field(key);
                 let (child, moved) = walk_pattern_step(&step, input, &reg)?;
                 // `{$b: P}`: the bind names the node the register just moved
                 // to, so it carries that position's marker, and is pushed
@@ -49281,6 +49292,18 @@ pub(crate) fn extract_pattern_bindings(
             }
             let mut bindings = Vec::new();
             for entry in entries {
+                // #2677: a computed key is not yet evaluated in value
+                // position either -- see `walk_pattern`'s identical stub
+                // (path position) for the shared rationale. Checked before
+                // the non-object-target check just below, matching real
+                // jq's own order (the key expression's own error, or a
+                // `Cannot index ... with ...` naming its actual type, would
+                // otherwise be masked by a generic non-object refusal here).
+                let ObjectKey::Literal(key) = &entry.key else {
+                    return Err(EvalError::new(
+                        "computed keys in a destructuring pattern are not yet supported (#2677)",
+                    ));
+                };
                 // jq destructures by indexing once per key, so a non-object
                 // reports exactly what `.<key>` would — and a pattern with no
                 // keys never indexes, so it cannot fail.
@@ -49289,11 +49312,11 @@ pub(crate) fn extract_pattern_bindings(
                     _ => {
                         return Err(EvalError::cannot_index_with_field(
                             owned_type_name(value),
-                            &entry.key,
+                            key,
                         ))
                     }
                 };
-                let field_value = obj.get(&entry.key).cloned().unwrap_or(OwnedValue::Null);
+                let field_value = obj.get(key).cloned().unwrap_or(OwnedValue::Null);
                 // `{$b: P}` binds `$b` to the matched value *before* running
                 // `P` against that same value (one `INDEX` step in jq's own
                 // compilation, #2649) -- pushed ahead of the sub-pattern's
@@ -88342,7 +88365,7 @@ mod tests {
     fn test_fold_pattern_admitted_gate_2676() {
         let bare = [Pattern::Var("x".to_string())];
         let object = [Pattern::Object(vec![crate::jq::PatternEntry {
-            key: "c".to_string(),
+            key: ObjectKey::Literal("c".to_string()),
             bind: None,
             pattern: Pattern::Var("x".to_string()),
         }])];

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -57,9 +57,9 @@ use super::eval::{
     classify_nth_n, classify_parent_n, clear_nonretryable_stop, collapse_vec,
     collect_pattern_var_names, compare_values, debug_assert_materialization_error,
     enter_def_call_frame, entries_to_object, eval_each_owned, eval_full as full_eval,
-    eval_reduce_with_values, extract_pattern_bindings, finish_fork_flow, finish_fork_from_flow,
-    finish_short_circuit, fold_escaped_generator_prefix, foreach_forks, format_owned,
-    has_type_mismatch_is_permissive, index_component_value, index_in_array_bounds,
+    eval_reduce_with_values, extract_single_pattern_binding, finish_fork_flow,
+    finish_fork_from_flow, finish_short_circuit, fold_escaped_generator_prefix, foreach_forks,
+    format_owned, has_type_mismatch_is_permissive, index_component_value, index_in_array_bounds,
     index_one_owned as index_owned_by_key, is_pure_chain_link, is_retryable_stop, literal_to_owned,
     mark_nonretryable_escape, needs_path_context, numeric_key_to_array_index, numeric_key_to_index,
     numeric_length_owned, owned_bound_to_i64, owned_to_expr, owned_to_string,
@@ -9375,7 +9375,7 @@ fn each_pattern_alternatives_generic<S: EvalSemantics, V: DocumentValue>(
     for (i, pattern) in patterns.iter().enumerate() {
         let is_last = i == last_idx;
 
-        let bindings = match extract_pattern_bindings(pattern, bound_val, invert_dedup) {
+        let bindings = match extract_single_pattern_binding::<S>(pattern, bound_val, invert_dedup) {
             Ok(b) => b,
             Err(e) => {
                 if is_last {
@@ -23578,7 +23578,7 @@ fn eval_owned_identity_stages<S: EvalSemantics, V: DocumentValue>(
             names.dedup();
             let null = OwnedValue::Null;
             for bound in bound_values {
-                let bindings = match extract_pattern_bindings(pattern, &bound, false) {
+                let bindings = match extract_single_pattern_binding::<S>(pattern, &bound, false) {
                     Ok(b) => b,
                     Err(e) => return Flow::Escaped(Control::Error(e)),
                 };

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -9462,15 +9462,25 @@ fn each_pattern_alternatives_generic<S: EvalSemantics, V: DocumentValue>(
                 Flow::Escaped(Control::Halt(code)) => return Flow::Escaped(Control::Halt(code)),
             }
         }
+        // #2873 review: `key_control` was computed eagerly, before any
+        // binding-set's body ran -- see `eval::each_pattern_alternatives`'s
+        // identical fix and doc comment for why a `Halt`/uncatchable
+        // `Error` it carries must win regardless of whatever an *earlier*
+        // binding-set's body already decided about retrying.
+        match &key_control {
+            Some(Control::Halt(code)) => return Flow::Escaped(Control::Halt(*code)),
+            Some(Control::Error(e)) if e.is_uncatchable_at_value_position() => {
+                return Flow::Escaped(Control::Error(e.clone()));
+            }
+            _ => {}
+        }
+
         if retry_next_alternative {
             continue;
         }
 
         match key_control {
             None => return Flow::Exhausted,
-            Some(Control::Error(e)) if e.is_uncatchable_at_value_position() => {
-                return Flow::Escaped(Control::Error(e));
-            }
             Some(Control::Error(e)) => {
                 if is_last {
                     return Flow::Escaped(Control::Error(e));
@@ -9483,7 +9493,7 @@ fn each_pattern_alternatives_generic<S: EvalSemantics, V: DocumentValue>(
                 }
                 continue;
             }
-            Some(Control::Halt(code)) => return Flow::Escaped(Control::Halt(code)),
+            Some(Control::Halt(_)) => unreachable!("handled above"),
         }
     }
 

--- a/src/jq/eval_generic.rs
+++ b/src/jq/eval_generic.rs
@@ -57,24 +57,24 @@ use super::eval::{
     classify_nth_n, classify_parent_n, clear_nonretryable_stop, collapse_vec,
     collect_pattern_var_names, compare_values, debug_assert_materialization_error,
     enter_def_call_frame, entries_to_object, eval_each_owned, eval_full as full_eval,
-    eval_reduce_with_values, extract_single_pattern_binding, finish_fork_flow,
-    finish_fork_from_flow, finish_short_circuit, fold_escaped_generator_prefix, foreach_forks,
-    format_owned, has_type_mismatch_is_permissive, index_component_value, index_in_array_bounds,
-    index_one_owned as index_owned_by_key, is_pure_chain_link, is_retryable_stop, literal_to_owned,
-    mark_nonretryable_escape, needs_path_context, numeric_key_to_array_index, numeric_key_to_index,
-    numeric_length_owned, owned_bound_to_i64, owned_to_expr, owned_to_string,
-    pattern_alternatives_var_names, prefer_pending_control, range_max_exceeded_error, range_num,
-    range_values_f64, range_values_int, resolve_computed_slice_bounds, resume_from_escape,
-    reverse_length_is_empty, select_emits, slice_component_value, slice_object_as_yq_children,
-    slice_owned_value_read_computed, stop_with_downstream, stop_with_error, stop_with_escape,
-    stop_with_escape_cell, streams_escaped_generator_prefix, streams_unbounded,
-    substitute_bound_var_from, substitute_vars, suppress_or_raise, suppresses, tonumber_from_str,
-    vec_with_capacity, yq_absent_key_read_is_empty, yq_assign_rhs_document,
-    yq_empty_operand_output, yq_field_index_on_scalar_is_empty, yq_negative_index_check,
-    yq_numeric_index_on_object_is_null, yq_object_key_stringify, yq_read_only_context,
-    BinaryFanoutRules, ComputedSliceBound, Control, Demand, EmptyOperandOp, EvalError,
-    EvalSemantics, EvalTag, Flow, ForeachElementSink, JqSemantics, LimitN, PathTrail, QueryResult,
-    RangeNum, SliceTargetKind, YqSemantics,
+    eval_reduce_with_values, extract_pattern_bindings, extract_single_pattern_binding,
+    finish_fork_flow, finish_fork_from_flow, finish_short_circuit, fold_escaped_generator_prefix,
+    foreach_forks, format_owned, has_type_mismatch_is_permissive, index_component_value,
+    index_in_array_bounds, index_one_owned as index_owned_by_key, is_pure_chain_link,
+    is_retryable_stop, literal_to_owned, mark_nonretryable_escape, needs_path_context,
+    numeric_key_to_array_index, numeric_key_to_index, numeric_length_owned, owned_bound_to_i64,
+    owned_to_expr, owned_to_string, pattern_alternatives_var_names, prefer_pending_control,
+    range_max_exceeded_error, range_num, range_values_f64, range_values_int,
+    resolve_computed_slice_bounds, resume_from_escape, reverse_length_is_empty, select_emits,
+    slice_component_value, slice_object_as_yq_children, slice_owned_value_read_computed,
+    stop_with_downstream, stop_with_error, stop_with_escape, stop_with_escape_cell,
+    streams_escaped_generator_prefix, streams_unbounded, substitute_bound_var_from,
+    substitute_vars, suppress_or_raise, suppresses, tonumber_from_str, vec_with_capacity,
+    yq_absent_key_read_is_empty, yq_assign_rhs_document, yq_empty_operand_output,
+    yq_field_index_on_scalar_is_empty, yq_negative_index_check, yq_numeric_index_on_object_is_null,
+    yq_object_key_stringify, yq_read_only_context, BinaryFanoutRules, ComputedSliceBound, Control,
+    Demand, EmptyOperandOp, EvalError, EvalSemantics, EvalTag, Flow, ForeachElementSink,
+    JqSemantics, LimitN, PathTrail, QueryResult, RangeNum, SliceTargetKind, YqSemantics,
 };
 #[cfg(test)]
 use super::expr::FuncDefBound;
@@ -9375,89 +9375,115 @@ fn each_pattern_alternatives_generic<S: EvalSemantics, V: DocumentValue>(
     for (i, pattern) in patterns.iter().enumerate() {
         let is_last = i == last_idx;
 
-        let bindings = match extract_single_pattern_binding::<S>(pattern, bound_val, invert_dedup) {
-            Ok(b) => b,
-            Err(e) => {
-                if is_last {
+        // #2677: fan out over every binding-set a computed key's own
+        // generator yields, in turn, running `body` once per one -- see
+        // `eval::each_pattern_alternatives`'s identical shape and doc
+        // comment (this is its generic-evaluator twin).
+        let (binding_sets, key_control) =
+            extract_pattern_bindings::<S>(pattern, bound_val, invert_dedup);
+
+        let mut retry_next_alternative = false;
+        for bindings in &binding_sets {
+            let null_value = OwnedValue::Null;
+            let substituted_body = substitute_vars(
+                body,
+                as_var_refs(bindings).chain(
+                    all_var_names
+                        .iter()
+                        .filter(|name| !bindings.iter().any(|(n, _)| n == *name))
+                        .map(|name| (name.as_str(), &null_value)),
+                ),
+            );
+
+            let mut lazy_fault: Option<Control> = None;
+            // #2180 WP3 review: one attempt, one clear -- see
+            // `eval::each_pattern_alternatives`'s identical call and
+            // `eval::nonretryable_stop`.
+            clear_nonretryable_stop();
+            let flow = eval_each_generic::<S, V>(
+                &substituted_body,
+                value.clone(),
+                optional,
+                cursor,
+                &mut |item| match check_lazy_item_for_try(item) {
+                    Ok(item) => sink.push(item),
+                    Err(control) => stop_with_escape(&mut lazy_fault, control),
+                },
+            );
+            let flow = resume_from_escape(lazy_fault, flow);
+
+            match flow {
+                Flow::Exhausted => {}
+                // #1519: a satisfied consumer is jq's escaping `break`, so it
+                // retries the next alternative just like `Control::Break` below.
+                // `pending` is dropped on the retry, matching
+                // `eval::each_pattern_alternatives`'s own arm.
+                Flow::Stopped { pending } => {
+                    if is_retryable_stop(is_last) {
+                        retry_next_alternative = true;
+                        break;
+                    }
+                    return Flow::Stopped { pending };
+                }
+                // #1620/#1660: same decode-failure exclusion as
+                // `eval::each_pattern_alternatives` -- always propagates,
+                // `is_last` or not. Live and load-bearing, not merely
+                // stale-twin parity: `first([.p,.q] as [$y] ?// [$z,$y] | ...)`
+                // reaches this loop via `eval_each_generic`'s own native
+                // `Expr::AsPattern` arm (`each_as_pattern_generic`), not
+                // `eval_single`'s wildcard fallback -- confirmed by removing
+                // this arm and observing the exact silently-wrong-value bug
+                // #1660 fixes elsewhere reappear here too.
+                //
+                // #2132: widened from `is_decode_failure()` to the shared
+                // value-position predicate, in step with `eval.rs`'s
+                // `each_pattern_alternatives` -- a resource cap inside a `?//`
+                // body must not read as "try the next alternative" either.
+                Flow::Escaped(Control::Error(e)) if e.is_uncatchable_at_value_position() => {
                     return Flow::Escaped(Control::Error(e));
                 }
-                continue;
-            }
-        };
-
-        let null_value = OwnedValue::Null;
-        let substituted_body = substitute_vars(
-            body,
-            as_var_refs(&bindings).chain(
-                all_var_names
-                    .iter()
-                    .filter(|name| !bindings.iter().any(|(n, _)| n == *name))
-                    .map(|name| (name.as_str(), &null_value)),
-            ),
-        );
-
-        let mut lazy_fault: Option<Control> = None;
-        // #2180 WP3 review: one attempt, one clear -- see
-        // `eval::each_pattern_alternatives`'s identical call and
-        // `eval::nonretryable_stop`.
-        clear_nonretryable_stop();
-        let flow = eval_each_generic::<S, V>(
-            &substituted_body,
-            value.clone(),
-            optional,
-            cursor,
-            &mut |item| match check_lazy_item_for_try(item) {
-                Ok(item) => sink.push(item),
-                Err(control) => stop_with_escape(&mut lazy_fault, control),
-            },
-        );
-        let flow = resume_from_escape(lazy_fault, flow);
-
-        match flow {
-            Flow::Exhausted => return Flow::Exhausted,
-            // #1519: a satisfied consumer is jq's escaping `break`, so it
-            // retries the next alternative just like `Control::Break` below.
-            // `pending` is dropped on the retry, matching
-            // `eval::each_pattern_alternatives`'s own arm.
-            Flow::Stopped { pending } => {
-                if is_retryable_stop(is_last) {
-                    continue;
+                // #1457: `Break` falls through like `Error`, not immediately
+                // like `Halt` -- same live-verified correction
+                // `eval::each_pattern_alternatives` itself documents.
+                Flow::Escaped(Control::Error(e)) => {
+                    if is_last {
+                        return Flow::Escaped(Control::Error(e));
+                    }
+                    retry_next_alternative = true;
+                    break;
                 }
-                return Flow::Stopped { pending };
+                Flow::Escaped(Control::Break(label)) => {
+                    if is_last {
+                        return Flow::Escaped(Control::Break(label));
+                    }
+                    retry_next_alternative = true;
+                    break;
+                }
+                Flow::Escaped(Control::Halt(code)) => return Flow::Escaped(Control::Halt(code)),
             }
-            // #1620/#1660: same decode-failure exclusion as
-            // `eval::each_pattern_alternatives` -- always propagates,
-            // `is_last` or not. Live and load-bearing, not merely
-            // stale-twin parity: `first([.p,.q] as [$y] ?// [$z,$y] | ...)`
-            // reaches this loop via `eval_each_generic`'s own native
-            // `Expr::AsPattern` arm (`each_as_pattern_generic`), not
-            // `eval_single`'s wildcard fallback -- confirmed by removing
-            // this arm and observing the exact silently-wrong-value bug
-            // #1660 fixes elsewhere reappear here too.
-            //
-            // #2132: widened from `is_decode_failure()` to the shared
-            // value-position predicate, in step with `eval.rs`'s
-            // `each_pattern_alternatives` -- a resource cap inside a `?//`
-            // body must not read as "try the next alternative" either.
-            Flow::Escaped(Control::Error(e)) if e.is_uncatchable_at_value_position() => {
+        }
+        if retry_next_alternative {
+            continue;
+        }
+
+        match key_control {
+            None => return Flow::Exhausted,
+            Some(Control::Error(e)) if e.is_uncatchable_at_value_position() => {
                 return Flow::Escaped(Control::Error(e));
             }
-            // #1457: `Break` falls through like `Error`, not immediately
-            // like `Halt` -- same live-verified correction
-            // `eval::each_pattern_alternatives` itself documents.
-            Flow::Escaped(Control::Error(e)) => {
+            Some(Control::Error(e)) => {
                 if is_last {
                     return Flow::Escaped(Control::Error(e));
                 }
                 continue;
             }
-            Flow::Escaped(Control::Break(label)) => {
+            Some(Control::Break(label)) => {
                 if is_last {
                     return Flow::Escaped(Control::Break(label));
                 }
                 continue;
             }
-            Flow::Escaped(Control::Halt(code)) => return Flow::Escaped(Control::Halt(code)),
+            Some(Control::Halt(code)) => return Flow::Escaped(Control::Halt(code)),
         }
     }
 

--- a/src/jq/expr.rs
+++ b/src/jq/expr.rs
@@ -1085,8 +1085,12 @@ pub enum Pattern {
 /// An entry in an object destructuring pattern.
 #[derive(Debug, Clone, PartialEq)]
 pub struct PatternEntry {
-    /// The key to match (always a string literal in patterns)
-    pub key: String,
+    /// The key to match -- a literal (`{a: P}`, `{"a": P}`, the `{$a}`/
+    /// `{$a: P}` shorthands) or a computed expression (`{(EXPR): P}`, or an
+    /// interpolated string `{"\(EXPR)": P}`, #2677). A `$name`-shorthand
+    /// entry's key is always [`ObjectKey::Literal`] -- the bound name itself,
+    /// never computed.
+    pub key: ObjectKey,
     /// The `$name` of a `{$name: P}` entry, bound to the matched value before
     /// `pattern` runs on it. `None` for `{key: P}` and for the `{$name}`
     /// shorthand (which desugars to `key: name, pattern: Var(name)`).

--- a/src/jq/parser.rs
+++ b/src/jq/parser.rs
@@ -2797,23 +2797,36 @@ impl<'a> Parser<'a> {
                             self.skip_ws();
                             let nested = self.parse_pattern()?;
                             entries.push(PatternEntry {
-                                key: name.clone(),
+                                key: ObjectKey::Literal(name.clone()),
                                 bind: Some(name),
                                 pattern: nested,
                             });
                         } else {
                             entries.push(PatternEntry {
-                                key: name.clone(),
+                                key: ObjectKey::Literal(name.clone()),
                                 bind: None,
                                 pattern: Pattern::Var(name),
                             });
                         }
                     } else {
-                        // Parse key (must be identifier or string)
-                        let key = if self.peek() == Some('"') {
-                            self.parse_string_literal()?
+                        // Parse key: `(expr)` (#2677, a computed key -- the
+                        // same production object construction's own
+                        // `(expr):` branch uses, just above in this file),
+                        // a plain or interpolated string (`"..."`/`"\(...)"`
+                        // -- an interpolation is itself a computed key, so
+                        // it shares the `Expr` arm), or a bare identifier.
+                        let key = if self.peek() == Some('(') {
+                            self.next();
+                            let key_expr = self.parse_expr()?;
+                            self.expect(')')?;
+                            ObjectKey::Expr(Box::new(key_expr))
+                        } else if self.peek() == Some('"') {
+                            match self.parse_string_or_interpolation()? {
+                                Expr::Literal(Literal::String(s)) => ObjectKey::Literal(s),
+                                interpolated => ObjectKey::Expr(Box::new(interpolated)),
+                            }
                         } else {
-                            self.parse_ident()?
+                            ObjectKey::Literal(self.parse_ident()?)
                         };
 
                         self.skip_ws();
@@ -7870,6 +7883,69 @@ mod tests {
                 assert!(matches!(entries[0].key, ObjectKey::Expr(_)));
             }
             _ => panic!("expected Object"),
+        }
+    }
+
+    /// #2677: an object *destructuring pattern*'s own key entry now accepts
+    /// the same `(EXPR)`/interpolated-string computed-key shapes object
+    /// *construction* already did (previous test) -- `PatternEntry.key`
+    /// widened from a plain `String` to `ObjectKey`. Parse-acceptance only:
+    /// evaluation of a computed pattern key still raises a dedicated "not
+    /// yet supported" error (see `tests/jq_cli_tests.rs`'s
+    /// `test_pattern_computed_key_parses_but_not_yet_evaluated_2677`) until
+    /// the rest of this issue's plan lands.
+    #[test]
+    fn test_object_pattern_computed_key_2677() {
+        let parenthesized = parse(". as {(.key): $q} | $q").unwrap();
+        match parenthesized {
+            Expr::AsPattern { patterns, .. } => {
+                let [Pattern::Object(entries)] = patterns.as_slice() else {
+                    panic!("expected a single Object pattern, got {patterns:?}");
+                };
+                assert_eq!(entries.len(), 1);
+                assert!(matches!(entries[0].key, ObjectKey::Expr(_)));
+                assert_eq!(entries[0].bind, None);
+            }
+            other => panic!("expected AsPattern, got {other:?}"),
+        }
+
+        let interpolated = parse(r#". as {"\(.k)": $q} | $q"#).unwrap();
+        match interpolated {
+            Expr::AsPattern { patterns, .. } => {
+                let [Pattern::Object(entries)] = patterns.as_slice() else {
+                    panic!("expected a single Object pattern, got {patterns:?}");
+                };
+                assert!(matches!(entries[0].key, ObjectKey::Expr(_)));
+            }
+            other => panic!("expected AsPattern, got {other:?}"),
+        }
+
+        // A plain (non-interpolated) string key still parses as `Literal`,
+        // unaffected by widening `key` to `ObjectKey`.
+        let literal = parse(r#". as {"a": $q} | $q"#).unwrap();
+        match literal {
+            Expr::AsPattern { patterns, .. } => {
+                let [Pattern::Object(entries)] = patterns.as_slice() else {
+                    panic!("expected a single Object pattern, got {patterns:?}");
+                };
+                assert_eq!(entries[0].key, ObjectKey::Literal("a".into()));
+            }
+            other => panic!("expected AsPattern, got {other:?}"),
+        }
+
+        // The `{$a}`/`{$a: P}` shorthands still key on the bound name
+        // itself, always `Literal` -- never computed.
+        let shorthand = parse(". as {$a} | $a").unwrap();
+        match shorthand {
+            Expr::AsPattern { patterns, .. } => {
+                let [Pattern::Object(entries)] = patterns.as_slice() else {
+                    panic!("expected a single Object pattern, got {patterns:?}");
+                };
+                assert_eq!(entries[0].key, ObjectKey::Literal("a".into()));
+                assert_eq!(entries[0].bind, None);
+                assert_eq!(entries[0].pattern, Pattern::Var("a".into()));
+            }
+            other => panic!("expected AsPattern, got {other:?}"),
         }
     }
 

--- a/src/jq/walk.rs
+++ b/src/jq/walk.rs
@@ -25,7 +25,10 @@ use alloc::rc::Rc;
 #[cfg(test)]
 use std::rc::Rc;
 
-use super::{BoundBody, Builtin, Expr, FuncDefBound, ObjectEntry, ObjectKey, StringPart};
+use super::{
+    BoundBody, Builtin, Expr, FuncDefBound, ObjectEntry, ObjectKey, Pattern, PatternEntry,
+    StringPart,
+};
 #[cfg(test)]
 use super::{FuncDefData, Param};
 
@@ -689,6 +692,38 @@ pub fn map_builtin_subexprs(builtin: &Builtin, f: &mut dyn FnMut(&Expr) -> Expr)
 /// `&mut dyn FnMut`, not a generic `F`, for the same reason
 /// [`map_builtin_subexprs`] and [`any_subexpr`] both give: this recurses, so
 /// a generic parameter would monomorphise the whole traversal per call site.
+/// Apply `f` to every computed-key expression inside `pattern` (#2677),
+/// rebuilding it with the same shape otherwise -- the `Pattern`-specific
+/// half of [`map_subexprs`]'s own recursion, needed because `PatternEntry`
+/// holds a real `Expr` since #2677's `ObjectKey::Expr` computed-key support
+/// (`{(EXPR): P}`, `{"\(EXPR)": P}`); a bare/string-literal key or a `$name`
+/// shorthand's own key carries no `Expr` and passes through unchanged, as
+/// does everything about the pattern's own shape (`bind`, nesting).
+pub fn map_pattern_subexprs(pattern: &Pattern, f: &mut dyn FnMut(&Expr) -> Expr) -> Pattern {
+    match pattern {
+        Pattern::Var(name) => Pattern::Var(name.clone()),
+        Pattern::Object(entries) => Pattern::Object(
+            entries
+                .iter()
+                .map(|entry| PatternEntry {
+                    key: match &entry.key {
+                        ObjectKey::Literal(s) => ObjectKey::Literal(s.clone()),
+                        ObjectKey::Expr(e) => ObjectKey::Expr(Box::new(f(e))),
+                    },
+                    bind: entry.bind.clone(),
+                    pattern: map_pattern_subexprs(&entry.pattern, f),
+                })
+                .collect(),
+        ),
+        Pattern::Array(patterns) => Pattern::Array(
+            patterns
+                .iter()
+                .map(|p| map_pattern_subexprs(p, f))
+                .collect(),
+        ),
+    }
+}
+
 pub fn map_subexprs(expr: &Expr, mut f: &mut dyn FnMut(&Expr) -> Expr) -> Expr {
     match expr {
         // --- Leaves: no `Expr` child, nothing for `f` to see -----------------
@@ -911,7 +946,10 @@ pub fn map_subexprs(expr: &Expr, mut f: &mut dyn FnMut(&Expr) -> Expr) -> Expr {
             update,
         } => Expr::Reduce {
             input: Box::new(f(input)),
-            patterns: patterns.clone(),
+            patterns: patterns
+                .iter()
+                .map(|p| map_pattern_subexprs(p, f))
+                .collect(),
             init: Box::new(f(init)),
             update: Box::new(f(update)),
         },
@@ -923,7 +961,10 @@ pub fn map_subexprs(expr: &Expr, mut f: &mut dyn FnMut(&Expr) -> Expr) -> Expr {
             extract,
         } => Expr::Foreach {
             input: Box::new(f(input)),
-            patterns: patterns.clone(),
+            patterns: patterns
+                .iter()
+                .map(|p| map_pattern_subexprs(p, f))
+                .collect(),
             init: Box::new(f(init)),
             update: Box::new(f(update)),
             extract: extract.as_deref().map(|e| Box::new(f(e))),
@@ -934,7 +975,10 @@ pub fn map_subexprs(expr: &Expr, mut f: &mut dyn FnMut(&Expr) -> Expr) -> Expr {
             body,
         } => Expr::AsPattern {
             expr: Box::new(f(expr)),
-            patterns: patterns.clone(),
+            patterns: patterns
+                .iter()
+                .map(|p| map_pattern_subexprs(p, f))
+                .collect(),
             body: Box::new(f(body)),
         },
         Expr::Label { name, body } => Expr::Label {
@@ -2026,8 +2070,10 @@ mod tests {
     /// The generic (unconditional-recursion) binder arms -- `As`/`Reduce`/
     /// `Foreach`/`AsPattern`/`Label` -- as reached directly through
     /// `map_subexprs` itself (no shadow check, since that lives in the three
-    /// `eval.rs` callers, not here). `patterns.clone()`/`var.clone()`/
-    /// `name.clone()` fields must also survive the round trip untouched.
+    /// `eval.rs` callers, not here). `var.clone()`/`name.clone()` fields
+    /// must also survive the round trip untouched; `patterns` itself now
+    /// recurses too (#2677), tested separately below since none of these
+    /// filters' own patterns carry a computed key to descend into.
     #[test]
     fn map_subexprs_binders_recurse_unconditionally() {
         for (filter, expected_calls) in [
@@ -2045,6 +2091,48 @@ mod tests {
             });
             assert_eq!(calls, expected_calls, "call count mismatch for {filter:?}");
             assert_eq!(result, expr, "identity round-trip failed for {filter:?}");
+        }
+    }
+
+    /// #2677 review: `Reduce`/`Foreach`/`AsPattern`'s own `patterns` field
+    /// now recurses into a computed key's `Expr` (`{(EXPR): P}`) too, not
+    /// just `expr`/`body`/`init`/`update`/`extract` -- confirmed via a
+    /// non-identity rewrite (uppercasing every `Expr::Field` name) so a
+    /// no-op `f` couldn't hide a missed visit, and via the call count
+    /// including the key expressions. Before this fix `patterns` was cloned
+    /// verbatim, so a `def`-bound call or an outer `$var` reference inside
+    /// a computed key was invisible to every caller built on `map_subexprs`
+    /// (`install_def_calls`/`bind_def`, `substitute_var_impl`) -- a `def`'d
+    /// function used as a pattern's own key wrongly reported "undefined
+    /// function" even though it *was* defined (`tests/jq_cli_tests.rs`'s
+    /// own CLI-level pin has the live-jq-confirmed accept case).
+    #[test]
+    fn map_subexprs_descends_into_pattern_computed_keys_2677() {
+        for (filter, expected_calls) in [
+            (". as {(.k):$q} | $q", 3),             // AsPattern: expr + key + body
+            ("reduce .a as {(.k):$q} (.b; .c)", 4), // Reduce: input + key + init + update
+            ("foreach .a as {(.k):$q} (.b; .c; .d)", 5), // Foreach: + extract
+            (". as {a:{(.k):$q}} | $q", 3),         // expr + nested key + body
+            (". as [{(.k):$q}] | $q", 3),           // expr + key-in-array-element + body
+        ] {
+            let expr = parse(filter).expect("filter should parse");
+            let mut calls = 0usize;
+            let uppercased = map_subexprs(&expr, &mut |e| {
+                calls += 1;
+                match e {
+                    Expr::Field(name) => Expr::Field(name.to_uppercase()),
+                    other => other.clone(),
+                }
+            });
+            assert_eq!(calls, expected_calls, "call count mismatch for {filter:?}");
+            // The rewrite actually reached inside the pattern: re-rendering
+            // the rewritten tree's own Debug output names the uppercased
+            // field, proving `f` was applied to the key expression itself
+            // and the result was kept, not discarded.
+            assert!(
+                format!("{uppercased:?}").contains("\"K\""),
+                "computed key's own .k field was not rewritten for {filter:?}: {uppercased:?}"
+            );
         }
     }
 

--- a/src/jq/walk.rs
+++ b/src/jq/walk.rs
@@ -1372,11 +1372,16 @@ pub fn reads_ambient_value(expr: &Expr) -> bool {
 
         // `input` and `init` are evaluated against the document; `update`
         // (and `foreach`'s `extract`) against the accumulator.
-        // `patterns` is not consulted: `PatternEntry::key` is a `String`,
-        // so a pattern holds no `Expr` to reach the document with. #2677
-        // would change that by widening it to a computed key -- if it lands,
-        // the new key expression is evaluated against the *document* and
-        // belongs on the `reads_ambient_value` side of these arms.
+        // `patterns` is not consulted: since #2677/#2873, `PatternEntry::key`
+        // can be an `ObjectKey::Expr`, a computed key evaluated against the
+        // *document* -- so this arm is a known, deliberately deferred gap
+        // (tracked in the #2873 follow-up, #2872), not an oversight. Missing
+        // it here is safe-direction-only: this function's callers use `true`
+        // to justify an optimization/early check, so a false `false` from an
+        // unconsulted computed key can only lose that optimization or defer
+        // a check to run later (as an ordinary runtime error instead), never
+        // produce a wrong value -- see `docs/compliance/jq/limitations.md`'s
+        // "three residual walker gaps" entry.
         Expr::Reduce {
             input,
             init,

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -48614,47 +48614,112 @@ fn test_fold_destructuring_pattern_moves_path_register_2676() -> Result<()> {
     Ok(())
 }
 
-/// #2677 step 1/2 (parser + type-change only, per the issue's own suggested
-/// landing order): an object destructuring pattern now *parses* a computed
-/// key (`{(EXPR): P}`) or an interpolated-string key (`{"\(EXPR)": P}`) the
-/// same way object *construction* already does -- real jq accepts every row
-/// below, where succinctly previously raised a *compile* error (exit 3).
-/// Evaluation of the computed key itself is not implemented yet (the rest of
-/// #2677's plan: `extract_pattern_bindings`/`walk_pattern` growing real
-/// generator/path-tracking logic, the `?//` fallthrough rules, and the
-/// walker-invariant audit) -- every row here now parses and then raises a
-/// dedicated, clearly-worded runtime error (exit 5) instead, which is
-/// intentional, incremental, and independently testable from the parser fix
-/// alone. This test pins that intermediate state; once evaluation lands,
-/// these rows move to a `_2677` accept-matrix test with jq's own values.
+/// #2677 step 3 (first increment): an object destructuring pattern's own
+/// computed key (`{(EXPR): P}`, or an interpolated-string key `{"\(EXPR)":
+/// P}`) now *evaluates* -- in both value position and inside `path()`/
+/// `del()`/an assignment target -- exactly the way real jq's own `Exp`
+/// production does, for the common case: a key expression that yields
+/// exactly one string. `extract_pattern_bindings` (value mode) and
+/// `walk_pattern` (path mode) both resolve the key expression against the
+/// pattern's own current node -- `Cannot index <type> with <type>` for a
+/// non-string key value, `Cannot index <type> with string "..."` for a
+/// non-object target, both the *same* wording jq's own `INDEX` bytecode
+/// gives, confirmed live against jq 1.7.1 for every row below (2026-09-13).
+/// A computed key that is itself a multi-output *generator*
+/// (`{("a","b"):$q}`) is not yet supported and refuses clearly instead
+/// (`test_pattern_computed_key_multi_output_refuses_cleanly_2677`, below) --
+/// real jq fans out one full pattern-match per key output there.
 #[test]
-fn test_pattern_computed_key_parses_but_not_yet_evaluated_2677() -> Result<()> {
+fn test_pattern_computed_key_evaluates_2677() -> Result<()> {
     // Control: a plain literal key is completely unaffected.
     let (stdout, stderr, code) =
         run_jq_full(&["-c", ". as {\"a\":$q} | $q"], Some(r#"{"a":[1,2,3]}"#))?;
     assert_eq!(code, 0, "stderr={stderr}");
     assert_eq!(stdout, "[1,2,3]\n");
 
-    for (input, filter) in [
-        (r#"{"a":[1,2,3]}"#, ". as {(\"a\"):$q} | $q"),
-        (r#"{"a":[1,2,3]}"#, ". as {(\"a\",\"b\"):$q} | $q"),
-        (r#"{"a":1,"b":2}"#, ". as {(\"a\",\"b\"):$q} | $q"),
-        (r#"{"a":[1,2,3],"k":"a"}"#, r#". as {"\(.k)":$q} | $q"#),
+    for (input, filter, expected) in [
+        (r#"{"a":[1,2,3]}"#, ". as {(\"a\"):$q} | $q", "[1,2,3]\n"),
+        (
+            r#"{"a":[1,2,3]}"#,
+            "path(. as {(\"a\"):$q} | $q)",
+            "[\"a\"]\n",
+        ),
+        (
+            r#"{"a":[1,2,3],"k":"a"}"#,
+            r#". as {"\(.k)":$q} | $q"#,
+            "[1,2,3]\n",
+        ),
+        (
+            r#"{"a":{"b":5}}"#,
+            ". as {(\"a\"):{(\"b\"):$q}} | $q",
+            "5\n",
+        ),
+        (
+            r#"{"a":[1,2,3]}"#,
+            "(. as {(\"a\"):$q} | $q) |= (.+[4])",
+            "{\"a\":[1,2,3,4]}\n",
+        ),
+        (r#"{"a":[1,2,3]}"#, "del(. as {(\"a\"):$q} | $q)", "{}\n"),
     ] {
-        // Real jq accepts every one of these (confirmed live, jq 1.7.1) --
-        // not asserted here since this intermediate state doesn't match it
-        // yet; only that succinctly now *parses* (no longer exit 3) and
-        // fails with this issue's own dedicated error, not a generic one.
+        let (stdout, stderr, code) = run_jq_full(&["-c", filter], Some(input))?;
+        assert_eq!(code, 0, "`{filter}`: stderr={stderr}");
+        assert_eq!(stdout, expected, "`{filter}`");
+    }
+
+    // Refuses exactly where real jq does: a non-string key value, or a
+    // computed key indexing a non-object target -- both the same "Cannot
+    // index" wording jq's own `INDEX` bytecode gives for any key, computed
+    // or literal.
+    for (input, filter, expected_stderr) in [
+        (
+            r#"{"a":1,"n":1}"#,
+            ". as {(.n):$q} | $q",
+            "Cannot index object with number",
+        ),
+        (
+            "[1,2,3]",
+            ". as {(\"a\"):$q} | $q",
+            "Cannot index array with string \"a\"",
+        ),
+    ] {
         let (stdout, stderr, code) = run_jq_full(&["-c", filter], Some(input))?;
         assert_eq!(code, 5, "`{filter}`: stdout={stdout} stderr={stderr}");
         assert!(stdout.is_empty(), "`{filter}` must not print: {stdout}");
         assert!(
-            stderr.contains("computed keys in a destructuring pattern are not yet supported"),
+            stderr.contains(expected_stderr),
             "`{filter}` -- stderr: {stderr}"
         );
+    }
+
+    Ok(())
+}
+
+/// #2677: a computed key that is itself a multi-output *generator*
+/// (`{("a","b"):$q}` -- real jq fans out one full pattern-match, and one
+/// full run of `body`, per key it yields: `{"a":1,"b":2} | . as
+/// {("a","b"):$q} | $q` is `1` then `2`, confirmed live) is not yet
+/// supported -- `extract_single_pattern_binding`'s own doc comment has the
+/// full rationale (every one of `extract_pattern_bindings`'s eight call
+/// sites would need its own alternative-retry/fold-matrix machinery
+/// threaded through to fan out correctly, not just the core function).
+/// Refuses clearly (a dedicated, distinctive message) in both value and
+/// path position, in every shape that can reach it -- zero key outputs
+/// (`empty`) and multi-key outputs alike -- never silently keeping just the
+/// first output or dropping the rest.
+#[test]
+fn test_pattern_computed_key_multi_output_refuses_cleanly_2677() -> Result<()> {
+    for (input, filter) in [
+        (r#"{"a":[1,2,3]}"#, ". as {(\"a\",\"b\"):$q} | $q"),
+        (r#"{"a":1,"b":2}"#, ". as {(\"a\",\"b\"):$q} | $q"),
+        (r#"{"a":1,"b":2}"#, "path(. as {(\"a\",\"b\"):$q} | $q)"),
+        (r#"{"a":1}"#, ". as {(empty):$q} | $q"),
+    ] {
+        let (stdout, stderr, code) = run_jq_full(&["-c", filter], Some(input))?;
+        assert_eq!(code, 5, "`{filter}`: stdout={stdout} stderr={stderr}");
+        assert!(stdout.is_empty(), "`{filter}` must not print: {stdout}");
         assert!(
-            !stderr.contains("parse error") && !stderr.contains("compile error"),
-            "`{filter}` must parse, not compile-error -- stderr: {stderr}"
+            stderr.contains("yet supported"),
+            "`{filter}` -- stderr: {stderr}"
         );
     }
 

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -48709,23 +48709,59 @@ fn test_pattern_computed_key_evaluates_2677() -> Result<()> {
 
 /// #2677: a computed key that is itself a multi-output *generator*
 /// (`{("a","b"):$q}` -- real jq fans out one full pattern-match, and one
-/// full run of `body`, per key it yields: `{"a":1,"b":2} | . as
-/// {("a","b"):$q} | $q` is `1` then `2`, confirmed live) is not yet
-/// supported -- `extract_single_pattern_binding`'s own doc comment has the
-/// full rationale (every one of `extract_pattern_bindings`'s eight call
-/// sites would need its own alternative-retry/fold-matrix machinery
-/// threaded through to fan out correctly, not just the core function).
-/// Refuses clearly (a dedicated, distinctive message) in both value and
-/// path position, in every shape that can reach it -- zero key outputs
-/// (`empty`) and multi-key outputs alike -- never silently keeping just the
-/// first output or dropping the rest.
+/// full run of `body`, per key it yields) or a zero-output one
+/// (`{(empty):$q}`, which legitimately binds nothing) now evaluates
+/// correctly in **value position** -- `each_pattern_alternatives`/
+/// `each_pattern_alternatives_generic` (the two `?//`-alternative loops,
+/// value mode's own evaluators) fan out over every binding-set
+/// `extract_pattern_bindings` yields, running `body` once per one, and only
+/// treat the key generator's own trailing error/break/halt the way a
+/// pre-#2677 match failure already was (retry the next `?//` alternative
+/// unless this is the last one). Every row below confirmed live against jq
+/// 1.7.1, including the two hardest interaction cases: a body error
+/// partway through a fan-out abandons the *remaining* key outputs and
+/// retries the next alternative, keeping whatever the fan-out already
+/// emitted (jq's own single-threaded generator model), and a zero-output
+/// key inside a `?//` chain still *wins* (no fallthrough to the next
+/// alternative) even though it contributes nothing.
+///
+/// **Path position** (`walk_pattern`/`resolve_as_pattern`) does not fan out
+/// yet -- see `test_pattern_computed_key_multi_output_refuses_in_path_position_2677`.
 #[test]
-fn test_pattern_computed_key_multi_output_refuses_cleanly_2677() -> Result<()> {
+fn test_pattern_computed_key_fans_out_in_value_position_2677() -> Result<()> {
+    for (input, filter, expected) in [
+        (r#"{"a":1,"b":2}"#, ". as {(\"a\",\"b\"):$q} | $q", "1\n2\n"),
+        (r#"{"a":1}"#, ". as {(empty):$q} | $q", ""),
+        (r#"{"a":1}"#, "[. as {(empty):$q} | $q]", "[]\n"),
+        (
+            r#"{"a":1,"b":2}"#,
+            "[. as {(\"a\",1,\"b\"):$q} ?// $q | $q]",
+            "[1,{\"a\":1,\"b\":2}]\n",
+        ),
+        (
+            r#"{"a":1,"b":2}"#,
+            "[. as {(\"a\",\"b\"):$q} ?// $z | if $q==2 then error(\"boom\") else $q end]",
+            "[1,null]\n",
+        ),
+        (r#"{"a":1}"#, "[. as {(empty):$q} ?// $z | $q]", "[]\n"),
+    ] {
+        let (stdout, stderr, code) = run_jq_full(&["-c", filter], Some(input))?;
+        assert_eq!(code, 0, "`{filter}`: stderr={stderr}");
+        assert_eq!(stdout, expected, "`{filter}`");
+    }
+
+    Ok(())
+}
+
+/// #2677: path position (`walk_pattern`/`resolve_as_pattern`) does not yet
+/// fan out over a multi-output or zero-output computed key the way value
+/// position now does -- refuses clearly (a dedicated, distinctive message)
+/// rather than keeping only the first output or dropping the rest.
+#[test]
+fn test_pattern_computed_key_multi_output_refuses_in_path_position_2677() -> Result<()> {
     for (input, filter) in [
-        (r#"{"a":[1,2,3]}"#, ". as {(\"a\",\"b\"):$q} | $q"),
-        (r#"{"a":1,"b":2}"#, ". as {(\"a\",\"b\"):$q} | $q"),
         (r#"{"a":1,"b":2}"#, "path(. as {(\"a\",\"b\"):$q} | $q)"),
-        (r#"{"a":1}"#, ". as {(empty):$q} | $q"),
+        (r#"{"a":1}"#, "path(. as {(empty):$q} | $q)"),
     ] {
         let (stdout, stderr, code) = run_jq_full(&["-c", filter], Some(input))?;
         assert_eq!(code, 5, "`{filter}`: stdout={stdout} stderr={stderr}");

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -48763,19 +48763,19 @@ fn test_pattern_computed_key_review_fixes_2873() -> Result<()> {
         // is generic, not object-only. The original implementation
         // unconditionally required a string key, wrongly raising "Cannot
         // index array with number" here.
-        (r#"[10,20,30]"#, "def one: 1; . as {(one):$q} | $q", "20\n"),
+        (r"[10,20,30]", "def one: 1; . as {(one):$q} | $q", "20\n"),
         (
-            r#"[10,20,30]"#,
+            r"[10,20,30]",
             "def one: 1; path(. as {(one):$q} | $q)",
             "[1]\n",
         ),
         (
-            r#"[10,20,30]"#,
+            r"[10,20,30]",
             "def negone: -1; path(. as {(negone):$q} | $q)",
             "[-1]\n",
         ),
         (
-            r#"[10,20,30]"#,
+            r"[10,20,30]",
             "def one: 1; reduce . as {(one):$q} (0; .+$q)",
             "20\n",
         ),

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -48753,6 +48753,75 @@ fn test_pattern_computed_key_fans_out_in_value_position_2677() -> Result<()> {
     Ok(())
 }
 
+/// #2873 (PR #2677 review): four bugs found and fixed in code review, each
+/// confirmed live against jq 1.7.1 before the fix and pinned here after.
+#[test]
+fn test_pattern_computed_key_review_fixes_2873() -> Result<()> {
+    for (input, filter, expected) in [
+        // A computed key can resolve to a *number* and index an *array*
+        // target exactly like `.[EXPR]` does -- real jq's `INDEX` bytecode
+        // is generic, not object-only. The original implementation
+        // unconditionally required a string key, wrongly raising "Cannot
+        // index array with number" here.
+        (r#"[10,20,30]"#, "def one: 1; . as {(one):$q} | $q", "20\n"),
+        (
+            r#"[10,20,30]"#,
+            "def one: 1; path(. as {(one):$q} | $q)",
+            "[1]\n",
+        ),
+        (
+            r#"[10,20,30]"#,
+            "def negone: -1; path(. as {(negone):$q} | $q)",
+            "[-1]\n",
+        ),
+        (
+            r#"[10,20,30]"#,
+            "def one: 1; reduce . as {(one):$q} (0; .+$q)",
+            "20\n",
+        ),
+        // `map_subexprs`'s #2677 fix (`c15aa1287`) covered the ordinary
+        // `install_def_calls`/`substitute_var_impl` catch-all path, but two
+        // separate, hand-written traversals had the identical gap:
+        // `substitute_func_param_impl` (a `$`-style def parameter) and
+        // `substitute_var_impl`'s own shadow-guarded arms (an outer
+        // variable the pattern's binding shadows for its body, but not for
+        // its own computed key, which runs before the shadow takes
+        // effect).
+        (
+            r#"{"a":1}"#,
+            "def f($x): . as {($x): $y} | $y; f(\"a\")",
+            "1\n",
+        ),
+        (
+            r#"{"a":42}"#,
+            "\"a\" as $x | (. as {($x): $x} | $x)",
+            "42\n",
+        ),
+    ] {
+        let (stdout, stderr, code) = run_jq_full(&["-c", filter], Some(input))?;
+        assert_eq!(code, 0, "`{filter}`: stderr={stderr}");
+        assert_eq!(stdout, expected, "`{filter}`");
+    }
+
+    // `each_pattern_alternatives`/`each_pattern_alternatives_generic`
+    // compute `key_control` eagerly, before any binding-set's body runs --
+    // an earlier binding-set's body triggering a `?//` retry must not drop
+    // a `Halt` (or uncatchable `Error`) the key generator's own later,
+    // never-processed output already raised. Confirmed live: real jq is
+    // lazy and never reaches `halt_error(7)` at all here (retries `$z`
+    // before pulling the key generator's second output), so its own exit
+    // code (0) is not what this pins -- succinctly's eager design already
+    // executes `halt_error(7)` (its stderr dump proves that), so the
+    // process must actually halt with its exit code once that happened,
+    // not silently swallow it into an ordinary alternative fallthrough.
+    let filter = ". as {(\"a\", halt_error(7)):$q} ?// $z | \
+                  if $q==1 then error(\"boom\") else ($q // $z) end";
+    let (_, _, code) = run_jq_full(&["-c", filter], Some(r#"{"a":1}"#))?;
+    assert_eq!(code, 7, "`{filter}` must actually halt, not retry `?//`");
+
+    Ok(())
+}
+
 /// #2677: path position (`walk_pattern`/`resolve_as_pattern`) does not yet
 /// fan out over a multi-output or zero-output computed key the way value
 /// position now does -- refuses clearly (a dedicated, distinctive message)

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -48660,6 +48660,19 @@ fn test_pattern_computed_key_evaluates_2677() -> Result<()> {
             "{\"a\":[1,2,3,4]}\n",
         ),
         (r#"{"a":[1,2,3]}"#, "del(. as {(\"a\"):$q} | $q)", "{}\n"),
+        // #2677 review: a `def`-bound function, or an outer-bound `$var`,
+        // referenced *inside* a computed key expression -- both used to
+        // wrongly refuse "undefined function"/leave the variable
+        // unsubstituted, because `map_subexprs`'s own `Expr::AsPattern`/
+        // `Reduce`/`Foreach` arms cloned `patterns` verbatim rather than
+        // descending into a computed key's own `Expr` (the same gap every
+        // one of these three arms had before this fix, predating #2677 --
+        // patterns held no `Expr` to miss until #2677's own
+        // `ObjectKey::Expr`). `install_def_calls`/`bind_def` and
+        // `substitute_var_impl` both route through `map_subexprs`, so
+        // fixing it once repairs both.
+        (r#"{"a":1}"#, "def f: \"a\"; . as {(f):$q} | $q", "1\n"),
+        (r#"{"a":1}"#, "\"a\" as $k | . as {($k):$q} | $q", "1\n"),
     ] {
         let (stdout, stderr, code) = run_jq_full(&["-c", filter], Some(input))?;
         assert_eq!(code, 0, "`{filter}`: stderr={stderr}");

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -48614,6 +48614,53 @@ fn test_fold_destructuring_pattern_moves_path_register_2676() -> Result<()> {
     Ok(())
 }
 
+/// #2677 step 1/2 (parser + type-change only, per the issue's own suggested
+/// landing order): an object destructuring pattern now *parses* a computed
+/// key (`{(EXPR): P}`) or an interpolated-string key (`{"\(EXPR)": P}`) the
+/// same way object *construction* already does -- real jq accepts every row
+/// below, where succinctly previously raised a *compile* error (exit 3).
+/// Evaluation of the computed key itself is not implemented yet (the rest of
+/// #2677's plan: `extract_pattern_bindings`/`walk_pattern` growing real
+/// generator/path-tracking logic, the `?//` fallthrough rules, and the
+/// walker-invariant audit) -- every row here now parses and then raises a
+/// dedicated, clearly-worded runtime error (exit 5) instead, which is
+/// intentional, incremental, and independently testable from the parser fix
+/// alone. This test pins that intermediate state; once evaluation lands,
+/// these rows move to a `_2677` accept-matrix test with jq's own values.
+#[test]
+fn test_pattern_computed_key_parses_but_not_yet_evaluated_2677() -> Result<()> {
+    // Control: a plain literal key is completely unaffected.
+    let (stdout, stderr, code) =
+        run_jq_full(&["-c", ". as {\"a\":$q} | $q"], Some(r#"{"a":[1,2,3]}"#))?;
+    assert_eq!(code, 0, "stderr={stderr}");
+    assert_eq!(stdout, "[1,2,3]\n");
+
+    for (input, filter) in [
+        (r#"{"a":[1,2,3]}"#, ". as {(\"a\"):$q} | $q"),
+        (r#"{"a":[1,2,3]}"#, ". as {(\"a\",\"b\"):$q} | $q"),
+        (r#"{"a":1,"b":2}"#, ". as {(\"a\",\"b\"):$q} | $q"),
+        (r#"{"a":[1,2,3],"k":"a"}"#, r#". as {"\(.k)":$q} | $q"#),
+    ] {
+        // Real jq accepts every one of these (confirmed live, jq 1.7.1) --
+        // not asserted here since this intermediate state doesn't match it
+        // yet; only that succinctly now *parses* (no longer exit 3) and
+        // fails with this issue's own dedicated error, not a generic one.
+        let (stdout, stderr, code) = run_jq_full(&["-c", filter], Some(input))?;
+        assert_eq!(code, 5, "`{filter}`: stdout={stdout} stderr={stderr}");
+        assert!(stdout.is_empty(), "`{filter}` must not print: {stdout}");
+        assert!(
+            stderr.contains("computed keys in a destructuring pattern are not yet supported"),
+            "`{filter}` -- stderr: {stderr}"
+        );
+        assert!(
+            !stderr.contains("parse error") && !stderr.contains("compile error"),
+            "`{filter}` must parse, not compile-error -- stderr: {stderr}"
+        );
+    }
+
+    Ok(())
+}
+
 /// #2103 review (coverage-diff bot, PR #2652): `eval_each_pipe_generic`'s
 /// empty-`exprs` tail fix changed the shape of item that flows out of a
 /// bare `keys_unsorted[]` (`OneCursorValue` instead of `One`), which


### PR DESCRIPTION
## Summary

Adds support for a computed or interpolated key in an object destructuring
pattern — `{(EXPR): $var}`, `{"\(EXPR)": $var}` — which real jq accepts and
succinctly previously rejected as a parse error.

- Parsing: `parse_pattern_inner` now accepts `(EXPR)` and `"\(EXPR)"` object
  keys in a pattern, alongside the existing literal/`$name`-shorthand forms.
  `PatternEntry.key` becomes `ObjectKey` (already used by object
  construction) instead of a bare `String`.
- Evaluation, single-output key (the common case): correct in both value
  position and path position (`path()`, `del()`, assignment targets like
  `|=`), including nested computed keys, matching jq's exact `INDEX`
  bytecode semantics — a non-string key value on a valid object gives
  `Cannot index <type> with <type>`; any key on an invalid container gives
  `Cannot index <type> with string "..."`.
- Evaluation, multi-output (generator) or zero-output key, **value position
  only** (`. as PATTERN | body`, with or without `?//` alternatives): fans
  out into one full pattern-match per key output, matching jq's own
  left-to-right, outer-to-inner nested-fork order, including the two
  trickiest `?//`-interaction edge cases — a body error partway through a
  fan-out retries the next alternative while keeping already-emitted output,
  and a zero-output key still wins a `?//` chain without falling through.
- Fixed an independently-discovered bug while working on this: `map_subexprs`
  cloned a pattern's own computed key verbatim instead of descending into
  it, so def-call resolution and variable substitution never saw a
  `FuncCall`/`Var` reference embedded in a computed key (`def f: "a"; . as
  {(f):$q} | $q` wrongly said "undefined function: f/0"). Fixed with a new
  `map_pattern_subexprs` helper wired into `map_subexprs`'s `Reduce`/
  `Foreach`/`AsPattern` arms.
- `docs/compliance/jq/limitations.md` and `docs/reference/jq-language.md`
  updated to describe exactly what's supported and what's deliberately
  scoped out.

## Scope

Path-position fan-out for a multi-/zero-output computed key, and
`reduce`/`foreach`'s own pattern fan-out, still refuse cleanly (never a wrong
answer) rather than fanning out — filed as a follow-up, #2872.

Fixes #2677

## Test plan
- [x] `cargo test --features cli --lib jq::` (2295 passed)
- [x] `cargo test --features cli --test jq_cli_tests` (1680 passed)
- [x] `cargo test --features cli --test yq_cli_tests` (1869 passed)
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo doc` with `RUSTDOCFLAGS="-D warnings"`
- [x] `cargo build --no-default-features` (no_std)
- [x] `cargo build --features cli --release`
- [x] Oracle sweep (`scripts/jq-bind-origin-oracle-sweep.sh`) and differential
      fuzz (`scripts/jq-bind-origin-fuzz.py`, multiple 2000-3000 case runs
      with `--baseline` attribution) — zero fabricate/mismatch/new-refuse
