### PR TITLE
perf(jq): stop parse_required_single_arg's O(2^depth) wrong-arity reparse

### DIFF
--- a/src/jq/parser.rs
+++ b/src/jq/parser.rs
@@ -3281,13 +3281,20 @@ impl<'a> Parser<'a> {
         self.expect(expected).map(|()| unreachable!())
     }
 
-    /// [`Self::wrong_arity_or_expect`] for a [`Self::try_parse_builtin`]
-    /// arm, whose answer is a `Builtin` rather than an `Expr` (#2807).
+    /// [`Self::wrong_arity_or_expect`] for a checkpoint whose caller's own
+    /// return type has no slot for an already-resolved `Expr` -- originally
+    /// every [`Self::try_parse_builtin`] arm answering a `Builtin` (#2807),
+    /// now also [`Self::parse_required_single_arg`] answering an `Expr`
+    /// directly (#2749). Generic over that answer type `T` purely so both
+    /// callers can return their own `Ok(None)`; the body never touches `T`
+    /// itself -- every real value travels through [`Self::wrong_arity_call`]
+    /// instead, exactly as it always did.
     ///
-    /// The 27 multi-argument and optional-arity arms in that function
-    /// checked their argument boundaries with a bare `self.expect(';')?` /
-    /// `self.expect(')')?`, so a wrong-arity call under a shadowing `def`
-    /// reached `parse_primary_inner`'s `Err` arm and was recovered only by
+    /// #2807's original motivation: the 27 multi-argument and
+    /// optional-arity arms in `try_parse_builtin` checked their argument
+    /// boundaries with a bare `self.expect(';')?` / `self.expect(')')?`, so
+    /// a wrong-arity call under a shadowing `def` reached
+    /// `parse_primary_inner`'s `Err` arm and was recovered only by
     /// [`Self::retry_shadow_candidate_as_generic_call`]'s re-parse -- which
     /// re-scans the whole argument text from the keyword (`O(2^depth)` when
     /// nested, #2686's shape) and spends one unit of the process-wide
@@ -3299,18 +3306,25 @@ impl<'a> Parser<'a> {
     /// *unshadowed* spelling, replaces that parse error with jq's own
     /// `test/3 is not defined` (#2573's MULTI-ARG remainder).
     ///
-    /// The parked `Expr` is collected by `parse_primary_inner`; see
+    /// #2749 reuses the identical mechanism for
+    /// [`Self::parse_required_single_arg`]'s own trailing-`)` checkpoint,
+    /// which had the same `O(2^depth)` shape via a plain rewind-and-reparse
+    /// (`has(1;2)` nested to depth *d* cost `2^d` re-parses of the same
+    /// text) -- that site answers an `Expr` rather than a `Builtin`, which
+    /// is why this helper is generic rather than staying `Builtin`-only.
+    ///
+    /// The parked value is collected by `parse_primary_inner`; see
     /// [`Self::wrong_arity_call`] for why it travels in a field. Shaped as
     /// "check, else return" like its sibling, so `args` moves only on the
     /// diverging branch and the caller keeps using its own bindings on the
     /// success path. yq mode raises `expect`'s own natural error, the same
     /// carve-out every member of this family applies.
-    fn builtin_wrong_arity_or_expect(
+    fn builtin_wrong_arity_or_expect<T>(
         &mut self,
         start_pos: usize,
         expected: char,
         args: Vec<Expr>,
-    ) -> Result<Option<Builtin>, ParseError> {
+    ) -> Result<Option<T>, ParseError> {
         let call = self.wrong_arity_or_expect(start_pos, expected, args)?;
         debug_assert!(
             self.wrong_arity_call.is_none(),
@@ -3554,24 +3568,40 @@ impl<'a> Parser<'a> {
     /// resolver the way #2110 already routes a *zero*-arity builtin's own
     /// wrong-arity call.
     ///
-    /// On the correct shape, returns `Ok(Some(expr))`. On either wrong-arity
-    /// shape, **in jq mode**, rewinds to `start_pos` (the position before
-    /// the keyword was consumed) and returns `Ok(None)` -- deliberately
-    /// reusing [`Self::try_parse_builtin`]'s own "not this builtin after
-    /// all" contract, so the caller's existing `else { self
+    /// On the correct shape, returns `Ok(Some(expr))`. On a wrong-arity
+    /// shape at the **first** checkpoint (no `(` at all, e.g. bare `has`) --
+    /// no argument has been parsed yet, so **in jq mode** this still rewinds
+    /// to `start_pos` and returns `Ok(None)`, deliberately reusing
+    /// [`Self::try_parse_builtin`]'s own "not this builtin after all"
+    /// contract so the caller's existing `else { self
     /// .parse_func_call_or_error() }` fallback (already present at every
-    /// call site through [`Self::parse_primary_inner`]) does the delegation,
-    /// with no `Builtin`-vs-`Expr` type mismatch to bridge. A genuine syntax
-    /// error *inside* the argument expression itself (`has(1 +)`) still
-    /// propagates as a raw ParseError unchanged -- only the two structural
-    /// checkpoints below ever trigger a rewind, mirroring
-    /// [`Self::zero_arity_or_wrong_arity_call`]'s own peek-based precision
-    /// rather than a blanket catch-and-retry.
+    /// call site through [`Self::parse_primary_inner`]) does the
+    /// delegation; the rewind is a cheap arity-0 reparse here since nothing
+    /// was parsed to discard.
     ///
-    /// yq mode never rewinds, matching that function's identical carve-out:
-    /// real yq has no name/arity resolution vocabulary at all, so jq's own
-    /// "X/N is not defined" wording would be a new divergence there, not a
-    /// fix -- yq mode keeps the pre-#2237 raw ParseError unchanged.
+    /// On a wrong-arity shape at the **second** checkpoint (`has(1;2)`,
+    /// `has(1 2)`, ...) an argument *has* already been parsed, so **in jq
+    /// mode** this instead routes it through
+    /// [`Self::builtin_wrong_arity_or_expect`] rather than rewinding and
+    /// discarding it (#2749): rewinding here re-scanned the same argument
+    /// text from `start_pos` on every enclosing failure, `O(2^depth)` when
+    /// nested (`"has(".repeat(d) + "1" + ";2)".repeat(d)` cost `2^d`
+    /// re-parses) -- the identical shape #2686 already fixed for the eight
+    /// dedicated special-form parsers, surviving here only because this
+    /// checkpoint's `Result<Option<Expr>, ParseError>` contract had no slot
+    /// for an already-parsed argument until #2807's parking field existed.
+    ///
+    /// A genuine syntax error *inside* the argument expression itself
+    /// (`has(1 +)`) still propagates as a raw ParseError unchanged from
+    /// either checkpoint -- only the two structural checkpoints below ever
+    /// divert, mirroring [`Self::zero_arity_or_wrong_arity_call`]'s own
+    /// peek-based precision rather than a blanket catch-and-retry.
+    ///
+    /// yq mode never rewinds or parks at either checkpoint, matching every
+    /// member of this family's identical carve-out: real yq has no
+    /// name/arity resolution vocabulary at all, so jq's own "X/N is not
+    /// defined" wording would be a new divergence there, not a fix -- yq
+    /// mode keeps the pre-#2237 raw ParseError unchanged.
     fn parse_required_single_arg(&mut self, start_pos: usize) -> Result<Option<Expr>, ParseError> {
         self.skip_ws();
         // #2391: `expect_or_none` -- yq mode's own not-a-rewind-case raises
@@ -3584,8 +3614,8 @@ impl<'a> Parser<'a> {
         self.skip_ws();
         let arg = self.parse_expr()?;
         self.skip_ws();
-        if let Err(early) = self.expect_or_none(')', start_pos) {
-            return early;
+        if self.peek() != Some(')') {
+            return self.builtin_wrong_arity_or_expect(start_pos, ')', vec![arg]);
         }
         self.next();
         Ok(Some(arg))

--- a/src/jq/parser.rs
+++ b/src/jq/parser.rs
@@ -443,12 +443,19 @@ struct Parser<'a> {
     /// wrong-arity call is an `Expr::FuncCall` -- no `Builtin` at all -- so
     /// an arm that has already parsed its arguments and then finds the
     /// boundary wrong ([`Self::builtin_wrong_arity_or_expect`]) has nowhere
-    /// to return it. It parks it here and answers `Ok(None)`, the same "not
-    /// this builtin after all" signal [`Self::parse_required_single_arg`]'s
-    /// rewind already uses; `parse_primary_inner`'s `Ok(None)` arm takes it
-    /// instead of re-parsing the call from source.
+    /// to return it. It parks it here and answers `Ok(None)`; `parse_primary_
+    /// inner`'s `Ok(None)` arm takes it instead of re-parsing the call from
+    /// source.
     ///
-    /// Always `None` between calls: the arm returns immediately after
+    /// #2749: [`Self::parse_required_single_arg`]'s own trailing-`)`
+    /// checkpoint is a second, direct writer into this same field (via
+    /// `builtin_wrong_arity_or_expect::<Expr>`, the same generic helper
+    /// genericized over its answer type for exactly this) -- not merely an
+    /// external caller mimicking the signal, as it was before that fix; only
+    /// that function's *first* checkpoint (no `(` at all) still rewinds
+    /// without touching this field.
+    ///
+    /// Always `None` between calls: every writer returns immediately after
     /// parking, and the sole caller takes it as the first thing it does.
     wrong_arity_call: Option<Expr>,
 }
@@ -3152,9 +3159,12 @@ impl<'a> Parser<'a> {
     }
 
     /// The `Expr`-returning counterpart of
-    /// [`Self::zero_arity_or_wrong_arity_call`]/
-    /// [`Self::parse_required_single_arg`]'s shared "detected wrong arity,
-    /// rewind and delegate" tail, for the dedicated-parse-function family
+    /// [`Self::zero_arity_or_wrong_arity_call`]'s "detected wrong arity,
+    /// rewind and delegate" shape -- also still how
+    /// [`Self::parse_required_single_arg`]'s *first* checkpoint (no `(` at
+    /// all) resolves a wrong-arity call; its *second* checkpoint no longer
+    /// rewinds at all as of #2749, see [`Self::wrong_arity_call`] -- for the
+    /// dedicated-parse-function family
     /// (`parse_range_expr`, `parse_first_expr`, `parse_limit_expr`, ...)
     /// that returns `Expr` directly rather than going through
     /// [`Self::try_parse_builtin`]'s `Option<Builtin>` fallback protocol

--- a/tests/jq_cli_tests.rs
+++ b/tests/jq_cli_tests.rs
@@ -49290,16 +49290,15 @@ fn test_collection_literal_postfix_does_not_capture_destructuring_2667() -> Resu
 /// Hence the table below covers all eight forms rather than the two named.
 ///
 /// **Scope: the eight dedicated special-form parsers only.** The same shape
-/// still exists behind `parse_required_single_arg`, which rewinds *after*
-/// parsing its argument and signals "not a match" so its caller re-parses --
-/// so the ~30 single-argument builtins in `try_parse_builtin` (`has`,
-/// `select`, ...) keep it. Measured on this branch: `"has(" * d + "1" +
-/// ";2)" * d` costs 2.4 s at depth 18, identical to the merge base, where
-/// the forms below are flat. That is a different protocol
-/// (`Result<Option<_>>`, resolved by the caller's own shadow fallback rather
-/// than in place), so it is tracked separately rather than folded in here --
-/// this test deliberately does not cover it, and should not be read as
-/// saying the wider surface is fixed.
+/// used to exist behind `parse_required_single_arg` too, which rewound
+/// *after* parsing its argument and signalled "not a match" so its caller
+/// re-parsed -- the ~30 single-argument builtins in `try_parse_builtin`
+/// (`has`, `select`, ...). Fixed separately in #2749 by routing that
+/// checkpoint through this same `wrong_arity_call`-parking mechanism (via
+/// `builtin_wrong_arity_or_expect`, generalized from #2807's `Builtin`-only
+/// form) instead of adding a second copy here --
+/// `test_wrong_arity_single_arg_deep_nesting_does_not_blow_up_2749` is that
+/// family's own timing guard.
 ///
 /// Same timing-guard shape and generous margin as
 /// `test_def_shadow_deep_nesting_does_not_blow_up_2036` and
@@ -49817,6 +49816,126 @@ fn test_wrong_arity_resolution_is_unchanged_2686() -> Result<()> {
         ("1 | until(. > 3; . + 1)", "4"),
         ("[first(1,2)]", "[1]"),
         ("[last(1,2)]", "[2]"),
+    ] {
+        let (stdout, stderr, code) = run_jq_full(&["-nc", filter], None)?;
+        assert_eq!(code, 0, "`{filter}`: stderr {stderr:?}");
+        assert_eq!(stdout.trim_end(), want, "`{filter}`");
+    }
+
+    Ok(())
+}
+
+/// #2749: `parse_required_single_arg`'s trailing-`)` checkpoint had the
+/// identical `O(2^depth)` shape #2686 fixed for the eight dedicated
+/// special-form parsers, surviving here because this checkpoint's
+/// `Result<Option<Expr>, ParseError>` contract had no slot for an
+/// already-parsed argument until #2807's `wrong_arity_call` parking field
+/// existed for `try_parse_builtin`'s `Builtin`-returning arms.
+/// `builtin_wrong_arity_or_expect` is now generic over that answer type, so
+/// this checkpoint parks an `Expr` in the same field instead of rewinding.
+///
+/// A representative spread of the 37 call sites rather than all of them --
+/// enough to cover a #2389-converted site (`has`, an original #2237
+/// conversion) and a #2750-converted one (`bsearch`), plus a mix of arities
+/// and postfix-bearing names. Same generous margin and reasoning as
+/// `test_wrong_arity_deep_nesting_does_not_blow_up_2686`.
+#[test]
+fn test_wrong_arity_single_arg_deep_nesting_does_not_blow_up_2749() -> Result<()> {
+    for kw in [
+        "has",
+        "select",
+        "map",
+        "getpath",
+        "join",
+        "bsearch",
+        "ltrimstr",
+        "startswith",
+    ] {
+        let depth = 40;
+        let filter = format!("{kw}(").repeat(depth) + "1" + &";2)".repeat(depth);
+        let start = std::time::Instant::now();
+        let (_stdout, _stderr, code) = run_jq_full(&["-nc", &filter], None)?;
+        let elapsed = start.elapsed();
+        assert_ne!(code, 0, "`{kw}` {depth} levels: expected a rejection");
+        assert!(
+            elapsed < std::time::Duration::from_secs(15),
+            "`{kw}` at {depth} levels took {elapsed:?} -- exponential parse blowup regressed"
+        );
+    }
+
+    Ok(())
+}
+
+/// #2749: the parked-`Expr` path must resolve a wrong-arity call to exactly
+/// what the rewinding path did -- same message, same shadow resolution, same
+/// postfix handling. Every expectation captured live from `/usr/bin/jq`
+/// 1.7.1. Verified in bulk while making the change: 666 programs (37 names
+/// x 9 shapes x both modes) produced byte-identical stdout, stderr and exit
+/// code against a binary built from the merge base; these rows are the
+/// load-bearing ones from that sweep, kept so the parity is pinned rather
+/// than only having been measured once.
+#[test]
+fn test_wrong_arity_single_arg_resolution_is_unchanged_2749() -> Result<()> {
+    for (filter, want_code, want_fragment) in [
+        // The resolver's own name/arity diagnostic, not a raw parse error.
+        ("has(1;2)", 3, "has/2 is not defined"),
+        ("select(1;2)", 3, "select/2 is not defined"),
+        ("getpath(1;2)", 3, "getpath/2 is not defined"),
+        ("bsearch(1;2)", 3, "bsearch/2 is not defined"),
+        // No parentheses at all -- the first (unaffected) checkpoint, still
+        // a cheap arity-0 rewind.
+        ("has", 3, "has/0 is not defined"),
+        // Postfix tail after the wrong-arity call still reaches the
+        // resolver rather than becoming a raw syntax error.
+        ("has(1;2).foo", 3, "has/2 is not defined"),
+        ("has(1;2)[0]", 3, "has/2 is not defined"),
+        // A malformed separator inside the *continued* argument list --
+        // the part this fix now parses itself rather than re-parsing --
+        // keeps `wrong_arity_call_from_parsed`'s own wording.
+        ("has(1;2 3)", 3, "expected ';' or ')' in function arguments"),
+    ] {
+        let (_stdout, stderr, code) = run_jq_full(&["-nc", filter], None)?;
+        assert_eq!(code, want_code, "`{filter}`: stderr {stderr:?}");
+        assert!(
+            stderr.contains(want_fragment),
+            "`{filter}`: stderr {stderr:?} lacks {want_fragment:?}"
+        );
+    }
+
+    // A `def` of the same name and arity still shadows, including through
+    // the resolved call's own postfix tail.
+    for (filter, want) in [
+        ("def has(a;b): a; has(1;2)", "1"),
+        ("def has(a;b): [a,b]; has(1;2)[0]", "1"),
+        ("def bsearch(a;b): [a,b]; bsearch(1;2)", "[1,2]"),
+    ] {
+        let (stdout, stderr, code) = run_jq_full(&["-nc", filter], None)?;
+        assert_eq!(code, 0, "`{filter}`: stderr {stderr:?}");
+        assert_eq!(stdout.trim_end(), want, "`{filter}`");
+    }
+
+    // A shadowing `def` at a *different* arity does not shadow -- the call
+    // still resolves to the builtin's own wrong-arity diagnostic.
+    for (filter, want_fragment) in [
+        ("def has(a;b;c): a; has(1;2)", "has/2 is not defined"),
+        (
+            "def select(a;b;c): a; select(1;2)",
+            "select/2 is not defined",
+        ),
+    ] {
+        let (_stdout, stderr, code) = run_jq_full(&["-nc", filter], None)?;
+        assert_eq!(code, 3, "`{filter}`: stderr {stderr:?}");
+        assert!(
+            stderr.contains(want_fragment),
+            "`{filter}`: stderr {stderr:?} lacks {want_fragment:?}"
+        );
+    }
+
+    // Correct-arity calls are untouched.
+    for (filter, want) in [
+        ("has(\"a\")", "false"),
+        ("[(1,2,3) | select(. > 1)]", "[2,3]"),
+        ("getpath([\"a\"])", "null"),
     ] {
         let (stdout, stderr, code) = run_jq_full(&["-nc", filter], None)?;
         assert_eq!(code, 0, "`{filter}`: stderr {stderr:?}");

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -44300,6 +44300,33 @@ fn test_wrong_arity_special_form_keeps_yq_parse_error_2686() -> Result<()> {
     Ok(())
 }
 
+/// #2749 (yq half): `parse_required_single_arg`'s trailing-`)` checkpoint
+/// keeps yq mode's identical carve-out after being routed through
+/// `builtin_wrong_arity_or_expect` instead of a rewind -- `wrong_arity_or_expect`
+/// (the shared non-jq arm both checkpoints use) raises `expect`'s own raw
+/// error there exactly as it always did, never jq's "X/N is not defined".
+#[test]
+fn test_wrong_arity_single_arg_keeps_yq_parse_error_2749() -> Result<()> {
+    for (filter, want_fragment) in [
+        ("has(1;2)", "expected ')', found ';'"),
+        ("select(1;2)", "expected ')', found ';'"),
+        ("join(1;2)", "expected ')', found ';'"),
+    ] {
+        let (_stdout, stderr, code) = run_yq_stdin_with_stderr(filter, "a: 1\n", &[])?;
+        assert_ne!(code, 0, "`{filter}`: expected a rejection");
+        assert!(
+            stderr.contains(want_fragment),
+            "`{filter}`: stderr {stderr:?} lacks {want_fragment:?}"
+        );
+        assert!(
+            !stderr.contains("is not defined"),
+            "`{filter}`: yq mode must not borrow jq's name/arity wording: {stderr:?}"
+        );
+    }
+
+    Ok(())
+}
+
 /// #2132 (yq half): the evaluator's resource caps are uncatchable in yq
 /// mode too -- they are not a reference behaviour in either mode, so the
 /// `ErrorKind::ResourceLimit` tag is mode-independent.


### PR DESCRIPTION
## Summary
- `parse_required_single_arg`'s trailing-`)` checkpoint rewound and discarded an already-parsed argument on a wrong-arity call (e.g. `has(1;2)`), so the caller's fallback re-parsed the same argument text from scratch. Nested (`has(has(...1...;2);2);2)`), each level re-parses everything below it: `O(2^depth)`. `"has(".repeat(18) + "1" + ";2)".repeat(18)` took ~315ms before this fix; depth 40 now takes ~12ms.
- This is the identical shape #2686 fixed for the eight dedicated special-form parsers (`until`/`while`/`limit`/...), surviving at this site only because its `Result<Option<Expr>, ParseError>` contract had no slot for an already-parsed argument.
- Fix: generalize #2807's `Builtin`-only `builtin_wrong_arity_or_expect` into `builtin_wrong_arity_or_expect<T>` (the body never touched `T`, it only ever parked the resolved call in the existing `wrong_arity_call` field), so this checkpoint can park an `Expr` there too instead of rewinding. Affects all ~30 single-argument builtins routed through `try_parse_builtin` (`has`, `select`, `map`, `getpath`, `join`, `bsearch`, `ltrimstr`, `startswith`, ...).
- Output is byte-identical to before at every arity/spelling — confirmed via a 666-way differential sweep (37 names × 9 shapes × both modes) against a binary built from the merge base — only the timing changes.

Fixes #2749

## Test plan
- [x] New timing-guard test (`test_wrong_arity_single_arg_deep_nesting_does_not_blow_up_2749`): 8 representative names at depth 40, must reject in well under 15s.
- [x] New parity tests (`test_wrong_arity_single_arg_resolution_is_unchanged_2749` jq-mode, `test_wrong_arity_single_arg_keeps_yq_parse_error_2749` yq-mode) pinning name/arity resolution, postfix tails, shadowing `def`s, and yq's own raw-error carve-out — every expectation captured live from `/usr/bin/jq` 1.7.1.
- [x] Existing `#2686`/`#2807` regression tests still pass unmodified.
- [x] `cargo test --features cli` (full suite, all targets): 0 failures.
- [x] `cargo clippy --all-targets --all-features -- -D warnings`: clean.
- [x] `cargo fmt --check`: clean.
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features`: clean.