### PR TITLE
fix(yq): reproduce real yq's token-pairing grammar for JSON flow mappings (#2777)

### DIFF
--- a/docs/compliance/yq/limitations.md
+++ b/docs/compliance/yq/limitations.md
@@ -1009,13 +1009,15 @@ over preserving that accidental top-level agreement; the resulting divergence fr
 the DOM bridge's other flow-mapping delimiter gaps in #2777 below, not carved out as a
 special case here.
 
-Scope is flow **sequence delimiters** only, and never mapping delimiters, because that is
-where real yq (v4.53.3, captured live) actually draws the line — the asymmetry this section
-already describes above. Tightening mappings would refuse `{"a":1,}`/`{,}`, all of which
-real yq accepts. The remaining divergences on this route are tracked separately: the
-flow-mapping *delimiter* grammar in
-[#2777](https://github.com/rust-works/succinctly/issues/2777) (including one silent wrong
-value, `{"a":1 "b":2}`), and genuine-YAML `[,]`/`{,}` in
+Scope was originally flow **sequence delimiters** only, and never mapping delimiters,
+because that is where real yq (v4.53.3, captured live) actually draws the line — the
+asymmetry this section already describes above: tightening mappings toward JSON would
+refuse `{"a":1,}`/`{,}`, both of which real yq accepts. The flow-**mapping** side (real yq's
+own, quite different, token-*pairing* leniency — including the one silent wrong value this
+issue originally found, `{"a":1 "b":2}`) is closed separately below by
+[#2777](https://github.com/rust-works/succinctly/issues/2777), on the plain route only —
+see that section for what it does and does not cover. Genuine-YAML `[,]`/`{,}` (unrelated to
+JSON-sourced input at all) is tracked separately as
 [#2779](https://github.com/rust-works/succinctly/issues/2779). (Scalar grammar, `[01]` vs
 `.5`, was the other half of #2279's original scope note — closed separately below by
 [#2778](https://github.com/rust-works/succinctly/issues/2778).)
@@ -1080,15 +1082,81 @@ An implicit single-pair mapping inside a JSON *array* (`[a: 1]`, `["a":1]`) is r
 same way, in `parse_flow_sequence_inner` — a JSON array element is a value, never a `key:
 value` pair, so the whole construct errors before the key's own text is even examined.
 
-**Mapping *keys* are exempt — deliberately, not an oversight.** Real yq's own JSON decoder
-*panics* (does not cleanly error) on a non-string key — `{1:1}`, `{true:1}` both crash with
-`interface conversion: json.Token is float64, not string` (exit 2, confirmed live). Per
-ADR-0018 rule 4(c), succinctly does not reproduce a reference panic; `{"1":1}` (succinctly's
-existing behavior for a numeric-looking key) is unchanged. Key *delimiter* and *quoting*
-rules (e.g. real yq also rejects an unquoted or single-quoted key, `{a:1}`/`{'a':1}`, which
-succinctly still accepts) are the mapping-key half of #2777, not this issue — #2778 only
-ever touches what a scalar *value* token may spell, plus the four structural, key-agnostic
-rejections above.
+**Mapping *keys* were exempt from this issue — deliberately, not an oversight — and are now
+closed by #2777, below.** Real yq's own JSON decoder *panics* (does not cleanly error) on a
+non-string key — `{1:1}`, `{true:1}` both crash with `interface conversion: json.Token is
+float64, not string` (exit 2, confirmed live). Per ADR-0018 rule 4(c), succinctly does not
+reproduce a reference panic; `{"1":1}` (a *string* `"1"` as key, succinctly's existing
+behavior) is unchanged and unrelated. #2778 itself only ever touched what a scalar *value*
+token may spell, plus the four structural, key-agnostic rejections above; key delimiter and
+quoting rules (`{a:1}`, `{'a':1}`) were left to #2777, which now rejects both — a key must be
+a double-quoted string, so anything else that isn't even a well-formed non-string JSON
+literal (a bareword, a single-quoted string, `?`/`&`/`!`/`*`) is an ordinary "invalid
+character as JSON object key" error, distinct from the rule-4(c) panic-class rejection a
+well-formed non-string literal (`1`, `true`, `null`) gets instead.
+
+**Closed by [#2777](https://github.com/rust-works/succinctly/issues/2777): flow-mapping
+token-pairing grammar, on the plain route.** Real yq's own object grammar is not a stricter
+or looser version of JSON's or YAML's flow-mapping grammar — it isn't a grammar for `{...}`
+at all. Traced from `goccy/go-json`'s own source (`Stream.Token()`/`PrepareForDecode`, the
+machinery `CandidateNode.UnmarshalJSON` actually calls for an object body): the decoder reads
+a flat stream of tokens and pairs them up (key, value, key, value, ...), where punctuation is
+just noise to skip, not structure to validate:
+
+- Before each key, whitespace and *any* run of `,`/`:` is skipped — both are pure separators,
+  so `{,}` → `{}`, `{,"a":1}` → `{"a":1}`, `{"a":1,,"b":2}` → `{"a":1,"b":2}`, and even `{:1}`
+  (the leading `:` is skipped the same as a `,` would be, leaving a bare numeric "key" that
+  then hits the panic-class rejection below).
+- A key must be a JSON string; anything else that scans as a well-formed *non-string* JSON
+  literal (`{1:1}`, `{true:1}`, `{null:1}`) is the reference's own interface-conversion panic
+  (exit 2) — reproduced as a clean rejection, not the crash, per ADR-0018 rule 4(c). Anything
+  that isn't even a well-formed literal at all (`{abc:1}`, `{'a':1}`) is an ordinary
+  scanner-level error in the reference too.
+- After the key, whitespace and *at most one* `,`/`:` is skipped — a stricter rule than the
+  key side, so `{"a" 1}`/`{"a":1}`/`{"a",1}` all reach the value, but `{"a"::1}`/`{"a",,1}`
+  (two separators) do not.
+- The value must then start on a genuine JSON value byte — `{`, `[`, `"`, or a number/
+  `true`/`false`/`null` token whose *boundary* stops at the first byte that cannot continue
+  it (not at the next comma/brace the way YAML's own unquoted-scalar scanner does), which is
+  what actually fixes the issue's own headline row: `{"a":1 "b":2}` used to read the space and
+  the following `"b":2` as part of one long invalid scalar (a silent wrong value before #2778
+  taught the scanner to at least *notice* that and reject it cleanly; #2777 is what makes it
+  split into two entries and match value-for-value). Nested arrays are unaffected — they keep
+  their own, unrelated strict `[...]` delimiter/scalar rules (#2279/#2778): `{"a":[1 2]}`
+  still errors, matching the reference's own asymmetry (object bodies are token-paired, array
+  bodies go through `json.Unmarshal`'s ordinary strict slice decoder).
+
+`Parser::parse_json_strict_flow_mapping_entries` (`src/yaml/parser.rs`) implements this as a
+wholly separate loop from the ordinary YAML flow-mapping entry loop
+(`parse_yaml_flow_mapping_entries`), rather than more `if json_strict` branches threaded
+through it, since the grammar is different in kind, not just stricter or looser in degree.
+
+**Not reproduced: which bracket ends the loop.** The reference's token scanner treats *every*
+bracket character (`{`, `}`, `[`, `]`) as a `Delim` that ends the *current* object's
+key-reading loop the instant one is seen — including a `]` or a second `{`/`[` where a key
+was expected, with no requirement that it be *this* object's own closing brace (confirmed
+live: `{"a":1 ]}` → `{"a":1}`; `{[1]:2}` → `{}`). Whatever is left unconsumed in that case is
+then read as the *next* top-level document by yq's own stream evaluator, whose own
+trailing-content handling is itself inconsistent — some leftover shapes produce no visible
+error at all, others (differing only in which byte is left over) print a stream-decode error
+to stderr while still emitting the correct value and exiting 0. Reproducing this would mean
+modelling a second, top-level-only decoder loop with the same inconsistency, for a shape (a
+bare bracket standing in for a key, with no quotes at all) that essentially never occurs in
+real-world JSON — deferred as
+[#2883](https://github.com/rust-works/succinctly/issues/2883), and succinctly instead
+reports an ordinary parse error for a `{`/`[`/`]`
+found where a key is expected, always failing the whole document cleanly rather than
+silently producing a truncated one.
+
+**Scope: the plain route only, not `--inplace`/`--slurp`/`--eval-all`.** Those routes
+materialize through `JsonIndex`'s DOM bridge (`yq_runner::parse_input`'s `InputFormat::Json`
+arm), a separate code path from the `YamlIndex`-backed parser this fix touches, and one that
+still applies #1975's own stricter-than-real-yq grammar. `succinctly yq -p json -i '.'` on a
+file containing `{"a":1 "b":2}` still refuses and leaves the file untouched, where real yq
+rewrites it to `a: 1\nb: 2`. Unifying the two routes onto one parser (so the DOM bridge gets
+this same leniency, and so the two stop disagreeing with each other as well as with real yq)
+is a separate, larger change that touches the destructive `--inplace` write path — tracked as
+[#2883](https://github.com/rust-works/succinctly/issues/2883) rather than folded into this fix.
 
 **Cost: `-p json`/`--input-format json` parsing is measurably slower, isolated entirely to
 that path.** Every plain (unquoted) scalar under `json_strict` now costs a byte-charset scan

--- a/src/yaml/parser.rs
+++ b/src/yaml/parser.rs
@@ -529,41 +529,48 @@ struct Parser<'a, const HAS_CR: bool> {
     /// `YamlCursor` method (`self.bp_pos`) keys its lookups on.
     last_open_bp_pos: usize,
 
-    /// Enforce JSON's stricter grammar for `-p json` input (#2279, #2778).
+    /// Enforce real yq's own grammar for `-p json` input, on the "plain"
+    /// route (#2279, #2778, #2777) -- not JSON's grammar, and not YAML's.
     ///
     /// Set only for input the caller already knows is JSON, i.e. exactly the
     /// callers that follow `YamlIndex::build` with
     /// [`mark_json_sourced`](crate::yaml::YamlIndex::mark_json_sourced).
     /// JSON is a subset of YAML's flow grammar, so the YAML parser accepts
-    /// it as-is -- but it also accepts things real yq's own JSON front end
-    /// rejects: `[1,]`/`[,1]`/`[1,,2]` (delimiters, #2279) and, at every
-    /// scalar *value* position (flow-sequence item, flow-mapping value,
-    /// block/top-level value), YAML-only spellings like `True`, `'a'`,
-    /// `.5`, `+1`, `~`, or an implicit-pair inside a sequence (`[a: 1]`,
-    /// #2778). `DocumentCursor::preceding_delimiter_ok`'s doc comment names
-    /// the invariant this restores: *every format but JSON validates
-    /// delimiters while parsing*. JSON-sourced YAML was the one case that
-    /// did neither -- a YAML parse that permits what JSON forbids, feeding
-    /// cursors whose delimiter checks all default to `true`.
+    /// it as-is -- but real yq's own JSON front end (`goccy/go-json` v0.10.6
+    /// feeding `CandidateNode.UnmarshalJSON`) is neither strict JSON nor
+    /// YAML: it rejects things the YAML parser would otherwise accept
+    /// (`[1,]`/`[,1]`/`[1,,2]` delimiters, #2279; YAML-only scalar
+    /// spellings like `True`/`'a'`/`.5`/`+1`/`~` at any value position,
+    /// #2778) while *also* accepting things neither grammar does inside a
+    /// flow **mapping** specifically (#2777, below). `DocumentCursor::
+    /// preceding_delimiter_ok`'s doc comment names the invariant the
+    /// delimiter half restores: *every format but JSON validates delimiters
+    /// while parsing*. JSON-sourced YAML was the one case that did neither.
     ///
     /// Deliberately a runtime flag rather than a third const generic: it
     /// would multiply the `HAS_CR` monomorphizations (#340) for a branch
     /// that is predictable and off the scalar-scanning hot path.
     ///
-    /// **Delimiters: sequences only, never mappings.** Real yq's own object
-    /// handling is *lenient* here -- it ignores punctuation inside `{}`
-    /// entirely and pairs up tokens (`{"a":1,}`, `{,}`, `{"a" 1}` all
-    /// parse) -- so extending the delimiter checks to flow mappings would
-    /// refuse input the reference accepts.
+    /// **Flow sequences: strict delimiters, strict scalar grammar.** `[1,]`,
+    /// `[,1]`, `[1,,2]` and a YAML-only scalar spelling all error --
+    /// `parse_flow_sequence_inner` (#2279) and `check_json_strict_scalar`/
+    /// `json_strict_plain_scalar_ok` (#2778, shared with every scalar
+    /// *value* position, not just array elements).
     ///
-    /// **Scalar grammar: values only, never keys.** Mapping *keys* are
-    /// exempt (real yq panics on a non-string JSON key -- `{1:1}`,
-    /// `{true:1}` -- which succinctly does not reproduce; see
-    /// `docs/compliance/yq/limitations.md`). `json_strict_plain_scalar_ok`
-    /// is the predicate; yq accepts `[01]`/`[00]`/`[1.]` (leading zeros, a
-    /// bare trailing `.` survive) while rejecting `.5`/`+1`/`1e` -- not
-    /// "strict JSON", the boundary is
-    /// `goccy/go-json`'s own token scanner plus `strconv.ParseFloat`.
+    /// **Flow mappings: real yq's own token-pairing grammar, not stricter
+    /// delimiters (#2777).** Real yq ignores punctuation inside `{}`
+    /// entirely and pairs up tokens -- `{"a":1,}`, `{,}`, `{"a" 1}` all
+    /// parse, and `{"a":1 "b":2}` (no separator between entries at all)
+    /// does too. `parse_json_strict_flow_mapping_entries` reproduces this
+    /// (see its own doc comment for the exact skip-before-key/skip-before-
+    /// value rules and the deliberately-deferred "any bracket ends the
+    /// loop" edge). A non-string key (`{1:1}`, `{true:1}`) would panic in
+    /// the reference (Go interface-conversion panic, exit 2); per
+    /// ADR-0018 rule 4(c) this refuses cleanly instead of reproducing the
+    /// crash. Applies only to the plain (`YamlIndex`-backed) route -- the
+    /// DOM-bridge route (`--inplace`/`--slurp`/`--eval-all`, `JsonIndex`-
+    /// backed) still applies #1975's stricter grammar there, a known,
+    /// separately-tracked gap (`docs/compliance/yq/limitations.md`).
     ///
     /// **Structural, key-agnostic rejections.** `?` (explicit key), `&`/`!`
     /// (anchor/tag), `*` (alias), and `'` (single quote) have no JSON
@@ -574,7 +581,9 @@ struct Parser<'a, const HAS_CR: bool> {
     /// unvalidated. Two shapes bypass that chokepoint's own dispatch and
     /// carry their own identical gate instead: `--- |`/`--- >`
     /// (`parse_inline_document_value`'s dedicated fast path) and `?` inside
-    /// a flow mapping (`parse_flow_mapping_inner`).
+    /// a flow mapping (`parse_yaml_flow_mapping_entries` -- `json_strict`'s
+    /// own mapping-entry loop never reaches a `?` in key position, since
+    /// only a `"` starts a valid key there).
     json_strict: bool,
 }
 
@@ -5972,6 +5981,217 @@ impl<'a, const HAS_CR: bool> Parser<'a, HAS_CR> {
         self.advance();
         self.skip_flow_whitespace();
 
+        // #2777: real yq's own JSON-sourced object grammar is not YAML's
+        // flow-mapping grammar at all -- see `parse_json_strict_flow_mapping_entries`'s
+        // own doc comment for the derivation and why it is a wholly separate
+        // loop rather than more `if self.json_strict` branches threaded
+        // through the one below.
+        if self.json_strict {
+            self.parse_json_strict_flow_mapping_entries()?;
+        } else {
+            self.parse_yaml_flow_mapping_entries()?;
+        }
+
+        // Skip `}`
+        if self.peek() == Some(b'}') {
+            self.set_ib();
+            self.advance();
+        }
+
+        // A trailing comment right after `}` belongs to this mapping as a
+        // whole (#710), e.g. `a: {b: 1} # comment`.
+        self.maybe_capture_line_comment(container_bp_pos);
+
+        // Close mapping
+        self.write_bp_close();
+
+        Ok(())
+    }
+
+    /// #2777: real yq's own JSON-sourced object grammar, traced from
+    /// `goccy/go-json`'s `Stream.Token()`/`PrepareForDecode` (the machinery
+    /// `CandidateNode.UnmarshalJSON` actually uses for an object body) --
+    /// not YAML's flow-mapping grammar at all, which is why this is a
+    /// wholly separate loop rather than more `if self.json_strict` branches
+    /// threaded through [`Self::parse_yaml_flow_mapping_entries`]:
+    ///
+    /// - Before each key, whitespace and *any* run of `,`/`:` is skipped --
+    ///   both are pure separators to yq's token scanner here, so `{,}`,
+    ///   `{,"a":1}`, `{"a":1,,"b":2}`, `{:1}` (the leading `:` is itself
+    ///   skipped as a separator, leaving a bare numeric "key" -- see below)
+    ///   all collapse the same way.
+    /// - A key must be a JSON string (`"..."`); yq's own code path does an
+    ///   unchecked cast of the decoded token to `string`, so a
+    ///   well-formed *non-string* JSON literal there (`{1:1}`, `{true:1}`,
+    ///   `{null:1}`) is a Go interface-conversion **panic** (exit 2) in the
+    ///   reference. Per ADR-0018 rule 4(c) ("matching would take the host
+    ///   process down"), this reproduces the *rejection*, as a clean parse
+    ///   error, not the crash. Anything that isn't even a well-formed JSON
+    ///   token at all (`{abc:1}`, `{'a':1}`) is an ordinary scanner-level
+    ///   error in the reference too (`invalid character ... as token`), so
+    ///   it gets an ordinary parse error here as well.
+    /// - After the key, whitespace and *at most one* `,`/`:` is skipped --
+    ///   `PrepareForDecode`'s own, stricter rule -- so `{"a" 1}`/`{"a":1}`/
+    ///   `{"a",1}` all reach the value, but `{"a"::1}`/`{"a",,1}` (two
+    ///   separators) do not.
+    /// - The value must then start on a genuine JSON value byte: `{`, `[`,
+    ///   `"`, or a token matched by [`Self::json_strict_token_end`]
+    ///   (number/`true`/`false`/`null`) -- reusing the exact same
+    ///   token-boundary rule the key check above uses, since both are the
+    ///   same underlying scanner in the reference. A quoted-string or
+    ///   container value goes through the ordinary flow-value machinery;
+    ///   nested arrays keep their own, unrelated strict `[...]` delimiter
+    ///   rules (#2279/#2778) unchanged -- yq's object leniency has no array
+    ///   counterpart (`json.Unmarshal`'s ordinary strict slice decoder
+    ///   parses a nested array, confirmed live: `{"a":[1 2]}` errors).
+    ///
+    /// **Deliberately not reproduced**: the reference's token scanner
+    /// treats *every* bracket character (`{`, `}`, `[`, `]`) as a `Delim`
+    /// that ends the *current* object's key-reading loop the instant one
+    /// is seen -- including a `]` or a second `{`/`[` where a key was
+    /// expected, with no requirement that it be *this* object's own closing
+    /// brace (confirmed live: `{"a":1 ]}` -> `{"a":1}`; `{[1]:2}` -> `{}`).
+    /// What (if anything) is left unconsumed in that case is then read as
+    /// the *next* top-level document by yq's own stream evaluator, whose
+    /// own trailing-content handling is itself inconsistent (some leftover
+    /// shapes silently produce no error at all; others, differing only in
+    /// which byte is left over, print a stream-decode error to stderr while
+    /// still emitting the correct value and exiting 0). Reproducing that
+    /// would mean modelling a second, top-level-only decoder loop with the
+    /// same inconsistency, for a shape (a bare bracket standing in for a
+    /// key, with no quotes at all) that essentially never occurs in
+    /// real-world JSON -- deferred, and this parser instead reports a
+    /// ordinary parse error for a `{`/`[`/`]` found where a key is expected,
+    /// always failing the whole document cleanly rather than silently
+    /// producing a truncated one.
+    fn parse_json_strict_flow_mapping_entries(&mut self) -> Result<(), YamlError> {
+        loop {
+            // Skip whitespace and any run of `,`/`:` before a key.
+            loop {
+                self.skip_flow_whitespace();
+                match self.peek() {
+                    Some(b',' | b':') => self.advance(),
+                    _ => break,
+                }
+            }
+            match self.peek() {
+                Some(b'}') => return Ok(()),
+                None => {
+                    return Err(YamlError::UnexpectedEof {
+                        context: "flow mapping",
+                    });
+                }
+                _ => {}
+            }
+
+            // Parse key: must be a JSON string.
+            self.set_ib();
+            self.write_bp_open();
+            match self.peek() {
+                Some(b'"') => {
+                    let end = self.parse_double_quoted()?;
+                    self.set_bp_text_end(end);
+                }
+                _ => {
+                    return Err(if self.json_strict_token_end().is_some() {
+                        self.err_unexpected_char(
+                            self.pos,
+                            "non-string JSON object key (would panic in real yq)",
+                        )
+                    } else {
+                        self.err_unexpected_char(self.pos, "invalid character as JSON object key")
+                    });
+                }
+            }
+            self.write_bp_close();
+
+            // Skip whitespace and at most one `,`/`:` before the value.
+            self.skip_flow_whitespace();
+            if matches!(self.peek(), Some(b',' | b':')) {
+                self.advance();
+                self.skip_flow_whitespace();
+            }
+
+            // Parse value.
+            match self.peek() {
+                Some(b'[') => {
+                    self.parse_flow_sequence()?;
+                }
+                Some(b'{') => {
+                    self.parse_flow_mapping()?;
+                }
+                Some(b'"') => {
+                    self.set_ib();
+                    self.write_bp_open();
+                    let end = self.parse_double_quoted()?;
+                    self.set_bp_text_end(end);
+                    self.write_bp_close();
+                }
+                _ => {
+                    let start = self.pos;
+                    let Some(end) = self.json_strict_token_end() else {
+                        return Err(
+                            self.err_unexpected_char(self.pos, "expected value in JSON object")
+                        );
+                    };
+                    self.check_json_strict_scalar(start, end)?;
+                    // `write_bp_open` records `self.pos` as the node's start
+                    // -- it must run before `self.pos` moves to `end`, the
+                    // same order every other scalar-value arm here follows.
+                    self.set_ib();
+                    self.write_bp_open();
+                    self.pos = end;
+                    self.set_bp_text_end(end);
+                    self.write_bp_close();
+                }
+            }
+        }
+    }
+
+    /// Where a JSON literal token (`true`/`false`/`null`/a number) would end
+    /// if scanned from the current position, without consuming it -- the
+    /// token-boundary rule real yq's own scanner uses (#2777), which stops
+    /// well short of YAML's own unquoted-scalar scanner
+    /// ([`Self::parse_flow_unquoted_value`]): at the first byte that cannot
+    /// continue the token, not at the next flow delimiter. `None` means the
+    /// current position cannot start such a token at all. The returned
+    /// range is not yet validated as a *well-formed* number (`1.2.3`,
+    /// `--5`) -- callers combine this with [`Self::check_json_strict_scalar`]
+    /// for that, the same predicate [`Self::parse_flow_scalar`] already
+    /// uses for ordinary scalar values.
+    fn json_strict_token_end(&self) -> Option<usize> {
+        let rest = self.input.get(self.pos..)?;
+        if rest.starts_with(b"true") {
+            return Some(self.pos + 4);
+        }
+        if rest.starts_with(b"false") {
+            return Some(self.pos + 5);
+        }
+        if rest.starts_with(b"null") {
+            return Some(self.pos + 4);
+        }
+        let mut end = self.pos;
+        while end < self.input.len()
+            && matches!(
+                self.input[end],
+                b'0'..=b'9' | b'.' | b'e' | b'E' | b'+' | b'-'
+            )
+        {
+            end += 1;
+        }
+        if end == self.pos {
+            None
+        } else {
+            Some(end)
+        }
+    }
+
+    /// The ordinary YAML flow-mapping entry loop (`parse_flow_mapping_inner`
+    /// before #2777 split it out) -- unchanged behavior, still used for
+    /// genuine YAML input and reused as-is for a JSON-sourced flow
+    /// *sequence's* nested object values are not affected since arrays
+    /// always route into [`Self::parse_flow_sequence_inner`], not here.
+    fn parse_yaml_flow_mapping_entries(&mut self) -> Result<(), YamlError> {
         // Parse key-value pairs
         let mut first = true;
         while self.peek() != Some(b'}') {
@@ -6080,19 +6300,6 @@ impl<'a, const HAS_CR: bool> Parser<'a, HAS_CR> {
 
             self.skip_flow_whitespace();
         }
-
-        // Skip `}`
-        if self.peek() == Some(b'}') {
-            self.set_ib();
-            self.advance();
-        }
-
-        // A trailing comment right after `}` belongs to this mapping as a
-        // whole (#710), e.g. `a: {b: 1} # comment`.
-        self.maybe_capture_line_comment(container_bp_pos);
-
-        // Close mapping
-        self.write_bp_close();
 
         Ok(())
     }

--- a/tests/yq_cli_tests.rs
+++ b/tests/yq_cli_tests.rs
@@ -44698,6 +44698,157 @@ fn genuine_yaml_scalars_are_unaffected_by_json_strict_2778() -> Result<()> {
     Ok(())
 }
 
+// ============================================================================
+// #2777: JSON-sourced flow-mapping token-pairing grammar
+// ============================================================================
+
+/// Captured live against Homebrew `yq` v4.53.3 (`goccy/go-json` v0.10.6).
+/// Real yq's own object grammar ignores punctuation inside `{}` entirely and
+/// pairs up tokens (key, value, key, value, ...) rather than validating
+/// JSON structure -- a fundamentally different model from YAML's own
+/// flow-mapping grammar, which this fix reproduces on the "plain" route
+/// (`YamlIndex`-backed `-p json`, not `--inplace`/DOM-bridge routes -- see
+/// `docs/compliance/yq/limitations.md` for that separately-tracked gap,
+/// #2872's sibling for this issue). `None` marks a row real yq accepts but
+/// with no value-preserving output worth pinning (would-panic rows); those
+/// are asserted separately below since only their exit code, not stdout,
+/// is meaningfully comparable.
+const JSON_SOURCED_FLOW_MAPPING_ROWS: &[(&str, Option<&str>)] = &[
+    // --- the issue's own 8 rows -----------------------------------------
+    (r#"{"a":1 "b":2}"#, Some(r#"{"a":1,"b":2}"#)),
+    (r#"{"a":1"b":2}"#, Some(r#"{"a":1,"b":2}"#)),
+    ("{,}", Some("{}")),
+    (r#"{,"a":1}"#, Some(r#"{"a":1}"#)),
+    (r#"{"a":1,,"b":2}"#, Some(r#"{"a":1,"b":2}"#)),
+    (r#"{"a" 1}"#, Some(r#"{"a":1}"#)),
+    // --- must-not-change controls ---------------------------------------
+    (r#"{"a":1,}"#, Some(r#"{"a":1}"#)),
+    (r#"{"a":1,"b":2,}"#, Some(r#"{"a":1,"b":2}"#)),
+    ("{}", Some("{}")),
+    (r#"{"a":{"b":1 "c":2}}"#, Some(r#"{"a":{"b":1,"c":2}}"#)),
+    (r#"[{"a":1 "b":2}]"#, Some(r#"[{"a":1,"b":2}]"#)),
+    // --- nested arrays keep their own, unrelated strict rules -----------
+    (r#"{"a":[1 2]}"#, None),
+    (r#"{"a":[1,]}"#, None),
+];
+
+#[test]
+fn json_sourced_flow_mapping_token_pairing_matches_yq_2777() -> Result<()> {
+    for (input, expected) in JSON_SOURCED_FLOW_MAPPING_ROWS {
+        let (stdout, code) =
+            run_yq_stdin(".", input, &["--input-format", "json", "-o=json", "-I=0"])?;
+        match expected {
+            Some(want) => {
+                assert_eq!(
+                    (stdout.trim(), code),
+                    (*want, 0),
+                    "#2777: {input:?} must be accepted with this exact value \
+                     (real yq v4.53.3 accepts it)"
+                );
+            }
+            None => {
+                assert_eq!(
+                    code, 1,
+                    "#2777: {input:?} must be rejected with exit 1 (real yq v4.53.3 \
+                     rejects it), got stdout {stdout:?}"
+                );
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Rule-4(c) carve-out (ADR-0018): real yq's object grammar does an
+/// unchecked cast of a non-string JSON literal key to `string`, which
+/// panics (Go interface-conversion panic, exit 2) rather than erroring
+/// cleanly -- reproducing the *rejection*, as a clean parse error, not the
+/// crash. `{:1}` is included because the leading `:` is itself skipped as
+/// a separator (the same rule that skips a leading `,`), leaving a bare
+/// numeric "key".
+#[test]
+// `"{1:1}"`/`"{:1}"` are JSON-source test fixtures, not formatting strings;
+// clippy cannot tell the two apart from the brace shape alone.
+#[allow(clippy::literal_string_with_formatting_args)]
+fn json_sourced_flow_mapping_non_string_key_refuses_cleanly_2777() -> Result<()> {
+    for input in [
+        "{1:1}",
+        "{1.5:1}",
+        "{true:1}",
+        "{false:1}",
+        "{null:1}",
+        "{:1}",
+    ] {
+        let (stdout, stderr, code) =
+            run_yq_stdin_with_stderr(".", input, &["--input-format", "json", "-o=json", "-I=0"])?;
+        assert_eq!(
+            code, 1,
+            "#2777: {input:?} must be rejected cleanly (real yq panics, exit 2, \
+             here) with exit 1, not a crash -- got stdout {stdout:?}"
+        );
+        assert!(
+            stderr.contains("panic"),
+            "#2777: {input:?} error should name the reference's own panic -- stderr: {stderr:?}"
+        );
+    }
+    Ok(())
+}
+
+/// A malformed key that isn't even a well-formed JSON literal is an
+/// ordinary scanner-level error in the reference too (`invalid character
+/// ... as token`), not a panic -- these must not be conflated with the
+/// rule-4(c) rows above.
+#[test]
+fn json_sourced_flow_mapping_malformed_key_is_an_ordinary_error_2777() -> Result<()> {
+    for input in ["{abc:1}", "{'a':1}"] {
+        let (stdout, code) =
+            run_yq_stdin(".", input, &["--input-format", "json", "-o=json", "-I=0"])?;
+        assert_eq!(
+            code, 1,
+            "#2777: {input:?} must be rejected with exit 1, got stdout {stdout:?}"
+        );
+    }
+    Ok(())
+}
+
+/// The gap was never output-shaped: `length` and `keys` answer from the BP
+/// structure too, matching #2279's own coverage rationale for its sibling
+/// delimiter fix.
+#[test]
+fn json_sourced_flow_mapping_check_covers_every_route_2777() -> Result<()> {
+    for filter in [".", ".a", "keys", "length"] {
+        let (stdout, code) = run_yq_stdin(
+            filter,
+            r#"{"a":1 "b":2}"#,
+            &["--input-format", "json", "-o=json", "-I=0"],
+        )?;
+        assert_eq!(
+            code, 0,
+            "#2777: `{filter}` on a space-separated pair must be accepted, got stdout {stdout:?}"
+        );
+    }
+    Ok(())
+}
+
+/// The tightening is gated on JSON-sourced input. Genuine YAML keeps its
+/// own flow-mapping grammar, where a bare `{"a" 1}`/stray comma is either
+/// a different, legal shape (implicit-null value) or an outright parse
+/// error -- neither of which is what real yq does with `-p json`.
+#[test]
+fn genuine_yaml_flow_mappings_keep_their_own_grammar_2777() -> Result<()> {
+    // `{a 1}` in real YAML is an unquoted plain-scalar key `a 1` (a space is
+    // ordinary key content), not a key/value pair -- unaffected by #2777.
+    let (stdout, code) = run_yq_stdin(".", "{a 1}", &["-o=json", "-I=0"])?;
+    assert_eq!((stdout.trim(), code), (r#"{"a 1":null}"#, 0));
+
+    // `{,}` in genuine YAML reads as a `""` key bound to an implicit `null`
+    // (the pre-#2777 -- and pre-#2279 -- YAML flow-mapping rule, unrelated
+    // to #2777's own json_strict-gated leniency, which instead drops the
+    // whole entry and gives a clean `{}`).
+    let (stdout, code) = run_yq_stdin(".", "{,}", &["-o=json", "-I=0"])?;
+    assert_eq!((stdout.trim(), code), (r#"{"":null}"#, 0));
+    Ok(())
+}
+
 /// #2724: jq mode's `{$a}` object-construction shorthand fix is scoped to
 /// jq mode only -- yq mode still raises the same pre-existing parse error
 /// it always has ("expected identifier, found '$'"), not jq's `{"a":1}".


### PR DESCRIPTION
## Summary

Real yq's own `-p json` object grammar isn't a stricter or looser version
of JSON's or YAML's flow-mapping grammar -- it isn't a mapping grammar at
all. Traced from `goccy/go-json`'s own source (`Stream.Token()`/
`PrepareForDecode`, the machinery `CandidateNode.UnmarshalJSON` actually
calls for an object body): the decoder reads a flat stream of tokens and
pairs them up (key, value, key, value, ...), where punctuation is just
noise to skip, not structure to validate.

- Before each key: whitespace and *any* run of `,`/`:` is skipped (`{,}`,
  `{,"a":1}`, `{"a":1,,"b":2}`, `{:1}` all collapse).
- A key must be a JSON string; a well-formed *non-string* JSON literal key
  (`{1:1}`, `{true:1}`, `{null:1}`) is the reference's own interface-
  conversion panic (exit 2) -- reproduced as a clean rejection per
  ADR-0018 rule 4(c), not the crash.
- After the key: whitespace and *at most one* `,`/`:` is skipped -- a
  stricter rule, so `{"a" 1}`/`{"a":1}`/`{"a",1}` reach the value but
  `{"a"::1}`/`{"a",,1}` do not.
- The value must start on a genuine JSON value byte, with its own token
  boundary (stopping at the first byte that can't continue it, not the
  next comma/brace) -- this is what actually fixes the issue's own
  headline row, `{"a":1 "b":2}` -> `{"a":1,"b":2}` (previously a silent
  wrong value). Nested arrays are unaffected, keeping their own strict
  `[...]` rules (#2279/#2778).

`Parser::parse_json_strict_flow_mapping_entries` (`src/yaml/parser.rs`) is
a wholly separate loop from the ordinary YAML flow-mapping entries
(`parse_yaml_flow_mapping_entries`), entered under the existing
`json_strict` flag.

## Scope

Applies to the "plain" route (`YamlIndex`-backed) only -- `--inplace`/
`--slurp`/`--eval-all` still materialize through a separate `JsonIndex`-
backed DOM bridge that keeps #1975's stricter grammar. Route unification is
a separate, larger change touching the destructive `--inplace` write path,
filed as #2883.

Also deliberately not reproduced (documented in
`docs/compliance/yq/limitations.md`): the reference's token scanner treats
*every* bracket character as ending the current object's key-reading loop,
even a mismatched one (`{"a":1 ]}` -> `{"a":1}` in real yq) -- essentially
never occurs in real-world JSON, tracked in the same follow-up.

Fixes #2777

## Test plan
- [x] `cargo test --features cli --lib` (3729 passed)
- [x] `cargo test --features cli --test yq_cli_tests` (1883 passed, +5 new)
- [x] `cargo test --features cli --test jq_cli_tests` (1684 passed)
- [x] `cargo test --features cli --test yq_golden_tests` / `yaml_test_suite`
      (conformance intact, unaffected)
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo doc` with `RUSTDOCFLAGS="-D warnings"`
- [x] `cargo build --no-default-features` (no_std)
- [x] `cargo build --features cli --release`
- [x] Live oracle spot-checks against Homebrew yq v4.53.3 across the
      issue's own 8 repro rows plus nested/mixed-leniency/bool/null/float
      combinations -- all match exactly
